### PR TITLE
Removes double definition of render settings

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.36.2"
+version = "0.36.3"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.36.3 (2025-03-14)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Definition of render settings in :class:`~isaaclab.sim.SimulationCfg` is changed to None, which means that
+  the default settings will be used from the experience files and the double definition is removed.
+
+
 0.36.2 (2025-03-12)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -156,55 +156,89 @@ class PhysxCfg:
 class RenderCfg:
     """Configuration for Omniverse RTX Renderer.
 
-    These parameters are used to configure the Omniverse RTX Renderer.
+    These parameters are used to configure the Omniverse RTX Renderer. The defaults for IsaacLab are set in the
+    experience files: `apps/isaaclab.python.rendering.kit` and `apps/isaaclab.python.headless.rendering.kit`. Setting any
+    value here will override the defaults of the experience files.
+
     For more information, see the `Omniverse RTX Renderer documentation`_.
 
     .. _Omniverse RTX Renderer documentation: https://docs.omniverse.nvidia.com/materials-and-rendering/latest/rtx-renderer.html
     """
 
-    enable_translucency: bool = False
-    """Enables translucency for specular transmissive surfaces such as glass at the cost of some performance. Default is False."""
+    enable_translucency: bool | None = None
+    """Enables translucency for specular transmissive surfaces such as glass at the cost of some performance. Default is False.
 
-    enable_reflections: bool = False
-    """Enables reflections at the cost of some performance. Default is False."""
+    Set variable: /rtx/translucency/enabled
+    """
 
-    enable_global_illumination: bool = False
-    """Enables Diffused Global Illumination at the cost of some performance. Default is False."""
+    enable_reflections: bool | None = None
+    """Enables reflections at the cost of some performance. Default is False.
 
-    antialiasing_mode: Literal["Off", "FXAA", "DLSS", "TAA", "DLAA"] = "DLSS"
+    Set variable: /rtx/reflections/enabled
+    """
+
+    enable_global_illumination: bool | None = None
+    """Enables Diffused Global Illumination at the cost of some performance. Default is False.
+
+    Set variable: /rtx/indirectDiffuse/enabled
+    """
+
+    antialiasing_mode: Literal["Off", "FXAA", "DLSS", "TAA", "DLAA"] | None = None
     """Selects the anti-aliasing mode to use. Defaults to DLSS.
        - DLSS: Boosts performance by using AI to output higher resolution frames from a lower resolution input. DLSS samples multiple lower resolution images and uses motion data and feedback from prior frames to reconstruct native quality images.
-       - DLAA: Provides higher image quality with an AI-based anti-aliasing technique. DLAA uses the same Super Resolution technology developed for DLSS, reconstructing a native resolution image to maximize image quality."""
+       - DLAA: Provides higher image quality with an AI-based anti-aliasing technique. DLAA uses the same Super Resolution technology developed for DLSS, reconstructing a native resolution image to maximize image quality.
 
-    enable_dlssg: bool = False
+    Set variable: /rtx/post/dlss/execMode
+    """
+
+    enable_dlssg: bool | None = None
     """"Enables the use of DLSS-G.
         DLSS Frame Generation boosts performance by using AI to generate more frames.
         DLSS analyzes sequential frames and motion data to create additional high quality frames.
         This feature requires an Ada Lovelace architecture GPU.
         Enabling this feature also enables additional thread-related activities, which can hurt performance.
-        Default is False."""
+        Default is False.
 
-    enable_dl_denoiser: bool = False
-    """Enables the use of a DL denoiser.
-       The DL denoiser can help improve the quality of renders, but comes at a cost of performance.
+    Set variable: /rtx-transient/dlssg/enabled
     """
 
-    dlss_mode: Literal[0, 1, 2, 3] = 0
+    enable_dl_denoiser: bool | None = None
+    """Enables the use of a DL denoiser.
+       The DL denoiser can help improve the quality of renders, but comes at a cost of performance.
+
+    Set variable: /rtx-transient/dldenoiser/enabled
+    """
+
+    dlss_mode: Literal[0, 1, 2, 3] | None = None
     """For DLSS anti-aliasing, selects the performance/quality tradeoff mode.
-       Valid values are 0 (Performance), 1 (Balanced), 2 (Quality), or 3 (Auto). Default is 0."""
+       Valid values are 0 (Performance), 1 (Balanced), 2 (Quality), or 3 (Auto). Default is 0.
 
-    enable_direct_lighting: bool = True
-    """Enable direct light contributions from lights."""
+    Set variable: /rtx/post/dlss/execMode
+    """
 
