### PR TITLE
Wraps unit tests with `build_simulation_context` method

### DIFF
--- a/source/extensions/omni.isaac.lab/test/controllers/test_differential_ik.py
+++ b/source/extensions/omni.isaac.lab/test/controllers/test_differential_ik.py
@@ -15,13 +15,13 @@ simulation_app = AppLauncher(headless=True).app
 import torch
 import unittest
 
-from omni.isaac.cloner import GridCloner
 import omni.isaac.core.utils.prims as prim_utils
+from omni.isaac.cloner import GridCloner
 
 import omni.isaac.lab.sim as sim_utils
-from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.assets import Articulation
 from omni.isaac.lab.controllers import DifferentialIKController, DifferentialIKControllerCfg
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.utils.math import compute_pose_error, subtract_frame_transforms
 
 ##

--- a/source/extensions/omni.isaac.lab/test/markers/test_visualization_markers.py
+++ b/source/extensions/omni.isaac.lab/test/markers/test_visualization_markers.py
@@ -16,12 +16,10 @@ simulation_app = AppLauncher(config).app
 import torch
 import unittest
 
-import omni.isaac.core.utils.stage as stage_utils
-from omni.isaac.core.simulation_context import SimulationContext
-
 import omni.isaac.lab.sim as sim_utils
 from omni.isaac.lab.markers import VisualizationMarkers, VisualizationMarkersCfg
 from omni.isaac.lab.markers.config import FRAME_MARKER_CFG, POSITION_GOAL_MARKER_CFG
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.utils.math import random_orientation
 from omni.isaac.lab.utils.timer import Timer
 
@@ -29,178 +27,164 @@ from omni.isaac.lab.utils.timer import Timer
 class TestUsdVisualizationMarkers(unittest.TestCase):
     """Test fixture for the VisualizationMarker class."""
 
-    def setUp(self):
-        """Create a blank new stage for each test."""
-        # Simulation time-step
-        self.dt = 0.01
-        # Open a new stage
-        stage_utils.create_new_stage()
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, backend="torch", device="cuda:0")
-
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        # close stage
-        stage_utils.close_stage()
-        # clear the simulation context
-        self.sim.clear_instance()
-
     def test_instantiation(self):
         """Test that the class can be initialized properly."""
-        config = VisualizationMarkersCfg(
-            prim_path="/World/Visuals/test",
-            markers={
-                "test": sim_utils.SphereCfg(radius=1.0),
-            },
-        )
-        test_marker = VisualizationMarkers(config)
-        print(test_marker)
-        # check number of markers
-        self.assertEqual(test_marker.num_prototypes, 1)
+        with build_simulation_context():
+            config = VisualizationMarkersCfg(
+                prim_path="/World/Visuals/test",
+                markers={
+                    "test": sim_utils.SphereCfg(radius=1.0),
+                },
+            )
+            test_marker = VisualizationMarkers(config)
+            print(test_marker)
+            # check number of markers
+            self.assertEqual(test_marker.num_prototypes, 1)
 
     def test_usd_marker(self):
         """Test with marker from a USD."""
-        # create a marker
-        config = FRAME_MARKER_CFG.replace(prim_path="/World/Visuals/test_frames")
-        test_marker = VisualizationMarkers(config)
+        with build_simulation_context() as sim:
+            # create a marker
+            config = FRAME_MARKER_CFG.replace(prim_path="/World/Visuals/test_frames")
+            test_marker = VisualizationMarkers(config)
 
-        # play the simulation
-        self.sim.reset()
-        # create a buffer
-        num_frames = 0
-        # run with randomization of poses
-        for count in range(1000):
-            # sample random poses
-            if count % 50 == 0:
-                num_frames = torch.randint(10, 1000, (1,)).item()
-                frame_translations = torch.randn((num_frames, 3))
-                frame_rotations = random_orientation(num_frames, device=self.sim.device)
-                # set the marker
-                test_marker.visualize(translations=frame_translations, orientations=frame_rotations)
-            # update the kit
-            self.sim.step()
-            # asset that count is correct
-            self.assertEqual(test_marker.count, num_frames)
+            # play the simulation
+            sim.reset()
+            # create a buffer
+            num_frames = 0
+            # run with randomization of poses
+            for count in range(1000):
+                # sample random poses
+                if count % 50 == 0:
+                    num_frames = torch.randint(10, 1000, (1,)).item()
+                    frame_translations = torch.randn((num_frames, 3), device=sim.device)
+                    frame_rotations = random_orientation(num_frames, device=sim.device)
+                    # set the marker
+                    test_marker.visualize(translations=frame_translations, orientations=frame_rotations)
+                # update the kit
+                sim.step()
+                # asset that count is correct
+                self.assertEqual(test_marker.count, num_frames)
 
     def test_usd_marker_color(self):
         """Test with marker from a USD with its color modified."""
-        # create a marker
-        config = FRAME_MARKER_CFG.copy()
-        config.prim_path = "/World/Visuals/test_frames"
-        config.markers["frame"].visual_material = sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0))
-        test_marker = VisualizationMarkers(config)
+        with build_simulation_context() as sim:
+            # create a marker
+            config = FRAME_MARKER_CFG.copy()
+            config.prim_path = "/World/Visuals/test_frames"
+            config.markers["frame"].visual_material = sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0))
+            test_marker = VisualizationMarkers(config)
 
-        # play the simulation
-        self.sim.reset()
-        # run with randomization of poses
-        for count in range(1000):
-            # sample random poses
-            if count % 50 == 0:
-                num_frames = torch.randint(10, 1000, (1,)).item()
-                frame_translations = torch.randn((num_frames, 3))
-                frame_rotations = random_orientation(num_frames, device=self.sim.device)
-                # set the marker
-                test_marker.visualize(translations=frame_translations, orientations=frame_rotations)
-            # update the kit
-            self.sim.step()
+            # play the simulation
+            sim.reset()
+            # run with randomization of poses
+            for count in range(1000):
+                # sample random poses
+                if count % 50 == 0:
+                    num_frames = torch.randint(10, 1000, (1,)).item()
+                    frame_translations = torch.randn((num_frames, 3), device=sim.device)
+                    frame_rotations = random_orientation(num_frames, device=sim.device)
+                    # set the marker
+                    test_marker.visualize(translations=frame_translations, orientations=frame_rotations)
+                # update the kit
+                sim.step()
 
     def test_multiple_prototypes_marker(self):
         """Test with multiple prototypes of spheres."""
-        # create a marker
-        config = POSITION_GOAL_MARKER_CFG.replace(prim_path="/World/Visuals/test_protos")
-        test_marker = VisualizationMarkers(config)
+        with build_simulation_context() as sim:
+            # create a marker
+            config = POSITION_GOAL_MARKER_CFG.replace(prim_path="/World/Visuals/test_protos")
+            test_marker = VisualizationMarkers(config)
 
-        # play the simulation
-        self.sim.reset()
-        # run with randomization of poses
-        for count in range(1000):
-            # sample random poses
-            if count % 50 == 0:
-                num_frames = torch.randint(100, 1000, (1,)).item()
-                frame_translations = torch.randn((num_frames, 3))
-                # randomly choose a prototype
-                marker_indices = torch.randint(0, test_marker.num_prototypes, (num_frames,))
-                # set the marker
-                test_marker.visualize(translations=frame_translations, marker_indices=marker_indices)
-            # update the kit
-            self.sim.step()
+            # play the simulation
+            sim.reset()
+            # run with randomization of poses
+            for count in range(1000):
+                # sample random poses
+                if count % 50 == 0:
+                    num_frames = torch.randint(100, 1000, (1,)).item()
+                    frame_translations = torch.randn((num_frames, 3), device=sim.device)
+                    # randomly choose a prototype
+                    marker_indices = torch.randint(0, test_marker.num_prototypes, (num_frames,), device=sim.device)
+                    # set the marker
+                    test_marker.visualize(translations=frame_translations, marker_indices=marker_indices)
+                # update the kit
+                sim.step()
 
     def test_visualization_time_based_on_prototypes(self):
         """Test with time taken when number of prototypes is increased."""
+        with build_simulation_context() as sim:
+            # create a marker
+            config = POSITION_GOAL_MARKER_CFG.replace(prim_path="/World/Visuals/test_protos")
+            test_marker = VisualizationMarkers(config)
 
-        # create a marker
-        config = POSITION_GOAL_MARKER_CFG.replace(prim_path="/World/Visuals/test_protos")
-        test_marker = VisualizationMarkers(config)
+            # play the simulation
+            sim.reset()
+            # number of frames
+            num_frames = 4096
 
-        # play the simulation
-        self.sim.reset()
-        # number of frames
-        num_frames = 4096
+            # check that visibility is true
+            self.assertTrue(test_marker.is_visible())
+            # run with randomization of poses and indices
+            frame_translations = torch.randn((num_frames, 3), device=sim.device)
+            marker_indices = torch.randint(0, test_marker.num_prototypes, (num_frames,), device=sim.device)
+            # set the marker
+            with Timer("Marker visualization with explicit indices") as timer:
+                test_marker.visualize(translations=frame_translations, marker_indices=marker_indices)
+                # save the time
+                time_with_marker_indices = timer.time_elapsed
 
-        # check that visibility is true
-        self.assertTrue(test_marker.is_visible())
-        # run with randomization of poses and indices
-        frame_translations = torch.randn((num_frames, 3))
-        marker_indices = torch.randint(0, test_marker.num_prototypes, (num_frames,))
-        # set the marker
-        with Timer("Marker visualization with explicit indices") as timer:
-            test_marker.visualize(translations=frame_translations, marker_indices=marker_indices)
-            # save the time
-            time_with_marker_indices = timer.time_elapsed
+            with Timer("Marker visualization with no indices") as timer:
+                test_marker.visualize(translations=frame_translations)
+                # save the time
+                time_with_no_marker_indices = timer.time_elapsed
 
-        with Timer("Marker visualization with no indices") as timer:
-            test_marker.visualize(translations=frame_translations)
-            # save the time
-            time_with_no_marker_indices = timer.time_elapsed
-
-        # update the kit
-        self.sim.step()
-        # check that the time is less
-        self.assertLess(time_with_no_marker_indices, time_with_marker_indices)
+            # update the kit
+            sim.step()
+            # check that the time is less
+            self.assertLess(time_with_no_marker_indices, time_with_marker_indices)
 
     def test_visualization_time_based_on_visibility(self):
         """Test with visibility of markers. When invisible, the visualize call should return."""
+        with build_simulation_context() as sim:
+            # create a marker
+            config = POSITION_GOAL_MARKER_CFG.replace(prim_path="/World/Visuals/test_protos")
+            test_marker = VisualizationMarkers(config)
 
-        # create a marker
-        config = POSITION_GOAL_MARKER_CFG.replace(prim_path="/World/Visuals/test_protos")
-        test_marker = VisualizationMarkers(config)
+            # play the simulation
+            sim.reset()
+            # number of frames
+            num_frames = 4096
 
-        # play the simulation
-        self.sim.reset()
-        # number of frames
-        num_frames = 4096
+            # check that visibility is true
+            self.assertTrue(test_marker.is_visible())
+            # run with randomization of poses and indices
+            frame_translations = torch.randn((num_frames, 3))
+            marker_indices = torch.randint(0, test_marker.num_prototypes, (num_frames,))
+            # set the marker
+            with Timer("Marker visualization") as timer:
+                test_marker.visualize(translations=frame_translations, marker_indices=marker_indices)
+                # save the time
+                time_with_visualization = timer.time_elapsed
 
-        # check that visibility is true
-        self.assertTrue(test_marker.is_visible())
-        # run with randomization of poses and indices
-        frame_translations = torch.randn((num_frames, 3))
-        marker_indices = torch.randint(0, test_marker.num_prototypes, (num_frames,))
-        # set the marker
-        with Timer("Marker visualization") as timer:
-            test_marker.visualize(translations=frame_translations, marker_indices=marker_indices)
-            # save the time
-            time_with_visualization = timer.time_elapsed
+            # update the kit
+            sim.step()
+            # make invisible
+            test_marker.set_visibility(False)
 
-        # update the kit
-        self.sim.step()
-        # make invisible
-        test_marker.set_visibility(False)
+            # check that visibility is false
+            self.assertFalse(test_marker.is_visible())
+            # run with randomization of poses and indices
+            frame_translations = torch.randn((num_frames, 3), device=sim.device)
+            marker_indices = torch.randint(0, test_marker.num_prototypes, (num_frames,), device=sim.device)
+            # set the marker
+            with Timer("Marker no visualization") as timer:
+                test_marker.visualize(translations=frame_translations, marker_indices=marker_indices)
+                # save the time
+                time_with_no_visualization = timer.time_elapsed
 
-        # check that visibility is false
-        self.assertFalse(test_marker.is_visible())
-        # run with randomization of poses and indices
-        frame_translations = torch.randn((num_frames, 3))
-        marker_indices = torch.randint(0, test_marker.num_prototypes, (num_frames,))
-        # set the marker
-        with Timer("Marker no visualization") as timer:
-            test_marker.visualize(translations=frame_translations, marker_indices=marker_indices)
-            # save the time
-            time_with_no_visualization = timer.time_elapsed
-
-        # check that the time is less
-        self.assertLess(time_with_no_visualization, time_with_visualization)
+            # check that the time is less
+            self.assertLess(time_with_no_visualization, time_with_visualization)
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.lab/test/sim/test_build_simulation_context_headless.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_build_simulation_context_headless.py
@@ -4,11 +4,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 """
-This test has a lot of duplication with ``test_build_simulation_context_nonheadless.py``. This is intentional to ensure that the
-tests are run in both headless and non-headless modes, and we currently can't re-build the simulation app in a script.
+This test has a lot of duplication with ``test_build_simulation_context_nonheadless.py``. This is intentional to
+ensure that the tests are run in both headless and non-headless modes, and we currently can't re-build the
+simulation app in a script.
 
-If you need to make a change to this test, please make sure to also make the same change to ``test_build_simulation_context_nonheadless.py``.
-
+If you need to make a change to this test, please make sure to also make the same change to
+``test_build_simulation_context_nonheadless.py``.
 """
 
 """Launch Isaac Sim Simulator first."""
@@ -22,8 +23,6 @@ simulation_app = app_launcher.app
 """Rest everything follows."""
 
 import unittest
-
-from omni.isaac.core.utils.prims import is_prim_path_valid
 
 from omni.isaac.lab.sim.simulation_cfg import SimulationCfg
 from omni.isaac.lab.sim.simulation_context import build_simulation_context
@@ -56,28 +55,27 @@ class TestBuildSimulationContextHeadless(unittest.TestCase):
                             self.assertEqual(sim.cfg.dt, dt)
 
                             # Ensure that dome light didn't get added automatically as we are headless
-                            self.assertFalse(is_prim_path_valid("/World/defaultDomeLight"))
+                            self.assertFalse(sim.stage.GetPrimAtPath("/World/defaultDomeLight").IsValid())
 
     def test_build_simulation_context_ground_plane(self):
         """Test that the simulation context is built with the correct ground plane."""
         for add_ground_plane in (True, False):
             with self.subTest(add_ground_plane=add_ground_plane):
-                with build_simulation_context(add_ground_plane=add_ground_plane) as _:
+                with build_simulation_context(add_ground_plane=add_ground_plane) as sim:
                     # Ensure that ground plane got added
-                    self.assertEqual(is_prim_path_valid("/World/defaultGroundPlane"), add_ground_plane)
+                    self.assertEqual(sim.stage.GetPrimAtPath("/World/defaultGroundPlane").IsValid(), add_ground_plane)
 
     def test_build_simulation_context_auto_add_lighting(self):
         """Test that the simulation context is built with the correct lighting."""
         for add_lighting in (True, False):
             for auto_add_lighting in (True, False):
                 with self.subTest(add_lighting=add_lighting, auto_add_lighting=auto_add_lighting):
-                    with build_simulation_context(add_lighting=add_lighting, auto_add_lighting=auto_add_lighting) as _:
-                        if add_lighting:
-                            # Ensure that dome light got added
-                            self.assertTrue(is_prim_path_valid("/World/defaultDomeLight"))
-                        else:
-                            # Ensure that dome light didn't get added as there's no GUI
-                            self.assertFalse(is_prim_path_valid("/World/defaultDomeLight"))
+                    with build_simulation_context(
+                        add_lighting=add_lighting, auto_add_lighting=auto_add_lighting
+                    ) as sim:
+                        # Ensure that dome light got added
+                        # note: when no GUI the dome light shouldn't get added automatically
+                        self.assertEqual(sim.stage.GetPrimAtPath("/World/defaultDomeLight").IsValid(), add_lighting)
 
     def test_build_simulation_context_cfg(self):
         """Test that the simulation context is built with the correct cfg and values don't get overridden."""

--- a/source/extensions/omni.isaac.lab/test/sim/test_build_simulation_context_nonheadless.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_build_simulation_context_nonheadless.py
@@ -3,11 +3,12 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""This test has a lot of duplication with ``test_build_simulation_context_headless.py``. This is intentional to ensure that the
-tests are run in both headless and non-headless modes, and we currently can't re-build the simulation app in a script.
+"""This test has a lot of duplication with ``test_build_simulation_context_headless.py``. This is intentional
+to ensure that the tests are run in both headless and non-headless modes, and we currently can't re-build the
+simulation app in a script.
 
-If you need to make a change to this test, please make sure to also make the same change to ``test_build_simulation_context_headless.py``.
-
+If you need to make a change to this test, please make sure to also make the same change to
+``test_build_simulation_context_headless.py``.
 """
 
 """Launch Isaac Sim Simulator first."""
