### PR TITLE
Add `OperationSpaceController` to docs and tests and implement corresponding action/action_cfg classes

### DIFF
--- a/docs/source/api/lab/omni.isaac.lab.controllers.rst
+++ b/docs/source/api/lab/omni.isaac.lab.controllers.rst
@@ -9,6 +9,8 @@
 
     DifferentialIKController
     DifferentialIKControllerCfg
+    OperationSpaceController
+    OperationSpaceControllerCfg
 
 Differential Inverse Kinematics
 -------------------------------
@@ -19,6 +21,20 @@ Differential Inverse Kinematics
     :show-inheritance:
 
 .. autoclass:: DifferentialIKControllerCfg
+    :members:
+    :inherited-members:
+    :show-inheritance:
+    :exclude-members: __init__, class_type
+
+Operational Space controllers
+-----------------------------
+
+.. autoclass:: OperationSpaceController
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
+.. autoclass:: OperationSpaceControllerCfg
     :members:
     :inherited-members:
     :show-inheritance:

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/controllers/__init__.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/controllers/__init__.py
@@ -13,3 +13,4 @@ commands to be sent to the robot.
 
 from .differential_ik import DifferentialIKController
 from .differential_ik_cfg import DifferentialIKControllerCfg
+from .operational_space import OperationSpaceController, OperationSpaceControllerCfg

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/actions_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/actions_cfg.py
@@ -5,7 +5,7 @@
 
 from dataclasses import MISSING
 
-from omni.isaac.lab.controllers import DifferentialIKControllerCfg
+from omni.isaac.lab.controllers import DifferentialIKControllerCfg, OperationSpaceControllerCfg
 from omni.isaac.lab.managers.action_manager import ActionTerm, ActionTermCfg
 from omni.isaac.lab.utils import configclass
 
@@ -248,3 +248,39 @@ class DifferentialInverseKinematicsActionCfg(ActionTermCfg):
     """Scale factor for the action. Defaults to 1.0."""
     controller: DifferentialIKControllerCfg = MISSING
     """The configuration for the differential IK controller."""
+
+
+@configclass
+class OperationSpaceControllerActionCfg(ActionTermCfg):
+    """Configuration for operation space controller action term.
+
+    See :class:`OperationSpaceControllerAction` for more details.
+    """
+
+    @configclass
+    class OffsetCfg:
+        """The offset pose from parent frame to child frame.
+
+        On many robots, end-effector frames are fictitious frames that do not have a corresponding
+        rigid body. In such cases, it is easier to define this transform w.r.t. their parent rigid body.
+        For instance, for the Franka Emika arm, the end-effector is defined at an offset to the the
+        "panda_hand" frame.
+        """
+
+        pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
+        """Translation w.r.t. the parent frame. Defaults to (0.0, 0.0, 0.0)."""
+        rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+        """Quaternion rotation ``(w, x, y, z)`` w.r.t. the parent frame. Defaults to (1.0, 0.0, 0.0, 0.0)."""
+
+    class_type: type[ActionTerm] = task_space_actions.OperationSpaceControllerAction
+
+    joint_names: list[str] = MISSING
+    """List of joint names or regex expressions that the action will be mapped to."""
+    body_name: str = MISSING
+    """Name of the body or frame for which IK is performed."""
+    body_offset: OffsetCfg | None = None
+    """Offset of target frame w.r.t. to the body frame. Defaults to None, in which case no offset is applied."""
+    scale: float | tuple[float, ...] = 1.0
+    """Scale factor for the action. Defaults to 1.0."""
+    controller: OperationSpaceControllerCfg = MISSING
+    """The configuration for the operation space controller."""

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/task_space_actions.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/task_space_actions.py
@@ -14,6 +14,7 @@ import carb
 import omni.isaac.lab.utils.math as math_utils
 from omni.isaac.lab.assets.articulation import Articulation
 from omni.isaac.lab.controllers.differential_ik import DifferentialIKController
+from omni.isaac.lab.controllers.operation_space_controller import OperationSpaceController
 from omni.isaac.lab.managers.action_manager import ActionTerm
 
 if TYPE_CHECKING:
@@ -140,6 +141,172 @@ class DifferentialInverseKinematicsAction(ActionTerm):
             joint_pos_des = joint_pos.clone()
         # set the joint position command
         self._asset.set_joint_position_target(joint_pos_des, self._joint_ids)
