### PR TITLE
[Newton] Fixes more quaternion issues

### DIFF
--- a/source/isaaclab/isaaclab/assets/asset_base.py
+++ b/source/isaaclab/isaaclab/assets/asset_base.py
@@ -74,11 +74,14 @@ class AssetBase(ABC):
 
         # spawn the asset
         if self.cfg.spawn is not None:
+            # convert quaternion from xyzw (config) to wxyz (spawner expects)
+            rot = self.cfg.init_state.rot
+            orientation_wxyz = (rot[3], rot[0], rot[1], rot[2])
             self.cfg.spawn.func(
                 self.cfg.prim_path,
                 self.cfg.spawn,
                 translation=self.cfg.init_state.pos,
-                orientation=self.cfg.init_state.rot,
+                orientation=orientation_wxyz,
             )
         # check that spawn was successful
         matching_prims = sim_utils.find_matching_prims(self.cfg.prim_path)

--- a/source/isaaclab/isaaclab/assets/asset_base_cfg.py
+++ b/source/isaaclab/isaaclab/assets/asset_base_cfg.py
@@ -35,8 +35,8 @@ class AssetBaseCfg:
         pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
         """Position of the root in simulation world frame. Defaults to (0.0, 0.0, 0.0)."""
         rot: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0)
-        """Quaternion rotation (w, x, y, z) of the root in simulation world frame.
-        Defaults to (1.0, 0.0, 0.0, 0.0).
+        """Quaternion rotation (x, y, z, w) of the root in simulation world frame.
+        Defaults to (0.0, 0.0, 0.0, 1.0).
         """
 
     class_type: type[AssetBase] = None

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -610,11 +610,14 @@ class InteractiveScene:
             elif isinstance(asset_cfg, AssetBaseCfg):
                 # manually spawn asset
                 if asset_cfg.spawn is not None:
+                    # convert quaternion from xyzw (config) to wxyz (spawner expects)
+                    rot = asset_cfg.init_state.rot
+                    orientation_wxyz = (rot[3], rot[0], rot[1], rot[2])
                     asset_cfg.spawn.func(
                         asset_cfg.prim_path,
                         asset_cfg.spawn,
                         translation=asset_cfg.init_state.pos,
-                        orientation=asset_cfg.init_state.rot,
+                        orientation=orientation_wxyz,
                     )
                 # store xform prim view corresponding to this asset
                 # all prims in the scene are Xform prims (i.e. have a transform component)

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -118,18 +118,20 @@ class Camera(SensorBase):
 
         # spawn the asset
         if self.cfg.spawn is not None:
-            # compute the rotation offset
+            # compute the rotation offset (cfg.offset.rot is in xyzw format)
             rot = torch.tensor(self.cfg.offset.rot, dtype=torch.float32, device="cpu").unsqueeze(0)
             rot_offset = convert_camera_frame_orientation_convention(
                 rot, origin=self.cfg.offset.convention, target="opengl"
             )
             rot_offset = rot_offset.squeeze(0).cpu().numpy()
+            # convert from xyzw to wxyz for spawner
+            rot_offset_wxyz = (rot_offset[3], rot_offset[0], rot_offset[1], rot_offset[2])
             # ensure vertical aperture is set, otherwise replace with default for squared pixels
             if self.cfg.spawn.vertical_aperture is None:
                 self.cfg.spawn.vertical_aperture = self.cfg.spawn.horizontal_aperture * self.cfg.height / self.cfg.width
             # spawn the asset
             self.cfg.spawn.func(
-                self.cfg.prim_path, self.cfg.spawn, translation=self.cfg.offset.pos, orientation=rot_offset
+                self.cfg.prim_path, self.cfg.spawn, translation=self.cfg.offset.pos, orientation=rot_offset_wxyz
             )
         # check that spawn was successful
         matching_prims = sim_utils.find_matching_prims(self.cfg.prim_path)

--- a/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
@@ -24,8 +24,8 @@ class CameraCfg(SensorBaseCfg):
         pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
         """Translation w.r.t. the parent frame. Defaults to (0.0, 0.0, 0.0)."""
 
-        rot: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
-        """Quaternion rotation (w, x, y, z) w.r.t. the parent frame. Defaults to (1.0, 0.0, 0.0, 0.0)."""
+        rot: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0)
+        """Quaternion rotation (x, y, z, w) w.r.t. the parent frame. Defaults to (0.0, 0.0, 0.0, 1.0)."""
 
         convention: Literal["opengl", "ros", "world"] = "ros"
         """The convention in which the frame offset is applied. Defaults to "ros".

