### PR TITLE
Fixes missing stage recorder extension for animation recorder

### DIFF
--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -75,6 +75,7 @@ keywords = ["experience", "app", "usd"]
 "omni.kit.property.bundle" = {}
 "omni.kit.raycast.query" = {}
 "omni.kit.stage_template.core" = {}
+"omni.kit.stagerecorder.bundle" = {}
 "omni.kit.telemetry" = {}
 "omni.kit.tool.asset_importer" = {}
 "omni.kit.tool.collect" = {}


### PR DESCRIPTION
# Description

The default python base app file was missing the necessary extension dependencies to enable the animation recorder. "omni.kit.stagerecorder.bundle" is now added as a dependency, which should enable the recording functionality again.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
