### PR TITLE
Updates documentation to explain known issue of missing references when uses URDF importer

### DIFF
--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -97,7 +97,7 @@ URDF Importer: Unresolved references for fixed joints
 -----------------------------------------------------
 
 Starting with Isaac Sim 5.1, links connected through ``fixed_joint`` elements are no longer merged when
-their URDF link entries specify mass and inertia even if ``merge-joint`` set to True. 
+their URDF link entries specify mass and inertia even if ``merge-joint`` set to True.
 This is expected behaviour—those links are treated as full bodies rather than zero-mass reference frames.
 However, the USD importer currently raises ``ReportError`` warnings showing unresolved references for such links
 when they lack visuals or colliders. This is a known bug in the importer; it creates references to visuals


### PR DESCRIPTION
# Description

This PR adds the know issue of URDF importer to documentation:

Links connected through ``fixed_joint`` elements are no longer merged when
their URDF link entries specify mass and inertia even if ``merge-joint`` set to True. 
This is expected behaviour—those links are treated as full bodies rather than zero-mass reference frames.
However, the USD importer currently raises ``ReportError`` warnings showing unresolved references for such links
when they lack visuals or colliders. This is a known bug in the importer; it creates references to visuals
that do not exist. The warnings can be safely ignored until the importer is updated.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
