### PR TITLE
Optimizes Kit XR Teleop CPU time

### DIFF
--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -26,6 +26,10 @@ rtx.hydra.readTransformsFromFabricInRenderDelegate = true
 app.hydra.renderSettings.useUsdAttributes = false
 app.hydra.renderSettings.useFabricAttributes = false
 
+# xr optimizations
+xr.skipInputDeviceUSDWrites = true
+'rtx-transient'.resourcemanager.enableTextureStreaming = false
+
 [settings.isaaclab]
 # This is used to check that this experience file is loaded when using cameras
 cameras_enabled = true

--- a/apps/isaaclab.python.xr.openxr.kit
+++ b/apps/isaaclab.python.xr.openxr.kit
@@ -36,6 +36,10 @@ rtx.hydra.readTransformsFromFabricInRenderDelegate = true
 app.hydra.renderSettings.useUsdAttributes = false
 app.hydra.renderSettings.useFabricAttributes = false
 
+# xr optimizations
+xr.skipInputDeviceUSDWrites = true
+'rtx-transient'.resourcemanager.enableTextureStreaming = false
+
 [dependencies]
 "isaaclab.python" = {}
 


### PR DESCRIPTION
# Description
With kitxr 107.3.111, we can save cpu time by skipping writes to usd stage since all the data is in fabric. This gives us back 11ms (on my machine) on the main thread. Additionally, texture streaming was bottlenecking the render thread. Disabling gave us back 11ms on the renderthread. Together, it gave me back 11ms.

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
