### PR TITLE
Add option to select prim when loading USD file

### DIFF
--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,5 +1,16 @@
-Changelog
+
 ---------
+
+
+0.36.5 (2025-04-02)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added new option :attr:`prim_path` to the :class:`~isaaclab.sim.spawners.from_files.from_files_cfg.UsdFileCfg`
+  class to allow loading a different prim than the default prim in the USD.
+
 
 0.36.4 (2025-03-24)
 ~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/isaaclab/assets/asset_base_cfg.py
+++ b/source/isaaclab/isaaclab/assets/asset_base_cfg.py
@@ -47,7 +47,7 @@ class AssetBaseCfg:
     """
 
     prim_path: str = MISSING
-    """Prim path (or expression) to the asset.
+    """Prim path (or expression) at which the asset will be spawned in the scene.
 
     .. note::
         The expression can contain the environment namespace regex ``{ENV_REGEX_NS}`` which

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
@@ -98,6 +98,12 @@ class UsdFileCfg(FileCfg):
     usd_path: str = MISSING
     """Path to the USD file to spawn asset from."""
 
+    prim_path: str | None = None
+    """Path to the prim in the USD file that will be spawned.
+
+    Defaults to None, in which case the default prim from the USD file will be used.
+    """
+
     variants: object | dict[str, str] | None = None
     """Variants to select from in the input USD file. Defaults to None, in which case no variants are applied.
 

--- a/source/isaaclab/test/sim/test_spawn_from_files.py
+++ b/source/isaaclab/test/sim/test_spawn_from_files.py
@@ -49,9 +49,8 @@ class TestSpawningFromFiles(unittest.TestCase):
     Basic spawning.
     """
 
-    def test_spawn_usd(self):
+    def test_spawn_usd_default_prim_path(self):
         """Test loading prim from Usd file."""
-        # Spawn cone
         cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd")
         prim = cfg.func("/World/Franka", cfg)
         # Check validity
@@ -59,12 +58,32 @@ class TestSpawningFromFiles(unittest.TestCase):
         self.assertTrue(prim_utils.is_prim_path_valid("/World/Franka"))
         self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
 
-    def test_spawn_usd_fails(self):
+    def test_spawn_usd_specific_prim_path(self):
+        """Test loading prim from Usd file with a specific prim path."""
+        cfg = sim_utils.UsdFileCfg(
+            usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd",
+            prim_path="/panda",
+        )
+        prim = cfg.func("/World/Franka", cfg)
+        # Check validity
+        self.assertTrue(prim.IsValid())
+        self.assertTrue(prim_utils.is_prim_path_valid("/World/Franka"))
+        self.assertEqual(prim.GetPrimTypeInfo().GetTypeName(), "Xform")
+
+    def test_spawn_usd_fails_invalid_usd_path(self):
         """Test loading prim from Usd file fails when asset usd path is invalid."""
-        # Spawn cone
         cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda2_instanceable.usd")
 
         with self.assertRaises(FileNotFoundError):
+            cfg.func("/World/Franka", cfg)
+
+    def test_spawn_usd_fails_invalid_prim_path(self):
+        cfg = sim_utils.UsdFileCfg(
+            usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd",
+            prim_path="/non_existing_prim_path",
+        )
+
+        with self.assertRaises(ValueError):
             cfg.func("/World/Franka", cfg)
 
     def test_spawn_urdf(self):


### PR DESCRIPTION
# Description

Normally a `UsdFileCfg` always loads the default prim. This PR allows to specify explicitly which prim should be loaded. This is useful when only a subprim of the default prim is needed (or a different prim).

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
