### PR TITLE
[Bug Fix] Fixes single-env handling of terrain out of bounds termination

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/terminations.py
@@ -30,7 +30,9 @@ def terrain_out_of_bounds(
     to the edge of the terrain is calculated based on the size of the terrain and the distance buffer.
     """
     if env.scene.cfg.terrain.terrain_type == "plane":
-        return False  # we have infinite terrain because it is a plane
+        return torch.zeros(
+            env.num_envs, dtype=torch.bool, device=env.device
+        )  # we have infinite terrain because it is a plane
     elif env.scene.cfg.terrain.terrain_type == "generator":
         # obtain the size of the sub-terrains
         terrain_gen_cfg = env.scene.terrain.cfg.terrain_generator


### PR DESCRIPTION
# Description

The `terrain_out_of_bounds` termination condition creates an error with single environments when called on an infinite plane because it returns the boolean `False`. This PR replaces the return in this case with a boolean tensor of size `(num_envs,)`.

## Type of change


- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [X] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
