### PR TITLE
Initializes manager term classes only when sim starts

### DIFF
--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -135,7 +135,6 @@ class DirectMARLEnv(gym.Env):
         #   that must happen before the simulation starts. Example: randomizing mesh scale
         if self.cfg.events:
             self.event_manager = EventManager(self.cfg.events, self)
-            print("[INFO] Event Manager: ", self.event_manager)
 
             # apply USD-related randomization events
             if "prestartup" in self.event_manager.available_modes:
@@ -198,6 +197,9 @@ class DirectMARLEnv(gym.Env):
 
         # perform events at the start of the simulation
         if self.cfg.events:
+            # we print it here to make the logging consistent
+            print("[INFO] Event Manager: ", self.event_manager)
+
             if "startup" in self.event_manager.available_modes:
                 self.event_manager.apply(mode="startup")
 

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -141,7 +141,6 @@ class DirectRLEnv(gym.Env):
         #   that must happen before the simulation starts. Example: randomizing mesh scale
         if self.cfg.events:
             self.event_manager = EventManager(self.cfg.events, self)
-            print("[INFO] Event Manager: ", self.event_manager)
 
             # apply USD-related randomization events
             if "prestartup" in self.event_manager.available_modes:
@@ -202,6 +201,9 @@ class DirectRLEnv(gym.Env):
 
         # perform events at the start of the simulation
         if self.cfg.events:
+            # we print it here to make the logging consistent
+            print("[INFO] Event Manager: ", self.event_manager)
+
             if "startup" in self.event_manager.available_modes:
                 self.event_manager.apply(mode="startup")
 

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -140,7 +140,6 @@ class ManagerBasedEnv:
         # note: this is needed here (rather than after simulation play) to allow USD-related randomization events
         #   that must happen before the simulation starts. Example: randomizing mesh scale
         self.event_manager = EventManager(self.cfg.events, self)
-        print("[INFO] Event Manager: ", self.event_manager)
 
         # apply USD-related randomization events
         if "prestartup" in self.event_manager.available_modes:
