### PR TITLE
Adds event manager call to simple manage-based env

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.19.3"
+version = "0.19.4"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.19.4 (2024-07-13)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Added the call to "startup" events when using the :class:`~omni.isaac.lab.envs.ManagerBasedEnv` class.
+  Earlier, the "startup" events were not being called when the environment was initialized. This issue
+  did not occur when using the :class:`~omni.isaac.lab.envs.ManagerBasedRLEnv` class since the "startup"
+  events were called in the constructor.
+
+
 0.19.3 (2024-07-13)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_env.py
@@ -223,6 +223,12 @@ class ManagerBasedEnv:
         self.event_manager = EventManager(self.cfg.events, self)
         print("[INFO] Event Manager: ", self.event_manager)
 
+        # perform events at the start of the simulation
+        # in-case a child implementation creates other managers, the randomization should happen
+        # when all the other managers are created
+        if self.__class__ == ManagerBasedEnv and "startup" in self.event_manager.available_modes:
+            self.event_manager.apply(mode="startup")
+
     """
     Operations - MDP.
     """

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
@@ -107,8 +107,10 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         # -- command manager
         self.command_manager: CommandManager = CommandManager(self.cfg.commands, self)
         print("[INFO] Command Manager: ", self.command_manager)
+
         # call the parent class to load the managers for observations and actions.
         super().load_managers()
+
         # prepare the managers
         # -- termination manager
         self.termination_manager = TerminationManager(self.cfg.terminations, self)
@@ -119,8 +121,10 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         # -- curriculum manager
         self.curriculum_manager = CurriculumManager(self.cfg.curriculum, self)
         print("[INFO] Curriculum Manager: ", self.curriculum_manager)
+
         # setup the action and observation spaces for Gym
         self._configure_gym_env_spaces()
+
         # perform events at the start of the simulation
         if "startup" in self.event_manager.available_modes:
             self.event_manager.apply(mode="startup")

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
@@ -19,7 +19,7 @@ from .manager_base import ManagerBase, ManagerTermBase
 from .manager_term_cfg import EventTermCfg
 
 if TYPE_CHECKING:
-    from omni.isaac.lab.envs import ManagerBasedRLEnv
+    from omni.isaac.lab.envs import ManagerBasedEnv
 
 
 class EventManager(ManagerBase):
@@ -53,10 +53,10 @@ class EventManager(ManagerBase):
 
     """
 
-    _env: ManagerBasedRLEnv
+    _env: ManagerBasedEnv
     """The environment instance."""
 
-    def __init__(self, cfg: object, env: ManagerBasedRLEnv):
+    def __init__(self, cfg: object, env: ManagerBasedEnv):
         """Initialize the event manager.
 
         Args:

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
@@ -295,7 +295,7 @@ class RandomizationManager(EventManager):
         renamed to EventManager  as it is more general purpose. The RandomizationManager will be removed in v0.4.0.
     """
 
-    def __init__(self, cfg: object, env: ManagerBasedRLEnv):
+    def __init__(self, cfg: object, env: ManagerBasedEnv):
         """Initialize the randomization manager.
 
         Args:

--- a/tools/per_test_timeouts.py
+++ b/tools/per_test_timeouts.py
@@ -9,4 +9,8 @@ Any tests not listed here will use the default timeout.
 """
 PER_TEST_TIMEOUTS = {
     "test_environments.py": 1200,  # This test runs through all the environments for 100 steps each
+    "test_env_rendering_logic.py": 200,
+    "test_rsl_rl_wrapper.py": 200,
+    "test_sb3_wrapper.py": 200,
+    "test_skrl_wrapper.py": 200,
 }


### PR DESCRIPTION
# Description

Earlier, the "startup" events were only triggered when used inside an RL environment. This MR makes sure they are also called inside the simple environment version as well.

Fixes #664

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there