### PR TITLE
Fixes deprecation notice for using `pxr.Semantics`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ known_third_party = [
     "omni.kit.*",
     "warp",
     "carb",
+    "Semantics",
 ]
 # Imports from this repository
 known_first_party = "omni.isaac.lab"

--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.24.16"
+version = "0.24.17"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.24.13"
+version = "0.24.16"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -31,7 +31,6 @@ Added
 * Added :meth:`grab_images` to be able to use images for an observation term in manager-based environments.
 
 
-
 0.24.14 (2024-09-20)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,13 +1,24 @@
 Changelog
 ---------
 
-0.22.15 (2024-09-20)
+0.24.16 (2024-10-03)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the deprecation notice for using ``pxr.Semantics``. The corresponding modules use ``Semantics`` module
+  directly.
+
+
+0.24.15 (2024-09-20)
 ~~~~~~~~~~~~~~~~~~~~
 
 Added
 ^^^^^
 
 * Added :meth:`grab_images` to be able to use images for an observation term in manager based environments
+
 
 0.24.14 (2024-09-20)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -8,7 +8,7 @@ Fixed
 ^^^^^
 
 * Fixed the deprecation notice for using ``pxr.Semantics``. The corresponding modules use ``Semantics`` module
-  directly. 
+  directly.
 
 
 0.24.16 (2024-10-03)

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/utils.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/utils.py
@@ -16,8 +16,9 @@ from typing import TYPE_CHECKING, Any
 import carb
 import omni.isaac.core.utils.stage as stage_utils
 import omni.kit.commands
+import Semantics
 from omni.isaac.cloner import Cloner
-from pxr import PhysxSchema, Sdf, Semantics, Usd, UsdGeom, UsdPhysics, UsdShade
+from pxr import PhysxSchema, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
 
 from omni.isaac.lab.utils.string import to_camel_case
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/utils.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/utils.py
@@ -16,9 +16,14 @@ from typing import TYPE_CHECKING, Any
 import carb
 import omni.isaac.core.utils.stage as stage_utils
 import omni.kit.commands
-import Semantics
 from omni.isaac.cloner import Cloner
 from pxr import PhysxSchema, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
+
+# from Isaac Sim 4.2 onwards, pxr.Semantics is deprecated
+try:
+    import Semantics
+except ModuleNotFoundError:
+    from pxr import Semantics
 
 from omni.isaac.lab.utils.string import to_camel_case
 

--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/direct/shadow_hand/shadow_hand_vision_env.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/direct/shadow_hand/shadow_hand_vision_env.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 import torch
 
 import omni.usd
-import Semantics
+
+# from Isaac Sim 4.2 onwards, pxr.Semantics is deprecated
+try:
+    import Semantics
+except ModuleNotFoundError:
+    from pxr import Semantics
 
 import omni.isaac.lab.sim as sim_utils
 from omni.isaac.lab.assets import Articulation, RigidObject

--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/direct/shadow_hand/shadow_hand_vision_env.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/direct/shadow_hand/shadow_hand_vision_env.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import torch
 
 import omni.usd
-from pxr import Semantics
+import Semantics
 
 import omni.isaac.lab.sim as sim_utils
 from omni.isaac.lab.assets import Articulation, RigidObject


### PR DESCRIPTION
# Description

It seems that `pxr.Semantics` module is now deprecated. Instead the `Semantics` module should be used directly. This MR makes changes to the affected modules.

Verified for Isaac Sim 4.2.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there