### PR TITLE
Fixes instructions on importing ANYmal URDF in docs

### DIFF
--- a/docs/source/how-to/import_new_asset.rst
+++ b/docs/source/how-to/import_new_asset.rst
@@ -15,12 +15,13 @@ extensions to Omniverse Kit:
 
 * **URDF Importer** - Import assets from URDF files.
 * **MJCF Importer** - Import assets from MJCF files.
-* **Asset Importer** - Import assets from various file formats, including
+* **Mesh Importer** - Import assets from various file formats, including
   OBJ, FBX, STL, and glTF.
 
 The recommended workflow from NVIDIA is to use the above importers to convert
 the asset into its USD representation. Once the asset is in USD format, you can
-use the Omniverse Kit to edit the asset and export it to other file formats. Isaac Sim includes these importers by default. They can also be enabled manually in Omniverse Kit.
+use the Omniverse Kit to edit the asset and export it to other file formats. Isaac Sim includes
+these importers by default. They can also be enabled manually in Omniverse Kit.
 
 
 An important note to use assets for large-scale simulation is to ensure that they
@@ -92,7 +93,10 @@ The following shows the steps to clone the repository and run the converter:
   ./isaaclab.sh -p scripts/tools/convert_urdf.py \
     ~/git/anymal_d_simple_description/urdf/anymal.urdf \
     source/isaaclab_assets/data/Robots/ANYbotics/anymal_d.usd \
-    --merge-joints
+    --merge-joints \
+    --joint-stiffness 0.0 \
+    --joint-damping 0.0 \
+    --joint-target-type none
 
 
 Executing the above script will create a USD file inside the
@@ -117,9 +121,16 @@ You can press play on the opened window to see the asset in the scene. The asset
 Using MJCF Importer
 -------------------
 
-Similar to the URDF Importer, the MJCF Importer also has a GUI interface. Please check the documentation at `MJCF importer`_ for more details. For using the MJCF importer from Python scripts, we include a utility tool called ``convert_mjcf.py``. This script creates an instance of :class:`~sim.converters.MjcfConverterCfg` which is then passed to the :class:`~sim.converters.MjcfConverter` class.
+Similar to the URDF Importer, the MJCF Importer also has a GUI interface. Please check the documentation at
+`MJCF importer`_ for more details. For using the MJCF importer from Python scripts, we include a utility tool
+called ``convert_mjcf.py``. This script creates an instance of :class:`~sim.converters.MjcfConverterCfg`
+which is then passed to the :class:`~sim.converters.MjcfConverter` class.
 
-The default values for the importer's configuration parameters are specified in the :class:`~sim.converters.MjcfConverterCfg` class. The configuration parameters are listed below. We made a few commonly modified settings to be available as command-line arguments when calling the ``convert_mjcf.py``, and they are marked with ``*`` in the list. For a comprehensive list of the configuration parameters, please check the the documentation at `MJCF importer`_.
+The default values for the importer's configuration parameters are specified in the
+:class:`~sim.converters.MjcfConverterCfg` class. The configuration parameters are listed below.
+We made a few commonly modified settings to be available as command-line arguments when calling the
+``convert_mjcf.py``, and they are marked with ``*`` in the list. For a comprehensive list of the configuration
+parameters, please check the the documentation at `MJCF importer`_.
 
 
 * :attr:`~sim.converters.MjcfConverterCfg.fix_base*` - Whether to fix the base of the robot.
@@ -165,8 +176,6 @@ Executing the above script will create USD files inside the
     :align: center
     :figwidth: 100%
     :alt: result of convert_mjcf.py
-
-
 
 
 Using Mesh Importer

--- a/docs/source/refs/release_notes.rst
+++ b/docs/source/refs/release_notes.rst
@@ -43,7 +43,7 @@ Highlights from the Isaac Sim 4.5 release
 - Enhanced OmniPVD for debugging physics simulation, enabling capturing reinforcement learning simulation
   workloads of up to 2000 environments
 - Physics simulation performance optimizations improving throughput of up to 70%
-- Physics support for dedicated cylinder and cone geometry designed for robot wheels that is fully GPU accelerated 
+- Physics support for dedicated cylinder and cone geometry designed for robot wheels that is fully GPU accelerated
 - A new physics GPU filtering mechanism allowing co-location of reinforcement learning environments at the
   origin with minimal performance loss for scenes with limited collider counts
 - Improvements in simulation stability for mimic joints at high joint gains
@@ -51,34 +51,34 @@ Highlights from the Isaac Sim 4.5 release
 New Features
 ------------
 
-* Adds humanoid AMP tasks for direct workflow by @Toni-SM 
-* Adds Isaac Lab Mimic based on MimicGen data generation for Imitation Learning by @peterd-NV @nvcyc @ashwinvkNV @karsten-nvidia 
-* Adds consolidated demo script for showcasing recording and mimic dataset generation in real-time in one simulation script by @nvcyc 
-* Adds Franka stacking environment for GR00T mimic by @peterd-NV @nvcyc 
-* Adds option to filter collisions and real-time playback by @kellyguo11 
+* Adds humanoid AMP tasks for direct workflow by @Toni-SM
+* Adds Isaac Lab Mimic based on MimicGen data generation for Imitation Learning by @peterd-NV @nvcyc @ashwinvkNV @karsten-nvidia
+* Adds consolidated demo script for showcasing recording and mimic dataset generation in real-time in one simulation script by @nvcyc
+* Adds Franka stacking environment for GR00T mimic by @peterd-NV @nvcyc
+* Adds option to filter collisions and real-time playback by @kellyguo11
 
 Improvements
 ------------
 
 * Adds a tutorial for policy inference in a prebuilt USD scene by @oahmednv
-* Adds unit tests for multi-tiled cameras by @matthewtrepte  
-* Updates render setting defaults for better quality by @kellyguo11 
-* Adds a flag to wait for texture loading completion when reset by @oahmednv 
-* Adds pre-trained checkpoints and tools for generating and uploading checkpoints by @nv-cupright 
-* Adds new denoiser optimization flags for rendering by @kellyguo11 
-* Updates torch to 2.5.1 by @kellyguo11 
+* Adds unit tests for multi-tiled cameras by @matthewtrepte
+* Updates render setting defaults for better quality by @kellyguo11
+* Adds a flag to wait for texture loading completion when reset by @oahmednv
+* Adds pre-trained checkpoints and tools for generating and uploading checkpoints by @nv-cupright
+* Adds new denoiser optimization flags for rendering by @kellyguo11
+* Updates torch to 2.5.1 by @kellyguo11
 
 Bug Fixes
 ---------
 
