### PR TITLE
Uses nightly index-url for Pytorch to support latest GPUs

### DIFF
--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -34,7 +34,6 @@ except Exception:
 INSTALL_REQUIRES = [
     # generic
     "numpy<2",
-    "torch==2.5.1",
     "onnx==1.16.1",  # 1.16.2 throws access violation on Windows
     "prettytable==3.3.0",
     "toml",
@@ -56,10 +55,14 @@ INSTALL_REQUIRES = [
 ]
 
 # The latest GPU architectures are supported by CUDA 12.8.
+# The torch nightly build is required for the latest GPU architectures.
+# FIXME: This is a workaround till we switch to the latest torch version.
 if any(arch in GPU_ARCH for arch in ["5060", "5070", "5080", "5090"]):
     PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/nightly/cu128"]
+    INSTALL_REQUIRES.append("torch")
 else:
     PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu118"]
+    INSTALL_REQUIRES.append("torch==2.5.1")
 
 # Installation operation
 setup(


### PR DESCRIPTION
# Description

This MR attempts to fix PyTorch installation on the latest NVIDIA GPUs (50XX series).

Reference: https://github.com/pytorch/pytorch/issues/146977

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there