### PR TITLE
Makes a separate function for invalidating views inside asset and sensor classes

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.24.13"
+version = "0.24.14"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.24.14 (2024-09-23)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Made a separate invalidate function inside asset and sensor base classes. This avoids the need to call the
+  parent's invalidate callback within the child class' callback function. Earlier, this behavior led to
+  PhysX error on subscription cannot be changed during the event call.
+
 
 0.24.13 (2024-09-08)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
@@ -878,7 +878,7 @@ class Articulation(AssetBase):
         )
 
     """
-    Internal helper.
+    Implementation.
     """
 
     def _initialize_impl(self):
@@ -941,6 +941,15 @@ class Articulation(AssetBase):
         self.update(0.0)
         # log joint information
         self._log_articulation_joint_info()
+
+    def _invalidate_initialize_impl(self):
+        # set all existing views to None to invalidate them
+        self._physics_sim_view = None
+        self._root_physx_view = None
+
+    """
+    Internal Helpers - Buffers.
+    """
 
     def _create_buffers(self):
         # constants
@@ -1072,22 +1081,6 @@ class Articulation(AssetBase):
         # -- joint limits
         self._data.default_joint_limits = self.root_physx_view.get_dof_limits().to(device=self.device).clone()
         self._data.joint_limits = self._data.default_joint_limits.clone()
-
-    """
-    Internal simulation callbacks.
-    """
-
-    def _invalidate_initialize_callback(self, event):
-        """Invalidates the scene elements."""
-        # call parent
-        super()._invalidate_initialize_callback(event)
-        # set all existing views to None to invalidate them
-        self._physics_sim_view = None
-        self._root_physx_view = None
-
-    """
-    Internal helpers -- Actuators.
-    """
 
     def _process_actuators_cfg(self):
         """Process and apply articulation joint properties."""

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/asset_base.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/asset_base.py
@@ -225,6 +225,11 @@ class AssetBase(ABC):
         """Initializes the PhysX handles and internal buffers."""
         raise NotImplementedError
 
+    @abstractmethod
+    def _invalidate_initialize_impl(self):
+        """Invalidates the PhysX handles and internal buffers."""
+        raise NotImplementedError
+
     def _set_debug_vis_impl(self, debug_vis: bool):
         """Set debug visualization into visualization objects.
 
@@ -267,3 +272,5 @@ class AssetBase(ABC):
     def _invalidate_initialize_callback(self, event):
         """Invalidates the scene elements."""
         self._is_initialized = False
+        # invalidate the asset
+        self._invalidate_initialize_impl()

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/deformable_object/deformable_object.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/deformable_object/deformable_object.py
@@ -257,7 +257,7 @@ class DeformableObject(AssetBase):
         return math_utils.transform_points(nodal_pos, pos, quat) + mean_nodal_pos
 
     """
-    Internal helper.
+    Implementation.
     """
 
     def _initialize_impl(self):
@@ -358,6 +358,15 @@ class DeformableObject(AssetBase):
         # update the deformable body data
         self.update(0.0)
 
+    def _invalidate_initialize_impl(self):
+        # set all existing views to None to invalidate them
+        self._physics_sim_view = None
+        self._root_physx_view = None
+
+    """
+    Internal helper - Buffers.
+    """
+
     def _create_buffers(self):
         """Create buffers for storing data."""
         # constants
@@ -403,11 +412,3 @@ class DeformableObject(AssetBase):
             positions = self.data.nodal_kinematic_target[targets_enabled][..., :3]
         # show target visualizer
         self.target_visualizer.visualize(positions)
-
-    def _invalidate_initialize_callback(self, event):
-        """Invalidates the scene elements."""
-        # call parent
-        super()._invalidate_initialize_callback(event)
-        # set all existing views to None to invalidate them
-        self._physics_sim_view = None
-        self._root_physx_view = None

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
@@ -259,7 +259,7 @@ class RigidObject(AssetBase):
             self.has_external_wrench = False
 
     """
