### PR TITLE
[dev/newton] Tighten reward thresholds for Humanoid/G1/H1 training tests.

### DIFF
--- a/source/isaaclab_tasks/test/benchmarking/configs.yaml
+++ b/source/isaaclab_tasks/test/benchmarking/configs.yaml
@@ -42,7 +42,7 @@ fast:
   rsl_rl:Isaac-Humanoid-Direct-v0:
     max_iterations: 500
     lower_thresholds:
-      reward: 600
+      reward: 6000
       episode_length: 500
     upper_thresholds:
       duration: 500
@@ -56,14 +56,14 @@ fast:
   rsl_rl:Isaac-Velocity-Flat-G1-v0:
     max_iterations: 500
     lower_thresholds:
-      reward: 15
+      reward: 20
       episode_length: 700
     upper_thresholds:
       duration: 3000
   rsl_rl:Isaac-Velocity-Flat-H1-v0:
     max_iterations: 500
     lower_thresholds:
-      reward: 15
+      reward: 25
       episode_length: 700
     upper_thresholds:
       duration: 3000


### PR DESCRIPTION
# Description

I ran these tests locally and the reward thresholds can be tightened a bit. I would like to have them tighter because we will start running the training tests in the newton CI as a forward-compatibility check.

## Type of change

- Test fix

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [~] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [~] I have added tests that prove my fix is effective or that my feature works
- [~] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

