### PR TITLE
improves recorder manager to support customized demo index

### DIFF
--- a/source/isaaclab/isaaclab/managers/recorder_manager.py
+++ b/source/isaaclab/isaaclab/managers/recorder_manager.py
@@ -442,7 +442,7 @@ class RecorderManager(ManagerBase):
         ep_meta = self._env.cfg.get_ep_meta()
         return ep_meta
 
-    def export_episodes(self, env_ids: Sequence[int] | None = None) -> None:
+    def export_episodes(self, env_ids: Sequence[int] | None = None, demo_id: int | None = None) -> None:
         """Concludes and exports the episodes for the given environment ids.
 
         Args:
@@ -484,7 +484,7 @@ class RecorderManager(ManagerBase):
                     else:
                         target_dataset_file_handler = self._failed_episode_dataset_file_handler
                 if target_dataset_file_handler is not None:
-                    target_dataset_file_handler.write_episode(self._episodes[env_id])
+                    target_dataset_file_handler.write_episode(self._episodes[env_id], demo_id)
                     need_to_flush = True
                 # Update episode count
                 if episode_succeeded:

--- a/source/isaaclab/isaaclab/utils/datasets/hdf5_dataset_file_handler.py
+++ b/source/isaaclab/isaaclab/utils/datasets/hdf5_dataset_file_handler.py
@@ -136,18 +136,25 @@ class HDF5DatasetFileHandler(DatasetFileHandlerBase):
 
         return episode
 
-    def write_episode(self, episode: EpisodeData):
+    def write_episode(self, episode: EpisodeData, demo_id: int | None = None):
         """Add an episode to the dataset.
 
         Args:
             episode: The episode data to add.
+            demo_id: Custom index for the episode. If None, uses default index.
         """
         self._raise_if_not_initialized()
         if episode.is_empty():
             return
 
-        # create episode group based on demo count
-        h5_episode_group = self._hdf5_data_group.create_group(f"demo_{self._demo_count}")
+        # Use custom demo id if provided, otherwise use default naming
+        if demo_id is not None:
+            episode_group_name = f"demo_{demo_id}"
+        else:
+            episode_group_name = f"demo_{self._demo_count}"
+
+        # create episode group with the specified name
+        h5_episode_group = self._hdf5_data_group.create_group(episode_group_name)
 
         # store number of steps taken
         if "actions" in episode.data:
@@ -176,8 +183,10 @@ class HDF5DatasetFileHandler(DatasetFileHandlerBase):
         # increment total step counts
         self._hdf5_data_group.attrs["total"] += h5_episode_group.attrs["num_samples"]
 
-        # increment total demo counts
-        self._demo_count += 1
+        # Only increment demo count if using default indexing
+        if demo_id is None:
+            # increment total demo counts
+            self._demo_count += 1
 
     def flush(self):
         """Flush the episode data to disk."""


### PR DESCRIPTION


# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Current manager-based workflow leveraged recorder_manager to store demo obs and actions to hdf5 file.
- But it only outputs successful demos and accumulates the demo index
- Not supporting customized demo index (the use case is like: replay an existing hdf5, and store successful demos while keeping its original demo index)

The modification in this PR:
- keeps original function, but extends to store demo with specific demo index

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)


## Screenshots

| Before | After |
| ------ | ----- |
|<img width="100" height="150" alt="Screenshot from 2025-09-25 10-20-31" src="https://github.com/user-attachments/assets/b4af24df-2781-4ba2-8693-fd246875012b" />|<img width="100" height="150" alt="Screenshot from 2025-09-25 10-20-47" src="https://github.com/user-attachments/assets/e86d3210-e205-4d6b-b83e-cf69a585743b" />  |


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
