### PR TITLE
Moves parameter `platform_height` to the correct mesh terrain configuration

### DIFF
--- a/source/isaaclab/isaaclab/terrains/height_field/hf_terrains_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/hf_terrains_cfg.py
@@ -145,8 +145,9 @@ class HfWaveTerrainCfg(HfTerrainBaseCfg):
 
     amplitude_range: tuple[float, float] = MISSING
     """The minimum and maximum amplitude of the wave (in m)."""
-    num_waves: int = 1.0
-    """The number of waves to generate. Defaults to 1.0."""
+
+    num_waves: int = 1
+    """The number of waves to generate. Defaults to 1."""
 
 
 @configclass

--- a/source/isaaclab/isaaclab/terrains/height_field/hf_terrains_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/hf_terrains_cfg.py
@@ -21,10 +21,13 @@ class HfTerrainBaseCfg(SubTerrainBaseCfg):
     The border width is subtracted from the :obj:`size` of the terrain. If non-zero, it must be
     greater than or equal to the :obj:`horizontal scale`.
     """
+
     horizontal_scale: float = 0.1
     """The discretization of the terrain along the x and y axes (in m). Defaults to 0.1."""
+
     vertical_scale: float = 0.005
     """The discretization of the terrain along the z axis (in m). Defaults to 0.005."""
+
     slope_threshold: float | None = None
     """The slope threshold above which surfaces are made vertical. Defaults to None,
     in which case no correction is applied."""
@@ -43,8 +46,10 @@ class HfRandomUniformTerrainCfg(HfTerrainBaseCfg):
 
     noise_range: tuple[float, float] = MISSING
     """The minimum and maximum height noise (i.e. along z) of the terrain (in m)."""
+
     noise_step: float = MISSING
     """The minimum height (in m) change between two points."""
+
     downsampled_scale: float | None = None
     """The distance between two randomly sampled points on the terrain. Defaults to None,
     in which case the :obj:`horizontal scale` is used.
@@ -62,8 +67,10 @@ class HfPyramidSlopedTerrainCfg(HfTerrainBaseCfg):
 
     slope_range: tuple[float, float] = MISSING
     """The slope of the terrain (in radians)."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
+
     inverted: bool = False
     """Whether the pyramid is inverted. Defaults to False.
 
@@ -92,10 +99,13 @@ class HfPyramidStairsTerrainCfg(HfTerrainBaseCfg):
 
     step_height_range: tuple[float, float] = MISSING
     """The minimum and maximum height of the steps (in m)."""
+
     step_width: float = MISSING
     """The width of the steps (in m)."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
+
     inverted: bool = False
     """Whether the pyramid stairs is inverted. Defaults to False.
 
@@ -127,12 +137,16 @@ class HfDiscreteObstaclesTerrainCfg(HfTerrainBaseCfg):
 
     The following modes are supported: "choice", "fixed".
     """
+
     obstacle_width_range: tuple[float, float] = MISSING
     """The minimum and maximum width of the obstacles (in m)."""
+
     obstacle_height_range: tuple[float, float] = MISSING
     """The minimum and maximum height of the obstacles (in m)."""
+
     num_obstacles: int = MISSING
     """The number of obstacles to generate."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
 
@@ -158,11 +172,15 @@ class HfSteppingStonesTerrainCfg(HfTerrainBaseCfg):
 
     stone_height_max: float = MISSING
     """The maximum height of the stones (in m)."""
+
     stone_width_range: tuple[float, float] = MISSING
     """The minimum and maximum width of the stones (in m)."""
+
     stone_distance_range: tuple[float, float] = MISSING
     """The minimum and maximum distance between stones (in m)."""
+
     holes_depth: float = -10.0
     """The depth of the holes (negative obstacles). Defaults to -10.0."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""

--- a/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains_cfg.py
@@ -36,10 +36,13 @@ class MeshPyramidStairsTerrainCfg(SubTerrainBaseCfg):
 
     The border is a flat terrain with the same height as the terrain.
     """
+
     step_height_range: tuple[float, float] = MISSING
     """The minimum and maximum height of the steps (in m)."""
+
     step_width: float = MISSING
     """The width of the steps (in m)."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
 
@@ -71,10 +74,13 @@ class MeshRandomGridTerrainCfg(SubTerrainBaseCfg):
 
     grid_width: float = MISSING
     """The width of the grid cells (in m)."""
+
     grid_height_range: tuple[float, float] = MISSING
     """The minimum and maximum height of the grid cells (in m)."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
+
     holes: bool = False
     """If True, the terrain will have holes in the steps. Defaults to False.
 
@@ -91,8 +97,10 @@ class MeshRailsTerrainCfg(SubTerrainBaseCfg):
 
     rail_thickness_range: tuple[float, float] = MISSING
     """The thickness of the inner and outer rails (in m)."""
+
     rail_height_range: tuple[float, float] = MISSING
     """The minimum and maximum height of the rails (in m)."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
 
