### PR TITLE
Invalidates state buffers correctly for RigidObject and RigidObjectCollection

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.39.6"
+version = "0.39.7"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,29 @@
 Changelog
 ---------
 
+
+0.39.7 (2025-05-21)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed issue where timestamp is not invalidated after direct write to state in methods
+  :meth:`~isaaclab.assets.rigid_object.RigidObject.write_root_pose_to_sim` and
+  :meth:`~isaaclab.assets.rigid_object.RigidObject.write_root_link_pose_to_sim` and
+  :meth:`~isaaclab.assets.rigid_object.RigidObject.write_root_velocity_to_sim` and
+  :meth:`~isaaclab.assets.rigid_object.RigidObject.write_root_com_velocity_to_sim`
+
+
+* Fixed issue where timestamp is not invalidated after direct write to state in methods
+  :meth:`~isaaclab.assets.rigid_object.RigidObjectCollection.write_object_pose_to_sim` and
+  :meth:`~isaaclab.assets.rigid_object.RigidObjectCollection.write_object_link_pose_to_sim` and
+  :meth:`~isaaclab.assets.rigid_object.RigidObjectCollection.write_object_velocity_to_sim` and
+  :meth:`~isaaclab.assets.rigid_object.RigidObjectCollection.write_object_com_velocity_to_sim`
+
+* Added unit tests to ensure the data consistency whenever one of those methods are invoked
+
+
 0.39.6 (2025-01-30)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/rigid_object.py
@@ -210,6 +210,9 @@ class RigidObject(AssetBase):
         # convert root quaternion from wxyz to xyzw
         root_poses_xyzw = self._data.root_state_w[:, :7].clone()
         root_poses_xyzw[:, 3:] = math_utils.convert_quat(root_poses_xyzw[:, 3:], to="xyzw")
+        # Need to invalidate the buffer to trigger the update with the new root pose.
+        self._data._root_link_state_w.timestamp = -1.0
+        self._data._root_com_state_w.timestamp = -1.0
         # set into simulation
         self.root_physx_view.set_transforms(root_poses_xyzw, indices=physx_env_ids)
 
@@ -234,6 +237,9 @@ class RigidObject(AssetBase):
         # convert root quaternion from wxyz to xyzw
         root_poses_xyzw = self._data.root_link_state_w[:, :7].clone()
         root_poses_xyzw[:, 3:] = math_utils.convert_quat(root_poses_xyzw[:, 3:], to="xyzw")
+        # Need to invalidate the buffer to trigger the update with the new root pose.
+        self._data._root_state_w.timestamp = -1.0
+        self._data._root_com_state_w.timestamp = -1.0
         # set into simulation
         self.root_physx_view.set_transforms(root_poses_xyzw, indices=physx_env_ids)
 
@@ -285,6 +291,9 @@ class RigidObject(AssetBase):
         # set into internal buffers
         self._data.root_state_w[env_ids, 7:] = root_velocity.clone()
         self._data.body_acc_w[env_ids] = 0.0
+        # Need to invalidate the buffer to trigger the update with the new com and link velocity.
+        self._data._root_com_state_w.timestamp = -1.0
+        self._data._root_link_state_w.timestamp = -1.0
         # set into simulation
         self.root_physx_view.set_velocities(self._data.root_state_w[:, 7:], indices=physx_env_ids)
 
@@ -309,6 +318,8 @@ class RigidObject(AssetBase):
         self._data.root_com_state_w[env_ids, 7:] = root_velocity.clone()
         self._data.root_state_w[env_ids, 7:] = self._data.root_com_state_w[env_ids, 7:]
         self._data.body_acc_w[env_ids] = 0.0
+        # Need to invalidate the buffer to trigger the update with the new link velocity.
+        self._data._root_link_state_w.timestamp = -1.0
         # set into simulation
         self.root_physx_view.set_velocities(self._data.root_com_state_w[:, 7:], indices=physx_env_ids)
 

--- a/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection.py
@@ -297,6 +297,11 @@ class RigidObjectCollection(AssetBase):
         # convert the quaternion from wxyz to xyzw
         poses_xyzw = self._data.object_state_w[..., :7].clone()
         poses_xyzw[..., 3:] = math_utils.convert_quat(poses_xyzw[..., 3:], to="xyzw")
