### PR TITLE
[Newton] Cherry-picks wrappers for new cloner

### DIFF
--- a/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers_cfg.py
@@ -34,11 +34,20 @@ class MultiAssetSpawnerCfg(RigidObjectSpawnerCfg, DeformableObjectSpawnerCfg):
     assets_cfg: list[SpawnerCfg] = MISSING
     """List of asset configurations to spawn."""
 
-    random_choice: bool = True
-    """Whether to randomly select an asset configuration. Default is True.
+    enable_clone: bool = False
+    """This is enables the cloning of spawned assets from first instance to all other instances that has the
+    same prefix path pattern, for example, given /World/env_.*/asset_.*, multi-asset spawner will spawn asset_0,
+    asset_1, asset_n under /World/env_0. Then if enable_clone is set to True, env_0 is cloned to env_1, env_2, etc.
+    If False, .* is not allowed in the prefix path of the prim_path, an safety check error will be raised."""
 
-    If False, the asset configurations are spawned in the order they are provided in the list.
-    If True, a random asset configuration is selected for each spawn.
+    random_choice: bool = True
+    """ This parameter is ignored.
+    See :attr:`isaaclab.scene.interactive_scene_cfg.InteractiveSceneCfg.random_heterogeneous_cloning` for details.
+
+    .. warning::
+
+        This attribute is deprecated. Use
+        :attr:`~isaaclab.scene.interactive_scene_cfg.InteractiveSceneCfg.random_heterogeneous_cloning` instead.
     """
 
 
@@ -64,4 +73,9 @@ class MultiUsdFileCfg(UsdFileCfg):
 
     If False, the asset configurations are spawned in the order they are provided in the list.
     If True, a random asset configuration is selected for each spawn.
+
+    .. warning::
+
+        This attribute is deprecated. Use
+        :attr:`~isaaclab.scene.interactive_scene_cfg.InteractiveSceneCfg.random_heterogeneous_cloning` instead.
     """

--- a/source/isaaclab/test/sim/test_spawn_wrappers.py
+++ b/source/isaaclab/test/sim/test_spawn_wrappers.py
@@ -12,6 +12,7 @@ simulation_app = AppLauncher(headless=True).app
 
 """Rest everything follows."""
 
+
 import pytest
 from isaacsim.core.api.simulation_context import SimulationContext
 
@@ -35,11 +36,32 @@ def sim():
     sim.clear_instance()
 
 
-def test_spawn_multiple_shapes_with_global_settings(sim):
-    """Test spawning of shapes randomly with global rigid body settings."""
-    num_clones = 10
-    for i in range(num_clones):
-        prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+def test_spawn_multiple_shapes_with_cloning_disabled(sim):
+    """Ensure regex prefix paths error when enable_clone is False."""
+    cfg = sim_utils.MultiAssetSpawnerCfg(
+        assets_cfg=[
+            sim_utils.ConeCfg(
+                radius=0.3,
+                height=0.6,
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0), metallic=0.2),
+                mass_props=sim_utils.MassPropertiesCfg(mass=100.0),  # this one should get overridden
+            )
+        ],
+        collision_props=sim_utils.CollisionPropertiesCfg(),
+    )
+
+    with pytest.raises(ValueError, match="enable_clone is False"):
+        cfg.func("/World/env_.*/Cone/asset_.*", cfg)
+
+
+def test_spawn_multiple_shapes_with_cloning(sim):
+    """Ensure regex prefix paths are allowed and cloned when enable_clone is True."""
+    num_envs = 3
+    num_assets = 3
+    for env_idx in range(num_envs):
+        env_path = f"/World/env_{env_idx}"
+        prim_utils.create_prim(env_path, "Xform", translation=(0, 0, 0))
+        prim_utils.create_prim(f"{env_path}/Cone", "Xform")
 
     cfg = sim_utils.MultiAssetSpawnerCfg(
         assets_cfg=[
@@ -58,19 +80,60 @@ def test_spawn_multiple_shapes_with_global_settings(sim):
                 visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 1.0), metallic=0.2),
             ),
         ],
