### PR TITLE
Fixes docstrings inconsistencies the code

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,6 +63,7 @@ Guidelines for modifications:
 * Jia Lin Yuan
 * Jinghuan Shang
 * Jingzhou Liu
+* Jinqi Wei
 * Johnson Sun
 * Kaixi Bao
 * Kourosh Darvish

--- a/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
@@ -103,7 +103,7 @@ class JointEffortActionCfg(JointActionCfg):
 class JointPositionToLimitsActionCfg(ActionTermCfg):
     """Configuration for the bounded joint position action term.
 
-    See :class:`JointPositionWithinLimitsAction` for more details.
+    See :class:`JointPositionToLimitsAction` for more details.
     """
 
     class_type: type[ActionTerm] = joint_actions_to_limits.JointPositionToLimitsAction

--- a/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
@@ -29,7 +29,7 @@ class ArticulationRootPropertiesCfg:
     """Solver position iteration counts for the body."""
 
     solver_velocity_iteration_count: int | None = None
-    """Solver position iteration counts for the body."""
+    """Solver velocity iteration counts for the body."""
 
     sleep_threshold: float | None = None
     """Mass-normalized kinetic energy threshold below which an actor may go to sleep."""

--- a/source/isaaclab/isaaclab/terrains/terrain_generator_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_generator_cfg.py
@@ -189,7 +189,7 @@ class TerrainGeneratorCfg:
     """
 
     use_cache: bool = False
-    """Whether to load the sub-terrain from cache if it exists. Defaults to True.
+    """Whether to load the sub-terrain from cache if it exists. Defaults to False.
 
     If enabled, the generated terrains are stored in the cache directory. When generating terrains, the cache
     is checked to see if the terrain already exists. If it does, the terrain is loaded from the cache. Otherwise,


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

* Fixed the mismatch in :class:`JointPositionToLimitsActionCfg` docstring which was incorrectly referring to ``JointPositionWithinLimitsAction`` instead of ``JointPositionToLimitsAction``.
* Fixed the issue of the :attr:`solver_velocity_iteration_count` docstring in :class:`ArticulationRootPropertiesCfg` being incorrect.
* Fixed the mismatch between the default value of :attr:`use_cache` in :class:`TerrainGeneratorCfg` and its docstring. Currently, the default value is set to ``False``.

Fixes #1330, #1377, #1827 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
