### PR TITLE
Fixes terminal output

### DIFF
--- a/source/isaaclab/isaaclab/devices/openxr/manus_vive_utils.py
+++ b/source/isaaclab/isaaclab/devices/openxr/manus_vive_utils.py
@@ -214,8 +214,10 @@ class ManusViveIntegration:
                     choose_A = True
                 elif errB < errA and errB < tolerance:
                     choose_A = False
+                elif len(self._pairA_trans_errs) % 10 == 0 or len(self._pairB_trans_errs) % 10 == 0:
+                    print("Computing pairing of Vive trackers with wrists")
+                    carb.log_info(f"Pairing Vive trackers with wrists: error of pairing A: {errA}, error of pairing B: {errB}")
             if choose_A is None:
-                carb.log_info(f"error A: {errA}, error B: {errB}")
                 return
 
             if choose_A:
@@ -227,11 +229,12 @@ class ManusViveIntegration:
 
             if len(chosen_list) >= min_frames:
                 cluster = select_mode_cluster(chosen_list)
-                carb.log_info(f"Wrist calibration: formed size {len(cluster)} cluster from {len(chosen_list)} samples")
+                if len(chosen_list) % 10 == 0:
+                    print(f"Computing wrist calibration: formed size {len(cluster)} cluster from {len(chosen_list)} samples")
                 if len(cluster) >= min_frames // 2:
                     averaged = average_transforms(cluster)
                     self.scene_T_lighthouse_static = averaged
-                    carb.log_info(f"Resolved mapping: {self._vive_left_id}->Left, {self._vive_right_id}->Right")
+                    print(f"Wrist calibration computed. Resolved mapping: {self._vive_left_id}->Left, {self._vive_right_id}->Right")
 
         except Exception as e:
             carb.log_error(f"Failed to initialize coordinate transformation: {e}")
@@ -304,7 +307,7 @@ class ManusViveIntegration:
             Pose dictionary with 'position' and 'orientation'.
         """
         if f"{hand}_6" not in transformed_data or f"{hand}_7" not in transformed_data:
-            carb.log_error(f"Joint data not found for {hand}")
+            # Joint data not arrived yet
             return self.default_pose
         metacarpal = transformed_data[f"{hand}_6"]
         proximal = transformed_data[f"{hand}_7"]


### PR DESCRIPTION
# Description

Update the user on wrist calibration status with terminal outputs. Remove unnecessary error logs at the beginning of the session, when joint data has not arrived yet. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
