### PR TITLE
Refines collision groups further based on asset's settings

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/scene/interactive_scene.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/scene/interactive_scene.py
@@ -503,7 +503,7 @@ class InteractiveScene:
                 raise ValueError(f"Unknown asset config type for {asset_name}: {asset_cfg}")
 
             # store prims in collision groups
-            if hasattr(asset_cfg, "collision_group"):
+            if isinstance(asset_cfg, AssetBaseCfg):
                 if asset_cfg.collision_group == -1:
                     asset_paths = sim_utils.find_matching_prim_paths(asset_cfg.prim_path)
                     self._collision_groups["global"] += asset_paths


### PR DESCRIPTION
# Description

Previously, we supported only two types of [collision groups for an asset](https://isaac-sim.github.io/IsaacLab/main/source/api/lab/omni.isaac.lab.assets.html#omni.isaac.lab.assets.AssetBaseCfg.collision_group): 

* `-1`: global collision group (collides with all assets in the scene)
* `0`: local collision group (collides with other assets in the same environment)

However, in some cases (for instance, dynamic obstacles), you may want to further refine the collisions within the same environment.

This MR implements the filter collision function in the interactive scene to handle this case.

The implementation is far from perfect. Would be great to discuss this further and make it cover more cases.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there