### PR TITLE
Add APIs for new deformable asset - WIP

### DIFF
--- a/source/isaaclab/isaaclab/assets/__init__.py
+++ b/source/isaaclab/isaaclab/assets/__init__.py
@@ -41,6 +41,7 @@ the corresponding actuator torques.
 from .articulation import Articulation, ArticulationCfg, ArticulationData
 from .asset_base import AssetBase
 from .asset_base_cfg import AssetBaseCfg
+from .deformable import Deformable, DeformableCfg, DeformableData
 from .deformable_object import DeformableObject, DeformableObjectCfg, DeformableObjectData
 from .rigid_object import RigidObject, RigidObjectCfg, RigidObjectData
 from .rigid_object_collection import RigidObjectCollection, RigidObjectCollectionCfg, RigidObjectCollectionData

--- a/source/isaaclab/isaaclab/assets/deformable/__init__.py
+++ b/source/isaaclab/isaaclab/assets/deformable/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sub-module for deformable object assets."""
+
+from .deformable_object import Deformable
+from .deformable_object_cfg import DeformableCfg
+from .deformable_object_data import DeformableData

--- a/source/isaaclab/isaaclab/assets/deformable/deformable_object.py
+++ b/source/isaaclab/isaaclab/assets/deformable/deformable_object.py
@@ -1,0 +1,367 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import omni.log
+import omni.physics.tensors.impl.api as physx
+from isaacsim.core.simulation_manager import SimulationManager
+from pxr import PhysxSchema, UsdShade
+
+import isaaclab.sim as sim_utils
+import isaaclab.utils.math as math_utils
+from isaaclab.markers import VisualizationMarkers
+
+from ..asset_base import AssetBase
+from .deformable_object_data import DeformableData
+
+if TYPE_CHECKING:
+    from .deformable_object_cfg import DeformableCfg
+
+
+class Deformable(AssetBase):
+    """A deformable object asset class.
+
+    Deformable objects are assets that can be deformed in the simulation. They are typically used for
+    soft bodies, such as stuffed animals and food items.
+
+    Unlike rigid object assets, deformable objects have a more complex structure and require additional
+    handling for simulation. The simulation of deformable objects follows a finite element approach, where
+    the object is discretized into a mesh of nodes and elements. The nodes are connected by elements, which
+    define the material properties of the object. The nodes can be moved and deformed, and the elements
+    respond to these changes.
+
+    The state of a deformable object comprises of its nodal positions and velocities, and not the object's root
+    position and orientation. The nodal positions and velocities are in the simulation frame.
+
+    Soft bodies can be `partially kinematic`_, where some nodes are driven by kinematic targets, and the rest are
+    simulated. The kinematic targets are the desired positions of the nodes, and the simulation drives the nodes
+    towards these targets. This is useful for partial control of the object, such as moving a stuffed animal's
+    head while the rest of the body is simulated.
+
+    .. attention::
+        This class is experimental and subject to change due to changes on the underlying PhysX API on which
+        it depends. We will try to maintain backward compatibility as much as possible but some changes may be
+        necessary.
+
+    .. _partially kinematic: https://nvidia-omniverse.github.io/PhysX/physx/5.4.1/docs/SoftBodies.html#kinematic-soft-bodies
+    """
+
+    cfg: DeformableCfg
+    """Configuration instance for the deformable object."""
+
+    def __init__(self, cfg: DeformableCfg):
+        """Initialize the deformable object.
+
+        Args:
+            cfg: A configuration instance.
+        """
+        super().__init__(cfg)
+
+    """
+    Properties
+    """
+
+    @property
+    def data(self) -> DeformableData:
+        return self._data
+
+    @property
+    def num_instances(self) -> int:
+        return self.root_physx_view.count
+
+    @property
+    def num_bodies(self) -> int:
+        """Number of bodies in the asset.
+
+        This is always 1 since each object is a single deformable body.
+        """
+        return 1
+
+    @property
+    def root_physx_view(self) -> physx.DeformableBodyView:
+        """Deformable body view for the asset (PhysX).
+
+        Note:
+            Use this view with caution. It requires handling of tensors in a specific way.
+        """
+        return self._root_physx_view
+    
+    @property
+    def simulation_mesh_prim_paths(self):
+        return self.root_physx_view.simulation_mesh_prim_paths
+
+    @property
+    def collision_mesh_prim_paths(self):
+        return self.root_physx_view.collision_mesh_prim_paths
+
+    @property
+    def max_simulation_elements_per_body(self):
+        return self.root_physx_view.max_simulation_elements_per_body
+
+    @property
+    def max_simulation_nodes_per_body(self):
+        return self.root_physx_view.max_simulation_nodes_per_body
+
+    @property
+    def max_rest_nodes_per_body(self):
+        return self.root_physx_view.max_rest_nodes_per_body
+
+    @property
+    def max_collision_elements_per_body(self):
+        return self.root_physx_view.max_collision_elements_per_body
+    
+    @property
+    def max_collision_nodes_per_body(self):
+        return self.root_physx_view.max_collision_nodes_per_body
+    
+    @property
+    def num_nodes_per_element(self):
+        return self.root_physx_view.num_nodes_per_element
+
+    """
+    Operations.
+    """
+
+    def reset(self, env_ids: Sequence[int] | None = None):
+        # Think: Should we reset the kinematic targets when resetting the object?
+        #  This is not done in the current implementation. We assume users will reset the kinematic targets.
+        pass
+
+    def write_data_to_sim(self):
+        pass
+
+    def update(self, dt: float):
+        self._data.update(dt)
+
+    """
+    Operations - Write to simulation.
+    """
+
+    def write_nodal_state_to_sim(self, nodal_state: torch.Tensor, env_ids: Sequence[int] | None = None):
+        """Set the nodal state over selected environment indices into the simulation.
+
+        The nodal state comprises of the nodal positions and velocities. Since these are nodes, the velocity only has
+        a translational component. All the quantities are in the simulation frame.
+
+        Args:
+            nodal_state: Nodal state in simulation frame.
+                Shape is (len(env_ids), max_sim_vertices_per_body, 6).
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        # set into simulation
+        self.write_nodal_pos_to_sim(nodal_state[..., :3], env_ids=env_ids)
+        self.write_nodal_velocity_to_sim(nodal_state[..., 3:], env_ids=env_ids)
+
+    def write_nodal_pos_to_sim(self, nodal_pos: torch.Tensor, env_ids: Sequence[int] | None = None):
+        """Set the nodal positions over selected environment indices into the simulation.
+
+        The nodal position comprises of individual nodal positions of the simulation mesh for the deformable body.
+        The positions are in the simulation frame.
+
+        Args:
+            nodal_pos: Nodal positions in simulation frame.
+                Shape is (len(env_ids), max_sim_vertices_per_body, 3).
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        # resolve all indices
+        physx_env_ids = env_ids
+        if env_ids is None:
+            env_ids = slice(None)
+            physx_env_ids = self._ALL_INDICES
+        # note: we need to do this here since tensors are not set into simulation until step.
+        # set into internal buffers
+        self._data.nodal_pos_w[env_ids] = nodal_pos.clone()
+        # set into simulation
+        self.root_physx_view.set_simulation_nodal_positions(self._data.nodal_pos_w, indices=physx_env_ids)
+
+    def write_nodal_velocity_to_sim(self, nodal_vel: torch.Tensor, env_ids: Sequence[int] | None = None):
+        """Set the nodal velocity over selected environment indices into the simulation.
+
+        The nodal velocity comprises of individual nodal velocities of the simulation mesh for the deformable
+        body. Since these are nodes, the velocity only has a translational component. The velocities are in the
+        simulation frame.
+
+        Args:
+            nodal_vel: Nodal velocities in simulation frame.
+                Shape is (len(env_ids), max_sim_vertices_per_body, 3).
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        # resolve all indices
+        physx_env_ids = env_ids
+        if env_ids is None:
+            env_ids = slice(None)
+            physx_env_ids = self._ALL_INDICES
+        # note: we need to do this here since tensors are not set into simulation until step.
+        # set into internal buffers
+        self._data.nodal_vel_w[env_ids] = nodal_vel.clone()
+        # set into simulation
+        self.root_physx_view.set_simulation_nodal_velocities(self._data.nodal_vel_w, indices=physx_env_ids)
+
+    def write_nodal_kinematic_target_to_sim(self, targets: torch.Tensor, env_ids: Sequence[int] | None = None):
+        """Set the kinematic targets of the simulation mesh for the deformable bodies indicated by the indices.
+
+        The kinematic targets comprise of individual nodal positions of the simulation mesh for the deformable body
+        and a flag indicating whether the node is kinematically driven or not. The positions are in the simulation frame.
+
+        Note:
+            The flag is set to 0.0 for kinematically driven nodes and 1.0 for free nodes.
+
+        Args:
+            targets: The kinematic targets comprising of nodal positions and flags.
+                Shape is (len(env_ids), max_sim_vertices_per_body, 4).
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        # resolve all indices
+        physx_env_ids = env_ids
+        if env_ids is None:
+            env_ids = slice(None)
+            physx_env_ids = self._ALL_INDICES
+        # store into internal buffers
+        self._data.nodal_kinematic_target[env_ids] = targets.clone()
+        # set into simulation
+        self.root_physx_view.set_simulation_nodal_kinematic_targets(self._data.nodal_kinematic_target, indices=physx_env_ids)
+
+    """
+    Operations - Helper.
+    """
+
+    def transform_nodal_pos(
+        self, nodal_pos: torch.tensor, pos: torch.Tensor | None = None, quat: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """Transform the nodal positions based on the pose transformation.
+
+        This function computes the transformation of the nodal positions based on the pose transformation.
+        It multiplies the nodal positions with the rotation matrix of the pose and adds the translation.
+        Internally, it calls the :meth:`isaaclab.utils.math.transform_points` function.
+
+        Args:
+            nodal_pos: The nodal positions in the simulation frame. Shape is (N, max_sim_vertices_per_body, 3).
+            pos: The position transformation. Shape is (N, 3).
+                Defaults to None, in which case the position is assumed to be zero.
+            quat: The orientation transformation as quaternion (w, x, y, z). Shape is (N, 4).
+                Defaults to None, in which case the orientation is assumed to be identity.
+
+        Returns:
+            The transformed nodal positions. Shape is (N, max_sim_vertices_per_body, 3).
+        """
+        # offset the nodal positions to center them around the origin
+        mean_nodal_pos = nodal_pos.mean(dim=1, keepdim=True)
+        nodal_pos = nodal_pos - mean_nodal_pos
+        # transform the nodal positions based on the pose around the origin
+        return math_utils.transform_points(nodal_pos, pos, quat) + mean_nodal_pos
+
+    """
+    Internal helper.
+    """
+
+    def _initialize_impl(self):
+        # obtain global simulation view
+        self._physics_sim_view = SimulationManager.get_physics_sim_view()
+
+        # obtain the first prim in the regex expression (all others are assumed to be a copy of this)
+        template_prim = sim_utils.find_first_matching_prim(self.cfg.prim_path)
+        if template_prim is None:
+            raise RuntimeError(f"Failed to find prim for expression: '{self.cfg.prim_path}'.")
+        template_prim_path = template_prim.GetPath().pathString
+
+        # find deformable root prims
+        root_prims = sim_utils.get_all_matching_child_prims(
+            template_prim_path, predicate=lambda prim: prim.HasAPI("OmniPhysicsSurfaceDeformableSimAPI")
+        )
+        if len(root_prims) == 0: 
+            raise RuntimeError(
+                f"Failed to find a deformable body when resolving '{self.cfg.prim_path}'."
+                " Please ensure that the prim has 'PhysxSchema.PhysxDeformableBodyAPI' applied."
+            )
+        if len(root_prims) > 1:
+            raise RuntimeError(
+                f"Failed to find a single deformable body when resolving '{self.cfg.prim_path}'."
+                f" Found multiple '{root_prims}' under '{template_prim_path}'."
+                " Please ensure that there is only one deformable body in the prim path tree."
+            )
+        # we only need the first one from the list
+        root_prim = root_prims[0]
+
+        # resolve root path back into regex expression
+        # -- root prim expression
+        root_prim_path = root_prim.GetPath().pathString
+        root_prim_path_expr = self.cfg.prim_path + root_prim_path[len(template_prim_path) :].rsplit('/', 1)[0]
+
+        # -- object view
+        self._root_physx_view = self._physics_sim_view.create_surface_deformable_body_view(root_prim_path_expr.replace(".*", "*"))
+
+        # Return if the asset is not found
+        if self._root_physx_view._backend is None:
+            raise RuntimeError(f"Failed to create deformable body at: {self.cfg.prim_path}. Please check PhysX logs.")
+
+        # log information about the deformable body
+        omni.log.info(f"Deformable body initialized at: {root_prim_path_expr}")
+        omni.log.info(f"Number of instances: {self.num_instances}")
+        omni.log.info(f"Number of bodies: {self.num_bodies}")
+
+        # container for data access
+        self._data = DeformableData(self.root_physx_view, self.device)
+
+        # create buffers
+        self._create_buffers()
+        # update the deformable body data
+        self.update(0.0)
+
+    def _create_buffers(self):
+        """Create buffers for storing data."""
+        # constants
+        self._ALL_INDICES = torch.arange(self.num_instances, dtype=torch.long, device=self.device)
+
+        # default state
+        # we use the initial nodal positions at spawn time as the default state
+        # note: these are all in the simulation frame
+        nodal_positions = self.root_physx_view.get_simulation_nodal_positions()
+        nodal_velocities = torch.zeros_like(nodal_positions)
+        self._data.default_nodal_state_w = torch.cat((nodal_positions, nodal_velocities), dim=-1)
+
+        # # kinematic targets
+        # self._data.nodal_kinematic_target = self.root_physx_view.get_simulation_nodal_kinematic_targets()
+        # # set all nodes as non-kinematic targets by default
+        # self._data.nodal_kinematic_target[..., -1] = 1.0
+
+    """
+    Internal simulation callbacks.
+    """
+
+    # def _set_debug_vis_impl(self, debug_vis: bool):
+    #     # set visibility of markers
+    #     # note: parent only deals with callbacks. not their visibility
+    #     if debug_vis:
+    #         if not hasattr(self, "target_visualizer"):
+    #             self.target_visualizer = VisualizationMarkers(self.cfg.visualizer_cfg)
+    #         # set their visibility to true
+    #         self.target_visualizer.set_visibility(True)
+    #     else:
+    #         if hasattr(self, "target_visualizer"):
+    #             self.target_visualizer.set_visibility(False)
+
+    # def _debug_vis_callback(self, event):
+    #     # check where to visualize
+    #     targets_enabled = self.data.nodal_kinematic_target[:, :, 3] == 0.0
+    #     num_enabled = int(torch.sum(targets_enabled).item())
+    #     # get positions if any targets are enabled
+    #     if num_enabled == 0:
+    #         # create a marker below the ground
+    #         positions = torch.tensor([[0.0, 0.0, -10.0]], device=self.device)
+    #     else:
+    #         positions = self.data.nodal_kinematic_target[targets_enabled][..., :3]
+    #     # show target visualizer
+    #     self.target_visualizer.visualize(positions)
+
+    # def _invalidate_initialize_callback(self, event):
+    #     """Invalidates the scene elements."""
+    #     # call parent
+    #     super()._invalidate_initialize_callback(event)
+    #     self._root_physx_view = None

--- a/source/isaaclab/isaaclab/assets/deformable/deformable_object_cfg.py
+++ b/source/isaaclab/isaaclab/assets/deformable/deformable_object_cfg.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.markers.config import DEFORMABLE_TARGET_MARKER_CFG
+from isaaclab.utils import configclass
+
+from ..asset_base_cfg import AssetBaseCfg
+from .deformable_object import Deformable
+
+
+@configclass
+class DeformableCfg(AssetBaseCfg):
+    """Configuration parameters for a deformable object."""
+
+    class_type: type = Deformable
+
+    visualizer_cfg: VisualizationMarkersCfg = DEFORMABLE_TARGET_MARKER_CFG.replace(
+        prim_path="/Visuals/DeformableTarget"
+    )
+    """The configuration object for the visualization markers. Defaults to DEFORMABLE_TARGET_MARKER_CFG.
+
+    Note:
+        This attribute is only used when debug visualization is enabled.
+    """

--- a/source/isaaclab/isaaclab/assets/deformable/deformable_object_data.py
+++ b/source/isaaclab/isaaclab/assets/deformable/deformable_object_data.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import torch
+import weakref
+
+import omni.physics.tensors.impl.api as physx
+from isaacsim.core.utils.stage import get_current_stage_id
+
+import isaaclab.utils.math as math_utils
+from isaaclab.utils.buffers import TimestampedBuffer
+
+
+class DeformableData:
+    """Data container for a deformable object.
+
+    This class contains the data for a deformable object in the simulation. The data includes the nodal states of
+    the root deformable body in the object. The data is stored in the simulation world frame unless otherwise specified.
+
+    A deformable object in PhysX uses two tetrahedral meshes to represent the object:
+
+    1. **Simulation mesh**: This mesh is used for the simulation and is the one that is deformed by the solver.
+    2. **Collision mesh**: This mesh only needs to match the surface of the simulation mesh and is used for
+       collision detection.
+
+    The APIs exposed provides the data for both the simulation and collision meshes. These are specified
+    by the `sim` and `collision` prefixes in the property names.
+
+    The data is lazily updated, meaning that the data is only updated when it is accessed. This is useful
+    when the data is expensive to compute or retrieve. The data is updated when the timestamp of the buffer
+    is older than the current simulation timestamp. The timestamp is updated whenever the data is updated.
+    """
+
+    def __init__(self, root_physx_view: physx.DeformableBodyView, device: str):
+        """Initializes the deformable object data.
+
+        Args:
+            root_physx_view: The root deformable body view of the object.
+            device: The device used for processing.
+        """
+        # Set the parameters
+        self.device = device
+        # Set the root deformable body view
+        # note: this is stored as a weak reference to avoid circular references between the asset class
+        #  and the data container. This is important to avoid memory leaks.
+        self._root_physx_view: physx.DeformableBodyView = weakref.proxy(root_physx_view)
+
+        # Set initial time stamp
+        self._sim_timestamp = 0.0
+
+        # Initialize the lazy buffers.
+        self._transforms = TimestampedBuffer()
+        # -- node state in simulation world frame
+        self._nodal_pos_w = TimestampedBuffer()
+        self._nodal_vel_w = TimestampedBuffer()
+        self._nodal_state_w = TimestampedBuffer()
+        # -- mesh element-wise rotations
+        self._sim_element_quat_w = TimestampedBuffer()
+        self._collision_element_quat_w = TimestampedBuffer()
+
+    def update(self, dt: float):
+        """Updates the data for the deformable object.
+
+        Args:
+            dt: The time step for the update. This must be a positive value.
+        """
+        # update the simulation timestamp
+        self._sim_timestamp += dt
+
+    ##
+    # Defaults.
+    ##
+
+    default_nodal_state_w: torch.Tensor = None
+    """Default nodal state ``[nodal_pos, nodal_vel]`` in simulation world frame.
+    Shape is (num_instances, max_sim_vertices_per_body, 6).
+    """
+
+    ##
+    # Kinematic commands
+    ##
+
+    nodal_kinematic_target: torch.Tensor = None
+    """Simulation mesh kinematic targets for the deformable bodies.
+    Shape is (num_instances, max_sim_vertices_per_body, 4).
+
+    The kinematic targets are used to drive the simulation mesh vertices to the target positions.
+    The targets are stored as (x, y, z, is_not_kinematic) where "is_not_kinematic" is a binary
+    flag indicating whether the vertex is kinematic or not. The flag is set to 0 for kinematic vertices
+    and 1 for non-kinematic vertices.
+    """
+
+    ##
+    # Properties.
+    ##
+
+    @property
+    def nodal_pos_w(self):
+        """Nodal positions in simulation world frame. Shape is (num_instances, max_sim_vertices_per_body, 3)."""
+        if self._nodal_pos_w.timestamp < self._sim_timestamp:
+            self._nodal_pos_w.data = self._root_physx_view.get_simulation_nodal_positions()
+            self._nodal_pos_w.timestamp = self._sim_timestamp
+        return self._nodal_pos_w.data
+
+    @property
+    def nodal_vel_w(self):
+        """Nodal velocities in simulation world frame. Shape is (num_instances, max_sim_vertices_per_body, 3)."""
+        if self._nodal_vel_w.timestamp < self._sim_timestamp:
+            self._nodal_vel_w.data = self._root_physx_view.get_simulation_nodal_velocities()
+            self._nodal_vel_w.timestamp = self._sim_timestamp
+        return self._nodal_vel_w.data
+
+    @property
+    def nodal_state_w(self):
+        """Nodal state ``[nodal_pos, nodal_vel]`` in simulation world frame.
+        Shape is (num_instances, max_sim_vertices_per_body, 6).
+        """
+        if self._nodal_state_w.timestamp < self._sim_timestamp:
+            self._nodal_state_w.data = torch.cat((self.nodal_pos_w, self.nodal_vel_w), dim=-1)
+            self._nodal_state_w.timestamp = self._sim_timestamp
+        return self._nodal_state_w.data
+
+    ##
+    # Derived properties.
+    ##
+
+    @property
+    def root_pos_w(self) -> torch.Tensor:
+        """Root position from nodal positions of the simulation mesh for the deformable bodies in simulation world frame.
+        Shape is (num_instances, 3).
+
+        This quantity is computed as the mean of the nodal positions.
+        """
+        return self.nodal_pos_w.mean(dim=1)
+
+    @property
+    def root_vel_w(self) -> torch.Tensor:
+        """Root velocity from vertex velocities for the deformable bodies in simulation world frame.
+        Shape is (num_instances, 3).
+
+        This quantity is computed as the mean of the nodal velocities.
+        """
+        return self.nodal_vel_w.mean(dim=1)

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -1323,6 +1323,10 @@ def reset_scene_to_default(env: ManagerBasedEnv, env_ids: torch.Tensor, reset_jo
         # obtain default and set into the physics simulation
         nodal_state = deformable_object.data.default_nodal_state_w[env_ids].clone()
         deformable_object.write_nodal_state_to_sim(nodal_state, env_ids=env_ids)
+    for deformable in env.scene.deformables.values():
+        # obtain default and set into the physics simulation
+        nodal_state = deformable.data.default_nodal_state_w[env_ids].clone()
+        deformable.write_nodal_state_to_sim(nodal_state, env_ids=env_ids)
 
 
 class randomize_visual_texture_material(ManagerTermBase):


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

This MR adds new deformable object APIs to assets in the core framework.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
