### PR TITLE
Loads actuator networks in eval() mode to prevent gradients

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.33.17"
+version = "0.33.18"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.33.18 (2025-02-14)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Ensured that the loaded torch JIT models inside actuator networks are correctly set to eval mode
+  to prevent any unexpected behavior during inference.
+
+
 0.33.17 (2025-02-13)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/actuators/actuator_net.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_net.py
@@ -47,7 +47,7 @@ class ActuatorNetLSTM(DCMotor):
 
         # load the model from JIT file
         file_bytes = read_file(self.cfg.network_file)
-        self.network = torch.jit.load(file_bytes, map_location=self._device)
+        self.network = torch.jit.load(file_bytes, map_location=self._device).eval()
 
         # extract number of lstm layers and hidden dim from the shape of weights
         num_layers = len(self.network.lstm.state_dict()) // 4
@@ -126,7 +126,7 @@ class ActuatorNetMLP(DCMotor):
 
         # load the model from JIT file
         file_bytes = read_file(self.cfg.network_file)
-        self.network = torch.jit.load(file_bytes, map_location=self._device)
+        self.network = torch.jit.load(file_bytes, map_location=self._device).eval()
 
         # create buffers for MLP history
         history_length = max(self.cfg.input_idx) + 1

--- a/source/isaaclab/isaaclab/actuators/actuator_net.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_net.py
@@ -175,7 +175,8 @@ class ActuatorNetMLP(DCMotor):
             )
 
         # run network inference
-        torques = self.network(network_input).view(self._num_envs, self.num_joints)
+        with torch.inference_mode():
+            torques = self.network(network_input).view(self._num_envs, self.num_joints)
         self.computed_effort = torques.view(self._num_envs, self.num_joints) * self.cfg.torque_scale
 
         # clip the computed effort based on the motor limits


### PR DESCRIPTION
# Description

Previously, the actuator networks were loaded using `torch.jit.load`, however, they weren't set to eval mode. This meant that gradient computation occurred in the background which is not desired. This MR fixes this issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there