### PR TITLE
Adds WebRTC livestreaming support with IP specification

### DIFF
--- a/docs/source/api/lab/isaaclab.app.rst
+++ b/docs/source/api/lab/isaaclab.app.rst
@@ -35,6 +35,8 @@ The following details the behavior of the class based on the environment variabl
     Connecting to an Isaac Sim instance that is currently serving a streaming client
     results in an error for the second user.
 
+* **Public IP Address**: When using the environment variable ``LIVESTREAM={1,2}`` set the ``PUBLIC_IP`` envvar to set the Public IP address endpoint for livestreaming remotely.
+
 * **Enable cameras**: If the environment variable ``ENABLE_CAMERAS`` is set to 1, then the
   cameras are enabled. This is useful for running the simulator without a GUI but still rendering the
   viewport and camera images.

--- a/docs/source/api/lab/isaaclab.app.rst
+++ b/docs/source/api/lab/isaaclab.app.rst
@@ -35,7 +35,7 @@ The following details the behavior of the class based on the environment variabl
     Connecting to an Isaac Sim instance that is currently serving a streaming client
     results in an error for the second user.
 
-* **Public IP Address**: When using the environment variable ``LIVESTREAM={1,2}`` set the ``PUBLIC_IP`` envvar to set the Public IP address endpoint for livestreaming remotely.
+* **Public IP Address**: When using the environment variable ``LIVESTREAM={1,2}``, set the ``PUBLIC_IP`` envvar to define the public IP address endpoint for livestreaming remotely.
 
 * **Enable cameras**: If the environment variable ``ENABLE_CAMERAS`` is set to 1, then the
   cameras are enabled. This is useful for running the simulator without a GUI but still rendering the

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.34.1"
+version = "0.34.3"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.34.3 (2025-02-28)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added IP address support for WebRTC livestream to allow specifying IP address to stream across networks.
+  This feature requires an updated livestream extension, which is current only available in the pre-built Isaac Lab 2.0.1 docker image.
+  Support for other Isaac Sim builds will become available in Isaac Sim 5.0.
+
+
 0.34.2 (2025-02-21)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -574,6 +574,9 @@ class AppLauncher:
                 " The file does not exist."
             )
 
+        # Set public IP address of a remote instance
+        public_ip_env = os.environ.get("PUBLIC_IP", "127.0.0.1")
+
         # Process livestream here before launching kit because some of the extensions only work when launched with the kit file
         self._livestream_args = []
         if self._livestream >= 1:
@@ -594,9 +597,10 @@ class AppLauncher:
                 ]
             elif self._livestream == 2:
                 self._livestream_args += [
-                    "--/app/livestream/allowResize=false",
+                    f"--/app/livestream/publicEndpointAddress={public_ip_env}",
+                    "--/app/livestream/port=49100",
                     "--enable",
-                    "omni.kit.livestream.webrtc",
+                    "omni.services.livestream.nvcf",
                 ]
             else:
                 raise ValueError(f"Invalid value for livestream: {self._livestream}. Expected: 1, 2 .")

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -36,6 +36,8 @@ INSTALL_REQUIRES = [
     "warp-lang",
     # make sure this is consistent with isaac sim version
     "pillow==11.0.0",
+    # livestream
+    "starlette==0.46.0",
 ]
 
 PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu118"]


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

Currently, the WebRTC livestream is limited to connections within the same local network. This change introduces the ability to set a public IP address as an environment variable to allow connecting over the Internet and allows for livestreaming remotely when using the pre-built Isaac Lab container. 

Note:
This may not fix the livestreaming issue when using pip or native install of Isaac Lab, as it requires an updated version of the livestream extension, which is only available through the docker image at the moment. This will be fully fixed in the next version of Isaac Sim.

Example: 

Run with `PUBLIC_IP=$(curl -s ifconfig.me) LIVESTREAM=2 ./isaaclab.sh -p scripts/demos/quadrupeds.py` then connect using the  [Isaac Sim WebRTC Streaming Client](https://docs.isaacsim.omniverse.nvidia.com/latest/installation/manual_livestream_clients.html#isaac-sim-short-webrtc-streaming-client).

`PUBLIC_IP` can also be set to a private IP address if connecting within the same local network.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
