### PR TITLE
Sets default clipping mode for cameras to None

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/camera_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/camera/camera_cfg.py
@@ -53,8 +53,8 @@ class CameraCfg(SensorBaseCfg):
     asset is already present in the scene.
     """
 
-    depth_clipping_behavior: Literal["max", "zero", "none"] = "zero"
-    """Clipping behavior for the camera for values exceed the maximum value. Defaults to "zero".
+    depth_clipping_behavior: Literal["max", "zero", "none"] = "none"
+    """Clipping behavior for the camera for values exceed the maximum value. Defaults to "none".
 
     - ``"max"``: Values are clipped to the maximum value.
     - ``"zero"``: Values are clipped to zero.

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/ray_caster/ray_caster_camera_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/ray_caster/ray_caster_camera_cfg.py
@@ -46,8 +46,8 @@ class RayCasterCameraCfg(RayCasterCfg):
     data_types: list[str] = ["distance_to_image_plane"]
     """List of sensor names/types to enable for the camera. Defaults to ["distance_to_image_plane"]."""
 
-    depth_clipping_behavior: Literal["max", "zero", "none"] = "zero"
-    """Clipping behavior for the camera for values exceed the maximum value. Defaults to "zero".
+    depth_clipping_behavior: Literal["max", "zero", "none"] = "none"
+    """Clipping behavior for the camera for values exceed the maximum value. Defaults to "none".
 
     - ``"max"``: Values are clipped to the maximum value.
     - ``"zero"``: Values are clipped to zero.


### PR DESCRIPTION
# Description

In https://github.com/isaac-sim/IsaacLab/pull/891, the `depth_clipping_behavior` parameter was added with the default mode set to `"zero"`. This introduced a breaking behavior in the depth cameras as previously, values returned by the cameras were not clipped. This PR sets the default behavior to `"none"`, which should bring us back to the original camera behavior.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
