### PR TITLE
Fix: accept both task ID and task name in command line --task argument

### DIFF
--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/parse_cfg.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/parse_cfg.py
@@ -52,7 +52,8 @@ def load_cfg_from_registry(task_name: str, entry_point_key: str) -> dict | objec
         ValueError: If the entry point key is not available in the gym registry for the task.
     """
     # obtain the configuration entry point
-    cfg_entry_point = gym.spec(task_name).kwargs.get(entry_point_key)
+    task_id = gym.envs.registration._find_spec(task_name).id
+    cfg_entry_point = gym.spec(task_id).kwargs.get(entry_point_key)
     # check if entry point exists
     if cfg_entry_point is None:
         raise ValueError(


### PR DESCRIPTION
# Description

When running tasks from the command line, e.g.
```shell
python source/standalone/workflows/rl_games/train.py --task=Isaac-Cartpole-Direct-v0 --headless
```
the `--task` argument should be the task ID (which includes the version number).

However, if an invalid task ID is provided, the error message from Gymnasium suggests using a similar task name, not a task ID, which can be confusing.

This pull request introduces the ability to use either a task ID or a task name in the `--task` argument. If a task name is provided, the script will default to using the latest version of the environment and print a warning to notify the user:
```shell
/workspace/isaaclab/source/Gymnasium/gymnasium/envs/registration.py:527: UserWarning: WARN: Using the latest versioned environment `Isaac-Cartpole-Direct-v0` instead of the unversioned environment `Isaac-Cartpole-Direct`.
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings