### PR TITLE
Update the Path to Isaaclab Dir in SkillGen Documentation

### DIFF
--- a/docs/source/overview/imitation-learning/skillgen.rst
+++ b/docs/source/overview/imitation-learning/skillgen.rst
@@ -124,7 +124,7 @@ Download and Setup
 .. code:: bash
 
    # Make sure you are in the root directory of your Isaac Lab workspace
-   cd /path/to/your/isaaclab/root
+   cd /path/to/your/IsaacLab
 
    # Create the datasets directory if it does not exist
    mkdir -p datasets


### PR DESCRIPTION
# Updates the path to IsaacLab directory in SkillGen documentation

## Description

This PR updates the IsaacLab workspace path for clarity and consistency in SkillGen documentation.

- Updated `docs/source/overview/imitation-learning/skillgen.rst` (Download and Setup section)
- Replaced:
  - Before: `cd /path/to/your/isaaclab/root`
  - After: `cd /path/to/your/IsaacLab`

Motivation: Aligns with the repository name and common workspace convention, reducing confusion and preventing copy-paste errors for users following setup steps.

Dependencies: None

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

