### PR TITLE
Improve observation manager for observation groups with `history_length != None`. 

### DIFF
--- a/source/isaaclab/isaaclab/managers/observation_manager.py
+++ b/source/isaaclab/isaaclab/managers/observation_manager.py
@@ -76,9 +76,7 @@ class ObservationManager(ManagerBase):
         """
         # check that cfg is not None
         if cfg is None:
-            raise ValueError(
-                "Observation manager configuration is None. Please provide a valid configuration."
-            )
+            raise ValueError("Observation manager configuration is None. Please provide a valid configuration.")
 
         # call the base class constructor (this will parse the terms config)
         super().__init__(cfg, env)
@@ -86,20 +84,14 @@ class ObservationManager(ManagerBase):
         # Compute combined vector for observation group.
         self._group_obs_dim: dict[str, tuple[int, ...] | list[tuple[int, ...]]] = dict()
         for group_name, group_term_dims in self._group_obs_term_dim.items():
-            self._group_obs_dim[group_name] = self.combine_group_dims(
-                group_term_dims, group_name
-            )
+            self._group_obs_dim[group_name] = self.combine_group_dims(group_term_dims, group_name)
 
         # Stores the latest observations.
-        self._obs_buffer: dict[str, torch.Tensor | dict[str, torch.Tensor]] | None = (
-            None
-        )
+        self._obs_buffer: dict[str, torch.Tensor | dict[str, torch.Tensor]] | None = None
 
     def __str__(self) -> str:
         """Returns: A string representation for the observation manager."""
-        msg = (
-            f"<ObservationManager> contains {len(self._group_obs_term_names)} groups.\n"
-        )
+        msg = f"<ObservationManager> contains {len(self._group_obs_term_names)} groups.\n"
 
         # add info for each group
         for group_name, group_dim in self._group_obs_dim.items():
@@ -127,9 +119,7 @@ class ObservationManager(ManagerBase):
 
         return msg
 
-    def get_active_iterable_terms(
-        self, env_idx: int
-    ) -> Sequence[tuple[str, Sequence[float]]]:
+    def get_active_iterable_terms(self, env_idx: int) -> Sequence[tuple[str, Sequence[float]]]:
         """Returns the active terms as iterable sequence of tuples.
 
         The first element of the tuple is the name of the term and the second element is the raw value(s) of the term.
@@ -149,9 +139,7 @@ class ObservationManager(ManagerBase):
         for group_name, _ in self._group_obs_dim.items():
             if not self.group_obs_concatenate[group_name]:
                 for name, term in obs_buffer[group_name].items():
-                    terms.append(
-                        (group_name + "-" + name, term[env_idx].cpu().tolist())
-                    )
+                    terms.append((group_name + "-" + name, term[env_idx].cpu().tolist()))
                 continue
 
             idx = 0
@@ -225,9 +213,7 @@ class ObservationManager(ManagerBase):
             # reset terms with history
             for term_name in self._group_obs_term_names[group_name]:
                 if term_name in self._group_obs_term_history_buffer[group_name]:
-                    self._group_obs_term_history_buffer[group_name][term_name].reset(
-                        batch_ids=env_ids
-                    )
+                    self._group_obs_term_history_buffer[group_name][term_name].reset(batch_ids=env_ids)
         # call all modifiers that are classes
         for mod in self._group_obs_class_modifiers:
             mod.reset(env_ids=env_ids)
@@ -324,9 +310,7 @@ class ObservationManager(ManagerBase):
             # Update the history buffer if observation term has history enabled
             if term_cfg.history_length > 0:
                 # Append the current observation to the term's history buffer.
-                history_buffer = self._group_obs_term_history_buffer[group_name][
-                    term_name
-                ]
+                history_buffer = self._group_obs_term_history_buffer[group_name][term_name]
                 history_buffer.append(obs)
 
                 # Decide whether to preserve the full history shape.
@@ -335,9 +319,7 @@ class ObservationManager(ManagerBase):
                     group_obs[term_name] = history_buffer.buffer
                 else:
                     # Flatten the history: merge all historical steps into the feature dimension.
-                    group_obs[term_name] = history_buffer.buffer.reshape(
-                        self._env.num_envs, -1
-                    )
+                    group_obs[term_name] = history_buffer.buffer.reshape(self._env.num_envs, -1)
             else:
                 group_obs[term_name] = obs
 
@@ -396,9 +378,7 @@ class ObservationManager(ManagerBase):
             # read common config for the group
             self._group_obs_concatenate[group_name] = group_cfg.concatenate_terms
             self._group_obs_history_length[group_name] = group_cfg.history_length
-            self._group_obs_flatten_history_dim[group_name] = (
-                group_cfg.flatten_history_dim
-            )
+            self._group_obs_flatten_history_dim[group_name] = group_cfg.flatten_history_dim
             # check if config is dict already
             if isinstance(group_cfg, dict):
                 group_cfg_items = group_cfg.items()
@@ -423,9 +403,7 @@ class ObservationManager(ManagerBase):
                         f" Received: '{type(term_cfg)}'."
                     )
                 # resolve common terms in the config
-                self._resolve_common_term_cfg(
-                    f"{group_name}/{term_name}", term_cfg, min_argc=1
-                )
+                self._resolve_common_term_cfg(f"{group_name}/{term_name}", term_cfg, min_argc=1)
 
                 # check noise settings
                 if not group_cfg.enable_corruption:
@@ -461,10 +439,7 @@ class ObservationManager(ManagerBase):
                             f"Scale for observation term '{term_name}' in group '{group_name}'"
                             f" is not of type float, int or tuple. Received: '{type(term_cfg.scale)}'."
                         )
-                    if (
-                        isinstance(term_cfg.scale, tuple)
-                        and len(term_cfg.scale) != obs_dims[1]
-                    ):
+                    if isinstance(term_cfg.scale, tuple) and len(term_cfg.scale) != obs_dims[1]:
                         raise ValueError(
                             f"Scale for observation term '{term_name}' in group '{group_name}'"
                             f" does not match the dimensions of the observation. Expected: {obs_dims[1]}"
@@ -472,9 +447,7 @@ class ObservationManager(ManagerBase):
                         )
 
                     # cast the scale into torch tensor
-                    term_cfg.scale = torch.tensor(
-                        term_cfg.scale, dtype=torch.float, device=self._env.device
-                    )
+                    term_cfg.scale = torch.tensor(term_cfg.scale, dtype=torch.float, device=self._env.device)
 
                 # prepare modifiers for each observation
                 if term_cfg.modifiers is not None:
@@ -513,16 +486,8 @@ class ObservationManager(ManagerBase):
                         # check if term's arguments are matched by params
                         term_params = list(mod_cfg.params.keys())
                         args = inspect.signature(mod_cfg.func).parameters
