### PR TITLE
Remove deprecated env variable in docs(#2920)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@ Guidelines for modifications:
 * Michael Gussert
 * Michael Noseworthy
 * Miguel Alonso Jr
+* Mingyu Lee
 * Muhong Guo
 * Nicola Loi
 * Norbert Cygiert

--- a/docs/source/api/lab/isaaclab.app.rst
+++ b/docs/source/api/lab/isaaclab.app.rst
@@ -55,7 +55,6 @@ To set the environment variables, one can use the following command in the termi
 
 .. code:: bash
 
-   export REMOTE_DEPLOYMENT=3
    export ENABLE_CAMERAS=1
    # run the python script
    ./isaaclab.sh -p scripts/demo/play_quadrupeds.py
@@ -64,7 +63,7 @@ Alternatively, one can set the environment variables to the python script direct
 
 .. code:: bash
 
-   REMOTE_DEPLOYMENT=3 ENABLE_CAMERAS=1 ./isaaclab.sh -p scripts/demo/play_quadrupeds.py
+   ENABLE_CAMERAS=1 ./isaaclab.sh -p scripts/demo/play_quadrupeds.py
 
 
 Overriding the environment variables


### PR DESCRIPTION
# Description

Remove the usage of the REMOTE_DEPLOYMENT environment variable (e.g., export REMOTE_DEPLOYMENT=3) from the example code blocks in the [IsaacLab App documentation](https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.app.html), as this variable has been deprecated.

Fixes #2920  (issue)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots
Before
<img width="817" height="279" alt="isaaclab_app" src="https://github.com/user-attachments/assets/cfd45532-8b43-4285-9ed9-81039c7624e1" />
After
<img width="810" height="256" alt="Screenshot from 2025-07-15 09-54-47" src="https://github.com/user-attachments/assets/65838873-7374-4eee-8963-f35ca661725e" />



## Checklist

- [O] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [O] I have made corresponding changes to the documentation
- [O] My changes generate no new warnings
- [O] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [O] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