+
+    def reset(self, env_ids: Sequence[int] | None = None) -> None:
+        self._raw_actions[env_ids] = 0.0
+
+    """
+    Helper functions.
+    """
+
+    def _compute_frame_pose(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Computes the pose of the target frame in the root frame.
+
+        Returns:
+            A tuple of the body's position and orientation in the root frame.
+        """
+        # obtain quantities from simulation
+        ee_pose_w = self._asset.data.body_state_w[:, self._body_idx, :7]
+        root_pose_w = self._asset.data.root_state_w[:, :7]
+        # compute the pose of the body in the root frame
+        ee_pose_b, ee_quat_b = math_utils.subtract_frame_transforms(
+            root_pose_w[:, 0:3], root_pose_w[:, 3:7], ee_pose_w[:, 0:3], ee_pose_w[:, 3:7]
+        )
+        # account for the offset
+        if self.cfg.body_offset is not None:
+            ee_pose_b, ee_quat_b = math_utils.combine_frame_transforms(
+                ee_pose_b, ee_quat_b, self._offset_pos, self._offset_rot
+            )
+
+        return ee_pose_b, ee_quat_b
+
+    def _compute_frame_jacobian(self):
+        """Computes the geometric Jacobian of the target frame in the root frame.
+
+        This function accounts for the target frame offset and applies the necessary transformations to obtain
+        the right Jacobian from the parent body Jacobian.
+        """
+        # read the parent jacobian
+        jacobian = self._asset.root_physx_view.get_jacobians()[:, self._jacobi_body_idx, :, self._joint_ids]
+        # account for the offset
+        if self.cfg.body_offset is not None:
+            # Modify the jacobian to account for the offset
+            # -- translational part
+            # v_link = v_ee + w_ee x r_link_ee = v_J_ee * q + w_J_ee * q x r_link_ee
+            #        = (v_J_ee + w_J_ee x r_link_ee ) * q
+            #        = (v_J_ee - r_link_ee_[x] @ w_J_ee) * q
+            jacobian[:, 0:3, :] += torch.bmm(-math_utils.skew_symmetric_matrix(self._offset_pos), jacobian[:, 3:, :])
+            # -- rotational part
+            # w_link = R_link_ee @ w_ee
+            jacobian[:, 3:, :] = torch.bmm(math_utils.matrix_from_quat(self._offset_rot), jacobian[:, 3:, :])
+
+        return jacobian
+
+
+
+
+class OperationSpaceControllerAction(ActionTerm):
+    r"""Operation space controller action term.
+
+    This action term performs pre-processing of the raw actions.
+
+    TODO To be added
+    """
+
+    cfg: actions_cfg.OperationSpaceControllerActionCfg
+    """The configuration of the action term."""
+    _asset: Articulation
+    """The articulation asset on which the action term is applied."""
+    _scale: torch.Tensor
+    """The scaling factor applied to the input action. Shape is (1, action_dim)."""
+
+    def __init__(self, cfg: actions_cfg.OperationSpaceControllerActionCfg, env: ManagerBasedEnv):
+        # initialize the action term
+        super().__init__(cfg, env)
+
+        # resolve the joints over which the action term is applied
+        self._joint_ids, self._joint_names = self._asset.find_joints(self.cfg.joint_names)
+        self._num_joints = len(self._joint_ids)
+        # parse the body index
+        body_ids, body_names = self._asset.find_bodies(self.cfg.body_name)
+        if len(body_ids) != 1:
+            raise ValueError(
+                f"Expected one match for the body name: {self.cfg.body_name}. Found {len(body_ids)}: {body_names}."
+            )
+        # save only the first body index
+        self._body_idx = body_ids[0]
+        self._body_name = body_names[0]
+        # check if articulation is fixed-base
+        # if fixed-base then the jacobian for the base is not computed
+        # this means that number of bodies is one less than the articulation's number of bodies
+        if self._asset.is_fixed_base:
+            self._jacobi_body_idx = self._body_idx - 1
+        else:
+            self._jacobi_body_idx = self._body_idx
+
+        # log info for debugging
+        carb.log_info(
+            f"Resolved joint names for the action term {self.__class__.__name__}:"
+            f" {self._joint_names} [{self._joint_ids}]"
+        )
+        carb.log_info(
+            f"Resolved body name for the action term {self.__class__.__name__}: {self._body_name} [{self._body_idx}]"
+        )
+        # Avoid indexing across all joints for efficiency
+        if self._num_joints == self._asset.num_joints:
+            self._joint_ids = slice(None)
+
+        # create the operation space controller
+        self._ik_controller = OperationSpaceController( #FIXME Change to correct arguments
+            cfg=self.cfg.controller, num_envs=self.num_envs, device=self.device
+        )
+
+        # create tensors for raw and processed actions
+        self._raw_actions = torch.zeros(self.num_envs, self.action_dim, device=self.device)
+        self._processed_actions = torch.zeros_like(self.raw_actions)
+
+        # save the scale as tensors
+        self._scale = torch.zeros((self.num_envs, self.action_dim), device=self.device)
+        self._scale[:] = torch.tensor(self.cfg.scale, device=self.device)
+
+        # convert the fixed offsets to torch tensors of batched shape
+        if self.cfg.body_offset is not None:
+            self._offset_pos = torch.tensor(self.cfg.body_offset.pos, device=self.device).repeat(self.num_envs, 1)
+            self._offset_rot = torch.tensor(self.cfg.body_offset.rot, device=self.device).repeat(self.num_envs, 1)
+        else:
+            self._offset_pos, self._offset_rot = None, None
+
+    """
+    Properties.
+    """
+
+    @property
+    def action_dim(self) -> int:
+        return self._ik_controller.action_dim
+
+    @property
+    def raw_actions(self) -> torch.Tensor:
+        return self._raw_actions
+
+    @property
+    def processed_actions(self) -> torch.Tensor:
+        return self._processed_actions
+
+    """
+    Operations.
+    """
+
+    def process_actions(self, actions: torch.Tensor):
+        # store the raw actions
+        self._raw_actions[:] = actions
+        self._processed_actions[:] = self.raw_actions * self._scale
+        # obtain quantities from simulation
+        ee_pos_curr, ee_quat_curr = self._compute_frame_pose()
+        # set command into controller
+        # self._ik_controller.set_command(self._processed_actions, ee_pos_curr, ee_quat_curr)
+
+    def apply_actions(self):
+        # obtain quantities from simulation
+        ee_pos_curr, ee_quat_curr = self._compute_frame_pose()
+        joint_pos = self._asset.data.joint_pos[:, self._joint_ids]
+        # compute the delta in joint-space
+        if ee_quat_curr.norm() != 0:
+            jacobian = self._compute_frame_jacobian()
+            joint_pos_des = self._ik_controller.compute(ee_pos_curr, ee_quat_curr, jacobian, joint_pos)
+        else:
+            joint_pos_des = joint_pos.clone()
+        # set the joint position command
+        # self._asset.set_joint_position_target(joint_pos_des, self._joint_ids)
 
     def reset(self, env_ids: Sequence[int] | None = None) -> None:
         self._raw_actions[env_ids] = 0.0

--- a/source/extensions/omni.isaac.lab/test/controllers/test_operation_space.py
+++ b/source/extensions/omni.isaac.lab/test/controllers/test_operation_space.py
@@ -29,7 +29,7 @@ from omni.isaac.lab.utils.math import compute_pose_error, subtract_frame_transfo
 ##
 from omni.isaac.lab_assets import FRANKA_PANDA_HIGH_PD_CFG, UR10_CFG  # isort:skip
 
-class TestDifferentialIKController(unittest.TestCase):
+class TestOperationSpaceController(unittest.TestCase):
     """Test fixture for checking that differential IK controller tracks commands properly."""
 
     def setUp(self):

--- a/source/extensions/omni.isaac.lab/test/controllers/test_operation_space.py
+++ b/source/extensions/omni.isaac.lab/test/controllers/test_operation_space.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Launch Isaac Sim Simulator first."""
+
+from omni.isaac.lab.app import AppLauncher, run_tests
+
+# launch omniverse app
+simulation_app = AppLauncher(headless=True).app
+
+"""Rest everything follows."""
+
+import torch
+import unittest
+
+import omni.isaac.core.utils.prims as prim_utils
+import omni.isaac.core.utils.stage as stage_utils
+from omni.isaac.cloner import GridCloner
+
+import omni.isaac.lab.sim as sim_utils
+from omni.isaac.lab.assets import Articulation
+from omni.isaac.lab.controllers import OperationSpaceController, OperationSpaceControllerCfg
+from omni.isaac.lab.utils.math import compute_pose_error, subtract_frame_transforms
+
+##
+# Pre-defined configs
+##
+from omni.isaac.lab_assets import FRANKA_PANDA_HIGH_PD_CFG, UR10_CFG  # isort:skip
+
+class TestDifferentialIKController(unittest.TestCase):
+    """Test fixture for checking that differential IK controller tracks commands properly."""
+
+    def setUp(self):
+        """Create a blank new stage for each test."""
+        # Wait for spawning
+        stage_utils.create_new_stage()
+        # Constants
+        self.num_envs = 128
+        # Load kit helper
+        sim_cfg = sim_utils.SimulationCfg(dt=0.01)
+        self.sim = sim_utils.SimulationContext(sim_cfg)
+        # TODO: Remove this once we have a better way to handle this.
+        self.sim._app_control_on_stop_handle = None
+
+        # Create a ground plane
+        cfg = sim_utils.GroundPlaneCfg()
+        cfg.func("/World/GroundPlane", cfg)
+
+        # Create interface to clone the scene
+        cloner = GridCloner(spacing=2.0)
+        cloner.define_base_env("/World/envs")
+        self.env_prim_paths = cloner.generate_paths("/World/envs/env", self.num_envs)
+        # create source prim
+        prim_utils.define_prim(self.env_prim_paths[0], "Xform")
+        # clone the env xform
+        self.env_origins = cloner.clone(
+            source_prim_path=self.env_prim_paths[0],
+            prim_paths=self.env_prim_paths,
+            replicate_physics=True,
+        )
+
+        # Define goals for the arm [xyz, quat_wxyz]
+        ee_goals_set = [
+            [0.5, 0.5, 0.7, 0.707, 0, 0.707, 0],
+            [0.5, -0.4, 0.6, 0.707, 0.707, 0.0, 0.0],
+            [0.5, 0, 0.5, 0.0, 1.0, 0.0, 0.0],
+        ]
+        self.ee_pose_b_des_set = torch.tensor(ee_goals_set, device=self.sim.device)
+
+    def tearDown(self):
+        """Stops simulator after each test."""
+        # stop simulation
+        self.sim.stop()
+        self.sim.clear()
+        self.sim.clear_all_callbacks()
+        self.sim.clear_instance()
+
+    """
+    Test fixtures.
+    """
+
+    def test_franka_position_abs(self):
+        """Test absolute position control."""
+        robot_cfg = FRANKA_PANDA_HIGH_PD_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+        robot = Articulation(cfg=robot_cfg)
+
+        ctrl_cfg = OperationSpaceControllerCfg()
+        controller = OperationSpaceController(ctrl_cfg,....)
+
+    def test_franka_pose_abs(self):
+        """Test absolute pose control."""
+
+    def test_franka_force_abs(self):
+        """test absolute force control."""
+
+    def test_franka_fixed(self):
+        """Tests operational space controller for franka using fixed impedance."""
+        
+    def test_franka_variable_kp(self):
+        """Tests operational space controller for franka using variable stiffness impedance."""
+
+    def test_franka_variable(self):
+        """Tests operational space controller for franka using variable stiffness and damping ratio impedance."""
+
+
+    def test_franka_gravity_compensation(self):
+        """Tests operational space control with gravity compensation."""
+    
+    def test_franka_inertial_compensation(self):
+        """Tests operational space control with inertial compensation."""
+    
+    def test_franka_control_hybrid_motion_force(self):
+        """Tests operational space control for hybrid motion and force control."""
+
+    """
+    Helper functions
+    """
+
+    def _run_op_space_controller(self):


### PR DESCRIPTION
# Description

This PR adds the `OperationSpaceController` to the docs and provides some tests for its parametric features. Moreover, it implements the corresponding `OperationSpaceControllerAction` and `OperationSpaceControllerActionCfg` classes so they can be used with manager-based environments.

Fixes #873 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
``