-* Fixes external force buffers to set to zero when no forces/torques are applied by @matthewtrepte 
+* Fixes external force buffers to set to zero when no forces/torques are applied by @matthewtrepte
 * Fixes RSL-RL package name in ``setup.py`` according to PyPI installation by @samibouziri
 
 Breaking Changes
 ----------------
 
-* Updates the URDF and MJCF importers for Isaac Sim 4.5 by @Dhoeller19 
-* Renames Isaac Lab extensions and folders by @kellyguo11 
+* Updates the URDF and MJCF importers for Isaac Sim 4.5 by @Dhoeller19
+* Renames Isaac Lab extensions and folders by @kellyguo11
 * Restructures extension folders and removes old imitation learning scripts by @kellyguo11
 * Renames default conda and venv Python environment from ``isaaclab`` to ``env_isaaclab`` by @Toni-SM
 

--- a/docs/source/refs/release_notes.rst
+++ b/docs/source/refs/release_notes.rst
@@ -123,13 +123,16 @@ Changes in URDF Importer
 
 Isaac Sim 4.5 brings some updates to the URDF Importer, with a fresh UI to allow for better configurations
 when importing robots from URDF. As a result, the Isaac Lab URDF Converter has also been updated to
-reflect these changes. The :class:`UrdfConverterCfg` includes some new settings, such as :class:`PDGainsCfg`
-and :class:`NaturalFrequencyGainsCfg` classes for configuring the gains of the drives.
+reflect these changes. The :class:`isaaclab.sim.converters.UrdfConverterCfg` includes some new settings,
+such as :class:`~isaaclab.sim.converters.JointDriveCfg.PDGainsCfg`
+and :class:`~isaaclab.sim.converters.JointDriveCfg.NaturalFrequencyGainsCfg` classes for configuring
+the gains of the drives.
 
-One breaking change to note is that the :attr:`UrdfConverterCfg.JointDriveCfg.gains` attribute must
-be of class type :class:`PDGainsCfg` or :class:`NaturalFrequencyGainsCfg`.
+One breaking change to note is that the :attr:`~isaaclab.sim.converters.UrdfConverterCfg.JointDriveCfg.gains`
+attribute must be of class type :class:`~isaaclab.sim.converters.JointDriveCfg.PDGainsCfg` or
+:class:`~isaaclab.sim.converters.JointDriveCfg.NaturalFrequencyGainsCfg`.
 
-The stiffness of the :class:`PDGainsCfg` must be specified, as such:
+The stiffness of the :class:`~isaaclab.sim.converters.JointDriveCfg.PDGainsCfg` must be specified, as such:
 
 .. code-block:: python
 
@@ -138,7 +141,8 @@ The stiffness of the :class:`PDGainsCfg` must be specified, as such:
     )
 
 
-The :attr:`natural_frequency` attribute must be specified for :class:`NaturalFrequencyGainsCfg`.
+The :attr:`~isaaclab.sim.converters.JointDriveCfg.NaturalFrequencyGainsCfg.natural_frequency` attribute must
+be specified for :class:`~isaaclab.sim.converters.JointDriveCfg.NaturalFrequencyGainsCfg`.
 
 
 Renaming of Isaac Lab Extensions and Folders

--- a/docs/source/refs/release_notes.rst
+++ b/docs/source/refs/release_notes.rst
@@ -97,11 +97,11 @@ Notably, the following commonly used Isaac Sim extensions in Isaac Lab are renam
 
 * ``omni.isaac.cloner`` --> :mod:`isaacsim.core.cloner`
 * ``omni.isaac.core.prims`` --> :mod:`isaacsim.core.prims`
-* ``omni.isaac.core.simulation_context`` --> :mod:`isaacsim.core.api.simulation_context``
-* ``omni.isaac.core.utils`` --> :mod:`isaacsim.core.utils``
-* ``omni.isaac.core.world`` --> :mod:`isaacsim.core.api.world``
-* ``omni.isaac.kit.SimulationApp`` --> :mod:`isaacsim.SimulationApp``
-* ``omni.isaac.ui`` --> :mod:`isaacsim.gui.components``
+* ``omni.isaac.core.simulation_context`` --> :mod:`isaacsim.core.api.simulation_context`
+* ``omni.isaac.core.utils`` --> :mod:`isaacsim.core.utils`
+* ``omni.isaac.core.world`` --> :mod:`isaacsim.core.api.world`
+* ``omni.isaac.kit.SimulationApp`` --> :mod:`isaacsim.SimulationApp`
+* ``omni.isaac.ui`` --> :mod:`isaacsim.gui.components`
 
 Renaming of the URDF and MJCF Importers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/refs/release_notes.rst
+++ b/docs/source/refs/release_notes.rst
@@ -1,85 +1,86 @@
 Release Notes
 =============
 
+The release notes are now available in the `Isaac Lab GitHub repository <https://github.com/isaac-sim/IsaacLab/releases>`_.
+We summarize the release notes here for convenience.
+
 v2.0.0
 ======
 
 Overview
 --------
 
-Isaac Lab 2.0 brings some exciting new features, including a new addition to the Imitation Learning
-workflow with the **Isaac Lab Mimic** extension.
-Isaac Lab Mimic provides the ability to automatically generate additional trajectories based on
-just a few human collected demonstrations, allowing for larger training datasets with less human effort.
-This work is based on the `MimicGenv <https://mimicgen.github.io/>`_ work for Scalable Robot Learning using Human Demonstrations.
+Isaac Lab 2.0 brings some exciting new features, including a new addition to the Imitation Learning workflow with
+the **Isaac Lab Mimic** extension.
 
-Additionally, we introduced a new set of AMP tasks based on `Adversarial Motion Priors <https://xbpeng.github.io/projects/AMP/index.html>`_,
-training humanoid robots to walk, run, and dance 👯
+Isaac Lab Mimic provides the ability to automatically generate additional trajectories based on just a few human
+collected demonstrations, allowing for larger training datasets with less human effort. This work is based on the
+`MimicGen <https://mimicgen.github.io/>`_ work for Scalable Robot Learning using Human Demonstrations.
 
