### PR TITLE
fix(robomimic): unify config loading logic to avoid FileNotFoundError in training

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -89,6 +89,7 @@ Guidelines for modifications:
 * Kourosh Darvish
 * Kousheek Chakraborty
 * Lionel Gulich
+* Litian Gong
 * Lotus Li
 * Louis Le Lay
 * Lorenz Wellhausen

--- a/scripts/imitation_learning/robomimic/train.py
+++ b/scripts/imitation_learning/robomimic/train.py
@@ -362,17 +362,17 @@ def main(args: argparse.Namespace):
         print(f"Loading configuration for task: {task_name}")
         print(gym.envs.registry.keys())
         print(" ")
-        
+
         # use the unified configuration loading utility (supports YAML, JSON, and Python classes)
         ext_cfg = load_cfg_from_registry(task_name, cfg_entry_point_key)
-        
+
         # ensure the configuration is a dictionary (robomimic expects JSON/YAML dict format)
         if not isinstance(ext_cfg, dict):
             raise TypeError(
                 f"Expected robomimic configuration to be a dictionary, but got {type(ext_cfg)}."
                 " Please ensure the configuration file is in JSON or YAML format."
             )
-        
+
         # create robomimic config from the loaded dictionary
         config = config_factory(ext_cfg["algo_name"])
         # update config with external json - this will throw errors if

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -100,6 +100,7 @@ def load_cfg_from_registry(task_name: str, entry_point_key: str) -> dict | objec
                 cfg = yaml.full_load(f)
             else:  # .json
                 import json
+
                 cfg = json.load(f)
     else:
         if callable(cfg_entry_point):

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -80,20 +80,27 @@ def load_cfg_from_registry(task_name: str, entry_point_key: str) -> dict | objec
             f"{msg if agents else ''}"
         )
     # parse the default config file
-    if isinstance(cfg_entry_point, str) and cfg_entry_point.endswith(".yaml"):
+    if isinstance(cfg_entry_point, str) and (cfg_entry_point.endswith(".yaml") or cfg_entry_point.endswith(".json")):
         if os.path.exists(cfg_entry_point):
             # absolute path for the config file
             config_file = cfg_entry_point
         else:
             # resolve path to the module location
             mod_name, file_name = cfg_entry_point.split(":")
-            mod_path = os.path.dirname(importlib.import_module(mod_name).__file__)
+            mod = importlib.import_module(mod_name)
+            if mod.__file__ is None:
+                raise ValueError(f"Could not determine file path for module: {mod_name}")
+            mod_path = os.path.dirname(mod.__file__)
             # obtain the configuration file path
             config_file = os.path.join(mod_path, file_name)
         # load the configuration
         print(f"[INFO]: Parsing configuration from: {config_file}")
         with open(config_file, encoding="utf-8") as f:
-            cfg = yaml.full_load(f)
+            if cfg_entry_point.endswith(".yaml"):
+                cfg = yaml.full_load(f)
+            else:  # .json
+                import json
+                cfg = json.load(f)
     else:
         if callable(cfg_entry_point):
             # resolve path to the module location


### PR DESCRIPTION
# Description

This PR fixes a FileNotFoundError raised during robomimic imitation learning training when
the configuration file path is provided in the `"module:file"` format.

**Issue:**  
`train.py` directly opened the module path string using `open()`, which failed to resolve
the actual file path. RL (e.g. rsl_rl) training lib already uses `load_cfg_from_registry` to correctly
parse this syntax, but IL (robomimic) training bypassed that utility.

**Solution:**  
- Extended `load_cfg_from_registry` to support `.json` configuration files.  
- Updated `robomimic/train.py` to use the unified loader instead of `open()`.  
- Now both RL and IL training pipelines share a consistent configuration loading mechanism.

Fixes #3980 

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Screenshots

N/A — change only affects config loading logic, no UI impact.

---

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and version in the corresponding `extension.toml`
- [x] I have added my name to `CONTRIBUTORS.md` or it already exists

---

### Acceptance Criteria

- [x] Robomimic training now supports `"module:file"` style config paths.  
- [x] Config loading logic is unified with updated `load_cfg_from_registry` implementation in `source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py`
