### PR TITLE
Fix typos and docstring inconsistencies across environment and utility files

### DIFF
--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -462,7 +462,7 @@ class DirectMARLEnv(gym.Env):
         By convention, if mode is:
 
         - **human**: Render to the current display and return nothing. Usually for human consumption.
-        - **rgb_array**: Return an numpy.ndarray with shape (x, y, 3), representing RGB values for an
+        - **rgb_array**: Return a numpy.ndarray with shape (x, y, 3), representing RGB values for an
           x-by-y pixel image, suitable for turning into a video.
 
         Args:

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -417,7 +417,7 @@ class DirectRLEnv(gym.Env):
         By convention, if mode is:
 
         - **human**: Render to the current display and return nothing. Usually for human consumption.
-        - **rgb_array**: Return an numpy.ndarray with shape (x, y, 3), representing RGB values for an
+        - **rgb_array**: Return a numpy.ndarray with shape (x, y, 3), representing RGB values for an
           x-by-y pixel image, suitable for turning into a video.
 
         Args:

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -248,7 +248,7 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         By convention, if mode is:
 
         - **human**: Render to the current display and return nothing. Usually for human consumption.
-        - **rgb_array**: Return an numpy.ndarray with shape (x, y, 3), representing RGB values for an
+        - **rgb_array**: Return a numpy.ndarray with shape (x, y, 3), representing RGB values for an
           x-by-y pixel image, suitable for turning into a video.
 
         Args:

--- a/source/isaaclab/isaaclab/envs/mdp/commands/pose_2d_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/pose_2d_command.py
@@ -121,7 +121,7 @@ class UniformPose2dCommand(CommandTerm):
         self.heading_command_b[:] = wrap_to_pi(self.heading_command_w - self.robot.data.heading_w)
 
     def _set_debug_vis_impl(self, debug_vis: bool):
-        # create markers if necessary for the first tome
+        # create markers if necessary for the first time
         if debug_vis:
             if not hasattr(self, "goal_pose_visualizer"):
                 self.goal_pose_visualizer = VisualizationMarkers(self.cfg.goal_pose_visualizer_cfg)

--- a/source/isaaclab/isaaclab/envs/mdp/commands/pose_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/pose_command.py
@@ -127,7 +127,7 @@ class UniformPoseCommand(CommandTerm):
         pass
 
     def _set_debug_vis_impl(self, debug_vis: bool):
-        # create markers if necessary for the first tome
+        # create markers if necessary for the first time
         if debug_vis:
             if not hasattr(self, "goal_pose_visualizer"):
                 # -- goal pose

--- a/source/isaaclab/isaaclab/envs/mdp/commands/velocity_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/velocity_command.py
@@ -163,7 +163,7 @@ class UniformVelocityCommand(CommandTerm):
         # set visibility of markers
         # note: parent only deals with callbacks. not their visibility
         if debug_vis:
-            # create markers if necessary for the first tome
+            # create markers if necessary for the first time
             if not hasattr(self, "goal_vel_visualizer"):
                 # -- goal
                 self.goal_vel_visualizer = VisualizationMarkers(self.cfg.goal_vel_visualizer_cfg)

--- a/source/isaaclab/isaaclab/markers/visualization_markers.py
+++ b/source/isaaclab/isaaclab/markers/visualization_markers.py
@@ -63,9 +63,9 @@ class VisualizationMarkers:
 
     The class parses the configuration to create different the marker prototypes into the stage. Each marker
     prototype prim is created as a child of the :class:`UsdGeom.PointInstancer` prim. The prim path for the
-    the marker prim is resolved using the key of the marker in the :attr:`VisualizationMarkersCfg.markers`
+    marker prim is resolved using the key of the marker in the :attr:`VisualizationMarkersCfg.markers`
     dictionary. The marker prototypes are created using the :meth:`isaacsim.core.utils.create_prim`
-    function, and then then instanced using :class:`UsdGeom.PointInstancer` prim to allow creating multiple
+    function, and then instanced using :class:`UsdGeom.PointInstancer` prim to allow creating multiple
     instances of the marker prims.
 
     Switching between different marker prototypes is possible by calling the :meth:`visualize` method with
