### PR TITLE
Adds enable_cpu_readback option for separation of sim and task device

### DIFF
--- a/scripts/demos/pick_and_place.py
+++ b/scripts/demos/pick_and_place.py
@@ -11,6 +11,7 @@ from isaaclab.app import AppLauncher
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Keyboard control for Isaac Lab Pick and Place.")
+parser.add_argument("--num_envs", type=int, default=32, help="Number of environments to spawn.")
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 # parse the arguments
@@ -66,7 +67,7 @@ class PickAndPlaceEnvCfg(DirectRLEnvCfg):
     # task_device is where data buffers are allocated (cpu for convenience)
     sim: SimulationCfg = SimulationCfg(
         dt=1 / 60,
-        device="cuda:0",  # Physics simulation runs on GPU
+        device=args_cli.device,  # Physics simulation runs on input device (GPU by default)
         render_interval=decimation,
         use_fabric=True,
         enable_scene_query_support=True,
@@ -147,8 +148,8 @@ class PickAndPlaceEnv(DirectRLEnv):
         self.joint_vel = self.pick_and_place.data.joint_vel
 
         # Buffers
-        self.go_to_cube = False
-        self.go_to_target = False
+        self.go_to_cube = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
+        self.go_to_target = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
         self.target_pos = torch.zeros((self.num_envs, 3), device=self.device, dtype=torch.float32)
         self.instant_controls = torch.zeros((self.num_envs, 3), device=self.device, dtype=torch.float32)
         self.permanent_controls = torch.zeros((self.num_envs, 1), device=self.device, dtype=torch.float32)
@@ -184,35 +185,36 @@ class PickAndPlaceEnv(DirectRLEnv):
         print("Keyboard set up!")
         print("The simulation is ready for you to try it out!")
         print("Your goal is pick up the purple cube and to drop it on the red sphere!")
-        print("Use the following controls to interact with the simulation:")
-        print("Press the 'A' key to have the gripper track the cube position.")
-        print("Press the 'D' key to have the gripper track the target position")
-        print("Press the 'W' or 'S' keys to move the gantry UP or DOWN respectively")
-        print("Press 'Q' or 'E' to OPEN or CLOSE the gripper respectively")
+        print(f"Number of environments: {self.num_envs}")
+        print("Use the following controls to interact with ALL environments simultaneously:")
+        print("Press the 'A' key to have all grippers track the cube position.")
+        print("Press the 'D' key to have all grippers track the target position")
+        print("Press the 'W' or 'S' keys to move all gantries UP or DOWN respectively")
+        print("Press 'Q' or 'E' to OPEN or CLOSE all grippers respectively")
 
     def _on_keyboard_event(self, event):
         """Checks for a keyboard event and assign the corresponding command control depending on key pressed."""
         if event.type == carb.input.KeyboardEventType.KEY_PRESS:
-            # Logic on key press
+            # Logic on key press - apply to ALL environments
             if event.input.name == self._auto_aim_target:
-                self.go_to_target = True
-                self.go_to_cube = False
+                self.go_to_target[:] = True
+                self.go_to_cube[:] = False
             if event.input.name == self._auto_aim_cube:
-                self.go_to_cube = True
-                self.go_to_target = False
+                self.go_to_cube[:] = True
+                self.go_to_target[:] = False
             if event.input.name in self._instant_key_controls:
-                self.go_to_cube = False
-                self.go_to_target = False
-                self.instant_controls[0] = self._instant_key_controls[event.input.name]
+                self.go_to_cube[:] = False
+                self.go_to_target[:] = False
+                self.instant_controls[:] = self._instant_key_controls[event.input.name]
             if event.input.name in self._permanent_key_controls:
-                self.go_to_cube = False
-                self.go_to_target = False
-                self.permanent_controls[0] = self._permanent_key_controls[event.input.name]
-        # On key release, the robot stops moving
+                self.go_to_cube[:] = False
+                self.go_to_target[:] = False
+                self.permanent_controls[:] = self._permanent_key_controls[event.input.name]
+        # On key release, all robots stop moving
         elif event.type == carb.input.KeyboardEventType.KEY_RELEASE:
-            self.go_to_cube = False
-            self.go_to_target = False
-            self.instant_controls[0] = self._instant_key_controls["ZEROS"]
+            self.go_to_cube[:] = False
+            self.go_to_target[:] = False
+            self.instant_controls[:] = self._instant_key_controls["ZEROS"]
 
     def _setup_scene(self):
         self.pick_and_place = Articulation(self.cfg.robot_cfg)
@@ -236,28 +238,31 @@ class PickAndPlaceEnv(DirectRLEnv):
 
     def _apply_action(self) -> None:
         # We use the keyboard outputs as an action.
-        if self.go_to_cube:
-            # Effort based proportional controller to track the cube position
-            head_pos_x = self.pick_and_place.data.joint_pos[:, self._x_dof_idx[0]]
-            head_pos_y = self.pick_and_place.data.joint_pos[:, self._y_dof_idx[0]]
-            cube_pos_x = self.cube.data.root_pos_w[:, 0] - self.scene.env_origins[:, 0]
-            cube_pos_y = self.cube.data.root_pos_w[:, 1] - self.scene.env_origins[:, 1]
-            d_cube_robot_x = cube_pos_x - head_pos_x
-            d_cube_robot_y = cube_pos_y - head_pos_y
-            self.instant_controls[0] = torch.tensor(
-                [d_cube_robot_x * 5.0, d_cube_robot_y * 5.0, 0.0], device=self.device
-            )
-        elif self.go_to_target:
-            # Effort based proportional controller to track the target position
-            head_pos_x = self.pick_and_place.data.joint_pos[:, self._x_dof_idx[0]]
-            head_pos_y = self.pick_and_place.data.joint_pos[:, self._y_dof_idx[0]]
-            target_pos_x = self.target_pos[:, 0]
-            target_pos_y = self.target_pos[:, 1]
-            d_target_robot_x = target_pos_x - head_pos_x
-            d_target_robot_y = target_pos_y - head_pos_y
-            self.instant_controls[0] = torch.tensor(
-                [d_target_robot_x * 5.0, d_target_robot_y * 5.0, 0.0], device=self.device
-            )
+        # Process each environment independently
+        for env_idx in range(self.num_envs):
+            if self.go_to_cube[env_idx]:
+                # Effort based proportional controller to track the cube position
+                head_pos_x = self.pick_and_place.data.joint_pos[env_idx, self._x_dof_idx[0]]
+                head_pos_y = self.pick_and_place.data.joint_pos[env_idx, self._y_dof_idx[0]]
+                cube_pos_x = self.cube.data.root_pos_w[env_idx, 0] - self.scene.env_origins[env_idx, 0]
+                cube_pos_y = self.cube.data.root_pos_w[env_idx, 1] - self.scene.env_origins[env_idx, 1]
+                d_cube_robot_x = cube_pos_x - head_pos_x
+                d_cube_robot_y = cube_pos_y - head_pos_y
+                self.instant_controls[env_idx] = torch.tensor(
+                    [d_cube_robot_x * 5.0, d_cube_robot_y * 5.0, 0.0], device=self.device
+                )
+            elif self.go_to_target[env_idx]:
+                # Effort based proportional controller to track the target position
+                head_pos_x = self.pick_and_place.data.joint_pos[env_idx, self._x_dof_idx[0]]
+                head_pos_y = self.pick_and_place.data.joint_pos[env_idx, self._y_dof_idx[0]]
+                target_pos_x = self.target_pos[env_idx, 0]
+                target_pos_y = self.target_pos[env_idx, 1]
+                d_target_robot_x = target_pos_x - head_pos_x
+                d_target_robot_y = target_pos_y - head_pos_y
+                self.instant_controls[env_idx] = torch.tensor(
+                    [d_target_robot_x * 5.0, d_target_robot_y * 5.0, 0.0], device=self.device
+                )
+        
         # Set the joint effort targets for the picker
         self.pick_and_place.set_joint_effort_target(
             self.instant_controls[:, 0].unsqueeze(dim=1), joint_ids=self._x_dof_idx
@@ -269,7 +274,7 @@ class PickAndPlaceEnv(DirectRLEnv):
             self.permanent_controls[:, 0].unsqueeze(dim=1), joint_ids=self._z_dof_idx
         )
         # Set the gripper command
-        self.gripper.set_grippers_command(self.instant_controls[:, 2].unsqueeze(dim=1))
+        self.gripper.set_grippers_command(self.instant_controls[:, 2])
 
     def _get_observations(self) -> dict:
         # Get the observations
@@ -408,8 +413,11 @@ class PickAndPlaceEnv(DirectRLEnv):
 
 def main():
     """Main function."""
+    # create environment configuration
+    env_cfg = PickAndPlaceEnvCfg()
+    env_cfg.scene.num_envs = args_cli.num_envs
     # create environment
-    pick_and_place = PickAndPlaceEnv(PickAndPlaceEnvCfg())
+    pick_and_place = PickAndPlaceEnv(env_cfg)
     obs, _ = pick_and_place.reset()
     while simulation_app.is_running():
         # check for selected robots

--- a/scripts/demos/pick_and_place.py
+++ b/scripts/demos/pick_and_place.py
@@ -59,11 +59,22 @@ class PickAndPlaceEnvCfg(DirectRLEnvCfg):
     action_space = 4
     observation_space = 6
     state_space = 0
-    device = "cpu"
 
-    # Simulation cfg. Note that we are forcing the simulation to run on CPU.
-    # This is because the surface gripper API is only supported on CPU backend for now.
-    sim: SimulationCfg = SimulationCfg(dt=1 / 60, render_interval=decimation, device="cpu")
+    # Simulation cfg. We run physics on GPU but enable CPU readback so that
+    # data is automatically available on CPU for the task/policy.
+    # sim_device is where physics runs (cuda for performance)
+    # task_device is where data buffers are allocated (cpu for convenience)
+    sim: SimulationCfg = SimulationCfg(
+        dt=1 / 60,
+        device="cuda:0",  # Physics simulation runs on GPU
+        render_interval=decimation,
+        use_fabric=True,
+        enable_scene_query_support=True,
+        enable_cpu_readback=True,  # Data automatically copied to CPU
+    )
+    # Task device - where tensor operations and data buffers live
+    # This should match where the simulation data is returned (CPU when enable_cpu_readback=True)
+    device: str = "cpu"
     debug_vis = True
 
     # robot

--- a/scripts/reinforcement_learning/rl_games/play.py
+++ b/scripts/reinforcement_learning/rl_games/play.py
@@ -95,10 +95,6 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
     # override configurations with non-hydra CLI arguments
     env_cfg.scene.num_envs = args_cli.num_envs if args_cli.num_envs is not None else env_cfg.scene.num_envs
     env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
-    # update agent device to match simulation device
-    if args_cli.device is not None:
-        agent_cfg["params"]["config"]["device"] = args_cli.device
-        agent_cfg["params"]["config"]["device_name"] = args_cli.device
 
     # randomly sample a seed if seed = -1
     if args_cli.seed == -1:

--- a/scripts/reinforcement_learning/rl_games/train.py
+++ b/scripts/reinforcement_learning/rl_games/train.py
@@ -102,11 +102,6 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
             "Please use GPU device (e.g., --device cuda) for distributed training."
         )
 
