### PR TITLE
Removes old license headers in scripts

### DIFF
--- a/.aws/premerge-ci-buildspec.yml
+++ b/.aws/premerge-ci-buildspec.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/.vscode/tools/setup_vscode.py
+++ b/.vscode/tools/setup_vscode.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script sets up the vs-code settings for the Isaac Lab project.
 
 This script merges the python.analysis.extraPaths from the "{ISAACSIM_DIR}/.vscode/settings.json" file into

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/docker/container.py
+++ b/docker/container.py
@@ -5,11 +5,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 import shutil
 from pathlib import Path

--- a/docker/container.sh
+++ b/docker/container.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/docker/test/test_docker.py
+++ b/docker/test/test_docker.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import os
 import subprocess
 import unittest

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from .container_interface import ContainerInterface
 
 __all__ = ["ContainerInterface"]

--- a/docker/utils/container_interface.py
+++ b/docker/utils/container_interface.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import os

--- a/docker/utils/state_file.py
+++ b/docker/utils/state_file.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import configparser

--- a/docker/utils/x11_utils.py
+++ b/docker/utils/x11_utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Utility functions for managing X11 forwarding in the docker container."""
 
 from __future__ import annotations

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/docs/source/refs/snippets/tutorial_modify_direct_rl_env.py
+++ b/docs/source/refs/snippets/tutorial_modify_direct_rl_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # fmt: off
 
 # [start-init-import]

--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/scripts/benchmarks/benchmark_cameras.py
+++ b/scripts/benchmarks/benchmark_cameras.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script might help you determine how many cameras your system can realistically run
 at different desired settings.

--- a/scripts/benchmarks/benchmark_load_robot.py
+++ b/scripts/benchmarks/benchmark_load_robot.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to benchmark loading multiple copies of a robot.
 
 .. code-block python

--- a/scripts/benchmarks/benchmark_non_rl.py
+++ b/scripts/benchmarks/benchmark_non_rl.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to benchmark non-RL environment."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/benchmarks/benchmark_rlgames.py
+++ b/scripts/benchmarks/benchmark_rlgames.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to benchmark RL agent with RL-Games."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/benchmarks/benchmark_rsl_rl.py
+++ b/scripts/benchmarks/benchmark_rsl_rl.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # Copyright (c) 2022-2025, The IsaacLab Project Developers.
 # All rights reserved.
 #

--- a/scripts/benchmarks/utils.py
+++ b/scripts/benchmarks/utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 import glob
 import os

--- a/scripts/demos/arms.py
+++ b/scripts/demos/arms.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates different single-arm manipulators.
 

--- a/scripts/demos/bipeds.py
+++ b/scripts/demos/bipeds.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to simulate bipedal robots.
 

--- a/scripts/demos/deformables.py
+++ b/scripts/demos/deformables.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates how to spawn deformable prims into the scene.
 
 .. code-block:: bash

--- a/scripts/demos/h1_locomotion.py
+++ b/scripts/demos/h1_locomotion.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates an interactive demo with the H1 rough terrain environment.
 

--- a/scripts/demos/hands.py
+++ b/scripts/demos/hands.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates different dexterous hands.
 

--- a/scripts/demos/markers.py
+++ b/scripts/demos/markers.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates different types of markers.
 
 .. code-block:: bash

--- a/scripts/demos/multi_asset.py
+++ b/scripts/demos/multi_asset.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates how to spawn multiple objects in multiple environments.
 
 .. code-block:: bash

--- a/scripts/demos/procedural_terrain.py
+++ b/scripts/demos/procedural_terrain.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates procedural terrains with flat patches.
 

--- a/scripts/demos/quadcopter.py
+++ b/scripts/demos/quadcopter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to simulate a quadcopter.
 

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates different legged robots.
 

--- a/scripts/demos/sensors/cameras.py
+++ b/scripts/demos/sensors/cameras.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates the different camera sensors that can be attached to a robot.
 

--- a/scripts/demos/sensors/contact_sensor.py
+++ b/scripts/demos/sensors/contact_sensor.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 import argparse

--- a/scripts/demos/sensors/frame_transformer_sensor.py
+++ b/scripts/demos/sensors/frame_transformer_sensor.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 
 from isaaclab.app import AppLauncher

--- a/scripts/demos/sensors/imu_sensor.py
+++ b/scripts/demos/sensors/imu_sensor.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 import argparse

--- a/scripts/demos/sensors/raycaster_sensor.py
+++ b/scripts/demos/sensors/raycaster_sensor.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 import numpy as np
 

--- a/scripts/environments/list_envs.py
+++ b/scripts/environments/list_envs.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Script to print all the available environments in Isaac Lab.
 

--- a/scripts/environments/random_agent.py
+++ b/scripts/environments/random_agent.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to an environment with random action agent."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/environments/state_machine/lift_cube_sm.py
+++ b/scripts/environments/state_machine/lift_cube_sm.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Script to run an environment with a pick and lift state machine.
 

--- a/scripts/environments/state_machine/lift_teddy_bear.py
+++ b/scripts/environments/state_machine/lift_teddy_bear.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Script to demonstrate lifting a deformable object with a robotic arm.
 

--- a/scripts/environments/state_machine/open_cabinet_sm.py
+++ b/scripts/environments/state_machine/open_cabinet_sm.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Script to run an environment with a cabinet opening state machine.
 

--- a/scripts/environments/teleoperation/teleop_se3_agent.py
+++ b/scripts/environments/teleoperation/teleop_se3_agent.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to run a keyboard teleoperation with Isaac Lab manipulation environments."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/environments/zero_agent.py
+++ b/scripts/environments/zero_agent.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to run an environment with zero action agent."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/imitation_learning/isaaclab_mimic/annotate_demos.py
+++ b/scripts/imitation_learning/isaaclab_mimic/annotate_demos.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """
 Script to add mimic annotations to demos to be used as source demos for mimic dataset generation.
 """

--- a/scripts/imitation_learning/isaaclab_mimic/consolidated_demo.py
+++ b/scripts/imitation_learning/isaaclab_mimic/consolidated_demo.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """
 Script to record teleoperated demos and run mimic dataset generation in real-time.
 """

--- a/scripts/imitation_learning/isaaclab_mimic/generate_dataset.py
+++ b/scripts/imitation_learning/isaaclab_mimic/generate_dataset.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """
 Main data generation script.
 """

--- a/scripts/imitation_learning/robomimic/play.py
+++ b/scripts/imitation_learning/robomimic/play.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to play and evaluate a trained policy from robomimic.
 
 This script loads a robomimic policy and plays it in an Isaac Lab environment.

--- a/scripts/imitation_learning/robomimic/train.py
+++ b/scripts/imitation_learning/robomimic/train.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # MIT License
 #
 # Copyright (c) 2021 Stanford Vision and Learning Lab

--- a/scripts/reinforcement_learning/ray/grok_cluster_with_kubectl.py
+++ b/scripts/reinforcement_learning/ray/grok_cluster_with_kubectl.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 import os
 import re

--- a/scripts/reinforcement_learning/ray/hyperparameter_tuning/vision_cartpole_cfg.py
+++ b/scripts/reinforcement_learning/ray/hyperparameter_tuning/vision_cartpole_cfg.py
@@ -2,11 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
 import pathlib
 import sys
 

--- a/scripts/reinforcement_learning/ray/hyperparameter_tuning/vision_cfg.py
+++ b/scripts/reinforcement_learning/ray/hyperparameter_tuning/vision_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import pathlib
 import sys
 

--- a/scripts/reinforcement_learning/ray/launch.py
+++ b/scripts/reinforcement_learning/ray/launch.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 import pathlib
 import subprocess

--- a/scripts/reinforcement_learning/ray/mlflow_to_local_tensorboard.py
+++ b/scripts/reinforcement_learning/ray/mlflow_to_local_tensorboard.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 import logging
 import multiprocessing as mp

--- a/scripts/reinforcement_learning/ray/submit_job.py
+++ b/scripts/reinforcement_learning/ray/submit_job.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 import os
 import time

--- a/scripts/reinforcement_learning/ray/tuner.py
+++ b/scripts/reinforcement_learning/ray/tuner.py
@@ -2,11 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
 import argparse
 import importlib.util
 import os

--- a/scripts/reinforcement_learning/ray/util.py
+++ b/scripts/reinforcement_learning/ray/util.py
@@ -2,11 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
 import argparse
 import os
 import re

--- a/scripts/reinforcement_learning/ray/wrap_resources.py
+++ b/scripts/reinforcement_learning/ray/wrap_resources.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 
 import ray

--- a/scripts/reinforcement_learning/rl_games/play.py
+++ b/scripts/reinforcement_learning/rl_games/play.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to play a checkpoint if an RL agent from RL-Games."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/reinforcement_learning/rl_games/train.py
+++ b/scripts/reinforcement_learning/rl_games/train.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to train RL agent with RL-Games."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/reinforcement_learning/rsl_rl/cli_args.py
+++ b/scripts/reinforcement_learning/rsl_rl/cli_args.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import argparse

--- a/scripts/reinforcement_learning/rsl_rl/play.py
+++ b/scripts/reinforcement_learning/rsl_rl/play.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to play a checkpoint if an RL agent from RSL-RL."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/reinforcement_learning/rsl_rl/train.py
+++ b/scripts/reinforcement_learning/rsl_rl/train.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to train RL agent with RSL-RL."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/reinforcement_learning/sb3/play.py
+++ b/scripts/reinforcement_learning/sb3/play.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to play a checkpoint if an RL agent from Stable-Baselines3."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/reinforcement_learning/sb3/train.py
+++ b/scripts/reinforcement_learning/sb3/train.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to train RL agent with Stable Baselines3.
 
 Since Stable-Baselines3 does not support buffers living on GPU directly,

--- a/scripts/reinforcement_learning/skrl/play.py
+++ b/scripts/reinforcement_learning/skrl/play.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Script to play a checkpoint of an RL agent from skrl.
 

--- a/scripts/reinforcement_learning/skrl/train.py
+++ b/scripts/reinforcement_learning/skrl/train.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Script to train RL agent with skrl.
 

--- a/scripts/tools/blender_obj.py
+++ b/scripts/tools/blender_obj.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Convert a mesh file to `.obj` using blender.
 

--- a/scripts/tools/check_instanceable.py
+++ b/scripts/tools/check_instanceable.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script uses the cloner API to check if asset has been instanced properly.
 

--- a/scripts/tools/convert_instanceable.py
+++ b/scripts/tools/convert_instanceable.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Utility to bulk convert URDFs or mesh files into instanceable USD format.
 

--- a/scripts/tools/convert_mesh.py
+++ b/scripts/tools/convert_mesh.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Utility to convert a OBJ/STL/FBX into USD format.
 

--- a/scripts/tools/convert_mjcf.py
+++ b/scripts/tools/convert_mjcf.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Utility to convert a MJCF into USD format.
 

--- a/scripts/tools/convert_urdf.py
+++ b/scripts/tools/convert_urdf.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Utility to convert a URDF into USD format.
 

--- a/scripts/tools/merge_hdf5_datasets.py
+++ b/scripts/tools/merge_hdf5_datasets.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 import h5py
 import os

--- a/scripts/tools/pretrained_checkpoint.py
+++ b/scripts/tools/pretrained_checkpoint.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Script to manage pretrained checkpoints for our environments.
 """

