### PR TITLE
Fix/replace slices with string

### DIFF
--- a/source/isaaclab/isaaclab/utils/dict.py
+++ b/source/isaaclab/isaaclab/utils/dict.py
@@ -267,6 +267,8 @@ def replace_slices_with_strings(data: dict) -> dict:
     """
     if isinstance(data, dict):
         return {k: replace_slices_with_strings(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [replace_slices_with_strings(v) for v in data]
     elif isinstance(data, slice):
         return f"slice({data.start},{data.stop},{data.step})"
     else:
@@ -284,6 +286,8 @@ def replace_strings_with_slices(data: dict) -> dict:
     """
     if isinstance(data, dict):
         return {k: replace_strings_with_slices(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [replace_strings_with_slices(v) for v in data]
     elif isinstance(data, str) and data.startswith("slice("):
         return string_to_slice(data)
     else:

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
@@ -29,6 +29,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": stack_joint_pos_env_cfg.FrankaCubeStackEnvCfg,
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:StackCubePPORunnerCfg",
     },
     disable_env_checker=True,
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/agents/rsl_rl_ppo_cfg.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.utils import configclass
+
+from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg
+
+
+@configclass
+class StackCubePPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    num_steps_per_env = 24
+    max_iterations = 1500
+    save_interval = 50
+    experiment_name = "franka_stack"
+    empirical_normalization = False
+    policy = RslRlPpoActorCriticCfg(
+        init_noise_std=1.0,
+        actor_hidden_dims=[256, 128, 64],
+        critic_hidden_dims=[256, 128, 64],
+        activation="elu",
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.006,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-4,
+        schedule="adaptive",
+        gamma=0.98,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+    )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_env_cfg.py
@@ -90,7 +90,7 @@ class ObservationsCfg:
 
         def __post_init__(self):
             self.enable_corruption = False
-            self.concatenate_terms = False
+            self.concatenate_terms = True
 
     @configclass
     class RGBCameraPolicyCfg(ObsGroup):


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

This request is to fix the problem of running Isaac-Stack-Cube-Franka-v0 with rsl_rl PPO.

The changes are around the Isaac-Stack-Cube-Franka-v0:
- _replace_slices_with_strings()_ and _replace_strings_with_slices()_ in [IsaacLab/source/isaaclab/isaaclab/utils/dict.py](https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab/isaaclab/utils/dict.py) are changed to allow slices being process if a list of dicts is passed in as input.
- add rsl_rl_ppo_cfg.py to Isaac-Stack-Cube-Franka-v0 and update gym.register
- set concatenate_terms to True in _IsaacLab/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_env_cfg.py_. Otherwise, RL lib following Gymnasium API will not work when setting up observation dimension with `obs_dim = obs.shape[1]`

To test, run the following:
```
cd IsaacLab
./isaaclab.sh -p ./scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Stack-Cube-Franka-v0  --num_envs 10
```
Note: Because there is no RewardCfg for this task, there will be no learning progress. This can only check the task can be run without any problem.

Fixes #2481

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots
- Change 1: _replace_slices_with_strings()_ and _replace_strings_with_slices()_ in [IsaacLab/source/isaaclab/isaaclab/utils/dict.py](https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab/isaaclab/utils/dict.py)

| Before | After |
| ------ | ----- |
| ![isaaclab_before](https://github.com/user-attachments/assets/32f30be5-d69e-46dc-9faa-5847cbde7c74) | ![isaaclab_after](https://github.com/user-attachments/assets/468b39cf-434e-43da-89df-b6824e77d6df) |

- Change 2: add rsl_rl_ppo_cfg.py to Isaac-Stack-Cube-Franka-v0 and update gym.register

| Before | After |
| ------ | ----- |
| |![change2_add_rsl_rl_ppo_cfg](https://github.com/user-attachments/assets/df2016d2-d323-490c-9503-b3d11c753038)
|![change2_before](https://github.com/user-attachments/assets/6c1febd3-33d4-4e4a-b3ab-1fff5f169792)|![change2_after](https://github.com/user-attachments/assets/ccf5cef0-a66f-4a88-9510-5d6459ae0ab0)|

- Change 3: set concatenate_terms to True in _IsaacLab/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_env_cfg.py_. Otherwise, RL lib following Gymnasium API will not work when setting up observation dimension with `obs_dim = obs.shape[1]`

| Before | After |
| ------ | ----- |
| ![change3_before](https://github.com/user-attachments/assets/51c2b6d9-cf3f-443d-8699-cc4dda69830b)|![change3_after](https://github.com/user-attachments/assets/4592dd56-4e3a-4791-9542-f57305e0c49c) |

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
