### PR TITLE
Simplifies buffer validation check for CircularBuffer

### DIFF
--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -116,8 +116,10 @@ class CircularBuffer:
         """
         # check the batch size
         if data.shape[0] != self.batch_size:
-            raise ValueError(f"The input data has {data.shape[0]} environments while expecting {self.batch_size}")
+            raise ValueError(f"The input data has '{data.shape[0]}' batch size while expecting '{self.batch_size}'")
 
+        # move the data to the device
+        data = data.to(self._device)
         # at the first call, initialize the buffer size
         if self._buffer is None:
             self._pointer = -1
@@ -125,12 +127,11 @@ class CircularBuffer:
         # move the head to the next slot
         self._pointer = (self._pointer + 1) % self.max_length
         # add the new data to the last layer
-        self._buffer[self._pointer] = data.to(self._device)
+        self._buffer[self._pointer] = data
         # Check for batches with zero pushes and initialize all values in batch to first append
-        if 0 in self._num_pushes.tolist():
-            fill_ids = [i for i, x in enumerate(self._num_pushes.tolist()) if x == 0]
-            self._num_pushes.tolist().index(0) if 0 in self._num_pushes.tolist() else None
-            self._buffer[:, fill_ids, :] = data.to(self._device)[fill_ids]
+        is_first_push = self._num_pushes == 0
+        if torch.any(is_first_push):
+            self._buffer[:, is_first_push] = data[is_first_push]
         # increment number of number of pushes for all batches
         self._num_pushes += 1
 

--- a/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
@@ -46,10 +46,10 @@ class DelayBuffer:
         # the buffer size: current data plus the history length
         self._circular_buffer = CircularBuffer(self._history_length + 1, batch_size, device)
 
-        # the minimum and maximum lags across all environments.
+        # the minimum and maximum lags across all batch indices.
         self._min_time_lag = 0
         self._max_time_lag = 0
-        # the lags for each environment.
+        # the lags for each batch index.
         self._time_lags = torch.zeros(batch_size, dtype=torch.int, device=device)
 
     """

--- a/source/isaaclab/isaaclab/utils/modifiers/__init__.py
+++ b/source/isaaclab/isaaclab/utils/modifiers/__init__.py
@@ -43,7 +43,7 @@ Usage with a class modifier:
 
     # create a modifier configuration
     # a digital filter with a simple delay of 1 timestep
-    cfg = modifiers.DigitalFilter(A=[0.0], B=[0.0, 1.0])
+    cfg = modifiers.DigitalFilterCfg(A=[0.0], B=[0.0, 1.0])
 
     # create the modifier instance
     my_modifier = modifiers.DigitalFilter(cfg, my_tensor.shape, "cuda")


### PR DESCRIPTION
# Description

As pointed out in the reported issue, there seem to be some expensive `tolist()` operations inside the circular buffer class, that aren't necessary. This MR simplifies the code.

Fixes #2590

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there