### PR TITLE
Adds available RL library configs on error message if entry point is invalid

### DIFF
--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.10.33"
+version = "0.10.34"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.10.34 (2025-06-16)
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Show available RL library configs on error message when an entry point key is not available for a given task.
+
+
 0.10.33 (2025-05-15)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -5,7 +5,7 @@
 
 """Sub-module with utilities for parsing and loading configurations."""
 
-
+import collections
 import gymnasium as gym
 import importlib
 import inspect
@@ -55,9 +55,27 @@ def load_cfg_from_registry(task_name: str, entry_point_key: str) -> dict | objec
     cfg_entry_point = gym.spec(task_name.split(":")[-1]).kwargs.get(entry_point_key)
     # check if entry point exists
     if cfg_entry_point is None:
+        # get existing agents and algorithms
+        agents = collections.defaultdict(list)
+        for k in gym.spec(task_name.split(":")[-1]).kwargs:
+            if k.endswith("_cfg_entry_point") and k != "env_cfg_entry_point":
+                spec = (
+                    k.replace("_cfg_entry_point", "")
+                    .replace("rl_games", "rl-games")
+                    .replace("rsl_rl", "rsl-rl")
+                    .split("_")
+                )
+                agent = spec[0].replace("-", "_")
+                algorithms = [item.upper() for item in (spec[1:] if len(spec) > 1 else ["PPO"])]
+                agents[agent].extend(algorithms)
+        msg = "\nExisting RL library (and algorithms) config entry points: "
+        for agent, algorithms in agents.items():
+            msg += f"\n  |-- {agent}: {', '.join(algorithms)}"
+        # raise error
         raise ValueError(
             f"Could not find configuration for the environment: '{task_name}'."
-            f" Please check that the gym registry has the entry point: '{entry_point_key}'."
+            f"\nPlease check that the gym registry has the entry point: '{entry_point_key}'."
+            f"{msg if agents else ''}"
         )
     # parse the default config file
     if isinstance(cfg_entry_point, str) and cfg_entry_point.endswith(".yaml"):


### PR DESCRIPTION
# Description

This PR show the available RL library (and algorithms) configs on error message when an entry point key is not available for a given task.

Example: for `./isaaclab.sh -p scripts/reinforcement_learning/sb3/train.py --task=Isaac-Cart-Double-Pendulum-Direct-v0 --headless`

Before:

```
ValueError: Could not find configuration for the environment: 'Isaac-Cart-Double-Pendulum-Direct-v0'. Please check that the gym registry has the entry point: 'sb3_cfg_entry_point'.
```

After

```
ValueError: Could not find configuration for the environment: 'Isaac-Cart-Double-Pendulum-Direct-v0'.
Please check that the gym registry has the entry point: 'sb3_cfg_entry_point'.
Existing RL library (and algorithms) config entry points: 
  |-- rl_games: PPO
  |-- skrl: PPO, IPPO, MAPPO
```

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
