### PR TITLE
Removes `ml_archive` as a dependency of `omni.isaac.lab` extension

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -13,7 +13,6 @@ keywords = ["kit", "robotics", "learning", "ai"]
 
 [dependencies]
 "omni.isaac.core" = {}
-"omni.isaac.ml_archive" = {}
 "omni.replicator.core" = {}
 
 [python.pipapi]


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/source/refs/contributing.html
-->

Extension ui can't load because of `omni.isaac.ml_archive`

Fixes https://github.com/isaac-sim/IsaacLabExtensionTemplate/issues/39

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.


| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/93a2973c-8934-4ba4-be77-2f7af657126f) | ![after](https://github.com/user-attachments/assets/605449ff-9280-4ee8-88d3-fc14cc2d4d5d) |

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
