### PR TITLE
Fixes JointAction not preserving order when using all joints

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/joint_actions.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/joint_actions.py
@@ -69,7 +69,7 @@ class JointAction(ActionTerm):
         )
 
         # Avoid indexing across all joints for efficiency
-        if self._num_joints == self._asset.num_joints:
+        if self._num_joints == self._asset.num_joints and not self.cfg.preserve_order:
             self._joint_ids = slice(None)
 
         # create tensors for raw and processed actions


### PR DESCRIPTION
# Description

This PR fixes #1586.

An additional condition is added to the `JointAction._joint_ids` logic where if user specifies to preserve the joint order, the `_joint_ids` field will not be cleared even if the speficied list contains all the joints.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

