### PR TITLE
set joint_friction_coeff only for selected physx_env_ids

### DIFF
--- a/source/isaaclab/isaaclab/assets/articulation/articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation.py
@@ -865,7 +865,7 @@ class Articulation(AssetBase):
             )
         else:
             friction_props = self.root_physx_view.get_dof_friction_properties()
-            friction_props[physx_env_ids.cpu(), :, 0] = self._data.joint_friction_coeff.cpu()
+            friction_props[physx_env_ids.cpu(), :, 0] = self._data.joint_friction_coeff[physx_env_ids, :].cpu()
 
     def write_joint_dynamic_friction_coefficient_to_sim(
         self,
@@ -890,7 +890,7 @@ class Articulation(AssetBase):
         self._data.joint_dynamic_friction_coeff[env_ids, joint_ids] = joint_dynamic_friction_coeff
         # set into simulation
         friction_props = self.root_physx_view.get_dof_friction_properties()
-        friction_props[physx_env_ids.cpu(), :, 1] = self._data.joint_dynamic_friction_coeff.cpu()
+        friction_props[physx_env_ids.cpu(), :, 1] = self._data.joint_dynamic_friction_coeff[physx_env_ids, :].cpu()
 
     def write_joint_viscous_friction_coefficient_to_sim(
         self,
@@ -915,7 +915,7 @@ class Articulation(AssetBase):
         self._data.joint_viscous_friction_coeff[env_ids, joint_ids] = joint_viscous_friction_coeff
         # set into simulation
         friction_props = self.root_physx_view.get_dof_friction_properties()
-        friction_props[physx_env_ids.cpu(), :, 2] = self._data.joint_viscous_friction_coeff.cpu()
+        friction_props[physx_env_ids.cpu(), :, 2] = self._data.joint_viscous_friction_coeff[physx_env_ids, :].cpu()
 
     """
     Operations - Setters.


### PR DESCRIPTION
# Bugfix

Previously, self._data.joint_dynamic_friction_coeff was being set for all environments, regardless of the intended targets. This behavior is incorrect — the friction coefficient should only be set for the specified physx_env_ids.