### PR TITLE
[SIM-950] Actuator Drive Model Improvements

### DIFF
--- a/docs/source/api/lab/isaaclab.actuators.rst
+++ b/docs/source/api/lab/isaaclab.actuators.rst
@@ -36,6 +36,9 @@ Actuator Base
   :inherited-members:
   :exclude-members: __init__, class_type
 
+.. autoclass:: isaaclab.actuators.actuator_base_cfg.ActuatorBaseCfg.DriveModelCfg
+  :members:
+
 Implicit Actuator
 -----------------
 

--- a/source/isaaclab/isaaclab/actuators/actuator_base_cfg.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_base_cfg.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from dataclasses import MISSING
+from torch import inf
+from typing import NamedTuple
 
 from isaaclab.utils import configclass
 
@@ -47,6 +49,18 @@ class ActuatorBaseCfg:
         it is more intuitive.
 
     """
+
+    """Optional settings to the drive model capturing performance envelope velocity-effort dependence. Requires IsaacSim>5.0.0.
+
+    See: https://docs.omniverse.nvidia.com/kit/docs/omni_physics/107.3/_downloads/f44e831b7f29e7c2ec8e3f2c54418430/drivePerformanceEnvelope.pdf
+    """
+
+    class DriveModelCfg(NamedTuple):
+        speed_effort_gradient: float = 0.0
+        max_actuator_velocity: float = inf
+        velocity_dependent_resistance: float = 0.0
+
+    drive_model: dict[str, DriveModelCfg] | DriveModelCfg | None = None
 
     velocity_limit: dict[str, float] | float | None = None
     """Velocity limit of the joints in the group. Defaults to None.

--- a/source/isaaclab/isaaclab/actuators/actuator_cfg.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_cfg.py
@@ -2,14 +2,16 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-
-import sys
 import warnings
 
 from . import actuator_base_cfg, actuator_net_cfg, actuator_pd_cfg
 
 
 def __getattr__(name):
+
+    if name == "__path__":
+        return __file__
+
     new_module = None
     if name in dir(actuator_pd_cfg):
         new_module = actuator_pd_cfg
@@ -27,10 +29,6 @@ def __getattr__(name):
             stacklevel=2,
         )
         return getattr(new_module, name)
-    if name in dir(sys.modules[__name__]):
-        return vars(sys.modules[__name__])[name]
-    if name == "__path__":
-        return __file__
     raise ImportError(
         f"Failed to import attribute {name} from actuator_cfg.py. Warning: actuator_cfg.py has been "
         + "deprecated. Please import actuator config classes directly from the isaaclab.actuators package.",

--- a/source/isaaclab/isaaclab/actuators/actuator_pd.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_pd.py
@@ -378,41 +378,17 @@ class RemotizedPDActuator(DelayedPDActuator):
     def __init__(
         self,
         cfg: RemotizedPDActuatorCfg,
-        joint_names: list[str],
-        joint_ids: Sequence[int],
-        num_envs: int,
-        device: str,
-        stiffness: torch.Tensor | float = 0.0,
-        damping: torch.Tensor | float = 0.0,
-        armature: torch.Tensor | float = 0.0,
-        friction: torch.Tensor | float = 0.0,
-        dynamic_friction: torch.Tensor | float = 0.0,
-        viscous_friction: torch.Tensor | float = 0.0,
-        effort_limit: torch.Tensor | float = torch.inf,
-        velocity_limit: torch.Tensor | float = torch.inf,
+        *args,
+        **kwargs,
     ):
         # remove effort and velocity box constraints from the base class
         cfg.effort_limit = torch.inf
         cfg.velocity_limit = torch.inf
         # call the base method and set default effort_limit and velocity_limit to inf
-        super().__init__(
-            cfg,
-            joint_names,
-            joint_ids,
-            num_envs,
-            device,
-            stiffness,
-            damping,
-            armature,
-            friction,
-            dynamic_friction,
-            viscous_friction,
-            effort_limit,
-            velocity_limit,
-        )
-        self._joint_parameter_lookup = torch.tensor(cfg.joint_parameter_lookup, device=device)
+        super().__init__(cfg, *args, **kwargs)
+        self._joint_parameter_lookup = torch.tensor(cfg.joint_parameter_lookup, device=self._device)
         # define remotized joint torque limit
-        self._torque_limit = LinearInterpolation(self.angle_samples, self.max_torque_samples, device=device)
+        self._torque_limit = LinearInterpolation(self.angle_samples, self.max_torque_samples, device=self._device)
 
     """
     Properties.

--- a/source/isaaclab/isaaclab/assets/articulation/articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation.py
@@ -815,7 +815,7 @@ class Articulation(AssetBase):
             joint_ids: The joint indices to set the joint torque limits for. Defaults to None (all joints).
             env_ids: The environment indices to set the joint torque limits for. Defaults to None (all environments).
         """
-        if int(get_version()[2]) >= 5:
+        if get_isaac_sim_version().major >= 5:
             # resolve indices
             physx_env_ids = env_ids
             if env_ids is None:
@@ -1637,7 +1637,7 @@ class Articulation(AssetBase):
         self._data.joint_pos_limits = self._data.default_joint_pos_limits.clone()
         self._data.joint_vel_limits = self.root_physx_view.get_dof_max_velocities().to(self.device).clone()
         self._data.joint_effort_limits = self.root_physx_view.get_dof_max_forces().to(self.device).clone()
-        if int(get_version()[2]) >= 5:
+        if get_isaac_sim_version().major >= 5:
             self._data.default_joint_drive_model_parameters = (
                 self.root_physx_view.get_dof_drive_model_properties().to(self.device).clone()
             )
@@ -1772,7 +1772,7 @@ class Articulation(AssetBase):
                 velocity_limit=self._data.joint_vel_limits[:, joint_ids],
                 drive_model=(
                     self._data.joint_drive_model_parameters[:, joint_ids]
-                    if int(get_version()[2]) >= 5
+                    if get_isaac_sim_version().major >= 5
                     else ActuatorBaseCfg.DriveModelCfg()
                 ),
             )

