### PR TITLE
Fixes default effort limit behavior for implicit actuators

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.36.2"
+version = "0.36.3"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.36.3 (2025-03-17)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fix default behavior of :class:`~isaaclab.actuators.ImplicitActuator` if no :attr:`effort_limits_sim` or
+  :attr:`effort_limit` is set.
+
+
 0.36.2 (2025-03-12)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Fixed
 ^^^^^
 
-* Fix default behavior of :class:`~isaaclab.actuators.ImplicitActuator` if no :attr:`effort_limits_sim` or
+* Fixed default behavior of :class:`~isaaclab.actuators.ImplicitActuator` if no :attr:`effort_limits_sim` or
   :attr:`effort_limit` is set.
 
 

--- a/source/isaaclab/isaaclab/actuators/actuator_base.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_base.py
@@ -140,7 +140,7 @@ class ActuatorBase(ABC):
 
         # For explicit models, we do not want to enforce the effort limit through the solver
         # (unless it is explicitly set)
-        if not ActuatorBase.is_implicit_model and self.cfg.effort_limit_sim is None:
+        if not self.is_implicit_model and self.cfg.effort_limit_sim is None:
             self.cfg.effort_limit_sim = 1.0e9
 
         # parse joint stiffness and damping

--- a/source/isaaclab/isaaclab/actuators/actuator_base.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_base.py
@@ -88,6 +88,13 @@ class ActuatorBase(ABC):
     friction: torch.Tensor
     """The joint friction of the actuator joints. Shape is (num_envs, num_joints)."""
 
+    _DEFAULT_MAX_EFFORT_SIM: ClassVar[float] = 1.0e9
+    """The default maximum effort for the actuator joints in the simulation. Defaults to 1.0e9.
+
+    If the :attr:`ActuatorBaseCfg.effort_limit_sim` is not specified and the actuator is an explicit
+    actuator, then this value is used.
+    """
+
     def __init__(
         self,
         cfg: ActuatorBaseCfg,
@@ -141,7 +148,7 @@ class ActuatorBase(ABC):
         # For explicit models, we do not want to enforce the effort limit through the solver
         # (unless it is explicitly set)
         if not self.is_implicit_model and self.cfg.effort_limit_sim is None:
-            self.cfg.effort_limit_sim = 1.0e9
+            self.cfg.effort_limit_sim = self._DEFAULT_MAX_EFFORT_SIM
 
         # parse joint stiffness and damping
         self.stiffness = self._parse_joint_parameter(self.cfg.stiffness, stiffness)

--- a/source/isaaclab/isaaclab/actuators/actuator_pd.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_pd.py
@@ -100,7 +100,7 @@ class ImplicitActuator(ActuatorBase):
                 )
 
         # set implicit actuator model flag
-        self.is_implicit_model = True
+        ImplicitActuator.is_implicit_model = True
         # call the base class
         super().__init__(cfg, *args, **kwargs)
 

--- a/source/isaaclab/isaaclab/actuators/actuator_pd.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_pd.py
@@ -100,7 +100,7 @@ class ImplicitActuator(ActuatorBase):
                 )
 
         # set implicit actuator model flag
-        ImplicitActuator.is_implicit_model = True
+        self.is_implicit_model = True
         # call the base class
         super().__init__(cfg, *args, **kwargs)
 

--- a/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
@@ -199,6 +199,36 @@ class JointDrivePropertiesCfg:
     then the joint is driven by an acceleration (usually used for kinematic joints).
     """
 
+    max_effort: float | None = None
+    """Maximum effort that can be applied to the joint (in kg-m^2/s^2)."""
+
+    max_velocity: float | None = None
+    """Maximum velocity of the joint.
+
+    The unit depends on the joint model:
+
+    * For linear joints, the unit is m/s.
+    * For angular joints, the unit is rad/s.
+    """
+
+    stiffness: float | None = None
+    """Stiffness of the joint drive.
+
+    The unit depends on the joint model:
+
+    * For linear joints, the unit is kg-m/s^2 (N/m).
+    * For angular joints, the unit is kg-m^2/s^2/rad (N-m/rad).
+    """
+
+    damping: float | None = None
+    """Damping of the joint drive.
+
+    The unit depends on the joint model:
+
+    * For linear joints, the unit is kg-m/s (N-s/m).
+    * For angular joints, the unit is kg-m^2/s/rad (N-m-s/rad).
+    """
+
 
 @configclass
 class FixedTendonPropertiesCfg:

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
@@ -43,7 +43,14 @@ class FileCfg(RigidObjectSpawnerCfg, DeformableObjectSpawnerCfg):
     """Properties to apply to the fixed tendons (if any)."""
 
     joint_drive_props: schemas.JointDrivePropertiesCfg | None = None
-    """Properties to apply to a joint."""
+    """Properties to apply to a joint.
+
+    .. note::
+        The joint drive properties set the USD attributes of all the joint drives in the asset.
+        We recommend using this attribute sparingly and only when necessary. Instead, please use the
+        :attr:`~isaaclab.assets.ArticulationCfg.actuators` parameter to set the joint drive properties
+        for specific joints in an articulation.
+    """
 
     visual_material_path: str = "material"
     """Path to the visual material to use for the prim. Defaults to "material".


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

Fix default behavior of implicit actuators if no effort limit is set.

Fixes #2054 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
