### PR TITLE
Add position to set external forces and torques

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
@@ -172,6 +172,7 @@ class Articulation(AssetBase):
         # reset external wrench
         self._external_force_b[env_ids] = 0.0
         self._external_torque_b[env_ids] = 0.0
+        self._external_wrench_positions_b[env_ids] = 0.0
 
     def write_data_to_sim(self):
         """Write external wrenches and joint commands to the simulation.
@@ -185,13 +186,26 @@ class Articulation(AssetBase):
         """
         # write external wrench
         if self.has_external_wrench:
-            self.root_physx_view.apply_forces_and_torques_at_position(
-                force_data=self._external_force_b.view(-1, 3),
-                torque_data=self._external_torque_b.view(-1, 3),
-                position_data=None,
-                indices=self._ALL_INDICES,
-                is_global=False,
-            )
+            if self.uses_external_wrench_positions:
+                self.root_physx_view.apply_forces_and_torques_at_position(
+                    force_data=self._external_force_b.view(-1, 3),
+                    torque_data=self._external_torque_b.view(-1, 3),
+                    position_data=self._external_wrench_positions_b.view(-1, 3),
+                    indices=self._ALL_INDICES,
+                    is_global=False,
+                )
+                # Reset the external wrench after writing to the simulation.
+                self.uses_external_wrench_positions = False
+                # Fill the positions tensor with zeros to avoid applying the wrench at the same position in the next step.
+                self._external_wrench_positions_b.fill_(0.0)
+            else:
+                self.root_physx_view.apply_forces_and_torques_at_position(
+                    force_data=self._external_force_b.view(-1, 3),
+                    torque_data=self._external_torque_b.view(-1, 3),
+                    position_data=None,
+                    indices=self._ALL_INDICES,
+                    is_global=False,
+                )
 
         # apply actuator models
         self._apply_actuator_model()
@@ -744,10 +758,12 @@ class Articulation(AssetBase):
         self,
         forces: torch.Tensor,
         torques: torch.Tensor,
+        positions: torch.Tensor | None = None,
         body_ids: Sequence[int] | slice | None = None,
         env_ids: Sequence[int] | None = None,
     ):
-        """Set external force and torque to apply on the asset's bodies in their local frame.
+        """Set external force and torque to apply on the asset's bodies in their local frame. Optionally, set the position
+        to apply the external wrench at (in the local frame of the bodies).
 
         For many applications, we want to keep the applied external force on rigid bodies constant over a period of
         time (for instance, during the policy control). This function allows us to store the external force and torque
@@ -770,6 +786,7 @@ class Articulation(AssetBase):
         Args:
             forces: External forces in bodies' local frame. Shape is (len(env_ids), len(body_ids), 3).
             torques: External torques in bodies' local frame. Shape is (len(env_ids), len(body_ids), 3).
