### PR TITLE
Fixes resume flag in rsl-rl cli args

### DIFF
--- a/scripts/reinforcement_learning/rsl_rl/cli_args.py
+++ b/scripts/reinforcement_learning/rsl_rl/cli_args.py
@@ -27,9 +27,7 @@ def add_rsl_rl_args(parser: argparse.ArgumentParser):
     )
     arg_group.add_argument("--run_name", type=str, default=None, help="Run name suffix to the log directory.")
     # -- load arguments
-    arg_group.add_argument(
-        "--resume", action="store_true", default=False, help="Whether to resume from a checkpoint."
-    )
+    arg_group.add_argument("--resume", action="store_true", default=False, help="Whether to resume from a checkpoint.")
     arg_group.add_argument("--load_run", type=str, default=None, help="Name of the run folder to resume from.")
     arg_group.add_argument("--checkpoint", type=str, default=None, help="Checkpoint file to resume from.")
     # -- logger arguments

--- a/scripts/reinforcement_learning/rsl_rl/cli_args.py
+++ b/scripts/reinforcement_learning/rsl_rl/cli_args.py
@@ -27,7 +27,9 @@ def add_rsl_rl_args(parser: argparse.ArgumentParser):
     )
     arg_group.add_argument("--run_name", type=str, default=None, help="Run name suffix to the log directory.")
     # -- load arguments
-    arg_group.add_argument("--resume", type=bool, default=None, help="Whether to resume from a checkpoint.")
+    arg_group.add_argument(
+        "--resume", action="store_true", default=False, help="Whether to resume from a checkpoint."
+    )
     arg_group.add_argument("--load_run", type=str, default=None, help="Name of the run folder to resume from.")
     arg_group.add_argument("--checkpoint", type=str, default=None, help="Checkpoint file to resume from.")
     # -- logger arguments


### PR DESCRIPTION
# Description

Previously, the default value was None which did not allow loading the model even if `--resume` was provided.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there