-Along with Isaac Lab 2.0, Isaac Sim 4.5 brings several new and breaking changes, including a full refactor of the Isaac Sim extensions,
-an improved URDF importer, an update to the PyTorch dependency to version 2.5.1,
-and many fixes for tiled rendering that now supports multiple tiled
-cameras at different resolutions.
+Additionally, we introduced a new set of AMP tasks based on
+`Adversarial Motion Priors <https://xbpeng.github.io/projects/AMP/index.html>`_, training humanoid robots to walk, run,
+and dance.
+
+Along with Isaac Lab 2.0, Isaac Sim 4.5 brings several new and breaking changes, including a full refactor of the
+Isaac Sim extensions, an improved URDF importer, an update to the PyTorch dependency to version 2.5.1, and many
+fixes for tiled rendering that now supports multiple tiled cameras at different resolutions.
 
 To follow the refactoring in Isaac Sim, we made similar refactoring and restructuring changes to Isaac Lab.
-These breaking changes will no longer be compatible with previous Isaac Sim versions. Please make sure to update to Isaac Sim 4.5
-when using the Isaac Lab 2.0 release.
+These breaking changes will no longer be compatible with previous Isaac Sim versions.
 
-Please refer to `Migration Guide <migration.html>`_ for a detailed list of breaking changes and guides for updating your codebase.
+.. attention::
 
-**Full Changelog**: https://github.com/isaac-sim/IsaacLab/compare/v1.4.0...v2.0.0
+    Please make sure to update to Isaac Sim 4.5 when using the Isaac Lab 2.0 release.
 
+**Full Changelog**: https://github.com/isaac-sim/IsaacLab/compare/v1.4.1...v2.0.0
+
+Highlights from the Isaac Sim 4.5 release
+-----------------------------------------
+
+- Support for multiple ``TiledCamera`` instances and varying resolutions
+- Improved rendering performance by up to 1.2x
+- Faster startup time through optimizations in the Cloner class that improves startup time by 30%
+- Enhanced OmniPVD for debugging physics simulation, enabling capturing reinforcement learning simulation
+  workloads of up to 2000 environments
+- Physics simulation performance optimizations improving throughput of up to 70%
+- Physics support for dedicated cylinder and cone geometry designed for robot wheels that is fully GPU accelerated 
+- A new physics GPU filtering mechanism allowing co-location of reinforcement learning environments at the
+  origin with minimal performance loss for scenes with limited collider counts
+- Improvements in simulation stability for mimic joints at high joint gains
 
 New Features
 ------------
 
-* Adds humanoid AMP tasks for direct workflow by @Toni-SM
-* Adds Isaac Lab Mimic based on MimicGen data generation for Imitation Learning by @peterd-NV @nvcyc @ashwinvkNV @karsten-nvidia
-* Adds consolidated demo script for showcasing recording and mimic dataset generation in real-time in one simulation script by @nvcyc
-* Adds Franka stacking environment for GR00T mimic by @peterd-NV @nvcyc
-* Adds option to filter collisions and real-time playback by @kellyguo11
+* Adds humanoid AMP tasks for direct workflow by @Toni-SM 
+* Adds Isaac Lab Mimic based on MimicGen data generation for Imitation Learning by @peterd-NV @nvcyc @ashwinvkNV @karsten-nvidia 
+* Adds consolidated demo script for showcasing recording and mimic dataset generation in real-time in one simulation script by @nvcyc 
+* Adds Franka stacking environment for GR00T mimic by @peterd-NV @nvcyc 
+* Adds option to filter collisions and real-time playback by @kellyguo11 
 
 Improvements
 ------------
 
-* Adds body tracking option to ViewerCfg by @KyleM73 in https://github.com/isaac-sim/IsaacLab/pull/1620
-* Updates pip installation documentation to clarify options by @steple in https://github.com/isaac-sim/IsaacLab/pull/1621
-* Adds dict conversion test for ActuatorBase configs by @mschweig in https://github.com/isaac-sim/IsaacLab/pull/1608
-* Adds documentation and demo script for IMU sensor by @mpgussert in https://github.com/isaac-sim/IsaacLab/pull/1694
-* Removes deprecation for root_state_w properties and setters by @jtigue-bdai in https://github.com/isaac-sim/IsaacLab/pull/1695
 * Adds a tutorial for policy inference in a prebuilt USD scene by @oahmednv
-* Adds unit tests for multi tiled cameras by @matthewtrepte
-* Updates render setting defaults for better quality by @kellyguo11
-* Adds flag to wait for texture loading completion when reset by @oahmednv
-* Adds pre-trained checkpoints and tools for generating and uploading checkpoints by @nv-cupright
-* Adds new denoiser optimization flags for rendering by @kellyguo11
-* Updates torch to 2.5.1 by @kellyguo11
+* Adds unit tests for multi-tiled cameras by @matthewtrepte  
+* Updates render setting defaults for better quality by @kellyguo11 
+* Adds a flag to wait for texture loading completion when reset by @oahmednv 
+* Adds pre-trained checkpoints and tools for generating and uploading checkpoints by @nv-cupright 
+* Adds new denoiser optimization flags for rendering by @kellyguo11 
+* Updates torch to 2.5.1 by @kellyguo11 
 
 Bug Fixes
 ---------
 