@@ -21,8 +22,6 @@ simulation_app = app_launcher.app
 """Rest everything follows."""
 
 import unittest
-
-from omni.isaac.core.utils.prims import is_prim_path_valid
 
 from omni.isaac.lab.sim.simulation_cfg import SimulationCfg
 from omni.isaac.lab.sim.simulation_context import build_simulation_context
@@ -62,22 +61,24 @@ class TestBuildSimulationContextNonheadless(unittest.TestCase):
         """Test that the simulation context is built with the correct ground plane."""
         for add_ground_plane in (True, False):
             with self.subTest(add_ground_plane=add_ground_plane):
-                with build_simulation_context(add_ground_plane=add_ground_plane) as _:
+                with build_simulation_context(add_ground_plane=add_ground_plane) as sim:
                     # Ensure that ground plane got added
-                    self.assertEqual(is_prim_path_valid("/World/defaultGroundPlane"), add_ground_plane)
+                    self.assertEqual(sim.stage.GetPrimAtPath("/World/defaultGroundPlane").IsValid(), add_ground_plane)
 
     def test_build_simulation_context_auto_add_lighting(self):
         """Test that the simulation context is built with the correct lighting."""
         for add_lighting in (True, False):
             for auto_add_lighting in (True, False):
                 with self.subTest(add_lighting=add_lighting, auto_add_lighting=auto_add_lighting):
-                    with build_simulation_context(add_lighting=add_lighting, auto_add_lighting=auto_add_lighting) as _:
-                        if auto_add_lighting or add_lighting:
-                            # Ensure that dome light got added
-                            self.assertTrue(is_prim_path_valid("/World/defaultDomeLight"))
-                        else:
-                            # Ensure that dome light didn't get added
-                            self.assertFalse(is_prim_path_valid("/World/defaultDomeLight"))
+                    with build_simulation_context(
+                        add_lighting=add_lighting, auto_add_lighting=auto_add_lighting
+                    ) as sim:
+                        # Ensure that dome light got added
+                        # If auto_add_lighting is True, then the dome light should be added regardless of add_lighting
+                        self.assertEqual(
+                            sim.stage.GetPrimAtPath("/World/defaultDomeLight").IsValid(),
+                            add_lighting or auto_add_lighting,
+                        )
 
     def test_build_simulation_context_cfg(self):
         """Test that the simulation context is built with the correct cfg and values don't get overridden."""

--- a/source/extensions/omni.isaac.lab/test/sim/test_mesh_converter.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_mesh_converter.py
@@ -18,10 +18,10 @@ import unittest
 
 import omni
 import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
-from omni.isaac.core.simulation_context import SimulationContext
+import omni.usd
 from pxr import UsdGeom, UsdPhysics
 
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.sim.converters import MeshConverter, MeshConverterCfg
 from omni.isaac.lab.sim.schemas import schemas_cfg
 from omni.isaac.lab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
@@ -47,162 +47,155 @@ class TestMeshConverter(unittest.TestCase):
         for key, value in cls.assets.items():
             cls.assets[key] = retrieve_file_path(value, download_dir=download_dir)
 
-    def setUp(self):
-        """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
-        # Simulation time-step
-        self.dt = 0.01
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, backend="numpy")
-
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        # cleanup stage and context
-        self.sim.clear()
-        self.sim.clear_all_callbacks()
-        self.sim.clear_instance()
-
     """
     Test fixtures.
     """
 
     def test_no_change(self):
         """Call conversion twice on the same input asset. This should not generate a new USD file if the hash is the same."""
-        # create an initial USD file from asset
-        mesh_config = MeshConverterCfg(asset_path=self.assets["obj"])
-        mesh_converter = MeshConverter(mesh_config)
-        time_usd_file_created = os.stat(mesh_converter.usd_path).st_mtime_ns
+        with build_simulation_context():
+            # create an initial USD file from asset
+            mesh_config = MeshConverterCfg(asset_path=self.assets["obj"])
+            mesh_converter = MeshConverter(mesh_config)
+            time_usd_file_created = os.stat(mesh_converter.usd_path).st_mtime_ns
 
-        # no change to config only define the usd directory
-        new_config = mesh_config
-        new_config.usd_dir = mesh_converter.usd_dir
-        # convert to usd but this time in the same directory as previous step
-        new_mesh_converter = MeshConverter(new_config)
-        new_time_usd_file_created = os.stat(new_mesh_converter.usd_path).st_mtime_ns
+            # no change to config only define the usd directory
+            new_config = mesh_config
+            new_config.usd_dir = mesh_converter.usd_dir
+            # convert to usd but this time in the same directory as previous step
+            new_mesh_converter = MeshConverter(new_config)
+            new_time_usd_file_created = os.stat(new_mesh_converter.usd_path).st_mtime_ns
 
-        self.assertEqual(time_usd_file_created, new_time_usd_file_created)
+            self.assertEqual(time_usd_file_created, new_time_usd_file_created)
 
     def test_config_change(self):
         """Call conversion twice but change the config in the second call. This should generate a new USD file."""
-        # create an initial USD file from asset
-        mesh_config = MeshConverterCfg(asset_path=self.assets["obj"])
-        mesh_converter = MeshConverter(mesh_config)
-        time_usd_file_created = os.stat(mesh_converter.usd_path).st_mtime_ns
+        with build_simulation_context():
+            # create an initial USD file from asset
+            mesh_config = MeshConverterCfg(asset_path=self.assets["obj"])
+            mesh_converter = MeshConverter(mesh_config)
+            time_usd_file_created = os.stat(mesh_converter.usd_path).st_mtime_ns
 
-        # change the config
-        new_config = mesh_config
-        new_config.make_instanceable = not mesh_config.make_instanceable
-        # define the usd directory
-        new_config.usd_dir = mesh_converter.usd_dir
-        # convert to usd but this time in the same directory as previous step
-        new_mesh_converter = MeshConverter(new_config)
-        new_time_usd_file_created = os.stat(new_mesh_converter.usd_path).st_mtime_ns
+            # change the config
+            new_config = mesh_config
+            new_config.make_instanceable = not mesh_config.make_instanceable
+            # define the usd directory
+            new_config.usd_dir = mesh_converter.usd_dir
+            # convert to usd but this time in the same directory as previous step
+            new_mesh_converter = MeshConverter(new_config)
+            new_time_usd_file_created = os.stat(new_mesh_converter.usd_path).st_mtime_ns
 
-        self.assertNotEqual(time_usd_file_created, new_time_usd_file_created)
+            self.assertNotEqual(time_usd_file_created, new_time_usd_file_created)
 
     def test_convert_obj(self):
         """Convert an OBJ file"""
-        mesh_config = MeshConverterCfg(asset_path=self.assets["obj"])
-        mesh_converter = MeshConverter(mesh_config)
+        with build_simulation_context():
+            mesh_config = MeshConverterCfg(asset_path=self.assets["obj"])
+            mesh_converter = MeshConverter(mesh_config)
 
-        # check that mesh conversion is successful
-        self._check_mesh_conversion(mesh_converter)
+            # check that mesh conversion is successful
+            self._check_mesh_conversion(mesh_converter)
 
     def test_convert_stl(self):
         """Convert an STL file"""
-        mesh_config = MeshConverterCfg(asset_path=self.assets["stl"])
-        mesh_converter = MeshConverter(mesh_config)
+        with build_simulation_context():
+            mesh_config = MeshConverterCfg(asset_path=self.assets["stl"])
+            mesh_converter = MeshConverter(mesh_config)
 
-        # check that mesh conversion is successful
-        self._check_mesh_conversion(mesh_converter)
+            # check that mesh conversion is successful
+            self._check_mesh_conversion(mesh_converter)
 
     def test_convert_fbx(self):
         """Convert an FBX file"""
-        mesh_config = MeshConverterCfg(asset_path=self.assets["fbx"])
-        mesh_converter = MeshConverter(mesh_config)
+        with build_simulation_context():
+            mesh_config = MeshConverterCfg(asset_path=self.assets["fbx"])
+            mesh_converter = MeshConverter(mesh_config)
 
-        # check that mesh conversion is successful
-        self._check_mesh_conversion(mesh_converter)
+            # check that mesh conversion is successful
+            self._check_mesh_conversion(mesh_converter)
 
     def test_collider_no_approximation(self):
         """Convert an OBJ file using no approximation"""
-        collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
-        mesh_config = MeshConverterCfg(
-            asset_path=self.assets["obj"],
-            collision_approximation="none",
-            collision_props=collision_props,
-        )
-        mesh_converter = MeshConverter(mesh_config)
+        with build_simulation_context():
+            collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
+            mesh_config = MeshConverterCfg(
+                asset_path=self.assets["obj"],
+                collision_approximation="none",
+                collision_props=collision_props,
+            )
+            mesh_converter = MeshConverter(mesh_config)
 
-        # check that mesh conversion is successful
-        self._check_mesh_collider_settings(mesh_converter)
+            # check that mesh conversion is successful
+            self._check_mesh_collider_settings(mesh_converter)
 
     def test_collider_convex_hull(self):
         """Convert an OBJ file using convex hull approximation"""
-        collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
-        mesh_config = MeshConverterCfg(
-            asset_path=self.assets["obj"],
-            collision_approximation="convexHull",
-            collision_props=collision_props,
-        )
-        mesh_converter = MeshConverter(mesh_config)
+        with build_simulation_context():
+            collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
+            mesh_config = MeshConverterCfg(
+                asset_path=self.assets["obj"],
+                collision_approximation="convexHull",
+                collision_props=collision_props,
+            )
+            mesh_converter = MeshConverter(mesh_config)
 
-        # check that mesh conversion is successful
-        self._check_mesh_collider_settings(mesh_converter)
+            # check that mesh conversion is successful
+            self._check_mesh_collider_settings(mesh_converter)
 
     def test_collider_mesh_simplification(self):
         """Convert an OBJ file using mesh simplification approximation"""
-        collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
-        mesh_config = MeshConverterCfg(
-            asset_path=self.assets["obj"],
-            collision_approximation="meshSimplification",
-            collision_props=collision_props,
-        )
-        mesh_converter = MeshConverter(mesh_config)
+        with build_simulation_context():
+            collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
+            mesh_config = MeshConverterCfg(
+                asset_path=self.assets["obj"],
+                collision_approximation="meshSimplification",
+                collision_props=collision_props,
+            )
+            mesh_converter = MeshConverter(mesh_config)
 
-        # check that mesh conversion is successful
-        self._check_mesh_collider_settings(mesh_converter)
+            # check that mesh conversion is successful
+            self._check_mesh_collider_settings(mesh_converter)
 
     def test_collider_mesh_bounding_cube(self):
         """Convert an OBJ file using bounding cube approximation"""
-        collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
-        mesh_config = MeshConverterCfg(
-            asset_path=self.assets["obj"],
-            collision_approximation="boundingCube",
-            collision_props=collision_props,
-        )
-        mesh_converter = MeshConverter(mesh_config)
+        with build_simulation_context():
+            collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
+            mesh_config = MeshConverterCfg(
+                asset_path=self.assets["obj"],
+                collision_approximation="boundingCube",
+                collision_props=collision_props,
+            )
+            mesh_converter = MeshConverter(mesh_config)
 
-        # check that mesh conversion is successful
-        self._check_mesh_collider_settings(mesh_converter)
+            # check that mesh conversion is successful
+            self._check_mesh_collider_settings(mesh_converter)
 
     def test_collider_mesh_bounding_sphere(self):
         """Convert an OBJ file using bounding sphere"""
-        collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
-        mesh_config = MeshConverterCfg(
-            asset_path=self.assets["obj"],
-            collision_approximation="boundingSphere",
-            collision_props=collision_props,
-        )
-        mesh_converter = MeshConverter(mesh_config)
+        with build_simulation_context():
+            collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=True)
+            mesh_config = MeshConverterCfg(
+                asset_path=self.assets["obj"],
+                collision_approximation="boundingSphere",
+                collision_props=collision_props,
+            )
+            mesh_converter = MeshConverter(mesh_config)
 
-        # check that mesh conversion is successful
-        self._check_mesh_collider_settings(mesh_converter)
+            # check that mesh conversion is successful
+            self._check_mesh_collider_settings(mesh_converter)
 
     def test_collider_mesh_no_collision(self):
-        """Convert an OBJ file using bounding sphere with collision disabled"""
-        collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=False)
-        mesh_config = MeshConverterCfg(
-            asset_path=self.assets["obj"],
-            collision_approximation="boundingSphere",
-            collision_props=collision_props,
-        )
-        mesh_converter = MeshConverter(mesh_config)
-        # check that mesh conversion is successful
-        self._check_mesh_collider_settings(mesh_converter)
+        with build_simulation_context():
+            """Convert an OBJ file using bounding sphere with collision disabled"""
+            collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=False)
+            mesh_config = MeshConverterCfg(
+                asset_path=self.assets["obj"],
+                collision_approximation="boundingSphere",
+                collision_props=collision_props,
+            )
+            mesh_converter = MeshConverter(mesh_config)
+            # check that mesh conversion is successful
+            self._check_mesh_collider_settings(mesh_converter)
 
     """
     Helper functions.
@@ -210,18 +203,20 @@ class TestMeshConverter(unittest.TestCase):
 
     def _check_mesh_conversion(self, mesh_converter: MeshConverter):
         """Check that mesh is loadable and stage is valid."""
+        # Get the stage
+        stage = omni.usd.get_context().get_stage()
+
         # Load the mesh
         prim_path = "/World/Object"
         prim_utils.create_prim(prim_path, usd_path=mesh_converter.usd_path)
         # Check prim can be properly spawned
-        self.assertTrue(prim_utils.is_prim_path_valid(prim_path))
+        self.assertTrue(stage.GetPrimAtPath(prim_path).IsValid())
         # Load a second time
         prim_path = "/World/Object2"
         prim_utils.create_prim(prim_path, usd_path=mesh_converter.usd_path)
         # Check prim can be properly spawned
-        self.assertTrue(prim_utils.is_prim_path_valid(prim_path))
+        self.assertTrue(stage.GetPrimAtPath(prim_path).IsValid())
 
-        stage = omni.usd.get_context().get_stage()
         # Check axis is z-up
         axis = UsdGeom.GetStageUpAxis(stage)
         self.assertEqual(axis, "Z")
@@ -230,18 +225,22 @@ class TestMeshConverter(unittest.TestCase):
         self.assertEqual(units, 1.0)
 
     def _check_mesh_collider_settings(self, mesh_converter: MeshConverter):
+        # Get the stage
+        stage = omni.usd.get_context().get_stage()
+
         # Check prim can be properly spawned
         prim_path = "/World/Object"
         prim_utils.create_prim(prim_path, usd_path=mesh_converter.usd_path)
-        self.assertTrue(prim_utils.is_prim_path_valid(prim_path))
+        self.assertTrue(stage.GetPrimAtPath(prim_path).IsValid())
 
         # Make uninstanceable to check collision settings
-        geom_prim = prim_utils.get_prim_at_path(prim_path + "/geometry")
+        geom_prim = stage.GetPrimAtPath(prim_path + "/geometry")
         # Check that instancing worked!
         self.assertEqual(geom_prim.IsInstanceable(), mesh_converter.cfg.make_instanceable)
+
         # Obtain mesh settings
         geom_prim.SetInstanceable(False)
-        mesh_prim = prim_utils.get_prim_at_path(prim_path + "/geometry/mesh")
+        mesh_prim = stage.GetPrimAtPath(prim_path + "/geometry/mesh")
 
         # Check collision settings
         # -- if collision is enabled, check that API is present

--- a/source/extensions/omni.isaac.lab/test/sim/test_mjcf_converter.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_mjcf_converter.py
@@ -18,10 +18,9 @@ import os
 import unittest
 
 import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
-from omni.isaac.core.simulation_context import SimulationContext
 from omni.isaac.core.utils.extensions import enable_extension, get_extension_path_from_name
 
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.sim.converters import MjcfConverter, MjcfConverterCfg
 
 
@@ -29,9 +28,6 @@ class TestMjcfConverter(unittest.TestCase):
     """Test fixture for the MjcfConverter class."""
 
     def setUp(self):
