### PR TITLE
Delayed observation modifier

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -96,6 +96,7 @@ Guidelines for modifications:
 * Manuel Schweiger
 * Masoud Moghani
 * Maurice Rahme
+* Michael Groom
 * Michael Gussert
 * Michael Noseworthy
 * Michael Lin

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+Unreleased
+~~~~~~~~~~
+
+Added
+^^^^^
+* Added :class:`isaaclab.utils.modifiers.DelayedObservation` for stochastic latency and multi-rate observation modeling (per-env lags, ``hold_prob``, ``update_period``, ``per_env_phase``).
+* Added :class:`isaaclab.utils.modifiers.DelayedObservationCfg` configuration class.
+
 0.46.1 (2025-09-10)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/utils/modifiers/__init__.py
+++ b/source/isaaclab/isaaclab/utils/modifiers/__init__.py
@@ -60,6 +60,8 @@ from .modifier import DigitalFilter
 from .modifier_cfg import DigitalFilterCfg
 from .modifier import Integrator
 from .modifier_cfg import IntegratorCfg
+from .modifier import DelayedObservation
+from .modifier_cfg import DelayedObservationCfg
 
 # isort: on
 from .modifier import bias, clip, scale

--- a/source/isaaclab/isaaclab/utils/modifiers/modifier_cfg.py
+++ b/source/isaaclab/isaaclab/utils/modifiers/modifier_cfg.py
@@ -77,6 +77,7 @@ class IntegratorCfg(ModifierCfg):
     dt: float = MISSING
     """The time step of the integrator."""
 
+
 @configclass
 class DelayedObservationCfg(ModifierCfg):
     """Configuration parameters for a delayed observation modifier.

--- a/source/isaaclab/isaaclab/utils/modifiers/modifier_cfg.py
+++ b/source/isaaclab/isaaclab/utils/modifiers/modifier_cfg.py
@@ -76,3 +76,46 @@ class IntegratorCfg(ModifierCfg):
 
     dt: float = MISSING
     """The time step of the integrator."""
+
+@configclass
+class DelayedObservationCfg(ModifierCfg):
+    """Configuration parameters for a delayed observation modifier.
+
+    For more information, please check the :class:`DelayedObservation` class.
+    """
+
+    func: type[modifier.DelayedObservation] = modifier.DelayedObservation
+    """The delayed observation function to be called for applying the delay."""
+
+    # Lag parameters
+    min_lag: int = 0
+    """The minimum lag (in number of policy steps) to be applied to the observations. Defaults to 0."""
+
+    max_lag: int = 3
+    """The maximum lag (in number of policy steps) to be applied to the observations.
+
+    This value must be greater than or equal to :attr:`min_lag`.
+    """
+
+    per_env: bool = True
+    """Whether to use a separate lag for each environment."""
+
+    hold_prob: float = 0.0
+    """The probability of holding the previous lag when updating the lag."""
+
+    # multi-rate emulation parameters (optional)
+    update_period: int = 1
+    """The period (in number of policy steps) at which the lag is updated.
+
+    If set to 0, the lag is sampled once at the beginning and remains constant throughout the simulation.
+    If set to a positive integer, the lag is updated every `update_period` policy steps. Defaults to 1.
+
+    This value must be less than or equal to :attr:`max_lag` if it is greater than 0.
+    """
+
+    per_env_phase: bool = True
+    """Whether to use a separate phase for each environment when updating the lag.
+
+    If set to True, each environment will have its own phase when updating the lag. If set to False, all
+    environments will share the same phase. Defaults to True.
+    """

--- a/source/isaaclab/test/utils/test_modifiers.py
+++ b/source/isaaclab/test/utils/test_modifiers.py
@@ -261,7 +261,7 @@ def test_delayed_observation_fixed_lag(device):
 
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 def test_delayed_observation_multi_rate_period_3(device):
-    """Multi-rate cadence: refresh every 3 steps with desired lag=2; holds in between."""
+    """Multi-rate cadence: refresh every 3 steps with desired lag=3; holds in between."""
     if device.startswith("cuda") and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 


### PR DESCRIPTION
# Description

Add `DelayedObservation` modifier for stochastic observation latency and multi-rate observation modelling. Closes issue #3465. The `DelayedObservation` modifier is a shape preserving observation modifier that returns a stale version of the input observation using the `DelayBuffer` class. It models:

- Variable latency on observations:  per-env (optional) integer lags sampled in `[min_lag, max_lag]` at each policy step, returning an observation from $$lag_{t}$$ steps in the past.
- Causal progression: $$lag_{t} <= lag_{t+1} + 1$$
- (Optional) Frame holds: either specified through `update_period` (deterministic) to simulate slow sensor updates (e.g., `update_period=2` means the observation is held constant, and refreshed every 2 policy steps), or stochastically with `hold_prob`. With probability `hold_prob`, the modifier will reuse the previous lag so consecutive steps return the same (older) frame, simulating jitter
- Supports applying both `update_period` and `hold_prob` together, to simulate jitter on low frequency observation updates

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
