### PR TITLE
Fixes initialization of normal velocity command generator

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/commands/velocity_command.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/commands/velocity_command.py
@@ -218,14 +218,14 @@ class NormalVelocityCommand(UniformVelocityCommand):
     cfg: NormalVelocityCommandCfg
     """The command generator configuration."""
 
-    def __init__(self, cfg: NormalVelocityCommandCfg, env: object):
+    def __init__(self, cfg: NormalVelocityCommandCfg, env: ManagerBasedEnv):
         """Initializes the command generator.
 
         Args:
             cfg: The command generator configuration.
             env: The environment.
         """
-        super().__init__(self, cfg, env)
+        super().__init__(cfg, env)
         # create buffers for zero commands envs
         self.is_zero_vel_x_env = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
         self.is_zero_vel_y_env = torch.zeros_like(self.is_zero_vel_x_env)


### PR DESCRIPTION
# Description

This MR resolved the exception occurring during the initialization of the parent class in NormalVelocityCommand.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there