### PR TITLE
Fixes reset of sensor drift inside the RayCaster sensor

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.33.14"
+version = "0.33.15"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.33.15 (2025-02-09)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed not updating the ``drift`` when calling :func:`~isaaclab.sensors.RayCaster.reset`
+
+
 0.33.14 (2025-02-01)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster.py
@@ -110,7 +110,7 @@ class RayCaster(SensorBase):
         if env_ids is None:
             env_ids = slice(None)
         # resample the drift
-        self.drift[env_ids].uniform_(*self.cfg.drift_range)
+        self.drift[env_ids] = self.drift[env_ids].uniform_(*self.cfg.drift_range)
 
     """
     Implementation.


### PR DESCRIPTION
## Description

The drift in raycaster didn't update when reset. This MR now updates it correctly:

before:
```python
self.drift[env_ids].uniform_(*self.cfg.drift_range)
```

now:
```python
self.drift[env_ids] = self.drift[env_ids].uniform_(*self.cfg.drift_range)
```

Fixes #1820 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there