### PR TITLE
Fixes broken URLs in markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,4 @@ the framework more mature and useful for everyone. These may happen in forms of 
 design proposals and more.
 
 For general information on how to contribute see
-<https://isaac-sim.github.io/IsaacLab/source/refs/contributing.html>.
+<https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html>.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,6 +42,7 @@ Guidelines for modifications:
 * Calvin Yu
 * Chenyu Yang
 * David Yang
+* Dorsa Rohani
 * Gary Lvov
 * Giulio Romualdi
 * HoJin Jeon

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ installation steps, features, tutorials, and how to set up your project with Isa
 
 We wholeheartedly welcome contributions from the community to make this framework mature and useful for everyone.
 These may happen as bug reports, feature requests, or code contributions. For details, please check our
-[contribution guidelines](https://isaac-sim.github.io/IsaacLab/source/refs/contributing.html).
+[contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html).
 
 ## Troubleshooting
 
-Please see the [troubleshooting](https://isaac-sim.github.io/IsaacLab/source/refs/troubleshooting.html) section for
+Please see the [troubleshooting](https://isaac-sim.github.io/IsaacLab/main/source/refs/troubleshooting.html) section for
 common fixes or [submit an issue](https://github.com/isaac-sim/IsaacLab/issues).
 
 For issues related to Isaac Sim, we recommend checking its [documentation](https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/overview.html)


### PR DESCRIPTION
# Description

Fixes the broken URLs in README.md and CONTRIBUTING.md

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable for this change

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
