### PR TITLE
Reads gravity direction from simulation inside `RigidObjectData`

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.18.4"
+version = "0.18.5"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.18.5 (2024-06-26)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the gravity vector direction used inside the :class:`omni.isaac.lab.assets.RigidObjectData`class.
+  Earlier, the gravity direction was hard-coded as (0, 0, -1) which may be different from the actual
+  gravity direction in the simulation. Now, the gravity direction is obtained from the simulation context
+  and used to compute the projection of the gravity vector on the object.
+
+
 0.18.4 (2024-06-26)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
@@ -19,6 +19,7 @@ import warnings
 from typing import TYPE_CHECKING, Literal
 
 import carb
+import omni.physics.tensors.impl.api as physx
 
 import omni.isaac.lab.sim as sim_utils
 import omni.isaac.lab.utils.math as math_utils
@@ -206,7 +207,12 @@ def randomize_physics_scene_gravity(
     """Randomize gravity by adding, scaling, or setting random values.
 
     This function allows randomizing gravity of the physics scene. The function samples random values from the
-    given distribution parameters and adds, scales, or sets the values into the physics simulation based on the operation.
+    given distribution parameters and adds, scales, or sets the values into the physics simulation based on the
+    operation.
+
+    The distribution parameters are lists of two elements each, representing the lower and upper bounds of the
+    distribution for the x, y, and z components of the gravity vector. The function samples random values for each
+    component independently.
 
     .. attention::
         This function applied the same gravity for all the environments.
@@ -225,9 +231,13 @@ def randomize_physics_scene_gravity(
         slice(None),
         operation=operation,
         distribution=distribution,
-    )[0]
+    )
+    # unbatch the gravity tensor into a list
+    gravity = gravity[0].tolist()
+
     # set the gravity into the physics simulation
-    sim_utils.SimulationContext.instance().physics_sim_view.set_gravity(carb.Float3(gravity[0], gravity[1], gravity[2]))
+    physics_sim_view: physx.SimulationView = sim_utils.SimulationContext.instance().physics_sim_view
+    physics_sim_view.set_gravity(carb.Float3(*gravity))
 
 
 def randomize_actuator_gains(
@@ -841,7 +851,7 @@ Internal helper functions.
 
 def _randomize_prop_by_op(
     data: torch.Tensor,
-    distribution_parameters: tuple[float, float],
+    distribution_parameters: tuple[float | torch.Tensor, float | torch.Tensor],
     dim_0_ids: torch.Tensor | None,
     dim_1_ids: torch.Tensor | slice,
     operation: Literal["add", "scale", "abs"],


### PR DESCRIPTION
# Description

Previously, the gravity direction inside the `RigidObjectData` class was hard-coded as (0, 0, -1). However, this quantity may have a different direction in some simulation situations. This MR removes this hard coding and directly reads the value from the simulation view.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./isaaclab.sh --test` and they pass
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there