### PR TITLE
Fixes check for re-initializing terms in ManagerBase

### DIFF
--- a/source/isaaclab/isaaclab/managers/manager_base.py
+++ b/source/isaaclab/isaaclab/managers/manager_base.py
@@ -145,6 +145,10 @@ class ManagerBase(ABC):
         self.cfg = copy.deepcopy(cfg)
         self._env = env
 
+        # flag for whether the scene entities have been resolved
+        # if sim is playing, we can resolve the scene entities directly
+        self._is_scene_entities_resolved = self._env.sim.is_playing()
+
         # if the simulation is not playing, we use callbacks to trigger the resolution of the scene
         # entities configuration. this is needed for cases where the manager is created after the
         # simulation, but before the simulation is playing.
@@ -265,6 +269,9 @@ class ManagerBase(ABC):
 
         Please check the :meth:`_process_term_cfg_at_play` method for more information.
         """
+        # check if scene entities have been resolved
+        if self._is_scene_entities_resolved:
+            return
         # check if config is dict already
         if isinstance(self.cfg, dict):
             cfg_items = self.cfg.items()
@@ -279,6 +286,9 @@ class ManagerBase(ABC):
             # process attributes at runtime
             # these properties are only resolvable once the simulation starts playing
             self._process_term_cfg_at_play(term_name, term_cfg)
+
+        # set the flag
+        self._is_scene_entities_resolved = True
 
     """
     Internal functions.


### PR DESCRIPTION
# Description

If you perform pause-play while running a checkpoint, the manager terms that are in the "play" callback gets called which leads to terminal spamming. This MR adds a check to make sure we don't reinitialize the terms twice.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there