### PR TITLE
Updates pip installation documentation to clarify options

### DIFF
--- a/docs/source/setup/installation/binaries_installation.rst
+++ b/docs/source/setup/installation/binaries_installation.rst
@@ -1,12 +1,9 @@
-.. _isaacsim-binaries-installation:
-
+.. _isaaclab-binaries-installation:
 
 Installation using Isaac Sim Binaries
 =====================================
 
-.. note::
-
-   If you use Conda, we recommend using `Miniconda <https://docs.anaconda.com/miniconda/miniconda-other-installer-links/>`_.
+Issac Lab requires Isaac Sim. Install Isaac Sim first, then Isaac Lab.
 
 Installing Isaac Sim
 --------------------
@@ -268,6 +265,10 @@ Setting up the conda environment (optional)
 
 .. attention::
    This step is optional. If you are using the bundled python with Isaac Sim, you can skip this step.
+
+.. note::
+
+   If you use Conda, we recommend using `Miniconda <https://docs.anaconda.com/miniconda/miniconda-other-installer-links/>`_.
 
 The executable ``isaaclab.sh`` automatically fetches the python bundled with Isaac
 Sim, using ``./isaaclab.sh -p`` command (unless inside a virtual environment). This executable

--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -1,11 +1,9 @@
-.. _isaacsim-pip-installation:
+.. _isaaclab-pip-installation:
 
-Installation using Isaac Sim pip
+Installation using pip
 ================================
 
-.. note::
-
-   If you use Conda, we recommend using `Miniconda <https://docs.anaconda.com/miniconda/miniconda-other-installer-links/>`_.
+Issac Lab requires Isaac Sim. Install Isaac Sim first, then Isaac Lab.
 
 Installing Isaac Sim
 --------------------
@@ -21,11 +19,15 @@ compatibility issues with some Linux distributions. If you encounter any issues,
 
    This may pose compatibility issues with some Linux distributions. For instance, Ubuntu 20.04 LTS has GLIBC 2.31
    by default. If you encounter compatibility issues, we recommend following the
-   :ref:`Isaac Sim Binaries Installation <isaacsim-binaries-installation>` approach.
+   :ref:`Isaac Sim Binaries Installation <isaaclab-binaries-installation>` approach.
 
 .. attention::
 
-      On Windows with CUDA 12, the GPU driver version 552.86 is required.
+   On Windows with CUDA 12, the GPU driver version 552.86 is required.
+
+.. note::
+
+   If you use Conda, we recommend using `Miniconda <https://docs.anaconda.com/miniconda/miniconda-other-installer-links/>`_.
 
 -  To use the pip installation approach for Isaac Sim, we recommend first creating a virtual environment.
    Ensure that the python version of the virtual environment is **Python 3.10**.
@@ -88,19 +90,21 @@ compatibility issues with some Linux distributions. If you encounter any issues,
       pip install --upgrade pip
 
 
--  Then, install the Isaac Sim packages
+-  Then, install the Isaac Sim packages. There are 2 options: A complete installation, or a minimal installation for running Isaac Lab only.
 
-   .. code-block:: bash
+   -  Complete installation:
 
-      pip install isaacsim==4.2.0.2 isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com
+      .. code-block:: bash
 
+         pip install isaacsim==4.2.0.2 isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com
 
-- To install a minimal set of packages for running Isaac Lab only, the following command can be used. Note that you cannot run ``isaacsim`` with this.
+   -  Minimal set of packages for running Isaac Lab only: 
 
-   .. code-block:: bash
+      .. code-block:: bash
 
-      pip install isaacsim-rl isaacsim-replicator isaacsim-extscache-physics isaacsim-extscache-kit-sdk isaacsim-extscache-kit isaacsim-app --extra-index-url https://pypi.nvidia.com
+         pip install isaacsim-rl isaacsim-replicator isaacsim-extscache-physics isaacsim-extscache-kit-sdk isaacsim-extscache-kit isaacsim-app --extra-index-url https://pypi.nvidia.com
 
+      Note that you cannot run ``isaacsim`` with this.
 
 Verifying the Isaac Sim installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -131,7 +135,9 @@ Verifying the Isaac Sim installation
    This process can take upwards of 10 minutes and is required on the first run of each experience file.
    Once the extensions are pulled, consecutive runs using the same experience file will use the cached extensions.
 
-   In addition, the first run will prompt users to accept the Nvidia Omniverse License Agreement.
+.. attention::
+
+   The first run will prompt users to accept the Nvidia Omniverse License Agreement.
    To accept the EULA, reply ``Yes`` when prompted with the below message:
 
    .. code:: bash

--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -98,7 +98,7 @@ compatibility issues with some Linux distributions. If you encounter any issues,
 
          pip install isaacsim==4.2.0.2 isaacsim-extscache-physics==4.2.0.2 isaacsim-extscache-kit==4.2.0.2 isaacsim-extscache-kit-sdk==4.2.0.2 --extra-index-url https://pypi.nvidia.com
 
-   -  Minimal set of packages for running Isaac Lab only: 
+   -  Minimal set of packages for running Isaac Lab only:
 
       .. code-block:: bash
 


### PR DESCRIPTION
# Description

- As a first time user, I skipped over the sim part at first because I wanted lab - clarify that sim is required.
- Rename anchors from sim to lab.
- Move the notes about miniconda to where conda is actually used.
- Clarify that there are two options for installation. Otherwise, a user progressing in order will run the full installation, and then discover that a minimal installation would have been an option.
- Use separate attention boxes for the two separate items.

Note: I was able to follow the pip instructions on Ubuntu24 with a minimal hack to force python3.10 instead of the default 3.12. I have not tried the binary installation instructions.

## Type of change

Documentation only.

## Checklist

I have built the documentation locally.

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - _n/a_
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file - _Does not affect an extension._
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
