### PR TITLE
Adds Isaac Sim and Lab versions to question and proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -21,6 +21,14 @@ If this is related to another GitHub issue, please link here too.
 
 A clear and concise description of any alternative solutions or features you've considered, if any.
 
+### Build Info
+
+Describe the versions where you are observing the missing feature in:
+
+<!-- Please complete the following description. -->
+- Isaac Lab Version: [e.g. 2.3.0]
+- Isaac Sim Version: [e.g. 5.1, this can be obtained by `cat ${ISAACSIM_PATH}/VERSION`]
+
 ### Additional context
 
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -11,3 +11,11 @@ Basic questions, related to robot learning, that are not bugs or feature request
 Advanced/nontrivial questions, especially in areas where documentation is lacking, are very much welcome.
 
 For questions that are related to running and understanding Isaac Sim, please post them at the official [Isaac Sim forums](https://forums.developer.nvidia.com/c/omniverse/simulation/69).
+
+### Build Info
+
+Describe the versions that you are currently using:
+
+<!-- Please complete the following description. -->
+- Isaac Lab Version: [e.g. 2.3.0]
+- Isaac Sim Version: [e.g. 5.1, this can be obtained by `cat ${ISAACSIM_PATH}/VERSION`]


### PR DESCRIPTION
# Description

To help track questions and proposals better by matching them to their corresponding versions, we are adding the version information to the question and proposal templates. Users should provide these when raising a question or proposal so that we can have a better understanding during which period the questions/proposals are being raised for.

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