-                        args_with_defaults = [
-                            arg
-                            for arg in args
-                            if args[arg].default is not inspect.Parameter.empty
-                        ]
-                        args_without_defaults = [
-                            arg
-                            for arg in args
-                            if args[arg].default is inspect.Parameter.empty
-                        ]
+                        args_with_defaults = [arg for arg in args if args[arg].default is not inspect.Parameter.empty]
+                        args_without_defaults = [arg for arg in args if args[arg].default is inspect.Parameter.empty]
                         args = args_without_defaults + args_with_defaults
                         # ignore first two arguments for env and env_ids
                         # Think: Check for cases when kwargs are set inside the function?
@@ -564,9 +529,7 @@ class ObservationManager(ManagerBase):
         if flattened and unflattened:
             if self._group_obs_concatenate[group_name]:
                 # Observation shapes should not be mixed if concatenating - raise error.
-                raise RuntimeError(
-                    f"In group '{group_name}', mixed dimension formats encountered: {group_term_dims}"
-                )
+                raise RuntimeError(f"In group '{group_name}', mixed dimension formats encountered: {group_term_dims}")
             else:
                 return group_term_dims
 
@@ -575,7 +538,8 @@ class ObservationManager(ManagerBase):
             histories = [dims[0] for dims in unflattened]
             if not all(h == histories[0] for h in histories):
                 raise RuntimeError(
-                    f"In group '{group_name}', not all observation terms have the same history dimension: {group_term_dims}"
+                    f"In group '{group_name}', not all observation terms have the same history dimension:"
+                    f" {group_term_dims}"
                 )
             common_history = histories[0]
 

--- a/source/isaaclab/test/managers/test_observation_manager.py
+++ b/source/isaaclab/test/managers/test_observation_manager.py
@@ -19,12 +19,7 @@ import torch
 import unittest
 from collections import namedtuple
 
-from isaaclab.managers import (
-    ManagerTermBase,
-    ObservationGroupCfg,
-    ObservationManager,
-    ObservationTermCfg,
-)
+from isaaclab.managers import ManagerTermBase, ObservationGroupCfg, ObservationManager, ObservationTermCfg
 from isaaclab.utils import configclass, modifiers
 
 
@@ -44,9 +39,7 @@ def grilled_chicken_with_yoghurt(env, hot: bool, bland: float):
     return hot * bland * torch.ones(env.num_envs, 5, device=env.device)
 
 
-def grilled_chicken_with_yoghurt_and_bbq(
-    env, hot: bool, bland: float, bbq: bool = False
-):
+def grilled_chicken_with_yoghurt_and_bbq(env, hot: bool, bland: float, bbq: bool = False):
     return hot * bland * bbq * torch.ones(env.num_envs, 3, device=env.device)
 
 
@@ -65,9 +58,7 @@ class grilled_chicken_freerange(ManagerTermBase):
         self.cfg = cfg
         self.env = env
         self._execs = torch.zeros(env.num_envs, device=env.device)
-        self._default_obs = (
-            torch.arange(4, device=env.device).reshape(1, 4).expand(env.num_envs, 4)
-        )
+        self._default_obs = torch.arange(4, device=env.device).reshape(1, 4).expand(env.num_envs, 4)
 
     def reset(self, env_ids: torch.Tensor | None = None):
         if env_ids is None:
@@ -149,9 +140,7 @@ class TestObservationManager(unittest.TestCase):
 
                 term_1 = ObservationTermCfg(func="__main__:grilled_chicken", scale=10)
                 term_2 = ObservationTermCfg(func=grilled_chicken, scale=2)
-                term_3 = ObservationTermCfg(
-                    func=grilled_chicken_with_bbq, scale=5, params={"bbq": True}
-                )
+                term_3 = ObservationTermCfg(func=grilled_chicken_with_bbq, scale=5, params={"bbq": True})
                 term_4 = ObservationTermCfg(
                     func=grilled_chicken_with_yoghurt,
                     scale=1.0,
@@ -197,9 +186,7 @@ class TestObservationManager(unittest.TestCase):
                     history_length=TERM_1_HISTORY,
                 )
                 term_2 = ObservationTermCfg(func=grilled_chicken, scale=2)
-                term_3 = ObservationTermCfg(
-                    func=grilled_chicken_with_bbq, scale=5, params={"bbq": True}
-                )
+                term_3 = ObservationTermCfg(func=grilled_chicken_with_bbq, scale=5, params={"bbq": True})
                 term_4 = ObservationTermCfg(
                     func=grilled_chicken_with_yoghurt,
                     scale=1.0,
@@ -238,13 +225,9 @@ class TestObservationManager(unittest.TestCase):
             class SampleGroupCfg(ObservationGroupCfg):
                 """Test config class for policy observation group."""
 
-                your_term = ObservationTermCfg(
-                    func="__main__:grilled_chicken", scale=10
-                )
+                your_term = ObservationTermCfg(func="__main__:grilled_chicken", scale=10)
                 his_term = ObservationTermCfg(func=grilled_chicken, scale=2)
-                my_term = ObservationTermCfg(
-                    func=grilled_chicken_with_bbq, scale=5, params={"bbq": True}
-                )
+                my_term = ObservationTermCfg(func=grilled_chicken_with_bbq, scale=5, params={"bbq": True})
                 her_term = ObservationTermCfg(
                     func=grilled_chicken_with_yoghurt,
                     scale=1.0,
@@ -266,12 +249,8 @@ class TestObservationManager(unittest.TestCase):
             class SampleGroupCfg(ObservationGroupCfg):
                 """Test config class for policy observation group."""
 
-                your_term: ObservationTermCfg = ObservationTermCfg(
-                    func="__main__:grilled_chicken", scale=10
-                )
-                his_term: ObservationTermCfg = ObservationTermCfg(
-                    func=grilled_chicken, scale=2
-                )
+                your_term: ObservationTermCfg = ObservationTermCfg(func="__main__:grilled_chicken", scale=10)
+                his_term: ObservationTermCfg = ObservationTermCfg(func=grilled_chicken, scale=2)
                 my_term: ObservationTermCfg = ObservationTermCfg(
                     func=grilled_chicken_with_bbq, scale=5, params={"bbq": True}
                 )
@@ -282,25 +261,19 @@ class TestObservationManager(unittest.TestCase):
                 )
 
             policy: ObservationGroupCfg = SampleGroupCfg()
-            critic: ObservationGroupCfg = SampleGroupCfg(
-                concatenate_terms=False, her_term=None
-            )
+            critic: ObservationGroupCfg = SampleGroupCfg(concatenate_terms=False, her_term=None)
 
         cfg = MyObservationManagerAnnotatedCfg()
         obs_man_from_annotated_cfg = ObservationManager(cfg, self.env)
 
         # check equivalence
         # parsed terms
-        self.assertEqual(
-            obs_man_from_cfg.active_terms, obs_man_from_annotated_cfg.active_terms
-        )
+        self.assertEqual(obs_man_from_cfg.active_terms, obs_man_from_annotated_cfg.active_terms)
         self.assertEqual(
             obs_man_from_cfg.group_obs_term_dim,
             obs_man_from_annotated_cfg.group_obs_term_dim,
         )
-        self.assertEqual(
-            obs_man_from_cfg.group_obs_dim, obs_man_from_annotated_cfg.group_obs_dim
-        )
+        self.assertEqual(obs_man_from_cfg.group_obs_dim, obs_man_from_annotated_cfg.group_obs_dim)
         # parsed term configs
         self.assertEqual(
             obs_man_from_cfg._group_obs_term_cfgs,
@@ -323,9 +296,7 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=10)
-                term_2 = ObservationTermCfg(
-                    func=grilled_chicken_with_curry, scale=0.0, params={"hot": False}
-                )
+                term_2 = ObservationTermCfg(func=grilled_chicken_with_curry, scale=0.0, params={"hot": False})
 
             @configclass
             class SampleMixedGroupCfg(ObservationGroupCfg):
@@ -333,9 +304,7 @@ class TestObservationManager(unittest.TestCase):
 
                 concatenate_terms = False
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=2.0)
-                term_2 = ObservationTermCfg(
-                    func=grilled_chicken_image, scale=1.5, params={"bland": 0.5}
-                )
+                term_2 = ObservationTermCfg(func=grilled_chicken_image, scale=1.5, params={"bland": 0.5})
 
             @configclass
             class SampleImageGroupCfg(ObservationGroupCfg):
