### PR TITLE
Allows zero robot ID to accept keyboard control in the `h1_locomotion.py` demo

### DIFF
--- a/scripts/demos/h1_locomotion.py
+++ b/scripts/demos/h1_locomotion.py
@@ -146,7 +146,7 @@ class H1RoughDemo:
         if event.type == carb.input.KeyboardEventType.KEY_PRESS:
             # Arrow keys map to pre-defined command vectors to control navigation of robot
             if event.input.name in self._key_to_control:
-                if self._selected_id:
+                if self._selected_id is not None:
                     self.commands[self._selected_id] = self._key_to_control[event.input.name]
             # Escape key exits out of the current selected robot view
             elif event.input.name == "ESCAPE":
@@ -160,7 +160,7 @@ class H1RoughDemo:
                         self.viewport.set_active_camera(self.camera_path)
         # On key release, the robot stops moving
         elif event.type == carb.input.KeyboardEventType.KEY_RELEASE:
-            if self._selected_id:
+            if self._selected_id is not None:
                 self.commands[self._selected_id] = self._key_to_control["ZEROS"]
 
     def update_selected_object(self):


### PR DESCRIPTION
# Description

This fix addresses an issue where robot ID 0 was not receiving keyboard controls due to the condition `if self._selected_id:` which evaluates 0 as False.

This ensures that all robot IDs, including 0, can properly receive keyboard commands.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there