### PR TITLE
Adds collision approximation choices convert_mesh.py

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -102,6 +102,7 @@ Guidelines for modifications:
 * Stephan Pleines
 * Tyler Lum
 * Victor Khaustov
+* Virgilio Gómez Lambo
 * Vladimir Fokow
 * Wei Yang
 * Xavier Nal

--- a/scripts/tools/convert_mesh.py
+++ b/scripts/tools/convert_mesh.py
@@ -57,7 +57,7 @@ parser.add_argument(
     "--collision-approximation",
     type=str,
     default="convexDecomposition",
-    choices=["convexDecomposition", "convexHull", "none"],
+    choices=["convexDecomposition", "convexHull", "boundingCube", "boundingSphere", "meshSimplification", "none"],
     help=(
         'The method used for approximating collision mesh. Set to "none" '
         "to not add a collision mesh to the converted mesh."


### PR DESCRIPTION
Add missing collision approximation choices

# Description

Add some missing collision approximation options in convert_mesh.py file. Some collision approximation options were missing in the code, but the MeshConverterCfg class has them as possible options 

https://github.com/isaac-sim/IsaacLab/blob/21173c3e933a9236d6eb5eb2adb903494ba9a418/source/standalone/tools/convert_mesh.py#L60

https://github.com/isaac-sim/IsaacLab/blob/21173c3e933a9236d6eb5eb2adb903494ba9a418/source/extensions/omni.isaac.lab/omni/isaac/lab/sim/converters/mesh_converter_cfg.py#L39-L41

Fixes  https://github.com/isaac-sim/IsaacLab/issues/1713#issue-2807158637


## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
