### PR TITLE
Removes extension startup messages from the Simulation App

### DIFF
--- a/docs/source/refs/troubleshooting.rst
+++ b/docs/source/refs/troubleshooting.rst
@@ -35,6 +35,26 @@ In the above example, the log file is located at ``.../logs/Kit/Isaac-Sim/2023.1
 You can open this file to check the internal logs from the simulator. Also when reporting issues, please include
 this log file to help us debug the issue.
 
+Changing logging channel levels for the simulator
+-------------------------------------------------
+
+By default, the simulator logs messages at the ``WARN`` level and above on the terminal. You can change the logging
+channel levels to get more detailed logs. The logging channel levels can be set through Omniverse's logging system.
+
+To obtain more detailed logs, you can run your application with the following flags:
+
+* ``--info``: This flag logs messages at the ``INFO`` level and above.
+* ``--verbose``: This flag logs messages at the ``VERBOSE`` level and above.
+
+For instance, to run a standalone script with verbose logging, you can use the following command:
+
+.. code-block:: bash
+
+    # Run the standalone script with info logging
+    ./isaaclab.sh -p source/standalone/tutorials/00_sim/create_empty.py --headless --info
+
+For more fine-grained control, you can modify the logging channels through the ``omni.log`` module.
+For more information, please refer to its `documentation <https://docs.omniverse.nvidia.com/kit/docs/carbonite/latest/docs/omni.log/Logging.html>`__.
 
 Using CPU Scaling Governor for performance
 ------------------------------------------

--- a/source/apps/isaaclab.python.headless.kit
+++ b/source/apps/isaaclab.python.headless.kit
@@ -34,6 +34,10 @@ renderer.active = "rtx"
 
 app.content.emptyStageOnStart = false
 
+# Disable print outs on extension startup information
+# this only disables the app print_and_log function
+app.enableStdoutOutput = false
+
 # Setting the port for the embedded http server
 exts."omni.services.transport.server.http".port = 8211
 

--- a/source/apps/isaaclab.python.kit
+++ b/source/apps/isaaclab.python.kit
@@ -124,6 +124,10 @@ exts."omni.kit.menu.utils".logDeprecated = false
 # app.content.emptyStageOnStart = false
 app.file.ignoreUnsavedOnExit = true # prevents save dialog when exiting
 
+# disable print outs on extension startup information
+# this only disables the app print_and_log function
+app.enableStdoutOutput = false
+
 # deprecate support for old kit.ui.menu
 app.menu.legacy_mode = false
 # use omni.ui.Menu for the MenuBar

--- a/source/apps/isaaclab.python.kit
+++ b/source/apps/isaaclab.python.kit
@@ -141,6 +141,9 @@ exts."omni.kit.window.viewport".blockingGetViewportDrawable = false
 
 exts."omni.kit.test".includeTests = [ "*isaac*" ]
 
+# set the default ros bridge to disable on startup
+isaac.startup.ros_bridge_extension = ""
+
 [settings.app.python]
 # These disable the kit app from also printing out python output, which gets confusing
 interceptSysStdOutput = false

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -579,8 +579,16 @@ class AppLauncher:
         for key in found_modules:
             hacked_modules[key] = sys.modules[key]
             del sys.modules[key]
+
+        # disable sys stdout and stderr to avoid printing the warning messages
+        # this is mainly done to purge the print statements from the simulation app
+        if "--verbose" not in sys.argv and "--info" not in sys.argv:
+            sys.stdout = open(os.devnull, "w")
         # launch simulation app
         self._app = SimulationApp(self._sim_app_config, experience=self._sim_experience_file)
