### PR TITLE
Adds missing "not" in  error message in setup_vscode.py

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 <!--
 Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.
 
-Link: https://isaac-sim.github.io/IsaacLab/source/refs/contributing.html
+Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
 -->
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

--- a/.vscode/tools/setup_vscode.py
+++ b/.vscode/tools/setup_vscode.py
@@ -38,8 +38,8 @@ if not os.path.exists(isaacsim_dir):
     raise FileNotFoundError(
         f"Could not find the isaac-sim directory: {isaacsim_dir}. There are two possible reasons for this:"
         f"\n\t1. The Isaac Sim directory does not exist as a symlink at: {os.path.join(ISAACLAB_DIR, '_isaac_sim')}"
-        "\n\t2. The script could import the 'isaacsim' package. This could be due to the 'isaacsim' package not being "
-        "installed in the Python environment.\n"
+        "\n\t2. The script could not import the 'isaacsim' package. This could be due to the 'isaacsim' package not "
+        "being installed in the Python environment.\n"
         "\nPlease make sure that the Isaac Sim directory exists or that the 'isaacsim' package is installed."
     )
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -77,6 +77,7 @@ Guidelines for modifications:
 * Rosario Scalise
 * Ryley McCarroll
 * Shafeef Omar
+* Stephan Pleines
 * Vladimir Fokow
 * Wei Yang
 * Xavier Nal


### PR DESCRIPTION
# Description

Adds a missing word in an error message.
Also fixes a broken link in the pull request template.

(I did not enter an issue since it seems like a tiny change, but will if you'd like me to.)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation - _I don't think any are necessary._
- [ ] My changes generate no new warnings - _I doubt it, but I have not been able to install everything, I discovered this issue on my first attempt to build._
- [ ] I have added tests that prove my fix is effective or that my feature works - _Not a feature._
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file - _Not sure which file that is in this case, please let me know if this is applicable._
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