@@ -105,8 +113,10 @@ class MeshPitTerrainCfg(SubTerrainBaseCfg):
 
     pit_depth_range: tuple[float, float] = MISSING
     """The minimum and maximum height of the pit (in m)."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
+
     double_pit: bool = False
     """If True, the pit contains two levels of stairs. Defaults to False."""
 
@@ -119,8 +129,10 @@ class MeshBoxTerrainCfg(SubTerrainBaseCfg):
 
     box_height_range: tuple[float, float] = MISSING
     """The minimum and maximum height of the box (in m)."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
+
     double_box: bool = False
     """If True, the pit contains two levels of stairs/boxes. Defaults to False."""
 
@@ -133,6 +145,7 @@ class MeshGapTerrainCfg(SubTerrainBaseCfg):
 
     gap_width_range: tuple[float, float] = MISSING
     """The minimum and maximum width of the gap (in m)."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
 
@@ -145,10 +158,13 @@ class MeshFloatingRingTerrainCfg(SubTerrainBaseCfg):
 
     ring_width_range: tuple[float, float] = MISSING
     """The minimum and maximum width of the ring (in m)."""
+
     ring_height_range: tuple[float, float] = MISSING
     """The minimum and maximum height of the ring (in m)."""
+
     ring_thickness: float = MISSING
     """The thickness (along z) of the ring (in m)."""
+
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
 
@@ -161,10 +177,13 @@ class MeshStarTerrainCfg(SubTerrainBaseCfg):
 
     num_bars: int = MISSING
     """The number of bars per-side the star. Must be greater than 2."""
+
     bar_width_range: tuple[float, float] = MISSING
     """The minimum and maximum width of the bars in the star (in m)."""
+
     bar_height_range: tuple[float, float] = MISSING
     """The minimum and maximum height of the bars in the star (in m)."""
+
     platform_width: float = 1.0
     """The width of the cylindrical platform at the center of the terrain. Defaults to 1.0."""
 
@@ -191,6 +210,7 @@ class MeshRepeatedObjectsTerrainCfg(SubTerrainBaseCfg):
     ``make_{object_type}`` in the current module scope. If it is a callable, the function will
     use the callable to generate the object.
     """
+
     object_params_start: ObjectCfg = MISSING
     """The object curriculum parameters at the start of the curriculum."""
 
@@ -243,6 +263,7 @@ class MeshRepeatedPyramidsTerrainCfg(MeshRepeatedObjectsTerrainCfg):
 
     object_params_start: ObjectCfg = MISSING
     """The object curriculum parameters at the start of the curriculum."""
+
     object_params_end: ObjectCfg = MISSING
     """The object curriculum parameters at the end of the curriculum."""
 
@@ -266,6 +287,7 @@ class MeshRepeatedBoxesTerrainCfg(MeshRepeatedObjectsTerrainCfg):
 
     object_params_start: ObjectCfg = MISSING
     """The box curriculum parameters at the start of the curriculum."""
+
     object_params_end: ObjectCfg = MISSING
     """The box curriculum parameters at the end of the curriculum."""
 
@@ -289,5 +311,6 @@ class MeshRepeatedCylindersTerrainCfg(MeshRepeatedObjectsTerrainCfg):
 
     object_params_start: ObjectCfg = MISSING
     """The box curriculum parameters at the start of the curriculum."""
+
     object_params_end: ObjectCfg = MISSING
     """The box curriculum parameters at the end of the curriculum."""

--- a/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/trimesh/mesh_terrains_cfg.py
@@ -42,10 +42,7 @@ class MeshPyramidStairsTerrainCfg(SubTerrainBaseCfg):
     """The width of the steps (in m)."""
     platform_width: float = 1.0
     """The width of the square platform at the center of the terrain. Defaults to 1.0."""
-    platform_height: float = -1.0
-    """The height of the platform.  Defaults to -1.0.
 
-    If the value is negative, the height is the same as the object height."""
     holes: bool = False
     """If True, the terrain will have holes in the steps. Defaults to False.
 
@@ -211,6 +208,12 @@ class MeshRepeatedObjectsTerrainCfg(SubTerrainBaseCfg):
 
     platform_width: float = 1.0
     """The width of the cylindrical platform at the center of the terrain. Defaults to 1.0."""
+
+    platform_height: float = -1.0
+    """The height of the platform. Defaults to -1.0.
+
+    If the value is negative, the height is the same as the object height.
+    """
 
     def __post_init__(self):
         if self.max_height_noise is not None:


### PR DESCRIPTION
# Description

This PR fixes a bug where the platform_height parameter was incorrectly placed in the MeshPyramidStairsTerrainCfg class instead of the appropriate base configuration class for mesh terrain objects.

- Removes the misplaced `platform_height` parameter from `MeshPyramidStairsTerrainCfg`
- Adds the `platform_height` parameter to the correct location in the `MeshRepeatedObjectsTerrainCfg` class
- Includes various formatting improvements with additional blank lines for consistency

Fixes #3162

Regression was introduced in MR https://github.com/isaac-sim/IsaacLab/pull/2695

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there