### PR TITLE
[Newton] Fix Cartpole "Error"

### DIFF
--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -2060,8 +2060,10 @@ class ArticulationData(BaseArticulationData):
         try:
             self._previous_root_com_vel = wp.clone(self._root_view.get_root_velocities(NewtonManager.get_state_0()))
         except Exception as e:
-            logger.error(f"Error getting root com velocity: {e}. If the articulation is fixed, this is expected.")
+            logger.warning(f"Failed to get root com velocity: {e}. If the articulation is fixed, this is expected.")
             self._previous_root_com_vel = wp.zeros((n_view, n_link), dtype=wp.spatial_vectorf, device=self.device)
+            logger.warning("Setting root com velocity to zeros.")
+            self._sim_bind_root_com_vel_w = wp.zeros((n_view, n_link), dtype=wp.spatial_vectorf, device=self.device)
         # -- default root pose and velocity
         self._default_root_pose = wp.zeros((n_view,), dtype=wp.transformf, device=self.device)
         self._default_root_vel = wp.zeros((n_view,), dtype=wp.spatial_vectorf, device=self.device)

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env.py
@@ -160,13 +160,13 @@ class CartpoleEnv(DirectRLEnv):
         )
         joint_vel = wp.to_torch(self.cartpole.data.default_joint_vel)[env_ids].clone()
 
-        default_root_state = wp.to_torch(self.cartpole.data.default_root_state)[env_ids].clone()
-        default_root_state[:, :3] += self.scene.env_origins[env_ids]
+        default_root_pose = wp.to_torch(self.cartpole.data.default_root_pose)[env_ids].clone()
+        default_root_pose[:, :3] += self.scene.env_origins[env_ids]
 
         self.joint_pos[env_ids] = joint_pos
         self.joint_vel[env_ids] = joint_vel
 
-        self.cartpole.write_root_pose_to_sim(default_root_state[:, :7], env_ids)
+        self.cartpole.write_root_pose_to_sim(default_root_pose, env_ids)
         self.cartpole.write_joint_state_to_sim(joint_pos, joint_vel, None, env_ids)
 
 


### PR DESCRIPTION
# Description

Changes cartpole to use default root pose + changed an error log into a warning.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
