### PR TITLE
[Newton] Disables auto env spacing in Newton Viewer

### DIFF
--- a/source/isaaclab/isaaclab/visualizers/newton_visualizer.py
+++ b/source/isaaclab/isaaclab/visualizers/newton_visualizer.py
@@ -287,10 +287,8 @@ class NewtonVisualizer(Visualizer):
         # Set the model
         self._viewer.set_model(self._model)
 
-        # Configure environment spacing/offsets
-        if not self.cfg.auto_env_spacing:
-            # Display at actual world positions (no offset)
-            self._viewer.set_world_offsets((0.0, 0.0, 0.0))
+        # Disable auto world spacing in Newton Viewer to display envs at actual world positions
+        self._viewer.set_world_offsets((0.0, 0.0, 0.0))
 
         # Configure camera
         self._viewer.camera.pos = wp.vec3(*self.cfg.camera_position)

--- a/source/isaaclab/isaaclab/visualizers/newton_visualizer_cfg.py
+++ b/source/isaaclab/isaaclab/visualizers/newton_visualizer_cfg.py
@@ -72,8 +72,3 @@ class NewtonVisualizerCfg(VisualizerCfg):
 
     light_color: tuple[float, float, float] = (1.0, 1.0, 1.0)
     """Light color RGB [0,1]."""
-
-    auto_env_spacing: bool = False
-    """Enable automatic environment spacing based on environment extents.
-    If False, environments are displayed at their actual world positions.
-    """


### PR DESCRIPTION
# Description

Disable auto env spacing in Newton Viewer by setting directly world offsets to 0. 

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