-* Fixes JointAction not preserving order when using all joints by @T-K-233 in https://github.com/isaac-sim/IsaacLab/pull/1587
-* Fixes event term for pushing root by setting velocity by @Mayankm96 in https://github.com/isaac-sim/IsaacLab/pull/1584
-* Fixes error in Articulation where default_joint_stiffness and default_joint_damping is not correctly set if actuator is instance of ImplicitActuator by @zoctipus in https://github.com/isaac-sim/IsaacLab/pull/1580
-* Fixes MARL workflows for recording videos during training/inferencing by @Rishi-V in https://github.com/isaac-sim/IsaacLab/pull/1596
-* Fixes the ``joint_parameter_lookup`` type in ``RemotizedPDActuatorCfg`` to support list format by @fan-ziqi in https://github.com/isaac-sim/IsaacLab/pull/1626
-* Fixes action reset of pre_trained_policy_action by @nicolaloi in https://github.com/isaac-sim/IsaacLab/pull/1623
-* Fixes issue where the indices were not created correctly. by @AntoineRichard in https://github.com/isaac-sim/IsaacLab/pull/1660
-* Fixes errors in tools and tutorial scripts by @kellyguo11 in https://github.com/isaac-sim/IsaacLab/pull/1669
-* Fixes rigid object's root com velocities timestamp check by @ori-gadot in https://github.com/isaac-sim/IsaacLab/pull/1674
-* Fixes infinite loop in repeated_objects_terrain: respawn only wrong object samples  by @nicolaloi in https://github.com/isaac-sim/IsaacLab/pull/1612
-* Corrects calculation of target height adjustment based on sensor data by @fan-ziqi in https://github.com/isaac-sim/IsaacLab/pull/1710
-* Clarifies Ray Documentation and Fixes Minor Issues by @garylvov in https://github.com/isaac-sim/IsaacLab/pull/1717
-* Fixes external force buffers to set to zero when no forces/torques are applied by @matthewtrepte
+* Fixes external force buffers to set to zero when no forces/torques are applied by @matthewtrepte 
+* Fixes RSL-RL package name in ``setup.py`` according to PyPI installation by @samibouziri
 
 Breaking Changes
 ----------------
 
-* Updates the URDF and MJCF importers for Isaac Sim 4.5 by @Dhoeller19
-* Renames Isaac Lab extensions and folders by @kellyguo11
+* Updates the URDF and MJCF importers for Isaac Sim 4.5 by @Dhoeller19 
+* Renames Isaac Lab extensions and folders by @kellyguo11 
 * Restructures extension folders and removes old imitation learning scripts by @kellyguo11
-* Renames conda and venv Python environment from ``isaaclab`` to ``env_isaaclab`` by @Toni-SM
-* Fixes RSL-RL package name in `setup.py` according to PyPI installation by @samibouziri
+* Renames default conda and venv Python environment from ``isaaclab`` to ``env_isaaclab`` by @Toni-SM
 
 Migration Guide
 ---------------
@@ -95,14 +96,13 @@ framework that can be customized by users through the use of app templates.
 
 Notably, the following commonly used Isaac Sim extensions in Isaac Lab are renamed as follow:
 
-* ``omni.isaac.cloner`` --> ``isaacsim.core.cloner``
-* ``omni.isaac.core.prims`` --> ``isaacsim.core.prims``
-* ``omni.isaac.core.simulation_context`` --> ``isaacsim.core.api.simulation_context``
-* ``omni.isaac.core.utils`` --> ``isaacsim.core.utils``
-* ``omni.isaac.core.world`` --> ``isaacsim.core.api.world``
-* ``omni.isaac.kit.SimulationApp`` --> ``isaacsim.SimulationApp``
-* ``omni.isaac.ui`` --> ``isaacsim.gui.components``
-
+* ``omni.isaac.cloner`` --> :mod:`isaacsim.core.cloner`
+* ``omni.isaac.core.prims`` --> :mod:`isaacsim.core.prims`
+* ``omni.isaac.core.simulation_context`` --> :mod:`isaacsim.core.api.simulation_context``
+* ``omni.isaac.core.utils`` --> :mod:`isaacsim.core.utils``
+* ``omni.isaac.core.world`` --> :mod:`isaacsim.core.api.world``
+* ``omni.isaac.kit.SimulationApp`` --> :mod:`isaacsim.SimulationApp``
+* ``omni.isaac.ui`` --> :mod:`isaacsim.gui.components``
 
 Renaming of the URDF and MJCF Importers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -119,7 +119,6 @@ Due to the extension name change, the Python module names have also been changed
 From the Isaac Sim UI, both URDF and MJCF importers can now be accessed directly from the File > Import
 menu when selecting a corresponding .urdf or .xml file in the file browser.
 
-
 Changes in URDF Importer
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -133,40 +132,14 @@ be of class type :class:`PDGainsCfg` or :class:`NaturalFrequencyGainsCfg`.
 
 The stiffness of the :class:`PDGainsCfg` must be specified, as such:
 
-.. code::python
+.. code-block:: python
 
     joint_drive=sim_utils.UrdfConverterCfg.JointDriveCfg(
         gains=sim_utils.UrdfConverterCfg.JointDriveCfg.PDGainsCfg(stiffness=None, damping=None)
     )
 
-The :attr:`natural_frequency` must be specified for :class:`NaturalFrequencyGainsCfg`.
 
-
-Renaming of omni.isaac.core Classes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Isaac Sim 4.5 introduced some naming changes to the core prim classes that are commonly
-used in Isaac Lab. These affect the single and ``View`` variations of the prim classes, including
-Articulation, RigidPrim, XFormPrim, and others. Single-object classes are now prefixed with
-``Single``, such as ``SingleArticulation``, while tensorized View classes now have the ``View``
-suffix removed.
-
-The exact renamings of the classes are as follow:
-
-* ``Articulation`` --> ``SingleArticulation``
-* ``ArticulationView`` --> ``Articulation``
-* ``ClothPrim`` --> ``SingleClothPrim``
-* ``ClothPrimView`` --> ``ClothPrim``
-* ``DeformablePrim`` --> ``SingleDeformablePrim``
-* ``DeformablePrimView`` --> ``DeformablePrim``
-* ``GeometryPrim`` --> ``SingleGeometryPrim``
-* ``GeometryPrimView`` --> ``GeometryPrim``
-* ``ParticleSystem`` --> ``SingleParticleSystem``
-* ``ParticleSystemView`` --> ``ParticleSystem``
-* ``RigidPrim`` --> ``SingleRigidPrim``
-* ``RigidPrimView`` --> ``RigidPrim``
-* ``XFormPrim`` --> ``SingleXFormPrim``
-* ``XFormPrimView`` --> ``XFormPrim``
+The :attr:`natural_frequency` attribute must be specified for :class:`NaturalFrequencyGainsCfg`.
 
 
 Renaming of Isaac Lab Extensions and Folders
@@ -179,16 +152,17 @@ The ``source/apps`` and ``source/standalone`` folders have been moved to the roo
 
 Isaac Lab extensions have been renamed to:
 
-* ``omni.isaac.lab`` --> ``isaaclab``
-* ``omni.isaac.lab_assets`` --> ``isaaclab_assets``
-* ``omni.isaac.lab_tasks`` --> ``isaaclab_tasks``
+* ``omni.isaac.lab`` --> :mod:`isaaclab`
+* ``omni.isaac.lab_assets`` --> :mod:`isaaclab_assets`
+* ``omni.isaac.lab_tasks`` --> :mod:`isaaclab_tasks`
 
 In addition, we have split up the previous ``source/standalone/workflows`` directory into ``scripts/imitation_learning``
 and ``scripts/reinforcement_learning`` directories. The RSL RL, Stable-Baselines, RL_Games, SKRL, and Ray directories
 are under ``scripts/reinforcement_learning``, while Robomimic and the new Isaac Lab Mimic directories are under
 ``scripts/imitation_learning``.
 
-To assist with the renaming of Isaac Lab extensions in your project, we have provided a `simple script`_ that will traverse
+To assist with the renaming of Isaac Lab extensions in your project, we have provided a
+`simple script <https://gist.github.com/kellyguo11/3e8f73f739b1c013b1069ad372277a85>`_ that will traverse
 through the ``source`` and ``docs`` directories in your local Isaac Lab project and replace any instance of the renamed
 directories and imports. **Please use the script at your own risk as it will overwrite source files directly.**
 
