### PR TITLE
Fixes VSCode settings to work with pip installation of Isaac Sim

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
             "label": "setup_python_env",
             "type": "shell",
             "linux": {
-                "command": "export CARB_APP_PATH=${workspaceFolder}/_isaac_sim/kit && export ISAAC_PATH=${workspaceFolder}/_isaac_sim && export EXP_PATH=${workspaceFolder}/_isaac_sim/apps && source ${workspaceFolder}/_isaac_sim/setup_python_env.sh && printenv >${workspaceFolder}/.vscode/.python.env && ${workspaceFolder}/_isaac_sim/python.sh ${workspaceFolder}/.vscode/tools/setup_vscode.py"
+                "command": "${workspaceFolder}/isaaclab.sh -p ${workspaceFolder}/.vscode/tools/setup_vscode.py"
             }
         },
         {

--- a/.vscode/tools/launch.template.json
+++ b/.vscode/tools/launch.template.json
@@ -12,8 +12,7 @@
             "console": "integratedTerminal",
             "env": {
                 "RESOURCE_NAME": "IsaacSim"
-            },
-            "envFile": "${workspaceFolder}/.vscode/.python.env"
+            }
         },
         {
             "name": "Python: Attach (windows-x86_64/linux-x86_64)",
@@ -31,8 +30,7 @@
             "console": "integratedTerminal",
             "env": {
                 "RESOURCE_NAME": "IsaacSim"
-            },
-            "envFile": "${workspaceFolder}/.vscode/.python.env"
+            }
         },
         {
             "name": "Python: Play Environment",
@@ -43,8 +41,7 @@
             "console": "integratedTerminal",
             "env": {
                 "RESOURCE_NAME": "IsaacSim"
-            },
-            "envFile": "${workspaceFolder}/.vscode/.python.env"
+            }
         }
     ]
 }

--- a/.vscode/tools/launch.template.json
+++ b/.vscode/tools/launch.template.json
@@ -11,11 +11,9 @@
             "program": "${file}",
             "console": "integratedTerminal",
             "env": {
-                "EXP_PATH": "${workspaceFolder}/_isaac_sim/apps",
                 "RESOURCE_NAME": "IsaacSim"
             },
-            "envFile": "${workspaceFolder}/.vscode/.python.env",
-            "preLaunchTask": "setup_python_env"
+            "envFile": "${workspaceFolder}/.vscode/.python.env"
         },
         {
             "name": "Python: Attach (windows-x86_64/linux-x86_64)",
@@ -32,11 +30,9 @@
             "program": "${workspaceFolder}/source/standalone/workflows/rsl_rl/train.py",
             "console": "integratedTerminal",
             "env": {
-                "EXP_PATH": "${workspaceFolder}/_isaac_sim/apps",
                 "RESOURCE_NAME": "IsaacSim"
             },
-            "envFile": "${workspaceFolder}/.vscode/.python.env",
-            "preLaunchTask": "setup_python_env"
+            "envFile": "${workspaceFolder}/.vscode/.python.env"
         },
         {
             "name": "Python: Play Environment",
@@ -46,11 +42,9 @@
             "program": "${workspaceFolder}/source/standalone/workflows/rsl_rl/play.py",
             "console": "integratedTerminal",
             "env": {
-                "EXP_PATH": "${workspaceFolder}/_isaac_sim/apps",
                 "RESOURCE_NAME": "IsaacSim"
             },
-            "envFile": "${workspaceFolder}/.vscode/.python.env",
-            "preLaunchTask": "setup_python_env"
-        },
+            "envFile": "${workspaceFolder}/.vscode/.python.env"
+        }
     ]
 }

--- a/.vscode/tools/launch.template.json
+++ b/.vscode/tools/launch.template.json
@@ -9,10 +9,7 @@
             "type": "python",
             "request": "launch",
             "program": "${file}",
-            "console": "integratedTerminal",
-            "env": {
-                "RESOURCE_NAME": "IsaacSim"
-            }
+            "console": "integratedTerminal"
         },
         {
             "name": "Python: Attach (windows-x86_64/linux-x86_64)",
@@ -27,10 +24,7 @@
             "request": "launch",
             "args" : ["--task", "Isaac-Reach-Franka-v0", "--headless"],
             "program": "${workspaceFolder}/source/standalone/workflows/rsl_rl/train.py",
-            "console": "integratedTerminal",
-            "env": {
-                "RESOURCE_NAME": "IsaacSim"
-            }
+            "console": "integratedTerminal"
         },
         {
             "name": "Python: Play Environment",
@@ -38,10 +32,7 @@
             "request": "launch",
             "args" : ["--task", "Isaac-Reach-Franka-v0", "--num_envs", "32"],
             "program": "${workspaceFolder}/source/standalone/workflows/rsl_rl/play.py",
-            "console": "integratedTerminal",
-            "env": {
-                "RESOURCE_NAME": "IsaacSim"
-            }
+            "console": "integratedTerminal"
         }
     ]
 }