-        random_choice=True,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            solver_position_iteration_count=4, solver_velocity_iteration_count=0
+        ),
+        mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        collision_props=sim_utils.CollisionPropertiesCfg(),
+        enable_clone=True,
+    )
+
+    prim = cfg.func("/World/env_.*/Cone/asset_.*", cfg)
+    assert prim_utils.get_prim_path(prim) == "/World/env_0/Cone/asset_0"
+
+    prim_paths = sim_utils.find_matching_prim_paths("/World/env_.*/Cone/asset_.*")
+    assert len(prim_paths) == num_assets * num_envs
+
+    for env_idx in range(num_envs):
+        for asset_idx in range(num_assets):
+            path = f"/World/env_{env_idx}/Cone/asset_{asset_idx}"
+            assert path in prim_paths
+            assert prim_utils.get_prim_at_path(path).GetAttribute("physics:mass").Get() == cfg.mass_props.mass
+
+
+def test_spawn_multiple_shapes_with_global_settings(sim):
+    """Test spawning of shapes randomly with global rigid body settings."""
+    prim_utils.create_prim("/World/template", "Xform", translation=(0, 0, 0))
+
+    cfg = sim_utils.MultiAssetSpawnerCfg(
+        assets_cfg=[
+            sim_utils.ConeCfg(
+                radius=0.3,
+                height=0.6,
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0), metallic=0.2),
+                mass_props=sim_utils.MassPropertiesCfg(mass=100.0),  # this one should get overridden
+            ),
+            sim_utils.CuboidCfg(
+                size=(0.3, 0.3, 0.3),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0), metallic=0.2),
+            ),
+            sim_utils.SphereCfg(
+                radius=0.3,
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 1.0), metallic=0.2),
+            ),
+        ],
         rigid_props=sim_utils.RigidBodyPropertiesCfg(
             solver_position_iteration_count=4, solver_velocity_iteration_count=0
         ),
         mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
         collision_props=sim_utils.CollisionPropertiesCfg(),
     )
-    prim = cfg.func("/World/env_.*/Cone", cfg)
+    prim = cfg.func("/World/template/Cone/asset_.*", cfg)
 
     assert prim.IsValid()
-    assert prim_utils.get_prim_path(prim) == "/World/env_0/Cone"
-    prim_paths = prim_utils.find_matching_prim_paths("/World/env_*/Cone")
-    assert len(prim_paths) == num_clones
+    assert prim_utils.get_prim_path(prim) == "/World/template/Cone/asset_0"
+    prim_paths = sim_utils.find_matching_prim_paths("/World/template/Cone/asset_.*")
+    assert len(prim_paths) == 3
 
     for prim_path in prim_paths:
         prim = prim_utils.get_prim_at_path(prim_path)
@@ -79,9 +142,7 @@ def test_spawn_multiple_shapes_with_global_settings(sim):
 
 def test_spawn_multiple_shapes_with_individual_settings(sim):
     """Test spawning of shapes randomly with individual rigid object settings."""
-    num_clones = 10
-    for i in range(num_clones):
-        prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+    prim_utils.create_prim("/World/template", "Xform", translation=(0, 0, 0))
 
     mass_variations = [2.0, 3.0, 4.0]
     cfg = sim_utils.MultiAssetSpawnerCfg(
@@ -109,14 +170,13 @@ def test_spawn_multiple_shapes_with_individual_settings(sim):
                 collision_props=sim_utils.CollisionPropertiesCfg(),
             ),
         ],
-        random_choice=True,
     )
-    prim = cfg.func("/World/env_.*/Cone", cfg)
+    prim = cfg.func("/World/template/Cone/asset_.*", cfg)
 
     assert prim.IsValid()
-    assert prim_utils.get_prim_path(prim) == "/World/env_0/Cone"
-    prim_paths = prim_utils.find_matching_prim_paths("/World/env_*/Cone")
-    assert len(prim_paths) == num_clones
+    assert prim_utils.get_prim_path(prim) == "/World/template/Cone/asset_0"
+    prim_paths = sim_utils.find_matching_prim_paths("/World/template/Cone/asset_.*")
+    assert len(prim_paths) == 3
 
     for prim_path in prim_paths:
         prim = prim_utils.get_prim_at_path(prim_path)
@@ -130,16 +190,13 @@ Tests - Multiple USDs.
 
 def test_spawn_multiple_files_with_global_settings(sim):
     """Test spawning of files randomly with global articulation settings."""
-    num_clones = 10
-    for i in range(num_clones):
-        prim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+    prim_utils.create_prim("/World/template", "Xform", translation=(0, 0, 0))
 
     cfg = sim_utils.MultiUsdFileCfg(
         usd_path=[
             f"{ISAACLAB_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-C/anymal_c.usd",
             f"{ISAACLAB_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-D/anymal_d.usd",
         ],
-        random_choice=True,
         rigid_props=sim_utils.RigidBodyPropertiesCfg(
             disable_gravity=False,
             retain_accelerations=False,
@@ -154,9 +211,9 @@ def test_spawn_multiple_files_with_global_settings(sim):
         ),
         activate_contact_sensors=True,
     )
-    prim = cfg.func("/World/env_.*/Robot", cfg)
+    prim = cfg.func("/World/template/Robot/asset_.*", cfg)
 
     assert prim.IsValid()
-    assert prim_utils.get_prim_path(prim) == "/World/env_0/Robot"
-    prim_paths = prim_utils.find_matching_prim_paths("/World/env_*/Robot")
-    assert len(prim_paths) == num_clones
+    assert prim_utils.get_prim_path(prim) == "/World/template/Robot/asset_0"
+    prim_paths = sim_utils.find_matching_prim_paths("/World/template/Robot/asset_.*")
+    assert len(prim_paths) == 2


### PR DESCRIPTION
# Description

Adds missing enable_clone from MultiAssetSpawnerCfg

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
