### PR TITLE
Fixes `activate_contact_sensors`  when using spawner.MultiUsdFileCfg

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.34.5"
+version = "0.34.6"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.34.6 (2025-03-02)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the propagation of the :attr:`activate_contact_sensors` attribute to the
+  :class:`~isaaclab.sim.spawners.wrappers.wrappers_cfg.MultiAssetSpawnerCfg` class. Previously, this value
+  was always set to False, which led to incorrect contact sensor settings for the spawned assets.
+
+
 0.34.5 (2025-03-02)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers.py
+++ b/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers.py
@@ -165,5 +165,13 @@ def spawn_multi_usd_file(
     # set random choice
     multi_asset_cfg.random_choice = cfg.random_choice
 
+    # propagate the contact sensor settings
+    # note: the default value for activate_contact_sensors in MultiAssetSpawnerCfg is False.
+    #  This ends up overwriting the usd-template-cfg's value when the `spawn_multi_asset`
+    #  function is called. We hard-code the value to the usd-template-cfg's value to ensure
+    #  that the contact sensor settings are propagated correctly.
+    if hasattr(cfg, "activate_contact_sensors"):
+        multi_asset_cfg.activate_contact_sensors = cfg.activate_contact_sensors
+
     # call the original function
     return spawn_multi_asset(prim_path, multi_asset_cfg, translation, orientation)


### PR DESCRIPTION
# Description

This MR fixes the propagation of the `activate_contact_sensors` attribute to the `MultiAssetSpawnerCfg` class. Previously, this value is always set to `False`, leading to incorrect contact sensor settings for spawned assets.

Fixes #1956 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there