### PR TITLE
Blacklists amp motion from auto-import in `isaaclab_tasks`

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/__init__.py
@@ -34,6 +34,6 @@ from .utils import import_packages
 
 # The blacklist is used to prevent importing configs from sub-packages
 # TODO(@ashwinvk): Remove pick_place from the blacklist once pinocchio from Isaac Sim is compatibility
-_BLACKLIST_PKGS = ["utils", ".mdp", "pick_place"]
+_BLACKLIST_PKGS = ["utils", ".mdp", "pick_place", "direct.humanoid_amp.motions"]
 # Import all configs in this package
 import_packages(__name__, _BLACKLIST_PKGS)


### PR DESCRIPTION
# Description

The package walking code is somewhat brittle. It went into AMP motions sub-module, leading to a minor increase in import time. This MR fixes the issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there