### PR TITLE
Fixes docs on running tutorials with cameras

### DIFF
--- a/docs/source/how-to/save_camera_output.rst
+++ b/docs/source/how-to/save_camera_output.rst
@@ -89,7 +89,7 @@ To run the accompanying script, execute the following command:
 .. code-block:: bash
 
    # Usage with saving and drawing
-   ./isaaclab.sh -p source/standalone/tutorials/04_sensors/run_usd_camera.py --save --draw
+   ./isaaclab.sh -p source/standalone/tutorials/04_sensors/run_usd_camera.py --save --draw --enable_cameras
 
    # Usage with saving only in headless mode
    ./isaaclab.sh -p source/standalone/tutorials/04_sensors/run_usd_camera.py --save --headless --enable_cameras

--- a/docs/source/tutorials/04_sensors/add_sensors_on_robot.rst
+++ b/docs/source/tutorials/04_sensors/add_sensors_on_robot.rst
@@ -174,7 +174,7 @@ Now that we have gone through the code, let's run the script and see the result:
 
 .. code-block:: bash
 
-   ./isaaclab.sh -p source/standalone/tutorials/04_sensors/add_sensors_on_robot.py --num_envs 2
+   ./isaaclab.sh -p source/standalone/tutorials/04_sensors/add_sensors_on_robot.py --num_envs 2 --enable_cameras
 
 
 This command should open a stage with a ground plane, lights, and two quadrupedal robots.

--- a/source/standalone/tutorials/04_sensors/add_sensors_on_robot.py
+++ b/source/standalone/tutorials/04_sensors/add_sensors_on_robot.py
@@ -15,7 +15,7 @@ We add the following sensors on the quadruped robot, ANYmal-C (ANYbotics):
 .. code-block:: bash
 
     # Usage
-    ./isaaclab.sh -p source/standalone/tutorials/04_sensors/add_sensors_on_robot.py
+    ./isaaclab.sh -p source/standalone/tutorials/04_sensors/add_sensors_on_robot.py --enable_cameras
 
 """
 

--- a/source/standalone/tutorials/04_sensors/run_usd_camera.py
+++ b/source/standalone/tutorials/04_sensors/run_usd_camera.py
@@ -12,7 +12,7 @@ the simulator or OpenGL convention for the camera, we use the robotics or ROS co
 .. code-block:: bash
 
     # Usage with GUI
-    ./isaaclab.sh -p source/standalone/tutorials/04_sensors/run_usd_camera.py
+    ./isaaclab.sh -p source/standalone/tutorials/04_sensors/run_usd_camera.py --enable_cameras
 
     # Usage with headless
     ./isaaclab.sh -p source/standalone/tutorials/04_sensors/run_usd_camera.py --headless --enable_cameras
@@ -53,7 +53,7 @@ parser.add_argument(
 AppLauncher.add_app_launcher_args(parser)
 # parse the arguments
 args_cli = parser.parse_args()
-args_cli.enable_cameras = True
+
 # launch omniverse app
 app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app


### PR DESCRIPTION
# Description

Adds the `enable_cameras` flag to tutorials requiring cameras.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there