### PR TITLE
Fixes TiledCameraCfg return_latest_camera_pose

### DIFF
--- a/source/isaaclab/isaaclab/sensors/camera/tiled_camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/tiled_camera.py
@@ -250,6 +250,10 @@ class TiledCamera(Camera):
         # Increment frame count
         self._frame[env_ids] += 1
 
+        # pose
+        if self.cfg.return_latest_camera_pose:
+            self._update_poses(env_ids)
+
         # Extract the flattened image buffer
         for data_type, annotator in self._annotators.items():
             # check whether returned data is a dict (used for segmentation)


### PR DESCRIPTION
This commit updates TiledCamera to respect the `return_latest_camera_pose` flag from `TiledCameraCfg`, ensuring consistency between configuration and camera behavior.

This fix helps avoid unexpected behavior when using `TiledCameraCfg(return_latest_camera_pose=True)` by making sure the underlying `TiledCamera` class actually uses this value.

# Description

This PR addresses a missing connection between the `return_latest_camera_pose` field in `TiledCameraCfg` and the actual `TiledCamera` implementation. Previously, setting this flag in the config had no effect.

Fixes: _no issue yet opened_

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
