### PR TITLE
update install docs to allow Isaac Lab to see IsaacSim python module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ For detailed Isaac Sim installation instructions, please refer to
 
     ```
     ./isaaclab.sh -i
+    source IsaacSim/_build/linux-x86_64/release/setup_conda_env.sh
     ```
 
     Windows:


### PR DESCRIPTION
# Description
Small documentation update

Fixes #2706

Installation on Linux requires this step on my machine. I am not sure if it is applicable to others.

## Type of change

Documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



