### PR TITLE
[Newton] Converts remaining omni.log to python logging

### DIFF
--- a/docs/source/refs/troubleshooting.rst
+++ b/docs/source/refs/troubleshooting.rst
@@ -75,8 +75,8 @@ For instance, to run a standalone script with verbose logging, you can use the f
     # Run the standalone script with info logging
     ./isaaclab.sh -p scripts/tutorials/00_sim/create_empty.py --headless --info
 
-For more fine-grained control, you can modify the logging channels through the ``omni.log`` module.
-For more information, please refer to its `documentation <https://docs.omniverse.nvidia.com/kit/docs/carbonite/latest/docs/omni.log/Logging.html>`__.
+For more fine-grained control, you can modify the logging channels through the python native ``logging`` module.
+For more information, please refer to its `documentation <https://docs.python.org/3/library/logging.html>`__.
 
 Using CPU Scaling Governor for performance
 ------------------------------------------

--- a/source/isaaclab/isaaclab/sim/converters/mesh_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/mesh_converter.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import asyncio
+import logging
 import os
 
 import omni
@@ -16,6 +17,8 @@ from isaaclab.sim.converters.asset_converter_base import AssetConverterBase
 from isaaclab.sim.converters.mesh_converter_cfg import MeshConverterCfg
 from isaaclab.sim.schemas import schemas
 from isaaclab.sim.utils import export_prim_to_file
+
+logger = logging.getLogger(__name__)
 
 
 class MeshConverter(AssetConverterBase):
@@ -87,7 +90,7 @@ class MeshConverter(AssetConverterBase):
             # Correct the name to a valid identifier and update the basename
             mesh_file_basename_original = mesh_file_basename
             mesh_file_basename = Tf.MakeValidIdentifier(mesh_file_basename)
