### PR TITLE
Fixes JointAction offsets not updated on reset

### DIFF
--- a/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
@@ -158,6 +158,13 @@ class JointPositionAction(JointAction):
     def apply_actions(self):
         # set position targets
         self._asset.set_joint_position_target(self.processed_actions, joint_ids=self._joint_ids)
+        
+    def reset(self, env_ids: Sequence[int] | None = None) -> None:
+        super().reset(env_ids)
+        
+        # reset offsets
+        if self.cfg.use_default_offset:
+            self._offset[env_ids] = self._asset.data.default_joint_pos[env_ids, self._joint_ids].clone()
 
 
 class RelativeJointPositionAction(JointAction):
@@ -209,6 +216,13 @@ class JointVelocityAction(JointAction):
     def apply_actions(self):
         # set joint velocity targets
         self._asset.set_joint_velocity_target(self.processed_actions, joint_ids=self._joint_ids)
+        
+    def reset(self, env_ids: Sequence[int] | None = None) -> None:
+        super().reset(env_ids)
+        
+        # reset offsets
+        if self.cfg.use_default_offset:
+            self._offset[env_ids] = self._asset.data.default_joint_pos[env_ids, self._joint_ids].clone()
 
 
 class JointEffortAction(JointAction):

--- a/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
@@ -158,10 +158,10 @@ class JointPositionAction(JointAction):
     def apply_actions(self):
         # set position targets
         self._asset.set_joint_position_target(self.processed_actions, joint_ids=self._joint_ids)
-        
+
     def reset(self, env_ids: Sequence[int] | None = None) -> None:
         super().reset(env_ids)
-        
+
         # reset offsets
         if self.cfg.use_default_offset:
             self._offset[env_ids] = self._asset.data.default_joint_pos[env_ids, self._joint_ids].clone()
@@ -216,10 +216,10 @@ class JointVelocityAction(JointAction):
     def apply_actions(self):
         # set joint velocity targets
         self._asset.set_joint_velocity_target(self.processed_actions, joint_ids=self._joint_ids)
-        
+
     def reset(self, env_ids: Sequence[int] | None = None) -> None:
         super().reset(env_ids)
-        
+
         # reset offsets
         if self.cfg.use_default_offset:
             self._offset[env_ids] = self._asset.data.default_joint_pos[env_ids, self._joint_ids].clone()


### PR DESCRIPTION
# Description

Currently, when a user updates the default joint offsets in an environment, the corresponding fields in the JointAction terms are not updated.
This PR updates the joint offsets in the joint actions when the environment is reset. 

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
