### PR TITLE
Fixes termination term effort limit check logic

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@ Guidelines for modifications:
 * Lukas Fröhlich
 * Manuel Schweiger
 * Masoud Moghani
+* Maurice Rahme
 * Michael Gussert
 * Michael Noseworthy
 * Miguel Alonso Jr

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.45.1"
+version = "0.45.3"
 
 
 # Description

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.45.3 (2025-08-20)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :meth:`isaaclab.envs.mdp.terminations.joint_effort_out_of_limit` so that it correctly reports whether a joint
+  effort limit has been violated. Previously, the implementation marked a violation when the applied and computed
+  torques were equal; in fact, equality should indicate no violation, and vice versa.
+
 0.45.2 (2025-08-18)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/envs/mdp/terminations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/terminations.py
@@ -134,12 +134,12 @@ def joint_effort_out_of_limit(
 
     In the actuators, the applied torque are the efforts applied on the joints. These are computed by clipping
     the computed torques to the joint limits. Hence, we check if the computed torques are equal to the applied
-    torques.
+    torques. If they are not, it means that clipping has occurred.
     """
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # check if any joint effort is out of limit
-    out_of_limits = torch.isclose(
+    out_of_limits = ~torch.isclose(
         asset.data.computed_torque[:, asset_cfg.joint_ids], asset.data.applied_torque[:, asset_cfg.joint_ids]
     )
     return torch.any(out_of_limits, dim=1)


### PR DESCRIPTION
# Description

Fix the logic in `joint_effort_out_of_limit()`; this function aims to detect effort limit violations by comparing the desired (computed) effort against the applied effort, noting that the simulator clips applied torque to the limit assign on creation.

Originally, the logic was written such that if the applied and computed torques are equal, then a violation has occurred. However, this is wrong as shown by the below example:

```python
from isaaclab.managers import SceneEntityCfg
from isaaclab.envs.mdp.terminations import joint_effort_out_of_limit

env = ...  # any ManagerBasedRLEnv with an Articulation named "robot"
cfg = SceneEntityCfg(name="robot", joint_ids=[0])  # single joint for clarity
art = env.scene["robot"]

# Case A: no clipping (should be False but returns True now)
art.data.computed_torque[:] = 0.0
art.data.applied_torque[:] = 0.0
assert joint_effort_out_of_limit(env, cfg).item() is False  # CURRENT: True (bug)

# Case B: clipping (should be True but returns False now)
art.data.computed_torque[:] = 100.0
art.data.applied_torque[:] = 50.0  # pretend actuator clipped to ±50
assert joint_effort_out_of_limit(env, cfg).item() is True   # CURRENT: False (bug)

```

The solution is hence simply to flip the limit detection logic.

Fixes #3155


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file (N/A)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

