### PR TITLE
[Newton] Supports zero-dof articulation

### DIFF
--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -2178,6 +2178,7 @@ class ArticulationData(BaseArticulationData):
         indexed. Newton willing this is the case all the time, but we should pay attention to this if things look off.
         """
         # Short-hand for the number of instances, number of links, and number of joints.
+        n_view = self._root_view.count
         n_dof = self._root_view.joint_dof_count
 
         # -- root properties
@@ -2242,20 +2243,20 @@ class ArticulationData(BaseArticulationData):
                 "joint_target_vel", NewtonManager.get_control()
             )[:, 0]
         else:
-            # No joints (e.g., free-floating rigid body) - set bindings to None
-            self._sim_bind_joint_pos_limits_lower = None
-            self._sim_bind_joint_pos_limits_upper = None
-            self._sim_bind_joint_stiffness_sim = None
-            self._sim_bind_joint_damping_sim = None
-            self._sim_bind_joint_armature = None
-            self._sim_bind_joint_friction_coeff = None
-            self._sim_bind_joint_vel_limits_sim = None
-            self._sim_bind_joint_effort_limits_sim = None
-            self._sim_bind_joint_pos = None
-            self._sim_bind_joint_vel = None
-            self._sim_bind_joint_effort = None
-            self._sim_bind_joint_position_target = None
-            self._sim_bind_joint_velocity_target = None
+            # No joints (e.g., free-floating rigid body) - set bindings to empty arrays
+            self._sim_bind_joint_pos_limits_lower = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_pos_limits_upper = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_stiffness_sim = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_damping_sim = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_armature = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_friction_coeff = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_vel_limits_sim = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_effort_limits_sim = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_pos = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_vel = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_effort = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_position_target = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
+            self._sim_bind_joint_velocity_target = wp.zeros((n_view, 0), dtype=wp.float32, device=self.device)
 
     def _create_buffers(self) -> None:
         """Create buffers for the root data."""


### PR DESCRIPTION
# Description

Articulation of pure body does not work anymore, this pr allow these 0 dof object can be used as newton articulation

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
