### PR TITLE
Set livestream 1 stream extensions to isaac 4.1-4.0 defaults

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -611,8 +611,8 @@ class AppLauncher:
             if self._livestream == 1:
                 # Enable Native Livestream extension
                 # Default App: Streaming Client from the Omniverse Launcher
-                enable_extension("omni.kit.streamsdk.plugins-4.5.1")
-                enable_extension("omni.kit.livestream.core-4.3.6")
+                enable_extension("omni.kit.streamsdk.plugins-3.2.1")
+                enable_extension("omni.kit.livestream.core-3.2.0")
                 enable_extension("omni.kit.livestream.native-4.1.0")
             elif self._livestream == 2:
                 # Enable WebRTC Livestream extension


### PR DESCRIPTION
# Description

Streaming does not work for  `isaaclab --livestream 1` using streaming client 103.1.1.

This change sets the streaming client extension versions to the defaults in isaac-sim-4.1.0/apps/omni.isaac.sim.headless.native.kit 

Fixes #949 

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
