### PR TITLE
Resets joint position/velocity targets in reset_scene_to_default()

### DIFF
--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -1156,6 +1156,8 @@ def reset_scene_to_default(env: ManagerBasedEnv, env_ids: torch.Tensor):
         default_joint_pos = articulation_asset.data.default_joint_pos[env_ids].clone()
         default_joint_vel = articulation_asset.data.default_joint_vel[env_ids].clone()
         # set into the physics simulation
+        articulation_asset.set_joint_position_target(default_joint_pos, env_ids=env_ids)
+        articulation_asset.set_joint_velocity_target(default_joint_pos, env_ids=env_ids)
         articulation_asset.write_joint_state_to_sim(default_joint_pos, default_joint_vel, env_ids=env_ids)
     # deformable objects
     for deformable_object in env.scene.deformable_objects.values():


### PR DESCRIPTION
Fix bug of reset joint initial state of articulation in event function `reset_scene_to_default` ref to: https://github.com/isaac-sim/IsaacLab/issues/2663, where the targets were not previously reset together with the joint positions.

# Description

ref: https://github.com/isaac-sim/IsaacLab/issues/2663
