### PR TITLE
Fixes warning message in Articulation config processing

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
@@ -1008,7 +1008,7 @@ class Articulation(RigidObject):
         if total_act_joints != (self.num_joints - self.num_fixed_tendons):
             carb.log_warn(
                 "Not all actuators are configured! Total number of actuated joints not equal to number of"
-                f" joints available: {total_act_joints} != {self.num_joints}."
+                f" joints available: {total_act_joints} != {self.num_joints - self.num_fixed_tendons}."
             )
 
     def _process_fixed_tendons(self):


### PR DESCRIPTION
# Description

Fixes #698

The sanity check compares the total actuator joints (total_act_joints) with the difference between the number of joints minus the number of fixed tendons (self.num_joints - self.num_fixed_tendons), but the warning message displays a comparison between total_act_joints and self.num_joints. This is misleading on complex robots that includes fixed tendons such as Franka hand.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
