### PR TITLE
Removes hamburger icon in template generator README

### DIFF
--- a/tools/template/templates/external/README.md
+++ b/tools/template/templates/external/README.md
@@ -63,10 +63,10 @@ To enable your extension, follow these steps:
 
 1. **Add the search path of this project/repository** to the extension manager:
     - Navigate to the extension manager using `Window` -> `Extensions`.
-    - Click on the **Hamburger Icon** (☰), then go to `Settings`.
+    - Click on the **Hamburger Icon**, then go to `Settings`.
     - In the `Extension Search Paths`, enter the absolute path to the `source` directory of this project/repository.
     - If not already present, in the `Extension Search Paths`, enter the path that leads to Isaac Lab's extension directory directory (`IsaacLab/source`)
-    - Click on the **Hamburger Icon** (☰), then click `Refresh`.
+    - Click on the **Hamburger Icon**, then click `Refresh`.
 
 2. **Search and enable your extension**:
     - Find your extension under the `Third Party` category.


### PR DESCRIPTION
# Description

This PR fixes https://github.com/isaac-sim/IsaacLab/issues/2094. Hamburger icon in the readme was causing encoding errors.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
