### PR TITLE
Adds an example showcasing different camera types

### DIFF
--- a/docs/source/api/lab/omni.isaac.lab.sensors.rst
+++ b/docs/source/api/lab/omni.isaac.lab.sensors.rst
@@ -18,6 +18,8 @@
     Camera
     CameraData
     CameraCfg
+    TiledCamera
+    TiledCameraCfg
     ContactSensor
     ContactSensorData
     ContactSensorCfg
@@ -29,8 +31,6 @@
     RayCasterCfg
     RayCasterCamera
     RayCasterCameraCfg
-    TiledCamera
-    TiledCameraCfg
 
 Sensor Base
 -----------
@@ -61,6 +61,20 @@ USD Camera
     :show-inheritance:
     :exclude-members: __init__, class_type
 
+Tile-Rendered USD Camera
+------------------------
+
+.. autoclass:: TiledCamera
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
+.. autoclass:: TiledCameraCfg
+    :members:
+    :inherited-members:
+    :show-inheritance:
+    :exclude-members: __init__, class_type
+
 Contact Sensor
 --------------
 
@@ -79,7 +93,6 @@ Contact Sensor
     :inherited-members:
     :show-inheritance:
     :exclude-members: __init__, class_type
-
 
 Frame Transformer
 -----------------
@@ -133,20 +146,6 @@ Ray-Cast Camera
     :show-inheritance:
 
 .. autoclass:: RayCasterCameraCfg
-    :members:
-    :inherited-members:
-    :show-inheritance:
-    :exclude-members: __init__, class_type
-
-Tiled Rendering
----------------
-
-.. autoclass:: TiledCamera
-    :members:
-    :inherited-members:
-    :show-inheritance:
-
-.. autoclass:: TiledCameraCfg
     :members:
     :inherited-members:
     :show-inheritance:

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/__init__.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/__init__.py
@@ -6,7 +6,8 @@
 """Sub-module for camera wrapper around USD camera prim."""
 
 from .camera import Camera
-from .camera_cfg import CameraCfg, TiledCameraCfg
+from .camera_cfg import CameraCfg
 from .camera_data import CameraData
 from .tiled_camera import TiledCamera
+from .tiled_camera_cfg import TiledCameraCfg
 from .utils import *  # noqa: F401, F403

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/camera_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/camera_cfg.py
@@ -11,7 +11,6 @@ from omni.isaac.lab.utils import configclass
 
 from ..sensor_base_cfg import SensorBaseCfg
 from .camera import Camera
-from .tiled_camera import TiledCamera
 
 
 @configclass
@@ -106,65 +105,4 @@ class CameraCfg(SensorBaseCfg):
 
     If True, instance segmentation is converted to an image where instance IDs are mapped to colors.
     and returned as a ``uint8`` 4-channel array. If False, the output is returned as a ``int32`` array.
