### PR TITLE
Removes hardcoded paths in docker compose

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -36,10 +36,10 @@ x-default-isaac-lab-volumes: &default-isaac-lab-volumes
     # be reflected within the container immediately
   - type: bind
     source: ../source
-    target: /workspace/isaaclab/source
+    target: ${DOCKER_ISAACLAB_PATH}/source
   - type: bind
     source: ../docs
-    target: /workspace/isaaclab/docs
+    target: ${DOCKER_ISAACLAB_PATH}/docs
     # The effect of these volumes is twofold:
     # 1. Prevent root-owned files from flooding the _build and logs dir
     #    on the host machine
@@ -47,13 +47,13 @@ x-default-isaac-lab-volumes: &default-isaac-lab-volumes
     #    to the host machine
   - type: volume
     source: isaac-lab-docs
-    target: /workspace/isaaclab/docs/_build
+    target: ${DOCKER_ISAACLAB_PATH}/docs/_build
   - type: volume
     source: isaac-lab-logs
-    target: /workspace/isaaclab/logs
+    target: ${DOCKER_ISAACLAB_PATH}/logs
   - type: volume
     source: isaac-lab-data
-    target: /workspace/isaaclab/data_storage
+    target: ${DOCKER_ISAACLAB_PATH}/data_storage
 
 x-default-isaac-lab-environment: &default-isaac-lab-environment
   - ISAACSIM_PATH=${DOCKER_ISAACLAB_PATH}/_isaac_sim


### PR DESCRIPTION
# Description

Removes hardcoded IsaacLab folder path in docker compose.

## Type of change

- Bug fix

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run all the tests with `./isaaclab.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
