### PR TITLE
Antoiner/action clipping

### DIFF
--- a/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
@@ -368,11 +368,11 @@ class OperationalSpaceControllerActionCfg(ActionTermCfg):
     """
 
     # TODO: Here the clip effects are not homogeneous, I don't like that depending on the controller mode the behavior
-    # is different. It makes it hard to understand what does what. Should we have an explicit velocity clip? 
+    # is different. It makes it hard to understand what does what. Should we have an explicit velocity clip?
 
     clip_position: list[tuple[float, float]] | None = None
     """Clip range for the position targets. Defaults to None for no clipping.
-    
+
     The expected format is a list of tuples, each containing two values. When using the controller in ``"abs"`` mode
     this limits the reachable range of the end-effector in the world frame. When using the controller in ``"rel"`` mode
     this limits the maximum velocity of the end-effector in the task frame. This must match the number of active axes

--- a/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
@@ -367,44 +367,42 @@ class OperationalSpaceControllerActionCfg(ActionTermCfg):
         ``OperationalSpaceControllerCfg``.
     """
 
-    # TODO: Here the clip effects are not homogeneous, but they have unique names that relate
-    # to specific control modes so it's fine to me.
+    # TODO: Here the clip effects are not homogeneous, I don't like that depending on the controller mode the behavior
+    # is different. It makes it hard to understand what does what. Should we have an explicit velocity clip? 
 
-    clip_pose_abs: list[tuple[float, float]] | None = None
-    """Clip range for the absolute pose targets. Defaults to None for no clipping.
-
-    The expected format is a list of tuples, each containing two values. This effectively bounds
-    the reachable range of the end-effector in the world frame.
+    clip_position: list[tuple[float, float]] | None = None
+    """Clip range for the position targets. Defaults to None for no clipping.
+    
+    The expected format is a list of tuples, each containing two values. When using the controller in ``"abs"`` mode
+    this limits the reachable range of the end-effector in the world frame. When using the controller in ``"rel"`` mode
+    this limits the maximum velocity of the end-effector in the task frame. This must match the number of active axes
+    in :attr:`controller_cfg.motion_control_axes_task`.
 
     Example:
     ..code-block:: python
-        clip_pose_abs = [
+        clip_position = [
             (min_x, max_x),
             (min_y, max_y),
             (min_z, max_z),
+        ]
+    """
+    clip_orientation: list[tuple[float, float]] | None = None
+    """Clip range for the orientation targets. Defaults to None for no clipping.
+
+    The expected format is a list of tuples, each containing two values. When using the controller in ``"abs"`` mode
+    this limits the reachable range of the end-effector in the world frame. When using the controller in ``"rel"`` mode
+    this limits the maximum velocity of the end-effector in the task frame. This must match the number of active axes
+    in :attr:`controller_cfg.motion_control_axes_task`.
+
+    Example:
+    ..code-block:: python
+        clip_orientation = [
             (min_roll, max_roll),
             (min_pitch, max_pitch),
             (min_yaw, max_yaw),
         ]
     """
-    clip_pose_rel: list[tuple[float, float]] | None = None
-    """Clip range for the relative pose targets. Defaults to None for no clipping.
-
-    The expected format is a list of tuples, each containing two values. This effectively limits
-    the end-effector's velocity in the task frame.
-
-    Example:
-    ..code-block:: python
-        clip_pose_rel = [
-            (min_x, max_x),
-            (min_y, max_y),
-            (min_z, max_z),
-            (min_roll, max_roll),
-            (min_pitch, max_pitch),
-            (min_yaw, max_yaw),
-        ]
-    """
-    clip_wrench_abs: list[tuple[float, float]] | None = None
+    clip_wrench: list[tuple[float, float]] | None = None
     """Clip range for the absolute wrench targets. Defaults to None for no clipping.
 
     The expected format is a list of tuples, each containing two values. This effectively limits
@@ -412,7 +410,7 @@ class OperationalSpaceControllerActionCfg(ActionTermCfg):
 
     Example:
     ..code-block:: python
-        clip_wrench_abs = [
+        clip_wrench = [
             (min_fx, max_fx),
             (min_fy, max_fy),
             (min_fz, max_fz),

--- a/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/actions_cfg.py
@@ -36,7 +36,11 @@ class JointActionCfg(ActionTermCfg):
     """Whether to preserve the order of the joint names in the action output. Defaults to False."""
 
     clip: dict[str, tuple] | None = None
-    """Clip range for the action (dict of regex expressions). Defaults to None."""
+    """Clip range for the action (dict of regex expressions). Defaults to None.
+    
+    Dictionary keys should be regex expressions of joint names and values should be tuples of
+    (lower, upper) bounds.
+    """
 
 
 @configclass
@@ -131,7 +135,11 @@ class JointPositionToLimitsActionCfg(ActionTermCfg):
     """
 
     clip: dict[str, tuple] | None = None
