### PR TITLE
Refactors environment cloner to directly work with physx and usd apis, removing isaac-sim cloner dependency

### DIFF
--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -333,7 +333,7 @@ def main() -> None:
     sim.set_camera_view((2.5, 0.0, 4.0), (0.0, 0.0, 2.0))
 
     # Design scene
-    scene_cfg = MultiObjectSceneCfg(num_envs=args_cli.num_envs, env_spacing=1.0, replicate_physics=False)
+    scene_cfg = MultiObjectSceneCfg(num_envs=args_cli.num_envs, env_spacing=1.0, replicate_physics=True)
     with Timer("[INFO] Time to create scene: "):
         scene = InteractiveScene(scene_cfg)
 

--- a/scripts/demos/multi_asset.py
+++ b/scripts/demos/multi_asset.py
@@ -286,7 +286,7 @@ def main():
     sim.set_camera_view([2.5, 0.0, 4.0], [0.0, 0.0, 2.0])
 
     # Design scene
-    scene_cfg = MultiObjectSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, replicate_physics=False)
+    scene_cfg = MultiObjectSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, replicate_physics=True)
     with Timer("[INFO] Time to create scene: "):
         scene = InteractiveScene(scene_cfg)
 

--- a/scripts/demos/sensors/multi_mesh_raycaster.py
+++ b/scripts/demos/sensors/multi_mesh_raycaster.py
@@ -280,7 +280,7 @@ def main():
     # Set main camera
     sim.set_camera_view(eye=[3.5, 3.5, 3.5], target=[0.0, 0.0, 0.0])
     # design scene
-    scene_cfg = RaycasterSensorSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, replicate_physics=False)
+    scene_cfg = RaycasterSensorSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, replicate_physics=True)
     scene = InteractiveScene(scene_cfg)
 
     if args_cli.asset_type == "objects":

--- a/scripts/demos/sensors/multi_mesh_raycaster_camera.py
+++ b/scripts/demos/sensors/multi_mesh_raycaster_camera.py
@@ -306,7 +306,7 @@ def main():
     # Set main camera
     sim.set_camera_view(eye=[3.5, 3.5, 3.5], target=[0.0, 0.0, 0.0])
     # design scene
-    scene_cfg = RaycasterSensorSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, replicate_physics=False)
+    scene_cfg = RaycasterSensorSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, replicate_physics=True)
     scene = InteractiveScene(scene_cfg)
 
     if args_cli.asset_type == "objects":

--- a/scripts/tutorials/03_envs/create_cube_base_env.py
+++ b/scripts/tutorials/03_envs/create_cube_base_env.py
@@ -289,7 +289,7 @@ class CubeEnvCfg(ManagerBasedEnvCfg):
     # The flag 'replicate_physics' is set to False, which means that the cube is not replicated
     # across multiple environments but rather each environment gets its own cube instance.
     # This allows modifying the cube's properties independently for each environment.
-    scene: MySceneCfg = MySceneCfg(num_envs=args_cli.num_envs, env_spacing=2.5, replicate_physics=False)
+    scene: MySceneCfg = MySceneCfg(num_envs=args_cli.num_envs, env_spacing=2.5, replicate_physics=True)
 
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.0.0"
+version = "4.1.0"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,31 @@
 Changelog
 ---------
 
+4.1.0 (2026-02-18)
+~~~~~~~~~~~~~~~~~~
+
+Removed
+^^^^^^^
+
+* Removed hard dependency on the Isaac Sim Cloner for scene replication. Replication now uses internal utilities
+  :func:`~isaaclab.scene.cloner.usd_replicate` and :func:`~isaaclab.scene.cloner.physx_replicate`, reducing coupling
+  to Isaac Sim. Public APIs in :class:`~isaaclab.scene.interactive_scene.InteractiveScene` remain unchanged; code
+  directly importing the external Cloner should migrate to these utilities.
+
+Added
+^^^^^
+
+* Added optional random prototype selection during environment cloning in
+  :class:`~isaaclab.scene.interactive_scene.InteractiveScene` via
+  :attr:`~isaaclab.scene.interactive_scene_cfg.InteractiveSceneCfg.random_heterogeneous_cloning`.
+  Defaults to ``True``; round-robin (modulo) mapping remains available by setting it to ``False``.
+
+* Added flexible per-object cloning path in
+  :class:`~isaaclab.scene.interactive_scene.InteractiveScene`: when environments are heterogeneous
+  (different prototypes across envs), replication switches to per-object instead of whole-env cloning.
+  This reduces PhysX cloning time in heterogeneous scenes.
+
+
 4.0.0 (2026-02-22)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/cloner/__init__.py
+++ b/source/isaaclab/isaaclab/cloner/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from .cloner_cfg import TemplateCloneCfg
+from .cloner_strategies import *
+from .cloner_utils import *

--- a/source/isaaclab/isaaclab/cloner/cloner_cfg.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_cfg.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from isaaclab.utils import configclass
+
+from .cloner_strategies import random
+
+
+@configclass
+class TemplateCloneCfg:
+    """Configuration for template-based cloning.
+
+    This configuration is consumed by :func:`~isaaclab.scene.cloner.clone_from_template` to
+    replicate one or more "prototype" prims authored under a template root into multiple
+    per-environment destinations. It supports both USD-spec replication and PhysX replication
+    and allows choosing between random or round-robin prototype assignment across environments.
+
+    The cloning flow is:
+
+    1. Discover prototypes under :attr:`template_root` whose base name starts with
+        :attr:`template_prototype_identifier` (for example, ``proto_asset_0``, ``proto_asset_1``).
+    2. Build a per-prototype mapping to environments according to
+        :attr:`random_heterogeneous_cloning` (random) or modulo assignment (deterministic).
+    3. Stamp the selected prototypes to destinations derived from :attr:`clone_regex`.
+    4. Optionally perform PhysX replication for the same mapping.
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        from isaaclab.cloner import TemplateCloneCfg, clone_from_template
+        from isaacsim.core.utils.stage import get_current_stage
+
+        stage = get_current_stage()
+        cfg = TemplateCloneCfg(
+            num_clones=128,
+            template_root="/World/template",
+            template_prototype_identifier="proto_asset",
+            clone_regex="/World/envs/env_.*",
+            clone_usd=True,
+            clone_physics=True,
+            random_heterogeneous_cloning=False,  # use round-robin mapping
+            device="cpu",
+        )
+
+        clone_from_template(stage, num_clones=cfg.num_clones, template_clone_cfg=cfg)
+    """
+
+    template_root: str = "/World/template"
+    """Root path under which template prototypes are authored."""
+
+    template_prototype_identifier: str = "proto_asset"
+    """Name prefix used to identify prototype prims under :attr:`template_root`."""
+
+    clone_regex: str = "/World/envs/env_.*"
+    """Destination template for per-environment paths.
+
+    The substring ``".*"`` is replaced with ``"{}"`` internally and formatted with the
+    environment index (e.g., ``/World/envs/env_0``, ``/World/envs/env_1``).
+    """
+
+    clone_usd: bool = True
+    """Enable USD-spec replication to author cloned prims and optional transforms."""
+
+    clone_physics: bool = True
+    """Enable PhysX replication for the same mapping to speed up physics setup."""
+
+    physics_clone_fn: callable | None = None
+    """Function used to perform physics replication."""
+
+    clone_strategy: callable = random
+    """Function used to build prototype-to-environment mapping. Default is :func:`random`."""
+
+    device: str = "cpu"
+    """Torch device on which mapping buffers are allocated."""
+
+    clone_in_fabric: bool = False
+    """Enable/disable cloning in fabric for PhysX replication. Default is False."""

--- a/source/isaaclab/isaaclab/cloner/cloner_strategies.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_strategies.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import torch
+
+
+def random(combinations: torch.Tensor, num_clones: int, device: str) -> torch.Tensor:
+    """Randomly assign prototypes to environments.
+
+    Each environment is assigned a random prototype combination sampled uniformly from
+    :attr:`combinations`.
+
+    Args:
+        combinations: Tensor of shape (num_combos, num_prototypes) containing all possible
+            prototype combinations.
+        num_clones: Number of environments to assign combinations to.
+        device: Torch device on which the output tensor is allocated.
+
+    Returns:
+        Tensor of shape (num_clones, num_prototypes) containing the chosen prototype
+        combination for each environment.
+    """
+    chosen = combinations[torch.randint(len(combinations), (num_clones,), device=device)]
+    return chosen
+
+
+def sequential(combinations: torch.Tensor, num_clones: int, device: str) -> torch.Tensor:
+    """Deterministically assign prototypes to environments in round-robin fashion.
+
+    Each environment is assigned a prototype combination based on its index modulo the
+    number of available combinations.
+
+    Args:
+        combinations: Tensor of shape (num_combos, num_prototypes) containing all possible
+            prototype combinations.
+        num_clones: Number of environments to assign combinations to.
+        device: Torch device on which the output tensor is allocated.
+
+    Returns:
+        Tensor of shape (num_clones, num_prototypes) containing the chosen prototype
+        combination for each environment.
+    """
+    chosen = combinations[torch.arange(num_clones, device=device) % len(combinations)]
+    return chosen