-    # update agent device to match simulation device
-    if args_cli.device is not None:
-        agent_cfg["params"]["config"]["device"] = args_cli.device
-        agent_cfg["params"]["config"]["device_name"] = args_cli.device
-
     # randomly sample a seed if seed = -1
     if args_cli.seed == -1:
         args_cli.seed = random.randint(0, 10000)

--- a/scripts/reinforcement_learning/rsl_rl/train.py
+++ b/scripts/reinforcement_learning/rsl_rl/train.py
@@ -182,7 +182,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
         env = gym.wrappers.RecordVideo(env, **video_kwargs)
 
     # wrap around environment for rsl-rl
-    env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+    env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions, rl_device=agent_cfg.device)
 
     # create runner from rsl-rl
     if agent_cfg.class_name == "OnPolicyRunner":

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.47.10"
+version = "0.48.0"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -2,6 +2,49 @@ Changelog
 ---------
 
 
+0.48.0 (2025-11-07)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``enable_cpu_readback`` parameter to :class:`~isaaclab.sim.SimulationCfg` to control whether physics data
+  is automatically copied from GPU to CPU. When enabled with GPU simulation, allows data to be returned on CPU
+  while physics runs on GPU.
+* Added ``device`` parameter to :class:`~isaaclab.scene.InteractiveScene` to explicitly specify device for scene
+  tensor allocation, enabling proper device separation between simulation and task/environment.
+* Added ``device`` configuration field to :class:`~isaaclab.envs.DirectRLEnvCfg`, 
+  :class:`~isaaclab.envs.DirectMARLEnvCfg`, and :class:`~isaaclab.envs.ManagerBasedEnvCfg` to allow explicit
+  control of task device independent from simulation device.
+* Added simulation device information to environment initialization print output for better visibility of the
+  three-layer device architecture (simulation device, environment device, training device).
+
+Changed
+^^^^^^^
+
+* Modified :class:`~isaaclab.assets.SurfaceGripper` to support GPU simulation with CPU readback. Now validates
+  that either simulation runs on CPU or ``enable_cpu_readback=True`` is set for GPU simulation.
+* Updated all environment classes (:class:`~isaaclab.envs.DirectRLEnv`, :class:`~isaaclab.envs.DirectMARLEnv`,
+  :class:`~isaaclab.envs.ManagerBasedEnv`) to pass task device to :class:`~isaaclab.scene.InteractiveScene`
+  for proper device initialization.
+* Updated RL training scripts (RSL-RL, RL-Games, skrl, Stable-Baselines3) to decouple simulation device (``--device`` flag)
+  from RL training device. RL training device now uses configuration defaults unless in distributed mode.
+* Enhanced RL library wrappers (:class:`~isaaclab_rl.rsl_rl.RslRlVecEnvWrapper`, 
+  :class:`~isaaclab_rl.rl_games.RlGamesVecEnvWrapper`) to properly handle device transfers between environment
+  device and RL training device.
+
+Fixed
+^^^^^
+
+* Fixed device mismatch issues when using ``enable_cpu_readback=True`` by ensuring ``scene.env_origins`` and
+  other scene tensors are allocated on the correct task device.
+* Fixed RL-Games wrapper to properly transfer observations from environment device to RL device in addition
+  to existing action transfers.
+* Fixed environment buffers (``reset_buf``, ``episode_length_buf``) in :class:`~isaaclab.envs.DirectRLEnv`,
+  :class:`~isaaclab.envs.DirectMARLEnv`, and :class:`~isaaclab.envs.ManagerBasedRLEnv` to be allocated on
+  environment device instead of simulation device.
+
+
 0.47.10 (2025-11-06)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -43,6 +43,12 @@ Fixed
 * Fixed environment buffers (``reset_buf``, ``episode_length_buf``) in :class:`~isaaclab.envs.DirectRLEnv`,
   :class:`~isaaclab.envs.DirectMARLEnv`, and :class:`~isaaclab.envs.ManagerBasedRLEnv` to be allocated on
   environment device instead of simulation device.