@@ -196,22 +170,80 @@ directories and imports. **Please use the script at your own risk as it will ove
 Restructuring of Isaac Lab Extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-With the introduction of ``isaaclab_mimic``, designed for supporting data generation workflows for imitation learning,
-we have also split out the previous ``wrappers`` folder under ``isaaclab_tasks`` to its own module, named ``isaaclab_rl``.
+With the introduction of :mod:`isaaclab_mimic`, designed for supporting data generation workflows for imitation learning,
+we have also split out the previous ``wrappers`` folder under ``isaaclab_tasks`` to its own module, named :mod:`isaaclab_rl`.
 This new extension will contain reinforcement learning specific wrappers for the various RL libraries supported by Isaac Lab.
 
-The new ``isaaclab_mimic`` extension will also replace the previous imitation learning scripts under the ``robomimic`` folder.
+The new :mod:`isaaclab_mimic` extension will also replace the previous imitation learning scripts under the ``robomimic`` folder.
 We have removed the old scripts for data collection and dataset preparation in favor of the new mimic workflow. For users
 who prefer to use the previous scripts, they will be available in previous release branches.
 
-Additionally, we have also restructured the ``isaaclab_assets`` extension to be split into ``robots`` and ``sensors``
+Additionally, we have also restructured the :mod:`isaaclab_assets` extension to be split into ``robots`` and ``sensors``
 subdirectories. This allows for clearer separation between the pre-defined configurations provided in the extension.
-For any existing imports such as ``from omni.isaac.lab_assets.anymal import ANYMAL_C_CFG``, please replace it with
-``from isaaclab.robots.anymal import ANYMAL_C_CFG``.
 
+As an example, the following imports:
+
+.. code-block:: python
+
+    from omni.isaac.lab_assets.anymal import ANYMAL_C_CFG
+
+should be replaced with:
+
+.. code-block:: python
+
+    from isaaclab_assets.robots.anymal import ANYMAL_C_CFG
+
+
+v1.4.1
+======
+
+Overview
+--------
+
+This release contains a set of improvements and bug fixes.
+
+Most importantly, we reverted one of the `changes from the previous release <https://github.com/isaac-sim/IsaacLab/pull/966>`_
+to ensure the training throughput performance remains the same.
+
+**Full Changelog**: https://github.com/isaac-sim/IsaacLab/compare/v1.4.0...v1.4.1
+
+This is the **final release compatible with Isaac Sim 4.2**. The next release will target Isaac Sim 4.5,
+which introduces breaking changes that will make Isaac Lab incompatible with earlier versions of Isaac Sim.
+
+New Features
+------------
+
+* Adds documentation and demo script for IMU sensor by @mpgussert in https://github.com/isaac-sim/IsaacLab/pull/1694
+
+Improvements
+------------
+
+* Removes deprecation for root_state_w properties and setters by @jtigue-bdai in https://github.com/isaac-sim/IsaacLab/pull/1695
+* Fixes MARL workflows for recording videos during training/inferencing by @Rishi-V in https://github.com/isaac-sim/IsaacLab/pull/1596
+* Adds body tracking option to ViewerCfg by @KyleM73 in https://github.com/isaac-sim/IsaacLab/pull/1620
+* Fixes the ``joint_parameter_lookup`` type in ``RemotizedPDActuatorCfg`` to support list format by @fan-ziqi in https://github.com/isaac-sim/IsaacLab/pull/1626
+* Updates pip installation documentation to clarify options by @steple in https://github.com/isaac-sim/IsaacLab/pull/1621
+* Fixes docstrings in Articulation Data that report wrong return dimension by @zoctipus in https://github.com/isaac-sim/IsaacLab/pull/1652
+* Fixes documentation error for PD Actuator by @kellyguo11 in https://github.com/isaac-sim/IsaacLab/pull/1668
+* Clarifies ray documentation and fixes minor issues by @garylvov in https://github.com/isaac-sim/IsaacLab/pull/1717
+* Updates code snippets in documentation to reference scripts by @mpgussert in https://github.com/isaac-sim/IsaacLab/pull/1693
+* Adds dict conversion test for ActuatorBase configs by @mschweig in https://github.com/isaac-sim/IsaacLab/pull/1608
+
+Bug Fixes
+---------
+
+* Fixes JointAction not preserving order when using all joints by @T-K-233 in https://github.com/isaac-sim/IsaacLab/pull/1587
+* Fixes event term for pushing root by setting velocity by @Mayankm96 in https://github.com/isaac-sim/IsaacLab/pull/1584
+* Fixes error in Articulation where ``default_joint_stiffness`` and ``default_joint_damping`` are not correctly set for implicit actuator by @zoctipus in https://github.com/isaac-sim/IsaacLab/pull/1580
+* Fixes action reset of ``pre_trained_policy_action`` in navigation environment by @nicolaloi in https://github.com/isaac-sim/IsaacLab/pull/1623
+* Fixes rigid object's root com velocities timestamp check by @ori-gadot in https://github.com/isaac-sim/IsaacLab/pull/1674
+* Adds interval resampling on event manager's reset call by @Mayankm96 in https://github.com/isaac-sim/IsaacLab/pull/1750
+* Corrects calculation of target height adjustment based on sensor data by @fan-ziqi in https://github.com/isaac-sim/IsaacLab/pull/1710
+* Fixes infinite loop in ``repeated_objects_terrain`` method  by @nicolaloi in https://github.com/isaac-sim/IsaacLab/pull/1612
+* Fixes issue where the indices were not created correctly for articulation setters by @AntoineRichard in https://github.com/isaac-sim/IsaacLab/pull/1660
 
 New Contributors