-    """
-
-
-@configclass
-class TiledCameraCfg(SensorBaseCfg):
-    """Configuration for a tiled rendering camera sensor."""
-
-    @configclass
-    class OffsetCfg:
-        """The offset pose of the sensor's frame from the sensor's parent frame."""
-
-        pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
-        """Translation w.r.t. the parent frame. Defaults to (0.0, 0.0, 0.0)."""
-
-        rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
-        """Quaternion rotation (w, x, y, z) w.r.t. the parent frame. Defaults to (1.0, 0.0, 0.0, 0.0)."""
-
-        convention: Literal["opengl", "ros", "world"] = "ros"
-        """The convention in which the frame offset is applied. Defaults to "ros".
-
-        - ``"opengl"`` - forward axis: ``-Z`` - up axis: ``+Y`` - Offset is applied in the OpenGL (Usd.Camera) convention.
-        - ``"ros"``    - forward axis: ``+Z`` - up axis: ``-Y`` - Offset is applied in the ROS convention.
-        - ``"world"``  - forward axis: ``+X`` - up axis: ``+Z`` - Offset is applied in the World Frame convention.
-
-        """
-
-    class_type: type = TiledCamera
-
-    offset: OffsetCfg = OffsetCfg()
-    """The offset pose of the sensor's frame from the sensor's parent frame. Defaults to identity.
-
-    Note:
-        The parent frame is the frame the sensor attaches to. For example, the parent frame of a
-        camera at path ``/World/envs/env_0/Robot/Camera`` is ``/World/envs/env_0/Robot``.
-    """
-
-    spawn: PinholeCameraCfg | FisheyeCameraCfg | None = MISSING
-    """Spawn configuration for the asset.
-
-    If None, then the prim is not spawned by the asset. Instead, it is assumed that the
-    asset is already present in the scene.
-    """
-
-    data_types: list[str] = ["rgb"]
-    """List of sensor names/types to enable for the camera. Defaults to ["rgb"].
-
-    Please refer to the :class:`Camera` class for a list of available data types.
-    """
-
-    width: int = MISSING
-    """Width of the image in pixels."""
-
-    height: int = MISSING
-    """Height of the image in pixels."""
-
-    return_latest_camera_pose: bool = False
-    """Whether to return the latest camera pose when fetching the camera's data. Defaults to False.
-
-    If True, the latest camera pose is returned in the camera's data which will slow down performance
-    due to the use of :class:`XformPrimView`.
-    If False, the pose of the camera during initialization is returned.
     """

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/tiled_camera_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/tiled_camera_cfg.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from dataclasses import MISSING
+from typing import Literal
+
+from omni.isaac.lab.sim import FisheyeCameraCfg, PinholeCameraCfg
+from omni.isaac.lab.utils import configclass
+
+from ..sensor_base_cfg import SensorBaseCfg
+from .tiled_camera import TiledCamera
+
+
+@configclass
+class TiledCameraCfg(SensorBaseCfg):
+    """Configuration for a tiled rendering-based camera sensor."""
+
+    @configclass
+    class OffsetCfg:
+        """The offset pose of the sensor's frame from the sensor's parent frame."""
+
+        pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
+        """Translation w.r.t. the parent frame. Defaults to (0.0, 0.0, 0.0)."""
+
+        rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+        """Quaternion rotation (w, x, y, z) w.r.t. the parent frame. Defaults to (1.0, 0.0, 0.0, 0.0)."""
+
+        convention: Literal["opengl", "ros", "world"] = "ros"
+        """The convention in which the frame offset is applied. Defaults to "ros".
+
+        - ``"opengl"`` - forward axis: ``-Z`` - up axis: ``+Y`` - Offset is applied in the OpenGL (Usd.Camera) convention.
+        - ``"ros"``    - forward axis: ``+Z`` - up axis: ``-Y`` - Offset is applied in the ROS convention.
+        - ``"world"``  - forward axis: ``+X`` - up axis: ``+Z`` - Offset is applied in the World Frame convention.
+        """
+
+    class_type: type = TiledCamera
+
+    offset: OffsetCfg = OffsetCfg()
+    """The offset pose of the sensor's frame from the sensor's parent frame. Defaults to identity.
+
+    Note:
+        The parent frame is the frame the sensor attaches to. For example, the parent frame of a
+        camera at path ``/World/envs/env_0/Robot/Camera`` is ``/World/envs/env_0/Robot``.
+    """
+
+    spawn: PinholeCameraCfg | FisheyeCameraCfg | None = MISSING
+    """Spawn configuration for the asset.
+
+    If None, then the prim is not spawned by the asset. Instead, it is assumed that the
+    asset is already present in the scene.
+    """
+
+    data_types: list[str] = ["rgb"]
+    """List of sensor names/types to enable for the camera. Defaults to ["rgb"].
+
+    Please refer to the :class:`TiledCamera` class for a list of available data types.
+    """
+
+    width: int = MISSING
+    """Width of the image in pixels."""
+
+    height: int = MISSING
+    """Height of the image in pixels."""
+
+    return_latest_camera_pose: bool = False
+    """Whether to return the latest camera pose when fetching the camera's data. Defaults to False.
+
+    If True, the latest camera pose is returned in the camera's data which will slow down performance
+    due to the use of :class:`XformPrimView`.
+    If False, the pose of the camera during initialization is returned.
+    """

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/warp/kernels.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/warp/kernels.py
@@ -83,25 +83,35 @@ def reshape_tiled_image(
     num_tiles_x: int,
     offset: int,
 ):
-    """Reshape a tiled image (height*width*num_channels*num_cameras,) to a batch of images (num_cameras, height, width, num_channels).
+    """Reshapes a tiled image into a batch of images.
+
+    This function reshapes the input tiled image buffer into a batch of images. The input image buffer
+    is assumed to be tiled in the x and y directions. The output image is a batch of images with the
+    specified height, width, and number of channels.
 
     Args:
-        tiled_image_buffer: The input image buffer. Shape is (height*width*num_channels*num_cameras,).
+        tiled_image_buffer: The input image buffer. Shape is (height * width * num_channels * num_cameras,).
         batched_image: The output image. Shape is (num_cameras, height, width, num_channels).
         image_width: The width of the image.
         image_height: The height of the image.
         num_channels: The number of channels in the image.
-        num_tiles_x: The number of tiles in x direction.
+        num_tiles_x: The number of tiles in x-direction.
         offset: The offset in the image buffer. This is used when multiple image types are concatenated in the buffer.
     """
