### PR TITLE
Adds absolute and relative noise to `MeshRepeatedObjectsTerrain`

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.40.11"
+version = "0.40.12"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.40.12 (2025-07-01)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :attr:`abs_height_noise` and :attr:`rel_height_noise` to give minimum and maximum absolute and relative noise to
+  :class:`isaaclab.terrrains.trimesh.MeshRepeatedObjectsTerrainCfg`
+* Added deprecation warnings to the existing :attr:`max_height_noise` but still functions.
+
+
 0.40.11 (2025-06-27)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains.py
+++ b/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains.py
@@ -840,7 +840,9 @@ def repeated_objects_terrain(
     # generate obstacles (but keep platform clean)
     for index in range(len(object_centers)):
         # randomize the height of the object
-        ob_height = height + np.random.uniform(-cfg.max_height_noise, cfg.max_height_noise)
+        abs_height_noise = np.random.uniform(cfg.abs_height_noise[0], cfg.abs_height_noise[1])
+        rel_height_noise = np.random.uniform(cfg.rel_height_noise[0], cfg.rel_height_noise[1])
+        ob_height = height * rel_height_noise + abs_height_noise
         if ob_height > 0.0:
             object_mesh = object_func(center=object_centers[index], height=ob_height, **object_kwargs)
             meshes_list.append(object_mesh)

--- a/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
 from dataclasses import MISSING
 from typing import Literal
 
@@ -191,13 +192,29 @@ class MeshRepeatedObjectsTerrainCfg(SubTerrainBaseCfg):
     """
     object_params_start: ObjectCfg = MISSING
     """The object curriculum parameters at the start of the curriculum."""
+
     object_params_end: ObjectCfg = MISSING
     """The object curriculum parameters at the end of the curriculum."""
 
-    max_height_noise: float = 0.0
-    """The maximum amount of noise to add to the height of the objects (in m). Defaults to 0.0."""
+    max_height_noise: float | None = None
+    """"This parameter is deprecated, but stated here to support backward compatibility"""
+
+    abs_height_noise: tuple[float, float] = (0.0, 0.0)
+    """The minimum and maximum amount of additive noise for the height of the objects. Default is set to 0.0, which is no noise."""
+
+    rel_height_noise: tuple[float, float] = (1.0, 1.0)
+    """The minimum and maximum amount of multiplicative noise for the height of the objects. Default is set to 1.0, which is no noise."""
+
     platform_width: float = 1.0
     """The width of the cylindrical platform at the center of the terrain. Defaults to 1.0."""
+
+    def __post_init__(self):
+        if self.max_height_noise is not None:
+            warnings.warn(
+                "MeshRepeatedObjectsTerrainCfg: max_height_noise:float is deprecated and support will be removed in the"
+                " future. Use abs_height_noise:list[float] instead."
+            )
+            self.abs_height_noise = (-self.max_height_noise, self.max_height_noise)
 
 
 @configclass

--- a/source/isaaclab/test/terrains/check_mesh_subterrains.py
+++ b/source/isaaclab/test/terrains/check_mesh_subterrains.py
@@ -340,7 +340,7 @@ def test_repeated_objects_terrain(
         cfg = mesh_gen.MeshRepeatedPyramidsTerrainCfg(
             size=(8.0, 8.0),
             platform_width=1.5,
-            max_height_noise=0.5,
+            abs_height_noise=(-0.5, 0.5),
             object_params_start=mesh_gen.MeshRepeatedPyramidsTerrainCfg.ObjectCfg(
                 num_objects=40, height=0.05, radius=0.6, max_yx_angle=0.0, degrees=True
             ),
@@ -352,7 +352,7 @@ def test_repeated_objects_terrain(
         cfg = mesh_gen.MeshRepeatedBoxesTerrainCfg(
             size=(8.0, 8.0),
             platform_width=1.5,
-            max_height_noise=0.5,
+            abs_height_noise=(-0.5, 0.5),
             object_params_start=mesh_gen.MeshRepeatedBoxesTerrainCfg.ObjectCfg(
                 num_objects=40, height=0.05, size=(0.6, 0.6), max_yx_angle=0.0, degrees=True
             ),
@@ -364,7 +364,7 @@ def test_repeated_objects_terrain(
         cfg = mesh_gen.MeshRepeatedCylindersTerrainCfg(
             size=(8.0, 8.0),
             platform_width=1.5,
-            max_height_noise=0.5,
+            abs_height_noise=(-0.5, 0.5),
             object_params_start=mesh_gen.MeshRepeatedCylindersTerrainCfg.ObjectCfg(
                 num_objects=40, height=0.05, radius=0.6, max_yx_angle=0.0, degrees=True
             ),


### PR DESCRIPTION
# Description

This PR expands the noise parameters of the MeshRepeatedObjectsTerrain by adding minimum and maximum absolute and relative noise for. 
This adds deprecation warnings to existing parameters but they will function normally.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Screenshots

Please attach before and after screenshots of the change if applicable.

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
