### PR TITLE
Fixed unintentional removal of '=' from command 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -102,6 +102,7 @@ Guidelines for modifications:
 * Miguel Alonso Jr
 * Mingyu Lee
 * Muhong Guo
+* Narendra Dahile
 * Neel Anand Jawale
 * Nicola Loi
 * Norbert Cygiert

--- a/isaaclab.bat
+++ b/isaaclab.bat
@@ -511,32 +511,20 @@ if "%arg%"=="-i" (
     call :extract_python_exe
     echo [INFO] Using python from: !python_exe!
     REM Loop through all arguments - mimic shift
-    set "allArgs="
-    for %%a in (%*) do (
-        REM Append each argument to the variable, skip the first one
-        if defined skip (
-            set "allArgs=!allArgs! %%a"
-        ) else (
-            set "skip=1"
-        )
+    for /f "tokens=1,* delims= " %%a in ("%*") do (
+        set "args_without_first=%%b"
     )
-    call !python_exe! !allArgs!
+    call !python_exe! !args_without_first!
     goto :end
 ) else if "%arg%"=="--python" (
     rem run the python provided by Isaac Sim
     call :extract_python_exe
     echo [INFO] Using python from: !python_exe!
     REM Loop through all arguments - mimic shift
-    set "allArgs="
-    for %%a in (%*) do (
-        REM Append each argument to the variable, skip the first one
-        if defined skip (
-            set "allArgs=!allArgs! %%a"
-        ) else (
-            set "skip=1"
-        )
+    for /f "tokens=1,* delims= " %%a in ("%*") do (
+        set "args_without_first=%%b"
     )
-    call !python_exe! !allArgs!
+    call !python_exe! !args_without_first!
     goto :end
 ) else if "%arg%"=="-s" (
     rem run the simulator exe provided by isaacsim


### PR DESCRIPTION
# Description
Fixed unintentional removal of '=' from command

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there