### PR TITLE
Add `bass_mass` and `body_inertia` to events

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.34.6"
+version = "0.34.7"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Added
 ^^^^^
 
-* Added ``randomize_rigid_body_inertia`` and ``randomize_com_positions`` to EventCfg in velocity_env_cfg.py.
+* Added ``randomize_rigid_body_inertia`` and ``randomize_com_positions`` to events.py.
 
 
 0.34.6 (2025-03-02)

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.34.7 (2025-03-04)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``randomize_rigid_body_inertia`` and ``randomize_com_positions`` to EventCfg in velocity_env_cfg.py.
+
+
 0.34.6 (2025-03-02)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -294,6 +294,120 @@ def randomize_rigid_body_collider_offsets(
         asset.root_physx_view.set_contact_offsets(contact_offset, env_ids.cpu())
 
 
+def randomize_rigid_body_inertia(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor | None,
+    asset_cfg: SceneEntityCfg,
+    inertia_distribution_params: tuple[float, float],
+    operation: Literal["add", "scale", "abs"],
+    distribution: Literal["uniform", "log_uniform", "gaussian"] = "uniform",
+):
+    """Randomize the inertia tensors of the bodies by adding, scaling, or setting random values.
+
+    This function allows randomizing only the diagonal inertia tensor components (xx, yy, zz) of the bodies.
+    The function samples random values from the given distribution parameters and adds, scales, or sets the values
+    into the physics simulation based on the operation.
+
+    .. tip::
+        This function uses CPU tensors to assign the body inertias. It is recommended to use this function
+        only during the initialization of the environment.
+    """
+    # extract the used quantities (to enable type-hinting)
+    asset: RigidObject | Articulation = env.scene[asset_cfg.name]
+
+    # resolve environment ids
+    if env_ids is None:
+        env_ids = torch.arange(env.scene.num_envs, device="cpu")
+    else:
+        env_ids = env_ids.cpu()
+
+    # resolve body indices
+    if asset_cfg.body_ids == slice(None):
+        body_ids = torch.arange(asset.num_bodies, dtype=torch.int, device="cpu")
+    else:
+        body_ids = torch.tensor(asset_cfg.body_ids, dtype=torch.int, device="cpu")
+
+    # get the current inertia tensors of the bodies (num_assets, num_bodies, 9 for articulations or 9 for rigid objects)
+    inertias = asset.root_physx_view.get_inertias()
+
+    # apply randomization on default values
+    inertias[env_ids[:, None], body_ids, :] = asset.data.default_inertia[env_ids[:, None], body_ids, :].clone()
+
+    # randomize each diagonal element (xx, yy, zz -> indices 0, 4, 8)
+    for idx in [0, 4, 8]:
+        # Extract and randomize the specific diagonal element
+        randomized_inertias = _randomize_prop_by_op(
+            inertias[:, :, idx],
+            inertia_distribution_params,
+            env_ids,
+            body_ids,
+            operation,
+            distribution,
+        )
+        # Assign the randomized values back to the inertia tensor
+        inertias[env_ids[:, None], body_ids, idx] = randomized_inertias
+
+    # set the inertia tensors into the physics simulation
+    asset.root_physx_view.set_inertias(inertias, env_ids)
+
+
+def randomize_com_positions(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor | None,
+    asset_cfg: SceneEntityCfg,
+    com_distribution_params: tuple[float, float],
+    operation: Literal["add", "scale", "abs"],
+    distribution: Literal["uniform", "log_uniform", "gaussian"] = "uniform",
+):
+    """Randomize the center of mass (COM) positions for the rigid bodies.
+
+    This function allows randomizing the COM positions of the bodies in the physics simulation. The positions can be
+    randomized by adding, scaling, or setting random values sampled from the specified distribution.
+
+    .. tip::
+        This function is intended for initialization or offline adjustments, as it modifies physics properties directly.
+
+    Args:
+        env (ManagerBasedEnv): The simulation environment.
+        env_ids (torch.Tensor | None): Specific environment indices to apply randomization, or None for all environments.
+        asset_cfg (SceneEntityCfg): The configuration for the target asset whose COM will be randomized.
+        com_distribution_params (tuple[float, float]): Parameters of the distribution (e.g., min and max for uniform).
+        operation (Literal["add", "scale", "abs"]): The operation to apply for randomization.
+        distribution (Literal["uniform", "log_uniform", "gaussian"]): The distribution to sample random values from.
+    """
+    # Extract the asset (Articulation or RigidObject)
+    asset: RigidObject | Articulation = env.scene[asset_cfg.name]
+
+    # Resolve environment indices
+    if env_ids is None:
+        env_ids = torch.arange(env.scene.num_envs, device="cpu")
+    else:
+        env_ids = env_ids.cpu()
+
+    # Resolve body indices
+    if asset_cfg.body_ids == slice(None):
+        body_ids = torch.arange(asset.num_bodies, dtype=torch.int, device="cpu")
+    else:
+        body_ids = torch.tensor(asset_cfg.body_ids, dtype=torch.int, device="cpu")
+
+    # Get the current COM offsets (num_assets, num_bodies, 3)
+    com_offsets = asset.root_physx_view.get_coms()
+
+    for dim_idx in range(3):  # Randomize x, y, z independently
+        randomized_offset = _randomize_prop_by_op(
+            com_offsets[:, :, dim_idx],
+            com_distribution_params,
+            env_ids,
+            body_ids,
+            operation,
+            distribution,
+        )
+        com_offsets[env_ids[:, None], body_ids, dim_idx] = randomized_offset[env_ids[:, None], body_ids]
+
+    # Set the randomized COM offsets into the simulation
+    asset.root_physx_view.set_coms(com_offsets, env_ids)
+
+
 def randomize_physics_scene_gravity(
     env: ManagerBasedEnv,
     env_ids: torch.Tensor | None,

--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.10.24"
+version = "0.10.25"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.10.25 (2025-03-04)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``body_inertia`` and ``base_com`` to EventCfg in velocity_env_cfg.py.
+
+
 0.10.24 (2025-02-13)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
@@ -173,6 +173,26 @@ class EventCfg:
         },
     )
 
+    body_inertia = EventTerm(
+        func=mdp.randomize_rigid_body_inertia,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=".*"),
+            "inertia_distribution_params": (0.5, 1.5),
+            "operation": "scale",
+        },
+    )
+
+    base_com = EventTerm(
+        func=mdp.randomize_com_positions,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names="base"),
+            "com_distribution_params": (-0.1, 0.1),
+            "operation": "add",
+        },
+    )
+
     # reset
     base_external_force_torque = EventTerm(
         func=mdp.apply_external_force_torque,


### PR DESCRIPTION
# Description

* Added ``randomize_rigid_body_inertia`` and ``randomize_com_positions`` to events.py.
* Added ``body_inertia`` and ``base_com`` to EventCfg in velocity_env_cfg.py.

This feature has already been verified here: https://github.com/fan-ziqi/robot_lab

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
