### PR TITLE
Debug an error yielded when no `python.analysis.extraPaths` item in `.vscode/settings.json`

### DIFF
--- a/.vscode/tools/setup_vscode.py
+++ b/.vscode/tools/setup_vscode.py
@@ -75,9 +75,12 @@ def overwrite_python_analysis_extra_paths(isaaclab_settings: str) -> str:
         settings = re.search(
             r"\"python.analysis.extraPaths\": \[.*?\]", vscode_settings, flags=re.MULTILINE | re.DOTALL
         )
-        settings = settings.group(0)
-        settings = settings.split('"python.analysis.extraPaths": [')[-1]
-        settings = settings.split("]")[0]
+        if settings is not None:
+            settings = settings.group(0)
+            settings = settings.split('"python.analysis.extraPaths": [')[-1]
+            settings = settings.split("]")[0]
+        else:
+            settings = ""
 
         # read the path names from the isaac-sim settings file
         path_names = settings.split(",")

--- a/tools/template/templates/external/.vscode/tools/setup_vscode.py
+++ b/tools/template/templates/external/.vscode/tools/setup_vscode.py
@@ -88,9 +88,12 @@ def overwrite_python_analysis_extra_paths(isaaclab_settings: str) -> str:
         settings = re.search(
             r"\"python.analysis.extraPaths\": \[.*?\]", vscode_settings, flags=re.MULTILINE | re.DOTALL
         )
-        settings = settings.group(0)
-        settings = settings.split('"python.analysis.extraPaths": [')[-1]
-        settings = settings.split("]")[0]
+        if settings is not None:
+            settings = settings.group(0)
+            settings = settings.split('"python.analysis.extraPaths": [')[-1]
+            settings = settings.split("]")[0]
+        else:
+            settings = ""
 
         # read the path names from the isaac-sim settings file
         path_names = settings.split(",")


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

This PR relates to a warning yielded during an installation process.
The installation process finishes with an error when we do not have `python.analysis.extraPaths` in `.vscode/settings.json`, but this is unwanted, so I fixed this issue.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there