### PR TITLE
Fixes typo in sensors tutorial documentation

### DIFF
--- a/docs/source/tutorials/04_sensors/add_sensors_on_robot.rst
+++ b/docs/source/tutorials/04_sensors/add_sensors_on_robot.rst
@@ -53,7 +53,7 @@ in seconds through the :attr:`sensors.SensorBaseCfg.update_period` attribute.
 Depending on the specified path and the sensor type, the sensors are attached to the prims in the scene.
 They may have an associated prim that is created in the scene or they may be attached to an existing prim.
 For instance, the camera sensor has a corresponding prim that is created in the scene, whereas for the
-contact sensor, the activating the contact reporting is a property on a rigid body prim.
+contact sensor, activating the contact reporting is a property on a rigid body prim.
 
 In the following, we introduce the different sensors we use in this tutorial and how they are configured.
 For more description about them, please check the :mod:`sensors` module.


### PR DESCRIPTION
# Description

A small typo in the tutorials.

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there