### PR TITLE
Updates documentation for conda, fabric, and inferencing

### DIFF
--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -554,6 +554,10 @@ Environments based on fixed-arm manipulation tasks.
 Comprehensive List of Environments
 ==================================
 
+For environments that have a different task name listed under ``Inference Task Name``, please use the Inference Task Name
+provided when running ``play.py`` or any inferencing workflows. These tasks provide more suitable configurations for
+inferencing, including reading from an already trained checkpoint and disabling runtime perturbations used for training.
+
 .. list-table::
     :widths: 33 25 19 25
 

--- a/docs/source/setup/installation/binaries_installation.rst
+++ b/docs/source/setup/installation/binaries_installation.rst
@@ -451,6 +451,10 @@ On Windows machines, please terminate the process from Command Prompt using
 
 If you see this, then the installation was successful! |:tada:|
 
+If you see an error ``ModuleNotFoundError: No module named 'isaacsim'``, ensure that the conda environment is activated
+and ``source _isaac_sim/setup_conda_env.sh`` has been executed.
+
+
 Train a robot!
 ~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -661,7 +661,8 @@ class AppLauncher:
             # pass command line variable to kit
             sys.argv.append(f"--/plugins/carb.tasking.plugin/threadCount={num_threads_per_process}")
 
-        # set physics and rendering device
+        # set rendering device. We do not need to set physics_gpu because it will automatically pick the same one
+        # as the active_gpu device. Setting physics_gpu explicitly may result in a different device to be used.
         launcher_args["physics_gpu"] = self.device_id
         launcher_args["active_gpu"] = self.device_id
 

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -309,6 +309,11 @@ class SimulationCfg:
     Note:
         When enabled, the GUI will not update the physics parameters in real-time. To enable real-time
         updates, please set this flag to :obj:`False`.
+
+        When using GPU simulation, it is required to enable Fabric to visualize updates in the renderer.
+        Transform updates are propagated to the renderer through Fabric. If Fabric is disabled with GPU simulation,
+        the renderer will not be able to render any updates in the simulation, although simulation will still be
+        running under the hood.
     """
 
     physx: PhysxCfg = PhysxCfg()


### PR DESCRIPTION
# Description

Various minor updates to documentation to clarify a few concepts:

- Adds note about source conda environment if installing from binaries using conda, but not using `./isaaclab.sh -c` option
- Adds note that Fabric should be enabled for GPU simulation and that rendering will not update if Fabric is not enabled
- Adds note about using the inference task names if available when running inferencing
- Removes unneeded physics cudaDevice flag for distributed training

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