--- a/source/isaaclab/isaaclab/cloner/cloner_utils.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_utils.py
@@ -1,0 +1,374 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import itertools
+import math
+from typing import TYPE_CHECKING
+
+import torch
+
+from pxr import Gf, Sdf, Usd, UsdGeom, Vt
+
+import isaaclab.sim as sim_utils
+
+if TYPE_CHECKING:
+    from .cloner_cfg import TemplateCloneCfg
+
+
+def clone_from_template(stage: Usd.Stage, num_clones: int, template_clone_cfg: TemplateCloneCfg) -> None:
+    """Clone assets from a template root into per-environment destinations.
+
+    This utility discovers prototype prims under ``cfg.template_root`` whose names start with
+    ``cfg.template_prototype_identifier``, builds a per-prototype mapping across
+    ``num_clones`` environments (random or modulo), and then performs USD and/or PhysX replication
+    according to the flags in ``cfg``.
+
+    Args:
+        stage: The USD stage to author into.
+        num_clones: Number of environments to clone to (typically equals ``cfg.num_clones``).
+        template_clone_cfg: Configuration describing template location, destination pattern,
+            and replication/mapping behavior.
+    """
+    cfg: TemplateCloneCfg = template_clone_cfg
+    world_indices = torch.arange(num_clones, device=cfg.device)
+    clone_path_fmt = cfg.clone_regex.replace(".*", "{}")
+    prototype_id = cfg.template_prototype_identifier
+    prototypes = sim_utils.get_all_matching_child_prims(
+        cfg.template_root,
+        predicate=lambda prim: str(prim.GetPath()).split("/")[-1].startswith(prototype_id),
+    )
+    if len(prototypes) > 0:
+        prototype_root_set = {"/".join(str(prototype.GetPath()).split("/")[:-1]) for prototype in prototypes}
+        # discover prototypes per root then make a clone plan
+        src: list[list[str]] = []
+        dest: list[str] = []
+
+        for prototype_root in prototype_root_set:
+            protos = sim_utils.find_matching_prim_paths(f"{prototype_root}/.*")
+            protos = [proto for proto in protos if proto.split("/")[-1].startswith(prototype_id)]
+            src.append(protos)
+            dest.append(prototype_root.replace(cfg.template_root, clone_path_fmt))
+
+        src_paths, dest_paths, clone_masking = make_clone_plan(src, dest, num_clones, cfg.clone_strategy, cfg.device)
+
+        # Spawn the first instance of clones from prototypes, then deactivate the prototypes, those first instances
+        # will be served as sources for usd and physx replication.
+        proto_idx = clone_masking.to(torch.int32).argmax(dim=1)
+        proto_mask = torch.zeros_like(clone_masking)
+        proto_mask.scatter_(1, proto_idx.view(-1, 1).to(torch.long), clone_masking.any(dim=1, keepdim=True))
+        usd_replicate(stage, src_paths, dest_paths, world_indices, proto_mask)
+        stage.GetPrimAtPath(cfg.template_root).SetActive(False)
+        get_pos = lambda path: stage.GetPrimAtPath(path).GetAttribute("xformOp:translate").Get()  # noqa: E731
+        positions = torch.tensor([get_pos(clone_path_fmt.format(i)) for i in world_indices])
+        # If all prototypes map to env_0, clone whole env_0 to all envs; else clone per-object
+        if torch.all(proto_idx == 0):
+            mapping = clone_masking.new_ones(1, num_clones)
+            replicate_args = [clone_path_fmt.format(0)], [clone_path_fmt], world_indices, mapping
+            if cfg.clone_physics and cfg.physics_clone_fn is not None:
+                cfg.physics_clone_fn(stage, *replicate_args, positions=positions, device=cfg.device)
+            if cfg.clone_usd:
+                # parse env_origins directly from clone_path
+                usd_replicate(stage, *replicate_args, positions=positions)
+
+        else:
+            selected_src = [tpl.format(int(idx)) for tpl, idx in zip(dest_paths, proto_idx.tolist())]
+            replicate_args = selected_src, dest_paths, world_indices, clone_masking
+            if cfg.clone_physics and cfg.physics_clone_fn is not None:
+                cfg.physics_clone_fn(stage, *replicate_args, positions=positions, device=cfg.device)
+            if cfg.clone_usd:
+                usd_replicate(stage, *replicate_args)
+
+
+def make_clone_plan(
+    sources: list[list[str]],
+    destinations: list[str],
+    num_clones: int,
+    clone_strategy: callable,
+    device: str = "cpu",
+) -> tuple[list[str], list[str], torch.Tensor]:
+    """Construct a cloning plan mapping prototype prims to per-environment destinations.
+
+    The plan enumerates all combinations of prototypes, selects a combination per environment using ``clone_strategy``,
+    and builds a boolean masking matrix indicating which prototype populates each environment slot.
+
+    Args:
+        sources: Prototype prim paths grouped by asset type (e.g., [[robot_a, robot_b], [obj_x]]).
+        destinations: Destination path templates (one per group) with ``"{}"`` placeholder for env id.
+        num_clones: Number of environments to populate.
+        clone_strategy: Function that picks a prototype combo per environment; signature
+            ``clone_strategy(combos: Tensor, num_clones: int, device: str) -> Tensor[num_clones, num_groups]``.
+        device: Torch device for tensors in the plan. Defaults to ``"cpu"``.
+
+    Returns:
+        tuple: ``(src, dest, masking)`` where ``src`` and ``dest`` are flattened lists of prototype and
+            destination paths, and ``masking`` is a ``[num_src, num_clones]`` boolean tensor with True
+            when source ``src[i]`` is used for clone ``j``.
+    """
+    # 1) Flatten into src and dest lists
+    src = [p for group in sources for p in group]
+    dest = [dst for dst, group in zip(destinations, sources) for _ in group]
+    group_sizes = [len(group) for group in sources]
+
+    # 2) Enumerate all combinations of "one prototype per group"
+    #    all_combos: list of tuples (g0_idx, g1_idx, ..., g_{G-1}_idx)
+    all_combos = list(itertools.product(*[range(s) for s in group_sizes]))
+    combos = torch.tensor(all_combos, dtype=torch.long, device=device)
+
+    # 3) Assign a combination to each environment
+    chosen = clone_strategy(combos, num_clones, device)
+
+    # 4) Build masking: [num_src, num_clones] boolean
+    #    For each env, for each group, mark exactly one prototype row as True.
+    group_offsets = torch.tensor([0] + list(itertools.accumulate(group_sizes[:-1])), dtype=torch.long, device=device)
+    rows = (chosen + group_offsets).view(-1)
+    cols = torch.arange(num_clones, device=device).view(-1, 1).expand(-1, len(group_sizes)).reshape(-1)
+
+    masking = torch.zeros((sum(group_sizes), num_clones), dtype=torch.bool, device=device)
+    masking[rows, cols] = True
+    return src, dest, masking
+
+
+def usd_replicate(
+    stage: Usd.Stage,
+    sources: list[str],
+    destinations: list[str],
+    env_ids: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    positions: torch.Tensor | None = None,
+    quaternions: torch.Tensor | None = None,
+) -> None:
+    """Replicate USD prims to per-environment destinations.
+
+    Copies each source prim spec to destination templates for selected environments
+    (``mask``). Optionally authors translate/orient from position/quaternion buffers.
+    Replication runs in path-depth order (parents before children) for robust composition.
+
+    Args:
+        stage: USD stage.
+        sources: Source prim paths.
+        destinations: Destination formattable templates with ``"{}"`` for env index.
+        env_ids: Environment indices.
+        mask: Optional per-source or shared mask. ``None`` selects all.
+        positions: Optional positions (``[E, 3]``) -> ``xformOp:translate``.
+        quaternions: Optional orientations (``[E, 4]``) in ``xyzw`` -> ``xformOp:orient``.
+
+    Returns:
+        None
+    """
+    rl = stage.GetRootLayer()
+
+    # Group replication by destination path depth so ancestors land before deeper paths.
+    # This avoids composition issues for nested or interdependent specs.
+    def dp_depth(template: str) -> int:
+        dp = template.format(0)
+        return Sdf.Path(dp).pathElementCount
+
+    order = sorted(range(len(sources)), key=lambda i: dp_depth(destinations[i]))
+
+    # Process in layers of equal depth, committing at each depth to stabilize composition
+    depth_to_indices: dict[int, list[int]] = {}
+    for i in order:
+        d = dp_depth(destinations[i])
+        depth_to_indices.setdefault(d, []).append(i)
+
+    for depth in sorted(depth_to_indices.keys()):
+        with Sdf.ChangeBlock():
+            for i in depth_to_indices[depth]:
+                src = sources[i]
+                tmpl = destinations[i]
+                # Select target environments for this source (supports None, [E], or [S, E])
+                target_envs = env_ids if mask is None else env_ids[mask[i]]
+                for wid in target_envs.tolist():
+                    dp = tmpl.format(wid)
+                    Sdf.CreatePrimInLayer(rl, dp)
+                    Sdf.CopySpec(rl, Sdf.Path(src), rl, Sdf.Path(dp))
+
+                    if positions is not None or quaternions is not None:
+                        ps = rl.GetPrimAtPath(dp)
+                        op_names = []
+                        if positions is not None:
+                            p = positions[wid]
+                            t_attr = ps.GetAttributeAtPath(dp + ".xformOp:translate")
+                            if t_attr is None:
+                                t_attr = Sdf.AttributeSpec(ps, "xformOp:translate", Sdf.ValueTypeNames.Double3)
+                            t_attr.default = Gf.Vec3d(float(p[0]), float(p[1]), float(p[2]))
+                            op_names.append("xformOp:translate")
+                        if quaternions is not None:
+                            q = quaternions[wid]
+                            o_attr = ps.GetAttributeAtPath(dp + ".xformOp:orient")
+                            if o_attr is None:
+                                o_attr = Sdf.AttributeSpec(ps, "xformOp:orient", Sdf.ValueTypeNames.Quatd)
+                            # xyzw convention: q[3] is w, q[0:3] is xyz
+                            o_attr.default = Gf.Quatd(float(q[3]), Gf.Vec3d(float(q[0]), float(q[1]), float(q[2])))
+                            op_names.append("xformOp:orient")
+                        # Only author xformOpOrder for the ops we actually authored
+                        if op_names:
+                            op_order = ps.GetAttributeAtPath(dp + ".xformOpOrder") or Sdf.AttributeSpec(
+                                ps, UsdGeom.Tokens.xformOpOrder, Sdf.ValueTypeNames.TokenArray
+                            )
+                            op_order.default = Vt.TokenArray(op_names)
+
+
+def filter_collisions(
+    stage: Usd.Stage,
+    physicsscene_path: str,
+    collision_root_path: str,
+    prim_paths: list[str],
+    global_paths: list[str] = [],
+) -> None:
+    """Create inverted collision groups for clones (PhysX only).
+
+    Sets PhysX scene attributes and collision groups on the prim at ``physicsscene_path``
+    (no PhysxSchema import). Call only when the physics backend is PhysX; Newton uses
+    its own collision/world handling and does not use USD PhysX collision groups.
+
+    Creates one PhysicsCollisionGroup per prim under ``collision_root_path``, enabling
+    inverted filtering so clones don't collide across groups. Optionally adds a global
+    group that collides with all.
+
+    Args:
+        stage: USD stage.
+        physicsscene_path: Path to PhysicsScene prim.
+        collision_root_path: Root scope for collision groups.
+        prim_paths: Per-clone prim paths.
+        global_paths: Optional global-collider paths.
+
+    Returns:
+        None
+    """
+
+    scene_prim = stage.GetPrimAtPath(physicsscene_path)
+    # We invert the collision group filters for more efficient collision filtering across environments
+    invert_attr = scene_prim.CreateAttribute("physxScene:invertCollisionGroupFilter", Sdf.ValueTypeNames.Bool)
+    invert_attr.Set(True)
+
+    # Make sure we create the collision_scope in the RootLayer since the edit target
+    # may be a live layer in the case of Live Sync.
+    with Usd.EditContext(stage, Usd.EditTarget(stage.GetRootLayer())):
+        UsdGeom.Scope.Define(stage, collision_root_path)
+
+    with Sdf.ChangeBlock():
+        if len(global_paths) > 0:
+            global_collision_group_path = collision_root_path + "/global_group"
+            # add collision group prim
+            global_collision_group = Sdf.PrimSpec(
+                stage.GetRootLayer().GetPrimAtPath(collision_root_path),
+                "global_group",
+                Sdf.SpecifierDef,
+                "PhysicsCollisionGroup",
+            )
+            # prepend collision API schema
+            global_collision_group.SetInfo(Usd.Tokens.apiSchemas, Sdf.TokenListOp.Create({"CollectionAPI:colliders"}))
+
+            # expansion rule
+            expansion_rule = Sdf.AttributeSpec(
+                global_collision_group,
+                "collection:colliders:expansionRule",
+                Sdf.ValueTypeNames.Token,
+                Sdf.VariabilityUniform,
+            )
+            expansion_rule.default = "expandPrims"
+
+            # includes rel
+            global_includes_rel = Sdf.RelationshipSpec(global_collision_group, "collection:colliders:includes", False)
+            for global_path in global_paths:
+                global_includes_rel.targetPathList.Append(global_path)
+
+            # filteredGroups rel
+            global_filtered_groups = Sdf.RelationshipSpec(global_collision_group, "physics:filteredGroups", False)
+            # We are using inverted collision group filtering, which means objects by default don't collide across
+            # groups. We need to add this group as a filtered group, so that objects within this group collide with
+            # each other.
+            global_filtered_groups.targetPathList.Append(global_collision_group_path)
+
+        # set collision groups and filters
+        for i, prim_path in enumerate(prim_paths):
+            collision_group_path = collision_root_path + f"/group{i}"
+            # add collision group prim
+            collision_group = Sdf.PrimSpec(
+                stage.GetRootLayer().GetPrimAtPath(collision_root_path),
+                f"group{i}",
+                Sdf.SpecifierDef,
+                "PhysicsCollisionGroup",
+            )
+            # prepend collision API schema
+            collision_group.SetInfo(Usd.Tokens.apiSchemas, Sdf.TokenListOp.Create({"CollectionAPI:colliders"}))
+
+            # expansion rule
+            expansion_rule = Sdf.AttributeSpec(
+                collision_group,
+                "collection:colliders:expansionRule",
+                Sdf.ValueTypeNames.Token,
+                Sdf.VariabilityUniform,
+            )
+            expansion_rule.default = "expandPrims"
+
+            # includes rel
+            includes_rel = Sdf.RelationshipSpec(collision_group, "collection:colliders:includes", False)
+            includes_rel.targetPathList.Append(prim_path)
+
+            # filteredGroups rel
+            filtered_groups = Sdf.RelationshipSpec(collision_group, "physics:filteredGroups", False)
+            # We are using inverted collision group filtering, which means objects by default don't collide across
+            # groups. We need to add this group as a filtered group, so that objects within this group collide with
+            # each other.
+            filtered_groups.targetPathList.Append(collision_group_path)
+            if len(global_paths) > 0:
+                filtered_groups.targetPathList.Append(global_collision_group_path)
+                global_filtered_groups.targetPathList.Append(collision_group_path)
+
+
+def grid_transforms(N: int, spacing: float = 1.0, up_axis: str = "z", device="cpu"):
+    """Create a centered grid of transforms for ``N`` instances.
+
+    Computes ``(x, y)`` coordinates in a roughly square grid centered at the origin
+    with the provided spacing, places the third coordinate according to ``up_axis``,
+    and returns identity orientations. This matches the grid layout used by
+    :class:`isaaclab.terrains.TerrainImporter` for consistent environment positioning.
+
+    Args:
+        N: Number of instances.
+        spacing: Distance between neighboring grid positions.
+        up_axis: Up axis for positions ("z", "y", or "x").
+        device: Torch device for returned tensors.
+
+    Returns:
+        A tuple ``(pos, ori)`` where:
+            - ``pos`` is a tensor of shape ``(N, 3)`` with positions.
+            - ``ori`` is a tensor of shape ``(N, 4)`` with identity quaternions in ``(x, y, z, w)``.
+    """
+    # Match terrain_importer._compute_env_origins_grid layout for consistency
+    num_rows = int(math.ceil(N / math.sqrt(N)))
+    num_cols = int(math.ceil(N / num_rows))
+
+    # Create meshgrid matching terrain's "ij" indexing
+    ii, jj = torch.meshgrid(
+        torch.arange(num_rows, device=device, dtype=torch.float32),
+        torch.arange(num_cols, device=device, dtype=torch.float32),
+        indexing="ij",
+    )
+    # Flatten and take first N elements
+    ii = ii.flatten()[:N]
+    jj = jj.flatten()[:N]
+
+    # Match terrain's coordinate system: X from rows (negated), Y from cols
+    x = -(ii - (num_rows - 1) / 2) * spacing
+    y = (jj - (num_cols - 1) / 2) * spacing
+    z0 = torch.zeros(N, device=device)
+
+    # place on plane based on up_axis
+    if up_axis.lower() == "z":
+        pos = torch.stack([x, y, z0], dim=1)
+    elif up_axis.lower() == "y":
+        pos = torch.stack([x, z0, y], dim=1)
+    else:  # up_axis == "x"
+        pos = torch.stack([z0, x, y], dim=1)
+
+    # identity orientations (x,y,z,w)
+    ori = torch.zeros((N, 4), device=device)
+    ori[:, 3] = 1.0  # w=1 for identity quaternion
+    return pos, ori

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -13,10 +13,10 @@ import torch
 import warp as wp
 from isaaclab_physx.assets import DeformableObject, DeformableObjectCfg, SurfaceGripper, SurfaceGripperCfg
 
