### PR TITLE
Fixes articulation and render_cfg tests to be proper pytests

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.40.11"
+version = "0.40.12"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.40.12"
+version = "0.40.13"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.40.12 (2025-07-03)
+~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed unittest tests that are floating inside pytests for articulation and rendering
+
+
 0.40.11 (2025-06-27)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/test/assets/test_articulation.py
+++ b/source/isaaclab/test/assets/test_articulation.py
@@ -1576,21 +1576,20 @@ def test_body_incoming_joint_wrench_b_single_joint(sim, num_articulations, devic
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_setting_articulation_root_prim_path(sim, device):
     """Test that the articulation root prim path can be set explicitly."""
-    with build_simulation_context(device=device, add_ground_plane=False, auto_add_lighting=True) as sim:
-        sim._app_control_on_stop_handle = None
-        # Create articulation
-        articulation_cfg = generate_articulation_cfg(articulation_type="humanoid")
-        print(articulation_cfg.spawn.usd_path)
-        articulation_cfg.articulation_root_prim_path = "/torso"
-        articulation, _ = generate_articulation(articulation_cfg, 1, device)
+    sim._app_control_on_stop_handle = None
+    # Create articulation
+    articulation_cfg = generate_articulation_cfg(articulation_type="humanoid")
+    print(articulation_cfg.spawn.usd_path)
+    articulation_cfg.articulation_root_prim_path = "/torso"
+    articulation, _ = generate_articulation(articulation_cfg, 1, device)
 
-        # Check that boundedness of articulation is correct
-        assert ctypes.c_long.from_address(id(articulation)).value == 1
+    # Check that boundedness of articulation is correct
+    assert ctypes.c_long.from_address(id(articulation)).value == 1
 
-        # Play sim
-        sim.reset()
-        # Check if articulation is initialized
-        assert articulation._is_initialized
+    # Play sim
+    sim.reset()
+    # Check if articulation is initialized
+    assert articulation._is_initialized
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])

--- a/source/isaaclab/test/assets/test_articulation.py
+++ b/source/isaaclab/test/assets/test_articulation.py
@@ -1572,40 +1572,43 @@ def test_body_incoming_joint_wrench_b_single_joint(sim, num_articulations, devic
         rtol=1e-3,
     )
 
-    def test_setting_articulation_root_prim_path(self):
-        """Test that the articulation root prim path can be set explicitly."""
-        with build_simulation_context(device="cuda:0", add_ground_plane=False, auto_add_lighting=True) as sim:
-            sim._app_control_on_stop_handle = None
-            # Create articulation
-            articulation_cfg = generate_articulation_cfg(articulation_type="humanoid")
-            print(articulation_cfg.spawn.usd_path)
-            articulation_cfg.articulation_root_prim_path = "/torso"
-            articulation, _ = generate_articulation(articulation_cfg, 1, "cuda:0")
 
-            # Check that boundedness of articulation is correct
-            self.assertEqual(ctypes.c_long.from_address(id(articulation)).value, 1)
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_setting_articulation_root_prim_path(sim, device):
+    """Test that the articulation root prim path can be set explicitly."""
+    with build_simulation_context(device=device, add_ground_plane=False, auto_add_lighting=True) as sim:
+        sim._app_control_on_stop_handle = None
+        # Create articulation
+        articulation_cfg = generate_articulation_cfg(articulation_type="humanoid")
+        print(articulation_cfg.spawn.usd_path)
+        articulation_cfg.articulation_root_prim_path = "/torso"
+        articulation, _ = generate_articulation(articulation_cfg, 1, device)
 
-            # Play sim
-            sim.reset()
-            # Check if articulation is initialized
-            self.assertTrue(articulation._is_initialized)
+        # Check that boundedness of articulation is correct
+        assert ctypes.c_long.from_address(id(articulation)).value == 1
 
-    def test_setting_invalid_articulation_root_prim_path(self):
-        """Test that the articulation root prim path can be set explicitly."""
-        with build_simulation_context(device="cuda:0", add_ground_plane=False, auto_add_lighting=True) as sim:
-            sim._app_control_on_stop_handle = None
-            # Create articulation
-            articulation_cfg = generate_articulation_cfg(articulation_type="humanoid")
-            print(articulation_cfg.spawn.usd_path)
-            articulation_cfg.articulation_root_prim_path = "/non_existing_prim_path"
-            articulation, _ = generate_articulation(articulation_cfg, 1, "cuda:0")
+        # Play sim
+        sim.reset()
+        # Check if articulation is initialized
+        assert articulation._is_initialized
 
-            # Check that boundedness of articulation is correct
-            self.assertEqual(ctypes.c_long.from_address(id(articulation)).value, 1)
 
