### PR TITLE
Adds support for underscore and hyphens in RL framework names

### DIFF
--- a/source/extensions/omni.isaac.lab_tasks/setup.py
+++ b/source/extensions/omni.isaac.lab_tasks/setup.py
@@ -44,13 +44,18 @@ EXTRAS_REQUIRE = {
     "rsl-rl": ["rsl-rl@git+https://github.com/leggedrobotics/rsl_rl.git"],
     "robomimic": [],
 }
+# Add the names with hyphens as aliases for convenience
+EXTRAS_REQUIRE["rl_games"] = EXTRAS_REQUIRE["rl-games"]
+EXTRAS_REQUIRE["rsl_rl"] = EXTRAS_REQUIRE["rsl-rl"]
 
 # Check if the platform is Linux and add the dependency
 if platform.system() == "Linux":
     EXTRAS_REQUIRE["robomimic"].append("robomimic@git+https://github.com/ARISE-Initiative/robomimic.git")
 
-# cumulation of all extra-requires
+# Cumulation of all extra-requires
 EXTRAS_REQUIRE["all"] = list(itertools.chain.from_iterable(EXTRAS_REQUIRE.values()))
+# Remove duplicates in the all list to avoid double installations
+EXTRAS_REQUIRE["all"] = list(set(EXTRAS_REQUIRE["all"]))
 
 
 # Installation operation


### PR DESCRIPTION
# Description

According to PIP, both`rl_games` and `rl-games` are valid PIP packages and are resolved similarly. This MR adds support for the different name conventions of PIP packages in the `setup.py` for the `omni.isaac.lab_tasks` extension.

Fixes #547

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./isaaclab.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there