### PR TITLE
Fixes error in apply_actions method in `NonHolonomicAction` action term.

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.27.23"
+version = "0.27.24"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.27.24 (2024-12-07)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the shape of `quat_w` in the `apply_actions` method of :attr:`~omni.isaac.lab.env.mdp.NonHolonomicAction` (previously (N,B,4), now (N,4) since the number of root bodies B is required to be 1). Previously `apply_actions` erred because `euler_xyz_from_quat` requires inputs of shape (N,4).
+
+
 0.27.23 (2024-12-06)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed the shape of `quat_w` in the `apply_actions` method of :attr:`~omni.isaac.lab.env.mdp.NonHolonomicAction` (previously (N,B,4), now (N,4) since the number of root bodies B is required to be 1). Previously `apply_actions` erred because `euler_xyz_from_quat` requires inputs of shape (N,4).
+* Fixed the shape of ``quat_w`` in the ``apply_actions`` method of :attr:`~omni.isaac.lab.env.mdp.NonHolonomicAction` (previously (N,B,4), now (N,4) since the number of root bodies B is required to be 1). Previously ``apply_actions`` errored because ``euler_xyz_from_quat`` requires inputs of shape (N,4).
 
 
 0.27.26 (2024-12-11)

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/non_holonomic_actions.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/non_holonomic_actions.py
@@ -132,7 +132,7 @@ class NonHolonomicAction(ActionTerm):
 
     def apply_actions(self):
         # obtain current heading
-        quat_w = self._asset.data.body_quat_w[:, self._body_idx]
+        quat_w = self._asset.data.body_quat_w[:, self._body_idx].view(self.num_envs, 4)
         yaw_w = euler_xyz_from_quat(quat_w)[2]
         # compute joint velocities targets
         self._joint_vel_command[:, 0] = torch.cos(yaw_w) * self.processed_actions[:, 0]  # x


### PR DESCRIPTION
# Description


After indexing the size of `quad_w` in the `apply_actions` method is (N,B,4) where B will always equal 1, since it is enforced in the `__init__` that only one body name is passed to the action term config. However, the `euler_xyz_from_quat` method requires inputs to be size (N,4), and so an error is thrown for input size (N,1,4). This PR just creates a (N,4) view of quat_w to be passed to `euler_xyz_from_quat`. This simple change does not introduce any new warnings and works with a simple non holonomic robot, like the Clearpath Husky.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
