### PR TITLE
[Newton] Updates Newton dependencies with new ncon_per_env change

### DIFF
--- a/source/isaaclab/isaaclab/sim/_impl/solvers_cfg.py
+++ b/source/isaaclab/isaaclab/sim/_impl/solvers_cfg.py
@@ -38,7 +38,7 @@ class MJWarpSolverCfg(NewtonSolverCfg):
     njmax: int = 300
     """Number of constraints per environment (world)."""
 
-    ncon_per_world: int | None = None
+    nconmax: int | None = None
     """Number of contact points per environment (world)."""
 
     iterations: int = 100

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -48,9 +48,9 @@ INSTALL_REQUIRES = [
     "flatdict==4.0.1",
     # newton
     "usd-core==25.05.0",
-    "mujoco>=3.3.7.dev811775910",
-    "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp.git@df3d9faac49bf004b26a85d71e339ddb8e6e94f3",
-    "newton @ git+https://github.com/newton-physics/newton.git@a3763a73ba4aeb0414b1b6663a767ee661b39250",
+    "mujoco>=3.3.8.dev821851540",
+    "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp.git@bbd757cace561de47512b560517ee728c8416de5",
+    "newton @ git+https://github.com/newton-physics/newton.git@15b9955bafa61f8fcb40c17dc00f0b552d3c65ca",
     "imgui-bundle==1.92.0",
     "PyOpenGL-accelerate==3.1.10",
 ]

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/allegro_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/allegro_hand_env_cfg.py
@@ -34,7 +34,7 @@ class AllegroHandEnvCfg(DirectRLEnvCfg):
         solver="newton",
         integrator="implicit",
         njmax=70,
-        ncon_per_world=70,
+        nconmax=70,
         impratio=10.0,
         cone="elliptic",
         update_data_interval=2,

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/ant/ant_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/ant/ant_env.py
@@ -32,7 +32,7 @@ class AntEnvCfg(DirectRLEnvCfg):
 
     solver_cfg = MJWarpSolverCfg(
         njmax=38,
-        ncon_per_world=15,
+        nconmax=15,
         ls_iterations=10,
         cone="pyramidal",
         ls_parallel=True,

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env.py
@@ -32,7 +32,7 @@ class HumanoidEnvCfg(DirectRLEnvCfg):
 
     solver_cfg = MJWarpSolverCfg(
         njmax=80,
-        ncon_per_world=25,
+        nconmax=25,
         ls_iterations=15,
         ls_parallel=True,
         cone="pyramidal",

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/ant_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/ant/ant_env_cfg.py
@@ -168,7 +168,7 @@ class AntEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.dt = 1 / 120.0
         self.sim.render_interval = self.decimation
         self.sim.newton_cfg.solver_cfg.njmax = 38
-        self.sim.newton_cfg.solver_cfg.ncon_per_world = 15
+        self.sim.newton_cfg.solver_cfg.nconmax = 15
         self.sim.newton_cfg.solver_cfg.ls_iterations = 10
         self.sim.newton_cfg.solver_cfg.ls_parallel = True
         self.sim.newton_cfg.solver_cfg.cone = "pyramidal"

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/cartpole_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/cartpole/cartpole_env_cfg.py
@@ -164,7 +164,7 @@ class CartpoleEnvCfg(ManagerBasedRLEnvCfg):
     sim: SimulationCfg = SimulationCfg(
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
-                ncon_per_world=5,
+                nconmax=5,
             ),
         )
     )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
@@ -209,7 +209,7 @@ class HumanoidEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.dt = 1 / 120.0
         self.sim.newton_cfg.num_substeps = 2
         self.sim.newton_cfg.solver_cfg.njmax = 80
