### PR TITLE
Feature: Adds rough slope terrain

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -145,6 +145,7 @@ Guidelines for modifications:
 * Xavier Nal
 * Xinjie Yao
 * Xinpeng Liu
+* Xin Xu
 * Yang Jin
 * Yanzi Zhu
 * Yijie Guo

--- a/source/isaaclab/isaaclab/terrains/height_field/__init__.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -29,9 +29,11 @@ from .hf_terrains_cfg import (
     HfDiscreteObstaclesTerrainCfg,
     HfInvertedPyramidSlopedTerrainCfg,
     HfInvertedPyramidStairsTerrainCfg,
+    HfInvertedRoughSlopeTerrainCfg,
     HfPyramidSlopedTerrainCfg,
     HfPyramidStairsTerrainCfg,
     HfRandomUniformTerrainCfg,
+    HfRoughSlopeTerrainCfg,
     HfSteppingStonesTerrainCfg,
     HfTerrainBaseCfg,
     HfWaveTerrainCfg,

--- a/source/isaaclab/isaaclab/terrains/height_field/hf_terrains.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/hf_terrains.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -146,6 +146,24 @@ def pyramid_sloped_terrain(difficulty: float, cfg: hf_terrains_cfg.HfPyramidSlop
 
     # round off the heights to the nearest vertical step
     return np.rint(hf_raw).astype(np.int16)
+
+
+@height_field_to_mesh
+def rough_slope_terrain(difficulty: float, cfg: hf_terrains_cfg.HfRoughSlopeTerrainCfg) -> np.ndarray:
+    # combine the two methods
+    terrain1 = pyramid_sloped_terrain.__wrapped__(difficulty, cfg)
+    terrain2 = random_uniform_terrain.__wrapped__(difficulty, cfg)
+    hf = terrain1 + terrain2
+
+    # the platform at center do not need to be rough
+    width_pixels = int(cfg.size[0] / cfg.horizontal_scale)
+    length_pixels = int(cfg.size[1] / cfg.horizontal_scale)
+    platform_width = int(cfg.platform_width / cfg.horizontal_scale / 2)
+    x_pf = width_pixels // 2 - platform_width
+    y_pf = length_pixels // 2 - platform_width
+    z_pf = hf[x_pf, y_pf]
+    hf = np.clip(hf, min(0, z_pf), max(0, z_pf))
+    return hf
 
 
 @height_field_to_mesh

--- a/source/isaaclab/isaaclab/terrains/height_field/hf_terrains_cfg.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/hf_terrains_cfg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -89,6 +89,20 @@ class HfInvertedPyramidSlopedTerrainCfg(HfPyramidSlopedTerrainCfg):
     """
 
     inverted: bool = True
+
+
+@configclass
+class HfRoughSlopeTerrainCfg(HfRandomUniformTerrainCfg, HfPyramidSlopedTerrainCfg):
+    "rough slope cfg, combine the cfg of random terrain and smooth slope terrain"
+
+    function = hf_terrains.rough_slope_terrain
+
+
+@configclass
+class HfInvertedRoughSlopeTerrainCfg(HfRandomUniformTerrainCfg, HfInvertedPyramidSlopedTerrainCfg):
+    "rough slope cfg, combine the cfg of random terrain and smooth slope terrain"
+
+    function = hf_terrains.rough_slope_terrain
 
 
 @configclass


### PR DESCRIPTION
# Description

Adds the rough slope terrain and its cfg, including both inverted and not inverted version. I combine the already defined `pyramid_sloped_terrain` and `random_uniform_terrain` method and their config to keep code simple.

## Type of change

- New feature (non-breaking change which adds functionality)


## Screenshots
**The rough slope terrains and the inverted version generated:**

![img_v3_02ub_6e035476-ea0d-4ede-aa0b-26326181bf5g](https://github.com/user-attachments/assets/b8829c7a-5da5-4e7c-a4f2-180c699203e7)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
