### PR TITLE
Fixes the double origin assignment in the quadrupeds example

### DIFF
--- a/source/standalone/demos/quadrupeds.py
+++ b/source/standalone/demos/quadrupeds.py
@@ -107,7 +107,7 @@ def design_scene() -> tuple[dict, list[list[float]]]:
     unitree_go2 = Articulation(UNITREE_GO2_CFG.replace(prim_path="/World/Origin6/Robot"))
 
     # Origin 7 with Boston Dynamics Spot
-    prim_utils.create_prim("/World/Origin7", "Xform", translation=origins[5])
+    prim_utils.create_prim("/World/Origin7", "Xform", translation=origins[6])
     # -- Robot
     spot = Articulation(SPOT_CFG.replace(prim_path="/World/Origin7/Robot"))
 


### PR DESCRIPTION
# Description

In the quadruped example, two robots are assigned the same origin. This PR fixes that. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

