### PR TITLE
Fixes GCC error for raycaster demo when running in conda

### DIFF
--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -34,7 +34,6 @@ PER_TEST_TIMEOUTS = {
     "test_operational_space.py": 500,
     "test_non_headless_launch.py": 1000,  # This test launches the app in non-headless mode and starts simulation
     "test_rl_games_wrapper.py": 500,
-    "test_manager_based_rl_env_obs_spaces.py": 500,
 }
 """A dictionary of tests and their timeouts in seconds.
 


### PR DESCRIPTION
# Description

With Isaac Sim 5.1, importing numpy before starting the AppLauncher results in libgcc errors in omni.sensors when running within a conda environment. This can be fixed by moving the numpy import to be after AppLauncher.


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