+    # get the thread id
     camera_id, height_id, width_id = wp.tid()
+
+    # resolve the tile indices
     tile_x_id = camera_id % num_tiles_x
     tile_y_id = camera_id // num_tiles_x
+    # compute the start index of the pixel in the tiled image buffer
     pixel_start = (
         offset
         + num_channels * num_tiles_x * image_width * (image_height * tile_y_id + height_id)
         + num_channels * tile_x_id * image_width
         + num_channels * width_id
     )
+
+    # copy the pixel values into the batched image
     for i in range(num_channels):
         batched_image[camera_id, height_id, width_id, i] = tiled_image_buffer[pixel_start + i]

--- a/source/standalone/demos/bipeds.py
+++ b/source/standalone/demos/bipeds.py
@@ -4,7 +4,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 """
-This script demonstrates how to simulate a bipedal robot.
+This script demonstrates how to simulate bipedal robots.
+
+.. code-block:: bash
+
+    # Usage
+    ./isaaclab.sh -p source/standalone/demos/bipeds.py
 
 """
 
@@ -16,7 +21,7 @@ import torch
 from omni.isaac.lab.app import AppLauncher
 
 # add argparse arguments
-parser = argparse.ArgumentParser(description="This script demonstrates how to simulate a bipedal robot.")
+parser = argparse.ArgumentParser(description="This script demonstrates how to simulate bipedal robots.")
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 # parse the arguments