--- a/.vscode/tools/settings.template.json
+++ b/.vscode/tools/settings.template.json
@@ -68,7 +68,7 @@
     "autoDocstring.docstringFormat": "google",
     "autoDocstring.guessTypes": true,
     // Python environment path
-    // note: the default interpreter is overriden when user selects a workspace interpreter
+    // note: the default interpreter is overridden when user selects a workspace interpreter
     //     in the status bar. For example, the virtual environment python interpreter
     "python.defaultInterpreterPath": "${workspaceFolder}/_isaac_sim/python.sh",
     // ROS distribution

--- a/.vscode/tools/settings.template.json
+++ b/.vscode/tools/settings.template.json
@@ -68,8 +68,9 @@
     "autoDocstring.docstringFormat": "google",
     "autoDocstring.guessTypes": true,
     // Python environment path
-    "python.defaultInterpreterPath": "${workspaceFolder}/_isaac_sim/kit/python/bin/python3",
-    "python.envFile": "${workspaceFolder}/.vscode/.python.env",
+    // note: the default interpreter is overriden when user selects a workspace interpreter
+    //     in the status bar. For example, the virtual environment python interpreter
+    "python.defaultInterpreterPath": "${workspaceFolder}/_isaac_sim/python.sh",
     // ROS distribution
     "ros.distro": "noetic",
     // Language specific settings

--- a/.vscode/tools/setup_vscode.py
+++ b/.vscode/tools/setup_vscode.py
@@ -80,7 +80,7 @@ def overwrite_python_analysis_extra_paths(isaaclab_settings: str) -> str:
 
     # change the path names to be relative to the Isaac Lab directory
     rel_path = os.path.relpath(ISAACSIM_DIR, ISAACLAB_DIR)
-    path_names = ['"${workspaceFolder}/' + rel_path + '/' + path_name + '"' for path_name in path_names]
+    path_names = ['"${workspaceFolder}/' + rel_path + "/" + path_name + '"' for path_name in path_names]
 
     # add the path names that are in the Isaac Lab extensions directory
     isaaclab_extensions = os.listdir(os.path.join(ISAACLAB_DIR, "source", "extensions"))

--- a/.vscode/tools/setup_vscode.py
+++ b/.vscode/tools/setup_vscode.py
@@ -5,10 +5,10 @@
 
 """This script sets up the vs-code settings for the Isaac Lab project.
 
-This script merges the python.analysis.extraPaths from the "_isaac_sim/.vscode/settings.json" file into
+This script merges the python.analysis.extraPaths from the "{ISAACSIM_DIR}/.vscode/settings.json" file into
 the ".vscode/settings.json" file.
 
-This is necessary because Isaac Sim 2022.2.1 does not add the necessary python packages to the python path
+This is necessary because Isaac Sim 2022.2.1 onwards does not add the necessary python packages to the python path
 when the "setup_python_env.sh" is run as part of the vs-code launch configuration.
 """
 
@@ -20,18 +20,33 @@ import pathlib
 
 ISAACLAB_DIR = pathlib.Path(__file__).parents[2]
 """Path to the Isaac Lab directory."""
-ISAACSIM_DIR = os.path.join(ISAACLAB_DIR, "_isaac_sim")
+
+try:
+    import isaacsim  # noqa: F401
+
+    isaacsim_dir = os.environ.get("ISAAC_PATH", "")
+except ModuleNotFoundError or ImportError:
+    isaacsim_dir = os.path.join(ISAACLAB_DIR, "_isaac_sim")
+
+# check if the isaac-sim directory exists
+if not os.path.exists(isaacsim_dir):
+    raise FileNotFoundError(
+        f"Could not find the isaac-sim directory: {isaacsim_dir}. There are two possible reasons for this:\n"
+        "\t1. The Isaac Sim directory does not exist as a symlink in the Isaac Lab directory.\n"
+        "\t2. The script could import the 'isaacsim' package. This could be due to the 'isaacsim' package not being "
+        "installed in the Python environment.\n"
+        "Please make sure that the Isaac Sim directory exists or that the 'isaacsim' package is installed."
+    )
+
+ISAACSIM_DIR = isaacsim_dir
 """Path to the isaac-sim directory."""