-        self.sim.newton_cfg.solver_cfg.ncon_per_world = 25
+        self.sim.newton_cfg.solver_cfg.nconmax = 25
         self.sim.newton_cfg.solver_cfg.ls_iterations = 15
         self.sim.newton_cfg.solver_cfg.ls_parallel = True
         self.sim.newton_cfg.solver_cfg.cone = "pyramidal"

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
@@ -17,7 +17,7 @@ class UnitreeA1FlatEnvCfg(UnitreeA1RoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=50,
-                ncon_per_world=30,
+                nconmax=30,
                 ls_iterations=10,
                 cone="elliptic",
                 impratio=100,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
@@ -17,7 +17,7 @@ class AnymalBFlatEnvCfg(AnymalBRoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=50,
-                ncon_per_world=15,
+                nconmax=15,
                 ls_iterations=15,
                 cone="elliptic",
                 impratio=100,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
@@ -17,7 +17,7 @@ class AnymalCFlatEnvCfg(AnymalCRoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=50,
-                ncon_per_world=15,
+                nconmax=15,
                 ls_iterations=15,
                 cone="elliptic",
                 impratio=100,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/flat_env_cfg.py
@@ -17,7 +17,7 @@ class AnymalDFlatEnvCfg(AnymalDRoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=60,
-                ncon_per_world=25,
+                nconmax=25,
                 ls_iterations=15,
                 cone="elliptic",
                 impratio=100.0,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
@@ -17,7 +17,7 @@ class CassieFlatEnvCfg(CassieRoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=52,
-                ncon_per_world=15,
+                nconmax=15,
                 ls_iterations=10,
                 cone="pyramidal",
                 impratio=1,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
@@ -18,7 +18,7 @@ class G1FlatEnvCfg(G1RoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=75,
-                ncon_per_world=10,
+                nconmax=10,
                 ls_iterations=10,
                 ls_parallel=True,
                 cone="pyramidal",

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1_29_dofs/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1_29_dofs/flat_env_cfg.py
@@ -24,7 +24,7 @@ class G1_29_DOFs_FlatEnvCfg(G1_29_DOFs_RoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=210,
-                ncon_per_world=35,
+                nconmax=35,
                 ls_iterations=10,
                 ls_parallel=True,
                 cone="pyramidal",

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
@@ -17,7 +17,7 @@ class UnitreeGo1FlatEnvCfg(UnitreeGo1RoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=60,
-                ncon_per_world=25,
+                nconmax=25,
                 ls_iterations=10,
                 cone="pyramidal",
                 impratio=1,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
@@ -17,7 +17,7 @@ class UnitreeGo2FlatEnvCfg(UnitreeGo2RoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=65,
-                ncon_per_world=35,
+                nconmax=35,
                 ls_iterations=10,
                 cone="pyramidal",
                 impratio=1,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
@@ -17,7 +17,7 @@ class H1FlatEnvCfg(H1RoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=65,
-                ncon_per_world=15,
+                nconmax=15,
                 ls_iterations=10,
                 cone="pyramidal",
                 impratio=1,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
@@ -302,7 +302,7 @@ class SpotFlatEnvCfg(LocomotionVelocityRoughEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=45,
-                ncon_per_world=30,
+                nconmax=30,
                 ls_iterations=10,
                 cone="pyramidal",
                 impratio=1,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/joint_pos_env_cfg.py
@@ -30,7 +30,7 @@ class FrankaReachEnvCfg(ReachEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=20,
-                ncon_per_world=20,
+                nconmax=20,
                 ls_iterations=10,
                 cone="pyramidal",
                 impratio=1,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/ur_10/joint_pos_env_cfg.py
@@ -30,7 +30,7 @@ class UR10ReachEnvCfg(ReachEnvCfg):
         newton_cfg=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=20,
-                ncon_per_world=20,
+                nconmax=20,
                 ls_iterations=10,
                 cone="pyramidal",
                 impratio=1,


### PR DESCRIPTION
# Description

Recent Newton updates went through some renaming of parameters, including changing ncon_per_env to nconmax. This change accommodates the Isaac Lab naming to match the same naming for consistency.


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
