### PR TITLE
Updates documentation for manus teleop

### DIFF
--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -422,6 +422,14 @@ Run the teleoperation example with Manus + Vive tracking:
 .. dropdown:: Installation instructions
    :open:
 
+   Vive tracker integration is provided through the libsurvive library. Install the required udev rules by copying
+   `81-vive.rules <https://github.com/collabora/libsurvive/blob/32cf62c52744fdc32003ef8169e8b81f6f31526b/useful_files/81-vive.rules>`_
+   to ``/etc/udev/rules.d/`` and restarting the udev service.
+
+   .. code-block:: bash
+
+      sudo udevadm control --reload-rules && sudo udevadm trigger
+
    The Manus integration is provided through the Isaac Sim teleoperation input plugin framework.
    Install the plugin by following the build and installation steps in `isaac-teleop-device-plugins <https://github.com/isaac-sim/isaac-teleop-device-plugins>`_.
 


### PR DESCRIPTION
# Description

Since the ManusSDK is not redistributed in Isaac Lab, we have implemented a input device plugin Isaac Sim extension which allows users to download and build the plugin against the ManusSDK, and use it in Isaac Lab teleportation. This change aims to provide documentation of the procedure.

## Type of change

- Documentation

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there