### PR TITLE
Skip operation to set velocity if kinematic is enabled for the rigido…

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.41.3"
+version = "0.41.5"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+
+0.41.5 (2025-07-30)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Skip operation to set velocity in :meth:`~isaaclab.assets.RigidObject` if KinematicEnabled is detected to be True
+
+
+
 0.41.4 (2025-07-30)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object/rigid_object.py
@@ -56,6 +56,8 @@ class RigidObject(AssetBase):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
+        prim = sim_utils.find_matching_prims(self.cfg.prim_path)
+        self.is_kinamtic_enabled = prim[0].GetAttribute("physics:kinematicEnabled").Get()
 
     """
     Properties
@@ -292,6 +294,8 @@ class RigidObject(AssetBase):
             root_velocity: Root center of mass velocities in simulation world frame. Shape is (len(env_ids), 6).
             env_ids: Environment indices. If None, then all indices are used.
         """
+        if self.is_kinamtic_enabled:
+            return
         self.write_root_com_velocity_to_sim(root_velocity=root_velocity, env_ids=env_ids)
 
     def write_root_com_velocity_to_sim(self, root_velocity: torch.Tensor, env_ids: Sequence[int] | None = None):
@@ -304,6 +308,8 @@ class RigidObject(AssetBase):
             root_velocity: Root center of mass velocities in simulation world frame. Shape is (len(env_ids), 6).
             env_ids: Environment indices. If None, then all indices are used.
         """
+        if self.is_kinamtic_enabled:
+            return
         # resolve all indices
         physx_env_ids = env_ids
         if env_ids is None:
@@ -335,6 +341,8 @@ class RigidObject(AssetBase):
             root_velocity: Root frame velocities in simulation world frame. Shape is (len(env_ids), 6).
             env_ids: Environment indices. If None, then all indices are used.
         """
+        if self.is_kinamtic_enabled:
+            return
         # resolve all indices
         if env_ids is None:
             local_env_ids = slice(env_ids)


### PR DESCRIPTION
Reset velocity is not a valid operation for RigidObject if kinematic enabled flag is True

This PR makes set-velocity an no-op if detected kinematic_enabled is True

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
