### PR TITLE
Uses --gpus instead of nvidia runtime for docker

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -106,6 +106,7 @@ Guidelines for modifications:
 * Wei Yang
 * Xavier Nal
 * Yang Jin
+* Yanzi Zhu
 * Yujian Zhang
 * Zhengyu Zhang
 * Ziqi Fan

--- a/docker/docker-compose.cloudxr-runtime.patch.yaml
+++ b/docker/docker-compose.cloudxr-runtime.patch.yaml
@@ -1,7 +1,6 @@
 services:
   cloudxr-runtime:
     image: ${CLOUDXR_RUNTIME_BASE_IMAGE_ARG}:${CLOUDXR_RUNTIME_VERSION_ARG}
-    runtime: nvidia
     ports:
       - "48010:48010/tcp" # signaling
       - "47998:47998/udp" # media
@@ -20,9 +19,15 @@ services:
       - ACCEPT_EULA=${ACCEPT_EULA}
     volumes:
       - openxr-volume:/openxr:rw
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [ gpu ]
 
   isaac-lab-base:
-    runtime: nvidia
     environment:
       - XDG_RUNTIME_DIR=/openxr/run
       - XR_RUNTIME_JSON=/openxr/share/openxr/1/openxr_cloudxr.json
@@ -30,6 +35,13 @@ services:
       - openxr-volume:/openxr:rw
     depends_on:
         - cloudxr-runtime
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [ gpu ]
 
 volumes:
   openxr-volume:

--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -185,7 +185,7 @@ There are two options to run the CloudXR Runtime Docker container:
 
          docker run -it --rm --name cloudxr-runtime \
              --user $(id -u):$(id -g) \
-             --runtime=nvidia \
+             --gpus=all \
              -e "ACCEPT_EULA=Y" \
              --mount type=bind,src=$(pwd)/openxr,dst=/openxr \
              -p 48010:48010 \
@@ -196,6 +196,10 @@ There are two options to run the CloudXR Runtime Docker container:
              -p 48008:48008/udp \
              -p 48012:48012/udp \
              nvcr.io/nvidia/cloudxr-runtime:0.1.0-isaac
+
+      .. note::
+         If you choose a particular GPU instead of `all`, you need to make sure Isaac Lab also runs
+         on that GPU.
 
    #. In a new terminal where you intend to run Isaac Lab, export the following environment
       variables, which reference the directory created above:

--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -198,7 +198,7 @@ There are two options to run the CloudXR Runtime Docker container:
              nvcr.io/nvidia/cloudxr-runtime:0.1.0-isaac
 
       .. note::
-         If you choose a particular GPU instead of `all`, you need to make sure Isaac Lab also runs
+         If you choose a particular GPU instead of ``all``, you need to make sure Isaac Lab also runs
          on that GPU.
 
    #. In a new terminal where you intend to run Isaac Lab, export the following environment


### PR DESCRIPTION
# Description

Use `--gpus all` instead of `nvidia: runtime` to prevent issues on unknown or invalid runtime name when running with docker or docker compose (python script).

Fixes #2390 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Screenshots

N/A

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
