### PR TITLE
Re-enables UR10e with Robotiq gripper tests

### DIFF
--- a/source/isaaclab/test/sim/test_utils_prims.py
+++ b/source/isaaclab/test/sim/test_utils_prims.py
@@ -424,7 +424,6 @@ def test_select_usd_variants():
     assert variant_set.GetVariantSelection() == "red"
 
 
-@pytest.mark.skip(reason="The USD asset seems to have some issues.")
 def test_select_usd_variants_in_usd_file():
     """Test select_usd_variants() function in USD file."""
     stage = sim_utils.get_current_stage()

--- a/source/isaaclab_assets/isaaclab_assets/robots/universal_robots.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/universal_robots.py
@@ -125,11 +125,7 @@ UR10_SHORT_SUCTION_CFG.spawn.variants = {"Gripper": "Short_Suction"}
 """Configuration of UR10 arm with short suction gripper."""
 
 UR10e_ROBOTIQ_GRIPPER_CFG = UR10e_CFG.copy()
-"""Configuration of UR10e arm with Robotiq_2f_140 gripper.
-
-FIXME: Something is wrong with selecting the variant for the Robotiq_2f_140 gripper.
-Even when tried on Isaac Sim GUI, the variant is not selected correctly.
-"""
+"""Configuration of UR10e arm with Robotiq_2f_140 gripper."""
 UR10e_ROBOTIQ_GRIPPER_CFG.spawn.variants = {"Gripper": "Robotiq_2f_140"}
 UR10e_ROBOTIQ_GRIPPER_CFG.spawn.rigid_props.disable_gravity = True
 UR10e_ROBOTIQ_GRIPPER_CFG.init_state.joint_pos["finger_joint"] = 0.0

--- a/source/isaaclab_assets/test/test_valid_configs.py
+++ b/source/isaaclab_assets/test/test_valid_configs.py
@@ -33,10 +33,6 @@ def registered_entities():
     # inspect all classes from the module
     for obj_name in dir(lab_assets):
         obj = getattr(lab_assets, obj_name)
-        # FIXME: skip UR10e_ROBOTIQ_GRIPPER_CFG since it is not a valid configuration
-        # Something has gone wrong with the recent Nucleus update.
-        if obj_name == "UR10e_ROBOTIQ_GRIPPER_CFG":
-            continue
         # store all registered entities configurations
         if isinstance(obj, AssetBaseCfg):
             registered_entities[obj_name] = obj


### PR DESCRIPTION
# Description

Reverting to runs skipped tests which should pass with the updates UR10e USD that does not have references to internal nucleus assets.

Reverts this PR partly https://github.com/isaac-sim/IsaacLab/pull/4316.
