### PR TITLE
Sets default tensor device to CPU for Camera rot buffer

### DIFF
--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -118,7 +118,7 @@ class Camera(SensorBase):
         # spawn the asset
         if self.cfg.spawn is not None:
             # compute the rotation offset
-            rot = torch.tensor(self.cfg.offset.rot, dtype=torch.float32).unsqueeze(0)
+            rot = torch.tensor(self.cfg.offset.rot, dtype=torch.float32, device="cpu").unsqueeze(0)
             rot_offset = convert_camera_frame_orientation_convention(
                 rot, origin=self.cfg.offset.convention, target="opengl"
             )


### PR DESCRIPTION
# Description

In the Camera class, we assumed that the default device for the torch tensor is CPU when we allocate the `rot` buffer during init. This isn't always the case if the user overwrites the torch device beforehand. This fix explicitly sets the tensor device to CPU on allocation.

Fixes #1863 

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
