### PR TITLE
Unsubscribes from debug vis handle when timeline is stopped

### DIFF
--- a/source/isaaclab/isaaclab/assets/asset_base.py
+++ b/source/isaaclab/isaaclab/assets/asset_base.py
@@ -269,3 +269,5 @@ class AssetBase(ABC):
     def _invalidate_initialize_callback(self, event):
         """Invalidates the scene elements."""
         self._is_initialized = False
+        if self._debug_vis_handle is not None:
+            self._debug_vis_handle.unsubscribe()

--- a/source/isaaclab/isaaclab/assets/asset_base.py
+++ b/source/isaaclab/isaaclab/assets/asset_base.py
@@ -271,3 +271,4 @@ class AssetBase(ABC):
         self._is_initialized = False
         if self._debug_vis_handle is not None:
             self._debug_vis_handle.unsubscribe()
+            self._debug_vis_handle = None

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -276,6 +276,8 @@ class SensorBase(ABC):
     def _invalidate_initialize_callback(self, event):
         """Invalidates the scene elements."""
         self._is_initialized = False
+        if self._debug_vis_handle is not None:
+            self._debug_vis_handle.unsubscribe()
 
     """
     Helper functions.

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -278,6 +278,7 @@ class SensorBase(ABC):
         self._is_initialized = False
         if self._debug_vis_handle is not None:
             self._debug_vis_handle.unsubscribe()
+            self._debug_vis_handle = None
 
     """
     Helper functions.


### PR DESCRIPTION
# Description
This PR fixes a bug where old callbacks for sensors were being called after the scene had been cleared, resulting in exceptions and a crash of extensions built off of Isaac Lab.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
