### PR TITLE
Adds replicator event for randomizing colors

### DIFF
--- a/scripts/tutorials/03_envs/create_cube_base_env.py
+++ b/scripts/tutorials/03_envs/create_cube_base_env.py
@@ -192,7 +192,7 @@ class MySceneCfg(InteractiveSceneCfg):
     # lights
     light = AssetBaseCfg(
         prim_path="/World/light",
-        spawn=sim_utils.DistantLightCfg(color=(0.75, 0.75, 0.75), intensity=3000.0),
+        spawn=sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=2000.0),
     )
 
 
@@ -261,6 +261,20 @@ class EventCfg:
         },
     )
 
+    # This event term randomizes the visual color of the cube.
+    # Similar to the scale randomization, this is also a USD-level randomization and requires the flag
+    # 'replicate_physics' to be set to False.
+    randomize_color = EventTerm(
+        func=mdp.randomize_visual_color,
+        mode="prestartup",
+        params={
+            "colors": {"r": (0.0, 1.0), "g": (0.0, 1.0), "b": (0.0, 1.0)},
+            "asset_cfg": SceneEntityCfg("cube"),
+            "mesh_name": "geometry/mesh",
+            "event_name": "rep_cube_randomize_color",
+        },
+    )
+
 
 ##
 # Environment configuration
@@ -290,6 +304,9 @@ class CubeEnvCfg(ManagerBasedEnvCfg):
         self.sim.dt = 0.01
         self.sim.physics_material = self.scene.terrain.physics_material
         self.sim.render_interval = 2  # render interval should be a multiple of decimation
+        # viewer settings
+        self.viewer.eye = (5.0, 5.0, 5.0)
+        self.viewer.lookat = (0.0, 0.0, 2.0)
 
 
 def main():

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -1235,6 +1235,10 @@ class randomize_visual_color(ManagerTermBase):
     and a mesh named "body_0/mesh", the prim path for the mesh would be
     "/World/asset/body_0/mesh".
 
+    The colors can be specified as a list of tuples of the form ``(r, g, b)`` or as a dictionary
+    with the keys ``r``, ``g``, ``b`` and values as tuples of the form ``(low, high)``.
+    If a dictionary is used, the function will sample random colors from the given ranges.
+
     .. note::
         When randomizing the color of individual assets, please make sure to set
         :attr:`isaaclab.scene.InteractiveSceneCfg.replicate_physics` to False. This ensures that physics
@@ -1273,6 +1277,15 @@ class randomize_visual_color(ManagerTermBase):
         mesh_prim_path = f"{asset.cfg.prim_path}{mesh_name}"
         # TODO: Need to make it work for multiple meshes.
 
+        # parse the colors into replicator format
+        if isinstance(colors, dict):
+            # (r, g, b) - low, high --> (low_r, low_g, low_b) and (high_r, high_g, high_b)
+            color_low = [colors[key][0] for key in ["r", "g", "b"]]
+            color_high = [colors[key][1] for key in ["r", "g", "b"]]
+            colors = rep.distribution.uniform(color_low, color_high)
+        else:
+            colors = list(colors)
+
         # Create the omni-graph node for the randomization term
         def rep_texture_randomization():
             prims_group = rep.get.prims(path_pattern=mesh_prim_path)
@@ -1292,8 +1305,8 @@ class randomize_visual_color(ManagerTermBase):
         env_ids: torch.Tensor,
         event_name: str,
         asset_cfg: SceneEntityCfg,
-        colors: list[tuple[float, float, float]],
-        child_prim_path: str = "",
+        colors: list[tuple[float, float, float]] | dict[str, tuple[float, float]],
+        mesh_name: str = "",
     ):
         # import replicator
         import omni.replicator.core as rep


### PR DESCRIPTION
# Description

This MR adds a replicator event to randomize the color of meshes on an asset. Currently, this supports only a single mesh.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

```bash
python scripts/tutorials/03_envs/create_cube_base_env.py
```

![image](https://github.com/user-attachments/assets/b525b858-bb2d-4f52-a7a8-d65703b2553d)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there