### PR TITLE
Fixes the valid configs test in `lab_assets` extension

### DIFF
--- a/source/extensions/omni.isaac.lab_assets/test/test_valid_configs.py
+++ b/source/extensions/omni.isaac.lab_assets/test/test_valid_configs.py
@@ -22,7 +22,6 @@ import unittest
 import omni.isaac.lab_assets as lab_assets  # noqa: F401
 
 from omni.isaac.lab.assets import AssetBase, AssetBaseCfg
-from omni.isaac.lab.sensors import SensorBase, SensorBaseCfg
 from omni.isaac.lab.sim import build_simulation_context
 
 
@@ -32,12 +31,12 @@ class TestValidEntitiesConfigs(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # load all registered entities configurations from the module
-        cls.registered_entities: dict[str, AssetBaseCfg | SensorBaseCfg] = {}
+        cls.registered_entities: dict[str, AssetBaseCfg] = {}
         # inspect all classes from the module
         for obj_name in dir(lab_assets):
             obj = getattr(lab_assets, obj_name)
             # store all registered entities configurations
-            if isinstance(obj, (AssetBaseCfg, SensorBaseCfg)):
+            if isinstance(obj, AssetBaseCfg):
                 cls.registered_entities[obj_name] = obj
         # print all existing entities names
         print(">>> All registered entities:", list(cls.registered_entities.keys()))
@@ -58,7 +57,7 @@ class TestValidEntitiesConfigs(unittest.TestCase):
                         # name the prim path
                         entity_cfg.prim_path = "/World/asset"
                         # create the asset / sensors
-                        entity: AssetBase | SensorBase = entity_cfg.class_type(entity_cfg)  # type: ignore
+                        entity: AssetBase = entity_cfg.class_type(entity_cfg)  # type: ignore
 
                         # play the sim
                         sim.reset()


### PR DESCRIPTION
# Description

Since the LiDAR configuration was added to the assets extension, the `test_valid_configs` test is failing. 
This MR removes sensors from configuration testing. The current set-up is not suitable for sensors, which require additional set-up (like creating a prim first or adding a mesh for the LiDAR).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there