### PR TITLE
Add automatic hand scaling factor calibration

### DIFF
--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/data/configs/dex-retargeting/fourier_hand_left_dexpilot.yml
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/data/configs/dex-retargeting/fourier_hand_left_dexpilot.yml
@@ -24,7 +24,6 @@ retargeting:
   - L_thumb_proximal_yaw_joint
   - L_thumb_proximal_pitch_joint
   - L_thumb_distal_joint
-  - L_thumb_distal_joint
   type: DexPilot
   urdf_path: /tmp/GR1_T2_left_hand.urdf
   wrist_link_name: l_hand_base_link

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/gr1_t2_dex_retargeting_utils.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/gr1_t2_dex_retargeting_utils.py
@@ -140,7 +140,9 @@ class GR1TR2DexRetargeting:
         except Exception as e:
             omni.log.error(f"Error updating YAML file {yaml_path}: {e}")
 
-    def convert_hand_joints(self, joint_positions: np.ndarray, wrist: np.ndarray, operator2mano: np.ndarray) -> np.ndarray:
+    def convert_hand_joints(
+        self, joint_positions: np.ndarray, wrist: np.ndarray, operator2mano: np.ndarray
+    ) -> np.ndarray:
         """Prepares the hand joints data for retargeting.
 
         Args:
@@ -242,7 +244,9 @@ class GR1TR2DexRetargeting:
         if left_joint_positions is not None and left_wrist is not None:
             # Collect hand length measurement for scaling factor calculation
             self.collect_hand_length_measurement(left_joint_positions, left_wrist)
-            left_hand_q = self.compute_one_hand(left_joint_positions, left_wrist, self._dex_left_hand, _OPERATOR2MANO_LEFT)
+            left_hand_q = self.compute_one_hand(
+                left_joint_positions, left_wrist, self._dex_left_hand, _OPERATOR2MANO_LEFT
+            )
         else:
             left_hand_q = np.zeros(len(_LEFT_HAND_JOINT_NAMES))
         return left_hand_q
@@ -260,14 +264,16 @@ class GR1TR2DexRetargeting:
         if right_joint_positions is not None and right_wrist is not None:
             # Collect hand length measurement for scaling factor calculation
             self.collect_hand_length_measurement(right_joint_positions, right_wrist)
-            right_hand_q = self.compute_one_hand(right_joint_positions, right_wrist, self._dex_right_hand, _OPERATOR2MANO_RIGHT)
+            right_hand_q = self.compute_one_hand(
+                right_joint_positions, right_wrist, self._dex_right_hand, _OPERATOR2MANO_RIGHT
+            )
         else:
             right_hand_q = np.zeros(len(_RIGHT_HAND_JOINT_NAMES))
         return right_hand_q
 
     def collect_hand_length_measurement(self, joint_positions: np.ndarray, wrist: np.ndarray):
         """Collect hand length measurement for scaling factor calculation.
-        
+
         Args:
             joint_positions: Array of joint positions from OpenXR
             wrist: Wrist pose [x, y, z, qw, qx, qy, qz]
@@ -278,7 +284,9 @@ class GR1TR2DexRetargeting:
             return
         # Calculate hand length (distance from wrist to middle finger tip)
         palm_dir = (joint_positions[12] - wrist[:3]) / np.linalg.norm(joint_positions[12] - wrist[:3])
-        middle_finger_dir = (joint_positions[15] - joint_positions[12]) / np.linalg.norm(joint_positions[15] - joint_positions[12])
+        middle_finger_dir = (joint_positions[15] - joint_positions[12]) / np.linalg.norm(
+            joint_positions[15] - joint_positions[12]
+        )
         is_hand_open = np.dot(palm_dir, middle_finger_dir) > 0.9
         hand_length = np.linalg.norm(wrist[:3] - joint_positions[15])
         if is_hand_open and 0.12 < hand_length < 0.27:
@@ -288,7 +296,7 @@ class GR1TR2DexRetargeting:
 
     def calibrate_scaling_factors(self, min_measurements: int = 50):
         """Update scaling factors directly in retargeting optimizers based on the collected hand length measurements.
-        
+
         Args:
             min_measurements: Minimum number of measurements required before updating scaling factors
         """
@@ -304,9 +312,9 @@ class GR1TR2DexRetargeting:
 
             # Update hand scaling factor
             try:
-                if hasattr(self._dex_left_hand, 'optimizer') and hasattr(self._dex_left_hand.optimizer, 'scaling'):
+                if hasattr(self._dex_left_hand, "optimizer") and hasattr(self._dex_left_hand.optimizer, "scaling"):
                     self._dex_left_hand.optimizer.scaling *= scaling_factor
-                if hasattr(self._dex_right_hand, 'optimizer') and hasattr(self._dex_right_hand.optimizer, 'scaling'):
+                if hasattr(self._dex_right_hand, "optimizer") and hasattr(self._dex_right_hand.optimizer, "scaling"):
                     self._dex_right_hand.optimizer.scaling *= scaling_factor
                     omni.log.info(f"Successfully updated hand scaling factor to {scaling_factor:.3f}")
                 else:
@@ -315,5 +323,6 @@ class GR1TR2DexRetargeting:
                 omni.log.warn(f"Failed to update scaling factor: {e}")
 
             self.scaling_factor_calibrated = True
