### PR TITLE
Fix tutorial script paths in documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,6 +38,7 @@ Guidelines for modifications:
 * Alice Zhou
 * Amr Mousa
 * Andrej Orsula
+* Anjie Xu
 * Anton Bjørndahl Mortensen
 * Arjun Bhardwaj
 * Ashwin Varghese Kuruttukulam

--- a/scripts/tutorials/03_envs/create_cube_base_env.py
+++ b/scripts/tutorials/03_envs/create_cube_base_env.py
@@ -14,7 +14,7 @@ scene entities. The rest of the environment is similar to the previous tutorials
 .. code-block:: bash
 
     # Run the script
-    ./isaaclab.sh -p scripts/tutorials/04_envs/floating_cube.py --num_envs 32
+    ./isaaclab.sh -p scripts/tutorials/03_envs/create_cube_base_env.py --num_envs 32
 """
 
 from __future__ import annotations

--- a/scripts/tutorials/03_envs/create_quadruped_base_env.py
+++ b/scripts/tutorials/03_envs/create_quadruped_base_env.py
@@ -13,7 +13,7 @@ the terrain.
 .. code-block:: bash
 
     # Run the script
-    ./isaaclab.sh -p scripts/tutorials/04_envs/quadruped_base_env.py --num_envs 32
+    ./isaaclab.sh -p scripts/tutorials/03_envs/create_quadruped_base_env.py --num_envs 32
 
 """
 


### PR DESCRIPTION
# Description

This PR fixes incorrect script path references in tutorial documentation to ensure users can properly execute environment creation examples under the `03_envs` directory.

1. In `scripts/tutorials/03_envs/create_cube_base_env.py`:
   - Incorrect path: `04_envs/floating_cube.py`
   - Corrected to: `03_envs/create_cube_base_env.py`

2. In `scripts/tutorials/03_envs/create_quadruped_base_env.py`:
   - Incorrect path: `04_envs/quadruped_base_env.py`
   - Corrected to: `03_envs/create_quadruped_base_env.py`

## Type of change

- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
