### PR TITLE
Fix Image Feature Extraction Observation by Removing Double Normalization and Using Only GPU Operations

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,6 +50,7 @@ Guidelines for modifications:
 * Jan Kerner
 * Jean Tampon
 * Jia Lin Yuan
+* Jinghuan Shang
 * Jingzhou Liu
 * Johnson Sun
 * Kaixi Bao

--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -2,7 +2,7 @@
 
 # Note: Semantic Versioning is used: https://semver.org/
 
-version = "0.27.7"
+version = "0.27.8"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -8,7 +8,7 @@ Fixed
 ^^^^^
 
 * Modified frozen feature extraction encoder preprocessing and inference to only normalize once while using
-  exclusively GPU operations for inference.
+  exclusively GPU operations for inference, with correct conversion to device.
 
 
 0.27.7 (2024-10-28)

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.27.8 (2024-10-28)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Modified frozen feature extraction encoder preprocessing and inference to only normalize once while using
+  exclusively GPU operations for inference.
+
 
 0.27.7 (2024-10-28)
 ~~~~~~~~~~~~~~~~~~~

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/observations.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/observations.py
@@ -295,21 +295,25 @@ class image_features(ManagerTermBase):
                     .eval()
                     .to("cuda:0")
                 ),
-                "preprocess": lambda img: (img - torch.amin(img, dim=(1, 2), keepdim=True)) / (
-                    torch.amax(img, dim=(1, 2), keepdim=True) - torch.amin(img, dim=(1, 2), keepdim=True)
-                ),
-                "inference": lambda model, images: model.forward_feature(
-                    images, do_rescale=False, interpolate_pos_encoding=True
-                ),
+                "preprocess": lambda img: {"pixel_values": 
+                    ( # This deconstructs default inferencing (CPU in transformers) into GPU only operations
+                    ( # as adviced by first author of Theia paper
+                        # Shifts mean, standard deviation, and format to match training set
+                        img.permute(0, 3, 1, 2).float()  # Convert [batch, height, width, 3] -> [batch, 3, height, width]
+                        - torch.tensor([0.485, 0.456, 0.406], device=img.device).view(1, 3, 1, 1)
+                    ) / torch.tensor([0.229, 0.224, 0.225], device=img.device).view(1, 3, 1, 1)
+                    ) / 255},
+                "inference": lambda model, images: # Taken from Transformers; inference converted to be GPU only
+                    model.backbone.model(**images, interpolate_pos_encoding=True).last_hidden_state[:, 1:]
             }
 
         def create_resnet_model(resnet_name):
             return {
                 "model": lambda: getattr(models, resnet_name)(pretrained=True).eval().to("cuda:0"),
-                "preprocess": lambda img: (
-                    img.permute(0, 3, 1, 2)  # Convert [batch, height, width, 3] -> [batch, 3, height, width]
+                "preprocess": lambda img: ((
+                    img.permute(0, 3, 1, 2).float()  # Convert [batch, height, width, 3] -> [batch, 3, height, width]
                     - torch.tensor([0.485, 0.456, 0.406], device=img.device).view(1, 3, 1, 1)
-                ) / torch.tensor([0.229, 0.224, 0.225], device=img.device).view(1, 3, 1, 1),
+                ) / torch.tensor([0.229, 0.224, 0.225], device=img.device).view(1, 3, 1, 1)) / 255,
                 "inference": lambda model, images: model(images),
             }
 
@@ -390,7 +394,7 @@ class image_features(ManagerTermBase):
             sensor_cfg=sensor_cfg,
             data_type=data_type,
             convert_perspective_to_orthogonal=convert_perspective_to_orthogonal,
-            normalize=True,  # want this for training stability
+            normalize=False,
         )
 
         image_device = images.device

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/observations.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/observations.py
@@ -400,9 +400,12 @@ class image_features(ManagerTermBase):
             print(f"[INFO]: Adding {model_name} to the model zoo")
             self.model_zoo[model_name] = self.model_zoo_cfg[model_name]["model"]()
 
-        if model_device is not None and self.model_zoo[model_name].device != model_device:
-            # want to offload vision model inference to another device
-            self.model_zoo[model_name] = self.model_zoo[model_name].to(model_device)
+        if model_device is not None:
+            # Check if the model is on the intended device by checking the device of its first parameter
+            current_device = next(self.model_zoo[model_name].parameters()).device
+            # Want to offload computation to another device...
+            if current_device != model_device:
+                self.model_zoo[model_name] = self.model_zoo[model_name].to(model_device)
 
         images = image(
             env=env,

--- a/source/extensions/omni.isaac.lab/setup.py
+++ b/source/extensions/omni.isaac.lab/setup.py
@@ -31,6 +31,8 @@ INSTALL_REQUIRES = [
     # procedural-generation
     "trimesh",
     "pyglet<2",
+    "transformers",
+    "einops",
 ]
 
 PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu118"]


### PR DESCRIPTION
# Description

Previously, image_features requested normalized images prior to normalizing as part of the preprocessing. As pointed out to me by Jinghuan Shang (Theia Vision Transformer first author), this lead to images being normalized more than once which is ineffective and incorrect. Furthermore, Jinghuan pointed out where Transformers needlessly converted from GPU to CPU for normalization, where these operations could be converted to be GPU only.

ALSO: Fixes device and setup.py

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