-    Internal helper.
+    Implementation.
     """
 
     def _initialize_impl(self):
@@ -314,6 +314,15 @@ class RigidObject(AssetBase):
         # update the rigid body data
         self.update(0.0)
 
+    def _invalidate_initialize_impl(self):
+        # set all existing views to None to invalidate them
+        self._physics_sim_view = None
+        self._root_physx_view = None
+
+    """
+    Internal helper - Buffers.
+    """
+
     def _create_buffers(self):
         """Create buffers for storing data."""
         # constants
@@ -342,15 +351,3 @@ class RigidObject(AssetBase):
         )
         default_root_state = torch.tensor(default_root_state, dtype=torch.float, device=self.device)
         self._data.default_root_state = default_root_state.repeat(self.num_instances, 1)
-
-    """
-    Internal simulation callbacks.
-    """
-
-    def _invalidate_initialize_callback(self, event):
-        """Invalidates the scene elements."""
-        # call parent
-        super()._invalidate_initialize_callback(event)
-        # set all existing views to None to invalidate them
-        self._physics_sim_view = None
-        self._root_physx_view = None

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/tiled_camera.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/tiled_camera.py
@@ -232,6 +232,10 @@ class TiledCamera(Camera):
         # Create internal buffers
         self._create_buffers()
 
+    def _invalidate_initialize_impl(self):
+        # set all existing views to None to invalidate them
+        self._view = None
+
     def _update_buffers_impl(self, env_ids: Sequence[int]):
         # Increment frame count
         self._frame[env_ids] += 1
@@ -393,14 +397,3 @@ class TiledCamera(Camera):
     def _process_annotator_output(self, name: str, output: Any) -> tuple[torch.tensor, dict | None]:
         # we do not need to process annotator output for the tiled camera sensor
         raise RuntimeError("This function should not be called for the tiled camera sensor.")
-
-    """
-    Internal simulation callbacks.
-    """
-
-    def _invalidate_initialize_callback(self, event):
-        """Invalidates the scene elements."""
-        # call parent
-        super()._invalidate_initialize_callback(event)
-        # set all existing views to None to invalidate them
-        self._view = None

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/contact_sensor/contact_sensor.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/contact_sensor/contact_sensor.py
@@ -311,6 +311,12 @@ class ContactSensor(SensorBase):
                 self._num_envs, self._num_bodies, num_filters, 3, device=self._device
             )
 
+    def _invalidate_initialize_impl(self):
+        # set all existing views to None to invalidate them
+        self._physics_sim_view = None
+        self._body_physx_view = None
+        self._contact_physx_view = None
+
     def _update_buffers_impl(self, env_ids: Sequence[int]):
         """Fills the buffers of the sensor data."""
         # default to all sensors
@@ -372,6 +378,10 @@ class ContactSensor(SensorBase):
                 is_contact, self._data.current_contact_time[env_ids] + elapsed_time.unsqueeze(-1), 0.0
             )
 
+    """
+    Implementation - Visualization.
+    """
+
     def _set_debug_vis_impl(self, debug_vis: bool):
         # set visibility of markers
         # note: parent only deals with callbacks. not their visibility
@@ -402,16 +412,3 @@ class ContactSensor(SensorBase):
             frame_origins = pose.view(-1, self._num_bodies, 7)[:, :, :3]
         # visualize
         self.contact_visualizer.visualize(frame_origins.view(-1, 3), marker_indices=marker_indices.view(-1))
-
-    """
-    Internal simulation callbacks.
-    """
-
-    def _invalidate_initialize_callback(self, event):
-        """Invalidates the scene elements."""
-        # call parent
-        super()._invalidate_initialize_callback(event)
-        # set all existing views to None to invalidate them
-        self._physics_sim_view = None
-        self._body_physx_view = None
-        self._contact_physx_view = None

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/frame_transformer/frame_transformer.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/frame_transformer/frame_transformer.py
@@ -279,6 +279,11 @@ class FrameTransformer(SensorBase):
         self._data.target_pos_source = torch.zeros_like(self._data.target_pos_w)
         self._data.target_quat_source = torch.zeros_like(self._data.target_quat_w)
 
+    def _invalidate_initialize_impl(self):
+        # set all existing views to None to invalidate them
+        self._physics_sim_view = None
+        self._frame_physx_view = None
+
     def _update_buffers_impl(self, env_ids: Sequence[int]):
         """Fills the buffers of the sensor data."""
         # default to all sensors
@@ -339,6 +344,10 @@ class FrameTransformer(SensorBase):
         self._data.target_pos_source[:] = target_pos_source.view(-1, total_num_frames, 3)
         self._data.target_quat_source[:] = target_quat_source.view(-1, total_num_frames, 4)
 
+    """
+    Implementation - Visualization.
+    """
+
     def _set_debug_vis_impl(self, debug_vis: bool):
         # set visibility of markers
         # note: parent only deals with callbacks. not their visibility
@@ -355,15 +364,3 @@ class FrameTransformer(SensorBase):
         # Update the visualized markers
         if self.frame_visualizer is not None:
             self.frame_visualizer.visualize(self._data.target_pos_w.view(-1, 3), self._data.target_quat_w.view(-1, 4))
-
-    """
-    Internal simulation callbacks.
-    """
-
-    def _invalidate_initialize_callback(self, event):
-        """Invalidates the scene elements."""
-        # call parent
-        super()._invalidate_initialize_callback(event)
-        # set all existing views to None to invalidate them
-        self._physics_sim_view = None
-        self._frame_physx_view = None

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/ray_caster/ray_caster.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/ray_caster/ray_caster.py
@@ -224,6 +224,11 @@ class RayCaster(SensorBase):
         self._data.quat_w = torch.zeros(self._view.count, 4, device=self._device)
         self._data.ray_hits_w = torch.zeros(self._view.count, self.num_rays, 3, device=self._device)
 
+    def _invalidate_initialize_impl(self):
+        # set all existing views to None to invalidate them
+        self._physics_sim_view = None
+        self._view = None
+
     def _update_buffers_impl(self, env_ids: Sequence[int]):
         """Fills the buffers of the sensor data."""
         # obtain the poses of the sensors
@@ -266,6 +271,10 @@ class RayCaster(SensorBase):
             mesh=RayCaster.meshes[self.cfg.mesh_prim_paths[0]],
         )[0]
 
+    """
+    Implementation - Visualization.
+    """
+
     def _set_debug_vis_impl(self, debug_vis: bool):
         # set visibility of markers
         # note: parent only deals with callbacks. not their visibility
@@ -281,15 +290,3 @@ class RayCaster(SensorBase):
     def _debug_vis_callback(self, event):
         # show ray hit positions
         self.ray_visualizer.visualize(self._data.ray_hits_w.view(-1, 3))
-
-    """
-    Internal simulation callbacks.
-    """
-
-    def _invalidate_initialize_callback(self, event):
-        """Invalidates the scene elements."""
-        # call parent
-        super()._invalidate_initialize_callback(event)
-        # set all existing views to None to invalidate them
-        self._physics_sim_view = None
-        self._view = None

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/sensor_base.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/sensor_base.py
@@ -229,6 +229,11 @@ class SensorBase(ABC):
         self._timestamp_last_update = torch.zeros_like(self._timestamp)
 
     @abstractmethod
+    def _invalidate_initialize_impl(self):
+        """Invalidates the sensor-related handles and internal buffers."""
+        raise NotImplementedError
+
+    @abstractmethod
     def _update_buffers_impl(self, env_ids: Sequence[int]):
         """Fills the sensor data for provided environment ids.
 
@@ -272,8 +277,10 @@ class SensorBase(ABC):
             self._is_initialized = True
 
     def _invalidate_initialize_callback(self, event):
-        """Invalidates the scene elements."""
+        """Invalidates the sensor elements."""
         self._is_initialized = False
+        # invalidate the sensor
+        self._invalidate_initialize_impl()
 
     """
     Helper functions.


### PR DESCRIPTION
# Description

This MR simplifies the invalidate callback for views inside asset and sensor classes. Earlier, the child's overridden function would call the parent's callback function. This led to a PhysX error on: subscription cannot be changed during the event call.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there