### PR TITLE
Updates torch to 2.7.0 with cuda 12.8 blackwell support

### DIFF
--- a/docs/source/setup/installation/binaries_installation.rst
+++ b/docs/source/setup/installation/binaries_installation.rst
@@ -383,26 +383,6 @@ Installation
 
    The valid options are ``rl_games``, ``rsl_rl``, ``sb3``, ``skrl``, ``robomimic``, ``none``.
 
-.. attention::
-
-   For 50 series GPUs, please use the latest PyTorch nightly build instead of PyTorch 2.5.1, which comes with Isaac Sim:
-
-   .. tab-set::
-      :sync-group: os
-
-      .. tab-item:: :icon:`fa-brands fa-linux` Linux
-         :sync: linux
-
-         .. code:: bash
-
-            ./isaaclab.sh -p -m pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
-
-      .. tab-item:: :icon:`fa-brands fa-windows` Windows
-         :sync: windows
-
-         .. code:: batch
-
-            isaaclab.bat -p -m pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
 
 Verifying the Isaac Lab installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -51,22 +51,11 @@ To learn about how to set up your own project on top of Isaac Lab, see :ref:`tem
                   env_isaaclab\Scripts\activate
 
 
--  Next, install a CUDA-enabled PyTorch 2.5.1 build based on the CUDA version available on your system. This step is optional for Linux, but required for Windows to ensure a CUDA-compatible version of PyTorch is installed.
+-  Next, install a CUDA-enabled PyTorch 2.7.0 build. This step is optional for Linux, but required for Windows to ensure a CUDA-compatible version of PyTorch is installed.
 
-   .. tab-set::
+   .. code-block:: bash
 
-      .. tab-item:: CUDA 11
-
-         .. code-block:: bash
-
-            pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu118
-
-      .. tab-item:: CUDA 12
-
-         .. code-block:: bash
-
-            pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu121
-
+      pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
 
 -  Before installing Isaac Lab, ensure the latest pip version is installed. To update pip, run
 
@@ -92,15 +81,6 @@ To learn about how to set up your own project on top of Isaac Lab, see :ref:`tem
    .. code-block:: none
 
       pip install isaaclab[isaacsim,all]==2.1.0 --extra-index-url https://pypi.nvidia.com
-
-
-.. attention::
-
-   For 50 series GPUs, please use the latest PyTorch nightly build instead of PyTorch 2.5.1, which comes with Isaac Sim:
-
-   .. code:: bash
-
-      pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
 
 
 Verifying the Isaac Sim installation

--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -76,21 +76,11 @@ If you encounter any issues, please report them to the
                   env_isaaclab\Scripts\activate
 
 
--  Next, install a CUDA-enabled PyTorch 2.5.1 build based on the CUDA version available on your system. This step is optional for Linux, but required for Windows to ensure a CUDA-compatible version of PyTorch is installed.
+-  Next, install a CUDA-enabled PyTorch 2.7.0 build based on the CUDA version available on your system. This step is optional for Linux, but required for Windows to ensure a CUDA-compatible version of PyTorch is installed.
 
-   .. tab-set::
+   .. code-block:: bash
 
-      .. tab-item:: CUDA 11
-
-         .. code-block:: bash
-
-            pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu118
-
-      .. tab-item:: CUDA 12
-
-         .. code-block:: bash
-
-            pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu121
+      pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
 
 -  Before installing Isaac Sim, ensure the latest pip version is installed. To update pip, run
 
@@ -300,13 +290,6 @@ Installation
 
    The valid options are ``rl_games``, ``rsl_rl``, ``sb3``, ``skrl``, ``robomimic``, ``none``.
 
-.. attention::
-
-   For 50 series GPUs, please use the latest PyTorch nightly build instead of PyTorch 2.5.1, which comes with Isaac Sim:
-
-   .. code:: bash
-
-      pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
 
 Verifying the Isaac Lab installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/setup/quickstart.rst
