### PR TITLE
Fixes job submitting for the cluster then an intended image is given

### DIFF
--- a/docker/cluster/cluster_interface.sh
+++ b/docker/cluster/cluster_interface.sh
@@ -177,7 +177,7 @@ case $command in
     job)
         if [ $# -ge 1 ]; then
             passed_profile=$1
-            if [ -f ".env.$passed_profile" ]; then
+            if [ -f "$SCRIPT_DIR/../.env.$passed_profile" ]; then
                 profile=$passed_profile
                 shift
             fi


### PR DESCRIPTION
# Description

The path to check if the first passed argument is a container profile included the wrong path. This PR fixes the path. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
