### PR TITLE
[Newton] Disables omni.kit.pip_archive to prevent numpy version conflicts

### DIFF
--- a/apps/isaaclab.python.headless.kit
+++ b/apps/isaaclab.python.headless.kit
@@ -99,6 +99,10 @@ isaac.startup.ros_bridge_extension = ""
 # disable the metrics assembler change listener, we don't want to do any runtime changes
 metricsAssembler.changeListenerEnabled = false
 
+# explicitly disable omni.kit.pip_archive to prevent conflicting dependencies
+# warp.core has this as a dependency, which forces numpy 1.26 to be pulled in
+app.extensions.excluded = ["omni.kit.pip_archive"]
+
 # Extensions
 ###############################
 [settings.exts."omni.kit.registry.nucleus"]

--- a/apps/isaaclab.python.headless.rendering.kit
+++ b/apps/isaaclab.python.headless.rendering.kit
@@ -94,6 +94,10 @@ exts."omni.replicator.core".Orchestrator.enabled = false
 # disable the metrics assembler change listener, we don't want to do any runtime changes
 metricsAssembler.changeListenerEnabled = false
 
+# explicitly disable omni.kit.pip_archive to prevent conflicting dependencies
+# warp.core has this as a dependency, which forces numpy 1.26 to be pulled in
+app.extensions.excluded = ["omni.kit.pip_archive"]
+
 [settings.exts."omni.kit.registry.nucleus"]
 registries = [
     { name = "kit/default", url = "https://ovextensionsprod.blob.core.windows.net/exts/kit/prod/107/shared" },

--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -131,6 +131,10 @@ metricsAssembler.changeListenerEnabled = false
 # set the default ros bridge to disable on startup
 isaac.startup.ros_bridge_extension = ""
 
+# explicitly disable omni.kit.pip_archive to prevent conflicting dependencies
+# warp.core has this as a dependency, which forces numpy 1.26 to be pulled in
+app.extensions.excluded = ["omni.kit.pip_archive"]
+
 # Disable for base application
 [settings."filter:platform"."windows-x86_64"]
 isaac.startup.ros_bridge_extension = ""

--- a/apps/isaaclab.python.rendering.kit
+++ b/apps/isaaclab.python.rendering.kit
@@ -92,6 +92,10 @@ exts."omni.replicator.core".Orchestrator.enabled = false
 # disable the metrics assembler change listener, we don't want to do any runtime changes
 metricsAssembler.changeListenerEnabled = false
 
+# explicitly disable omni.kit.pip_archive to prevent conflicting dependencies
+# warp.core has this as a dependency, which forces numpy 1.26 to be pulled in
+app.extensions.excluded = ["omni.kit.pip_archive"]
+
 [settings.physics]
 updateToUsd = false
 updateParticlesToUsd = false


### PR DESCRIPTION
# Description

omni.warp extension has omni.kit.pip_archive listed as a dependency, which forces numpy 1.26 to be pulled in from pip_archive even if it's not discovered by pip. This causes issues in newton code since mujoco-warp requires numpy 2+. We are now forcing omni.kit.pip_archive to be disabled so that we pick up the correct numpy version from pip.


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