--- a/source/isaaclab/isaaclab/assets/articulation/articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation.py
@@ -331,7 +331,6 @@ class Articulation(AssetBase):
 
     def write_root_com_state_to_sim(self, root_state: torch.Tensor, env_ids: Sequence[int] | None = None):
         """Set the root center of mass state over selected environment indices into the simulation.
-
         The root state comprises of the cartesian position, quaternion orientation in (w, x, y, z), and linear
         and angular velocity. All the quantities are in the simulation frame.
 
@@ -795,6 +794,47 @@ class Articulation(AssetBase):
         self._data.joint_effort_limits[env_ids, joint_ids] = limits
         # set into simulation
         self.root_physx_view.set_dof_max_forces(self._data.joint_effort_limits.cpu(), indices=physx_env_ids.cpu())
+
+    def write_joint_drive_model_to_sim(
+        self,
+        drive_params: torch.Tensor | tuple[float, float, float] | None = None,
+        joint_ids: Sequence[int] | slice | None = None,
+        env_ids: Sequence[int] | None = None,
+    ):
+        """Write parameters (in additional to max forces) necessary to model motor drive performance envelopes.
+
+        Additional parameters can be provided to improve sim-to-real transfer by more accurately modeling the motor drive's
+        performance envelope. Specifically, we define linear constraints on the torque-speed boundary and the speed-torque
+        boundary by defining a speed-effort grandient, maximum actuator velocity, and velocity dependent resistance for each
+        motor in the articulation. See: https://docs.omniverse.nvidia.com/kit/docs/omni_physics/107.3/_downloads/f44e831b7f29e7c2ec8e3f2c54418430/drivePerformanceEnvelope.pdf
+
+        Args:
+            drive_params: The drive parameters. Shape is (len(env_ids), len(joint_ids), 3). The final three dimensions
+                          reflect the speed-effort gradient, max actuator velocity, and velocity dependent resistance
+                          respectively.
+            joint_ids: The joint indices to set the joint torque limits for. Defaults to None (all joints).
+            env_ids: The environment indices to set the joint torque limits for. Defaults to None (all environments).
+        """
+        if int(get_version()[2]) >= 5:
+            # resolve indices
+            physx_env_ids = env_ids
+            if env_ids is None:
+                env_ids = slice(None)
+                physx_env_ids = self._ALL_INDICES
+            if joint_ids is None:
+                joint_ids = slice(None)
+            # broadcast env_ids if needed to allow double indexing
+            if env_ids != slice(None) and joint_ids != slice(None):
+                env_ids = env_ids[:, None]
+            # move tensor to cpu if needed
+            if isinstance(drive_params, torch.Tensor):
+                drive_params = drive_params.to(self.device)
+            # set into internal buffers
+            self._data.joint_drive_model_parameters[env_ids, joint_ids] = drive_params
+            # set into simulation
+            self.root_physx_view.set_dof_drive_model_properties(
+                self._data.joint_drive_model_parameters.cpu(), indices=physx_env_ids.cpu()
+            )
 
     def write_joint_armature_to_sim(
         self,
@@ -1597,6 +1637,17 @@ class Articulation(AssetBase):
         self._data.joint_pos_limits = self._data.default_joint_pos_limits.clone()
         self._data.joint_vel_limits = self.root_physx_view.get_dof_max_velocities().to(self.device).clone()
         self._data.joint_effort_limits = self.root_physx_view.get_dof_max_forces().to(self.device).clone()
+        if int(get_version()[2]) >= 5:
+            self._data.default_joint_drive_model_parameters = (
+                self.root_physx_view.get_dof_drive_model_properties().to(self.device).clone()
+            )
+            self._data.joint_drive_model_parameters = self._data.default_joint_drive_model_parameters.clone()
+        else:
+            # Initialize with zeros for v<5 compatibility
+            default_shape = (self.num_instances, self.num_joints, 3)
+            self._data.default_joint_drive_model_parameters = torch.zeros(default_shape, device=self.device)
+            self._data.joint_drive_model_parameters = self._data.default_joint_drive_model_parameters.clone()
+
         self._data.joint_stiffness = self._data.default_joint_stiffness.clone()
         self._data.joint_damping = self._data.default_joint_damping.clone()
         self._data.joint_armature = self._data.default_joint_armature.clone()
@@ -1704,6 +1755,7 @@ class Articulation(AssetBase):
                 joint_ids = torch.tensor(joint_ids, device=self.device)
             # create actuator collection
             # note: for efficiency avoid indexing when over all indices
+
             actuator: ActuatorBase = actuator_cfg.class_type(
                 cfg=actuator_cfg,
                 joint_names=joint_names,
@@ -1718,6 +1770,11 @@ class Articulation(AssetBase):
                 viscous_friction=self._data.default_joint_viscous_friction_coeff[:, joint_ids],
                 effort_limit=self._data.joint_effort_limits[:, joint_ids].clone(),
                 velocity_limit=self._data.joint_vel_limits[:, joint_ids],
+                drive_model=(
+                    self._data.joint_drive_model_parameters[:, joint_ids]
+                    if int(get_version()[2]) >= 5
+                    else ActuatorBaseCfg.DriveModelCfg()
+                ),
             )
             # log information on actuator groups
             model_type = "implicit" if actuator.is_implicit_model else "explicit"
@@ -1745,6 +1802,7 @@ class Articulation(AssetBase):
             self.write_joint_armature_to_sim(actuator.armature, joint_ids=actuator.joint_indices)
             self.write_joint_friction_coefficient_to_sim(actuator.friction, joint_ids=actuator.joint_indices)
             if get_isaac_sim_version().major >= 5:
+                self.write_joint_drive_model_to_sim(actuator.drive_model, joint_ids=actuator.joint_indices)
                 self.write_joint_dynamic_friction_coefficient_to_sim(
                     actuator.dynamic_friction, joint_ids=actuator.joint_indices
                 )
@@ -1761,7 +1819,7 @@ class Articulation(AssetBase):
             if get_isaac_sim_version().major >= 5:
                 self._data.default_joint_dynamic_friction_coeff[:, actuator.joint_indices] = actuator.dynamic_friction
                 self._data.default_joint_viscous_friction_coeff[:, actuator.joint_indices] = actuator.viscous_friction
-
+                self._data.default_joint_drive_model_parameters[:, actuator.joint_indices] = actuator.drive_model
         # perform some sanity checks to ensure actuators are prepared correctly
         total_act_joints = sum(actuator.num_joints for actuator in self.actuators.values())
         if total_act_joints != (self.num_joints - self.num_fixed_tendons):
@@ -1778,7 +1836,16 @@ class Articulation(AssetBase):
                     for prop_idx, resolution_detail in enumerate(resolution_details):
                         actuator_group_str = actuator_group if group_count == 0 else ""
                         property_str = property if prop_idx == 0 else ""
-                        fmt = [f"{v:.2e}" if isinstance(v, float) else str(v) for v in resolution_detail]
+                        fmt = [
+                            (
+                                f"{v:.2e}"
+                                if isinstance(v, float)
+                                else (
+                                    "(" + ", ".join([f"{vt:.2e}" for vt in v]) + ")" if isinstance(v, tuple) else str(v)
+                                )
+                            )
+                            for v in resolution_detail
+                        ]
                         t.add_row([actuator_group_str, property_str, *fmt])
                         group_count += 1
             logger.warning(f"\nActuatorCfg-USD Value Discrepancy Resolution (matching values are skipped): \n{t}")

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
@@ -5,7 +5,8 @@
 
 from dataclasses import MISSING
 
-from isaaclab.actuators import ActuatorBaseCfg
+from isaaclab.actuators import ActuatorBaseCfg, actuator_pd
+from isaaclab.sim import JointDrivePropertiesCfg
 from isaaclab.utils import configclass
 
 from ..asset_base_cfg import AssetBaseCfg
@@ -69,3 +70,25 @@ class ArticulationCfg(AssetBaseCfg):
     actuator_value_resolution_debug_print = False
     """Print the resolution of actuator final value when input cfg is different from USD value, Defaults to False
     """
+
+    def __post_init__(self):
+        """This Post init is meant to determine if we need to apply the new drive model api to the joints for this articulation.
+        If the drive model is not explicitly enabled by the USD, but an actuator configuration attempts to configure the new
+        api, it will silent default to legacy behavior. If we see an attempt to parametrize the drive model, we configure
+        the primitive spawner to enable the API so that when the actuators are configured, after the primitive is spawned
+        the necessary attributes exist and are available to be configured by the usual configuration parser logic.
+
+        .. Note: Importantly, configuring the drive model on any actuator in the articulation will enable the api on _all_
+           actuators in the articulation (with some default values). It is not currently possible to enable the api on
+           specific joint indices. This may lead to unexpected impacts on drive behavior or frame rate."""
+
+        if self.actuators is not None:
+            if len(self.actuators.keys()) > 0:
+                for act_cfg in self.actuators.values():
+                    if act_cfg.class_type == actuator_pd.ImplicitActuator:
+                        if act_cfg.drive_model is not None:
+                            if hasattr(self.spawn, "joint_drive_props"):
+                                if self.spawn.joint_drive_props is not None:
+                                    self.spawn.joint_drive_props.enable_physx_perf_env = True
+                                else:
+                                    self.spawn.joint_drive_props = JointDrivePropertiesCfg(enable_physx_perf_env=True)

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_data.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_data.py
@@ -289,6 +289,10 @@ class ArticulationData:
     This quantity is parsed from the USD schema at the time of initialization.
     """
 
