### PR TITLE
Defaults the gym video recorder fps to match episode decimation

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/direct_rl_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/direct_rl_env.py
@@ -185,7 +185,7 @@ class DirectRLEnv(gym.Env):
                 self.event_manager.apply(mode="startup")
 
         # -- set the framerate of the gym video recorder wrapper so that the playback speed of the produced video matches the simulation
-        self.metadata["render_fps"] = 1 / (self.cfg.decimation * self.cfg.sim.dt)
+        self.metadata["render_fps"] = 1 / self.step_dt
 
         # print the environment information
         print("[INFO]: Completed setting up the environment...")

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/direct_rl_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/direct_rl_env.py
@@ -184,6 +184,9 @@ class DirectRLEnv(gym.Env):
             if "startup" in self.event_manager.available_modes:
                 self.event_manager.apply(mode="startup")
 
+        # -- set the framerate of the gym video recorder wrapper so that the playback speed of the produced video matches the simulation
+        self.metadata["render_fps"] = 1 / (self.cfg.decimation * self.cfg.sim.dt)
+
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
@@ -81,6 +81,8 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         self.common_step_counter = 0
         # -- init buffers
         self.episode_length_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.long)
+        # -- set the framerate of the gym video recorder wrapper so that the duration of the produced video matches the episode length
+        self.metadata["render_fps"] = 1 / (self.cfg.decimation * self.cfg.sim.dt)
         print("[INFO]: Completed setting up the environment...")
 
     """

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
@@ -81,7 +81,7 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         self.common_step_counter = 0
         # -- init buffers
         self.episode_length_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.long)
-        # -- set the framerate of the gym video recorder wrapper so that the duration of the produced video matches the episode length
+        # -- set the framerate of the gym video recorder wrapper so that the playback speed of the produced video matches the simulation
         self.metadata["render_fps"] = 1 / (self.cfg.decimation * self.cfg.sim.dt)
         print("[INFO]: Completed setting up the environment...")
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
@@ -82,7 +82,8 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         # -- init buffers
         self.episode_length_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.long)
         # -- set the framerate of the gym video recorder wrapper so that the playback speed of the produced video matches the simulation
-        self.metadata["render_fps"] = 1 / (self.cfg.decimation * self.cfg.sim.dt)
+        self.metadata["render_fps"] = 1 / self.step_dt
+
         print("[INFO]: Completed setting up the environment...")
 
     """


### PR DESCRIPTION
Sets the "render_fps" metadata used by the gym.wrappers.RecordVideo such that, if it is used, the produced video will have the correct episode length (i.e., the environment in the video will play at the correct speed). 

The correct render_fps should be equal to `1 / (self.cfg.decimation * self.cfg.sim.dt)` which I integrated to the init function of the ManagerBasedRLEnv. This seems to work well.

Fixes #892

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

<img width="1048" alt="Screenshot 2024-08-28 at 18 10 30" src="https://github.com/user-attachments/assets/d4fd8482-fbbc-48fa-8890-6a75a3fd99dc">

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