-    """Clip range for the action (dict of regex expressions). Defaults to None."""
+    """Clip range for the action (dict of regex expressions). Defaults to None.
+    
+    Dictionary keys should be regex expressions of joint names and values should be tuples of
+    (lower, upper) bounds.
+    """
 
 
 @configclass
@@ -228,6 +236,7 @@ class NonHolonomicActionCfg(ActionTermCfg):
     """Clip range for the action (dict of regex expressions).
 
     The expected keys are "v", and "yaw". Defaults to None for no clipping.
+    Values should be tuples of (lower, upper) bounds.
     """
 
 
@@ -346,13 +355,22 @@ class OperationalSpaceControllerActionCfg(ActionTermCfg):
     """The configuration for the operational space controller."""
 
     position_scale: float = 1.0
-    """Scale factor for the position targets. Defaults to 1.0."""
+    """Scale factor for the position targets. Defaults to 1.0.
+    
+    Note: The scaling is applied before the clipping of the position targets.
+    """
 
     orientation_scale: float = 1.0
-    """Scale factor for the orientation (quad for ``pose_abs`` or axis-angle for ``pose_rel``). Defaults to 1.0."""
+    """Scale factor for the orientation (quad for ``pose_abs`` or axis-angle for ``pose_rel``). Defaults to 1.0.
+    
+    Note: The scaling is applied before the clipping of the orientation targets.
+    """
 
     wrench_scale: float = 1.0
-    """Scale factor for the wrench targets. Defaults to 1.0."""
+    """Scale factor for the wrench targets. Defaults to 1.0.
+    
+    Note: The scaling is applied before the clipping of the wrench targets.
+    """
 
     stiffness_scale: float = 1.0
     """Scale factor for the stiffness commands. Defaults to 1.0."""
@@ -377,6 +395,8 @@ class OperationalSpaceControllerActionCfg(ActionTermCfg):
     this limits the reachable range of the end-effector in the world frame. When using the controller in ``"rel"`` mode
     this limits the maximum velocity of the end-effector in the task frame. This must match the number of active axes
     in :attr:`controller_cfg.motion_control_axes_task`.
+    
+    Note: The clipping is applied after the scale factor is applied.
 
     Example:
     ..code-block:: python
@@ -392,7 +412,9 @@ class OperationalSpaceControllerActionCfg(ActionTermCfg):
     The expected format is a list of tuples, each containing two values. When using the controller in ``"abs"`` mode
     this limits the reachable range of the end-effector in the world frame. When using the controller in ``"rel"`` mode
     this limits the maximum velocity of the end-effector in the task frame. This must match the number of active axes
-    in :attr:`controller_cfg.motion_control_axes_task`.
+    in :attr:`controller_cfg.motion_control_axes_task`. Angles are given in the following order: (roll, pitch, yaw).
+
+    Note: The clipping is applied after the scale factor is applied.
 
     Example:
     ..code-block:: python
@@ -407,6 +429,8 @@ class OperationalSpaceControllerActionCfg(ActionTermCfg):
 
     The expected format is a list of tuples, each containing two values. This effectively limits
     the maximum force and torque that can be commanded in the task frame.
+
+    Note: The clipping is applied after the scale factor is applied.
 
     Example:
     ..code-block:: python

--- a/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
@@ -84,17 +84,6 @@ class BinaryJointAction(ActionTerm):
             )
         self._close_command[index_list] = torch.tensor(value_list, device=self.device)
 
-        # parse clip
-        if self.cfg.clip is not None:
-            if isinstance(cfg.clip, dict):
-                self._clip = torch.tensor([[-float("inf"), float("inf")]], device=self.device).repeat(
-                    self.num_envs, self.action_dim, 1
-                )
-                index_list, _, value_list = string_utils.resolve_matching_names_values(self.cfg.clip, self._joint_names)
-                self._clip[:, index_list] = torch.tensor(value_list, device=self.device)
-            else:
-                raise ValueError(f"Unsupported clip type: {type(cfg.clip)}. Supported types are dict.")
-
     """
     Properties.
     """
