### PR TITLE
Internal template generator warning for case when user pip installed isaaclab

### DIFF
--- a/docs/source/overview/developer-guide/template.rst
+++ b/docs/source/overview/developer-guide/template.rst
@@ -22,6 +22,12 @@ The template generator enables you to create an:
 * **Internal task**: A task that is part of the Isaac Lab repository. This approach should only be used to create
   new tasks within the Isaac Lab repository in order to contribute to it.
 
+  .. warning::
+   
+    If you installed Isaac Lab via pip, any internal task generated outside of the pip-installed environment may not
+    be discovered properly. We are working on better support, but please prefer external projects when using
+    isaac lab pip installation.
+
 Running the template generator
 ------------------------------
 

--- a/docs/source/overview/developer-guide/template.rst
+++ b/docs/source/overview/developer-guide/template.rst
@@ -23,7 +23,7 @@ The template generator enables you to create an:
   new tasks within the Isaac Lab repository in order to contribute to it.
 
   .. warning::
-   
+
     If you installed Isaac Lab via pip, any internal task generated outside of the pip-installed environment may not
     be discovered properly. We are working on better support, but please prefer external projects when using
     isaac lab pip installation.


### PR DESCRIPTION

# Description

User may install isaaclab with pip but also want to create an internal template in cloned isaaclab that doesn't sit in miniconda's python site-packages, and of course this internal template will not be detect by python, but we also don't want to create templates in site-package neither, nobody do development in site-packages

The proper fix is to support both internal and external template regardless the method user pick to install isaaclab, but for now, we will add the warning to documentation that internal template with pip isaaclab package is not supported


Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.
<img width="863" height="947" alt="Screenshot from 2025-07-25 13-42-25" src="https://github.com/user-attachments/assets/6ae4ced6-2d6d-4949-a652-74cdd452613f" />

<!--
Example:


| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
