### PR TITLE
Initializes the EventManager before the ObservationManager in ManagerBasedEnv

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -69,6 +69,7 @@ Guidelines for modifications:
 * Zhengyu Zhang
 * Ziqi Fan
 * Qian Wan
+* Peter Du
 
 ## Acknowledgements
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,8 +59,8 @@ Guidelines for modifications:
 * Nuralem Abizov
 * Özhan Özen
 * Peter Du
-* Qinxi Yu
 * Qian Wan
+* Qinxi Yu
 * René Zurbrügg
 * Ritvik Singh
 * Rosario Scalise

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,7 +58,9 @@ Guidelines for modifications:
 * Muhong Guo
 * Nuralem Abizov
 * Özhan Özen
+* Peter Du
 * Qinxi Yu
+* Qian Wan
 * René Zurbrügg
 * Ritvik Singh
 * Rosario Scalise
@@ -69,8 +71,6 @@ Guidelines for modifications:
 * Yang Jin
 * Zhengyu Zhang
 * Ziqi Fan
-* Qian Wan
-* Peter Du
 
 ## Acknowledgements
 

--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.25.2"
+version = "0.25.3"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -7,8 +7,9 @@ Changelog
 Changed
 ^^^^^^^
 
-* initialize ``EventManager`` and trigger startup events before ``ObservationManager`` in ``load_managers`` API of 
+* Initialize ``EventManager`` and trigger startup events before ``ObservationManager`` in ``load_managers`` API of 
   ``ManagerBasedEnv``. This allows observations that may depend on a startup event. 
+* Enable startup events in ``load_managers`` for child classes. 
 
 0.25.2 (2024-10-16)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.25.3 (2024-10-17)
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* initialize ``EventManager`` and trigger startup events before ``ObservationManager`` in ``load_managers`` API of 
+  ``ManagerBasedEnv``. This allows observations that may depend on a startup event. 
+
 0.25.2 (2024-10-16)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -7,9 +7,9 @@ Changelog
 Changed
 ^^^^^^^
 
-* Initialize ``EventManager`` and trigger startup events before ``ObservationManager`` in ``load_managers`` API of 
-  ``ManagerBasedEnv``. This allows observations that may depend on a startup event. 
-* Enable startup events in ``load_managers`` for child classes. 
+* Initialize ``EventManager`` and trigger startup events before ``ObservationManager`` in ``load_managers`` API of
+  ``ManagerBasedEnv``. This allows observations that may depend on a startup event.
+* Enable startup events in ``load_managers`` for child classes.
 
 0.25.2 (2024-10-16)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_env.py
@@ -209,18 +209,18 @@ class ManagerBasedEnv:
         # -- action manager
         self.action_manager = ActionManager(self.cfg.actions, self)
         print("[INFO] Action Manager: ", self.action_manager)
-        # -- observation manager
-        self.observation_manager = ObservationManager(self.cfg.observations, self)
-        print("[INFO] Observation Manager:", self.observation_manager)
+
         # -- event manager
         self.event_manager = EventManager(self.cfg.events, self)
         print("[INFO] Event Manager: ", self.event_manager)
-
         # perform events at the start of the simulation
-        # in-case a child implementation creates other managers, the randomization should happen
-        # when all the other managers are created
-        if self.__class__ == ManagerBasedEnv and "startup" in self.event_manager.available_modes:
+        if "startup" in self.event_manager.available_modes:
             self.event_manager.apply(mode="startup")
+
+        # -- observation manager
+        self.observation_manager = ObservationManager(self.cfg.observations, self)
+        print("[INFO] Observation Manager:", self.observation_manager)
+
 
     """
     Operations - MDP.

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_env.py
@@ -221,7 +221,6 @@ class ManagerBasedEnv:
         self.observation_manager = ObservationManager(self.cfg.observations, self)
         print("[INFO] Observation Manager:", self.observation_manager)
 
-
     """
     Operations - MDP.
     """


### PR DESCRIPTION
# Description

Currently the EventManager is initialized after the ObservationManager in ManagerBasedEnv. This change reorders the two and initializes EventManager and applies startup events prior to initialization of the ObserverationManager. This is to support the case where the correct observation may depend on a startup event. The change was tested for existing envs using the `test_enviornments.py` script. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there