### PR TITLE
Adds parsing of instanced meshes to fetching prims utils

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.45.12"
+version = "0.46.0"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.46.0 (2025-09-06)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Added parsing of instanced prims in :meth:`~isaaclab.sim.utils.get_all_matching_child_prims` and :meth:`~isaaclab.sim.utils.get_first_matching_child_prim`.
+  Earlier, instanced prims were skipped since :meth:`Usd.Prim.GetChildren` does not return instanced prims.
+* Added parsing of instanced prims in :meth:`~isaaclab.sim.utils.make_uninstanceable` to make all prims uninstanceable.
+
+
 0.45.12 (2025-09-05)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/sim/utils.py
+++ b/source/isaaclab/isaaclab/sim/utils.py
@@ -570,7 +570,7 @@ def make_uninstanceable(prim_path: str | Sdf.Path, stage: Usd.Stage | None = Non
             # make the prim uninstanceable
             child_prim.SetInstanceable(False)
         # add children to list
-        all_prims += child_prim.GetChildren()
+        all_prims += child_prim.GetFilteredChildren(Usd.TraverseInstanceProxies())
 
 
 """
@@ -617,7 +617,7 @@ def get_first_matching_child_prim(
         if predicate(child_prim):
             return child_prim
         # add children to list
-        all_prims += child_prim.GetChildren()
+        all_prims += child_prim.GetFilteredChildren(Usd.TraverseInstanceProxies())
     return None
 
 
@@ -673,7 +673,7 @@ def get_all_matching_child_prims(
             output_prims.append(child_prim)
         # add children to list
         if depth is None or current_depth < depth:
-            all_prims_queue += [(child, current_depth + 1) for child in child_prim.GetChildren()]
+            all_prims_queue += [(child, current_depth + 1) for child in child_prim.GetFilteredChildren(Usd.TraverseInstanceProxies())]
 
     return output_prims
 

--- a/source/isaaclab/test/sim/test_utils.py
+++ b/source/isaaclab/test/sim/test_utils.py
@@ -17,7 +17,7 @@ import numpy as np
 import isaacsim.core.utils.prims as prim_utils
 import isaacsim.core.utils.stage as stage_utils
 import pytest
-from pxr import Sdf, Usd, UsdGeom
+from pxr import Sdf, Usd, UsdGeom, UsdPhysics
 
 import isaaclab.sim as sim_utils
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
@@ -42,18 +42,60 @@ def test_get_all_matching_child_prims():
     # create scene
     prim_utils.create_prim("/World/Floor")
     prim_utils.create_prim(
-        "/World/Floor/thefloor", "Cube", position=np.array([75, 75, -150.1]), attributes={"size": 300}
+        "/World/Floor/Box", "Cube", position=np.array([75, 75, -150.1]), attributes={"size": 300}
     )
-    prim_utils.create_prim("/World/Room", "Sphere", attributes={"radius": 1e3})
+    prim_utils.create_prim("/World/Wall", "Sphere", attributes={"radius": 1e3})
 
     # test
     isaac_sim_result = prim_utils.get_all_matching_child_prims("/World")
     isaaclab_result = sim_utils.get_all_matching_child_prims("/World")
     assert isaac_sim_result == isaaclab_result
 
+    # add articulation root prim -- this asset has instanced prims
+    # note: isaac sim function does not support instanced prims so we add it here
+    #  after the above test for the above test to still pass.
+    prim_utils.create_prim(
+        "/World/Franka", "Xform", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+    )
+
+    # test with predicate
+    isaaclab_result = sim_utils.get_all_matching_child_prims("/World", predicate=lambda x: x.GetTypeName() == "Cube")
+    assert len(isaaclab_result) == 1
+    assert isaaclab_result[0].GetPrimPath() == "/World/Floor/Box"
+
+    # test with predicate and instanced prims
+    isaaclab_result = sim_utils.get_all_matching_child_prims("/World/Franka/panda_hand/visuals", predicate=lambda x: x.GetTypeName() == "Mesh")
+    assert len(isaaclab_result) == 1
+    assert isaaclab_result[0].GetPrimPath() == "/World/Franka/panda_hand/visuals/panda_hand"
+
     # test valid path
     with pytest.raises(ValueError):
         sim_utils.get_all_matching_child_prims("World/Room")
+
+
+def test_get_first_matching_child_prim():
+    """Test get_first_matching_child_prim() function."""
+    # create scene
+    prim_utils.create_prim("/World/Floor")
+    prim_utils.create_prim(
+        "/World/env_1/Franka", "Xform", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+    )
+    prim_utils.create_prim(
+        "/World/env_2/Franka", "Xform", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+    )
+    prim_utils.create_prim(
+        "/World/env_0/Franka", "Xform", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+    )
+
+    # test
+    isaaclab_result = sim_utils.get_first_matching_child_prim("/World", predicate=lambda prim: prim.HasAPI(UsdPhysics.ArticulationRootAPI))
+    assert isaaclab_result is not None
+    assert isaaclab_result.GetPrimPath() == "/World/env_1/Franka"
+
+    # test with instanced prims
+    isaaclab_result = sim_utils.get_first_matching_child_prim("/World/env_1/Franka", predicate=lambda prim: prim.GetTypeName() == "Mesh")
+    assert isaaclab_result is not None
+    assert isaaclab_result.GetPrimPath() == "/World/env_1/Franka/panda_link0/visuals/panda_link0"
 
 
 def test_find_matching_prim_paths():

--- a/source/isaaclab/utils/assets.py
+++ b/source/isaaclab/utils/assets.py
@@ -1,4 +1,0 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
# Description


* Adds parsing of instanced prims in :meth:`~isaaclab.sim.utils.get_all_matching_child_prims` and :meth:`~isaaclab.sim.utils.get_first_matching_child_prim`.
  Earlier, instanced prims were skipped since :meth:`Usd.Prim.GetChildren` does not return instanced prims.
* Adds parsing of instanced prims in :meth:`~isaaclab.sim.utils.make_uninstanceable` to make all prims uninstanceable.

These are needed to parse meshes for the dynamic raycaster class in #3298

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there