### PR TITLE
Fix syntax for checking if pre-commit is installed in isaaclab.sh

### DIFF
--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -328,7 +328,7 @@ while [[ $# -gt 0 ]]; do
             fi
             # run the formatter over the repository
             # check if pre-commit is installed
-            if [ ! command -v pre-commit &>/dev/null ]; then
+            if ! command -v pre-commit &>/dev/null; then
                 echo "[INFO] Installing pre-commit..."
                 pip install pre-commit
             fi

--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.27.14"
+version = "0.27.15"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,4 +1,12 @@
 Changelog
+
+0.27.15 (2024-11-14)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the condition in `isaaclab.sh` that checks whether `pre-commit` is installed before attempting installation.
 ---------
 
 0.27.14 (2024-10-23)


### PR DESCRIPTION
# Description

When running `./isaaclab.sh --format` for another pull request, I got a `command not found` error for `pre-commit`. Looking into the script, I found a condition to check if `pre-commit` was installed, but the syntax was off. 

It was written like this:

```bash
if [ ! command -v pre-commit &>/dev/null ]; then
```

But it should be:

```bash
if ! command -v pre-commit &>/dev/null; then
```

I fixed it, and the script worked as expected, installing `pre-commit` when I ran it again.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there