### PR TITLE
Adds example on Hydra integration for running environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 
 # Outputs
 **/output/*
+**/outputs/*
 *.tmp
 
 # Isaac-Sim packman

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,6 +118,8 @@ autodoc_mock_imports = [
     "hid",
     "prettytable",
     "tqdm",
+    "hydra",
+    "omegaconf",
 ]
 
 # List of zero or more Sphinx-specific warning categories to be squelched (i.e.,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ extra_standard_library = [
     "yaml",
     "prettytable",
     "toml",
+    "hydra",
+    "omegaconf",
 ]
 # Imports from Isaac Sim and Omniverse
 known_third_party = [

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/controllers/operational_space.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/controllers/operational_space.py
@@ -5,7 +5,7 @@
 
 import torch
 from dataclasses import MISSING
-from typing import Optional, Sequence, Tuple, Union
+from typing import Optional, List, Tuple, Union
 
 from omni.isaac.orbit.utils import configclass
 from omni.isaac.orbit.utils.math import apply_delta_pose, compute_pose_error
@@ -15,7 +15,7 @@ from omni.isaac.orbit.utils.math import apply_delta_pose, compute_pose_error
 class OperationSpaceControllerCfg:
     """Configuration for operation-space controller."""
 
-    command_types: Sequence[str] = MISSING
+    command_types: List[str] = MISSING
     """Type of command.
 
     It has two sub-strings joined by underscore:
@@ -29,9 +29,9 @@ class OperationSpaceControllerCfg:
     uncouple_motion_wrench: bool = False
     """Whether to decouple the wrench computation from task-space pose (motion) error."""
 
-    motion_control_axes: Sequence[int] = (1, 1, 1, 1, 1, 1)
+    motion_control_axes: List[int] = (1, 1, 1, 1, 1, 1)
     """Motion direction to control. Mark as 0/1 for each axis."""
-    force_control_axes: Sequence[int] = (0, 0, 0, 0, 0, 0)
+    force_control_axes: List[int] = (0, 0, 0, 0, 0, 0)
     """Force direction to control. Mark as 0/1 for each axis."""
 
     inertial_compensation: bool = False
@@ -40,10 +40,10 @@ class OperationSpaceControllerCfg:
     gravity_compensation: bool = False
     """Whether to perform gravity compensation."""
 
-    stiffness: Union[float, Sequence[float]] = MISSING
+    stiffness: Union[float, List[float]] = MISSING
     """The positional gain for determining wrenches based on task-space pose error."""
 
-    damping_ratio: Optional[Union[float, Sequence[float]]] = None
+    damping_ratio: Optional[Union[float, List[float]]] = None
     """The damping ratio is used in-conjunction with positional gain to compute wrenches
     based on task-space velocity error.
 
@@ -63,7 +63,7 @@ class OperationSpaceControllerCfg:
     Note: Used only when :obj:`impedance_mode` is "variable".
     """
 
-    force_stiffness: Union[float, Sequence[float]] = None
+    force_stiffness: Union[float, List[float]] = None
     """The positional gain for determining wrenches for closed-loop force control.
 
     If obj:`None`, then open-loop control of desired forces is performed.

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/controllers/operational_space.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/controllers/operational_space.py
@@ -5,7 +5,7 @@
 
 import torch
 from dataclasses import MISSING
-from typing import Optional, List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from omni.isaac.orbit.utils import configclass
 from omni.isaac.orbit.utils.math import apply_delta_pose, compute_pose_error

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object_cfg.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from dataclasses import MISSING
-from typing import Dict, Optional, Sequence, Tuple
+from typing import Dict, Optional, List, Tuple
 
 from omni.isaac.orbit.utils import configclass
 
@@ -21,7 +21,7 @@ class ArticulatedObjectCfg:
         """USD file to spawn asset from."""
         scale: Tuple[float] = (1.0, 1.0, 1.0)
         """Scale of the object. Default to (1.0, 1.0, 1.0)."""
-        sites_names: Optional[Sequence[str]] = None
+        sites_names: Optional[List[str]] = None
         """Name of the sites to track (added to :obj:`data`). Defaults to :obj:`None`."""
 
     @configclass

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object_cfg.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from dataclasses import MISSING
-from typing import Dict, Optional, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from omni.isaac.orbit.utils import configclass
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm_cfg.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from dataclasses import MISSING
-from typing import Optional, Sequence, Tuple
+from typing import Optional, List, Tuple
 
 from omni.isaac.orbit.utils import configclass
 
@@ -23,7 +23,7 @@ class SingleArmManipulatorCfg(RobotBaseCfg):
         """Number of degrees of freedom of arm."""
         tool_num_dof: int = MISSING
         """Number of degrees of freedom of tool."""
-        tool_sites_names: Optional[Sequence[str]] = None
+        tool_sites_names: Optional[List[str]] = None
         """Name of the tool sites to track (added to :obj:`data`). Defaults to :obj:`None`.
 
         If :obj:`None`, then no tool sites are tracked. The returned tensor for tool sites state
@@ -41,6 +41,7 @@ class SingleArmManipulatorCfg(RobotBaseCfg):
         rot_offset: Tuple[float, float, float] = (1.0, 0.0, 0.0, 0.0)
         """Additional rotation offset ``(w, x, y, z)`` from the body frame. Defaults to (1, 0, 0, 0)."""
 
+    @configclass
     class DataInfoCfg:
         """Information about what all data to read from simulator.
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm_cfg.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from dataclasses import MISSING
-from typing import Optional, List, Tuple
+from typing import List, Optional, Tuple
 
 from omni.isaac.orbit.utils import configclass
 

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/utils/__init__.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/utils/__init__.py
@@ -9,9 +9,9 @@
 import os
 
 # submodules
-from .parse_cfg import load_default_env_cfg, parse_env_cfg
+from .parse_cfg import load_default_env_cfg, parse_env_cfg, register_cfg_to_hydra
 
-__all__ = ["load_default_env_cfg", "parse_env_cfg", "get_checkpoint_path"]
+__all__ = ["load_default_env_cfg", "parse_env_cfg", "register_cfg_to_hydra", "get_checkpoint_path"]
 
 
 def get_checkpoint_path(log_path: str, run_dir: str = "*", checkpoint: str = None) -> str:

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/utils/parse_cfg.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/utils/parse_cfg.py
@@ -11,8 +11,8 @@ import importlib
 import inspect
 import os
 import yaml
-from typing import Any, Union
 from hydra.core.config_store import ConfigStore
+from typing import Any, Union
 
 from omni.isaac.orbit.utils import update_class_from_dict, update_dict
 

--- a/source/extensions/omni.isaac.orbit_envs/setup.py
+++ b/source/extensions/omni.isaac.orbit_envs/setup.py
@@ -28,6 +28,8 @@ INSTALL_REQUIRES = [
     "importlib-metadata~=4.13.0",
     # data collection
     "h5py",
+    # config management
+    "hydra-core",
 ]
 
 # Extra dependencies for RL agents

--- a/source/standalone/environments/zero_agent.py
+++ b/source/standalone/environments/zero_agent.py
@@ -8,8 +8,8 @@
 """Launch Isaac Sim Simulator first."""
 
 
-import sys
 import argparse
+import sys
 
 from omni.isaac.kit import SimulationApp
 
@@ -30,9 +30,8 @@ simulation_app = SimulationApp(config)
 
 
 import gym
-import torch
-
 import hydra
+import torch
 from omegaconf import OmegaConf
 
 import omni.isaac.contrib_envs  # noqa: F401

--- a/source/standalone/environments/zero_agent.py
+++ b/source/standalone/environments/zero_agent.py
@@ -8,6 +8,7 @@
 """Launch Isaac Sim Simulator first."""
 
 
+import sys
 import argparse
 
 from omni.isaac.kit import SimulationApp
@@ -15,10 +16,11 @@ from omni.isaac.kit import SimulationApp
 # add argparse arguments
 parser = argparse.ArgumentParser("Welcome to Orbit: Omniverse Robotics Environments!")
 parser.add_argument("--headless", action="store_true", default=False, help="Force display off at all times.")
-parser.add_argument("--cpu", action="store_true", default=False, help="Use CPU pipeline.")
-parser.add_argument("--num_envs", type=int, default=None, help="Number of environments to simulate.")
 parser.add_argument("--task", type=str, default=None, help="Name of the task.")
-args_cli = parser.parse_args()
+args_cli, remaining = parser.parse_known_args()
+# clear out sys.argv
+sys.argv = [sys.argv[0]] + remaining
+sys.argc = len(sys.argv)
 
 # launch the simulator
 config = {"headless": args_cli.headless}
@@ -30,15 +32,27 @@ simulation_app = SimulationApp(config)
 import gym
 import torch
 
+import hydra
+from omegaconf import OmegaConf
+
 import omni.isaac.contrib_envs  # noqa: F401
 import omni.isaac.orbit_envs  # noqa: F401
-from omni.isaac.orbit_envs.utils import parse_env_cfg
+from omni.isaac.orbit_envs.isaac_env_cfg import IsaacEnvCfg
+from omni.isaac.orbit_envs.utils.parse_cfg import register_cfg_to_hydra
 
 
-def main():
+@hydra.main(config_path=None, config_name=args_cli.task, version_base="1.3")
+def main(env_cfg: IsaacEnvCfg):
     """Zero actions agent with Isaac Orbit environment."""
-    # parse configuration
-    env_cfg = parse_env_cfg(args_cli.task, use_gpu=not args_cli.cpu, num_envs=args_cli.num_envs)
+    # get underlying object
+    env_cfg = OmegaConf.to_object(env_cfg)
+    # modify the environment configuration
+    if env_cfg.sim.device == "cpu":
+        env_cfg.sim.use_gpu_pipeline = False
+        env_cfg.sim.physx.use_gpu = False
+    elif "cuda" in env_cfg.sim.device:
+        env_cfg.sim.use_gpu_pipeline = True
+        env_cfg.sim.physx.use_gpu = True
     # create environment
     env = gym.make(args_cli.task, cfg=env_cfg, headless=args_cli.headless)
 
@@ -56,8 +70,10 @@ def main():
 
     # close the simulator
     env.close()
-    simulation_app.close()
 
 
 if __name__ == "__main__":
+    # configure hydra configuration
+    register_cfg_to_hydra(args_cli.task)
+    # run main function
     main()


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

This PR adds a method to register the environment configuration instance as a Hydra configuration object. Doing so allows configuring a bunch of environment parameters from the command line. It finally gets around the main motivation to use `configclass` decorator.

```bash
python source/standalone/environments/zero_agent.py --task Isaac-Lift-Franka-v0 --headless env.num_envs=2
```

Fixes #57 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
