### PR TITLE
[Newton] Adapts cloner to world pose convention of newton. 

### DIFF
--- a/source/isaaclab/isaaclab/cloner/cloner_utils.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_utils.py
@@ -301,7 +301,13 @@ def newton_replicate(
         p = ModelBuilder(up_axis=up_axis)
         solvers.SolverMuJoCo.register_custom_attributes(p)
         inverse_env_xform = get_inverse_env_xform(stage, src_path)
-        p.add_usd(stage, root_path=src_path, load_visual_shapes=True, skip_mesh_approximation=True, xform=inverse_env_xform,)
+        p.add_usd(
+            stage,
+            root_path=src_path,
+            load_visual_shapes=True,
+            skip_mesh_approximation=True,
+            xform=inverse_env_xform,
+        )
         if simplify_meshes:
             p.approximate_meshes("convex_hull")
         protos[src_path] = p
@@ -496,16 +502,15 @@ def get_inverse_env_xform(stage, src_path: str):
     xform_cache = UsdGeom.XformCache()
     world_xform = xform_cache.GetLocalToWorldTransform(stage.GetPrimAtPath(src_path))
 
-    # Extract translation and rotation
-    translation = world_xform.ExtractTranslation()
-    rotation = world_xform.ExtractRotationQuat()
+    # Get the inverse of the world transform
+    inv_xform = world_xform.GetInverse()
 
-    # Convert Gf.Quatd to Warp format (x, y, z, w)
-    quat_imag = rotation.GetImaginary()
-    world_transform = wp.transform(
-        (translation[0], translation[1], translation[2]),
-        (quat_imag[0], quat_imag[1], quat_imag[2], rotation.GetReal()),
-    )
+    # Extract translation and rotation from inverse
+    inv_translation = inv_xform.ExtractTranslation()
+    inv_rotation = inv_xform.ExtractRotationQuat()
 
-    # Properly compute the inverse transform
-    return wp.transform_inverse(world_transform)
+    inv_pos = (inv_translation[0], inv_translation[1], inv_translation[2])
+    inv_quat = (inv_rotation.GetImaginary()[0], inv_rotation.GetImaginary()[1], 
+                inv_rotation.GetImaginary()[2], inv_rotation.GetReal())
+
+    return wp.transform(inv_pos, inv_quat)


### PR DESCRIPTION
# Description

newton switched add_usd from local pose to world pose, and without this pr, all cloning will have issue...

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
