### PR TITLE
Initializes extras dict before loading managers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,6 +67,7 @@ Guidelines for modifications:
 * Johnson Sun
 * Kaixi Bao
 * Kourosh Darvish
+* Kousheek Chakraborty
 * Lionel Gulich
 * Louis Le Lay
 * Lorenz Wellhausen

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -122,6 +122,9 @@ class ManagerBasedEnv:
         # counter for simulation steps
         self._sim_step_counter = 0
 
+        # allocate dictionary to store metrics
+        self.extras = {}
+
         # generate scene
         with Timer("[INFO]: Time taken for scene creation", "scene_creation"):
             self.scene = InteractiveScene(self.cfg.scene)
@@ -169,9 +172,6 @@ class ManagerBasedEnv:
         else:
             # if no window, then we don't need to store the window
             self._window = None
-
-        # allocate dictionary to store metrics
-        self.extras = {}
 
         # initialize observation buffers
         self.obs_buf = {}


### PR DESCRIPTION
# Description

Unable to add new entries to self.extras dictionary in ManagerBasedEnv because the dictionary was initialised after loading the managers.

Fixes #2177 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
