### PR TITLE
Fixes `anyio` license checking

### DIFF
--- a/.github/workflows/license-exceptions.json
+++ b/.github/workflows/license-exceptions.json
@@ -365,5 +365,10 @@
     "package": "regex",
     "license": "UNKNOWN",
     "comment": "Apache 2.0"
+  },
+  {
+    "package": "anyio",
+    "license": "UNKNOWN",
+    "comment": "MIT"
   }
 ]


### PR DESCRIPTION
# Description

Fixes `anyio` license checking. Current return is UNKNOWN, actual license is MIT.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
