### PR TITLE
Add v2.0.0 breaking changes on python environment names and RSL-RL package rename

### DIFF
--- a/docs/source/refs/release_notes.rst
+++ b/docs/source/refs/release_notes.rst
@@ -78,6 +78,7 @@ Breaking Changes
 * Updates the URDF and MJCF importers for Isaac Sim 4.5 by @Dhoeller19
 * Renames Isaac Lab extensions and folders by @kellyguo11
 * Restructures extension folders and removes old imitation learning scripts by @kellyguo11
+* Renames conda and venv Python environment from ``isaaclab`` to ``env_isaaclab`` by @Toni-SM
 
 Migration Guide
 ---------------

--- a/docs/source/refs/release_notes.rst
+++ b/docs/source/refs/release_notes.rst
@@ -79,6 +79,7 @@ Breaking Changes
 * Renames Isaac Lab extensions and folders by @kellyguo11
 * Restructures extension folders and removes old imitation learning scripts by @kellyguo11
 * Renames conda and venv Python environment from ``isaaclab`` to ``env_isaaclab`` by @Toni-SM
+* The RSL-RL package has been renamed from ``rsl-rl`` to ``rsl-rl-lib`` by @samibouziri
 
 Migration Guide
 ---------------

--- a/docs/source/refs/release_notes.rst
+++ b/docs/source/refs/release_notes.rst
@@ -79,7 +79,7 @@ Breaking Changes
 * Renames Isaac Lab extensions and folders by @kellyguo11
 * Restructures extension folders and removes old imitation learning scripts by @kellyguo11
 * Renames conda and venv Python environment from ``isaaclab`` to ``env_isaaclab`` by @Toni-SM
-* The RSL-RL package has been renamed from ``rsl-rl`` to ``rsl-rl-lib`` by @samibouziri
+* Fixes RSL-RL package name in `setup.py` according to PyPI installation by @samibouziri
 
 Migration Guide
 ---------------


### PR DESCRIPTION
# Description

Partially addresses issue: https://github.com/isaac-sim/IsaacLab/issues/1840

The [v2.0.0 release notes](https://github.com/isaac-sim/IsaacLab/releases/tag/v2.0.0) on GitHub should also be modified accordingly.

Although this PR doesn't fix the RSL-RL package name change for Isaac Lab v1.4.1 and earlier versions, listing this change in the release notes would be better.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
