### PR TITLE
Adds Kit command line argument support

### DIFF
--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -350,7 +350,7 @@ while [[ $# -gt 0 ]]; do
             python_exe=$(extract_python_exe)
             echo "[INFO] Using python from: ${python_exe}"
             shift # past argument
-            ${python_exe} $@
+            ${python_exe} "$@"
             # exit neatly
             break
             ;;

--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.26.0"
+version = "0.26.1"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Added
 ^^^^^
 
-* Added ``--ov_args`` to :class:`~omni.isaac.lab.app.AppLauncher` to allow passing command line arguments directly to Omniverse.
+* Added ``--kit_args`` to :class:`~omni.isaac.lab.app.AppLauncher` to allow passing command line arguments directly to Omniverse Kit SDK.
 
 
 0.27.0 (2024-10-14)

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.26.1 (2024-10-21)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``--ov_args`` to allow passing command line arguments directly to Omniverse.
+
+
 0.26.0 (2024-10-16)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -572,7 +572,7 @@ class AppLauncher:
 
         # Resolve additional arguments passed to Kit
         self._ov_args = []
-        if launcher_args["ov_args"]:
+        if "ov_args" in launcher_args:
             self._ov_args = [arg for arg in launcher_args["ov_args"].split()]
             sys.argv += self._ov_args
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -281,7 +281,7 @@ class AppLauncher:
             default="",
             help=(
                 "Command line arguments for Omniverse Kit as a string separated by a space delimiter."
-                ' Example usage: --ov_args "--ext-folder=/path/to/ext1 --ext-folder=/path/to/ext2"'
+                ' Example usage: --kit_args "--ext-folder=/path/to/ext1 --ext-folder=/path/to/ext2"'
             ),
         )
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -276,7 +276,7 @@ class AppLauncher:
             ),
         )
         arg_group.add_argument(
-            "--ov_args",
+            "--kit_args",
             type=str,
             default="",
             help=(

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -186,8 +186,8 @@ class AppLauncher:
           * If headless is True and enable_cameras is False, the experience file is set to ``isaaclab.python.headless.kit``.
 
         * ``ov_args`` (str): Optional command line arguments to be passed to Omniverse Kit directly.
-          Arguments should be combined into a single string separated by a comma ','.
-          Example usage: --ov_args "--ext-folder=/path/to/ext1,--ext-folder=/path/to/ext2"
+          Arguments should be combined into a single string separated by space.
+          Example usage: --ov_args "--ext-folder=/path/to/ext1 --ext-folder=/path/to/ext2"
 
         Args:
             parser: An argument parser instance to be extended with the AppLauncher specific options.

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -185,6 +185,10 @@ class AppLauncher:
           * If headless and enable_cameras are False, the experience file is set to ``isaaclab.python.kit``.
           * If headless is True and enable_cameras is False, the experience file is set to ``isaaclab.python.headless.kit``.
 
+        * ``ov_args`` (str): Optional command line arguments to be passed to Omniverse Kit directly.
+          Arguments should be combined into a single string separated by a comma ','.
+          Example usage: --ov_args "--ext-folder=/path/to/ext1,--ext-folder=/path/to/ext2"
+
         Args:
             parser: An argument parser instance to be extended with the AppLauncher specific options.
         """
@@ -269,6 +273,15 @@ class AppLauncher:
                 "The experience file to load when launching the SimulationApp. If an empty string is provided,"
                 " the experience file is determined based on the headless flag. If a relative path is provided,"
                 " it is resolved relative to the `apps` folder in Isaac Sim and Isaac Lab (in that order)."
+            ),
+        )
+        arg_group.add_argument(
+            "--ov_args",
+            type=str,
+            default="",
+            help=(
+                "Command line arguments for Omniverse Kit as a string separated by delimiter ','."
+                ' Example usage: --ov_args "--ext-folder=/path/to/ext1,--ext-folder=/path/to/ext2"'
             ),
         )
 
@@ -557,6 +570,12 @@ class AppLauncher:
                 " The file does not exist."
             )
 
+        # Resolve additional arguments passed to Kit
+        self._ov_args = []
+        if launcher_args["ov_args"]:
+            self._ov_args = [arg.strip() for arg in launcher_args["ov_args"].split(",")]
+            sys.argv += self._ov_args
+
         # Resolve the absolute path of the experience file
         self._sim_experience_file = os.path.abspath(self._sim_experience_file)
         print(f"[INFO][AppLauncher]: Loading experience file: {self._sim_experience_file}")
@@ -595,6 +614,9 @@ class AppLauncher:
         # remove the threadCount argument from sys.argv if it was added for distributed training
         pattern = r"--/plugins/carb\.tasking\.plugin/threadCount=\d+"
         sys.argv = [arg for arg in sys.argv if not re.match(pattern, arg)]
+        # remove additional OV args from sys.argv
+        if len(self._ov_args) > 0:
+            sys.argv = [arg for arg in sys.argv if arg not in self._ov_args]
 
     def _rendering_enabled(self) -> bool:
         """Check if rendering is required by the app."""

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -185,7 +185,7 @@ class AppLauncher:
           * If headless and enable_cameras are False, the experience file is set to ``isaaclab.python.kit``.
           * If headless is True and enable_cameras is False, the experience file is set to ``isaaclab.python.headless.kit``.
 
-        * ``ov_args`` (str): Optional command line arguments to be passed to Omniverse Kit directly.
+        * ``kit_args`` (str): Optional command line arguments to be passed to Omniverse Kit directly.
           Arguments should be combined into a single string separated by space.
           Example usage: --ov_args "--ext-folder=/path/to/ext1 --ext-folder=/path/to/ext2"
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -187,7 +187,7 @@ class AppLauncher:
 
         * ``kit_args`` (str): Optional command line arguments to be passed to Omniverse Kit directly.
           Arguments should be combined into a single string separated by space.
-          Example usage: --ov_args "--ext-folder=/path/to/ext1 --ext-folder=/path/to/ext2"
+          Example usage: --kit_args "--ext-folder=/path/to/ext1 --ext-folder=/path/to/ext2"
 
         Args:
             parser: An argument parser instance to be extended with the AppLauncher specific options.
@@ -571,10 +571,10 @@ class AppLauncher:
             )
 
         # Resolve additional arguments passed to Kit
-        self._ov_args = []
-        if "ov_args" in launcher_args:
-            self._ov_args = [arg for arg in launcher_args["ov_args"].split()]
-            sys.argv += self._ov_args
+        self._kit_args = []
+        if "kit_args" in launcher_args:
+            self._kit_args = [arg for arg in launcher_args["kit_args"].split()]
+            sys.argv += self._kit_args
 
         # Resolve the absolute path of the experience file
         self._sim_experience_file = os.path.abspath(self._sim_experience_file)
@@ -615,8 +615,8 @@ class AppLauncher:
         pattern = r"--/plugins/carb\.tasking\.plugin/threadCount=\d+"
         sys.argv = [arg for arg in sys.argv if not re.match(pattern, arg)]
         # remove additional OV args from sys.argv
-        if len(self._ov_args) > 0:
-            sys.argv = [arg for arg in sys.argv if arg not in self._ov_args]
+        if len(self._kit_args) > 0:
+            sys.argv = [arg for arg in sys.argv if arg not in self._kit_args]
 
     def _rendering_enabled(self) -> bool:
         """Check if rendering is required by the app."""

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/app/app_launcher.py
@@ -280,8 +280,8 @@ class AppLauncher:
             type=str,
             default="",
             help=(
-                "Command line arguments for Omniverse Kit as a string separated by delimiter ','."
-                ' Example usage: --ov_args "--ext-folder=/path/to/ext1,--ext-folder=/path/to/ext2"'
+                "Command line arguments for Omniverse Kit as a string separated by a space delimiter."
+                ' Example usage: --ov_args "--ext-folder=/path/to/ext1 --ext-folder=/path/to/ext2"'
             ),
         )
 
@@ -573,7 +573,7 @@ class AppLauncher:
         # Resolve additional arguments passed to Kit
         self._ov_args = []
         if launcher_args["ov_args"]:
-            self._ov_args = [arg.strip() for arg in launcher_args["ov_args"].split(",")]
+            self._ov_args = [arg for arg in launcher_args["ov_args"].split()]
             sys.argv += self._ov_args
 
         # Resolve the absolute path of the experience file


### PR DESCRIPTION
# Description

This change adds the option to pass command line arguments directly to OV kit. This avoids the need of having to modify the app files to change settings for OV.


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
