### PR TITLE
Adds support for underactuated joints in Articulation

### DIFF
--- a/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
@@ -48,5 +48,11 @@ class ArticulationCfg(AssetBaseCfg):
     This is accessible in the articulation data through :attr:`ArticulationData.soft_joint_pos_limits` attribute.
     """
 
+    actuated_joints_expr: list[str] | str | None = None
+    """Regular expression to specify the actuated joints. Defaults to None which means all joints are actuated."""
+
+    mimic_joints: dict[str, dict[str, float | str]] | None = None
+    """Mimic joints configuration for the articulation. Defaults to None."""
+
     actuators: dict[str, ActuatorBaseCfg] = MISSING
     """Actuators for the robot with corresponding joint names."""

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
@@ -48,11 +48,29 @@ class ArticulationCfg(AssetBaseCfg):
     This is accessible in the articulation data through :attr:`ArticulationData.soft_joint_pos_limits` attribute.
     """
 
-    actuated_joints_expr: list[str] | str | None = None
-    """Regular expression to specify the actuated joints. Defaults to None which means all joints are actuated."""
+    actuated_joint_names: list[str] | str = ".*"
+    """List of joint names or regular expression to specify the actuated joints. Defaults to '.*' which means all
+    joints are actuated."""
 
-    mimic_joints: dict[str, dict[str, float | str]] | None = None
-    """Mimic joints configuration for the articulation. Defaults to None."""
+    mimic_joints_info: dict[str, dict[str, float | str]] = {}
+    """Mimic joints configuration for the articulation. Defaults to an empty dictionary.
+
+    The key indicates the name of the joint that is being mimicked. The value is a dictionary with the following keys:
+
+    * ``"parent"``: The name of the parent joint.
+    * ``"multiplier"``: The multiplier for the mimic joint.
+    * ``"offset"``: The offset for the mimic joint. Defaults to 0.0.
+
+    For example, the following configuration mimics the joint ``"joint_1"`` with the parent joint ``"joint_0"``
+    with a multiplier of ``2.0`` and an offset of ``1.0``:
+
+    .. code-block:: python
+
+        mimic_joints_info = {
+            "joint_1": {"parent": "joint_0", "multiplier": 2.0, "offset": 1.0}
+        }
+
+    """
 
     actuators: dict[str, ActuatorBaseCfg] = MISSING
     """Actuators for the robot with corresponding joint names."""

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_data.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_data.py
@@ -92,9 +92,6 @@ class ArticulationData:
     joint_names: list[str] = None
     """Joint names in the order parsed by the simulation view."""
 
-    mimic_joint_names: list[str] = None
-    """Mimic joint names in the order parsed by the simulation view."""
-
     fixed_tendon_names: list[str] = None
     """Fixed tendon names in the order parsed by the simulation view."""
 
@@ -228,18 +225,34 @@ class ArticulationData:
     ##
     # Mimic joint properties.
     ##
-    mimic_joint_indices: torch.Tensor = None
 
-    mimic_joint_parents_indices: torch.Tensor = None
-
-    mimic_joint_assignements: torch.Tensor = None
-
-    mimic_joint_infos: torch.Tensor = None
     actuated_joint_names: list[str] = None
     """Actuated joint names in the order parsed by the simulation view."""
 
     actuated_joint_indices: torch.Tensor = None
     """Actuated joint indices in the order parsed by the simulation view."""
+
+    mimic_joint_names: list[str] = None
+    """Mimic joint names in the order parsed by the simulation view."""
+
+    mimic_joint_indices: torch.Tensor = None
+    """Mimic joint indices in the order parsed by the simulation view."""
+
+    mimic_joint_assignments: torch.Tensor = None
+    """Mimic joint assignments in the order parsed by the simulation view. Shape is (num_joints,).
+
+    The index of the tensor corresponds to the index of the parent joint. The value at that index is the index
+    of the mimic joint that is assigned to the parent joint.
+
+    A value of ``-1`` indicates that the joint is not a parent of any mimic joint.
+    """
+
+    mimic_joint_params: torch.Tensor = None
+    """Mimic joint parameters in the order parsed by the simulation view. Shape is (num_joints, 2).
+
+    The first column and second column correspond to the multiplier and offset for the mimic joint, respectively.
+    In case of no mimic joint, the values are set to 0.0.
+    """
 
     @property
     @cache

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_data.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_data.py
@@ -5,6 +5,7 @@
 
 import torch
 import weakref
+from functools import cache
 
 import omni.physics.tensors.impl.api as physx
 
@@ -90,6 +91,9 @@ class ArticulationData:
 
     joint_names: list[str] = None
     """Joint names in the order parsed by the simulation view."""
+
+    mimic_joint_names: list[str] = None
+    """Mimic joint names in the order parsed by the simulation view."""
 
     fixed_tendon_names: list[str] = None
     """Fixed tendon names in the order parsed by the simulation view."""
@@ -220,6 +224,42 @@ class ArticulationData:
 
     joint_velocity_limits: torch.Tensor = None
     """Joint maximum velocity provided to simulation. Shape is (num_instances, num_joints)."""
+
+    ##
+    # Mimic joint properties.
+    ##
+    mimic_joint_indices: torch.Tensor = None
+
+    mimic_joint_parents_indices: torch.Tensor = None
+
+    mimic_joint_assignements: torch.Tensor = None
+
+    mimic_joint_infos: torch.Tensor = None
+    actuated_joint_names: list[str] = None
+    """Actuated joint names in the order parsed by the simulation view."""
+
+    actuated_joint_indices: torch.Tensor = None
+    """Actuated joint indices in the order parsed by the simulation view."""
+
+    @property
+    @cache
+    def underactuated_joint_names(self):
+        """Underactuated joint names in the order parsed by the simulation view."""
+        names = []
+        for name in self.joint_names:
+            if name not in self.actuated_joint_names:
+                names.append(name)
+        return names
+
+    @property
+    @cache
+    def underactuated_joint_indices(self):
+        """Underactuated joint indices in the order parsed by the simulation view."""
+        indices = []
+        for idx, name in enumerate(self.joint_names):
+            if name not in self.actuated_joint_names:
+                indices.append(idx)
+        return indices
 
     ##
     # Fixed tendon properties.


### PR DESCRIPTION
# Description

This MR adds support for articulation with underactuated and mimic joint systems.

It introduces the following changes:

1. The fields `actuated_joints_names` and `mimic_joints_info` to the articulation config.
2. The following fields to ArticulationData
     - `actuated_joint_names` and `actuated_joint_indices`
     - `mimic_joint_names` and `mimic_joint_indices`

3. Modifications inside the articulation class to update joint targets, joint states, and default joint states by providing only the actuated joint values and inferring the underactuated ones.

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