+    default_joint_drive_model_parameters: torch.Tensor = None
+    """Default joint drive model parameters. Shape is (num_instances, num_drive_models, 3). The last indices reflect
+       the speed_effort_gradient, the max_actuator_velocity, and the velocity_dependent_resistance respectively."""
+
     ##
     # Joint commands -- Set into simulation.
     ##
@@ -383,6 +387,9 @@ class ArticulationData:
 
     joint_effort_limits: torch.Tensor = None
     """Joint maximum effort provided to the simulation. Shape is (num_instances, num_joints)."""
+
+    joint_drive_model_parameters = None
+    """Joint drive model parameters provided to the simulation. Shape is (num_instances, num_joints, 3)."""
 
     ##
     # Joint properties - Custom.

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from typing import Any
 
 import omni.physx.scripts.utils as physx_utils
+from omni.physx.bindings._physx import PERF_ENV_API
 from omni.physx.scripts import deformableUtils as deformable_utils
 from pxr import PhysxSchema, Usd, UsdPhysics
 
@@ -652,6 +653,7 @@ def modify_joint_drive_properties(
         "max_velocity": "max_joint_velocity",
         "max_effort": "max_force",
         "drive_type": "type",
+        "enable_physx_perf_env": None,
     }
     # convert to dict
     cfg = cfg.to_dict()
