### PR TITLE
Passes `stage` argument to avoid unnecessary stage retrieval calls

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.51.1"
+version = "0.52.0"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,23 @@
 Changelog
 ---------
 
+0.52.0 (2026-01-02)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :mod:`~isaaclab.sim.utils.transforms` module to handle USD Xform operations.
+* Added passing of ``stage`` to the :func:`~isaaclab.sim.utils.prims.create_prim` function
+  inside spawning functions to allow for the creation of prims in a specific stage.
+
+Changed
+^^^^^^^
+
+* Changed :func:`~isaaclab.sim.utils.prims.create_prim` function to use the :mod:`~isaaclab.sim.utils.transforms`
+  module for USD Xform operations. It removes the usage of Isaac Sim's XformPrim class.
+
+
 0.51.2 (2025-12-30)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/sim/utils/prims.py
+++ b/source/isaaclab/isaaclab/sim/utils/prims.py
@@ -21,7 +21,7 @@ import omni.usd
 import usdrt  # noqa: F401
 from isaacsim.core.cloner import Cloner
 from omni.usd.commands import DeletePrimsCommand, MovePrimCommand
-from pxr import PhysxSchema, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
+from pxr import PhysxSchema, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade, UsdUtils
 
 from isaaclab.utils.string import to_camel_case
 from isaaclab.utils.version import get_isaac_sim_version
@@ -197,6 +197,12 @@ def delete_prim(prim_path: str | Sequence[str], stage: Usd.Stage | None = None) 
         prim_path = [prim_path]
     # get stage handle
     stage = get_current_stage() if stage is None else stage
+    # the prim command looks for the stage ID in the stage cache
+    # so we need to ensure the stage is cached
+    stage_cache = UsdUtils.StageCache.Get()
+    stage_id = stage_cache.GetId(stage).ToLongInt()
+    if stage_id < 0:
+        stage_id = stage_cache.Insert(stage).ToLongInt()
     # delete prims
     DeletePrimsCommand(prim_path, stage=stage).do()
 

--- a/source/isaaclab/isaaclab/sim/utils/transforms.py
+++ b/source/isaaclab/isaaclab/sim/utils/transforms.py
@@ -213,6 +213,38 @@ def standardize_xform_ops(
     return True
 
 
+def validate_standard_xform_ops(prim: Usd.Prim) -> bool:
+    """Validate if the transform operations on a prim are standardized.
+
+    This function checks if the transform operations on a prim are standardized to the canonical form:
+    [translate, orient, scale].
+
+    Args:
+        prim: The USD prim to validate.
+    """
+    # check if prim is valid
+    if not prim.IsValid():
+        logger.error(f"Prim at path '{prim.GetPath().pathString}' is not valid.")
+        return False
+    # check if prim is an xformable
+    if not prim.IsA(UsdGeom.Xformable):
+        logger.error(f"Prim at path '{prim.GetPath().pathString}' is not an xformable.")
+        return False
+    # get the xformable interface
+    xformable = UsdGeom.Xformable(prim)
+    # get the xform operation order
+    xform_op_order = xformable.GetOrderedXformOps()
+    xform_op_order = [op.GetOpName() for op in xform_op_order]
+    # check if the xform operation order is the canonical form
+    if xform_op_order != ["xformOp:translate", "xformOp:orient", "xformOp:scale"]:
+        msg = f"Xform operation order for prim at path '{prim.GetPath().pathString}' is not the canonical form."
+        msg += f" Received order: {xform_op_order}"
+        msg += " Expected order: ['xformOp:translate', 'xformOp:orient', 'xformOp:scale']"
+        logger.error(msg)
+        return False
+    return True
+
+
 def resolve_prim_pose(
     prim: Usd.Prim, ref_prim: Usd.Prim | None = None
 ) -> tuple[tuple[float, float, float], tuple[float, float, float, float]]:
@@ -268,19 +300,18 @@ def resolve_prim_pose(
     prim_tf = xform.ComputeLocalToWorldTransform(Usd.TimeCode.Default())
     # sanitize quaternion
     # this is needed, otherwise the quaternion might be non-normalized
-    prim_tf = prim_tf.GetOrthonormalized()
+    prim_tf.Orthonormalize()
 
     if ref_prim is not None:
-        # check if ref prim is valid
-        if not ref_prim.IsValid():
-            raise ValueError(f"Ref prim at path '{ref_prim.GetPath().pathString}' is not valid.")
-        # get ref prim xform
-        ref_xform = UsdGeom.Xformable(ref_prim)
-        ref_tf = ref_xform.ComputeLocalToWorldTransform(Usd.TimeCode.Default())
-        # make sure ref tf is orthonormal
-        ref_tf = ref_tf.GetOrthonormalized()
-        # compute relative transform to get prim in ref frame
-        prim_tf = prim_tf * ref_tf.GetInverse()
+        # if reference prim is the root, we can skip the computation
+        if ref_prim.GetPath() != Sdf.Path.absoluteRootPath:
+            # get ref prim xform
+            ref_xform = UsdGeom.Xformable(ref_prim)
+            ref_tf = ref_xform.ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+            # make sure ref tf is orthonormal
+            ref_tf.Orthonormalize()
+            # compute relative transform to get prim in ref frame
+            prim_tf = prim_tf * ref_tf.GetInverse()
 
     # extract position and orientation
     prim_pos = [*prim_tf.ExtractTranslation()]
@@ -345,15 +376,15 @@ def convert_world_pose_to_local(
     ``local_transform = world_transform * inverse(ref_world_transform)``
 
     .. note::
-        If the reference prim is invalid or is the root path, the position and orientation are returned
+        If the reference prim is the root prim ("/"), the position and orientation are returned
         unchanged, as they are already effectively in local/world space.
 
     Args:
         position: The world-space position as (x, y, z).
         orientation: The world-space orientation as quaternion (w, x, y, z). If None, only position is converted
             and None is returned for orientation.
-        ref_prim: The reference USD prim to compute the local transform relative to. If this is invalid or
-            is the root path, the world pose is returned unchanged.
+        ref_prim: The reference USD prim to compute the local transform relative to. If this is
+            the root prim ("/"), the world pose is returned unchanged.
 
     Returns:
         A tuple of (local_translation, local_orientation) where:
@@ -363,7 +394,6 @@ def convert_world_pose_to_local(
 
     Raises:
         ValueError: If the reference prim is not a valid USD prim.
-        ValueError: If the reference prim is not a valid USD Xformable.
 
     Example:
         >>> import isaaclab.sim as sim_utils
@@ -392,9 +422,6 @@ def convert_world_pose_to_local(
 
     # Check if reference prim is a valid xformable
     ref_xformable = UsdGeom.Xformable(ref_prim)
-    if not ref_xformable:
-        raise ValueError(f"Reference prim at path '{ref_prim.GetPath().pathString}' is not a valid xformable.")
-
     # Get reference prim's world transform
     ref_world_tf = ref_xformable.ComputeLocalToWorldTransform(Usd.TimeCode.Default())
 


### PR DESCRIPTION
# Description

This MR passes the `stage` attribute to the functions where applicable. This helps avoid unnecessary `get_current_stage()` calls as that calls the USD context and can be at times expensive. It is a better practice to give the stage as much as possible.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there