### PR TITLE
Shifts order of docker deployment documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,7 +78,7 @@ Table of Contents
 
    source/setup/ecosystem
    source/setup/installation/index
-   source/setup/installation/cloud_installation
+   source/deployment/index
    source/refs/reference_architecture/index
 
 
@@ -122,7 +122,7 @@ Table of Contents
    :caption: Resources
    :titlesonly:
 
-   source/deployment/index
+   source/setup/installation/cloud_installation
    source/policy_deployment/index
 
 .. toctree::


### PR DESCRIPTION
# Description

There were some confusion with the Automator and docker deployment documentation. The order of which these pages were placed didn't make too much sense. This change moves the docker deployment up to the top section and moves Automator docs to the Resources section.

## Type of change

- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