@@ -127,10 +116,6 @@ class BinaryJointAction(ActionTerm):
             binary_mask = actions < 0
         # compute the command
         self._processed_actions = torch.where(binary_mask, self._close_command, self._open_command)
-        if self.cfg.clip is not None:
-            self._processed_actions = torch.clamp(
-                self._processed_actions, min=self._clip[:, :, 0], max=self._clip[:, :, 1]
-            )
 
     def reset(self, env_ids: Sequence[int] | None = None) -> None:
         self._raw_actions[env_ids] = 0.0

--- a/source/isaaclab/isaaclab/envs/mdp/actions/non_holonomic_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/non_holonomic_actions.py
@@ -109,11 +109,17 @@ class NonHolonomicAction(ActionTerm):
         self._offset = torch.tensor(self.cfg.offset, device=self.device).unsqueeze(0)
         # parse clip
         if self.cfg.clip is not None:
+            allowed_clipping_keys = ["v", "yaw"]
             if isinstance(cfg.clip, dict):
+                for key in self.cfg.clip.keys():
+                    if key not in allowed_clipping_keys:
+                        raise ValueError(f"Unsupported clip key: {key}. Supported keys are {allowed_clipping_keys}.")
                 self._clip = torch.tensor([[-float("inf"), float("inf")]], device=self.device).repeat(
                     self.num_envs, self.action_dim, 1
                 )
-                index_list, _, value_list = string_utils.resolve_matching_names_values(self.cfg.clip, self._joint_names)
+                index_list, _, value_list = string_utils.resolve_matching_names_values(
+                    self.cfg.clip, allowed_clipping_keys
+                )
                 self._clip[:, index_list] = torch.tensor(value_list, device=self.device)
             else:
                 raise ValueError(f"Unsupported clip type: {type(cfg.clip)}. Supported types are dict.")

--- a/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
@@ -830,9 +830,9 @@ class OperationalSpaceControllerAction(ActionTerm):
                     min=self._clip_pose_abs[:, :3, 0],
                     max=self._clip_pose_abs[:, :3, 1],
                 )
-                rpy = math_utils.euler_xyz_from_quat(
+                rpy = torch.transpose(torch.stack(math_utils.euler_xyz_from_quat(
                     self.processed_actions[:, self._pose_abs_idx + 3 : self._pose_abs_idx + 7] * self._orientation_scale
-                )
+                )), 0, 1)
                 rpy_clamped = torch.clamp(rpy, min=self._clip_pose_abs[:, 3:6, 0], max=self._clip_pose_abs[:, 3:6, 1])
                 self.processed_actions[:, self._pose_abs_idx + 3 : self._pose_abs_idx + 7] = (
                     math_utils.quat_from_euler_xyz(rpy_clamped[:, 0], rpy_clamped[:, 1], rpy_clamped[:, 2])
@@ -847,9 +847,9 @@ class OperationalSpaceControllerAction(ActionTerm):
                     min=self._clip_pose_rel[:, :3, 0],
                     max=self._clip_pose_rel[:, :3, 1],
                 )
