### PR TITLE
[Newton] Fixes cloner env spacing

### DIFF
--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -177,7 +177,7 @@ class InteractiveScene:
 
             if not copy_from_source:
                 # skip physx cloning, this means physx will walk and parse the stage one by one faithfully
-                cloner.newton_replicate(self.stage, *replicate_args)
+                cloner.newton_replicate(self.stage, *replicate_args, positions=self._default_env_origins)
             cloner.usd_replicate(self.stage, *replicate_args, positions=self._default_env_origins)
 
     def filter_collisions(self, global_prim_paths: list[str] | None = None):


### PR DESCRIPTION
# Description

This PR fixes env spacing issue seen in the allegro 

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
