### PR TITLE
Inverts SE-2 keyboard device actions (Z, X)  for yaw command

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/devices/keyboard/se2_keyboard.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/devices/keyboard/se2_keyboard.py
@@ -30,7 +30,7 @@ class Se2Keyboard(DeviceBase):
         ====================== ========================= ========================
         Move along x-axis      Numpad 8 / Arrow Up       Numpad 2 / Arrow Down
         Move along y-axis      Numpad 4 / Arrow Right    Numpad 6 / Arrow Left
-        Rotate along z-axis    Numpad 7 / X              Numpad 9 / Y
+        Rotate along z-axis    Numpad 7 / Z              Numpad 9 / X
         ====================== ========================= ========================
 
     .. seealso::
@@ -82,8 +82,8 @@ class Se2Keyboard(DeviceBase):
         msg += "\tMove backward  (along x-axis): Numpad 2 / Arrow Down\n"
         msg += "\tMove right     (along y-axis): Numpad 4 / Arrow Right\n"
         msg += "\tMove left      (along y-axis): Numpad 6 / Arrow Left\n"
-        msg += "\tYaw positively (along z-axis): Numpad 7 / X\n"
-        msg += "\tYaw negatively (along z-axis): Numpad 9 / Y"
+        msg += "\tYaw positively (along z-axis): Numpad 7 / Z\n"
+        msg += "\tYaw negatively (along z-axis): Numpad 9 / X"
         return msg
 
     """
@@ -160,8 +160,8 @@ class Se2Keyboard(DeviceBase):
             "RIGHT": np.asarray([0.0, -1.0, 0.0]) * self.v_y_sensitivity,
             # yaw command (positive)
             "NUMPAD_7": np.asarray([0.0, 0.0, 1.0]) * self.omega_z_sensitivity,
-            "X": np.asarray([0.0, 0.0, 1.0]) * self.omega_z_sensitivity,
+            "Z": np.asarray([0.0, 0.0, 1.0]) * self.omega_z_sensitivity,
             # yaw command (negative)
             "NUMPAD_9": np.asarray([0.0, 0.0, -1.0]) * self.omega_z_sensitivity,
-            "Z": np.asarray([0.0, 0.0, -1.0]) * self.omega_z_sensitivity,
+            "X": np.asarray([0.0, 0.0, -1.0]) * self.omega_z_sensitivity,
         }


### PR DESCRIPTION
# Description

Swapping the keyboard command (X, Z) for yaw in the `Se2Keyboard` class to have the following mapping:
- Z - positive yaw
- X - negative yaw

Corrected also the docstring of the `Se2Keyboard` class.
See Issue https://github.com/isaac-sim/IsaacLab/issues/1029

_Note:_ I double checked the `Se3Keyboard` class and the implementation there is correct.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./isaaclab.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
