### PR TITLE
Fixes timestamp of com and link buffers when writing articulation pose to sim

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,6 +56,7 @@ Guidelines for modifications:
 * HoJin Jeon
 * Hongwei Xiong
 * Iretiayo Akinola
+* Jack Zeng
 * Jan Kerner
 * Jean Tampon
 * Jia Lin Yuan

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.33.13"
+version = "0.33.14"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.33.14 (2025-01-31)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed not updating the timestamp of `body_link_state_w` and `body_com_state_w` when `write_root_pose_to_sim` in the `Articulation` class is called.
+
 0.33.13 (2025-01-30)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed not updating the timestamp of `body_link_state_w` and `body_com_state_w` when `write_root_pose_to_sim` in the `Articulation` class is called.
+* Fixed not updating the timestamp of ``body_link_state_w`` and ``body_com_state_w`` when ``write_root_pose_to_sim`` in the ``Articulation`` class is called.
 
 0.33.13 (2025-01-30)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,13 +1,13 @@
 Changelog
 ---------
 
-0.33.14 (2025-01-31)
+0.33.14 (2025-02-01)
 ~~~~~~~~~~~~~~~~~~~~
 
 Fixed
 ^^^^^
 
-* Fixed not updating the timestamp of ``body_link_state_w`` and ``body_com_state_w`` when ``write_root_pose_to_sim`` in the ``Articulation`` class is called.
+* Fixed not updating the timestamp of ``body_link_state_w`` and ``body_com_state_w`` when ``write_root_pose_to_sim`` and ``write_joint_state_to_sim`` in the ``Articulation`` class are called.
 
 0.33.13 (2025-01-30)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/isaaclab/assets/articulation/articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation.py
@@ -501,8 +501,8 @@ class Articulation(AssetBase):
         self._data.joint_acc[env_ids, joint_ids] = 0.0
         # Need to invalidate the buffer to trigger the update with the new root pose.
         self._data._body_state_w.timestamp = -1.0
-        # self._data._body_link_state_w.timestamp = -1.0
-        # self._data._body_com_state_w.timestamp = -1.0
+        self._data._body_link_state_w.timestamp = -1.0
+        self._data._body_com_state_w.timestamp = -1.0
         # set into simulation
         self.root_physx_view.set_dof_positions(self._data.joint_pos, indices=physx_env_ids)
         self.root_physx_view.set_dof_velocities(self._data.joint_vel, indices=physx_env_ids)

--- a/source/isaaclab/isaaclab/assets/articulation/articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation.py
@@ -335,6 +335,8 @@ class Articulation(AssetBase):
         root_poses_xyzw[:, 3:] = math_utils.convert_quat(root_poses_xyzw[:, 3:], to="xyzw")
         # Need to invalidate the buffer to trigger the update with the new root pose.
         self._data._body_state_w.timestamp = -1.0
+        self._data._body_link_state_w.timestamp = -1.0
+        self._data._body_com_state_w.timestamp = -1.0
         # set into simulation
         self.root_physx_view.set_root_transforms(root_poses_xyzw, indices=physx_env_ids)
 


### PR DESCRIPTION
# Description

This PR is linked to https://github.com/isaac-sim/IsaacLab/issues/1756. 
In short, with the recent deprecation of the `body_state_w` variable, and then the removal of the deprecation, there are now 3 ways to get the states from the `ArticulationData` class: `body_state_w`, `body_com_state_w` and `body_link_state_w`. Commit 999c1e9ab93acb07c0e31acca7bfe796ebfd3ab4 removed the deprecation, removing any `write_root_com.*` and `write_root_link.*` calls and therefore not updating the `body_com_state_w` and `body_link_state_w` until the next physics step. This caused any use of the  `body_com_state_w` and `body_link_state_w` buffers to be 1 step behind after an environment is reset.

Fixes #1762 

This PR updates the timestep of the  `body_com_state_w` and `body_link_state_w` buffers to -1 in the `write_root_pose_to_sim` function in the `Articulation` class so that they update correctly. It allows for use of all 3 buffers instead of only `body_state_w`.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

