### PR TITLE
[feature] adding a holonomic action term to mirror non holonomic action term

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,6 +39,7 @@ Guidelines for modifications:
 * Jia Lin Yuan
 * Jingzhou Liu
 * Kourosh Darvish
+* Kyle Morgenstein
 * Qinxi Yu
 * René Zurbrügg
 * Ritvik Singh

--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,11 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-<<<<<<< Updated upstream
-version = "0.15.4"
-=======
 version = "0.15.5"
->>>>>>> Stashed changes
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,11 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
+<<<<<<< Updated upstream
 version = "0.15.4"
+=======
+version = "0.15.5"
+>>>>>>> Stashed changes
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,23 @@
 Changelog
 ---------
 
+0.15.5 (2024-03-23)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+
+* Added ``HolonomicAction`` action term to mirror the ``NonHolonomicAction`` action term but with an additional lateral velocity component.  This type of action can be accomplished with the joint velocity action term but requires transforming the coordinates of the learned policy to run on a real robot; with this action term the policy can be used directly for velocity control on holonomic mobile bases.
+
+
+Fixed
+^^^^^
+
+
+* Squeezed ``quat_w`` in  ``NonHolonomicAction`` action term where the quaternion in ``apply_action()`` was shaped as ``[num envs, 1, 4]`` but it needs to be shaped ``[num envs, 4]`` in order to get the yaw component via ``euler_xyz_from_quat()``.
+
+
 0.15.4 (2024-03-22)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/__init__.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/__init__.py
@@ -7,6 +7,6 @@
 
 from .actions_cfg import *
 from .binary_joint_actions import *
+from .holonomic_actions import *
 from .joint_actions import *
 from .non_holonomic_actions import *
-from .holonomic_actions import *

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/__init__.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/__init__.py
@@ -9,3 +9,4 @@ from .actions_cfg import *
 from .binary_joint_actions import *
 from .joint_actions import *
 from .non_holonomic_actions import *
+from .holonomic_actions import *

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/actions_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/actions_cfg.py
@@ -11,7 +11,7 @@ from omni.isaac.orbit.controllers import DifferentialIKControllerCfg
 from omni.isaac.orbit.managers.action_manager import ActionTerm, ActionTermCfg
 from omni.isaac.orbit.utils import configclass
 
-from . import binary_joint_actions, joint_actions, non_holonomic_actions, task_space_actions, holonomic_actions
+from . import binary_joint_actions, holonomic_actions, joint_actions, non_holonomic_actions, task_space_actions
 
 ##
 # Joint actions.
@@ -218,6 +218,7 @@ class DifferentialInverseKinematicsActionCfg(ActionTermCfg):
     controller: DifferentialIKControllerCfg = MISSING
     """The configuration for the differential IK controller."""
 
+
 @configclass
 class HolonomicActionCfg(ActionTermCfg):
     """Configuration for the holonomic action term with dummy joints at the base.
@@ -225,7 +226,7 @@ class HolonomicActionCfg(ActionTermCfg):
     See :class:`HolonomicAction` for more details.
     """
 
-    class_type: type[ActionTerm] = HolonomicAction
+    class_type: type[ActionTerm] = holonomic_actions.HolonomicAction
 
     body_name: str = MISSING
     """Name of the body which has the dummy mechanism connected to."""

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/actions_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/actions_cfg.py
@@ -11,7 +11,7 @@ from omni.isaac.orbit.controllers import DifferentialIKControllerCfg
 from omni.isaac.orbit.managers.action_manager import ActionTerm, ActionTermCfg
 from omni.isaac.orbit.utils import configclass
 
-from . import binary_joint_actions, joint_actions, non_holonomic_actions, task_space_actions
+from . import binary_joint_actions, joint_actions, non_holonomic_actions, task_space_actions, holonomic_actions
 
 ##
 # Joint actions.
@@ -217,3 +217,25 @@ class DifferentialInverseKinematicsActionCfg(ActionTermCfg):
     """Scale factor for the action. Defaults to 1.0."""
     controller: DifferentialIKControllerCfg = MISSING
     """The configuration for the differential IK controller."""
