### PR TITLE
Fixes export LSTM to onnx file

### DIFF
--- a/source/isaaclab/isaaclab/utils/math.py
+++ b/source/isaaclab/isaaclab/utils/math.py
@@ -133,8 +133,8 @@ def copysign(mag: float, other: torch.Tensor) -> torch.Tensor:
     Returns:
         The output tensor.
     """
-    mag_torch = torch.tensor(mag, device=other.device, dtype=torch.float).repeat(other.shape[0])
-    return torch.abs(mag_torch) * torch.sign(other)
+    mag_torch = abs(mag) * torch.ones_like(other)
+    return torch.copysign(mag_torch, other)
 
 
 """
@@ -250,7 +250,7 @@ def quat_conjugate(q: torch.Tensor) -> torch.Tensor:
     """
     shape = q.shape
     q = q.reshape(-1, 4)
-    return torch.cat((q[:, 0:1], -q[:, 1:]), dim=-1).view(shape)
+    return torch.cat((q[..., 0:1], -q[..., 1:]), dim=-1).view(shape)
 
 
 @torch.jit.script
@@ -401,7 +401,7 @@ def _axis_angle_rotation(axis: Literal["X", "Y", "Z"], angle: torch.Tensor) -> t
 
 def matrix_from_euler(euler_angles: torch.Tensor, convention: str) -> torch.Tensor:
     """
-    Convert rotations given as Euler angles in radians to rotation matrices.
+    Convert rotations given as Euler angles (intrinsic) in radians to rotation matrices.
 
     Args:
         euler_angles: Euler angles in radians. Shape is (..., 3).
@@ -436,7 +436,7 @@ def euler_xyz_from_quat(
     """Convert rotations given as quaternions to Euler angles in radians.
 
     Note:
-        The euler angles are assumed in XYZ convention.
+        The euler angles are assumed in XYZ extrinsic convention.
 
     Args:
         quat: The quaternion orientation in (w, x, y, z). Shape is (N, 4).
@@ -928,14 +928,8 @@ def compute_pose_error(
     Raises:
         ValueError: Invalid rotation error type.
     """
-    # Compute quaternion error (i.e., difference quaternion)
-    # Reference: https://personal.utdallas.edu/~sxb027100/dock/quaternion.html
-    # q_current_norm = q_current * q_current_conj
-    source_quat_norm = quat_mul(q01, quat_conjugate(q01))[:, 0]
-    # q_current_inv = q_current_conj / q_current_norm
-    source_quat_inv = quat_conjugate(q01) / source_quat_norm.unsqueeze(-1)
-    # q_error = q_target * q_current_inv
-    quat_error = quat_mul(q02, source_quat_inv)
+    # Compute quaternion error (i.e., quat_box_minus)
+    quat_error = quat_mul(q01, quat_conjugate(q02))
 
     # Compute position error
     pos_error = t02 - t01

--- a/source/isaaclab/isaaclab/utils/math.py
+++ b/source/isaaclab/isaaclab/utils/math.py
@@ -133,8 +133,8 @@ def copysign(mag: float, other: torch.Tensor) -> torch.Tensor:
     Returns:
         The output tensor.
     """
-    mag_torch = abs(mag) * torch.ones_like(other)
-    return torch.copysign(mag_torch, other)
+    mag_torch = torch.tensor(mag, device=other.device, dtype=torch.float).repeat(other.shape[0])
+    return torch.abs(mag_torch) * torch.sign(other)
 
 
 """
@@ -250,7 +250,7 @@ def quat_conjugate(q: torch.Tensor) -> torch.Tensor:
     """
     shape = q.shape
     q = q.reshape(-1, 4)
-    return torch.cat((q[..., 0:1], -q[..., 1:]), dim=-1).view(shape)
+    return torch.cat((q[:, 0:1], -q[:, 1:]), dim=-1).view(shape)
 
 
 @torch.jit.script
@@ -401,7 +401,7 @@ def _axis_angle_rotation(axis: Literal["X", "Y", "Z"], angle: torch.Tensor) -> t
 
 def matrix_from_euler(euler_angles: torch.Tensor, convention: str) -> torch.Tensor:
     """
-    Convert rotations given as Euler angles (intrinsic) in radians to rotation matrices.
+    Convert rotations given as Euler angles in radians to rotation matrices.
 
     Args:
         euler_angles: Euler angles in radians. Shape is (..., 3).
@@ -436,7 +436,7 @@ def euler_xyz_from_quat(
     """Convert rotations given as quaternions to Euler angles in radians.
 
     Note:
-        The euler angles are assumed in XYZ extrinsic convention.
+        The euler angles are assumed in XYZ convention.
 
     Args:
         quat: The quaternion orientation in (w, x, y, z). Shape is (N, 4).
@@ -928,8 +928,14 @@ def compute_pose_error(
     Raises:
         ValueError: Invalid rotation error type.
     """
-    # Compute quaternion error (i.e., quat_box_minus)
-    quat_error = quat_mul(q01, quat_conjugate(q02))
+    # Compute quaternion error (i.e., difference quaternion)
+    # Reference: https://personal.utdallas.edu/~sxb027100/dock/quaternion.html
+    # q_current_norm = q_current * q_current_conj
+    source_quat_norm = quat_mul(q01, quat_conjugate(q01))[:, 0]
+    # q_current_inv = q_current_conj / q_current_norm
+    source_quat_inv = quat_conjugate(q01) / source_quat_norm.unsqueeze(-1)
+    # q_error = q_target * q_current_inv
+    quat_error = quat_mul(q02, source_quat_inv)
 
     # Compute position error
     pos_error = t02 - t01

--- a/source/isaaclab_rl/config/extension.toml
+++ b/source/isaaclab_rl/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.1.6"
+version = "0.1.7"
 
 # Description
 title = "Isaac Lab RL"

--- a/source/isaaclab_rl/docs/CHANGELOG.rst
+++ b/source/isaaclab_rl/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.1.7 (2025-06-30)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Call :meth:`eval` during :meth:`forward`` RSL-RL OnnxPolicyExporter
+
+
 0.1.6 (2025-06-26)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/exporter.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/exporter.py
@@ -140,6 +140,7 @@ class _OnnxPolicyExporter(torch.nn.Module):
 
     def export(self, path, filename):
         self.to("cpu")
+        self.eval()
         if self.is_recurrent:
             obs = torch.zeros(1, self.rnn.input_size)
             h_in = torch.zeros(self.rnn.num_layers, 1, self.rnn.hidden_size)


### PR DESCRIPTION
# Description

This PR fixes an issue when exporting LSTM to ONNX. The normalizer was resetting to zero. This PR calls `eval()` during the `forward()`.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots
Left: After, Right: Before

![image](https://github.com/user-attachments/assets/9a8f765f-653a-4a57-b9ee-af00e8e0539c)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