-                rpy = math_utils.euler_xyz_from_quat(
+                rpy = torch.transpose(torch.stack(math_utils.euler_xyz_from_quat(
                     self.processed_actions[:, self._pose_rel_idx + 3 : self._pose_rel_idx + 7] * self._orientation_scale
-                )
+                )), 0, 1)
                 rpy_clamped = torch.clamp(rpy, min=self._clip_pose_rel[:, 3:6, 0], max=self._clip_pose_rel[:, 3:6, 1])
                 self.processed_actions[:, self._pose_rel_idx + 3 : self._pose_rel_idx + 7] = (
                     math_utils.quat_from_euler_xyz(rpy_clamped[:, 0], rpy_clamped[:, 1], rpy_clamped[:, 2])

--- a/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
@@ -500,31 +500,8 @@ class OperationalSpaceControllerAction(ActionTerm):
         self._nullspace_joint_pos_target = None
         self._resolve_nullspace_joint_pos_targets()
 
-        # parse clip
-        if cfg.clip_pose_abs is not None:
-            if len(self.cfg.clip_pose_abs) != 6:
-                raise ValueError("clip_pose_abs must be a list of 6 tuples.")
-            for t in self.cfg.clip_pose_abs:
-                if len(t) != 2:
-                    raise ValueError("Each tuple in clip_pose_abs must contain 2 values.")
-            self._clip_pose_abs = torch.zeros((self.num_envs, 6, 2), device=self.device)
-            self._clip_pose_abs[:] = torch.tensor(self.cfg.clip_pose_abs, device=self.device)
-        if cfg.clip_pose_rel is not None:
-            if len(self.cfg.clip_pose_rel) != 6:
-                raise ValueError("clip_pose_rel must be a list of 6 tuples.")
-            for t in self.cfg.clip_pose_rel:
-                if len(t) != 2:
-                    raise ValueError("Each tuple in clip_pose_rel must contain 2 values.")
-            self._clip_pose_rel = torch.zeros((self.num_envs, 6, 2), device=self.device)
-            self._clip_pose_rel[:] = torch.tensor(self.cfg.clip_pose_rel, device=self.device)
-        if cfg.clip_wrench_abs is not None:
-            if len(self.cfg.clip_wrench_abs) != 6:
-                raise ValueError("clip_wrench_abs must be a list of 6 tuples.")
-            for t in self.cfg.clip_wrench_abs:
-                if len(t) != 2:
-                    raise ValueError("Each tuple in clip_wrench_abs must contain 2 values.")
-            self._clip_wrench_abs = torch.zeros((self.num_envs, 6, 2), device=self.device)
-            self._clip_wrench_abs[:] = torch.tensor(self.cfg.clip_wrench_abs, device=self.device)
+        # parse clipping cfg
+        self._parse_clipping_cfg(self.cfg)
 
     """
     Properties.
@@ -621,6 +598,118 @@ class OperationalSpaceControllerAction(ActionTerm):
             self._contact_sensor.reset(env_ids)
         if self._task_frame_transformer is not None:
             self._task_frame_transformer.reset(env_ids)
+            
+    """
+    Parameter modification functions.
+    """
+
+    def _validate_clipping_values(self, value: list[tuple[float, float]] | torch.Tensor, name: str) -> torch.Tensor:
+        if isinstance(value, torch.Tensor):
+            assert value.shape == (self.num_envs, 6, 2), f"Expected {name} to be a tensor of shape ({self.num_envs}, 6, 2) but got {value.shape}"
+        elif isinstance(value, list):
+            if len(value) != 6:
+                value = self._gen_clip(self.cfg.controller_cfg.motion_control_axes_task, value, name)
+            for i in range(6):
+                self._clip_pose_abs[:, i, 0] = -value[i][0]
+                self._clip_pose_abs[:, i, 1] = value[i][1]
+        else:
+            raise ValueError(f"Expected {name} to be a tensor or a list but got {type(value)}")
+        return value
+    
+    def _validate_scale_values(self, target, value, name):
+        if isinstance(value, torch.Tensor):
+            assert value.shape == (self.num_envs,), f"Expected {name} to be a tensor of shape ({self.num_envs},) but got {value.shape}"
+        elif isinstance(value, float):
+            value = torch.full((self.num_envs,), value, device=self.device)
+        return value
+
+    def set_clipping_values(
+        self,
+        pose_abs_clip: list[tuple[float, float]] | torch.Tensor | None = None,
+        pose_rel_clip: list[tuple[float, float]] | torch.Tensor | None = None,
+        wrench_clip: list[tuple[float, float]] | torch.Tensor | None = None,
+    ):
+        """Sets the clipping values for the pose and wrench commands.
+
+        If a tensor is provided, it must be of shape (num_envs, 6, 2). The setter performs a direct assignment so no
+        copy is made. If a list is provided, it must be a list of tuples, each containing two values. The setter will
+        convert the list to a tensor and assign it to the clipping values.
+        
+        Args:
+            pose_abs_clip: The clipping values for the pose absolute command.
+            pose_rel_clip: The clipping values for the pose relative command.
+            wrench_clip: The clipping values for the wrench command.
+        """
+        
+        if pose_abs_clip is not None:
+            if isinstance(pose_abs_clip, torch.Tensor):
+                assert pose_abs_clip.shape == (self.num_envs, 6, 2), f"Expected pose_abs_clip to be a tensor of shape ({self.num_envs}, 6, 2) but got {pose_abs_clip.shape}"
+                self._clip_pose_abs = pose_abs_clip
+            elif isinstance(pose_abs_clip, list):
+                if len(pose_abs_clip) != 6:
+                    raise ValueError("pose_abs_clip must be a list of 6 tuples")
+                for i in range(6):
+                    self._clip_pose_abs[:, i, 0] = -pose_abs_clip[i][0]
+                    self._clip_pose_abs[:, i, 1] = pose_abs_clip[i][1]
+            else:
+                raise ValueError(f"Expected pose_abs_clip to be a tensor or a list but got {type(pose_abs_clip)}")
+
+        if pose_rel_clip is not None:
+            if isinstance(pose_rel_clip, torch.Tensor):
+                assert pose_rel_clip.shape == (self.num_envs, 6, 2), f"Expected pose_rel_clip to be a tensor of shape ({self.num_envs}, 6, 2) but got {pose_rel_clip.shape}"
+                self._clip_pose_rel = pose_rel_clip
+            elif isinstance(pose_abs_clip, list):
+                if len(pose_abs_clip) != 6:
+                    raise ValueError("pose_abs_clip must be a list of 6 tuples")
+                for i in range(6):
+                    self._clip_pose_abs[:, i, 0] = -pose_abs_clip[i][0]
+                    self._clip_pose_abs[:, i, 1] = pose_abs_clip[i][1]
+            else:
+                raise ValueError(f"Expected pose_rel_clip to be a tensor or a list but got {type(pose_rel_clip)}")
+            
+        if wrench_clip is not None:
+            if isinstance(wrench_clip, torch.Tensor):
+                assert wrench_clip.shape == (self.num_envs, 6, 2), f"Expected wrench_clip to be a tensor of shape ({self.num_envs}, 6, 2) but got {wrench_clip.shape}"
+                self._clip_wrench_abs = wrench_clip
+            elif isinstance(pose_abs_clip, list):
+                if len(pose_abs_clip) != 6:
+                    raise ValueError("pose_abs_clip must be a list of 6 tuples")
+                for i in range(6):
+                    self._clip_pose_abs[:, i, 0] = -pose_abs_clip[i][0]
+                    self._clip_pose_abs[:, i, 1] = pose_abs_clip[i][1]
+            else:
+                raise ValueError(f"Expected wrench_clip to be a tensor or a list but got {type(wrench_clip)}")
+
+    def set_scale_values(
+        self,
+        pos_scale: float | torch.Tensor | None = None,
+        ori_scale: float | torch.Tensor | None = None,
+        wrench_scale: float | torch.Tensor | None = None,
+        stiffness_scale: float | torch.Tensor | None = None,
+        damping_ratio_scale: float | torch.Tensor | None = None,
+    ):
+
+        if pos_scale is not None:
+            if isinstance(pos_scale, torch.Tensor):
+                assert pos_scale.shape == (self.num_envs,), f"Expected pos_scale to be a tensor of shape ({self.num_envs},) but got {pos_scale.shape}"
+                self._position_scale = pos_scale
+            elif isinstance(pos_scale, float):
+                self._position_scale = torch.full((self.num_envs,), pos_scale, device=self.device)
+            else:
+                raise ValueError(f"Expected pos_scale to be a tensor or a float but got {type(pos_scale)}")
+        if ori_scale is not None:
+            ori_scale = self._validate_modified_param(ori_scale, "ori_scale")
+            self._orientation_scale.copy_(ori_scale)
+        if wrench_scale is not None:
+            wrench_scale = self._validate_modified_param(wrench_scale, "wrench_scale")
+            self._wrench_scale.copy_(wrench_scale)
+        if stiffness_scale is not None:
+            stiffness_scale = self._validate_modified_param(stiffness_scale, "stiffness_scale")
+            self._stiffness_scale.copy_(stiffness_scale)
+        if damping_ratio_scale is not None:
+            damping_ratio_scale = self._validate_modified_param(damping_ratio_scale, "damping_ratio_scale")
+            self._damping_ratio_scale.copy_(damping_ratio_scale)
+
 
     """
     Helper functions.
@@ -830,9 +919,8 @@ class OperationalSpaceControllerAction(ActionTerm):
                     min=self._clip_pose_abs[:, :3, 0],
                     max=self._clip_pose_abs[:, :3, 1],
                 )
