### PR TITLE
Fixes noise_model initialized in direct_marl_env

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,6 +33,7 @@ Guidelines for modifications:
 
 ## Contributors
 
+* Haoran Zhou
 * Alice Zhou
 * Amr Mousa
 * Andrej Orsula

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,7 +33,6 @@ Guidelines for modifications:
 
 ## Contributors
 
-* Haoran Zhou
 * Alice Zhou
 * Amr Mousa
 * Andrej Orsula
@@ -48,6 +47,7 @@ Guidelines for modifications:
 * Felix Yu
 * Gary Lvov
 * Giulio Romualdi
+* Haoran Zhou
 * HoJin Jeon
 * Jan Kerner
 * Jean Tampon

--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.27.17"
+version = "0.27.18"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.27.16 (2024-11-29)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the order of the incoming parameters in :class:`omni.isaac.lab.envs.DirectMARLEnv` to correctly use ``NoiseModel`` in marl-envs.
+
+
 0.27.15 (2024-11-09)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/direct_marl_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/direct_marl_env.py
@@ -175,13 +175,13 @@ class DirectMARLEnv:
         # setup noise cfg for adding action and observation noise
         if self.cfg.action_noise_model:
             self._action_noise_model: dict[AgentID, NoiseModel] = {
-                agent: noise_model.class_type(self.num_envs, noise_model, self.device)
+                agent: noise_model.class_type(noise_model, num_envs=self.num_envs, device=self.device)
                 for agent, noise_model in self.cfg.action_noise_model.items()
                 if noise_model is not None
             }
         if self.cfg.observation_noise_model:
             self._observation_noise_model: dict[AgentID, NoiseModel] = {
-                agent: noise_model.class_type(self.num_envs, noise_model, self.device)
+                agent: noise_model.class_type(noise_model, num_envs=self.num_envs, device=self.device)
                 for agent, noise_model in self.cfg.observation_noise_model.items()
                 if noise_model is not None
             }


### PR DESCRIPTION
# Description

This change fixes bugs in `DirectMARLEnv` class, where previously `_action_noise_model` and `_observation_noise_model` cannot successfully initialized  when the noise-model-cfg passed in.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

