### PR TITLE
Add `only_positive_rewards` to ManagerBasedRLEnv

### DIFF
--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -204,6 +204,8 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         self.reset_time_outs = self.termination_manager.time_outs
         # -- reward computation
         self.reward_buf = self.reward_manager.compute(dt=self.step_dt)
+        if self.cfg.only_positive_rewards:
+            self.reward_buf[:] = torch.clip(self.reward_buf[:], min=0.0)
 
         if len(self.recorder_manager.active_terms) > 0:
             # update observations for recording if needed

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env_cfg.py
@@ -54,6 +54,13 @@ class ManagerBasedRLEnvCfg(ManagerBasedEnvCfg):
     then the episode length in steps is 100.
     """
 
+    only_positive_rewards: bool = False
+    """Whether to clip negative total rewards at zero. Defaults to False.
+
+    If True, then negative total rewards are clipped at zero. This is useful for avoiding early termination problems
+    in some learning algorithms.
+    """
+
     # environment settings
     rewards: object = MISSING
     """Reward settings.


### PR DESCRIPTION
# Description

Users can selectively calculate only positive rewards in reward manager

Fixes #1076

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