@@ -385,9 +354,7 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=10)
-                term_2 = ObservationTermCfg(
-                    func=grilled_chicken_with_curry, scale=0.0, params={"hot": False}
-                )
+                term_2 = ObservationTermCfg(func=grilled_chicken_with_curry, scale=0.0, params={"hot": False})
                 term_3 = ObservationTermCfg(func=pos_w_data, scale=pos_scale_tuple)
                 term_4 = ObservationTermCfg(func=lin_vel_w_data, scale=1.5)
 
@@ -456,9 +423,7 @@ class TestObservationManager(unittest.TestCase):
             class PolicyCfg(ObservationGroupCfg):
                 """Test config class for policy observation group."""
 
-                term_1 = ObservationTermCfg(
-                    func=grilled_chicken, history_length=HISTORY_LENGTH
-                )
+                term_1 = ObservationTermCfg(func=grilled_chicken, history_length=HISTORY_LENGTH)
                 # total observation size: term_dim (4) * history_len (5) = 20
                 term_2 = ObservationTermCfg(func=lin_vel_w_data)
                 # total observation size: term_dim (3) = 3
@@ -475,25 +440,17 @@ class TestObservationManager(unittest.TestCase):
         # check the observation shape
         self.assertEqual((self.env.num_envs, 23), obs_policy.shape)
         # check the observation data
-        expected_obs_term_1_data = torch.ones(
-            self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device
-        )
+        expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device)
         expected_obs_term_2_data = lin_vel_w_data(self.env)
-        expected_obs_data_t0 = torch.concat(
-            (expected_obs_term_1_data, expected_obs_term_2_data), dim=-1
-        )
+        expected_obs_data_t0 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
         print(expected_obs_data_t0, obs_policy)
         self.assertTrue(torch.equal(expected_obs_data_t0, obs_policy))
         # test that the history buffer holds previous data
         for _ in range(HISTORY_LENGTH):
             observations = self.obs_man.compute()
             obs_policy = observations["policy"]
-        expected_obs_term_1_data = torch.ones(
-            self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device
-        )
-        expected_obs_data_t5 = torch.concat(
-            (expected_obs_term_1_data, expected_obs_term_2_data), dim=-1
-        )
+        expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device)
+        expected_obs_data_t5 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
         self.assertTrue(torch.equal(expected_obs_data_t5, obs_policy))
         # test reset
         self.obs_man.reset()
@@ -503,9 +460,7 @@ class TestObservationManager(unittest.TestCase):
         # test reset of specific env ids
         reset_env_ids = [2, 4, 16]
         self.obs_man.reset(reset_env_ids)
-        self.assertTrue(
-            torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids])
-        )
+        self.assertTrue(torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids]))
 
     def test_compute_with_2d_history(self):
         """Test the observation computation with history buffers for 2D observations."""
@@ -551,9 +506,7 @@ class TestObservationManager(unittest.TestCase):
         obs_policy: torch.Tensor = observations["policy"]
         # check the observation shapes
         self.assertEqual((self.env.num_envs, 163840), obs_policy_flat.shape)
-        self.assertEqual(
-            (self.env.num_envs, HISTORY_LENGTH, 128, 256, 1), obs_policy.shape
-        )
+        self.assertEqual((self.env.num_envs, HISTORY_LENGTH, 128, 256, 1), obs_policy.shape)
 
     def test_compute_with_group_history(self):
         """Test the observation computation with group level history buffer configuration."""
@@ -572,9 +525,7 @@ class TestObservationManager(unittest.TestCase):
                 # group level history length will override all terms.
                 # uses the freerange test to check history is stored correctly +
                 # not shuffled across dimensions.
-                term_1 = ObservationTermCfg(
-                    func=grilled_chicken_freerange, history_length=TERM_HISTORY_LENGTH
-                )
+                term_1 = ObservationTermCfg(func=grilled_chicken_freerange, history_length=TERM_HISTORY_LENGTH)
                 # total observation size: term_dim (4) * history_len (5) = 20
                 # with override total obs size: term_dim (4) * history_len (10) = 40
                 term_2 = ObservationTermCfg(func=lin_vel_w_data)
@@ -595,20 +546,16 @@ class TestObservationManager(unittest.TestCase):
 
         # check the observation data is initialized properly
         expected_obs_term_1_data = (
-            torch.arange(4, device=self.env.device)
-            .reshape(1, 1, 4)
-            .expand(self.env.num_envs, GROUP_HISTORY_LENGTH, 4)
+            torch.arange(4, device=self.env.device).reshape(1, 1, 4).expand(self.env.num_envs, GROUP_HISTORY_LENGTH, 4)
         )
 
         expected_obs_term_2_data = (
-            lin_vel_w_data(self.env)
-            .reshape(self.env.num_envs, 1, -1)
-            .expand(-1, GROUP_HISTORY_LENGTH, -1)
+            lin_vel_w_data(self.env).reshape(self.env.num_envs, 1, -1).expand(-1, GROUP_HISTORY_LENGTH, -1)
         )
 
-        expected_obs_data_t0 = torch.concat(
-            (expected_obs_term_1_data, expected_obs_term_2_data), dim=-1
-        ).reshape(self.env.num_envs, -1)
+        expected_obs_data_t0 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1).reshape(
+            self.env.num_envs, -1
+        )
 
         self.assertTrue(torch.equal(expected_obs_data_t0, obs_policy))
 
