### PR TITLE
Disables default viewport in some scenarios for better performance

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.22.1"
+version = "0.22.2"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.22.2 (2024-08-21)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Disabled default viewport in certain headless scenarios for better performance.
+
+
 0.22.1 (2024-08-17)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -462,6 +462,14 @@ class AppLauncher:
         self._offscreen_render = False
         if self._enable_cameras and self._headless:
             self._offscreen_render = True
+
+        # Check if we can disable the viewport to improve performance
+        #   This should only happen if we are running headless and do not require livestreaming or video recording
+        #   This is different from offscreen_render because this only affects the default viewport and not other renderproducts in the scene
+        self._render_viewport = True
+        if self._headless and not self._livestream and not launcher_args.get("video", False):
+            self._render_viewport = False
+
         # hide_ui flag
         launcher_args["hide_ui"] = False
         if self._headless and not self._livestream:
@@ -619,6 +627,11 @@ class AppLauncher:
         # this flag is used by the SimulationContext class to enable the offscreen_render pipeline
         # when the render() method is called.
         carb_settings_iface.set_bool("/isaaclab/render/offscreen", self._offscreen_render)
+
+        # set carb setting to indicate Isaac Lab's render_viewport pipeline should be enabled
+        # this flag is used by the SimulationContext class to enable the render_viewport pipeline
+        # when the render() method is called.
+        carb_settings_iface.set_bool("/isaaclab/render/render_viewport", self._render_viewport)
 
         # set carb setting to indicate no RTX sensors are used
         # this flag is set to True when an RTX-rendering related sensor is created

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/simulation_context.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/simulation_context.py
@@ -146,6 +146,8 @@ class SimulationContext(_SimulationContext):
         # casting None to False if the flag doesn't exist
         # this flag is set from the AppLauncher class
         self._offscreen_render = bool(carb_settings_iface.get("/isaaclab/render/offscreen"))
+        # read flag for whether the default viewport should be enabled
+        self._render_viewport = bool(carb_settings_iface.get("/isaaclab/render/_render_viewport"))
         # flag for whether any GUI will be rendered (local, livestreamed or viewport)
         self._has_gui = self._local_gui or self._livestream_gui
 
@@ -182,6 +184,14 @@ class SimulationContext(_SimulationContext):
             self._render_throttle_counter = 0
             # rendering frequency in terms of number of render calls
             self._render_throttle_period = 5
+
+        # check the case where we don't need to render the viewport
+        # since render_viewport can only be False in headless mode, we only need to check for offscreen_render
+        if not self._render_viewport and self._offscreen_render:
+            # disable the viewport if offscreen_render is enabled
+            from omni.kit.viewport.utility import get_active_viewport
+
+            get_active_viewport().updates_enabled = False
 
         # override enable scene querying if rendering is enabled
         # this is needed for some GUI features


### PR DESCRIPTION
# Description

When cameras are enabled, a default render product always gets created for the viewport, which brings additional overhead for rendering the viewport at each step. However, when running in headless mode, we may not need to render the viewport if we are not recording or livestreaming.

This change disables viewport rendering in the headless cases where recording and livestreaming are not required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