--- a/scripts/tools/process_meshes_to_obj.py
+++ b/scripts/tools/process_meshes_to_obj.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Convert all mesh files to `.obj` in given folders."""
 
 import argparse

--- a/scripts/tools/record_demos.py
+++ b/scripts/tools/record_demos.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Script to record demonstrations with Isaac Lab environments using human teleoperation.
 

--- a/scripts/tools/replay_demos.py
+++ b/scripts/tools/replay_demos.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to replay demonstrations with Isaac Lab environments."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/tutorials/00_sim/create_empty.py
+++ b/scripts/tutorials/00_sim/create_empty.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates how to create a simple stage in Isaac Sim.
 
 .. code-block:: bash

--- a/scripts/tutorials/00_sim/launch_app.py
+++ b/scripts/tutorials/00_sim/launch_app.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to run IsaacSim via the AppLauncher
 

--- a/scripts/tutorials/00_sim/log_time.py
+++ b/scripts/tutorials/00_sim/log_time.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to generate log outputs while the simulation plays.
 It accompanies the tutorial on docker usage.

--- a/scripts/tutorials/00_sim/set_rendering_mode.py
+++ b/scripts/tutorials/00_sim/set_rendering_mode.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates how to spawn prims into the scene.
 
 .. code-block:: bash

--- a/scripts/tutorials/00_sim/spawn_prims.py
+++ b/scripts/tutorials/00_sim/spawn_prims.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates how to spawn prims into the scene.
 
 .. code-block:: bash

--- a/scripts/tutorials/01_assets/add_new_robot.py
+++ b/scripts/tutorials/01_assets/add_new_robot.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 
 from isaaclab.app import AppLauncher

--- a/scripts/tutorials/01_assets/run_articulation.py
+++ b/scripts/tutorials/01_assets/run_articulation.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates how to spawn a cart-pole and interact with it.
 
 .. code-block:: bash

--- a/scripts/tutorials/01_assets/run_deformable_object.py
+++ b/scripts/tutorials/01_assets/run_deformable_object.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to work with the deformable object and interact with it.
 

--- a/scripts/tutorials/01_assets/run_rigid_object.py
+++ b/scripts/tutorials/01_assets/run_rigid_object.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to create a rigid object and interact with it.
 

--- a/scripts/tutorials/02_scene/create_scene.py
+++ b/scripts/tutorials/02_scene/create_scene.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates how to use the interactive scene interface to setup a scene with multiple prims.
 
 .. code-block:: bash

--- a/scripts/tutorials/03_envs/create_cartpole_base_env.py
+++ b/scripts/tutorials/03_envs/create_cartpole_base_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to create a simple environment with a cartpole. It combines the concepts of
 scene, action, observation and event managers to create an environment.

--- a/scripts/tutorials/03_envs/create_cube_base_env.py
+++ b/scripts/tutorials/03_envs/create_cube_base_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script creates a simple environment with a floating cube. The cube is controlled by a PD
 controller to track an arbitrary target position.

--- a/scripts/tutorials/03_envs/create_quadruped_base_env.py
+++ b/scripts/tutorials/03_envs/create_quadruped_base_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates the environment for a quadruped robot with height-scan sensor.
 

--- a/scripts/tutorials/03_envs/policy_inference_in_usd.py
+++ b/scripts/tutorials/03_envs/policy_inference_in_usd.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates policy inference in a prebuilt USD environment.
 

--- a/scripts/tutorials/03_envs/run_cartpole_rl_env.py
+++ b/scripts/tutorials/03_envs/run_cartpole_rl_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to run the RL environment for the cartpole balancing task.
 

--- a/scripts/tutorials/04_sensors/add_sensors_on_robot.py
+++ b/scripts/tutorials/04_sensors/add_sensors_on_robot.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to add and simulate on-board sensors for a robot.
 

--- a/scripts/tutorials/04_sensors/run_frame_transformer.py
+++ b/scripts/tutorials/04_sensors/run_frame_transformer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates the FrameTransformer sensor by visualizing the frames that it creates.
 

--- a/scripts/tutorials/04_sensors/run_ray_caster.py
+++ b/scripts/tutorials/04_sensors/run_ray_caster.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to use the ray-caster sensor.
 

--- a/scripts/tutorials/04_sensors/run_ray_caster_camera.py
+++ b/scripts/tutorials/04_sensors/run_ray_caster_camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script shows how to use the ray-cast camera sensor from the Isaac Lab framework.
 

--- a/scripts/tutorials/04_sensors/run_usd_camera.py
+++ b/scripts/tutorials/04_sensors/run_usd_camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script shows how to use the camera sensor from the Isaac Lab framework.
 

--- a/scripts/tutorials/05_controllers/run_diff_ik.py
+++ b/scripts/tutorials/05_controllers/run_diff_ik.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to use the differential inverse kinematics controller with the simulator.
 

--- a/scripts/tutorials/05_controllers/run_osc.py
+++ b/scripts/tutorials/05_controllers/run_osc.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to use the operational space controller (OSC) with the simulator.
 

--- a/source/isaaclab/isaaclab/__init__.py
+++ b/source/isaaclab/isaaclab/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Package containing the core framework."""
 
 import os

--- a/source/isaaclab/isaaclab/actuators/__init__.py
+++ b/source/isaaclab/isaaclab/actuators/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package for different actuator models.
 
 Actuator models are used to model the behavior of the actuators in an articulation. These

--- a/source/isaaclab/isaaclab/actuators/actuator_base.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_base.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/actuators/actuator_cfg.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from collections.abc import Iterable
 from dataclasses import MISSING
 from typing import Literal

--- a/source/isaaclab/isaaclab/actuators/actuator_net.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_net.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Neural network models for actuators.
 
 Currently, the following models are supported:

--- a/source/isaaclab/isaaclab/actuators/actuator_pd.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_pd.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/app/__init__.py
+++ b/source/isaaclab/isaaclab/app/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package containing app-specific functionalities.
 
 These include:

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package with the utility class to configure the :class:`isaacsim.simulation_app.SimulationApp`.
 
 The :class:`AppLauncher` parses environment variables and input CLI arguments to launch the simulator in

--- a/source/isaaclab/isaaclab/assets/__init__.py
+++ b/source/isaaclab/isaaclab/assets/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package for different assets, such as rigid objects and articulations.
 
 An asset is a physical object that can be spawned in the simulation. The class handles both

--- a/source/isaaclab/isaaclab/assets/articulation/__init__.py
+++ b/source/isaaclab/isaaclab/assets/articulation/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for rigid articulated assets."""
 
 from .articulation import Articulation

--- a/source/isaaclab/isaaclab/assets/articulation/articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # Flag for pyright to ignore type errors in this file.
 # pyright: reportPrivateUsage=false
 

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.actuators import ActuatorBaseCfg

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_data.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_data.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 import weakref
 

--- a/source/isaaclab/isaaclab/assets/asset_base.py
+++ b/source/isaaclab/isaaclab/assets/asset_base.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import builtins

--- a/source/isaaclab/isaaclab/assets/asset_base_cfg.py
+++ b/source/isaaclab/isaaclab/assets/asset_base_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 from typing import Literal
 

--- a/source/isaaclab/isaaclab/assets/deformable_object/__init__.py
+++ b/source/isaaclab/isaaclab/assets/deformable_object/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for deformable object assets."""
 
 from .deformable_object import DeformableObject

--- a/source/isaaclab/isaaclab/assets/deformable_object/deformable_object.py
+++ b/source/isaaclab/isaaclab/assets/deformable_object/deformable_object.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/assets/deformable_object/deformable_object_cfg.py
+++ b/source/isaaclab/isaaclab/assets/deformable_object/deformable_object_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from isaaclab.markers import VisualizationMarkersCfg

--- a/source/isaaclab/isaaclab/assets/deformable_object/deformable_object_data.py
+++ b/source/isaaclab/isaaclab/assets/deformable_object/deformable_object_data.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 import weakref
 

--- a/source/isaaclab/isaaclab/assets/rigid_object/__init__.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for rigid object assets."""
 
 from .rigid_object import RigidObject

--- a/source/isaaclab/isaaclab/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/rigid_object.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_cfg.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from ..asset_base_cfg import AssetBaseCfg

--- a/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/rigid_object_data.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 import weakref
 

--- a/source/isaaclab/isaaclab/assets/rigid_object_collection/__init__.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object_collection/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for rigid object collection."""
 
 from .rigid_object_collection import RigidObjectCollection

--- a/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import re

--- a/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection_cfg.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.assets.rigid_object import RigidObjectCfg

--- a/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 import weakref
 

--- a/source/isaaclab/isaaclab/controllers/__init__.py
+++ b/source/isaaclab/isaaclab/controllers/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package for different controllers and motion-generators.
 
 Controllers or motion generators are responsible for closed-loop tracking of a given command. The

--- a/source/isaaclab/isaaclab/controllers/config/__init__.py
+++ b/source/isaaclab/isaaclab/controllers/config/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab/isaaclab/controllers/config/rmp_flow.py
+++ b/source/isaaclab/isaaclab/controllers/config/rmp_flow.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import os
 
 from isaacsim.core.utils.extensions import get_extension_path_from_name

--- a/source/isaaclab/isaaclab/controllers/differential_ik.py
+++ b/source/isaaclab/isaaclab/controllers/differential_ik.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/controllers/differential_ik_cfg.py
+++ b/source/isaaclab/isaaclab/controllers/differential_ik_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 from typing import Literal
 

--- a/source/isaaclab/isaaclab/controllers/joint_impedance.py
+++ b/source/isaaclab/isaaclab/controllers/joint_impedance.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from collections.abc import Sequence
 from dataclasses import MISSING

--- a/source/isaaclab/isaaclab/controllers/operational_space.py
+++ b/source/isaaclab/isaaclab/controllers/operational_space.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/controllers/operational_space_cfg.py
+++ b/source/isaaclab/isaaclab/controllers/operational_space_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from collections.abc import Sequence
 from dataclasses import MISSING
 

--- a/source/isaaclab/isaaclab/controllers/rmp_flow.py
+++ b/source/isaaclab/isaaclab/controllers/rmp_flow.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from dataclasses import MISSING
 

--- a/source/isaaclab/isaaclab/devices/__init__.py
+++ b/source/isaaclab/isaaclab/devices/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package providing interfaces to different teleoperation devices.
 
 Currently, the following categories of devices are supported:

--- a/source/isaaclab/isaaclab/devices/device_base.py
+++ b/source/isaaclab/isaaclab/devices/device_base.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Base class for teleoperation interface."""
 
 from abc import ABC, abstractmethod

--- a/source/isaaclab/isaaclab/devices/gamepad/__init__.py
+++ b/source/isaaclab/isaaclab/devices/gamepad/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Gamepad device for SE(2) and SE(3) control."""
 
 from .se2_gamepad import Se2Gamepad

--- a/source/isaaclab/isaaclab/devices/gamepad/se2_gamepad.py
+++ b/source/isaaclab/isaaclab/devices/gamepad/se2_gamepad.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Gamepad controller for SE(2) control."""
 
 import numpy as np

--- a/source/isaaclab/isaaclab/devices/gamepad/se3_gamepad.py
+++ b/source/isaaclab/isaaclab/devices/gamepad/se3_gamepad.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Gamepad controller for SE(3) control."""
 
 import numpy as np

