### PR TITLE
Fixes missing actuator indices variable in joint randomization

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.46.1"
+version = "0.46.2"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+
+0.46.2 (2025-09-13)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Fixed missing actuator indicies in :meth:`~isaaclab.envs.mdp.events.randomize_actuator_gains`
+
+
 0.46.1 (2025-09-10)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changelog
 Changed
 ^^^^^^^
 
-* Fixed missing actuator indicies in :meth:`~isaaclab.envs.mdp.events.randomize_actuator_gains`
+* Fixed missing actuator indices in :meth:`~isaaclab.envs.mdp.events.randomize_actuator_gains`
 
 
 0.46.1 (2025-09-10)

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -602,7 +602,7 @@ class randomize_actuator_gains(ManagerTermBase):
                     raise TypeError("Actuator joint indices must be a slice or a torch.Tensor.")
             elif isinstance(actuator.joint_indices, slice):
                 # we take the joints defined in the asset config
-                global_indices = torch.tensor(self.asset_cfg.joint_ids, device=self.asset.device)
+                global_indices = actuator_indices = torch.tensor(self.asset_cfg.joint_ids, device=self.asset.device)
             else:
                 # we take the intersection of the actuator joints and the asset config joints
                 actuator_joint_indices = actuator.joint_indices


### PR DESCRIPTION
# Description

This PR fixes an issue introduced in #3251 , which accidentally deleted actuator_indices in the case where `asset_cfg.joint_id` is not a `slice` and `actuator.joint_indices` is a `slice`

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
