### PR TITLE
Sets numpy version to below 2.0 in `setup.py`

### DIFF
--- a/source/extensions/omni.isaac.lab/setup.py
+++ b/source/extensions/omni.isaac.lab/setup.py
@@ -18,7 +18,7 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
-    "numpy",
+    "numpy<2",
     "torch==2.2.2",
     "prettytable==3.3.0",
     "tensordict",


### PR DESCRIPTION
# Description

When installing Isaac Lab in conda environment, numpy version 2.0 gets installed, which breaks all the scripts from running properly.

This MR fixes compatibility issues with NumPy by setting its installation version to less than 2.0.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there