### PR TITLE
Mount git-related folders in Docker

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -35,6 +35,15 @@ x-default-isaac-lab-volumes: &default-isaac-lab-volumes
     # This overlay allows changes on the local files to
     # be reflected within the container immediately
   - type: bind
+    source: ../.git
+    target: ${DOCKER_ISAACLAB_PATH}/.git
+  - type: bind
+    source: ../.github
+    target: ${DOCKER_ISAACLAB_PATH}/.github
+  - type: bind
+    source: ../.gitignore
+    target: ${DOCKER_ISAACLAB_PATH}/.gitignore
+  - type: bind
     source: ../source
     target: ${DOCKER_ISAACLAB_PATH}/source
   - type: bind


### PR DESCRIPTION
# Description

Mount Git-related files in the Docker container. This enables the use of Git features during development within the container.

The build phase remains unaffected since these files are excluded from the build.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there