+
+        # Need to invalidate the buffer to trigger the update with the new com pose.
+        self._data._object_com_state_w.timestamp = -1.0
+        self._data._object_link_state_w.timestamp = -1.0
+
         # set into simulation
         view_ids = self._env_obj_ids_to_view_ids(env_ids, object_ids)
         self.root_physx_view.set_transforms(self.reshape_data_to_view(poses_xyzw), indices=view_ids)
@@ -331,6 +336,10 @@ class RigidObjectCollection(AssetBase):
         # convert the quaternion from wxyz to xyzw
         poses_xyzw = self._data.object_link_state_w[..., :7].clone()
         poses_xyzw[..., 3:] = math_utils.convert_quat(poses_xyzw[..., 3:], to="xyzw")
+
+        # Need to invalidate the buffer to trigger the update with the new com pose.
+        self._data._object_com_state_w.timestamp = -1.0
+
         # set into simulation
         view_ids = self._env_obj_ids_to_view_ids(env_ids, object_ids)
         self.root_physx_view.set_transforms(self.reshape_data_to_view(poses_xyzw), indices=view_ids)
@@ -397,6 +406,10 @@ class RigidObjectCollection(AssetBase):
         self._data.object_state_w[env_ids[:, None], object_ids, 7:] = object_velocity.clone()
         self._data.object_acc_w[env_ids[:, None], object_ids] = 0.0
 