--- a/source/isaaclab/isaaclab/sim/converters/mesh_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/mesh_converter.py
@@ -151,9 +151,11 @@ class MeshConverter(AssetConverterBase):
         # translation
         translate_op = geom_xform.AddTranslateOp(UsdGeom.XformOp.PrecisionDouble)
         translate_op.Set(Gf.Vec3d(*cfg.translation))
-        # rotation
+        # rotation (cfg.rotation is in xyzw format, Gf.Quatd expects wxyz)
+        rot = cfg.rotation
+        rotation_wxyz = (rot[3], rot[0], rot[1], rot[2])
         orient_op = geom_xform.AddOrientOp(UsdGeom.XformOp.PrecisionDouble)
-        orient_op.Set(Gf.Quatd(*cfg.rotation))
+        orient_op.Set(Gf.Quatd(*rotation_wxyz))
         # scale
         scale_op = geom_xform.AddScaleOp(UsdGeom.XformOp.PrecisionDouble)
         scale_op.Set(Gf.Vec3d(*cfg.scale))

--- a/source/isaaclab/isaaclab/sim/converters/mesh_converter_cfg.py
+++ b/source/isaaclab/isaaclab/sim/converters/mesh_converter_cfg.py
@@ -41,8 +41,8 @@ class MeshConverterCfg(AssetConverterBaseCfg):
     translation: tuple[float, float, float] = (0.0, 0.0, 0.0)
     """The translation of the mesh to the origin. Defaults to (0.0, 0.0, 0.0)."""
 
-    rotation: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
-    """The rotation of the mesh in quaternion format (w, x, y, z). Defaults to (1.0, 0.0, 0.0, 0.0)."""
+    rotation: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0)
+    """The rotation of the mesh in quaternion format (x, y, z, w). Defaults to (0.0, 0.0, 0.0, 1.0)."""
 
     scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
     """The scale of the mesh. Defaults to (1.0, 1.0, 1.0)."""

--- a/source/isaaclab/test/assets/test_articulation.py
+++ b/source/isaaclab/test/assets/test_articulation.py
@@ -140,7 +140,7 @@ def generate_articulation_cfg(
             init_state=ArticulationCfg.InitialStateCfg(
                 pos=(0.0, 0.0, 0.0),
                 joint_pos=({"RevoluteJoint": 1.5708}),
-                rot=(0.7071055, 0.7071081, 0, 0),
+                rot=(0.7071081, 0, 0, 0.7071055),  # x, y, z, w
             ),
         )
     elif articulation_type == "single_joint_explicit":

--- a/source/isaaclab/test/sim/test_mesh_converter.py
+++ b/source/isaaclab/test/sim/test_mesh_converter.py
@@ -102,8 +102,11 @@ def check_mesh_conversion(mesh_converter: MeshConverter):
     pos = tuple(prim_utils.get_prim_at_path("/World/Object/geometry").GetAttribute("xformOp:translate").Get())
     assert pos == mesh_converter.cfg.translation
     quat = prim_utils.get_prim_at_path("/World/Object/geometry").GetAttribute("xformOp:orient").Get()
