### PR TITLE
Apply semantic_tags to ground

### DIFF
--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -11,7 +11,7 @@ import isaacsim.core.utils.prims as prim_utils
 import isaacsim.core.utils.stage as stage_utils
 import omni.kit.commands
 import omni.log
-from pxr import Gf, Sdf, Usd
+from pxr import Gf, Sdf, Usd, Semantics
 
 from isaaclab.sim import converters, schemas
 from isaaclab.sim.utils import bind_physics_material, bind_visual_material, clone, select_usd_variants
@@ -173,8 +173,22 @@ def spawn_ground_plane(
     # It isn't bright enough and messes up with the user's lighting settings
     omni.kit.commands.execute("ToggleVisibilitySelectedPrims", selected_paths=[f"{prim_path}/SphereLight"])
 
+    prim = prim_utils.get_prim_at_path(prim_path)
+    # Apply semantic tags
+    if hasattr(cfg, "semantic_tags") and cfg.semantic_tags is not None:
+        # note: taken from replicator scripts.utils.utils.py
+        for semantic_type, semantic_value in cfg.semantic_tags:
+            # deal with spaces by replacing them with underscores
+            semantic_type_sanitized = semantic_type.replace(" ", "_")
+            semantic_value_sanitized = semantic_value.replace(" ", "_")
+            # set the semantic API for the instance
+            instance_name = f"{semantic_type_sanitized}_{semantic_value_sanitized}"
+            sem = Semantics.SemanticsAPI.Apply(prim, instance_name)
+            # create semantic type and data attributes
+            sem.CreateSemanticTypeAttr().Set(semantic_type)
+            sem.CreateSemanticDataAttr().Set(semantic_value)
     # return the prim
-    return prim_utils.get_prim_at_path(prim_path)
+    return prim
 
 
 """


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

The check [here](https://github.com/isaac-sim/IsaacLab/blob/2e6946afb9b26f6949d4b1fd0a00e9f4ef733fcc/source/isaaclab/isaaclab/sim/utils.py#L260): the [RigidBodyMaterialCfg](https://github.com/isaac-sim/IsaacLab/blob/2e6946afb9b26f6949d4b1fd0a00e9f4ef733fcc/source/isaaclab/isaaclab/sim/spawners/materials/physics_materials_cfg.py#L30) used by [GroundPlaneCfg](https://github.com/isaac-sim/IsaacLab/blob/2e6946afb9b26f6949d4b1fd0a00e9f4ef733fcc/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py#L158) lacks a semantic_tags attribute. So the semantic_tags will not set to the ground correctly, then the semantic_segmentation_mapping can not been correctly mapped.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.
Ground didn't been mapping correctly.
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/904c8223-4100-45d9-b0ea-ab54833269e3) | ![Screenshot 2025-04-29 at 17 57 24](https://github.com/user-attachments/assets/4ef18c5f-8587-4ed0-9890-c7dfaae30675)|
<!--
To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
