### PR TITLE
Replaces torch.norm with torch.linalg.norm for consistency

### DIFF
--- a/scripts/demos/pick_and_place.py
+++ b/scripts/demos/pick_and_place.py
@@ -294,7 +294,7 @@ class PickAndPlaceEnv(DirectRLEnv):
         cube_to_target_x_dist = self.cube.data.root_pos_w[:, 0] - self.target_pos[:, 0] - self.scene.env_origins[:, 0]
         cube_to_target_y_dist = self.cube.data.root_pos_w[:, 1] - self.target_pos[:, 1] - self.scene.env_origins[:, 1]
         cube_to_target_z_dist = self.cube.data.root_pos_w[:, 2] - self.target_pos[:, 2] - self.scene.env_origins[:, 2]
-        cube_to_target_distance = torch.norm(
+        cube_to_target_distance = torch.linalg.norm(
             torch.stack((cube_to_target_x_dist, cube_to_target_y_dist, cube_to_target_z_dist), dim=1), dim=1
         )
         self.target_reached = cube_to_target_distance < 0.3

--- a/scripts/tutorials/03_envs/create_cube_base_env.py
+++ b/scripts/tutorials/03_envs/create_cube_base_env.py
@@ -337,7 +337,7 @@ def main():
             # step env
             obs, _ = env.step(target_position)
             # print mean squared position error between target and current position
-            error = torch.norm(obs["policy"] - target_position).mean().item()
+            error = torch.linalg.norm(obs["policy"] - target_position).mean().item()
             print(f"[Step: {count:04d}]: Mean position error: {error:.4f}")
             # update counter
             count += 1

--- a/source/isaaclab/isaaclab/envs/mdp/commands/pose_2d_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/pose_2d_command.py
@@ -81,7 +81,7 @@ class UniformPose2dCommand(CommandTerm):
 
     def _update_metrics(self):
         # logs data
-        self.metrics["error_pos_2d"] = torch.norm(self.pos_command_w[:, :2] - self.robot.data.root_pos_w[:, :2], dim=1)
+        self.metrics["error_pos_2d"] = torch.linalg.norm(self.pos_command_w[:, :2] - self.robot.data.root_pos_w[:, :2], dim=1)
         self.metrics["error_heading"] = torch.abs(wrap_to_pi(self.heading_command_w - self.robot.data.heading_w))
 
     def _resample_command(self, env_ids: Sequence[int]):

--- a/source/isaaclab/isaaclab/envs/mdp/commands/pose_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/pose_command.py
@@ -104,8 +104,8 @@ class UniformPoseCommand(CommandTerm):
             self.robot.data.body_pos_w[:, self.body_idx],
             self.robot.data.body_quat_w[:, self.body_idx],
         )
-        self.metrics["position_error"] = torch.norm(pos_error, dim=-1)
-        self.metrics["orientation_error"] = torch.norm(rot_error, dim=-1)
+        self.metrics["position_error"] = torch.linalg.norm(pos_error, dim=-1)
+        self.metrics["orientation_error"] = torch.linalg.norm(rot_error, dim=-1)
 
     def _resample_command(self, env_ids: Sequence[int]):
         # sample new pose targets

