### PR TITLE
Adds option to search for RigidBodyAPI on all matching prim paths

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.24.13"
+version = "0.24.14"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.24.14 (2024-09-25)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``use_first_matching_path`` flag to ``RigidObjectCfg`` to allow option for traversal of all matching prim paths
+  for a ``RigidObject`` regex instead of only traversing the first matching prim path and assuming that all other
+  paths follow the same topology.
+
 
 0.24.13 (2024-09-08)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
@@ -298,10 +298,22 @@ class RigidObject(AssetBase):
                 root_prim_path_expr.replace(".*", "*")
             )
         else:
-            # obtain all prims matching the regex expression
-            matching_prim_paths = sim_utils.find_matching_prims(self.cfg.prim_path)
-            if len(matching_prim_paths) == 0:
+            # obtain the first prim in the regex expression (all others are assumed to be a copy of this)
+            template_prim = sim_utils.find_first_matching_prim(self.cfg.prim_path)
+            if template_prim is None:
                 raise RuntimeError(f"Failed to find prim for expression: '{self.cfg.prim_path}'.")
+            template_prim_path = template_prim.GetPath().pathString
+            template_parent_path = template_prim.GetPath().GetParentPath().pathString
+
+            # resolve template prim back into regex expression
+            template_prim_path_expr = (
+                self.cfg.prim_path[: len(template_parent_path) + 1] + template_prim_path[len(template_parent_path) :]
+            )
+
+            # obtain all prims matching the regex expression
+            matching_prim_paths = sim_utils.find_matching_prims(template_prim_path_expr)
+            if len(matching_prim_paths) == 0:
+                raise RuntimeError(f"Failed to find prim for expression: '{template_prim_path_expr}'.")
 
             # find rigid root prims
             root_prim_path_expr = []

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object.py
@@ -266,33 +266,64 @@ class RigidObject(AssetBase):
         # create simulation view
         self._physics_sim_view = physx.create_simulation_view(self._backend)
         self._physics_sim_view.set_subspace_roots("/")
-        # obtain the first prim in the regex expression (all others are assumed to be a copy of this)
-        template_prim = sim_utils.find_first_matching_prim(self.cfg.prim_path)
-        if template_prim is None:
-            raise RuntimeError(f"Failed to find prim for expression: '{self.cfg.prim_path}'.")
-        template_prim_path = template_prim.GetPath().pathString
 
-        # find rigid root prims
-        root_prims = sim_utils.get_all_matching_child_prims(
-            template_prim_path, predicate=lambda prim: prim.HasAPI(UsdPhysics.RigidBodyAPI)
-        )
-        if len(root_prims) == 0:
-            raise RuntimeError(
-                f"Failed to find a rigid body when resolving '{self.cfg.prim_path}'."
-                " Please ensure that the prim has 'USD RigidBodyAPI' applied."
-            )
-        if len(root_prims) > 1:
-            raise RuntimeError(
-                f"Failed to find a single rigid body when resolving '{self.cfg.prim_path}'."
-                f" Found multiple '{root_prims}' under '{template_prim_path}'."
-                " Please ensure that there is only one rigid body in the prim path tree."
-            )
+        if self.cfg.use_first_matching_path:
+            # obtain the first prim in the regex expression (all others are assumed to be a copy of this)
+            template_prim = sim_utils.find_first_matching_prim(self.cfg.prim_path)
+            if template_prim is None:
+                raise RuntimeError(f"Failed to find prim for expression: '{self.cfg.prim_path}'.")
+            template_prim_path = template_prim.GetPath().pathString
 
-        # resolve root prim back into regex expression
-        root_prim_path = root_prims[0].GetPath().pathString
-        root_prim_path_expr = self.cfg.prim_path + root_prim_path[len(template_prim_path) :]
-        # -- object view
-        self._root_physx_view = self._physics_sim_view.create_rigid_body_view(root_prim_path_expr.replace(".*", "*"))
+            # find rigid root prims
+            root_prims = sim_utils.get_all_matching_child_prims(
+                template_prim_path, predicate=lambda prim: prim.HasAPI(UsdPhysics.RigidBodyAPI)
+            )
+            if len(root_prims) == 0:
+                raise RuntimeError(
+                    f"Failed to find a rigid body when resolving '{self.cfg.prim_path}'."
+                    " Please ensure that the prim has 'USD RigidBodyAPI' applied."
+                )
+            if len(root_prims) > 1:
+                raise RuntimeError(
+                    f"Failed to find a single rigid body when resolving '{self.cfg.prim_path}'."
+                    f" Found multiple '{root_prims}' under '{template_prim_path}'."
+                    " Please ensure that there is only one rigid body in the prim path tree."
+                )
+
+            # resolve root prim back into regex expression
+            root_prim_path = root_prims[0].GetPath().pathString
+            root_prim_path_expr = self.cfg.prim_path + root_prim_path[len(template_prim_path) :]
+            # -- object view
+            self._root_physx_view = self._physics_sim_view.create_rigid_body_view(
+                root_prim_path_expr.replace(".*", "*")
+            )
+        else:
+            # obtain all prims matching the regex expression
+            matching_prim_paths = sim_utils.find_matching_prims(self.cfg.prim_path)
+            if len(matching_prim_paths) == 0:
+                raise RuntimeError(f"Failed to find prim for expression: '{self.cfg.prim_path}'.")
+
+            # find rigid root prims
+            root_prim_path_expr = []
+            for prim_path in matching_prim_paths:
+                root_prims = sim_utils.get_all_matching_child_prims(
+                    prim_path.GetPath().pathString, predicate=lambda prim: prim.HasAPI(UsdPhysics.RigidBodyAPI)
+                )
+                if len(root_prims) == 0:
+                    raise RuntimeError(
+                        f"Failed to find a rigid body when resolving '{self.cfg.prim_path}'."
+                        " Please ensure that the prim has 'USD RigidBodyAPI' applied."
+                    )
+                if len(root_prims) > 1:
+                    raise RuntimeError(
+                        f"Failed to find a single rigid body when resolving '{self.cfg.prim_path}'."
+                        f" Found multiple '{root_prims}' under '{prim_path}'."
+                        " Please ensure that there is only one rigid body in the prim path tree."
+                    )
+                root_prim_path_expr.append(root_prims[0].GetPath().pathString)
+
+            # -- object view
+            self._root_physx_view = self._physics_sim_view.create_rigid_body_view(root_prim_path_expr)
 
         # check if the rigid body was created
         if self._root_physx_view._backend is None:

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object_cfg.py
@@ -30,3 +30,12 @@ class RigidObjectCfg(AssetBaseCfg):
 
     init_state: InitialStateCfg = InitialStateCfg()
     """Initial state of the rigid object. Defaults to identity pose with zero velocity."""
