### PR TITLE
Adds security and show&tell notes to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ We encourage you to utilize our [Show & Tell](https://github.com/isaac-sim/Isaac
 * Showcase your learning content
 * Present exciting projects you've developed
 
-By sharing your work, you'll inspire others and contribute to the collective knowledge of our community. Your contributions can spark new ideas and collaborations, fostering innovation in robotics and simulation.
+By sharing your work, you'll inspire others and contribute to the collective knowledge
+of our community. Your contributions can spark new ideas and collaborations, fostering
+innovation in robotics and simulation.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ We wholeheartedly welcome contributions from the community to make this framewor
 These may happen as bug reports, feature requests, or code contributions. For details, please check our
 [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html).
 
+## Show & Tell: Share Your Inspiration
+
+We encourage you to utilize our [Show & Tell](https://github.com/isaac-sim/IsaacLab/discussions/categories/show-and-tell) area in the Discussions section of this repository. This space is designed for you to:
+* Share tutorials you've created
+* Showcase your learning content
+* Present exciting projects you've developed
+
+By sharing your work, you'll inspire others and contribute to the collective knowledge of our community. Your contributions can spark new ideas and collaborations, fostering innovation in robotics and simulation.
+
 ## Troubleshooting
 
 Please see the [troubleshooting](https://isaac-sim.github.io/IsaacLab/main/source/refs/troubleshooting.html) section for
@@ -55,6 +64,12 @@ or opening a question on its [forums](https://forums.developer.nvidia.com/c/agx-
 
 * Please use GitHub [Discussions](https://github.com/isaac-sim/IsaacLab/discussions) for discussing ideas, asking questions, and requests for new features.
 * Github [Issues](https://github.com/isaac-sim/IsaacLab/issues) should only be used to track executable pieces of work with a definite scope and a clear deliverable. These can be fixing bugs, documentation issues, new features, or general updates.
+
+## Connect with the NVIDIA Omniverse Community
+
+Have a project or resource you'd like to share more widely? We'd love to hear from you! Reach out to the NVIDIA Omniverse Community team at OmniverseCommunity@nvidia.com to discuss potential opportunities for broader dissemination of your work.
+
+Join us in building a vibrant, collaborative ecosystem where creativity and technology intersect. Your contributions can make a significant impact on the Isaac Lab community and beyond!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,12 @@ or opening a question on its [forums](https://forums.developer.nvidia.com/c/agx-
 
 ## Connect with the NVIDIA Omniverse Community
 
-Have a project or resource you'd like to share more widely? We'd love to hear from you! Reach out to the NVIDIA Omniverse Community team at OmniverseCommunity@nvidia.com to discuss potential opportunities for broader dissemination of your work.
+Have a project or resource you'd like to share more widely? We'd love to hear from you! Reach out to the
+NVIDIA Omniverse Community team at OmniverseCommunity@nvidia.com to discuss potential opportunities
+for broader dissemination of your work.
 
-Join us in building a vibrant, collaborative ecosystem where creativity and technology intersect. Your contributions can make a significant impact on the Isaac Lab community and beyond!
+Join us in building a vibrant, collaborative ecosystem where creativity and technology intersect. Your
+contributions can make a significant impact on the Isaac Lab community and beyond!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ These may happen as bug reports, feature requests, or code contributions. For de
 
 ## Show & Tell: Share Your Inspiration
 
-We encourage you to utilize our [Show & Tell](https://github.com/isaac-sim/IsaacLab/discussions/categories/show-and-tell) area in the Discussions section of this repository. This space is designed for you to:
-* Share tutorials you've created
+We encourage you to utilize our [Show & Tell](https://github.com/isaac-sim/IsaacLab/discussions/categories/show-and-tell) area in the
+`Discussions` section of this repository. This space is designed for you to:
+
+* Share the tutorials you've created
 * Showcase your learning content
 * Present exciting projects you've developed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,10 @@
-## Security
+# Security
 
-NVIDIA is dedicated to the security and trust of our software products and services, including all source code repositories managed through our organization.
+NVIDIA is dedicated to the security and trust of our software products and services, including all source code
+repositories managed through our organization.
 
-If you need to report a security issue, please use the appropriate contact points outlined below. **Please do not report security vulnerabilities through GitHub.**
+If you need to report a security issue, please use the appropriate contact points outlined below. **Please do 
+not report security vulnerabilities through GitHub.**
 
 ## Reporting Potential Security Vulnerability in an NVIDIA Product
 
@@ -26,8 +28,11 @@ To report a potential security vulnerability in any NVIDIA product:
 
     - Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
 
-While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
+While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an 
+externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please 
+visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/)
+policies page for more information.
 
 ## NVIDIA Product Security
 
-For all security-related concerns, please visit NVIDIA's Product Security portal at https://www.nvidia.com/en-us/security
+For all security-related concerns, please visit NVIDIA's Product Security portal at: https://www.nvidia.com/en-us/security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 NVIDIA is dedicated to the security and trust of our software products and services, including all source code
 repositories managed through our organization.
 
-If you need to report a security issue, please use the appropriate contact points outlined below. **Please do 
+If you need to report a security issue, please use the appropriate contact points outlined below. **Please do
 not report security vulnerabilities through GitHub.**
 
 ## Reporting Potential Security Vulnerability in an NVIDIA Product
@@ -28,8 +28,8 @@ To report a potential security vulnerability in any NVIDIA product:
 
     - Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
 
-While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an 
-externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please 
+While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an
+externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please
 visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/)
 policies page for more information.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+## Security
+
+NVIDIA is dedicated to the security and trust of our software products and services, including all source code repositories managed through our organization.
+
+If you need to report a security issue, please use the appropriate contact points outlined below. **Please do not report security vulnerabilities through GitHub.**
+
+## Reporting Potential Security Vulnerability in an NVIDIA Product
+
+To report a potential security vulnerability in any NVIDIA product:
+
+- Web: [Security Vulnerability Submission Form](https://www.nvidia.com/object/submit-security-vulnerability.html)
+
+- E-Mail: psirt@nvidia.com
+
+    - We encourage you to use the following PGP key for secure email communication: [NVIDIA public PGP Key for communication](https://www.nvidia.com/en-us/security/pgp-key)
+
+    - Please include the following information:
+
+    - Product/Driver name and version/branch that contains the vulnerability
+
+    - Type of vulnerability (code execution, denial of service, buffer overflow, etc.)
+
+    - Instructions to reproduce the vulnerability
+
+    - Proof-of-concept or exploit code
+
+    - Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
+
+While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
+
+## NVIDIA Product Security
+
+For all security-related concerns, please visit NVIDIA's Product Security portal at https://www.nvidia.com/en-us/security


### PR DESCRIPTION
# Description

Adds a security page for indicating process on reporting security issues. 
Also adds a note in readme to point users to the Show & Tell section of the discussion board to share projects and tutorials.

## Type of change

- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
