### PR TITLE
Move curriculum manager call to after scene reset

### DIFF
--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -350,10 +350,10 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         Args:
             env_ids: List of environment ids which must be reset
         """
-        # update the curriculum for environments that need a reset
-        self.curriculum_manager.compute(env_ids=env_ids)
         # reset the internal buffers of the scene elements
         self.scene.reset(env_ids)
+        # update the curriculum for environments that need a reset
+        self.curriculum_manager.compute(env_ids=env_ids)
         # apply events such as randomizations for environments that need a reset
         if "reset" in self.event_manager.available_modes:
             env_step_count = self._sim_step_counter // self.cfg.decimation


### PR DESCRIPTION
# Description
Moves the curriculum manager compute method to come after scene.reset() has been called to allow curriculum managers to set information related to external wrenches on an articulation. Previously, any attempt to set the external wrench buffers will be cleared after calling scene.reset() which calls the articulation reset.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
## Screenshots

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
