### PR TITLE
Setup conda environment correctly for ZSH

### DIFF
--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -158,7 +158,9 @@ setup_conda_env() {
         # add variables to environment during activation
         printf '%s\n' \
             '# for Isaac Sim' \
-            'source '${isaacsim_setup_conda_env_script}'' \
+            'cd '${ISAACLAB_PATH}'/_isaac_sim' \
+            'source setup_conda_env.sh' \
+            'cd $OLDPWD' \
             '' >> ${CONDA_PREFIX}/etc/conda/activate.d/setenv.sh
     fi
 


### PR DESCRIPTION
# Description

The `source setup_conda_env.sh` must be run in the Isaac Sim directory for the script to run correctly when using ZSH.

Fixes #703, #103

<hr>

This PR also depends on a upstream Isaac Sim issue (internal nvbugs 3752249) to make conda fully usable in ZSH. Meanwhile, we can use a quick patch as described below:

- Clone and link isaac lab
  ```sh
  git clone git@github.com:isaac-sim/IsaacLab.git
  cd IsaacLab
  ln -s ~/.local/share/ov/pkg/isaac-sim-4.0.0 _isaac_sim
  ```
- Quick patch (not required after resolving internal nvbugs 3752249)
  ```sh
  cd _isaac_sim
  mv setup_python_env.sh setup_python_env.sh.bak
  curl -O https://raw.githubusercontent.com/j3soon/isaac-extended/master/isaac-sim-4.0.0-patch/linux/setup_python_env.sh
  chmod +x setup_python_env.sh
  cd ..
  ```
- Activate without error, install and run example
  ```sh
  ./isaaclab.sh --conda
  conda activate isaaclab
  sudo apt install cmake build-essential
  ./isaaclab.sh --install
  # Run any script, for an example:
  ./isaaclab.sh -p source/standalone/demos/quadrupeds.py
  ```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