+
+@configclass
+class HolonomicActionCfg(ActionTermCfg):
+    """Configuration for the holonomic action term with dummy joints at the base.
+
+    See :class:`HolonomicAction` for more details.
+    """
+
+    class_type: type[ActionTerm] = HolonomicAction
+
+    body_name: str = MISSING
+    """Name of the body which has the dummy mechanism connected to."""
+    x_joint_name: str = MISSING
+    """The dummy joint name in the x direction."""
+    y_joint_name: str = MISSING
+    """The dummy joint name in the y direction."""
+    yaw_joint_name: str = MISSING
+    """The dummy joint name in the yaw direction."""
+    scale: tuple[float, float] = (1.0, 1.0)
+    """Scale factor for the action. Defaults to (1.0, 1.0)."""
+    offset: tuple[float, float] = (0.0, 0.0)
+    """Offset factor for the action. Defaults to (0.0, 0.0)."""

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/holonomic_actions.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/holonomic_actions.py
@@ -1,17 +1,14 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch
 from typing import TYPE_CHECKING
+from dataclasses import MISSING
 
 import carb
 
+from omni.isaac.orbit.utils import configclass
+from omni.isaac.orbit.managers.action_manager import ActionTerm, ActionTermCfg
 from omni.isaac.orbit.assets.articulation import Articulation
-from omni.isaac.orbit.managers.action_manager import ActionTerm
 from omni.isaac.orbit.utils.math import euler_xyz_from_quat
 
 if TYPE_CHECKING:
@@ -19,19 +16,19 @@ if TYPE_CHECKING:
 
     from . import actions_cfg
 
+class HolonomicAction(ActionTerm):
+    r"""Holonomic action that maps a three dimensional action in the robot's local frame to the velocity of the robot in
+    the x, y and yaw directions in the world frame.
 
-class NonHolonomicAction(ActionTerm):
-    r"""Non-holonomic action that maps a two dimensional action to the velocity of the robot in
-    the x, y and yaw directions.
-
-    This action term helps model a skid-steer robot base. The action is a 2D vector which comprises of the
-    forward velocity :math:`v_{B,x}` and the turning rate :\omega_{B,z}: in the base frame. Using the current
-    base orientation, the commands are transformed into dummy joint velocity targets as:
+    This action term helps model a holonomic robot base. The action is a 3D vector which comprises of the
+    forward velocity :math:`v_{B,x}`, lateral velocity :math:`v_{B,y}`,and the turning rate :\omega_{B,z}: 
+    in the base frame. Using the current base orientation, the commands are transformed into dummy joint 
+    velocity targets as:
 
     .. math::
 
-        \dot{q}_{0, des} &= v_{B,x} \cos(\theta) \\
-        \dot{q}_{1, des} &= v_{B,x} \sin(\theta) \\
+        \dot{q}_{0, des} &= v_{B,x} \cos(\theta) + v_{B,y} \cos(\theta) \\
+        \dot{q}_{1, des} &= v_{B,x} \sin(\theta) - v_{B,y} \sin(\theta) \\
         \dot{q}_{2, des} &= \omega_{B,z}
 
     where :math:`\theta` is the yaw of the 2-D base. Since the base is simulated as a dummy joint, the yaw is directly
