### PR TITLE
Pins python version of pre-commmit.yaml workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -15,4 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
+      with:
+        python-version: "3.12"
     - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
# Description

pre-commit CI runs have been failing (see [example](https://github.com/isaac-sim/IsaacLab/actions/runs/19017065661/job/54306430424)) due to an incompatibility between our specified flake version and python 3.14, as python3.14 has started to be installed by the setup-python GHA. This PR pins python to 3.12 in order to fix these failures.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)