### PR TITLE
Fix DigitalFilter documentation: A coefficient should be -alpha for l…

### DIFF
--- a/source/isaaclab/isaaclab/utils/modifiers/modifier.py
+++ b/source/isaaclab/isaaclab/utils/modifiers/modifier.py
@@ -123,11 +123,13 @@ class DigitalFilter(ModifierBase):
     where :math:`\alpha` is a smoothing parameter between 0 and 1. Typically, the value of :math:`\alpha` is
     chosen based on the desired cut-off frequency of the filter.
 
-    This filter can be implemented as a digital filter with the coefficients :math:`A = [\alpha]` and
+    This filter can be implemented as a digital filter with the coefficients :math:`A = [-\alpha]` and
     :math:`B = [1 - \alpha]`.
     """
 
-    def __init__(self, cfg: modifier_cfg.DigitalFilterCfg, data_dim: tuple[int, ...], device: str) -> None:
+    def __init__(
+        self, cfg: modifier_cfg.DigitalFilterCfg, data_dim: tuple[int, ...], device: str
+    ) -> None:
         """Initializes digital filter.
 
         Args:
@@ -141,7 +143,9 @@ class DigitalFilter(ModifierBase):
         """
         # check that filter coefficients are not None
         if cfg.A is None or cfg.B is None:
-            raise ValueError("Digital filter coefficients A and B must not be None. Please provide valid coefficients.")
+            raise ValueError(
+                "Digital filter coefficients A and B must not be None. Please provide valid coefficients."
+            )
 
         # initialize parent class
         super().__init__(cfg, data_dim, device)
@@ -213,7 +217,9 @@ class Integrator(ModifierBase):
     :math:`\Delta t` is the time step between samples.
     """
 
-    def __init__(self, cfg: modifier_cfg.IntegratorCfg, data_dim: tuple[int, ...], device: str):
+    def __init__(
+        self, cfg: modifier_cfg.IntegratorCfg, data_dim: tuple[int, ...], device: str
+    ):
         """Initializes the integrator configuration and state.
 
         Args:


### PR DESCRIPTION
…ow-pass filter

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #3293

Corrects the documentation for implementing a low-pass filter with DigitalFilter. 
The coefficient A should be [-α] not [α] because DigitalFilter subtracts the 
recursive term (Y*A) in its implementation.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
