### PR TITLE
Enable composite compose

### DIFF
--- a/docker/container.sh
+++ b/docker/container.sh
@@ -258,7 +258,6 @@ process_mode_args() {
                     value=${1}
                     shift
                 fi
-                echo "$add_yamls --file ${value}"
                 add_yamls="$add_yamls --file ${value}"
                 ;;
             -ae*|--add_env*)
@@ -268,7 +267,6 @@ process_mode_args() {
                     value=${1}
                     shift
                 fi
-                echo "$add_envs --env-file ${value}"
                 add_envs="$add_envs --env-file ${value}"
                 ;;
             *)

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -36,10 +36,10 @@ x-default-isaac-lab-volumes: &default-isaac-lab-volumes
     # be reflected within the container immediately
   - type: bind
     source: ../source
-    target: /workspace/isaaclab/source
+    target: ${DOCKER_ISAACLAB_PATH}/source
   - type: bind
     source: ../docs
-    target: /workspace/isaaclab/docs
+    target: ${DOCKER_ISAACLAB_PATH}/docs
     # The effect of these volumes is twofold:
     # 1. Prevent root-owned files from flooding the _build and logs dir
     #    on the host machine
@@ -47,13 +47,13 @@ x-default-isaac-lab-volumes: &default-isaac-lab-volumes
     #    to the host machine
   - type: volume
     source: isaac-lab-docs
-    target: /workspace/isaaclab/docs/_build
+    target: ${DOCKER_ISAACLAB_PATH}/docs/_build
   - type: volume
     source: isaac-lab-logs
-    target: /workspace/isaaclab/logs
+    target: ${DOCKER_ISAACLAB_PATH}/logs
   - type: volume
     source: isaac-lab-data
-    target: /workspace/isaaclab/data_storage
+    target: ${DOCKER_ISAACLAB_PATH}/data_storage
 
 x-default-isaac-lab-environment: &default-isaac-lab-environment
   - ISAACSIM_PATH=${DOCKER_ISAACLAB_PATH}/_isaac_sim


### PR DESCRIPTION
# Description

This PR updates the `container.sh` script to support the creation of composite Compose files. By allowing external docker-compose and environment files to be provided to the Compose command, users can utilize both the Merge and Extend strategies.

Example for Merge: Users can supply a new .env file to override the `DOCKER_ISAACLAB_PATH` variable in the base Docker configuration.
Example for Extend: Users can provide external docker-compose and env files to extend the base service.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./isaaclab.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
