### PR TITLE
Disables GPU testing for suction gripper environments

### DIFF
--- a/source/isaaclab/test/assets/test_surface_gripper.py
+++ b/source/isaaclab/test/assets/test_surface_gripper.py
@@ -114,7 +114,7 @@ def generate_surface_gripper(
     for i in range(num_surface_grippers):
         prim_utils.create_prim(f"/World/Env_{i}", "Xform", translation=translations[i][:3])
     articulation = Articulation(articulation_cfg.replace(prim_path="/World/Env_.*/Robot"))
-    surface_gripper_cfg = surface_gripper_cfg.replace(prim_expr="/World/Env_.*/Robot/Gripper/SurfaceGripper")
+    surface_gripper_cfg = surface_gripper_cfg.replace(prim_path="/World/Env_.*/Robot/Gripper/SurfaceGripper")
     surface_gripper = SurfaceGripper(surface_gripper_cfg)
 
     return surface_gripper, articulation, translations

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/ur10_gripper/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/ur10_gripper/stack_joint_pos_env_cfg.py
@@ -140,6 +140,9 @@ class UR10LongSuctionCubeStackEnvCfg(UR10CubeStackEnvCfg):
         # post init of parent
         super().__post_init__()
 
+        # Suction grippers currently require CPU simulation
+        self.device = "cpu"
+
         # Set events
         self.events = EventCfgLongSuction()
 
@@ -177,6 +180,9 @@ class UR10ShortSuctionCubeStackEnvCfg(UR10CubeStackEnvCfg):
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
+
+        # Suction grippers currently require CPU simulation
+        self.device = "cpu"
 
         # Set UR10 as robot
         self.scene.robot = UR10_SHORT_SUCTION_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")

--- a/source/isaaclab_tasks/test/env_test_utils.py
+++ b/source/isaaclab_tasks/test/env_test_utils.py
@@ -114,6 +114,10 @@ def _run_environments(
     if isaac_sim_version < 5 and create_stage_in_memory:
         pytest.skip("Stage in memory is not supported in this version of Isaac Sim")
 
+    # skip suction gripper environments as they require CPU simulation and cannot be run with GPU simulation
+    if "Suction" in task_name and device != "cpu":
+        return
+
     # skip these environments as they cannot be run with 32 environments within reasonable VRAM
     if num_envs == 32 and task_name in [
         "Isaac-Stack-Cube-Franka-IK-Rel-Blueprint-v0",


### PR DESCRIPTION
# Description

Since suction gripper requires CPU simulation currently, we disable GPU environment testing for them for now and explicitly sets the device for these environments to CPU.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
