### PR TITLE
Fix typo in list_envs.py script path

### DIFF
--- a/docs/source/setup/quickstart.rst
+++ b/docs/source/setup/quickstart.rst
@@ -125,7 +125,7 @@ List Available Environments
 
 Above, ``Isaac-Ant-v0`` is the task name and ``skrl`` is the RL framework being used.  The ``Isaac-Ant-v0`` environment
 has been registered with the `Gymnasium API <https://gymnasium.farama.org/>`_, and you can see how the entry point is defined
-by calling the ``list_envs.py`` script, which can be found in ``isaaclab/scripts/environments/lsit_envs.py``. You should see entries like the following
+by calling the ``list_envs.py`` script, which can be found in ``isaaclab/scripts/environments/list_envs.py``. You should see entries like the following
 
 .. code-block:: bash
 


### PR DESCRIPTION
# Description

Corrected the file path for the list_envs.py script in the documentation.

Fixes # (issue)

## Type of change

- Fix a typo


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