-----------------
+~~~~~~~~~~~~~~~~
 
 * @T-K-233 made their first contribution in https://github.com/isaac-sim/IsaacLab/pull/1587
 * @steple made their first contribution in https://github.com/isaac-sim/IsaacLab/pull/1616

--- a/docs/source/refs/release_notes.rst
+++ b/docs/source/refs/release_notes.rst
@@ -37,16 +37,15 @@ These breaking changes will no longer be compatible with previous Isaac Sim vers
 Highlights from the Isaac Sim 4.5 release
 -----------------------------------------
 
-- Support for multiple ``TiledCamera`` instances and varying resolutions
-- Improved rendering performance by up to 1.2x
-- Faster startup time through optimizations in the Cloner class that improves startup time by 30%
-- Enhanced OmniPVD for debugging physics simulation, enabling capturing reinforcement learning simulation
-  workloads of up to 2000 environments
-- Physics simulation performance optimizations improving throughput of up to 70%
-- Physics support for dedicated cylinder and cone geometry designed for robot wheels that is fully GPU accelerated
-- A new physics GPU filtering mechanism allowing co-location of reinforcement learning environments at the
+* Support for multiple ``TiledCamera`` instances and varying resolutions
+* Improved rendering performance by up to 1.2x
+* Faster startup time through optimizations in the Cloner class that improves startup time by 30%
+* Enhanced OmniPVD for debugging physics simulation, enabling capturing reinforcement learning simulation
+* Physics simulation performance optimizations improving throughput of up to 70%
+* Physics support for dedicated cylinder and cone geometry designed for robot wheels that is fully GPU accelerated
+* A new physics GPU filtering mechanism allowing co-location of reinforcement learning environments at the
   origin with minimal performance loss for scenes with limited collider counts
-- Improvements in simulation stability for mimic joints at high joint gains
+* Improvements in simulation stability for mimic joints at high joint gains
 
 New Features
 ------------
@@ -181,7 +180,7 @@ who prefer to use the previous scripts, they will be available in previous relea
 Additionally, we have also restructured the :mod:`isaaclab_assets` extension to be split into ``robots`` and ``sensors``
 subdirectories. This allows for clearer separation between the pre-defined configurations provided in the extension.
 
-As an example, the following imports:
+As an example, the following import:
 
 .. code-block:: python
 
@@ -260,11 +259,16 @@ v1.4.0
 
 Overview
 --------
-Due to a great amount of amazing updates, we are putting out one more Isaac Lab release based off of Isaac Sim 4.2. This release contains many great new additions and bug fixes, including several new environments, distributed training and hyperparameter support with Ray, new live plot feature for Manager-based environments, and more.
 
-We will now spend more focus on the next Isaac Lab release geared towards the new Isaac Sim 4.5 release coming soon. The upcoming release will contain breaking changes in both Isaac Lab and Isaac Sim and breaks backwards compatibility, but will come with many great fixes and improvements.
+Due to a great amount of amazing updates, we are putting out one more Isaac Lab release based off of Isaac Sim 4.2.
+This release contains many great new additions and bug fixes, including several new environments, distributed training
+and hyperparameter support with Ray, new live plot feature for Manager-based environments, and more.
 
-Full Changelog: https://github.com/isaac-sim/IsaacLab/compare/v1.3.0...v1.4.0
+We will now spend more focus on the next Isaac Lab release geared towards the new Isaac Sim 4.5 release coming
+soon. The upcoming release will contain breaking changes in both Isaac Lab and Isaac Sim and breaks backwards
+compatibility, but will come with many great fixes and improvements.
+
+**Full Changelog**: https://github.com/isaac-sim/IsaacLab/compare/v1.3.0...v1.4.0
 
 New Features
 ------------
@@ -325,7 +329,10 @@ v1.3.0
 Overview
 --------
 
-This release will be a final release based on Isaac Sim 4.2 before the transition to Isaac Sim 4.5, which will likely contain breaking changes and no longer backwards compatible with Isaac Sim 4.2 and earlier. In this release, we introduce many features, improvements, and bug fixes, including IMU sensors, support for various types of gymnasium spaces, manager-based perception environments, and more.
+This release will be a final release based on Isaac Sim 4.2 before the transition to Isaac Sim 4.5, which will
+likely contain breaking changes and no longer backwards compatible with Isaac Sim 4.2 and earlier. In this release,
+we introduce many features, improvements, and bug fixes, including IMU sensors, support for various types of
+gymnasium spaces, manager-based perception environments, and more.
 
 **Full Changelog**: https://github.com/isaac-sim/IsaacLab/compare/v1.2.0...v1.3.0
 
@@ -419,9 +426,11 @@ v1.2.0
 Overview
 --------
 
-We leverage the new release of Isaac Sim, 4.2.0, and bring RTX-based tiled rendering, support for multi-agent environments, and introduce many bug fixes and improvements.
+We leverage the new release of Isaac Sim, 4.2.0, and bring RTX-based tiled rendering, support for multi-agent
+environments, and introduce many bug fixes and improvements.
 
-Additionally, we have published an example for generating rewards using an LLM based on `Eureka <https://github.com/eureka-research/Eureka>`_, available here https://github.com/isaac-sim/IsaacLabEureka.
+Additionally, we have published an example for generating rewards using an LLM based on
+`Eureka <https://github.com/eureka-research/Eureka>`_, available here: https://github.com/isaac-sim/IsaacLabEureka
 
 **Full Changelog**: https://github.com/isaac-sim/IsaacLab/compare/v1.1.0...v1.2.0
 