--- a/source/isaaclab/isaaclab/envs/mdp/commands/velocity_command.py
+++ b/source/isaaclab/isaaclab/envs/mdp/commands/velocity_command.py
@@ -114,7 +114,7 @@ class UniformVelocityCommand(CommandTerm):
         max_command_step = max_command_time / self._env.step_dt
         # logs data
         self.metrics["error_vel_xy"] += (
-            torch.norm(self.vel_command_b[:, :2] - self.robot.data.root_lin_vel_b[:, :2], dim=-1) / max_command_step
+            torch.linalg.norm(self.vel_command_b[:, :2] - self.robot.data.root_lin_vel_b[:, :2], dim=-1) / max_command_step
         )
         self.metrics["error_vel_yaw"] += (
             torch.abs(self.vel_command_b[:, 2] - self.robot.data.root_ang_vel_b[:, 2]) / max_command_step

--- a/source/isaaclab/isaaclab/envs/mdp/rewards.py
+++ b/source/isaaclab/isaaclab/envs/mdp/rewards.py
@@ -125,7 +125,7 @@ def base_height_l2(
 def body_lin_acc_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
     """Penalize the linear acceleration of bodies using L2-kernel."""
     asset: Articulation = env.scene[asset_cfg.name]
-    return torch.sum(torch.norm(asset.data.body_lin_acc_w[:, asset_cfg.body_ids, :], dim=-1), dim=1)
+    return torch.sum(torch.linalg.norm(asset.data.body_lin_acc_w[:, asset_cfg.body_ids, :], dim=-1), dim=1)
 
 
 """
@@ -263,7 +263,7 @@ def undesired_contacts(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: Sce
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
     # check if contact force is above threshold
     net_contact_forces = contact_sensor.data.net_forces_w_history
-    is_contact = torch.max(torch.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > threshold
+    is_contact = torch.max(torch.linalg.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > threshold
     # sum over contacts for each environment
     return torch.sum(is_contact, dim=1)
 
@@ -284,7 +284,7 @@ def contact_forces(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: SceneEn
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
     net_contact_forces = contact_sensor.data.net_forces_w_history
     # compute the violation
-    violation = torch.max(torch.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] - threshold
+    violation = torch.max(torch.linalg.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] - threshold
     # compute the penalty
     return torch.sum(violation.clip(min=0.0), dim=1)
 

--- a/source/isaaclab/isaaclab/envs/mdp/terminations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/terminations.py
@@ -157,5 +157,5 @@ def illegal_contact(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: SceneE
     net_contact_forces = contact_sensor.data.net_forces_w_history
     # check if any contact force exceeds the threshold
     return torch.any(
-        torch.max(torch.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > threshold, dim=1
+        torch.max(torch.linalg.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > threshold, dim=1
     )

--- a/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor.py
@@ -412,7 +412,7 @@ class ContactSensor(SensorBase):
             # since this function is called every frame, we can use the difference to get the elapsed time
             elapsed_time = self._timestamp[env_ids] - self._timestamp_last_update[env_ids]
             # -- check contact state of bodies
-            is_contact = torch.norm(self._data.net_forces_w[env_ids, :, :], dim=-1) > self.cfg.force_threshold
+            is_contact = torch.linalg.norm(self._data.net_forces_w[env_ids, :, :], dim=-1) > self.cfg.force_threshold
             is_first_contact = (self._data.current_air_time[env_ids] > 0) * is_contact
             is_first_detached = (self._data.current_contact_time[env_ids] > 0) * ~is_contact
             # -- update the last contact time if body has just become in contact
@@ -456,7 +456,7 @@ class ContactSensor(SensorBase):
             return
         # marker indices
         # 0: contact, 1: no contact
-        net_contact_force_w = torch.norm(self._data.net_forces_w, dim=-1)
+        net_contact_force_w = torch.linalg.norm(self._data.net_forces_w, dim=-1)
         marker_indices = torch.where(net_contact_force_w > self.cfg.force_threshold, 0, 1)
         # check if prim is visualized
         if self.cfg.track_pose:

--- a/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer.py
+++ b/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer.py
@@ -496,7 +496,7 @@ class FrameTransformer(SensorBase):
             lengths: The length of each connecting line. Shape is (N,).
         """
         direction = end_pos - start_pos
-        lengths = torch.norm(direction, dim=-1)
+        lengths = torch.linalg.norm(direction, dim=-1)
         positions = (start_pos + end_pos) / 2
 
         # Get default direction (along z-axis)
@@ -507,7 +507,7 @@ class FrameTransformer(SensorBase):
 
         # Calculate rotation from default direction to target direction
         rotation_axis = torch.linalg.cross(default_direction, direction_norm)
-        rotation_axis_norm = torch.norm(rotation_axis, dim=-1)
+        rotation_axis_norm = torch.linalg.norm(rotation_axis, dim=-1)
 
         # Handle case where vectors are parallel
         mask = rotation_axis_norm > 1e-6

--- a/source/isaaclab/isaaclab/sensors/ray_caster/patterns/patterns.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/patterns/patterns.py
@@ -96,7 +96,7 @@ def pinhole_camera_pattern(
     transform_vec = torch.tensor([1, -1, -1], device=device).unsqueeze(0).unsqueeze(2)
     pix_in_cam_frame = pix_in_cam_frame[:, [2, 0, 1], :] * transform_vec
     # normalize ray directions
-    ray_directions = (pix_in_cam_frame / torch.norm(pix_in_cam_frame, dim=1, keepdim=True)).permute(0, 2, 1)
+    ray_directions = (pix_in_cam_frame / torch.linalg.norm(pix_in_cam_frame, dim=1, keepdim=True)).permute(0, 2, 1)
     # for camera, we always ray-cast from the sensor's origin
     ray_starts = torch.zeros_like(ray_directions, device=device)
 

--- a/source/isaaclab/isaaclab/utils/math.py
+++ b/source/isaaclab/isaaclab/utils/math.py
@@ -731,7 +731,7 @@ def quat_error_magnitude(q1: torch.Tensor, q2: torch.Tensor) -> torch.Tensor:
 
     Returns:
         Angular error between input quaternions in radians.
-    """
+    """torch.linalg.norm
     axis_angle_error = quat_box_minus(q1, q2)
     return torch.norm(axis_angle_error, dim=-1)
 
@@ -1461,9 +1461,9 @@ def sample_gaussian(
         Sampled tensor.
     """
     if isinstance(mean, float):
-        if isinstance(size, int):
+        if isintorch.linalg.norme, int):
             size = (size,)
-        return torch.normal(mean=mean, std=std, size=size).to(device=device)
+        return torch.linalg.normal(mean=mean, std=std, size=size).to(device=device)
     else:
         return torch.normal(mean=mean, std=std).to(device=device)
 
@@ -1854,8 +1854,8 @@ def interpolate_poses(
             num_steps,
         )
 
-    delta_pos = pos2 - pos1
-    if num_steps is None:
+    delta_pos =torch.linalg.norms1
+    if num_steps is None:torch.linalg.norm
         assert torch.norm(delta_pos) > 0
         num_steps = math.ceil(torch.norm(delta_pos) / step_size)
 

--- a/source/isaaclab/test/controllers/test_differential_ik.py
+++ b/source/isaaclab/test/controllers/test_differential_ik.py
@@ -174,8 +174,8 @@ def _run_ik_controller(
                 pos_error, rot_error = compute_pose_error(
                     ee_pos_b, ee_quat_b, ee_pose_b_des[:, 0:3], ee_pose_b_des[:, 3:7]
                 )
-                pos_error_norm = torch.norm(pos_error, dim=-1)
-                rot_error_norm = torch.norm(rot_error, dim=-1)
+                pos_error_norm = torch.linalg.norm(pos_error, dim=-1)
+                rot_error_norm = torch.linalg.norm(rot_error, dim=-1)
                 # desired error (zer)
                 des_error = torch.zeros_like(pos_error_norm)
                 # check convergence

--- a/source/isaaclab/test/controllers/test_operational_space.py
+++ b/source/isaaclab/test/controllers/test_operational_space.py
@@ -1617,8 +1617,8 @@ def _check_convergence(
             pos_error, rot_error = compute_pose_error(
                 ee_pose_b[:, 0:3], ee_pose_b[:, 3:7], ee_target_pose_b[:, 0:3], ee_target_pose_b[:, 3:7]
             )
-            pos_error_norm = torch.norm(pos_error * pos_mask, dim=-1)
-            rot_error_norm = torch.norm(rot_error * rot_mask, dim=-1)
+            pos_error_norm = torch.linalg.norm(pos_error * pos_mask, dim=-1)
+            rot_error_norm = torch.linalg.norm(rot_error * rot_mask, dim=-1)
             # desired error (zer)
             des_error = torch.zeros_like(pos_error_norm)
             # check convergence
@@ -1629,8 +1629,8 @@ def _check_convergence(
             pos_error, rot_error = compute_pose_error(
                 ee_pose_b[:, 0:3], ee_pose_b[:, 3:7], ee_target_pose_b[:, 0:3], ee_target_pose_b[:, 3:7]
             )
-            pos_error_norm = torch.norm(pos_error * pos_mask, dim=-1)
-            rot_error_norm = torch.norm(rot_error * rot_mask, dim=-1)
+            pos_error_norm = torch.linalg.norm(pos_error * pos_mask, dim=-1)
+            rot_error_norm = torch.linalg.norm(rot_error * rot_mask, dim=-1)
             # desired error (zer)
             des_error = torch.zeros_like(pos_error_norm)
             # check convergence
@@ -1645,7 +1645,7 @@ def _check_convergence(
                 R_task_b = matrix_from_quat(task_frame_pose_b[:, 3:])
                 force_target_b[:] = (R_task_b @ force_target_b[:].unsqueeze(-1)).squeeze(-1)
             force_error = ee_force_b - force_target_b
-            force_error_norm = torch.norm(
+            force_error_norm = torch.linalg.norm(
                 force_error * force_mask, dim=-1
             )  # ignore torque part as we cannot measure it
             des_error = torch.zeros_like(force_error_norm)

--- a/source/isaaclab/test/controllers/test_pink_ik.py
+++ b/source/isaaclab/test/controllers/test_pink_ik.py
@@ -315,7 +315,7 @@ def verify_errors(errors, test_setup, tolerances):
 
     for hand in ["left", "right"]:
         # Check PD controller errors
-        pd_error_norm = torch.norm(errors[f"{hand}_pd_error"], dim=1)
+        pd_error_norm = torch.linalg.norm(errors[f"{hand}_pd_error"], dim=1)
         torch.testing.assert_close(
             pd_error_norm,
             zero_tensor,
@@ -328,7 +328,7 @@ def verify_errors(errors, test_setup, tolerances):
         )
 
         # Check IK position errors
-        pos_error_norm = torch.norm(errors[f"{hand}_pos_error"], dim=1)
+        pos_error_norm = torch.linalg.norm(errors[f"{hand}_pos_error"], dim=1)
         torch.testing.assert_close(
             pos_error_norm,
             zero_tensor,

--- a/source/isaaclab/test/envs/check_manager_based_env_floating_cube.py
+++ b/source/isaaclab/test/envs/check_manager_based_env_floating_cube.py
@@ -253,7 +253,7 @@ def main():
             # step env
             obs, _ = env.step(target_position)
             # print mean squared position error between target and current position
-            error = torch.norm(obs["policy"] - target_position).mean().item()
+            error = torch.linalg.norm(obs["policy"] - target_position).mean().item()
             print(f"[Step: {count:04d}]: Mean position error: {error:.4f}")
             # update counter
             count += 1

--- a/source/isaaclab/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab/test/sensors/test_contact_sensor.py
@@ -579,7 +579,7 @@ def _test_contact_position(shape: RigidObject, sensor: ContactSensor, mode: Cont
                 [[0.0, 0.0, -shape.cfg.spawn.radius]], device=sensor._data.pos_w.device
             )
             assert torch.all(
-                torch.abs(torch.norm(sensor._data.contact_pos_w - contact_position.unsqueeze(1), p=2, dim=-1)) < 1e-2
+                torch.abs(torch.linalg.norm(sensor._data.contact_pos_w - contact_position.unsqueeze(1), p=2, dim=-1)) < 1e-2
             ).item()
         elif mode == ContactTestMode.NON_CONTACT:
             assert torch.all(torch.isnan(sensor._data.contact_pos_w)).item()

--- a/source/isaaclab/test/utils/test_math.py
+++ b/source/isaaclab/test/utils/test_math.py
@@ -622,7 +622,7 @@ def test_quat_to_and_from_angle_axis(device):
     )
     torch.testing.assert_close(rot_vec_scipy, rot_vec_value)
     axis = math_utils.normalize(rot_vec_value.clone())
-    angle = torch.norm(rot_vec_value.clone(), dim=-1)
+    angle = torch.linalg.norm(rot_vec_value.clone(), dim=-1)
     q_value = math_utils.quat_unique(math_utils.quat_from_angle_axis(angle, axis))
     torch.testing.assert_close(q_rand, q_value)
 
@@ -780,7 +780,7 @@ def test_compute_pose_error(device, rot_error_type):
     else:
         axis_angle = math_utils.quat_box_minus(q02, q01)
         axis = math_utils.normalize(axis_angle)
-        angle = torch.norm(axis_angle, dim=-1)
+        angle = torch.linalg.norm(axis_angle, dim=-1)
 
         torch.testing.assert_close(
             math_utils.quat_unique(math_utils.quat_from_angle_axis(angle, axis)),

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/anymal_c_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/anymal_c_env.py
@@ -128,12 +128,12 @@ class AnymalCEnv(DirectRLEnv):
         first_contact = self._contact_sensor.compute_first_contact(self.step_dt)[:, self._feet_ids]
         last_air_time = self._contact_sensor.data.last_air_time[:, self._feet_ids]
         air_time = torch.sum((last_air_time - 0.5) * first_contact, dim=1) * (
-            torch.norm(self._commands[:, :2], dim=1) > 0.1
+            torch.linalg.norm(self._commands[:, :2], dim=1) > 0.1
         )
         # undesired contacts
         net_contact_forces = self._contact_sensor.data.net_forces_w_history
         is_contact = (
-            torch.max(torch.norm(net_contact_forces[:, :, self._undesired_contact_body_ids], dim=-1), dim=1)[0] > 1.0
+            torch.max(torch.linalg.norm(net_contact_forces[:, :, self._undesired_contact_body_ids], dim=-1), dim=1)[0] > 1.0
         )
         contacts = torch.sum(is_contact, dim=1)
         # flat orientation
@@ -160,7 +160,7 @@ class AnymalCEnv(DirectRLEnv):
     def _get_dones(self) -> tuple[torch.Tensor, torch.Tensor]:
         time_out = self.episode_length_buf >= self.max_episode_length - 1
         net_contact_forces = self._contact_sensor.data.net_forces_w_history
-        died = torch.any(torch.max(torch.norm(net_contact_forces[:, :, self._base_id], dim=-1), dim=1)[0] > 1.0, dim=1)
+        died = torch.any(torch.max(torch.linalg.norm(net_contact_forces[:, :, self._base_id], dim=-1), dim=1)[0] > 1.0, dim=1)
         return died, time_out
 
     def _reset_idx(self, env_ids: torch.Tensor | None):

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env.py
@@ -355,7 +355,7 @@ class AssemblyEnv(DirectRLEnv):
                 keypoint_offset.repeat(self.num_envs, 1),
             )[1]
 
-        self.keypoint_dist = torch.norm(self.keypoints_held - self.keypoints_fixed, p=2, dim=-1).mean(-1)
+        self.keypoint_dist = torch.linalg.norm(self.keypoints_held - self.keypoints_fixed, p=2, dim=-1).mean(-1)
         self.last_update_timestamp = self._robot._data._sim_timestamp
 
     def _get_observations(self):
@@ -420,7 +420,7 @@ class AssemblyEnv(DirectRLEnv):
         rot_actions = actions[:, 3:6]
 
         # Convert to quat and set rot target
-        angle = torch.norm(rot_actions, p=2, dim=-1)
+        angle = torch.linalg.norm(rot_actions, p=2, dim=-1)
         axis = rot_actions / angle.unsqueeze(-1)
 
         rot_actions_quat = torch_utils.quat_from_angle_axis(angle, axis)
@@ -472,7 +472,7 @@ class AssemblyEnv(DirectRLEnv):
         self.ctrl_target_fingertip_midpoint_pos = self.fixed_pos_action_frame + pos_error_clipped
 
         # Convert to quat and set rot target
-        angle = torch.norm(rot_actions, p=2, dim=-1)
+        angle = torch.linalg.norm(rot_actions, p=2, dim=-1)
         axis = rot_actions / angle.unsqueeze(-1)
 
         rot_actions_quat = torch_utils.quat_from_angle_axis(angle, axis)

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/automate_algo_utils.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/automate_algo_utils.py
@@ -390,7 +390,7 @@ def check_plug_close_to_socket(keypoints_plug, keypoints_socket, dist_threshold,
     """Check if plug is close to socket."""
 
     # Compute keypoint distance between plug and socket
-    keypoint_dist = torch.norm(keypoints_socket - keypoints_plug, p=2, dim=-1)
+    keypoint_dist = torch.linalg.norm(keypoints_socket - keypoints_plug, p=2, dim=-1)
 
     # Check if keypoint distance is below threshold
     is_plug_close_to_socket = torch.where(

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env.py
@@ -314,7 +314,7 @@ class DisassemblyEnv(DirectRLEnv):
         rot_actions = actions[:, 3:6]
 
         # Convert to quat and set rot target
-        angle = torch.norm(rot_actions, p=2, dim=-1)
+        angle = torch.linalg.norm(rot_actions, p=2, dim=-1)
         axis = rot_actions / angle.unsqueeze(-1)
 
         rot_actions_quat = torch_utils.quat_from_angle_axis(angle, axis)
@@ -366,7 +366,7 @@ class DisassemblyEnv(DirectRLEnv):
         self.ctrl_target_fingertip_midpoint_pos = self.fixed_pos_action_frame + pos_error_clipped
 
         # Convert to quat and set rot target
-        angle = torch.norm(rot_actions, p=2, dim=-1)
+        angle = torch.linalg.norm(rot_actions, p=2, dim=-1)
         axis = rot_actions / angle.unsqueeze(-1)
 
         rot_actions_quat = torch_utils.quat_from_angle_axis(angle, axis)

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/industreal_algo_utils.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/industreal_algo_utils.py
@@ -230,7 +230,7 @@ def check_plug_close_to_socket(keypoints_plug, keypoints_socket, dist_threshold,
     """Check if plug is close to socket."""
 
     # Compute keypoint distance between plug and socket
-    keypoint_dist = torch.norm(keypoints_socket - keypoints_plug, p=2, dim=-1)
+    keypoint_dist = torch.linalg.norm(keypoints_socket - keypoints_plug, p=2, dim=-1)
 
     # Check if keypoint distance is below threshold
     is_plug_close_to_socket = torch.where(

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_env.py
@@ -224,7 +224,7 @@ class FactoryEnv(DirectRLEnv):
         rot_actions = actions[:, 3:6]
 
         # Convert to quat and set rot target
-        angle = torch.norm(rot_actions, p=2, dim=-1)
+        angle = torch.linalg.norm(rot_actions, p=2, dim=-1)
         axis = rot_actions / angle.unsqueeze(-1)
 
         rot_actions_quat = torch_utils.quat_from_angle_axis(angle, axis)
@@ -276,7 +276,7 @@ class FactoryEnv(DirectRLEnv):
         ctrl_target_fingertip_midpoint_pos = fixed_pos_action_frame + pos_error_clipped
 
         # Convert to quat and set rot target
-        angle = torch.norm(rot_actions, p=2, dim=-1)
+        angle = torch.linalg.norm(rot_actions, p=2, dim=-1)
         axis = rot_actions / angle.unsqueeze(-1)
 
         rot_actions_quat = torch_utils.quat_from_angle_axis(angle, axis)
@@ -455,14 +455,14 @@ class FactoryEnv(DirectRLEnv):
                 torch.tensor([1.0, 0.0, 0.0, 0.0], device=self.device).unsqueeze(0).repeat(self.num_envs, 1),
                 keypoint_offset.repeat(self.num_envs, 1),
             )[1]
-        keypoint_dist = torch.norm(keypoints_held - keypoints_fixed, p=2, dim=-1).mean(-1)
+        keypoint_dist = torch.linalg.norm(keypoints_held - keypoints_fixed, p=2, dim=-1).mean(-1)
 
         a0, b0 = self.cfg_task.keypoint_coef_baseline
         a1, b1 = self.cfg_task.keypoint_coef_coarse
         a2, b2 = self.cfg_task.keypoint_coef_fine
         # Action penalties.
-        action_penalty_ee = torch.norm(self.actions, p=2)
-        action_grad_penalty = torch.norm(self.actions - self.prev_actions, p=2, dim=-1)
+        action_penalty_ee = torch.linalg.norm(self.actions, p=2)
+        action_grad_penalty = torch.linalg.norm(self.actions - self.prev_actions, p=2, dim=-1)
         curr_engaged = self._get_curr_successes(success_threshold=self.cfg_task.engage_threshold, check_rot=False)
 
         rew_dict = {
@@ -707,7 +707,7 @@ class FactoryEnv(DirectRLEnv):
                 env_ids=bad_envs,
             )
             pos_error = torch.linalg.norm(pos_error, dim=1) > 1e-3
-            angle_error = torch.norm(aa_error, dim=1) > 1e-3
+            angle_error = torch.linalg.norm(aa_error, dim=1) > 1e-3
             any_error = torch.logical_or(pos_error, angle_error)
             bad_envs = bad_envs[any_error.nonzero(as_tuple=False).squeeze(-1)]
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/forge/forge_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/forge/forge_env.py
@@ -231,10 +231,10 @@ class ForgeEnv(FactoryEnv):
 
         rew_dict, rew_scales = {}, {}
         # Calculate action penalty for the asset-relative action space.
-        pos_error = torch.norm(self.delta_pos, p=2, dim=-1) / self.cfg.ctrl.pos_action_threshold[0]
+        pos_error = torch.linalg.norm(self.delta_pos, p=2, dim=-1) / self.cfg.ctrl.pos_action_threshold[0]
         rot_error = torch.abs(self.delta_yaw) / self.cfg.ctrl.rot_action_threshold[0]
         # Contact penalty.
-        contact_force = torch.norm(self.force_sensor_smooth[:, 0:3], p=2, dim=-1, keepdim=False)
+        contact_force = torch.linalg.norm(self.force_sensor_smooth[:, 0:3], p=2, dim=-1, keepdim=False)
         contact_penalty = torch.nn.functional.relu(contact_force - self.contact_penalty_thresholds)
         # Add success prediction rewards.
         check_rot = self.cfg_task.name == "nut_thread"

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/franka_cabinet_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/franka_cabinet_env.py
@@ -413,7 +413,7 @@ class FrankaCabinetEnv(DirectRLEnv):
         joint_positions,
     ):
         # distance from hand to the drawer
-        d = torch.norm(franka_grasp_pos - drawer_grasp_pos, p=2, dim=-1)
+        d = torch.linalg.norm(franka_grasp_pos - drawer_grasp_pos, p=2, dim=-1)
         dist_reward = 1.0 / (1.0 + d**2)
         dist_reward *= dist_reward
         dist_reward = torch.where(d <= 0.02, dist_reward * 2, dist_reward)

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/inhand_manipulation_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/inhand_manipulation_env.py
@@ -180,7 +180,7 @@ class InHandManipulationEnv(DirectRLEnv):
         self._compute_intermediate_values()
 
         # reset when cube has fallen
-        goal_dist = torch.norm(self.object_pos - self.in_hand_pos, p=2, dim=-1)
+        goal_dist = torch.linalg.norm(self.object_pos - self.in_hand_pos, p=2, dim=-1)
         out_of_reach = goal_dist >= self.cfg.fall_dist
 
         if self.cfg.max_consecutive_success > 0:
@@ -371,7 +371,7 @@ def randomize_rotation(rand0, rand1, x_unit_tensor, y_unit_tensor):
 def rotation_distance(object_rot, target_rot):
     # Orientation alignment for the cube in hand and goal cube
     quat_diff = quat_mul(object_rot, quat_conjugate(target_rot))
-    return 2.0 * torch.asin(torch.clamp(torch.norm(quat_diff[:, 1:4], p=2, dim=-1), max=1.0))  # changed quat convention
+    return 2.0 * torch.asin(torch.clamp(torch.linalg.norm(quat_diff[:, 1:4], p=2, dim=-1), max=1.0))  # changed quat convention
 
 
 @torch.jit.script
@@ -397,7 +397,7 @@ def compute_rewards(
     av_factor: float,
 ):
 
-    goal_dist = torch.norm(object_pos - target_pos, p=2, dim=-1)
+    goal_dist = torch.linalg.norm(object_pos - target_pos, p=2, dim=-1)
     rot_dist = rotation_distance(object_rot, target_rot)
 
     dist_rew = goal_dist * dist_reward_scale

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py
@@ -169,7 +169,7 @@ class LocomotionEnv(DirectRLEnv):
 
         to_target = self.targets[env_ids] - default_root_state[:, :3]
         to_target[:, 2] = 0.0
-        self.potentials[env_ids] = -torch.norm(to_target, p=2, dim=-1) / self.cfg.sim.dt
+        self.potentials[env_ids] = -torch.linalg.norm(to_target, p=2, dim=-1) / self.cfg.sim.dt
 
         self._compute_intermediate_values()
 
@@ -261,7 +261,7 @@ def compute_intermediate_values(
     to_target = targets - torso_position
     to_target[:, 2] = 0.0
     prev_potentials[:] = potentials
-    potentials = -torch.norm(to_target, p=2, dim=-1) / dt
+    potentials = -torch.linalg.norm(to_target, p=2, dim=-1) / dt
 
     return (
         up_proj,

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env.py
@@ -276,7 +276,7 @@ class ShadowHandOverEnv(DirectMARLEnv):
 
     def _get_rewards(self) -> dict[str, torch.Tensor]:
         # compute reward
-        goal_dist = torch.norm(self.object_pos - self.goal_pos, p=2, dim=-1)
+        goal_dist = torch.linalg.norm(self.object_pos - self.goal_pos, p=2, dim=-1)
         rew_dist = 2 * torch.exp(-self.cfg.dist_reward_scale * goal_dist)
 
         # log reward components

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/rewards.py
@@ -55,7 +55,7 @@ class progress_reward(ManagerTermBase):
         target_pos = torch.tensor(self.cfg.params["target_pos"], device=self.device)
         to_target_pos = target_pos - asset.data.root_pos_w[env_ids, :3]
         # reward terms
-        self.potentials[env_ids] = -torch.norm(to_target_pos, p=2, dim=-1) / self._env.step_dt
+        self.potentials[env_ids] = -torch.linalg.norm(to_target_pos, p=2, dim=-1) / self._env.step_dt
         self.prev_potentials[env_ids] = self.potentials[env_ids]
 
     def __call__(
@@ -72,7 +72,7 @@ class progress_reward(ManagerTermBase):
         to_target_pos[:, 2] = 0.0
         # update history buffer and compute new potential
         self.prev_potentials[:] = self.potentials[:]
-        self.potentials[:] = -torch.norm(to_target_pos, p=2, dim=-1) / env.step_dt
+        self.potentials[:] = -torch.linalg.norm(to_target_pos, p=2, dim=-1) / env.step_dt
 
         return self.potentials - self.prev_potentials
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/mdp/rewards.py
@@ -48,7 +48,7 @@ def air_time_reward(
     t_max = torch.max(current_air_time, current_contact_time)
     t_min = torch.clip(t_max, max=mode_time)
     stance_cmd_reward = torch.clip(current_contact_time - current_air_time, -mode_time, mode_time)
-    cmd = torch.norm(env.command_manager.get_command("base_velocity"), dim=1).unsqueeze(dim=1).expand(-1, 4)
+    cmd = torch.linalg.norm(env.command_manager.get_command("base_velocity"), dim=1).unsqueeze(dim=1).expand(-1, 4)
     body_vel = torch.linalg.norm(asset.data.root_lin_vel_b[:, :2], dim=1).unsqueeze(dim=1).expand(-1, 4)
     reward = torch.where(
         torch.logical_or(cmd > 0.0, body_vel > velocity_threshold),
@@ -147,7 +147,7 @@ class GaitReward(ManagerTermBase):
         async_reward_3 = self._async_reward_func(self.synced_feet_pairs[1][0], self.synced_feet_pairs[0][1])
         async_reward = async_reward_0 * async_reward_1 * async_reward_2 * async_reward_3
         # only enforce gait if cmd > 0
-        cmd = torch.norm(env.command_manager.get_command("base_velocity"), dim=1)
+        cmd = torch.linalg.norm(env.command_manager.get_command("base_velocity"), dim=1)
         body_vel = torch.linalg.norm(self.asset.data.root_lin_vel_b[:, :2], dim=1)
         return torch.where(
             torch.logical_or(cmd > 0.0, body_vel > self.velocity_threshold), sync_reward * async_reward, 0.0
@@ -183,7 +183,7 @@ def foot_clearance_reward(
     """Reward the swinging feet for clearing a specified height off the ground"""
     asset: RigidObject = env.scene[asset_cfg.name]
     foot_z_target_error = torch.square(asset.data.body_pos_w[:, asset_cfg.body_ids, 2] - target_height)
-    foot_velocity_tanh = torch.tanh(tanh_mult * torch.norm(asset.data.body_lin_vel_w[:, asset_cfg.body_ids, :2], dim=2))
+    foot_velocity_tanh = torch.tanh(tanh_mult * torch.linalg.norm(asset.data.body_lin_vel_w[:, asset_cfg.body_ids, :2], dim=2))
     reward = foot_z_target_error * foot_velocity_tanh
     return torch.exp(-torch.sum(reward, dim=1) / std)
 
@@ -242,7 +242,7 @@ def foot_slip_penalty(
 
     # check if contact force is above threshold
     net_contact_forces = contact_sensor.data.net_forces_w_history
-    is_contact = torch.max(torch.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > threshold
+    is_contact = torch.max(torch.linalg.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > threshold
     foot_planar_velocity = torch.linalg.norm(asset.data.body_lin_vel_w[:, asset_cfg.body_ids, :2], dim=2)
 
     reward = is_contact * foot_planar_velocity

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/curriculums.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/curriculums.py
@@ -43,11 +43,11 @@ def terrain_levels_vel(
     terrain: TerrainImporter = env.scene.terrain
     command = env.command_manager.get_command("base_velocity")
     # compute the distance the robot walked
-    distance = torch.norm(asset.data.root_pos_w[env_ids, :2] - env.scene.env_origins[env_ids, :2], dim=1)
+    distance = torch.linalg.norm(asset.data.root_pos_w[env_ids, :2] - env.scene.env_origins[env_ids, :2], dim=1)
     # robots that walked far enough progress to harder terrains
     move_up = distance > terrain.cfg.terrain_generator.size[0] / 2
     # robots that walked less than half of their required distance go to simpler terrains
-    move_down = distance < torch.norm(command[env_ids, :2], dim=1) * env.max_episode_length_s * 0.5
+    move_down = distance < torch.linalg.norm(command[env_ids, :2], dim=1) * env.max_episode_length_s * 0.5
     move_down *= ~move_up
     # update terrain levels
     terrain.update_env_origins(env_ids, move_up, move_down)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/mdp/rewards.py
@@ -41,7 +41,7 @@ def feet_air_time(
     last_air_time = contact_sensor.data.last_air_time[:, sensor_cfg.body_ids]
     reward = torch.sum((last_air_time - threshold) * first_contact, dim=1)
     # no reward for zero command
-    reward *= torch.norm(env.command_manager.get_command(command_name)[:, :2], dim=1) > 0.1
+    reward *= torch.linalg.norm(env.command_manager.get_command(command_name)[:, :2], dim=1) > 0.1
     return reward
 
 
@@ -63,7 +63,7 @@ def feet_air_time_positive_biped(env, command_name: str, threshold: float, senso
     reward = torch.min(torch.where(single_stance.unsqueeze(-1), in_mode_time, 0.0), dim=1)[0]
     reward = torch.clamp(reward, max=threshold)
     # no reward for zero command
-    reward *= torch.norm(env.command_manager.get_command(command_name)[:, :2], dim=1) > 0.1
+    reward *= torch.linalg.norm(env.command_manager.get_command(command_name)[:, :2], dim=1) > 0.1
     return reward
 
 
@@ -113,4 +113,4 @@ def stand_still_joint_deviation_l1(
     """Penalize offsets from the default joint positions when the command is very small."""
     command = env.command_manager.get_command(command_name)
     # Penalize motion when command is nearly zero.
-    return mdp.joint_deviation_l1(env, asset_cfg) * (torch.norm(command[:, :2], dim=1) < command_threshold)
+    return mdp.joint_deviation_l1(env, asset_cfg) * (torch.linalg.norm(command[:, :2], dim=1) < command_threshold)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/rewards.py
@@ -32,7 +32,7 @@ def approach_ee_handle(env: ManagerBasedRLEnv, threshold: float) -> torch.Tensor
     handle_pos = env.scene["cabinet_frame"].data.target_pos_w[..., 0, :]
 
     # Compute the distance of the end-effector to the handle
-    distance = torch.norm(handle_pos - ee_tcp_pos, dim=-1, p=2)
+    distance = torch.linalg.norm(handle_pos - ee_tcp_pos, dim=-1, p=2)
 
     # Reward the robot for reaching the handle
     reward = 1.0 / (1.0 + distance**2)
@@ -129,7 +129,7 @@ def grasp_handle(
     handle_pos = env.scene["cabinet_frame"].data.target_pos_w[..., 0, :]
     gripper_joint_pos = env.scene[asset_cfg.name].data.joint_pos[:, asset_cfg.joint_ids]
 
-    distance = torch.norm(handle_pos - ee_tcp_pos, dim=-1, p=2)
+    distance = torch.linalg.norm(handle_pos - ee_tcp_pos, dim=-1, p=2)
     is_close = distance <= threshold
 
     return is_close * torch.sum(open_joint_pos - gripper_joint_pos, dim=-1)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/mdp/rewards.py
@@ -95,7 +95,7 @@ def compute_keypoint_distance(
             target_quat, target_pos, identity_quat, keypoint_offset.repeat(num_envs, 1)
         )[1]
     # Calculate L2 norm distance between corresponding keypoints
-    keypoint_dist_sep = torch.norm(keypoints_target - keypoints_current, p=2, dim=-1)
+    keypoint_dist_sep = torch.linalg.norm(keypoints_target - keypoints_current, p=2, dim=-1)
 
     return keypoint_dist_sep
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/orientation_command.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/orientation_command.py
@@ -98,7 +98,7 @@ class InHandReOrientationCommand(CommandTerm):
             self.object.data.root_quat_w, self.quat_command_w
         )
         # -- compute the position error
-        self.metrics["position_error"] = torch.norm(self.object.data.root_pos_w - self.pos_command_w, dim=1)
+        self.metrics["position_error"] = torch.linalg.norm(self.object.data.root_pos_w - self.pos_command_w, dim=1)
         # -- compute the number of consecutive successes
         successes = self.metrics["orientation_error"] < self.cfg.orientation_success_threshold
         self.metrics["consecutive_success"] += successes.float()

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/rewards.py
@@ -65,7 +65,7 @@ def track_pos_l2(
     # obtain the object position in the environment frame
     object_pos_e = asset.data.root_pos_w - env.scene.env_origins
 
-    return torch.norm(goal_pos_e - object_pos_e, p=2, dim=-1)
+    return torch.linalg.norm(goal_pos_e - object_pos_e, p=2, dim=-1)
 
 
 def track_orientation_inv_l2(

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/terminations.py
@@ -53,7 +53,7 @@ def object_away_from_goal(
     asset_pos_e = asset.data.root_pos_w - env.scene.env_origins
     goal_pos_e = command_term.command[:, :3]
 
-    return torch.norm(asset_pos_e - goal_pos_e, p=2, dim=1) > threshold
+    return torch.linalg.norm(asset_pos_e - goal_pos_e, p=2, dim=1) > threshold
 
 
 def object_away_from_robot(
@@ -78,6 +78,6 @@ def object_away_from_robot(
     object = env.scene[object_cfg.name]
 
     # compute distance
-    dist = torch.norm(robot.data.root_pos_w - object.data.root_pos_w, dim=1)
+    dist = torch.linalg.norm(robot.data.root_pos_w - object.data.root_pos_w, dim=1)
 
     return dist > threshold

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/rewards.py
@@ -40,7 +40,7 @@ def object_ee_distance(
     # End-effector position: (num_envs, 3)
     ee_w = ee_frame.data.target_pos_w[..., 0, :]
     # Distance of the end-effector to the object: (num_envs,)
-    object_ee_distance = torch.norm(cube_pos_w - ee_w, dim=1)
+    object_ee_distance = torch.linalg.norm(cube_pos_w - ee_w, dim=1)
 
     return 1 - torch.tanh(object_ee_distance / std)
 
@@ -62,6 +62,6 @@ def object_goal_distance(
     des_pos_b = command[:, :3]
     des_pos_w, _ = combine_frame_transforms(robot.data.root_pos_w, robot.data.root_quat_w, des_pos_b)
     # distance of the end-effector to the object: (num_envs,)
-    distance = torch.norm(des_pos_w - object.data.root_pos_w, dim=1)
+    distance = torch.linalg.norm(des_pos_w - object.data.root_pos_w, dim=1)
     # rewarded if the object is lifted above the threshold
     return (object.data.root_pos_w[:, 2] > minimal_height) * (1 - torch.tanh(distance / std))

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/terminations.py
@@ -47,7 +47,7 @@ def object_reached_goal(
     des_pos_b = command[:, :3]
     des_pos_w, _ = combine_frame_transforms(robot.data.root_pos_w, robot.data.root_quat_w, des_pos_b)
     # distance of the end-effector to the object: (num_envs,)
-    distance = torch.norm(des_pos_w - object.data.root_pos_w[:, :3], dim=1)
+    distance = torch.linalg.norm(des_pos_w - object.data.root_pos_w[:, :3], dim=1)
 
     # rewarded if the object is lifted above the threshold
     return distance < threshold

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/mdp/rewards.py
@@ -30,7 +30,7 @@ def position_command_error(env: ManagerBasedRLEnv, command_name: str, asset_cfg:
     des_pos_b = command[:, :3]
     des_pos_w, _ = combine_frame_transforms(asset.data.root_pos_w, asset.data.root_quat_w, des_pos_b)
     curr_pos_w = asset.data.body_pos_w[:, asset_cfg.body_ids[0]]  # type: ignore
-    return torch.norm(curr_pos_w - des_pos_w, dim=1)
+    return torch.linalg.norm(curr_pos_w - des_pos_w, dim=1)
 
 
 def position_command_error_tanh(
@@ -48,7 +48,7 @@ def position_command_error_tanh(
     des_pos_b = command[:, :3]
     des_pos_w, _ = combine_frame_transforms(asset.data.root_pos_w, asset.data.root_quat_w, des_pos_b)
     curr_pos_w = asset.data.body_pos_w[:, asset_cfg.body_ids[0]]  # type: ignore
-    distance = torch.norm(curr_pos_w - des_pos_w, dim=1)
+    distance = torch.linalg.norm(curr_pos_w - des_pos_w, dim=1)
     return 1 - torch.tanh(distance / std)
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
@@ -43,12 +43,12 @@ def cubes_stacked(
     pos_diff_c23 = cube_2.data.root_pos_w - cube_3.data.root_pos_w
 
     # Compute cube position difference in x-y plane
-    xy_dist_c12 = torch.norm(pos_diff_c12[:, :2], dim=1)
-    xy_dist_c23 = torch.norm(pos_diff_c23[:, :2], dim=1)
+    xy_dist_c12 = torch.linalg.norm(pos_diff_c12[:, :2], dim=1)
+    xy_dist_c23 = torch.linalg.norm(pos_diff_c23[:, :2], dim=1)
 
     # Compute cube height difference
-    h_dist_c12 = torch.norm(pos_diff_c12[:, 2:], dim=1)
-    h_dist_c23 = torch.norm(pos_diff_c23[:, 2:], dim=1)
+    h_dist_c12 = torch.linalg.norm(pos_diff_c12[:, 2:], dim=1)
+    h_dist_c23 = torch.linalg.norm(pos_diff_c23[:, 2:], dim=1)
 
     # Check cube positions
     stacked = torch.logical_and(xy_dist_c12 < xy_threshold, xy_dist_c23 < xy_threshold)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/mdp/rewards.py
@@ -16,7 +16,7 @@ def position_command_error_tanh(env: ManagerBasedRLEnv, std: float, command_name
     """Reward position tracking with tanh kernel."""
     command = env.command_manager.get_command(command_name)
     des_pos_b = command[:, :3]
-    distance = torch.norm(des_pos_b, dim=1)
+    distance = torch.linalg.norm(des_pos_b, dim=1)
     return 1 - torch.tanh(distance / std)
 
 


### PR DESCRIPTION
# Description

Since `torch.norm` is deprecated and may be removed in a future PyTorch release ([document](https://docs.pytorch.org/docs/stable/generated/torch.norm.html#torch-norm) here), Standardizes tensor norm calculations throughout the codebase by switching from torch.norm to torch.linalg.norm. This ensures compatibility with current PyTorch best practices and improves clarity for future maintenance.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
