### PR TITLE
Fixes '!python_exe!' is not recognized as an internal or external command

### DIFF
--- a/isaaclab.bat
+++ b/isaaclab.bat
@@ -95,8 +95,6 @@ if not exist "%python_exe%" (
     echo %tab%2. Python executable is not available at the default path: %ISAACLAB_PATH%\_isaac_sim\python.bat
     exit /b 1
 )
-echo [DEBUG] python_exe is set to: !python_exe!
-
 goto :eof
 
 
@@ -317,7 +315,7 @@ goto :eof
 
 rem Main
 :main
-setlocal EnableDelayedExpansion
+
 rem check argument provided
 if "%~1"=="" (
     echo [Error] No arguments provided.

--- a/isaaclab.bat
+++ b/isaaclab.bat
@@ -67,6 +67,7 @@ rem -----------------------------------------------------------------------
 
 rem extract the python from isaacsim
 :extract_python_exe
+setlocal EnableDelayedExpansion
 rem check if using conda
 if not "%CONDA_PREFIX%"=="" (
     rem use conda python
@@ -94,6 +95,8 @@ if not exist "%python_exe%" (
     echo %tab%2. Python executable is not available at the default path: %ISAACLAB_PATH%\_isaac_sim\python.bat
     exit /b 1
 )
+echo [DEBUG] python_exe is set to: !python_exe!
+
 goto :eof
 
 
@@ -314,7 +317,7 @@ goto :eof
 
 rem Main
 :main
-
+setlocal EnableDelayedExpansion
 rem check argument provided
 if "%~1"=="" (
     echo [Error] No arguments provided.


### PR DESCRIPTION
# Description

This pull request fixes an issue where the isaaclab.bat script would fail with the error '!python_exe!' is not recognized as an internal or external command, operable program or batch file. when running commands that require the Python executable. The root cause was that the python_exe variable, set in the :extract_python_exe subroutine, was not correctly propagated back to the main context with delayed variable expansion enabled.

## Motivation and context:
This bug prevented users from running commands such as` isaaclab.bat --new` and other commands that rely on the Python executable, breaking core functionality of the batch script on Windows.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Summary of the change:

Added setlocal EnableDelayedExpansion at the start of the :extract_python_exe subroutine.
Used endlocal & set "python_exe=%python_exe%" at the end of the subroutine to propagate the variable back to the parent context.
This ensures that !python_exe! is correctly expanded and available after calling :extract_python_exe.

## Screenshots

Before the fix, the script will error out:
<img width="400" height="146" alt="Screenshot 2025-08-01 002050" src="https://github.com/user-attachments/assets/99aff1c4-7a93-4fe3-8a76-811e1ba1b8ed" />

After the fix, the script run correctly:

<img width="560" height="194" alt="Screenshot 2025-08-01 002125" src="https://github.com/user-attachments/assets/f7c63676-89a1-48f6-adbf-641537fba978" />