+* Fixed environment device property in all environment classes to automatically default to CPU when
+  ``enable_cpu_readback=True`` is set, ensuring ``env_ids`` and other environment buffers are created on
+  the correct device without requiring explicit ``device`` configuration.
+* Fixed ``episode_length_buf`` initialization in :class:`~isaaclab.envs.ManagerBasedRLEnv` to respect
+  ``enable_cpu_readback`` setting, preventing device mismatch errors in termination manager when using
+  CPU readback with GPU simulation.
 
 
 0.47.10 (2025-11-06)

--- a/source/isaaclab/isaaclab/assets/surface_gripper/surface_gripper.py
+++ b/source/isaaclab/isaaclab/assets/surface_gripper/surface_gripper.py
@@ -42,8 +42,10 @@ class SurfaceGripper(AssetBase):
          function is called automatically for every simulation step, and does not need to be called by the user.
 
     Note:
-        The SurfaceGripper is only supported on CPU for now. Please set the simulation backend to run on CPU.
-        Use `--device cpu` to run the simulation on CPU.
+        The SurfaceGripper requires data on CPU. You can either:
+        
+        1. Run simulation on CPU: ``sim.device='cpu'``
+        2. Run simulation on GPU with CPU readback: ``sim.device='cuda:0'`` and ``sim.enable_cpu_readback=True``
     """
 
     def __init__(self, cfg: SurfaceGripperCfg):
@@ -243,22 +245,32 @@ class SurfaceGripper(AssetBase):
         """Initializes the gripper-related handles and internal buffers.
 
         Raises:
-            ValueError: If the simulation backend is not CPU.
+            ValueError: If GPU simulation is used without CPU readback enabled.
             RuntimeError: If the Simulation Context is not initialized or if gripper prims are not found.
 
         Note:
-            The SurfaceGripper is only supported on CPU for now. Please set the simulation backend to run on CPU.
-            Use `--device cpu` to run the simulation on CPU.
+            The SurfaceGripper requires data on CPU. When using GPU physics (``sim.device='cuda:0'``),
+            you must enable CPU readback (``sim.enable_cpu_readback=True``) so that data is automatically
+            copied to CPU.
         """
 
         enable_extension("isaacsim.robot.surface_gripper")
         from isaacsim.robot.surface_gripper import GripperView
 
-        # Check that we are using the CPU backend.
-        if self._device != "cpu":
-            raise Exception(
-                "SurfaceGripper is only supported on CPU for now. Please set the simulation backend to run on CPU. Use"
-                " `--device cpu` to run the simulation on CPU."
+        # Check that if GPU simulation is used, CPU readback must be enabled
+        # SurfaceGripper needs data on CPU, so either:
+        # 1. Simulation on CPU (self._device == "cpu"), or
+        # 2. Simulation on GPU with enable_cpu_readback=True (data returned on CPU)
+        sim_device = sim_utils.SimulationContext.instance().cfg.device
+        enable_cpu_readback = sim_utils.SimulationContext.instance().cfg.enable_cpu_readback
+        
+        if "cuda" in sim_device.lower() and not enable_cpu_readback:
+            raise ValueError(
+                f"SurfaceGripper requires data on CPU. Current configuration has simulation device '{sim_device}' "
+                f"with enable_cpu_readback={enable_cpu_readback}. "
+                "Please either:\n"
+                "  1. Set sim.device='cpu', or\n"
+                "  2. Set sim.enable_cpu_readback=True to run GPU physics with CPU data readback."
             )
 
         # obtain the first prim in the regex expression (all others are assumed to be a copy of this)

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -185,7 +185,7 @@ class DirectMARLEnv(gym.Env):
         self.common_step_counter = 0
         # -- init buffers
         self.episode_length_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.long)
-        self.reset_buf = torch.zeros(self.num_envs, dtype=torch.bool, device=self.sim.device)
+        self.reset_buf = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
 
         # setup the observation, state and action spaces
         self._configure_env_spaces()

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -266,7 +266,15 @@ class DirectMARLEnv(gym.Env):
 
     @property
     def device(self):
-        """The device on which the environment is running."""
+        """The device on which the task computations are performed.
+
+        This can be different from :attr:`sim.device` when using CPU readback.
+        For example, physics can run on GPU while task buffers are on CPU.
+        """
+        # If device is explicitly set in config, use that
+        if hasattr(self.cfg, "device") and self.cfg.device is not None:
+            return self.cfg.device
+        # Otherwise fall back to simulation device
         return self.sim.device
 
     @property

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -275,6 +275,10 @@ class DirectMARLEnv(gym.Env):
         # If device is explicitly set in config, use that
         if hasattr(self.cfg, "device") and self.cfg.device is not None:
             return self.cfg.device
+        # If CPU readback is enabled, default to CPU for environment device
+        # since simulation data will be automatically copied to CPU
+        if self.cfg.sim.enable_cpu_readback:
+            return "cpu"
         # Otherwise fall back to simulation device
         return self.sim.device
 

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -103,6 +103,7 @@ class DirectMARLEnv(gym.Env):
 
         # print useful information
         print("[INFO]: Base environment:")
+        print(f"\tSimulation device     : {self.sim.device}")
         print(f"\tEnvironment device    : {self.device}")
         print(f"\tEnvironment seed      : {self.cfg.seed}")
         print(f"\tPhysics step-size     : {self.physics_dt}")
@@ -121,7 +122,7 @@ class DirectMARLEnv(gym.Env):
         with Timer("[INFO]: Time taken for scene creation", "scene_creation"):
             # set the stage context for scene creation steps which use the stage
             with use_stage(self.sim.get_initial_stage()):
-                self.scene = InteractiveScene(self.cfg.scene)
+                self.scene = InteractiveScene(self.cfg.scene, device=self.device)
                 self._setup_scene()
                 attach_stage_to_usd_context()
         print("[INFO]: Scene manager: ", self.scene)

--- a/source/isaaclab/isaaclab/envs/direct_marl_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env_cfg.py
@@ -29,6 +29,21 @@ class DirectMARLEnvCfg:
     sim: SimulationCfg = SimulationCfg()
     """Physics simulation configuration. Default is SimulationCfg()."""
 
+    device: str | None = None
+    """Device for task computations (e.g., 'cuda:0', 'cpu'). Default is None.
+
+    If None, the device is inferred from the simulation device (:attr:`sim.device`).
+
+    This parameter allows separating the physics simulation device from the device where
+    task buffers and computations occur. For example, you can run physics on GPU
+    (:attr:`sim.device` = 'cuda:0') while keeping task data on CPU (:attr:`device` = 'cpu')
+    by enabling CPU readback (:attr:`sim.enable_cpu_readback` = True).
+
+    Note:
+        When using :attr:`sim.enable_cpu_readback` = True with GPU physics, this should
+        be set to 'cpu' since simulation data will be returned on CPU.
+    """
+
     # ui settings
     ui_window_class_type: type | None = BaseEnvWindow
     """The class type of the UI window. Default is None.

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -277,6 +277,10 @@ class DirectRLEnv(gym.Env):
         # If device is explicitly set in config, use that
         if hasattr(self.cfg, "device") and self.cfg.device is not None:
             return self.cfg.device
