### PR TITLE
Fixes setting the seed from CLI for RSL-RL

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -47,6 +47,7 @@ Guidelines for modifications:
 * Jia Lin Yuan
 * Jingzhou Liu
 * Johnson Sun
+* Kaixi Bao
 * Kourosh Darvish
 * Lorenz Wellhausen
 * Masoud Moghani

--- a/source/standalone/workflows/rsl_rl/cli_args.py
+++ b/source/standalone/workflows/rsl_rl/cli_args.py
@@ -67,7 +67,7 @@ def update_rsl_rl_cfg(agent_cfg: RslRlOnPolicyRunnerCfg, args_cli: argparse.Name
         The updated configuration for RSL-RL agent based on inputs.
     """
     # override the default configuration with CLI arguments
-    if hasattr("args_cli", "seed") and args_cli.seed is not None:
+    if hasattr(args_cli, "seed") and args_cli.seed is not None:
         agent_cfg.seed = args_cli.seed
     if args_cli.resume is not None:
         agent_cfg.resume = args_cli.resume


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/source/refs/contributing.html
-->

This pull request fixes a bug that prevented setting the seed from CLI arguments. The issue was caused by an extra pair of quotation marks in the `hasattr` check for `args_cli`. Removing these allows the seed to be correctly set via CLI.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Before: The seed could not be set via CLI due to an extra pair of quotation marks around `args_cli` in the `hasattr` check.
After: The seed can now be correctly set from CLI.
<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