--- a/source/standalone/demos/cameras.py
+++ b/source/standalone/demos/cameras.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+This script demonstrates the different camera sensors that can be attached to a robot.
+
+.. code-block:: bash
+
+    # Usage
+    ./isaaclab.sh -p source/standalone/demos/cameras.py
+
+"""
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+
+from omni.isaac.lab.app import AppLauncher
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="This script demonstrates the different camera sensor implementations.")
+parser.add_argument("--num_envs", type=int, default=2, help="Number of environments to spawn.")
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli = parser.parse_args()
+
+# launch omniverse app
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+import omni.isaac.lab.sim as sim_utils
+from omni.isaac.lab.assets import ArticulationCfg, AssetBaseCfg
+from omni.isaac.lab.scene import InteractiveScene, InteractiveSceneCfg
+from omni.isaac.lab.sensors import CameraCfg, RayCasterCameraCfg, TiledCameraCfg
+from omni.isaac.lab.sensors.ray_caster import patterns
+from omni.isaac.lab.terrains import TerrainImporterCfg
+from omni.isaac.lab.utils import configclass
+
+##
+# Pre-defined configs
+##
+from omni.isaac.lab.terrains.config.rough import ROUGH_TERRAINS_CFG  # isort:skip
+from omni.isaac.lab_assets.anymal import ANYMAL_C_CFG  # isort: skip
+
+
+@configclass
+class SensorsSceneCfg(InteractiveSceneCfg):
+    """Design the scene with sensors on the robot."""
+
+    # ground plane
+    ground = TerrainImporterCfg(
+        num_envs=2048,
+        env_spacing=3.0,
+        prim_path="/World/ground",
+        max_init_terrain_level=None,
+        terrain_type="generator",
+        terrain_generator=ROUGH_TERRAINS_CFG.replace(color_scheme="random"),
+        visual_material=None,
+        debug_vis=True,
+    )
+
+    # lights
+    dome_light = AssetBaseCfg(
+        prim_path="/World/Light", spawn=sim_utils.DomeLightCfg(intensity=3000.0, color=(0.75, 0.75, 0.75))
+    )
+
+    # robot
+    robot: ArticulationCfg = ANYMAL_C_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+
+    # sensors
+    camera = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/base/front_cam",
+        update_period=0.1,
+        height=480,
+        width=640,
+        data_types=["rgb", "distance_to_image_plane"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=24.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 1.0e5)
+        ),
+        offset=CameraCfg.OffsetCfg(pos=(0.510, 0.0, 0.015), rot=(0.5, -0.5, 0.5, -0.5), convention="ros"),
+    )
+    tiled_camera = TiledCameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/base/front_cam",
+        update_period=0.1,
+        height=480,
+        width=640,
+        data_types=["rgb", "depth"],
+        spawn=None,
+        offset=TiledCameraCfg.OffsetCfg(pos=(0.510, 0.0, 0.015), rot=(0.5, -0.5, 0.5, -0.5), convention="ros"),
+    )
+    raycast_camera = RayCasterCameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/base",
+        mesh_prim_paths=["/World/ground"],
+        update_period=0.1,
+        offset=RayCasterCameraCfg.OffsetCfg(pos=(0.510, 0.0, 0.015), rot=(0.5, -0.5, 0.5, -0.5), convention="ros"),
+        data_types=["distance_to_image_plane", "normals", "distance_to_camera"],
+        pattern_cfg=patterns.PinholeCameraPatternCfg(
+            focal_length=24.0,
+            horizontal_aperture=20.955,
+            height=480,
+            width=640,
+        ),
+    )
+
+
+def save_images_grid(
+    images: list[torch.Tensor],
+    nrow: int = 1,
+    subtitles: list[str] | None = None,
+    title: str | None = None,
+    filename: str | None = None,
+    cmap: str | None = None,
+):
+    # show images in a grid
+    n_images = len(images)
+    ncol = int(np.ceil(n_images / nrow))
+
+    fig, axes = plt.subplots(nrow, ncol, figsize=(ncol * 2, nrow * 2))
+    axes = axes.flatten()
+
+    # plot images
+    for idx, (img, ax) in enumerate(zip(images, axes)):
+        img = img.detach().cpu().numpy()
+        ax.imshow(img, cmap=cmap)
+        ax.axis("off")
+        if subtitles:
+            ax.set_title(subtitles[idx])
+    # remove extra axes if any
+    for ax in axes[n_images:]:
+        fig.delaxes(ax)
+    # set title
+    if title:
+        plt.suptitle(title)
+
+    # adjust layout to fit the title
+    plt.tight_layout()
+    # save the figure
+    if filename:
+        plt.savefig(filename)
+    # close the figure
+    plt.close()
+
+
+def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
+    """Run the simulator."""
+    # Define simulation stepping
+    sim_dt = sim.get_physics_dt()
+    sim_time = 0.0
+    count = 0
+
+    # Simulate physics
+    while simulation_app.is_running():
+        # Reset
+        if count % 500 == 0:
+            # reset counter
+            count = 0
+            # reset the scene entities
+            # root state
+            # we offset the root state by the origin since the states are written in simulation world frame
+            # if this is not done, then the robots will be spawned at the (0, 0, 0) of the simulation world
+            root_state = scene["robot"].data.default_root_state.clone()
+            root_state[:, :3] += scene.env_origins
+            scene["robot"].write_root_state_to_sim(root_state)
+            # set joint positions with some noise
+            joint_pos, joint_vel = (
+                scene["robot"].data.default_joint_pos.clone(),
+                scene["robot"].data.default_joint_vel.clone(),
+            )
+            joint_pos += torch.rand_like(joint_pos) * 0.1
+            scene["robot"].write_joint_state_to_sim(joint_pos, joint_vel)
+            # clear internal buffers
+            scene.reset()
+            print("[INFO]: Resetting robot state...")
+        # Apply default actions to the robot
+        # -- generate actions/commands
+        targets = scene["robot"].data.default_joint_pos
+        # -- apply action to the robot
+        scene["robot"].set_joint_position_target(targets)
+        # -- write data to sim
+        scene.write_data_to_sim()
+        # perform step
+        sim.step()
+        # update sim-time
+        sim_time += sim_dt
+        count += 1
+        # update buffers
+        scene.update(sim_dt)
+
+        # print information from the sensors
+        print("-------------------------------")
+        print(scene["camera"])
+        print("Received shape of rgb   image: ", scene["camera"].data.output["rgb"].shape)
+        print("Received shape of depth image: ", scene["camera"].data.output["distance_to_image_plane"].shape)
+        print("-------------------------------")
+        print(scene["tiled_camera"])
+        print("Received shape of rgb   image: ", scene["tiled_camera"].data.output["rgb"].shape)
+        print("Received shape of depth image: ", scene["tiled_camera"].data.output["depth"].shape)
+        print("-------------------------------")
+        print(scene["raycast_camera"])
+        print(
+            "Received shape of distance_to_image_plane: ",
+            scene["raycast_camera"].data.output["distance_to_image_plane"].shape,
+        )
+        print("Received shape of normals: ", scene["raycast_camera"].data.output["normals"].shape)
+        print("Received shape of distance_to_camera: ", scene["raycast_camera"].data.output["distance_to_camera"].shape)
+
+        # show images
+        rgb_images = [scene["camera"].data.output["rgb"][0, :, :, :3], scene["tiled_camera"].data.output["rgb"][0]]
+        depth_images = [
+            scene["camera"].data.output["distance_to_image_plane"][0],
+            scene["tiled_camera"].data.output["depth"][0, :, :, 0],
+            scene["raycast_camera"].data.output["distance_to_image_plane"][0],
+        ]
+
+        # compare generated RGB images across different cameras
+        save_images_grid(
+            rgb_images, nrow=1, subtitles=["Camera", "TiledCamera"], title="RGB Image", filename="rgb_images.png"
+        )
+        # compare generated Depth images across different cameras
+        save_images_grid(
+            depth_images,
+            nrow=1,
+            cmap="turbo",
+            subtitles=["Camera", "TiledCamera", "RaycasterCamera"],
+            title="Depth Image",
+            filename="depth_images.png",
+        )
+
+        # save all tiled RGB images
+        tiled_images = scene["tiled_camera"].data.output["rgb"]
+        save_images_grid(tiled_images, nrow=1, subtitles=["0", "1"], title="RGB Image", filename="tiled_rgb_images.png")
+
+        # save all camera RGB images
+        cam_images = scene["camera"].data.output["rgb"][..., :3]
+        save_images_grid(cam_images, nrow=1, subtitles=["0", "1"], title="RGB Image", filename="cam_rgb_images.png")
+
+
+def main():
+    """Main function."""
+
+    # Initialize the simulation context
+    sim_cfg = sim_utils.SimulationCfg(dt=0.005, substeps=1)
+    sim = sim_utils.SimulationContext(sim_cfg)
+    # Set main camera
+    sim.set_camera_view(eye=[3.5, 3.5, 3.5], target=[0.0, 0.0, 0.0])
+    # design scene
+    scene_cfg = SensorsSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0)
+    scene = InteractiveScene(scene_cfg)
+    # Play the simulator
+    sim.reset()
+    # Now we are ready!
+    print("[INFO]: Setup complete...")
+    # Run the simulator
+    run_simulator(sim, scene)
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()


### PR DESCRIPTION
# Description

This MR fixes some of the docstrings related to the tile-rendering camera. Additionally, it adds a demo script showcasing the images obtained through the different camera implementations in IsaacLab.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./isaaclab.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there