+
+    use_first_matching_path: bool = True
+    """Determines whether to parse only the first matching path to the regex expression and assume that
+       all other matching assets follow the same topology as the first matching path.
+
+       If set to False, each path matching to the regex will be parsed to find the required predicate.
+       Only set to False when the regex encapsulates assets that have predicates specified at different
+       locations in the topology tree. This will impact scene creation performance.
+    """

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object_cfg.py
@@ -35,7 +35,7 @@ class RigidObjectCfg(AssetBaseCfg):
     """Determines whether to parse only the first matching path to the regex expression and assume that
        all other matching assets follow the same topology as the first matching path.
 
-       If set to False, each path matching to the regex will be parsed to find the required predicate.
-       Only set to False when the regex encapsulates assets that have predicates specified at different
+       If set to False, each path matching to the regex will be parsed to find the RigidBodyAPI schema.
+       Only set to False when the regex encapsulates assets that have RigidBodyAPI attached to different
        locations in the topology tree. This will impact scene creation performance.
     """

--- a/source/extensions/omni.isaac.lab/test/assets/test_rigid_object.py
+++ b/source/extensions/omni.isaac.lab/test/assets/test_rigid_object.py
@@ -79,13 +79,10 @@ def generate_cubes_scene(
     return cube_object, origins
 
 
-def generate_heterogeneous_cubes_scene(
-    num_cubes: int = 2, height=1.0, device: str = "cuda:0"
-) -> tuple[RigidObject, torch.Tensor]:
+def generate_heterogeneous_cubes_scene(height=1.0, device: str = "cuda:0") -> tuple[RigidObject, torch.Tensor]:
     """Generate a scene with the provided number of cubes.
 
     Args:
-        num_cubes: Number of cubes to generate.
         height: Height of the cubes.
         device: Device to use for the simulation.
 
@@ -93,6 +90,7 @@ def generate_heterogeneous_cubes_scene(
         A tuple containing the rigid object representing the cubes and the origins of the cubes.
 
     """
+    num_cubes = 2
     origins = torch.tensor([(i * 1.0, 0, height) for i in range(num_cubes)]).to(device)
     # Create Top-level Xforms, one for each cube
     for i, origin in enumerate(origins):
@@ -126,7 +124,11 @@ def generate_heterogeneous_cubes_scene(
         use_first_matching_path=False,
     )
 
-    return cube_object_cfg, [cube_object_cfg_1, cube_object_cfg_2], origins
+    # Spawn objects to scene
+    RigidObject(cube_object_cfg_1)
+    RigidObject(cube_object_cfg_2)
+
+    return cube_object_cfg, origins
 
 
 class TestRigidObject(unittest.TestCase):
@@ -174,14 +176,8 @@ class TestRigidObject(unittest.TestCase):
         for device in ("cuda:0", "cpu"):
             with self.subTest(num_cubes=num_cubes, device=device):
                 with build_simulation_context(device=device, auto_add_lighting=True) as sim:
-                    # Generate cubes configs
-                    cube_object_cfg, spawn_cfgs, _ = generate_heterogeneous_cubes_scene(
-                        num_cubes=num_cubes, device=device
-                    )
-
-                    # Spawn objects to scene
-                    for cfg in spawn_cfgs:
-                        RigidObject(cfg)
+                    # Generate 2 different cubes
+                    cube_object_cfg, _ = generate_heterogeneous_cubes_scene(device=device)
 
                     # Main RigidObject instance
                     cube_object = RigidObject(cube_object_cfg)


### PR DESCRIPTION
# Description

When defining `RigidObject` instances with regex that encapsulates heterogeneous objects, the objects may not always have the RigidBodyAPI schema attached to the same prim path in the object hierarchy. Currently, we make this assumption such that we only search for the location of the RigidBodyAPI schema on the first matching prim path of the regex. However, when the assumption doesn't hold on objects that have different topologies, the `RigidObject` instance is not able to find all objects in the scene that match the regex.

This change introduces a new option in the `RigidObjectCfg` that allows for parsing of all matching prim paths instead of just the first matching path. This will incur performance costs when parsing large stages, so it is recommended to only use this option when necessary, when it is desired to have a `RigidObject` that encapsulates a collection of varying objects where the `RigidBodyAPI` schema is attached to different locations.


## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
