### PR TITLE
Adds dataclass replacement for comand-line config overwrite

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/dict.py
@@ -9,10 +9,11 @@ import collections.abc
 import hashlib
 import json
 from collections.abc import Iterable, Mapping
+from dataclasses import is_dataclass
 from typing import Any
 
 from .array import TENSOR_TYPE_CONVERSIONS, TENSOR_TYPES
-from .string import callable_to_string, string_to_callable, string_to_slice
+from .string import callable_to_string, string_to_callable, string_to_dataclass_instance, string_to_slice
 
 """
 Dictionary <-> Class operations.
@@ -112,6 +113,8 @@ def update_class_from_dict(obj, data: dict[str, Any], _ns: str = "") -> None:
             elif callable(obj_mem):
                 # update function name
                 value = string_to_callable(value)
+            elif is_dataclass(obj_mem):
+                value = string_to_dataclass_instance(value)
             elif isinstance(value, type(obj_mem)) or value is None:
                 pass
             else:

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/string.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/utils/string.py
@@ -10,6 +10,7 @@ import importlib
 import inspect
 import re
 from collections.abc import Callable, Sequence
+from dataclasses import is_dataclass
 from typing import Any
 
 """
@@ -164,6 +165,27 @@ def string_to_callable(name: str) -> Callable:
     except (ValueError, ModuleNotFoundError) as e:
         msg = (
             f"Could not resolve the input string '{name}' into callable object."
+            " The format of input should be 'module:attribute_name'.\n"
+            f"Received the error:\n {e}."
+        )
+        raise ValueError(msg)
+
+
+def string_to_dataclass_instance(name: str) -> Callable:
+    try:
+        mod_name, attr_name = name.split(":")
+        mod = importlib.import_module(mod_name)
+        dataclass_instance = getattr(mod, attr_name)
+        if is_dataclass(dataclass_instance):
+            if isinstance(dataclass_instance, type):
+                return dataclass_instance()
+            else:
+                return dataclass_instance
+        else:
+            raise AttributeError(f"The imported object is not a dataclass: '{name}'")
+    except (ValueError, ModuleNotFoundError) as e:
+        msg = (
+            f"Could not resolve the input string '{name}' into dataclass instance."
             " The format of input should be 'module:attribute_name'.\n"
             f"Received the error:\n {e}."
         )


### PR DESCRIPTION
# Description

For example, I have a field `robot` in `DirectEnvCfg` with default value `FRANKA_ISAACLAB_CFG`
```python
@configclass
class MyTaskEnvCfg(DirectRLEnvCfg):
    robot: ArticulationCfg = FRANKA_ISAACLAB_CFG
```

And `FRANKA_ISAACLAB_CFG` is defined as 
```python
@configclass
class FrankaIsaaclabCfg(ArticulationCfg):
    prim_path = "/World/envs/env_.*/Robot"
    spawn = sim_utils.UsdFileCfg(
    ...
FRANKA_ISAACLAB_CFG = FrankaIsaaclabCfg()
```

When I want to replace the robot config to another one, say `FrankaWithGripperExtensionCfg`, which is defined as
```python
@configclass
class FrankaWithGripperExtensionCfg(ArticulationCfg):
    prim_path = "/World/envs/env_.*/Robot"
    spawn = sim_utils.UsdFileCfg(
    ...
FRANKA_WITH_GRIPPER_EXTENSION_CFG = FrankaIsaaclabCfg()
```

I can either run
```
python my_script.py env.robot=src.cfg.robot.franka:FRANKA_WITH_GRIPPER_EXTENSION_CFG <other_args>
```

or
```
python my_script.py env.robot=src.cfg.robot.franka:FrankaWithGripperExtensionCfg <other_args>
```

Currently I didn't find any support for this functionality in [doc](https://isaac-sim.github.io/IsaacLab/main/source/features/hydra.html), so I implement a prototype, which is tested successfully in my own codebase.


## Type of change
- New feature (non-breaking change which adds functionality)

## Screenshots

Run without `env.robot=src.cfg.robot.franka:FrankaWithGripperExtensionCfg`:
![image](https://github.com/user-attachments/assets/4d805d79-5f6e-418e-b700-73f885c727a3)


Run with `env.robot=src.cfg.robot.franka:FrankaWithGripperExtensionCfg`:
![image](https://github.com/user-attachments/assets/15f8913e-dd56-4abd-a5f2-cff4a21da3f9)

As you can see, the color of two arm is different, since I use two different configuration linked to different usd file.


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
