### PR TITLE
Fixes broken image link of `stack-cube` in document

### DIFF
--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -134,7 +134,7 @@ for the lift-cube environment:
 .. |cabi-franka| image:: ../_static/tasks/manipulation/franka_open_drawer.jpg
 .. |cube-allegro| image:: ../_static/tasks/manipulation/allegro_cube.jpg
 .. |cube-shadow| image:: ../_static/tasks/manipulation/shadow_cube.jpg
-.. |stack-franka| image:: ../_static/tasks/manipulation/franka_stack.jpg
+.. |stack-cube| image:: ../_static/tasks/manipulation/franka_stack.jpg
 
 .. |reach-franka-link| replace:: `Isaac-Reach-Franka-v0 <https://github.com/isaac-sim/IsaacLab/blob/main/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/manipulation/reach/config/franka/joint_pos_env_cfg.py>`__
 .. |reach-ur10-link| replace:: `Isaac-Reach-UR10-v0 <https://github.com/isaac-sim/IsaacLab/blob/main/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/manager_based/manipulation/reach/config/ur_10/joint_pos_env_cfg.py>`__


### PR DESCRIPTION
# Description

Fixes broken image link of `stack-cube` in document

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Screenshots

![2024-12-17 11-33-32 的屏幕截图](https://github.com/user-attachments/assets/dc8b4862-2df4-451c-b4ed-9b630f9f5f0e)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

