### PR TITLE
Checks if success term exists before recording in RecorderManager

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.36.3"
+version = "0.36.5"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.36.5 (2025-04-01)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Adds check in RecorderManager to ensure that the success indicator is only set if the termination manager is present.
+
+
 0.36.4 (2025-03-24)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/managers/recorder_manager.py
+++ b/source/isaaclab/isaaclab/managers/recorder_manager.py
@@ -385,8 +385,9 @@ class RecorderManager(ManagerBase):
         # Set task success values for the relevant episodes
         success_results = torch.zeros(len(env_ids), dtype=bool, device=self._env.device)
         # Check success indicator from termination terms
-        if "success" in self._env.termination_manager.active_terms:
-            success_results |= self._env.termination_manager.get_term("success")[env_ids]
+        if hasattr(self._env, "termination_manager"):
+            if "success" in self._env.termination_manager.active_terms:
+                success_results |= self._env.termination_manager.get_term("success")[env_ids]
         self.set_success_to_episodes(env_ids, success_results)
 
         if force_export_or_skip or (force_export_or_skip is None and self.cfg.export_in_record_pre_reset):


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

Adds a check in RecorderManager to only record success results if success termination term exists.

Fixes #2190 

Fixes recorder crash if added to ManagerBasedEnv.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
