### PR TITLE
[Feature] Importing a terrain from a mesh

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -105,6 +105,7 @@ Guidelines for modifications:
 * Ritvik Singh
 * Rosario Scalise
 * Ryley McCarroll
+* Sami Bouziri
 * Shafeef Omar
 * Shaoshu Su
 * Shundo Kishi

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,5 +1,13 @@
 Changelog
 ---------
+0.41.0 (2025-07-03)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added the possibility to import a terrain from a mesh. For that, a new terrain type name ``mesh`` and a new attribute named ``mesh_path`` were added to 
+the :class:`~isaaclab.terrains.terrains_importer_cfg.TerrainImporterCfg`
 
 0.40.11 (2025-06-27)
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/isaaclab/terrains/terrain_importer.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_importer.py
@@ -104,6 +104,15 @@ class TerrainImporter:
             self.import_ground_plane("terrain")
             # configure the origins in a grid
             self.configure_env_origins()
+        elif self.cfg.terrain_type == "mesh":
+            # check if config is provided
+            if self.cfg.mesh_path is None:
+                raise ValueError("Input terrain type is 'mesh' but no value provided for 'mesh_path'.")
+            # import the terrain
+            mesh = trimesh.load_mesh(self.cfg.mesh_path)
+            self.import_mesh("terrain", mesh)
+            # configure the origins in a grid
+            self.configure_env_origins()
         else:
             raise ValueError(f"Terrain type '{self.cfg.terrain_type}' not available.")
 
@@ -217,7 +226,7 @@ class TerrainImporter:
         ground_plane_cfg = sim_utils.GroundPlaneCfg(physics_material=self.cfg.physics_material, size=size, color=color)
         ground_plane_cfg.func(prim_path, ground_plane_cfg)
 
-    def import_mesh(self, name: str, mesh: trimesh.Trimesh):
+    def import_mesh(self, name: str, mesh: trimesh.Trimesh, **kwargs):
         """Import a mesh into the simulator.
 
         The mesh is imported into the simulator under the prim path ``cfg.prim_path/{key}``. The created path
@@ -243,7 +252,11 @@ class TerrainImporter:
 
         # import the mesh
         create_prim_from_mesh(
-            prim_path, mesh, visual_material=self.cfg.visual_material, physics_material=self.cfg.physics_material
+            prim_path,
+            mesh,
+            visual_material=self.cfg.visual_material,
+            physics_material=self.cfg.physics_material,
+            **kwargs,
         )
 
     def import_usd(self, name: str, usd_path: str):

--- a/source/isaaclab/isaaclab/terrains/terrain_importer_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_importer_cfg.py
@@ -43,10 +43,10 @@ class TerrainImporterCfg:
     :attr:`isaaclab.scene.InteractiveSceneCfg.num_envs` attribute.
     """
 
-    terrain_type: Literal["generator", "plane", "usd"] = "generator"
+    terrain_type: Literal["generator", "plane", "usd", "mesh"] = "generator"
     """The type of terrain to generate. Defaults to "generator".
 
-    Available options are "plane", "usd", and "generator".
+    Available options are "plane", "usd", "generator", "mesh".
     """
 
     terrain_generator: TerrainGeneratorCfg | None = None
@@ -59,6 +59,12 @@ class TerrainImporterCfg:
     """The path to the USD file containing the terrain.
 
     Only used if ``terrain_type`` is set to "usd".
+    """
+
+    mesh_path: str | None = None
+    """The path to the mesh file containing the terrain.
+
+    Only used if ``terrain_type`` is set to "mesh".
     """
 
     env_spacing: float | None = None


### PR DESCRIPTION
# Description

Currently, to load a terrain from a mesh, one needs to transform the mesh into a usd or hack around the terrain generator. With this PR we offer a simple and direct way to load terrain from a mesh via the mesh path.

Fixes #2846

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