-            omni.log.warn(
+            logger.warning(
                 f"Input file name '{mesh_file_basename_original}' is an invalid identifier for the mesh prim path."
                 f" Renaming it to '{mesh_file_basename}' for the conversion."
             )

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -6,9 +6,9 @@
 # needed to import for allowing type-hinting: Usd.Stage | None
 from __future__ import annotations
 
+import logging
 import math
 
-import omni.log
 import omni.physx.scripts.utils as physx_utils
 from omni.physx.scripts import deformableUtils as deformable_utils
 from pxr import PhysxSchema, Usd, UsdPhysics
@@ -26,6 +26,8 @@ from . import schemas_cfg
 """
 Articulation root properties.
 """
+
+logger = logging.getLogger(__name__)
 
 
 def define_articulation_root_properties(
@@ -136,12 +138,12 @@ def modify_articulation_root_properties(
         # if we found a fixed joint, enable/disable it based on the input
         # otherwise, create a fixed joint between the world and the root link
         if existing_fixed_joint_prim is not None:
-            omni.log.info(
+            logger.info(
                 f"Found an existing fixed joint for the articulation: '{prim_path}'. Setting it to: {fix_root_link}."
             )
             existing_fixed_joint_prim.GetJointEnabledAttr().Set(fix_root_link)
         elif fix_root_link:
-            omni.log.info(f"Creating a fixed joint for the articulation: '{prim_path}'.")
+            logger.info(f"Creating a fixed joint for the articulation: '{prim_path}'.")
 
             # note: we have to assume that the root prim is a rigid body,
             #   i.e. we don't handle the case where the root prim is not a rigid body but has articulation api on it
@@ -517,10 +519,10 @@ def activate_contact_sensors(prim_path: str, threshold: float = 0.0, stage: Usd.
             rb.CreateSleepThresholdAttr().Set(0.0)
             # add contact report API with threshold of zero
             if not child_prim.HasAPI(PhysxSchema.PhysxContactReportAPI):
-                omni.log.verbose(f"Adding contact report API to prim: '{child_prim.GetPrimPath()}'")
+                logger.debug(f"Adding contact report API to prim: '{child_prim.GetPrimPath()}'")
                 cr_api = PhysxSchema.PhysxContactReportAPI.Apply(child_prim)
             else:
-                omni.log.verbose(f"Contact report API already exists on prim: '{child_prim.GetPrimPath()}'")
+                logger.debug(f"Contact report API already exists on prim: '{child_prim.GetPrimPath()}'")
                 cr_api = PhysxSchema.PhysxContactReportAPI.Get(stage, child_prim.GetPrimPath())
             # set threshold to zero
             cr_api.CreateThresholdAttr().Set(threshold)

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -5,10 +5,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import omni.kit.commands
-import omni.log
 from pxr import Gf, Sdf, Usd
 
 import isaaclab.sim.utils.prims as prim_utils
@@ -31,6 +31,8 @@ from isaaclab.sim.utils.stage import get_current_stage
 
 if TYPE_CHECKING:
     from . import from_files_cfg
+
+logger = logging.getLogger(__name__)
 
 
 @clone
@@ -182,7 +184,7 @@ def spawn_ground_plane(
         # avoiding this step if stage is in memory since the "ChangePropertyCommand" kit command
         # is not supported in stage in memory
         if is_current_stage_in_memory():
-            omni.log.warn(
+            logger.warning(
                 "Ground plane color modification is not supported while the stage is in memory. Skipping operation."
             )
 
@@ -281,7 +283,7 @@ def _spawn_from_usd_file(
             scale=cfg.scale,
         )
     else:
-        omni.log.warn(f"A prim already exists at prim path: '{prim_path}'.")
+        logger.warning(f"A prim already exists at prim path: '{prim_path}'.")
 
     # modify variants
     if hasattr(cfg, "variants") and cfg.variants is not None:

--- a/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
@@ -5,10 +5,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import omni.kit.commands
-import omni.log
 from pxr import Usd
 
 import isaaclab.sim.utils.prims as prim_utils
@@ -17,6 +17,8 @@ from isaaclab.utils.assets import NVIDIA_NUCLEUS_DIR
 
 if TYPE_CHECKING:
     from . import visual_materials_cfg
+
+logger = logging.getLogger(__name__)
 
 
 @clone

--- a/source/isaaclab/isaaclab/sim/spawners/sensors/sensors.py
+++ b/source/isaaclab/isaaclab/sim/spawners/sensors/sensors.py
@@ -5,10 +5,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import omni.kit.commands
-import omni.log
 from pxr import Sdf, Usd
 
 import isaaclab.sim.utils.prims as prim_utils
@@ -27,6 +27,7 @@ CUSTOM_PINHOLE_CAMERA_ATTRIBUTES = {
 The dictionary maps the attribute name in the configuration to the attribute name in the USD prim.
 """
 
+logger = logging.getLogger(__name__)
 
 CUSTOM_FISHEYE_CAMERA_ATTRIBUTES = {
     "projection_type": ("cameraProjectionType", Sdf.ValueTypeNames.Token),
@@ -110,7 +111,7 @@ def spawn_camera(
     # TODO: Adjust to handle aperture offsets once supported by omniverse
     #   Internal ticket from rendering team: OM-42611
     if cfg.horizontal_aperture_offset > 1e-4 or cfg.vertical_aperture_offset > 1e-4:
-        omni.log.warn("Camera aperture offsets are not supported by Omniverse. These parameters will be ignored.")
+        logger.warning("Camera aperture offsets are not supported by Omniverse. These parameters will be ignored.")
 
     # custom attributes in the config that are not USD Camera parameters
     non_usd_cfg_param_names = [

--- a/source/isaaclab/isaaclab/visualizers/ov_visualizer.py
+++ b/source/isaaclab/isaaclab/visualizers/ov_visualizer.py
@@ -13,13 +13,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
-import omni.log
 from pxr import UsdGeom
 
 from .ov_visualizer_cfg import OVVisualizerCfg
 from .visualizer import Visualizer
+
+logger = logging.getLogger(__name__)
 
 
 class OVVisualizer(Visualizer):
@@ -43,7 +45,7 @@ class OVVisualizer(Visualizer):
     def initialize(self, scene_data: dict[str, Any] | None = None) -> None:
         """Initialize OV visualizer."""
         if self._is_initialized:
-            omni.log.warn("[OVVisualizer] Already initialized.")
+            logger.warning("[OVVisualizer] Already initialized.")
             return
 
         usd_stage = None
@@ -78,7 +80,7 @@ class OVVisualizer(Visualizer):
 
         num_envs = metadata.get("num_envs", 0)
         physics_backend = metadata.get("physics_backend", "unknown")
-        omni.log.info(f"[OVVisualizer] Initialized ({num_envs} envs, {physics_backend} physics)")
+        logger.info(f"[OVVisualizer] Initialized ({num_envs} envs, {physics_backend} physics)")
 
         self._is_initialized = True
 
@@ -160,20 +162,20 @@ class OVVisualizer(Visualizer):
 
                     # Check if running in headless mode
                     if self._simulation_app.config.get("headless", False):
-                        omni.log.warn(
+                        logger.warning(
                             "[OVVisualizer] Running in headless mode. "
                             "OV visualizer requires GUI mode (launch with --headless=False) to create viewports."
                         )
                     else:
-                        omni.log.info("[OVVisualizer] Using existing Isaac Sim app instance.")
+                        logger.info("[OVVisualizer] Using existing Isaac Sim app instance.")
                 else:
                     # App is running but we couldn't get SimulationApp instance
                     # This is okay - we can still use omni APIs
-                    omni.log.info("[OVVisualizer] Isaac Sim app is running (via omni.kit.app).")
+                    logger.info("[OVVisualizer] Isaac Sim app is running (via omni.kit.app).")
 
             except ImportError:
                 # SimulationApp not available, but omni.kit.app is running
-                omni.log.info("[OVVisualizer] Using running Isaac Sim app (SimulationApp module not available).")
+                logger.info("[OVVisualizer] Using running Isaac Sim app (SimulationApp module not available).")
 
         except ImportError as e:
             raise ImportError(
@@ -207,7 +209,7 @@ class OVVisualizer(Visualizer):
                     docked=True,
                 )
 
-                omni.log.info(f"[OVVisualizer] Created viewport '{self.cfg.viewport_name}'")
+                logger.info(f"[OVVisualizer] Created viewport '{self.cfg.viewport_name}'")
 
                 # Dock the viewport asynchronously (needs to wait for window creation)
                 asyncio.ensure_future(self._dock_viewport_async(self.cfg.viewport_name, dock_pos))
@@ -221,19 +223,19 @@ class OVVisualizer(Visualizer):
                     self._viewport_window = vp_utils.get_viewport_window_by_name(self.cfg.viewport_name)
 
                     if self._viewport_window is None:
-                        omni.log.warn(
+                        logger.warning(
                             f"[OVVisualizer] Viewport '{self.cfg.viewport_name}' not found. "
                             "Using active viewport instead."
                         )
                         self._viewport_window = vp_utils.get_active_viewport_window()
                     else:
-                        omni.log.info(f"[OVVisualizer] Using existing viewport '{self.cfg.viewport_name}'")
+                        logger.info(f"[OVVisualizer] Using existing viewport '{self.cfg.viewport_name}'")
                 else:
                     self._viewport_window = vp_utils.get_active_viewport_window()
-                    omni.log.info("[OVVisualizer] Using existing active viewport")
+                    logger.info("[OVVisualizer] Using existing active viewport")
 
             if self._viewport_window is None:
-                omni.log.warn("[OVVisualizer] Could not get/create viewport.")
+                logger.warning("[OVVisualizer] Could not get/create viewport.")
                 return
 
             # Get viewport API for camera control
@@ -242,14 +244,12 @@ class OVVisualizer(Visualizer):
             # Set camera pose (uses existing camera if not created above)
             self._set_viewport_camera(self.cfg.camera_position, self.cfg.camera_target)
 
-            omni.log.info(
-                f"[OVVisualizer] Viewport configured (size: {self.cfg.window_width}x{self.cfg.window_height})"
-            )
+            logger.info(f"[OVVisualizer] Viewport configured (size: {self.cfg.window_width}x{self.cfg.window_height})")
 
         except ImportError as e:
-            omni.log.warn(f"[OVVisualizer] Viewport utilities unavailable: {e}")
+            logger.warning(f"[OVVisualizer] Viewport utilities unavailable: {e}")
         except Exception as e:
-            omni.log.error(f"[OVVisualizer] Error setting up viewport: {e}")
+            logger.error(f"[OVVisualizer] Error setting up viewport: {e}")
 
     async def _dock_viewport_async(self, viewport_name: str, dock_position) -> None:
         """Dock viewport window asynchronously after it's created.
@@ -267,12 +267,12 @@ class OVVisualizer(Visualizer):
             for i in range(10):  # Try up to 10 frames
                 viewport_window = omni.ui.Workspace.get_window(viewport_name)
                 if viewport_window:
-                    omni.log.info(f"[OVVisualizer] Found viewport window '{viewport_name}' after {i} frames")
+                    logger.info(f"[OVVisualizer] Found viewport window '{viewport_name}' after {i} frames")
                     break
                 await omni.kit.app.get_app().next_update_async()
 
             if not viewport_window:
-                omni.log.warn(
+                logger.warning(
                     f"[OVVisualizer] Could not find viewport window '{viewport_name}' in workspace for docking."
                 )
                 return
@@ -302,18 +302,18 @@ class OVVisualizer(Visualizer):
                 await omni.kit.app.get_app().next_update_async()
                 viewport_window.focus()
 
-                omni.log.info(
+                logger.info(
                     f"[OVVisualizer] Docked viewport '{viewport_name}' at position {self.cfg.dock_position} and set as"
                     " active"
                 )
             else:
-                omni.log.info(
+                logger.info(
                     f"[OVVisualizer] Could not find main viewport for docking. Viewport '{viewport_name}' will remain"
                     " floating."
                 )
 
         except Exception as e:
-            omni.log.warn(f"[OVVisualizer] Error docking viewport: {e}")
+            logger.warning(f"[OVVisualizer] Error docking viewport: {e}")
 
     def _create_and_assign_camera(self, usd_stage) -> None:
         """Create a dedicated camera for this viewport and assign it."""
@@ -326,17 +326,17 @@ class OVVisualizer(Visualizer):
             if not camera_prim.IsValid():
                 # Create camera prim
                 UsdGeom.Camera.Define(usd_stage, camera_path)
-                omni.log.info(f"[OVVisualizer] Created camera: {camera_path}")
+                logger.info(f"[OVVisualizer] Created camera: {camera_path}")
             else:
-                omni.log.info(f"[OVVisualizer] Using existing camera: {camera_path}")
+                logger.info(f"[OVVisualizer] Using existing camera: {camera_path}")
 
             # Assign camera to viewport
             if self._viewport_api:
                 self._viewport_api.set_active_camera(camera_path)
-                omni.log.info(f"[OVVisualizer] Assigned camera '{camera_path}' to viewport '{self.cfg.viewport_name}'")
+                logger.info(f"[OVVisualizer] Assigned camera '{camera_path}' to viewport '{self.cfg.viewport_name}'")
 
         except Exception as e:
-            omni.log.warn(f"[OVVisualizer] Could not create/assign camera: {e}. Using default camera.")
+            logger.warning(f"[OVVisualizer] Could not create/assign camera: {e}. Using default camera.")
 
     def _set_viewport_camera(self, position: tuple[float, float, float], target: tuple[float, float, float]) -> None:
         """Set viewport camera position and target using Isaac Sim utilities."""
@@ -357,7 +357,7 @@ class OVVisualizer(Visualizer):
                 eye=list(position), target=list(target), camera_prim_path=camera_path, viewport_api=self._viewport_api
             )
 
-            omni.log.info(f"[OVVisualizer] Camera set: pos={position}, target={target}, camera={camera_path}")
+            logger.info(f"[OVVisualizer] Camera set: pos={position}, target={target}, camera={camera_path}")
 
         except Exception as e:
-            omni.log.warn(f"[OVVisualizer] Could not set camera: {e}")
+            logger.warning(f"[OVVisualizer] Could not set camera: {e}")


### PR DESCRIPTION
# Description

As new PR comes in some still uses omni.log and this pr converts them to python logging.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
