### PR TITLE
[Newton]Fixes xform prim set_world_poses to respect its ancestral transform tree

### DIFF
--- a/source/isaaclab/isaaclab/sim/prims/xform_prim.py
+++ b/source/isaaclab/isaaclab/sim/prims/xform_prim.py
@@ -246,7 +246,6 @@ class XFormPrim:
         local_tf = Gf.Transform(local_m)
         return local_tf.GetTranslation(), local_tf.GetRotation().GetQuat()
 
-
     def set_world_poses(
         self,
         positions: torch.Tensor | np.ndarray | Sequence[float] | None = None,


### PR DESCRIPTION
# Description

Our pure-USD `XFormPrim.set_world_poses() `was writing world positions/orientations directly into local `xformOp:translate/orient`, instead of converting the desired world pose into the prim’s parent-local frame. For prims under a transformed parent/ancestor, this could bake the parent’s world translation into the child’s local translate, effectively applying the translation twice (and leading to misplaced collision geometry / missing contacts). This PR fixes `set_world_poses()` to compute local ops via world→local conversion using the parent transform, matching expected world-pose semantics.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
