### PR TITLE
Optimizes getters of data inside asset classes

### DIFF
--- a/source/isaaclab/isaaclab/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/rigid_object.py
@@ -252,14 +252,14 @@ class RigidObject(AssetBase):
         else:
             local_env_ids = env_ids
 
-        com_pos = self.data.com_pos_b[local_env_ids, 0, :]
-        com_quat = self.data.com_quat_b[local_env_ids, 0, :]
+        com_pos_b = self.data.body_com_pos_b[local_env_ids, 0, :]
+        com_quat_b = self.data.body_com_quat_b[local_env_ids, 0, :]
 
         root_link_pos, root_link_quat = math_utils.combine_frame_transforms(
             root_pose[..., :3],
             root_pose[..., 3:7],
-            math_utils.quat_rotate(math_utils.quat_inv(com_quat), -com_pos),
-            math_utils.quat_inv(com_quat),
+            math_utils.quat_rotate(math_utils.quat_inv(com_quat_b), -com_pos_b),
+            math_utils.quat_inv(com_quat_b),
         )
 
         root_link_pose = torch.cat((root_link_pos, root_link_quat), dim=-1)
@@ -329,7 +329,7 @@ class RigidObject(AssetBase):
 
         root_com_velocity = root_velocity.clone()
         quat = self.data.root_link_state_w[local_env_ids, 3:7]