@@ -619,16 +566,14 @@ class TestObservationManager(unittest.TestCase):
 
         # compute the increments that the freerange obs manager would add
         # over the full history.
-        increments = torch.arange(GROUP_HISTORY_LENGTH, device=self.env.device).reshape(
-            1, -1, 1
-        )
+        increments = torch.arange(GROUP_HISTORY_LENGTH, device=self.env.device).reshape(1, -1, 1)
 
         expected_obs_term_1_data = expected_obs_term_1_data + increments
         # expected_obs_term_2_data same as before since it's constant.
 
-        expected_obs_data_t10 = torch.concat(
-            (expected_obs_term_1_data, expected_obs_term_2_data), dim=-1
-        ).reshape(self.env.num_envs, -1)
+        expected_obs_data_t10 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1).reshape(
+            self.env.num_envs, -1
+        )
 
         self.assertTrue(torch.equal(expected_obs_data_t10, obs_policy))
 
@@ -641,9 +586,7 @@ class TestObservationManager(unittest.TestCase):
         # test reset of specific env ids
         reset_env_ids = [2, 4, 16]
         self.obs_man.reset(reset_env_ids)
-        self.assertTrue(
-            torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids])
-        )
+        self.assertTrue(torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids]))
 
     def test_invalid_observation_config(self):
         """Test the invalid observation config."""
@@ -656,12 +599,8 @@ class TestObservationManager(unittest.TestCase):
             class PolicyCfg(ObservationGroupCfg):
                 """Test config class for policy observation group."""
 
-                term_1 = ObservationTermCfg(
-                    func=grilled_chicken_with_bbq, scale=0.1, params={"hot": False}
-                )
-                term_2 = ObservationTermCfg(
-                    func=grilled_chicken_with_yoghurt, scale=2.0, params={"hot": False}
-                )
+                term_1 = ObservationTermCfg(func=grilled_chicken_with_bbq, scale=0.1, params={"hot": False})
+                term_2 = ObservationTermCfg(func=grilled_chicken_with_yoghurt, scale=2.0, params={"hot": False})
 
             policy: ObservationGroupCfg = PolicyCfg()
 
@@ -683,9 +622,7 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=10)
-                term_2 = ObservationTermCfg(
-                    func=complex_function_class, scale=0.2, params={"interval": 0.5}
-                )
+                term_2 = ObservationTermCfg(func=complex_function_class, scale=0.2, params={"interval": 0.5})
 
             policy: ObservationGroupCfg = PolicyCfg()
 
@@ -702,17 +639,13 @@ class TestObservationManager(unittest.TestCase):
         num_exec_count = 10
         for _ in range(num_exec_count):
             observations = self.obs_man.compute()
-        self.assertAlmostEqual(
-            observations["policy"][0, -1].item(), 0.2 * 0.5 * (num_exec_count + 1)
-        )
+        self.assertAlmostEqual(observations["policy"][0, -1].item(), 0.2 * 0.5 * (num_exec_count + 1))
 
         # check reset works
         self.obs_man.reset(env_ids=[0, 4, 9, 14, 19])
         observations = self.obs_man.compute()
         self.assertAlmostEqual(observations["policy"][0, -1].item(), 0.2 * 0.5)
-        self.assertAlmostEqual(
-            observations["policy"][1, -1].item(), 0.2 * 0.5 * (num_exec_count + 2)
-        )
+        self.assertAlmostEqual(observations["policy"][1, -1].item(), 0.2 * 0.5 * (num_exec_count + 2))
 
     def test_non_callable_class_term(self):
         """Test the observation computation with non-callable class term."""
@@ -726,9 +659,7 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=10)
-                term_2 = ObservationTermCfg(
-                    func=non_callable_complex_function_class, scale=0.2
-                )
+                term_2 = ObservationTermCfg(func=non_callable_complex_function_class, scale=0.2)
 
             policy: ObservationGroupCfg = PolicyCfg()
 
@@ -742,12 +673,8 @@ class TestObservationManager(unittest.TestCase):
         """Test the observation computation with modifiers."""
 
         modifier_1 = modifiers.ModifierCfg(func=modifiers.bias, params={"value": 1.0})
-        modifier_2 = modifiers.ModifierCfg(
-            func=modifiers.scale, params={"multiplier": 2.0}
-        )
-        modifier_3 = modifiers.ModifierCfg(
-            func=modifiers.clip, params={"bounds": (-0.5, 0.5)}
-        )
+        modifier_2 = modifiers.ModifierCfg(func=modifiers.scale, params={"multiplier": 2.0})
+        modifier_3 = modifiers.ModifierCfg(func=modifiers.clip, params={"bounds": (-0.5, 0.5)})
         modifier_4 = modifiers.IntegratorCfg(dt=self.env.dt)
 
         @configclass
@@ -761,9 +688,7 @@ class TestObservationManager(unittest.TestCase):
                 concatenate_terms = False
                 term_1 = ObservationTermCfg(func=pos_w_data, modifiers=[])
                 term_2 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1])
-                term_3 = ObservationTermCfg(
-                    func=pos_w_data, modifiers=[modifier_1, modifier_4]
-                )
+                term_3 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1, modifier_4])
 
             @configclass
             class CriticCfg(ObservationGroupCfg):
@@ -772,12 +697,8 @@ class TestObservationManager(unittest.TestCase):
                 concatenate_terms = False
                 term_1 = ObservationTermCfg(func=pos_w_data, modifiers=[])
                 term_2 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1])
-                term_3 = ObservationTermCfg(
-                    func=pos_w_data, modifiers=[modifier_1, modifier_2]
-                )
-                term_4 = ObservationTermCfg(
-                    func=pos_w_data, modifiers=[modifier_1, modifier_2, modifier_3]
-                )
+                term_3 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1, modifier_2])
+                term_4 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1, modifier_2, modifier_3])
 
             policy: ObservationGroupCfg = PolicyCfg()
             critic: ObservationGroupCfg = CriticCfg()
@@ -795,18 +716,14 @@ class TestObservationManager(unittest.TestCase):
         # check correct application of modifications
         torch.testing.assert_close(obs_policy["term_1"] + 1.0, obs_policy["term_2"])
         torch.testing.assert_close(obs_critic["term_1"] + 1.0, obs_critic["term_2"])
-        torch.testing.assert_close(
-            2.0 * (obs_critic["term_1"] + 1.0), obs_critic["term_3"]
-        )
+        torch.testing.assert_close(2.0 * (obs_critic["term_1"] + 1.0), obs_critic["term_3"])
         self.assertTrue(torch.min(obs_critic["term_4"]) >= -0.5)
         self.assertTrue(torch.max(obs_critic["term_4"]) <= 0.5)
 
     def test_modifier_invalid_config(self):
         """Test modifier initialization with invalid config."""
 