-            # Play sim
-            with pytest.raises(RuntimeError):
-                sim.reset()
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_setting_invalid_articulation_root_prim_path(sim, device):
+    """Test that the articulation root prim path can be set explicitly."""
+    sim._app_control_on_stop_handle = None
+    # Create articulation
+    articulation_cfg = generate_articulation_cfg(articulation_type="humanoid")
+    print(articulation_cfg.spawn.usd_path)
+    articulation_cfg.articulation_root_prim_path = "/non_existing_prim_path"
+    articulation, _ = generate_articulation(articulation_cfg, 1, device=device)
+
+    # Check that boundedness of articulation is correct
+    assert ctypes.c_long.from_address(id(articulation)).value == 1
+
+    # Play sim
+    with pytest.raises(RuntimeError):
+        sim.reset()
 
 
 @pytest.mark.parametrize("num_articulations", [1, 2])

--- a/source/isaaclab/test/sim/test_simulation_render_config.py
+++ b/source/isaaclab/test/sim/test_simulation_render_config.py
@@ -89,50 +89,51 @@ def test_render_cfg():
     assert carb_settings_iface.get("/rtx/ambientOcclusion/enabled") == sim.cfg.render.enable_ambient_occlusion
     assert carb_settings_iface.get("/rtx/post/aa/op") == 4  # dlss = 3, dlaa=4
 
-    def test_render_cfg_presets(self):
-        """Test that the simulation context is created with the correct render cfg preset with overrides."""
 
-        # carb setting dictionary overrides
-        carb_settings = {"/rtx/raytracing/subpixel/mode": 3, "/rtx/pathtracing/maxSamplesPerLaunch": 999999}
-        # user-friendly setting overrides
-        dlss_mode = ("/rtx/post/dlss/execMode", 5)
+def test_render_cfg_presets():
+    """Test that the simulation context is created with the correct render cfg preset with overrides."""
 
-        rendering_modes = ["performance", "balanced", "quality", "xr"]
+    # carb setting dictionary overrides
+    carb_settings = {"/rtx/raytracing/subpixel/mode": 3, "/rtx/pathtracing/maxSamplesPerLaunch": 999999}
+    # user-friendly setting overrides
+    dlss_mode = ("/rtx/post/dlss/execMode", 5)
 
-        for rendering_mode in rendering_modes:
-            # grab groundtruth preset settings
-            preset_filename = f"apps/rendering_modes/{rendering_mode}.kit"
-            with open(preset_filename) as file:
-                preset_dict = toml.load(file)
-            preset_dict = dict(flatdict.FlatDict(preset_dict, delimiter="."))
+    rendering_modes = ["performance", "balanced", "quality", "xr"]
 
-            render_cfg = RenderCfg(
-                rendering_mode=rendering_mode,
-                dlss_mode=dlss_mode[1],
-                carb_settings=carb_settings,
-            )
+    for rendering_mode in rendering_modes:
+        # grab groundtruth preset settings
+        preset_filename = f"apps/rendering_modes/{rendering_mode}.kit"
+        with open(preset_filename) as file:
+            preset_dict = toml.load(file)
+        preset_dict = dict(flatdict.FlatDict(preset_dict, delimiter="."))
 
-            cfg = SimulationCfg(render=render_cfg)
+        render_cfg = RenderCfg(
+            rendering_mode=rendering_mode,
+            dlss_mode=dlss_mode[1],
+            carb_settings=carb_settings,
+        )
 
-            SimulationContext(cfg)
+        cfg = SimulationCfg(render=render_cfg)
 
-            carb_settings_iface = carb.settings.get_settings()
-            for key, val in preset_dict.items():
-                setting_name = "/" + key.replace(".", "/")  # convert to carb setting format
+        SimulationContext(cfg)
 
-                if setting_name in carb_settings:
-                    # grab groundtruth from carb setting dictionary overrides
-                    setting_gt = carb_settings[setting_name]
-                elif setting_name == dlss_mode[0]:
-                    # grab groundtruth from user-friendly setting overrides
-                    setting_gt = dlss_mode[1]
-                else:
-                    # grab groundtruth from preset
-                    setting_gt = val
+        carb_settings_iface = carb.settings.get_settings()
+        for key, val in preset_dict.items():
+            setting_name = "/" + key.replace(".", "/")  # convert to carb setting format
 
-                setting_val = get_carb_setting(carb_settings_iface, setting_name)
+            if setting_name in carb_settings:
+                # grab groundtruth from carb setting dictionary overrides
+                setting_gt = carb_settings[setting_name]
+            elif setting_name == dlss_mode[0]:
+                # grab groundtruth from user-friendly setting overrides
+                setting_gt = dlss_mode[1]
+            else:
+                # grab groundtruth from preset
+                setting_gt = val
 
-                self.assertEqual(setting_gt, setting_val)
+            setting_val = get_carb_setting(carb_settings_iface, setting_name)
+
+            assert setting_gt == setting_val
 
 
 @pytest.mark.skip(reason="Timeline not stopped")


### PR DESCRIPTION
# Description

Fixes some pytest migration errors for test_articulation and test_render_cfg

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
