### PR TITLE
Re-enable tests for UR10e robot with Robotiq gripper

### DIFF
--- a/source/isaaclab/test/sim/test_utils_prims.py
+++ b/source/isaaclab/test/sim/test_utils_prims.py
@@ -22,7 +22,7 @@ from pxr import Gf, Sdf, Usd, UsdGeom
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim.utils.prims import _to_tuple  # type: ignore[reportPrivateUsage]
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 
 
 @pytest.fixture(autouse=True)
@@ -406,8 +406,6 @@ def test_get_usd_references():
 def test_select_usd_variants():
     """Test select_usd_variants() function."""
     stage = sim_utils.get_current_stage()
-
-    # Create a dummy prim
     prim: Usd.Prim = UsdGeom.Xform.Define(stage, Sdf.Path("/World")).GetPrim()
     stage.SetDefaultPrim(prim)
 
@@ -422,52 +420,6 @@ def test_select_usd_variants():
 
     # Check if the variant selection is correct
     assert variant_set.GetVariantSelection() == "red"
-
-
-@pytest.mark.skip(reason="The USD asset seems to have some issues.")
-def test_select_usd_variants_in_usd_file():
-    """Test select_usd_variants() function in USD file."""
-    stage = sim_utils.get_current_stage()
-
-    prim = sim_utils.create_prim(
-        "/World/Test", "Xform", usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/UniversalRobots/ur10e/ur10e.usd", stage=stage
-    )
-
-    variant_sets = prim.GetVariantSets()
-
-    # show all variants
-    for name in variant_sets.GetNames():
-        vs = variant_sets.GetVariantSet(name)
-        options = vs.GetVariantNames()
-        selected = vs.GetVariantSelection()
-
-        print(f"{name}: {selected} / {options}")
-
-    print("Setting variant 'Gripper' to 'Robotiq_2f_140'.")
-    # The following performs the operations done internally
-    # in Isaac Lab. This should be removed in favor of 'select_usd_variants'.
-    target_vs = variant_sets.GetVariantSet("Gripper")
-    target_vs.SetVariantSelection("Robotiq_2f_140")
-
-    # show again all variants
-    variant_sets = prim.GetVariantSets()
-
-    for name in variant_sets.GetNames():
-        vs = variant_sets.GetVariantSet(name)
-        options = vs.GetVariantNames()
-        selected = vs.GetVariantSelection()
-
-        print(f"{name}: {selected} / {options}")
-
-    # Uncomment the following once resolved
-
-    # Set the variant selection
-    # sim_utils.select_usd_variants(prim.GetPath(), {"Gripper": "Robotiq_2f_140"}, stage)
-
-    # Obtain variant set
-    # variant_set = prim.GetVariantSet("Gripper")
-    # # Check if the variant selection is correct
-    # assert variant_set.GetVariantSelection() == "Robotiq_2f_140"
 
 
 """

--- a/source/isaaclab_assets/isaaclab_assets/robots/universal_robots.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/universal_robots.py
@@ -125,11 +125,6 @@ UR10_SHORT_SUCTION_CFG.spawn.variants = {"Gripper": "Short_Suction"}
 """Configuration of UR10 arm with short suction gripper."""
 
 UR10e_ROBOTIQ_GRIPPER_CFG = UR10e_CFG.copy()
-"""Configuration of UR10e arm with Robotiq_2f_140 gripper.
-
-FIXME: Something is wrong with selecting the variant for the Robotiq_2f_140 gripper.
-Even when tried on Isaac Sim GUI, the variant is not selected correctly.
-"""
 UR10e_ROBOTIQ_GRIPPER_CFG.spawn.variants = {"Gripper": "Robotiq_2f_140"}
 UR10e_ROBOTIQ_GRIPPER_CFG.spawn.rigid_props.disable_gravity = True
 UR10e_ROBOTIQ_GRIPPER_CFG.init_state.joint_pos["finger_joint"] = 0.0

--- a/source/isaaclab_assets/test/test_valid_configs.py
+++ b/source/isaaclab_assets/test/test_valid_configs.py
@@ -33,10 +33,6 @@ def registered_entities():
     # inspect all classes from the module
     for obj_name in dir(lab_assets):
         obj = getattr(lab_assets, obj_name)
-        # FIXME: skip UR10e_ROBOTIQ_GRIPPER_CFG since it is not a valid configuration
-        # Something has gone wrong with the recent Nucleus update.
-        if obj_name == "UR10e_ROBOTIQ_GRIPPER_CFG":
-            continue
         # store all registered entities configurations
         if isinstance(obj, AssetBaseCfg):
             registered_entities[obj_name] = obj

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -34,7 +34,6 @@ PER_TEST_TIMEOUTS = {
     "test_operational_space.py": 500,
     "test_non_headless_launch.py": 1000,  # This test launches the app in non-headless mode and starts simulation
     "test_rl_games_wrapper.py": 500,
-    "test_skrl_wrapper.py": 500,
 }
 """A dictionary of tests and their timeouts in seconds.
 


### PR DESCRIPTION
Reverts isaac-sim/IsaacLab#4316.

Reverting to runs skipped tests which should pass with the updates UR10e USD that does not have references to internal nucleus assets.