### PR TITLE
Removes remaining deprecation warning in RigidObject deprecation

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.33.15"
+version = "0.33.16"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.33.16 (2025-02-09)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Removes old deprecation warning from :attr:`isaaclab.assets.RigidObectData.body_state_w`
+
+
 0.33.15 (2025-02-09)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_data.py
@@ -182,11 +182,6 @@ class RigidObjectData:
         velocities are of the rigid bodies' center of mass frame.
         """
 
-        omni.log.warn(
-            "DeprecationWarning: body_state_w and it's derived properties will be deprecated in a future release."
-            " Please use body_link_state_w or body_com_state_w."
-        )
-
         return self.root_state_w.view(-1, 1, 13)
 
     @property

--- a/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_data.py
@@ -6,7 +6,6 @@
 import torch
 import weakref
 
-import omni.log
 import omni.physics.tensors.impl.api as physx
 
 import isaaclab.utils.math as math_utils


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

This PR removes a hanging deprecation warning from RigidObject.data.body_state_w.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
