### PR TITLE
Fixes scaling of default ground plane

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.24.13"
+version = "0.24.16"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 ---------
 
-0.22.16 (2024-10-03)
+0.24.16 (2024-10-03)
 ~~~~~~~~~~~~~~~~~~~~
 
 Fixed
@@ -10,7 +10,7 @@ Fixed
 * Fixes parsing and application of ``size`` parameter for ``GroundPlaneCfg`` to scale the default ground plane.
 
 
-0.22.15 (2024-09-20)
+0.24.15 (2024-09-20)
 ~~~~~~~~~~~~~~~~~~~~
 
 Added

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -7,7 +7,8 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixes parsing and application of ``size`` parameter for ``GroundPlaneCfg`` to scale the default ground plane.
+* Fixes parsing and application of ``size`` parameter for :class:`~omni.isaac.lab.sim.spawn.GroundPlaneCfg` to correctly
+  scale the grid-based ground plane.
 
 
 0.24.17 (2024-10-04)

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.22.16 (2024-10-03)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixes parsing and application of ``size`` parameter for ``GroundPlaneCfg`` to scale the default ground plane.
+
+
 0.22.15 (2024-09-20)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/spawners/from_files/from_files.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/spawners/from_files/from_files.py
@@ -151,16 +151,11 @@ def spawn_ground_plane(
 
     # Scale only the mesh
     # Warning: This is specific to the default grid plane asset.
-    if prim_utils.is_prim_path_valid(f"{prim_path}/Enviroment"):
+    if prim_utils.is_prim_path_valid(f"{prim_path}/Environment"):
         # compute scale from size
         scale = (cfg.size[0] / 100.0, cfg.size[1] / 100.0, 1.0)
         # apply scale to the mesh
-        omni.kit.commands.execute(
-            "ChangeProperty",
-            prop_path=Sdf.Path(f"{prim_path}/Enviroment.xformOp:scale"),
-            value=scale,
-            prev=None,
-        )
+        prim_utils.set_prim_property(f"{prim_path}/Environment", "xformOp:scale", scale)
 
     # Change the color of the plane
     # Warning: This is specific to the default grid plane asset.


### PR DESCRIPTION
# Description

A typo in the code was preventing the `size` parameter in GroundPlaneCfg from being parsed and applied to the default ground plane. In addition, some errors are being thrown with the kit command use to apply the scale. This change fixes the typo and switches to use isaac sim core APIs for applying scale.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