+++ b/docs/source/setup/quickstart.rst
@@ -43,22 +43,20 @@ To begin, we first define our virtual environment. We recommend using `miniconda
     # activate the virtual environment
     conda activate env_isaaclab
 
-Next, we need to install the CUDA-enabled version of PyTorch 2.5.1. This step is optional for Linux, but required for Windows to ensure a CUDA-compatible version of PyTorch is installed. If in doubt on which
-version to use, use 11.8.
-
+Next, we need to install the CUDA-enabled version of PyTorch 2.7.0. This step is optional for Linux, but required for Windows to ensure a CUDA-compatible version of PyTorch is installed.
 .. tab-set::
 
     .. tab-item:: CUDA 11
 
         .. code-block:: bash
 
-            pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu118
+            pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
 
     .. tab-item:: CUDA 12
 
         .. code-block:: bash
 
-            pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu121
+            pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
 
 Before we can install Isaac Sim, we need to make sure pip is updated.  To update pip, run
 

--- a/docs/source/tutorials/03_envs/policy_inference_in_usd.rst
+++ b/docs/source/tutorials/03_envs/policy_inference_in_usd.rst
@@ -58,7 +58,8 @@ Note that not all learning libraries support exporting the policy to a jit or on
 For libraries that don't currently support this functionality, please refer to the corresponding ``play.py`` script for the library
 to learn about how to initialize the policy.
 
-We can then load the warehouse asset and run inference on the H1 robot using the exported jit policy.
+We can then load the warehouse asset and run inference on the H1 robot using the exported jit policy
+(``policy.pt`` file in the ``exported/`` directory).
 
 .. code-block:: bash
 

--- a/isaaclab.bat
+++ b/isaaclab.bat
@@ -270,6 +270,27 @@ if "%arg%"=="-i" (
     rem install the python packages in isaaclab/source directory
     echo [INFO] Installing extensions inside the Isaac Lab repository...
     call :extract_python_exe
+
+    rem check if pytorch is installed and its version
+    rem install pytorch with cuda 12.8 for blackwell support
+    call !python_exe! -m pip list | findstr /C:"torch" >nul
+    if %errorlevel% equ 0 (
+        for /f "tokens=2" %%i in ('!python_exe! -m pip show torch ^| findstr /C:"Version:"') do (
+            set torch_version=%%i
+        )
+        if not "!torch_version!"=="2.7.0+cu128" (
+            echo [INFO] Uninstalling PyTorch version !torch_version!...
+            call !python_exe! -m pip uninstall -y torch torchvision torchaudio
+            echo [INFO] Installing PyTorch 2.7.0 with CUDA 12.8 support...
+            call !python_exe! -m pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+        ) else (
+            echo [INFO] PyTorch 2.7.0 is already installed.
+        )
+    ) else (
+        echo [INFO] Installing PyTorch 2.7.0 with CUDA 12.8 support...
+        call !python_exe! -m pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+    )
+
     for /d %%d in ("%ISAACLAB_PATH%\source\*") do (
         set ext_folder="%%d"
         call :install_isaaclab_extension
@@ -295,6 +316,27 @@ if "%arg%"=="-i" (
     rem install the python packages in source directory
     echo [INFO] Installing extensions inside the Isaac Lab repository...
     call :extract_python_exe
+
+    rem check if pytorch is installed and its version
+    rem install pytorch with cuda 12.8 for blackwell support
+    call !python_exe! -m pip list | findstr /C:"torch" >nul
+    if %errorlevel% equ 0 (
+        for /f "tokens=2" %%i in ('!python_exe! -m pip show torch ^| findstr /C:"Version:"') do (
+            set torch_version=%%i
+        )
+        if not "!torch_version!"=="2.7.0+cu128" (
+            echo [INFO] Uninstalling PyTorch version !torch_version!...
+            call !python_exe! -m pip uninstall -y torch torchvision torchaudio
+            echo [INFO] Installing PyTorch 2.7.0 with CUDA 12.8 support...
+            call !python_exe! -m pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+        ) else (
+            echo [INFO] PyTorch 2.7.0 is already installed.
+        )
+    ) else (
+        echo [INFO] Installing PyTorch 2.7.0 with CUDA 12.8 support...
+        call !python_exe! -m pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+    )
+
     for /d %%d in ("%ISAACLAB_PATH%\source\*") do (
         set ext_folder="%%d"
         call :install_isaaclab_extension

--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -276,6 +276,23 @@ while [[ $# -gt 0 ]]; do
             # install the python packages in IsaacLab/source directory
             echo "[INFO] Installing extensions inside the Isaac Lab repository..."
             python_exe=$(extract_python_exe)
+            # check if pytorch is installed and its version
+            # install pytorch with cuda 12.8 for blackwell support
+            if ${python_exe} -m pip list 2>/dev/null | grep -q "torch"; then
+                torch_version=$(${python_exe} -m pip show torch 2>/dev/null | grep "Version:" | awk '{print $2}')
+                echo "[INFO] Found PyTorch version ${torch_version} installed."
+                if [[ "${torch_version}" != "2.7.0+cu128" ]]; then
+                    echo "[INFO] Uninstalling PyTorch version ${torch_version}..."
+                    ${python_exe} -m pip uninstall -y torch torchvision torchaudio
+                    echo "[INFO] Installing PyTorch 2.7.0 with CUDA 12.8 support..."
+                    ${python_exe} -m pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+                else
+                    echo "[INFO] PyTorch 2.7.0 is already installed."
+                fi
+            else
+                echo "[INFO] Installing PyTorch 2.7.0 with CUDA 12.8 support..."
+                ${python_exe} -m pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+            fi
             # recursively look into directories and install them
             # this does not check dependencies between extensions
             export -f extract_python_exe

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.40.23"
+version = "0.41.0"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.41.0 (2025-07-21)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Updates torch version to 2.7.0 and torchvision to 0.22.0.
+  Some dependencies now require torch>=2.6, and given the vulnerabilities in Torch 2.5.1,
+  we are updating the torch version to 2.7.0 to also include Blackwell support. Since Isaac Sim 4.5 has not updated the
+  torch version, we are now overwriting the torch installation step in isaaclab.sh when running ``./isaaclab.sh -i``.
+
+
 0.40.23 (2025-06-29)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -20,7 +20,7 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 INSTALL_REQUIRES = [
     # generic
     "numpy<2",
-    "torch==2.5.1",
+    "torch>=2.5.1",
     "onnx==1.16.1",  # 1.16.2 throws access violation on Windows
     "prettytable==3.3.0",
     "toml",
@@ -53,7 +53,7 @@ if platform.system() == "Linux":
         "dex-retargeting==0.4.6",  # required by isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1_t2_dex_retargeting_utils
     ]
 
-PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu118"]
+PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu128"]
 
 # Installation operation
 setup(

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -20,7 +20,7 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 INSTALL_REQUIRES = [
     # generic
     "numpy<2",
-    "torch==2.5.1",
+    "torch>=2.5.1",
     "torchvision>=0.14.1",  # ensure compatibility with torch 1.13.1
     "protobuf>=3.20.2,!=5.26.0",
     # configuration management
@@ -35,7 +35,7 @@ INSTALL_REQUIRES = [
     "pillow==11.2.1",
 ]
 
-PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu118"]
+PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu128"]
 
 # Extra dependencies for RL agents
 EXTRAS_REQUIRE = {

--- a/source/isaaclab_tasks/setup.py
+++ b/source/isaaclab_tasks/setup.py
@@ -19,7 +19,7 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 INSTALL_REQUIRES = [
     # generic
     "numpy<2",
-    "torch==2.5.1",
+    "torch>=2.5.1",
     "torchvision>=0.14.1",  # ensure compatibility with torch 1.13.1
     "protobuf>=3.20.2,!=5.26.0",
     # basic logger
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     "numba",
 ]
 
-PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu118"]
+PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu128"]
 
 # Installation operation
 setup(


### PR DESCRIPTION
# Description

As required by https://github.com/isaac-sim/IsaacLab/pull/2962 and vulnerabilities in torch 2.5.1, this change updates torch to 2.7.0 during the installation of Isaac Lab.

Although inconsistent with Isaac Sim 4.5 (still on torch 2.5.1), Isaac Lab should work fine with 2.7.0+cu128. This update will also allow us to have better support for blackwell GPUs.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
