### PR TITLE
Fixes example in migration docs

### DIFF
--- a/docs/source/migration/migrating_from_isaacgymenvs.rst
+++ b/docs/source/migration/migrating_from_isaacgymenvs.rst
@@ -782,7 +782,7 @@ The ``progress_buf`` variable has also been renamed to ``episode_length_buf``.
 |     velocities = 0.5 * (torch.rand((len(env_ids), self.num_dof),      |                                                                           |
 |         device=self.device) - 0.5)                                    |     time_out = self.episode_length_buf >= self.max_episode_length - 1     |
 |                                                                       |     out_of_bounds = torch.any(torch.abs(                                  |
-|     self.dof_pos[env_ids, :] = positions[:]                           |         self.joint_pos[:, self._pole_dof_idx] > self.cfg.max_cart_pos),   |
+|     self.dof_pos[env_ids, :] = positions[:]                           |         self.joint_pos[:, self._cart_dof_idx]) > self.cfg.max_cart_pos,   |
 |     self.dof_vel[env_ids, :] = velocities[:]                          |         dim=1)                                                            |
 |                                                                       |     out_of_bounds = out_of_bounds | torch.any(                            |
 |     env_ids_int32 = env_ids.to(dtype=torch.int32)                     |         torch.abs(self.joint_pos[:, self._pole_dof_idx]) > math.pi / 2,   |

--- a/docs/source/migration/migrating_from_omniisaacgymenvs.rst
+++ b/docs/source/migration/migrating_from_omniisaacgymenvs.rst
@@ -706,7 +706,7 @@ reset the ``episode_length_buf`` buffer.
 |   resets = torch.where(                                          |                                                                          |
 |     torch.abs(self.pole_pos) > math.pi / 2, 1, resets)           |     time_out = self.episode_length_buf >= self.max_episode_length - 1    |
 |   resets = torch.where(                                          |     out_of_bounds = torch.any(torch.abs(                                 |
-|     self.progress_buf >= self._max_episode_length, 1, resets)    |         self.joint_pos[:, self._pole_dof_idx] > self.cfg.max_cart_pos),  |
+|     self.progress_buf >= self._max_episode_length, 1, resets)    |         self.joint_pos[:, self._cart_dof_idx]) > self.cfg.max_cart_pos,  |
 |   self.reset_buf[:] = resets                                     |         dim=1)                                                           |
 |                                                                  |     out_of_bounds = out_of_bounds | torch.any(                           |
 |                                                                  |         torch.abs(self.joint_pos[:, self._pole_dof_idx]) > math.pi / 2,  |


### PR DESCRIPTION
# Description

Fix docs innacuracy.

Now the docs correspond to the actual code:

https://github.com/isaac-sim/IsaacLab/blob/7937a186c1f98a8171d98aad8cac7f1b778cfdd8/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/direct/cartpole/cartpole_env.py#L122

Fixes #706

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- This change requires a documentation update

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
