### PR TITLE
Adds buildspec for mirroring job

### DIFF
--- a/.github/workflows/mirror-buildspec.yml
+++ b/.github/workflows/mirror-buildspec.yml
@@ -1,0 +1,15 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 14
+  pre_build:
+    commands:
+      - git config --global user.name "Isaac LAB CI Bot"
+      - git config --global user.email "isaac-lab-ci-bot@nvidia.com"
+  build:
+    commands:
+      - git remote set-url origin https://github.com/${TARGET_REPO}.git
+      - git checkout $SOURCE_BRANCH
+      - git push --force https://$GITHUB_TOKEN@github.com/${TARGET_REPO}.git $SOURCE_BRANCH:$TARGET_BRANCH


### PR DESCRIPTION
# Description

Adding a buildspec for repo mirroring job:
- Mirrors a branch
- Uses personal github token
- Target repo and branch names are coming from env variables
- Pushing code with force