@@ -50,16 +47,16 @@ class NonHolonomicAction(ActionTerm):
         This ensures that the base remains unperturbed from external disturbances, such as an arm mounted on the base.
     """
 
-    cfg: actions_cfg.NonHolonomicActionCfg
+    cfg: actions_cfg.HolonomicActionCfg
     """The configuration of the action term."""
     _asset: Articulation
     """The articulation asset on which the action term is applied."""
     _scale: torch.Tensor
-    """The scaling factor applied to the input action. Shape is (1, 2)."""
+    """The scaling factor applied to the input action. Shape is (1, 3)."""
     _offset: torch.Tensor
-    """The offset applied to the input action. Shape is (1, 2)."""
+    """The offset applied to the input action. Shape is (1, 3)."""
 
-    def __init__(self, cfg: actions_cfg.NonHolonomicActionCfg, env: BaseEnv):
+    def __init__(self, cfg: actions_cfg.HolonomicActionCfg, env: BaseEnv):
         # initialize the action term
         super().__init__(cfg, env)
 
@@ -73,12 +70,16 @@ class NonHolonomicAction(ActionTerm):
         # -- y joint
         y_joint_id, y_joint_name = self._asset.find_joints(self.cfg.y_joint_name)
         if len(y_joint_id) != 1:
-            raise ValueError(f"Found more than one joint match for the y joint name: {self.cfg.y_joint_name}")
+            raise ValueError(
+                f"Expected a single joint match for the y joint name: {self.cfg.y_joint_name}, got {len(y_joint_id)}"
+            )
         # -- yaw joint
         yaw_joint_id, yaw_joint_name = self._asset.find_joints(self.cfg.yaw_joint_name)
         if len(yaw_joint_id) != 1:
-            raise ValueError(f"Found more than one joint match for the yaw joint name: {self.cfg.yaw_joint_name}")
-        # parse the body index
+            raise ValueError(
+                f"Expected a single joint match for the yaw joint name: {self.cfg.yaw_joint_name}, got {len(yaw_joint_id)}"
+            )
+        # -- body link
         self._body_idx, self._body_name = self._asset.find_bodies(self.cfg.body_name)
         if len(self._body_idx) != 1:
             raise ValueError(f"Found more than one body match for the body name: {self.cfg.body_name}")
@@ -110,7 +111,7 @@ class NonHolonomicAction(ActionTerm):
 
     @property
     def action_dim(self) -> int:
-        return 2
+        return 3
 
     @property
     def raw_actions(self) -> torch.Tensor:
@@ -134,8 +135,8 @@ class NonHolonomicAction(ActionTerm):
         quat_w = self._asset.data.body_quat_w[:, self._body_idx].squeeze(1)
         yaw_w = euler_xyz_from_quat(quat_w)[2]
         # compute joint velocities targets
-        self._joint_vel_command[:, 0] = torch.cos(yaw_w) * self.processed_actions[:, 0]  # x
-        self._joint_vel_command[:, 1] = torch.sin(yaw_w) * self.processed_actions[:, 0]  # y
-        self._joint_vel_command[:, 2] = self.processed_actions[:, 1]  # yaw
+        self._joint_vel_command[:, 0] = torch.cos(yaw_w) * (self.processed_actions[:, 0] + self.processed_actions[:, 1])  # x
+        self._joint_vel_command[:, 1] = torch.sin(yaw_w) * (self.processed_actions[:, 0] - self.processed_actions[:, 1])  # y
+        self._joint_vel_command[:, 2] = self.processed_actions[:, 2]  # yaw
         # set the joint velocity targets
         self._asset.set_joint_velocity_target(self._joint_vel_command, joint_ids=self._joint_ids)


### PR DESCRIPTION
# Description

- Added ``HolonomicAction`` action term to mirror the ``NonHolonomicAction`` action term but with an additional lateral velocity component.  This type of action can be accomplished with the joint velocity action term but requires transforming the coordinates of the learned policy to run on a real robot; with this action term the policy can be used directly for velocity control on holonomic mobile bases.

And a small bug fix:
- Squeezed ``quat_w`` in  ``NonHolonomicAction`` action term where the quaternion in ``apply_action()`` was shaped as ``[num envs, 1, 4]`` but it needs to be shaped ``[num envs, 4]`` in order to get the yaw component via ``euler_xyz_from_quat()``.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Screenshots

for the bug fix:

before:
``quat_w = self._asset.data.body_quat_w[:, self._body_idx]``

after:
``quat_w = self._asset.data.body_quat_w[:, self._body_idx].squeeze(1)``

See the commit for the ``HolonomicAction`` documentation, provided in the docstring.

## Checklist

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have run all the tests with `./orbit.sh --test` and they pass
- [X] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [X] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
