### PR TITLE
Fixes offset from object obs for Franka stacking env when using parallel envs

### DIFF
--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.10.22"
+version = "0.10.23"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -9,7 +9,7 @@ Fixed
 
 * Fixed the inconsistent object pos observations in the ``Isaac-Stack-Cube-Franka`` environment when using parallel envs by
   subtracting out the env origin from each object pos observation.
-  
+
 
 0.10.22 (2025-01-14)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.10.23 (2025-02-11)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the inconsistent object pos observations in the ``Isaac-Stack-Cube-Franka`` environment when using parallel envs by
+  subtracting out the env origin from each object pos observation.
+  
+
 0.10.22 (2025-01-14)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/observations.py
@@ -147,11 +147,11 @@ def object_obs(
 
     return torch.cat(
         (
-            cube_1_pos_w,
+            cube_1_pos_w - env.scene.env_origins,
             cube_1_quat_w,
-            cube_2_pos_w,
+            cube_2_pos_w - env.scene.env_origins,
             cube_2_quat_w,
-            cube_3_pos_w,
+            cube_3_pos_w - env.scene.env_origins,
             cube_3_quat_w,
             gripper_to_cube_1,
             gripper_to_cube_2,
@@ -225,11 +225,11 @@ def instance_randomize_object_obs(
 
     return torch.cat(
         (
-            cube_1_pos_w,
+            cube_1_pos_w - env.scene.env_origins,
             cube_1_quat_w,
-            cube_2_pos_w,
+            cube_2_pos_w - env.scene.env_origins,
             cube_2_quat_w,
-            cube_3_pos_w,
+            cube_3_pos_w - env.scene.env_origins,
             cube_3_quat_w,
             gripper_to_cube_1,
             gripper_to_cube_2,


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

The "object" obs group in the Franka stacking environment contains the absolute position of each of the cubes. At the moment they are being returned as world positions which include the env offset if running multiple envs in parallel, causing inconsistent position values. 

Fixes:

Eliminates the environment offset from the cube positions in the "object" obs group of the Franka stacking environment by subtracting out the environment origin.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