+        # enable sys stdout and stderr
+        sys.stdout = sys.__stdout__
+
         # add Isaac Lab modules back to sys.modules
         for key, value in hacked_modules.items():
             sys.modules[key] = value

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -254,7 +254,12 @@ class AppLauncher:
         arg_group.add_argument(
             "--verbose",  # Note: This is read by SimulationApp through sys.argv
             action="store_true",
-            help="Enable verbose terminal output from the SimulationApp.",
+            help="Enable verbose-level log output from the SimulationApp.",
+        )
+        arg_group.add_argument(
+            "--info",  # Note: This is read by SimulationApp through sys.argv
+            action="store_true",
+            help="Enable info-level log output from the SimulationApp.",
         )
         arg_group.add_argument(
             "--experience",

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -583,7 +583,7 @@ class AppLauncher:
         # disable sys stdout and stderr to avoid printing the warning messages
         # this is mainly done to purge the print statements from the simulation app
         if "--verbose" not in sys.argv and "--info" not in sys.argv:
-            sys.stdout = open(os.devnull, "w")
+            sys.stdout = open(os.devnull, "w")  # noqa: SIM115
         # launch simulation app
         self._app = SimulationApp(self._sim_app_config, experience=self._sim_experience_file)
         # enable sys stdout and stderr

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -557,6 +557,8 @@ class AppLauncher:
                 " The file does not exist."
             )
 
+        # Resolve the absolute path of the experience file
+        self._sim_experience_file = os.path.abspath(self._sim_experience_file)
         print(f"[INFO][AppLauncher]: Loading experience file: {self._sim_experience_file}")
         # Remove all values from input keyword args which are not meant for SimulationApp
         # Assign all the passed settings to a dictionary for the simulation app

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/simulation_context.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/simulation_context.py
@@ -297,8 +297,8 @@ class SimulationContext(_SimulationContext):
     Operations - New utilities.
     """
 
-    @staticmethod
     def set_camera_view(
+        self,
         eye: tuple[float, float, float],
         target: tuple[float, float, float],
         camera_prim_path: str = "/OmniverseKit_Persp",
@@ -315,7 +315,9 @@ class SimulationContext(_SimulationContext):
             camera_prim_path: The path to the camera primitive in the stage. Defaults to
                 "/OmniverseKit_Persp".
         """
