### PR TITLE
Adds single-shot events

### DIFF
--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.46.2 (2025-09-15)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^^^
+
+* Added argument :attr:`is_single_shot` to :class:`~isaaclab.managers.EventTermCfg` to control whether the event is only applied once.
+
+
 0.46.1 (2025-09-10)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/managers/event_manager.py
+++ b/source/isaaclab/isaaclab/managers/event_manager.py
@@ -212,8 +212,11 @@ class EventManager(ManagerBase):
                 # note: we compare with a small value to handle floating point errors
                 if term_cfg.is_global_time:
                     if time_left < 1e-6:
-                        lower, upper = term_cfg.interval_range_s
-                        sampled_interval = torch.rand(1) * (upper - lower) + lower
+                        if not term_cfg.is_single_shot:
+                            lower, upper = term_cfg.interval_range_s
+                            sampled_interval = torch.rand(1) * (upper - lower) + lower
+                        else:
+                            sampled_interval = float('inf')
                         self._interval_term_time_left[index][:] = sampled_interval
 
                         # call the event term (with None for env_ids)
@@ -221,8 +224,12 @@ class EventManager(ManagerBase):
                 else:
                     valid_env_ids = (time_left < 1e-6).nonzero().flatten()
                     if len(valid_env_ids) > 0:
-                        lower, upper = term_cfg.interval_range_s
-                        sampled_time = torch.rand(len(valid_env_ids), device=self.device) * (upper - lower) + lower
+                        if not term_cfg.is_single_shot:
+                            lower, upper = term_cfg.interval_range_s
+                            sampled_time = torch.rand(len(valid_env_ids), device=self.device) * (upper - lower) + lower
+                        else:
+                            sampled_time = float('inf')
+
                         self._interval_term_time_left[index][valid_env_ids] = sampled_time
 
                         # call the event term

--- a/source/isaaclab/isaaclab/managers/event_manager.py
+++ b/source/isaaclab/isaaclab/managers/event_manager.py
@@ -216,7 +216,7 @@ class EventManager(ManagerBase):
                             lower, upper = term_cfg.interval_range_s
                             sampled_interval = torch.rand(1) * (upper - lower) + lower
                         else:
-                            sampled_interval = float('inf')
+                            sampled_interval = float("inf")
                         self._interval_term_time_left[index][:] = sampled_interval
 
                         # call the event term (with None for env_ids)
@@ -228,7 +228,7 @@ class EventManager(ManagerBase):
                             lower, upper = term_cfg.interval_range_s
                             sampled_time = torch.rand(len(valid_env_ids), device=self.device) * (upper - lower) + lower
                         else:
-                            sampled_time = float('inf')
+                            sampled_time = float("inf")
 
                         self._interval_term_time_left[index][valid_env_ids] = sampled_time
 

--- a/source/isaaclab/isaaclab/managers/manager_term_cfg.py
+++ b/source/isaaclab/isaaclab/managers/manager_term_cfg.py
@@ -300,6 +300,14 @@ class EventTermCfg(ManagerTermBaseCfg):
         This is only used if the mode is ``"reset"``.
     """
 
+    is_single_shot: bool = False
+    """Whether the event is only applied once. Defaults to False.
+
+    If True, the event is only applied once when the condition is met. After that, it is never applied again until
+    the environment is reset. This is useful for events that should only happen once, such as a one-time
+    perturbation.
+    """
+
 
 ##
 # Reward manager.


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

This PR introduces one-shot events.

A one-shot event is triggered at most once before the environment is reset. This makes it possible to modify the environment at a specific time, for example by lowering the friction after one second or by applying forces at different moments such as 1s, 2s, and 3s.

## Example

The following example schedules different forces to be applied at one-second intervals without being repeated. Without the is_single_shot option, the pull_up event would instead be triggered repeatedly at 1s, 2s, and 3s.

```python

@configclass
class SingleShotEventExample:
    pull_up = EventTerm(
        func=mdp.pull_object,
        mode="interval",
        is_global_time=True,
        interval_range_s=(1.0, 1.0),
        is_single_shot=True,
        params={"direction": (0.0, 0.0, 1.0)},
    )
    
    pull_down = EventTerm(
        func=mdp.pull_object,
        mode="interval",
        is_global_time=True,
        interval_range_s=(2.0, 2.0),
        is_single_shot=True,
        params={"direction": (0.0, 0.0, -1.0)},
    )
    
    pull_left = EventTerm(
        func=mdp.pull_object,
        mode="interval",
        is_global_time=True,
        interval_range_s=(3.0, 3.0),
        is_single_shot=True,
        params={"direction": (1.0, 0.0, 0.0)},
    )
    reset_in_betweeen = EventTerm(
        func=mdp.reset,
        mode="interval",
        is_global_time=True,
        interval_range_s=(1.0, 1.0),
    )
```

## Type of change
- New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