-    quat = (quat.GetReal(), quat.GetImaginary()[0], quat.GetImaginary()[1], quat.GetImaginary()[2])
-    assert quat == mesh_converter.cfg.rotation
+    # USD returns wxyz format, convert to xyzw to compare with cfg.rotation
+    quat_wxyz = (quat.GetReal(), quat.GetImaginary()[0], quat.GetImaginary()[1], quat.GetImaginary()[2])
+    # cfg.rotation is in xyzw format, so convert wxyz to xyzw for comparison
+    quat_xyzw = (quat_wxyz[1], quat_wxyz[2], quat_wxyz[3], quat_wxyz[0])
+    assert quat_xyzw == mesh_converter.cfg.rotation
     scale = tuple(prim_utils.get_prim_at_path("/World/Object/geometry").GetAttribute("xformOp:scale").Get())
     assert scale == mesh_converter.cfg.scale
 

--- a/source/isaaclab/test/utils/test_configclass.py
+++ b/source/isaaclab/test/utils/test_configclass.py
@@ -107,7 +107,7 @@ class EnvCfg:
 @configclass
 class RobotDefaultStateCfg:
     pos = (0.0, 0.0, 0.0)  # type annotation missing on purpose (immutable)
-    rot: tuple = (1.0, 0.0, 0.0, 0.0)
+    rot: tuple = (0.0, 0.0, 0.0, 1.0)  # x, y, z, w
     dof_pos: tuple = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     dof_vel = [0.0, 0.0, 0.0, 0.0, 0.0, 1.0]  # type annotation missing on purpose (mutable)
 
@@ -217,7 +217,7 @@ class ChildADemoCfg(ParentDemoCfg):
 
     def __post_init__(self):
         self.b = 3  # change value of existing field
-        self.m.rot = (2.0, 0.0, 0.0, 0.0)  # change value of default
+        self.m.rot = (0.0, 0.0, 0.0, 2.0)  # change value of default (x, y, z, w)
         self.i = ["a", "b"]  # change value of existing field
 
 