-        modifier = modifiers.ModifierCfg(
-            func=modifiers.clip, params={"min": -0.5, "max": 0.5}
-        )
+        modifier = modifiers.ModifierCfg(func=modifiers.clip, params={"min": -0.5, "max": 0.5})
 
         @configclass
         class MyObservationManagerCfg:

--- a/source/isaaclab/test/managers/test_observation_manager.py
+++ b/source/isaaclab/test/managers/test_observation_manager.py
@@ -19,7 +19,12 @@ import torch
 import unittest
 from collections import namedtuple
 
-from isaaclab.managers import ManagerTermBase, ObservationGroupCfg, ObservationManager, ObservationTermCfg
+from isaaclab.managers import (
+    ManagerTermBase,
+    ObservationGroupCfg,
+    ObservationManager,
+    ObservationTermCfg,
+)
 from isaaclab.utils import configclass, modifiers
 
 
@@ -39,12 +44,41 @@ def grilled_chicken_with_yoghurt(env, hot: bool, bland: float):
     return hot * bland * torch.ones(env.num_envs, 5, device=env.device)
 
 
-def grilled_chicken_with_yoghurt_and_bbq(env, hot: bool, bland: float, bbq: bool = False):
+def grilled_chicken_with_yoghurt_and_bbq(
+    env, hot: bool, bland: float, bbq: bool = False
+):
     return hot * bland * bbq * torch.ones(env.num_envs, 3, device=env.device)
 
 
 def grilled_chicken_image(env, bland: float, channel: int = 1):
     return bland * torch.ones(env.num_envs, 128, 256, channel, device=env.device)
+
+
+class grilled_chicken_freerange(ManagerTermBase):
+    """A ManagerTermBase designed to test history storage.
+
+    Returns a default arange measurement (to distinguish along dims), and increments
+    the measurement each time the manager is called (resets to zero when reset).
+    """
+
+    def __init__(self, cfg: ObservationTermCfg, env: object):
+        self.cfg = cfg
+        self.env = env
+        self._execs = torch.zeros(env.num_envs, device=env.device)
+        self._default_obs = (
+            torch.arange(4, device=env.device).reshape(1, 4).expand(env.num_envs, 4)
+        )
+
+    def reset(self, env_ids: torch.Tensor | None = None):
+        if env_ids is None:
+            env_ids = slice(None)
+        self._execs[env_ids] = 0.0
+
+    def __call__(self, env: object) -> torch.Tensor:
+        obs = self._execs[:, None] + self._default_obs
+        self._execs = self._execs + 1
+
+        return obs
 
 
 class complex_function_class(ManagerTermBase):
@@ -76,7 +110,6 @@ class non_callable_complex_function_class(ManagerTermBase):
 
 
 class MyDataClass:
-
     def __init__(self, num_envs: int, device: str):
         self.pos_w = torch.rand((num_envs, 3), device=device)
         self.lin_vel_w = torch.rand((num_envs, 3), device=device)
@@ -116,12 +149,18 @@ class TestObservationManager(unittest.TestCase):
 
                 term_1 = ObservationTermCfg(func="__main__:grilled_chicken", scale=10)
                 term_2 = ObservationTermCfg(func=grilled_chicken, scale=2)
-                term_3 = ObservationTermCfg(func=grilled_chicken_with_bbq, scale=5, params={"bbq": True})
+                term_3 = ObservationTermCfg(
+                    func=grilled_chicken_with_bbq, scale=5, params={"bbq": True}
+                )
                 term_4 = ObservationTermCfg(
-                    func=grilled_chicken_with_yoghurt, scale=1.0, params={"hot": False, "bland": 2.0}
+                    func=grilled_chicken_with_yoghurt,
+                    scale=1.0,
+                    params={"hot": False, "bland": 2.0},
                 )
                 term_5 = ObservationTermCfg(
-                    func=grilled_chicken_with_yoghurt_and_bbq, scale=1.0, params={"hot": False, "bland": 2.0}
+                    func=grilled_chicken_with_yoghurt_and_bbq,
+                    scale=1.0,
+                    params={"hot": False, "bland": 2.0},
                 )
 
             policy: ObservationGroupCfg = SampleGroupCfg()
@@ -152,14 +191,24 @@ class TestObservationManager(unittest.TestCase):
             class SampleGroupCfg(ObservationGroupCfg):
                 """Test config class for policy observation group."""
 
-                term_1 = ObservationTermCfg(func="__main__:grilled_chicken", scale=10, history_length=TERM_1_HISTORY)
+                term_1 = ObservationTermCfg(
+                    func="__main__:grilled_chicken",
+                    scale=10,
+                    history_length=TERM_1_HISTORY,
+                )
                 term_2 = ObservationTermCfg(func=grilled_chicken, scale=2)
-                term_3 = ObservationTermCfg(func=grilled_chicken_with_bbq, scale=5, params={"bbq": True})
+                term_3 = ObservationTermCfg(
+                    func=grilled_chicken_with_bbq, scale=5, params={"bbq": True}
+                )
                 term_4 = ObservationTermCfg(
-                    func=grilled_chicken_with_yoghurt, scale=1.0, params={"hot": False, "bland": 2.0}
+                    func=grilled_chicken_with_yoghurt,
+                    scale=1.0,
+                    params={"hot": False, "bland": 2.0},
                 )
                 term_5 = ObservationTermCfg(
-                    func=grilled_chicken_with_yoghurt_and_bbq, scale=1.0, params={"hot": False, "bland": 2.0}
+                    func=grilled_chicken_with_yoghurt_and_bbq,
+                    scale=1.0,
+                    params={"hot": False, "bland": 2.0},
                 )
 
             policy: ObservationGroupCfg = SampleGroupCfg()
@@ -189,11 +238,17 @@ class TestObservationManager(unittest.TestCase):
             class SampleGroupCfg(ObservationGroupCfg):
                 """Test config class for policy observation group."""
 
-                your_term = ObservationTermCfg(func="__main__:grilled_chicken", scale=10)
+                your_term = ObservationTermCfg(
+                    func="__main__:grilled_chicken", scale=10
+                )
                 his_term = ObservationTermCfg(func=grilled_chicken, scale=2)
-                my_term = ObservationTermCfg(func=grilled_chicken_with_bbq, scale=5, params={"bbq": True})
+                my_term = ObservationTermCfg(
+                    func=grilled_chicken_with_bbq, scale=5, params={"bbq": True}
+                )
                 her_term = ObservationTermCfg(
-                    func=grilled_chicken_with_yoghurt, scale=1.0, params={"hot": False, "bland": 2.0}
+                    func=grilled_chicken_with_yoghurt,
+                    scale=1.0,
+                    params={"hot": False, "bland": 2.0},
                 )
 
             policy = SampleGroupCfg()
