### PR TITLE
Allows configclass `to_dict` operation to handle a list of configclasses

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.25.1"
+version = "0.25.2"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed the issue with using list or tuples of ``configclass`` within a ``configclass``. Ealier, the list of
+* Fixed the issue with using list or tuples of ``configclass`` within a ``configclass``. Earlier, the list of
   configclass objects were not converted to dictionary properly when ``to_dict`` function was called.
 
 

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+
+0.25.2 (2024-10-15)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed issues with using list or tuples of ``configclass`` within a ``configclass`` when using Modifiers.
+
+
 0.25.1 (2024-10-10)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
@@ -38,13 +38,11 @@ def class_to_dict(obj: object) -> dict[str, Any]:
     if not hasattr(obj, "__class__"):
         raise ValueError(f"Expected a class instance. Received: {type(obj)}.")
     # convert object to dictionary
-    obj_dict = None
     if isinstance(obj, dict):
         obj_dict = obj
     elif hasattr(obj, '__dict__'):
         obj_dict = obj.__dict__
-
-    if obj_dict is None:
+    else:
         return obj
 
     # convert to dictionary

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
@@ -40,7 +40,7 @@ def class_to_dict(obj: object) -> dict[str, Any]:
     # convert object to dictionary
     if isinstance(obj, dict):
         obj_dict = obj
-    elif hasattr(obj, '__dict__'):
+    elif hasattr(obj, "__dict__"):
         obj_dict = obj.__dict__
     else:
         return obj

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
@@ -38,10 +38,14 @@ def class_to_dict(obj: object) -> dict[str, Any]:
     if not hasattr(obj, "__class__"):
         raise ValueError(f"Expected a class instance. Received: {type(obj)}.")
     # convert object to dictionary
+    obj_dict = None
     if isinstance(obj, dict):
         obj_dict = obj
-    else:
+    elif hasattr(obj, '__dict__'):
         obj_dict = obj.__dict__
+
+    if obj_dict is None:
+        return obj
 
     # convert to dictionary
     data = dict()
@@ -55,6 +59,8 @@ def class_to_dict(obj: object) -> dict[str, Any]:
         # check if attribute is a dictionary
         elif hasattr(value, "__dict__") or isinstance(value, dict):
             data[key] = class_to_dict(value)
+        elif isinstance(value, list):
+            data[key] = [class_to_dict(v) for v in value]
         else:
             data[key] = value
     return data

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
@@ -57,8 +57,8 @@ def class_to_dict(obj: object) -> dict[str, Any]:
         # check if attribute is a dictionary
         elif hasattr(value, "__dict__") or isinstance(value, dict):
             data[key] = class_to_dict(value)
-        elif isinstance(value, list):
-            data[key] = [class_to_dict(v) for v in value]
+        elif isinstance(value, (list, tuple)):
+            data[key] = type(value)([class_to_dict(v) for v in value])
         else:
             data[key] = value
     return data

--- a/source/extensions/omni.isaac.lab/test/utils/test_configclass.py
+++ b/source/extensions/omni.isaac.lab/test/utils/test_configclass.py
@@ -84,6 +84,11 @@ def double(x):
     """Dummy function."""
     return 2 * x
 
+@configclass
+class ModifierCfg:
+    func: Callable = MISSING
+    params: dict[str, Any] = {"A":1,"B":2}
+
 
 @configclass
 class ViewerCfg:
@@ -113,6 +118,8 @@ class BasicDemoCfg:
     device_id: int = 0
     env: EnvCfg = EnvCfg()
     robot_default_state: RobotDefaultStateCfg = RobotDefaultStateCfg()
+    list_config = [ModifierCfg(func=dummy_function1),
+                    ModifierCfg(func=dummy_function2, params={"A":3,"B":4})]
 
 
 @configclass
