### PR TITLE
Replaces `nucleus_utils` with reimplementation as part of `IsaacLab`

### DIFF
--- a/source/isaaclab/isaaclab/sim/utils/__init__.py
+++ b/source/isaaclab/isaaclab/sim/utils/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from .utils import *  # noqa: F401, F403

--- a/source/isaaclab/isaaclab/sim/utils/nucleus.py
+++ b/source/isaaclab/isaaclab/sim/utils/nucleus.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+
+import carb
+import omni.client
+from omni.client import Result
+
+# import logger
+logger = logging.getLogger(__name__)
+
+DEFAULT_ASSET_ROOT_PATH_SETTING = "/persistent/isaac/asset_root/default"
+DEFAULT_ASSET_ROOT_TIMEOUT_SETTING = "/persistent/isaac/asset_root/timeout"
+
+
+def check_server(server: str, path: str, timeout: float = 10.0) -> bool:
+    """Check a specific server for a path
+
+    Args:
+        server (str): Name of Nucleus server
+        path (str): Path to search
+        timeout (float): Default value: 10 seconds
+
+    Returns:
+        bool: True if folder is found
+    """
+    logger.info(f"Checking path: {server}{path}")
+    # Increase hang detection timeout
+    omni.client.set_hang_detection_time_ms(20000)
+    result, _ = omni.client.stat(f"{server}{path}")
+    if result == Result.OK:
+        logger.info(f"Success: {server}{path}")
+        return True
+    else:
+        logger.info(f"Failure: {server}{path} not accessible")
+        return False
+
+
+def get_assets_root_path(*, skip_check: bool = False) -> str:
+    """Tries to find the root path to the Isaac Sim assets on a Nucleus server
+
+    Args:
+        skip_check (bool): If True, skip the checking step to verify that the resolved path exists.
+
+    Raises:
+        RuntimeError: if the root path setting is not set.
+        RuntimeError: if the root path is not found.
+
+    Returns:
+        url (str): URL of Nucleus server with root path to assets folder.
+    """
+
+    # get timeout
+    timeout = carb.settings.get_settings().get(DEFAULT_ASSET_ROOT_TIMEOUT_SETTING)
+    if not isinstance(timeout, (int, float)):
+        timeout = 10.0
+
+    # resolve path
+    logger.info(f"Check {DEFAULT_ASSET_ROOT_PATH_SETTING} setting")
+    default_asset_root = carb.settings.get_settings().get(DEFAULT_ASSET_ROOT_PATH_SETTING)
+    if not default_asset_root:
+        raise RuntimeError(f"The '{DEFAULT_ASSET_ROOT_PATH_SETTING}' setting is not set")
+    if skip_check:
+        return default_asset_root
+
+    # check path
+    result = check_server(default_asset_root, "/Isaac", timeout)
+    if result:
+        result = check_server(default_asset_root, "/NVIDIA", timeout)
+        if result:
+            logger.info(f"Assets root found at {default_asset_root}")
+            return default_asset_root
+
+    raise RuntimeError(f"Could not find assets root folder: {default_asset_root}")

--- a/source/isaaclab/isaaclab/sim/utils/utils.py
+++ b/source/isaaclab/isaaclab/sim/utils/utils.py
@@ -31,9 +31,8 @@ try:
 except ModuleNotFoundError:
     from pxr import Semantics
 
+from isaaclab.sim import schemas
 from isaaclab.utils.string import to_camel_case
-
-from . import schemas
 
 if TYPE_CHECKING:
     from .spawners.spawner_cfg import SpawnerCfg

--- a/source/isaaclab/test/deps/isaacsim/check_camera.py
+++ b/source/isaaclab/test/deps/isaacsim/check_camera.py
@@ -45,11 +45,6 @@ import numpy as np
 import os
 import random
 
-try:
-    import isaacsim.storage.native as nucleus_utils
-except ModuleNotFoundError:
-    import isaacsim.core.utils.nucleus as nucleus_utils
-
 import isaacsim.core.utils.prims as prim_utils
 import omni.replicator.core as rep
 from isaacsim.core.api.world import World
@@ -58,6 +53,8 @@ from isaacsim.core.utils.carb import set_carb_setting
 from isaacsim.core.utils.viewports import set_camera_view
 from PIL import Image, ImageChops
 from pxr import Gf, UsdGeom
+
+import isaaclab.sim.utils.nucleus as nucleus_utils
 
 # check nucleus connection
 if nucleus_utils.get_assets_root_path() is None:

--- a/source/isaaclab/test/deps/isaacsim/check_floating_base_made_fixed.py
+++ b/source/isaaclab/test/deps/isaacsim/check_floating_base_made_fixed.py
@@ -32,7 +32,6 @@ simulation_app = SimulationApp({"headless": args_cli.headless})
 
 import torch
 
-import isaacsim.core.utils.nucleus as nucleus_utils
 import isaacsim.core.utils.prims as prim_utils
 import isaacsim.core.utils.stage as stage_utils
 import omni.kit.commands
@@ -43,6 +42,8 @@ from isaacsim.core.prims import Articulation
 from isaacsim.core.utils.carb import set_carb_setting
 from isaacsim.core.utils.viewports import set_camera_view
 from pxr import PhysxSchema, UsdPhysics
+
+import isaaclab.sim.utils.nucleus as nucleus_utils
 
 # check nucleus connection
 if nucleus_utils.get_assets_root_path() is None:

--- a/source/isaaclab/test/deps/isaacsim/check_legged_robot_clone.py
+++ b/source/isaaclab/test/deps/isaacsim/check_legged_robot_clone.py
@@ -43,19 +43,15 @@ simulation_app = SimulationApp({"headless": args_cli.headless})
 import os
 import torch
 
-import omni.log
-
-try:
-    import isaacsim.storage.native as nucleus_utils
-except ModuleNotFoundError:
-    import isaacsim.core.utils.nucleus as nucleus_utils
-
 import isaacsim.core.utils.prims as prim_utils
+import omni.log
 from isaacsim.core.api.world import World
 from isaacsim.core.cloner import GridCloner
 from isaacsim.core.prims import Articulation
 from isaacsim.core.utils.carb import set_carb_setting
 from isaacsim.core.utils.viewports import set_camera_view
+
+import isaaclab.sim.utils.nucleus as nucleus_utils
 
 # check nucleus connection
 if nucleus_utils.get_assets_root_path() is None:

--- a/source/isaaclab/test/deps/isaacsim/check_ref_count.py
+++ b/source/isaaclab/test/deps/isaacsim/check_ref_count.py
@@ -37,17 +37,13 @@ import ctypes
 import gc
 import torch  # noqa: F401
 
-import omni.log
-
-try:
-    import isaacsim.storage.native as nucleus_utils
-except ModuleNotFoundError:
-    import isaacsim.core.utils.nucleus as nucleus_utils
-
 import isaacsim.core.utils.prims as prim_utils
+import omni.log
 from isaacsim.core.api.simulation_context import SimulationContext
 from isaacsim.core.prims import Articulation
 from isaacsim.core.utils.carb import set_carb_setting
+
+import isaaclab.sim.utils.nucleus as nucleus_utils
 
 # check nucleus connection
 if nucleus_utils.get_assets_root_path() is None:


### PR DESCRIPTION
# Description

Replaces import of 

```
try:
    import isaacsim.storage.native as nucleus_utils
except ModuleNotFoundError:
    import isaacsim.core.utils.nucleus as nucleus_utils
```

with own utils implemented inside the sim  utils folder.

```
import isaaclab.sim.utils.nucleus as nucleus_utils
```


## Type of change

- Dependency removal

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
