### PR TITLE
Fix: Expose 'is_global' flag when calling write_da…

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
@@ -169,7 +169,7 @@ class Articulation(AssetBase):
         self._external_force_b[env_ids] = 0.0
         self._external_torque_b[env_ids] = 0.0
 
-    def write_data_to_sim(self):
+    def write_data_to_sim(self, is_global=False):
         """Write external wrenches and joint commands to the simulation.
 
         If any explicit actuators are present, then the actuator models are used to compute the
@@ -186,7 +186,7 @@ class Articulation(AssetBase):
                 torque_data=self._external_torque_b.view(-1, 3),
                 position_data=None,
                 indices=self._ALL_INDICES,
-                is_global=True, # Maybe we can expose this flag?
+                is_global=False, # Maybe we can expose this flag?
             )
 
         # apply actuator models

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
@@ -186,7 +186,7 @@ class Articulation(AssetBase):
                 torque_data=self._external_torque_b.view(-1, 3),
                 position_data=None,
                 indices=self._ALL_INDICES,
-                is_global=False,
+                is_global=True, # Maybe we can expose this flag?
             )
 
         # apply actuator models


### PR DESCRIPTION
…ta_to_sim(). That way forces & torques in global coordinates can be applied without any issues.

# Description

The flag 'is_global' in the function: self.root_physx_view.apply_forces_and_torques_at_position() is set to False.

If I want to apply forces and torques which are in the global coordinate system, then I need to change this flag to True.

I suggest to expose this flag to the function call: articulation.write_data_to_sim(is_global=False)

Fixes # (issue)

I am not familiar in software deployment and am not sure, if the fix is as simple as just adding the argument to the signature of the function. This is what I would recommend, but I want to leave it to those who know what they are doing.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
