### PR TITLE
Update training_jetbot_reward_exploration.rst

### DIFF
--- a/docs/source/setup/walkthrough/training_jetbot_reward_exploration.rst
+++ b/docs/source/setup/walkthrough/training_jetbot_reward_exploration.rst
@@ -20,7 +20,7 @@ the x axis, so we apply the ``root_link_quat_w`` to ``[1,0,0]`` to get the forwa
         observations = {"policy": obs}
         return observations
 
- So now what should the reward be?
+So now what should the reward be?
 
 When the robot is behaving as desired, it will be driving at full speed in the direction of the command. If we reward both
 "driving forward" and "alignment to the command", then maximizing that combined signal should result in driving to the command... right?


### PR DESCRIPTION
tiny doc formatting issue

# Description

Just fixed a doc formatting issue (an extra space prevents proper syntax highlighting on this documentation page)

Fixes # (issue)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.



## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
