### PR TITLE
Sets enable_stabilization to false by default.

### DIFF
--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -87,8 +87,14 @@ class PhysxCfg:
     """Enable a second broad-phase pass that makes it possible to prevent objects from tunneling through each other.
     Default is False."""
 
-    enable_stabilization: bool = True
-    """Enable/disable additional stabilization pass in solver. Default is True."""
+    enable_stabilization: bool = False
+    """Enable/disable additional stabilization pass in solver. Default is False.
+
+    .. note::
+
+        Setting this flag to True should only be done if the simulation steps are very large (less than 30Hz).
+        Enabling this flag can lead to incorrect forces being read from the contact sensor.
+    """
 
     enable_enhanced_determinism: bool = False
     """Enable/disable improved determinism at the expense of performance. Defaults to False.

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -95,7 +95,7 @@ class PhysxCfg:
         We recommend setting this flag to true only when the simulation step size is large (i.e., less than 30 Hz or more than 0.0333 seconds).
 
     .. warn::
-    
+
         Enabling this flag may lead to incorrect contact forces report from the contact sensor.
     """
 

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -92,7 +92,7 @@ class PhysxCfg:
 
     .. note::
 
-        Setting this flag to True should only be done if the simulation steps are very large (less than 30Hz).
+        We recommend setting this flag to true only when the simulation step size is large (i.e., less than 30 Hz or more than 0.0333 seconds).
 
     .. warn::
     

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -93,7 +93,10 @@ class PhysxCfg:
     .. note::
 
         Setting this flag to True should only be done if the simulation steps are very large (less than 30Hz).
-        Enabling this flag can lead to incorrect forces being read from the contact sensor.
+
+    .. warn::
+    
+        Enabling this flag may lead to incorrect contact forces report from the contact sensor.
     """
 
     enable_enhanced_determinism: bool = False

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -234,6 +234,14 @@ class SimulationContext(_SimulationContext):
                 physx_params = sim_params.pop("physx")
                 sim_params.update(physx_params)
         # create a simulation context to control the simulator
+
+        if not self.cfg.physx.enable_stabilization and (self.cfg.dt > 0.0333):
+            omni.log.warn(
+                "Large simulation step size (> 0.0333 seconds) is not recommended without enabling stabilization."
+                " Consider setting the `enable_stabilization` flag to True in the PhysxCfg, or reducing the"
+                " simulation step size if you run into physics issues."
+            )
+
         super().__init__(
             stage_units_in_meters=1.0,
             physics_dt=self.cfg.dt,

--- a/source/isaaclab/test/assets/test_rigid_object.py
+++ b/source/isaaclab/test/assets/test_rigid_object.py
@@ -591,7 +591,7 @@ def test_rigid_body_with_static_friction(num_cubes, device):
                 cube_object.update(sim.cfg.dt)
                 if force == "below_mu":
                     # Assert that the block has not moved
-                    torch.testing.assert_close(cube_object.data.root_pos_w, initial_root_pos, rtol=1e-3, atol=1e-3)
+                    torch.testing.assert_close(cube_object.data.root_pos_w, initial_root_pos, rtol=2e-3, atol=2e-3)
             if force == "above_mu":
                 assert (cube_object.data.root_state_w[..., 0] - initial_root_pos[..., 0] > 0.02).all()
 
@@ -848,8 +848,8 @@ def test_body_root_state_properties(num_cubes, device, with_offset):
                 lin_vel_rel_root_gt = quat_apply_inverse(root_link_state_w[..., 3:7], root_link_state_w[..., 7:10])
                 lin_vel_rel_body_gt = quat_apply_inverse(body_link_state_w[..., 3:7], body_link_state_w[..., 7:10])
                 lin_vel_rel_gt = torch.linalg.cross(spin_twist.repeat(num_cubes, 1)[..., 3:], -offset)
-                torch.testing.assert_close(lin_vel_rel_gt, lin_vel_rel_root_gt, atol=1e-4, rtol=1e-4)
-                torch.testing.assert_close(lin_vel_rel_gt, lin_vel_rel_body_gt.squeeze(-2), atol=1e-4, rtol=1e-4)
+                torch.testing.assert_close(lin_vel_rel_gt, lin_vel_rel_root_gt, atol=1e-3, rtol=1e-3)
+                torch.testing.assert_close(lin_vel_rel_gt, lin_vel_rel_body_gt.squeeze(-2), atol=1e-3, rtol=1e-3)
 
                 # ang_vel will always match
                 torch.testing.assert_close(root_state_w[..., 10:], root_com_state_w[..., 10:])


### PR DESCRIPTION
# Description

Changes the default setting for the enable stabilization flag from True to False.

Fixes #2319

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

| Before | After |
:-------------------------:|:-------------------------:
![net_contact_forces_1kz](https://github.com/user-attachments/assets/a9d7851c-d42a-4f22-8ea7-6b187070057e)| ![net_contact_forces_after](https://github.com/user-attachments/assets/523b8b5c-d8db-435c-bb66-c4312d2c6c18)
![force_matrices_1khz](https://github.com/user-attachments/assets/30feb2e1-d1f6-402f-8ca0-3a727bce4424)  | ![force_matrices_after](https://github.com/user-attachments/assets/3294335f-c5d5-4c4d-ac8a-e2c2e995e2a0) 



## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
