### PR TITLE
Adds windows pip installation instruction in local pip installation documentation

### DIFF
--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -37,6 +37,13 @@ Installing dependencies
 
             pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
 
+      .. tab-item:: :icon:`fa-brands fa-windows` Windows (x86_64)
+         :sync: windows-x86_64
+
+         .. code-block:: bash
+
+            pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+
       .. tab-item:: :icon:`fa-brands fa-linux` Linux (aarch64)
          :sync: linux-aarch64
 

--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -54,6 +54,13 @@ Installing dependencies
 
             pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
 
+      .. tab-item:: :icon:`fa-brands fa-windows` Windows (x86_64)
+         :sync: windows-x86_64
+
+         .. code-block:: bash
+
+            pip install torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+
       .. tab-item:: :icon:`fa-brands fa-linux` Linux (aarch64)
          :sync: linux-aarch64
 


### PR DESCRIPTION
# Description

This PR fixes the missing windows pip installation tab, previously, only linux system were listed

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

<img width="868" height="506" alt="Screenshot from 2025-10-15 12-11-55" src="https://github.com/user-attachments/assets/4102228c-9650-4c61-b220-e8ce1e8f1306" />

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
