### PR TITLE
Adds interval resampling on event manager's reset call

### DIFF
--- a/source/extensions/omni.isaac.lab/config/extension.toml
+++ b/source/extensions/omni.isaac.lab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.30.6"
+version = "0.30.7"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.lab/docs/CHANGELOG.rst
@@ -1,33 +1,45 @@
 Changelog
 ---------
 
+0.30.7 (2025-01-30)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed resampling of interval time left for the next event in the :class:`~omni.isaac.lab.managers.EventManager`
+  class. Earlier, the time left for interval-based events was not being resampled on episodic resets. This led
+  to the event being triggered at the wrong time after the reset.
+
+
 0.30.6 (2025-01-17)
 ~~~~~~~~~~~~~~~~~~~
 
 Fixed
 ^^^^^
 
-* removed deprecation of :attr:`omni.isaac.lab.assets.ArticulationData.root_state_w` and
+* Removed deprecation of :attr:`omni.isaac.lab.assets.ArticulationData.root_state_w` and
   :attr:`omni.isaac.lab.assets.ArticulationData.body_state_w` derived properties.
-* removed deprecation of :meth:`omni.isaac.lab.assets.Articulation.write_root_state_to_sim`.
-* replaced calls to :attr:`omni.isaac.lab.assets.ArticulationData.root_com_state_w` and
+* Removed deprecation of :meth:`omni.isaac.lab.assets.Articulation.write_root_state_to_sim`.
+* Replaced calls to :attr:`omni.isaac.lab.assets.ArticulationData.root_com_state_w` and
   :attr:`omni.isaac.lab.assets.ArticulationData.root_link_state_w` with corresponding calls to
   :attr:`omni.isaac.lab.assets.ArticulationData.root_state_w`.
-* replaced calls to :attr:`omni.isaac.lab.assets.ArticulationData.body_com_state_w` and
+* Replaced calls to :attr:`omni.isaac.lab.assets.ArticulationData.body_com_state_w` and
   :attr:`omni.isaac.lab.assets.ArticulationData.body_link_state_w` properties with corresponding calls to
   :attr:`omni.isaac.lab.assets.ArticulationData.body_state_w` properties.
-* removed deprecation of :attr:`omni.isaac.lab.assets.RigidObjectData.root_state_w` derived properties  .
-* removed deprecation of :meth:`omni.isaac.lab.assets.RigidObject.write_root_state_to_sim`.
-* replaced calls to :attr:`omni.isaac.lab.assets.RigidObjectData.root_com_state_w` and
+* Removed deprecation of :attr:`omni.isaac.lab.assets.RigidObjectData.root_state_w` derived properties.
+* Removed deprecation of :meth:`omni.isaac.lab.assets.RigidObject.write_root_state_to_sim`.
+* Replaced calls to :attr:`omni.isaac.lab.assets.RigidObjectData.root_com_state_w` and
   :attr:`omni.isaac.lab.assets.RigidObjectData.root_link_state_w` properties with corresponding calls to
   :attr:`omni.isaac.lab.assets.RigidObjectData.root_state_w` properties.
-* removed deprecation of :attr:`omni.isaac.lab.assets.RigidObjectCollectionData.root_state_w` derived properties.
-* removed deprecation of :meth:`omni.isaac.lab.assets.RigidObjectCollection.write_root_state_to_sim`.
-* replaced calls to :attr:`omni.isaac.lab.assets.RigidObjectCollectionData.root_com_state_w` and
+* Removed deprecation of :attr:`omni.isaac.lab.assets.RigidObjectCollectionData.root_state_w` derived properties.
+* Removed deprecation of :meth:`omni.isaac.lab.assets.RigidObjectCollection.write_root_state_to_sim`.
+* Replaced calls to :attr:`omni.isaac.lab.assets.RigidObjectCollectionData.root_com_state_w` and
   :attr:`omni.isaac.lab.assets.RigidObjectData.root_link_state_w` properties with corresponding calls to
   :attr:`omni.isaac.lab.assets.RigidObjectData.root_state_w` properties.
-* fixed indexing issue in ``write_root_link_velocity_to_sim`` in :class:`omni.isaac.lab.assets.RigidObject`
-* fixed index broadcasting in ``write_object_link_velocity_to_sim`` and ``write_object_com_pose_to_sim`` in :class:`omni.isaac.lab.assets.RigidObjectCollection`
+* Fixed indexing issue in ``write_root_link_velocity_to_sim`` in :class:`omni.isaac.lab.assets.RigidObject`
+* Fixed index broadcasting in ``write_object_link_velocity_to_sim`` and ``write_object_com_pose_to_sim`` in
+  the :class:`omni.isaac.lab.assets.RigidObjectCollection` class.
 
 
 0.30.5 (2025-01-14)

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
@@ -128,10 +128,14 @@ class EventManager(ManagerBase):
             num_envs = self._env.num_envs
         else:
             num_envs = len(env_ids)
-        # if we are doing interval based events then we need to reset the time left when the episode starts
+        # if we are doing interval based events then we need to reset the time left
+        # when the episode starts. otherwise the counter will start from the last time
+        # for that environment
         if "interval" in self._mode_class_term_cfgs:
             for index, term_cfg in enumerate(self._mode_class_term_cfgs["interval"]):
                 # sample a new interval and set that as time left
+                # note: global time events are based on simulation time and not episode time
+                #   so we do not reset them
                 if not term_cfg.is_global_time:
                     lower, upper = term_cfg.interval_range_s
                     sampled_interval = torch.rand(num_envs, device=self.device) * (upper - lower) + lower

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/event_manager.py
@@ -132,11 +132,7 @@ class EventManager(ManagerBase):
         if "interval" in self._mode_class_term_cfgs:
             for index, term_cfg in enumerate(self._mode_class_term_cfgs["interval"]):
                 # sample a new interval and set that as time left
-                if term_cfg.is_global_time:
-                    lower, upper = term_cfg.interval_range_s
-                    sampled_interval = torch.rand(1) * (upper - lower) + lower
-                    self._interval_term_time_left[index][:] = sampled_interval
-                else:
+                if not term_cfg.is_global_time:
                     lower, upper = term_cfg.interval_range_s
                     sampled_interval = torch.rand(num_envs, device=self.device) * (upper - lower) + lower
                     self._interval_term_time_left[index][env_ids] = sampled_interval


### PR DESCRIPTION
# Description

Previously on episodic resets, the "time left" for the interval events were not getting resampled. This means that if the user expects the event to happen in the range 6-8s of an episode, it could be that in a new episode, the push happens at a time outside this range as the time left variable keeps its old value.

This MR fixes this issue by resampling the time left inside the manager's reset call.

Note: This only matters for the case when "is_global_time" is False (which is the default). The reason is that when there is global time, the events are triggered through simulation time and not episode time.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there