### PR TITLE
Fix `terrain_out_of_bounds` to return tensor instead of bool

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/terminations.py
@@ -30,7 +30,7 @@ def terrain_out_of_bounds(
     to the edge of the terrain is calculated based on the size of the terrain and the distance buffer.
     """
     if env.scene.cfg.terrain.terrain_type == "plane":
-        return False  # we have infinite terrain because it is a plane
+        return torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)  # we have infinite terrain because it is a plane
     elif env.scene.cfg.terrain.terrain_type == "generator":
         # obtain the size of the sub-terrains
         terrain_gen_cfg = env.scene.terrain.cfg.terrain_generator

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/terminations.py
@@ -30,7 +30,8 @@ def terrain_out_of_bounds(
     to the edge of the terrain is calculated based on the size of the terrain and the distance buffer.
     """
     if env.scene.cfg.terrain.terrain_type == "plane":
-        return torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)  # we have infinite terrain because it is a plane
+        # we have infinite terrain because it is a plane
+        return torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
     elif env.scene.cfg.terrain.terrain_type == "generator":
         # obtain the size of the sub-terrains
         terrain_gen_cfg = env.scene.terrain.cfg.terrain_generator


### PR DESCRIPTION
# Description

Fix terrain_out_of_bounds to return tensor instead of bool

Ensure the function always returns a PyTorch tensor (shape [num_envs]) rather than a Python boolean when terrain_type is "plane", preventing AttributeError in termination_manager.

Before:

```bash
Error executing job with overrides: []
Traceback (most recent call last):
  File "/home/ubuntu/workspaces/IsaacLab/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py", line 101, in hydra_main
    func(env_cfg, agent_cfg, *args, **kwargs)
  File "/home/ubuntu/workspaces/robot_lab/scripts/reinforcement_learning/rsl_rl/train.py", line 165, in main
    runner.learn(num_learning_iterations=agent_cfg.max_iterations, init_at_random_ep_len=True)
  File "/home/ubuntu/miniconda3/envs/lab/lib/python3.11/site-packages/rsl_rl/runners/on_policy_runner.py", line 206, in learn
    obs, rewards, dones, infos = self.env.step(actions.to(self.env.device))
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspaces/IsaacLab/source/isaaclab_rl/isaaclab_rl/rsl_rl/vecenv_wrapper.py", line 176, in step
    obs_dict, rew, terminated, truncated, extras = self.env.step(actions)
                                                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/miniconda3/envs/lab/lib/python3.11/site-packages/gymnasium/wrappers/common.py", line 393, in step
    return super().step(action)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/miniconda3/envs/lab/lib/python3.11/site-packages/gymnasium/core.py", line 327, in step
    return self.env.step(action)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspaces/IsaacLab/source/isaaclab/isaaclab/envs/manager_based_rl_env.py", line 204, in step
    self.reset_buf = self.termination_manager.compute()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/workspaces/IsaacLab/source/isaaclab/isaaclab/managers/termination_manager.py", line 172, in compute
    rows = value.nonzero(as_tuple=True)[0]  # indexing is cheaper than boolean advance indexing
           ^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'nonzero'
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

