### PR TITLE
Fix some typo issues

### DIFF
--- a/docs/source/tutorials/03_envs/create_direct_rl_env.rst
+++ b/docs/source/tutorials/03_envs/create_direct_rl_env.rst
@@ -263,7 +263,7 @@ Below is an example of a configuration class for domain randomization:
 
 Each ``EventTerm`` object is of the :class:`~managers.EventTermCfg` class and takes in a ``func`` parameter
 for specifying the function to call during randomization, a ``mode`` parameter, which can be ``startup``,
-``reset`` or ``interval``. THe ``params`` dictionary should provide the necessary arguments to the
+``reset`` or ``interval``. The ``params`` dictionary should provide the necessary arguments to the
 function that is specified in the ``func`` parameter.
 Functions specified as ``func`` for the ``EventTerm`` can be found in the :class:`~envs.mdp.events` module.
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -189,7 +189,7 @@ def get_checkpoint_path(
     """
     # check if runs present in directory
     try:
-        # find all runs in the directory that math the regex expression
+        # find all runs in the directory that match the regex expression
         runs = [
             os.path.join(log_path, run) for run in os.scandir(log_path) if run.is_dir() and re.match(run_dir, run.name)
         ]


### PR DESCRIPTION
# Description

Correct two typos in documentation and a code comment:

- Change `THe` to `The` in the direct RL environment guide.
- Change `math` to `match` in the checkpoint-path regex comment.

Fixes #4601

## Type of change

- Documentation update

## Validation

- `uv run isaaclab -f`
- `uv run --isolated --extra dev -- make -C docs current-docs`

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`