+        # If CPU readback is enabled, default to CPU for environment device
+        # since simulation data will be automatically copied to CPU
+        if self.cfg.sim.enable_cpu_readback:
+            return "cpu"
         # Otherwise fall back to simulation device
         return self.sim.device
 

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -110,6 +110,7 @@ class DirectRLEnv(gym.Env):
 
         # print useful information
         print("[INFO]: Base environment:")
+        print(f"\tSimulation device     : {self.sim.device}")
         print(f"\tEnvironment device    : {self.device}")
         print(f"\tEnvironment seed      : {self.cfg.seed}")
         print(f"\tPhysics step-size     : {self.physics_dt}")
@@ -128,7 +129,7 @@ class DirectRLEnv(gym.Env):
         with Timer("[INFO]: Time taken for scene creation", "scene_creation"):
             # set the stage context for scene creation steps which use the stage
             with use_stage(self.sim.get_initial_stage()):
-                self.scene = InteractiveScene(self.cfg.scene)
+                self.scene = InteractiveScene(self.cfg.scene, device=self.device)
                 self._setup_scene()
                 attach_stage_to_usd_context()
         print("[INFO]: Scene manager: ", self.scene)

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -268,7 +268,15 @@ class DirectRLEnv(gym.Env):
 
     @property
     def device(self):
-        """The device on which the environment is running."""
+        """The device on which the task computations are performed.
+
+        This can be different from :attr:`sim.device` when using CPU readback.
+        For example, physics can run on GPU while task buffers are on CPU.
+        """
+        # If device is explicitly set in config, use that
+        if hasattr(self.cfg, "device") and self.cfg.device is not None:
+            return self.cfg.device
+        # Otherwise fall back to simulation device
         return self.sim.device
 
     @property

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -194,7 +194,7 @@ class DirectRLEnv(gym.Env):
         self.episode_length_buf = torch.zeros(self.num_envs, device=self.device, dtype=torch.long)
         self.reset_terminated = torch.zeros(self.num_envs, device=self.device, dtype=torch.bool)
         self.reset_time_outs = torch.zeros_like(self.reset_terminated)
-        self.reset_buf = torch.zeros(self.num_envs, dtype=torch.bool, device=self.sim.device)
+        self.reset_buf = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
 
         # setup the action and observation spaces for Gym
         self._configure_gym_env_spaces()

--- a/source/isaaclab/isaaclab/envs/direct_rl_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env_cfg.py
@@ -29,6 +29,21 @@ class DirectRLEnvCfg:
     sim: SimulationCfg = SimulationCfg()
     """Physics simulation configuration. Default is SimulationCfg()."""
 
