### PR TITLE
Fixes env test failure for Isaac-Stack-Cube-Franka-IK-Rel-Blueprint-v0

### DIFF
--- a/source/isaaclab/isaaclab/managers/recorder_manager.py
+++ b/source/isaaclab/isaaclab/managers/recorder_manager.py
@@ -223,6 +223,8 @@ class RecorderManager(ManagerBase):
         Returns:
             The number of successful episodes.
         """
+        if not hasattr(self, "_exported_successful_episode_count"):
+            return 0
         if env_id is not None:
             return self._exported_successful_episode_count.get(env_id, 0)
         return sum(self._exported_successful_episode_count.values())
@@ -237,6 +239,8 @@ class RecorderManager(ManagerBase):
         Returns:
             The number of failed episodes.
         """
+        if not hasattr(self, "_exported_failed_episode_count"):
+            return 0
         if env_id is not None:
             return self._exported_failed_episode_count.get(env_id, 0)
         return sum(self._exported_failed_episode_count.values())

--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.10.26"
+version = "0.10.27"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.10.27 (2025-03-25)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed environment test failure for ``Isaac-Stack-Cube-Franka-IK-Rel-Blueprint-v0``.
+
+
 0.10.26 (2025-03-18)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_blueprint_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_blueprint_env_cfg.py
@@ -84,7 +84,13 @@ def image(
         if images.dtype == torch.uint8:
             images = images.float() / 255.0
         # Get total successful episodes
-        total_successes = sum(env.recorder_manager._exported_successful_episode_count.values())
+        total_successes = 0
+        if (
+            hasattr(env, "recorder_manager")
+            and env.recorder_manager is not None
+            and hasattr(env.recorder_manager, "_exported_successful_episode_count")
+        ):
+            total_successes = sum(env.recorder_manager._exported_successful_episode_count.values())
 
         for tile in range(images.shape[0]):
             tile_chw = torch.swapaxes(images[tile : tile + 1].unsqueeze(1), 1, -1).squeeze(-1)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_blueprint_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_blueprint_env_cfg.py
@@ -85,12 +85,8 @@ def image(
             images = images.float() / 255.0
         # Get total successful episodes
         total_successes = 0
-        if (
-            hasattr(env, "recorder_manager")
-            and env.recorder_manager is not None
-            and hasattr(env.recorder_manager, "_exported_successful_episode_count")
-        ):
-            total_successes = sum(env.recorder_manager._exported_successful_episode_count.values())
+        if hasattr(env, "recorder_manager") and env.recorder_manager is not None:
+            total_successes = env.recorder_manager.exported_successful_episode_count
 
         for tile in range(images.shape[0]):
             tile_chw = torch.swapaxes(images[tile : tile + 1].unsqueeze(1), 1, -1).squeeze(-1)


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

Fixes the environment test failure for Isaac-Stack-Cube-Franka-IK-Rel-Blueprint-v0. The env uses a custom image observation term which tries to access an element in the recorder manager. During env creation, the observation manager is initialized before the recorder manager, thus causing an error in the observation term. The custom image obs term has been updated to only try to access the element in the recorder manager if it exists.

Fixes # (issue)

Environment test failure of Isaac-Stack-Cube-Franka-IK-Rel-Blueprint-v0

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
