### PR TITLE
[Bugfix] use effort_limit from USD asset if not specified in cfg

### DIFF
--- a/source/isaaclab/isaaclab/actuators/actuator_base.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_base.py
@@ -159,7 +159,10 @@ class ActuatorBase(ABC):
         self.joint_property_resolution_table: dict[str, list] = {}
         # For explicit models, we do not want to enforce the effort limit through the solver
         # (unless it is explicitly set)
-        if not self.is_implicit_model and self.cfg.effort_limit_sim is None:
+        effort_limit_is_finite = (
+            effort_limit != torch.inf if isinstance(effort_limit, float) else torch.all(effort_limit != torch.inf)
+        )
+        if not self.is_implicit_model and self.cfg.effort_limit_sim is None and (not effort_limit_is_finite):
             self.cfg.effort_limit_sim = self._DEFAULT_MAX_EFFORT_SIM
 
         # resolve usd, actuator configuration values


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

This PR fixes a bug in actuator initialization where effort limits specified in USD assets were being incorrectly overridden with a very large default value (1.0e9) for explicit actuator models.

Fixes # (issue)

Previously, the ActuatorBase initialization logic would unconditionally fall back to _DEFAULT_MAX_EFFORT_SIM (1.0e9) for explicit actuator models when effort_limit_sim was not explicitly set in the configuration, even when the USD asset contained finite, meaningful effort limit values.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
