### PR TITLE
Skips dependency installation for directories with no extension.toml

### DIFF
--- a/tools/install_deps.py
+++ b/tools/install_deps.py
@@ -52,17 +52,17 @@ def install_apt_packages(paths: list[str]):
         paths: A list of paths to the extension's root.
 
     Raises:
-        FileNotFoundError: If the extension.toml file is not found.
         SystemError: If 'apt' is not a known command. This is a system error.
     """
     for path in paths:
         if shutil.which("apt"):
             # Check if the extension.toml file exists
             if not os.path.exists(f"{path}/config/extension.toml"):
-                raise FileNotFoundError(
-                    "During the installation of 'apt' dependencies, unable to find a"
+                print(
+                    "[WARN] During the installation of 'apt' dependencies, unable to find a"
                     f" valid file at: {path}/config/extension.toml."
                 )
+                continue
             # Load the extension.toml file and check for apt_deps
             with open(f"{path}/config/extension.toml") as fd:
                 ext_toml = toml.load(fd)
@@ -94,7 +94,6 @@ def install_rosdep_packages(paths: list[str], ros_distro: str = "humble"):
         ros_distro: The ROS distribution to use for rosdep. Default is 'humble'.
 
     Raises:
-        FileNotFoundError: If the extension.toml file is not found under the path.
         FileNotFoundError: If a valid ROS workspace is not found while installing ROS dependencies.
         SystemError: If 'rosdep' is not a known command. This is raised if 'rosdep' is not installed on the system.
     """
@@ -102,10 +101,11 @@ def install_rosdep_packages(paths: list[str], ros_distro: str = "humble"):
         if shutil.which("rosdep"):
             # Check if the extension.toml file exists
             if not os.path.exists(f"{path}/config/extension.toml"):
-                raise FileNotFoundError(
-                    "During the installation of 'rosdep' dependencies, unable to find a"
+                print(
+                    "[WARN] During the installation of 'rosdep' dependencies, unable to find a"
                     f" valid file at: {path}/config/extension.toml."
                 )
+                continue
             # Load the extension.toml file and check for ros_ws
             with open(f"{path}/config/extension.toml") as fd:
                 ext_toml = toml.load(fd)


### PR DESCRIPTION
## Description

Previously empty or non-extension directories in the `source` folder caused installation to crash, forcing users to delete the empty directory. This MR replaces raising the error with a warning print.

## Type of change

- Bug fix
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there