-                rpy = torch.transpose(torch.stack(math_utils.euler_xyz_from_quat(
-                    self.processed_actions[:, self._pose_abs_idx + 3 : self._pose_abs_idx + 7] * self._orientation_scale
-                )), 0, 1)
+                normed_quat = math_utils.normalize(self.processed_actions[:, self._pose_abs_idx + 3 : self._pose_abs_idx + 7] * self._orientation_scale)
+                rpy = torch.transpose(torch.stack(math_utils.euler_xyz_from_quat(normed_quat)), 0, 1)
                 rpy_clamped = torch.clamp(rpy, min=self._clip_pose_abs[:, 3:6, 0], max=self._clip_pose_abs[:, 3:6, 1])
                 self.processed_actions[:, self._pose_abs_idx + 3 : self._pose_abs_idx + 7] = (
                     math_utils.quat_from_euler_xyz(rpy_clamped[:, 0], rpy_clamped[:, 1], rpy_clamped[:, 2])
@@ -851,7 +939,7 @@ class OperationalSpaceControllerAction(ActionTerm):
                     self.processed_actions[:, self._pose_rel_idx + 3 : self._pose_rel_idx + 7] * self._orientation_scale
                 )), 0, 1)
                 rpy_clamped = torch.clamp(rpy, min=self._clip_pose_rel[:, 3:6, 0], max=self._clip_pose_rel[:, 3:6, 1])