-        """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
         # retrieve path to mjcf importer extension
         enable_extension("omni.importer.mjcf")
         extension_path = get_extension_path_from_name("omni.importer.mjcf")
@@ -43,61 +39,47 @@ class TestMjcfConverter(unittest.TestCase):
             make_instanceable=True,
         )
 
-        # Simulation time-step
-        self.dt = 0.01
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, backend="numpy")
-
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        # cleanup stage and context
-        self.sim.clear()
-        self.sim.clear_all_callbacks()
-        self.sim.clear_instance()
-
     def test_no_change(self):
         """Call conversion twice. This should not generate a new USD file."""
+        with build_simulation_context():
+            mjcf_converter = MjcfConverter(self.config)
+            time_usd_file_created = os.stat(mjcf_converter.usd_path).st_mtime_ns
 
-        mjcf_converter = MjcfConverter(self.config)
-        time_usd_file_created = os.stat(mjcf_converter.usd_path).st_mtime_ns
+            # no change to config only define the usd directory
+            new_config = self.config
+            new_config.usd_dir = mjcf_converter.usd_dir
+            # convert to usd but this time in the same directory as previous step
+            new_mjcf_converter = MjcfConverter(new_config)
+            new_time_usd_file_created = os.stat(new_mjcf_converter.usd_path).st_mtime_ns
 
-        # no change to config only define the usd directory
-        new_config = self.config
-        new_config.usd_dir = mjcf_converter.usd_dir
-        # convert to usd but this time in the same directory as previous step
-        new_mjcf_converter = MjcfConverter(new_config)
-        new_time_usd_file_created = os.stat(new_mjcf_converter.usd_path).st_mtime_ns
-
-        self.assertEqual(time_usd_file_created, new_time_usd_file_created)
+            self.assertEqual(time_usd_file_created, new_time_usd_file_created)
 
     def test_config_change(self):
         """Call conversion twice but change the config in the second call. This should generate a new USD file."""
+        with build_simulation_context():
+            mjcf_converter = MjcfConverter(self.config)
+            time_usd_file_created = os.stat(mjcf_converter.usd_path).st_mtime_ns
 
-        mjcf_converter = MjcfConverter(self.config)
-        time_usd_file_created = os.stat(mjcf_converter.usd_path).st_mtime_ns
+            # change the config
+            new_config = self.config
+            new_config.fix_base = not self.config.fix_base
+            # define the usd directory
+            new_config.usd_dir = mjcf_converter.usd_dir
+            # convert to usd but this time in the same directory as previous step
+            new_mjcf_converter = MjcfConverter(new_config)
+            new_time_usd_file_created = os.stat(new_mjcf_converter.usd_path).st_mtime_ns
 
-        # change the config
-        new_config = self.config
-        new_config.fix_base = not self.config.fix_base
-        # define the usd directory
-        new_config.usd_dir = mjcf_converter.usd_dir
-        # convert to usd but this time in the same directory as previous step
-        new_mjcf_converter = MjcfConverter(new_config)
-        new_time_usd_file_created = os.stat(new_mjcf_converter.usd_path).st_mtime_ns
-
-        self.assertNotEqual(time_usd_file_created, new_time_usd_file_created)
+            self.assertNotEqual(time_usd_file_created, new_time_usd_file_created)
 
     def test_create_prim_from_usd(self):
         """Call conversion and create a prim from it."""
+        with build_simulation_context():
+            mjcf_converter = MjcfConverter(self.config)
 
-        urdf_converter = MjcfConverter(self.config)
+            prim_path = "/World/Robot"
+            prim_utils.create_prim(prim_path, usd_path=mjcf_converter.usd_path)
 
-        prim_path = "/World/Robot"
-        prim_utils.create_prim(prim_path, usd_path=urdf_converter.usd_path)
-
-        self.assertTrue(prim_utils.is_prim_path_valid(prim_path))
+            self.assertTrue(prim_utils.is_prim_path_valid(prim_path))
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.lab/test/sim/test_schemas.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_schemas.py
@@ -15,12 +15,12 @@ simulation_app = AppLauncher(headless=True).app
 import unittest
 
 import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
-from omni.isaac.core.simulation_context import SimulationContext
+import omni.usd
 from pxr import UsdPhysics
 
+import omni.isaac.lab.sim as sim_utils
 import omni.isaac.lab.sim.schemas as schemas
-from omni.isaac.lab.sim.utils import find_global_fixed_joint_prim
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.utils.assets import ISAAC_NUCLEUS_DIR
 from omni.isaac.lab.utils.string import to_camel_case
 
@@ -30,12 +30,6 @@ class TestPhysicsSchema(unittest.TestCase):
 
     def setUp(self) -> None:
         """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