@@ -211,29 +266,50 @@ class TestObservationManager(unittest.TestCase):
             class SampleGroupCfg(ObservationGroupCfg):
                 """Test config class for policy observation group."""
 
-                your_term: ObservationTermCfg = ObservationTermCfg(func="__main__:grilled_chicken", scale=10)
-                his_term: ObservationTermCfg = ObservationTermCfg(func=grilled_chicken, scale=2)
+                your_term: ObservationTermCfg = ObservationTermCfg(
+                    func="__main__:grilled_chicken", scale=10
+                )
+                his_term: ObservationTermCfg = ObservationTermCfg(
+                    func=grilled_chicken, scale=2
+                )
                 my_term: ObservationTermCfg = ObservationTermCfg(
                     func=grilled_chicken_with_bbq, scale=5, params={"bbq": True}
                 )
                 her_term: ObservationTermCfg = ObservationTermCfg(
-                    func=grilled_chicken_with_yoghurt, scale=1.0, params={"hot": False, "bland": 2.0}
+                    func=grilled_chicken_with_yoghurt,
+                    scale=1.0,
+                    params={"hot": False, "bland": 2.0},
                 )
 
             policy: ObservationGroupCfg = SampleGroupCfg()
-            critic: ObservationGroupCfg = SampleGroupCfg(concatenate_terms=False, her_term=None)
+            critic: ObservationGroupCfg = SampleGroupCfg(
+                concatenate_terms=False, her_term=None
+            )
 
         cfg = MyObservationManagerAnnotatedCfg()
         obs_man_from_annotated_cfg = ObservationManager(cfg, self.env)
 
         # check equivalence
         # parsed terms
-        self.assertEqual(obs_man_from_cfg.active_terms, obs_man_from_annotated_cfg.active_terms)
-        self.assertEqual(obs_man_from_cfg.group_obs_term_dim, obs_man_from_annotated_cfg.group_obs_term_dim)
-        self.assertEqual(obs_man_from_cfg.group_obs_dim, obs_man_from_annotated_cfg.group_obs_dim)
+        self.assertEqual(
+            obs_man_from_cfg.active_terms, obs_man_from_annotated_cfg.active_terms
+        )
+        self.assertEqual(
+            obs_man_from_cfg.group_obs_term_dim,
+            obs_man_from_annotated_cfg.group_obs_term_dim,
+        )
+        self.assertEqual(
+            obs_man_from_cfg.group_obs_dim, obs_man_from_annotated_cfg.group_obs_dim
+        )
         # parsed term configs
-        self.assertEqual(obs_man_from_cfg._group_obs_term_cfgs, obs_man_from_annotated_cfg._group_obs_term_cfgs)
-        self.assertEqual(obs_man_from_cfg._group_obs_concatenate, obs_man_from_annotated_cfg._group_obs_concatenate)
+        self.assertEqual(
+            obs_man_from_cfg._group_obs_term_cfgs,
+            obs_man_from_annotated_cfg._group_obs_term_cfgs,
+        )
+        self.assertEqual(
+            obs_man_from_cfg._group_obs_concatenate,
+            obs_man_from_annotated_cfg._group_obs_concatenate,
+        )
 
     def test_config_terms(self):
         """Test the number of terms in the observation manager."""
@@ -247,7 +323,9 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=10)
-                term_2 = ObservationTermCfg(func=grilled_chicken_with_curry, scale=0.0, params={"hot": False})
+                term_2 = ObservationTermCfg(
+                    func=grilled_chicken_with_curry, scale=0.0, params={"hot": False}
+                )
 
             @configclass
             class SampleMixedGroupCfg(ObservationGroupCfg):
@@ -255,13 +333,22 @@ class TestObservationManager(unittest.TestCase):
 
                 concatenate_terms = False
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=2.0)
-                term_2 = ObservationTermCfg(func=grilled_chicken_image, scale=1.5, params={"bland": 0.5})
+                term_2 = ObservationTermCfg(
+                    func=grilled_chicken_image, scale=1.5, params={"bland": 0.5}
+                )
 
             @configclass
             class SampleImageGroupCfg(ObservationGroupCfg):
-
-                term_1 = ObservationTermCfg(func=grilled_chicken_image, scale=1.5, params={"bland": 0.5, "channel": 1})
-                term_2 = ObservationTermCfg(func=grilled_chicken_image, scale=0.5, params={"bland": 0.1, "channel": 3})
+                term_1 = ObservationTermCfg(
+                    func=grilled_chicken_image,
+                    scale=1.5,
+                    params={"bland": 0.5, "channel": 1},
+                )
+                term_2 = ObservationTermCfg(
+                    func=grilled_chicken_image,
+                    scale=0.5,
+                    params={"bland": 0.1, "channel": 3},
+                )
 
             policy: ObservationGroupCfg = SampleGroupCfg()
             critic: ObservationGroupCfg = SampleGroupCfg(term_2=None)
@@ -298,7 +385,9 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=10)
-                term_2 = ObservationTermCfg(func=grilled_chicken_with_curry, scale=0.0, params={"hot": False})
+                term_2 = ObservationTermCfg(
+                    func=grilled_chicken_with_curry, scale=0.0, params={"hot": False}
+                )
                 term_3 = ObservationTermCfg(func=pos_w_data, scale=pos_scale_tuple)
                 term_4 = ObservationTermCfg(func=lin_vel_w_data, scale=1.5)
 
@@ -311,9 +400,16 @@ class TestObservationManager(unittest.TestCase):
 
             @configclass
             class ImageCfg(ObservationGroupCfg):
-
-                term_1 = ObservationTermCfg(func=grilled_chicken_image, scale=1.5, params={"bland": 0.5, "channel": 1})
-                term_2 = ObservationTermCfg(func=grilled_chicken_image, scale=0.5, params={"bland": 0.1, "channel": 3})
+                term_1 = ObservationTermCfg(
+                    func=grilled_chicken_image,
+                    scale=1.5,
+                    params={"bland": 0.5, "channel": 1},
+                )
+                term_2 = ObservationTermCfg(
+                    func=grilled_chicken_image,
+                    scale=0.5,
+                    params={"bland": 0.1, "channel": 3},
+                )
 
             policy: ObservationGroupCfg = PolicyCfg()
             critic: ObservationGroupCfg = CriticCfg()
@@ -336,7 +432,8 @@ class TestObservationManager(unittest.TestCase):
         self.assertEqual((self.env.num_envs, 128, 256, 4), obs_image.shape)
         # check that the scales are applied correctly
         torch.testing.assert_close(
-            self.env.data.pos_w * torch.tensor(pos_scale_tuple, device=self.env.device), obs_critic[:, :3]
+            self.env.data.pos_w * torch.tensor(pos_scale_tuple, device=self.env.device),
+            obs_critic[:, :3],
         )
         torch.testing.assert_close(self.env.data.lin_vel_w * 1.5, obs_critic[:, 3:6])
         # make sure that the data are the same for same terms
