### PR TITLE
Store `black` configuration in `pyproject.toml` and enhance `pyright` support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,13 @@ exclude = [
     ".vscode",
 ]
 
+extraPaths = [
+    "source/isaaclab",
+    "source/isaaclab_assets",
+    "source/isaaclab_rl",
+    "source/isaaclab_tasks",
+]
+
 typeCheckingMode = "basic"
 pythonVersion = "3.11"
 pythonPlatform = "Linux"


### PR DESCRIPTION
# Description

This PR updates the `pyproject.toml` configuration to improve compatibility with tooling such as `black` and `pyright`. The changes affect both standalone usage of these tools and their integration when invoked from IDEs like VSCode.

This allows users who are not interested in autogenerating the `settings.json` file to have their IDEs configured out of the box.

This approach could be also extended to other tools like flake, pylint, etc.

> [!NOTE]
> This PR targets `feature/newton`, which is the branch I'm currently interested. It can be backported to `main` if needed.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
