### PR TITLE
Removes dex-retargeting package from setup for aarch64/arm64 platforms.

### DIFF
--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -47,10 +47,11 @@ INSTALL_REQUIRES = [
 ]
 
 # Append Linux x86_64 and ARM64 deps via PEP 508 markers
-SUPPORTED_ARCHS = "platform_machine in 'x86_64,AMD64,aarch64,arm64'"
+SUPPORTED_ARCHS_ARM = "platform_machine in 'x86_64,AMD64,aarch64,arm64'"
+SUPPORTED_ARCHS = "platform_machine in 'x86_64,AMD64'"
 INSTALL_REQUIRES += [
     # required by isaaclab.isaaclab.controllers.pink_ik
-    f"pin-pink==3.1.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
+    f"pin-pink==3.1.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
     # required by isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1_t2_dex_retargeting_utils
     f"dex-retargeting==0.4.6 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
 ]


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

./isaaclab --install is failing on ARM64 platform because of a prior change #3686 that installs dex-retargeting for arm64/aarch64. The problem is that we are installing `dex-retargeting==0.4.6` which is dependent on `nlopt==2.6.2` and ARM is not supported through the pip install of this dependency. dex-retargeting is not required for the supported features on ARM64 since we are currently not supporting OpenXR, so the fix is to remove this install for this platform.

Additional context: this bug was not caught previously in #3686 because apparently if `nlopt==2.6.2` is installed through pip then there are no wheels for arm64 available. However, if installed through conda there are binaries for arm64 in their channels. Coincidentally this was only tested on conda install.

Long term solution: Is to upgrate teh dependency to `dex-retargeting==0.5.0` which installs a newer version of nlopt and that does not have this discrepancy in platform support. However, we are leaving that for the future as this upgrade needs to be tested thoroughly in the teleop pipeline.

Fixes # (issue)

`note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for nlopt` during `./isaaclab -i`


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
