### PR TITLE
Fixes invalid callbacks for debug vis when simulation is restarted

### DIFF
--- a/source/isaaclab/isaaclab/assets/deformable_object/deformable_object.py
+++ b/source/isaaclab/isaaclab/assets/deformable_object/deformable_object.py
@@ -358,6 +358,11 @@ class DeformableObject(AssetBase):
         # update the deformable body data
         self.update(0.0)
 
+        # Initialize debug visualization handle
+        if self._debug_vis_handle is None:
+            # set initial state of debug visualization
+            self.set_debug_vis(self.cfg.debug_vis)
+
     def _create_buffers(self):
         """Create buffers for storing data."""
         # constants

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -216,6 +216,11 @@ class SensorBase(ABC):
         # Timestamp from last update
         self._timestamp_last_update = torch.zeros_like(self._timestamp)
 
+        # Initialize debug visualization handle
+        if self._debug_vis_handle is None:
+            # set initial state of debug visualization
+            self.set_debug_vis(self.cfg.debug_vis)
+
     @abstractmethod
     def _update_buffers_impl(self, env_ids: Sequence[int]):
         """Fills the sensor data for provided environment ids.


### PR DESCRIPTION
# Description

In some teleoperation scripts, we restart the simulation to ensure determinism across captured trajectories. However, stopping the simulation invalidates callbacks used for updating debug visualization, which do not get re-initialized after simulation is restarted. 

Adds a fix for re-initializing the callbacks when we re-initialize the simulation for sensors and deformable objects.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
