### PR TITLE
Ground plane tutorial correction

### DIFF
--- a/docs/source/setup/installation/binaries_installation.rst
+++ b/docs/source/setup/installation/binaries_installation.rst
@@ -388,10 +388,10 @@ top of the repository:
 
          # Option 1: Using the isaaclab.sh executable
          # note: this works for both the bundled python and the virtual environment
-         ./isaaclab.sh -p source/standalone/tutorials/00_sim/create_empty.py
+         ./isaaclab.sh -p source/standalone/tutorials/00_sim/create_ground.py
 
          # Option 2: Using python in your virtual environment
-         python source/standalone/tutorials/00_sim/create_empty.py
+         python source/standalone/tutorials/00_sim/create_ground.py
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows
       :sync: windows
@@ -400,10 +400,10 @@ top of the repository:
 
          :: Option 1: Using the isaaclab.bat executable
          :: note: this works for both the bundled python and the virtual environment
-         isaaclab.bat -p source\standalone\tutorials\00_sim\create_empty.py
+         isaaclab.bat -p source\standalone\tutorials\00_sim\create_ground.py
 
          :: Option 2: Using python in your virtual environment
-         python source\standalone\tutorials\00_sim\create_empty.py
+         python source\standalone\tutorials\00_sim\create_ground.py
 
 
 The above command should launch the simulator and display a window with a black

--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -291,10 +291,10 @@ top of the repository:
 
          # Option 1: Using the isaaclab.sh executable
          # note: this works for both the bundled python and the virtual environment
-         ./isaaclab.sh -p source/standalone/tutorials/00_sim/create_empty.py
+         ./isaaclab.sh -p source/standalone/tutorials/00_sim/create_ground.py
 
          # Option 2: Using python in your virtual environment
-         python source/standalone/tutorials/00_sim/create_empty.py
+         python source/standalone/tutorials/00_sim/create_ground.py
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows
       :sync: windows
@@ -303,10 +303,10 @@ top of the repository:
 
          :: Option 1: Using the isaaclab.bat executable
          :: note: this works for both the bundled python and the virtual environment
-         isaaclab.bat -p source\standalone\tutorials\00_sim\create_empty.py
+         isaaclab.bat -p source\standalone\tutorials\00_sim\create_ground.py
 
          :: Option 2: Using python in your virtual environment
-         python source\standalone\tutorials\00_sim\create_empty.py
+         python source\standalone\tutorials\00_sim\create_ground.py
 
 
 The above command should launch the simulator and display a window with a black

--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.27.14"
+version = "0.27.15"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.27.15 (2024-11-13)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the tutorial script mentionned in the installation doc to make a black ground plane appear.
+
 0.27.14 (2024-10-23)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed the tutorial script mentionned in the installation doc to make a black ground plane appear.
+* Created a new script based on the previous tutorial script, implementing the changes to add a black ground plane. Updated the installation documentation to reference the path to this new script.
 
 0.27.14 (2024-10-23)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/standalone/tutorials/00_sim/create_empty.py
+++ b/source/standalone/tutorials/00_sim/create_empty.py
@@ -32,6 +32,7 @@ simulation_app = app_launcher.app
 """Rest everything follows."""
 
 from omni.isaac.lab.sim import SimulationCfg, SimulationContext
+import omni.isaac.lab.sim as sim_utils
 
 
 def main():
@@ -42,6 +43,10 @@ def main():
     sim = SimulationContext(sim_cfg)
     # Set main camera
     sim.set_camera_view([2.5, 2.5, 2.5], [0.0, 0.0, 0.0])
+
+    # Ground-plane
+    cfg_ground = sim_utils.GroundPlaneCfg()
+    cfg_ground.func("/World/defaultGroundPlane", cfg_ground)
 
     # Play the simulator
     sim.reset()

--- a/source/standalone/tutorials/00_sim/create_ground.py
+++ b/source/standalone/tutorials/00_sim/create_ground.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""This script demonstrates how to create a simple stage in Isaac Sim.
+"""This script demonstrates how to create a black ground plane in Isaac Sim.
 
 .. code-block:: bash
 
     # Usage
-    ./isaaclab.sh -p source/standalone/tutorials/00_sim/create_empty.py
+    ./isaaclab.sh -p source/standalone/tutorials/00_sim/create_ground.py
 
 """
 
@@ -20,7 +20,7 @@ import argparse
 from omni.isaac.lab.app import AppLauncher
 
 # create argparser
-parser = argparse.ArgumentParser(description="Tutorial on creating an empty stage.")
+parser = argparse.ArgumentParser(description="Tutorial on creating a black ground plane.")
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 # parse the arguments
@@ -43,6 +43,10 @@ def main():
     sim = SimulationContext(sim_cfg)
     # Set main camera
     sim.set_camera_view([2.5, 2.5, 2.5], [0.0, 0.0, 0.0])
+
+    # Ground-plane
+    cfg_ground = sim_utils.GroundPlaneCfg()
+    cfg_ground.func("/World/defaultGroundPlane", cfg_ground)
 
     # Play the simulator
     sim.reset()


### PR DESCRIPTION
# Description

To verify the proper installation of IsaacLab, a test is performed using the script source/standalone/tutorials/00_sim/create_empty.py. As mentioned in issue #1265, the tutorial suggests that a black plane should appear, but none was initialized in the script, which could be misleading. Without the black plane, users might assume there is an error. To address this, I updated the script to ensure the ground plane is displayed.

Fixes #1265 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Screenshots

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/f972cc12-0e66-45a5-94f2-45c77e4e7f46) | ![after](https://github.com/user-attachments/assets/608d66e6-c693-4a8e-8bab-9c3120722bc9) |


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
