### PR TITLE
Updates installation verfication for Windows

### DIFF
--- a/docs/source/setup/installation/verifying_installation.rst
+++ b/docs/source/setup/installation/verifying_installation.rst
@@ -81,7 +81,7 @@ variables to your terminal for the remaining of the installation instructions:
          :: Isaac Sim root directory
          set ISAACSIM_PATH="C:\Users\user\AppData\Local\ov\pkg\isaac-sim-4.1.0"
          :: Isaac Sim python executable
-         set ISAACSIM_PYTHON_EXE="%ISAACSIM_PATH%\python.bat"
+         set ISAACSIM_PYTHON_EXE="%ISAACSIM_PATH:"=%\python.bat"
 
 
 For more information on common paths, please check the Isaac Sim


### PR DESCRIPTION
# Description

In the verification step for Isaac Sim installed from binaries, if I set the `ISAACSIM_PYTHON_EXE`  variable as specified and print it, there are extra quotes, so the later steps don't work.

This MR fixes the environment variable in Windows verification.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there