### PR TITLE
Fixes typo in rl-games configuration for cartpole task

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/agents/rl_games_feature_ppo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/agents/rl_games_feature_ppo_cfg.yaml
@@ -57,7 +57,7 @@ params:
     mixed_precision: False
     normalize_input: True
     normalize_value: True
-    value_bootstraop: True
+    value_bootstrap: True
     num_actors: -1  # configured from the script (based on num_envs)
     reward_shaper:
       scale_value: 1.0


### PR DESCRIPTION
# Description
Fixed a typo in the RL Games PPO configuration file for the Cartpole feature-based environment. Changed value_bootstraop to value_bootstrap on line 60 to match the correct parameter name used throughout the codebase.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Screenshots

Not applicable (text-only typo fix in YAML configuration file)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
