### PR TITLE
[Newton] Fixes ncollision error message for Ant and Humanoid manager-based environments

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/ant_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/ant_env_cfg.py
@@ -167,6 +167,12 @@ class AntEnvCfg(ManagerBasedRLEnvCfg):
         # simulation settings
         self.sim.dt = 1 / 120.0
         self.sim.render_interval = self.decimation
+        self.sim.newton_cfg.solver_cfg.njmax = 38
+        self.sim.newton_cfg.solver_cfg.ncon_per_env = 15
+        self.sim.newton_cfg.solver_cfg.ls_iterations = 10
+        self.sim.newton_cfg.solver_cfg.ls_parallel = True
+        self.sim.newton_cfg.solver_cfg.cone = "pyramidal"
+        self.sim.newton_cfg.solver_cfg.impratio = 1
         # default friction material
         self.sim.physics_material.static_friction = 1.0
         self.sim.physics_material.dynamic_friction = 1.0

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
@@ -208,6 +208,13 @@ class HumanoidEnvCfg(ManagerBasedRLEnvCfg):
         # simulation settings
         self.sim.dt = 1 / 120.0
         self.sim.newton_cfg.num_substeps = 2
+        self.sim.newton_cfg.solver_cfg.njmax = 80
+        self.sim.newton_cfg.solver_cfg.ncon_per_env = 25
+        self.sim.newton_cfg.solver_cfg.ls_iterations = 15
+        self.sim.newton_cfg.solver_cfg.ls_parallel = True
+        self.sim.newton_cfg.solver_cfg.cone = "pyramidal"
+        self.sim.newton_cfg.solver_cfg.update_data_interval = 2
+        self.sim.newton_cfg.solver_cfg.impratio = 1
         self.sim.render_interval = self.decimation
         # default friction material
         self.sim.physics_material.static_friction = 1.0


### PR DESCRIPTION
# Description

Matching the manager-based configs with the direct environment solver configs for mujoco ant and humanoid environments to avoid the ncollision overflow error.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
