### PR TITLE
Fixes handling of invalid values ​​for sensor data

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/rewards.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/rewards.py
@@ -114,7 +114,11 @@ def base_height_l2(
     if sensor_cfg is not None:
         sensor: RayCaster = env.scene[sensor_cfg.name]
         # Adjust the target height using the sensor data
-        adjusted_target_height = target_height + torch.mean(sensor.data.ray_hits_w[..., 2], dim=1)
+        ray_hits = sensor.data.ray_hits_w[..., 2]
+        if torch.isnan(ray_hits).any() or torch.isinf(ray_hits).any() or torch.max(torch.abs(ray_hits)) > 1e6:
+            adjusted_target_height = asset.data.root_link_pos_w[:, 2]
+        else:
+            adjusted_target_height = target_height + torch.mean(ray_hits, dim=1)
     else:
         # Use the provided target height directly for flat terrain
         adjusted_target_height = target_height


### PR DESCRIPTION
# Description

Fixes #1698 

The PR https://github.com/isaac-sim/IsaacLab/pull/1710 cause a new bug. Sometimes height scan outputs none, after a period of training, the following problems will occur:

```bash
################################################################################
 Learning iteration 2586/5000 

Computation: 85132 steps/s (collection: 1.089s, learning 0.066s)
Value function loss: 0.1565
Surrogate loss: -0.0064
Mean action noise std: 0.76
Mean reward: 44.35
Mean episode length: 804.99
Episode_Reward/lin_vel_z_l2: -0.0784
Episode_Reward/ang_vel_xy_l2: -0.4739
Episode_Reward/base_height_l2: -0.0072
Episode_Reward/joint_torques_l2: -0.0109
Episode_Reward/joint_acc_l2: -0.2853
Episode_Reward/joint_pos_limits: -0.0104
Episode_Reward/action_rate_l2: -0.2222
Episode_Reward/undesired_contacts: -0.0567
Episode_Reward/track_lin_vel_xy_exp: 0.4555
Episode_Reward/track_ang_vel_z_exp: 0.2709
Episode_Reward/feet_air_time: 0.1819
Episode_Reward/feet_gait: 2.1170
Episode_Reward/feet_height_exp: 0.9502
Episode_Reward/joint_power: -0.0029
Episode_Reward/stand_still_when_zero_command: -0.0909
Episode_Reward/joint_position_penalty: -0.5345
Curriculum/terrain_levels: 4.4967
Metrics/base_velocity/error_vel_xy: 0.9245
Metrics/base_velocity/error_vel_yaw: 1.0580
Episode_Termination/time_out: 3.0000
Episode_Termination/terrain_out_of_bounds: 0.0000
Episode_Termination/illegal_contact: 1.3333
--------------------------------------------------------------------------------
Total timesteps: 254312448
Iteration time: 1.15s
Total time: 2878.07s
ETA: 2685.6s

Error executing job with overrides: []
Traceback (most recent call last):
File "/home/ubuntu/workspaces/IsaacLab/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/hydra.py", line 99, in hydra_main
func(env_cfg, agent_cfg, *args, **kwargs)
File "/home/ubuntu/workspaces/robot_lab/scripts/rsl_rl/base/train.py", line 146, in main
runner.learn(num_learning_iterations=agent_cfg.max_iterations, init_at_random_ep_len=True)
File "/home/ubuntu/workspaces/robot_lab/exts/robot_lab/robot_lab/third_party/rsl_rl/runners/on_policy_runner.py", line 149, in learn
mean_value_loss, mean_surrogate_loss = self.alg.update()
File "/home/ubuntu/workspaces/robot_lab/exts/robot_lab/robot_lab/third_party/rsl_rl/algorithms/ppo.py", line 121, in update
self.actor_critic.act(obs_batch, masks=masks_batch, hidden_states=hid_states_batch[0])
File "/home/ubuntu/workspaces/robot_lab/exts/robot_lab/robot_lab/third_party/rsl_rl/modules/actor_critic.py", line 104, in act
self.update_distribution(observations)
File "/home/ubuntu/workspaces/robot_lab/exts/robot_lab/robot_lab/third_party/rsl_rl/modules/actor_critic.py", line 101, in update_distribution
self.distribution = Normal(mean, mean * 0.0 + self.std)
File "/home/ubuntu/anaconda3/envs/lab/lib/python3.10/site-packages/torch/distributions/normal.py", line 57, in __init__
super().__init__(batch_shape, validate_args=validate_args)
File "/home/ubuntu/anaconda3/envs/lab/lib/python3.10/site-packages/torch/distributions/distribution.py", line 70, in __init__
raise ValueError(
ValueError: Expected parameter loc (Tensor of shape (24576, 12)) of distribution Normal(loc: torch.Size([24576, 12]), scale: torch.Size([24576, 12])) to satisfy the constraint Real(), but found invalid values:
tensor([[nan, nan, nan,  ..., nan, nan, nan],
[nan, nan, nan,  ..., nan, nan, nan],
[nan, nan, nan,  ..., nan, nan, nan],
...,
[nan, nan, nan,  ..., nan, nan, nan],
[nan, nan, nan,  ..., nan, nan, nan],
[nan, nan, nan,  ..., nan, nan, nan]], device='cuda:0',
grad_fn=<AddmmBackward0>)

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