@@ -359,7 +456,9 @@ class TestObservationManager(unittest.TestCase):
             class PolicyCfg(ObservationGroupCfg):
                 """Test config class for policy observation group."""
 
-                term_1 = ObservationTermCfg(func=grilled_chicken, history_length=HISTORY_LENGTH)
+                term_1 = ObservationTermCfg(
+                    func=grilled_chicken, history_length=HISTORY_LENGTH
+                )
                 # total observation size: term_dim (4) * history_len (5) = 20
                 term_2 = ObservationTermCfg(func=lin_vel_w_data)
                 # total observation size: term_dim (3) = 3
@@ -376,17 +475,25 @@ class TestObservationManager(unittest.TestCase):
         # check the observation shape
         self.assertEqual((self.env.num_envs, 23), obs_policy.shape)
         # check the observation data
-        expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device)
+        expected_obs_term_1_data = torch.ones(
+            self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device
+        )
         expected_obs_term_2_data = lin_vel_w_data(self.env)
-        expected_obs_data_t0 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
+        expected_obs_data_t0 = torch.concat(
+            (expected_obs_term_1_data, expected_obs_term_2_data), dim=-1
+        )
         print(expected_obs_data_t0, obs_policy)
         self.assertTrue(torch.equal(expected_obs_data_t0, obs_policy))
         # test that the history buffer holds previous data
         for _ in range(HISTORY_LENGTH):
             observations = self.obs_man.compute()
             obs_policy = observations["policy"]
-        expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device)
-        expected_obs_data_t5 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
+        expected_obs_term_1_data = torch.ones(
+            self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device
+        )
+        expected_obs_data_t5 = torch.concat(
+            (expected_obs_term_1_data, expected_obs_term_2_data), dim=-1
+        )
         self.assertTrue(torch.equal(expected_obs_data_t5, obs_policy))
         # test reset
         self.obs_man.reset()
@@ -396,7 +503,9 @@ class TestObservationManager(unittest.TestCase):
         # test reset of specific env ids
         reset_env_ids = [2, 4, 16]
         self.obs_man.reset(reset_env_ids)
-        self.assertTrue(torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids]))
+        self.assertTrue(
+            torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids])
+        )
 
     def test_compute_with_2d_history(self):
         """Test the observation computation with history buffers for 2D observations."""
@@ -411,7 +520,9 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 term_1 = ObservationTermCfg(
-                    func=grilled_chicken_image, params={"bland": 1.0, "channel": 1}, history_length=HISTORY_LENGTH
+                    func=grilled_chicken_image,
+                    params={"bland": 1.0, "channel": 1},
+                    history_length=HISTORY_LENGTH,
                 )
                 # total observation size: term_dim (128, 256) * history_len (5) = 163840
 
@@ -440,7 +551,9 @@ class TestObservationManager(unittest.TestCase):
         obs_policy: torch.Tensor = observations["policy"]
         # check the observation shapes
         self.assertEqual((self.env.num_envs, 163840), obs_policy_flat.shape)
-        self.assertEqual((self.env.num_envs, HISTORY_LENGTH, 128, 256, 1), obs_policy.shape)
+        self.assertEqual(
+            (self.env.num_envs, HISTORY_LENGTH, 128, 256, 1), obs_policy.shape
+        )
 
     def test_compute_with_group_history(self):
         """Test the observation computation with group level history buffer configuration."""
@@ -456,8 +569,12 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 history_length = GROUP_HISTORY_LENGTH
-                # group level history length will override all terms
-                term_1 = ObservationTermCfg(func=grilled_chicken, history_length=TERM_HISTORY_LENGTH)
+                # group level history length will override all terms.
+                # uses the freerange test to check history is stored correctly +
+                # not shuffled across dimensions.
+                term_1 = ObservationTermCfg(
+                    func=grilled_chicken_freerange, history_length=TERM_HISTORY_LENGTH
+                )
                 # total observation size: term_dim (4) * history_len (5) = 20
                 # with override total obs size: term_dim (4) * history_len (10) = 40
                 term_2 = ObservationTermCfg(func=lin_vel_w_data)
@@ -475,28 +592,58 @@ class TestObservationManager(unittest.TestCase):
         obs_policy: torch.Tensor = observations["policy"]
         # check the total observation shape
         self.assertEqual((self.env.num_envs, 70), obs_policy.shape)
+
         # check the observation data is initialized properly
-        expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * GROUP_HISTORY_LENGTH, device=self.env.device)
-        expected_obs_term_2_data = lin_vel_w_data(self.env).repeat(1, GROUP_HISTORY_LENGTH)
-        expected_obs_data_t0 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
+        expected_obs_term_1_data = (
+            torch.arange(4, device=self.env.device)
+            .reshape(1, 1, 4)
+            .expand(self.env.num_envs, GROUP_HISTORY_LENGTH, 4)
+        )
+
+        expected_obs_term_2_data = (
+            lin_vel_w_data(self.env)
+            .reshape(self.env.num_envs, 1, -1)
+            .expand(-1, GROUP_HISTORY_LENGTH, -1)
+        )
+
+        expected_obs_data_t0 = torch.concat(
+            (expected_obs_term_1_data, expected_obs_term_2_data), dim=-1
+        ).reshape(self.env.num_envs, -1)
+
         self.assertTrue(torch.equal(expected_obs_data_t0, obs_policy))
+
         # test that the history buffer holds previous data
-        for _ in range(GROUP_HISTORY_LENGTH):
+        for _ in range(GROUP_HISTORY_LENGTH - 1):
             observations = self.obs_man.compute()
             obs_policy = observations["policy"]
-        expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * GROUP_HISTORY_LENGTH, device=self.env.device)
-        expected_obs_term_2_data = lin_vel_w_data(self.env).repeat(1, GROUP_HISTORY_LENGTH)
-        expected_obs_data_t10 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
+
+        # compute the increments that the freerange obs manager would add
+        # over the full history.
+        increments = torch.arange(GROUP_HISTORY_LENGTH, device=self.env.device).reshape(
+            1, -1, 1
+        )
+
+        expected_obs_term_1_data = expected_obs_term_1_data + increments
+        # expected_obs_term_2_data same as before since it's constant.
+
+        expected_obs_data_t10 = torch.concat(
+            (expected_obs_term_1_data, expected_obs_term_2_data), dim=-1
+        ).reshape(self.env.num_envs, -1)
+
         self.assertTrue(torch.equal(expected_obs_data_t10, obs_policy))
+
         # test reset
         self.obs_man.reset()
         observations = self.obs_man.compute()
         obs_policy = observations["policy"]
         self.assertTrue(torch.equal(expected_obs_data_t0, obs_policy))