+    device: str | None = None
+    """Device for task computations (e.g., 'cuda:0', 'cpu'). Default is None.
+
+    If None, the device is inferred from the simulation device (:attr:`sim.device`).
+
+    This parameter allows separating the physics simulation device from the device where
+    task buffers and computations occur. For example, you can run physics on GPU
+    (:attr:`sim.device` = 'cuda:0') while keeping task data on CPU (:attr:`device` = 'cpu')
+    by enabling CPU readback (:attr:`sim.enable_cpu_readback` = True).
+
+    Note:
+        When using :attr:`sim.enable_cpu_readback` = True with GPU physics, this should
+        be set to 'cpu' since simulation data will be returned on CPU.
+    """
+
     # ui settings
     ui_window_class_type: type | None = BaseEnvWindow
     """The class type of the UI window. Default is None.

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -245,6 +245,10 @@ class ManagerBasedEnv:
         # If device is explicitly set in config, use that
         if hasattr(self.cfg, "device") and self.cfg.device is not None:
             return self.cfg.device
+        # If CPU readback is enabled, default to CPU for environment device
+        # since simulation data will be automatically copied to CPU
+        if self.cfg.sim.enable_cpu_readback:
+            return "cpu"
         # Otherwise fall back to simulation device
         return self.sim.device
 

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -110,6 +110,7 @@ class ManagerBasedEnv:
 
         # print useful information
         print("[INFO]: Base environment:")
+        print(f"\tSimulation device     : {self.sim.device}")
         print(f"\tEnvironment device    : {self.device}")
         print(f"\tEnvironment seed      : {self.cfg.seed}")
         print(f"\tPhysics step-size     : {self.physics_dt}")
@@ -134,7 +135,7 @@ class ManagerBasedEnv:
         with Timer("[INFO]: Time taken for scene creation", "scene_creation"):
             # set the stage context for scene creation steps which use the stage
             with use_stage(self.sim.get_initial_stage()):
-                self.scene = InteractiveScene(self.cfg.scene)
+                self.scene = InteractiveScene(self.cfg.scene, device=self.device)
                 attach_stage_to_usd_context()
         print("[INFO]: Scene manager: ", self.scene)
 

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -236,7 +236,15 @@ class ManagerBasedEnv:
 
     @property
     def device(self):
-        """The device on which the environment is running."""
+        """The device on which the task computations are performed.
+
+        This can be different from :attr:`sim.device` when using CPU readback.
+        For example, physics can run on GPU while task buffers are on CPU.
+        """
+        # If device is explicitly set in config, use that
+        if hasattr(self.cfg, "device") and self.cfg.device is not None:
+            return self.cfg.device
+        # Otherwise fall back to simulation device
         return self.sim.device
 
     @property

--- a/source/isaaclab/isaaclab/envs/manager_based_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env_cfg.py
@@ -46,6 +46,21 @@ class ManagerBasedEnvCfg:
     sim: SimulationCfg = SimulationCfg()
     """Physics simulation configuration. Default is SimulationCfg()."""
 
+    device: str | None = None
+    """Device for task computations (e.g., 'cuda:0', 'cpu'). Default is None.
+
+    If None, the device is inferred from the simulation device (:attr:`sim.device`).
+
+    This parameter allows separating the physics simulation device from the device where
+    task buffers and computations occur. For example, you can run physics on GPU
+    (:attr:`sim.device` = 'cuda:0') while keeping task data on CPU (:attr:`device` = 'cpu')
+    by enabling CPU readback (:attr:`sim.enable_cpu_readback` = True).
+
+    Note:
+        When using :attr:`sim.enable_cpu_readback` = True with GPU physics, this should
+        be set to 'cpu' since simulation data will be returned on CPU.
+    """
+
     # ui settings
     ui_window_class_type: type | None = BaseEnvWindow
     """The class type of the UI window. Default is None.

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -76,7 +76,8 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         self.common_step_counter = 0
 
         # initialize the episode length buffer BEFORE loading the managers to use it in mdp functions.
-        self.episode_length_buf = torch.zeros(cfg.scene.num_envs, device=cfg.sim.device, dtype=torch.long)
+        # Note: This needs to be on the environment device, not the simulation device
+        self.episode_length_buf = torch.zeros(cfg.scene.num_envs, device=self.device, dtype=torch.long)
 
         # initialize the base class to setup the scene.
         super().__init__(cfg=cfg)

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -77,7 +77,15 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
 
         # initialize the episode length buffer BEFORE loading the managers to use it in mdp functions.
         # Note: This needs to be on the environment device, not the simulation device
-        self.episode_length_buf = torch.zeros(cfg.scene.num_envs, device=self.device, dtype=torch.long)
+        # We compute device from cfg directly since self.cfg is not set yet
+        if hasattr(cfg, "device") and cfg.device is not None:
+            device = cfg.device
+        elif cfg.sim.enable_cpu_readback:
+            # If CPU readback is enabled, default to CPU for environment device
+            device = "cpu"
+        else:
+            device = cfg.sim.device
+        self.episode_length_buf = torch.zeros(cfg.scene.num_envs, device=device, dtype=torch.long)
 
         # initialize the base class to setup the scene.
         super().__init__(cfg=cfg)

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -107,16 +107,18 @@ class InteractiveScene:
         for more details.
     """
 
-    def __init__(self, cfg: InteractiveSceneCfg):
+    def __init__(self, cfg: InteractiveSceneCfg, device: str | None = None):
         """Initializes the scene.
 
         Args:
             cfg: The configuration class for the scene.
+            device: The device on which scene tensors should be allocated. If None, defaults to simulation device.
         """
         # check that the config is valid
         cfg.validate()
         # store inputs
         self.cfg = cfg
+        self._device = device
         # initialize scene elements
         self._terrain = None
         self._articulations = dict()
@@ -338,6 +340,8 @@ class InteractiveScene:
     @property
     def device(self) -> str:
         """The device on which the scene is created."""
+        if self._device is not None:
+            return self._device
         return sim_utils.SimulationContext.instance().device  # pyright: ignore [reportOptionalMemberAccess]
 
     @property

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -390,6 +390,26 @@ class SimulationCfg:
         running under the hood.
     """
 