-    samples_per_pixel: int = 1
+    enable_direct_lighting: bool | None = None
+    """Enable direct light contributions from lights.
+
+    Set variable: /rtx/directLighting/enabled
+    """
+
+    samples_per_pixel: int | None = None
     """Defines the Direct Lighting samples per pixel.
-       Higher values increase the direct lighting quality at the cost of performance. Default is 1."""
+       Higher values increase the direct lighting quality at the cost of performance. Default is 1.
 
-    enable_shadows: bool = True
-    """Enables shadows at the cost of performance. When disabled, lights will not cast shadows. Defaults to True."""
+    Set variable: /rtx/directLighting/sampledLighting/samplesPerPixel"""
 
-    enable_ambient_occlusion: bool = False
-    """Enables ambient occlusion at the cost of some performance. Default is False."""
+    enable_shadows: bool | None = None
+    """Enables shadows at the cost of performance. When disabled, lights will not cast shadows. Defaults to True.
+
+    Set variable: /rtx/shadows/enabled
+    """
+
+    enable_ambient_occlusion: bool | None = None
+    """Enables ambient occlusion at the cost of some performance. Default is False.
+
+    Set variable: /rtx/ambientOcclusion/enabled
+    """
 
 
 @configclass

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -165,18 +165,28 @@ class SimulationContext(_SimulationContext):
         self._has_gui = self._local_gui or self._livestream_gui
 
         # apply render settings from render config
-        carb_settings_iface.set_bool("/rtx/translucency/enabled", self.cfg.render.enable_translucency)
-        carb_settings_iface.set_bool("/rtx/reflections/enabled", self.cfg.render.enable_reflections)
-        carb_settings_iface.set_bool("/rtx/indirectDiffuse/enabled", self.cfg.render.enable_global_illumination)
-        carb_settings_iface.set_bool("/rtx-transient/dlssg/enabled", self.cfg.render.enable_dlssg)
-        carb_settings_iface.set_bool("/rtx-transient/dldenoiser/enabled", self.cfg.render.enable_dl_denoiser)
-        carb_settings_iface.set_int("/rtx/post/dlss/execMode", self.cfg.render.dlss_mode)
-        carb_settings_iface.set_bool("/rtx/directLighting/enabled", self.cfg.render.enable_direct_lighting)
-        carb_settings_iface.set_int(
-            "/rtx/directLighting/sampledLighting/samplesPerPixel", self.cfg.render.samples_per_pixel
-        )
-        carb_settings_iface.set_bool("/rtx/shadows/enabled", self.cfg.render.enable_shadows)
-        carb_settings_iface.set_bool("/rtx/ambientOcclusion/enabled", self.cfg.render.enable_ambient_occlusion)
+        if self.cfg.render.enable_translucency is not None:
+            carb_settings_iface.set_bool("/rtx/translucency/enabled", self.cfg.render.enable_translucency)
+        if self.cfg.render.enable_reflections is not None:
+            carb_settings_iface.set_bool("/rtx/reflections/enabled", self.cfg.render.enable_reflections)
+        if self.cfg.render.enable_global_illumination is not None:
+            carb_settings_iface.set_bool("/rtx/indirectDiffuse/enabled", self.cfg.render.enable_global_illumination)
+        if self.cfg.render.enable_dlssg is not None:
+            carb_settings_iface.set_bool("/rtx-transient/dlssg/enabled", self.cfg.render.enable_dlssg)
+        if self.cfg.render.enable_dl_denoiser is not None:
+            carb_settings_iface.set_bool("/rtx-transient/dldenoiser/enabled", self.cfg.render.enable_dl_denoiser)
+        if self.cfg.render.dlss_mode is not None:
+            carb_settings_iface.set_int("/rtx/post/dlss/execMode", self.cfg.render.dlss_mode)
+        if self.cfg.render.enable_direct_lighting is not None:
+            carb_settings_iface.set_bool("/rtx/directLighting/enabled", self.cfg.render.enable_direct_lighting)
+        if self.cfg.render.samples_per_pixel is not None:
+            carb_settings_iface.set_int(
+                "/rtx/directLighting/sampledLighting/samplesPerPixel", self.cfg.render.samples_per_pixel
+            )
+        if self.cfg.render.enable_shadows is not None:
+            carb_settings_iface.set_bool("/rtx/shadows/enabled", self.cfg.render.enable_shadows)
+        if self.cfg.render.enable_ambient_occlusion is not None:
+            carb_settings_iface.set_bool("/rtx/ambientOcclusion/enabled", self.cfg.render.enable_ambient_occlusion)
         # set denoiser mode
         try:
             import omni.replicator.core as rep


### PR DESCRIPTION
# Description

The definition of render settings in `SimulationCfg` is changed to None, which means that the default settings will be used from the experience files, and the double definition is removed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
