### PR TITLE
[Newton] Allows shape_cfg to be spawned with rootArticulationAPI, both float base and fixed based with some hack

### DIFF
--- a/source/isaaclab/isaaclab/sim/schemas/__init__.py
+++ b/source/isaaclab/isaaclab/sim/schemas/__init__.py
@@ -36,6 +36,7 @@ from .schemas import (
     PHYSX_MESH_COLLISION_CFGS,
     USD_MESH_COLLISION_CFGS,
     activate_contact_sensors,
+    create_joint,
     define_articulation_root_properties,
     define_collision_properties,
     define_deformable_body_properties,
@@ -76,6 +77,8 @@ __all__ = [
     "ArticulationRootPropertiesCfg",
     "define_articulation_root_properties",
     "modify_articulation_root_properties",
+    # joints
+    "create_joint",
     # rigid bodies
     "RigidBodyPropertiesCfg",
     "define_rigid_body_properties",

--- a/source/isaaclab/isaaclab/sim/spawners/spawner_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/spawner_cfg.py
@@ -79,6 +79,9 @@ class RigidObjectSpawnerCfg(SpawnerCfg):
     mass_props: schemas.MassPropertiesCfg | None = None
     """Mass properties."""
 
+    articulation_props: schemas.ArticulationRootPropertiesCfg | None = None
+    """Articulation properties."""
+
     rigid_props: schemas.RigidBodyPropertiesCfg | None = None
     """Rigid body properties.
 


### PR DESCRIPTION
…ach fake body

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