+    enable_cpu_readback: bool = False
+    """Enable/disable automatic readback of physics data to CPU. Default is False.
+
+    When set to :obj:`True`, physics simulation data (positions, velocities, etc.) is
+    copied to the CPU, making it readily available on the host. This may be necessary for certain
+    operations that require CPU access to physics data, at the cost of reduced performance.
+
+    When set to :obj:`False` (default), physics data is kept on the GPU and not automatically
+    copied to the CPU. This provides optimal performance when running GPU-accelerated physics by avoiding
+    unnecessary memory transfers.
+
+    Note:
+        This setting is only applicable when :attr:`device` is a CUDA device. When the simulation
+        device is CPU, this flag is ignored as all data is already on the CPU.
+
+        Setting this to :obj:`True` with a CUDA device allows running physics simulation on the GPU
+        while still having CPU access to the data, which can be useful when
+        interfacing with CPU-only code.
+    """
+
     physx: PhysxCfg = PhysxCfg()
     """PhysX solver settings. Default is PhysxCfg()."""
 

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -297,6 +297,10 @@ class SimulationContext(_SimulationContext):
                 stage=self._initial_stage,
             )
 
+        # apply cpu readback setting after creating the simulation context
+        # this overrides the default behavior set by omni_isaac_sim's PhysicsContext
+        self._apply_cpu_readback_setting()
+
     """
     Properties - Override.
     """
@@ -648,6 +652,30 @@ class SimulationContext(_SimulationContext):
     """
     Helper Functions
     """
+
+    def _apply_cpu_readback_setting(self):
+        """Applies the CPU readback setting from the configuration.
+
+        This method overrides the default suppress readback behavior set by Isaac Sim
+        based on the user-specified configuration. This allows users to control whether
+        physics data is automatically copied from device (GPU) to host (CPU).
+
+        When enable_cpu_readback is False (default), data is kept on GPU when simulation is set to GPU.
+        When explicitly set to True, data will be returned on CPU even when simulation is set to GPU.
+
+        Note:
+            This setting is only applicable when the simulation device is CUDA. For CPU
+            simulations, this setting is ignored as data is already on CPU.
+        """
+        # Only apply if user has enabled cpu readback AND device is CUDA
+        if self.cfg.enable_cpu_readback and "cuda" in self.cfg.device.lower():
+            # User wants CPU readback enabled, so we override the default behavior
+            # Note: enable_cpu_readback=True means suppressReadback=False
+            set_carb_setting(self.carb_settings, "/physics/suppressReadback", False)
+            omni.log.info(
+                "Physics CPU readback enabled: Data will be automatically copied to host (CPU). "
+                "This may reduce performance but makes data readily available on CPU."
+            )
 
     def _apply_physics_settings(self):
         """Sets various carb physics settings."""

--- a/source/isaaclab_rl/isaaclab_rl/rl_games/rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/rl_games/rl_games.py
@@ -319,6 +319,10 @@ class RlGamesVecEnvWrapper(IVecEnv):
             - ``"obs"``: either a concatenated tensor (``concate_obs_group=True``) or a Dict of group tensors.
             - ``"states"`` (optional): same structure as above when state groups are configured; omitted otherwise.
         """
+        # move observations to RL device if different from sim device
+        if self._rl_device != self._sim_device:
+            obs_dict = {key: obs.to(device=self._rl_device) for key, obs in obs_dict.items()}
+        
         # clip the observations
         for key, obs in obs_dict.items():
             obs_dict[key] = torch.clamp(obs, -self._clip_obs, self._clip_obs)

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
@@ -139,7 +139,15 @@ class RslRlBaseRunnerCfg:
     """The seed for the experiment. Default is 42."""
 
     device: str = "cuda:0"
-    """The device for the rl-agent. Default is cuda:0."""
+    """The device for the rl-agent. Default is cuda:0.
+
+    This is where the RL policy and training computations occur. This can be different
+    from the environment device (where task buffers are) and the simulation device
+    (where physics runs). For example:
+    - sim.device = "cuda:0" (GPU physics)
+    - env.device = "cpu" (task buffers with CPU readback)
+    - rl.device = "cuda:0" (RL training on GPU)
+    """
 
     num_steps_per_env: int = MISSING
     """The number of steps per environment per update."""

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/vecenv_wrapper.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/vecenv_wrapper.py
@@ -24,7 +24,7 @@ class RslRlVecEnvWrapper(VecEnv):
         https://github.com/leggedrobotics/rsl_rl/blob/master/rsl_rl/env/vec_env.py
     """
 
