### PR TITLE
Fixes libgomp conflict when using conda with Spark

### DIFF
--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -286,6 +286,8 @@ setup_conda_env() {
         'export ISAACLAB_PATH='${ISAACLAB_PATH}'' \
         'alias isaaclab='${ISAACLAB_PATH}'/isaaclab.sh' \
         '' \
+        '# WAR for ARM to load Isaac Sim libgomp' \
+        'export LD_PRELOAD="'${ISAACLAB_PATH}'/_isaac_sim/kit/python/lib/python3.11/site-packages/torch/lib/libgomp.so.1"' \
         '# show icon if not runninng headless' \
         'export RESOURCE_NAME="IsaacSim"' \
         '' > ${CONDA_PREFIX}/etc/conda/activate.d/setenv.sh


### PR DESCRIPTION
# Description

When running with conda on Spark, we sometimes see errors related to `ImportError: .../torch/lib/libgomp.so.1: cannot allocate memory in static TLS block`. This can be fixed by setting LD_PRELOAD to use libgomp from Isaac Sim. In this setup, we automatically add the LD_PRELOAD flag when setting up the conda environment through `./isaaclab.sh -c`.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
