### PR TITLE
Sets profiler backend to NVTX by default

### DIFF
--- a/apps/isaaclab.python.headless.kit
+++ b/apps/isaaclab.python.headless.kit
@@ -88,6 +88,9 @@ app.audio.enabled = false
 # Enable Vulkan - avoids torch+cu12 error on windows
 app.vulkan = true
 
+# Set profiler backend to NVTX by default
+app.profilerBackend = "nvtx"
+
 # Disables rate limit in runloop
 app.runLoops.main.rateLimitEnabled=false
 

--- a/apps/isaaclab.python.headless.rendering.kit
+++ b/apps/isaaclab.python.headless.rendering.kit
@@ -88,6 +88,9 @@ app.audio.enabled = false
 # Enable Vulkan - avoids torch+cu12 error on windows
 app.vulkan = true
 
+# Set profiler backend to NVTX by default
+app.profilerBackend = "nvtx"
+
 # Disables rate limit in runloop
 app.runLoops.main.rateLimitEnabled=false
 

--- a/apps/isaacsim_4_5/isaaclab.python.headless.kit
+++ b/apps/isaacsim_4_5/isaaclab.python.headless.kit
@@ -78,6 +78,9 @@ app.audio.enabled = false
 # Enable Vulkan - avoids torch+cu12 error on windows
 app.vulkan = true
 
+# Set profiler backend to NVTX by default
+app.profilerBackend = "nvtx"
+
 # hide NonToggleable Exts
 exts."omni.kit.window.extensions".hideNonToggleableExts = true
 exts."omni.kit.window.extensions".showFeatureOnly = false

--- a/apps/isaacsim_4_5/isaaclab.python.headless.rendering.kit
+++ b/apps/isaacsim_4_5/isaaclab.python.headless.rendering.kit
@@ -83,6 +83,9 @@ app.audio.enabled = false
 # Enable Vulkan - avoids torch+cu12 error on windows
 app.vulkan = true
 
+# Set profiler backend to NVTX by default
+app.profilerBackend = "nvtx"
+
 # disable replicator orchestrator for better runtime perf
 exts."omni.replicator.core".Orchestrator.enabled = false
 


### PR DESCRIPTION
# Description

We found that performance overhead varies depending on the profiler backend, even when profiling is not enabled.
For optimization, we changed the default profiler backend to NVTX.
Depending on the test case, we observed a performance improvement of about 1–12%.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
- [x] I have done this task