### PR TITLE
[Bug Fix] Instantiate event class term_cfg.func with parameters to enable resetting

### DIFF
--- a/source/isaaclab/isaaclab/managers/event_manager.py
+++ b/source/isaaclab/isaaclab/managers/event_manager.py
@@ -387,6 +387,7 @@ class EventManager(ManagerBase):
 
             # check if the term is a class
             if inspect.isclass(term_cfg.func):
+                term_cfg.func = term_cfg.func(cfg=term_cfg, env=self._env)
                 self._mode_class_term_cfgs[term_cfg.mode].append(term_cfg)
 
             # resolve the mode of the events


### PR DESCRIPTION
# Description

Event manager needs to instantiate class-based terms or else func.reset(env_ids) will not work (requires positional argument self).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [X] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
