### PR TITLE
Added `command_levels_vel` function for curriculum-based velocity command adjustment

### DIFF
--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.10.24"
+version = "0.10.25"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.10.25 (2025-03-03)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``command_levels_vel`` function for curriculum-based velocity command adjustment,
+  increasing the command range when the robot's tracking reward exceeds 80% of the maximum.
+
+
 0.10.24 (2025-02-13)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/curriculums.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/curriculums.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from isaaclab.assets import Articulation
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.terrains import TerrainImporter
+import numpy as np
 
 if TYPE_CHECKING:
     from isaaclab.envs import ManagerBasedRLEnv
@@ -53,3 +54,29 @@ def terrain_levels_vel(
     terrain.update_env_origins(env_ids, move_up, move_down)
     # return the mean terrain level
     return torch.mean(terrain.terrain_levels.float())
+
+
+def command_levels_vel(
+    env: ManagerBasedRLEnv, env_ids: Sequence[int], reward_term_name: str, max_curriculum: float = 1.0
+) -> None:
+    """Curriculum based on the tracking reward of the robot when commanded to move at a desired velocity.
+
+    This term is used to increase the range of commands when the robot's tracking reward is above 80% of the
+    maximum.
+
+    Returns:
+        The cumulative increase in velocity command range.
+    """
+    episode_sums = env.reward_manager._episode_sums[reward_term_name]
+    reward_term_cfg = env.reward_manager.get_term_cfg(reward_term_name)
+    base_velocity = env.command_manager.get_term("base_velocity")
+    if not hasattr(env, "delta_lin_vel"):
+        env.delta_lin_vel = torch.tensor(0.0, device=env.device)
+    # If the tracking reward is above 80% of the maximum, increase the range of commands
+    if torch.mean(episode_sums[env_ids]) / env.max_episode_length > 0.0001 * reward_term_cfg.weight:
+        lin_vel_x = torch.tensor(base_velocity.cfg.ranges.lin_vel_x, device=env.device)
+        lin_vel_y = torch.tensor(base_velocity.cfg.ranges.lin_vel_y, device=env.device)
+        base_velocity.cfg.ranges.lin_vel_x = torch.clamp(lin_vel_x + torch.tensor([-0.1, 0.1], device=env.device), -max_curriculum, max_curriculum).tolist()
+        base_velocity.cfg.ranges.lin_vel_y = torch.clamp(lin_vel_y + torch.tensor([-0.1, 0.1], device=env.device), -max_curriculum, max_curriculum).tolist()
+        env.delta_lin_vel = torch.clamp(env.delta_lin_vel + 0.1, 0.0, max_curriculum)
+    return env.delta_lin_vel


### PR DESCRIPTION
# Description

Added `command_levels_vel` function for curriculum-based velocity command adjustment, increasing the command range when the robot's tracking reward exceeds 80% of the maximum.

Modify from the `update_command_curriculum()` function in `legged_gym`

```python
    def update_command_curriculum(self, env_ids):
        """ Implements a curriculum of increasing commands

        Args:
            env_ids (List[int]): ids of environments being reset
        """
        # If the tracking reward is above 80% of the maximum, increase the range of commands
        if torch.mean(self.episode_sums["tracking_lin_vel"][env_ids]) / self.max_episode_length > 0.8 * self.reward_scales["tracking_lin_vel"]:
            self.command_ranges["lin_vel_x"][0] = np.clip(self.command_ranges["lin_vel_x"][0] - 0.1, -self.cfg.commands.max_curriculum, 0.)
            self.command_ranges["lin_vel_x"][1] = np.clip(self.command_ranges["lin_vel_x"][1] + 0.1, 0., self.cfg.commands.max_curriculum)
            self.command_ranges["lin_vel_y"][0] = np.clip(self.command_ranges["lin_vel_y"][0] - 0.1, -self.cfg.commands.max_curriculum, 0.)
            self.command_ranges["lin_vel_y"][1] = np.clip(self.command_ranges["lin_vel_y"][1] + 0.1, 0., self.cfg.commands.max_curriculum)
```

Usage:

```python
@configclass
class CurriculumCfg:
    """Curriculum terms for the MDP."""

    terrain_levels = CurrTerm(func=mdp.terrain_levels_vel)

    command_levels = CurrTerm(func=mdp.command_levels_vel, params={
        "reward_term_name": "track_lin_vel_xy_exp",
        "max_curriculum": 1.5,
    })
```

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