+        # Need to invalidate the buffer to trigger the update with the new link and com velocities
+        self._data._object_link_state_w.timestamp = -1.0
+        self._data._object_com_state_w.timestamp = -1.0
+
         # set into simulation
         view_ids = self._env_obj_ids_to_view_ids(env_ids, object_ids)
         self.root_physx_view.set_velocities(
@@ -427,6 +440,9 @@ class RigidObjectCollection(AssetBase):
         self._data.object_com_state_w[env_ids[:, None], object_ids, 7:] = object_velocity.clone()
         self._data.object_state_w[env_ids[:, None], object_ids, 7:] = object_velocity.clone()
         self._data.object_acc_w[env_ids[:, None], object_ids] = 0.0
+
+        # Need to invalidate the buffer to trigger the update with the new object link velocity.
+        self._data._object_link_state_w.timestamp = -1.0
 
         # set into simulation
         view_ids = self._env_obj_ids_to_view_ids(env_ids, object_ids)

--- a/source/isaaclab/test/assets/test_rigid_object.py
+++ b/source/isaaclab/test/assets/test_rigid_object.py
@@ -28,7 +28,16 @@ from isaaclab.assets import RigidObject, RigidObjectCfg
 from isaaclab.sim import build_simulation_context
 from isaaclab.sim.spawners import materials
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
-from isaaclab.utils.math import default_orientation, quat_mul, quat_rotate_inverse, random_orientation
+from isaaclab.utils.math import (
+    combine_frame_transforms,
+    default_orientation,
+    quat_inv,
+    quat_mul,
+    quat_rotate,
+    quat_rotate_inverse,
+    random_orientation,
+    subtract_frame_transforms,
+)
 
 
 def generate_cubes_scene(
@@ -914,3 +923,114 @@ def test_write_root_state(num_cubes, device, with_offset, state_location):
                 torch.testing.assert_close(rand_state, cube_object.data.root_com_state_w)
             elif state_location == "link":
                 torch.testing.assert_close(rand_state, cube_object.data.root_link_state_w)
+
+
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("with_offset", [True])
+@pytest.mark.parametrize("state_location", ["com", "link", "root"])
+def test_write_state_functions_data_consistency(num_cubes, device, with_offset, state_location):
+    """Test the setters for root_state using both the link frame and center of mass as reference frame."""
+    with build_simulation_context(device=device, gravity_enabled=False, auto_add_lighting=True) as sim:
+        sim._app_control_on_stop_handle = None
+        # Create a scene with random cubes
+        cube_object, env_pos = generate_cubes_scene(num_cubes=num_cubes, height=0.0, device=device)
+        env_idx = torch.tensor([x for x in range(num_cubes)])
+
+        # Play sim
+        sim.reset()
+
+        # Check if cube_object is initialized
+        assert cube_object.is_initialized
+
+        # change center of mass offset from link frame
+        if with_offset:
+            offset = torch.tensor([0.1, 0.0, 0.0], device=device).repeat(num_cubes, 1)
+        else:
+            offset = torch.tensor([0.0, 0.0, 0.0], device=device).repeat(num_cubes, 1)
+
+        com = cube_object.root_physx_view.get_coms()
+        com[..., :3] = offset.to("cpu")
+        cube_object.root_physx_view.set_coms(com, env_idx)
+
+        # check ceter of mass has been set
+        torch.testing.assert_close(cube_object.root_physx_view.get_coms(), com)
+
+        rand_state = torch.rand_like(cube_object.data.root_state_w)
+        # rand_state[..., :7] = cube_object.data.default_root_state[..., :7]
+        rand_state[..., :3] += env_pos
+        # make quaternion a unit vector
+        rand_state[..., 3:7] = torch.nn.functional.normalize(rand_state[..., 3:7], dim=-1)
+
+        env_idx = env_idx.to(device)
+
+        # perform step
+        sim.step()
+        # update buffers
+        cube_object.update(sim.cfg.dt)
+
+        link_to_com_pos, link_to_com_quat = subtract_frame_transforms(
+            cube_object.data.root_link_state_w[:, :3],
+            cube_object.data.root_link_state_w[:, 3:7],
+            cube_object.data.root_com_state_w[:, :3],
+            cube_object.data.root_com_state_w[:, 3:7],
+        )
+
+        if state_location == "com":
+            cube_object.write_root_com_state_to_sim(rand_state)
+        elif state_location == "link":
+            cube_object.write_root_link_state_to_sim(rand_state)
+        elif state_location == "root":
+            cube_object.write_root_state_to_sim(rand_state)
+
+        if state_location == "com":
+            expected_root_link_pos, expected_root_link_quat = combine_frame_transforms(
+                cube_object.data.root_com_state_w[:, :3],
+                cube_object.data.root_com_state_w[:, 3:7],
+                quat_rotate(quat_inv(link_to_com_quat), -link_to_com_pos),
+                quat_inv(link_to_com_quat),
+            )
+            expected_root_link_pose = torch.cat((expected_root_link_pos, expected_root_link_quat), dim=1)
+            # test both root_pose and root_link_state_w successfully updated when root_com_state_w updates
+            torch.testing.assert_close(expected_root_link_pose, cube_object.data.root_link_state_w[:, :7])
+            # skip 7:10 because they differs from link frame, this should be fine because we are only checking
+            # if velocity update is triggered, which can be determined by comparing angular velocity
+            torch.testing.assert_close(
+                cube_object.data.root_com_state_w[:, 10:], cube_object.data.root_link_state_w[:, 10:]
+            )
+            torch.testing.assert_close(expected_root_link_pose, cube_object.data.root_state_w[:, :7])
+            torch.testing.assert_close(cube_object.data.root_com_state_w[:, 10:], cube_object.data.root_state_w[:, 10:])
+        elif state_location == "link":
+            expected_com_pos, expected_com_quat = combine_frame_transforms(
+                cube_object.data.root_link_state_w[:, :3],
+                cube_object.data.root_link_state_w[:, 3:7],
+                link_to_com_pos,
+                link_to_com_quat,
+            )
+            expected_com_pose = torch.cat((expected_com_pos, expected_com_quat), dim=1)
+            # test both root_pose and root_com_state_w successfully updated when root_link_state_w updates
+            torch.testing.assert_close(expected_com_pose, cube_object.data.root_com_state_w[:, :7])
+            # skip 7:10 because they differs from link frame, this should be fine because we are only checking
+            # if velocity update is triggered, which can be determined by comparing angular velocity
+            torch.testing.assert_close(
+                cube_object.data.root_link_state_w[:, 10:], cube_object.data.root_com_state_w[:, 10:]
+            )
+            torch.testing.assert_close(cube_object.data.root_link_state_w[:, :7], cube_object.data.root_state_w[:, :7])
+            torch.testing.assert_close(
+                cube_object.data.root_link_state_w[:, 10:], cube_object.data.root_state_w[:, 10:]
+            )
+        elif state_location == "root":
+            expected_com_pos, expected_com_quat = combine_frame_transforms(
+                cube_object.data.root_state_w[:, :3],
+                cube_object.data.root_state_w[:, 3:7],
+                link_to_com_pos,
+                link_to_com_quat,
+            )
+            expected_com_pose = torch.cat((expected_com_pos, expected_com_quat), dim=1)
+            # test both root_com_state_w and root_link_state_w successfully updated when root_pose updates
+            torch.testing.assert_close(expected_com_pose, cube_object.data.root_com_state_w[:, :7])
+            torch.testing.assert_close(cube_object.data.root_state_w[:, 7:], cube_object.data.root_com_state_w[:, 7:])
+            torch.testing.assert_close(cube_object.data.root_state_w[:, :7], cube_object.data.root_link_state_w[:, :7])
+            torch.testing.assert_close(
+                cube_object.data.root_state_w[:, 10:], cube_object.data.root_link_state_w[:, 10:]
+            )

--- a/source/isaaclab/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab/test/assets/test_rigid_object_collection.py
@@ -26,7 +26,16 @@ import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg, RigidObjectCollection, RigidObjectCollectionCfg
 from isaaclab.sim import build_simulation_context
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
-from isaaclab.utils.math import default_orientation, quat_mul, quat_rotate_inverse, random_orientation
+from isaaclab.utils.math import (
+    combine_frame_transforms,
+    default_orientation,
+    quat_inv,
+    quat_mul,
+    quat_rotate,
+    quat_rotate_inverse,
+    random_orientation,
+    subtract_frame_transforms,
+)
 
 
 def generate_cubes_scene(
@@ -603,3 +612,128 @@ def test_gravity_vec_w(sim, num_envs, num_cubes, device, gravity_enabled):
 
         # Check the body accelerations are correct
         torch.testing.assert_close(object_collection.data.object_acc_w, gravity)
+
+
+@pytest.mark.parametrize("num_envs", [1, 3])
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("with_offset", [True])
+@pytest.mark.parametrize("state_location", ["com", "link", "root"])
+@pytest.mark.parametrize("gravity_enabled", [False])
+def test_write_object_state_functions_data_consistency(
+    sim, num_envs, num_cubes, device, with_offset, state_location, gravity_enabled
+):
+    """Test the setters for object_state using both the link frame and center of mass as reference frame."""
+    # Create a scene with random cubes
+    cube_object, env_pos = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, height=0.0, device=device)
+    view_ids = torch.tensor([x for x in range(num_cubes * num_cubes)])
+    env_ids = torch.tensor([x for x in range(num_envs)])
+    object_ids = torch.tensor([x for x in range(num_cubes)])
+
+    sim.reset()
+
+    # Check if cube_object is initialized
+    assert cube_object.is_initialized
+
+    # change center of mass offset from link frame
+    offset = (
+        torch.tensor([0.1, 0.0, 0.0], device=device).repeat(num_envs, num_cubes, 1)
+        if with_offset
+        else torch.tensor([0.0, 0.0, 0.0], device=device).repeat(num_envs, num_cubes, 1)
+    )
+
+    com = cube_object.reshape_view_to_data(cube_object.root_physx_view.get_coms())
+    com[..., :3] = offset.to("cpu")
+    cube_object.root_physx_view.set_coms(cube_object.reshape_data_to_view(com.clone()), view_ids)
+
+    # check center of mass has been set
+    torch.testing.assert_close(cube_object.reshape_view_to_data(cube_object.root_physx_view.get_coms()), com)
+
+    rand_state = torch.rand_like(cube_object.data.object_link_state_w)
+    rand_state[..., :3] += cube_object.data.object_link_pos_w
+    # make quaternion a unit vector
+    rand_state[..., 3:7] = torch.nn.functional.normalize(rand_state[..., 3:7], dim=-1)
+
+    env_ids = env_ids.to(device)
+    object_ids = object_ids.to(device)
+    sim.step()
+    cube_object.update(sim.cfg.dt)
+
+    object_link_to_com_pos, object_link_to_com_quat = subtract_frame_transforms(
+        cube_object.data.object_link_state_w[..., :3].view(-1, 3),
+        cube_object.data.object_link_state_w[..., 3:7].view(-1, 4),
+        cube_object.data.object_com_state_w[..., :3].view(-1, 3),
+        cube_object.data.object_com_state_w[..., 3:7].view(-1, 4),
+    )
+
+    if state_location == "com":
+        cube_object.write_object_com_state_to_sim(rand_state, env_ids=env_ids, object_ids=object_ids)
+    elif state_location == "link":
+        cube_object.write_object_link_state_to_sim(rand_state, env_ids=env_ids, object_ids=object_ids)
+    elif state_location == "root":
+        cube_object.write_object_state_to_sim(rand_state, env_ids=env_ids, object_ids=object_ids)
+
+    if state_location == "com":
+        expected_root_link_pos, expected_root_link_quat = combine_frame_transforms(
+            cube_object.data.object_com_state_w[..., :3].view(-1, 3),
+            cube_object.data.object_com_state_w[..., 3:7].view(-1, 4),
+            quat_rotate(quat_inv(object_link_to_com_quat), -object_link_to_com_pos),
+            quat_inv(object_link_to_com_quat),
+        )
+        # torch.testing.assert_close(rand_state, cube_object.data.object_com_state_w)
+        expected_object_link_pose = torch.cat((expected_root_link_pos, expected_root_link_quat), dim=1).view(
+            num_envs, -1, 7
+        )
+        # test both root_pose and root_link_state_w successfully updated when root_com_state_w updates
+        torch.testing.assert_close(expected_object_link_pose, cube_object.data.object_link_state_w[..., :7])
+        # skip 7:10 because they differs from link frame, this should be fine because we are only checking
+        # if velocity update is triggered, which can be determined by comparing angular velocity
+        torch.testing.assert_close(
+            cube_object.data.object_com_state_w[..., 10:], cube_object.data.object_link_state_w[..., 10:]
+        )
+        torch.testing.assert_close(expected_object_link_pose, cube_object.data.object_state_w[..., :7])
+        torch.testing.assert_close(
+            cube_object.data.object_com_state_w[..., 10:], cube_object.data.object_state_w[..., 10:]
+        )
+    elif state_location == "link":
+        expected_com_pos, expected_com_quat = combine_frame_transforms(
+            cube_object.data.object_link_state_w[..., :3].view(-1, 3),
+            cube_object.data.object_link_state_w[..., 3:7].view(-1, 4),
+            object_link_to_com_pos,
+            object_link_to_com_quat,
+        )
+        expected_object_com_pose = torch.cat((expected_com_pos, expected_com_quat), dim=1).view(num_envs, -1, 7)
+        # test both root_pose and root_com_state_w successfully updated when root_link_state_w updates
+        torch.testing.assert_close(expected_object_com_pose, cube_object.data.object_com_state_w[..., :7])
+        # skip 7:10 because they differs from link frame, this should be fine because we are only checking
+        # if velocity update is triggered, which can be determined by comparing angular velocity
+        torch.testing.assert_close(
+            cube_object.data.object_link_state_w[..., 10:], cube_object.data.object_com_state_w[..., 10:]
+        )
+        torch.testing.assert_close(
+            cube_object.data.object_link_state_w[..., :7], cube_object.data.object_state_w[..., :7]
+        )
+        torch.testing.assert_close(
+            cube_object.data.object_link_state_w[..., 10:], cube_object.data.object_state_w[..., 10:]
+        )
+    elif state_location == "root":
+        expected_object_com_pos, expected_object_com_quat = combine_frame_transforms(
+            cube_object.data.object_state_w[..., :3].view(-1, 3),
+            cube_object.data.object_state_w[..., 3:7].view(-1, 4),
+            object_link_to_com_pos,
+            object_link_to_com_quat,
+        )
+        expected_object_com_pose = torch.cat((expected_object_com_pos, expected_object_com_quat), dim=1).view(
+            num_envs, -1, 7
+        )
+        # test both root_com_state_w and root_link_state_w successfully updated when root_pose updates
+        torch.testing.assert_close(expected_object_com_pose, cube_object.data.object_com_state_w[..., :7])
+        torch.testing.assert_close(
+            cube_object.data.object_state_w[..., 7:], cube_object.data.object_com_state_w[..., 7:]
+        )
+        torch.testing.assert_close(
+            cube_object.data.object_state_w[..., :7], cube_object.data.object_link_state_w[..., :7]
+        )
+        torch.testing.assert_close(
+            cube_object.data.object_state_w[..., 10:], cube_object.data.object_link_state_w[..., 10:]
+        )


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

When `WriteState`, `WriteLink`, `WriteCOM` are invoked, there is a inconsistency when reading values of `ReadState`, `ReadLink`, `ReadCOM`. The Source of the bug is because of missing timestamp invalidation of relative data within the write function. Below I list the all functions that is problematics

RigitObject:
write_root_pose_to_sim
write_root_link_pose_to_sim
write_root_velocity_to_sim
write_root_com_velocity_to_sim

RigitObjectCollection:
write_object_pose_to_sim
write_object_link_pose_to_sim
write_object_velocity_to_sim
write_object_com_velocity_to_sim

Fixes #2534 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

The bug if fixed by invalidating the relevant data timestamps in write_(state|link|com)_to_sim function.
I have added the tests cases that checks the consistency among `ReadState`, `ReadLink`, `ReadCOM` when either `WriteState`, `WriteLink`, `WriteCOM`is called and passed all tests.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
