### PR TITLE
Imitation learning docs ordering fix.

### DIFF
--- a/docs/source/overview/imitation-learning/index.rst
+++ b/docs/source/overview/imitation-learning/index.rst
@@ -7,6 +7,6 @@ with Isaac Lab.
 .. toctree::
   :maxdepth: 1
 
-  augmented_imitation
   teleop_imitation
+  augmented_imitation
   skillgen


### PR DESCRIPTION
# Description

Fixes the order of the 'Imitation Learning' docs to have teleop docs appear above/before the augmented imitation learning page as the latter is dependent on the former.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
