### PR TITLE
Adds windows configuration to VS code tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,9 @@
             "type": "shell",
             "linux": {
                 "command": "${workspaceFolder}/isaaclab.sh -p ${workspaceFolder}/.vscode/tools/setup_vscode.py"
+            },
+            "windows": {
+                "command": "${workspaceFolder}/isaaclab.bat -p ${workspaceFolder}/.vscode/tools/setup_vscode.py"
             }
         },
         {
@@ -17,6 +20,9 @@
             "type": "shell",
             "linux": {
                 "command": "${workspaceFolder}/isaaclab.sh --format"
+            },
+            "windows": {
+                "command": "${workspaceFolder}/isaaclab.bat --format"
             }
         }
     ]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,6 +40,7 @@ Guidelines for modifications:
 * Calvin Yu
 * Chenyu Yang
 * HoJin Jeon
+* Jean Tampon
 * Jia Lin Yuan
 * Jingzhou Liu
 * Johnson Sun


### PR DESCRIPTION
# Description

Currently, the tasks shipped with the VS code configuration only specify Linux commands, which prevent the use of them on Windows. This MR adds those tasks for Windows OS as well.

Fixes #962

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there