### PR TITLE
Fixes terrain origin computing in the inverted pyramid slope terrain

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -145,6 +145,7 @@ Guidelines for modifications:
 * Xavier Nal
 * Xinjie Yao
 * Xinpeng Liu
+* Xin Xu
 * Yang Jin
 * Yanzi Zhu
 * Yijie Guo

--- a/source/isaaclab/isaaclab/terrains/height_field/hf_terrains.py
+++ b/source/isaaclab/isaaclab/terrains/height_field/hf_terrains.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
@@ -11,7 +11,7 @@ import numpy as np
 import scipy.interpolate as interpolate
 from typing import TYPE_CHECKING
 
-from .utils import height_field_to_mesh
+from .utils import height_field_to_mesh, height_field_to_mesh_v2
 
 if TYPE_CHECKING:
     from . import hf_terrains_cfg
@@ -79,7 +79,7 @@ def random_uniform_terrain(difficulty: float, cfg: hf_terrains_cfg.HfRandomUnifo
     return np.rint(z_upsampled).astype(np.int16)
 
 
-@height_field_to_mesh
+@height_field_to_mesh_v2(terrain_origin_judge_width=1.0)
 def pyramid_sloped_terrain(difficulty: float, cfg: hf_terrains_cfg.HfPyramidSlopedTerrainCfg) -> np.ndarray:
     """Generate a terrain with a truncated pyramid structure.
 


### PR DESCRIPTION
# Description
In `height_field_to_mesh` function, the terrain origin is computed as the max in the square area around the center of the terrain,
and the square has a fixed width of 2 meters.
```
        # compute origin
        x1 = int((cfg.size[0] * 0.5 - 1) / cfg.horizontal_scale)  # fixed width
        x2 = int((cfg.size[0] * 0.5 + 1) / cfg.horizontal_scale)
        y1 = int((cfg.size[1] * 0.5 - 1) / cfg.horizontal_scale)
        y2 = int((cfg.size[1] * 0.5 + 1) / cfg.horizontal_scale)
        origin_z = np.max(heights[x1:x2, y1:y2]) * cfg.vertical_scale
        origin = np.array([0.5 * cfg.size[0], 0.5 * cfg.size[1], origin_z])
```
In inverted pyramid slope terrain, the default `platform_width` is `1.0` meter. Therefore the area outside the platform is also calculated in the `np.max` function. This caused the terrain origin to be a little higher than the ground. See the `Screenshots` below. Non-inverted pyramid terrain do not have this problem because the function is `max`.

To fix, a param `terrain_origin_judge_width` is added to the `height_field_to_mesh` wrapper (default is 2.0 so the behaviour is same as before) and we can use decorator `@height_field_to_mesh_v2(terrain_origin_judge_width=1.0)` to change the `max` function area. For the default platform 1.0 meter in inverted pyramid slope terrain, a half width `terrain_origin_judge_width=1.0` is ok.
```
        # compute origin
        x1 = int((cfg.size[0] * 0.5 - terrain_origin_judge_width / 2.0) / cfg.horizontal_scale)
        x2 = int((cfg.size[0] * 0.5 + terrain_origin_judge_width / 2.0) / cfg.horizontal_scale)
        y1 = int((cfg.size[1] * 0.5 - terrain_origin_judge_width / 2.0) / cfg.horizontal_scale)
        y2 = int((cfg.size[1] * 0.5 + terrain_origin_judge_width / 2.0) / cfg.horizontal_scale)
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

| Before | After |
| ------ | ----- |
| ![img_v3_02ub_d9221c73-c96d-4b7d-967a-f5aa279e240g](https://github.com/user-attachments/assets/eef5309e-6422-41a3-af43-c99a582532cb) | ![img_v3_02ub_d8c4226e-419a-4342-9e83-95357df2fefg](https://github.com/user-attachments/assets/bdd742ab-9c81-4b44-9455-cb41b6760a73)|


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