@@ -232,6 +231,8 @@ class ManagerBasedEnv:
 
         """
         # prepare the managers
+        # -- event manager (we print it here to make the logging consistent)
+        print("[INFO] Event Manager: ", self.event_manager)
         # -- recorder manager
         self.recorder_manager = RecorderManager(self.cfg.recorders, self)
         print("[INFO] Recorder Manager: ", self.recorder_manager)

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -1162,7 +1162,9 @@ class randomize_visual_texture_material(ManagerTermBase):
         event_name = cfg.params.get("event_name")
         texture_rotation = cfg.params.get("texture_rotation", (0.0, 0.0))
 
-        # check to make sure replicate_physics is set to False, else raise warning
+        # check to make sure replicate_physics is set to False, else raise error
+        # note: We add an explicit check here since texture randomization can happen outside of 'prestartup' mode
+        #   and the event manager doesn't check in that case.
         if env.cfg.scene.replicate_physics:
             raise RuntimeError(
                 "Unable to randomize visual texture material with scene replication enabled."
@@ -1260,7 +1262,9 @@ class randomize_visual_color(ManagerTermBase):
         event_name = cfg.params.get("event_name")
         mesh_name: str = cfg.params.get("mesh_name", "")  # type: ignore
 
-        # check to make sure replicate_physics is set to False, else raise warning
+        # check to make sure replicate_physics is set to False, else raise error
+        # note: We add an explicit check here since texture randomization can happen outside of 'prestartup' mode
+        #   and the event manager doesn't check in that case.
         if env.cfg.scene.replicate_physics:
             raise RuntimeError(
                 "Unable to randomize visual color with scene replication enabled."

--- a/source/isaaclab/isaaclab/managers/event_manager.py
+++ b/source/isaaclab/isaaclab/managers/event_manager.py
@@ -187,15 +187,6 @@ class EventManager(ManagerBase):
         if mode not in self._mode_term_names:
             omni.log.warn(f"Event mode '{mode}' is not defined. Skipping event.")
             return
-        # check if mode is pre-startup and scene replication is enabled
-        if mode == "prestartup" and self._env.scene.cfg.replicate_physics:
-            raise RuntimeError(
-                "Scene replication is enabled, which may affect USD-level randomization."
-                " When assets are replicated, their properties are shared across instances,"
-                " potentially leading to unintended behavior."
-                " For stable USD-level randomization, please disable scene replication"
-                " by setting 'replicate_physics' to False in 'InteractiveSceneCfg'."
-            )
 
         # check if mode is interval and dt is not provided
         if mode == "interval" and dt is None:
@@ -365,9 +356,21 @@ class EventManager(ManagerBase):
             # resolve common parameters
             self._resolve_common_term_cfg(term_name, term_cfg, min_argc=2)
 
+            # check if mode is pre-startup and scene replication is enabled
+            if term_cfg.mode == "prestartup" and self._env.scene.cfg.replicate_physics:
+                raise RuntimeError(
+                    "Scene replication is enabled, which may affect USD-level randomization."
+                    " When assets are replicated, their properties are shared across instances,"
+                    " potentially leading to unintended behavior."
+                    " For stable USD-level randomization, please disable scene replication"
+                    " by setting 'replicate_physics' to False in 'InteractiveSceneCfg'."
+                )
+
             # for event terms with mode "prestartup", we assume a callable class term
             # can be initialized before the simulation starts.
+            # this is done to ensure that the USD-level randomization is possible before the simulation starts.
             if inspect.isclass(term_cfg.func) and term_cfg.mode == "prestartup":
+                omni.log.info(f"Initializing term '{term_name}' with class '{term_cfg.func.__name__}'.")
                 term_cfg.func = term_cfg.func(cfg=term_cfg, env=self._env)
 
             # check if mode is a new mode

--- a/source/isaaclab/isaaclab/managers/manager_base.py
+++ b/source/isaaclab/isaaclab/managers/manager_base.py
@@ -391,4 +391,5 @@ class ManagerBase(ABC):
 
         # initialize the term if it is a class
         if inspect.isclass(term_cfg.func):
+            omni.log.info(f"Initializing term '{term_name}' with class '{term_cfg.func.__name__}'.")
             term_cfg.func = term_cfg.func(cfg=term_cfg, env=self._env)

--- a/source/isaaclab/isaaclab/managers/manager_base.py
+++ b/source/isaaclab/isaaclab/managers/manager_base.py
@@ -139,6 +139,8 @@ class ManagerBase(ABC):
         # if the simulation is not playing, we use callbacks to trigger the resolution of the scene
         # entities configuration. this is needed for cases where the manager is created after the
         # simulation, but before the simulation is playing.
+        # FIXME: Once Isaac Sim supports storing this information as USD schema, we can remove this
+        #   callback and resolve the scene entities directly inside `_prepare_terms`.
         if not self._env.sim.is_playing():
             # note: Use weakref on all callbacks to ensure that this object can be deleted when its destructor
             # is called

--- a/source/isaaclab/test/managers/test_observation_manager.py
+++ b/source/isaaclab/test/managers/test_observation_manager.py
@@ -19,8 +19,8 @@ import torch
 import unittest
 from collections import namedtuple
 
+import isaaclab.sim as sim_utils
 from isaaclab.managers import ManagerTermBase, ObservationGroupCfg, ObservationManager, ObservationTermCfg
-from isaaclab.sim import SimulationContext
 from isaaclab.utils import configclass, modifiers
 
 
@@ -100,11 +100,15 @@ class TestObservationManager(unittest.TestCase):
         self.num_envs = 20
         self.device = "cuda:0"
         # set up sim
-        self.sim = SimulationContext()
+        sim_cfg = sim_utils.SimulationCfg(dt=self.dt, device=self.device)
+        sim = sim_utils.SimulationContext(sim_cfg)
         # create dummy environment
         self.env = namedtuple("ManagerBasedEnv", ["num_envs", "device", "data", "dt", "sim"])(
-            self.num_envs, self.device, MyDataClass(self.num_envs, self.device), self.dt, self.sim
+            self.num_envs, self.device, MyDataClass(self.num_envs, self.device), self.dt, sim
         )
+        # let the simulation play (we need this for observation manager to compute obs dims)
+        self.env.sim._app_control_on_stop_handle = None
+        self.env.sim.reset()
 
     def test_str(self):
         """Test the string representation of the observation manager."""
@@ -382,24 +386,25 @@ class TestObservationManager(unittest.TestCase):
         expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device)
         expected_obs_term_2_data = lin_vel_w_data(self.env)
         expected_obs_data_t0 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
-        print(expected_obs_data_t0, obs_policy)
-        self.assertTrue(torch.equal(expected_obs_data_t0, obs_policy))
+        torch.testing.assert_close(expected_obs_data_t0, obs_policy)
+
         # test that the history buffer holds previous data
         for _ in range(HISTORY_LENGTH):
             observations = self.obs_man.compute()
             obs_policy = observations["policy"]
         expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * HISTORY_LENGTH, device=self.env.device)
         expected_obs_data_t5 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
-        self.assertTrue(torch.equal(expected_obs_data_t5, obs_policy))
+        torch.testing.assert_close(expected_obs_data_t5, obs_policy)
+
         # test reset
         self.obs_man.reset()
         observations = self.obs_man.compute()
         obs_policy = observations["policy"]
-        self.assertTrue(torch.equal(expected_obs_data_t0, obs_policy))
+        torch.testing.assert_close(expected_obs_data_t0, obs_policy)
         # test reset of specific env ids
         reset_env_ids = [2, 4, 16]
         self.obs_man.reset(reset_env_ids)
-        self.assertTrue(torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids]))
+        torch.testing.assert_close(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids])
 
     def test_compute_with_2d_history(self):
         """Test the observation computation with history buffers for 2D observations."""
@@ -482,7 +487,7 @@ class TestObservationManager(unittest.TestCase):
         expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * GROUP_HISTORY_LENGTH, device=self.env.device)
         expected_obs_term_2_data = lin_vel_w_data(self.env).repeat(1, GROUP_HISTORY_LENGTH)
         expected_obs_data_t0 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
-        self.assertTrue(torch.equal(expected_obs_data_t0, obs_policy))
+        torch.testing.assert_close(expected_obs_data_t0, obs_policy)
         # test that the history buffer holds previous data
         for _ in range(GROUP_HISTORY_LENGTH):
             observations = self.obs_man.compute()
@@ -490,16 +495,16 @@ class TestObservationManager(unittest.TestCase):
         expected_obs_term_1_data = torch.ones(self.env.num_envs, 4 * GROUP_HISTORY_LENGTH, device=self.env.device)
         expected_obs_term_2_data = lin_vel_w_data(self.env).repeat(1, GROUP_HISTORY_LENGTH)
         expected_obs_data_t10 = torch.concat((expected_obs_term_1_data, expected_obs_term_2_data), dim=-1)
-        self.assertTrue(torch.equal(expected_obs_data_t10, obs_policy))
+        torch.testing.assert_close(expected_obs_data_t10, obs_policy)
         # test reset
         self.obs_man.reset()
         observations = self.obs_man.compute()
         obs_policy = observations["policy"]
-        self.assertTrue(torch.equal(expected_obs_data_t0, obs_policy))
+        torch.testing.assert_close(expected_obs_data_t0, obs_policy)
         # test reset of specific env ids
         reset_env_ids = [2, 4, 16]
         self.obs_man.reset(reset_env_ids)
-        self.assertTrue(torch.equal(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids]))
+        torch.testing.assert_close(expected_obs_data_t0[reset_env_ids], obs_policy[reset_env_ids])
 
     def test_invalid_observation_config(self):
         """Test the invalid observation config."""

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/rewards.py
@@ -95,7 +95,11 @@ class joint_pos_limits_penalty_ratio(ManagerTermBase):
         self.gear_ratio_scaled = self.gear_ratio / torch.max(self.gear_ratio)
 
     def __call__(
-        self, env: ManagerBasedRLEnv, threshold: float, gear_ratio: dict[str, float], asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
+        self,
+        env: ManagerBasedRLEnv,
+        threshold: float,
+        gear_ratio: dict[str, float],
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
     ) -> torch.Tensor:
         # extract the used quantities (to enable type-hinting)
         asset: Articulation = env.scene[asset_cfg.name]
@@ -131,8 +135,8 @@ class power_consumption(ManagerTermBase):
         self.gear_ratio_scaled = self.gear_ratio / torch.max(self.gear_ratio)
 
     def __call__(
-            self, env: ManagerBasedRLEnv, gear_ratio: dict[str, float], asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
-        ) -> torch.Tensor:
+        self, env: ManagerBasedRLEnv, gear_ratio: dict[str, float], asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
+    ) -> torch.Tensor:
         # extract the used quantities (to enable type-hinting)
         asset: Articulation = env.scene[asset_cfg.name]
         # return power = torque * velocity (here actions: joint torques)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/rewards.py
@@ -82,10 +82,10 @@ class joint_pos_limits_penalty_ratio(ManagerTermBase):
 
     def __init__(self, env: ManagerBasedRLEnv, cfg: RewardTermCfg):
         # add default argument
-        if "asset_cfg" not in cfg.params:
-            cfg.params["asset_cfg"] = SceneEntityCfg("robot")
+        asset_cfg = cfg.params.get("asset_cfg", SceneEntityCfg("robot"))
         # extract the used quantities (to enable type-hinting)
-        asset: Articulation = env.scene[cfg.params["asset_cfg"].name]
+        asset: Articulation = env.scene[asset_cfg.name]
+
         # resolve the gear ratio for each joint
         self.gear_ratio = torch.ones(env.num_envs, asset.num_joints, device=env.device)
         index_list, _, value_list = string_utils.resolve_matching_names_values(
@@ -95,7 +95,7 @@ class joint_pos_limits_penalty_ratio(ManagerTermBase):
         self.gear_ratio_scaled = self.gear_ratio / torch.max(self.gear_ratio)
 
     def __call__(
-        self, env: ManagerBasedRLEnv, threshold: float, gear_ratio: dict[str, float], asset_cfg: SceneEntityCfg
+        self, env: ManagerBasedRLEnv, threshold: float, gear_ratio: dict[str, float], asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
     ) -> torch.Tensor:
         # extract the used quantities (to enable type-hinting)
         asset: Articulation = env.scene[asset_cfg.name]
@@ -118,10 +118,10 @@ class power_consumption(ManagerTermBase):
 
     def __init__(self, env: ManagerBasedRLEnv, cfg: RewardTermCfg):
         # add default argument
-        if "asset_cfg" not in cfg.params:
-            cfg.params["asset_cfg"] = SceneEntityCfg("robot")
+        asset_cfg = cfg.params.get("asset_cfg", SceneEntityCfg("robot"))
         # extract the used quantities (to enable type-hinting)
-        asset: Articulation = env.scene[cfg.params["asset_cfg"].name]
+        asset: Articulation = env.scene[asset_cfg.name]
+
         # resolve the gear ratio for each joint
         self.gear_ratio = torch.ones(env.num_envs, asset.num_joints, device=env.device)
         index_list, _, value_list = string_utils.resolve_matching_names_values(
@@ -130,7 +130,9 @@ class power_consumption(ManagerTermBase):
         self.gear_ratio[:, index_list] = torch.tensor(value_list, device=env.device)
         self.gear_ratio_scaled = self.gear_ratio / torch.max(self.gear_ratio)
 
-    def __call__(self, env: ManagerBasedRLEnv, gear_ratio: dict[str, float], asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    def __call__(
+            self, env: ManagerBasedRLEnv, gear_ratio: dict[str, float], asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
+        ) -> torch.Tensor:
         # extract the used quantities (to enable type-hinting)
         asset: Articulation = env.scene[asset_cfg.name]
         # return power = torque * velocity (here actions: joint torques)


### PR DESCRIPTION
# Description

To support creation of managers before the simulation starts playing (as needed by the event manager for USD randomizations), the MR in #2040 added a callback to resolve scene entities at runtime. However, certain class-based manager terms can also not be initialized if the simulation is not playing. Those terms may often rely on parameters that are only available once simulation plays (for instance, joint position limits).

This MR moves the initializations of class-based manager terms to the callback too.

Fixes #2136

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there