+
         # test reset of specific env ids
         reset_env_ids = [2, 4, 16]
         self.obs_man.reset(reset_env_ids)
-        self.assertTrue(torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids]))
+        self.assertTrue(
+            torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids])
+        )
 
     def test_invalid_observation_config(self):
         """Test the invalid observation config."""
@@ -509,8 +656,12 @@ class TestObservationManager(unittest.TestCase):
             class PolicyCfg(ObservationGroupCfg):
                 """Test config class for policy observation group."""
 
-                term_1 = ObservationTermCfg(func=grilled_chicken_with_bbq, scale=0.1, params={"hot": False})
-                term_2 = ObservationTermCfg(func=grilled_chicken_with_yoghurt, scale=2.0, params={"hot": False})
+                term_1 = ObservationTermCfg(
+                    func=grilled_chicken_with_bbq, scale=0.1, params={"hot": False}
+                )
+                term_2 = ObservationTermCfg(
+                    func=grilled_chicken_with_yoghurt, scale=2.0, params={"hot": False}
+                )
 
             policy: ObservationGroupCfg = PolicyCfg()
 
@@ -532,7 +683,9 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=10)
-                term_2 = ObservationTermCfg(func=complex_function_class, scale=0.2, params={"interval": 0.5})
+                term_2 = ObservationTermCfg(
+                    func=complex_function_class, scale=0.2, params={"interval": 0.5}
+                )
 
             policy: ObservationGroupCfg = PolicyCfg()
 
@@ -549,13 +702,17 @@ class TestObservationManager(unittest.TestCase):
         num_exec_count = 10
         for _ in range(num_exec_count):
             observations = self.obs_man.compute()
-        self.assertAlmostEqual(observations["policy"][0, -1].item(), 0.2 * 0.5 * (num_exec_count + 1))
+        self.assertAlmostEqual(
+            observations["policy"][0, -1].item(), 0.2 * 0.5 * (num_exec_count + 1)
+        )
 
         # check reset works
         self.obs_man.reset(env_ids=[0, 4, 9, 14, 19])
         observations = self.obs_man.compute()
         self.assertAlmostEqual(observations["policy"][0, -1].item(), 0.2 * 0.5)
-        self.assertAlmostEqual(observations["policy"][1, -1].item(), 0.2 * 0.5 * (num_exec_count + 2))
+        self.assertAlmostEqual(
+            observations["policy"][1, -1].item(), 0.2 * 0.5 * (num_exec_count + 2)
+        )
 
     def test_non_callable_class_term(self):
         """Test the observation computation with non-callable class term."""
@@ -569,7 +726,9 @@ class TestObservationManager(unittest.TestCase):
                 """Test config class for policy observation group."""
 
                 term_1 = ObservationTermCfg(func=grilled_chicken, scale=10)
-                term_2 = ObservationTermCfg(func=non_callable_complex_function_class, scale=0.2)
+                term_2 = ObservationTermCfg(
+                    func=non_callable_complex_function_class, scale=0.2
+                )
 
             policy: ObservationGroupCfg = PolicyCfg()
 
@@ -583,8 +742,12 @@ class TestObservationManager(unittest.TestCase):
         """Test the observation computation with modifiers."""
 
         modifier_1 = modifiers.ModifierCfg(func=modifiers.bias, params={"value": 1.0})
-        modifier_2 = modifiers.ModifierCfg(func=modifiers.scale, params={"multiplier": 2.0})
-        modifier_3 = modifiers.ModifierCfg(func=modifiers.clip, params={"bounds": (-0.5, 0.5)})
+        modifier_2 = modifiers.ModifierCfg(
+            func=modifiers.scale, params={"multiplier": 2.0}
+        )
+        modifier_3 = modifiers.ModifierCfg(
+            func=modifiers.clip, params={"bounds": (-0.5, 0.5)}
+        )
         modifier_4 = modifiers.IntegratorCfg(dt=self.env.dt)
 
         @configclass
@@ -598,7 +761,9 @@ class TestObservationManager(unittest.TestCase):
                 concatenate_terms = False
                 term_1 = ObservationTermCfg(func=pos_w_data, modifiers=[])
                 term_2 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1])
-                term_3 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1, modifier_4])
+                term_3 = ObservationTermCfg(
+                    func=pos_w_data, modifiers=[modifier_1, modifier_4]
+                )
 
             @configclass
             class CriticCfg(ObservationGroupCfg):
@@ -607,8 +772,12 @@ class TestObservationManager(unittest.TestCase):
                 concatenate_terms = False
                 term_1 = ObservationTermCfg(func=pos_w_data, modifiers=[])
                 term_2 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1])
-                term_3 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1, modifier_2])
-                term_4 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier_1, modifier_2, modifier_3])
+                term_3 = ObservationTermCfg(
+                    func=pos_w_data, modifiers=[modifier_1, modifier_2]
+                )
+                term_4 = ObservationTermCfg(
+                    func=pos_w_data, modifiers=[modifier_1, modifier_2, modifier_3]
+                )
 
             policy: ObservationGroupCfg = PolicyCfg()
             critic: ObservationGroupCfg = CriticCfg()
@@ -626,14 +795,18 @@ class TestObservationManager(unittest.TestCase):
         # check correct application of modifications
         torch.testing.assert_close(obs_policy["term_1"] + 1.0, obs_policy["term_2"])
         torch.testing.assert_close(obs_critic["term_1"] + 1.0, obs_critic["term_2"])
-        torch.testing.assert_close(2.0 * (obs_critic["term_1"] + 1.0), obs_critic["term_3"])
+        torch.testing.assert_close(
+            2.0 * (obs_critic["term_1"] + 1.0), obs_critic["term_3"]
+        )
         self.assertTrue(torch.min(obs_critic["term_4"]) >= -0.5)
         self.assertTrue(torch.max(obs_critic["term_4"]) <= 0.5)
 
     def test_modifier_invalid_config(self):
         """Test modifier initialization with invalid config."""
 
-        modifier = modifiers.ModifierCfg(func=modifiers.clip, params={"min": -0.5, "max": 0.5})
+        modifier = modifiers.ModifierCfg(
+            func=modifiers.clip, params={"min": -0.5, "max": 0.5}
+        )
 
         @configclass
         class MyObservationManagerCfg:


### PR DESCRIPTION
# Description
This PR makes some low-level changes to the `observation_manager`, particularly w/r/t how it handles `ObservationGroups` with non-zero `history_length`. It first changes how the observation group shapes are computed - which fixes a shape bug in the `env.observation_space` for this group downstream.

It also changes the handling of flattened obs groups to construct tensors in a way that the history dimension is preserved. 

Fixes #1957. 

## Type of change

Unsure if this is a bugfix or breaking change, since it would change the ordering of elements in observation groups with `history_length != None`. Policies trained with the old ordering would not work - but the proposed ordering seems more in line with the shapes described in the documentation. 

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
