### PR TITLE
Fixes tensor construction warning in `events.py`

### DIFF
--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -597,13 +597,13 @@ class randomize_actuator_gains(ManagerTermBase):
                 if isinstance(actuator.joint_indices, slice):
                     global_indices = slice(None)
                 else:
-                    global_indices = torch.tensor(actuator.joint_indices, device=self.asset.device)
+                    global_indices = actuator_joint_indices = actuator.joint_indices.to(self.asset.device)
             elif isinstance(actuator.joint_indices, slice):
                 # we take the joints defined in the asset config
                 global_indices = actuator_indices = torch.tensor(self.asset_cfg.joint_ids, device=self.asset.device)
             else:
                 # we take the intersection of the actuator joints and the asset config joints
-                actuator_joint_indices = torch.tensor(actuator.joint_indices, device=self.asset.device)
+                actuator_joint_indices = actuator.joint_indices.to(self.asset.device)
                 asset_joint_ids = torch.tensor(self.asset_cfg.joint_ids, device=self.asset.device)
                 # the indices of the joints in the actuator that have to be randomized
                 actuator_indices = torch.nonzero(torch.isin(actuator_joint_indices, asset_joint_ids)).view(-1)


### PR DESCRIPTION
# Description

This PR removes a `UserWarning` from PyTorch about using `torch.tensor()` on an existing tensor in `events.py`. It replaces `torch.tensor(actuator.joint_indices, device=asset.device)` with .to(device) to avoid unnecessary copies.

Warning mentionned:

```bash
/home/spring/IsaacLab/source/isaaclab/isaaclab/envs/mdp/events.py:542: 
UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor). actuator_joint_indices = torch.tensor(actuator.joint_indices, device=asset.device)
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