@@ -433,10 +442,13 @@ New Features
 * Adds support for multi-agent environments with the Direct workflow, with support for MAPPO and IPPO in SKRL by @Toni-SM
 * Adds the direct workflow multi-agent environments ``Isaac-Cart-Double-Pendulum-Direct-v0`` and ``Isaac-Shadow-Hand-Over-Direct-v0`` by @Toni-SM
 * Adds throughput benchmarking scripts for the different learning workflows by @kellyguo11 in https://github.com/isaac-sim/IsaacLab/pull/759
-* Adds results for the benchmarks in the documentation `here <https://isaac-sim.github.io/IsaacLab/main/source/overview/reinforcement-learning/performance_benchmarks.html>`_ for different types of hardware by @kellyguo11
+* Adds results for the benchmarks in the documentation
+  `here <https://isaac-sim.github.io/IsaacLab/main/source/overview/reinforcement-learning/performance_benchmarks.html>`__
+  for different types of hardware by @kellyguo11
 * Adds the direct workflow Allegro hand environment by @kellyguo11 in https://github.com/isaac-sim/IsaacLab/pull/709
 * Adds video recording to the play scripts in RL workflows by @j3soon in https://github.com/isaac-sim/IsaacLab/pull/763
-* Adds comparison tables for the supported RL libraries `here <https://isaac-sim.github.io/IsaacLab/main/source/overview/reinforcement-learning/rl_frameworks.html>`_ by @kellyguo11
+* Adds comparison tables for the supported RL libraries
+  `here <https://isaac-sim.github.io/IsaacLab/main/source/overview/reinforcement-learning/rl_frameworks.html>`__ by @kellyguo11
 * Add APIs for deformable asset by @masoudmoghani in https://github.com/isaac-sim/IsaacLab/pull/630
 * Adds support for MJCF converter by @qqqwan in https://github.com/isaac-sim/IsaacLab/pull/957
 * Adds a function to define camera configs through intrinsic matrix by @pascal-roth in https://github.com/isaac-sim/IsaacLab/pull/617
@@ -469,7 +481,7 @@ Bug Fixes
 ---------
 
 * Fixes rendering frame delays. Rendered images now faithfully represent the latest state of the physics scene. We added the flag
-``rerender_on_reset`` in the environment configs to toggle an additional render step when a reset happens. When activated, the images/observation always represent the latest state of the environment, but this also reduces performance.
+  ``rerender_on_reset`` in the environment configs to toggle an additional render step when a reset happens. When activated, the images/observation always represent the latest state of the environment, but this also reduces performance.
 * Fixes ``wrap_to_pi`` function in math utilities by @Mayankm96 in https://github.com/isaac-sim/IsaacLab/pull/771
 * Fixes setting of pose when spawning a mesh by @masoudmoghani in https://github.com/isaac-sim/IsaacLab/pull/692
 * Fixes caching of the terrain using the terrain generator by @Mayankm96 in https://github.com/isaac-sim/IsaacLab/pull/757
@@ -609,9 +621,13 @@ v1.1.0
 Overview
 --------
 
-With the release of Isaac Sim 4.0 and 4.1, support for Isaac Sim 2023.1.1 has been discontinued. We strongly encourage all users to upgrade to Isaac Sim 4.1 to take advantage of the latest features and improvements. For detailed information on this upgrade, please refer to the release notes available `here <https://docs.isaacsim.omniverse.nvidia.com/latest/overview/release_notes.html#>`_.
+With the release of Isaac Sim 4.0 and 4.1, support for Isaac Sim 2023.1.1 has been discontinued.
+We strongly encourage all users to upgrade to Isaac Sim 4.1 to take advantage of the latest features
+and improvements. For detailed information on this upgrade, please refer to the release notes available
+`here <https://docs.isaacsim.omniverse.nvidia.com/latest/overview/release_notes.html#>`__.
 
-Besides the above, the Isaac Lab release brings new features and improvements, as detailed below. We thank all our contributors for their continued support.
+Besides the above, the Isaac Lab release brings new features and improvements, as detailed below. We thank
+all our contributors for their continued support.
 
 **Full Changelog**: https://github.com/isaac-sim/IsaacLab/compare/v1.0.0...v1.1.0
 
@@ -670,15 +686,16 @@ Removal of Deprecated Attributes
 As notified in previous releases, we removed the classes and attributes marked as deprecated. These are as follows:
 
 * The ``mdp.add_body_mass`` method in the events. Please use the ``mdp.randomize_rigid_body_mass`` instead.
-* The classes ``managers.RandomizationManager`` and ``managers.RandomizationTermCfg``. Please use the ``managers.EventManager`` and ``managers.EventTermCfg`` classes instead.
+* The classes ``managers.RandomizationManager`` and ``managers.RandomizationTermCfg``. Please use the
+  ``managers.EventManager`` and ``managers.EventTermCfg`` classes instead.
 * The following properties in ``omni.isaac.lab.sensors.FrameTransformerData``:
-   * ``target_rot_source`` --> ``target_quat_w``
-   * ``target_rot_w`` --> ``target_quat_source``
-   * ``source_rot_w`` --> ``source_quat_w``
-* The attribute ``body_physx_view`` from the ``omni.isaac.lab.assets.Articulation`` and ``omni.isaac.lab.assets.RigidObject`` classes. These caused confusion when used with the articulation view since the body names did not follow the same ordering.
+  * ``target_rot_source`` --> ``target_quat_w``
+  * ``target_rot_w`` --> ``target_quat_source``
+  * ``source_rot_w`` --> ``source_quat_w``
 
-New Contributors
-----------------
+* The attribute ``body_physx_view`` from the ``omni.isaac.lab.assets.Articulation`` and
+  ``omni.isaac.lab.assets.RigidObject`` classes. These caused confusion when used with the articulation view
+  since the body names did not follow the same ordering.
 
 v1.0.0
 ======
@@ -688,9 +705,13 @@ Overview
 
 Welcome to the first official release of Isaac Lab!
 
-Building upon the foundation of the `Orbit <https://isaac-orbit.github.io/>`_ framework, we have integrated the RL environment designing workflow from `OmniIsaacGymEnvs <https://github.com/NVIDIA-Omniverse/OmniIsaacGymEnvs>`_. This allows users to choose a suitable `task-design approach <https://isaac-sim.github.io/IsaacLab/source/features/task_workflows.html>`_ for their applications.
+Building upon the foundation of the `Orbit <https://isaac-orbit.github.io/>`_ framework, we have integrated
+the RL environment designing workflow from `OmniIsaacGymEnvs <https://github.com/NVIDIA-Omniverse/OmniIsaacGymEnvs>`_.
+This allows users to choose a suitable `task-design approach <https://isaac-sim.github.io/IsaacLab/source/features/task_workflows.html>`_
+for their applications.
 
