### PR TITLE
Fixes the event for randomizing rigid body material

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.24.13"
+version = "0.24.16"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,7 +1,17 @@
 Changelog
 ---------
 
-0.22.15 (2024-09-20)
+0.24.16 (2024-10-04)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixes
+^^^^^
+
+* Fixed the :meth:`omni.isaac.lab.envs.mdp.events.randomize_rigid_body_material` function to acutally sample randomly 
+  from the given ranges
+
+
+0.24.15 (2024-09-20)
 ~~~~~~~~~~~~~~~~~~~~
 
 Added

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
@@ -65,6 +65,9 @@ class randomize_rigid_body_material(ManagerTermBase):
         Args:
             cfg: The configuration of the event term.
             env: The environment instance.
+
+        Raises:
+            ValueError: If the asset is not a RigidObject or an Articulation.
         """
         super().__init__(cfg, env)
 
@@ -86,6 +89,14 @@ class randomize_rigid_body_material(ManagerTermBase):
             for link_path in self.asset.root_physx_view.link_paths[0]:
                 link_physx_view = self.asset._physics_sim_view.create_rigid_body_view(link_path)  # type: ignore
                 self.num_shapes_per_body.append(link_physx_view.max_shapes)
+            # ensure the parsing is correct
+            num_shapes = sum(self.num_shapes_per_body)
+            expected_shapes = self.asset.root_physx_view.max_shapes
+            if num_shapes != expected_shapes:
+                raise ValueError(
+                    "Randomization term 'randomize_rigid_body_material' failed to parse the number of shapes per body."
+                    f" Expected total shapes: {expected_shapes}, but got: {num_shapes}."
+                )
         else:
             # in this case, we don't need to do special indexing
             self.num_shapes_per_body = None

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
@@ -82,9 +82,9 @@ def randomize_rigid_body_material(
 
     # sample material properties from the given ranges
     material_samples = np.zeros(materials[env_ids].shape)
-    material_samples[..., 0] = np.random.uniform(*static_friction_range)
-    material_samples[..., 1] = np.random.uniform(*dynamic_friction_range)
-    material_samples[..., 2] = np.random.uniform(*restitution_range)
+    material_samples[..., 0] = np.random.uniform(*static_friction_range, size=tuple(materials.shape[:-1]))
+    material_samples[..., 1] = np.random.uniform(*dynamic_friction_range, size=tuple(materials.shape[:-1]))
+    material_samples[..., 2] = np.random.uniform(*restitution_range, size=tuple(materials.shape[:-1]))
 
     # create uniform range tensor for bucketing
     lo = np.array([static_friction_range[0], dynamic_friction_range[0], restitution_range[0]])
@@ -94,7 +94,9 @@ def randomize_rigid_body_material(
     # into buckets based on the number of buckets specified
     for d in range(3):
         buckets = np.array([(hi[d] - lo[d]) * i / num_buckets + lo[d] for i in range(num_buckets)])
-        material_samples[..., d] = buckets[np.searchsorted(buckets, material_samples[..., d]) - 1]
+        material_samples[..., d] = buckets[
+            np.clip(np.searchsorted(buckets, material_samples[..., d]), 0, num_buckets - 1)
+        ]
 
     # update material buffer with new samples
     if isinstance(asset, Articulation) and asset_cfg.body_ids != slice(None):

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
@@ -14,7 +14,6 @@ the event introduced by the function.
 
 from __future__ import annotations
 
-import numpy as np
 import torch
 from typing import TYPE_CHECKING, Literal
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
@@ -91,7 +91,7 @@ def randomize_rigid_body_material(
         material_buckets[:, 1] = torch.min(material_buckets[:, 0], material_buckets[:, 1])
 
     # randomly assign material IDs to the geometries
-    bucket_ids = torch.randint(0, num_buckets, (len(env_ids) * asset.root_physx_view.max_shapes, ), device="cpu")
+    bucket_ids = torch.randint(0, num_buckets, (len(env_ids) * asset.root_physx_view.max_shapes,), device="cpu")
     material_samples = material_buckets[bucket_ids].view(len(env_ids), -1, 3)
 
     # retrieve material buffer from the physics simulation

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
@@ -90,8 +90,8 @@ def randomize_rigid_body_material(
         material_buckets[:, 1] = torch.min(material_buckets[:, 0], material_buckets[:, 1])
 
     # randomly assign material IDs to the geometries
-    bucket_ids = torch.randint(0, num_buckets, (len(env_ids) * asset.root_physx_view.max_shapes,), device="cpu")
-    material_samples = material_buckets[bucket_ids].view(len(env_ids), -1, 3)
+    bucket_ids = torch.randint(0, num_buckets, (len(env_ids), asset.root_physx_view.max_shapes,), device="cpu")
+    material_samples = material_buckets[bucket_ids]
 
     # retrieve material buffer from the physics simulation
     materials = asset.root_physx_view.get_material_properties()

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/events.py
@@ -97,19 +97,16 @@ class randomize_rigid_body_material(ManagerTermBase):
         num_buckets = int(cfg.params.get("num_buckets", 1))
 
         # sample material properties from the given ranges
+        # note: we only sample the materials once during initialization
+        #   afterwards these are randomly assigned to the geometries of the asset
         range_list = [static_friction_range, dynamic_friction_range, restitution_range]
         ranges = torch.tensor(range_list, device="cpu")
-        material_buckets = math_utils.sample_uniform(ranges[:, 0], ranges[:, 1], (num_buckets, 3), device="cpu")
+        self.material_buckets = math_utils.sample_uniform(ranges[:, 0], ranges[:, 1], (num_buckets, 3), device="cpu")
 
         # ensure dynamic friction is always less than static friction
         make_consistent = cfg.params.get("make_consistent", False)
         if make_consistent:
-            material_buckets[:, 1] = torch.min(material_buckets[:, 0], material_buckets[:, 1])
-
-        # store the material buckets
-        # note: we only sample the materials once during initialization
-        #   afterwards these are randomly assigned to the geometries of the asset
-        self.material_buckets = material_buckets
+            self.material_buckets[:, 1] = torch.min(self.material_buckets[:, 0], self.material_buckets[:, 1])
 
     def __call__(
         self,


### PR DESCRIPTION
# Description

The current friction randomization event only selects a single random number in the given range and does not vary them. With the given PR, this is getting fixed, and there is a sampling of the entire given range. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

| Before | After |
| ------ | ----- |
| ![Screenshot from 2024-10-03 22-26-49](https://github.com/user-attachments/assets/d13f86ee-c776-4046-af2e-46be8f271a00) | ![Screenshot from 2024-10-03 22-27-15](https://github.com/user-attachments/assets/cf0a536d-20d0-47f1-b580-25241049cdd4) |


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
