### PR TITLE
Adds Cosmos Transfer1 limitation for DGX spark

### DIFF
--- a/docs/source/overview/imitation-learning/augmented_imitation.rst
+++ b/docs/source/overview/imitation-learning/augmented_imitation.rst
@@ -80,6 +80,8 @@ Example usage for the cube stacking task:
     --input_file datasets/mimic_dataset_1k.hdf5 \
     --output_dir datasets/mimic_dataset_1k_mp4
 
+.. _running-cosmos:
+
 Running Cosmos for Visual Augmentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -90,6 +90,8 @@ Other notable limitations with respect to Isaac Lab include...
 
 #. :ref:`Isaac Lab Mimic <generating-additional-demonstrations>` data generation and policy inference for visuomotor envrionements are not supported on DGX Spark due to a lack of non-DLSS image denoiser on aarch64.
 
+#. :ref:`Running Cosmos Transfer1 <running-cosmos>` is not currently supported on the DGX Spark.
+
 Troubleshooting
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Description

Added note to docs for Cosmos Transfer1 limitation on DGX Spark.

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
