### PR TITLE
Fixes Isaac Sim path in installation guide

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,6 +43,7 @@ Guidelines for modifications:
 * Kourosh Darvish
 * Lorenz Wellhausen
 * Muhong Guo
+* Nuralem Abizov
 * Özhan Özen
 * Qinxi Yu
 * René Zurbrügg
@@ -50,7 +51,6 @@ Guidelines for modifications:
 * Rosario Scalise
 * Shafeef Omar
 * Vladimir Fokow
-* Nuralem Abizov
 
 ## Acknowledgements
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,6 +50,7 @@ Guidelines for modifications:
 * Rosario Scalise
 * Shafeef Omar
 * Vladimir Fokow
+* Nuralem Abizov
 
 ## Acknowledgements
 

--- a/docs/source/setup/installation/verifying_installation.rst
+++ b/docs/source/setup/installation/verifying_installation.rst
@@ -67,7 +67,7 @@ variables to your terminal for the remaining of the installation instructions:
       .. code:: bash
 
          # Isaac Sim root directory
-         export ISAACSIM_PATH="${HOME}/.local/share/ov/pkg/isaac_sim-4.0"
+         export ISAACSIM_PATH="${HOME}/.local/share/ov/pkg/isaac-sim-4.0.0"
          # Isaac Sim python executable
          export ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 
@@ -76,7 +76,7 @@ variables to your terminal for the remaining of the installation instructions:
       .. code:: batch
 
          :: Isaac Sim root directory
-         set ISAACSIM_PATH="C:\Users\user\AppData\Local\ov\pkg\isaac_sim-4.0"
+         set ISAACSIM_PATH="C:\Users\user\AppData\Local\ov\pkg\isaac-sim-4.0.0"
          :: Isaac Sim python executable
          set ISAACSIM_PYTHON_EXE="%ISAACSIM_PATH%\python.bat"
 


### PR DESCRIPTION
# Description

Fixed the path issue during the export IsaacSim 4.0 location path. 
After installing the new IsaacSim 4.0 it creates a folder with isaac-sim-4.0.0 name by default.

Fixes https://github.com/isaac-sim/IsaacLab/issues/448

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run all the tests with `./isaaclab.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there