-            omni.log.info(f"Calibrated scaling factor to {scaling_factor:.3f} "
-                         f"(hand length average: {hand_length:.3f}m)")
+            omni.log.info(
+                f"Calibrated scaling factor to {scaling_factor:.3f} (hand length average: {hand_length:.3f}m)"
+            )

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/gr1_t2_dex_retargeting_utils.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/gr1_t2_dex_retargeting_utils.py
@@ -74,6 +74,7 @@ class GR1TR2DexRetargeting:
         left_hand_config_filename: str = "fourier_hand_left_dexpilot.yml",
         left_hand_urdf_path: str = f"{ISAACLAB_NUCLEUS_DIR}/Mimic/GR1T2_assets/GR1_T2_left_hand.urdf",
         right_hand_urdf_path: str = f"{ISAACLAB_NUCLEUS_DIR}/Mimic/GR1T2_assets/GR1_T2_right_hand.urdf",
+        calibrate_scaling_factor: bool = False,
     ):
         """Initialize the hand retargeting.
 
@@ -81,6 +82,7 @@ class GR1TR2DexRetargeting:
             hand_joint_names: Names of hand joints in the robot model
             right_hand_config_filename: Config file for right hand retargeting
             left_hand_config_filename: Config file for left hand retargeting
+            calibrate_scaling_factor: If True, calibrate the scaling factor for the robot hands
         """
         data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data/"))
         config_dir = os.path.join(data_dir, "configs/dex-retargeting")
@@ -103,6 +105,12 @@ class GR1TR2DexRetargeting:
         self.right_dof_names = self._dex_right_hand.optimizer.robot.dof_joint_names
         self.dof_names = self.left_dof_names + self.right_dof_names
         self.isaac_lab_hand_joint_names = hand_joint_names
+
+        # Hand length measurement
+        self.hand_length = []
+        self.max_measurements = 200
+        self.scaling_factor_calibrated = False
+        self.calibrate_scaling_factor = calibrate_scaling_factor
 
         omni.log.info("[GR1T2DexRetargeter] init done.")
 

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/gr1t2_retargeter.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/gr1t2_retargeter.py
@@ -51,7 +51,9 @@ class GR1T2Retargeter(RetargeterBase):
         """
 
         self._hand_joint_names = cfg.hand_joint_names
-        self._hands_controller = GR1TR2DexRetargeting(self._hand_joint_names, calibrate_scaling_factor=cfg.calibrate_scaling_factor)
+        self._hands_controller = GR1TR2DexRetargeting(
+            self._hand_joint_names, calibrate_scaling_factor=cfg.calibrate_scaling_factor
+        )
 
         # Initialize visualization if enabled
         self._enable_visualization = cfg.enable_visualization

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/exhaustpipe_gr1t2_pink_ik_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/exhaustpipe_gr1t2_pink_ik_env_cfg.py
@@ -197,6 +197,7 @@ class ExhaustPipeGR1T2PinkIKEnvCfg(ExhaustPipeGR1T2BaseEnvCfg):
                             num_open_xr_hand_joints=2 * self.NUM_OPENXR_HAND_JOINTS,
                             sim_device=self.sim.device,
                             hand_joint_names=self.actions.gr1_action.hand_joint_names,
+                            calibrate_scaling_factor=True,
                         ),
                     ],
                     sim_device=self.sim.device,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/nutpour_gr1t2_pink_ik_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/nutpour_gr1t2_pink_ik_env_cfg.py
@@ -195,6 +195,7 @@ class NutPourGR1T2PinkIKEnvCfg(NutPourGR1T2BaseEnvCfg):
                             num_open_xr_hand_joints=2 * self.NUM_OPENXR_HAND_JOINTS,
                             sim_device=self.sim.device,
                             hand_joint_names=self.actions.gr1_action.hand_joint_names,
+                            calibrate_scaling_factor=True,
                         ),
                     ],
                     sim_device=self.sim.device,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_gr1t2_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_gr1t2_env_cfg.py
@@ -434,6 +434,7 @@ class PickPlaceGR1T2EnvCfg(ManagerBasedRLEnvCfg):
                             num_open_xr_hand_joints=2 * self.NUM_OPENXR_HAND_JOINTS,
                             sim_device=self.sim.device,
                             hand_joint_names=self.actions.pink_ik_cfg.hand_joint_names,
+                            calibrate_scaling_factor=True,
                         ),
                     ],
                     sim_device=self.sim.device,


### PR DESCRIPTION
# Description

Adding auto-calibration of the scaling factor param in retargeter, according to human  hand length from the hand poses. The robot pinky curls on its own if the scaling factor is too small, and the index finger have trouble curling if the scaling factor is too large, but "small/large" depend on the hand size. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

| Before | After |
| ------ | ----- |
|
<img width="472" height="265" alt="Screenshot from 2025-07-30 15-53-42" src="https://github.com/user-attachments/assets/7020fa2e-9ba4-4a88-b90b-f147ef7ebc6b" />
  |  
<img width="472" height="265" alt="Screenshot from 2025-07-30 15-54-32" src="https://github.com/user-attachments/assets/8b188814-b865-4b36-ab9b-9d1ec1f47149" />
|

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [X] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
-->

