### PR TITLE
Fixes ViewportCameraController numpy array missing datatype

### DIFF
--- a/source/isaaclab/isaaclab/envs/ui/viewport_camera_controller.py
+++ b/source/isaaclab/isaaclab/envs/ui/viewport_camera_controller.py
@@ -52,8 +52,8 @@ class ViewportCameraController:
         self._env = env
         self._cfg = copy.deepcopy(cfg)
         # cast viewer eye and look-at to numpy arrays
-        self.default_cam_eye = np.array(self._cfg.eye)
-        self.default_cam_lookat = np.array(self._cfg.lookat)
+        self.default_cam_eye = np.array(self._cfg.eye, dtype=np.float32)
+        self.default_cam_lookat = np.array(self._cfg.lookat, dtype=np.float32)
 
         # set the camera origins
         if self.cfg.origin_type == "env":
@@ -207,9 +207,9 @@ class ViewportCameraController:
         """
         # store the camera view pose for later use
         if eye is not None:
-            self.default_cam_eye = np.asarray(eye)
+            self.default_cam_eye = np.asarray(eye, dtype=np.float32)
         if lookat is not None:
-            self.default_cam_lookat = np.asarray(lookat)
+            self.default_cam_lookat = np.asarray(lookat, dtype=np.float32)
         # set the camera locations
         viewer_origin = self.viewer_origin.detach().cpu().numpy()
         cam_eye = viewer_origin + self.default_cam_eye


### PR DESCRIPTION
# Description

This PR fixes #3374. The numpy array type is specified upon creation to be fp32.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
