### PR TITLE
Fixes root view to body view mapping in articulation

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
@@ -846,7 +846,7 @@ class Articulation(RigidObject):
         prim_paths = self._body_physx_view.prim_paths[: self.num_bodies]
         body_view_body_names = [path.split("/")[-1] for path in prim_paths]
         # -- mapping from articulation view to body view
-        self._body_view_ordering = [body_view_body_names.index(name) for name in root_view_body_names]
+        self._body_view_ordering = [root_view_body_names.index(name) for name in body_view_body_names]
         self._body_view_ordering = torch.tensor(self._body_view_ordering, dtype=torch.long, device=self.device)
 
         # log information about the articulation


### PR DESCRIPTION
# Description

Thank you for the really great framework!

fixes the index ordering between the articulation view and the rigid object view.
I know that body_view will not be used anymore from 0.4.0, but for the current version, there is a bug 
in Articulation.set_external_force  function. The re-ordering was not performing correctly and was applying forces to different rigid bodies. The bug was fixed by changing one line.

Fixes #475

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run all the tests with `./isaaclab.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
