### PR TITLE
Fixes the `joint_parameter_lookup` type in `RemotizedPDActuatorCfg` to support list format

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_cfg.py
@@ -181,7 +181,7 @@ class RemotizedPDActuatorCfg(DelayedPDActuatorCfg):
 
     class_type: type = actuator_pd.RemotizedPDActuator
 
-    joint_parameter_lookup: torch.Tensor = MISSING
+    joint_parameter_lookup: list[list[float]] = MISSING
     """Joint parameter lookup table. Shape is (num_lookup_points, 3).
 
     This tensor describes the relationship between the joint angle (rad), the transmission ratio (in/out),

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_cfg.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import torch
 from collections.abc import Iterable
 from dataclasses import MISSING
 from typing import Literal

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_pd.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_pd.py
@@ -324,7 +324,7 @@ class RemotizedPDActuator(DelayedPDActuator):
         super().__init__(
             cfg, joint_names, joint_ids, num_envs, device, stiffness, damping, armature, friction, torch.inf, torch.inf
         )
-        self._joint_parameter_lookup = cfg.joint_parameter_lookup.to(device=device)
+        self._joint_parameter_lookup = torch.tensor(cfg.joint_parameter_lookup, device=device)
         # define remotized joint torque limit
         self._torque_limit = LinearInterpolation(self.angle_samples, self.max_torque_samples, device=device)
 

--- a/source/extensions/omni.isaac.lab_assets/omni/isaac/lab_assets/spot.py
+++ b/source/extensions/omni.isaac.lab_assets/omni/isaac/lab_assets/spot.py
@@ -11,8 +11,6 @@ The following configuration parameters are available:
 * :obj:`SPOT_CFG`: The Spot robot with delay PD and remote PD actuators.
 """
 
-import torch
-
 import omni.isaac.lab.sim as sim_utils
 from omni.isaac.lab.actuators import DelayedPDActuatorCfg, RemotizedPDActuatorCfg
 from omni.isaac.lab.assets.articulation import ArticulationCfg

--- a/source/extensions/omni.isaac.lab_assets/omni/isaac/lab_assets/spot.py
+++ b/source/extensions/omni.isaac.lab_assets/omni/isaac/lab_assets/spot.py
@@ -19,7 +19,7 @@ from omni.isaac.lab.assets.articulation import ArticulationCfg
 from omni.isaac.lab.utils.assets import ISAAC_NUCLEUS_DIR
 
 # Note: This data was collected by the Boston Dynamics AI Institute.
