### PR TITLE
Uses PhysX accelerations for rigid body acceleration data

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.20.0"
+version = "0.20.1"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.20.1 (2024-07-30)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Modified the computation of body acceleration for rigid body data to use PhysX APIs instead of
+  numerical finite-differencing. This removes the need for computation of body acceleration at
+  every update call of the data buffer.
+
+
 0.20.0 (2024-07-26)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
@@ -191,7 +191,6 @@ class RigidObject(AssetBase):
         # note: we need to do this here since tensors are not set into simulation until step.
         # set into internal buffers
         self._data.root_state_w[env_ids, 7:] = root_velocity.clone()
-        self._data._previous_body_vel_w[env_ids, 0] = root_velocity.clone()
         self._data.body_acc_w[env_ids] = 0.0
         # set into simulation
         self.root_physx_view.set_velocities(self._data.root_state_w[:, 7:], indices=physx_env_ids)

--- a/source/extensions/omni.isaac.lab/test/assets/test_rigid_object.py
+++ b/source/extensions/omni.isaac.lab/test/assets/test_rigid_object.py
@@ -665,12 +665,12 @@ class TestRigidObject(unittest.TestCase):
                                 # update object
                                 cube_object.update(sim.cfg.dt)
 
-                            # Expected gravity value is the acceleration of the body
-                            gravity = torch.zeros(num_cubes, 1, 6, device=device)
-                            if gravity_enabled:
-                                gravity[:, :, 2] = -9.81
-                            # Check the body accelerations are correct
-                            torch.testing.assert_close(cube_object.data.body_acc_w, gravity)
+                                # Expected gravity value is the acceleration of the body
+                                gravity = torch.zeros(num_cubes, 1, 6, device=device)
+                                if gravity_enabled:
+                                    gravity[:, :, 2] = -9.81
+                                # Check the body accelerations are correct
+                                torch.testing.assert_close(cube_object.data.body_acc_w, gravity)
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.lab/test/assets/test_rigid_object.py
+++ b/source/extensions/omni.isaac.lab/test/assets/test_rigid_object.py
@@ -602,6 +602,7 @@ class TestRigidObject(unittest.TestCase):
                     with build_simulation_context(
                         device=device, gravity_enabled=False, add_ground_plane=True, auto_add_lighting=True
                     ) as sim:
+                        # Create a scene with random cubes
                         cube_object, _ = generate_cubes_scene(num_cubes=num_cubes, height=1.0, device=device)
 
                         # Play sim
@@ -640,6 +641,7 @@ class TestRigidObject(unittest.TestCase):
                 for gravity_enabled in [True, False]:
                     with self.subTest(num_cubes=num_cubes, device=device, gravity_enabled=gravity_enabled):
                         with build_simulation_context(device=device, gravity_enabled=gravity_enabled) as sim:
+                            # Create a scene with random cubes
                             cube_object, _ = generate_cubes_scene(num_cubes=num_cubes, device=device)
 
                             # Obtain gravity direction
@@ -662,6 +664,13 @@ class TestRigidObject(unittest.TestCase):
                                 sim.step()
                                 # update object
                                 cube_object.update(sim.cfg.dt)
+
+                            # Expected gravity value is the acceleration of the body
+                            gravity = torch.zeros(num_cubes, 1, 6, device=device)
+                            if gravity_enabled:
+                                gravity[:, :, 2] = -9.81
+                            # Check the body accelerations are correct
+                            torch.testing.assert_close(cube_object.data.body_acc_w, gravity)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Previously, we used finite differencing to compute rigid body accelerations. Since Isaac Sim 4.0, we can obtain the accelerations directly from PhysX. This MR removes the need for finite differencing.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there