### PR TITLE
Clears object names list on initialization of RigidObjectCollection

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -166,6 +166,7 @@ Guidelines for modifications:
 * David Leon
 * Song Yi
 * Weihua Zhang
+* Tsz Ki GAO
 
 ## Acknowledgements
 

--- a/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab/isaaclab/assets/rigid_object_collection/rigid_object_collection.py
@@ -591,6 +591,8 @@ class RigidObjectCollection(AssetBase):
     """
 
     def _initialize_impl(self):
+        # clear object names list to prevent double counting on re-initialization
+        self._object_names_list.clear()
         # obtain global simulation view
         self._physics_sim_view = SimulationManager.get_physics_sim_view()
         root_prim_path_exprs = []


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

This PR fixes a bug in RigidObjectCollection where _object_names_list accumulates duplicate entries when the simulation resets multiple times, leading to incorrect object counts.

Fixes [# (4258)](https://github.com/isaac-sim/IsaacLab/issues/4258)

**Problem:** 
When using workflows that trigger multiple simulation resets (e.g., `record_demos.py`), the `_initialize_impl()` method gets called multiple times without clearing the existing `_object_names_list`, causing duplicate object names to be appended.

**Solution:**
Added `self._object_names_list.clear()` at the beginning of `_initialize_impl()` to ensure the list is reset before repopulating it, making the initialization process idempotent.

**Test Command:**
```bash
python scripts/tools/record_demos.py --task Isaac-Stack-Cube-Instance-Randomize-Franka-IK-Rel-v0 --teleop_device keyboard
```

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

<img width="1492" height="403" alt="image" src="https://github.com/user-attachments/assets/4402d016-85b3-43e6-8830-dcb862bcd8b7" />

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
