### PR TITLE
Fixes visualization error for RayCaster with `inf` values

### DIFF
--- a/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster.py
@@ -272,8 +272,11 @@ class RayCaster(SensorBase):
                 self.ray_visualizer.set_visibility(False)
 
     def _debug_vis_callback(self, event):
+        # remove possible inf values
+        viz_points = self._data.ray_hits_w.reshape(-1, 3)
+        viz_points = viz_points[~torch.any(torch.isinf(viz_points), dim=1)]
         # show ray hit positions
-        self.ray_visualizer.visualize(self._data.ray_hits_w.view(-1, 3))
+        self.ray_visualizer.visualize(viz_points)
 
     """
     Internal simulation callbacks.


### PR DESCRIPTION
# Description

Fixes the rendering error when trying to have debug visualization enabled for a raycaster whose data points contain inf values. 

Observed error message
```
2025-03-04 09:56:31 [39,045ms] [Error] [carb.graphics-vulkan.plugin] GPU crash is detected. Trying to write crash dump into: /home/pascal/isaacsim/v4.5/kit/logs/Kit/Isaac-Sim/4.5/kit_20250304_105552-0.nv-gpudmp
2025-03-04 09:56:31 [39,045ms] [Error] [carb.graphics-vulkan.plugin] GPU crash dump is successfully written
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