+            positions: Positions to apply external wrench. Shape is (len(env_ids), len(body_ids), 3). Defaults to None.
             body_ids: Body indices to apply external wrench to. Defaults to None (all bodies).
             env_ids: Environment indices to apply external wrench to. Defaults to None (all instances).
         """
@@ -798,6 +815,17 @@ class Articulation(AssetBase):
             # note: these are applied in the write_to_sim function
             self._external_force_b.flatten(0, 1)[indices] = forces.flatten(0, 1)
             self._external_torque_b.flatten(0, 1)[indices] = torques.flatten(0, 1)
+
+            # If the positions are not provided, the behavior and performance of the simulation should not be affected.
+            if positions is not None:
+                # Generates a flag that is set for a full simulation step. This is done to avoid discarding
+                # the external wrench positions when multiple calls to this functions are made with and without positions.
+                self.uses_external_wrench_positions = True
+                self._external_wrench_positions_b.flatten(0, 1)[indices] = positions.flatten(0, 1)
+            else:
+                # If the positions are not provided, and the flag is set, then we need to ensure that the desired positions are zeroed.
+                if self.uses_external_wrench_positions:
+                    self._external_wrench_positions_b.flatten(0, 1)[indices].fill_(0.0)
         else:
             self.has_external_wrench = False
 
@@ -1142,8 +1170,10 @@ class Articulation(AssetBase):
 
         # external forces and torques
         self.has_external_wrench = False
+        self.uses_external_wrench_positions = False
         self._external_force_b = torch.zeros((self.num_instances, self.num_bodies, 3), device=self.device)
         self._external_torque_b = torch.zeros_like(self._external_force_b)
+        self._external_wrench_positions_b = torch.zeros_like(self._external_force_b)
 
         # asset data
         # -- properties

--- a/source/extensions/omni.isaac.lab/test/assets/test_articulation.py
+++ b/source/extensions/omni.isaac.lab/test/assets/test_articulation.py
@@ -615,50 +615,318 @@ class TestArticulation(unittest.TestCase):
         """Test application of external force on the base of the articulation."""
         for num_articulations in (1, 2):
             for device in ("cuda:0", "cpu"):
-                with self.subTest(num_articulations=num_articulations, device=device):
-                    with build_simulation_context(device=device, add_ground_plane=False, auto_add_lighting=True) as sim:
-                        articulation_cfg = generate_articulation_cfg(articulation_type="anymal")
-                        articulation, _ = generate_articulation(articulation_cfg, num_articulations, device)
-                        # Play the simulator
-                        sim.reset()
+                for use_wrench_positions in (True, False):
+                    with self.subTest(
+                        num_articulations=num_articulations, device=device, use_wrench_positions=use_wrench_positions
+                    ):
+                        with build_simulation_context(
+                            device=device, add_ground_plane=False, auto_add_lighting=True
+                        ) as sim:
+                            articulation_cfg = generate_articulation_cfg(articulation_type="anymal")
+                            articulation, _ = generate_articulation(articulation_cfg, num_articulations, device)
+                            # Play the simulator
+                            sim.reset()
 
-                        # Find bodies to apply the force
-                        body_ids, _ = articulation.find_bodies("base")
-                        # Sample a large force
-                        external_wrench_b = torch.zeros(articulation.num_instances, len(body_ids), 6, device=sim.device)
-                        external_wrench_b[..., 1] = 1000.0
+                            # Find bodies to apply the force
+                            body_ids, _ = articulation.find_bodies("base")
+                            # Sample a large force
+                            external_wrench_b = torch.zeros(
+                                articulation.num_instances, len(body_ids), 6, device=sim.device
+                            )
+                            external_wrench_b[..., 1] = 1000.0
 
-                        # Now we are ready!
+                            # If we use wrench positions, we need to set the positions of the wrenches
+                            # We perform 4 variations of the test to ensure that the wrench positions are set correctly
+                            if use_wrench_positions:
+                                external_wrench_positions_b_0 = torch.zeros((1, len(body_ids), 3), device=sim.device)
+                                external_wrench_positions_b_0[0, 0, 2] = 0.5
+                                external_wrench_positions_b_1 = torch.zeros((1, len(body_ids), 3), device=sim.device)
+                                external_wrench_positions_b_1[0, 0, 2] = 1.0
+                                external_wrench_positions_b_2 = torch.zeros((2, len(body_ids), 3), device=sim.device)
+                                external_wrench_positions_b_2[0, 0, 2] = 0.5
+                                external_wrench_positions_b_2[1, 0, 2] = 1.0
+                                external_wrench_positions_b_3 = torch.zeros((2, len(body_ids), 3), device=sim.device)
+                                external_wrench_positions_b_3[0, 0, 2] = 0.0
+                                external_wrench_positions_b_3[1, 0, 2] = 1.0
+                                external_wrench_positions_b_4 = torch.zeros((2, len(body_ids), 3), device=sim.device)
+                                external_wrench_positions_b_4[0, 0, 2] = 0.5
+                                external_wrench_positions_b_4[1, 0, 2] = 0.0
+
+                            # Now we are ready!
+                            for it in range(20):
+                                # reset root state
+                                root_state = articulation.data.default_root_state.clone()
+
+                                articulation.write_root_link_pose_to_sim(root_state[:, :7])
+                                articulation.write_root_com_velocity_to_sim(root_state[:, 7:])
+                                # reset dof state
+                                joint_pos, joint_vel = (
+                                    articulation.data.default_joint_pos,
+                                    articulation.data.default_joint_vel,
+                                )
+                                articulation.write_joint_state_to_sim(joint_pos, joint_vel)
+                                # reset articulation
+                                articulation.reset()
+                                # apply force
+                                if use_wrench_positions:
+                                    if num_articulations == 1:
+                                        articulation.set_external_force_and_torque(
+                                            external_wrench_b[..., :3],
+                                            external_wrench_b[..., 3:],
+                                            positions=external_wrench_positions_b_0,
+                                            body_ids=body_ids,
+                                        )
+                                        self.assertTrue(
+                                            torch.equal(
+                                                articulation._external_wrench_positions_b[:, body_ids],
+                                                external_wrench_positions_b_0,
+                                            )
+                                        )
+                                    else:
+                                        k = it % 4
+                                        match k:
+                                            case 0:
+                                                # Applied in one step
+                                                articulation.set_external_force_and_torque(
+                                                    external_wrench_b[..., :3],
+                                                    external_wrench_b[..., 3:],
+                                                    positions=external_wrench_positions_b_2,
+                                                    body_ids=body_ids,
+                                                )
+                                                self.assertTrue(
+                                                    torch.equal(
+                                                        articulation._external_wrench_positions_b[:, body_ids],
+                                                        external_wrench_positions_b_2,
+                                                    )
+                                                )
+                                            case 1:
+                                                # Applied in two steps
+                                                articulation.set_external_force_and_torque(
+                                                    external_wrench_b[0, :, :3],
+                                                    external_wrench_b[0, :, 3:],
+                                                    positions=external_wrench_positions_b_0,
+                                                    body_ids=body_ids,
+                                                    env_ids=[0],
+                                                )
+                                                articulation.set_external_force_and_torque(
+                                                    external_wrench_b[1, :, :3],
+                                                    external_wrench_b[1, :, 3:],
+                                                    positions=external_wrench_positions_b_1,
+                                                    body_ids=body_ids,
+                                                    env_ids=[1],
+                                                )
+                                                self.assertTrue(
+                                                    torch.equal(
+                                                        articulation._external_wrench_positions_b[:, body_ids],
+                                                        external_wrench_positions_b_2,
+                                                    )
+                                                )
+                                            case 2:
+                                                # First call does not provide wrench positions
+                                                articulation.set_external_force_and_torque(
+                                                    external_wrench_b[0, :, :3],
+                                                    external_wrench_b[0, :, 3:],
+                                                    body_ids=body_ids,
+                                                    env_ids=[0],
+                                                )
+                                                articulation.set_external_force_and_torque(
+                                                    external_wrench_b[1, :, :3],
+                                                    external_wrench_b[1, :, 3:],
+                                                    positions=external_wrench_positions_b_1,
+                                                    body_ids=body_ids,
+                                                    env_ids=[1],
+                                                )
+                                                self.assertTrue(
+                                                    torch.equal(
+                                                        articulation._external_wrench_positions_b[:, body_ids],
+                                                        external_wrench_positions_b_3,
+                                                    )
+                                                )
+                                            case 3:
+                                                # Second call does not provide wrench positions
+                                                articulation.set_external_force_and_torque(
+                                                    external_wrench_b[0, :, :3],
+                                                    external_wrench_b[0, :, 3:],
+                                                    positions=external_wrench_positions_b_0,
+                                                    body_ids=body_ids,
+                                                    env_ids=[0],
+                                                )
+                                                articulation.set_external_force_and_torque(
+                                                    external_wrench_b[1, :, :3],
+                                                    external_wrench_b[1, :, 3:],
+                                                    body_ids=body_ids,
+                                                    env_ids=[1],
+                                                )
+                                                self.assertTrue(
+                                                    torch.equal(
+                                                        articulation._external_wrench_positions_b[:, body_ids],
+                                                        external_wrench_positions_b_4,
+                                                    )
+                                                )
+
+                                else:
+                                    articulation.set_external_force_and_torque(
+                                        external_wrench_b[..., :3], external_wrench_b[..., 3:], body_ids=body_ids
+                                    )
+                                # perform simulation
+                                for i in range(100):
+                                    # apply action to the articulation
+                                    articulation.set_joint_position_target(articulation.data.default_joint_pos.clone())
+                                    articulation.write_data_to_sim()
+                                    if use_wrench_positions and (i == 0):
+                                        # check that the wrench positions are set to zero after application
+                                        self.assertTrue(
+                                            torch.equal(
+                                                articulation._external_wrench_positions_b,
+                                                torch.zeros_like(articulation._external_wrench_positions_b),
+                                            )
+                                        )
+                                    # perform step
+                                    sim.step()
+                                    # update buffers
+                                    articulation.update(sim.cfg.dt)
+                                # check condition that the articulations have fallen down
+                                for i in range(num_articulations):
+                                    self.assertLess(articulation.data.root_link_pos_w[i, 2].item(), 0.2)
+
+    def test_external_wrench_with_position(self):
+        """Test the application of an external wrench at a given position on a single body.
+        It only focuses on the indexing and trusts PhysX to apply it correctly.
+        The device and force test is covered by :func:`test_external_force_on_single_body`."""
+        device = "cuda:0"
+
+        # When use wrench positions, we need to set the positions of the wrenches
+        # We perform 5 variations of the test to ensure that the wrench positions are set correctly.
+        # 1 - Set for only 1 articulation with positions
+        # 2 - Set for 2 articulations in one step with positions
+        # 3 - Set for 2 articulations in two steps both with positions
+        # 4 - Set for 2 articulations in two steps the first without positions, the second with
+        # 5 - Set for 2 articulations in two steps the first with positions, the second without
+
+        for case in range(5):
+            with self.subTest(case=case):
+                with build_simulation_context(device=device, add_ground_plane=False, auto_add_lighting=True) as sim:
+                    if case == 0:
+                        num_articulations = 1
+                    else:
+                        num_articulations = 2
+
+                    articulation_cfg = generate_articulation_cfg(articulation_type="anymal")
+                    articulation, _ = generate_articulation(articulation_cfg, num_articulations, device)
+                    # Play the simulator
+                    sim.reset()
+
+                    # Find bodies to apply the force
+                    body_ids, _ = articulation.find_bodies("base")
+                    # Sample a large force
+                    force = torch.zeros((articulation.num_instances, 1, 3), device=device)
+                    torque = torch.zeros((articulation.num_instances, 1, 3), device=device)
+                    force[..., 1] = 1000.0
+
+                    # Now we are ready
+                    for it in range(5):
+                        # reset root state
+                        root_state = articulation.data.default_root_state.clone()
+
+                        articulation.write_root_link_pose_to_sim(root_state[:, :7])
+                        articulation.write_root_com_velocity_to_sim(root_state[:, 7:])
+                        # reset dof state
+                        joint_pos, joint_vel = (
+                            articulation.data.default_joint_pos,
+                            articulation.data.default_joint_vel,
+                        )
+                        articulation.write_joint_state_to_sim(joint_pos, joint_vel)
+                        # reset articulation
+                        articulation.reset()
+
+                        # perform simulation
                         for _ in range(5):
-                            # reset root state
-                            root_state = articulation.data.default_root_state.clone()
-
-                            articulation.write_root_link_pose_to_sim(root_state[:, :7])
-                            articulation.write_root_com_velocity_to_sim(root_state[:, 7:])
-                            # reset dof state
-                            joint_pos, joint_vel = (
-                                articulation.data.default_joint_pos,
-                                articulation.data.default_joint_vel,
-                            )
-                            articulation.write_joint_state_to_sim(joint_pos, joint_vel)
-                            # reset articulation
-                            articulation.reset()
                             # apply force
-                            articulation.set_external_force_and_torque(
-                                external_wrench_b[..., :3], external_wrench_b[..., 3:], body_ids=body_ids
+                            match case:
+                                case 0:
+                                    # Applied only on one articulation
+                                    ext_wrench_p0 = torch.rand((1, 1, 3), device=device)
+                                    articulation.set_external_force_and_torque(
+                                        force, torque, positions=ext_wrench_p0, body_ids=body_ids
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p0
+                                        )
+                                    )
+                                case 1:
+                                    # Applied in one step
+                                    ext_wrench_p2 = torch.rand((2, 1, 3), device=device)
+                                    articulation.set_external_force_and_torque(
+                                        force, torque, positions=ext_wrench_p2, body_ids=body_ids
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p2
+                                        )
+                                    )
+                                case 2:
+                                    # Applied in two steps
+                                    ext_wrench_p0 = torch.rand((1, 1, 3), device=device)
+                                    ext_wrench_p1 = torch.rand((1, 1, 3), device=device)
+                                    ext_wrench_p2 = torch.cat([ext_wrench_p0, ext_wrench_p1], axis=0)
+                                    articulation.set_external_force_and_torque(
+                                        force[0], torque[0], positions=ext_wrench_p0, body_ids=body_ids, env_ids=[0]
+                                    )
+                                    articulation.set_external_force_and_torque(
+                                        force[1], torque[1], positions=ext_wrench_p1, body_ids=body_ids, env_ids=[1]
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p2
+                                        )
+                                    )
+                                case 3:
+                                    # First call does not provide wrench positions
+                                    ext_wrench_p0 = torch.zeros((1, 1, 3), device=device)
+                                    ext_wrench_p1 = torch.rand((1, 1, 3), device=device)
+                                    ext_wrench_p2 = torch.cat([ext_wrench_p0, ext_wrench_p1], axis=0)
+                                    articulation.set_external_force_and_torque(
+                                        force[0], torque[0], body_ids=body_ids, env_ids=[0]
+                                    )
+                                    articulation.set_external_force_and_torque(
+                                        force[1], torque[1], positions=ext_wrench_p1, body_ids=body_ids, env_ids=[1]
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p2
+                                        )
+                                    )
+                                case 4:
+                                    # Second call does not provide wrench positions
+                                    ext_wrench_p0 = torch.rand((1, 1, 3), device=device)
+                                    ext_wrench_p1 = torch.zeros((1, 1, 3), device=device)
+                                    ext_wrench_p2 = torch.cat([ext_wrench_p0, ext_wrench_p1], axis=0)
+                                    articulation.set_external_force_and_torque(
+                                        force[0], torque[0], positions=ext_wrench_p0, body_ids=body_ids, env_ids=[0]
+                                    )
+                                    articulation.set_external_force_and_torque(
+                                        force[1], torque[1], body_ids=body_ids, env_ids=[1]
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p2
+                                        )
+                                    )
+                            # apply action to the articulation
+                            articulation.set_joint_position_target(articulation.data.default_joint_pos.clone())
+                            articulation.write_data_to_sim()
+                            # check that the wrench positions are set to zero after application
+                            self.assertTrue(
+                                torch.equal(
+                                    articulation._external_wrench_positions_b,
+                                    torch.zeros_like(articulation._external_wrench_positions_b),
+                                )
                             )
-                            # perform simulation
-                            for _ in range(100):
-                                # apply action to the articulation
-                                articulation.set_joint_position_target(articulation.data.default_joint_pos.clone())
-                                articulation.write_data_to_sim()
-                                # perform step
-                                sim.step()
-                                # update buffers
-                                articulation.update(sim.cfg.dt)
-                            # check condition that the articulations have fallen down
-                            for i in range(num_articulations):
-                                self.assertLess(articulation.data.root_link_pos_w[i, 2].item(), 0.2)
+                            # perform step
+                            sim.step()
+                            # update buffers
+                            articulation.update(sim.cfg.dt)
 
     def test_external_force_on_multiple_bodies(self):
         """Test application of external force on the legs of the articulation."""
@@ -712,6 +980,162 @@ class TestArticulation(unittest.TestCase):
                             for i in range(num_articulations):
                                 # since there is a moment applied on the articulation, the articulation should rotate
                                 self.assertTrue(articulation.data.root_com_ang_vel_w[i, 2].item() > 0.1)
+
+    def test_external_wrench_with_position_on_multiple_bodies(self):
+        """Test the application of an external wrench at a given position on a single body.
+        It only focuses on the indexing and trusts PhysX to apply it correctly.
+        The device and force test is covered by :func:`test_external_force_on_multiple_bodies`."""
+        device = "cuda:0"
+
+        # When use wrench positions, we need to set the positions of the wrenches
+        # We perform 5 variations of the test to ensure that the wrench positions are set correctly.
+        # 1 - Set for only 1 articulation with positions
+        # 2 - Set for 2 articulations in one step with positions
+        # 3 - Set for 2 articulations in two steps both with positions
+        # 4 - Set for 2 articulations in two steps the first without positions, the second with
+        # 5 - Set for 2 articulations in two steps the first with positions, the second without
+
+        for case in range(5):
+            with self.subTest(case=case):
+                with build_simulation_context(device=device, add_ground_plane=False, auto_add_lighting=True) as sim:
+                    if case == 0:
+                        num_articulations = 1
+                    else:
+                        num_articulations = 2
+
+                    articulation_cfg = generate_articulation_cfg(articulation_type="anymal")
+                    articulation, _ = generate_articulation(articulation_cfg, num_articulations, device)
+                    # Play the simulator
+                    sim.reset()
+
+                    # Find bodies to apply the force
+                    body_ids, _ = articulation.find_bodies(".*_SHANK")
+                    num_bodies = len(body_ids)
+                    # Sample a large force
+                    force = torch.zeros((articulation.num_instances, num_bodies, 3), device=device)
+                    torque = torch.zeros((articulation.num_instances, num_bodies, 3), device=device)
+                    force[..., 1] = 100.0
+
+                    # Now we are ready
+                    for it in range(5):
+                        # reset root state
+                        root_state = articulation.data.default_root_state.clone()
+
+                        articulation.write_root_link_pose_to_sim(root_state[:, :7])
+                        articulation.write_root_com_velocity_to_sim(root_state[:, 7:])
+                        # reset dof state
+                        joint_pos, joint_vel = (
+                            articulation.data.default_joint_pos,
+                            articulation.data.default_joint_vel,
+                        )
+                        articulation.write_joint_state_to_sim(joint_pos, joint_vel)
+                        # reset articulation
+                        articulation.reset()
+
+                        # perform simulation
+                        for _ in range(5):
+                            # apply force
+                            match case:
+                                case 0:
+                                    # Applied only on one articulation
+                                    ext_wrench_p0 = torch.rand((1, num_bodies, 3), device=device)
+                                    articulation.set_external_force_and_torque(
+                                        force, torque, positions=ext_wrench_p0, body_ids=body_ids
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p0
+                                        )
+                                    )
+                                case 1:
+                                    # Applied in one step
+                                    ext_wrench_p2 = torch.rand((2, num_bodies, 3), device=device)
+                                    articulation.set_external_force_and_torque(
+                                        force, torque, positions=ext_wrench_p2, body_ids=body_ids
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p2
+                                        )
+                                    )
+                                case 2:
+                                    # Applied in two steps
+                                    ext_wrench_p0 = torch.rand((1, num_bodies, 3), device=device)
+                                    ext_wrench_p1 = torch.rand((1, num_bodies, 3), device=device)
+                                    ext_wrench_p2 = torch.cat([ext_wrench_p0, ext_wrench_p1], axis=0)
+                                    articulation.set_external_force_and_torque(
+                                        force[0].unsqueeze(0),
+                                        torque[0].unsqueeze(0),
+                                        positions=ext_wrench_p0,
+                                        body_ids=body_ids,
+                                        env_ids=[0],
+                                    )
+                                    articulation.set_external_force_and_torque(
+                                        force[1].unsqueeze(0),
+                                        torque[1].unsqueeze(0),
+                                        positions=ext_wrench_p1,
+                                        body_ids=body_ids,
+                                        env_ids=[1],
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p2
+                                        )
+                                    )
+                                case 3:
+                                    # First call does not provide wrench positions
+                                    ext_wrench_p0 = torch.zeros((1, num_bodies, 3), device=device)
+                                    ext_wrench_p1 = torch.rand((1, num_bodies, 3), device=device)
+                                    ext_wrench_p2 = torch.cat([ext_wrench_p0, ext_wrench_p1], axis=0)
+                                    articulation.set_external_force_and_torque(
+                                        force[0].unsqueeze(0), torque[0].unsqueeze(0), body_ids=body_ids, env_ids=[0]
+                                    )
+                                    articulation.set_external_force_and_torque(
+                                        force[1].unsqueeze(0),
+                                        torque[1].unsqueeze(0),
+                                        positions=ext_wrench_p1,
+                                        body_ids=body_ids,
+                                        env_ids=[1],
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p2
+                                        )
+                                    )
+                                case 4:
+                                    # Second call does not provide wrench positions
+                                    ext_wrench_p0 = torch.rand((1, num_bodies, 3), device=device)
+                                    ext_wrench_p1 = torch.zeros((1, num_bodies, 3), device=device)
+                                    ext_wrench_p2 = torch.cat([ext_wrench_p0, ext_wrench_p1], axis=0)
+                                    articulation.set_external_force_and_torque(
+                                        force[0].unsqueeze(0),
+                                        torque[0].unsqueeze(0),
+                                        positions=ext_wrench_p0,
+                                        body_ids=body_ids,
+                                        env_ids=[0],
+                                    )
+                                    articulation.set_external_force_and_torque(
+                                        force[1].unsqueeze(0), torque[1].unsqueeze(0), body_ids=body_ids, env_ids=[1]
+                                    )
+                                    self.assertTrue(
+                                        torch.equal(
+                                            articulation._external_wrench_positions_b[:, body_ids], ext_wrench_p2
+                                        )
+                                    )
+                            # apply action to the articulation
+                            articulation.set_joint_position_target(articulation.data.default_joint_pos.clone())
+                            articulation.write_data_to_sim()
+                            # check that the wrench positions are set to zero after application
+                            self.assertTrue(
+                                torch.equal(
+                                    articulation._external_wrench_positions_b,
+                                    torch.zeros_like(articulation._external_wrench_positions_b),
+                                )
+                            )
+                            # perform step
+                            sim.step()
+                            # update buffers
+                            articulation.update(sim.cfg.dt)
 
     def test_loading_gains_from_usd(self):
         """Test that gains are loaded from USD file if actuator model has them as None."""


### PR DESCRIPTION
# Description

This PR adds the option to set wrench positions to `set_external_force_and_torque`. This is a non-breaking change as the positions are passed as an optional argument. When no positions are set, the function defaults to the original implementation, that is, no positions are passed to PhysX. The PR also adds tests to check that the position values are correctly set into their buffer, but does not check if the resulting wrenches are correct. I did test the Quadcopter task before and after this PR and the training results are exactly the same.

As of now, the function follows the original layout. But it could make sense to offer the option to set the position in either the link frame or the CoM frame. This would follow the recent changes made to the set_pose and set_velocity methods for instance. However, this would be a breaking change. Hence, for now, this has not been implemented. One could also argue, that this could be done prior to feeding the positions outside this method. Please let me know what you feel is best, and I'll update the PR accordingly.

If one wanted to test the resulting wrenches, it would require a simple test articulation like a 1kg sphere that would be used to accurately compute the expected velocities. This is also feasible, but I feel like this test is more on the PhysX side of things, let me know.

This change will require an update of the API documentation to include the position argument.

Fixes #1678 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
