### PR TITLE
Adapts A and D button bindings in the keyboard device

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.22.6"
+version = "0.22.7"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.22.5 (2024-08-30)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Keyboard  :meth:`omni.isaac.lab.device.Se3Keyboard._create_key_bindings` now has A binded to +y axis(was -y) and D 
+  binded to -y axis(was +y), this is now in accordance with both keyboard device documentation and right hand rule.
+
 0.22.4 (2024-08-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -10,6 +10,7 @@ Fixed
 * Keyboard  :meth:`omni.isaac.lab.device.Se3Keyboard._create_key_bindings` now has A binded to +y axis(was -y) and D 
   binded to -y axis(was +y), this is now in accordance with both keyboard device documentation and right hand rule.
 
+
 0.22.4 (2024-08-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/devices/keyboard/se3_keyboard.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/devices/keyboard/se3_keyboard.py
@@ -170,9 +170,9 @@ class Se3Keyboard(DeviceBase):
             # x-axis (forward)
             "W": np.asarray([1.0, 0.0, 0.0]) * self.pos_sensitivity,
             "S": np.asarray([-1.0, 0.0, 0.0]) * self.pos_sensitivity,
-            # y-axis (right-left)
-            "D": np.asarray([0.0, 1.0, 0.0]) * self.pos_sensitivity,
-            "A": np.asarray([0.0, -1.0, 0.0]) * self.pos_sensitivity,
+            # y-axis (left-right)
+            "A": np.asarray([0.0, 1.0, 0.0]) * self.pos_sensitivity,
+            "D": np.asarray([0.0, -1.0, 0.0]) * self.pos_sensitivity,
             # z-axis (up-down)
             "Q": np.asarray([0.0, 0.0, 1.0]) * self.pos_sensitivity,
             "E": np.asarray([0.0, 0.0, -1.0]) * self.pos_sensitivity,


### PR DESCRIPTION
# Description

While developing some teleoperation methods, I discovered that the keyboard y-axis was moving in a non-intuitive direction. It turned out that the +ve and -ve y-axis are bound to keys (D, A) instead of (A, D).  This MR fixes the issue in both keyboard device documentation instructions to follow the right-hand rule.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Screenshot from 2024-08-30 14-57-26](https://github.com/user-attachments/assets/5f29054e-f0e8-4b8e-bb90-49f3403a1e08)


## Checklist

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [X] I have added my name to the `CONTRIBUTORS.md` or my name already exists there