### PR TITLE
Improves uv environment support in isaaclab.sh

### DIFF
--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -584,7 +584,7 @@ while [[ $# -gt 0 ]]; do
             python_exe=$(extract_python_exe)
             pip_command=$(extract_pip_command)
             pip_uninstall_command=$(extract_pip_uninstall_command)
-            
+
             # show which environment is being used
             if [ -n "${VIRTUAL_ENV}" ]; then
                 echo "[INFO] Using uv/venv environment: ${VIRTUAL_ENV}"


### PR DESCRIPTION
# Description

This PR enhances the `isaaclab.sh` installation script to support flexible virtual environment workflows by allowing installation into existing uv/venv environments.

## Changes

- **Environment Detection**: Detect and use active uv/venv/conda environments during installation
- **Environment Display**: Show current environment path and Python executable when installing
- **Smart Python Selection**: Auto-detect Isaac Sim version (4.5 vs 5.0+) and select appropriate Python version (3.10 vs 3.11)
- **Improved UX**: Provide helpful hints when running `-u` with an active environment
- **Compatibility Fix**: Fix tabs command error in non-interactive terminals

## Motivation

Previously, users had to create a new environment in the IsaacLab directory. This PR enables modern Python workflows where users can:
- Install Isaac Lab into project-specific virtual environments
- Use `uv` project-based workflows
- Manage multiple Isaac Lab installations in different environments
The issue is mentioned in https://github.com/isaac-sim/IsaacLab/issues/3783 and https://github.com/isaac-sim/IsaacLab/pull/3560
## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (help text improvements)

## Testing

Tested scenarios:
- ✅ Installation in existing uv environment
- ✅ Installation in existing conda environment
- ✅ Creating new environment with `-u` flag
- ✅ Environment switching between multiple installations
- ✅ Script help output (`./isaaclab.sh -h`)

## Checklist

- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (help text)
- [x] My changes generate no new warnings
- [x] Maintains backward compatibility with existing workflows