### PR TITLE
Fixes GitHub edit link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,6 +229,7 @@ html_static_path = ["source/_static/css"]
 html_css_files = ["custom.css"]
 
 html_theme_options = {
+    "path_to_docs": "docs/",
     "collapse_navigation": True,
     "repository_url": "https://github.com/isaac-sim/IsaacLab",
     "use_repository_button": True,


### PR DESCRIPTION
I added the path_to_docs key to the html_theme_options dictionary in conf.py and set it to docs/

## Checklist

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [X] I have added my name to the `CONTRIBUTORS.md` or my name already exists there


