### PR TITLE
Makes pre and post merge pipelines more flexible on the Isaac SIM base image version

### DIFF
--- a/.aws/postmerge-ci-buildspec.yml
+++ b/.aws/postmerge-ci-buildspec.yml
@@ -34,7 +34,7 @@ phases:
         docker login -u \$oauthtoken -p $NGC_TOKEN nvcr.io
         docker build -t $IMAGE_NAME:$COMBINED_TAG \
           --build-arg ISAACSIM_BASE_IMAGE_ARG=$ISAACSIM_BASE_IMAGE \
-          --build-arg ISAACSIM_VERSION_ARG=4.2.0 \
+          --build-arg ISAACSIM_VERSION_ARG=$ISAACSIM_BASE_VERSION \
           --build-arg ISAACSIM_ROOT_PATH_ARG=/isaac-sim \
           --build-arg ISAACLAB_PATH_ARG=/workspace/isaaclab \
           --build-arg DOCKER_USER_HOME_ARG=/root \

--- a/.aws/premerge-ci-buildspec.yml
+++ b/.aws/premerge-ci-buildspec.yml
@@ -69,7 +69,7 @@ phases:
           cd $SRC_DIR
           DOCKER_BUILDKIT=1 docker build -t isaac-lab-dev \
             --build-arg ISAACSIM_BASE_IMAGE_ARG=$ISAACSIM_BASE_IMAGE \
-            --build-arg ISAACSIM_VERSION_ARG=4.2.0 \
+            --build-arg ISAACSIM_VERSION_ARG=$ISAACSIM_BASE_VERSION \
             --build-arg ISAACSIM_ROOT_PATH_ARG=/isaac-sim \
             --build-arg ISAACLAB_PATH_ARG=/workspace/isaaclab \
             --build-arg DOCKER_USER_HOME_ARG=/root \


### PR DESCRIPTION
# Description

Making the base image version a parameter so the pipelines can use different versions without the need to hardcode that.