### PR TITLE
Removes duplicate enabling of faulthandler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,7 +44,6 @@ To upload images to a PR -- simply drag and drop an image while in edit mode and
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have run all the tests with `./isaaclab.sh --test` and they pass
 - [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
 - [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -14,7 +14,6 @@ fault occurs. The launched :class:`omni.isaac.kit.SimulationApp` instance is acc
 
 import argparse
 import contextlib
-import faulthandler
 import os
 import re
 import signal
@@ -69,9 +68,6 @@ class AppLauncher:
         .. _argparse.Namespace: https://docs.python.org/3/library/argparse.html?highlight=namespace#argparse.Namespace
         .. _SimulationApp: https://docs.omniverse.nvidia.com/py/isaacsim/source/extensions/omni.isaac.kit/docs/index.html
         """
-        # Enable call-stack on crash
-        faulthandler.enable()
-
         # We allow users to pass either a dict or an argparse.Namespace into
         # __init__, anticipating that these will be all of the argparse arguments
         # used by the calling script. Those which we appended via add_app_launcher_args

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/commands/pose_command.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/commands/pose_command.py
@@ -148,6 +148,10 @@ class UniformPoseCommand(CommandTerm):
                 self.body_pose_visualizer.set_visibility(False)
 
     def _debug_vis_callback(self, event):
+        # check if robot is initialized
+        # note: this is needed in-case the robot is de-initialized. we can't access the data
+        if not self.robot.is_initialized:
+            return
         # update the markers
         # -- goal pose
         self.goal_pose_visualizer.visualize(self.pose_command_w[:, :3], self.pose_command_w[:, 3:])

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/commands/velocity_command.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/commands/velocity_command.py
@@ -168,6 +168,10 @@ class UniformVelocityCommand(CommandTerm):
                 self.base_vel_visualizer.set_visibility(False)
 
     def _debug_vis_callback(self, event):
+        # check if robot is initialized
+        # note: this is needed in-case the robot is de-initialized. we can't access the data
+        if not self.robot.is_initialized:
+            return
         # get marker location
         # -- base state
         base_pos_w = self.robot.data.root_pos_w.clone()

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/simulation_context.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/simulation_context.py
@@ -642,6 +642,7 @@ class SimulationContext(_SimulationContext):
         # self._app.shutdown()
         self._framework.unload_all_plugins()
 
+
 @contextmanager
 def build_simulation_context(
     create_new_stage: bool = True,

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/simulation_context.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/simulation_context.py
@@ -140,12 +140,14 @@ class SimulationContext(_SimulationContext):
         self._local_gui = carb_settings_iface.get("/app/window/enabled")
         # read flag for whether livestreaming GUI is enabled
         self._livestream_gui = carb_settings_iface.get("/app/livestream/enabled")
+
         # read flag for whether the Isaac Lab viewport capture pipeline will be used,
         # casting None to False if the flag doesn't exist
         # this flag is set from the AppLauncher class
         self._offscreen_render = bool(carb_settings_iface.get("/isaaclab/render/offscreen"))
         # flag for whether any GUI will be rendered (local, livestreamed or viewport)
         self._has_gui = self._local_gui or self._livestream_gui
+
         # store the default render mode
         if not self._has_gui and not self._offscreen_render:
             # set default render mode
@@ -204,6 +206,7 @@ class SimulationContext(_SimulationContext):
             )
         else:
             self._app_control_on_stop_handle = None
+
         # flatten out the simulation dictionary
         sim_params = self.cfg.to_dict()
         if sim_params is not None:
@@ -588,31 +591,56 @@ class SimulationContext(_SimulationContext):
                 )
                 while self.app.is_running():
                     self.render()
-            # make sure that any replicator workflows finish rendering/writing
-            if not builtins.ISAAC_LAUNCHED_FROM_TERMINAL:
-                try:
-                    import omni.replicator.core as rep
 
-                    rep_status = rep.orchestrator.get_status()
-                    if rep_status not in [rep.orchestrator.Status.STOPPED, rep.orchestrator.Status.STOPPING]:
-                        rep.orchestrator.stop()
-                    if rep_status != rep.orchestrator.Status.STOPPED:
-                        rep.orchestrator.wait_until_complete()
-                except Exception:
-                    pass
-            # clear the instance and all callbacks
-            # note: clearing callbacks is important to prevent memory leaks
-            self.clear_all_callbacks()
-            # workaround for exit issues, clean the stage first:
-            if omni.usd.get_context().can_close_stage():
-                omni.usd.get_context().close_stage()
-            # print logging information
-            self.app.print_and_log("Simulation is stopped. Shutting down the app.")
-            # shutdown the simulator
-            self.app.shutdown()
-            # disabled on linux to avoid a crash
-            carb.get_framework().unload_all_plugins()
+        # Note: For the following code:
+        #   The method is an exact copy of the implementation in the `omni.isaac.kit.SimulationApp` class.
+        #   We need to remove this method once the SimulationApp class becomes a singleton.
 
+        # make sure that any replicator workflows finish rendering/writing
+        try:
+            import omni.replicator.core as rep
+
+            rep_status = rep.orchestrator.get_status()
+            if rep_status not in [rep.orchestrator.Status.STOPPED, rep.orchestrator.Status.STOPPING]:
+                rep.orchestrator.stop()
+            if rep_status != rep.orchestrator.Status.STOPPED:
+                rep.orchestrator.wait_until_complete()
+
+            # Disable capture on play to avoid replicator engaging on any new timeline events
+            rep.orchestrator.set_capture_on_play(False)
+        except Exception:
+            pass
+
+        # clear the instance and all callbacks
+        # note: clearing callbacks is important to prevent memory leaks
+        self.clear_all_callbacks()
+
+        # workaround for exit issues, clean the stage first:
+        if omni.usd.get_context().can_close_stage():
+            omni.usd.get_context().close_stage()
+
+        # print logging information
+        self.app.print_and_log("Simulation is stopped. Shutting down the app...")
+
+        # Cleanup any running tracy instances so data is not lost
+        try:
+            profiler_tracy = carb.profiler.acquire_profiler_interface(plugin_name="carb.profiler-tracy.plugin")
+            if profiler_tracy:
+                profiler_tracy.set_capture_mask(0)
+                profiler_tracy.end(0)
+                profiler_tracy.shutdown()
+        except RuntimeError:
+            # Tracy plugin was not loaded, so profiler never started - skip checks.
+            pass
+
+        # Disable logging before shutdown to keep the log clean
+        # Warnings at this point don't matter as the python process is about to be terminated
+        logging = carb.logging.acquire_logging()
+        logging.set_level_threshold(carb.logging.LEVEL_ERROR)
+
+        # App shutdown is disabled to prevent crashes on shutdown. Terminating carb is faster
+        # self._app.shutdown()
+        self._framework.unload_all_plugins()
 
 @contextmanager
 def build_simulation_context(

--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/navigation/mdp/pre_trained_policy_action.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/navigation/mdp/pre_trained_policy_action.py
@@ -122,6 +122,10 @@ class PreTrainedPolicyAction(ActionTerm):
                 self.base_vel_visualizer.set_visibility(False)
 
     def _debug_vis_callback(self, event):
+        # check if robot is initialized
+        # note: this is needed in-case the robot is de-initialized. we can't access the data
+        if not self.robot.is_initialized:
+            return
         # get marker location
         # -- base state
         base_pos_w = self.robot.data.root_pos_w.clone()


### PR DESCRIPTION
# Description

Sometimes the simulation app got stuck when trying to interrupt the process from the terminal. Removing the call to faulthandler resolved this issue (I think). In Isaac Sim 4.0, the fault handler is enabled inside the SimulationApp directly so we don't need to do it anymore.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./isaaclab.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there