-                self.processed_actions[:, self._pose_rel_idx + 3 : self._pose_rel_idx + 7] = (
+                self.processed_actions[:, self._pose_rel_idx + 3 : self._pose_rel_idx + 6] = (
                     math_utils.quat_from_euler_xyz(rpy_clamped[:, 0], rpy_clamped[:, 1], rpy_clamped[:, 2])
                 )
             else:
@@ -875,3 +963,62 @@ class OperationalSpaceControllerAction(ActionTerm):
                 min=self.cfg.controller_cfg.motion_damping_ratio_limits_task[0],
                 max=self.cfg.controller_cfg.motion_damping_ratio_limits_task[1],
             )
+
+    @staticmethod
+    def _gen_clip(control_flags, clip_cfg: list[tuple[float, float]], name: str) -> list[tuple[float, float]]:
+        """Generates the clipping configuration for the operational space controller.
+        
+        The expected format is a list of tuples, each containing two values. Note that the order in which the tuples are provided
+        must match the order of the active axes in motion_control_axes_task.
+
+        Args:
+            control_flags: The control flags for the operational space controller.
+            clip_cfg: The clipping configuration for the operational space controller.
+            name: The name of the clipping configuration.
+        """
+        # Ensure the length of the clip_cfg is the same as the number of active axes
+        if len(clip_cfg) != sum(control_flags):
+            raise ValueError(f"{name} must be a list of tuples of the same length as there are active axes in motion_control_axes_task. There are {sum(control_flags)} active axes and {len(clip_cfg)} tuples in {name}.")
+        clip_pose_abs_new = []
+        # Iterate over the control flags and add the corresponding clip to the list
+        for i, flag in enumerate(control_flags):
+            # If the axis is active, add the corresponding clip
+            if flag:
+                # Get the corresponding clip
+                clip = clip_cfg[sum(control_flags[:i])]
+                # Ensure the clip is a tuple of 2 values
+                if len(clip) != 2:
+                    raise ValueError(f"Each tuple in {name} must contain 2 values.")
+                clip_pose_abs_new.append(clip)
+            else:
+                # If the axis is not active, add a clip of (-inf, inf). (Don't clip)
+                clip_pose_abs_new.append((-float('inf'), float('inf')))
+        return clip_pose_abs_new    
+
+    def _parse_clipping_cfg(self, cfg: actions_cfg.OperationalSpaceControllerActionCfg) -> None:
+        """Parses the clipping configuration for the operational space controller.
+        
+        Args:
+            cfg: The configuration of the action term.
+        """
+
+        # Parse clip based on the controller cfg
+
+
+        # Parse clip_pose_abs
+        if cfg.clip_pose_abs is not None:
+            clip_pose_abs = self._gen_clip(self.cfg.controller_cfg.motion_control_axes_task, cfg.clip_pose_abs, "clip_pose_abs")
+            self._clip_pose_abs = torch.zeros((self.num_envs, 6, 2), device=self.device)
+            self._clip_pose_abs[:] = torch.tensor(clip_pose_abs, device=self.device)
+
+        # Parse clip_pose_rel
+        if cfg.clip_pose_rel is not None:
+            clip_pose_rel = self._gen_clip(self.cfg.controller_cfg.motion_control_axes_task, cfg.clip_pose_rel, "clip_pose_rel")
+            self._clip_pose_rel = torch.zeros((self.num_envs, 6, 2), device=self.device)
+            self._clip_pose_rel[:] = torch.tensor(clip_pose_rel, device=self.device)
+
+        # Parse clip_wrench_abs
+        if cfg.clip_wrench_abs is not None:
+            clip_wrench_abs = self._gen_clip(self.cfg.controller_cfg.contact_wrench_control_axes_task, cfg.clip_wrench_abs, "clip_wrench_abs")
+            self._clip_wrench_abs = torch.zeros((self.num_envs, 6, 2), device=self.device)
+            self._clip_wrench_abs[:] = torch.tensor(clip_wrench_abs, device=self.device)

