### PR TITLE
Fix: observation space Dict for non-concatenated groups only keeps last term

### DIFF
--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -334,12 +334,12 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
                 self.single_observation_space[group_name] = gym.spaces.Box(low=-np.inf, high=np.inf, shape=group_dim)
             else:
                 group_term_cfgs = self.observation_manager._group_obs_term_cfgs[group_name]
+                term_dict = {}
                 for term_name, term_dim, term_cfg in zip(group_term_names, group_dim, group_term_cfgs):
                     low = -np.inf if term_cfg.clip is None else term_cfg.clip[0]
                     high = np.inf if term_cfg.clip is None else term_cfg.clip[1]
-                    self.single_observation_space[group_name] = gym.spaces.Dict(
-                        {term_name: gym.spaces.Box(low=low, high=high, shape=term_dim)}
-                    )
+                    term_dict[term_name] = gym.spaces.Box(low=low, high=high, shape=term_dim)
+                self.single_observation_space[group_name] = gym.spaces.Dict(term_dict)
         # action space (unbounded since we don't impose any limits)
         action_dim = sum(self.action_manager.action_term_dim)
         self.single_action_space = gym.spaces.Box(low=-np.inf, high=np.inf, shape=(action_dim,))


### PR DESCRIPTION
# Description

This PR fixes a bug in the observation space construction for non-concatenated groups in `ManagerBasedRLEnv._configure_gym_env_spaces` method. Previously, only the last term in each group was included in the Dict, causing loss of observation information. Now, all terms are correctly added to the group Dict.

Fixes #3133 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

