### PR TITLE
Removes unused 'relevant_link_name' parameter in nutpour and exhaust pipe envs

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/exhaustpipe_gr1t2_base_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/exhaustpipe_gr1t2_base_env_cfg.py
@@ -219,7 +219,7 @@ class TerminationsCfg:
         params={"minimum_height": 0.5, "asset_cfg": SceneEntityCfg("blue_exhaust_pipe")},
     )
 
-    success = DoneTerm(func=mdp.task_done_exhaust_pipe, params={"relevant_link_name": "right_hand_roll_link"})
+    success = DoneTerm(func=mdp.task_done_exhaust_pipe)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/nutpour_gr1t2_base_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/nutpour_gr1t2_base_env_cfg.py
@@ -246,7 +246,7 @@ class TerminationsCfg:
         func=mdp.root_height_below_minimum, params={"minimum_height": 0.5, "asset_cfg": SceneEntityCfg("factory_nut")}
     )
 
-    success = DoneTerm(func=mdp.task_done_nut_pour, params={"relevant_link_name": "right_hand_roll_link"})
+    success = DoneTerm(func=mdp.task_done_nut_pour)
 
 
 @configclass


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Parameter 'relevant_link_name' to nutpour and exhaust pipe mimic environments was mistakenly added in the Isaac Lab 2.3 PRs and this is causing an error. This PR removes them.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->
[Isaac-Sim 5.1 rc14][Isaac-Lab 2.3] task_done_nut_pour() got an unexpected keyword argument 'relevant_link_name' https://nvbugspro.nvidia.com/bug/5566828

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