--- a/source/isaaclab/isaaclab/devices/keyboard/__init__.py
+++ b/source/isaaclab/isaaclab/devices/keyboard/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Keyboard device for SE(2) and SE(3) control."""
 
 from .se2_keyboard import Se2Keyboard

--- a/source/isaaclab/isaaclab/devices/keyboard/se2_keyboard.py
+++ b/source/isaaclab/isaaclab/devices/keyboard/se2_keyboard.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Keyboard controller for SE(2) control."""
 
 import numpy as np

--- a/source/isaaclab/isaaclab/devices/keyboard/se3_keyboard.py
+++ b/source/isaaclab/isaaclab/devices/keyboard/se3_keyboard.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Keyboard controller for SE(3) control."""
 
 import numpy as np

--- a/source/isaaclab/isaaclab/devices/openxr/__init__.py
+++ b/source/isaaclab/isaaclab/devices/openxr/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Keyboard device for SE(2) and SE(3) control."""
 
 from .openxr_device import OpenXRDevice

--- a/source/isaaclab/isaaclab/devices/openxr/common.py
+++ b/source/isaaclab/isaaclab/devices/openxr/common.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # Standard set of hand joint names based on OpenXR specification.
 # Input devices for dexterous hands can use this as a reference,
 # but may provide any subset or superset of these joints.

--- a/source/isaaclab/isaaclab/devices/openxr/openxr_device.py
+++ b/source/isaaclab/isaaclab/devices/openxr/openxr_device.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """OpenXR-powered device for teleoperation and interaction."""
 
 import contextlib

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/__init__.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/__init__.py
@@ -2,11 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
 """Retargeters for mapping input device data to robot commands."""
 
 from .humanoid.fourier.gr1t2_retargeter import GR1T2Retargeter

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/dex/dex_retargeter.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/dex/dex_retargeter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import numpy as np
 from typing import Any
 

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/manipulator/__init__.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/manipulator/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Franka manipulator retargeting module.
 
 This module provides functionality for retargeting motion to Franka robots.

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/manipulator/gripper_retargeter.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/manipulator/gripper_retargeter.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import numpy as np
 from typing import Final
 

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/manipulator/se3_abs_retargeter.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/manipulator/se3_abs_retargeter.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import numpy as np
 from scipy.spatial.transform import Rotation, Slerp
 

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/manipulator/se3_rel_retargeter.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/manipulator/se3_rel_retargeter.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import numpy as np
 from scipy.spatial.transform import Rotation
 

--- a/source/isaaclab/isaaclab/devices/retargeter_base.py
+++ b/source/isaaclab/isaaclab/devices/retargeter_base.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/source/isaaclab/isaaclab/devices/spacemouse/__init__.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Spacemouse device for SE(2) and SE(3) control."""
 
 from .se2_spacemouse import Se2SpaceMouse

--- a/source/isaaclab/isaaclab/devices/spacemouse/se2_spacemouse.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/se2_spacemouse.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Spacemouse controller for SE(2) control."""
 
 import hid

--- a/source/isaaclab/isaaclab/devices/spacemouse/se3_spacemouse.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/se3_spacemouse.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Spacemouse controller for SE(3) control."""
 
 import hid

--- a/source/isaaclab/isaaclab/devices/spacemouse/utils.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Helper functions for SpaceMouse."""
 
 # MIT License

--- a/source/isaaclab/isaaclab/envs/__init__.py
+++ b/source/isaaclab/isaaclab/envs/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package for environment definitions.
 
 Environments define the interface between the agent and the simulation.

--- a/source/isaaclab/isaaclab/envs/common.py
+++ b/source/isaaclab/isaaclab/envs/common.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import gymnasium as gym

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import builtins

--- a/source/isaaclab/isaaclab/envs/direct_marl_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.devices.openxr import XrCfg

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import builtins

--- a/source/isaaclab/isaaclab/envs/direct_rl_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.devices.openxr import XrCfg

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import builtins
 import torch
 from collections.abc import Sequence

--- a/source/isaaclab/isaaclab/envs/manager_based_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Base configuration of the environment.
 
 This module defines the general configuration of the environment. It includes parameters for

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # needed to import for allowing type-hinting: np.ndarray | None
 from __future__ import annotations
 

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.utils import configclass

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_mimic_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_mimic_env.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from collections.abc import Sequence
 

--- a/source/isaaclab/isaaclab/envs/mdp/__init__.py
+++ b/source/isaaclab/isaaclab/envs/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module with implementation of manager terms.
 
 The functions can be provided to different managers that are responsible for the