-import carb
-from isaacsim.core.cloner import GridCloner
+from pxr import Sdf
 
 import isaaclab.sim as sim_utils
+from isaaclab import cloner
 from isaaclab.assets import (
     Articulation,
     ArticulationCfg,
@@ -31,7 +31,6 @@ from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils.stage import get_current_stage, get_current_stage_id
 from isaaclab.sim.views import XformPrimView
 from isaaclab.terrains import TerrainImporter, TerrainImporterCfg
-from isaaclab.utils.version import get_isaac_sim_version
 
 # Note: This is a temporary import for the VisuoTactileSensorCfg class.
 # It will be removed once the VisuoTactileSensor class is added to the core Isaac Lab framework.
@@ -136,81 +135,48 @@ class InteractiveScene:
         self.sim = SimulationContext.instance()
         self.stage = get_current_stage()
         self.stage_id = get_current_stage_id()
+        # physics backend and clone fn (PhysX uses PhysxSchema/physx_replicate; Newton uses its own worlds)
+        self.physics_backend = self.sim.physics_manager.__name__
+        if "Physx" in self.physics_backend:
+            from isaaclab_physx.cloner import physx_replicate
+
+            physics_clone_fn = physx_replicate
+        elif "Newton" in self.physics_backend:
+            from isaaclab_newton.cloner import newton_replicate
+
+            physics_clone_fn = newton_replicate
+        else:
+            raise ValueError(f"Unsupported physics backend: {self.physics_backend}")
         # physics scene path
         self._physics_scene_path = None
         # prepare cloner for environment replication
-        self.cloner = GridCloner(spacing=self.cfg.env_spacing, stage=self.stage)
-        self.cloner.define_base_env(self.env_ns)
-        self.env_prim_paths = self.cloner.generate_paths(f"{self.env_ns}/env", self.cfg.num_envs)
+        self.env_prim_paths = [f"{self.env_ns}/env_{i}" for i in range(self.cfg.num_envs)]
+
+        self.cloner_cfg = cloner.TemplateCloneCfg(
+            clone_regex=self.env_regex_ns,
+            clone_in_fabric=self.cfg.clone_in_fabric,
+            device=self.device,
+            physics_clone_fn=physics_clone_fn,
+        )
+
         # create source prim
         self.stage.DefinePrim(self.env_prim_paths[0], "Xform")
+        self.stage.DefinePrim(self.cloner_cfg.template_root, "Xform")
+        self.env_fmt = self.env_regex_ns.replace(".*", "{}")
         # allocate env indices
         self._ALL_INDICES = torch.arange(self.cfg.num_envs, dtype=torch.long, device=self.device)
-        # when replicate_physics=False, we assume heterogeneous environments and clone the xforms first.
-        # this triggers per-object level cloning in the spawner.
-        if not self.cfg.replicate_physics:
-            # check version of Isaac Sim to determine whether clone_in_fabric is valid
-            if get_isaac_sim_version().major < 5:
-                # clone the env xform
-                env_origins = self.cloner.clone(
-                    source_prim_path=self.env_prim_paths[0],
-                    prim_paths=self.env_prim_paths,
-                    replicate_physics=False,
-                    copy_from_source=True,
-                    enable_env_ids=(
-                        self.cfg.filter_collisions if self.device != "cpu" else False
-                    ),  # this won't do anything because we are not replicating physics
-                )
-            else:
-                # clone the env xform
-                env_origins = self.cloner.clone(
-                    source_prim_path=self.env_prim_paths[0],
-                    prim_paths=self.env_prim_paths,
-                    replicate_physics=False,
-                    copy_from_source=True,
-                    enable_env_ids=(
-                        self.cfg.filter_collisions if self.device != "cpu" else False
-                    ),  # this won't do anything because we are not replicating physics
-                    clone_in_fabric=self.cfg.clone_in_fabric,
-                )
-            self._default_env_origins = torch.tensor(env_origins, device=self.device, dtype=torch.float32)
-        else:
-            # otherwise, environment origins will be initialized during cloning at the end of environment creation
-            self._default_env_origins = None
+        self._default_env_origins, _ = cloner.grid_transforms(self.num_envs, self.cfg.env_spacing, device=self.device)
+        # copy empty prim of env_0 to env_1, env_2, ..., env_{num_envs-1} with correct location.
+        cloner.usd_replicate(
+            self.stage, [self.env_fmt.format(0)], [self.env_fmt], self._ALL_INDICES, positions=self._default_env_origins
+        )
 
         self._global_prim_paths = list()
         if self._is_scene_setup_from_cfg():
-            # add entities from config
             self._add_entities_from_cfg()
-            # clone environments on a global scope if environment is homogeneous
-            if self.cfg.replicate_physics:
-                self.clone_environments(copy_from_source=False)
-            # replicate physics if we have more than one environment
-            # this is done to make scene initialization faster at play time
-            if self.cfg.replicate_physics and self.cfg.num_envs > 1:
-                # check version of Isaac Sim to determine whether clone_in_fabric is valid
-                if get_isaac_sim_version().major < 5:
-                    self.cloner.replicate_physics(
-                        source_prim_path=self.env_prim_paths[0],
-                        prim_paths=self.env_prim_paths,
-                        base_env_path=self.env_ns,
-                        root_path=self.env_regex_ns.replace(".*", ""),
-                        enable_env_ids=self.cfg.filter_collisions if self.device != "cpu" else False,
-                    )
-                else:
-                    self.cloner.replicate_physics(
-                        source_prim_path=self.env_prim_paths[0],
-                        prim_paths=self.env_prim_paths,
-                        base_env_path=self.env_ns,
-                        root_path=self.env_regex_ns.replace(".*", ""),
-                        enable_env_ids=self.cfg.filter_collisions if self.device != "cpu" else False,
-                        clone_in_fabric=self.cfg.clone_in_fabric,
-                    )
-
-            # since env_ids is only applicable when replicating physics, we have to fallback to the previous method
-            # to filter collisions if replicate_physics is not enabled
-            # additionally, env_ids is only supported in GPU simulation
-            if (not self.cfg.replicate_physics and self.cfg.filter_collisions) or self.device == "cpu":
+            self.clone_environments(copy_from_source=(not self.cfg.replicate_physics))
+            # Collision filtering is PhysX-specific (PhysxSchema.PhysxSceneAPI)
+            if self.cfg.filter_collisions and "Physx" in self.physics_backend:
                 self.filter_collisions(self._global_prim_paths)
 
     def clone_environments(self, copy_from_source: bool = False):
@@ -221,57 +187,22 @@ class InteractiveScene:
             If True, clones are independent copies of the source prim and won't reflect its changes (start-up time
             may increase). Defaults to False.
         """
-        # check if user spawned different assets in individual environments
-        # this flag will be None if no multi asset is spawned
-        carb_settings_iface = carb.settings.get_settings()
-        has_multi_assets = carb_settings_iface.get("/isaaclab/spawn/multi_assets")
-        if has_multi_assets and self.cfg.replicate_physics:
-            logger.warning(
-                "Varying assets might have been spawned under different environments."
-                " However, the replicate physics flag is enabled in the 'InteractiveScene' configuration."
-                " This may adversely affect PhysX parsing. We recommend disabling this property."
-            )
+        # PhysX-only: set env id bit count for replicated physics. Newton handles env separation in its own API.
+        if self.cfg.replicate_physics and "Physx" in self.physics_backend:
+            prim = self.stage.GetPrimAtPath("/physicsScene")
+            prim.CreateAttribute("physxScene:envIdInBoundsBitCount", Sdf.ValueTypeNames.Int).Set(4)
 
-        # check version of Isaac Sim to determine whether clone_in_fabric is valid
-        if get_isaac_sim_version().major < 5:
-            # clone the environment
-            env_origins = self.cloner.clone(
-                source_prim_path=self.env_prim_paths[0],
-                prim_paths=self.env_prim_paths,
-                replicate_physics=self.cfg.replicate_physics,
-                copy_from_source=copy_from_source,
-                enable_env_ids=(
-                    self.cfg.filter_collisions if self.device != "cpu" else False
-                ),  # this automatically filters collisions between environments
-            )
+        if self._is_scene_setup_from_cfg():
+            self.cloner_cfg.clone_physics = not copy_from_source
+            cloner.clone_from_template(self.stage, num_clones=self.num_envs, template_clone_cfg=self.cloner_cfg)
         else:
-            # clone the environment
-            env_origins = self.cloner.clone(
-                source_prim_path=self.env_prim_paths[0],
-                prim_paths=self.env_prim_paths,
-                replicate_physics=self.cfg.replicate_physics,
-                copy_from_source=copy_from_source,
-                enable_env_ids=(
-                    self.cfg.filter_collisions if self.device != "cpu" else False
-                ),  # this automatically filters collisions between environments
-                clone_in_fabric=self.cfg.clone_in_fabric,
-            )
+            mapping = torch.ones((1, self.num_envs), device=self.device, dtype=torch.bool)
+            replicate_args = [self.env_fmt.format(0)], [self.env_fmt], self._ALL_INDICES, mapping
 
-        # since env_ids is only applicable when replicating physics, we have to fallback to the previous method
-        # to filter collisions if replicate_physics is not enabled
-        # additionally, env_ids is only supported in GPU simulation
-        if (not self.cfg.replicate_physics and self.cfg.filter_collisions) or self.device == "cpu":
-            # if scene is specified through cfg, this is already taken care of
-            if not self._is_scene_setup_from_cfg():
-                logger.warning(
-                    "Collision filtering can only be automatically enabled when replicate_physics=True and using GPU"
-                    " simulation. Please call scene.filter_collisions(global_prim_paths) to filter collisions across"
-                    " environments."
-                )
-
-        # in case of heterogeneous cloning, the env origins is specified at init
-        if self._default_env_origins is None:
-            self._default_env_origins = torch.tensor(env_origins, device=self.device, dtype=torch.float32)
+            if not copy_from_source:
+                # skip physx cloning, this means physx will walk and parse the stage one by one faithfully
+                self.cloner_cfg.physics_clone_fn(self.stage, *replicate_args, device=self.cloner_cfg.device)
+            cloner.usd_replicate(self.stage, *replicate_args, positions=self._default_env_origins)
 
     def filter_collisions(self, global_prim_paths: list[str] | None = None):
         """Filter environments collisions.
