### PR TITLE
Fixes the event manager's apply method

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
@@ -226,17 +226,18 @@ class EventManager(ManagerBase):
 
                     # select the valid environment indices based on the trigger
                     if env_ids == slice(None):
-                        env_ids = valid_trigger.nonzero().flatten()
+                        valid_env_ids = valid_trigger.nonzero().flatten()
                     else:
-                        env_ids = env_ids[valid_trigger]
+                        valid_env_ids = env_ids[valid_trigger]
 
                     # reset the last reset step for each environment to the current env step count
-                    if len(env_ids) > 0:
-                        self._reset_term_last_triggered_once[index][env_ids] = True
-                        self._reset_term_last_triggered_step_id[index][env_ids] = global_env_step_count
-                    else:
-                        # no need to call func to apply term
-                        continue
+                    if len(valid_env_ids) > 0:
+                        self._reset_term_last_triggered_once[index][valid_env_ids] = True
+                        self._reset_term_last_triggered_step_id[index][valid_env_ids] = global_env_step_count
+                        # call the event term
+                        term_cfg.func(self._env, valid_env_ids, **term_cfg.params)
+                    # no need to call func to apply term again
+                    continue
             # call the event term
             term_cfg.func(self._env, env_ids, **term_cfg.params)
 


### PR DESCRIPTION
# Description

Before, the environment IDs in the Event Manager's apply call in reset mode could be overwritten when iterating through the event terms. This could make the environment IDs invalid in some cases.
This change avoids overwriting the global env_ids variable when checking for valid environment IDs that satisfy the frequency condition.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there