### PR TITLE
Fixes XR UI when used with teleop devices other than "handtracking"

### DIFF
--- a/scripts/tools/record_demos.py
+++ b/scripts/tools/record_demos.py
@@ -305,7 +305,7 @@ def setup_ui(label_text: str, env: gym.Env) -> InstructionDisplay:
     Returns:
         InstructionDisplay: The configured instruction display object
     """
-    instruction_display = InstructionDisplay(args_cli.teleop_device)
+    instruction_display = InstructionDisplay(args_cli.xr)
     if not args_cli.xr:
         window = EmptyWindow(env, "Instruction")
         with window.ui_window_elements["main_vstack"]:

--- a/source/isaaclab_mimic/config/extension.toml
+++ b/source/isaaclab_mimic/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Semantic Versioning is used: https://semver.org/
-version = "1.0.14"
+version = "1.0.15"
 
 # Description
 category = "isaaclab"

--- a/source/isaaclab_mimic/docs/CHANGELOG.rst
+++ b/source/isaaclab_mimic/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+1.0.15 (2025-09-25)
+
+Fixed
+^^^^^
+
+* Fixed a bug in the instruction UI logic that caused incorrect switching between XR and non-XR display modes. The instruction display now properly detects and updates the UI based on the teleoperation device (e.g., handtracking/XR vs. keyboard).
+
+
 1.0.14 (2025-09-08)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_mimic/isaaclab_mimic/ui/instruction_display.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/ui/instruction_display.py
@@ -20,10 +20,10 @@ from isaaclab.envs.mimic_env_cfg import MimicEnvCfg
 class InstructionDisplay:
     """Handles instruction display for different teleop devices."""
 
-    def __init__(self, teleop_device):
-        self.teleop_device = teleop_device.lower()
+    def __init__(self, xr: bool):
+        self.xr = xr
 
-        if "handtracking" in self.teleop_device.lower():
+        if self.xr:
             from isaaclab.ui.xr_widgets import show_instruction
 
             self._display_subtask = lambda text: show_instruction(


### PR DESCRIPTION
When teleop devices are configured in the env config, they are given a name such as "handtracking". The xr ui logic was switching based on the name of the teleop device. Instead, let's check if the XR flag is used, which specifies whether or not XR UI should be used.

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
