### PR TITLE
Add action history

### DIFF
--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.30.2 (2024-12-31)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``prev_prev_action`` and ``_prev_prev_action`` to :class:`omni.isaac.lab.managers.ActionTerm`
+
+
 0.30.1 (2024-12-17)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/action_manager.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/action_manager.py
@@ -195,6 +195,7 @@ class ActionManager(ManagerBase):
         # create buffers to store actions
         self._action = torch.zeros((self.num_envs, self.total_action_dim), device=self.device)
         self._prev_action = torch.zeros_like(self._action)
+        self._prev_prev_action = torch.zeros_like(self._action)
 
         # check if any term has debug visualization implemented
         self.cfg.debug_vis = False
@@ -249,6 +250,11 @@ class ActionManager(ManagerBase):
     def prev_action(self) -> torch.Tensor:
         """The previous actions sent to the environment. Shape is (num_envs, total_action_dim)."""
         return self._prev_action
+
+    @property
+    def prev_prev_action(self) -> torch.Tensor:
+        """The previous actions sent to the environment. Shape is (num_envs, total_action_dim)."""
+        return self._prev_prev_action
 
     @property
     def has_debug_vis_implementation(self) -> bool:
@@ -307,6 +313,7 @@ class ActionManager(ManagerBase):
         if env_ids is None:
             env_ids = slice(None)
         # reset the action history
+        self._prev_prev_action[env_ids] = 0.0
         self._prev_action[env_ids] = 0.0
         self._action[env_ids] = 0.0
         # reset all action terms
@@ -328,6 +335,7 @@ class ActionManager(ManagerBase):
         if self.total_action_dim != action.shape[1]:
             raise ValueError(f"Invalid action shape, expected: {self.total_action_dim}, received: {action.shape[1]}.")
         # store the input actions
+        self._prev_prev_action[:] = self._prev_action
         self._prev_action[:] = self._action
         self._action[:] = action.to(self.device)
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/action_manager.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/action_manager.py
@@ -253,7 +253,7 @@ class ActionManager(ManagerBase):
 
     @property
     def prev_prev_action(self) -> torch.Tensor:
-        """The previous actions sent to the environment. Shape is (num_envs, total_action_dim)."""
+        """The previous previous actions sent to the environment. Shape is (num_envs, total_action_dim)."""
         return self._prev_prev_action
 
     @property


### PR DESCRIPTION
# Description

This PR introduces a new feature in the Antion Manager by adding a `prev_prev_action` to `ActionTerm`. The purpose of this addition is to allow the computation of second-order smoothing for actions, providing a smoother transition between actions over time.

Such as

```python
def smoothness_2(env: ManagerBasedRLEnv) -> torch.Tensor:
    # Penalize changes in actions
    diff = torch.square(env.action_manager.action - 2 * env.action_manager.prev_action + env.action_manager.prev_prev_action)
    diff = diff * (env.action_manager.prev_action[:, :] != 0)  # ignore first step
    diff = diff * (env.action_manager.prev_prev_action[:, :] != 0)  # ignore second step
    return torch.sum(diff, dim=1)
```

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