--- a/source/isaaclab/isaaclab/envs/mdp/actions/__init__.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Various action terms that can be used in the environment."""
 
 from .actions_cfg import *

--- a/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.controllers import DifferentialIKControllerCfg, OperationalSpaceControllerCfg

--- a/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions_to_limits.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions_to_limits.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/envs/mdp/actions/non_holonomic_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/non_holonomic_actions.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/envs/mdp/commands/__init__.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Various command terms that can be used in the environment."""
 
 from .commands_cfg import (

--- a/source/isaaclab/isaaclab/envs/mdp/commands/commands_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/commands_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import math
 from dataclasses import MISSING
 

--- a/source/isaaclab/isaaclab/envs/mdp/commands/null_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/null_command.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing command generator that does nothing."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/envs/mdp/commands/pose_2d_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/pose_2d_command.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing command generators for the 2D-pose for locomotion tasks."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/envs/mdp/commands/pose_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/pose_command.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing command generators for pose tracking."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/envs/mdp/commands/velocity_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/velocity_command.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing command generators for the velocity-based locomotion task."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/envs/mdp/curriculums.py
+++ b/source/isaaclab/isaaclab/envs/mdp/curriculums.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to create curriculum for the learning environment.
 
 The functions can be passed to the :class:`isaaclab.managers.CurriculumTermCfg` object to enable

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to enable different events.
 
 Events include anything related to altering the simulation state. This includes changing the physics

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to create observation terms.
 
 The functions can be passed to the :class:`isaaclab.managers.ObservationTermCfg` object to enable

--- a/source/isaaclab/isaaclab/envs/mdp/recorders/__init__.py
+++ b/source/isaaclab/isaaclab/envs/mdp/recorders/__init__.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Various recorder terms that can be used in the environment."""
 
 from .recorders import *

--- a/source/isaaclab/isaaclab/envs/mdp/recorders/recorders.py
+++ b/source/isaaclab/isaaclab/envs/mdp/recorders/recorders.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/source/isaaclab/isaaclab/envs/mdp/recorders/recorders_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mdp/recorders/recorders_cfg.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.managers.recorder_manager import RecorderManagerBaseCfg, RecorderTerm, RecorderTermCfg
 from isaaclab.utils import configclass
 

--- a/source/isaaclab/isaaclab/envs/mdp/rewards.py
+++ b/source/isaaclab/isaaclab/envs/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to enable reward functions.
 
 The functions can be passed to the :class:`isaaclab.managers.RewardTermCfg` object to include

--- a/source/isaaclab/isaaclab/envs/mdp/terminations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/terminations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to activate certain terminations.
 
 The functions can be passed to the :class:`isaaclab.managers.TerminationTermCfg` object to enable

--- a/source/isaaclab/isaaclab/envs/mimic_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mimic_env_cfg.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the NVIDIA Source Code License [see LICENSE for details].

--- a/source/isaaclab/isaaclab/envs/ui/__init__.py
+++ b/source/isaaclab/isaaclab/envs/ui/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module providing UI window implementation for environments.
 
 The UI elements are used to control the environment and visualize the state of the environment.

--- a/source/isaaclab/isaaclab/envs/ui/base_env_window.py
+++ b/source/isaaclab/isaaclab/envs/ui/base_env_window.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import asyncio

--- a/source/isaaclab/isaaclab/envs/ui/manager_based_rl_env_window.py
+++ b/source/isaaclab/isaaclab/envs/ui/manager_based_rl_env_window.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/source/isaaclab/isaaclab/envs/ui/viewport_camera_controller.py
+++ b/source/isaaclab/isaaclab/envs/ui/viewport_camera_controller.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import copy

--- a/source/isaaclab/isaaclab/envs/utils/__init__.py
+++ b/source/isaaclab/isaaclab/envs/utils/__init__.py
@@ -3,9 +3,4 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package for environment utils."""

--- a/source/isaaclab/isaaclab/envs/utils/marl.py
+++ b/source/isaaclab/isaaclab/envs/utils/marl.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 import math
 import numpy as np

--- a/source/isaaclab/isaaclab/envs/utils/spaces.py
+++ b/source/isaaclab/isaaclab/envs/utils/spaces.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 import json
 import numpy as np

--- a/source/isaaclab/isaaclab/managers/__init__.py
+++ b/source/isaaclab/isaaclab/managers/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for environment managers.
 
 The managers are used to handle various aspects of the environment such as randomization events, curriculum,

--- a/source/isaaclab/isaaclab/managers/action_manager.py
+++ b/source/isaaclab/isaaclab/managers/action_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Action manager for processing actions sent to the environment."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/managers/command_manager.py
+++ b/source/isaaclab/isaaclab/managers/command_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Command manager for generating and updating commands."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/managers/curriculum_manager.py
+++ b/source/isaaclab/isaaclab/managers/curriculum_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Curriculum manager for updating environment quantities subject to a training curriculum."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/managers/event_manager.py
+++ b/source/isaaclab/isaaclab/managers/event_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Event manager for orchestrating operations based on different simulation events."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/managers/manager_base.py
+++ b/source/isaaclab/isaaclab/managers/manager_base.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import copy

--- a/source/isaaclab/isaaclab/managers/manager_term_cfg.py
+++ b/source/isaaclab/isaaclab/managers/manager_term_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration terms for different managers."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/managers/observation_manager.py
+++ b/source/isaaclab/isaaclab/managers/observation_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Observation manager for computing observation signals for a given world."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/managers/recorder_manager.py
+++ b/source/isaaclab/isaaclab/managers/recorder_manager.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Recorder manager for recording data produced from the given world."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/managers/reward_manager.py
+++ b/source/isaaclab/isaaclab/managers/reward_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Reward manager for computing reward signals for a given world."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/managers/scene_entity_cfg.py
+++ b/source/isaaclab/isaaclab/managers/scene_entity_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration terms for different managers."""
 
 from dataclasses import MISSING

--- a/source/isaaclab/isaaclab/managers/termination_manager.py
+++ b/source/isaaclab/isaaclab/managers/termination_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Termination manager for computing done signals for a given world."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/markers/__init__.py
+++ b/source/isaaclab/isaaclab/markers/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package for marker utilities to simplify creation of UI elements in the GUI.
 
 Currently, the sub-package provides the following classes:

--- a/source/isaaclab/isaaclab/markers/config/__init__.py
+++ b/source/isaaclab/isaaclab/markers/config/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.markers.visualization_markers import VisualizationMarkersCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR

--- a/source/isaaclab/isaaclab/markers/visualization_markers.py
+++ b/source/isaaclab/isaaclab/markers/visualization_markers.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """A class to coordinate groups of visual markers (such as spheres, frames or arrows)
 using `UsdGeom.PointInstancer`_ class.
 

--- a/source/isaaclab/isaaclab/scene/__init__.py
+++ b/source/isaaclab/isaaclab/scene/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package containing an interactive scene definition.
 
 A scene is a collection of entities (e.g., terrain, articulations, sensors, lights, etc.) that can be added to the

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from collections.abc import Sequence
 from typing import Any

--- a/source/isaaclab/isaaclab/scene/interactive_scene_cfg.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.utils.configclass import configclass

--- a/source/isaaclab/isaaclab/sensors/__init__.py
+++ b/source/isaaclab/isaaclab/sensors/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package containing various sensor classes implementations.
 
 This subpackage contains the sensor classes that are compatible with Isaac Sim. We include both

--- a/source/isaaclab/isaaclab/sensors/camera/__init__.py
+++ b/source/isaaclab/isaaclab/sensors/camera/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for camera wrapper around USD camera prim."""
 
 from .camera import Camera

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import json

--- a/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 from typing import Literal
 

--- a/source/isaaclab/isaaclab/sensors/camera/camera_data.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_data.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from dataclasses import dataclass
 from typing import Any

--- a/source/isaaclab/isaaclab/sensors/camera/tiled_camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/tiled_camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import json

--- a/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from .camera_cfg import CameraCfg

--- a/source/isaaclab/isaaclab/sensors/camera/utils.py
+++ b/source/isaaclab/isaaclab/sensors/camera/utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Helper functions to project between pointcloud and depth images."""
 
 # needed to import for allowing type-hinting: torch.device | str | None

--- a/source/isaaclab/isaaclab/sensors/contact_sensor/__init__.py
+++ b/source/isaaclab/isaaclab/sensors/contact_sensor/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for rigid contact sensor based on :class:`isaacsim.core.prims.RigidContactView`."""
 
 from .contact_sensor import ContactSensor

--- a/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # Ignore optional memory usage warning globally
 # pyright: reportOptionalSubscript=false
 

--- a/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.markers import VisualizationMarkersCfg
 from isaaclab.markers.config import CONTACT_SENSOR_MARKER_CFG
 from isaaclab.utils import configclass

--- a/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor_data.py
+++ b/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor_data.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # needed to import for allowing type-hinting: torch.Tensor | None
 from __future__ import annotations
 

--- a/source/isaaclab/isaaclab/sensors/frame_transformer/__init__.py
+++ b/source/isaaclab/isaaclab/sensors/frame_transformer/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for frame transformer sensor."""
 
 from .frame_transformer import FrameTransformer

--- a/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer.py
+++ b/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import re

--- a/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.markers.config import FRAME_MARKER_CFG, VisualizationMarkersCfg

--- a/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer_data.py
+++ b/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer_data.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from dataclasses import dataclass
 

--- a/source/isaaclab/isaaclab/sensors/imu/__init__.py
+++ b/source/isaaclab/isaaclab/sensors/imu/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Imu Sensor
 """

--- a/source/isaaclab/isaaclab/sensors/imu/imu.py
+++ b/source/isaaclab/isaaclab/sensors/imu/imu.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/sensors/imu/imu_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/imu/imu_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from isaaclab.markers import VisualizationMarkersCfg

--- a/source/isaaclab/isaaclab/sensors/imu/imu_data.py
+++ b/source/isaaclab/isaaclab/sensors/imu/imu_data.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/sensors/ray_caster/__init__.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for Warp-based ray-cast sensor."""
 
 from . import patterns

--- a/source/isaaclab/isaaclab/sensors/ray_caster/patterns/__init__.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/patterns/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for ray-casting patterns used by the ray-caster."""
 
 from .patterns import bpearl_pattern, grid_pattern, lidar_pattern, pinhole_camera_pattern

--- a/source/isaaclab/isaaclab/sensors/ray_caster/patterns/patterns.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/patterns/patterns.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import math

--- a/source/isaaclab/isaaclab/sensors/ray_caster/patterns/patterns_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/patterns/patterns_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the ray-cast sensor."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import numpy as np

--- a/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster_camera.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster_camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster_camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster_camera_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the ray-cast camera sensor."""
 
 from dataclasses import MISSING

--- a/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the ray-cast sensor."""
 
 

--- a/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster_data.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster_data.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from dataclasses import dataclass
 

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Base class for sensors.
 
 This class defines an interface for sensors similar to how the :class:`isaaclab.assets.AssetBase` class works.

--- a/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.utils import configclass

--- a/source/isaaclab/isaaclab/sim/__init__.py
+++ b/source/isaaclab/isaaclab/sim/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package containing simulation-specific functionalities.
 
 These include:

--- a/source/isaaclab/isaaclab/sim/converters/__init__.py
+++ b/source/isaaclab/isaaclab/sim/converters/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing converters for converting various file types to USD.
 
 In order to support direct loading of various file types into Omniverse, we provide a set of

--- a/source/isaaclab/isaaclab/sim/converters/asset_converter_base.py
+++ b/source/isaaclab/isaaclab/sim/converters/asset_converter_base.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import abc
 import hashlib
 import json

--- a/source/isaaclab/isaaclab/sim/converters/asset_converter_base_cfg.py
+++ b/source/isaaclab/isaaclab/sim/converters/asset_converter_base_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.utils import configclass

--- a/source/isaaclab/isaaclab/sim/converters/mesh_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/mesh_converter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import asyncio
 import os
 

--- a/source/isaaclab/isaaclab/sim/converters/mesh_converter_cfg.py
+++ b/source/isaaclab/isaaclab/sim/converters/mesh_converter_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.sim.converters.asset_converter_base_cfg import AssetConverterBaseCfg
 from isaaclab.sim.schemas import schemas_cfg
 from isaaclab.utils import configclass

--- a/source/isaaclab/isaaclab/sim/converters/mjcf_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/mjcf_converter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import os

--- a/source/isaaclab/isaaclab/sim/converters/mjcf_converter_cfg.py
+++ b/source/isaaclab/isaaclab/sim/converters/mjcf_converter_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.sim.converters.asset_converter_base_cfg import AssetConverterBaseCfg

--- a/source/isaaclab/isaaclab/sim/converters/urdf_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/urdf_converter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import math

--- a/source/isaaclab/isaaclab/sim/converters/urdf_converter_cfg.py
+++ b/source/isaaclab/isaaclab/sim/converters/urdf_converter_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 from typing import Literal
 

--- a/source/isaaclab/isaaclab/sim/schemas/__init__.py
+++ b/source/isaaclab/isaaclab/sim/schemas/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing utilities for schemas used in Omniverse.
 
 We wrap the USD schemas for PhysX and USD Physics in a more convenient API for setting the parameters from

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # needed to import for allowing type-hinting: Usd.Stage | None
 from __future__ import annotations
 

--- a/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from typing import Literal
 
 from isaaclab.utils import configclass

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Base configuration of the environment.
 
 This module defines the general configuration of the environment. It includes parameters for

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import builtins
 import enum
 import numpy as np

--- a/source/isaaclab/isaaclab/sim/spawners/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing utilities for creating prims in Omniverse.
 
 Spawners are used to create prims into Omniverse simulator. At their core, they are calling the

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for spawners that spawn assets from files.
 
 Currently, the following spawners are supported:

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/source/isaaclab/isaaclab/sim/spawners/lights/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/lights/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for spawners that spawn lights in the simulation.
 
 There are various different kinds of lights that can be spawned into the USD stage.

--- a/source/isaaclab/isaaclab/sim/spawners/lights/lights.py
+++ b/source/isaaclab/isaaclab/sim/spawners/lights/lights.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/source/isaaclab/isaaclab/sim/spawners/lights/lights_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/lights/lights_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from collections.abc import Callable
 from dataclasses import MISSING
 from typing import Literal

--- a/source/isaaclab/isaaclab/sim/spawners/materials/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for spawners that spawn USD-based and PhysX-based materials.
 
 `Materials`_ are used to define the appearance and physical properties of objects in the simulation.

--- a/source/isaaclab/isaaclab/sim/spawners/materials/physics_materials.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/physics_materials.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/source/isaaclab/isaaclab/sim/spawners/materials/physics_materials_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/physics_materials_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from collections.abc import Callable
 from dataclasses import MISSING
 from typing import Literal

--- a/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from collections.abc import Callable
 from dataclasses import MISSING
 

--- a/source/isaaclab/isaaclab/sim/spawners/meshes/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/meshes/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for spawning meshes in the simulation.
 
 NVIDIA Omniverse deals with meshes as `USDGeomMesh`_ prims. This sub-module provides various

--- a/source/isaaclab/isaaclab/sim/spawners/meshes/meshes.py
+++ b/source/isaaclab/isaaclab/sim/spawners/meshes/meshes.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import numpy as np

--- a/source/isaaclab/isaaclab/sim/spawners/meshes/meshes_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/meshes/meshes_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/source/isaaclab/isaaclab/sim/spawners/sensors/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/sensors/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for spawners that spawn sensors in the simulation.
 
 Currently, the following sensors are supported:

--- a/source/isaaclab/isaaclab/sim/spawners/sensors/sensors.py
+++ b/source/isaaclab/isaaclab/sim/spawners/sensors/sensors.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/source/isaaclab/isaaclab/sim/spawners/sensors/sensors_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/sensors/sensors_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/source/isaaclab/isaaclab/sim/spawners/shapes/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/shapes/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for spawning primitive shapes in the simulation.
 
 NVIDIA Omniverse provides various primitive shapes that can be used to create USDGeom prims. Based

--- a/source/isaaclab/isaaclab/sim/spawners/shapes/shapes.py
+++ b/source/isaaclab/isaaclab/sim/spawners/shapes/shapes.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/source/isaaclab/isaaclab/sim/spawners/shapes/shapes_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/shapes/shapes_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from collections.abc import Callable
 from dataclasses import MISSING
 from typing import Literal

--- a/source/isaaclab/isaaclab/sim/spawners/spawner_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/spawner_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/source/isaaclab/isaaclab/sim/spawners/wrappers/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/wrappers/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for wrapping spawner configurations.
 
 Unlike the other spawner modules, this module provides a way to wrap multiple spawner configurations

--- a/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers.py
+++ b/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import random

--- a/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.sim.spawners.from_files import UsdFileCfg

--- a/source/isaaclab/isaaclab/sim/utils.py
+++ b/source/isaaclab/isaaclab/sim/utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module with USD-related utilities."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/terrains/__init__.py
+++ b/source/isaaclab/isaaclab/terrains/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package with utilities for creating terrains procedurally.
 
 There are two main components in this package:

--- a/source/isaaclab/isaaclab/terrains/config/__init__.py
+++ b/source/isaaclab/isaaclab/terrains/config/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Pre-defined terrain configurations for the terrain generator."""
 
 from .rough import *  # noqa: F401

--- a/source/isaaclab/isaaclab/terrains/config/rough.py
+++ b/source/isaaclab/isaaclab/terrains/config/rough.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for custom terrains."""
 
 import isaaclab.terrains as terrain_gen

--- a/source/isaaclab/isaaclab/terrains/height_field/__init__.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This sub-module provides utilities to create different terrains as height fields (HF).
 

--- a/source/isaaclab/isaaclab/terrains/height_field/hf_terrains.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/hf_terrains.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Functions to generate height fields for different terrains."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/terrains/height_field/hf_terrains_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/hf_terrains_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.utils import configclass

--- a/source/isaaclab/isaaclab/terrains/height_field/utils.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import copy

--- a/source/isaaclab/isaaclab/terrains/terrain_generator.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_generator.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import numpy as np

--- a/source/isaaclab/isaaclab/terrains/terrain_generator_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_generator_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Configuration classes defining the different terrains available. Each configuration class must
 inherit from ``isaaclab.terrains.terrains_cfg.TerrainConfig`` and define the following attributes:

--- a/source/isaaclab/isaaclab/terrains/terrain_importer.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_importer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import numpy as np

--- a/source/isaaclab/isaaclab/terrains/terrain_importer_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_importer_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from dataclasses import MISSING

--- a/source/isaaclab/isaaclab/terrains/trimesh/__init__.py
+++ b/source/isaaclab/isaaclab/terrains/trimesh/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This sub-module provides methods to create different terrains using the ``trimesh`` library.
 

--- a/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains.py
+++ b/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Functions to generate different terrains using the ``trimesh`` library."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 from typing import Literal
 

--- a/source/isaaclab/isaaclab/terrains/trimesh/utils.py
+++ b/source/isaaclab/isaaclab/terrains/trimesh/utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import numpy as np
 import scipy.spatial.transform as tf
 import trimesh

--- a/source/isaaclab/isaaclab/terrains/utils.py
+++ b/source/isaaclab/isaaclab/terrains/utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # needed to import for allowing type-hinting: np.ndarray | torch.Tensor | None
 from __future__ import annotations
 

--- a/source/isaaclab/isaaclab/ui/widgets/__init__.py
+++ b/source/isaaclab/isaaclab/ui/widgets/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from .image_plot import ImagePlot
 from .line_plot import LiveLinePlot
 from .manager_live_visualizer import ManagerLiveVisualizer

--- a/source/isaaclab/isaaclab/ui/widgets/image_plot.py
+++ b/source/isaaclab/isaaclab/ui/widgets/image_plot.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import numpy as np
 from contextlib import suppress
 from matplotlib import cm

--- a/source/isaaclab/isaaclab/ui/widgets/line_plot.py
+++ b/source/isaaclab/isaaclab/ui/widgets/line_plot.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import colorsys

--- a/source/isaaclab/isaaclab/ui/widgets/manager_live_visualizer.py
+++ b/source/isaaclab/isaaclab/ui/widgets/manager_live_visualizer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import numpy

--- a/source/isaaclab/isaaclab/ui/widgets/ui_visualizer_base.py
+++ b/source/isaaclab/isaaclab/ui/widgets/ui_visualizer_base.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import inspect

--- a/source/isaaclab/isaaclab/ui/widgets/ui_widget_wrapper.py
+++ b/source/isaaclab/isaaclab/ui/widgets/ui_widget_wrapper.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # This file has been adapted from _isaac_sim/exts/isaacsim.gui.components/isaacsim/gui/components/element_wrappers/base_ui_element_wrappers.py
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/utils/__init__.py
+++ b/source/isaaclab/isaaclab/utils/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package containing utilities for common operations and helper functions."""
 
 from .array import *

--- a/source/isaaclab/isaaclab/utils/array.py
+++ b/source/isaaclab/isaaclab/utils/array.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing utilities for working with different array backends."""
 
 # needed to import for allowing type-hinting: torch.device | str | None

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module that defines the host-server where assets and resources are stored.
 
 By default, we use the Isaac Sim Nucleus Server for hosting assets and resources. This makes

--- a/source/isaaclab/isaaclab/utils/buffers/__init__.py
+++ b/source/isaaclab/isaaclab/utils/buffers/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing different buffers."""
 
 from .circular_buffer import CircularBuffer

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from collections.abc import Sequence
 

--- a/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # needed because we concatenate int and torch.Tensor in the type hints
 from __future__ import annotations
 

--- a/source/isaaclab/isaaclab/utils/buffers/timestamped_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/timestamped_buffer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from dataclasses import dataclass
 

--- a/source/isaaclab/isaaclab/utils/configclass.py
+++ b/source/isaaclab/isaaclab/utils/configclass.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module that provides a wrapper around the Python 3.7 onwards ``dataclasses`` module."""
 
 import inspect

--- a/source/isaaclab/isaaclab/utils/dict.py
+++ b/source/isaaclab/isaaclab/utils/dict.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for utilities for working with dictionaries."""
 
 import collections.abc

--- a/source/isaaclab/isaaclab/utils/interpolation/__init__.py
+++ b/source/isaaclab/isaaclab/utils/interpolation/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Submodule for different interpolation methods.
 """

--- a/source/isaaclab/isaaclab/utils/interpolation/linear_interpolation.py
+++ b/source/isaaclab/isaaclab/utils/interpolation/linear_interpolation.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 
 

--- a/source/isaaclab/isaaclab/utils/io/__init__.py
+++ b/source/isaaclab/isaaclab/utils/io/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Submodules for files IO operations.
 """

--- a/source/isaaclab/isaaclab/utils/io/pkl.py
+++ b/source/isaaclab/isaaclab/utils/io/pkl.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Utilities for file I/O with pickle."""
 
 import os

--- a/source/isaaclab/isaaclab/utils/io/yaml.py
+++ b/source/isaaclab/isaaclab/utils/io/yaml.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Utilities for file I/O with yaml."""
 
 import os

--- a/source/isaaclab/isaaclab/utils/math.py
+++ b/source/isaaclab/isaaclab/utils/math.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing utilities for various math operations."""
 
 # needed to import for allowing type-hinting: torch.Tensor | np.ndarray

--- a/source/isaaclab/isaaclab/utils/modifiers/__init__.py
+++ b/source/isaaclab/isaaclab/utils/modifiers/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing different modifiers implementations.
 
 Modifiers are used to apply stateful or stateless modifications to tensor data. They take

--- a/source/isaaclab/isaaclab/utils/modifiers/modifier.py
+++ b/source/isaaclab/isaaclab/utils/modifiers/modifier.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/utils/modifiers/modifier_base.py
+++ b/source/isaaclab/isaaclab/utils/modifiers/modifier_base.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/utils/modifiers/modifier_cfg.py
+++ b/source/isaaclab/isaaclab/utils/modifiers/modifier_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 from collections.abc import Callable
 from dataclasses import MISSING

--- a/source/isaaclab/isaaclab/utils/noise/__init__.py
+++ b/source/isaaclab/isaaclab/utils/noise/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing different noise models implementations.
 
 The noise models are implemented as functions that take in a tensor and a configuration and return a tensor

--- a/source/isaaclab/isaaclab/utils/noise/noise_cfg.py
+++ b/source/isaaclab/isaaclab/utils/noise/noise_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/utils/noise/noise_model.py
+++ b/source/isaaclab/isaaclab/utils/noise/noise_model.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab/isaaclab/utils/pretrained_checkpoint.py
+++ b/source/isaaclab/isaaclab/utils/pretrained_checkpoint.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for handling various pre-trained checkpoint tasks"""
 
 import glob

--- a/source/isaaclab/isaaclab/utils/sensors.py
+++ b/source/isaaclab/isaaclab/utils/sensors.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import omni
 
 

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing utilities for transforming strings and regular expressions."""
 
 import ast

--- a/source/isaaclab/isaaclab/utils/timer.py
+++ b/source/isaaclab/isaaclab/utils/timer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for a timer class that can be used for performance measurements."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/utils/types.py
+++ b/source/isaaclab/isaaclab/utils/types.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module for different data types."""
 
 from __future__ import annotations

--- a/source/isaaclab/isaaclab/utils/warp/__init__.py
+++ b/source/isaaclab/isaaclab/utils/warp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing operations based on warp."""
 
 from .ops import convert_to_warp_mesh, raycast_mesh

--- a/source/isaaclab/isaaclab/utils/warp/kernels.py
+++ b/source/isaaclab/isaaclab/utils/warp/kernels.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Custom kernels for warp."""
 
 from typing import Any

--- a/source/isaaclab/isaaclab/utils/warp/ops.py
+++ b/source/isaaclab/isaaclab/utils/warp/ops.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Wrapping around warp kernels for compatibility with torch tensors."""
 
 # needed to import for allowing type-hinting: torch.Tensor | None

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Installation script for the 'isaaclab' python package."""
 
 import os

--- a/source/isaaclab/test/app/test_argparser_launch.py
+++ b/source/isaaclab/test/app/test_argparser_launch.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 
 import pytest

--- a/source/isaaclab/test/app/test_env_var_launch.py
+++ b/source/isaaclab/test/app/test_env_var_launch.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import os
 
 import pytest

--- a/source/isaaclab/test/app/test_kwarg_launch.py
+++ b/source/isaaclab/test/app/test_kwarg_launch.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import pytest
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/assets/check_external_force.py
+++ b/source/isaaclab/test/assets/check_external_force.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script checks if the external force is applied correctly on the robot.
 

--- a/source/isaaclab/test/assets/check_fixed_base_assets.py
+++ b/source/isaaclab/test/assets/check_fixed_base_assets.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates fixed-base API for different robots.
 

--- a/source/isaaclab/test/assets/check_ridgeback_franka.py
+++ b/source/isaaclab/test/assets/check_ridgeback_franka.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to simulate a mobile manipulator.
 

--- a/source/isaaclab/test/assets/test_articulation.py
+++ b/source/isaaclab/test/assets/test_articulation.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/assets/test_deformable_object.py
+++ b/source/isaaclab/test/assets/test_deformable_object.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/assets/test_rigid_object.py
+++ b/source/isaaclab/test/assets/test_rigid_object.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab/test/assets/test_rigid_object_collection.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/controllers/test_differential_ik.py
+++ b/source/isaaclab/test/controllers/test_differential_ik.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/controllers/test_operational_space.py
+++ b/source/isaaclab/test/controllers/test_operational_space.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/deps/isaacsim/check_camera.py
+++ b/source/isaaclab/test/deps/isaacsim/check_camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script shows the issue with renderer in Isaac Sim that affects episodic resets.
 

--- a/source/isaaclab/test/deps/isaacsim/check_floating_base_made_fixed.py
+++ b/source/isaaclab/test/deps/isaacsim/check_floating_base_made_fixed.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates how to make a floating robot fixed in Isaac Sim."""
 
 """Launch Isaac Sim Simulator first."""

--- a/source/isaaclab/test/deps/isaacsim/check_legged_robot_clone.py
+++ b/source/isaaclab/test/deps/isaacsim/check_legged_robot_clone.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to use the cloner API from Isaac Sim.
 

--- a/source/isaaclab/test/deps/isaacsim/check_ref_count.py
+++ b/source/isaaclab/test/deps/isaacsim/check_ref_count.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates reference count of the robot view in Isaac Sim.
 

--- a/source/isaaclab/test/deps/isaacsim/check_rep_texture_randomizer.py
+++ b/source/isaaclab/test/deps/isaacsim/check_rep_texture_randomizer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script shows how to use replicator to randomly change the textures of a USD scene.
 

--- a/source/isaaclab/test/deps/test_scipy.py
+++ b/source/isaaclab/test/deps/test_scipy.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # isort: off
 import warnings
 

--- a/source/isaaclab/test/deps/test_torch.py
+++ b/source/isaaclab/test/deps/test_torch.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 import torch.utils.benchmark as benchmark
 

--- a/source/isaaclab/test/devices/check_keyboard.py
+++ b/source/isaaclab/test/devices/check_keyboard.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script shows how to use a teleoperation device with Isaac Sim.
 

--- a/source/isaaclab/test/envs/check_manager_based_env_anymal_locomotion.py
+++ b/source/isaaclab/test/envs/check_manager_based_env_anymal_locomotion.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates the environment concept that combines a scene with an action,
 observation and event manager for a quadruped robot.

--- a/source/isaaclab/test/envs/check_manager_based_env_floating_cube.py
+++ b/source/isaaclab/test/envs/check_manager_based_env_floating_cube.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates the base environment concept that combines a scene with an action,
 observation and event manager for a floating cube.

--- a/source/isaaclab/test/envs/test_action_state_recorder_term.py
+++ b/source/isaaclab/test/envs/test_action_state_recorder_term.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/envs/test_direct_marl_env.py
+++ b/source/isaaclab/test/envs/test_direct_marl_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/envs/test_env_rendering_logic.py
+++ b/source/isaaclab/test/envs/test_env_rendering_logic.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/envs/test_manager_based_env.py
+++ b/source/isaaclab/test/envs/test_manager_based_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/envs/test_manager_based_rl_env_ui.py
+++ b/source/isaaclab/test/envs/test_manager_based_rl_env_ui.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/envs/test_null_command_term.py
+++ b/source/isaaclab/test/envs/test_null_command_term.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/envs/test_scale_randomization.py
+++ b/source/isaaclab/test/envs/test_scale_randomization.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script checks the functionality of scale randomization.
 """

--- a/source/isaaclab/test/envs/test_spaces_utils.py
+++ b/source/isaaclab/test/envs/test_spaces_utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/envs/test_texture_randomization.py
+++ b/source/isaaclab/test/envs/test_texture_randomization.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script tests the functionality of texture randomization applied to the cartpole scene.
 """

--- a/source/isaaclab/test/managers/test_event_manager.py
+++ b/source/isaaclab/test/managers/test_event_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/managers/test_observation_manager.py
+++ b/source/isaaclab/test/managers/test_observation_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # needed to import for allowing type-hinting: torch.Tensor | None
 from __future__ import annotations
 

--- a/source/isaaclab/test/managers/test_recorder_manager.py
+++ b/source/isaaclab/test/managers/test_recorder_manager.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # needed to import for allowing type-hinting: torch.Tensor | None
 from __future__ import annotations
 

--- a/source/isaaclab/test/managers/test_reward_manager.py
+++ b/source/isaaclab/test/managers/test_reward_manager.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/markers/check_markers_visibility.py
+++ b/source/isaaclab/test/markers/check_markers_visibility.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script checks if the debug markers are visible from the camera.
 

--- a/source/isaaclab/test/markers/test_visualization_markers.py
+++ b/source/isaaclab/test/markers/test_visualization_markers.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/performance/test_kit_startup_performance.py
+++ b/source/isaaclab/test/performance/test_kit_startup_performance.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/performance/test_robot_load_performance.py
+++ b/source/isaaclab/test/performance/test_robot_load_performance.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/scene/check_interactive_scene.py
+++ b/source/isaaclab/test/scene/check_interactive_scene.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to use the scene interface to quickly setup a scene with multiple
 articulated robots and sensors.

--- a/source/isaaclab/test/scene/test_interactive_scene.py
+++ b/source/isaaclab/test/scene/test_interactive_scene.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sensors/check_contact_sensor.py
+++ b/source/isaaclab/test/sensors/check_contact_sensor.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script demonstrates how to use the contact sensor sensor in Isaac Lab.
 

--- a/source/isaaclab/test/sensors/check_imu_sensor.py
+++ b/source/isaaclab/test/sensors/check_imu_sensor.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Visual test script for the imu sensor from the Orbit framework.
 """

--- a/source/isaaclab/test/sensors/check_ray_caster.py
+++ b/source/isaaclab/test/sensors/check_ray_caster.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script shows how to use the ray caster from the Isaac Lab framework.
 

--- a/source/isaaclab/test/sensors/test_camera.py
+++ b/source/isaaclab/test/sensors/test_camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab/test/sensors/test_contact_sensor.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Tests to verify contact sensor functionality on rigid object prims."""
 
 """Launch Isaac Sim Simulator first."""

--- a/source/isaaclab/test/sensors/test_frame_transformer.py
+++ b/source/isaaclab/test/sensors/test_frame_transformer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sensors/test_imu.py
+++ b/source/isaaclab/test/sensors/test_imu.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sensors/test_multi_tiled_camera.py
+++ b/source/isaaclab/test/sensors/test_multi_tiled_camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/sensors/test_outdated_sensor.py
+++ b/source/isaaclab/test/sensors/test_outdated_sensor.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sensors/test_ray_caster_camera.py
+++ b/source/isaaclab/test/sensors/test_ray_caster_camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/sensors/test_tiled_camera.py
+++ b/source/isaaclab/test/sensors/test_tiled_camera.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab/test/sensors/test_tiled_camera_env.py
+++ b/source/isaaclab/test/sensors/test_tiled_camera_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 import argparse

--- a/source/isaaclab/test/sim/check_meshes.py
+++ b/source/isaaclab/test/sim/check_meshes.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script demonstrates different rigid and deformable meshes in the scene.
 
 It randomly spawns different types of meshes in the scene. The meshes can be rigid or deformable

--- a/source/isaaclab/test/sim/test_build_simulation_context_headless.py
+++ b/source/isaaclab/test/sim/test_build_simulation_context_headless.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This test has a lot of duplication with ``test_build_simulation_context_nonheadless.py``. This is intentional to ensure that the
 tests are run in both headless and non-headless modes, and we currently can't re-build the simulation app in a script.

--- a/source/isaaclab/test/sim/test_build_simulation_context_nonheadless.py
+++ b/source/isaaclab/test/sim/test_build_simulation_context_nonheadless.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This test has a lot of duplication with ``test_build_simulation_context_headless.py``. This is intentional to ensure that the
 tests are run in both headless and non-headless modes, and we currently can't re-build the simulation app in a script.
 

--- a/source/isaaclab/test/sim/test_mesh_converter.py
+++ b/source/isaaclab/test/sim/test_mesh_converter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_mjcf_converter.py
+++ b/source/isaaclab/test/sim/test_mjcf_converter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_schemas.py
+++ b/source/isaaclab/test/sim/test_schemas.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_simulation_context.py
+++ b/source/isaaclab/test/sim/test_simulation_context.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_simulation_render_config.py
+++ b/source/isaaclab/test/sim/test_simulation_render_config.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 """Launch Isaac Sim Simulator first."""
 

--- a/source/isaaclab/test/sim/test_spawn_from_files.py
+++ b/source/isaaclab/test/sim/test_spawn_from_files.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.app import AppLauncher
 
 """Launch Isaac Sim Simulator first."""

--- a/source/isaaclab/test/sim/test_spawn_lights.py
+++ b/source/isaaclab/test/sim/test_spawn_lights.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_spawn_materials.py
+++ b/source/isaaclab/test/sim/test_spawn_materials.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_spawn_meshes.py
+++ b/source/isaaclab/test/sim/test_spawn_meshes.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_spawn_sensors.py
+++ b/source/isaaclab/test/sim/test_spawn_sensors.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_spawn_shapes.py
+++ b/source/isaaclab/test/sim/test_spawn_shapes.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_spawn_wrappers.py
+++ b/source/isaaclab/test/sim/test_spawn_wrappers.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_urdf_converter.py
+++ b/source/isaaclab/test/sim/test_urdf_converter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/sim/test_utils.py
+++ b/source/isaaclab/test/sim/test_utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/terrains/check_height_field_subterrains.py
+++ b/source/isaaclab/test/terrains/check_height_field_subterrains.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 import argparse

--- a/source/isaaclab/test/terrains/check_mesh_subterrains.py
+++ b/source/isaaclab/test/terrains/check_mesh_subterrains.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 import argparse

--- a/source/isaaclab/test/terrains/check_terrain_importer.py
+++ b/source/isaaclab/test/terrains/check_terrain_importer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script shows how to use the terrain generator from the Isaac Lab framework.
 

--- a/source/isaaclab/test/terrains/test_terrain_generator.py
+++ b/source/isaaclab/test/terrains/test_terrain_generator.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/terrains/test_terrain_importer.py
+++ b/source/isaaclab/test/terrains/test_terrain_importer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 """Launch Isaac Sim Simulator first."""

--- a/source/isaaclab/test/utils/test_circular_buffer.py
+++ b/source/isaaclab/test/utils/test_circular_buffer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 
 import pytest

--- a/source/isaaclab/test/utils/test_configclass.py
+++ b/source/isaaclab/test/utils/test_configclass.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 # NOTE: While we don't actually use the simulation app in this test, we still need to launch it

--- a/source/isaaclab/test/utils/test_delay_buffer.py
+++ b/source/isaaclab/test/utils/test_delay_buffer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/utils/test_dict.py
+++ b/source/isaaclab/test/utils/test_dict.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # NOTE: While we don't actually use the simulation app in this test, we still need to launch it
 #       because warp is only available in the context of a running simulation
 """Launch Isaac Sim Simulator first."""

--- a/source/isaaclab/test/utils/test_episode_data.py
+++ b/source/isaaclab/test/utils/test_episode_data.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/utils/test_hdf5_dataset_file_handler.py
+++ b/source/isaaclab/test/utils/test_hdf5_dataset_file_handler.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/utils/test_math.py
+++ b/source/isaaclab/test/utils/test_math.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first.
 
 This is only needed because of warp dependency.

--- a/source/isaaclab/test/utils/test_modifiers.py
+++ b/source/isaaclab/test/utils/test_modifiers.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/utils/test_noise.py
+++ b/source/isaaclab/test/utils/test_noise.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab/test/utils/test_string.py
+++ b/source/isaaclab/test/utils/test_string.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # NOTE: While we don't actually use the simulation app in this test, we still need to launch it
 #       because warp is only available in the context of a running simulation
 """Launch Isaac Sim Simulator first."""

--- a/source/isaaclab/test/utils/test_timer.py
+++ b/source/isaaclab/test/utils/test_timer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # NOTE: While we don't actually use the simulation app in this test, we still need to launch it
 #       because warp is only available in the context of a running simulation
 """Launch Isaac Sim Simulator first."""

--- a/source/isaaclab_assets/isaaclab_assets/__init__.py
+++ b/source/isaaclab_assets/isaaclab_assets/__init__.py
@@ -2,11 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
 """Package containing asset and sensor configurations."""
 
 import os

--- a/source/isaaclab_assets/isaaclab_assets/robots/__init__.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 ##
 # Configuration for different assets.
 ##

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the Allegro Hand robots from Wonik Robotics.
 
 The following configurations are available:

--- a/source/isaaclab_assets/isaaclab_assets/robots/ant.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/ant.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the Mujoco Ant robot."""
 
 from __future__ import annotations

--- a/source/isaaclab_assets/isaaclab_assets/robots/anymal.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/anymal.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the ANYbotics robots.
 
 The following configuration parameters are available:

--- a/source/isaaclab_assets/isaaclab_assets/robots/cart_double_pendulum.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/cart_double_pendulum.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for a simple inverted Double Pendulum on a Cart robot."""
 
 

--- a/source/isaaclab_assets/isaaclab_assets/robots/cartpole.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/cartpole.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for a simple Cartpole robot."""
 
 

--- a/source/isaaclab_assets/isaaclab_assets/robots/cassie.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/cassie.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for Agility robots.
 
 The following configurations are available:

--- a/source/isaaclab_assets/isaaclab_assets/robots/franka.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/franka.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the Franka Emika robots.
 
 The following configurations are available:

--- a/source/isaaclab_assets/isaaclab_assets/robots/humanoid.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/humanoid.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the Mujoco Humanoid robot."""
 
 from __future__ import annotations

--- a/source/isaaclab_assets/isaaclab_assets/robots/humanoid_28.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/humanoid_28.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the 28-DOFs Mujoco Humanoid robot."""
 
 from __future__ import annotations

--- a/source/isaaclab_assets/isaaclab_assets/robots/kinova.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/kinova.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the Kinova Robotics arms.
 
 The following configuration parameters are available:

--- a/source/isaaclab_assets/isaaclab_assets/robots/quadcopter.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/quadcopter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the quadcopters"""
 
 from __future__ import annotations

--- a/source/isaaclab_assets/isaaclab_assets/robots/ridgeback_franka.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/ridgeback_franka.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the Ridgeback-Manipulation robots.
 
 The following configurations are available:

--- a/source/isaaclab_assets/isaaclab_assets/robots/sawyer.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/sawyer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the Rethink Robotics arms.
 
 The following configuration parameters are available:

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the dexterous hand from Shadow Robot.
 
 The following configurations are available:

--- a/source/isaaclab_assets/isaaclab_assets/robots/spot.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/spot.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 """Configuration for the Boston Dynamics robot.
 

--- a/source/isaaclab_assets/isaaclab_assets/robots/unitree.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/unitree.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for Unitree robots.
 
 The following configurations are available:

--- a/source/isaaclab_assets/isaaclab_assets/robots/universal_robots.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/universal_robots.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for the Universal Robots.
 
 The following configuration parameters are available:

--- a/source/isaaclab_assets/isaaclab_assets/sensors/__init__.py
+++ b/source/isaaclab_assets/isaaclab_assets/sensors/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 ##
 # Configuration for different assets.
 ##

--- a/source/isaaclab_assets/isaaclab_assets/sensors/velodyne.py
+++ b/source/isaaclab_assets/isaaclab_assets/sensors/velodyne.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configuration for Velodyne LiDAR sensors."""
 
 

--- a/source/isaaclab_assets/setup.py
+++ b/source/isaaclab_assets/setup.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Installation script for the 'isaaclab_assets' python package."""
 
 import os

--- a/source/isaaclab_assets/test/test_valid_configs.py
+++ b/source/isaaclab_assets/test/test_valid_configs.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 

--- a/source/isaaclab_mimic/isaaclab_mimic/__init__.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """Package containing implementation of Isaac Lab Mimic data generation."""
 
 __version__ = "1.0.0"

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/__init__.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """Sub-package with core implementation logic for Isaac Lab Mimic."""
 
 from .data_generator import *

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/data_generator.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/data_generator.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """
 Base class for data generator.
 """

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/datagen_info.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/datagen_info.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """
 Defines structure of information that is needed from an environment for data generation.
 """

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/datagen_info_pool.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/datagen_info_pool.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 import asyncio
 
 from isaaclab.utils.datasets import EpisodeData, HDF5DatasetFileHandler

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/selection_strategy.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/selection_strategy.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """
 Selection strategies used by Isaac Lab Mimic to select subtask segments from
 source human demonstrations.

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/waypoint.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/waypoint.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """
 A collection of classes used to represent waypoints and trajectories.
 """

--- a/source/isaaclab_mimic/isaaclab_mimic/envs/__init__.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/envs/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """Sub-package with environment wrappers for Isaac Lab Mimic."""
 
 import gymnasium as gym

--- a/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_abs_mimic_env.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_abs_mimic_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 import torch
 from collections.abc import Sequence
 

--- a/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_abs_mimic_env_cfg.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_abs_mimic_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 from isaaclab.envs.mimic_env_cfg import MimicEnvCfg, SubTaskConfig
 from isaaclab.utils import configclass
 

--- a/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_rel_blueprint_mimic_env_cfg.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_rel_blueprint_mimic_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 from isaaclab.envs.mimic_env_cfg import MimicEnvCfg, SubTaskConfig
 from isaaclab.utils import configclass
 

--- a/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_rel_mimic_env.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_rel_mimic_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 import torch
 from collections.abc import Sequence
 

--- a/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_rel_mimic_env_cfg.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/envs/franka_stack_ik_rel_mimic_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 from isaaclab.envs.mimic_env_cfg import MimicEnvCfg, SubTaskConfig
 from isaaclab.utils import configclass
 

--- a/source/isaaclab_mimic/isaaclab_mimic/ui/instruction_display.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/ui/instruction_display.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 # Copyright (c) 2025, The Isaac Lab Project Developers.
 # All rights reserved.
 #

--- a/source/isaaclab_mimic/setup.py
+++ b/source/isaaclab_mimic/setup.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """Installation script for the 'isaaclab_mimic' python package."""
 
 import itertools

--- a/source/isaaclab_mimic/test/test_generate_dataset.py
+++ b/source/isaaclab_mimic/test/test_generate_dataset.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """Test dataset generation for Isaac Lab Mimic workflow."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab_mimic/test/test_selection_strategy.py
+++ b/source/isaaclab_mimic/test/test_selection_strategy.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 from isaaclab.app import AppLauncher
 
 # launch omniverse app

--- a/source/isaaclab_rl/isaaclab_rl/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Package for environment wrappers to different learning frameworks.
 
 Wrappers allow you to modify the behavior of an environment without modifying the environment itself.

--- a/source/isaaclab_rl/isaaclab_rl/rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/rl_games.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Wrapper to configure an environment instance to RL-Games vectorized environment.
 
 The following example shows how to wrap an environment for RL-Games and register the environment construction

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Wrappers and utilities to configure an environment for RSL-RL library.
 
 The following example shows how to wrap an environment for RSL-RL:

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/distillation_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/distillation_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from dataclasses import MISSING

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/exporter.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/exporter.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import copy
 import os
 import torch

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from dataclasses import MISSING

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rnd_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rnd_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.utils import configclass

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/symmetry_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/symmetry_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 from isaaclab.utils import configclass

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/vecenv_wrapper.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/vecenv_wrapper.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 import torch
 

--- a/source/isaaclab_rl/isaaclab_rl/sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/sb3.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Wrapper to configure an environment instance to Stable-Baselines3 vectorized environment.
 
 The following example shows how to wrap an environment for Stable-Baselines3:

--- a/source/isaaclab_rl/isaaclab_rl/skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/skrl.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Wrapper to configure an environment instance to skrl environment.
 
 The following example shows how to wrap an environment for skrl:

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Installation script for the 'isaaclab_rl' python package."""
 
 import itertools

--- a/source/isaaclab_rl/test/test_rl_games_wrapper.py
+++ b/source/isaaclab_rl/test/test_rl_games_wrapper.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab_rl/test/test_rsl_rl_wrapper.py
+++ b/source/isaaclab_rl/test/test_rsl_rl_wrapper.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab_rl/test/test_sb3_wrapper.py
+++ b/source/isaaclab_rl/test/test_sb3_wrapper.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab_rl/test/test_skrl_wrapper.py
+++ b/source/isaaclab_rl/test/test_skrl_wrapper.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab_tasks/isaaclab_tasks/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Package containing task implementations for various robotic environments."""
 
 import os

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Direct workflow environments.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Allegro Inhand Manipulation environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/allegro_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/allegro_hand_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 from isaaclab_assets.robots.allegro import ALLEGRO_HAND_CFG
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/ant/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/ant/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Ant locomotion environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/ant/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/ant/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/ant/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/ant/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/ant/ant_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/ant/ant_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from isaaclab_assets.robots.ant import ANT_CFG

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Ant locomotion environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/anymal_c_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/anymal_c_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import gymnasium as gym

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/anymal_c_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/anymal_c_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.envs.mdp as mdp
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import json
 import numpy as np
 import os

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.actuators.actuator_cfg import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_tasks_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_tasks_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/automate_algo_utils.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/automate_algo_utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import numpy as np
 import os
 import sys

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/automate_log_utils.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/automate_log_utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import h5py
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import json
 import numpy as np
 import os

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.actuators.actuator_cfg import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_tasks_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_tasks_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/factory_control.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/factory_control.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Factory: control module.
 
 Imported by base, environment, and task classes. Not directly executed.

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/industreal_algo_utils.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/industreal_algo_utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # Copyright (c) 2023, NVIDIA Corporation
 # All rights reserved.
 #

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_disassembly_w_id.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_disassembly_w_id.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 import os
 import re

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_w_id.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_w_id.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import argparse
 import re
 import subprocess

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/soft_dtw_cuda.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/soft_dtw_cuda.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 # MIT License
 #
 # Copyright (c) 2020 Mehran Maghoumi

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Inverted Double Pendulum on a Cart balancing environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/cart_double_pendulum_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/cart_double_pendulum_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import math

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Cartpole balancing environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import math

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import math

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Cartpole environment showcase for the supported Gymnasium spaces."""
 
 from .cartpole import *  # noqa

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Cartpole balancing environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole/cartpole_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole/cartpole_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import gymnasium as gym

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole/cartpole_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole/cartpole_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from gymnasium import spaces

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole_camera/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole_camera/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Cartpole balancing environment with camera.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole_camera/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole_camera/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole_camera/cartpole_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole_camera/cartpole_camera_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import gymnasium as gym

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole_camera/cartpole_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole_showcase/cartpole_camera/cartpole_camera_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from gymnasium import spaces

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/factory/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/factory/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/factory/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/factory/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_control.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_control.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Factory: control module.
 
 Imported by base, environment, and task classes. Not directly executed.

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import numpy as np
 import torch
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.actuators.actuator_cfg import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_tasks_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_tasks_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/__init__.py
@@ -2,11 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
 """
 Franka-Cabinet environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/franka_cabinet_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/franka_cabinet_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Humanoid locomotion environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from isaaclab_assets import HUMANOID_CFG

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 AMP Humanoid locomotion environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/humanoid_amp_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/humanoid_amp_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import gymnasium as gym

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/humanoid_amp_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/humanoid_amp_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import os

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/motions/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/motions/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 AMP Motion Loader and motion files.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/motions/motion_loader.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/motions/motion_loader.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import numpy as np
 import os
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/motions/motion_viewer.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/motions/motion_viewer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import matplotlib
 import matplotlib.animation
 import matplotlib.pyplot as plt

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/inhand_manipulation_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/inhand_manipulation_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 from __future__ import annotations
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Quacopter environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/quadcopter_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/quadcopter_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import gymnasium as gym

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Shadow Hand environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/feature_extractor.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/feature_extractor.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import glob
 import os
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 from isaaclab_assets.robots.shadow_hand import SHADOW_HAND_CFG
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_vision_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_vision_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 from __future__ import annotations
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 ShadowHand Over environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 from __future__ import annotations
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 from isaaclab_assets.robots.shadow_hand import SHADOW_HAND_CFG
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Config-based workflow environments.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Classic environments for control.
 
 These environments are based on the MuJoCo environments provided by OpenAI.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Ant locomotion environment (similar to OpenAI Gym Ant-v2).
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/ant_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/ant_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.assets import AssetBaseCfg
 from isaaclab.envs import ManagerBasedRLEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Cartpole balancing environment.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/cartpole_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/cartpole_camera_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/cartpole_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/cartpole_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import math
 
 import isaaclab.sim as sim_utils

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the cartpole environments."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Humanoid locomotion environment (similar to OpenAI Gym Humanoid-v2).
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the humanoid environment."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/observations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Locomotion environments for legged robots."""
 
 from .velocity import *  # noqa

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Locomotion environments with velocity-tracking commands.
 
 These environments are based on the `legged_gym` environments provided by Rudin et al.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for velocity-based locomotion environments."""
 
 # We leave this file empty since we don't want to expose any configs in this package directly.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from .rough_env_cfg import UnitreeA1RoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/rough_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/__init__.py
@@ -2,11 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from .rough_env_cfg import AnymalBRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/rough_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from .rough_env_cfg import AnymalCRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/rough_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from .rough_env_cfg import AnymalDRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/rough_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from .rough_env_cfg import CassieRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/rough_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.utils import configclass
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/rough_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from .rough_env_cfg import UnitreeGo1RoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/rough_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from .rough_env_cfg import UnitreeGo2RoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/rough_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from .rough_env_cfg import H1RoughEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/rough_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import isaaclab.sim as sim_utils
 import isaaclab.terrains as terrain_gen
 from isaaclab.envs import ViewerCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 """This sub-module contains the functions that are specific to the Spot locomotion task."""
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/mdp/events.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/mdp/events.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 """This sub-module contains the functions that can be used to enable Spot randomizations.
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the reward functions that can be used for Spot's locomotion task.
 
 The functions can be passed to the :class:`isaaclab.managers.RewardTermCfg` object to

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the locomotion environments."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/curriculums.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/curriculums.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to create curriculum for the learning environment.
 
 The functions can be passed to the :class:`isaaclab.managers.CurriculumTermCfg` object to enable

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to define rewards for the learning environment.
 
 The functions can be passed to the :class:`isaaclab.managers.RewardTermCfg` object to

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/terminations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to activate certain terminations.
 
 The functions can be passed to the :class:`isaaclab.managers.TerminationTermCfg` object to enable

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import math
 from dataclasses import MISSING
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Manipulation environments for fixed-arm robots."""
 
 from .reach import *  # noqa

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/__init__.py
@@ -3,9 +3,4 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Manipulation environments to open drawers in a cabinet."""

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/cabinet_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 from dataclasses import MISSING
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for the cabinet environments."""
 
 # We leave this file empty since we don't want to expose any configs in this package directly.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/ik_abs_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/ik_abs_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/ik_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/ik_rel_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/franka/joint_pos_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.sensors import FrameTransformerCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the cabinet environments."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/observations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """In-hand object reorientation environment.
 
 These environments are based on the `dexterous cube manipulation`_ environments

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for in-hand manipulation environments."""
 
 # We leave this file empty since we don't want to expose any configs in this package directly.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/allegro_hand/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/allegro_hand/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/allegro_hand/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/allegro_hand/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/allegro_hand/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/allegro_hand/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/allegro_hand/allegro_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/config/allegro_hand/allegro_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 import isaaclab_tasks.manager_based.manipulation.inhand.inhand_env_cfg as inhand_env_cfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/inhand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/inhand_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 from dataclasses import MISSING

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the in-hand manipulation environments."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing command terms for 3D orientation goals."""
 
 from .commands_cfg import InHandReOrientationCommandCfg  # noqa: F401

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/commands_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/commands_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 import isaaclab.sim as sim_utils

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/orientation_command.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/orientation_command.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module containing command generators for 3D orientation goals for objects."""
 
 from __future__ import annotations

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/events.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/events.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Functions specific to the in-hand dexterous manipulation environments."""
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/observations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Functions specific to the in-hand dexterous manipulation environments."""
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Functions specific to the in-hand dexterous manipulation environments."""
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/terminations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Functions specific to the in-hand dexterous manipulation environments."""
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for the object lift environments."""
 
 # We leave this file empty since we don't want to expose any configs in this package directly.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for the object lift environments."""
 
 # We leave this file empty since we don't want to expose any configs in this package directly.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/__init__.py
@@ -2,11 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
 import gymnasium as gym
 import os
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/ik_abs_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/ik_abs_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.assets import DeformableObjectCfg
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/ik_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/ik_rel_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/joint_pos_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.assets import RigidObjectCfg
 from isaaclab.sensors import FrameTransformerCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/lift_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/lift_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 import isaaclab.sim as sim_utils

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the lift environments."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/observations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/terminations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to activate certain terminations for the lift task.
 
 The functions can be passed to the :class:`isaaclab.managers.TerminationTermCfg` object to enable

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/__init__.py
@@ -3,9 +3,4 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Fixed-arm environments with end-effector pose tracking commands."""

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for arm-based reach-tracking environments."""
 
 # We leave this file empty since we don't want to expose any configs in this package directly.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/ik_abs_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/ik_abs_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/ik_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/ik_rel_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/joint_pos_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import math
 
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/osc_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/osc_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.controllers.operational_space_cfg import OperationalSpaceControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import OperationalSpaceControllerActionCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/joint_pos_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import math
 
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the locomotion environments."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/reach_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 import isaaclab.sim as sim_utils

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for the object stack environments."""
 
 # We leave this file empty since we don't want to expose any configs in this package directly.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for the object stack environments."""
 
 # We leave this file empty since we don't want to expose any configs in this package directly.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
@@ -2,11 +2,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
 import gymnasium as gym
 import os
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_abs_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_abs_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_blueprint_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_blueprint_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import os
 import torch
 from torchvision.utils import save_image

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_instance_randomize_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_instance_randomize_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils import configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_joint_pos_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.assets import RigidObjectCfg
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import SceneEntityCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_joint_pos_instance_randomize_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_joint_pos_instance_randomize_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import torch
 
 import isaaclab.sim as sim_utils

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the lift environments."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/franka_stack_events.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/franka_stack_events.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 
 from __future__ import annotations
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/observations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to activate certain terminations for the lift task.
 
 The functions can be passed to the :class:`isaaclab.managers.TerminationTermCfg` object to enable

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 import isaaclab.sim as sim_utils

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_instance_randomize_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_instance_randomize_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from dataclasses import MISSING
 
 import isaaclab.sim as sim_utils

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Navigation environments."""
 
 from .config import anymal_c

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/__init__.py
@@ -3,9 +3,4 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for navigation environments."""

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/agents/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/agents/rsl_rl_ppo_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/navigation_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/navigation_env_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import math
 
 from isaaclab.envs import ManagerBasedRLEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the locomotion environments."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/pre_trained_policy_action.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/pre_trained_policy_action.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-package with utilities, data collectors and environment wrappers."""
 
 from .importer import import_packages

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module with utilities for the hydra configuration system."""
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/importer.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/importer.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module with utility for importing all modules in a package recursively."""
 
 from __future__ import annotations

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Sub-module with utilities for parsing and loading configurations."""
 
 

--- a/source/isaaclab_tasks/setup.py
+++ b/source/isaaclab_tasks/setup.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Installation script for the 'isaaclab_tasks' python package."""
 
 import os

--- a/source/isaaclab_tasks/test/benchmarking/conftest.py
+++ b/source/isaaclab_tasks/test/benchmarking/conftest.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import json
 
 import pytest

--- a/source/isaaclab_tasks/test/benchmarking/test_environments_training.py
+++ b/source/isaaclab_tasks/test/benchmarking/test_environments_training.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab_tasks/test/benchmarking/test_utils.py
+++ b/source/isaaclab_tasks/test/benchmarking/test_utils.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import glob
 import json
 import math

--- a/source/isaaclab_tasks/test/test_environment_determinism.py
+++ b/source/isaaclab_tasks/test/test_environment_determinism.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab_tasks/test/test_environments.py
+++ b/source/isaaclab_tasks/test/test_environments.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 import sys

--- a/source/isaaclab_tasks/test/test_factory_environments.py
+++ b/source/isaaclab_tasks/test/test_factory_environments.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab_tasks/test/test_hydra.py
+++ b/source/isaaclab_tasks/test/test_hydra.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 import sys

--- a/source/isaaclab_tasks/test/test_multi_agent_environments.py
+++ b/source/isaaclab_tasks/test/test_multi_agent_environments.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/source/isaaclab_tasks/test/test_record_video.py
+++ b/source/isaaclab_tasks/test/test_record_video.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import os
 import subprocess
 import sys

--- a/tools/install_deps.py
+++ b/tools/install_deps.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This script is a utility to install dependencies mentioned in an extension.toml file of an extension.
 

--- a/tools/run_all_tests.py
+++ b/tools/run_all_tests.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """A runner script for all the tests within source directory.
 
 .. code-block:: bash

--- a/tools/run_train_envs.py
+++ b/tools/run_train_envs.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This scripts run training with different RL libraries over a subset of the environments.
 

--- a/tools/template/__init__.py
+++ b/tools/template/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/cli.py
+++ b/tools/template/cli.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import enum
 import os
 from collections.abc import Callable

--- a/tools/template/common.py
+++ b/tools/template/common.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import os
 
 # paths

--- a/tools/template/generator.py
+++ b/tools/template/generator.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import glob
 import os
 import shutil

--- a/tools/template/templates/agents/rsl_rl_ppo_cfg
+++ b/tools/template/templates/agents/rsl_rl_ppo_cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/extension/__init__ext
+++ b/tools/template/templates/extension/__init__ext
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/extension/__init__tasks
+++ b/tools/template/templates/extension/__init__tasks
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/extension/__init__workflow
+++ b/tools/template/templates/extension/__init__workflow
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/extension/setup.py
+++ b/tools/template/templates/extension/setup.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Installation script for the '{{ name }}' python package."""
 
 import os

--- a/tools/template/templates/extension/ui_extension_example.py
+++ b/tools/template/templates/extension/ui_extension_example.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import omni.ext
 
 

--- a/tools/template/templates/external/.vscode/tools/setup_vscode.py
+++ b/tools/template/templates/external/.vscode/tools/setup_vscode.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script sets up the vs-code settings for the Isaac Lab project.
 
 This script merges the python.analysis.extraPaths from the "{ISAACSIM_DIR}/.vscode/settings.json" file into

--- a/tools/template/templates/tasks/__init__agents
+++ b/tools/template/templates/tasks/__init__agents
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/tasks/__init__task
+++ b/tools/template/templates/tasks/__init__task
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/tasks/direct_multi-agent/env
+++ b/tools/template/templates/tasks/direct_multi-agent/env
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/tasks/direct_multi-agent/env_cfg
+++ b/tools/template/templates/tasks/direct_multi-agent/env_cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/tasks/direct_single-agent/env
+++ b/tools/template/templates/tasks/direct_single-agent/env
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/tasks/direct_single-agent/env_cfg
+++ b/tools/template/templates/tasks/direct_single-agent/env_cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/tasks/manager-based_single-agent/env_cfg
+++ b/tools/template/templates/tasks/manager-based_single-agent/env_cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tools/template/templates/tasks/manager-based_single-agent/mdp/__init__.py
+++ b/tools/template/templates/tasks/manager-based_single-agent/mdp/__init__.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the environment."""
 
 from isaaclab.envs.mdp import *  # noqa: F401, F403

--- a/tools/template/templates/tasks/manager-based_single-agent/mdp/rewards.py
+++ b/tools/template/templates/tasks/manager-based_single-agent/mdp/rewards.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 This file contains the settings for the tests.
 """


### PR DESCRIPTION
# Description

Removes the old license headers in scripts and keep only the new one.


## Type of change

- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
