### PR TITLE
Fixes `quat_box_minus` operation

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.36.23"
+version = "0.36.24"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.36.24 (2025-04-27)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the issue where the quaternion difference was not unique in :func:`~isaaclab.utils.math.quat_box_minus`.
+
+
 0.36.23 (2025-04-24)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 0.36.24 (2025-04-27)
 ~~~~~~~~~~~~~~~~~~~~
 
+Added
+^^^^^
+
+* Added :func:`~isaaclab.utils.math.quat_box_plus`.
+
 Fixed
 ^^^^^
 

--- a/source/isaaclab/isaaclab/utils/math.py
+++ b/source/isaaclab/isaaclab/utils/math.py
@@ -511,6 +511,7 @@ def quat_box_minus(q1: torch.Tensor, q2: torch.Tensor) -> torch.Tensor:
         The difference between the two quaternions. Shape is (N, 3).
     """
     quat_diff = quat_mul(q1, quat_conjugate(q2))  # q1 * q2^-1
+    quat_diff = quat_unique(quat_diff)
     re = quat_diff[:, 0]  # real part, q = [w, x, y, z] = [re, im]
     im = quat_diff[:, 1:]  # imaginary part
     norm_im = torch.norm(im, dim=1)

--- a/source/isaaclab/test/utils/test_math.py
+++ b/source/isaaclab/test/utils/test_math.py
@@ -598,6 +598,26 @@ class TestMathUtilities(unittest.TestCase):
             np.testing.assert_array_almost_equal(result_quat, expected_quat, decimal=DECIMAL_PRECISION)
             np.testing.assert_array_almost_equal(result_pos, expected_pos, decimal=DECIMAL_PRECISION)
 
+    def test_quat_box_minus_non_unique(self):
+        """Test quat_box_minus method with non-unique quaternions.
+
+        This test specifically checks the case where the quaternion from quat_mul(q1, quat_conjugate(q2))
+        is not unique (has negative real part).
+        """
+        # Create quaternions that will result in a non-unique quaternion after multiplication
+        q1 = torch.tensor([[0.5, 0.5, 0.5, 0.5]], dtype=torch.float32)
+        q2 = torch.tensor([[-0.5, -0.5, -0.5, -0.5]], dtype=torch.float32)
+
+        # Compute quat_box_minus
+        result = math_utils.quat_box_minus(q1, q2)
+
+        # The quaternion difference should be unique (positive real part)
+        # and should represent the same rotation as the non-unique quaternion
+        expected = torch.tensor([[0.0, 0.0, 0.0]], dtype=torch.float32)
+
+        # Check that the result is close to the expected value
+        torch.testing.assert_close(result, expected, atol=1e-5)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
# Description

Fixes `quat_box_minus` operation for non-unique quaternions. 

credit to @adrialopezescoriza

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
