### PR TITLE
Fixes `wrap_to_pi` function in math utilities

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.20.0"
+version = "0.20.1"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.20.1 (2024-07-26)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the :meth:`omni.isaac.lab.utils.math.wrap_to_pi` method to handle the wrapping of angles correctly.
+  Earlier, the method was not wrapping the angles to the range [-pi, pi] correctly when the angles were outside
+  the range [-2*pi, 2*pi].
+
+
 0.20.0 (2024-07-26)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/math.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/math.py
@@ -100,6 +100,9 @@ def wrap_to_pi(angles: torch.Tensor) -> torch.Tensor:
     odd positive multiples of :math:`\pi` are mapped to :math:`\pi`, and odd negative
     multiples of :math:`\pi` are mapped to :math:`-\pi`.
 
+    The function behaves similar to MATLAB's `wrapToPi <https://www.mathworks.com/help/map/ref/wraptopi.html>`_
+    function.
+
     Args:
         angles: Input angles of any shape.
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/math.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/math.py
@@ -106,10 +106,11 @@ def wrap_to_pi(angles: torch.Tensor) -> torch.Tensor:
     Returns:
         Angles in the range :math:`[-\pi, \pi]`.
     """
-    angles = angles.clone()
-    angles %= 2 * torch.pi
-    angles -= 2 * torch.pi * (angles > torch.pi)
-    return angles
+    # wrap to [0, 2*pi)
+    wrapped_angle = (angles + torch.pi) % (2 * torch.pi)
+    # map to [-pi, pi]
+    # we check for zero in wrapped angle to make it go to pi when input angle is odd multiple of pi
+    return torch.where((wrapped_angle == 0) & (angles > 0), torch.pi, wrapped_angle - torch.pi)
 
 
 @torch.jit.script
@@ -126,8 +127,8 @@ def copysign(mag: float, other: torch.Tensor) -> torch.Tensor:
     Returns:
         The output tensor.
     """
-    mag = torch.tensor(mag, device=other.device, dtype=torch.float).repeat(other.shape[0])
-    return torch.abs(mag) * torch.sign(other)
+    mag_torch = torch.tensor(mag, device=other.device, dtype=torch.float).repeat(other.shape[0])
+    return torch.abs(mag_torch) * torch.sign(other)
 
 
 """

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/math.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/math.py
@@ -93,13 +93,18 @@ def normalize(x: torch.Tensor, eps: float = 1e-9) -> torch.Tensor:
 
 @torch.jit.script
 def wrap_to_pi(angles: torch.Tensor) -> torch.Tensor:
-    """Wraps input angles (in radians) to the range [-pi, pi].
+    r"""Wraps input angles (in radians) to the range :math:`[-\pi, \pi]`.
+
+    This function wraps angles in radians to the range :math:`[-\pi, \pi]`, such that
+    :math:`\pi` maps to :math:`\pi`, and :math:`-\pi` maps to :math:`-\pi`. In general,
+    odd positive multiples of :math:`\pi` are mapped to :math:`\pi`, and odd negative
+    multiples of :math:`\pi` are mapped to :math:`-\pi`.
 
     Args:
         angles: Input angles of any shape.
 
     Returns:
-        Angles in the range [-pi, pi].
+        Angles in the range :math:`[-\pi, \pi]`.
     """
     angles = angles.clone()
     angles %= 2 * torch.pi


### PR DESCRIPTION
# Description

The previous implementation of `wrap_to_pi` was rather incorrect since it would map -PI to PI but -3PI to -PI. Following the general convention of this function (based on MATLAB), all odd positive multiples of PI should map to PI, and all negative multiples should map to -PI.

This MR fixes the function and also adds a unit test for it.

Fixes #770

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there