### PR TITLE
Imports the proper module for get_stage_id

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.48.6"
+version = "0.48.7"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.48.7 (2025-11-25)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Changed import from ``isaaclab.sim.utils`` to ``isaaclab.sim.utils.stage`` to properly propagate the Isaac Sim stage context.
+
 0.48.6 (2025-11-18)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/devices/openxr/xr_anchor_utils.py
+++ b/source/isaaclab/isaaclab/devices/openxr/xr_anchor_utils.py
@@ -18,8 +18,8 @@ from typing import Any
 # import logger
 logger = logging.getLogger(__name__)
 
-import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationContext
+from isaaclab.sim.utils.stage import get_current_stage_id
 
 from .xr_cfg import XrAnchorRotationMode
 
@@ -72,7 +72,7 @@ class XrAnchorSynchronizer:
             if self._xr_cfg.anchor_prim_path is None:
                 return
 
-            stage_id = sim_utils.get_current_stage_id()
+            stage_id = get_current_stage_id()
             rt_stage = usdrt.Usd.Stage.Attach(stage_id)
             if rt_stage is None:
                 return


### PR DESCRIPTION
# Description

An Isaac Sim import path changed in Isaac Lab which broke a fragile import in xr_anchor_utils. This change fixed the import. 

Fixes # (issue)

## Type of change


- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
