### PR TITLE
Fixes `Sb3VecEnvWrapper` to clear buffer on reset

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,6 +59,7 @@ Guidelines for modifications:
 * Shafeef Omar
 * Vladimir Fokow
 * Xavier Nal
+* Yang Jin
 * Zhengyu Zhang
 * Ziqi Fan
 * Qian Wan

--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/wrappers/sb3.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/wrappers/sb3.py
@@ -205,6 +205,9 @@ class Sb3VecEnvWrapper(VecEnv):
 
     def reset(self) -> VecEnvObs:  # noqa: D102
         obs_dict, _ = self.env.reset()
+        # reset episodic information buffers
+        self._ep_rew_buf.zero_()
+        self._ep_len_buf.zero_()
         # convert data types to numpy depending on backend
         return self._process_obs(obs_dict)
 


### PR DESCRIPTION
# Description

In previous version of the SB3 environment wrapper, the episode buffer was not cleared when `env.reset` was called. This led to an overestimation of the number of time-steps and rewards in subsequent episodes, as reflected in the `infos` returned by `env.steps`. This commit aims to address this.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x]  I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [ ]  I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x]  I have added my name to the `CONTRIBUTORS.md` or my name already exists there