### PR TITLE
Fix MuJoCo link

### DIFF
--- a/docs/source/setup/ecosystem.rst
+++ b/docs/source/setup/ecosystem.rst
@@ -149,6 +149,7 @@ to Isaac Lab, please reach out to us.
 .. _ManiSkill: https://github.com/haosulab/ManiSkill
 .. _ThreeDWorld: https://www.threedworld.org/
 .. _RoboSuite: https://robosuite.ai/
+.. _MuJoCo: https://mujoco.org/
 .. _MuJoCo Playground: https://playground.mujoco.org/
 .. _MJX: https://mujoco.readthedocs.io/en/stable/mjx.html
 .. _Bullet: https://github.com/bulletphysics/bullet3


### PR DESCRIPTION
# Description

Fix MuJoCo link

<img width="1726" height="1220" alt="image" src="https://github.com/user-attachments/assets/fed03af9-cc0c-4b94-8a8c-42ecd5992f6c" />

## Type of change

- This change requires a documentation update

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
