### PR TITLE
[Newton] Fixes bugs in environment and inference scripts when not launching kit

### DIFF
--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -253,9 +253,8 @@ outDirectory = "${data}"
 ###############################
 [settings.exts."omni.kit.registry.nucleus"]
 registries = [
-    { name = "kit/default", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/107/shared" },
-    { name = "kit/sdk", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/sdk/${kit_version_short}/${kit_git_hash}" },
-    { name = "kit/community", url = "https://dw290v42wisod.cloudfront.net/exts/kit/community" },
+    { name = "kit/default", url = "omniverse://kit-extensions.ov.nvidia.com/exts/kit/default" },
+    { name = "kit/sdk", url = "omniverse://kit-extensions.ov.nvidia.com/exts/kit/sdk/${kit_version_short}/${kit_git_hash}" },
 ]
 [settings.app.extensions]
 skipPublishVerification = false

--- a/scripts/environments/random_agent.py
+++ b/scripts/environments/random_agent.py
@@ -32,6 +32,7 @@ simulation_app = app_launcher.app
 import gymnasium as gym
 import torch
 
+from isaaclab.utils import close_simulation, is_simulation_running
 from isaaclab.utils.timer import Timer
 
 Timer.enable = False
@@ -64,7 +65,7 @@ def main():
     # reset environment
     env.reset()
     # simulate environment
-    while simulation_app.is_running():
+    while is_simulation_running(simulation_app, env.unwrapped.sim):
         # run everything in inference mode
         with torch.inference_mode():
             # sample actions from -1 to 1
@@ -80,4 +81,4 @@ if __name__ == "__main__":
     # run the main function
     main()
     # close sim app
-    simulation_app.close()
+    close_simulation(simulation_app)

--- a/scripts/environments/zero_agent.py
+++ b/scripts/environments/zero_agent.py
@@ -32,6 +32,7 @@ simulation_app = app_launcher.app
 import gymnasium as gym
 import torch
 
+from isaaclab.utils import close_simulation, is_simulation_running
 from isaaclab.utils.timer import Timer
 
 Timer.enable = False
@@ -64,7 +65,7 @@ def main():
     # reset environment
     env.reset()
     # simulate environment
-    while simulation_app.is_running():
+    while is_simulation_running(simulation_app, env.unwrapped.sim):
         # run everything in inference mode
         with torch.inference_mode():
             # compute zero actions
@@ -80,4 +81,4 @@ if __name__ == "__main__":
     # run the main function
     main()
     # close sim app
-    simulation_app.close()
+    close_simulation(simulation_app)

--- a/scripts/reinforcement_learning/rl_games/play.py
+++ b/scripts/reinforcement_learning/rl_games/play.py
@@ -57,6 +57,7 @@ from rl_games.common import env_configurations, vecenv
 from rl_games.common.player import BasePlayer
 from rl_games.torch_runner import Runner
 
+from isaaclab.utils import close_simulation, is_simulation_running
 from isaaclab.utils.timer import Timer
 
 Timer.enable = False
@@ -172,7 +173,7 @@ def main():
     # note: We simplified the logic in rl-games player.py (:func:`BasePlayer.run()`) function in an
     #   attempt to have complete control over environment stepping. However, this removes other
     #   operations such as masking that is used for multi-agent learning by RL-Games.
-    while simulation_app.is_running():
+    while is_simulation_running(simulation_app, env.unwrapped.sim):
         start_time = time.time()
         # run everything in inference mode
         with torch.inference_mode():
@@ -208,5 +209,4 @@ if __name__ == "__main__":
     # run the main function
     main()
     # close sim app
-    if simulation_app:
-        simulation_app.close()
+    close_simulation(simulation_app)

--- a/scripts/reinforcement_learning/rsl_rl/play.py
+++ b/scripts/reinforcement_learning/rsl_rl/play.py
@@ -61,6 +61,8 @@ import torch
 
 from rsl_rl.runners import DistillationRunner, OnPolicyRunner
 
+from isaaclab.utils import close_simulation, is_simulation_running
+from isaaclab.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 from isaaclab.utils.timer import Timer
 
 Timer.enable = False
@@ -71,7 +73,6 @@ import isaaclab_tasks_experimental  # noqa: F401
 from isaaclab.envs import DirectRLEnvCfg, ManagerBasedRLEnvCfg
 from isaaclab.utils.assets import retrieve_file_path
 from isaaclab.utils.dict import print_dict
-from isaaclab.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
 from isaaclab_rl.rsl_rl import RslRlBaseRunnerCfg, RslRlVecEnvWrapper, export_policy_as_jit, export_policy_as_onnx
 
@@ -176,7 +177,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg, agent_cfg: RslRlBaseRun
     obs = env.get_observations()
     timestep = 0
     # simulate environment
-    while simulation_app.is_running():
+    while is_simulation_running(simulation_app, env.unwrapped.sim):
         start_time = time.time()
         # run everything in inference mode
         with torch.inference_mode():
@@ -203,5 +204,4 @@ if __name__ == "__main__":
     # run the main function
     main()
     # close sim app
-    if simulation_app:
-        simulation_app.close()
+    close_simulation(simulation_app)

--- a/scripts/reinforcement_learning/sb3/play.py
+++ b/scripts/reinforcement_learning/sb3/play.py
@@ -58,6 +58,7 @@ import os
 import time
 import torch
 
+from isaaclab.utils import close_simulation, is_simulation_running
 from isaaclab.utils.timer import Timer
 
 Timer.enable = False
@@ -160,7 +161,7 @@ def main():
     obs = env.reset()
     timestep = 0
     # simulate environment
-    while simulation_app.is_running():
+    while is_simulation_running(simulation_app, env.unwrapped.sim):
         start_time = time.time()
         # run everything in inference mode
         with torch.inference_mode():
@@ -187,5 +188,4 @@ if __name__ == "__main__":
     # run the main function
     main()
     # close sim app
-    if simulation_app:
-        simulation_app.close()
+    close_simulation(simulation_app)

--- a/scripts/reinforcement_learning/skrl/play.py
+++ b/scripts/reinforcement_learning/skrl/play.py
@@ -68,6 +68,7 @@ import torch
 import skrl
 from packaging import version
 
+from isaaclab.utils import close_simulation, is_simulation_running
 from isaaclab.utils.timer import Timer
 
 Timer.enable = False
@@ -178,7 +179,7 @@ def main():
     obs, _ = env.reset()
     timestep = 0
     # simulate environment
-    while simulation_app.is_running():
+    while is_simulation_running(simulation_app, env.unwrapped.sim):
         start_time = time.time()
 
         # run everything in inference mode
@@ -212,5 +213,4 @@ if __name__ == "__main__":
     # run the main function
     main()
     # close sim app
-    if simulation_app:
-        simulation_app.close()
+    close_simulation(simulation_app)

--- a/scripts/sim2sim_transfer/rsl_rl_transfer.py
+++ b/scripts/sim2sim_transfer/rsl_rl_transfer.py
@@ -59,6 +59,7 @@ import yaml
 
 from rsl_rl.runners import OnPolicyRunner
 
+from isaaclab.utils import close_simulation, is_simulation_running
 from isaaclab.utils.timer import Timer
 
 Timer.enable = False
@@ -242,7 +243,7 @@ def main():
         return actions
 
     # simulate environment
-    while simulation_app.is_running():
+    while is_simulation_running(simulation_app, env.unwrapped.sim):
         start_time = time.time()
         # run everything in inference mode
         with torch.inference_mode():
@@ -269,4 +270,4 @@ if __name__ == "__main__":
     # run the main function
     main()
     # close sim app
-    simulation_app.close()
+    close_simulation(simulation_app)

--- a/source/isaaclab/isaaclab/utils/__init__.py
+++ b/source/isaaclab/isaaclab/utils/__init__.py
@@ -13,6 +13,7 @@ from .dict import *
 from .helpers import deprecated, warn_overhead_cost
 from .interpolation import *
 from .modifiers import *
+from .simulation_runner import close_simulation, is_simulation_running
 from .string import *
 from .timer import Timer
 from .types import *

--- a/source/isaaclab/isaaclab/utils/pretrained_checkpoint.py
+++ b/source/isaaclab/isaaclab/utils/pretrained_checkpoint.py
@@ -9,17 +9,12 @@ import glob
 import json
 import os
 
-import carb.settings
-
+import isaaclab.utils.assets as assets_utils
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry  # noqa: F401
 
-from .assets import retrieve_file_path
-
-PRETRAINED_CHECKPOINTS_ASSET_ROOT_DIR = carb.settings.get_settings().get(
-    "/persistent/isaaclab/asset_root/pretrained_checkpoints"
-)
+PRETRAINED_CHECKPOINTS_ASSET_ROOT_DIR = f"{assets_utils.NUCLEUS_ASSET_ROOT_DIR}"
 """Path to the root directory on the Nucleus Server."""
 
 WORKFLOWS = ["rl_games", "rsl_rl", "sb3", "skrl"]
@@ -124,7 +119,7 @@ def get_published_pretrained_checkpoint(workflow: str, task_name: str) -> str | 
     if not os.path.exists(resume_path):
         print(f"Fetching pre-trained checkpoint : {ov_path}")
         try:
-            resume_path = retrieve_file_path(ov_path, download_dir)
+            resume_path = assets_utils.retrieve_file_path(ov_path, download_dir)
         except Exception:
             print("A pre-trained checkpoint is currently unavailable for this task.")
             return None

--- a/source/isaaclab/isaaclab/utils/simulation_runner.py
+++ b/source/isaaclab/isaaclab/utils/simulation_runner.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Utility functions for running simulation loops with visualizer-agnostic is_running checks.
+
+This module provides a unified interface for running simulation loops that works with both
+Omniverse SimulationApp and standalone Newton/Rerun visualizers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from isaaclab.sim import SimulationContext
+
+
+def is_simulation_running(simulation_app: Any | None, sim_context: SimulationContext | None = None) -> bool:
+    """Check if the simulation should continue running.
+
+    This function abstracts the is_running check for both Omniverse and standalone modes:
+    - In Omniverse mode: delegates to SimulationApp.is_running()
+    - In standalone mode with visualizers: checks if any visualizer window is still open
+    - In headless mode (no visualizers): always returns True (use Ctrl+C or break to exit)
+
+    Args:
+        simulation_app: The SimulationApp instance from AppLauncher.app.
+            This will be None when running in standalone mode (Newton/Rerun visualizers).
+        sim_context: The SimulationContext instance (e.g., env.unwrapped.sim).
+            Required for checking visualizer status in standalone mode.
+
+    Returns:
+        True if the simulation loop should continue, False otherwise.
+
+    Example:
+
+        .. code-block:: python
+
+            from isaaclab.app import AppLauncher
+            from isaaclab.utils import is_simulation_running, close_simulation
+
+            app_launcher = AppLauncher(args_cli)
+            simulation_app = app_launcher.app
+
+            env = gym.make(args_cli.task, cfg=env_cfg)
+
+            while is_simulation_running(simulation_app, env.unwrapped.sim):
+                # ... step logic ...
+                pass
+
+            env.close()
+            close_simulation(simulation_app)
+
+    """
+    if simulation_app is not None:
+        # Omniverse mode - use SimulationApp's is_running
+        return simulation_app.is_running()
+
+    # Standalone mode - check visualizers if available
+    if sim_context is not None and hasattr(sim_context, "_visualizers"):
+        visualizers = sim_context._visualizers
+        if visualizers:
+            # Return True if at least one visualizer is still running
+            return any(v.is_running() for v in visualizers)
+
+    # Pure headless mode or no sim_context - always return True
+    # The user should use Ctrl+C or a break condition to exit the loop
+    return True
+
+
+def close_simulation(simulation_app: Any | None) -> None:
+    """Close the simulation app if running in Omniverse mode.
+
+    This function should be called at the end of the script to properly clean up resources.
+    In standalone mode, this is a no-op (visualizers are closed via SimulationContext).
+
+    Args:
+        simulation_app: The SimulationApp instance from AppLauncher.app, or None if standalone.
+
+    Example:
+
+        .. code-block:: python
+
+            # At end of script
+            env.close()
+            close_simulation(simulation_app)
+
+    """
+    if simulation_app is not None:
+        simulation_app.close()


### PR DESCRIPTION
# Description

Fixes environment and inference scripts to not use simulation_app when kit is not launched.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
