### PR TITLE
Fixes vertical aperture check in RayCasterCamera test

### DIFF
--- a/source/isaaclab/test/sensors/test_ray_caster_camera.py
+++ b/source/isaaclab/test/sensors/test_ray_caster_camera.py
@@ -572,7 +572,11 @@ class TestWarpCamera(unittest.TestCase):
         )
         torch.testing.assert_close(
             camera_usd._sensor_prims[0].GetVerticalApertureAttr().Get(),
-            camera_cfg_warp.pattern_cfg.vertical_aperture,
+            (
+                camera_cfg_warp.pattern_cfg.horizontal_aperture
+                * camera_cfg_warp.pattern_cfg.height
+                / camera_cfg_warp.pattern_cfg.width
+            ),
         )
 
         # check image data


### PR DESCRIPTION
# Description

The RayCasterCamera test checks that the vertical aperture should match the value specified in the config. However, the config's vertical aperture is not set. This PR updates the test to check against the default computed vertical aperture value instead.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
