### PR TITLE
Fixes rigid object's root com velocities timestamp check

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -69,6 +69,7 @@ Guidelines for modifications:
 * Muhong Guo
 * Nicola Loi
 * Nuralem Abizov
+* Ori Gadot
 * Oyindamola Omotuyi
 * Özhan Özen
 * Peter Du

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation_data.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation_data.py
@@ -547,7 +547,7 @@ class ArticulationData:
 
         This quantity is the position of the actor frame of the root rigid body relative to the world.
         """
-        if self._body_com_state_w.timestamp < self._sim_timestamp:
+        if self._root_link_state_w.timestamp < self._sim_timestamp:
             # read data from simulation (pose is of link)
             pose = self._root_physx_view.get_root_transforms()
             return pose[:, :3]
@@ -559,7 +559,7 @@ class ArticulationData:
 
         This quantity is the orientation of the actor frame of the root rigid body.
         """
-        if self._body_com_state_w.timestamp < self._sim_timestamp:
+        if self._root_link_state_w.timestamp < self._sim_timestamp:
             # read data from simulation (pose is of link)
             pose = self._root_physx_view.get_root_transforms().clone()
             pose[:, 3:7] = math_utils.convert_quat(pose[:, 3:7], to="wxyz")

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object_data.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/rigid_object/rigid_object_data.py
@@ -399,7 +399,7 @@ class RigidObjectData:
 
         This quantity contains the linear and angular velocities of the root rigid body's center of mass frame relative to the world.
         """
-        if self._root_link_state_w.timestamp < self._sim_timestamp:
+        if self._root_com_state_w.timestamp < self._sim_timestamp:
             # read data from simulation
             velocity = self._root_physx_view.get_velocities()
             return velocity
@@ -411,7 +411,7 @@ class RigidObjectData:
 
         This quantity is the linear velocity of the root rigid body's center of mass frame relative to the world.
         """
-        if self._root_link_state_w.timestamp < self._sim_timestamp:
+        if self._root_com_state_w.timestamp < self._sim_timestamp:
             # read data from simulation
             velocity = self._root_physx_view.get_velocities()
             return velocity[:, 0:3]
@@ -423,7 +423,7 @@ class RigidObjectData:
 
         This quantity is the angular velocity of the root rigid body's center of mass frame relative to the world.
         """
-        if self._root_link_state_w.timestamp < self._sim_timestamp:
+        if self._root_com_state_w.timestamp < self._sim_timestamp:
             # read data from simulation
             velocity = self._root_physx_view.get_velocities()
             return velocity[:, 3:6]


### PR DESCRIPTION
# Description
The rigid body data properties root_com_vel_w, root_com_pos_w, and root_com_ang_vel_w currently check the private state field's timestamp before updating their state. However, the issue lies in the fact that these COM state properties are incorrectly checking the link state field's timestamp instead of the COM's own state.

Fixes # (issue)
Replacing root link state with root com state at these properties.

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