-# check if ISAACSIM_DIR is valid:
-if not os.path.isdir(ISAACSIM_DIR):
-    ISAACSIM_DIR = os.environ.get("ISAACSIM_PATH", "")
 
 
 def overwrite_python_analysis_extra_paths(isaaclab_settings: str) -> str:
     """Overwrite the python.analysis.extraPaths in the Isaac Lab settings file.
 
     The extraPaths are replaced with the path names from the isaac-sim settings file that exists in the
-    "_isaac_sim/.vscode/settings.json" file.
+    "{ISAACSIM_DIR}/.vscode/settings.json" file.
 
     Args:
         isaaclab_settings: The settings string to use as template.
@@ -57,10 +72,15 @@ def overwrite_python_analysis_extra_paths(isaaclab_settings: str) -> str:
     settings = settings.group(0)
     settings = settings.split('"python.analysis.extraPaths": [')[-1]
     settings = settings.split("]")[0]
-    # change the path names to be relative to the Isaac Lab directory
+
+    # read the path names from the isaac-sim settings file
     path_names = settings.split(",")
     path_names = [path_name.strip().strip('"') for path_name in path_names]
-    path_names = ['"${workspaceFolder}/_isaac_sim/' + path_name + '"' for path_name in path_names if len(path_name) > 0]
+    path_names = [path_name for path_name in path_names if len(path_name) > 0]
+
+    # change the path names to be relative to the Isaac Lab directory
+    rel_path = os.path.relpath(ISAACSIM_DIR, ISAACLAB_DIR)
+    path_names = ['"${workspaceFolder}/' + rel_path + '/' + path_name + '"' for path_name in path_names]
 
     # add the path names that are in the Isaac Lab extensions directory
     isaaclab_extensions = os.listdir(os.path.join(ISAACLAB_DIR, "source", "extensions"))
@@ -68,6 +88,8 @@ def overwrite_python_analysis_extra_paths(isaaclab_settings: str) -> str:
 
     # combine them into a single string
     path_names = ",\n\t\t".expandtabs(4).join(path_names)
+    # deal with the path separator being different on Windows and Unix
+    path_names = path_names.replace("/", os.sep)
 
     # replace the path names in the Isaac Lab settings file with the path names from the isaac-sim settings file
     isaaclab_settings = re.sub(
@@ -157,6 +179,12 @@ def main():
         # write the Isaac Lab launch settings file
         with open(isaaclab_vscode_launch_filename, "w") as f:
             f.write(isaaclab_launch_settings)
+
+    # save the current set of environment variables into the .env file
+    isaaclab_env_filename = os.path.join(ISAACLAB_DIR, ".vscode", ".python.env")
+    with open(isaaclab_env_filename, "w") as f:
+        for key, value in os.environ.items():
+            f.write(f"{key}={value}\n")
 
 
 if __name__ == "__main__":

--- a/.vscode/tools/setup_vscode.py
+++ b/.vscode/tools/setup_vscode.py
@@ -180,12 +180,6 @@ def main():
         with open(isaaclab_vscode_launch_filename, "w") as f:
             f.write(isaaclab_launch_settings)
 
-    # save the current set of environment variables into the .env file
-    isaaclab_env_filename = os.path.join(ISAACLAB_DIR, ".vscode", ".python.env")
-    with open(isaaclab_env_filename, "w") as f:
-        for key, value in os.environ.items():
-            f.write(f"{key}={value}\n")
-
 
 if __name__ == "__main__":
     main()

--- a/docs/source/setup/developer.rst
+++ b/docs/source/setup/developer.rst
@@ -41,11 +41,10 @@ To setup the IDE, please follow these instructions:
       :align: center
       :alt: VSCode Tasks
 
-If everything executes correctly, it should create a file
-``.python.env`` in the ``.vscode`` directory. The file contains the python
-paths to all the extensions provided by Isaac Sim and Omniverse. This helps
-in indexing all the python modules for intelligent suggestions while writing
-code.
+If everything executes correctly, it should create the following files:
+
+* ``.vscode/launch.json``: Contains the launch configurations for debugging python code.
+* ``.vscode/settings.json``: Contains the settings for the python interpreter and the python environment.
 
 For more information on VSCode support for Omniverse, please refer to the
 following links:
@@ -64,8 +63,7 @@ python executable provided by Omniverse. This is specified in the
 .. code-block:: json
 
    {
-      "python.defaultInterpreterPath": "${workspaceFolder}/_isaac_sim/kit/python/bin/python3",
-      "python.envFile": "${workspaceFolder}/.vscode/.python.env",
+      "python.defaultInterpreterPath": "${workspaceFolder}/_isaac_sim/python.sh",
    }
 
 If you want to use a different python interpreter (for instance, from your conda environment),


### PR DESCRIPTION
# Description

Earlier, the VSCode settings were only made for installation with binaries. This expected the path to be "_isaac_sim". As many users reported, this doesn't work if we have PIP installation of Isaac Sim.

This MR fixes the above issue to ensure a smooth setup of vscode.

Fixes #620, #629

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there