### PR TITLE
Add check to avoid creating transforms for non-xformable prims

### DIFF
--- a/source/isaaclab/isaaclab/sim/utils/prims.py
+++ b/source/isaaclab/isaaclab/sim/utils/prims.py
@@ -161,6 +161,15 @@ def create_prim(
     if semantic_label is not None:
         add_labels(prim, labels=[semantic_label], instance_name=semantic_type)
 
+    # check if prim type is Xformable
+    if not prim.IsA(UsdGeom.Xformable):
+        logger.debug(
+            f"Prim at path '{prim.GetPath().pathString}' is of type '{prim.GetTypeName()}', "
+            "which is not an Xformable. Transform operations will not be standardized. "
+            "This is expected for material, shader, and scope prims."
+        )
+        return prim
+
     # convert input arguments to tuples
     position = _to_tuple(position) if position is not None else None
     translation = _to_tuple(translation) if translation is not None else None

--- a/source/isaaclab/isaaclab/sim/utils/transforms.py
+++ b/source/isaaclab/isaaclab/sim/utils/transforms.py
@@ -130,7 +130,11 @@ def standardize_xform_ops(
 
     # Check if prim is an Xformable
     if not prim.IsA(UsdGeom.Xformable):
-        logger.error(f"Prim at path '{prim.GetPath()}' is not an Xformable.")
+        logger.error(
+            f"Prim at path '{prim.GetPath().pathString}' is of type '{prim.GetTypeName()}', "
+            "which is not an Xformable. Transform operations will not be standardized. "
+            "This is expected for material, shader, and scope prims."
+        )
         return False
 
     # Create xformable interface

--- a/source/isaaclab/test/sim/test_utils_prims.py
+++ b/source/isaaclab/test/sim/test_utils_prims.py
@@ -249,6 +249,61 @@ def test_create_prim_with_world_position_different_types(input_type: str):
     assert quat_match or quat_match_neg
 
 
+def test_create_prim_non_xformable():
+    """Test create_prim() with non-Xformable prim types (Material, Shader, Scope).
+
+    This test verifies that prims which are not Xformable (like Material, Shader, Scope)
+    are created successfully but transform operations are not applied to them.
+    This is expected behavior as documented in the create_prim function.
+    """
+    # obtain stage handle
+    stage = sim_utils.get_current_stage()
+
+    # Test with Material prim (not Xformable)
+    material_prim = sim_utils.create_prim(
+        "/World/TestMaterial",
+        "Material",
+        stage=stage,
+        translation=(1.0, 2.0, 3.0),  # These should be ignored
+        orientation=(1.0, 0.0, 0.0, 0.0),  # These should be ignored
+        scale=(2.0, 2.0, 2.0),  # These should be ignored
+    )
+
+    # Verify prim was created
+    assert material_prim.IsValid()
+    assert material_prim.GetPrimPath() == "/World/TestMaterial"
+    assert material_prim.GetTypeName() == "Material"
+
+    # Verify that it's not Xformable
+    assert not material_prim.IsA(UsdGeom.Xformable)
+
+    # Verify that no xform operations were applied (Material prims don't support these)
+    assert not material_prim.HasAttribute("xformOp:translate")
+    assert not material_prim.HasAttribute("xformOp:orient")
+    assert not material_prim.HasAttribute("xformOp:scale")
+
+    # Test with Scope prim (not Xformable)
+    scope_prim = sim_utils.create_prim(
+        "/World/TestScope",
+        "Scope",
+        stage=stage,
+        translation=(5.0, 6.0, 7.0),  # These should be ignored
+    )
+
+    # Verify prim was created
+    assert scope_prim.IsValid()
+    assert scope_prim.GetPrimPath() == "/World/TestScope"
+    assert scope_prim.GetTypeName() == "Scope"
+
+    # Verify that it's not Xformable
+    assert not scope_prim.IsA(UsdGeom.Xformable)
+
+    # Verify that no xform operations were applied (Scope prims don't support these)
+    assert not scope_prim.HasAttribute("xformOp:translate")
+    assert not scope_prim.HasAttribute("xformOp:orient")
+    assert not scope_prim.HasAttribute("xformOp:scale")
+
+
 def test_delete_prim():
     """Test delete_prim() function."""
     # obtain stage handle


### PR DESCRIPTION
# Description

This MR ensures we don't try setting transforms for non-xformable prims (Scopes, Materials, Shaders). Previously, they were not being set but an error was being thrown.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there