### PR TITLE
Fixes type name for tendon properties in `from_files` config

### DIFF
--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
@@ -39,10 +39,10 @@ class FileCfg(RigidObjectSpawnerCfg, DeformableObjectSpawnerCfg):
     articulation_props: schemas.ArticulationRootPropertiesCfg | None = None
     """Properties to apply to the articulation root."""
 
-    fixed_tendons_props: schemas.FixedTendonsPropertiesCfg | None = None
+    fixed_tendons_props: schemas.FixedTendonPropertiesCfg | None = None
     """Properties to apply to the fixed tendons (if any)."""
 
-    spatial_tendons_props: schemas.SpatialTendonsPropertiesCfg | None = None
+    spatial_tendons_props: schemas.SpatialTendonPropertiesCfg | None = None
     """Properties to apply to the spatial tendons (if any)."""
 
     joint_drive_props: schemas.JointDrivePropertiesCfg | None = None


### PR DESCRIPTION
Tendon imports in from_files_cfg had a typo that prevented importing. This is resolved in this commit.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [X] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [X] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