-        set_camera_view(eye, target, camera_prim_path)
+        # safe call only if we have a GUI or viewport rendering enabled
+        if self._has_gui or self._offscreen_render or self._render_viewport:
+            set_camera_view(eye, target, camera_prim_path)
 
     def set_render_mode(self, mode: RenderMode):
         """Change the current render mode of the simulation.
@@ -614,7 +616,7 @@ class SimulationContext(_SimulationContext):
         if event.type == int(omni.timeline.TimelineEventType.STOP):
             # keep running the simulator when configured to not shutdown the app
             if self._has_gui and sys.exc_info()[0] is None:
-                self.app.print_and_log(
+                carb.log_warn(
                     "Simulation is stopped. The app will keep running with physics disabled."
                     " Press Ctrl+C or close the window to exit the app."
                 )
@@ -649,7 +651,7 @@ class SimulationContext(_SimulationContext):
             omni.usd.get_context().close_stage()
 
         # print logging information
-        self.app.print_and_log("Simulation is stopped. Shutting down the app...")
+        print("[INFO]: Simulation is stopped. Shutting down the app.")
 
         # Cleanup any running tracy instances so data is not lost
         try:

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/warp/ops.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/warp/ops.py
@@ -13,6 +13,9 @@ import torch
 
 import warp as wp
 
+# disable warp module initialization messages
+wp.config.quiet = True
+# initialize the warp module
 wp.init()
 
 from . import kernels


### PR DESCRIPTION
# Description

This MR disables terminal spamming when launching the app. With the flag `/app/enableStdoutOutput` disabled, we no longer have the app output when the kit extensions are startup.

Fixes #1097, #196

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

```
./isaaclab.sh -p source/standalone/environments/zero_agent.py --task Isaac-Velocity-Rough-Anymal-C-v0 --num_envs 32
```

Output:

```
[INFO] Using python from: /home/mayank/mambaforge/envs/isaaclab-rsl/bin/python                                                   
[INFO][AppLauncher]: Loading experience file: /home/mayank/git_nv/IsaacLab/source/extensions/omni.isaac.lab/omni/isaac/lab/app/../../../../../../apps/isaaclab.python.kit
Loading user config located at: '/media/vulcan/packman-repo/chk/kit-kernel/106.1.0+release.140981.10a4b5c0.gl.linux-x86_64.release/data/Kit/Isaac-Sim/4.2/user.config.json'
[Info] [carb] Logging to file: /media/vulcan/packman-repo/chk/kit-kernel/106.1.0+release.140981.10a4b5c0.gl.linux-x86_64.release/logs/Kit/Isaac-Sim/4.2/kit_20241011_180901.log
2024-10-11 16:09:01 [0ms] [Warning] [omni.kit.app.plugin] No crash reporter present, dumps uploading isn't available.

|---------------------------------------------------------------------------------------------|
| Driver Version: 535.183.01    | Graphics API: Vulkan
|=============================================================================================|
| GPU | Name                             | Active | LDA | GPU Memory | Vendor-ID | LUID       |
|     |                                  |        |     |            | Device-ID | UUID       |
|     |                                  |        |     |            | Bus-ID    |            |
|---------------------------------------------------------------------------------------------|
| 0   | NVIDIA RTX A6000                 | Yes: 0 |     | 49386   MB | 10de      | 0          |
|     |                                  |        |     |            | 2230      | bffafd0e.. |
|     |                                  |        |     |            | 68        |            |
|=============================================================================================|
| OS: 20.04.6 LTS (Focal Fossa) ubuntu, Version: 20.04.6, Kernel: 5.15.0-122-generic
| XServer Vendor: The X.Org Foundation, XServer Version: 12013000 (1.20.13.0)
| Processor: Intel(R) Core(TM) i9-9820X CPU @ 3.30GHz | Cores: 10 | Logical: 20
|---------------------------------------------------------------------------------------------|
| Total Memory (MB): 63970 | Free Memory: 41524
| Total Page/Swap (MB): 2047 | Free Page/Swap: 2047
|---------------------------------------------------------------------------------------------|
2024-10-11 16:09:07 [6,565ms] [Warning] [omni.replicator.core.scripts.annotators] Annotator PostProcessDispatch is already registered, overwriting annotator template
2024-10-11 16:09:08 [7,613ms] [Warning] [omni.kit.widget.cache_indicator.cache_state_menu] Unable to detect Omniverse Cache Server. Consider installing it for better IO performance.
[INFO]: Parsing configuration from: <class 'omni.isaac.lab_tasks.manager_based.locomotion.velocity.config.anymal_c.rough_env_cfg.AnymalCRoughEnvCfg'>
2024-10-11 16:09:17 [16,685ms] [Warning] [omni.isaac.lab.envs.manager_based_env] Seed not set for the environment. The environment creation may not be deterministic.
[INFO]: Base environment:
    Environment device    : cuda:0
    Environment seed      : None
    Physics step-size     : 0.005
    Rendering step-size   : 0.02
    Environment step-size : 0.02
[INFO] Generating terrains based on curriculum took : 1.881988 seconds
[INFO]: Time taken for scene creation : 4.564743 seconds
[INFO]: Scene manager:  <class InteractiveScene>
    Number of environments: 32
    Environment spacing   : 2.5
    Source prim name      : /World/envs/env_0
    Global prim paths     : ['/World/ground']
    Replicate physics     : True
[INFO]: Starting the simulation. This may take a few seconds. Please wait...
2024-10-11 16:09:29 [27,861ms] [Warning] [omni.hydra.scene_delegate.plugin] Calling getBypassRenderSkelMeshProcessing for prim /World/envs/env_0/Robot/LF_THIGH/visuals.proto_mesh_1_id1 that has not been populated
2024-10-11 16:09:29 [27,880ms] [Warning] [omni.hydra] Mesh '/World/envs/env_0/Robot/base/visuals.proto_mesh_0_id0' has corrupted data in primvar 'st': buffer size 702 doesn't match expected size 12828 in faceVarying primvars
[INFO]: Time taken for simulation start : 7.193578 seconds
[INFO] Command Manager:  <CommandManager> contains 1 active terms.
+------------------------------------------------+
|              Active Command Terms              |
+-------+---------------+------------------------+
| Index | Name          |          Type          |
+-------+---------------+------------------------+
|   0   | base_velocity | UniformVelocityCommand |
+-------+---------------+------------------------+

[INFO] Action Manager:  <ActionManager> contains 1 active terms.
+------------------------------------+
|  Active Action Terms (shape: 12)   |
+--------+-------------+-------------+
| Index  | Name        |   Dimension |
+--------+-------------+-------------+
|   0    | joint_pos   |          12 |
+--------+-------------+-------------+

Module omni.isaac.lab.utils.warp.kernels 6cb40f6 load on device 'cuda:0' took 0.44 ms
[INFO] Observation Manager: <ObservationManager> contains 1 groups.
+----------------------------------------------------------+
| Active Observation Terms in Group: 'policy' (shape: (235,)) |
+-----------+--------------------------------+-------------+
|   Index   | Name                           |    Shape    |
+-----------+--------------------------------+-------------+
|     0     | base_lin_vel                   |     (3,)    |
|     1     | base_ang_vel                   |     (3,)    |
|     2     | projected_gravity              |     (3,)    |
|     3     | velocity_commands              |     (3,)    |
|     4     | joint_pos                      |    (12,)    |
|     5     | joint_vel                      |    (12,)    |
|     6     | actions                        |    (12,)    |
|     7     | height_scan                    |    (187,)   |
+-----------+--------------------------------+-------------+

[INFO] Event Manager:  <EventManager> contains 3 active terms.
+--------------------------------------+
| Active Event Terms in Mode: 'startup' |
+----------+---------------------------+
|  Index   | Name                      |
+----------+---------------------------+
|    0     | physics_material          |
|    1     | add_base_mass             |
+----------+---------------------------+
+---------------------------------------+
|  Active Event Terms in Mode: 'reset'  |
+--------+------------------------------+
| Index  | Name                         |
+--------+------------------------------+
|   0    | base_external_force_torque   |
|   1    | reset_base                   |
|   2    | reset_robot_joints           |
+--------+------------------------------+
+----------------------------------------------+
|    Active Event Terms in Mode: 'interval'    |
+-------+------------+-------------------------+
| Index | Name       | Interval time range (s) |
+-------+------------+-------------------------+
|   0   | push_robot |       (10.0, 15.0)      |
+-------+------------+-------------------------+

[INFO] Termination Manager:  <TerminationManager> contains 2 active terms.
+---------------------------------+
|     Active Termination Terms    |
+-------+--------------+----------+
| Index | Name         | Time Out |
+-------+--------------+----------+
|   0   | time_out     |   True   |
|   1   | base_contact |  False   |
+-------+--------------+----------+

[INFO] Reward Manager:  <RewardManager> contains 11 active terms.
+-----------------------------------------+
|           Active Reward Terms           |
+-------+----------------------+----------+
| Index | Name                 |   Weight |
+-------+----------------------+----------+
|   0   | track_lin_vel_xy_exp |      1.0 |
|   1   | track_ang_vel_z_exp  |      0.5 |
|   2   | lin_vel_z_l2         |     -2.0 |
|   3   | ang_vel_xy_l2        |    -0.05 |
|   4   | dof_torques_l2       |   -1e-05 |
|   5   | dof_acc_l2           | -2.5e-07 |
|   6   | action_rate_l2       |    -0.01 |
|   7   | feet_air_time        |    0.125 |
|   8   | undesired_contacts   |     -1.0 |
|   9   | flat_orientation_l2  |      0.0 |
|   10  | dof_pos_limits       |      0.0 |
+-------+----------------------+----------+

[INFO] Curriculum Manager:  <CurriculumManager> contains 1 active terms.
+---------------------------+
|  Active Curriculum Terms  |
+--------+------------------+
| Index  | Name             |
+--------+------------------+
|   0    | terrain_levels   |
+--------+------------------+

Creating window for environment.
[INFO]: Completed setting up the environment...
[INFO]: Gym observation space: Dict('policy': Box(-inf, inf, (32, 235), float32))
[INFO]: Gym action space: Box(-inf, inf, (32, 12), float32)
```

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there