### PR TITLE
Fix bugs: change of mesh collision configuration strategy in v2.2.0

### DIFF
--- a/scripts/tools/convert_mesh.py
+++ b/scripts/tools/convert_mesh.py
@@ -118,6 +118,18 @@ def main():
     collision_props = schemas_cfg.CollisionPropertiesCfg(collision_enabled=args_cli.collision_approximation != "none")
 
     # Create Mesh converter config
+    collision_cfg = None
+    if args_cli.collision_approximation == 'convexDecomposition':
+        collision_cfg = schemas_cfg.ConvexDecompositionPropertiesCfg()
+    elif args_cli.collision_approximation == 'convexHull':
+        collision_cfg = schemas_cfg.ConvexHullPropertiesCfg()
+    elif args_cli.collision_approximation == 'boundingCube':
+        collision_cfg = schemas_cfg.BoundingCubePropertiesCfg()
+    elif args_cli.collision_approximation == "boundingSphere":
+        collision_cfg = schemas_cfg.BoundingSpherePropertiesCfg()
+    elif args_cli.collision_approximation == "meshSimplification":
+        collision_cfg = schemas_cfg.TriangleMeshSimplificationPropertiesCfg()
+        
     mesh_converter_cfg = MeshConverterCfg(
         mass_props=mass_props,
         rigid_props=rigid_props,
@@ -127,7 +139,7 @@ def main():
         usd_dir=os.path.dirname(dest_path),
         usd_file_name=os.path.basename(dest_path),
         make_instanceable=args_cli.make_instanceable,
-        collision_approximation=args_cli.collision_approximation,
+        mesh_collision_props=collision_cfg
     )
 
     # Print info


### PR DESCRIPTION
# Description

The collision approximation configuration changed in v2.2.0, but the code in tools/convert_mesh.py does not sync.

Fixes #3557 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

