### PR TITLE
Updates tested docker and apptainer versions for cluster deployment

### DIFF
--- a/docker/cluster/cluster_interface.sh
+++ b/docker/cluster/cluster_interface.sh
@@ -154,25 +154,25 @@ case $command in
         fi
         # Check if Docker image exists
         check_image_exists isaac-lab-$profile:latest
-        # Check if Docker version is greater than 25
+        # Check docker and apptainer version
         check_docker_version
         # source env file to get cluster login and path information
-        # source $SCRIPT_DIR/.env.cluster
-        # # make sure exports directory exists
-        # mkdir -p /$SCRIPT_DIR/exports
-        # # clear old exports for selected profile
-        # rm -rf /$SCRIPT_DIR/exports/isaac-lab-$profile*
-        # # create singularity image
-        # # NOTE: we create the singularity image as non-root user to allow for more flexibility. If this causes
-        # # issues, remove the --fakeroot flag and open an issue on the IsaacLab repository.
-        # cd /$SCRIPT_DIR/exports
-        # APPTAINER_NOHTTPS=1 apptainer build --sandbox --fakeroot isaac-lab-$profile.sif docker-daemon://isaac-lab-$profile:latest
-        # # tar image (faster to send single file as opposed to directory with many files)
-        # tar -cvf /$SCRIPT_DIR/exports/isaac-lab-$profile.tar isaac-lab-$profile.sif
-        # # make sure target directory exists
-        # ssh $CLUSTER_LOGIN "mkdir -p $CLUSTER_SIF_PATH"
-        # # send image to cluster
-        # scp $SCRIPT_DIR/exports/isaac-lab-$profile.tar $CLUSTER_LOGIN:$CLUSTER_SIF_PATH/isaac-lab-$profile.tar
+        source $SCRIPT_DIR/.env.cluster
+        # make sure exports directory exists
+        mkdir -p /$SCRIPT_DIR/exports
+        # clear old exports for selected profile
+        rm -rf /$SCRIPT_DIR/exports/isaac-lab-$profile*
+        # create singularity image
+        # NOTE: we create the singularity image as non-root user to allow for more flexibility. If this causes
+        # issues, remove the --fakeroot flag and open an issue on the IsaacLab repository.
+        cd /$SCRIPT_DIR/exports
+        APPTAINER_NOHTTPS=1 apptainer build --sandbox --fakeroot isaac-lab-$profile.sif docker-daemon://isaac-lab-$profile:latest
+        # tar image (faster to send single file as opposed to directory with many files)
+        tar -cvf /$SCRIPT_DIR/exports/isaac-lab-$profile.tar isaac-lab-$profile.sif
+        # make sure target directory exists
+        ssh $CLUSTER_LOGIN "mkdir -p $CLUSTER_SIF_PATH"
+        # send image to cluster
+        scp $SCRIPT_DIR/exports/isaac-lab-$profile.tar $CLUSTER_LOGIN:$CLUSTER_SIF_PATH/isaac-lab-$profile.tar
         ;;
     job)
         if [ $# -ge 1 ]; then

--- a/docs/source/deployment/cluster.rst
+++ b/docs/source/deployment/cluster.rst
@@ -209,4 +209,3 @@ The above will, in addition, also render videos of the training progress and sto
 .. _apptainer: https://apptainer.org/
 .. _documentation: https://www.apptainer.org/docs/admin/main/installation.html#install-ubuntu-packages
 .. _SLURM documentation: https://www.slurm.schedmd.com/sbatch.html
-.. _forum post: https://forums.docker.com/t/trouble-after-upgrade-to-docker-ce-25-0-1-on-debian-12/139613

--- a/docs/source/deployment/cluster.rst
+++ b/docs/source/deployment/cluster.rst
@@ -45,15 +45,13 @@ development machine and the cluster. Such a connection will simplify the file tr
 the user cluster password from being requested multiple times.
 
 .. attention::
-  The workflow has been tested with ``apptainer version 1.2.5-1.el7`` and ``docker version 24.0.7``.
+  The workflow has been tested with:
 
-  - ``apptainer``:
-    There have been reported binding issues with previous versions (such as ``apptainer version 1.1.3-1.el7``). Please
-    ensure that you are using the latest version.
-  - ``Docker``:
-    The latest versions (``25.x``) cannot be used as they are not compatible yet with apptainer/ singularity.
+  - ``apptainer version 1.2.5-1.el7`` and ``docker version 24.0.7``
+  - ``apptainer version 1.3.4`` and ``docker version 27.3.1``
 
-    We are waiting for an update from the apptainer team. To track this issue, please check the `forum post`_.
+  In the case of issues, please try to switch to those versions.
+
 
 Configuring the cluster parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Description

The cluster workflow succeeded with a newer version of apptainer and docker. This PR removes the error when not the specific old versions are used and instead prints a warning once non-tested versions are deployed. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
