### PR TITLE
Added specific joint selection to reset_joints_by_offset

### DIFF
--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/events.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/events.py
@@ -584,8 +584,8 @@ def reset_joints_by_offset(
     joint_vel = joint_vel.clamp_(-joint_vel_limits, joint_vel_limits)
 
     # select which joints to update
-    joint_pos = joint_pos[:, asset_cfg.joint_ids]
-    joint_vel = joint_vel[:, asset_cfg.joint_ids]
+    joint_pos = joint_pos[:, asset_cfg.joint_ids][0]
+    joint_vel = joint_vel[:, asset_cfg.joint_ids][0]
 
     # set into the physics simulation
     asset.write_joint_state_to_sim(joint_pos, joint_vel, joint_ids=asset_cfg.joint_ids, env_ids=env_ids)

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/events.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/events.py
@@ -583,8 +583,12 @@ def reset_joints_by_offset(
     joint_vel_limits = asset.data.soft_joint_vel_limits[env_ids]
     joint_vel = joint_vel.clamp_(-joint_vel_limits, joint_vel_limits)
 
+    # select which joints to update
+    joint_pos = joint_pos[:, asset_cfg.joint_ids]
+    joint_vel = joint_vel[:, asset_cfg.joint_ids]
+
     # set into the physics simulation
-    asset.write_joint_state_to_sim(joint_pos, joint_vel, env_ids=env_ids)
+    asset.write_joint_state_to_sim(joint_pos, joint_vel, joint_ids=asset_cfg.joint_ids, env_ids=env_ids)
 
 
 def reset_scene_to_default(env: BaseEnv, env_ids: torch.Tensor):


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->
The `reset_joints_by_offset` function resets all the robot joint variables regardless of the ones passed through with `asset_cfg`.

This change only fixes `reset_joints_by_offset` however It may also apply to `reset_joints_by_scale` and others, I just have not tested these other functions. 

Fixes #368 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Screenshots
<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run all the tests with `./orbit.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