-    def __init__(self, env: ManagerBasedRLEnv | DirectRLEnv, clip_actions: float | None = None):
+    def __init__(self, env: ManagerBasedRLEnv | DirectRLEnv, clip_actions: float | None = None, rl_device: str | None = None):
         """Initializes the wrapper.
 
         Note:
@@ -33,6 +33,9 @@ class RslRlVecEnvWrapper(VecEnv):
         Args:
             env: The environment to wrap around.
             clip_actions: The clipping value for actions. If ``None``, then no clipping is done.
+            rl_device: The device for RL agent/policy. If ``None``, uses the environment device.
+                This allows running the RL agent on a different device than the environment.
+                For example, you can run physics on GPU, have task buffers on CPU, and run RL on GPU.
 
         Raises:
             ValueError: When the environment is not an instance of :class:`ManagerBasedRLEnv` or :class:`DirectRLEnv`.
@@ -48,11 +51,22 @@ class RslRlVecEnvWrapper(VecEnv):
         # initialize the wrapper
         self.env = env
         self.clip_actions = clip_actions
+        
+        # store the RL device (where policy/training happens)
+        # this may be different from env.device (where task buffers are)
+        if rl_device is None:
+            self.rl_device = self.unwrapped.device
+        else:
+            self.rl_device = rl_device
 
         # store information required by wrapper
         self.num_envs = self.unwrapped.num_envs
-        self.device = self.unwrapped.device
+        # RSL-RL accesses self.device to know where the policy should be
+        self.device = self.rl_device
         self.max_episode_length = self.unwrapped.max_episode_length
+        
+        # track the environment device separately
+        self.env_device = self.unwrapped.device
 
         # obtain dimensions of the environment
         if hasattr(self.unwrapped, "action_manager"):
@@ -139,6 +153,9 @@ class RslRlVecEnvWrapper(VecEnv):
     def reset(self) -> tuple[TensorDict, dict]:  # noqa: D102
         # reset the environment
         obs_dict, extras = self.env.reset()
+        # move observations to RL device if different from env device
+        if self.rl_device != self.env_device:
+            obs_dict = {k: v.to(self.rl_device) if isinstance(v, torch.Tensor) else v for k, v in obs_dict.items()}
         return TensorDict(obs_dict, batch_size=[self.num_envs]), extras
 
     def get_observations(self) -> TensorDict:
@@ -147,14 +164,26 @@ class RslRlVecEnvWrapper(VecEnv):
             obs_dict = self.unwrapped.observation_manager.compute()
         else:
             obs_dict = self.unwrapped._get_observations()
+        # move observations to RL device if different from env device
+        if self.rl_device != self.env_device:
+            obs_dict = {k: v.to(self.rl_device) if isinstance(v, torch.Tensor) else v for k, v in obs_dict.items()}
         return TensorDict(obs_dict, batch_size=[self.num_envs])
 
     def step(self, actions: torch.Tensor) -> tuple[TensorDict, torch.Tensor, torch.Tensor, dict]:
+        # move actions to env device if coming from different RL device
+        if self.rl_device != self.env_device:
+            actions = actions.to(self.env_device)
         # clip actions
         if self.clip_actions is not None:
             actions = torch.clamp(actions, -self.clip_actions, self.clip_actions)
         # record step information
         obs_dict, rew, terminated, truncated, extras = self.env.step(actions)
+        # move outputs to RL device if different from env device
+        if self.rl_device != self.env_device:
+            obs_dict = {k: v.to(self.rl_device) if isinstance(v, torch.Tensor) else v for k, v in obs_dict.items()}
+            rew = rew.to(self.rl_device)
+            terminated = terminated.to(self.rl_device)
+            truncated = truncated.to(self.rl_device)
         # compute dones for compatibility with RSL-RL
         dones = (terminated | truncated).to(dtype=torch.long)
         # move time out information to the extras dict

--- a/source/isaaclab_tasks/test/test_environments.py
+++ b/source/isaaclab_tasks/test/test_environments.py
@@ -33,3 +33,16 @@ import isaaclab_tasks  # noqa: F401
 def test_environments(task_name, num_envs, device):
     # run environments without stage in memory
     _run_environments(task_name, device, num_envs, create_stage_in_memory=False)
+
+
+@pytest.mark.parametrize("num_envs, device", [(32, "cuda"), (1, "cuda")])
+@pytest.mark.parametrize("task_name", setup_environment(include_play=False, factory_envs=False, multi_agent=False))
+@pytest.mark.isaacsim_ci
+def test_environments_with_cpu_readback(task_name, num_envs, device):
+    """Test environments with CPU readback enabled.
+    
+    This test forces enable_cpu_readback=True for all environments to ensure that
+    the device separation between simulation (GPU) and environment (CPU) works correctly.
+    """
+    # run environments with CPU readback enabled
+    _run_environments(task_name, device, num_envs, create_stage_in_memory=False, enable_cpu_readback=True)


### PR DESCRIPTION
# Description

Up until now, we have been working under the assumption of keeping consistency between simulation device and the task device. Data returned from simulation will always match the device simulation is running on, which in turn, should also be the environment device and training device.

Recent surface gripper interface allows for running simulation on the GPU, but does not support the full end-to-end GPU pipeline and instead requires data to be copied back onto the CPU for additional processing. To allow for this type of workflow, we have to relax our assumption and allow for having different devices for which simulation runs computation on and which data from simulation is returned on.

This means we can now mix and match between simulation, environment, and training device:
- simulation device: GPU, enable_cpu_readback: True (simulation data returned on CPU), environment device: CPU, training device: optional GPU/CPU (default follows training config)
- simulation device: GPU, enable_cpu_readback: False (previous behavior and still the default behavior), environment device: GPU, training device: optional GPU/CPU (default follows training config
- simulation device: CPU, enable_cpu_readback: ignored, environment device: CPU, training device: optional GPU/CPU (default follows training config)

I'm not 100% convinced we should do this though, it requires a lot of additional code paths and checks for different devices that feels very error prone, and we likely won't need this flexibility in most cases...

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
