### PR TITLE
Fixes hanging issue in test_manager_based_rl_env_obs_spaces.py

### DIFF
--- a/source/isaaclab/test/envs/test_manager_based_rl_env_obs_spaces.py
+++ b/source/isaaclab/test/envs/test_manager_based_rl_env_obs_spaces.py
@@ -26,38 +26,6 @@ from isaaclab_tasks.manager_based.classic.cartpole.cartpole_camera_env_cfg impor
 from isaaclab_tasks.manager_based.locomotion.velocity.config.anymal_c.rough_env_cfg import AnymalCRoughEnvCfg
 
 
-@pytest.mark.parametrize(
-    "env_cfg_cls",
-    [CartpoleRGBCameraEnvCfg, CartpoleDepthCameraEnvCfg, AnymalCRoughEnvCfg],
-    ids=["RGB", "Depth", "RayCaster"],
-)
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
-def test_obs_space_follows_clip_contraint(env_cfg_cls, device):
-    """Ensure curriculum terms apply correctly after the fallback and replacement."""
-    # new USD stage
-    omni.usd.get_context().new_stage()
-
-    # configure the cartpole env
-    env_cfg = env_cfg_cls()
-    env_cfg.scene.num_envs = 2  # keep num_envs small for testing
-    env_cfg.observations.policy.concatenate_terms = False
-    env_cfg.sim.device = device
-
-    env = ManagerBasedRLEnv(cfg=env_cfg)
-    for group_name, group_space in env.observation_space.spaces.items():
-        for term_name, term_space in group_space.spaces.items():
-            term_cfg = getattr(getattr(env_cfg.observations, group_name), term_name)
-            low = -np.inf if term_cfg.clip is None else term_cfg.clip[0]
-            high = np.inf if term_cfg.clip is None else term_cfg.clip[1]
-            assert isinstance(
-                term_space, gym.spaces.Box
-            ), f"Expected Box space for {term_name} in {group_name}, got {type(term_space)}"
-            assert np.all(term_space.low == low)
-            assert np.all(term_space.high == high)
-
-    env.close()
-
-
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 def test_non_concatenated_obs_groups_contain_all_terms(device):
     """Test that non-concatenated observation groups contain all defined terms (issue #3133).
@@ -137,5 +105,37 @@ def test_non_concatenated_obs_groups_contain_all_terms(device):
 
     for term_name in expected_subtask_terms:
         assert term_name in obs["subtask_terms"], f"Term '{term_name}' missing from subtask_terms observation"
+
+    env.close()
+
+
+@pytest.mark.parametrize(
+    "env_cfg_cls",
+    [CartpoleRGBCameraEnvCfg, CartpoleDepthCameraEnvCfg, AnymalCRoughEnvCfg],
+    ids=["RGB", "Depth", "RayCaster"],
+)
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_obs_space_follows_clip_contraint(env_cfg_cls, device):
+    """Ensure curriculum terms apply correctly after the fallback and replacement."""
+    # new USD stage
+    omni.usd.get_context().new_stage()
+
+    # configure the cartpole env
+    env_cfg = env_cfg_cls()
+    env_cfg.scene.num_envs = 2  # keep num_envs small for testing
+    env_cfg.observations.policy.concatenate_terms = False
+    env_cfg.sim.device = device
+
+    env = ManagerBasedRLEnv(cfg=env_cfg)
+    for group_name, group_space in env.observation_space.spaces.items():
+        for term_name, term_space in group_space.spaces.items():
+            term_cfg = getattr(getattr(env_cfg.observations, group_name), term_name)
+            low = -np.inf if term_cfg.clip is None else term_cfg.clip[0]
+            high = np.inf if term_cfg.clip is None else term_cfg.clip[1]
+            assert isinstance(
+                term_space, gym.spaces.Box
+            ), f"Expected Box space for {term_name} in {group_name}, got {type(term_space)}"
+            assert np.all(term_space.low == low)
+            assert np.all(term_space.high == high)
 
     env.close()


### PR DESCRIPTION
# Description

In Isaac Sim 5.1, the ordering of the tests cause a hang when executing the second test. Switching the order of the 2 tests allows both to run successfully.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
