### PR TITLE
Support root_height_below_minimum for rough terrain 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,6 +67,7 @@ Guidelines for modifications:
 * Felix Yu
 * Gary Lvov
 * Giulio Romualdi
+* Hany Hamed
 * Haoran Zhou
 * Harsh Patel
 * HoJin Jeon

--- a/source/isaaclab/isaaclab/envs/mdp/terminations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/terminations.py
@@ -60,7 +60,10 @@ def bad_orientation(
 
 
 def root_height_below_minimum(
-    env: ManagerBasedRLEnv, minimum_height: float, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
+    env: ManagerBasedRLEnv,
+    minimum_height: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    sensor_cfg: SceneEntityCfg | None = None,
 ) -> torch.Tensor:
     """Terminate when the asset's root height is below the minimum height.
 

--- a/source/isaaclab/isaaclab/envs/mdp/terminations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/terminations.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 
 from isaaclab.assets import Articulation, RigidObject
 from isaaclab.managers import SceneEntityCfg
-from isaaclab.sensors import ContactSensor
+from isaaclab.sensors import ContactSensor, RayCaster
 
 if TYPE_CHECKING:
     from isaaclab.envs import ManagerBasedRLEnv
@@ -65,11 +65,16 @@ def root_height_below_minimum(
     """Terminate when the asset's root height is below the minimum height.
 
     Note:
-        This is currently only supported for flat terrains, i.e. the minimum height is in the world frame.
+        For rough terrain, sensor readings can adjust the asset height to account for the terrain.
     """
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return asset.data.root_pos_w[:, 2] < minimum_height
+    asset_height = asset.data.root_pos_w[:, 2]
+    if sensor_cfg is not None:
+        sensor: RayCaster = env.scene[sensor_cfg.name]
+        # Adjust the asset height using the sensor data
+        asset_height = asset_height - torch.mean(sensor.data.ray_hits_w[..., 2], dim=1)
+    return asset_height < minimum_height
 
 
 """


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Similar to `rewards.base_height_l2` https://github.com/isaac-sim/IsaacLab/blob/7e8ebe67ef3e3c280eb3fda39443d643317fdeca/source/isaaclab/isaaclab/envs/mdp/rewards.py#L100-L122

I have added the support of rough terrains to `terminations.root_height_below_minimum`

Fixes #3986

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [X] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
