### PR TITLE
Fixes incorrect local documentation preview path in xdg-open command

### DIFF
--- a/docs/source/refs/contributing.rst
+++ b/docs/source/refs/contributing.rst
@@ -151,7 +151,7 @@ in the terminal:
 
 .. code:: bash
 
-   xdg-open docs/_build/html/index.html
+   xdg-open docs/_build/current/index.html
 
 .. hint::
 

--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -67,6 +67,12 @@ To learn about how to set up your own extension project on top of Isaac Lab, vis
 
             pip install torch==2.5.1 --index-url https://download.pytorch.org/whl/cu121
 
+-  Due to limitations of PyPI, we were not able to package the RSL RL library into the Isaac Lab pip package. Therefore, we recommend first installing the RSL RL library separately
+
+   .. code-block:: bash
+
+      pip install rsl-rl@git+https://github.com/leggedrobotics/rsl_rl.git
+
 -  Before installing Isaac Lab, ensure the latest pip version is installed. To update pip, run
 
    .. tab-set::

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -64,7 +64,7 @@ Fixed
 Fixed
 ^^^^^
 
-]* Removed deprecation of :attr:`isaaclab.assets.ArticulationData.root_state_w` and
+* Removed deprecation of :attr:`isaaclab.assets.ArticulationData.root_state_w` and
   :attr:`isaaclab.assets.ArticulationData.body_state_w` derived properties.
 * Removed deprecation of :meth:`isaaclab.assets.Articulation.write_root_state_to_sim`.
 * Replaced calls to :attr:`isaaclab.assets.ArticulationData.root_com_state_w` and


### PR DESCRIPTION
# Description

This PR fixes the `xdg-open` command in the documentation that instructs users on how to preview the documentation locally. Previously, the command pointed to `docs/_build/html/index.html`, which is incorrect. The correct path is now `docs/_build/current/index.html`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