@@ -299,7 +230,8 @@ class InteractiveScene:
             self._global_prim_paths += global_prim_paths
 
         # filter collisions within each environment instance
-        self.cloner.filter_collisions(
+        cloner.filter_collisions(
+            self.stage,
             self.physics_scene_path,
             "/World/collisions",
             self.env_prim_paths,
@@ -720,19 +652,40 @@ class InteractiveScene:
             for asset_name, asset_cfg in self.cfg.__dict__.items()
         )
 
-    def _add_entities_from_cfg(self):
+    def _add_entities_from_cfg(self):  # noqa: C901
         """Add scene entities from the config."""
         # store paths that are in global collision filter
         self._global_prim_paths = list()
-        # parse the entire scene config and resolve regex
-        for asset_name, asset_cfg in self.cfg.__dict__.items():
-            # skip keywords
-            # note: easier than writing a list of keywords: [num_envs, env_spacing, lazy_sensor_update]
-            if asset_name in InteractiveSceneCfg.__dataclass_fields__ or asset_cfg is None:
-                continue
-            # resolve regex
+        # Process non-sensor entities before sensors so that asset prims exist in the template
+        # when sensors (e.g. cameras attached to robot links) need to spawn under them.
+        all_items = [
+            (k, v)
+            for k, v in self.cfg.__dict__.items()
+            if k not in InteractiveSceneCfg.__dataclass_fields__ and v is not None
+        ]
+        ordered_items = [(k, v) for k, v in all_items if not isinstance(v, SensorBaseCfg)] + [
+            (k, v) for k, v in all_items if isinstance(v, SensorBaseCfg)
+        ]
+
+        for asset_name, asset_cfg in ordered_items:
+            # resolve prim_path with env regex
             if hasattr(asset_cfg, "prim_path"):
                 asset_cfg.prim_path = asset_cfg.prim_path.format(ENV_REGEX_NS=self.env_regex_ns)
+            # set spawn_path on spawner if cloning is needed
+            if hasattr(asset_cfg, "spawn") and asset_cfg.spawn is not None:
+                if hasattr(asset_cfg, "prim_path") and self.env_ns in asset_cfg.prim_path:
+                    template_base = asset_cfg.prim_path.replace(self.env_regex_ns, self.cloner_cfg.template_root)
+                    proto_id = self.cloner_cfg.template_prototype_identifier
+                    if isinstance(asset_cfg, SensorBaseCfg):
+                        # Sensor may be nested under a proto_asset_N prim (e.g. a camera on a robot
+                        # link). Search for the actual template location so spawning succeeds even
+                        # though the parent asset lives at template_root/<Asset>/proto_asset_0/...
+                        asset_cfg.spawn.spawn_path = self._resolve_sensor_template_spawn_path(template_base, proto_id)
+                    else:
+                        asset_cfg.spawn.spawn_path = f"{template_base}/{proto_id}_.*"
+                else:
+                    # No cloning - spawn directly at prim_path
+                    asset_cfg.spawn.spawn_path = asset_cfg.prim_path
             # create asset
             if isinstance(asset_cfg, TerrainImporterCfg):
                 # terrains are special entities since they define environment origins
@@ -748,6 +701,16 @@ class InteractiveScene:
             elif isinstance(asset_cfg, RigidObjectCollectionCfg):
                 for rigid_object_cfg in asset_cfg.rigid_objects.values():
                     rigid_object_cfg.prim_path = rigid_object_cfg.prim_path.format(ENV_REGEX_NS=self.env_regex_ns)
+                    # set spawn_path on spawner if cloning is needed
+                    if hasattr(rigid_object_cfg, "spawn") and rigid_object_cfg.spawn is not None:
+                        if self.env_ns in rigid_object_cfg.prim_path:
+                            spawn_tmpl = rigid_object_cfg.prim_path.replace(
+                                self.env_regex_ns, self.cloner_cfg.template_root
+                            )
+                            proto_id = self.cloner_cfg.template_prototype_identifier
+                            rigid_object_cfg.spawn.spawn_path = f"{spawn_tmpl}/{proto_id}_.*"
+                        else:
+                            rigid_object_cfg.spawn.spawn_path = rigid_object_cfg.prim_path
                 self._rigid_object_collections[asset_name] = asset_cfg.class_type(asset_cfg)
                 for rigid_object_cfg in asset_cfg.rigid_objects.values():
                     if hasattr(rigid_object_cfg, "collision_group") and rigid_object_cfg.collision_group == -1:
@@ -787,7 +750,7 @@ class InteractiveScene:
                 # manually spawn asset
                 if asset_cfg.spawn is not None:
                     asset_cfg.spawn.func(
-                        asset_cfg.prim_path,
+                        asset_cfg.spawn.spawn_path,
                         asset_cfg.spawn,
                         translation=asset_cfg.init_state.pos,
                         orientation=asset_cfg.init_state.rot,
@@ -797,7 +760,44 @@ class InteractiveScene:
                 self._extras[asset_name] = XformPrimView(asset_cfg.prim_path, device=self.device, stage=self.stage)
             else:
                 raise ValueError(f"Unknown asset config type for {asset_name}: {asset_cfg}")
+
             # store global collision paths
             if hasattr(asset_cfg, "collision_group") and asset_cfg.collision_group == -1:
                 asset_paths = sim_utils.find_matching_prim_paths(asset_cfg.prim_path)
                 self._global_prim_paths += asset_paths
+
+    def _resolve_sensor_template_spawn_path(self, template_base: str, proto_id: str) -> str:
+        """Resolve the actual template spawn path for a sensor nested under a proto_asset prim.
+
+        Sensors parented to robot links live inside ``proto_asset_0`` rather than directly under
+        the template root.  For example, a wrist camera at
+        ``/World/template/Robot/panda_hand/wrist_cam`` is actually spawned at
+        ``/World/template/Robot/proto_asset_0/panda_hand/wrist_cam``.
+
+        This method inserts a ``proto_id_.*`` wildcard one level below the template root and
+        searches for the concrete parent prim so the camera spawner can find it.
+
+        Args:
+            template_base: Template path derived by replacing the env regex with the template root.
+                Example: ``/World/template/Robot/panda_hand/wrist_cam``.
+            proto_id: Prototype identifier prefix (e.g. ``proto_asset``).
+
+        Returns:
+            Concrete spawn path (e.g. ``/World/template/Robot/proto_asset_0/panda_hand/wrist_cam``)
+            if the parent is found, otherwise ``template_base/proto_id_.*`` as a fallback.
+        """
+        template_root = self.cloner_cfg.template_root
+        # rel = e.g. "Robot/panda_hand/wrist_cam"
+        rel = template_base[len(template_root) + 1 :]
+        # asset = "Robot", remainder = "panda_hand/wrist_cam"
+        asset, _, remainder = rel.partition("/")
+        if not remainder:
+            return f"{template_base}/{proto_id}_.*"
+
+        # parent = "panda_hand", leaf = "wrist_cam"
+        parent, _, leaf = remainder.rpartition("/")
+        search = (
+            f"{template_root}/{asset}/{proto_id}_.*/{parent}" if parent else f"{template_root}/{asset}/{proto_id}_.*"
+        )
+        found = sim_utils.find_matching_prim_paths(search)
+        return f"{found[0]}/{leaf}" if found else f"{template_base}/{proto_id}_.*"

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -114,16 +113,6 @@ class Camera(SensorBase):
             RuntimeError: If no camera prim is found at the given path.
             ValueError: If the provided data types are not supported by the camera.
         """
-        # check if sensor path is valid
-        # note: currently we do not handle environment indices if there is a regex pattern in the leaf
-        #   For example, if the prim path is "/World/Sensor_[1,2]".
-        sensor_path = cfg.prim_path.split("/")[-1]
-        sensor_path_is_regex = re.match(r"^[a-zA-Z0-9/_]+$", sensor_path) is None
-        if sensor_path_is_regex:
-            raise RuntimeError(
-                f"Invalid prim path for the camera sensor: {self.cfg.prim_path}."
-                "\n\tHint: Please ensure that the prim path does not contain any regex patterns in the leaf."
-            )
         # perform check on supported data types
         self._check_supported_data_types(cfg)
         # initialize base class
@@ -163,6 +152,14 @@ class Camera(SensorBase):
 
         # spawn the asset
         if self.cfg.spawn is not None:
+            # Use spawn_path when set (points to template location for scene-cloned sensors).
+            # This allows the camera to be spawned inside the asset template (e.g. inside
+            # proto_asset_0) before clone_environments replicates it to all env paths.
+            spawn_target = (
+                self.cfg.spawn.spawn_path
+                if getattr(self.cfg.spawn, "spawn_path", None) is not None
+                else self.cfg.prim_path
+            )
             # compute the rotation offset
             rot = torch.tensor(self.cfg.offset.rot, dtype=torch.float32, device="cpu").unsqueeze(0)
             rot_offset = convert_camera_frame_orientation_convention(
@@ -172,14 +169,17 @@ class Camera(SensorBase):
             # ensure vertical aperture is set, otherwise replace with default for squared pixels
             if self.cfg.spawn.vertical_aperture is None:
                 self.cfg.spawn.vertical_aperture = self.cfg.spawn.horizontal_aperture * self.cfg.height / self.cfg.width
-            # spawn the asset
-            self.cfg.spawn.func(
-                self.cfg.prim_path, self.cfg.spawn, translation=self.cfg.offset.pos, orientation=rot_offset
-            )
-        # check that spawn was successful
-        matching_prims = sim_utils.find_matching_prims(self.cfg.prim_path)
+            self.cfg.spawn.func(spawn_target, self.cfg.spawn, translation=self.cfg.offset.pos, orientation=rot_offset)
+        # check that spawn was successful; use spawn_path if set (template location) since env
+        # paths are not yet populated at init time — they are filled in by clone_environments.
+        check_path = (
+            self.cfg.spawn.spawn_path
+            if self.cfg.spawn is not None and getattr(self.cfg.spawn, "spawn_path", None) is not None
+            else self.cfg.prim_path
+        )
+        matching_prims = sim_utils.find_matching_prims(check_path)
         if len(matching_prims) == 0:
-            raise RuntimeError(f"Could not find prim with path {self.cfg.prim_path}.")
+            raise RuntimeError(f"Could not find prim with path {check_path}.")
 
         # UsdGeom Camera prim for the sensor
         self._sensor_prims: list[UsdGeom.Camera] = list()

--- a/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/ray_caster.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, ClassVar
 
@@ -69,16 +68,6 @@ class RayCaster(SensorBase):
             cfg: The configuration parameters.
         """
         RayCaster._instance_count += 1
-        # check if sensor path is valid
-        # note: currently we do not handle environment indices if there is a regex pattern in the leaf
-        #   For example, if the prim path is "/World/Sensor_[1,2]".
-        sensor_path = cfg.prim_path.split("/")[-1]
-        sensor_path_is_regex = re.match(r"^[a-zA-Z0-9/_]+$", sensor_path) is None
-        if sensor_path_is_regex:
-            raise RuntimeError(
-                f"Invalid prim path for the ray-caster sensor: {cfg.prim_path}."
-                "\n\tHint: Please ensure that the prim path does not contain any regex patterns in the leaf."
-            )
         # Initialize base class
         super().__init__(cfg)
         # Create empty variables for storing output data

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -475,7 +475,7 @@ class SimulationContext:
             render: Whether to render the scene after stepping. Defaults to True.
         """
         self.physics_manager.step()
-        if render:
+        if render and self.is_rendering:
             self.render()
 
     def render(self, mode: int | None = None) -> None:

--- a/source/isaaclab/isaaclab/sim/spawners/lights/lights.py
+++ b/source/isaaclab/isaaclab/sim/spawners/lights/lights.py
@@ -59,7 +59,7 @@ def spawn_light(
     # delete spawner func specific parameters
     del cfg["prim_type"]
     # delete custom attributes in the config that are not USD parameters
-    non_usd_cfg_param_names = ["func", "copy_from_source", "visible", "semantic_tags"]
+    non_usd_cfg_param_names = ["func", "copy_from_source", "visible", "semantic_tags", "spawn_path"]
     for param_name in non_usd_cfg_param_names:
         del cfg[param_name]
     # set into USD API

--- a/source/isaaclab/isaaclab/sim/spawners/sensors/sensors.py
+++ b/source/isaaclab/isaaclab/sim/spawners/sensors/sensors.py
@@ -118,6 +118,7 @@ def spawn_camera(
         "visible",
         "semantic_tags",
         "from_intrinsic_matrix",
+        "spawn_path",
     ]
     # get camera prim
     prim = stage.GetPrimAtPath(prim_path)

--- a/source/isaaclab/isaaclab/sim/spawners/spawner_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/spawner_cfg.py
@@ -66,6 +66,9 @@ class SpawnerCfg:
     the source prim, i.e. all USD changes to the source prim will be reflected in the cloned prims.
     """
 
+    spawn_path: str | None = None
+    """Path where the prototype is spawned. Defaults to None."""
+
 
 @configclass
 class RigidObjectSpawnerCfg(SpawnerCfg):

--- a/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers.py
+++ b/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers.py
@@ -5,18 +5,18 @@
 
 from __future__ import annotations
 
-import random
-import re
+import logging
 from typing import TYPE_CHECKING
 
-import carb
-from pxr import Sdf, Usd
+from pxr import Usd
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim.spawners.from_files import UsdFileCfg
 
 if TYPE_CHECKING:
     from . import wrappers_cfg
+
+logger = logging.getLogger(__name__)
 
 
 def spawn_multi_asset(
@@ -27,11 +27,13 @@ def spawn_multi_asset(
     clone_in_fabric: bool = False,
     replicate_physics: bool = False,
 ) -> Usd.Prim:
-    """Spawn multiple assets based on the provided configurations.
+    """Spawn multiple assets into numbered prim paths derived from the provided configuration.
 
-    This function spawns multiple assets based on the provided configurations. The assets are spawned
-    in the order they are provided in the list. If the :attr:`~MultiAssetSpawnerCfg.random_choice` parameter is
-    set to True, a random asset configuration is selected for each spawn.
+    Assets are created in the order they appear in ``cfg.assets_cfg`` using the base name in ``prim_path``,
+    which must contain ``.*`` (for example, ``/World/Env_0/asset_.*`` spawns ``asset_0``, ``asset_1``, ...).
+    The prefix portion of ``prim_path`` may also include ``.*`` (for example, ``/World/env_.*/asset_.*``);
+    in this case, assets are spawned under the first match (``env_0``) and that structure is cloned to
+    other matching environments by the scene's cloner.
 
     Args:
         prim_path: The prim path to spawn the assets.
@@ -44,32 +46,19 @@ def spawn_multi_asset(
     Returns:
         The created prim at the first prim path.
     """
-    # get stage handle
-    stage = sim_utils.get_current_stage()
+    split_path = prim_path.split("/")
+    prefix_path, base_name = "/".join(split_path[:-1]), split_path[-1]
+    if ".*" not in base_name:
+        raise ValueError(
+            f" The base name '{base_name}' in the prim path '{prim_path}' must contain '.*' to indicate"
+            " the path each individual multiple-asset to be spawned."
+        )
+    if cfg.random_choice:
+        logger.warning(
+            "`random_choice` parameter in `spawn_multi_asset` is deprecated, and nothing will happen. "
+            "Use `isaaclab.scene.interactive_scene_cfg.InteractiveSceneCfg.random_heterogeneous_cloning` instead."
+        )
 
-    # resolve: {SPAWN_NS}/AssetName
-    # note: this assumes that the spawn namespace already exists in the stage
-    root_path, asset_path = prim_path.rsplit("/", 1)
-    # check if input is a regex expression
-    # note: a valid prim path can only contain alphanumeric characters, underscores, and forward slashes
-    is_regex_expression = re.match(r"^[a-zA-Z0-9/_]+$", root_path) is None
-
-    # resolve matching prims for source prim path expression
-    if is_regex_expression and root_path != "":
-        source_prim_paths = sim_utils.find_matching_prim_paths(root_path)
-        # if no matching prims are found, raise an error
-        if len(source_prim_paths) == 0:
-            raise RuntimeError(
-                f"Unable to find source prim path: '{root_path}'. Please create the prim before spawning."
-            )
-    else:
-        source_prim_paths = [root_path]
-
-    # find a free prim path to hold all the template prims
-    template_prim_path = sim_utils.get_next_free_prim_path("/World/Template", stage=stage)
-    sim_utils.create_prim(template_prim_path, "Scope", stage=stage)
-
-    # spawn everything first in a "Dataset" prim
     proto_prim_paths = list()
     for index, asset_cfg in enumerate(cfg.assets_cfg):
         # append semantic tags if specified
@@ -84,8 +73,8 @@ def spawn_multi_asset(
             attr_value = getattr(cfg, attr_name)
             if hasattr(asset_cfg, attr_name) and attr_value is not None:
                 setattr(asset_cfg, attr_name, attr_value)
-        # spawn single instance
-        proto_prim_path = f"{template_prim_path}/Asset_{index:04d}"
+
+        proto_prim_path = f"{prefix_path}/{base_name.replace('.*', str(index))}"
         asset_cfg.func(
             proto_prim_path,
             asset_cfg,
@@ -97,35 +86,7 @@ def spawn_multi_asset(
         # append to proto prim paths
         proto_prim_paths.append(proto_prim_path)
 
-    # resolve prim paths for spawning and cloning
-    prim_paths = [f"{source_prim_path}/{asset_path}" for source_prim_path in source_prim_paths]
-
-    # manually clone prims if the source prim path is a regex expression
-    # note: unlike in the cloner API from Isaac Sim, we do not "reset" xforms on the copied prims.
-    #   This is because the "spawn" calls during the creation of the proto prims already handles this operation.
-    with Sdf.ChangeBlock():
-        for index, prim_path in enumerate(prim_paths):
-            # spawn single instance
-            env_spec = Sdf.CreatePrimInLayer(stage.GetRootLayer(), prim_path)
-            # randomly select an asset configuration
-            if cfg.random_choice:
-                proto_path = random.choice(proto_prim_paths)
-            else:
-                proto_path = proto_prim_paths[index % len(proto_prim_paths)]
-            # copy the proto prim
-            Sdf.CopySpec(env_spec.layer, Sdf.Path(proto_path), env_spec.layer, Sdf.Path(prim_path))
-
-    # delete the dataset prim after spawning
-    sim_utils.delete_prim(template_prim_path, stage=stage)
-
-    # set carb setting to indicate Isaac Lab's environments that different prims have been spawned
-    # at varying prim paths. In this case, PhysX parser shouldn't optimize the stage parsing.
-    # the flag is mainly used to inform the user that they should disable `InteractiveScene.replicate_physics`
-    carb_settings_iface = carb.settings.get_settings()
-    carb_settings_iface.set_bool("/isaaclab/spawn/multi_assets", True)
-
-    # return the prim
-    return stage.GetPrimAtPath(prim_paths[0])
+    return sim_utils.find_first_matching_prim(proto_prim_paths[0])
 
 
 def spawn_multi_usd_file(
@@ -165,7 +126,7 @@ def spawn_multi_usd_file(
     usd_template_cfg = UsdFileCfg()
     for attr_name, attr_value in cfg.__dict__.items():
         # skip names we know are not present
-        if attr_name in ["func", "usd_path", "random_choice"]:
+        if attr_name in ["func", "usd_path", "random_choice", "spawn_path"]:
             continue
         # set the attribute into the template
         setattr(usd_template_cfg, attr_name, attr_value)
@@ -175,8 +136,6 @@ def spawn_multi_usd_file(
     for usd_path in usd_paths:
         usd_cfg = usd_template_cfg.replace(usd_path=usd_path)
         multi_asset_cfg.assets_cfg.append(usd_cfg)
-    # set random choice
-    multi_asset_cfg.random_choice = cfg.random_choice
 
     # propagate the contact sensor settings
     # note: the default value for activate_contact_sensors in MultiAssetSpawnerCfg is False.

--- a/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers_cfg.py
@@ -35,10 +35,13 @@ class MultiAssetSpawnerCfg(RigidObjectSpawnerCfg, DeformableObjectSpawnerCfg):
     """List of asset configurations to spawn."""
 
     random_choice: bool = True
-    """Whether to randomly select an asset configuration. Default is True.
+    """ This parameter is ignored.
+    See :attr:`isaaclab.scene.interactive_scene_cfg.InteractiveSceneCfg.random_heterogeneous_cloning` for details.
 
-    If False, the asset configurations are spawned in the order they are provided in the list.
-    If True, a random asset configuration is selected for each spawn.
+    .. warning::
+
+        This attribute is deprecated. Use
+        :attr:`~isaaclab.scene.interactive_scene_cfg.InteractiveSceneCfg.random_heterogeneous_cloning` instead.
     """
 
 
@@ -64,4 +67,9 @@ class MultiUsdFileCfg(UsdFileCfg):
 
     If False, the asset configurations are spawned in the order they are provided in the list.
     If True, a random asset configuration is selected for each spawn.
+
+    .. warning::
+
+        This attribute is deprecated. Use
+        :attr:`~isaaclab.scene.interactive_scene_cfg.InteractiveSceneCfg.random_heterogeneous_cloning` instead.
     """

--- a/source/isaaclab/isaaclab/terrains/terrain_importer.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_importer.py
@@ -355,17 +355,9 @@ class TerrainImporter:
 
     def _compute_env_origins_grid(self, num_envs: int, env_spacing: float) -> torch.Tensor:
         """Compute the origins of the environments in a grid based on configured spacing."""
-        # create tensor based on number of environments
-        env_origins = torch.zeros(num_envs, 3, device=self.device)
-        # create a grid of origins
-        num_rows = np.ceil(num_envs / int(np.sqrt(num_envs)))
-        num_cols = np.ceil(num_envs / num_rows)
-        ii, jj = torch.meshgrid(
-            torch.arange(num_rows, device=self.device), torch.arange(num_cols, device=self.device), indexing="ij"
-        )
-        env_origins[:, 0] = -(ii.flatten()[:num_envs] - (num_rows - 1) / 2) * env_spacing
-        env_origins[:, 1] = (jj.flatten()[:num_envs] - (num_cols - 1) / 2) * env_spacing
-        env_origins[:, 2] = 0.0
+        from isaaclab.cloner import grid_transforms
+
+        env_origins, _ = grid_transforms(num_envs, env_spacing, device=self.device)
         return env_origins
 
     """

--- a/source/isaaclab/test/benchmark/test_recorders.py
+++ b/source/isaaclab/test/benchmark/test_recorders.py
@@ -237,7 +237,9 @@ class TestGPUInfoRecorder:
         measurement_data = recorder.get_data()
         assert isinstance(measurement_data, MeasurementData)
         # GPU data includes measurements (memory and utilization stats)
-        assert len(measurement_data.measurements) == 6  # memory (mean, std, n) + utilization (mean, std, n)
+        # 6 measurements per GPU: memory (mean, std, n) + utilization (mean, std, n)
+        num_gpus = data["gpu_metadata"]["device_count"]
+        assert len(measurement_data.measurements) == 6 * num_gpus
         # 4 metadata entries: device_count, current_device, cuda_version, gpu_devices dict
         assert len(measurement_data.metadata) == 4
 

--- a/source/isaaclab/test/envs/test_env_rendering_logic.py
+++ b/source/isaaclab/test/envs/test_env_rendering_logic.py
@@ -179,6 +179,9 @@ def test_env_rendering_logic(env_type, render_interval, physics_callback, render
         #   Without it, the test will exit after the environment is closed
         env.sim._app_control_on_stop_handle = None  # type: ignore
 
+        # Reset to initialize visualizers (they're created lazily in reset())
+        env.reset()
+
         # Ensure the default Kit visualizer is active for rendering callbacks.
         assert isinstance(env.sim.visualizers[0], KitVisualizer)
 

--- a/source/isaaclab/test/envs/test_scale_randomization.py
+++ b/source/isaaclab/test/envs/test_scale_randomization.py
@@ -262,6 +262,7 @@ class CubeEnvCfg(ManagerBasedEnvCfg):
     """Configuration for the locomotion velocity-tracking environment."""
 
     # Scene settings
+    # Note: replicate_physics=False is required for prestartup events (scale randomization)
     scene: MySceneCfg = MySceneCfg(num_envs=10, env_spacing=2.5, replicate_physics=False)
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for cloner utilities and InteractiveScene cloning behavior."""
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+# launch omniverse app
+simulation_app = AppLauncher(headless=True).app
+
+"""Rest everything follows."""
+
+import pytest
+import torch
+import warp as wp
+from isaaclab_physx.cloner import physx_replicate
+
+from pxr import UsdGeom
+
+import isaaclab.sim as sim_utils
+from isaaclab.cloner import TemplateCloneCfg, clone_from_template, sequential, usd_replicate
+from isaaclab.sim import build_simulation_context
+
+
+@pytest.fixture(params=["cpu", "cuda"])
+def sim(request):
+    """Provide a fresh simulation context for each test on CPU and CUDA."""
+    with build_simulation_context(device=request.param, dt=0.01, add_lighting=False) as sim:
+        yield sim
+
+
+def test_usd_replicate_with_positions_and_mask(sim):
+    """Replicate sources to selected envs and author translate ops from positions."""
+    # Prepare sources under /World/template
+    sim_utils.create_prim("/World/template", "Xform")
+    sim_utils.create_prim("/World/template/A", "Xform")
+    sim_utils.create_prim("/World/template/B", "Xform")
+
+    # Prepare destination env namespaces
+    num_envs = 3
+    env_ids = torch.arange(num_envs, dtype=torch.long)
+    sim_utils.create_prim("/World/envs", "Xform")
+    for i in range(num_envs):
+        sim_utils.create_prim(f"/World/envs/env_{i}", "Xform")
+
+    # Map A -> env 0 and 2; B -> env 1 only
+    mask = torch.zeros((2, num_envs), dtype=torch.bool)
+    mask[0, [0, 2]] = True
+    mask[1, [1]] = True
+
+    usd_replicate(
+        sim_utils.get_current_stage(),
+        sources=["/World/template/A", "/World/template/B"],
+        destinations=["/World/envs/env_{}/Object/A", "/World/envs/env_{}/Object/B"],
+        env_ids=env_ids,
+        mask=mask,
+    )
+
+    # Validate replication and translate op
+    stage = sim_utils.get_current_stage()
+    assert stage.GetPrimAtPath("/World/envs/env_0/Object/A").IsValid()
+    assert not stage.GetPrimAtPath("/World/envs/env_0/Object/B").IsValid()
+    assert stage.GetPrimAtPath("/World/envs/env_1/Object/B").IsValid()
+    assert not stage.GetPrimAtPath("/World/envs/env_1/Object/A").IsValid()
+    assert stage.GetPrimAtPath("/World/envs/env_2/Object/A").IsValid()
+
+    # Check xformOp:translate authored for env_2/A
+    prim = stage.GetPrimAtPath("/World/envs/env_2/Object/A")
+    xform = UsdGeom.Xformable(prim)
+    ops = xform.GetOrderedXformOps()
+    assert any(op.GetOpType() == UsdGeom.XformOp.TypeTranslate for op in ops)
+
+
+def test_usd_replicate_depth_order_parent_child(sim):
+    """Replicate parent and child when provided out of order; parent should exist before child."""
+    # Prepare sources
+    sim_utils.create_prim("/World/template", "Xform")
+    sim_utils.create_prim("/World/template/Parent", "Xform")
+    sim_utils.create_prim("/World/template/Parent/Child", "Xform")
+
+    # Destinations (single env)
+    env_ids = torch.tensor([0, 1], dtype=torch.long)
+    sim_utils.create_prim("/World/envs", "Xform")
+    sim_utils.create_prim("/World/envs/env_0", "Xform")
+    sim_utils.create_prim("/World/envs/env_1", "Xform")
+
+    # Provide child first, then parent; depth sort should handle this
+    usd_replicate(
+        sim_utils.get_current_stage(),
+        sources=["/World/template/Parent/Child", "/World/template/Parent"],
+        destinations=["/World/envs/env_{}/Parent/Child", "/World/envs/env_{}/Parent"],
+        env_ids=env_ids,
+    )
+
+    stage = sim_utils.get_current_stage()
+    for i in range(2):
+        assert stage.GetPrimAtPath(f"/World/envs/env_{i}/Parent").IsValid()
+        assert stage.GetPrimAtPath(f"/World/envs/env_{i}/Parent/Child").IsValid()
+
+
+def test_physx_replicate_no_error(sim):
+    """PhysX replicator call runs without raising exceptions for simple mapping."""
+    # Prepare sources and envs
+    sim_utils.create_prim("/World/envs", "Xform")
+    sim_utils.create_prim("/World/template", "Xform")
+    sim_utils.create_prim("/World/template/A", "Xform")
+
+    num_envs = 2
+    env_ids = torch.arange(num_envs, dtype=torch.long)
+    for i in range(num_envs):
+        sim_utils.create_prim(f"/World/envs/env_{i}", "Xform")
+
+    mapping = torch.ones((1, num_envs), dtype=torch.bool)
+
+    # Should not raise
+    physx_replicate(
+        sim_utils.get_current_stage(),
+        sources=["/World/template/A"],
+        destinations=["/World/envs/env_{}/A"],
+        env_ids=env_ids,
+        mapping=mapping,
+    )
+
+
+def test_clone_from_template(sim):
+    """Clone prototypes via TemplateCloneCfg and clone_from_template and exercise both USD and PhysX.
+
+    Steps:
+    - Create /World/template and /World/envs/env_0..env_31
+    - Spawn three prototypes under /World/template/Object/proto_asset_.*
+    - Clone using TemplateCloneCfg with random_heterogeneous_cloning=False (modulo mapping)
+    - Verify modulo placement exists; then call sim.reset(), and create PhysX view
+    """
+    num_clones = 32
+    clone_cfg = TemplateCloneCfg(device=sim.cfg.device, clone_strategy=sequential)
+    sim_utils.create_prim(clone_cfg.template_root, "Xform")
+    sim_utils.create_prim(f"{clone_cfg.template_root}/Object", "Xform")  # Parent for prototypes
+    sim_utils.create_prim("/World/envs", "Xform")
+    for i in range(num_clones):
+        sim_utils.create_prim(f"/World/envs/env_{i}", "Xform", translation=(0, 0, 0))
+
+    # Spawn prototypes under template
+    cfg = sim_utils.MultiAssetSpawnerCfg(
+        assets_cfg=[
+            sim_utils.ConeCfg(
+                radius=0.3,
+                height=0.6,
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0), metallic=0.2),
+                mass_props=sim_utils.MassPropertiesCfg(mass=100.0),
+            ),
+            sim_utils.CuboidCfg(
+                size=(0.3, 0.3, 0.3),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0), metallic=0.2),
+            ),
+            sim_utils.SphereCfg(
+                radius=0.3,
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 1.0), metallic=0.2),
+            ),
+        ],
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            solver_position_iteration_count=4, solver_velocity_iteration_count=0
+        ),
+        mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        collision_props=sim_utils.CollisionPropertiesCfg(),
+    )
+    prim = cfg.func(f"{clone_cfg.template_root}/Object/{clone_cfg.template_prototype_identifier}_.*", cfg)
+    assert prim.IsValid()
+
+    stage = sim_utils.get_current_stage()
+    clone_from_template(stage, num_clones=num_clones, template_clone_cfg=clone_cfg)
+
+    primitive_prims = sim_utils.get_all_matching_child_prims(
+        "/World/envs", predicate=lambda prim: prim.GetTypeName() in ["Cone", "Cube", "Sphere"]
+    )
+
+    for i, primitive_prim in enumerate(primitive_prims):
+        modulus = i % 3
+        if modulus == 0:
+            assert primitive_prim.GetTypeName() == "Cone"
+        elif modulus == 1:
+            assert primitive_prim.GetTypeName() == "Cube"
+        else:
+            assert primitive_prim.GetTypeName() == "Sphere"
+
+    # Exercise PhysX initialization; should not raise error
+    sim.reset()
+    object_view_regex = f"{clone_cfg.clone_regex}/Object".replace(".*", "*")
+    physics_sim_view = sim.physics_manager.get_physics_sim_view()
+    physx_view = physics_sim_view.create_rigid_body_view(object_view_regex)
+    assert physx_view is not None
+
+
+def _run_colocation_collision_filter(sim, asset_cfg, expected_types, assert_count=False):
+    """Shared harness for colocated collision filter checks across devices."""
+    num_clones = 32
+    clone_cfg = TemplateCloneCfg(device=sim.cfg.device, clone_strategy=sequential)
+    sim_utils.create_prim(clone_cfg.template_root, "Xform")
+    sim_utils.create_prim(f"{clone_cfg.template_root}/Object", "Xform")  # Parent for prototypes
+    sim_utils.create_prim("/World/envs", "Xform")
+    for i in range(num_clones):
+        sim_utils.create_prim(f"/World/envs/env_{i}", "Xform", translation=(0, 0, 0))
+
+    # Use _.*  pattern - the @clone decorator replaces .* with 0 for single-asset spawners
+    prim = asset_cfg.func(f"{clone_cfg.template_root}/Object/{clone_cfg.template_prototype_identifier}_.*", asset_cfg)
+    assert prim.IsValid()
+
+    stage = sim_utils.get_current_stage()
+    clone_from_template(stage, num_clones=num_clones, template_clone_cfg=clone_cfg)
+
+    primitive_prims = sim_utils.get_all_matching_child_prims(
+        "/World/envs", predicate=lambda prim: prim.GetTypeName() in expected_types
+    )
+
+    if assert_count:
+        assert len(primitive_prims) == num_clones
+
+    for i, primitive_prim in enumerate(primitive_prims):
+        assert primitive_prim.GetTypeName() == expected_types[i % len(expected_types)]
+
+    sim.reset()
+    object_view_regex = f"{clone_cfg.clone_regex}/Object".replace(".*", "*")
+    physics_sim_view = sim.physics_manager.get_physics_sim_view()
+    physx_view = physics_sim_view.create_rigid_body_view(object_view_regex)
+    for _ in range(100):
+        sim.step()
+    transforms = wp.to_torch(physx_view.get_transforms())
+    distance_from_origin = torch.linalg.norm(transforms[:, :2], dim=-1)
+    assert torch.all(distance_from_origin < 0.1)
+
+
+def test_colocation_collision_filter_homogeneous(sim):
+    """Verify colocated clones of a single prototype stay stable after PhysX cloning.
+
+    All clones are spawned at exactly the same pose; if the collision filter is wrong the pile
+    explodes on reset. This asserts the filter keeps the colocated objects stable while stepping
+    across CPU and CUDA backends.
+    """
+    _run_colocation_collision_filter(
+        sim,
+        sim_utils.ConeCfg(
+            radius=0.3,
+            height=0.6,
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0), metallic=0.2),
+            mass_props=sim_utils.MassPropertiesCfg(mass=100.0),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                solver_position_iteration_count=4, solver_velocity_iteration_count=0
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+        ),
+        expected_types=["Cone"],
+        assert_count=True,
+    )
+
+
+@pytest.mark.xfail(reason="Heterogeneous cloning with collision filtering not yet fully supported")
+def test_colocation_collision_filter_heterogeneous(sim):
+    """Verify colocated clones of multiple prototypes retain modulo ordering and remain stable.
+
+    The cone, cube, and sphere are all spawned in the identical pose for every clone; an incorrect
+    collision filter would blow up the simulation on reset. This guards both modulo ordering and
+    that the colocated set stays stable through PhysX steps across CPU and CUDA.
+    """
+    _run_colocation_collision_filter(
+        sim,
+        sim_utils.MultiAssetSpawnerCfg(
+            assets_cfg=[
+                sim_utils.ConeCfg(
+                    radius=0.3,
+                    height=0.6,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0), metallic=0.2),
+                    mass_props=sim_utils.MassPropertiesCfg(mass=100.0),
+                ),
+                sim_utils.CuboidCfg(
+                    size=(0.3, 0.3, 0.3),
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0), metallic=0.2),
+                ),
+                sim_utils.SphereCfg(
+                    radius=0.3,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 1.0), metallic=0.2),
+                ),
+            ],
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                solver_position_iteration_count=4, solver_velocity_iteration_count=0
+            ),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+        ),
+        expected_types=["Cone", "Cube", "Sphere"],
+    )

--- a/source/isaaclab/test/sim/test_spawn_shapes.py
+++ b/source/isaaclab/test/sim/test_spawn_shapes.py
@@ -256,26 +256,18 @@ def test_spawn_cone_clones_invalid_paths(sim):
 
 def test_spawn_cone_clones(sim):
     """Test spawning of cone clones."""
-    num_clones = 10
-    for i in range(num_clones):
-        sim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+    sim_utils.create_prim("/World/env_0", "Xform", translation=(0, 0, 0))
     # Spawn cone on valid cloning path
     cfg = sim_utils.ConeCfg(radius=1.0, height=2.0, copy_from_source=True)
     prim = cfg.func("/World/env_.*/Cone", cfg)
-
     # Check validity
     assert prim.IsValid()
     assert str(prim.GetPath()) == "/World/env_0/Cone"
-    # find matching prims
-    prims = sim_utils.find_matching_prim_paths("/World/env_.*/Cone")
-    assert len(prims) == num_clones
 
 
 def test_spawn_cone_clone_with_all_props_global_material(sim):
     """Test spawning of cone clones with global material reference."""
-    num_clones = 10
-    for i in range(num_clones):
-        sim_utils.create_prim(f"/World/env_{i}", "Xform", translation=(i, i, 0))
+    sim_utils.create_prim("/World/env_0", "Xform", translation=(0, 0, 0))
     # Spawn cone on valid cloning path
     cfg = sim_utils.ConeCfg(
         radius=1.0,
@@ -293,9 +285,6 @@ def test_spawn_cone_clone_with_all_props_global_material(sim):
     # Check validity
     assert prim.IsValid()
     assert str(prim.GetPath()) == "/World/env_0/Cone"
-    # find matching prims
-    prims = sim_utils.find_matching_prim_paths("/World/env_.*/Cone")
-    assert len(prims) == num_clones
     # find matching material prims
     prims = sim_utils.find_matching_prim_paths("/Looks/visualMaterial.*")
     assert len(prims) == 1

--- a/source/isaaclab_newton/isaaclab_newton/cloner/__init__.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from .newton_replicate import newton_replicate
+
+__all__ = ["newton_replicate"]

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+
+from pxr import Usd
+
+
+def newton_replicate(
+    stage: Usd.Stage,
+    sources: list[str],
+    destinations: list[str],
+    env_ids: torch.Tensor,
+    mapping: torch.Tensor,
+    positions: torch.Tensor | None = None,
+    quaternions: torch.Tensor | None = None,
+    device: str = "cpu",
+    up_axis: str = "Z",
+    simplify_meshes: bool = True,
+):
+    """Replicate prims for Newton physics backend.
+
+    Newton does not require explicit physics replication like PhysX.
+    This is a no-op placeholder that maintains API compatibility.
+
+    Args:
+        stage: USD stage.
+        sources: Source prim paths.
+        destinations: Destination templates with ``"{}"`` for env index.
+        env_ids: Environment indices.
+        mapping: Bool mask selecting envs per source.
+        use_fabric: Unused (for API compatibility).
+        device: Unused (for API compatibility).
+
+    Returns:
+        None
+    """
+    # Newton doesn't need explicit physics replication - USD replication is sufficient
+    pass

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
@@ -77,17 +77,10 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         self.cfg = cfg.copy()
         # flag for whether the asset is initialized
         self._is_initialized = False
-        self._prim_paths = []
         # spawn the rigid objects
         for rigid_body_cfg in self.cfg.rigid_objects.values():
-            # check if the rigid object path is valid
-            # note: currently the spawner does not work if there is a regex pattern in the leaf
-            #   For example, if the prim path is "/World/Object_[1,2]" since the spawner will not
-            #   know which prim to spawn. This is a limitation of the spawner and not the asset.
-            asset_path = rigid_body_cfg.prim_path.split("/")[-1]
-            asset_path_is_regex = re.match(r"^[a-zA-Z0-9/_]+$", asset_path) is None
             # spawn the asset
-            if rigid_body_cfg.spawn is not None and not asset_path_is_regex:
+            if rigid_body_cfg.spawn is not None:
                 rigid_body_cfg.spawn.func(
                     rigid_body_cfg.prim_path,
                     rigid_body_cfg.spawn,
@@ -98,7 +91,6 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             matching_prims = sim_utils.find_matching_prims(rigid_body_cfg.prim_path)
             if len(matching_prims) == 0:
                 raise RuntimeError(f"Could not find prim with path {rigid_body_cfg.prim_path}.")
-            self._prim_paths.append(rigid_body_cfg.prim_path)
         # stores object names
         self._body_names_list = []
 
@@ -1201,7 +1193,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         if prim_path == "/":
             self._clear_callbacks()
             return
-        for prim_path_expr in self._prim_paths:
+        for prim_path_expr in [obj.prim_path for obj in self.cfg.rigid_objects.values()]:
             result = re.match(
                 pattern="^" + "/".join(prim_path_expr.split("/")[: prim_path.count("/") + 1]) + "$", string=prim_path
             )

--- a/source/isaaclab_physx/isaaclab_physx/cloner/__init__.py
+++ b/source/isaaclab_physx/isaaclab_physx/cloner/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from .physx_replicate import physx_replicate
+
+__all__ = ["physx_replicate"]

--- a/source/isaaclab_physx/isaaclab_physx/cloner/physx_replicate.py
+++ b/source/isaaclab_physx/isaaclab_physx/cloner/physx_replicate.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+
+from omni.physx import get_physx_replicator_interface
+from pxr import Usd, UsdUtils
+
+
+def physx_replicate(
+    stage: Usd.Stage,
+    sources: list[str],  # e.g. ["/World/Template/A", "/World/Template/B"]
+    destinations: list[str],  # e.g. ["/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"]
+    env_ids: torch.Tensor,  # env_ids
+    mapping: torch.Tensor,  # (num_sources, num_envs) bool; True -> place sources[i] into world=j
+    positions: torch.Tensor | None = None,
+    quaternions: torch.Tensor | None = None,
+    use_fabric: bool = False,
+    device: str = "cpu",
+) -> None:
+    """Replicate prims via PhysX replicator with per-row mapping.
+
+    Builds per-source destination lists from ``mapping`` and calls PhysX ``replicate``.
+    Rows covering all environments use ``useEnvIds=True``; partial rows use ``False``.
+    The replicator is registered for the call and then unregistered.
+
+    Args:
+        stage: USD stage.
+        sources: Source prim paths (``S``).
+        destinations: Destination templates (``S``) with ``"{}"`` for env index.
+        env_ids: Environment indices (``[E]``).
+        mapping: Bool/int mask (``[S, E]``) selecting envs per source.
+        positions: Optional positions (unused, for API compatibility).
+        quaternions: Optional orientations (unused, for API compatibility).
+        use_fabric: Use Fabric for replication.
+        device: Torch device for determining replication mode.
+
+    Returns:
+        None
+    """
+    # Note: positions and quaternions are unused by PhysX replicator
+    # They are included for API compatibility with other backends (e.g., Newton)
+    del positions, quaternions
+
+    stage_id = UsdUtils.StageCache.Get().Insert(stage).ToLongInt()
+    current_worlds: list[int] = []
+    current_template: str = ""
+    num_envs = mapping.size(1)
+
+    def attach_fn(_stage_id: int):
+        return ["/World/envs", *sources]
+
+    def rename_fn(_replicate_path: str, i: int):
+        return current_template.format(current_worlds[i])
+
+    def attach_end_fn(_stage_id: int):
+        nonlocal current_template
+        rep = get_physx_replicator_interface()
+        for i, src in enumerate(sources):
+            current_worlds[:] = env_ids[mapping[i]].tolist()
+            current_template = destinations[i]
+            rep.replicate(
+                _stage_id,
+                src,
+                len(current_worlds),
+                useEnvIds=(len(current_worlds) == num_envs) and device != "cpu",
+                useFabricForReplication=use_fabric,
+            )
+        # unregister only AFTER all replicate() calls completed
+        rep.unregister_replicator(_stage_id)
+
+    get_physx_replicator_interface().register_replicator(stage_id, attach_fn, attach_end_fn, rename_fn)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/dexsuite_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/dexsuite_env_cfg.py
@@ -187,13 +187,6 @@ class ObservationsCfg:
 class EventCfg:
     """Configuration for randomization."""
 
-    # -- pre-startup
-    randomize_object_scale = EventTerm(
-        func=mdp.randomize_rigid_body_scale,
-        mode="prestartup",
-        params={"scale_range": (0.75, 1.5), "asset_cfg": SceneEntityCfg("object")},
-    )
-
     robot_physics_material = EventTerm(
         func=mdp.randomize_rigid_body_material,
         mode="startup",
@@ -395,7 +388,7 @@ class DexsuiteReorientEnvCfg(ManagerBasedEnvCfg):
 
     # Scene settings
     viewer: ViewerCfg = ViewerCfg(eye=(-2.25, 0.0, 0.75), lookat=(0.0, 0.0, 0.45), origin_type="env")
-    scene: SceneCfg = SceneCfg(num_envs=4096, env_spacing=3, replicate_physics=False)
+    scene: SceneCfg = SceneCfg(num_envs=4096, env_spacing=3, replicate_physics=True)
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()
     actions: ActionsCfg = ActionsCfg()


### PR DESCRIPTION
# Description
This PR refactors cloner logic into usd_replicate, physx_replicate, (also test to work for newton_replicate but not include in this PR)

At the highest level, This PR decouples cloning responsibility away from spawner, and delegate it to a dedicated lab cloner. The only job for spawner is to spawn prototype, and if any cloning is intended, one needs to use the cloner(either USD cloner, Physx Cloner, or Newton Cloner, whether that be homogeneous cloning or heterogeneous cloning).


In detail this PR
- Adds heterogeneous cloning to InteractiveScene with per-object replication when envs differ, improving PhysX cloning time for heterogeneous scenes while perserving whole env replication in homogenous setting.
- Introduces scene-level flag InteractiveSceneCfg.random_heterogenous_cloning (defaults True) to control prototype assignment:
---True: randomly assigns a prototype per env.
---False: uses round‑robin (env_index % num_prototypes) for determinism (previous behavior).

- Removes hard dependency on the Isaac Sim Cloner; uses internal replicators usd_replicate and physx_replicate.
Deprecates random_choice in MultiAssetSpawnerCfg and MultiUsdFileCfg in favor of the scene-level flag for consistent, scalable control.


While this PR tries to preserve as much original behavior as possible,
with new refactors, it makes cloning with explicit constraints and composition, even proportion very easy, and I will be working on that as next goal.

# Perf

Runing `scripts/demos/multi_asset.py` with 8192 envs

Before:
>[INFO] Time to create scene:  : 29.790888 seconds
>[INFO] Time to randomize scene:  : 0.161381 seconds
>[INFO] to start Simulation:  : 27.550733 seconds

After:
>[INFO] Time to create scene:  : 31.276912 seconds
>[INFO] Time to randomize scene:  : 0.004585 seconds
>[INFO] Time to start Simulation:  : 5.232237 seconds  <--------------- much quicker

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)

## Screenshots

Please attach before and after screenshots of the change if applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