-        # Simulation time-step
-        self.dt = 0.1
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, backend="numpy")
         # Set some default values for test
         self.arti_cfg = schemas.ArticulationRootPropertiesCfg(
             enabled_self_collisions=False,
@@ -73,13 +67,9 @@ class TestPhysicsSchema(unittest.TestCase):
         self.mass_cfg = schemas.MassPropertiesCfg(mass=1.0, density=100.0)
         self.joint_cfg = schemas.JointDrivePropertiesCfg(drive_type="acceleration")
 
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        self.sim.clear()
-        self.sim.clear_all_callbacks()
-        self.sim.clear_instance()
+    """
+    Test cases.
+    """
 
     def test_valid_properties_cfg(self):
         """Test that all the config instances have non-None values.
@@ -102,98 +92,102 @@ class TestPhysicsSchema(unittest.TestCase):
 
         In this case, modifying collision properties on the articulation instanced usd will fail.
         """
-        # spawn asset to the stage
-        asset_usd_file = f"{ISAAC_NUCLEUS_DIR}/Robots/ANYbotics/anymal_instanceable.usd"
-        prim_utils.create_prim("/World/asset_instanced", usd_path=asset_usd_file, translation=(0.0, 0.0, 0.62))
+        with build_simulation_context():
+            # spawn asset to the stage
+            asset_usd_file = f"{ISAAC_NUCLEUS_DIR}/Robots/ANYbotics/anymal_instanceable.usd"
+            prim_utils.create_prim("/World/asset_instanced", usd_path=asset_usd_file, translation=(0.0, 0.0, 0.62))
 
-        # set properties on the asset and check all properties are set
-        schemas.modify_articulation_root_properties("/World/asset_instanced", self.arti_cfg)
-        schemas.modify_rigid_body_properties("/World/asset_instanced", self.rigid_cfg)
-        schemas.modify_mass_properties("/World/asset_instanced", self.mass_cfg)
-        schemas.modify_joint_drive_properties("/World/asset_instanced", self.joint_cfg)
-        # validate the properties
-        self._validate_articulation_properties_on_prim("/World/asset_instanced", has_default_fixed_root=False)
-        self._validate_rigid_body_properties_on_prim("/World/asset_instanced")
-        self._validate_mass_properties_on_prim("/World/asset_instanced")
-        self._validate_joint_drive_properties_on_prim("/World/asset_instanced")
-
-        # make a fixed joint
-        # note: for this asset, it doesn't work because the root is not a rigid body
-        self.arti_cfg.fix_root_link = True
-        with self.assertRaises(NotImplementedError):
+            # set properties on the asset and check all properties are set
             schemas.modify_articulation_root_properties("/World/asset_instanced", self.arti_cfg)
+            schemas.modify_rigid_body_properties("/World/asset_instanced", self.rigid_cfg)
+            schemas.modify_mass_properties("/World/asset_instanced", self.mass_cfg)
+            schemas.modify_joint_drive_properties("/World/asset_instanced", self.joint_cfg)
+            # validate the properties
+            self._validate_articulation_properties_on_prim("/World/asset_instanced", has_default_fixed_root=False)
+            self._validate_rigid_body_properties_on_prim("/World/asset_instanced")
+            self._validate_mass_properties_on_prim("/World/asset_instanced")
+            self._validate_joint_drive_properties_on_prim("/World/asset_instanced")
+
+            # make a fixed joint
+            # note: for this asset, it doesn't work because the root is not a rigid body
+            self.arti_cfg.fix_root_link = True
+            with self.assertRaises(NotImplementedError):
+                schemas.modify_articulation_root_properties("/World/asset_instanced", self.arti_cfg)
 
     def test_modify_properties_on_articulation_usd(self):
         """Test setting properties on articulation usd."""
-        # spawn asset to the stage
-        asset_usd_file = f"{ISAAC_NUCLEUS_DIR}/Robots/Franka/franka.usd"
-        prim_utils.create_prim("/World/asset", usd_path=asset_usd_file, translation=(0.0, 0.0, 0.62))
+        with build_simulation_context():
+            # spawn asset to the stage
+            asset_usd_file = f"{ISAAC_NUCLEUS_DIR}/Robots/Franka/franka.usd"
+            prim_utils.create_prim("/World/asset", usd_path=asset_usd_file, translation=(0.0, 0.0, 0.62))
 
-        # set properties on the asset and check all properties are set
-        schemas.modify_articulation_root_properties("/World/asset", self.arti_cfg)
-        schemas.modify_rigid_body_properties("/World/asset", self.rigid_cfg)
-        schemas.modify_collision_properties("/World/asset", self.collision_cfg)
-        schemas.modify_mass_properties("/World/asset", self.mass_cfg)
-        schemas.modify_joint_drive_properties("/World/asset", self.joint_cfg)
-        # validate the properties
-        self._validate_articulation_properties_on_prim("/World/asset", has_default_fixed_root=True)
-        self._validate_rigid_body_properties_on_prim("/World/asset")
-        self._validate_collision_properties_on_prim("/World/asset")
-        self._validate_mass_properties_on_prim("/World/asset")
-        self._validate_joint_drive_properties_on_prim("/World/asset")
+            # set properties on the asset and check all properties are set
+            schemas.modify_articulation_root_properties("/World/asset", self.arti_cfg)
+            schemas.modify_rigid_body_properties("/World/asset", self.rigid_cfg)
+            schemas.modify_collision_properties("/World/asset", self.collision_cfg)
+            schemas.modify_mass_properties("/World/asset", self.mass_cfg)
+            schemas.modify_joint_drive_properties("/World/asset", self.joint_cfg)
+            # validate the properties
+            self._validate_articulation_properties_on_prim("/World/asset", has_default_fixed_root=True)
+            self._validate_rigid_body_properties_on_prim("/World/asset")
+            self._validate_collision_properties_on_prim("/World/asset")
+            self._validate_mass_properties_on_prim("/World/asset")
+            self._validate_joint_drive_properties_on_prim("/World/asset")
 
-        # make a fixed joint
-        self.arti_cfg.fix_root_link = True
-        schemas.modify_articulation_root_properties("/World/asset", self.arti_cfg)
-        # validate the properties
-        self._validate_articulation_properties_on_prim("/World/asset", has_default_fixed_root=True)
+            # make a fixed joint
+            self.arti_cfg.fix_root_link = True
+            schemas.modify_articulation_root_properties("/World/asset", self.arti_cfg)
+            # validate the properties
+            self._validate_articulation_properties_on_prim("/World/asset", has_default_fixed_root=True)
 
     def test_defining_rigid_body_properties_on_prim(self):
         """Test defining rigid body properties on a prim."""
-        # create a prim
-        prim_utils.create_prim("/World/parent", prim_type="XForm")
-        # spawn a prim
-        prim_utils.create_prim("/World/cube1", prim_type="Cube", translation=(0.0, 0.0, 0.62))
-        # set properties on the asset and check all properties are set
-        schemas.define_rigid_body_properties("/World/cube1", self.rigid_cfg)
-        schemas.define_collision_properties("/World/cube1", self.collision_cfg)
-        schemas.define_mass_properties("/World/cube1", self.mass_cfg)
-        # validate the properties
-        self._validate_rigid_body_properties_on_prim("/World/cube1")
-        self._validate_collision_properties_on_prim("/World/cube1")
-        self._validate_mass_properties_on_prim("/World/cube1")
+        with build_simulation_context() as sim:
+            # create a prim
+            prim_utils.create_prim("/World/parent", prim_type="XForm")
+            # spawn a prim
+            prim_utils.create_prim("/World/cube1", prim_type="Cube", translation=(0.0, 0.0, 0.62))
+            # set properties on the asset and check all properties are set
+            schemas.define_rigid_body_properties("/World/cube1", self.rigid_cfg)
+            schemas.define_collision_properties("/World/cube1", self.collision_cfg)
+            schemas.define_mass_properties("/World/cube1", self.mass_cfg)
+            # validate the properties
+            self._validate_rigid_body_properties_on_prim("/World/cube1")
+            self._validate_collision_properties_on_prim("/World/cube1")
+            self._validate_mass_properties_on_prim("/World/cube1")
 
-        # spawn another prim
-        prim_utils.create_prim("/World/cube2", prim_type="Cube", translation=(1.0, 1.0, 0.62))
-        # set properties on the asset and check all properties are set
-        schemas.define_rigid_body_properties("/World/cube2", self.rigid_cfg)
-        schemas.define_collision_properties("/World/cube2", self.collision_cfg)
-        # validate the properties
-        self._validate_rigid_body_properties_on_prim("/World/cube2")
-        self._validate_collision_properties_on_prim("/World/cube2")
+            # spawn another prim
+            prim_utils.create_prim("/World/cube2", prim_type="Cube", translation=(1.0, 1.0, 0.62))
+            # set properties on the asset and check all properties are set
+            schemas.define_rigid_body_properties("/World/cube2", self.rigid_cfg)
+            schemas.define_collision_properties("/World/cube2", self.collision_cfg)
+            # validate the properties
+            self._validate_rigid_body_properties_on_prim("/World/cube2")
+            self._validate_collision_properties_on_prim("/World/cube2")
 
-        # check if we can play
-        self.sim.reset()
-        for _ in range(100):
-            self.sim.step()
+            # check if we can play
+            sim.reset()
+            for _ in range(100):
+                sim.step()
 
     def test_defining_articulation_properties_on_prim(self):
         """Test defining articulation properties on a prim."""
-        # create a parent articulation
-        prim_utils.create_prim("/World/parent", prim_type="Xform")
-        schemas.define_articulation_root_properties("/World/parent", self.arti_cfg)
-        # validate the properties
-        self._validate_articulation_properties_on_prim("/World/parent", has_default_fixed_root=False)
+        with build_simulation_context() as sim:
+            # create a parent articulation
+            prim_utils.create_prim("/World/parent", prim_type="Xform")
+            schemas.define_articulation_root_properties("/World/parent", self.arti_cfg)
+            # validate the properties
+            self._validate_articulation_properties_on_prim("/World/parent", has_default_fixed_root=False)
 
-        # create a child articulation
-        prim_utils.create_prim("/World/parent/child", prim_type="Cube", translation=(0.0, 0.0, 0.62))
-        schemas.define_rigid_body_properties("/World/parent/child", self.rigid_cfg)
-        schemas.define_mass_properties("/World/parent/child", self.mass_cfg)
+            # create a child articulation
+            prim_utils.create_prim("/World/parent/child", prim_type="Cube", translation=(0.0, 0.0, 0.62))
+            schemas.define_rigid_body_properties("/World/parent/child", self.rigid_cfg)
+            schemas.define_mass_properties("/World/parent/child", self.mass_cfg)
 
-        # check if we can play
-        self.sim.reset()
-        for _ in range(100):
-            self.sim.step()
+            # check if we can play
+            sim.reset()
+            for _ in range(100):
+                sim.step()
 
     """
     Helper functions.
@@ -207,8 +201,10 @@ class TestPhysicsSchema(unittest.TestCase):
         If :attr:`has_default_fixed_root` is True, then the asset already has a fixed root link. This is used to check the
         expected behavior of the fixed root link configuration.
         """
+        # get current stage
+        stage = omni.usd.get_context().get_stage()
         # the root prim
-        root_prim = prim_utils.get_prim_at_path(prim_path)
+        root_prim = stage.GetPrimAtPath(prim_path)
         # check articulation properties are set correctly
         for attr_name, attr_value in self.arti_cfg.__dict__.items():
             # skip names we know are not present
@@ -217,7 +213,7 @@ class TestPhysicsSchema(unittest.TestCase):
             # handle fixed root link
             if attr_name == "fix_root_link" and attr_value is not None:
                 # obtain the fixed joint prim
-                fixed_joint_prim = find_global_fixed_joint_prim(prim_path)
+                fixed_joint_prim = sim_utils.find_global_fixed_joint_prim(prim_path)
                 # if asset does not have a fixed root link then check if the joint is created
                 if not has_default_fixed_root:
                     if attr_value:
@@ -249,8 +245,10 @@ class TestPhysicsSchema(unittest.TestCase):
             Right now this function exploits the hierarchy in the asset to check the properties. This is not a
             fool-proof way of checking the properties.
         """
+        # get current stage
+        stage = omni.usd.get_context().get_stage()
         # the root prim
-        root_prim = prim_utils.get_prim_at_path(prim_path)
+        root_prim = stage.GetPrimAtPath(prim_path)
         # check rigid body properties are set correctly
         for link_prim in root_prim.GetChildren():
             if UsdPhysics.RigidBodyAPI(link_prim):
@@ -277,8 +275,10 @@ class TestPhysicsSchema(unittest.TestCase):
             Right now this function exploits the hierarchy in the asset to check the properties. This is not a
             fool-proof way of checking the properties.
         """
+        # get current stage
+        stage = omni.usd.get_context().get_stage()
         # the root prim
-        root_prim = prim_utils.get_prim_at_path(prim_path)
+        root_prim = stage.GetPrimAtPath(prim_path)
         # check collision properties are set correctly
         for link_prim in root_prim.GetChildren():
             for mesh_prim in link_prim.GetChildren():
@@ -306,8 +306,10 @@ class TestPhysicsSchema(unittest.TestCase):
             Right now this function exploits the hierarchy in the asset to check the properties. This is not a
             fool-proof way of checking the properties.
         """
+        # get current stage
+        stage = omni.usd.get_context().get_stage()
         # the root prim
-        root_prim = prim_utils.get_prim_at_path(prim_path)
+        root_prim = stage.GetPrimAtPath(prim_path)
         # check rigid body mass properties are set correctly
         for link_prim in root_prim.GetChildren():
             if UsdPhysics.MassAPI(link_prim):
@@ -334,8 +336,10 @@ class TestPhysicsSchema(unittest.TestCase):
             Right now this function exploits the hierarchy in the asset to check the properties. This is not a
             fool-proof way of checking the properties.
         """
+        # get current stage
+        stage = omni.usd.get_context().get_stage()
         # the root prim
-        root_prim = prim_utils.get_prim_at_path(prim_path)
+        root_prim = stage.GetPrimAtPath(prim_path)
         # check joint drive properties are set correctly
         for link_prim in root_prim.GetAllChildren():
             for joint_prim in link_prim.GetChildren():

--- a/source/extensions/omni.isaac.lab/test/sim/test_spawn_from_files.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_spawn_from_files.py
@@ -14,8 +14,8 @@ simulation_app = AppLauncher(headless=True).app
 
 import unittest
 
-from omni.isaac.core.utils.extensions import enable_extension, get_extension_path_from_name
 import omni.usd
+from omni.isaac.core.utils.extensions import enable_extension, get_extension_path_from_name
 
 import omni.isaac.lab.sim as sim_utils
 from omni.isaac.lab.sim import build_simulation_context

--- a/source/extensions/omni.isaac.lab/test/sim/test_spawn_from_files.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_spawn_from_files.py
@@ -14,36 +14,16 @@ simulation_app = AppLauncher(headless=True).app
 
 import unittest
 
-import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
-from omni.isaac.core.simulation_context import SimulationContext
 from omni.isaac.core.utils.extensions import enable_extension, get_extension_path_from_name
+import omni.usd
 
 import omni.isaac.lab.sim as sim_utils
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.utils.assets import ISAACLAB_NUCLEUS_DIR
 
 
 class TestSpawningFromFiles(unittest.TestCase):
     """Test fixture for checking spawning of USD references from files with different settings."""
-
-    def setUp(self) -> None:
-        """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
-        # Simulation time-step
-        self.dt = 0.1
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, backend="numpy")
-        # Wait for spawning
-        stage_utils.update_stage()
-
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        self.sim.clear()
-        self.sim.clear_all_callbacks()
-        self.sim.clear_instance()
 
     """
     Basic spawning.
@@ -51,46 +31,62 @@ class TestSpawningFromFiles(unittest.TestCase):
 
     def test_spawn_usd(self):
         """Test loading prim from Usd file."""
-        # Spawn cone
-        cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd")
-        prim = cfg.func("/World/Franka", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Franka"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+        with build_simulation_context():
+            # Spawn cone
+            cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd")
+            prim = cfg.func("/World/Franka", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Franka").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
 
     def test_spawn_usd_fails(self):
         """Test loading prim from Usd file fails when asset usd path is invalid."""
-        # Spawn cone
-        cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda2_instanceable.usd")
+        with build_simulation_context():
+            # Spawn cone
+            cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda2_instanceable.usd")
 
-        with self.assertRaises(FileNotFoundError):
-            cfg.func("/World/Franka", cfg)
+            with self.assertRaises(FileNotFoundError):
+                cfg.func("/World/Franka", cfg)
 
     def test_spawn_urdf(self):
         """Test loading prim from URDF file."""
-        # retrieve path to urdf importer extension
-        enable_extension("omni.importer.urdf")
-        extension_path = get_extension_path_from_name("omni.importer.urdf")
-        # Spawn franka from URDF
-        cfg = sim_utils.UrdfFileCfg(
-            asset_path=f"{extension_path}/data/urdf/robots/franka_description/robots/panda_arm_hand.urdf", fix_base=True
-        )
-        prim = cfg.func("/World/Franka", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Franka"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+        with build_simulation_context():
+            # enable URDF importer extension
+            enable_extension("omni.importer.urdf")
+            # retrieve path to URDF importer extension
+            extension_path = get_extension_path_from_name("omni.importer.urdf")
+
+            # Spawn franka from URDF
+            cfg = sim_utils.UrdfFileCfg(
+                asset_path=f"{extension_path}/data/urdf/robots/franka_description/robots/panda_arm_hand.urdf",
+                fix_base=True,
+            )
+            prim = cfg.func("/World/Franka", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Franka").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
 
     def test_spawn_ground_plane(self):
         """Test loading prim for the ground plane from grid world USD."""
-        # Spawn ground plane
-        cfg = sim_utils.GroundPlaneCfg(color=(0.1, 0.1, 0.1), size=(10.0, 10.0))
-        prim = cfg.func("/World/ground_plane", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/ground_plane"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+        with build_simulation_context():
+            # Spawn ground plane
+            cfg = sim_utils.GroundPlaneCfg(color=(0.1, 0.1, 0.1), size=(10.0, 10.0))
+            prim = cfg.func("/World/ground_plane", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/ground_plane").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.lab/test/sim/test_spawn_lights.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_spawn_lights.py
@@ -14,36 +14,16 @@ simulation_app = AppLauncher(headless=True).app
 
 import unittest
 
-import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
-from omni.isaac.core.simulation_context import SimulationContext
+import omni.usd
 from pxr import UsdLux
 
 import omni.isaac.lab.sim as sim_utils
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.utils.string import to_camel_case
 
 
 class TestSpawningLights(unittest.TestCase):
     """Test fixture for checking spawning of USD lights with different settings."""
-
-    def setUp(self) -> None:
-        """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
-        # Simulation time-step
-        self.dt = 0.1
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, backend="numpy")
-        # Wait for spawning
-        stage_utils.update_stage()
-
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        self.sim.clear()
-        self.sim.clear_all_callbacks()
-        self.sim.clear_instance()
 
     """
     Basic spawning.
@@ -51,73 +31,88 @@ class TestSpawningLights(unittest.TestCase):
 
     def test_spawn_disk_light(self):
         """Test spawning a disk light source."""
-        cfg = sim_utils.DiskLightCfg(
-            color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100, radius=20.0
-        )
-        prim = cfg.func("/World/disk_light", cfg)
+        with build_simulation_context():
+            cfg = sim_utils.DiskLightCfg(
+                color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100, radius=20.0
+            )
+            prim = cfg.func("/World/disk_light", cfg)
 
-        # check if the light is spawned
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/disk_light"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "DiskLight")
-        # validate properties on the prim
-        self._validate_properties_on_prim("/World/disk_light", cfg)
+            # get current stage
+            stage = omni.usd.get_context().get_stage()
+            # check if the light is spawned
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/disk_light").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "DiskLight")
+            # validate properties on the prim
+            self._validate_properties_on_prim("/World/disk_light", cfg)
 
     def test_spawn_distant_light(self):
         """Test spawning a distant light."""
-        cfg = sim_utils.DistantLightCfg(
-            color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100, angle=20
-        )
-        prim = cfg.func("/World/distant_light", cfg)
+        with build_simulation_context():
+            cfg = sim_utils.DistantLightCfg(
+                color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100, angle=20
+            )
+            prim = cfg.func("/World/distant_light", cfg)
 
-        # check if the light is spawned
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/distant_light"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "DistantLight")
-        # validate properties on the prim
-        self._validate_properties_on_prim("/World/distant_light", cfg)
+            # get current stage
+            stage = omni.usd.get_context().get_stage()
+            # check if the light is spawned
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/distant_light").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "DistantLight")
+            # validate properties on the prim
+            self._validate_properties_on_prim("/World/distant_light", cfg)
 
     def test_spawn_dome_light(self):
         """Test spawning a dome light source."""
-        cfg = sim_utils.DomeLightCfg(
-            color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100
-        )
-        prim = cfg.func("/World/dome_light", cfg)
+        with build_simulation_context():
+            cfg = sim_utils.DomeLightCfg(
+                color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100
+            )
+            prim = cfg.func("/World/dome_light", cfg)
 
-        # check if the light is spawned
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/dome_light"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "DomeLight")
-        # validate properties on the prim
-        self._validate_properties_on_prim("/World/dome_light", cfg)
+            # get current stage
+            stage = omni.usd.get_context().get_stage()
+            # check if the light is spawned
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/dome_light").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "DomeLight")
+            # validate properties on the prim
+            self._validate_properties_on_prim("/World/dome_light", cfg)
 
     def test_spawn_cylinder_light(self):
         """Test spawning a cylinder light source."""
-        cfg = sim_utils.CylinderLightCfg(
-            color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100, radius=20.0
-        )
-        prim = cfg.func("/World/cylinder_light", cfg)
+        with build_simulation_context():
+            cfg = sim_utils.CylinderLightCfg(
+                color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100, radius=20.0
+            )
+            prim = cfg.func("/World/cylinder_light", cfg)
 
-        # check if the light is spawned
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/cylinder_light"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "CylinderLight")
-        # validate properties on the prim
-        self._validate_properties_on_prim("/World/cylinder_light", cfg)
+            # get current stage
+            stage = omni.usd.get_context().get_stage()
+            # check if the light is spawned
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/cylinder_light").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "CylinderLight")
+            # validate properties on the prim
+            self._validate_properties_on_prim("/World/cylinder_light", cfg)
 
     def test_spawn_sphere_light(self):
         """Test spawning a sphere light source."""
-        cfg = sim_utils.SphereLightCfg(
-            color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100, radius=20.0
-        )
-        prim = cfg.func("/World/sphere_light", cfg)
+        with build_simulation_context():
+            cfg = sim_utils.SphereLightCfg(
+                color=(0.1, 0.1, 0.1), enable_color_temperature=True, color_temperature=5500, intensity=100, radius=20.0
+            )
+            prim = cfg.func("/World/sphere_light", cfg)
 
-        # check if the light is spawned
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/sphere_light"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "SphereLight")
-        # validate properties on the prim
-        self._validate_properties_on_prim("/World/sphere_light", cfg)
+            # get current stage
+            stage = omni.usd.get_context().get_stage()
+            # check if the light is spawned
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/sphere_light").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "SphereLight")
+            # validate properties on the prim
+            self._validate_properties_on_prim("/World/sphere_light", cfg)
 
     """
     Helper functions.
@@ -130,10 +125,12 @@ class TestSpawningLights(unittest.TestCase):
             prim_path: The prim name.
             cfg: The configuration for the light source.
         """
+        # get current stage
+        stage = omni.usd.get_context().get_stage()
         # default list of params to skip
         non_usd_params = ["func", "prim_type", "visible", "semantic_tags", "copy_from_source"]
         # obtain prim
-        prim = prim_utils.get_prim_at_path(prim_path)
+        prim = stage.GetPrimAtPath(prim_path)
         for attr_name, attr_value in cfg.__dict__.items():
             # skip names we know are not present
             if attr_name in non_usd_params or attr_value is None:

--- a/source/extensions/omni.isaac.lab/test/sim/test_spawn_materials.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_spawn_materials.py
@@ -14,6 +14,7 @@ simulation_app = AppLauncher(headless=True).app
 
 import unittest
 
+import omni.isaac.core.utils.prims as prim_utils
 import omni.usd
 from pxr import UsdPhysics, UsdShade
 

--- a/source/extensions/omni.isaac.lab/test/sim/test_spawn_materials.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_spawn_materials.py
@@ -14,183 +14,193 @@ simulation_app = AppLauncher(headless=True).app
 
 import unittest
 
-import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
-from omni.isaac.core.simulation_context import SimulationContext
+import omni.usd
 from pxr import UsdPhysics, UsdShade
 
 import omni.isaac.lab.sim as sim_utils
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.utils.assets import NVIDIA_NUCLEUS_DIR
 
 
 class TestSpawningMaterials(unittest.TestCase):
     """Test fixture for checking spawning of materials."""
 
-    def setUp(self) -> None:
-        """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
-        # Simulation time-step
-        self.dt = 0.1
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, backend="numpy")
-        # Wait for spawning
-        stage_utils.update_stage()
-
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        self.sim.clear()
-        self.sim.clear_all_callbacks()
-        self.sim.clear_instance()
-
     def test_spawn_preview_surface(self):
         """Test spawning preview surface."""
-        # Spawn preview surface
-        cfg = sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0))
-        prim = cfg.func("/Looks/PreviewSurface", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/Looks/PreviewSurface"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Shader")
-        # Check properties
-        self.assertEqual(prim.GetAttribute("inputs:diffuseColor").Get(), cfg.diffuse_color)
+        with build_simulation_context():
+            # Spawn preview surface
+            cfg = sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0))
+            prim = cfg.func("/Looks/PreviewSurface", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/Looks/PreviewSurface").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Shader")
+            # Check properties
+            self.assertEqual(prim.GetAttribute("inputs:diffuseColor").Get(), cfg.diffuse_color)
 
     def test_spawn_mdl_material(self):
         """Test spawning mdl material."""
-        # Spawn mdl material
-        cfg = sim_utils.materials.MdlFileCfg(
-            mdl_path=f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Metals/Aluminum_Anodized.mdl",
-            project_uvw=True,
-            albedo_brightness=0.5,
-        )
-        prim = cfg.func("/Looks/MdlMaterial", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/Looks/MdlMaterial"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Shader")
-        # Check properties
-        self.assertEqual(prim.GetAttribute("inputs:project_uvw").Get(), cfg.project_uvw)
-        self.assertEqual(prim.GetAttribute("inputs:albedo_brightness").Get(), cfg.albedo_brightness)
+        with build_simulation_context():
+            # Spawn mdl material
+            cfg = sim_utils.materials.MdlFileCfg(
+                mdl_path=f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Metals/Aluminum_Anodized.mdl",
+                project_uvw=True,
+                albedo_brightness=0.5,
+            )
+            prim = cfg.func("/Looks/MdlMaterial", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/Looks/MdlMaterial").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Shader")
+            # Check properties
+            self.assertEqual(prim.GetAttribute("inputs:project_uvw").Get(), cfg.project_uvw)
+            self.assertEqual(prim.GetAttribute("inputs:albedo_brightness").Get(), cfg.albedo_brightness)
 
     def test_spawn_glass_mdl_material(self):
         """Test spawning a glass mdl material."""
-        # Spawn mdl material
-        cfg = sim_utils.materials.GlassMdlCfg(thin_walled=False, glass_ior=1.0, glass_color=(0.0, 1.0, 0.0))
-        prim = cfg.func("/Looks/GlassMaterial", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/Looks/GlassMaterial"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Shader")
-        # Check properties
-        self.assertEqual(prim.GetAttribute("inputs:thin_walled").Get(), cfg.thin_walled)
-        self.assertEqual(prim.GetAttribute("inputs:glass_ior").Get(), cfg.glass_ior)
-        self.assertEqual(prim.GetAttribute("inputs:glass_color").Get(), cfg.glass_color)
+        with build_simulation_context():
+            # Spawn mdl material
+            cfg = sim_utils.materials.GlassMdlCfg(thin_walled=False, glass_ior=1.0, glass_color=(0.0, 1.0, 0.0))
+            prim = cfg.func("/Looks/GlassMaterial", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/Looks/GlassMaterial").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Shader")
+            # Check properties
+            self.assertEqual(prim.GetAttribute("inputs:thin_walled").Get(), cfg.thin_walled)
+            self.assertEqual(prim.GetAttribute("inputs:glass_ior").Get(), cfg.glass_ior)
+            self.assertEqual(prim.GetAttribute("inputs:glass_color").Get(), cfg.glass_color)
 
     def test_spawn_rigid_body_material(self):
         """Test spawning a rigid body material."""
-        # spawn physics material
-        cfg = sim_utils.materials.RigidBodyMaterialCfg(
-            dynamic_friction=1.5,
-            restitution=1.5,
-            static_friction=0.5,
-            restitution_combine_mode="max",
-            friction_combine_mode="max",
-            improve_patch_friction=True,
-        )
-        prim = cfg.func("/Looks/RigidBodyMaterial", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/Looks/RigidBodyMaterial"))
-        # Check properties
-        self.assertEqual(prim.GetAttribute("physics:staticFriction").Get(), cfg.static_friction)
-        self.assertEqual(prim.GetAttribute("physics:dynamicFriction").Get(), cfg.dynamic_friction)
-        self.assertEqual(prim.GetAttribute("physics:restitution").Get(), cfg.restitution)
-        self.assertEqual(prim.GetAttribute("physxMaterial:improvePatchFriction").Get(), cfg.improve_patch_friction)
-        self.assertEqual(prim.GetAttribute("physxMaterial:restitutionCombineMode").Get(), cfg.restitution_combine_mode)
-        self.assertEqual(prim.GetAttribute("physxMaterial:frictionCombineMode").Get(), cfg.friction_combine_mode)
+        with build_simulation_context():
+            # spawn physics material
+            cfg = sim_utils.materials.RigidBodyMaterialCfg(
+                dynamic_friction=1.5,
+                restitution=1.5,
+                static_friction=0.5,
+                restitution_combine_mode="max",
+                friction_combine_mode="max",
+                improve_patch_friction=True,
+            )
+            prim = cfg.func("/Looks/RigidBodyMaterial", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/Looks/RigidBodyMaterial").IsValid())
+            # Check properties
+            self.assertEqual(prim.GetAttribute("physics:staticFriction").Get(), cfg.static_friction)
+            self.assertEqual(prim.GetAttribute("physics:dynamicFriction").Get(), cfg.dynamic_friction)
+            self.assertEqual(prim.GetAttribute("physics:restitution").Get(), cfg.restitution)
+            self.assertEqual(prim.GetAttribute("physxMaterial:improvePatchFriction").Get(), cfg.improve_patch_friction)
+            self.assertEqual(
+                prim.GetAttribute("physxMaterial:restitutionCombineMode").Get(), cfg.restitution_combine_mode
+            )
+            self.assertEqual(prim.GetAttribute("physxMaterial:frictionCombineMode").Get(), cfg.friction_combine_mode)
 
     def test_spawn_deformable_body_material(self):
         """Test spawning a deformable body material."""
-        # spawn deformable body material
-        cfg = sim_utils.materials.DeformableBodyMaterialCfg(
-            density=1.0,
-            dynamic_friction=0.25,
-            youngs_modulus=50000000.0,
-            poissons_ratio=0.5,
-            elasticity_damping=0.005,
-            damping_scale=1.0,
-        )
-        prim = cfg.func("/Looks/DeformableBodyMaterial", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/Looks/DeformableBodyMaterial"))
-        # Check properties
-        self.assertEqual(prim.GetAttribute("physxDeformableBodyMaterial:density").Get(), cfg.density)
-        self.assertEqual(prim.GetAttribute("physxDeformableBodyMaterial:dynamicFriction").Get(), cfg.dynamic_friction)
-        self.assertEqual(prim.GetAttribute("physxDeformableBodyMaterial:youngsModulus").Get(), cfg.youngs_modulus)
-        self.assertEqual(prim.GetAttribute("physxDeformableBodyMaterial:poissonsRatio").Get(), cfg.poissons_ratio)
-        self.assertAlmostEqual(
-            prim.GetAttribute("physxDeformableBodyMaterial:elasticityDamping").Get(), cfg.elasticity_damping
-        )
-        self.assertEqual(prim.GetAttribute("physxDeformableBodyMaterial:dampingScale").Get(), cfg.damping_scale)
+        with build_simulation_context():
+            # spawn deformable body material
+            cfg = sim_utils.materials.DeformableBodyMaterialCfg(
+                density=1.0,
+                dynamic_friction=0.25,
+                youngs_modulus=50000000.0,
+                poissons_ratio=0.5,
+                elasticity_damping=0.005,
+                damping_scale=1.0,
+            )
+            prim = cfg.func("/Looks/DeformableBodyMaterial", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/Looks/DeformableBodyMaterial").IsValid())
+            # Check properties
+            self.assertEqual(prim.GetAttribute("physxDeformableBodyMaterial:density").Get(), cfg.density)
+            self.assertEqual(
+                prim.GetAttribute("physxDeformableBodyMaterial:dynamicFriction").Get(), cfg.dynamic_friction
+            )
+            self.assertEqual(prim.GetAttribute("physxDeformableBodyMaterial:youngsModulus").Get(), cfg.youngs_modulus)
+            self.assertEqual(prim.GetAttribute("physxDeformableBodyMaterial:poissonsRatio").Get(), cfg.poissons_ratio)
+            self.assertAlmostEqual(
+                prim.GetAttribute("physxDeformableBodyMaterial:elasticityDamping").Get(), cfg.elasticity_damping
+            )
+            self.assertEqual(prim.GetAttribute("physxDeformableBodyMaterial:dampingScale").Get(), cfg.damping_scale)
 
     def test_apply_rigid_body_material_on_visual_material(self):
         """Test applying a rigid body material on a visual material."""
-        # Spawn mdl material
-        cfg = sim_utils.materials.GlassMdlCfg(thin_walled=False, glass_ior=1.0, glass_color=(0.0, 1.0, 0.0))
-        prim = cfg.func("/Looks/Material", cfg)
-        # spawn physics material
-        cfg = sim_utils.materials.RigidBodyMaterialCfg(
-            dynamic_friction=1.5,
-            restitution=1.5,
-            static_friction=0.5,
-            restitution_combine_mode="max",
-            friction_combine_mode="max",
-            improve_patch_friction=True,
-        )
-        prim = cfg.func("/Looks/Material", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/Looks/Material"))
-        # Check properties
-        self.assertEqual(prim.GetAttribute("physics:staticFriction").Get(), cfg.static_friction)
-        self.assertEqual(prim.GetAttribute("physics:dynamicFriction").Get(), cfg.dynamic_friction)
-        self.assertEqual(prim.GetAttribute("physics:restitution").Get(), cfg.restitution)
-        self.assertEqual(prim.GetAttribute("physxMaterial:improvePatchFriction").Get(), cfg.improve_patch_friction)
-        self.assertEqual(prim.GetAttribute("physxMaterial:restitutionCombineMode").Get(), cfg.restitution_combine_mode)
-        self.assertEqual(prim.GetAttribute("physxMaterial:frictionCombineMode").Get(), cfg.friction_combine_mode)
+        with build_simulation_context():
+            # Spawn mdl material
+            cfg = sim_utils.materials.GlassMdlCfg(thin_walled=False, glass_ior=1.0, glass_color=(0.0, 1.0, 0.0))
+            prim = cfg.func("/Looks/Material", cfg)
+            # spawn physics material
+            cfg = sim_utils.materials.RigidBodyMaterialCfg(
+                dynamic_friction=1.5,
+                restitution=1.5,
+                static_friction=0.5,
+                restitution_combine_mode="max",
+                friction_combine_mode="max",
+                improve_patch_friction=True,
+            )
+            prim = cfg.func("/Looks/Material", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/Looks/Material").IsValid())
+            # Check properties
+            self.assertEqual(prim.GetAttribute("physics:staticFriction").Get(), cfg.static_friction)
+            self.assertEqual(prim.GetAttribute("physics:dynamicFriction").Get(), cfg.dynamic_friction)
+            self.assertEqual(prim.GetAttribute("physics:restitution").Get(), cfg.restitution)
+            self.assertEqual(prim.GetAttribute("physxMaterial:improvePatchFriction").Get(), cfg.improve_patch_friction)
+            self.assertEqual(
+                prim.GetAttribute("physxMaterial:restitutionCombineMode").Get(), cfg.restitution_combine_mode
+            )
+            self.assertEqual(prim.GetAttribute("physxMaterial:frictionCombineMode").Get(), cfg.friction_combine_mode)
 
     def test_bind_prim_to_material(self):
         """Test binding a rigid body material on a mesh prim."""
+        with build_simulation_context():
+            # create a mesh prim
+            object_prim = prim_utils.create_prim("/World/Geometry/box", "Cube")
+            UsdPhysics.CollisionAPI.Apply(object_prim)
 
-        # create a mesh prim
-        object_prim = prim_utils.create_prim("/World/Geometry/box", "Cube")
-        UsdPhysics.CollisionAPI.Apply(object_prim)
+            # create a visual material
+            visual_material_cfg = sim_utils.GlassMdlCfg(glass_ior=1.0, thin_walled=True)
+            visual_material_cfg.func("/World/Looks/glassMaterial", visual_material_cfg)
+            # create a physics material
+            physics_material_cfg = sim_utils.RigidBodyMaterialCfg(
+                static_friction=0.5, dynamic_friction=1.5, restitution=1.5
+            )
+            physics_material_cfg.func("/World/Physics/rubberMaterial", physics_material_cfg)
+            # bind the visual material to the mesh prim
+            sim_utils.bind_visual_material("/World/Geometry/box", "/World/Looks/glassMaterial")
+            sim_utils.bind_physics_material("/World/Geometry/box", "/World/Physics/rubberMaterial")
 
-        # create a visual material
-        visual_material_cfg = sim_utils.GlassMdlCfg(glass_ior=1.0, thin_walled=True)
-        visual_material_cfg.func("/World/Looks/glassMaterial", visual_material_cfg)
-        # create a physics material
-        physics_material_cfg = sim_utils.RigidBodyMaterialCfg(
-            static_friction=0.5, dynamic_friction=1.5, restitution=1.5
-        )
-        physics_material_cfg.func("/World/Physics/rubberMaterial", physics_material_cfg)
-        # bind the visual material to the mesh prim
-        sim_utils.bind_visual_material("/World/Geometry/box", "/World/Looks/glassMaterial")
-        sim_utils.bind_physics_material("/World/Geometry/box", "/World/Physics/rubberMaterial")
-
-        # check the main material binding
-        material_binding_api = UsdShade.MaterialBindingAPI(object_prim)
-        # -- visual
-        material_direct_binding = material_binding_api.GetDirectBinding()
-        self.assertEqual(material_direct_binding.GetMaterialPath(), "/World/Looks/glassMaterial")
-        self.assertEqual(material_direct_binding.GetMaterialPurpose(), "")
-        # -- physics
-        material_direct_binding = material_binding_api.GetDirectBinding("physics")
-        self.assertEqual(material_direct_binding.GetMaterialPath(), "/World/Physics/rubberMaterial")
-        self.assertEqual(material_direct_binding.GetMaterialPurpose(), "physics")
+            # check the main material binding
+            material_binding_api = UsdShade.MaterialBindingAPI(object_prim)
+            # -- visual
+            material_direct_binding = material_binding_api.GetDirectBinding()
+            self.assertEqual(material_direct_binding.GetMaterialPath(), "/World/Looks/glassMaterial")
+            self.assertEqual(material_direct_binding.GetMaterialPurpose(), "")
+            # -- physics
+            material_direct_binding = material_binding_api.GetDirectBinding("physics")
+            self.assertEqual(material_direct_binding.GetMaterialPath(), "/World/Physics/rubberMaterial")
+            self.assertEqual(material_direct_binding.GetMaterialPurpose(), "physics")
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.lab/test/sim/test_spawn_meshes.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_spawn_meshes.py
@@ -14,34 +14,14 @@ simulation_app = AppLauncher(headless=True).app
 
 import unittest
 
-import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
-from omni.isaac.core.simulation_context import SimulationContext
+import omni.usd
 
 import omni.isaac.lab.sim as sim_utils
+from omni.isaac.lab.sim import build_simulation_context
 
 
 class TestSpawningMeshGeometries(unittest.TestCase):
     """Test fixture for checking spawning of USD-Mesh prim with different settings."""
-
-    def setUp(self) -> None:
-        """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
-        # Simulation time-step
-        self.dt = 0.1
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, device="cuda:0")
-        # Wait for spawning
-        stage_utils.update_stage()
-
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        self.sim.clear()
-        self.sim.clear_all_callbacks()
-        self.sim.clear_instance()
 
     """
     Basic spawning.
@@ -49,68 +29,88 @@ class TestSpawningMeshGeometries(unittest.TestCase):
 
     def test_spawn_cone(self):
         """Test spawning of UsdGeomMesh as a cone prim."""
-        # Spawn cone
-        cfg = sim_utils.MeshConeCfg(radius=1.0, height=2.0, axis="Y")
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cone/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
+        with build_simulation_context():
+            # Spawn cone
+            cfg = sim_utils.MeshConeCfg(radius=1.0, height=2.0, axis="Y")
+            prim = cfg.func("/World/Cone", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cone/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
 
     def test_spawn_capsule(self):
         """Test spawning of UsdGeomMesh as a capsule prim."""
-        # Spawn capsule
-        cfg = sim_utils.MeshCapsuleCfg(radius=1.0, height=2.0, axis="Y")
-        prim = cfg.func("/World/Capsule", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Capsule"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Capsule/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
+        with build_simulation_context():
+            # Spawn capsule
+            cfg = sim_utils.MeshCapsuleCfg(radius=1.0, height=2.0, axis="Y")
+            prim = cfg.func("/World/Capsule", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Capsule").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Capsule/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
 
     def test_spawn_cylinder(self):
         """Test spawning of UsdGeomMesh as a cylinder prim."""
-        # Spawn cylinder
-        cfg = sim_utils.MeshCylinderCfg(radius=1.0, height=2.0, axis="Y")
-        prim = cfg.func("/World/Cylinder", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cylinder"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cylinder/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
+        with build_simulation_context():
+            # Spawn cylinder
+            cfg = sim_utils.MeshCylinderCfg(radius=1.0, height=2.0, axis="Y")
+            prim = cfg.func("/World/Cylinder", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cylinder").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cylinder/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
 
     def test_spawn_cuboid(self):
         """Test spawning of UsdGeomMesh as a cuboid prim."""
-        # Spawn cuboid
-        cfg = sim_utils.MeshCuboidCfg(size=(1.0, 2.0, 3.0))
-        prim = cfg.func("/World/Cube", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cube"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cube/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
+        with build_simulation_context():
+            # Spawn cuboid
+            cfg = sim_utils.MeshCuboidCfg(size=(1.0, 2.0, 3.0))
+            prim = cfg.func("/World/Cube", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cube").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cube/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
 
     def test_spawn_sphere(self):
         """Test spawning of UsdGeomMesh as a sphere prim."""
-        # Spawn sphere
-        cfg = sim_utils.MeshSphereCfg(radius=1.0)
-        prim = cfg.func("/World/Sphere", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Sphere"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Sphere/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
+        with build_simulation_context():
+            # Spawn sphere
+            cfg = sim_utils.MeshSphereCfg(radius=1.0)
+            prim = cfg.func("/World/Sphere", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Sphere").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Sphere/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Mesh")
 
     """
     Physics properties.
@@ -118,45 +118,53 @@ class TestSpawningMeshGeometries(unittest.TestCase):
 
     def test_spawn_cone_with_deformable_props(self):
         """Test spawning of UsdGeomMesh prim for a cone with deformable body API."""
-        # Spawn cone
-        cfg = sim_utils.MeshConeCfg(
-            radius=1.0,
-            height=2.0,
-            deformable_props=sim_utils.DeformableBodyPropertiesCfg(deformable_enabled=True),
-        )
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
+        with build_simulation_context():
+            # Spawn cone
+            cfg = sim_utils.MeshConeCfg(
+                radius=1.0,
+                height=2.0,
+                deformable_props=sim_utils.DeformableBodyPropertiesCfg(deformable_enabled=True),
+            )
+            prim = cfg.func("/World/Cone", cfg)
 
-        # Check properties
-        # Unlike rigid body, deformable body properties are on the mesh prim
-        prim = prim_utils.get_prim_at_path("/World/Cone/geometry/mesh")
-        self.assertEqual(
-            prim.GetAttribute("physxDeformable:deformableEnabled").Get(), cfg.deformable_props.deformable_enabled
-        )
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+
+            # Check properties
+            # Unlike rigid body, deformable body properties are on the mesh prim
+            prim = stage.GetPrimAtPath("/World/Cone/geometry/mesh")
+            self.assertEqual(
+                prim.GetAttribute("physxDeformable:deformableEnabled").Get(), cfg.deformable_props.deformable_enabled
+            )
 
     def test_spawn_cone_with_deformable_and_mass_props(self):
         """Test spawning of UsdGeomMesh prim for a cone with deformable body and mass API."""
-        # Spawn cone
-        cfg = sim_utils.MeshConeCfg(
-            radius=1.0,
-            height=2.0,
-            deformable_props=sim_utils.DeformableBodyPropertiesCfg(deformable_enabled=True),
-            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
-        )
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cone/geometry/mesh")
-        self.assertEqual(prim.GetAttribute("physics:mass").Get(), cfg.mass_props.mass)
+        with build_simulation_context():
+            # Spawn cone
+            cfg = sim_utils.MeshConeCfg(
+                radius=1.0,
+                height=2.0,
+                deformable_props=sim_utils.DeformableBodyPropertiesCfg(deformable_enabled=True),
+                mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            )
+            prim = cfg.func("/World/Cone", cfg)
 
-        # check sim playing
-        self.sim.play()
-        for _ in range(10):
-            self.sim.step()
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cone/geometry/mesh")
+            self.assertEqual(prim.GetAttribute("physics:mass").Get(), cfg.mass_props.mass)
+
+            # check sim playing
+            self.sim.play()
+            for _ in range(10):
+                self.sim.step()
 
     def test_spawn_cone_with_deformable_and_density_props(self):
         """Test spawning of UsdGeomMesh prim for a cone with deformable body and mass API.
@@ -166,91 +174,103 @@ class TestSpawningMeshGeometries(unittest.TestCase):
             the collision shape to compute the mass. Thus, we have to set the collider properties. In
             order to not have a collision shape, we disable the collision.
         """
-        # Spawn cone
-        cfg = sim_utils.MeshConeCfg(
-            radius=1.0,
-            height=2.0,
-            deformable_props=sim_utils.DeformableBodyPropertiesCfg(deformable_enabled=True),
-            mass_props=sim_utils.MassPropertiesCfg(density=10.0),
-        )
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cone/geometry/mesh")
-        self.assertEqual(prim.GetAttribute("physics:density").Get(), cfg.mass_props.density)
-        # check sim playing
-        self.sim.play()
-        for _ in range(10):
-            self.sim.step()
+        with build_simulation_context():
+            # Spawn cone
+            cfg = sim_utils.MeshConeCfg(
+                radius=1.0,
+                height=2.0,
+                deformable_props=sim_utils.DeformableBodyPropertiesCfg(deformable_enabled=True),
+                mass_props=sim_utils.MassPropertiesCfg(density=10.0),
+            )
+            prim = cfg.func("/World/Cone", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cone/geometry/mesh")
+            self.assertEqual(prim.GetAttribute("physics:density").Get(), cfg.mass_props.density)
+            # check sim playing
+            self.sim.play()
+            for _ in range(10):
+                self.sim.step()
 
     def test_spawn_cone_with_all_deformable_props(self):
         """Test spawning of UsdGeomMesh prim for a cone with all deformable properties."""
-        # Spawn cone
-        cfg = sim_utils.MeshConeCfg(
-            radius=1.0,
-            height=2.0,
-            mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
-            deformable_props=sim_utils.DeformableBodyPropertiesCfg(),
-            visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
-            physics_material=sim_utils.materials.DeformableBodyMaterialCfg(),
-        )
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone/geometry/material"))
-        # Check properties
-        # -- deformable body
-        prim = prim_utils.get_prim_at_path("/World/Cone/geometry/mesh")
-        self.assertEqual(prim.GetAttribute("physxDeformable:deformableEnabled").Get(), True)
+        with build_simulation_context() as sim:
+            # Spawn cone
+            cfg = sim_utils.MeshConeCfg(
+                radius=1.0,
+                height=2.0,
+                mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
+                deformable_props=sim_utils.DeformableBodyPropertiesCfg(),
+                visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
+                physics_material=sim_utils.materials.DeformableBodyMaterialCfg(),
+            )
+            prim = cfg.func("/World/Cone", cfg)
 
-        # check sim playing
-        self.sim.play()
-        for _ in range(10):
-            self.sim.step()
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone/geometry/mesh").IsValid())
+            # Check properties
+            # -- deformable body
+            prim = stage.GetPrimAtPath("/World/Cone/geometry/mesh")
+            self.assertEqual(prim.GetAttribute("physxDeformable:deformableEnabled").Get(), True)
+
+            # check sim playing
+            sim.play()
+            for _ in range(10):
+                sim.step()
 
     def test_spawn_cone_with_all_rigid_props(self):
         """Test spawning of UsdGeomMesh prim for a cone with all rigid properties."""
-        # Spawn cone
-        cfg = sim_utils.MeshConeCfg(
-            radius=1.0,
-            height=2.0,
-            mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
-                rigid_body_enabled=True, solver_position_iteration_count=8, sleep_threshold=0.1
-            ),
-            collision_props=sim_utils.CollisionPropertiesCfg(),
-            visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
-            physics_material=sim_utils.materials.RigidBodyMaterialCfg(),
-        )
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone/geometry/material"))
-        # Check properties
-        # -- rigid body
-        prim = prim_utils.get_prim_at_path("/World/Cone")
-        self.assertEqual(prim.GetAttribute("physics:rigidBodyEnabled").Get(), cfg.rigid_props.rigid_body_enabled)
-        self.assertEqual(
-            prim.GetAttribute("physxRigidBody:solverPositionIterationCount").Get(),
-            cfg.rigid_props.solver_position_iteration_count,
-        )
-        self.assertAlmostEqual(
-            prim.GetAttribute("physxRigidBody:sleepThreshold").Get(), cfg.rigid_props.sleep_threshold
-        )
-        # -- mass
-        self.assertEqual(prim.GetAttribute("physics:mass").Get(), cfg.mass_props.mass)
-        # -- collision shape
-        prim = prim_utils.get_prim_at_path("/World/Cone/geometry/mesh")
-        self.assertEqual(prim.GetAttribute("physics:collisionEnabled").Get(), True)
+        with build_simulation_context() as sim:
+            # Spawn cone
+            cfg = sim_utils.MeshConeCfg(
+                radius=1.0,
+                height=2.0,
+                mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                    rigid_body_enabled=True, solver_position_iteration_count=8, sleep_threshold=0.1
+                ),
+                collision_props=sim_utils.CollisionPropertiesCfg(),
+                visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
+                physics_material=sim_utils.materials.RigidBodyMaterialCfg(),
+            )
+            prim = cfg.func("/World/Cone", cfg)
 
-        # check sim playing
-        self.sim.play()
-        for _ in range(10):
-            self.sim.step()
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone/geometry/material").IsValid())
+            # Check properties
+            # -- rigid body
+            prim = stage.GetPrimAtPath("/World/Cone")
+            self.assertEqual(prim.GetAttribute("physics:rigidBodyEnabled").Get(), cfg.rigid_props.rigid_body_enabled)
+            self.assertEqual(
+                prim.GetAttribute("physxRigidBody:solverPositionIterationCount").Get(),
+                cfg.rigid_props.solver_position_iteration_count,
+            )
+            self.assertAlmostEqual(
+                prim.GetAttribute("physxRigidBody:sleepThreshold").Get(), cfg.rigid_props.sleep_threshold
+            )
+            # -- mass
+            self.assertEqual(prim.GetAttribute("physics:mass").Get(), cfg.mass_props.mass)
+            # -- collision shape
+            prim = stage.GetPrimAtPath("/World/Cone/geometry/mesh")
+            self.assertEqual(prim.GetAttribute("physics:collisionEnabled").Get(), True)
+
+            # check sim playing
+            sim.play()
+            for _ in range(10):
+                sim.step()
 
     def test_spawn_deformable_rigid_cone_invalid(self):
         """Test specifying both rigid and deformable properties for a cone causes an error."""
@@ -310,56 +330,63 @@ class TestSpawningMeshGeometries(unittest.TestCase):
 
     def test_spawn_cone_clones_invalid_paths(self):
         """Test spawning of cone clones on invalid cloning paths."""
-        num_clones = 10
-        for i in range(num_clones):
-            prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
-        # Spawn cone
-        cfg = sim_utils.MeshConeCfg(radius=1.0, height=2.0, copy_from_source=True)
-        # Should raise error for invalid path
-        with self.assertRaises(RuntimeError):
-            cfg.func("/World/env/env_.*/Cone", cfg)
+        with build_simulation_context():
+            num_clones = 10
+            for i in range(num_clones):
+                prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+            # Spawn cone
+            cfg = sim_utils.MeshConeCfg(radius=1.0, height=2.0, copy_from_source=True)
+            # Should raise error for invalid path
+            with self.assertRaises(RuntimeError):
+                cfg.func("/World/env/env_.*/Cone", cfg)
 
     def test_spawn_cone_clones(self):
         """Test spawning of cone clones."""
-        num_clones = 10
-        for i in range(num_clones):
-            prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
-        # Spawn cone
-        cfg = sim_utils.MeshConeCfg(radius=1.0, height=2.0, copy_from_source=True)
-        prim = cfg.func("/World/env_.*/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertEqual(prim_utils.get_prim_path(prim), "/World/env_0/Cone")
-        # Find matching prims
-        prims = prim_utils.find_matching_prim_paths("/World/env_*/Cone")
-        self.assertEqual(len(prims), num_clones)
+        with build_simulation_context():
+            num_clones = 10
+            for i in range(num_clones):
+                prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+            # Spawn cone
+            cfg = sim_utils.MeshConeCfg(radius=1.0, height=2.0, copy_from_source=True)
+            prim = cfg.func("/World/env_.*/Cone", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/env_0/Cone").IsValid())
+            # Find matching prims
+            prim_paths = sim_utils.find_matching_prim_paths("/World/env_*/Cone")
+            self.assertEqual(len(prim_paths), num_clones)
 
     def test_spawn_cone_clone_with_all_props_global_material(self):
         """Test spawning of cone clones with global material reference."""
-        num_clones = 10
-        for i in range(num_clones):
-            prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
-        # Spawn cone
-        cfg = sim_utils.MeshConeCfg(
-            radius=1.0,
-            height=2.0,
-            mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
-            deformable_props=sim_utils.DeformableBodyPropertiesCfg(),
-            visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
-            physics_material=sim_utils.materials.DeformableBodyMaterialCfg(),
-            visual_material_path="/Looks/visualMaterial",
-            physics_material_path="/Looks/physicsMaterial",
-        )
-        prim = cfg.func("/World/env_.*/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertEqual(prim_utils.get_prim_path(prim), "/World/env_0/Cone")
-        # Find matching prims
-        prims = prim_utils.find_matching_prim_paths("/World/env_*/Cone")
-        self.assertEqual(len(prims), num_clones)
-        # Find global materials
-        prims = prim_utils.find_matching_prim_paths("/Looks/visualMaterial.*")
-        self.assertEqual(len(prims), 1)
+        with build_simulation_context():
+            num_clones = 10
+            for i in range(num_clones):
+                prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+            # Spawn cone
+            cfg = sim_utils.MeshConeCfg(
+                radius=1.0,
+                height=2.0,
+                mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
+                deformable_props=sim_utils.DeformableBodyPropertiesCfg(),
+                visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
+                physics_material=sim_utils.materials.DeformableBodyMaterialCfg(),
+                visual_material_path="/Looks/visualMaterial",
+                physics_material_path="/Looks/physicsMaterial",
+            )
+            prim = cfg.func("/World/env_.*/Cone", cfg)
+
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertEqual(prim.GetPath().pathString, "/World/env_0/Cone")
+            # Find matching prims
+            prim_paths = sim_utils.find_matching_prim_paths("/World/env_*/Cone")
+            self.assertEqual(len(prim_paths), num_clones)
+            # Find global materials
+            prim_paths = sim_utils.find_matching_prim_paths("/Looks/visualMaterial.*")
+            self.assertEqual(len(prim_paths), 1)
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.lab/test/sim/test_spawn_meshes.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_spawn_meshes.py
@@ -14,6 +14,7 @@ simulation_app = AppLauncher(headless=True).app
 
 import unittest
 
+import omni.isaac.core.utils.prims as prim_utils
 import omni.usd
 
 import omni.isaac.lab.sim as sim_utils

--- a/source/extensions/omni.isaac.lab/test/sim/test_spawn_shapes.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_spawn_shapes.py
@@ -14,34 +14,14 @@ simulation_app = AppLauncher(headless=True).app
 
 import unittest
 
-import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
-from omni.isaac.core.simulation_context import SimulationContext
+import omni.usd
 
 import omni.isaac.lab.sim as sim_utils
+from omni.isaac.lab.sim import build_simulation_context
 
 
 class TestSpawningUsdGeometries(unittest.TestCase):
     """Test fixture for checking spawning of USDGeom prim with different settings."""
-
-    def setUp(self) -> None:
-        """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
-        # Simulation time-step
-        self.dt = 0.1
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, backend="numpy")
-        # Wait for spawning
-        stage_utils.update_stage()
-
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        self.sim.clear()
-        self.sim.clear_all_callbacks()
-        self.sim.clear_instance()
 
     """
     Basic spawning.
@@ -49,79 +29,99 @@ class TestSpawningUsdGeometries(unittest.TestCase):
 
     def test_spawn_cone(self):
         """Test spawning of UsdGeom.Cone prim."""
-        # Spawn cone
-        cfg = sim_utils.ConeCfg(radius=1.0, height=2.0, axis="Y")
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cone/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Cone")
-        self.assertEqual(prim.GetAttribute("radius").Get(), cfg.radius)
-        self.assertEqual(prim.GetAttribute("height").Get(), cfg.height)
-        self.assertEqual(prim.GetAttribute("axis").Get(), cfg.axis)
+        with build_simulation_context():
+            # Spawn cone
+            cfg = sim_utils.ConeCfg(radius=1.0, height=2.0, axis="Y")
+            prim = cfg.func("/World/Cone", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cone/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Cone")
+            self.assertEqual(prim.GetAttribute("radius").Get(), cfg.radius)
+            self.assertEqual(prim.GetAttribute("height").Get(), cfg.height)
+            self.assertEqual(prim.GetAttribute("axis").Get(), cfg.axis)
 
     def test_spawn_capsule(self):
         """Test spawning of UsdGeom.Capsule prim."""
-        # Spawn capsule
-        cfg = sim_utils.CapsuleCfg(radius=1.0, height=2.0, axis="Y")
-        prim = cfg.func("/World/Capsule", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Capsule"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Capsule/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Capsule")
-        self.assertEqual(prim.GetAttribute("radius").Get(), cfg.radius)
-        self.assertEqual(prim.GetAttribute("height").Get(), cfg.height)
-        self.assertEqual(prim.GetAttribute("axis").Get(), cfg.axis)
+        with build_simulation_context():
+            # Spawn capsule
+            cfg = sim_utils.CapsuleCfg(radius=1.0, height=2.0, axis="Y")
+            prim = cfg.func("/World/Capsule", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Capsule").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Capsule/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Capsule")
+            self.assertEqual(prim.GetAttribute("radius").Get(), cfg.radius)
+            self.assertEqual(prim.GetAttribute("height").Get(), cfg.height)
+            self.assertEqual(prim.GetAttribute("axis").Get(), cfg.axis)
 
     def test_spawn_cylinder(self):
         """Test spawning of UsdGeom.Cylinder prim."""
-        # Spawn cylinder
-        cfg = sim_utils.CylinderCfg(radius=1.0, height=2.0, axis="Y")
-        prim = cfg.func("/World/Cylinder", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cylinder"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cylinder/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Cylinder")
-        self.assertEqual(prim.GetAttribute("radius").Get(), cfg.radius)
-        self.assertEqual(prim.GetAttribute("height").Get(), cfg.height)
-        self.assertEqual(prim.GetAttribute("axis").Get(), cfg.axis)
+        with build_simulation_context():
+            # Spawn cylinder
+            cfg = sim_utils.CylinderCfg(radius=1.0, height=2.0, axis="Y")
+            prim = cfg.func("/World/Cylinder", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cylinder").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cylinder/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Cylinder")
+            self.assertEqual(prim.GetAttribute("radius").Get(), cfg.radius)
+            self.assertEqual(prim.GetAttribute("height").Get(), cfg.height)
+            self.assertEqual(prim.GetAttribute("axis").Get(), cfg.axis)
 
     def test_spawn_cuboid(self):
         """Test spawning of UsdGeom.Cube prim."""
-        # Spawn cuboid
-        cfg = sim_utils.CuboidCfg(size=(1.0, 2.0, 3.0))
-        prim = cfg.func("/World/Cube", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cube"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cube/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Cube")
-        self.assertEqual(prim.GetAttribute("size").Get(), min(cfg.size))
+        with build_simulation_context():
+            # Spawn cuboid
+            cfg = sim_utils.CuboidCfg(size=(1.0, 2.0, 3.0))
+            prim = cfg.func("/World/Cube", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cube").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cube/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Cube")
+            self.assertEqual(prim.GetAttribute("size").Get(), min(cfg.size))
 
     def test_spawn_sphere(self):
         """Test spawning of UsdGeom.Sphere prim."""
-        # Spawn sphere
-        cfg = sim_utils.SphereCfg(radius=1.0)
-        prim = cfg.func("/World/Sphere", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Sphere"))
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Sphere/geometry/mesh")
-        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Sphere")
-        self.assertEqual(prim.GetAttribute("radius").Get(), cfg.radius)
+        with build_simulation_context():
+            # Spawn sphere
+            cfg = sim_utils.SphereCfg(radius=1.0)
+            prim = cfg.func("/World/Sphere", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Sphere").IsValid())
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Sphere/geometry/mesh")
+            self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Sphere")
+            self.assertEqual(prim.GetAttribute("radius").Get(), cfg.radius)
 
     """
     Physics properties.
@@ -134,52 +134,60 @@ class TestSpawningUsdGeometries(unittest.TestCase):
             Playing the simulation in this case will give a warning that no mass is specified!
             Need to also setup mass and colliders.
         """
-        # Spawn cone
-        cfg = sim_utils.ConeCfg(
-            radius=1.0,
-            height=2.0,
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
-                rigid_body_enabled=True, solver_position_iteration_count=8, sleep_threshold=0.1
-            ),
-        )
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cone")
-        self.assertEqual(prim.GetAttribute("physics:rigidBodyEnabled").Get(), cfg.rigid_props.rigid_body_enabled)
-        self.assertEqual(
-            prim.GetAttribute("physxRigidBody:solverPositionIterationCount").Get(),
-            cfg.rigid_props.solver_position_iteration_count,
-        )
-        self.assertAlmostEqual(
-            prim.GetAttribute("physxRigidBody:sleepThreshold").Get(), cfg.rigid_props.sleep_threshold
-        )
+        with build_simulation_context():
+            # Spawn cone
+            cfg = sim_utils.ConeCfg(
+                radius=1.0,
+                height=2.0,
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                    rigid_body_enabled=True, solver_position_iteration_count=8, sleep_threshold=0.1
+                ),
+            )
+            prim = cfg.func("/World/Cone", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cone")
+            self.assertEqual(prim.GetAttribute("physics:rigidBodyEnabled").Get(), cfg.rigid_props.rigid_body_enabled)
+            self.assertEqual(
+                prim.GetAttribute("physxRigidBody:solverPositionIterationCount").Get(),
+                cfg.rigid_props.solver_position_iteration_count,
+            )
+            self.assertAlmostEqual(
+                prim.GetAttribute("physxRigidBody:sleepThreshold").Get(), cfg.rigid_props.sleep_threshold
+            )
 
     def test_spawn_cone_with_rigid_and_mass_props(self):
         """Test spawning of UsdGeom.Cone prim with rigid body and mass API."""
-        # Spawn cone
-        cfg = sim_utils.ConeCfg(
-            radius=1.0,
-            height=2.0,
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
-                rigid_body_enabled=True, solver_position_iteration_count=8, sleep_threshold=0.1
-            ),
-            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
-        )
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cone")
-        self.assertEqual(prim.GetAttribute("physics:mass").Get(), cfg.mass_props.mass)
+        with build_simulation_context() as sim:
+            # Spawn cone
+            cfg = sim_utils.ConeCfg(
+                radius=1.0,
+                height=2.0,
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                    rigid_body_enabled=True, solver_position_iteration_count=8, sleep_threshold=0.1
+                ),
+                mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            )
+            prim = cfg.func("/World/Cone", cfg)
 
-        # check sim playing
-        self.sim.play()
-        for _ in range(10):
-            self.sim.step()
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cone")
+            self.assertEqual(prim.GetAttribute("physics:mass").Get(), cfg.mass_props.mass)
+
+            # check sim playing
+            sim.play()
+            for _ in range(10):
+                sim.step()
 
     def test_spawn_cone_with_rigid_and_density_props(self):
         """Test spawning of UsdGeom.Cone prim with rigid body and mass API.
@@ -189,57 +197,66 @@ class TestSpawningUsdGeometries(unittest.TestCase):
             the collision shape to compute the mass. Thus, we have to set the collider properties. In
             order to not have a collision shape, we disable the collision.
         """
-        # Spawn cone
-        cfg = sim_utils.ConeCfg(
-            radius=1.0,
-            height=2.0,
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
-                rigid_body_enabled=True, solver_position_iteration_count=8, sleep_threshold=0.1
-            ),
-            mass_props=sim_utils.MassPropertiesCfg(density=10.0),
-            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
-        )
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        # Check properties
-        prim = prim_utils.get_prim_at_path("/World/Cone")
-        self.assertEqual(prim.GetAttribute("physics:density").Get(), cfg.mass_props.density)
-        # check sim playing
-        self.sim.play()
-        for _ in range(10):
-            self.sim.step()
+        with build_simulation_context() as sim:
+            # Spawn cone
+            cfg = sim_utils.ConeCfg(
+                radius=1.0,
+                height=2.0,
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                    rigid_body_enabled=True, solver_position_iteration_count=8, sleep_threshold=0.1
+                ),
+                mass_props=sim_utils.MassPropertiesCfg(density=10.0),
+                collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+            )
+            prim = cfg.func("/World/Cone", cfg)
+
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            # Check properties
+            prim = stage.GetPrimAtPath("/World/Cone")
+            self.assertEqual(prim.GetAttribute("physics:density").Get(), cfg.mass_props.density)
+
+            # check sim playing
+            sim.play()
+            for _ in range(10):
+                sim.step()
 
     def test_spawn_cone_with_all_props(self):
         """Test spawning of UsdGeom.Cone prim with all properties."""
-        # Spawn cone
-        cfg = sim_utils.ConeCfg(
-            radius=1.0,
-            height=2.0,
-            mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(),
-            collision_props=sim_utils.CollisionPropertiesCfg(),
-            visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
-            physics_material=sim_utils.materials.RigidBodyMaterialCfg(),
-        )
-        prim = cfg.func("/World/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone"))
-        self.assertTrue(prim_utils.is_prim_path_valid("/World/Cone/geometry/material"))
-        # Check properties
-        # -- rigid body
-        prim = prim_utils.get_prim_at_path("/World/Cone")
-        self.assertEqual(prim.GetAttribute("physics:rigidBodyEnabled").Get(), True)
-        # -- collision shape
-        prim = prim_utils.get_prim_at_path("/World/Cone/geometry/mesh")
-        self.assertEqual(prim.GetAttribute("physics:collisionEnabled").Get(), True)
+        with build_simulation_context() as sim:
+            # Spawn cone
+            cfg = sim_utils.ConeCfg(
+                radius=1.0,
+                height=2.0,
+                mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(),
+                collision_props=sim_utils.CollisionPropertiesCfg(),
+                visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
+                physics_material=sim_utils.materials.RigidBodyMaterialCfg(),
+            )
+            prim = cfg.func("/World/Cone", cfg)
 
-        # check sim playing
-        self.sim.play()
-        for _ in range(10):
-            self.sim.step()
+            # Get stage
+            stage = omni.usd.get_context().get_stage()
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone").IsValid())
+            self.assertTrue(stage.GetPrimAtPath("/World/Cone/geometry/material").IsValid())
+            # Check properties
+            # -- rigid body
+            prim = stage.GetPrimAtPath("/World/Cone")
+            self.assertEqual(prim.GetAttribute("physics:rigidBodyEnabled").Get(), True)
+            # -- collision shape
+            prim = stage.GetPrimAtPath("/World/Cone/geometry/mesh")
+            self.assertEqual(prim.GetAttribute("physics:collisionEnabled").Get(), True)
+
+            # check sim playing
+            sim.play()
+            for _ in range(10):
+                sim.step()
 
     """
     Cloning.
@@ -247,57 +264,61 @@ class TestSpawningUsdGeometries(unittest.TestCase):
 
     def test_spawn_cone_clones_invalid_paths(self):
         """Test spawning of cone clones on invalid cloning paths."""
-        num_clones = 10
-        for i in range(num_clones):
-            prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
-        # Spawn cone
-        cfg = sim_utils.ConeCfg(radius=1.0, height=2.0, copy_from_source=True)
-        # Should raise error for invalid path
-        with self.assertRaises(RuntimeError):
-            cfg.func("/World/env/env_.*/Cone", cfg)
+        with build_simulation_context():
+            num_clones = 10
+            for i in range(num_clones):
+                prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+            # Spawn cone
+            cfg = sim_utils.ConeCfg(radius=1.0, height=2.0, copy_from_source=True)
+            # Should raise error for invalid path
+            with self.assertRaises(RuntimeError):
+                cfg.func("/World/env/env_.*/Cone", cfg)
 
     def test_spawn_cone_clones(self):
         """Test spawning of cone clones."""
-        num_clones = 10
-        for i in range(num_clones):
-            prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
-        # Spawn cone
-        cfg = sim_utils.ConeCfg(radius=1.0, height=2.0, copy_from_source=True)
-        prim = cfg.func("/World/env_.*/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertEqual(prim_utils.get_prim_path(prim), "/World/env_0/Cone")
-        # Find matching prims
-        prims = prim_utils.find_matching_prim_paths("/World/env_*/Cone")
-        self.assertEqual(len(prims), num_clones)
+        with build_simulation_context():
+            num_clones = 10
+            for i in range(num_clones):
+                prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+            # Spawn cone
+            cfg = sim_utils.ConeCfg(radius=1.0, height=2.0, copy_from_source=True)
+            prim = cfg.func("/World/env_.*/Cone", cfg)
+
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertEqual(prim.GetPath().pathString, "/World/env_0/Cone")
+            # Find matching prims
+            prim_paths = sim_utils.find_matching_prim_paths("/World/env_*/Cone")
+            self.assertEqual(len(prim_paths), num_clones)
 
     def test_spawn_cone_clone_with_all_props_global_material(self):
         """Test spawning of cone clones with global material reference."""
-        num_clones = 10
-        for i in range(num_clones):
-            prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
-        # Spawn cone
-        cfg = sim_utils.ConeCfg(
-            radius=1.0,
-            height=2.0,
-            mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(),
-            collision_props=sim_utils.CollisionPropertiesCfg(),
-            visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
-            physics_material=sim_utils.materials.RigidBodyMaterialCfg(),
-            visual_material_path="/Looks/visualMaterial",
-            physics_material_path="/Looks/physicsMaterial",
-        )
-        prim = cfg.func("/World/env_.*/Cone", cfg)
-        # Check validity
-        self.assertTrue(prim.IsValid())
-        self.assertEqual(prim_utils.get_prim_path(prim), "/World/env_0/Cone")
-        # Find matching prims
-        prims = prim_utils.find_matching_prim_paths("/World/env_*/Cone")
-        self.assertEqual(len(prims), num_clones)
-        # Find global materials
-        prims = prim_utils.find_matching_prim_paths("/Looks/visualMaterial.*")
-        self.assertEqual(len(prims), 1)
+        with build_simulation_context():
+            num_clones = 10
+            for i in range(num_clones):
+                prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+            # Spawn cone
+            cfg = sim_utils.ConeCfg(
+                radius=1.0,
+                height=2.0,
+                mass_props=sim_utils.MassPropertiesCfg(mass=5.0),
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(),
+                collision_props=sim_utils.CollisionPropertiesCfg(),
+                visual_material=sim_utils.materials.PreviewSurfaceCfg(diffuse_color=(0.0, 0.75, 0.5)),
+                physics_material=sim_utils.materials.RigidBodyMaterialCfg(),
+                visual_material_path="/Looks/visualMaterial",
+                physics_material_path="/Looks/physicsMaterial",
+            )
+            prim = cfg.func("/World/env_.*/Cone", cfg)
+            # Check validity
+            self.assertTrue(prim.IsValid())
+            self.assertEqual(prim.GetPath().pathString, "/World/env_0/Cone")
+            # Find matching prims
+            prim_paths = sim_utils.find_matching_prim_paths("/World/env_*/Cone")
+            self.assertEqual(len(prim_paths), num_clones)
+            # Find global materials
+            prim_paths = sim_utils.find_matching_prim_paths("/Looks/visualMaterial.*")
+            self.assertEqual(len(prim_paths), 1)
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.lab/test/sim/test_spawn_shapes.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_spawn_shapes.py
@@ -14,6 +14,7 @@ simulation_app = AppLauncher(headless=True).app
 
 import unittest
 
+import omni.isaac.core.utils.prims as prim_utils
 import omni.usd
 
 import omni.isaac.lab.sim as sim_utils

--- a/source/extensions/omni.isaac.lab/test/sim/test_urdf_converter.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_urdf_converter.py
@@ -19,7 +19,7 @@ import os
 import unittest
 
 import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
+import omni.usd
 from omni.isaac.core.articulations import ArticulationView
 from omni.isaac.core.utils.extensions import enable_extension, get_extension_path_from_name
 

--- a/source/extensions/omni.isaac.lab/test/sim/test_urdf_converter.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_urdf_converter.py
@@ -21,9 +21,10 @@ import unittest
 import omni.isaac.core.utils.prims as prim_utils
 import omni.isaac.core.utils.stage as stage_utils
 from omni.isaac.core.articulations import ArticulationView
-from omni.isaac.core.simulation_context import SimulationContext
 from omni.isaac.core.utils.extensions import enable_extension, get_extension_path_from_name
 
+
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.sim.converters import UrdfConverter, UrdfConverterCfg
 
 
@@ -31,9 +32,6 @@ class TestUrdfConverter(unittest.TestCase):
     """Test fixture for the UrdfConverter class."""
 
     def setUp(self):
-        """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
         # retrieve path to urdf importer extension
         enable_extension("omni.importer.urdf")
         extension_path = get_extension_path_from_name("omni.importer.urdf")
@@ -42,121 +40,119 @@ class TestUrdfConverter(unittest.TestCase):
             asset_path=f"{extension_path}/data/urdf/robots/franka_description/robots/panda_arm_hand.urdf",
             fix_base=True,
         )
-        # Simulation time-step
-        self.dt = 0.01
-        # Load kit helper
-        self.sim = SimulationContext(physics_dt=self.dt, rendering_dt=self.dt, backend="numpy")
-
-    def tearDown(self) -> None:
-        """Stops simulator after each test."""
-        # stop simulation
-        self.sim.stop()
-        # cleanup stage and context
-        self.sim.clear()
-        self.sim.clear_all_callbacks()
-        self.sim.clear_instance()
 
     def test_no_change(self):
         """Call conversion twice. This should not generate a new USD file."""
+        with build_simulation_context():
+            urdf_converter = UrdfConverter(self.config)
+            time_usd_file_created = os.stat(urdf_converter.usd_path).st_mtime_ns
 
-        urdf_converter = UrdfConverter(self.config)
-        time_usd_file_created = os.stat(urdf_converter.usd_path).st_mtime_ns
+            # no change to config only define the usd directory
+            new_config = self.config
+            new_config.usd_dir = urdf_converter.usd_dir
+            # convert to usd but this time in the same directory as previous step
+            new_urdf_converter = UrdfConverter(new_config)
+            new_time_usd_file_created = os.stat(new_urdf_converter.usd_path).st_mtime_ns
 
-        # no change to config only define the usd directory
-        new_config = self.config
-        new_config.usd_dir = urdf_converter.usd_dir
-        # convert to usd but this time in the same directory as previous step
-        new_urdf_converter = UrdfConverter(new_config)
-        new_time_usd_file_created = os.stat(new_urdf_converter.usd_path).st_mtime_ns
-
-        self.assertEqual(time_usd_file_created, new_time_usd_file_created)
+            self.assertEqual(time_usd_file_created, new_time_usd_file_created)
 
     def test_config_change(self):
         """Call conversion twice but change the config in the second call. This should generate a new USD file."""
+        with build_simulation_context():
+            urdf_converter = UrdfConverter(self.config)
+            time_usd_file_created = os.stat(urdf_converter.usd_path).st_mtime_ns
 
-        urdf_converter = UrdfConverter(self.config)
-        time_usd_file_created = os.stat(urdf_converter.usd_path).st_mtime_ns
+            # change the config
+            new_config = self.config
+            new_config.fix_base = not self.config.fix_base
+            # define the usd directory
+            new_config.usd_dir = urdf_converter.usd_dir
+            # convert to usd but this time in the same directory as previous step
+            new_urdf_converter = UrdfConverter(new_config)
+            new_time_usd_file_created = os.stat(new_urdf_converter.usd_path).st_mtime_ns
 
-        # change the config
-        new_config = self.config
-        new_config.fix_base = not self.config.fix_base
-        # define the usd directory
-        new_config.usd_dir = urdf_converter.usd_dir
-        # convert to usd but this time in the same directory as previous step
-        new_urdf_converter = UrdfConverter(new_config)
-        new_time_usd_file_created = os.stat(new_urdf_converter.usd_path).st_mtime_ns
-
-        self.assertNotEqual(time_usd_file_created, new_time_usd_file_created)
+            self.assertNotEqual(time_usd_file_created, new_time_usd_file_created)
 
     def test_create_prim_from_usd(self):
         """Call conversion and create a prim from it."""
+        with build_simulation_context():
+            urdf_converter = UrdfConverter(self.config)
 
-        urdf_converter = UrdfConverter(self.config)
+            prim_path = "/World/Robot"
+            prim_utils.create_prim(prim_path, usd_path=urdf_converter.usd_path)
 
-        prim_path = "/World/Robot"
-        prim_utils.create_prim(prim_path, usd_path=urdf_converter.usd_path)
-
-        self.assertTrue(prim_utils.is_prim_path_valid(prim_path))
+            # get current stage
+            stage = omni.usd.get_context().get_stage()
+            self.assertTrue(stage.GetPrimAtPath(prim_path).IsValid())
 
     def test_config_drive_type(self):
         """Change the drive mechanism of the robot to be position."""
+        with build_simulation_context() as sim:
+            # Create directory to dump results
+            test_dir = os.path.dirname(os.path.abspath(__file__))
+            output_dir = os.path.join(test_dir, "output", "urdf_converter")
+            if not os.path.exists(output_dir):
+                os.makedirs(output_dir, exist_ok=True)
 
-        # Create directory to dump results
-        test_dir = os.path.dirname(os.path.abspath(__file__))
-        output_dir = os.path.join(test_dir, "output", "urdf_converter")
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir, exist_ok=True)
+            # change the config
+            self.config.force_usd_conversion = True
+            self.config.default_drive_type = "position"
+            self.config.default_drive_stiffness = 400.0
+            self.config.default_drive_damping = 40.0
+            self.config.override_joint_dynamics = True
+            self.config.usd_dir = output_dir
+            urdf_converter = UrdfConverter(self.config)
+            # check the drive type of the robot
+            prim_path = "/World/Robot"
+            prim_utils.create_prim(prim_path, usd_path=urdf_converter.usd_path)
 
-        # change the config
-        self.config.force_usd_conversion = True
-        self.config.default_drive_type = "position"
-        self.config.default_drive_stiffness = 400.0
-        self.config.default_drive_damping = 40.0
-        self.config.override_joint_dynamics = True
-        self.config.usd_dir = output_dir
-        urdf_converter = UrdfConverter(self.config)
-        # check the drive type of the robot
-        prim_path = "/World/Robot"
-        prim_utils.create_prim(prim_path, usd_path=urdf_converter.usd_path)
+            # access the robot
+            robot = ArticulationView(prim_path, reset_xform_properties=False)
+            # play the simulator and initialize the robot
+            sim.reset()
+            robot.initialize()
 
-        # access the robot
-        robot = ArticulationView(prim_path, reset_xform_properties=False)
-        # play the simulator and initialize the robot
-        self.sim.reset()
-        robot.initialize()
+            # check drive values for the robot (read from physx)
+            drive_stiffness, drive_damping = robot.get_gains()
+            # convert to numpy
+            drive_stiffness = drive_stiffness.cpu().numpy()
+            drive_damping = drive_damping.cpu().numpy()
 
-        # check drive values for the robot (read from physx)
-        drive_stiffness, drive_damping = robot.get_gains()
-        # -- for the arm (revolute joints)
-        # user provides the values in radians but simulator sets them as in degrees
-        expected_drive_stiffness = math.degrees(self.config.default_drive_stiffness)
-        expected_drive_damping = math.degrees(self.config.default_drive_damping)
-        np.testing.assert_array_equal(drive_stiffness[:, :7], expected_drive_stiffness)
-        np.testing.assert_array_equal(drive_damping[:, :7], expected_drive_damping)
-        # -- for the hand (prismatic joints)
-        # note: from isaac sim 2023.1, the test asset has mimic joints for the hand
-        #  so the mimic joint doesn't have drive values
-        expected_drive_stiffness = self.config.default_drive_stiffness
-        expected_drive_damping = self.config.default_drive_damping
-        np.testing.assert_array_equal(drive_stiffness[:, 7], expected_drive_stiffness)
-        np.testing.assert_array_equal(drive_damping[:, 7], expected_drive_damping)
+            # -- for the arm (revolute joints)
+            # user provides the values in radians but simulator sets them as in degrees
+            expected_drive_stiffness = math.degrees(self.config.default_drive_stiffness)
+            expected_drive_damping = math.degrees(self.config.default_drive_damping)
+            np.testing.assert_array_equal(drive_stiffness[:, :7], expected_drive_stiffness)
+            np.testing.assert_array_equal(drive_damping[:, :7], expected_drive_damping)
+            # -- for the hand (prismatic joints)
+            # note: from isaac sim 2023.1, the test asset has mimic joints for the hand
+            #  so the mimic joint doesn't have drive values
+            expected_drive_stiffness = self.config.default_drive_stiffness
+            expected_drive_damping = self.config.default_drive_damping
+            np.testing.assert_array_equal(drive_stiffness[:, 7], expected_drive_stiffness)
+            np.testing.assert_array_equal(drive_damping[:, 7], expected_drive_damping)
 
-        # check drive values for the robot (read from usd)
-        self.sim.stop()
-        drive_stiffness, drive_damping = robot.get_gains()
-        # -- for the arm (revolute joints)
-        # user provides the values in radians but simulator sets them as in degrees
-        expected_drive_stiffness = math.degrees(self.config.default_drive_stiffness)
-        expected_drive_damping = math.degrees(self.config.default_drive_damping)
-        np.testing.assert_array_equal(drive_stiffness[:, :7], expected_drive_stiffness)
-        np.testing.assert_array_equal(drive_damping[:, :7], expected_drive_damping)
-        # -- for the hand (prismatic joints)
-        # note: from isaac sim 2023.1, the test asset has mimic joints for the hand
-        #  so the mimic joint doesn't have drive values
-        expected_drive_stiffness = self.config.default_drive_stiffness
-        expected_drive_damping = self.config.default_drive_damping
-        np.testing.assert_array_equal(drive_stiffness[:, 7], expected_drive_stiffness)
-        np.testing.assert_array_equal(drive_damping[:, 7], expected_drive_damping)
+            # stop the simulator
+            sim.stop()
+            # check drive values for the robot (read from usd since the simulator is stopped)
+            drive_stiffness, drive_damping = robot.get_gains()
+            # convert to numpy
+            drive_stiffness = drive_stiffness.cpu().numpy()
+            drive_damping = drive_damping.cpu().numpy()
+
+            # -- for the arm (revolute joints)
+            # user provides the values in radians but simulator sets them as in degrees
+            expected_drive_stiffness = math.degrees(self.config.default_drive_stiffness)
+            expected_drive_damping = math.degrees(self.config.default_drive_damping)
+            np.testing.assert_array_equal(drive_stiffness[:, :7], expected_drive_stiffness)
+            np.testing.assert_array_equal(drive_damping[:, :7], expected_drive_damping)
+            # -- for the hand (prismatic joints)
+            # note: from isaac sim 2023.1, the test asset has mimic joints for the hand
+            #  so the mimic joint doesn't have drive values
+            expected_drive_stiffness = self.config.default_drive_stiffness
+            expected_drive_damping = self.config.default_drive_damping
+            np.testing.assert_array_equal(drive_stiffness[:, 7], expected_drive_stiffness)
+            np.testing.assert_array_equal(drive_damping[:, 7], expected_drive_damping)
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.lab/test/sim/test_urdf_converter.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_urdf_converter.py
@@ -23,7 +23,6 @@ import omni.usd
 from omni.isaac.core.articulations import ArticulationView
 from omni.isaac.core.utils.extensions import enable_extension, get_extension_path_from_name
 
-
 from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.sim.converters import UrdfConverter, UrdfConverterCfg
 

--- a/source/extensions/omni.isaac.lab/test/sim/test_utils.py
+++ b/source/extensions/omni.isaac.lab/test/sim/test_utils.py
@@ -17,113 +17,108 @@ import numpy as np
 import unittest
 
 import omni.isaac.core.utils.prims as prim_utils
-import omni.isaac.core.utils.stage as stage_utils
+import omni.usd
 from pxr import Sdf, Usd, UsdGeom
 
 import omni.isaac.lab.sim as sim_utils
+from omni.isaac.lab.sim import build_simulation_context
 from omni.isaac.lab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 
 class TestUtilities(unittest.TestCase):
     """Test fixture for the sim utility functions."""
 
-    def setUp(self):
-        """Create a blank new stage for each test."""
-        # Create a new stage
-        stage_utils.create_new_stage()
-        stage_utils.update_stage()
-
-    def tearDown(self) -> None:
-        """Clear stage after each test."""
-        stage_utils.clear_stage()
-
     def test_get_all_matching_child_prims(self):
         """Test get_all_matching_child_prims() function."""
-        # create scene
-        prim_utils.create_prim("/World/Floor")
-        prim_utils.create_prim(
-            "/World/Floor/thefloor", "Cube", position=np.array([75, 75, -150.1]), attributes={"size": 300}
-        )
-        prim_utils.create_prim("/World/Room", "Sphere", attributes={"radius": 1e3})
+        with build_simulation_context():
+            # create scene
+            prim_utils.create_prim("/World/Floor")
+            prim_utils.create_prim(
+                "/World/Floor/thefloor", "Cube", position=np.array([75, 75, -150.1]), attributes={"size": 300}
+            )
+            prim_utils.create_prim("/World/Room", "Sphere", attributes={"radius": 1e3})
 
-        # test
-        isaac_sim_result = prim_utils.get_all_matching_child_prims("/World")
-        isaaclab_result = sim_utils.get_all_matching_child_prims("/World")
-        self.assertListEqual(isaac_sim_result, isaaclab_result)
+            # test
+            isaac_sim_result = prim_utils.get_all_matching_child_prims("/World")
+            isaaclab_result = sim_utils.get_all_matching_child_prims("/World")
+            self.assertListEqual(isaac_sim_result, isaaclab_result)
 
-        # test valid path
-        with self.assertRaises(ValueError):
-            sim_utils.get_all_matching_child_prims("World/Room")
+            # test valid path
+            with self.assertRaises(ValueError):
+                sim_utils.get_all_matching_child_prims("World/Room")
 
     def test_find_matching_prim_paths(self):
         """Test find_matching_prim_paths() function."""
-        # create scene
-        for index in range(2048):
-            random_pos = np.random.uniform(-100, 100, size=3)
-            prim_utils.create_prim(f"/World/Floor_{index}", "Cube", position=random_pos, attributes={"size": 2.0})
-            prim_utils.create_prim(f"/World/Floor_{index}/Sphere", "Sphere", attributes={"radius": 10})
-            prim_utils.create_prim(f"/World/Floor_{index}/Sphere/childSphere", "Sphere", attributes={"radius": 1})
-            prim_utils.create_prim(f"/World/Floor_{index}/Sphere/childSphere2", "Sphere", attributes={"radius": 1})
+        with build_simulation_context():
+            # create scene
+            for index in range(2048):
+                random_pos = np.random.uniform(-100, 100, size=3)
+                prim_utils.create_prim(f"/World/Floor_{index}", "Cube", position=random_pos, attributes={"size": 2.0})
+                prim_utils.create_prim(f"/World/Floor_{index}/Sphere", "Sphere", attributes={"radius": 10})
+                prim_utils.create_prim(f"/World/Floor_{index}/Sphere/childSphere", "Sphere", attributes={"radius": 1})
+                prim_utils.create_prim(f"/World/Floor_{index}/Sphere/childSphere2", "Sphere", attributes={"radius": 1})
 
-        # test leaf paths
-        isaac_sim_result = prim_utils.find_matching_prim_paths("/World/Floor_.*/Sphere")
-        isaaclab_result = sim_utils.find_matching_prim_paths("/World/Floor_.*/Sphere")
-        self.assertListEqual(isaac_sim_result, isaaclab_result)
+            # test leaf paths
+            isaac_sim_result = prim_utils.find_matching_prim_paths("/World/Floor_.*/Sphere")
+            isaaclab_result = sim_utils.find_matching_prim_paths("/World/Floor_.*/Sphere")
+            self.assertListEqual(isaac_sim_result, isaaclab_result)
 
-        # test non-leaf paths
-        isaac_sim_result = prim_utils.find_matching_prim_paths("/World/Floor_.*")
-        isaaclab_result = sim_utils.find_matching_prim_paths("/World/Floor_.*")
-        self.assertListEqual(isaac_sim_result, isaaclab_result)
+            # test non-leaf paths
+            isaac_sim_result = prim_utils.find_matching_prim_paths("/World/Floor_.*")
+            isaaclab_result = sim_utils.find_matching_prim_paths("/World/Floor_.*")
+            self.assertListEqual(isaac_sim_result, isaaclab_result)
 
-        # test child-leaf paths
-        isaac_sim_result = prim_utils.find_matching_prim_paths("/World/Floor_.*/Sphere/childSphere.*")
-        isaaclab_result = sim_utils.find_matching_prim_paths("/World/Floor_.*/Sphere/childSphere.*")
-        self.assertListEqual(isaac_sim_result, isaaclab_result)
+            # test child-leaf paths
+            isaac_sim_result = prim_utils.find_matching_prim_paths("/World/Floor_.*/Sphere/childSphere.*")
+            isaaclab_result = sim_utils.find_matching_prim_paths("/World/Floor_.*/Sphere/childSphere.*")
+            self.assertListEqual(isaac_sim_result, isaaclab_result)
 
-        # test valid path
-        with self.assertRaises(ValueError):
-            sim_utils.get_all_matching_child_prims("World/Floor_.*")
+            # test valid path
+            with self.assertRaises(ValueError):
+                sim_utils.get_all_matching_child_prims("World/Floor_.*")
 
     def test_find_global_fixed_joint_prim(self):
         """Test find_global_fixed_joint_prim() function."""
-        # create scene
-        prim_utils.create_prim("/World")
-        prim_utils.create_prim(
-            "/World/ANYmal", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-C/anymal_c.usd"
-        )
-        prim_utils.create_prim(
-            "/World/Franka", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
-        )
-        prim_utils.create_prim("/World/Franka_Isaac", usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/Franka/franka.usd")
+        with build_simulation_context():
+            # create scene
+            prim_utils.create_prim("/World")
+            prim_utils.create_prim(
+                "/World/ANYmal", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-C/anymal_c.usd"
+            )
+            prim_utils.create_prim(
+                "/World/Franka", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+            )
+            prim_utils.create_prim("/World/Franka_Isaac", usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/Franka/franka.usd")
 
-        # test
-        self.assertIsNone(sim_utils.find_global_fixed_joint_prim("/World/ANYmal"))
-        self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka"))
-        self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka_Isaac"))
+            # test
+            self.assertIsNone(sim_utils.find_global_fixed_joint_prim("/World/ANYmal"))
+            self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka"))
+            self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka_Isaac"))
 
-        # make fixed joint disabled manually
-        joint_prim = sim_utils.find_global_fixed_joint_prim("/World/Franka")
-        joint_prim.GetJointEnabledAttr().Set(False)
-        self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka"))
-        self.assertIsNone(sim_utils.find_global_fixed_joint_prim("/World/Franka", check_enabled_only=True))
+            # make fixed joint disabled manually
+            joint_prim = sim_utils.find_global_fixed_joint_prim("/World/Franka")
+            joint_prim.GetJointEnabledAttr().Set(False)
+            self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka"))
+            self.assertIsNone(sim_utils.find_global_fixed_joint_prim("/World/Franka", check_enabled_only=True))
 
     def test_select_usd_variants(self):
         """Test select_usd_variants() function."""
-        stage = stage_utils.get_current_stage()
-        prim: Usd.Prim = UsdGeom.Xform.Define(stage, Sdf.Path("/World")).GetPrim()
-        stage.SetDefaultPrim(prim)
+        with build_simulation_context():
+            stage = omni.usd.get_context().get_stage()
+            prim: Usd.Prim = UsdGeom.Xform.Define(stage, Sdf.Path("/World")).GetPrim()
+            stage.SetDefaultPrim(prim)
 
-        # Create the variant set and add your variants to it.
-        variants = ["red", "blue", "green"]
-        variant_set = prim.GetVariantSets().AddVariantSet("colors")
-        for variant in variants:
-            variant_set.AddVariant(variant)
+            # Create the variant set and add your variants to it.
+            variants = ["red", "blue", "green"]
+            variant_set = prim.GetVariantSets().AddVariantSet("colors")
+            for variant in variants:
+                variant_set.AddVariant(variant)
 
-        # Set the variant selection
-        sim_utils.utils.select_usd_variants("/World", {"colors": "red"}, stage)
+            # Set the variant selection
+            sim_utils.utils.select_usd_variants("/World", {"colors": "red"}, stage)
 
-        # Check if the variant selection is correct
-        self.assertEqual(variant_set.GetVariantSelection(), "red")
+            # Check if the variant selection is correct
+            self.assertEqual(variant_set.GetVariantSelection(), "red")
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.lab/test/terrains/test_terrain_importer.py
+++ b/source/extensions/omni.isaac.lab/test/terrains/test_terrain_importer.py
@@ -16,7 +16,6 @@ import numpy as np
 import torch
 import unittest
 
-import omni.isaac.core.utils.prims as prim_utils
 import omni.kit
 import omni.kit.commands
 from omni.isaac.cloner import GridCloner
@@ -25,6 +24,7 @@ from omni.isaac.core.objects import DynamicSphere
 from omni.isaac.core.prims import GeometryPrim, RigidPrim, RigidPrimView
 from omni.isaac.core.utils.extensions import enable_extension
 
+import omni.isaac.lab.sim as sim_utils
 import omni.isaac.lab.terrains as terrain_gen
 from omni.isaac.lab.sim import SimulationContext, build_simulation_context
 from omni.isaac.lab.terrains import TerrainImporter, TerrainImporterCfg
@@ -223,7 +223,7 @@ class TestTerrainImporter(unittest.TestCase):
         cloner = GridCloner(spacing=env_spacing)
         cloner.define_base_env("/World/envs")
         envs_prim_paths = cloner.generate_paths("/World/envs/env", num_paths=num_envs)
-        prim_utils.define_prim("/World/envs/env_0")
+        prim_utils.create_prim("/World/envs/env_0")
         # clone envs using grid cloner
         env_origins = cloner.clone(
             source_prim_path="/World/envs/env_0", prim_paths=envs_prim_paths, replicate_physics=True
@@ -251,7 +251,7 @@ class TestTerrainImporter(unittest.TestCase):
         cloner = GridCloner(spacing=2.0)
         cloner.define_base_env("/World/envs")
         # Everything under the namespace "/World/envs/env_0" will be cloned
-        prim_utils.define_prim(prim_path="/World/envs/env_0", prim_type="Xform")
+        prim_utils.create_prim(prim_path="/World/envs/env_0", prim_type="Xform")
 
         # Define the scene
         # -- Ball
@@ -264,7 +264,7 @@ class TestTerrainImporter(unittest.TestCase):
             # -- Ball geometry
             enable_extension("omni.kit.primitive.mesh")
             cube_prim_path = omni.kit.commands.execute("CreateMeshPrimCommand", prim_type="Sphere")[1]
-            prim_utils.move_prim(cube_prim_path, "/World/envs/env_0/ball")
+            omni.kit.commands.execute("MovePrimCommand", path_from=cube_prim_path, path_to="/World/envs/env_0/ball")
             # -- Ball physics
             RigidPrim(prim_path="/World/envs/env_0/ball", mass=0.5, scale=(0.5, 0.5, 0.5), translation=(0.0, 0.0, 0.5))
             GeometryPrim(prim_path="/World/envs/env_0/ball", collision=True)

--- a/source/extensions/omni.isaac.lab/test/terrains/test_terrain_importer.py
+++ b/source/extensions/omni.isaac.lab/test/terrains/test_terrain_importer.py
@@ -16,6 +16,7 @@ import numpy as np
 import torch
 import unittest
 
+import omni.isaac.core.utils.prims as prim_utils
 import omni.kit
 import omni.kit.commands
 from omni.isaac.cloner import GridCloner
@@ -24,7 +25,6 @@ from omni.isaac.core.objects import DynamicSphere
 from omni.isaac.core.prims import GeometryPrim, RigidPrim, RigidPrimView
 from omni.isaac.core.utils.extensions import enable_extension
 
-import omni.isaac.lab.sim as sim_utils
 import omni.isaac.lab.terrains as terrain_gen
 from omni.isaac.lab.sim import SimulationContext, build_simulation_context
 from omni.isaac.lab.terrains import TerrainImporter, TerrainImporterCfg


### PR DESCRIPTION
# Description

This MR modifies the tests to use `build_simulation_context` instead of the repeated code for `setUp` and `tearDown`. It still needs to be propagated everywhere.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there