### PR TITLE
Fixes border height to be above the ground in the `TerrainGenerator`

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/terrains/terrain_generator.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/terrains/terrain_generator.py
@@ -268,7 +268,7 @@ class TerrainGenerator:
         border_center = (
             self.cfg.num_rows * self.cfg.size[0] / 2,
             self.cfg.num_cols * self.cfg.size[1] / 2,
-            -self.cfg.border_height / 2,
+            self.cfg.border_height / 2,
         )
         # border mesh
         border_meshes = make_border(border_size, inner_size, height=self.cfg.border_height, position=border_center)


### PR DESCRIPTION
# Description

Currently, the border center is set to -border_height / 2, which means the max border height will reach  the 0 point. This PR fixes the height and sets it to border_height / 2. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