@@ -401,7 +401,7 @@ basic_demo_cfg_correct = {
     "env": {"num_envs": 56, "episode_length": 2000, "viewer": {"eye": [7.5, 7.5, 7.5], "lookat": [0.0, 0.0, 0.0]}},
     "robot_default_state": {
         "pos": (0.0, 0.0, 0.0),
-        "rot": (1.0, 0.0, 0.0, 0.0),
+        "rot": (0.0, 0.0, 0.0, 1.0),
         "dof_pos": (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
@@ -413,7 +413,7 @@ basic_demo_cfg_change_correct = {
     "env": {"num_envs": 22, "episode_length": 2000, "viewer": {"eye": (2.0, 2.0, 2.0), "lookat": [0.0, 0.0, 0.0]}},
     "robot_default_state": {
         "pos": (0.0, 0.0, 0.0),
-        "rot": (1.0, 0.0, 0.0, 0.0),
+        "rot": (0.0, 0.0, 0.0, 1.0),
         "dof_pos": (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
@@ -425,7 +425,7 @@ basic_demo_cfg_change_with_none_correct = {
     "env": {"num_envs": 22, "episode_length": 2000, "viewer": None},
     "robot_default_state": {
         "pos": (0.0, 0.0, 0.0),
-        "rot": (1.0, 0.0, 0.0, 0.0),
+        "rot": (0.0, 0.0, 0.0, 1.0),
         "dof_pos": (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
@@ -437,7 +437,7 @@ basic_demo_cfg_change_with_tuple_correct = {
     "env": {"num_envs": 56, "episode_length": 2000, "viewer": {"eye": [7.5, 7.5, 7.5], "lookat": [0.0, 0.0, 0.0]}},
     "robot_default_state": {
         "pos": (0.0, 0.0, 0.0),
-        "rot": (1.0, 0.0, 0.0, 0.0),
+        "rot": (0.0, 0.0, 0.0, 1.0),
         "dof_pos": (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
@@ -459,7 +459,7 @@ basic_demo_post_init_cfg_correct = {
     "env": {"num_envs": 56, "episode_length": 2000, "viewer": {"eye": [7.5, 7.5, 7.5], "lookat": [0.0, 0.0, 0.0]}},
     "robot_default_state": {
         "pos": (0.0, 0.0, 0.0),
-        "rot": (1.0, 0.0, 0.0, 0.0),
+        "rot": (0.0, 0.0, 0.0, 1.0),
         "dof_pos": (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         "dof_vel": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
     },
@@ -930,7 +930,7 @@ def test_config_inheritance():
     # check post init
     assert cfg_a.b == 3
     assert cfg_a.i == ["a", "b"]
-    assert cfg_a.m.rot == (2.0, 0.0, 0.0, 0.0)
+    assert cfg_a.m.rot == (0.0, 0.0, 0.0, 2.0)
 
 
 def test_config_inheritance_independence():
@@ -951,8 +951,8 @@ def test_config_inheritance_independence():
     assert cfg_b.b == 8
     assert cfg_a.c == RobotDefaultStateCfg()
     assert isinstance(cfg_b.c, type(MISSING))
-    assert cfg_a.m.rot == (2.0, 0.0, 0.0, 0.0)
-    assert cfg_b.m.rot == (1.0, 0.0, 0.0, 0.0)
+    assert cfg_a.m.rot == (0.0, 0.0, 0.0, 2.0)
+    assert cfg_b.m.rot == (0.0, 0.0, 0.0, 1.0)
     assert isinstance(cfg_a.j, type(MISSING))
     assert cfg_b.j == ["3", "4"]
     assert cfg_a.i == ["a", "b"]

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -34,7 +34,7 @@ ALLEGRO_HAND_CFG = ArticulationCfg(
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         pos=(0.0, 0.0, 0.5),
-        rot=(0.257551, 0.283045, 0.683330, -0.621782),
+        rot=(0.283045, 0.683330, -0.621782, 0.257551),  # x, y, z, w
         joint_pos={"^(?!thumb_joint_0).*": 0.0, "thumb_joint_0": 0.28},
     ),
     actuators={

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -1843,13 +1843,8 @@ class Articulation(BaseArticulation):
 
     def _process_cfg(self):
         """Post processing of configuration parameters."""
-        # default pose with quaternion given as (w, x, y, z) --> (x, y, z, w)
-        default_root_pose = tuple(self.cfg.init_state.pos) + (
-            self.cfg.init_state.rot[1],
-            self.cfg.init_state.rot[2],
-            self.cfg.init_state.rot[3],
-            self.cfg.init_state.rot[0],
-        )
+        # default pose with quaternion already in (x, y, z, w) format
+        default_root_pose = tuple(self.cfg.init_state.pos) + tuple(self.cfg.init_state.rot)
         # update the default root pose
         self._update_array_with_value(
             wp.transformf(*default_root_pose), self._data.default_root_pose, self.num_instances

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
@@ -956,13 +956,8 @@ class RigidObject(BaseRigidObject):
 
     def _process_cfg(self) -> None:
         """Post processing of configuration parameters."""
-        # default pose with quaternion given as (w, x, y, z) --> (x, y, z, w)
-        default_root_pose = tuple(self.cfg.init_state.pos) + (
-            self.cfg.init_state.rot[1],
-            self.cfg.init_state.rot[2],
-            self.cfg.init_state.rot[3],
-            self.cfg.init_state.rot[0],
-        )
+        # default pose with quaternion already in (x, y, z, w) format
+        default_root_pose = tuple(self.cfg.init_state.pos) + tuple(self.cfg.init_state.rot)
         # update the default root pose
         self._update_array_with_value(
             wp.transformf(*default_root_pose), self._data.default_root_pose, self.num_instances

--- a/source/isaaclab_newton/test/assets/articulation/test_articulation.py
+++ b/source/isaaclab_newton/test/assets/articulation/test_articulation.py
@@ -3005,7 +3005,7 @@ class TestProcessCfg:
     """Tests for _process_cfg method.
 
     Tests that the configuration processing correctly:
-    - Converts quaternion from (w, x, y, z) to (x, y, z, w) format for default root pose
+    - Uses quaternion in (x, y, z, w) format for default root pose
     - Sets default root velocity from lin_vel and ang_vel
     - Sets default joint positions from joint_pos dict with pattern matching
     - Sets default joint velocities from joint_vel dict with pattern matching
@@ -3023,15 +3023,15 @@ class TestProcessCfg:
         )
 
         # Set up init_state with specific position and rotation
-        # Rotation is in (w, x, y, z) format in the config
+        # Rotation is in (x, y, z, w) format in the config
         articulation.cfg.init_state.pos = (1.0, 2.0, 3.0)
-        articulation.cfg.init_state.rot = (0.707, 0.0, 0.707, 0.0)  # w, x, y, z
+        articulation.cfg.init_state.rot = (0.0, 0.707, 0.0, 0.707)  # x, y, z, w
 
         # Call _process_cfg
         articulation._process_cfg()
 
         # Verify the default root pose
-        # Expected: position (1, 2, 3) + quaternion converted to (x, y, z, w) = (0, 0.707, 0, 0.707)
+        # Expected: position (1, 2, 3) + quaternion in (x, y, z, w) = (0, 0.707, 0, 0.707)
         expected_pose = torch.tensor(
             [[1.0, 2.0, 3.0, 0.0, 0.707, 0.0, 0.707]] * num_instances,
             device=device,
@@ -3191,15 +3191,15 @@ class TestProcessCfg:
             device=device,
         )
 
-        # Set up init_state with identity quaternion (w=1, x=0, y=0, z=0)
+        # Set up init_state with identity quaternion (x=0, y=0, z=0, w=1)
         articulation.cfg.init_state.pos = (0.0, 0.0, 0.0)
-        articulation.cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)  # Identity: w, x, y, z
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.0, 1.0)  # Identity: x, y, z, w
 
         # Call _process_cfg
         articulation._process_cfg()
 
         # Verify the default root pose
-        # Expected: position (0, 0, 0) + quaternion converted to (x, y, z, w) = (0, 0, 0, 1)
+        # Expected: position (0, 0, 0) + quaternion in (x, y, z, w) = (0, 0, 0, 1)
         expected_pose = torch.tensor(
             [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]] * num_instances,
             device=device,
@@ -3222,7 +3222,7 @@ class TestProcessCfg:
 
         # Set up init_state
         articulation.cfg.init_state.pos = (1.0, 2.0, 3.0)
-        articulation.cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.0, 1.0)  # x, y, z, w
         articulation.cfg.init_state.lin_vel = (0.5, 0.5, 0.5)
         articulation.cfg.init_state.ang_vel = (0.1, 0.1, 0.1)
         articulation.cfg.init_state.joint_pos = {}
@@ -3285,7 +3285,7 @@ class TestProcessCfg:
 
         # Set up default root pose in config: position (1.0, 2.0, 3.0), identity quaternion
         articulation.cfg.init_state.pos = (1.0, 2.0, 3.0)
-        articulation.cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)  # w, x, y, z (identity)
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.0, 1.0)  # x, y, z, w (identity)
 
         # Set up initial spawned positions for each instance
         # Instance 0: (5.0, 6.0, 0.0)
@@ -3335,7 +3335,7 @@ class TestProcessCfg:
 
         # Set up default root pose with zero position
         articulation.cfg.init_state.pos = (0.0, 0.0, 0.0)
-        articulation.cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.0, 1.0)  # x, y, z, w
 
         # Set up initial spawned positions
         spawned_transforms = torch.tensor(
@@ -3375,9 +3375,9 @@ class TestProcessCfg:
         )
 
         # Set up default root pose with specific rotation (90 degrees around z-axis)
-        # Quaternion for 90 degrees around z: (w=0.707, x=0, y=0, z=0.707)
+        # Quaternion for 90 degrees around z: (x=0, y=0, z=0.707, w=0.707)
         articulation.cfg.init_state.pos = (1.0, 2.0, 5.0)
-        articulation.cfg.init_state.rot = (0.707, 0.0, 0.0, 0.707)  # w, x, y, z
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.707, 0.707)  # x, y, z, w
 
         # Set up initial spawned positions
         spawned_transforms = torch.tensor(

--- a/source/isaaclab_newton/test/assets/rigid_object/test_rigid_object.py
+++ b/source/isaaclab_newton/test/assets/rigid_object/test_rigid_object.py
@@ -3005,7 +3005,7 @@ class TestProcessCfg:
     """Tests for _process_cfg method.
 
     Tests that the configuration processing correctly:
-    - Converts quaternion from (w, x, y, z) to (x, y, z, w) format for default root pose
+    - Uses quaternion in (x, y, z, w) format for default root pose
     - Sets default root velocity from lin_vel and ang_vel
     - Sets default joint positions from joint_pos dict with pattern matching
     - Sets default joint velocities from joint_vel dict with pattern matching
@@ -3023,15 +3023,15 @@ class TestProcessCfg:
         )
 
         # Set up init_state with specific position and rotation
-        # Rotation is in (w, x, y, z) format in the config
+        # Rotation is in (x, y, z, w) format in the config
         articulation.cfg.init_state.pos = (1.0, 2.0, 3.0)
-        articulation.cfg.init_state.rot = (0.707, 0.0, 0.707, 0.0)  # w, x, y, z
+        articulation.cfg.init_state.rot = (0.0, 0.707, 0.0, 0.707)  # x, y, z, w
 
         # Call _process_cfg
         articulation._process_cfg()
 
         # Verify the default root pose
-        # Expected: position (1, 2, 3) + quaternion converted to (x, y, z, w) = (0, 0.707, 0, 0.707)
+        # Expected: position (1, 2, 3) + quaternion in (x, y, z, w) = (0, 0.707, 0, 0.707)
         expected_pose = torch.tensor(
             [[1.0, 2.0, 3.0, 0.0, 0.707, 0.0, 0.707]] * num_instances,
             device=device,
@@ -3191,15 +3191,15 @@ class TestProcessCfg:
             device=device,
         )
 
-        # Set up init_state with identity quaternion (w=1, x=0, y=0, z=0)
+        # Set up init_state with identity quaternion (x=0, y=0, z=0, w=1)
         articulation.cfg.init_state.pos = (0.0, 0.0, 0.0)
-        articulation.cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)  # Identity: w, x, y, z
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.0, 1.0)  # Identity: x, y, z, w
 
         # Call _process_cfg
         articulation._process_cfg()
 
         # Verify the default root pose
-        # Expected: position (0, 0, 0) + quaternion converted to (x, y, z, w) = (0, 0, 0, 1)
+        # Expected: position (0, 0, 0) + quaternion in (x, y, z, w) = (0, 0, 0, 1)
         expected_pose = torch.tensor(
             [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]] * num_instances,
             device=device,
@@ -3222,7 +3222,7 @@ class TestProcessCfg:
 
         # Set up init_state
         articulation.cfg.init_state.pos = (1.0, 2.0, 3.0)
-        articulation.cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.0, 1.0)  # x, y, z, w
         articulation.cfg.init_state.lin_vel = (0.5, 0.5, 0.5)
         articulation.cfg.init_state.ang_vel = (0.1, 0.1, 0.1)
         articulation.cfg.init_state.joint_pos = {}
@@ -3285,7 +3285,7 @@ class TestProcessCfg:
 
         # Set up default root pose in config: position (1.0, 2.0, 3.0), identity quaternion
         articulation.cfg.init_state.pos = (1.0, 2.0, 3.0)
-        articulation.cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)  # w, x, y, z (identity)
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.0, 1.0)  # x, y, z, w (identity)
 
         # Set up initial spawned positions for each instance
         # Instance 0: (5.0, 6.0, 0.0)
@@ -3335,7 +3335,7 @@ class TestProcessCfg:
 
         # Set up default root pose with zero position
         articulation.cfg.init_state.pos = (0.0, 0.0, 0.0)
-        articulation.cfg.init_state.rot = (1.0, 0.0, 0.0, 0.0)
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.0, 1.0)  # x, y, z, w
 
         # Set up initial spawned positions
         spawned_transforms = torch.tensor(
@@ -3375,9 +3375,9 @@ class TestProcessCfg:
         )
 
         # Set up default root pose with specific rotation (90 degrees around z-axis)
-        # Quaternion for 90 degrees around z: (w=0.707, x=0, y=0, z=0.707)
+        # Quaternion for 90 degrees around z: (x=0, y=0, z=0.707, w=0.707)
         articulation.cfg.init_state.pos = (1.0, 2.0, 5.0)
-        articulation.cfg.init_state.rot = (0.707, 0.0, 0.0, 0.707)  # w, x, y, z
+        articulation.cfg.init_state.rot = (0.0, 0.0, 0.707, 0.707)  # x, y, z, w
 
         # Set up initial spawned positions
         spawned_transforms = torch.tensor(

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/allegro_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/allegro_hand_env_cfg.py
@@ -95,7 +95,7 @@ class AllegroHandEnvCfg(DirectRLEnvCfg):
             mass_props=sim_utils.MassPropertiesCfg(density=400.0),
             scale=(1.2, 1.2, 1.2),
         ),
-        init_state=ArticulationCfg.InitialStateCfg(pos=(0.0, -0.17, 0.56), rot=(1.0, 0.0, 0.0, 0.0)),
+        init_state=ArticulationCfg.InitialStateCfg(pos=(0.0, -0.17, 0.56), rot=(0.0, 0.0, 0.0, 1.0)),
         actuators={},
         articulation_root_prim_path="",
     )

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env.py
@@ -82,7 +82,7 @@ class CartpoleDepthCameraEnvCfg(CartpoleRGBCameraEnvCfg):
     # camera
     tiled_camera: TiledCameraCfg = TiledCameraCfg(
         prim_path="/World/envs/env_.*/Camera",
-        offset=TiledCameraCfg.OffsetCfg(pos=(-5.0, 0.0, 2.0), rot=(1.0, 0.0, 0.0, 0.0), convention="world"),
+        offset=TiledCameraCfg.OffsetCfg(pos=(-5.0, 0.0, 2.0), rot=(0.0, 0.0, 0.0, 1.0), convention="world"),
         data_types=["depth"],
         spawn=sim_utils.PinholeCameraCfg(
             focal_length=24.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 20.0)

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/locomotion/locomotion_env.py
@@ -86,7 +86,7 @@ class LocomotionEnv(DirectRLEnv):
             (self.num_envs, 1)
         )
         self.targets += self.scene.env_origins
-        self.start_rotation = torch.tensor([1, 0, 0, 0], device=self.sim.device, dtype=torch.float32)
+        self.start_rotation = torch.tensor([0, 0, 0, 1], device=self.sim.device, dtype=torch.float32)  # x, y, z, w
         self.up_vec = torch.tensor([0, 0, 1], dtype=torch.float32, device=self.sim.device).repeat((self.num_envs, 1))
         self.heading_vec = torch.tensor([1, 0, 0], dtype=torch.float32, device=self.sim.device).repeat(
             (self.num_envs, 1)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
@@ -208,7 +208,7 @@ class HumanoidEnvCfg(ManagerBasedRLEnvCfg):
         # simulation settings
         self.sim.dt = 1 / 120.0
         self.sim.newton_cfg.num_substeps = 2
-        self.sim.newton_cfg.solver_cfg.njmax = 80
+        self.sim.newton_cfg.solver_cfg.njmax = 100
         self.sim.newton_cfg.solver_cfg.nconmax = 25
         self.sim.newton_cfg.solver_cfg.ls_iterations = 15
         self.sim.newton_cfg.solver_cfg.ls_parallel = True


### PR DESCRIPTION
# Description

Switches initial transform quaternion convention to XYZW and fixes some issues with how that's parsed/used in various classes and tests.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