--- a/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
@@ -886,6 +886,7 @@ class OperationalSpaceControllerAction(ActionTerm):
                 )
             else:
                 self._processed_actions[:, self._pose_abs_idx : self._pose_abs_idx + 3] *= self._position_scale
+
             if self._clip_orientation is not None:
                 normed_quat = math_utils.normalize(
                     self.processed_actions[:, self._pose_abs_idx + 3 : self._pose_abs_idx + 7] * self._orientation_scale
@@ -897,6 +898,7 @@ class OperationalSpaceControllerAction(ActionTerm):
                 )
             else:
                 self._processed_actions[:, self._pose_abs_idx + 3 : self._pose_abs_idx + 7] *= self._orientation_scale
+
         if self._pose_rel_idx is not None:
             if self._clip_position is not None:
                 self._processed_actions[:, self._pose_rel_idx : self._pose_rel_idx + 3] = torch.clamp(
@@ -906,6 +908,7 @@ class OperationalSpaceControllerAction(ActionTerm):
                 )
             else:
                 self._processed_actions[:, self._pose_rel_idx : self._pose_rel_idx + 3] *= self._position_scale
+
             if self._clip_orientation is not None:
                 rpy = (
                     self.processed_actions[:, self._pose_rel_idx + 3 : self._pose_rel_idx + 6] * self._orientation_scale
@@ -914,6 +917,7 @@ class OperationalSpaceControllerAction(ActionTerm):
                 self.processed_actions[:, self._pose_rel_idx + 3 : self._pose_rel_idx + 6] = rpy_clamped
             else:
                 self._processed_actions[:, self._pose_rel_idx + 3 : self._pose_rel_idx + 6] *= self._orientation_scale
+
         if self._wrench_abs_idx is not None:
             if self.cfg.clip_wrench is not None:
                 self._processed_actions[:, self._wrench_abs_idx : self._wrench_abs_idx + 6] = torch.clamp(
@@ -923,6 +927,7 @@ class OperationalSpaceControllerAction(ActionTerm):
                 )
             else:
                 self._processed_actions[:, self._wrench_abs_idx : self._wrench_abs_idx + 6] *= self._wrench_scale
+
         if self._damping_ratio_idx is not None:
             self._processed_actions[
                 :, self._damping_ratio_idx : self._damping_ratio_idx + 6

--- a/source/isaaclab/isaaclab/managers/manager_term_cfg.py
+++ b/source/isaaclab/isaaclab/managers/manager_term_cfg.py
@@ -93,9 +93,6 @@ class ActionTermCfg:
     debug_vis: bool = False
     """Whether to visualize debug information. Defaults to False."""
 
-    clip: dict[str, tuple] | None = None
-    """Clip range for the action (dict of regex expressions). Defaults to None."""
-
 
 ##
 # Command manager.


### PR DESCRIPTION
# Description

Improves the support for clipping in the action terms. The `clip` parameter was removed from the `ActionTermCfg`, and per action term clipping is implemented where relevant. For instance, the Binary action no longer supports clipping. However, the JointActions remain unchanged. Where the biggest changes occurs is on the Holonomic, DifferentialIK, and OSC controllers. These controllers get unique clip configurations tailored to their use-cases.

@ozhanozen I know it's been a while since you posted your initial PR, though if you have time, could you check that this PR does what you'd like it to? 

Fixes #1548 #1732 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
