### PR TITLE
Relax upper version pin for torch for Blackwell GPU support.

### DIFF
--- a/docs/source/setup/installation/binaries_installation.rst
+++ b/docs/source/setup/installation/binaries_installation.rst
@@ -385,7 +385,7 @@ Installation
 
 .. attention::
 
-   For 50 series GPUs, please use the latest PyTorch nightly build instead of PyTorch 2.5.1, which comes with Isaac Sim:
+   For 50 series (Blackwell) GPUs, please use PyTorch >=2.7 (`release notes <https://pytorch.org/get-started/previous-versions/#v270>`__) instead of PyTorch 2.5.1, which comes with Isaac Sim:
 
    .. tab-set::
       :sync-group: os
@@ -395,14 +395,14 @@ Installation
 
          .. code:: bash
 
-            ./isaaclab.sh -p -m pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
+            ./isaaclab.sh -p -m pip install --upgrade torch==2.7.1 torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
 
       .. tab-item:: :icon:`fa-brands fa-windows` Windows
          :sync: windows
 
          .. code:: batch
 
-            isaaclab.bat -p -m pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
+            isaaclab.bat -p -m pip install --upgrade torch==2.7.1 torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
 
 Verifying the Isaac Lab installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -96,11 +96,12 @@ To learn about how to set up your own project on top of Isaac Lab, see :ref:`tem
 
 .. attention::
 
-   For 50 series GPUs, please use the latest PyTorch nightly build instead of PyTorch 2.5.1, which comes with Isaac Sim:
+   For 50 series (Blackwell) GPUs, please use PyTorch >=2.7 (`release notes <https://pytorch.org/get-started/previous-versions/#v270>`__) instead of PyTorch 2.5.1, which comes with Isaac Sim:
+
 
    .. code:: bash
 
-      pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
+      pip install --upgrade torch==2.7.1 torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
 
 
 Verifying the Isaac Sim installation

--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -302,11 +302,11 @@ Installation
 
 .. attention::
 
-   For 50 series GPUs, please use the latest PyTorch nightly build instead of PyTorch 2.5.1, which comes with Isaac Sim:
+   For 50 series (Blackwell) GPUs, please use PyTorch >=2.7 (`release notes <https://pytorch.org/get-started/previous-versions/#v270>`__) instead of PyTorch 2.5.1, which comes with Isaac Sim:
 
    .. code:: bash
 
-      pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
+      pip install --upgrade torch==2.7.1 torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
 
 Verifying the Isaac Lab installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -20,7 +20,7 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 INSTALL_REQUIRES = [
     # generic
     "numpy<2",
-    "torch==2.5.1",
+    "torch>=2.5.1",
     "onnx==1.16.1",  # 1.16.2 throws access violation on Windows
     "prettytable==3.3.0",
     "toml",

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -20,7 +20,7 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 INSTALL_REQUIRES = [
     # generic
     "numpy",
-    "torch==2.5.1",
+    "torch>=2.5.1",
     "torchvision>=0.14.1",  # ensure compatibility with torch 1.13.1
     "protobuf>=3.20.2,!=5.26.0",
     # configuration management

--- a/source/isaaclab_tasks/setup.py
+++ b/source/isaaclab_tasks/setup.py
@@ -19,7 +19,7 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 INSTALL_REQUIRES = [
     # generic
     "numpy",
-    "torch==2.5.1",
+    "torch>=2.5.1",
     "torchvision>=0.14.1",  # ensure compatibility with torch 1.13.1
     "protobuf>=3.20.2,!=5.26.0",
     # basic logger


### PR DESCRIPTION
# Description

This relaxes the maximum upper version for `torch` to allow for version 2.7 and above, which supports Blackwell GPUs. User reports in #1888 indicate that some folks are already operating successfully in a similar environment. This also updates the docs accordingly to use the released version of torch with this support vs the pre-release.

Fixes #2431
Relates to #1888

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there