-joint_parameter_lookup = torch.tensor([
+joint_parameter_lookup = [
     [-2.792900, -24.776718, 37.165077],
     [-2.767442, -26.290108, 39.435162],
     [-2.741984, -27.793369, 41.690054],
@@ -121,7 +121,7 @@ joint_parameter_lookup = torch.tensor([
     [-0.298016, -24.632576, 36.948864],
     [-0.272558, -22.528547, 33.792821],
     [-0.247100, -20.401667, 30.602500],
-])
+]
 """The lookup table for the knee joint parameters of the Boston Dynamics Spot robot.
 
 This table describes the relationship between the joint angle (rad), the transmission ratio (in/out),


### PR DESCRIPTION
# Description

Bug description: When I run `python source/standalone/workflows/rsl_rl/train.py --task Isaac-Velocity-Flat-Spot-v0 --headless`

```bash
(isaaclab) ubuntu@ubuntu-4090:~/workspaces/IsaacLab$ python source/standalone/workflows/rsl_rl/train.py --task Isaac-Velocity-Flat-Spot-v0 --headless
[INFO][AppLauncher]: Loading experience file: /home/ubuntu/workspaces/IsaacLab/source/apps/isaaclab.python.headless.kit
[Warning] [omni.isaac.kit.simulation_app] Modules: ['omni.kit_app'] were loaded before SimulationApp was started and might not be loaded correctly.
[Warning] [omni.isaac.kit.simulation_app] Please check to make sure no extra omniverse or pxr modules are imported before the call to SimulationApp(...)
Loading user config located at: '/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omni/data/Kit/Isaac-Sim/4.2/user.config.json'
[Info] [carb] Logging to file: /home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omni/logs/Kit/Isaac-Sim/4.2/kit_20250104_162107.log
2025-01-04 08:21:07 [0ms] [Warning] [omni.kit.app.plugin] No crash reporter present, dumps uploading isn't available.

|---------------------------------------------------------------------------------------------|
| Driver Version: 550.100       | Graphics API: Vulkan
|=============================================================================================|
| GPU | Name                             | Active | LDA | GPU Memory | Vendor-ID | LUID       |
|     |                                  |        |     |            | Device-ID | UUID       |
|     |                                  |        |     |            | Bus-ID    |            |
|---------------------------------------------------------------------------------------------|
| 0   | NVIDIA GeForce RTX 4090          | Yes: 0 |     | 24564   MB | 10de      | 0          |
|     |                                  |        |     |            | 2684      | 16760a40.. |
|     |                                  |        |     |            | 1         |            |
|=============================================================================================|
| OS: 20.04.6 LTS (Focal Fossa) ubuntu, Version: 20.04.6, Kernel: 5.15.0-126-generic
| XServer Vendor: The X.Org Foundation, XServer Version: 12013000 (1.20.13.0)
| Processor: Intel(R) Core(TM) i9-14900KF | Cores: 24 | Logical: 32
|---------------------------------------------------------------------------------------------|
| Total Memory (MB): 64106 | Free Memory: 39407
| Total Page/Swap (MB): 2047 | Free Page/Swap: 2046
|---------------------------------------------------------------------------------------------|
[INFO]: Parsing configuration from: omni.isaac.lab_tasks.manager_based.locomotion.velocity.config.spot.flat_env_cfg:SpotFlatEnvCfg
[INFO]: Parsing configuration from: omni.isaac.lab_tasks.manager_based.locomotion.velocity.config.spot.agents.rsl_rl_ppo_cfg:SpotFlatPPORunnerCfg
Traceback (most recent call last):
  File "/home/ubuntu/workspaces/IsaacLab/source/standalone/workflows/rsl_rl/train.py", line 151, in <module>
    main()
  File "/home/ubuntu/workspaces/IsaacLab/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/hydra.py", line 79, in wrapper
    env_cfg, agent_cfg = register_task_to_hydra(task_name, agent_cfg_entry_point)
  File "/home/ubuntu/workspaces/IsaacLab/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/hydra.py", line 57, in register_task_to_hydra
    ConfigStore.instance().store(name=task_name, node=cfg_dict)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/hydra/core/config_store.py", line 85, in store
    cfg = OmegaConf.structured(node)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 125, in structured
    return OmegaConf.create(obj, parent, flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 178, in create
    return OmegaConf._create_impl(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 900, in _create_impl
    format_and_raise(node=None, key=None, value=None, msg=str(e), cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 861, in _create_impl
    return DictConfig(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 111, in __init__
    format_and_raise(node=None, key=key, value=None, cause=ex, msg=str(ex))
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 109, in __init__
    self._set_value(content, flags=flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 647, in _set_value
    raise e
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 644, in _set_value
    self._set_value_impl(value, flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 690, in _set_value_impl
    self.__setitem__(k, v)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 314, in __setitem__
    self._format_and_raise(key=key, value=value, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 308, in __setitem__
    self.__set_impl(key=key, value=value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 318, in __set_impl
    self._set_item_impl(key, value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 620, in _set_item_impl
    self._wrap_value_and_set(key, value, target_type_hint)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 636, in _wrap_value_and_set
    self._format_and_raise(key=key, value=val, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 628, in _wrap_value_and_set
    wrapped = _maybe_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1105, in _maybe_wrap
    return _node_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1004, in _node_wrap
    node = DictConfig(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 111, in __init__
    format_and_raise(node=None, key=key, value=None, cause=ex, msg=str(ex))
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 109, in __init__
    self._set_value(content, flags=flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 647, in _set_value
    raise e
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 644, in _set_value
    self._set_value_impl(value, flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 690, in _set_value_impl
    self.__setitem__(k, v)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 314, in __setitem__
    self._format_and_raise(key=key, value=value, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 308, in __setitem__
    self.__set_impl(key=key, value=value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 318, in __set_impl
    self._set_item_impl(key, value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 620, in _set_item_impl
    self._wrap_value_and_set(key, value, target_type_hint)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 636, in _wrap_value_and_set
    self._format_and_raise(key=key, value=val, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 628, in _wrap_value_and_set
    wrapped = _maybe_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1105, in _maybe_wrap
    return _node_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1004, in _node_wrap
    node = DictConfig(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 111, in __init__
    format_and_raise(node=None, key=key, value=None, cause=ex, msg=str(ex))
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 109, in __init__
    self._set_value(content, flags=flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 647, in _set_value
    raise e
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 644, in _set_value
    self._set_value_impl(value, flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 690, in _set_value_impl
    self.__setitem__(k, v)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 314, in __setitem__
    self._format_and_raise(key=key, value=value, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 308, in __setitem__
    self.__set_impl(key=key, value=value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 318, in __set_impl
    self._set_item_impl(key, value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 620, in _set_item_impl
    self._wrap_value_and_set(key, value, target_type_hint)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 636, in _wrap_value_and_set
    self._format_and_raise(key=key, value=val, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 628, in _wrap_value_and_set
    wrapped = _maybe_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1105, in _maybe_wrap
    return _node_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1004, in _node_wrap
    node = DictConfig(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 111, in __init__
    format_and_raise(node=None, key=key, value=None, cause=ex, msg=str(ex))
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 109, in __init__
    self._set_value(content, flags=flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 647, in _set_value
    raise e
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 644, in _set_value
    self._set_value_impl(value, flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 690, in _set_value_impl
    self.__setitem__(k, v)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 314, in __setitem__
    self._format_and_raise(key=key, value=value, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 308, in __setitem__
    self.__set_impl(key=key, value=value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 318, in __set_impl
    self._set_item_impl(key, value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 620, in _set_item_impl
    self._wrap_value_and_set(key, value, target_type_hint)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 636, in _wrap_value_and_set
    self._format_and_raise(key=key, value=val, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 628, in _wrap_value_and_set
    wrapped = _maybe_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1105, in _maybe_wrap
    return _node_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1004, in _node_wrap
    node = DictConfig(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 111, in __init__
    format_and_raise(node=None, key=key, value=None, cause=ex, msg=str(ex))
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 109, in __init__
    self._set_value(content, flags=flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 647, in _set_value
    raise e
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 644, in _set_value
    self._set_value_impl(value, flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 690, in _set_value_impl
    self.__setitem__(k, v)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 314, in __setitem__
    self._format_and_raise(key=key, value=value, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 308, in __setitem__
    self.__set_impl(key=key, value=value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 318, in __set_impl
    self._set_item_impl(key, value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 620, in _set_item_impl
    self._wrap_value_and_set(key, value, target_type_hint)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 636, in _wrap_value_and_set
    self._format_and_raise(key=key, value=val, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 628, in _wrap_value_and_set
    wrapped = _maybe_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1105, in _maybe_wrap
    return _node_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1004, in _node_wrap
    node = DictConfig(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 111, in __init__
    format_and_raise(node=None, key=key, value=None, cause=ex, msg=str(ex))
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 109, in __init__
    self._set_value(content, flags=flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 647, in _set_value
    raise e
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 644, in _set_value
    self._set_value_impl(value, flags)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 690, in _set_value_impl
    self.__setitem__(k, v)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 314, in __setitem__
    self._format_and_raise(key=key, value=value, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 819, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 308, in __setitem__
    self.__set_impl(key=key, value=value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/dictconfig.py", line 318, in __set_impl
    self._set_item_impl(key, value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 620, in _set_item_impl
    self._wrap_value_and_set(key, value, target_type_hint)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 636, in _wrap_value_and_set
    self._format_and_raise(key=key, value=val, cause=e)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/base.py", line 231, in _format_and_raise
    format_and_raise(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 899, in format_and_raise
    _raise(ex, cause)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/_utils.py", line 797, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set env var OC_CAUSE=1 for full trace
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/basecontainer.py", line 628, in _wrap_value_and_set
    wrapped = _maybe_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1105, in _maybe_wrap
    return _node_wrap(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/omegaconf.py", line 1045, in _node_wrap
    node = AnyNode(value=value, key=key, parent=parent)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/nodes.py", line 135, in __init__
    super().__init__(
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/nodes.py", line 29, in __init__
    self._set_value(value)  # lgtm [py/init-calls-subclass]
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/nodes.py", line 46, in _set_value
    self._val = self.validate_and_convert(value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/nodes.py", line 76, in validate_and_convert
    return self._validate_and_convert_impl(value)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/omegaconf/nodes.py", line 154, in _validate_and_convert_impl
    raise UnsupportedValueType(
omegaconf.errors.UnsupportedValueType: Value 'Tensor' is not a supported primitive type
    full_key: env.scene.robot.actuators.spot_knee.joint_parameter_lookup
    object_type=dict
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

