### PR TITLE
Fixes teleop doc in Isaac Lab

### DIFF
--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -638,8 +638,6 @@ Here's an example of setting up hand tracking:
        if terminated or truncated:
            break
 
-.. _control-robot-with-xr-callbacks:
-
 Here's a diagram for the dataflow and algorithm used in humanoid teleoperation. Using Apple Vision Pro, we collect 26 keypoints for each hand.
 The wrist keypoint is used to control the hand end-effector, while the remaining hand keypoints are used for hand retargeting.
 
@@ -656,6 +654,8 @@ to the image below for hand asset selection, find a suitable hand asset, or add 
   :align: center
   :figwidth: 60%
   :alt: hand_asset
+
+.. _control-robot-with-xr-callbacks:
 
 Adding Callbacks for XR UI Events
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Description

Minor bug fix for the teleop doc.

Fixes # (issue)

cloudxr_teleoperation.rst:52: WARNING: Failed to create a cross reference. A title or caption not found: 'control-robot-with-xr-callbacks'

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
