### PR TITLE
Fixes setting of root velocities in the event term `reset_root_state_from_terrain`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,6 +86,7 @@ Guidelines for modifications:
 * Rosario Scalise
 * Ryley McCarroll
 * Shafeef Omar
+* Shundo Kishi
 * Stephan Pleines
 * Vladimir Fokow
 * Wei Yang

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -7,7 +7,8 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed crash when using reset_root_state_from_terrain
+* Fixed setting of root velocities inside the event term :meth:`reset_root_state_from_terrain`. Earlier, the indexing
+  based on the environment IDs was missing.
 
 
 0.34.1 (2025-02-17)

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.34.2 (2025-02-21)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed crash when using reset_root_state_from_terrain
+
+
 0.34.1 (2025-02-17)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -792,7 +792,7 @@ def reset_root_state_from_terrain(
     ranges = torch.tensor(range_list, device=asset.device)
     rand_samples = math_utils.sample_uniform(ranges[:, 0], ranges[:, 1], (len(env_ids), 6), device=asset.device)
 
-    velocities = asset.data.default_root_state[:, 7:13] + rand_samples
+    velocities = asset.data.default_root_state[env_ids, 7:13] + rand_samples
 
     # set into the physics simulation
     asset.write_root_pose_to_sim(torch.cat([positions, orientations], dim=-1), env_ids=env_ids)


### PR DESCRIPTION
# Description
Fix tensor size mismatch in reset_root_state_from_terrain

When reset_root_state_from_terrain is called from an EventTerm, we cannot predict which env_ids will be targeted. To prevent program crashes due to tensor size mismatches, this MR modifies the velocity calculation to use only the specified env_ids instead of referencing all environments.

Changes:
- Updated velocity calculation to use env_ids indexing for default_root_state
- This ensures tensor dimensions match between default_root_state and rand_samples

Fixes #1882 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

NONE

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