-        com_pos_b = self.data.com_pos_b[local_env_ids, 0, :]
+        com_pos_b = self.data.body_com_pos_b[local_env_ids, 0, :]
         # transform given velocity to center of mass
         root_com_velocity[:, :3] += torch.linalg.cross(
             root_com_velocity[:, 3:], math_utils.quat_rotate(quat, com_pos_b), dim=-1

--- a/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_data.py
@@ -67,7 +67,7 @@ class RigidObjectData:
         self._root_link_pose_w = TimestampedBuffer()
         self._root_link_vel_w = TimestampedBuffer()
         # -- com frame w.r.t. link frame
-        self._root_com_pose_b = TimestampedBuffer()
+        self._body_com_pose_b = TimestampedBuffer()
         # -- com frame w.r.t. world frame
         self._root_com_pose_w = TimestampedBuffer()
         self._root_com_vel_w = TimestampedBuffer()
@@ -120,9 +120,10 @@ class RigidObjectData:
 
     @property
     def root_link_pose_w(self) -> torch.Tensor:
-        """Root link pose in simulation world frame. Shape is (num_instances, 7).
+        """Root link pose ``[pos, quat]`` in simulation world frame. Shape is (num_instances, 7).
 
-        This quantity is the position of the actor frame of the root rigid body relative to the world.
+        This quantity is the pose of the actor frame of the root rigid body relative to the world.
+        The orientation is provided in (w, x, y, z) format.
         """
         if self._root_link_pose_w.timestamp < self._sim_timestamp:
             # read data from simulation
@@ -136,7 +137,7 @@ class RigidObjectData:
 
     @property
     def root_link_vel_w(self) -> torch.Tensor:
-        """Root link velocity in simulation world frame. Shape is (num_instances, 6).
+        """Root link velocity ``[lin_vel, ang_vel]`` in simulation world frame. Shape is (num_instances, 6).
 
         This quantity contains the linear and angular velocities of the actor frame of the root
         rigid body relative to the world.
@@ -156,9 +157,10 @@ class RigidObjectData:
 
     @property
     def root_com_pose_w(self) -> torch.Tensor:
-        """Root center of mass pose in simulation world frame. Shape is (num_instances, 3).
+        """Root center of mass pose ``[pos, quat]`` in simulation world frame. Shape is (num_instances, 7).
 
-        This quantity is the pose of the actor frame of the root rigid body relative to the world.
+        This quantity is the pose of the center of mass frame of the root rigid body relative to the world.
+        The orientation is provided in (w, x, y, z) format.
         """
         if self._root_com_pose_w.timestamp < self._sim_timestamp:
             # read the link pose
@@ -175,7 +177,7 @@ class RigidObjectData:
 
     @property
     def root_com_vel_w(self) -> torch.Tensor:
-        """Root center of mass velocity in simulation world frame. Shape is (num_instances, 6).
+        """Root center of mass velocity ``[lin_vel, ang_vel]`` in simulation world frame. Shape is (num_instances, 6).
 
         This quantity contains the linear and angular velocities of the root rigid body's center of mass frame
         relative to the world.
@@ -192,7 +194,7 @@ class RigidObjectData:
         """Root state ``[pos, quat, lin_vel, ang_vel]`` in simulation world frame. Shape is (num_instances, 13).
 
         The position, quaternion, and linear/angular velocity are of the rigid body root frame relative to the
-        world.
+        world. The orientation is provided in (w, x, y, z) format.
         """
         if self._root_link_state_w.timestamp < self._sim_timestamp:
             # set the buffer data and timestamp
@@ -203,7 +205,8 @@ class RigidObjectData:
 
     @property
     def root_com_state_w(self):
-        """Root center of mass state ``[pos, quat, lin_vel, ang_vel]`` in simulation world frame. Shape is (num_instances, 13).
+        """Root center of mass state ``[pos, quat, lin_vel, ang_vel]`` in simulation world frame.
+        Shape is (num_instances, 13).
 
         The position, quaternion, and linear/angular velocity are of the rigid body's center of mass frame
         relative to the world. Center of mass frame is the orientation principle axes of inertia.
@@ -220,15 +223,16 @@ class RigidObjectData:
 
     @property
     def body_link_pose_w(self) -> torch.Tensor:
-        """Body link pose in simulation world frame. Shape is (num_instances, 7).
+        """Body link pose ``[pos, quat]`` in simulation world frame. Shape is (num_instances, 7).
 
-        This quantity is the position of the actor frame of the rigid body relative to the world.
+        This quantity is the pose of the actor frame of the rigid body relative to the world.
+        The orientation is provided in (w, x, y, z) format.
         """
         return self.root_link_pose_w.view(-1, 1, 7)
 
     @property
     def body_link_vel_w(self) -> torch.Tensor:
-        """Body link velocity in simulation world frame. Shape is (num_instances, 6).
+        """Body link velocity ``[lin_vel, ang_vel]`` in simulation world frame. Shape is (num_instances, 6).
 
         This quantity contains the linear and angular velocities of the actor frame of the root
         rigid body relative to the world.
@@ -237,15 +241,16 @@ class RigidObjectData:
 
     @property
     def body_com_pose_w(self) -> torch.Tensor:
-        """Body center of mass pose in simulation world frame. Shape is (num_instances, 3).
+        """Body center of mass pose ``[pos, quat]`` in simulation world frame. Shape is (num_instances, 7).
 
-        This quantity is the pose of the actor frame of the rigid body relative to the world.
+        This quantity is the pose of the center of mass frame of the rigid body relative to the world.
+        The orientation is provided in (w, x, y, z) format.
         """
         return self.root_com_pose_w.view(-1, 1, 3)
 
     @property
     def body_com_vel_w(self) -> torch.Tensor:
-        """Body center of mass velocity in simulation world frame. Shape is (num_instances, 6).
+        """Body center of mass velocity ``[lin_vel, ang_vel]`` in simulation world frame. Shape is (num_instances, 6).
 
         This quantity contains the linear and angular velocities of the root rigid body's center of mass frame
         relative to the world.
@@ -254,27 +259,28 @@ class RigidObjectData:
 
     @property
     def body_link_state_w(self):
-        """State of all bodies `[pos, quat, lin_vel, ang_vel]` in simulation world frame.
+        """State of all bodies ``[pos, quat, lin_vel, ang_vel]`` in simulation world frame.
         Shape is (num_instances, 1, 13).
 
         The position, quaternion, and linear/angular velocity are of the body's link frame relative to the world.
+        The orientation is provided in (w, x, y, z) format.
         """
         return self.root_link_state_w.view(-1, 1, 13)
 
     @property
     def body_com_state_w(self):
-        """State of all bodies `[pos, quat, lin_vel, ang_vel]` in simulation world frame.
+        """State of all bodies ``[pos, quat, lin_vel, ang_vel]`` in simulation world frame.
         Shape is (num_instances, num_bodies, 13).
 
         The position, quaternion, and linear/angular velocity are of the body's center of mass frame relative to the
         world. Center of mass frame is assumed to be the same orientation as the link rather than the orientation of the
-        principle inertia.
+        principle inertia. The orientation is provided in (w, x, y, z) format.
         """
         return self.root_com_state_w.view(-1, 1, 13)
 
     @property
     def body_com_acc_w(self):
-        """Acceleration of all bodies in the simulation world frame. Shape is (num_instances, 1, 6).
+        """Acceleration of all bodies ``[lin_acc, ang_acc]`` in the simulation world frame. Shape is (num_instances, 1, 6).
 
         This quantity is the acceleration of the rigid bodies' center of mass frame relative to the world.
         """
@@ -287,18 +293,19 @@ class RigidObjectData:
 
     @property
     def body_com_pose_b(self) -> torch.Tensor:
-        """Body center of mass pose in simulation body frame. Shape is (num_instances, 7).
+        """Body center of mass pose ``[pos, quat]`` in simulation body frame. Shape is (num_instances, 1,7).
 
-        This quantity is the pose of the actor frame of the root rigid body relative to the body frame.
+        This quantity is the pose of the center of mass frame of the rigid body relative to the body frame.
+        The orientation is provided in (w, x, y, z) format.
         """
-        if self._root_com_pose_b.timestamp < self._sim_timestamp:
+        if self._body_com_pose_b.timestamp < self._sim_timestamp:
             # read data from simulation
             pose = self._root_physx_view.get_coms().to(self.device)
             pose[:, 3:7] = math_utils.convert_quat(pose[:, 3:7], to="wxyz")
             # set the buffer data and timestamp
-            self._root_com_pose_b.data = pose
-            self._root_com_pose_b.timestamp = self._sim_timestamp
-        return self._root_com_pose_b.data
+            self._body_com_pose_b.data = pose.view(-1, 1, 7)
+            self._body_com_pose_b.timestamp = self._sim_timestamp
+        return self._body_com_pose_b.data
 
     ##
     # Derived Properties.
@@ -466,7 +473,7 @@ class RigidObjectData:
 
     @property
     def body_com_quat_w(self) -> torch.Tensor:
-        """Orientation (w, x, y, z) of the prinicple axies of inertia of all bodies in simulation world frame.
+        """Orientation (w, x, y, z) of the principle axis of inertia of all bodies in simulation world frame.
 
         Shape is (num_instances, 1, 4). This quantity is the orientation of the rigid bodies' actor frame.
         """
@@ -510,7 +517,7 @@ class RigidObjectData:
 
         This quantity is the center of mass location relative to its body frame.
         """
-        return self.body_com_pose_b[:, :3]
+        return self.body_com_pose_b[..., :3]
 
     @property
     def body_com_quat_b(self) -> torch.Tensor:
@@ -519,7 +526,7 @@ class RigidObjectData:
 
         This quantity is the orientation of the principles axes of inertia relative to its body frame.
         """
-        return self.body_com_pose_b[:, 3:7]
+        return self.body_com_pose_b[..., 3:7]
 
     ##
     # Properties for backwards compatibility.
@@ -623,3 +630,13 @@ class RigidObjectData:
     def body_ang_acc_w(self) -> torch.Tensor:
         """Same as :attr:`body_com_ang_acc_w`."""
         return self.body_com_ang_acc_w
+
+    @property
+    def com_pos_b(self) -> torch.Tensor:
+        """Same as :attr:`body_com_pos_b`."""
+        return self.body_com_pos_b
+
+    @property
+    def com_quat_b(self) -> torch.Tensor:
+        """Same as :attr:`body_com_quat_b`."""
+        return self.body_com_quat_b

--- a/source/isaaclab/test/assets/test_rigid_object.py
+++ b/source/isaaclab/test/assets/test_rigid_object.py
@@ -847,7 +847,7 @@ class TestRigidObject(unittest.TestCase):
                                 else:
                                     # cubes are spinning around center of mass
                                     # position will not match
-                                    # center of mass position will be constant (i.e. spining around com)
+                                    # center of mass position will be constant (i.e. spinning around com)
                                     torch.testing.assert_close(env_pos + offset, root_com_state_w[..., :3])
                                     torch.testing.assert_close(env_pos + offset, body_com_state_w[..., :3].squeeze(-2))
                                     # link position will be moving but should stay constant away from center of mass
@@ -863,7 +863,7 @@ class TestRigidObject(unittest.TestCase):
                                     torch.testing.assert_close(-offset, body_link_state_pos_rel_com.squeeze(-2))
 
                                     # orientation of com will be a constant rotation from link orientation
-                                    com_quat_b = cube_object.data.com_quat_b
+                                    com_quat_b = cube_object.data.body_com_quat_b
                                     com_quat_w = quat_mul(body_link_state_w[..., 3:7], com_quat_b)
                                     torch.testing.assert_close(com_quat_w, body_com_state_w[..., 3:7])
                                     torch.testing.assert_close(com_quat_w.squeeze(-2), root_com_state_w[..., 3:7])
@@ -873,7 +873,7 @@ class TestRigidObject(unittest.TestCase):
                                     torch.testing.assert_close(body_state_w[..., 3:7], body_link_state_w[..., 3:7])
 
                                     # lin_vel will not match
-                                    # center of mass vel will be constant (i.e. spining around com)
+                                    # center of mass vel will be constant (i.e. spinning around com)
                                     torch.testing.assert_close(
                                         torch.zeros_like(root_com_state_w[..., 7:10]), root_com_state_w[..., 7:10]
                                     )


### PR DESCRIPTION
# Description

Previously the root positions was obtained by performing the following steps:

1. Call PhysX getters to get transforms and velocities
2. Concatenating the two to make a single state tensor
3. Indexing this tensor to get the position

For applications where we only want the positions, the above is an expensive operation as we call CUDA-MemCpy twice and then do concatenation which adds overhead.

This MR simplifies the above process by having separate lazy buffers for poses, velocities and states.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there