### PR TITLE
Fixes typo `RF_FOOT` to `RH_FOOT` in tutorials

### DIFF
--- a/docs/source/tutorials/04_sensors/add_sensors_on_robot.rst
+++ b/docs/source/tutorials/04_sensors/add_sensors_on_robot.rst
@@ -126,7 +126,7 @@ obtain the contact information. Additional flags can be set to obtain more infor
 the contact, such as the contact air time, contact forces between filtered prims, etc.
 
 In this tutorial, we attach the contact sensor to the feet of the robot. The feet of the robot are
-named ``"LF_FOOT"``, ``"RF_FOOT"``, ``"LH_FOOT"``, and ``"RF_FOOT"``. We pass a Regex expression
+named ``"LF_FOOT"``, ``"RF_FOOT"``, ``"LH_FOOT"``, and ``"RH_FOOT"``. We pass a Regex expression
 ``".*_FOOT"`` to simplify the prim path specification. This Regex expression matches all prims that
 end with ``"_FOOT"``.
 


### PR DESCRIPTION
# Description

Fixes #2169

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there