### PR TITLE
Adds a unit tests for catching non-headless app file launch

### DIFF
--- a/source/isaaclab/test/app/test_non_headless_launch.py
+++ b/source/isaaclab/test/app/test_non_headless_launch.py
@@ -21,6 +21,8 @@ simulation_app = app_launcher.app
 """Rest everything follows."""
 
 import isaaclab.sim as sim_utils
+from isaaclab.assets import AssetBaseCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.utils import configclass
 
 

--- a/source/isaaclab/test/app/test_non_headless_launch.py
+++ b/source/isaaclab/test/app/test_non_headless_launch.py
@@ -10,8 +10,6 @@ This script checks if the app can be launched with non-headless app and start th
 """Launch Isaac Sim Simulator first."""
 
 
-import os
-
 import pytest
 
 from isaaclab.app import AppLauncher
@@ -23,8 +21,6 @@ simulation_app = app_launcher.app
 """Rest everything follows."""
 
 import isaaclab.sim as sim_utils
-from isaaclab.assets import ArticulationCfg, AssetBaseCfg
-from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.utils import configclass
 
 

--- a/source/isaaclab/test/app/test_non_headless_launch.py
+++ b/source/isaaclab/test/app/test_non_headless_launch.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+This script checks if the app can be launched with non-headless app and start the simulation.
+"""
+
+"""Launch Isaac Sim Simulator first."""
+
+
+import os
+
+import pytest
+
+from isaaclab.app import AppLauncher
+
+# launch omniverse app
+app_launcher = AppLauncher(experience="isaaclab.python.kit", headless=True)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.utils import configclass
+
+
+@configclass
+class SensorsSceneCfg(InteractiveSceneCfg):
+    """Design the scene with sensors on the robot."""
+
+    # ground plane
+    ground = AssetBaseCfg(prim_path="/World/defaultGroundPlane", spawn=sim_utils.GroundPlaneCfg())
+
+
+def run_simulator(
+    sim: sim_utils.SimulationContext,
+):
+    """Run the simulator."""
+
+    count = 0
+
+    # Simulate physics
+    while simulation_app.is_running() and count < 100:
+        # perform step
+        sim.step()
+        count += 1
+
+
+@pytest.mark.isaacsim_ci
+def test_non_headless_launch():
+    # Initialize the simulation context
+    sim_cfg = sim_utils.SimulationCfg(dt=0.005)
+    sim = sim_utils.SimulationContext(sim_cfg)
+    # design scene
+    scene_cfg = SensorsSceneCfg(num_envs=1, env_spacing=2.0)
+    scene = InteractiveScene(scene_cfg)
+    # Play the simulator
+    sim.reset()
+    # Now we are ready!
+    print("[INFO]: Setup complete...")
+    # Run the simulator
+    run_simulator(sim)

--- a/source/isaaclab/test/performance/test_kit_startup_performance.py
+++ b/source/isaaclab/test/performance/test_kit_startup_performance.py
@@ -15,7 +15,6 @@ import pytest
 from isaaclab.app import AppLauncher
 
 
-@pytest.mark.isaacsim_ci
 def test_kit_start_up_time():
     """Test kit start-up time."""
     start_time = time.time()

--- a/source/isaaclab/test/performance/test_robot_load_performance.py
+++ b/source/isaaclab/test/performance/test_robot_load_performance.py
@@ -33,7 +33,6 @@ from isaaclab.utils.timer import Timer
         ({"name": "Anymal_D", "robot_cfg": ANYMAL_D_CFG, "expected_load_time": 40.0}, "cpu"),
     ],
 )
-@pytest.mark.isaacsim_ci
 def test_robot_load_performance(test_config, device):
     """Test robot load time."""
     with build_simulation_context(device=device) as sim:


### PR DESCRIPTION
# Description

Recent isaac sim update introduced a new bug for non-headless scripts where some scripts were hanging at simulation startup. This change introduces a new unit test that aims to capture issues like this by forcing the use of the non-headless app file.

Additionally, the isaac sim CI system has very unstable results for perf testing, so we are disabling the performance-related tests for the sim CI.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x]  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
