### PR TITLE
Fixes reference count in asset instances due to circular references

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.18.3"
+version = "0.18.4"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+0.18.4 (2024-06-26)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed double reference count of the physics sim view inside the asset classes. This was causing issues
+  when destroying the asset class instance since the physics sim view was not being properly released.
+
+Added
+^^^^^
+
+* Added the attribute :attr:`~omni.isaac.lab.assets.AssetBase.is_initialized` to check if the asset and sensor
+  has been initialized properly. This can be used to ensure that the asset or sensor is ready to use in the simulation.
+
+
 0.18.3 (2024-06-25)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import torch
 import warnings
-import weakref
 from collections.abc import Sequence
 from prettytable import PrettyTable
 from typing import TYPE_CHECKING
@@ -854,8 +853,7 @@ class Articulation(RigidObject):
             raise RuntimeError("Failed to parse all bodies properly in the articulation.")
 
         # container for data access
-        # note: we send a weak reference to the root view to avoid circular references
-        self._data = ArticulationData(weakref.proxy(self.root_physx_view), self.device)
+        self._data = ArticulationData(self.root_physx_view, self.device)
 
         # create buffers
         self._create_buffers()

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import torch
 import warnings
+import weakref
 from collections.abc import Sequence
 from prettytable import PrettyTable
 from typing import TYPE_CHECKING
@@ -847,7 +848,7 @@ class Articulation(RigidObject):
             raise RuntimeError("Failed to parse all bodies properly in the articulation.")
 
         # container for data access
-        self._data = ArticulationData(self.root_physx_view, self.device)
+        self._data = ArticulationData(weakref.proxy(self.root_physx_view), self.device)
 
         # create buffers
         self._create_buffers()

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation_data.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation_data.py
@@ -21,7 +21,12 @@ class ArticulationData(RigidObjectData):
     """
 
     _root_physx_view: physx.ArticulationView
-    """The root articulation view of the object."""
+    """The root articulation view of the object.
+
+    Note:
+        Internally, this is stored as a weak reference to avoid circular references between the asset class
+        and the data container. This is important to avoid memory leaks.
+    """
 
     def __init__(self, root_physx_view: physx.ArticulationView, device: str):
         # Initialize the parent class

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/asset_base.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/asset_base.py
@@ -121,6 +121,14 @@ class AssetBase(ABC):
     """
 
     @property
+    def is_initialized(self) -> bool:
+        """Whether the asset is initialized.
+
+        Returns True if the asset is initialized, False otherwise.
+        """
+        return self._is_initialized
+
+    @property
     @abstractmethod
     def num_instances(self) -> int:
         """Number of instances of the asset.

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
@@ -77,7 +77,7 @@ class RigidObject(AssetBase):
 
     @property
     def body_names(self) -> list[str]:
-        """Ordered names of bodies in articulation."""
+        """Ordered names of bodies in the rigid object."""
         prim_paths = self.root_physx_view.prim_paths[: self.num_bodies]
         return [path.split("/")[-1] for path in prim_paths]
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import torch
 import warnings
+import weakref
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -319,7 +320,7 @@ class RigidObject(AssetBase):
         carb.log_info(f"Body names: {self.body_names}")
 
         # container for data access
-        self._data = RigidObjectData(self.root_physx_view, self.device)
+        self._data = RigidObjectData(weakref.proxy(self.root_physx_view), self.device)
 
         # create buffers
         self._create_buffers()

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import torch
 import warnings
-import weakref
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -320,8 +319,7 @@ class RigidObject(AssetBase):
         carb.log_info(f"Body names: {self.body_names}")
 
         # container for data access
-        # note: we send a weak reference to the root view to avoid circular references
-        self._data = RigidObjectData(weakref.proxy(self.root_physx_view), self.device)
+        self._data = RigidObjectData(self.root_physx_view, self.device)
 
         # create buffers
         self._create_buffers()

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
@@ -320,6 +320,7 @@ class RigidObject(AssetBase):
         carb.log_info(f"Body names: {self.body_names}")
 
         # container for data access
+        # note: we send a weak reference to the root view to avoid circular references
         self._data = RigidObjectData(weakref.proxy(self.root_physx_view), self.device)
 
         # create buffers
@@ -341,6 +342,7 @@ class RigidObject(AssetBase):
         self._external_force_b = torch.zeros((self.num_instances, self.num_bodies, 3), device=self.device)
         self._external_torque_b = torch.zeros_like(self._external_force_b)
 
+        # set information about rigid body into data
         self._data.body_names = self.body_names
         self._data.default_mass = self.root_physx_view.get_masses().clone()
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object_data.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object_data.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import torch
+import weakref
 
 import omni.physics.tensors.impl.api as physx
 
@@ -24,7 +25,12 @@ class RigidObjectData:
     """
 
     _root_physx_view: physx.RigidBodyView
-    """The root rigid body view of the object."""
+    """The root rigid body view of the object.
+
+    Note:
+        Internally, this is stored as a weak reference to avoid circular references between the asset class
+        and the data container. This is important to avoid memory leaks.
+    """
 
     def __init__(self, root_physx_view: physx.RigidBodyView, device: str):
         """Initializes the rigid object data.
@@ -35,7 +41,7 @@ class RigidObjectData:
         """
         # Set the parameters
         self.device = device
-        self._root_physx_view = root_physx_view
+        self._root_physx_view = weakref.proxy(root_physx_view)  # weak reference to avoid circular references
         # Set initial time stamp
         self._sim_timestamp = 0.0
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_env.py
@@ -308,11 +308,11 @@ class ManagerBasedEnv:
         """Cleanup for the environment."""
         if not self._is_closed:
             # destructor is order-sensitive
+            del self.viewport_camera_controller
             del self.action_manager
             del self.observation_manager
             del self.event_manager
             del self.scene
-            del self.viewport_camera_controller
             # clear callbacks and instance
             self.sim.clear_all_callbacks()
             self.sim.clear_instance()

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/sensor_base.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/sensor_base.py
@@ -93,6 +93,14 @@ class SensorBase(ABC):
     """
 
     @property
+    def is_initialized(self) -> bool:
+        """Whether the sensor is initialized.
+
+        Returns True if the sensor is initialized, False otherwise.
+        """
+        return self._is_initialized
+
+    @property
     def num_instances(self) -> int:
         """Number of instances of the sensor.
 

--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/classic/humanoid/mdp/observations.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/classic/humanoid/mdp/observations.py
@@ -50,7 +50,7 @@ def base_heading_proj(
     to_target_pos[:, 2] = 0.0
     to_target_dir = math_utils.normalize(to_target_pos)
     # compute base forward vector
-    heading_vec = math_utils.quat_rotate(asset.data.root_quat_w, asset.data.forward_vec_b)
+    heading_vec = math_utils.quat_rotate(asset.data.root_quat_w, asset.data.FORWARD_VEC_B)
     # compute dot product between heading and target direction
     heading_proj = torch.bmm(heading_vec.view(env.num_envs, 1, 3), to_target_dir.view(env.num_envs, 3, 1))
 


### PR DESCRIPTION
# Description

With the lazy buffer implementation in asset classes, we pass the physics sim-view to the data object. This increments the reference count of the sim-view instance and blocks the asset instance itself to be garbage collected properly.

This MR takes steps to fix this issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./isaaclab.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there