@@ -678,7 +680,11 @@ def modify_joint_drive_properties(
     # set into USD API
     for attr_name, attr_value in cfg.items():
         attr_name = cfg_to_usd_map.get(attr_name, attr_name)
-        safe_set_attribute_on_usd_schema(usd_drive_api, attr_name, attr_value, camel_case=True)
+        if attr_name is not None:
+            safe_set_attribute_on_usd_schema(usd_drive_api, attr_name, attr_value, camel_case=True)
+
+    if cfg["enable_physx_perf_env"]:
+        prim.ApplyAPI(PERF_ENV_API, UsdPhysics.Tokens.angular)
 
     return True
 

--- a/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
@@ -202,6 +202,10 @@ class JointDrivePropertiesCfg:
     then the joint is driven by an acceleration (usually used for kinematic joints).
     """
 
+    enable_physx_perf_env: bool = False
+    """Enable the new physx drive model for all joints in this articulation. This is automatically set to true if any
+        actuator_cfgs in the articulation supply a drive_model property, but the usd file does not have the api enabled."""
+
     max_effort: float | None = None
     """Maximum effort that can be applied to the joint (in kg-m^2/s^2)."""
 

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -45,6 +45,7 @@ INSTALL_REQUIRES = [
     "flatdict==4.0.1",
     "flaky",
     "packaging",
+    "xacro",
 ]
 
 # Append Linux x86_64 and ARM64 deps via PEP 508 markers

--- a/source/isaaclab/test/actuators/test_drive_model_properties.py
+++ b/source/isaaclab/test/actuators/test_drive_model_properties.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.app import AppLauncher
+
+HEADLESS = True
+
+# if not AppLauncher.instance():
+simulation_app = AppLauncher(headless=HEADLESS).app
+
+"""Rest of imports follows"""
+
+import torch
+
+import pytest
+
+from isaaclab.actuators import IdealPDActuatorCfg
+
+
+@pytest.mark.parametrize("num_envs", [1, 2])
+@pytest.mark.parametrize("num_joints", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_init_drive_model(num_envs, num_joints, device):
+    joint_names = [f"joint_{d}" for d in range(num_joints)]
+    joint_ids = [d for d in range(num_joints)]
+    stiffness = 200
+    damping = 10
+    effort_limit = 60.0
+    velocity_limit = 50
+    drive_model = IdealPDActuatorCfg.DriveModelCfg(
+        speed_effort_gradient=100.0,
+        max_actuator_velocity=200.0,
+        velocity_dependent_resistance=0.1,
+    )
+
+    actuator_cfg = IdealPDActuatorCfg(
+        joint_names_expr=joint_names,
+        stiffness=stiffness,
+        damping=damping,
+        effort_limit=effort_limit,
+        velocity_limit=velocity_limit,
+        drive_model=drive_model,
+    )
+    # assume Articulation class:
+    #   - finds joints (names and ids) associate with the provided joint_names_expr
+
+    actuator = actuator_cfg.class_type(
+        actuator_cfg,
+        joint_names=joint_names,
+        joint_ids=joint_ids,
+        num_envs=num_envs,
+        device=device,
+    )
+
+    # check device and shape
+    torch.testing.assert_close(
+        actuator.drive_model[:, :, 2],
+        drive_model.velocity_dependent_resistance * torch.ones(num_envs, num_joints, device=device),
+    )
+    torch.testing.assert_close(
+        actuator.drive_model[:, :, 1],
+        drive_model.max_actuator_velocity * torch.ones(num_envs, num_joints, device=device),
+    )
+    torch.testing.assert_close(
+        actuator.drive_model[:, :, 0],
+        drive_model.speed_effort_gradient * torch.ones(num_envs, num_joints, device=device),
+    )

--- a/source/isaaclab/test/assets/test_articulation.py
+++ b/source/isaaclab/test/assets/test_articulation.py
@@ -24,7 +24,7 @@ import torch
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
 import isaaclab.utils.string as string_utils
-from isaaclab.actuators import ActuatorBase, IdealPDActuatorCfg, ImplicitActuatorCfg
+from isaaclab.actuators import ActuatorBase, ActuatorBaseCfg, IdealPDActuatorCfg, ImplicitActuatorCfg
 from isaaclab.assets import Articulation, ArticulationCfg
 from isaaclab.envs.mdp.terminations import joint_effort_out_of_limit
 from isaaclab.managers import SceneEntityCfg
@@ -46,6 +46,7 @@ def generate_articulation_cfg(
     effort_limit: float | None = None,
     velocity_limit_sim: float | None = None,
     effort_limit_sim: float | None = None,
+    drive_model: tuple[float, float, float] | None = None,
 ) -> ArticulationCfg:
     """Generate an articulation configuration.
 
@@ -65,11 +66,13 @@ def generate_articulation_cfg(
             Only currently used for "single_joint_implicit" and "single_joint_explicit".
         effort_limit_sim: Effort limit for the actuators (set into the simulation).
             Only currently used for "single_joint_implicit" and "single_joint_explicit".
+        drive_model: Drive model parameters for the actuators.
+            Only currently used for "single_joint_implicit" and "single_joint_explicit".
 
     Returns:
         The articulation configuration for the requested articulation type.
-
     """
+
     if articulation_type == "humanoid":
         articulation_cfg = ArticulationCfg(
             spawn=sim_utils.UsdFileCfg(
@@ -89,7 +92,14 @@ def generate_articulation_cfg(
             # we set 80.0 default for max force because default in USD is 10e10 which makes testing annoying.
             spawn=sim_utils.UsdFileCfg(
                 usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/IsaacSim/SimpleArticulation/revolute_articulation.usd",
-                joint_drive_props=sim_utils.JointDrivePropertiesCfg(max_effort=80.0, max_velocity=5.0),
+                #                articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+                #                    enabled_self_collisions=True,
+                #                    solver_position_iteration_count=32,
+                #                    solver_velocity_iteration_count=32,
+                #                    sleep_threshold=0.005,
+                #                    stabilization_threshold=0.001,
+                #                ),
+                #               joint_drive_props=sim_utils.JointDrivePropertiesCfg(max_effort=80.0, max_velocity=5.0),
             ),
             actuators={
                 "joint": ImplicitActuatorCfg(
@@ -98,8 +108,9 @@ def generate_articulation_cfg(
                     velocity_limit_sim=velocity_limit_sim,
                     effort_limit=effort_limit,
                     velocity_limit=velocity_limit,
-                    stiffness=2000.0,
-                    damping=100.0,
+                    stiffness=stiffness,
+                    damping=damping,
+                    drive_model=drive_model,
                 ),
             },
             init_state=ArticulationCfg.InitialStateCfg(
@@ -122,8 +133,9 @@ def generate_articulation_cfg(
                     velocity_limit_sim=velocity_limit_sim,
                     effort_limit=effort_limit,
                     velocity_limit=velocity_limit,
-                    stiffness=0.0,
-                    damping=10.0,
+                    stiffness=stiffness,
+                    damping=damping,
+                    drive_model=drive_model,
                 ),
             },
         )
@@ -136,8 +148,8 @@ def generate_articulation_cfg(
             actuators={
                 "joint": ImplicitActuatorCfg(
                     joint_names_expr=[".*"],
-                    stiffness=2000.0,
-                    damping=100.0,
+                    stiffness=stiffness,
+                    damping=damping,
                 ),
             },
         )
@@ -394,7 +406,11 @@ def test_initialization_fixed_base_single_joint(sim, num_articulations, device, 
         num_articulations: Number of articulations to test
         device: The device to run the simulation on
     """
-    articulation_cfg = generate_articulation_cfg(articulation_type="single_joint_implicit")
+    articulation_cfg = generate_articulation_cfg(
+        articulation_type="single_joint_implicit",
+        stiffness=2000.0,  # These magic values were previously hardcoded and short-circuited provided parameters.
+        damping=100.0,  # They have been migrated here to ensure the test behavior is unchanged.
+    )
     articulation, translations = generate_articulation(articulation_cfg, num_articulations, device=device)
 
     # Check that boundedness of articulation is correct
@@ -1271,6 +1287,8 @@ def test_setting_velocity_limit_implicit(sim, num_articulations, device, vel_lim
         articulation_type="single_joint_implicit",
         velocity_limit_sim=vel_limit_sim,
         velocity_limit=vel_limit,
+        stiffness=2000.0,  # These magic values were previously hardcoded and short-circuited provided parameters.
+        damping=100.0,  # They have been migrated here to ensure the test behavior is unchanged.
     )
     articulation, _ = generate_articulation(
         articulation_cfg=articulation_cfg,
@@ -1324,6 +1342,8 @@ def test_setting_velocity_limit_explicit(sim, num_articulations, device, vel_lim
         articulation_type="single_joint_explicit",
         velocity_limit_sim=vel_limit_sim,
         velocity_limit=vel_limit,
+        stiffness=0.0,  # These magic values were previously hardcoded and short-circuited provided parameters.
+        damping=10.0,  # They have been migrated here to ensure the test behavior is unchanged.
     )
     articulation, _ = generate_articulation(
         articulation_cfg=articulation_cfg,
@@ -1369,6 +1389,211 @@ def test_setting_velocity_limit_explicit(sim, num_articulations, device, vel_lim
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("drive_model", [(100.0, 200.0, 0.1), None])
+@pytest.mark.skipif(int(get_version()[2]) < 5, reason="Simulator version must be 5 or greater")
+@pytest.mark.isaacsim_ci
+def test_setting_drive_model_explicit(sim, num_articulations, device, drive_model):
+    """Test setting of velocity limit for explicit actuators."""
+    articulation_cfg = generate_articulation_cfg(articulation_type="single_joint_explicit", drive_model=drive_model)
+    articulation, _ = generate_articulation(
+        articulation_cfg=articulation_cfg,
+        num_articulations=num_articulations,
+        device=device,
+    )
+    # Play sim
+    sim.reset()
+
+    # collect dm init values
+    physx_dm = articulation.root_physx_view.get_dof_drive_model_properties().to(device)
+    actuator_dm = articulation.actuators["joint"].drive_model
+
+    # check data buffer for joint_
+    torch.testing.assert_close(articulation.data.joint_drive_model_parameters, physx_dm)
+
+    if drive_model is not None:
+        expected_actuator_dm = torch.zeros(
+            (articulation.num_instances, articulation.num_joints, 3),
+            device=articulation.device,
+        )
+        expected_actuator_dm[:, :, 0] = drive_model[0]
+        expected_actuator_dm[:, :, 1] = drive_model[1]
+        expected_actuator_dm[:, :, 2] = drive_model[2]
+
+        # check actuator is set
+        torch.testing.assert_close(actuator_dm, expected_actuator_dm)
+    else:
+        # check actuator velocity_limit is the same as the PhysX default
+        torch.testing.assert_close(actuator_dm, physx_dm)
+
+
+@pytest.mark.parametrize("num_articulations", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("drive_model", [(100.0, 200.0, 0.1), None])
+@pytest.mark.skipif(int(get_version()[2]) < 5, reason="Simulator version must be 5 or greater")
+@pytest.mark.isaacsim_ci
+def test_setting_drive_model_implicit(sim, num_articulations, device, drive_model):
+    """Test setting of velocity limit for explicit actuators."""
+    articulation_cfg = generate_articulation_cfg(articulation_type="single_joint_implicit", drive_model=drive_model)
+    articulation, _ = generate_articulation(
+        articulation_cfg=articulation_cfg,
+        num_articulations=num_articulations,
+        device=device,
+    )
+    # Play sim
+    sim.reset()
+
+    # collect dm init values
+    physx_dm = articulation.root_physx_view.get_dof_drive_model_properties().to(device)
+    actuator_dm = articulation.actuators["joint"].drive_model
+
+    # check data buffer for joint_
+    torch.testing.assert_close(articulation.data.joint_drive_model_parameters, physx_dm)
+
+    if drive_model is not None:
+        expected_actuator_dm = torch.zeros(
+            (articulation.num_instances, articulation.num_joints, 3),
+            device=articulation.device,
+        )
+        expected_actuator_dm[:, :, 0] = drive_model[0]
+        expected_actuator_dm[:, :, 1] = drive_model[1]
+        expected_actuator_dm[:, :, 2] = drive_model[2]
+
+        # check actuator is set
+        torch.testing.assert_close(actuator_dm, expected_actuator_dm)
+    else:
+        # check actuator velocity_limit is the same as the PhysX default
+        torch.testing.assert_close(actuator_dm, physx_dm)
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        {
+            "description": "No constraint on effort. Test that no clipping is applied.",
+            "effort_limit": 1e5,
+            "drive_model": ActuatorBaseCfg.DriveModelCfg(
+                speed_effort_gradient=0,
+                max_actuator_velocity=1e5,
+                velocity_dependent_resistance=0,
+            ),
+            "velocity_state": 0.0,
+            "effort_state": 0.0,
+        },
+        {
+            "description": "Strictly effort limited. Test that effort is clipped at max effort.",
+            "effort_limit": 1.0,
+            "drive_model": ActuatorBaseCfg.DriveModelCfg(
+                speed_effort_gradient=1.0,
+                max_actuator_velocity=1.0,
+                velocity_dependent_resistance=1.0,
+            ),
+            "velocity_state": 0.0,
+            "effort_state": 0.0,
+        },
+        {
+            "description": "Effort and velocity limited. Test that effort is dependent on velocity.",
+            "effort_limit": 0.5,
+            "drive_model": ActuatorBaseCfg.DriveModelCfg(
+                speed_effort_gradient=1,
+                max_actuator_velocity=0.5,
+                velocity_dependent_resistance=1,
+            ),
+            "velocity_state": 0.0,
+            "effort_state": 0.0,
+        },
+    ],
+)
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("gravity_enabled", [False])  # Disable gravity to remove external forces to consider
+@pytest.mark.isaacsim_ci
+def test_drive_model_constraints_implicit(sim, device, condition, gravity_enabled):
+    """Test the implicit actuator's drive model constraints impact on limiting actuator effort.
+
+    Args:
+        sim: the sim context fixture
+        device: the device were tensors are stored.
+        condition: dict
+            A dictionary containing the parameters for the current test condition.
+            Keys and their descriptions:
+            ``"description"`` : str
+                A written description motivating the condition.
+            ``"effort_limit"`` : float
+                The maximum effort the actuator can produce (Nm).
+            ``"drive_model"`` : tuple[float,float,float] | ActuatorBaseCfg.DriveModelCfg
+                The other parameters in the actuator drive model including:
+                1) drive_model.speed_effort_gradient : float
+                    Slope (Nm/(rad/s)) defining the speed-torque boundary which limits to the maximum velocity for any applied torque.
+                2) drive_model.max_actuator_velocity : float
+                    The maximum velocity (rad/s) achievable by the actuator with no effort applied.
+                3) drive_model.velocity_dependent_resistance : float
+                    Slope ((rad/s)/Nm) defining the torque-speed boundary which limits the maximum achievable torque at a given velocity.
+            ``"velocity_state"`` : float
+                Pre step actuator velocity (rad/s).
+            ``"effort_state"`` : float
+                Pre step actuator effort (Nm).
+    """
+    _test_drive_model_constraints_implicit(sim, device, **condition)
+
+
+def _test_drive_model_constraints_implicit(
+    sim,
+    device,
+    description,
+    effort_limit,
+    drive_model,
+    velocity_state,
+    effort_state,
+):
+    print(f"Test Description: {description}")
+    articulation_cfg = generate_articulation_cfg(
+        articulation_type="single_joint_implicit",
+        effort_limit_sim=effort_limit,
+        drive_model=drive_model,
+        stiffness=1.0,
+        damping=1.0,
+    )
+    articulation, _ = generate_articulation(
+        articulation_cfg=articulation_cfg,
+        num_articulations=1,
+        device=device,
+    )
+    sim.reset()
+
+    # Establish the articulation state
+    physx = articulation.root_physx_view
+    dm = physx.get_dof_drive_model_properties()
+    maxf = physx.get_dof_max_forces()
+    print(f"condition drive_model: {drive_model}, max forces: {effort_limit}")
+    print(f"physx values drive model: {dm}, max forces: {maxf}")
+    all_indices = torch.arange(physx.count, device=device)
+    dof_velocities = velocity_state * torch.ones(physx.count * physx.max_dofs, dtype=torch.float32, device=device)
+    physx.set_dof_velocities(dof_velocities, all_indices)
+    sim.step()
+
+    pos = physx.get_dof_positions()
+    pos = pos + 1
+    pos = pos % (2 * torch.pi)
+    articulation.set_joint_position_target(pos, all_indices)
+    articulation.write_data_to_sim()
+    mf = articulation.root_physx_view.get_dof_projected_joint_forces()
+    mv = articulation.root_physx_view.get_dof_velocities()
+
+    for i in range(500):
+        sim.step()
+        pos = physx.get_dof_positions()
+        pos = pos + 1
+        pos = pos % (2 * torch.pi)
+        articulation.set_joint_position_target(pos, all_indices)
+        articulation.set_joint_velocity_target(drive_model.max_actuator_velocity, all_indices)
+        articulation.write_data_to_sim()
+        if i % 1 == 0:
+            mf = articulation.root_physx_view.get_dof_projected_joint_forces()
+            mv = articulation.root_physx_view.get_dof_velocities()
+            print(f"post step {i}: force {mf}, velocity {mv}")
+
+
+@pytest.mark.parametrize("num_articulations", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("effort_limit_sim", [1e5, None])
 @pytest.mark.parametrize("effort_limit", [1e2, 80.0, None])
 @pytest.mark.isaacsim_ci
@@ -1384,6 +1609,8 @@ def test_setting_effort_limit_implicit(sim, num_articulations, device, effort_li
         articulation_type="single_joint_implicit",
         effort_limit_sim=effort_limit_sim,
         effort_limit=effort_limit,
+        stiffness=2000.0,  # These magic values were previously hardcoded and short-circuited provided parameters.
+        damping=100.0,  # They have been migrated here to ensure the test behavior is unchanged.
     )
     articulation, _ = generate_articulation(
         articulation_cfg=articulation_cfg,
@@ -1439,6 +1666,8 @@ def test_setting_effort_limit_explicit(sim, num_articulations, device, effort_li
         articulation_type="single_joint_explicit",
         effort_limit_sim=effort_limit_sim,
         effort_limit=effort_limit,
+        stiffness=0.0,  # These magic values were previously hardcoded and short-circuited provided parameters.
+        damping=10.0,  # They have been migrated here to ensure the test behavior is unchanged.
     )
     articulation, _ = generate_articulation(
         articulation_cfg=articulation_cfg,
@@ -1564,7 +1793,11 @@ def test_body_root_state(sim, num_articulations, device, with_offset):
         with_offset: Whether to test with offset
     """
     sim._app_control_on_stop_handle = None
-    articulation_cfg = generate_articulation_cfg(articulation_type="single_joint_implicit")
+    articulation_cfg = generate_articulation_cfg(
+        articulation_type="single_joint_implicit",
+        stiffness=2000.0,  # These magic values were previously hardcoded and short-circuited provided parameters.
+        damping=100.0,  # They have been migrated here to ensure the test behavior is unchanged.
+    )
     articulation, env_pos = generate_articulation(articulation_cfg, num_articulations, device)
     env_idx = torch.tensor([x for x in range(num_articulations)], device=device)
     # Check that boundedness of articulation is correct
@@ -1752,7 +1985,11 @@ def test_body_incoming_joint_wrench_b_single_joint(sim, num_articulations, devic
         num_articulations: Number of articulations to test
         device: The device to run the simulation on
     """
-    articulation_cfg = generate_articulation_cfg(articulation_type="single_joint_implicit")
+    articulation_cfg = generate_articulation_cfg(
+        articulation_type="single_joint_implicit",
+        stiffness=2000.0,  # These magic values were previously hardcoded and short-circuited provided parameters.
+        damping=100.0,  # They have been migrated here to ensure the test behavior is unchanged.
+    )
     articulation, _ = generate_articulation(
         articulation_cfg=articulation_cfg, num_articulations=num_articulations, device=device
     )
@@ -1958,7 +2195,11 @@ def test_spatial_tendons(sim, num_articulations, device):
     if get_isaac_sim_version().major < 5:
         pytest.skip("Spatial tendons are not supported in Isaac Sim < 5.0. Please update to Isaac Sim 5.0 or later.")
         return
-    articulation_cfg = generate_articulation_cfg(articulation_type="spatial_tendon_test_asset")
+    articulation_cfg = generate_articulation_cfg(
+        articulation_type="spatial_tendon_test_asset",
+        stiffness=2000.0,  # These magic values were previously hardcoded and short-circuited provided parameters.
+        damping=100.0,  # They have been migrated here to ensure the test behavior is unchanged.
+    )
     articulation, _ = generate_articulation(articulation_cfg, num_articulations, device=device)
 
     # Check that boundedness of articulation is correct

--- a/source/isaaclab/test/assets/urdfs/flywheel.urdf
+++ b/source/isaaclab/test/assets/urdfs/flywheel.urdf
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<robot name="simple_fly_wheel">
+    <link name="world">
+        <inertial>
+            <origin xyz="0.0 0.0 0" rpy="0.0 0.0 0.0"/>
+            <mass value="0.001"/>
+            <inertia ixx="0.00001" ixy="0.0" ixz="0.0" iyy="0.00001" iyz="0.0" izz="0.00001"/>
+        </inertial>
+    </link>
+    <link name="base">
+        <inertial>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <mass value="1"/>
+         </inertial>
+        <visual>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <geometry>
+                <box size="0.1 0.5 5"/>
+            </geometry>
+            <material name="blue">
+                <color rgba="0.0 0.0 0.8 1.0"/>
+            </material>
+        </visual>
+    </link>
+    <link name="axle">
+        <inertial>
+            <origin xyz="0 0 0" rpy="0.0 0.0 0.0"/>
+            <mass value="0.000001"/>
+         </inertial>
+        <visual>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <geometry>
+                <cylinder length="0.6" radius="0.01"/>
+            </geometry>
+            <material name="red">
+                <color rgba="0.8 0.0 0.0 1.0"/>
+            </material>
+        </visual>
+    </link>
+    <link name="flywheel">
+        <inertial>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <mass value="10"/>
+            <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="100"/>
+        </inertial>
+        <visual>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <geometry>
+                <cylinder length="0.4" radius="2"/>
+            </geometry>
+            <material name="gray">
+                <color rgba="0.5 0.5 0.5 1.0"/>
+            </material>
+        </visual>
+    </link>
+    <joint name="world" type="fixed">
+        <parent link="world"/>
+        <child link="base"/>
+        <origin xyz="0.0 0.0 2.5" rpy="0.0 0.0 0.0"/>
+    </joint>
+    <joint name="axle" type="fixed">
+        <parent link="base"/>
+        <child link="axle"/>
+        <origin xyz="0.25 0.0 2" rpy="-1.570796327 0.0 -1.570796327"/>
+    </joint>
+    <joint name="wheel" type="revolute">
+        <parent link="axle"/>
+        <child link="flywheel"/>
+        <origin xyz="0.0 0.0 .1" rpy="0 0 0"/>
+        <axis xyz="0.0 0.0 1.0"/>
+    </joint>
+</robot>

--- a/source/isaaclab/test/assets/urdfs/flywheel.xacro
+++ b/source/isaaclab/test/assets/urdfs/flywheel.xacro
@@ -20,7 +20,7 @@
         <visual>
             <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
             <geometry>
-                <box size="0.1 0.5 3"/>
+                <box size="0.1 0.5 5"/>
             </geometry>
             <material name="blue">
                 <color rgba="0.0 0.0 0.8 1.0"/>
@@ -44,12 +44,12 @@
     </link>
     <link name="flywheel">
         <inertial>
-            <origin xyz="10.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
             <mass value="${wheel_mass}"/>
             <inertia ixx="${0.5 * axis_inertia}" ixy="0" ixz="0" iyy="${0.5 * axis_inertia}" iyz="0" izz="${axis_inertia}" />
         </inertial>
         <visual>
-            <origin xyz="10 0 0" rpy="0 0 0"/>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
             <geometry>
                 <cylinder length="0.4" radius="${wheel_radius}"/>
             </geometry>
@@ -61,17 +61,17 @@
     <joint name="world" type="fixed">
         <parent link="world"/>
         <child link="base"/>
-        <origin xyz="0.0 0.0 1.5" rpy="0.0 0.0 0.0"/>
+        <origin xyz="0.0 0.0 2.5" rpy="0.0 0.0 0.0"/>
     </joint>
     <joint name="axle" type="fixed">
         <parent link="base"/>
         <child link="axle"/>
-        <origin xyz="0.25 0.0 1" rpy="-1.570796327 0.0 -1.570796327"/>
+        <origin xyz="0.25 0.0 2" rpy="-1.570796327 0.0 -1.570796327"/>
     </joint>
     <joint name="wheel" type="revolute">
         <parent link="axle"/>
         <child link="flywheel"/>
-        <origin xyz="2.0 0.0 .1" rpy="0 0 0"/>
+        <origin xyz="0.0 0.0 .1" rpy="0 0 0"/>
         <axis xyz="0.0 0.0 1.0"/>
     </joint>
 </robot>


### PR DESCRIPTION
This change implements the necessary changes to the articulation and actuator classes in order to configure the new actuator drive model including velocity and effort dependent constraints on motor actuation.

I have written tests against instantiation, and no other tests fail. I began looking into testing whether the drive model is being applied by physX. Doing so will require getting an isaacsim rather than isaaclab or physx view into the articulation in order to access the measured effort. @jtigue-bdai suggested we are trying to minimize dependence on the isaacsim api, preferring direct access to the physx layer. I decided to PR these changes without testing the physX level behavior. If we decide we want to introduce a dependency on the IsaacSim ArticulationView within the tests, I can either modify this PR, or create a follow on PR. 

Fixes #3909 

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there