@@ -342,6 +349,8 @@ basic_demo_cfg_correct = {
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
     "device_id": 0,
+    "list_configs": [{"func": "__main__:dummy_function1" , "params" :  {"A":1,"B":2}},
+                    {"func": "__main__:dummy_function2" , "params" :  {"A":3,"B":4}}],
 }
 
 basic_demo_cfg_change_correct = {
@@ -353,6 +362,8 @@ basic_demo_cfg_change_correct = {
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
     "device_id": 0,
+    "list_configs": [{"func": "__main__:dummy_function1" , "params" :  {"A":1,"B":2}},
+                    {"func": "__main__:dummy_function2" , "params" :  {"A":3,"B":4}}],
 }
 
 basic_demo_cfg_change_with_none_correct = {
@@ -364,6 +375,8 @@ basic_demo_cfg_change_with_none_correct = {
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
     "device_id": 0,
+    "list_configs": [{"func": "__main__:dummy_function1" , "params" :  {"A":1,"B":2}},
+                    {"func": "__main__:dummy_function2" , "params" :  {"A":3,"B":4}}],
 }
 
 basic_demo_cfg_nested_dict_and_list = {

--- a/source/extensions/omni.isaac.lab/test/utils/test_configclass.py
+++ b/source/extensions/omni.isaac.lab/test/utils/test_configclass.py
@@ -375,6 +375,18 @@ basic_demo_cfg_change_with_none_correct = {
     "list_config": [{"params": {"A": 1, "B": 2}}, {"params": {"A": 3, "B": 4}}],
 }
 
+basic_demo_cfg_change_with_tuple_correct = {
+    "env": {"num_envs": 56, "episode_length": 2000, "viewer": {"eye": [7.5, 7.5, 7.5], "lookat": [0.0, 0.0, 0.0]}},
+    "robot_default_state": {
+        "pos": (0.0, 0.0, 0.0),
+        "rot": (1.0, 0.0, 0.0, 0.0),
+        "dof_pos": (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+    },
+    "device_id": 0,
+    "list_config": [{"params": {"A": -1, "B": -2}}, {"params": {"A": -3, "B": -4}}],
+}
+
 basic_demo_cfg_nested_dict_and_list = {
     "dict_1": {
         "dict_2": {"func": dummy_function2},
@@ -504,6 +516,13 @@ class TestConfigClass(unittest.TestCase):
         cfg_dict = {"env": {"num_envs": 22, "viewer": None}}
         update_class_from_dict(cfg, cfg_dict)
         self.assertDictEqual(asdict(cfg), basic_demo_cfg_change_with_none_correct)
+
+    def test_config_update_dict_tuple(self):
+        """Test updating configclass using a dictionary that modifies a tuple."""
+        cfg = BasicDemoCfg()
+        cfg_dict = {"list_config": [{"params": {"A": -1, "B": -2}}, {"params": {"A": -3, "B": -4}}]}
+        update_class_from_dict(cfg, cfg_dict)
+        self.assertDictEqual(asdict(cfg), basic_demo_cfg_change_with_tuple_correct)
 
     def test_config_update_nested_dict(self):
         """Test updating configclass with sub-dictionaries."""

--- a/source/extensions/omni.isaac.lab/test/utils/test_configclass.py
+++ b/source/extensions/omni.isaac.lab/test/utils/test_configclass.py
@@ -23,7 +23,7 @@ import unittest
 from collections.abc import Callable
 from dataclasses import MISSING, asdict, field
 from functools import wraps
-from typing import ClassVar, Any
+from typing import Any, ClassVar
 
 from omni.isaac.lab.utils.configclass import configclass
 from omni.isaac.lab.utils.dict import class_to_dict, dict_to_md5_hash, update_class_from_dict
@@ -84,9 +84,10 @@ def double(x):
     """Dummy function."""
     return 2 * x
 
+
 @configclass
 class ModifierCfg:
-    params: dict[str, Any] = {"A":1,"B":2}
+    params: dict[str, Any] = {"A": 1, "B": 2}
 
 
 @configclass
@@ -117,8 +118,7 @@ class BasicDemoCfg:
     device_id: int = 0
     env: EnvCfg = EnvCfg()
     robot_default_state: RobotDefaultStateCfg = RobotDefaultStateCfg()
-    list_config = [ModifierCfg(),
-                    ModifierCfg(params={"A":3,"B":4})]
+    list_config = [ModifierCfg(), ModifierCfg(params={"A": 3, "B": 4})]
 
 
 @configclass
@@ -348,8 +348,7 @@ basic_demo_cfg_correct = {
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
     "device_id": 0,
-    "list_config": [{"params" :  {"A":1,"B":2}},
-                    {"params" :  {"A":3,"B":4}}],
+    "list_config": [{"params": {"A": 1, "B": 2}}, {"params": {"A": 3, "B": 4}}],
 }
 
 basic_demo_cfg_change_correct = {
@@ -361,8 +360,7 @@ basic_demo_cfg_change_correct = {
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
     "device_id": 0,
-    "list_config": [{"params" :  {"A":1,"B":2}},
-                    {"params" :  {"A":3,"B":4}}],
+    "list_config": [{"params": {"A": 1, "B": 2}}, {"params": {"A": 3, "B": 4}}],
 }
 
 basic_demo_cfg_change_with_none_correct = {
@@ -374,8 +372,7 @@ basic_demo_cfg_change_with_none_correct = {
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
     "device_id": 0,
-    "list_config": [{"params" :  {"A":1,"B":2}},
-                    {"params" :  {"A":3,"B":4}}],
+    "list_config": [{"params": {"A": 1, "B": 2}}, {"params": {"A": 3, "B": 4}}],
 }
 
 basic_demo_cfg_nested_dict_and_list = {
@@ -488,8 +485,6 @@ class TestConfigClass(unittest.TestCase):
         cfg = BasicDemoCfg()
         cfg.env.num_envs = 22
         cfg.env.viewer.eye = (2.0, 2.0, 2.0)  # note: changes from list to tuple
-        test_dict = asdict(cfg)
-        
         self.assertDictEqual(asdict(cfg), basic_demo_cfg_change_correct)
 
     def test_config_update_dict(self):

--- a/source/extensions/omni.isaac.lab/test/utils/test_configclass.py
+++ b/source/extensions/omni.isaac.lab/test/utils/test_configclass.py
@@ -23,7 +23,7 @@ import unittest
 from collections.abc import Callable
 from dataclasses import MISSING, asdict, field
 from functools import wraps
-from typing import ClassVar
+from typing import ClassVar, Any
 
 from omni.isaac.lab.utils.configclass import configclass
 from omni.isaac.lab.utils.dict import class_to_dict, dict_to_md5_hash, update_class_from_dict
@@ -86,7 +86,6 @@ def double(x):
 
 @configclass
 class ModifierCfg:
-    func: Callable = MISSING
     params: dict[str, Any] = {"A":1,"B":2}
 
 
@@ -118,8 +117,8 @@ class BasicDemoCfg:
     device_id: int = 0
     env: EnvCfg = EnvCfg()
     robot_default_state: RobotDefaultStateCfg = RobotDefaultStateCfg()
-    list_config = [ModifierCfg(func=dummy_function1),
-                    ModifierCfg(func=dummy_function2, params={"A":3,"B":4})]
+    list_config = [ModifierCfg(),
+                    ModifierCfg(params={"A":3,"B":4})]
 
 
 @configclass
@@ -349,8 +348,8 @@ basic_demo_cfg_correct = {
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
     "device_id": 0,
-    "list_configs": [{"func": "__main__:dummy_function1" , "params" :  {"A":1,"B":2}},
-                    {"func": "__main__:dummy_function2" , "params" :  {"A":3,"B":4}}],
+    "list_config": [{"params" :  {"A":1,"B":2}},
+                    {"params" :  {"A":3,"B":4}}],
 }
 
 basic_demo_cfg_change_correct = {
@@ -362,8 +361,8 @@ basic_demo_cfg_change_correct = {
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
     "device_id": 0,
-    "list_configs": [{"func": "__main__:dummy_function1" , "params" :  {"A":1,"B":2}},
-                    {"func": "__main__:dummy_function2" , "params" :  {"A":3,"B":4}}],
+    "list_config": [{"params" :  {"A":1,"B":2}},
+                    {"params" :  {"A":3,"B":4}}],
 }
 
 basic_demo_cfg_change_with_none_correct = {
@@ -375,8 +374,8 @@ basic_demo_cfg_change_with_none_correct = {
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
     "device_id": 0,
-    "list_configs": [{"func": "__main__:dummy_function1" , "params" :  {"A":1,"B":2}},
-                    {"func": "__main__:dummy_function2" , "params" :  {"A":3,"B":4}}],
+    "list_config": [{"params" :  {"A":1,"B":2}},
+                    {"params" :  {"A":3,"B":4}}],
 }
 
 basic_demo_cfg_nested_dict_and_list = {
@@ -454,7 +453,7 @@ class TestConfigClass(unittest.TestCase):
 
     def test_dict_conversion_order(self):
         """Tests that order is conserved when converting to dictionary."""
-        true_outer_order = ["device_id", "env", "robot_default_state"]
+        true_outer_order = ["device_id", "env", "robot_default_state", "list_config"]
         true_env_order = ["num_envs", "episode_length", "viewer"]
         # create config
         cfg = BasicDemoCfg()
@@ -472,7 +471,7 @@ class TestConfigClass(unittest.TestCase):
             self.assertEqual(label, parsed_value)
         # check ordering when copied
         cfg_dict_copied = copy.deepcopy(cfg_dict)
-        cfg_dict_copied.pop("robot_default_state")
+        cfg_dict_copied.pop("list_config")
         # check ordering
         for label, parsed_value in zip(true_outer_order, cfg_dict_copied.keys()):
             self.assertEqual(label, parsed_value)
@@ -489,6 +488,8 @@ class TestConfigClass(unittest.TestCase):
         cfg = BasicDemoCfg()
         cfg.env.num_envs = 22
         cfg.env.viewer.eye = (2.0, 2.0, 2.0)  # note: changes from list to tuple
+        test_dict = asdict(cfg)
+        
         self.assertDictEqual(asdict(cfg), basic_demo_cfg_change_correct)
 
     def test_config_update_dict(self):


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/source/refs/contributing.html
-->

This PR add in the ability to properly convert configclass to dict if a configclass instance contains a list of configclasses.

Fixes #1219 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
