### PR TITLE
Fixes warp-lang import and pip install documentation

### DIFF
--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -88,11 +88,11 @@ compatibility issues with some Linux distributions. If you encounter any issues,
       pip install --upgrade pip
 
 
--  Then, install the Isaac Sim package
+-  Then, install the Isaac Sim packages
 
    .. code-block:: bash
 
-      pip install isaacsim==4.2.0.2 --extra-index-url https://pypi.nvidia.com
+      pip install isaacsim==4.2.0.2 isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com
 
 
 - To install a minimal set of packages for running Isaac Lab only, the following command can be used. Note that you cannot run ``isaacsim`` with this.

--- a/source/extensions/omni.isaac.lab/setup.py
+++ b/source/extensions/omni.isaac.lab/setup.py
@@ -34,6 +34,7 @@ INSTALL_REQUIRES = [
     # image processing
     "transformers",
     "einops",  # needed for transformers, doesn't always auto-install
+    "warp-lang",
 ]
 
 PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu118"]


### PR DESCRIPTION
# Description

This change adds warp-lang as a module dependency for omni.isaac.lab. In certain workflows, the warp module was not being found on initialization. In addition, missing isaac sim pip modules are now added to the documentation to make sure all dependencies are installed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
