### PR TITLE
Allows slicing to be processed from lists

### DIFF
--- a/source/isaaclab/isaaclab/utils/dict.py
+++ b/source/isaaclab/isaaclab/utils/dict.py
@@ -299,6 +299,8 @@ def replace_slices_with_strings(data: dict) -> dict:
     """
     if isinstance(data, dict):
         return {k: replace_slices_with_strings(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [replace_slices_with_strings(v) for v in data]
     elif isinstance(data, slice):
         return f"slice({data.start},{data.stop},{data.step})"
     else:
@@ -316,6 +318,8 @@ def replace_strings_with_slices(data: dict) -> dict:
     """
     if isinstance(data, dict):
         return {k: replace_strings_with_slices(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [replace_strings_with_slices(v) for v in data]
     elif isinstance(data, str) and data.startswith("slice("):
         return string_to_slice(data)
     else:


### PR DESCRIPTION
# Description

replace_slices_with_strings() and replace_strings_with_slices() in [IsaacLab/source/isaaclab/isaaclab/utils/dict.py](https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab/isaaclab/utils/dict.py) are changed to allow slices being process if a list of dicts is passed in as input.

Cherry picks changes from https://github.com/isaac-sim/IsaacLab/pull/2571 by @LinghengMeng 

Fixes #2481 


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
