### PR TITLE
Fixes manager tests requiring sim

### DIFF
--- a/source/isaaclab/test/managers/test_event_manager.py
+++ b/source/isaaclab/test/managers/test_event_manager.py
@@ -20,9 +20,10 @@ import unittest
 from collections import namedtuple
 
 from isaaclab.managers import EventManager, EventTermCfg
+from isaaclab.sim import SimulationContext
 from isaaclab.utils import configclass
 
-DummyEnv = namedtuple("ManagerBasedRLEnv", ["num_envs", "dt", "device", "dummy1", "dummy2"])
+DummyEnv = namedtuple("ManagerBasedRLEnv", ["num_envs", "dt", "device", "sim", "dummy1", "dummy2"])
 """Dummy environment for testing."""
 
 
@@ -56,8 +57,10 @@ class TestEventManager(unittest.TestCase):
         # create dummy tensors
         dummy1 = torch.zeros((num_envs, 2), device=device)
         dummy2 = torch.zeros((num_envs, 10), device=device)
+        # create sim
+        sim = SimulationContext()
         # create dummy environment
-        self.env = DummyEnv(num_envs, 0.01, device, dummy1, dummy2)
+        self.env = DummyEnv(num_envs, 0.01, device, sim, dummy1, dummy2)
 
     def test_str(self):
         """Test the string representation of the event manager."""

--- a/source/isaaclab/test/managers/test_observation_manager.py
+++ b/source/isaaclab/test/managers/test_observation_manager.py
@@ -20,6 +20,7 @@ import unittest
 from collections import namedtuple
 
 from isaaclab.managers import ManagerTermBase, ObservationGroupCfg, ObservationManager, ObservationTermCfg
+from isaaclab.sim import SimulationContext
 from isaaclab.utils import configclass, modifiers
 
 
@@ -98,9 +99,11 @@ class TestObservationManager(unittest.TestCase):
         self.dt = 0.01
         self.num_envs = 20
         self.device = "cuda:0"
+        # set up sim
+        self.sim = SimulationContext()
         # create dummy environment
-        self.env = namedtuple("ManagerBasedEnv", ["num_envs", "device", "data", "dt"])(
-            self.num_envs, self.device, MyDataClass(self.num_envs, self.device), self.dt
+        self.env = namedtuple("ManagerBasedEnv", ["num_envs", "device", "data", "dt", "sim"])(
+            self.num_envs, self.device, MyDataClass(self.num_envs, self.device), self.dt, self.sim
         )
 
     def test_str(self):

--- a/source/isaaclab/test/managers/test_recorder_manager.py
+++ b/source/isaaclab/test/managers/test_recorder_manager.py
@@ -26,6 +26,7 @@ from collections.abc import Sequence
 
 from isaaclab.envs import ManagerBasedEnv
 from isaaclab.managers import DatasetExportMode, RecorderManager, RecorderManagerBaseCfg, RecorderTerm, RecorderTermCfg
+from isaaclab.sim import SimulationContext
 from isaaclab.utils import configclass
 
 
@@ -84,8 +85,9 @@ def create_dummy_env(device: str = "cpu") -> ManagerBasedEnv:
         active_terms = []
 
     dummy_termination_manager = DummyTerminationManager()
-    return namedtuple("ManagerBasedEnv", ["num_envs", "device", "cfg", "termination_manager"])(
-        20, device, dict(), dummy_termination_manager
+    sim = SimulationContext()
+    return namedtuple("ManagerBasedEnv", ["num_envs", "device", "sim", "cfg", "termination_manager"])(
+        20, device, sim, dict(), dummy_termination_manager
     )
 
 

--- a/source/isaaclab/test/managers/test_reward_manager.py
+++ b/source/isaaclab/test/managers/test_reward_manager.py
@@ -17,6 +17,7 @@ import unittest
 from collections import namedtuple
 
 from isaaclab.managers import RewardManager, RewardTermCfg
+from isaaclab.sim import SimulationContext
 from isaaclab.utils import configclass
 
 
@@ -40,7 +41,8 @@ class TestRewardManager(unittest.TestCase):
     """Test cases for various situations with reward manager."""
 
     def setUp(self) -> None:
-        self.env = namedtuple("ManagerBasedRLEnv", ["num_envs", "dt", "device"])(20, 0.1, "cpu")
+        sim = SimulationContext()
+        self.env = namedtuple("ManagerBasedRLEnv", ["num_envs", "dt", "device", "sim"])(20, 0.1, "cpu", sim)
 
     def test_str(self):
         """Test the string representation of the reward manager."""


### PR DESCRIPTION
# Description

A recent change requires the manager based env to have a sim object. This update fixes the manager tests to initialize a sim variable in the env class.


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