@@ -369,9 +369,7 @@ class VisualizationMarkers:
         to see the marker prims on camera images.
 
         Args:
-            prim_path: The prim path to check.
-            stage: The stage where the prim exists.
-                Defaults to None, in which case the current stage is used.
+            prim: The prim to check.
         """
         # check if prim is valid
         if not prim.IsValid():

--- a/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor.py
@@ -391,7 +391,7 @@ class ContactSensor(SensorBase):
         # set visibility of markers
         # note: parent only deals with callbacks. not their visibility
         if debug_vis:
-            # create markers if necessary for the first tome
+            # create markers if necessary for the first time
             if not hasattr(self, "contact_visualizer"):
                 self.contact_visualizer = VisualizationMarkers(self.cfg.visualizer_cfg)
             # set their visibility to true

--- a/source/isaaclab/isaaclab/sensors/imu/imu.py
+++ b/source/isaaclab/isaaclab/sensors/imu/imu.py
@@ -219,7 +219,7 @@ class Imu(SensorBase):
         # set visibility of markers
         # note: parent only deals with callbacks. not their visibility
         if debug_vis:
-            # create markers if necessary for the first tome
+            # create markers if necessary for the first time
             if not hasattr(self, "acceleration_visualizer"):
                 self.acceleration_visualizer = VisualizationMarkers(self.cfg.visualizer_cfg)
             # set their visibility to true

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -40,7 +40,7 @@ class PhysxCfg:
     Available solvers:
 
     * :obj:`0`: PGS (Projective Gauss-Seidel)
-    * :obj:`1`: TGS (Truncated Gauss-Seidel)
+    * :obj:`1`: TGS (Temporal Gauss-Seidel)
     """
 
     min_position_iteration_count: int = 1

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/quadcopter_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/quadcopter/quadcopter_env.py
@@ -232,7 +232,7 @@ class QuadcopterEnv(DirectRLEnv):
         self._robot.write_joint_state_to_sim(joint_pos, joint_vel, None, env_ids)
 
     def _set_debug_vis_impl(self, debug_vis: bool):
-        # create markers if necessary for the first tome
+        # create markers if necessary for the first time
         if debug_vis:
             if not hasattr(self, "goal_pos_visualizer"):
                 marker_cfg = CUBOID_MARKER_CFG.copy()

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/pre_trained_policy_action.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/pre_trained_policy_action.py
@@ -107,7 +107,7 @@ class PreTrainedPolicyAction(ActionTerm):
         # set visibility of markers
         # note: parent only deals with callbacks. not their visibility
         if debug_vis:
-            # create markers if necessary for the first tome
+            # create markers if necessary for the first time
             if not hasattr(self, "base_vel_goal_visualizer"):
                 # -- goal
                 marker_cfg = GREEN_ARROW_X_MARKER_CFG.copy()


### PR DESCRIPTION
# Description

Fixes #1910,  #3010

### ✅ Typo Fixes

- Replaced `tome` → `time` in the following files:
  - `velocity_command.py`
  - `quadcopter_env.py`
  - `pre_trained_policy_action.py`
  - `pose_command.py`
  - `pose_2d_command.py`
  - `imu.py`
  - `contact_sensor.py`

- Corrected article usage `an numpy` → `a numpy` in:
  - `manager_based_rl_env.py`
  - `direct_rl_env.py`
  - `direct_marl_env.py`

- Removed repeated determiners (`the the`, `then then`) in:
  - `visualization_markers.py`

- Fixed incorrect expansion of the abbreviation **TGS** (In issue 1910):
  - Changed **TGS (Truncated Gauss-Seidel)** → **TGS (Temporal Gauss-Seidel)**

---

### 🛠️ Docstring Fix

- In `visualization_markers.py`, the `_process_prototype_prim` function had a docstring referencing `prim_path` and `stage`, which are not part of the function signature.  
  The docstring has been updated to correctly document only the `prim` argument.

  > Note: The original docstring seems to have been copied from [`utils.py`](https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab/isaaclab/sim/utils.py) without modification.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots


## Checklist

- [] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [X] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
