### PR TITLE
Fixes Warp kernel compilation error in Fabric backend

### DIFF
--- a/source/isaaclab/isaaclab/utils/warp/fabric.py
+++ b/source/isaaclab/isaaclab/utils/warp/fabric.py
@@ -158,10 +158,17 @@ def compose_fabric_transformation_matrix_from_warp_arrays(
         scale[0] = array_scales[index, 0]
         scale[1] = array_scales[index, 1]
         scale[2] = array_scales[index, 2]
-    # set transform matrix (need transpose for column-major ordering)
-    # Using transform_compose as wp.matrix() is deprecated
-    fabric_matrices[fabric_index] = wp.mat44d(  # type: ignore[arg-type]
-        wp.transpose(wp.transform_compose(position, rotation, scale))  # type: ignore[arg-type]
+    # compose and set transform matrix (transpose for column-major ordering)
+    rot = wp.quat_to_matrix(rotation)  # type: ignore[arg-type]
+    m00, m01, m02 = rot[0, 0] * scale[0], rot[0, 1] * scale[1], rot[0, 2] * scale[2]
+    m10, m11, m12 = rot[1, 0] * scale[0], rot[1, 1] * scale[1], rot[1, 2] * scale[2]
+    m20, m21, m22 = rot[2, 0] * scale[0], rot[2, 1] * scale[1], rot[2, 2] * scale[2]
+    fabric_matrices[fabric_index] = wp.mat44d(
+        wp.transpose(
+            wp.mat44f(  # type: ignore[arg-type]
+                m00, m01, m02, position[0], m10, m11, m12, position[1], m20, m21, m22, position[2], 0.0, 0.0, 0.0, 1.0
+            )
+        )
     )
 
 


### PR DESCRIPTION
# Description

The Fabric backend uses `wp.transform_compose` to build transformation matrices, but this function was added in Warp 1.7. Isaac Sim 4.5 ships with Warp 1.5, so the kernel fails to compile when calling `set_world_poses` on cameras or other prims with Fabric enabled. This PR replaces the missing function with inline matrix math using `wp.quat_to_matrix`, which exists in Warp 1.5.

Fixes #4529

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A - this is a runtime error fix, no visual changes.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there