### PR TITLE
Fixes documentation error for PD Actuator

### DIFF
--- a/docs/source/overview/core-concepts/actuators.rst
+++ b/docs/source/overview/core-concepts/actuators.rst
@@ -34,7 +34,7 @@ maximum effort:
 
 .. math::
 
-    \tau_{j, computed} & = k_p * (q - q_{des}) + k_d * (\dot{q} - \dot{q}_{des}) + \tau_{ff} \\
+    \tau_{j, computed} & = k_p * (q_{des} - q) + k_d * (\dot{q}_{des} - \dot{q}) + \tau_{ff} \\
     \tau_{j, applied} & = clip(\tau_{computed}, -\tau_{j, max}, \tau_{j, max})
 
 


### PR DESCRIPTION
# Description

There was a mismatch in the implementation of the IdealPDActuator code and the equation provided in the actuators docs. This change fixes the ordering of parameters in the docs to match the implementation in code.

Fixes #1643 

## Type of change

- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