-While we maintain backward compatibility with Isaac Sim 2023.1.1, we highly recommend using Isaac Lab with Isaac Sim 4.0.0 version for the latest features and improvements.
+While we maintain backward compatibility with Isaac Sim 2023.1.1, we highly recommend using Isaac Lab with
+Isaac Sim 4.0.0 version for the latest features and improvements.
 
 **Full Changelog**: https://github.com/isaac-sim/IsaacLab/compare/v0.3.1...v1.0.0
 

--- a/scripts/tools/convert_mjcf.py
+++ b/scripts/tools/convert_mjcf.py
@@ -6,10 +6,13 @@
 """
 Utility to convert a MJCF into USD format.
 
-MuJoCo XML Format (MJCF) is an XML file format used in MuJoCo to describe all elements of a robot. For more information, see: http://www.mujoco.org/book/XMLreference.html
+MuJoCo XML Format (MJCF) is an XML file format used in MuJoCo to describe all elements of a robot.
+For more information, see: http://www.mujoco.org/book/XMLreference.html
 
-This script uses the MJCF importer extension from Isaac Sim (``isaacsim.asset.importer.mjcf``) to convert a MJCF asset into USD format. It is designed as a convenience script for command-line use. For more information on the MJCF importer, see the documentation for the extension:
-https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/ext_omni_isaac_mjcf.html
+This script uses the MJCF importer extension from Isaac Sim (``isaacsim.asset.importer.mjcf``) to convert
+a MJCF asset into USD format. It is designed as a convenience script for command-line use. For more information
+on the MJCF importer, see the documentation for the extension:
+https://docs.isaacsim.omniverse.nvidia.com/latest/robot_setup/ext_isaacsim_asset_importer_mjcf.html
 
 
 positional arguments:

--- a/scripts/tools/convert_urdf.py
+++ b/scripts/tools/convert_urdf.py
@@ -12,7 +12,7 @@ a robot. For more information, see: http://wiki.ros.org/urdf
 This script uses the URDF importer extension from Isaac Sim (``isaacsim.asset.importer.urdf``) to convert a
 URDF asset into USD format. It is designed as a convenience script for command-line use. For more
 information on the URDF importer, see the documentation for the extension:
-https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/ext_omni_isaac_urdf.html
+https://docs.isaacsim.omniverse.nvidia.com/latest/robot_setup/ext_isaacsim_asset_importer_urdf.html
 
 
 positional arguments:
@@ -23,6 +23,9 @@ optional arguments:
   -h, --help                Show this help message and exit
   --merge-joints            Consolidate links that are connected by fixed joints. (default: False)
   --fix-base                Fix the base to where it is imported. (default: False)
+  --joint-stiffness         The stiffness of the joint drive. (default: 100.0)
+  --joint-damping           The damping of the joint drive. (default: 1.0)
+  --joint-target-type       The type of control to use for the joint drive. (default: "position")
 
 """
 
@@ -43,6 +46,26 @@ parser.add_argument(
     help="Consolidate links that are connected by fixed joints.",
 )
 parser.add_argument("--fix-base", action="store_true", default=False, help="Fix the base to where it is imported.")
+parser.add_argument(
+    "--joint-stiffness",
+    type=float,
+    default=100.0,
+    help="The stiffness of the joint drive.",
+)
+parser.add_argument(
+    "--joint-damping",
+    type=float,
+    default=1.0,
+    help="The damping of the joint drive.",
+)
+parser.add_argument(
+    "--joint-target-type",
+    type=str,
+    default="position",
+    choices=["position", "velocity", "none"],
+    help="The type of control to use for the joint drive.",
+)
+
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 # parse the arguments
@@ -87,7 +110,11 @@ def main():
         merge_fixed_joints=args_cli.merge_joints,
         force_usd_conversion=True,
         joint_drive=UrdfConverterCfg.JointDriveCfg(
-            gains=UrdfConverterCfg.JointDriveCfg.PDGainsCfg(stiffness=100.0, damping=1.0)
+            gains=UrdfConverterCfg.JointDriveCfg.PDGainsCfg(
+                stiffness=args_cli.joint_stiffness,
+                damping=args_cli.joint_damping,
+            ),
+            target_type=args_cli.joint_target_type,
         ),
     )
 

--- a/source/isaaclab/isaaclab/sim/converters/urdf_converter_cfg.py
+++ b/source/isaaclab/isaaclab/sim/converters/urdf_converter_cfg.py
@@ -16,6 +16,7 @@ class UrdfConverterCfg(AssetConverterBaseCfg):
 
     @configclass
     class JointDriveCfg:
+        """Configuration for the joint drive."""
 
         @configclass
         class PDGainsCfg:
@@ -105,16 +106,18 @@ class UrdfConverterCfg(AssetConverterBaseCfg):
     """Convert mimic joints to normal joints. Defaults to False."""
 
     joint_drive: JointDriveCfg | None = JointDriveCfg()
-    """The joint drive settings.
+    """The joint drive settings. Defaults to :class:`JointDriveCfg`.
 
-    None can be used for URDFs without joints.
+    The parameter can be set to ``None`` for URDFs without joints.
     """
 
     collision_from_visuals = False
-    """Create collision geometry from visual geometry."""
+    """Whether to create collision geometry from visual geometry. Defaults to False."""
 
     collider_type: Literal["convex_hull", "convex_decomposition"] = "convex_hull"
-    """The collision shape simplification. Defaults to ``"convex_hull"``.
+    """The collision shape simplification. Defaults to "convex_hull".
+
+    Supported values are:
 
     * ``"convex_hull"``: The collision shape is simplified to a convex hull.
     * ``"convex_decomposition"``: The collision shape is decomposed into smaller convex shapes for a closer fit.


### PR DESCRIPTION
# Description

Previously, the ANYmal URDF importer example was setting the stiffness and damping to new defaults (100.0 and 0.1 respectively). However, this is undesirable as we want to import the asset with no stiffness and damping (as we do effort control). This MR corrects the instructions to convert ANYmal asset.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there