### PR TITLE
fix net_arch in sb3_ppo_cfg.yaml for Isaac-Lift-Cube-Franka-v0

### DIFF
--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/manipulation/lift/config/franka/__init__.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/manipulation/lift/config/franka/__init__.py
@@ -23,6 +23,7 @@ gym.register(
         "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:LiftCubePPORunnerCfg",
         "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
         "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
     },
     disable_env_checker=True,
 )
@@ -35,6 +36,7 @@ gym.register(
         "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:LiftCubePPORunnerCfg",
         "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
         "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
     },
     disable_env_checker=True,
 )

--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/manipulation/lift/config/franka/agents/sb3_ppo_cfg.yaml
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/manipulation/lift/config/franka/agents/sb3_ppo_cfg.yaml
@@ -16,7 +16,7 @@ learning_rate: !!float 3e-4
 clip_range: 0.2
 policy_kwargs: "dict(
                   activation_fn=nn.ELU,
-                  net_arch=[32, 32, dict(pi=[256, 128, 64], vf=[256, 128, 64])]
+                  net_arch=dict(pi=[256, 128, 64], vf=[256, 128, 64])
                 )"
 target_kl: 0.01
 max_grad_norm: 1.0


### PR DESCRIPTION
# Description
Two changes are made to fix _[Bug Report] sb3_ppo_cfg.yaml not work for Isaac-Lift-Cube-Franka-v0 #1248_:

1. Add `sb3_cfg_entry_point` to `source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/manipulation/lift/config/franka/init.py`
2. Change `net_arch=[32, 32, dict(pi=[256, 128, 64], vf=[256, 128, 64])]` to `net_arch=dict(pi=[256, 128, 64], vf=[256, 128, 64])` in  line 19 of `sb3_ppo_cfg.yaml`.


Fixes #1248

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/fc63cb04-ef53-44be-97c7-22aae6ed5c80) | ![image](https://github.com/user-attachments/assets/68fd2cf2-7bbd-46fa-9506-38576d129468)|

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings

