### PR TITLE
Feature/3438 uv windows support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,6 +65,7 @@ Guidelines for modifications:
 * Fabian Jenelten
 * Felipe Mohr
 * Felix Yu
+* Francisco Beltrao
 * Gary Lvov
 * Giulio Romualdi
 * Haoran Zhou


### PR DESCRIPTION
# Description

Adds `uv` support to the Windows batch script `isaaclab.bat` to match the functionality already available in the bash version `isaaclab.sh`.

All changes are in `isaaclab.bat` file:

- Modified `extract_python_exe`: Added detection for VIRTUAL_ENV environment variable to support uv virtual environments
- Added `extract_pip_command`: Detects uv environments and returns appropriate pip command (uv pip install vs python -m pip install)
- Added `extract_pip_uninstall_command`: Similar detection logic for uninstall operations
- Added `setup_uv_env`: Creates and configures uv environments with Isaac Lab settings
- Added `-u/--uv` arguments: Create uv environments with optional name parameter (defaults to "env_isaaclab")

Fixes #3438


## Type of change

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

