### PR TITLE
Fixes hydra parsing of nested dicts

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
@@ -95,6 +95,16 @@ def update_class_from_dict(obj, data: dict[str, Any], _ns: str = "") -> None:
                     )
                 if isinstance(obj_mem, tuple):
                     value = tuple(value)
+                else:
+                    set_obj = True
+                    # recursively call if iterable contains dictionaries
+                    for i, item in enumerate(obj_mem):
+                        if isinstance(value[i], dict):
+                            update_class_from_dict(obj_mem[i], value[i], _ns=key_ns)
+                            set_obj = False
+                    # do not set value to obj, otherwise it overwrites the cfg class with the dict
+                    if not set_obj:
+                        continue
             elif callable(obj_mem):
                 # update function name
                 value = string_to_callable(value)

--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/hydra.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/hydra.py
@@ -74,7 +74,7 @@ def hydra_task_config(task_name: str, agent_cfg_entry_point: str) -> Callable:
             # register the task to Hydra
             env_cfg, agent_cfg = register_task_to_hydra(task_name, agent_cfg_entry_point)
 
-            # define thr new Hydra main function
+            # define the new Hydra main function
             @hydra.main(config_path=None, config_name=task_name, version_base="1.3")
             def hydra_main(hydra_env_cfg: DictConfig, env_cfg=env_cfg, agent_cfg=agent_cfg):
                 # convert to a native dictionary


### PR DESCRIPTION
# Description

When configclass dicts are nested inside lists, the list is treated as an Iterable object and assigned directly to the outer configclass when updating configclass data with dicts. This overwrites the configclass object in the list with a dict object and causes undesired behavor.

This change checks for nested dictionaries inside Iterables and updates the values inside the dictionary individually without overwiting the full Iterable.

Fixes # (issue)

Fixes https://github.com/isaac-sim/IsaacLab/issues/843

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
