### PR TITLE
Fixes CI to fail the job for a fork PRs when general tests fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,11 +121,19 @@ jobs:
         retention-days: 1
         compression-level: 9
 
-    - name: Fail on Test Failure for Fork PRs
-      if: github.event.pull_request.head.repo.full_name != github.repository && steps.run-general-tests.outcome == 'failure'
+    - name: Check Test Results for Fork PRs
+      if: github.event.pull_request.head.repo.full_name != github.repository
       run: |
-        echo "Tests failed for PR from fork. The test report is in the logs. Failing the job."
-        exit 1
+        if [ -f "reports/general-tests-report.xml" ]; then
+          # Check if the test results contain any failures
+          if grep -q 'failures="[1-9]' reports/general-tests-report.xml || grep -q 'errors="[1-9]' reports/general-tests-report.xml; then
+            echo "Tests failed for PR from fork. The test report is in the logs. Failing the job."
+            exit 1
+          fi
+        else
+          echo "No test results file found. This might indicate test execution failed."
+          exit 1
+        fi
 
   combine-results:
     needs: [test-isaaclab-tasks, test-general]


### PR DESCRIPTION
# Description

Fail the pre-merge CI job for a fork PRs when general tests fail
- Add step to check test results for PRs from forks
- Parse XML test report to detect failures/errors
- Fail job immediately if tests don't pass for fork PRs
- Maintain existing behavior for same-repo PRs

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

