### PR TITLE
Fixes collision synchronization in cuRobo planner

### DIFF
--- a/source/isaaclab_mimic/isaaclab_mimic/motion_planners/curobo/curobo_planner.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/motion_planners/curobo/curobo_planner.py
@@ -27,6 +27,7 @@ from isaaclab.envs.manager_based_env import ManagerBasedEnv
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.sim.spawners.materials import PreviewSurfaceCfg
 from isaaclab.sim.spawners.meshes import MeshSphereCfg, spawn_mesh_sphere
+from isaaclab.utils.math import subtract_frame_transforms
 
 from isaaclab_mimic.motion_planners.curobo.curobo_planner_cfg import CuroboPlannerCfg
 from isaaclab_mimic.motion_planners.motion_planner_base import MotionPlannerBase
@@ -626,6 +627,14 @@ class CuroboPlanner(MotionPlannerBase):
             env_origin = self.env.scene.env_origins[self.env_id]
             current_pos_raw = obj.data.root_pos_w[self.env_id] - env_origin
             current_quat_raw = obj.data.root_quat_w[self.env_id]  # (w, x, y, z)
+
+            # Transform object pose from world frame to robot base frame
+            robot_base_pos = self.robot.data.root_pos_w[self.env_id, :3]
+            robot_base_quat = self.robot.data.root_quat_w[self.env_id]  # [w, x, y, z]
+
+            current_pos_raw, current_quat_raw = subtract_frame_transforms(
+                robot_base_pos, robot_base_quat, current_pos_raw, current_quat_raw
+            )
 
             # Convert to cuRobo device and extract float values for pose list
             current_pos = self._to_curobo_device(current_pos_raw)


### PR DESCRIPTION
# Description

This PR fixes a bug in the cuRobo motion planner where object poses were not correctly transformed from world frame to robot base frame during  collision world synchronization.

The issue occurred in the `_sync_object_poses_with_isaaclab` method, which  was directly using world-frame object poses without accounting for the  robot's base position and orientation. This caused incorrect collision detection when the robot was not located at the origin point of world coordinate, as cuRobo expects poses relative to the robot base frame.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
