### PR TITLE
Updates documentation on Isaac Lab installation path for Windows

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,6 +52,7 @@ Guidelines for modifications:
 * Kaixi Bao
 * Kourosh Darvish
 * Lionel Gulich
+* Louis Le Lay
 * Lorenz Wellhausen
 * Masoud Moghani
 * Michael Gussert

--- a/docs/source/setup/installation/binaries_installation.rst
+++ b/docs/source/setup/installation/binaries_installation.rst
@@ -38,7 +38,7 @@ To check the minimum system requirements,refer to the documentation
          :sync: windows
 
          On Windows systems, by default,Isaac Sim is installed in the directory
-         ``C:\Users\%USERPROFILE%\AppData\Local\ov\pkg\isaac_sim-*``, with ``*`` corresponding to the Isaac Sim version.
+         ``%USERPROFILE%\AppData\Local\ov\pkg\isaac_sim-*``, with ``*`` corresponding to the Isaac Sim version.
 
 Verifying the Isaac Sim installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -66,7 +66,7 @@ variables to your terminal for the remaining of the installation instructions:
       .. code:: batch
 
          :: Isaac Sim root directory
-         set ISAACSIM_PATH="C:\Users\%USERPROFILE%\AppData\Local\ov\pkg\isaac-sim-4.2.0"
+         set ISAACSIM_PATH="%USERPROFILE%\AppData\Local\ov\pkg\isaac-sim-4.2.0"
          :: Isaac Sim python executable
          set ISAACSIM_PYTHON_EXE="%ISAACSIM_PATH:"=%\python.bat"
 

--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.26.0"
+version = "0.26.1"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,4 +1,13 @@
 Changelog
+
+
+0.26.1 (2024-10-18)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Updated installation path instructions for Windows in the Isaac Lab documentation to remove redundancy in the use of %USERPROFILE% for path definitions.
 ---------
 
 0.26.0 (2024-10-16)

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,14 +1,14 @@
 Changelog
+---------
 
-
-0.26.1 (2024-10-18)
+0.27.4 (2024-10-18)
 ~~~~~~~~~~~~~~~~~~~
 
 Fixed
 ^^^^^
 
 * Updated installation path instructions for Windows in the Isaac Lab documentation to remove redundancy in the use of %USERPROFILE% for path definitions.
----------
+
 
 0.27.3 (2024-10-22)
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Description

This update addresses a minor inconsistency found in the Isaac Lab installation documentation for Windows.

While following the installation instructions on Isaac Lab for "Option 2: Installation using Isaac Sim binaries" on Windows, I encountered the following lines:

> `C:\Users\%USERPROFILE%\AppData\Local\ov\pkg\isaac_sim-*`, with `*` corresponding to the Isaac Sim version.

> `set ISAACSIM_PATH="C:\Users\%USERPROFILE%\AppData\Local\ov\pkg\isaac-sim-4.2.0"`

This seemed redundant, as `%USERPROFILE%` already refers to the path `C:\Users\name_of_user`. 

I have compiled and verified the documentation changes to ensure proper display. Additionally, I tested this update on a Windows system, confirming that it works as intended.

## Type of change

- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there