### PR TITLE
Fix bug of base_height_l2 reward function

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -94,6 +94,7 @@ Guidelines for modifications:
 * Yujian Zhang
 * Zhengyu Zhang
 * Ziqi Fan
+* Xu Liu
 
 ## Acknowledgements
 


### PR DESCRIPTION
# Description

When using the manager-based env, configuring the terrain to be rough, using 'base_height_l2' in the reward term, and using raycaster to adjust the target height to account for the terrain, the program will calculate 'Nan' or 'inf', or suddenly calculate a singular value at a certain moment, causing the code to crash. Therefore, the following modifications are made:

- Determine whether there are Nan, inf or singular values
- Calculate the number of ray_hits for Nan, inf and singular values ​​in each environment respectively
- Remove Nan, inf and singular values and calculate the average of the valid values
- If all ray_hits values ​​in an environment are Nan, inf or singular values, use its root height as target_hight

NOTE: I think the cause of this bug may be in the underlying structure of Isaaclab or Isaacsim. The modifications I made can only avoid training failures due to data anomalies. I hope the maintainers can investigate the underlying cause of this problem.

Fixes #1727 

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

None

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
