### PR TITLE
Removes isaaclab.controller import of Pink IK to prevent pinocchio import error

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.45.8"
+version = "0.45.9"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.45.9 (2025-08-27)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed removing import of pink_ik controller from isaaclab.controllers which is causing pinocchio import error.
+
+
 0.45.8 (2025-07-25)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/controllers/__init__.py
+++ b/source/isaaclab/isaaclab/controllers/__init__.py
@@ -15,4 +15,3 @@ from .differential_ik import DifferentialIKController
 from .differential_ik_cfg import DifferentialIKControllerCfg
 from .operational_space import OperationalSpaceController
 from .operational_space_cfg import OperationalSpaceControllerCfg
-from .pink_ik import NullSpacePostureTask, PinkIKController, PinkIKControllerCfg


### PR DESCRIPTION
# Description

Feature introduced in #3149 imports pink_ik for isaaclab.controller module. This is causing an error IsaacLab wide due to pinocchio import. This PR removes the import.

Fixes # (issue)
Fixed pinocchio import error due to isaaclab.controller module importing pink_ik by default.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
