### PR TITLE
Changes default ground color back to dark grey

### DIFF
--- a/source/isaaclab/isaaclab/terrains/terrain_importer_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_importer_cfg.py
@@ -68,9 +68,7 @@ class TerrainImporterCfg:
       This parameter is used only when the ``terrain_type`` is "plane" or "usd".
     """
 
-    visual_material: sim_utils.VisualMaterialCfg | None = sim_utils.PreviewSurfaceCfg(
-        diffuse_color=(0.0, 0.0, 0.0)
-    )
+    visual_material: sim_utils.VisualMaterialCfg | None = sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 0.0))
     """The visual material of the terrain. Defaults to a dark gray color material.
 
     This parameter is used for both the "generator" and "plane" terrains.

--- a/source/isaaclab/isaaclab/terrains/terrain_importer_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_importer_cfg.py
@@ -69,7 +69,7 @@ class TerrainImporterCfg:
     """
 
     visual_material: sim_utils.VisualMaterialCfg | None = sim_utils.PreviewSurfaceCfg(
-        diffuse_color=(0.065, 0.0725, 0.080)
+        diffuse_color=(0.0, 0.0, 0.0)
     )
     """The visual material of the terrain. Defaults to a dark gray color material.
 

--- a/source/isaaclab_rl/isaaclab_rl/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/__init__.py
@@ -17,7 +17,3 @@ the initialized environment instance to the wrapper constructor. However, since 
 expect different input and output data structures, their wrapper classes are not compatible with each other.
 Thus, they should always be used in conjunction with the respective learning framework.
 """
-
-from . import rl_games, rsl_rl, sb3, skrl
-
-__all__ = ["sb3", "skrl", "rsl_rl", "rl_games"]


### PR DESCRIPTION
# Description

This MR fixes the ground color to the original dark grey instead of a grey-ish blue shade. The change was introduced in #1791 and was unintentional.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/655fd5b2-5b64-4e9f-adb1-c2b706b0aa13) | ![image](https://github.com/user-attachments/assets/10ba218e-eff8-441b-9d5f-1705c90d7345) |

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there