### PR TITLE
Fixes a minor typo in rsl_rl `rl_cfg` docstrings

### DIFF
--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
@@ -110,8 +110,8 @@ class RslRlPpoAlgorithmCfg:
     normalize_advantage_per_mini_batch: bool = False
     """Whether to normalize the advantage per mini-batch. Default is False.
 
-    If True, the advantage is normalized over the entire collected trajectories.
-    Otherwise, the advantage is normalized over the mini-batches only.
+    If True, the advantage is normalized over the mini-batches only.
+    Otherwise, the advantage is normalized over the entire collected trajectories.
     """
 
     symmetry_cfg: RslRlSymmetryCfg | None = None


### PR DESCRIPTION
# Description

Fixes a minor typo in rsl_rl `rl_cfg` docstrings.

**Before**
```
normalize_advantage_per_mini_batch: bool = False
"""Whether to normalize the advantage per mini-batch. Default is False.

If True, the advantage is normalized over the entire collected trajectories.
Otherwise, the advantage is normalized over the mini-batches only.
"""
```
**After**
```
normalize_advantage_per_mini_batch: bool = False
"""Whether to normalize the advantage per mini-batch. Default is False.

If True, the advantage is normalized over the mini-batches only.
Otherwise, the advantage is normalized over the entire collected trajectories.
"""
```


## Type of change

- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
