### PR TITLE
Adds github action to close stale github issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,7 +64,7 @@
 # Github Actions
 # This list is for people wanting to be notified every time there's a change
 # related to Github Actions
-/.github/ @kellyguo11 @jsmith-bdai
+/.github/ @kellyguo11 @jsmith-bdai @pascal-roth
 
 # Visual Studio Code
 /.vscode/ @hhansen-bdai @Mayankm96

--- a/.github/workflows/inactivity.yaml
+++ b/.github/workflows/inactivity.yaml
@@ -1,0 +1,24 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: "dev team"
+          exempt-pr-labels: "dev team"


### PR DESCRIPTION
# Description

The workflow will find issues that have been inactive for 30 days and will add the specified comment and "stale" label. Additionally, the workflow will close any previously labeled issues if no additional activity has occurred in the next 14 days. All issues with the label "dev team" should be exempt. 

Currently, the workflow will only label and/or close 30 issues at a time in order to avoid exceeding a rate limit.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
