### PR TITLE
Migrates settings access from carb.settings to SettingsManager.

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "3.5.2"
+version = "3.5.3"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+
+3.4.3 (2026-02-22)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Migrated settings access from ``carb.settings`` to :class:`~isaaclab.app.settings_manager.SettingsManager`.
+  Application code and tests now use :func:`~isaaclab.app.settings_manager.get_settings_manager` or
+  :meth:`~isaaclab.sim.SimulationContext.get_setting` / :meth:`~isaaclab.sim.SimulationContext.set_setting`
+  instead of ``carb.settings.get_settings()``.
+
+
 3.4.2 (2026-02-20)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/app/__init__.py
+++ b/source/isaaclab/isaaclab/app/__init__.py
@@ -13,3 +13,4 @@ These include:
 """
 
 from .app_launcher import AppLauncher  # noqa: F401, F403
+from .settings_manager import SettingsManager, get_settings_manager, initialize_carb_settings  # noqa: F401, F403

--- a/source/isaaclab/isaaclab/app/settings_manager.py
+++ b/source/isaaclab/isaaclab/app/settings_manager.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Settings manager for Isaac Lab that works with or without Omniverse carb.settings.
+
+This module provides a unified settings interface that can work in two modes:
+1. Omniverse mode: Uses carb.settings when SimulationApp is launched
+2. Standalone mode: Uses pure Python dictionary when running without Omniverse
+
+This allows Isaac Lab to run visualizers like Rerun and Newton without requiring
+the full Omniverse/SimulationApp stack.
+"""
+
+import sys
+from typing import Any
+
+# Key for storing singleton in sys.modules to survive module reloads (e.g., from Hydra)
+_SINGLETON_KEY = "__isaaclab_settings_manager_singleton__"
+
+
+class SettingsManager:
+    """A settings manager that provides a carb.settings-like interface without requiring Omniverse.
+
+    This class can work in two modes:
+    - Standalone mode: Uses a Python dictionary to store settings
+    - Omniverse mode: Delegates to carb.settings when available
+
+    The interface is designed to be compatible with the carb.settings API.
+
+    This is implemented as a singleton to ensure only one instance exists across the application,
+    even when used in different execution contexts (e.g., Hydra). The singleton is stored in
+    sys.modules to survive module reloads.
+    """
+
+    def __new__(cls):
+        """Singleton pattern - always return the same instance, stored in sys.modules to survive reloads."""
+        # Check if instance exists in sys.modules (survives module reloads)
+        instance = sys.modules.get(_SINGLETON_KEY)
+
+        if instance is None:
+            instance = super().__new__(cls)
+            sys.modules[_SINGLETON_KEY] = instance
+            # Mark that this instance needs initialization
+            instance._needs_init = True
+
+        return instance
+
+    def __init__(self):
+        """Initialize the settings manager (only runs once due to singleton pattern)."""
+        # Check if this instance needs initialization
+        needs_init = getattr(self, "_needs_init", False)
+
+        if not needs_init:
+            return
+
+        self._standalone_settings: dict[str, Any] = {}
+        self._carb_settings = None
+        self._use_carb = False
+        self._needs_init = False
+
+    @classmethod
+    def instance(cls) -> "SettingsManager":
+        """Get the singleton instance of the settings manager.
+
+        Returns:
+            The singleton SettingsManager instance
+        """
+        # Get instance from sys.modules (survives module reloads)
+        instance = sys.modules.get(_SINGLETON_KEY)
+
+        if instance is None:
+            instance = cls()
+
+        return instance
+
+    def initialize_carb_settings(self):
+        """Initialize carb.settings if SimulationApp has been launched.
+
+        This should be called after SimulationApp is created to enable
+        Omniverse mode. If not called, the manager operates in standalone mode.
+        """
+        try:
+            import carb
+
+            self._carb_settings = carb.settings.get_settings()
+            self._use_carb = True
+        except (ImportError, AttributeError):
+            # carb not available or SimulationApp not launched - use standalone mode
+            self._use_carb = False
+
+    def set(self, path: str, value: Any) -> None:
+        """Set a setting value at the given path.
+
+        Args:
+            path: The settings path (e.g., "/isaaclab/render/offscreen")
+            value: The value to set
+        """
+        if self._use_carb and self._carb_settings is not None:
+            # Delegate to carb.settings
+            if isinstance(value, bool):
+                self._carb_settings.set_bool(path, value)
+            elif isinstance(value, int):
+                self._carb_settings.set_int(path, value)
+            elif isinstance(value, float):
+                self._carb_settings.set_float(path, value)
+            elif isinstance(value, str):
+                self._carb_settings.set_string(path, value)
+            else:
+                # For other types, try generic set
+                self._carb_settings.set(path, value)
+        else:
+            # Standalone mode - use dictionary
+            self._standalone_settings[path] = value
+
+    def get(self, path: str, default: Any = None) -> Any:
+        """Get a setting value at the given path.
+
+        Args:
+            path: The settings path (e.g., "/isaaclab/render/offscreen")
+            default: Default value to return if path doesn't exist
+
+        Returns:
+            The value at the path, or default if not found
+        """
+        if self._use_carb and self._carb_settings is not None:
+            # Delegate to carb.settings
+            value = self._carb_settings.get(path)
+            return value if value is not None else default
+        else:
+            # Standalone mode - use dictionary
+            return self._standalone_settings.get(path, default)
+
+    def set_bool(self, path: str, value: bool) -> None:
+        """Set a boolean setting value.
+
+        Args:
+            path: The settings path
+            value: The boolean value to set
+        """
+        self.set(path, value)
+
+    def set_int(self, path: str, value: int) -> None:
+        """Set an integer setting value.
+
+        Args:
+            path: The settings path
+            value: The integer value to set
+        """
+        self.set(path, value)
+
+    def set_float(self, path: str, value: float) -> None:
+        """Set a float setting value.
+
+        Args:
+            path: The settings path
+            value: The float value to set
+        """
+        self.set(path, value)
+
+    def set_string(self, path: str, value: str) -> None:
+        """Set a string setting value.
+
+        Args:
+            path: The settings path
+            value: The string value to set
+        """
+        self.set(path, value)
+
+    @property
+    def is_omniverse_mode(self) -> bool:
+        """Check if the settings manager is using carb.settings (Omniverse mode).
+
+        Returns:
+            True if using carb.settings, False if using standalone mode
+        """
+        return self._use_carb
+
+
+def get_settings_manager() -> SettingsManager:
+    """Get the global settings manager instance.
+
+    The SettingsManager is implemented as a singleton, so this function
+    always returns the same instance. The singleton is stored in sys.modules
+    to survive module reloads (e.g., from Hydra).
+
+    Returns:
+        The global SettingsManager instance
+    """
+    # Get instance from sys.modules (survives module reloads)
+    instance = sys.modules.get(_SINGLETON_KEY)
+    if instance is None:
+        instance = SettingsManager()
+    return instance
+
+
+def initialize_carb_settings():
+    """Initialize carb.settings integration for the global settings manager.
+
+    This should be called after SimulationApp is created to enable
+    Omniverse mode for the global settings manager.
+    """
+    manager = get_settings_manager()
+    manager.initialize_carb_settings()

--- a/source/isaaclab/isaaclab/devices/gamepad/se2_gamepad.py
+++ b/source/isaaclab/isaaclab/devices/gamepad/se2_gamepad.py
@@ -18,6 +18,8 @@ import carb
 import carb.input
 import omni
 
+from isaaclab.app.settings_manager import get_settings_manager
+
 from ..device_base import DeviceBase, DeviceCfg
 
 
@@ -59,8 +61,7 @@ class Se2Gamepad(DeviceBase):
                 this value will be ignored. Defaults to 0.01.
         """
         # turn off simulator gamepad control
-        carb_settings_iface = carb.settings.get_settings()
-        carb_settings_iface.set_bool("/persistent/app/omniverse/gamepadCameraControl", False)
+        get_settings_manager().set_bool("/persistent/app/omniverse/gamepadCameraControl", False)
         # store inputs
         self.v_x_sensitivity = cfg.v_x_sensitivity
         self.v_y_sensitivity = cfg.v_y_sensitivity

--- a/source/isaaclab/isaaclab/devices/gamepad/se3_gamepad.py
+++ b/source/isaaclab/isaaclab/devices/gamepad/se3_gamepad.py
@@ -18,6 +18,8 @@ from scipy.spatial.transform import Rotation
 import carb
 import omni
 
+from isaaclab.app.settings_manager import get_settings_manager
+
 from ..device_base import DeviceBase, DeviceCfg
 
 
@@ -62,8 +64,7 @@ class Se3Gamepad(DeviceBase):
             cfg: Configuration object for gamepad settings.
         """
         # turn off simulator gamepad control
-        carb_settings_iface = carb.settings.get_settings()
-        carb_settings_iface.set_bool("/persistent/app/omniverse/gamepadCameraControl", False)
+        get_settings_manager().set_bool("/persistent/app/omniverse/gamepadCameraControl", False)
         # store inputs
         self.pos_sensitivity = cfg.pos_sensitivity
         self.rot_sensitivity = cfg.rot_sensitivity

--- a/source/isaaclab/isaaclab/sensors/camera/tiled_camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/tiled_camera.py
@@ -14,9 +14,9 @@ import numpy as np
 import torch
 import warp as wp
 
-import carb
 from pxr import UsdGeom
 
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.sim.views import XformPrimView
 from isaaclab.utils.warp.kernels import reshape_tiled_image
 
@@ -145,8 +145,7 @@ class TiledCamera(Camera):
             RuntimeError: If the number of camera prims in the view does not match the number of environments.
             RuntimeError: If replicator was not found.
         """
-        carb_settings_iface = carb.settings.get_settings()
-        if not carb_settings_iface.get("/isaaclab/cameras_enabled"):
+        if not get_settings_manager().get("/isaaclab/cameras_enabled"):
             raise RuntimeError(
                 "A camera was spawned without the --enable_cameras flag. Please use --enable_cameras to enable"
                 " rendering."
@@ -193,7 +192,7 @@ class TiledCamera(Camera):
             # Set simple shading mode (if requested) before rendering
             simple_shading_mode = self._resolve_simple_shading_mode()
             if simple_shading_mode is not None:
-                carb.settings.get_settings().set_int(self.SIMPLE_SHADING_MODE_SETTING, simple_shading_mode)
+                get_settings_manager().set_int(self.SIMPLE_SHADING_MODE_SETTING, simple_shading_mode)
         # Define the annotators based on requested data types
         self._annotators = dict()
         for annotator_type in self.cfg.data_types:

--- a/source/isaaclab/test/app/test_argparser_launch.py
+++ b/source/isaaclab/test/app/test_argparser_launch.py
@@ -27,16 +27,11 @@ def test_livestream_launch_with_argparser(mocker):
     # everything defaults to None
     app = AppLauncher(mock_args).app
 
-    # import settings
-    import carb
+    from isaaclab.app.settings_manager import get_settings_manager
 
-    # acquire settings interface
-    carb_settings_iface = carb.settings.get_settings()
-    # check settings
-    # -- no-gui mode
-    assert carb_settings_iface.get("/app/window/enabled") is False
-    # -- livestream
-    assert carb_settings_iface.get("/app/livestream/enabled") is True
+    settings = get_settings_manager()
+    assert settings.get("/app/window/enabled") is False
+    assert settings.get("/app/livestream/enabled") is True
 
     # close the app on exit
     app.close()

--- a/source/isaaclab/test/app/test_env_var_launch.py
+++ b/source/isaaclab/test/app/test_env_var_launch.py
@@ -18,16 +18,11 @@ def test_livestream_launch_with_env_vars(mocker):
     # everything defaults to None
     app = AppLauncher().app
 
-    # import settings
-    import carb
+    from isaaclab.app.settings_manager import get_settings_manager
 
-    # acquire settings interface
-    carb_settings_iface = carb.settings.get_settings()
-    # check settings
-    # -- no-gui mode
-    assert carb_settings_iface.get("/app/window/enabled") is False
-    # -- livestream
-    assert carb_settings_iface.get("/app/livestream/enabled") is True
+    settings = get_settings_manager()
+    assert settings.get("/app/window/enabled") is False
+    assert settings.get("/app/livestream/enabled") is True
 
     # close the app on exit
     app.close()

--- a/source/isaaclab/test/app/test_kwarg_launch.py
+++ b/source/isaaclab/test/app/test_kwarg_launch.py
@@ -14,16 +14,11 @@ def test_livestream_launch_with_kwargs(mocker):
     # everything defaults to None
     app = AppLauncher(headless=True, livestream=1).app
 
-    # import settings
-    import carb
+    from isaaclab.app.settings_manager import get_settings_manager
 
-    # acquire settings interface
-    carb_settings_iface = carb.settings.get_settings()
-    # check settings
-    # -- no-gui mode
-    assert carb_settings_iface.get("/app/window/enabled") is False
-    # -- livestream
-    assert carb_settings_iface.get("/app/livestream/enabled") is True
+    settings = get_settings_manager()
+    assert settings.get("/app/window/enabled") is False
+    assert settings.get("/app/livestream/enabled") is True
 
     # close the app on exit
     app.close()

--- a/source/isaaclab/test/envs/test_action_state_recorder_term.py
+++ b/source/isaaclab/test/envs/test_action_state_recorder_term.py
@@ -20,9 +20,8 @@ import gymnasium as gym
 import pytest
 import torch
 
-import carb
-
 import isaaclab.sim as sim_utils
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.envs.mdp.recorders.recorders_cfg import ActionStateRecorderManagerCfg
 
 import isaaclab_tasks  # noqa: F401
@@ -31,9 +30,8 @@ from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_carb_settings():
-    """Set up carb settings to prevent simulation getting stuck."""
-    carb_settings_iface = carb.settings.get_settings()
-    carb_settings_iface.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+    """Set up settings to prevent simulation getting stuck."""
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
 
 
 @pytest.fixture

--- a/source/isaaclab/test/envs/test_manager_based_rl_env_ui.py
+++ b/source/isaaclab/test/envs/test_manager_based_rl_env_ui.py
@@ -16,7 +16,6 @@ simulation_app = AppLauncher(headless=True, enable_cameras=True).app
 
 """Rest everything follows."""
 
-import carb
 from isaacsim.core.utils.extensions import enable_extension
 
 import isaaclab.sim as sim_utils
@@ -78,7 +77,9 @@ def test_ui_window():
     """Test UI window of ManagerBasedRLEnv."""
     device = "cuda:0"
     # override sim setting to enable UI
-    carb.settings.get_settings().set_bool("/app/window/enabled", True)
+    from isaaclab.app.settings_manager import get_settings_manager
+
+    get_settings_manager().set_bool("/app/window/enabled", True)
     # create a new stage
     sim_utils.create_new_stage()
     # create environment

--- a/source/isaaclab/test/sensors/test_outdated_sensor.py
+++ b/source/isaaclab/test/sensors/test_outdated_sensor.py
@@ -19,9 +19,8 @@ import gymnasium as gym
 import pytest
 import torch
 
-import carb
-
 import isaaclab.sim as sim_utils
+from isaaclab.app.settings_manager import get_settings_manager
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
@@ -32,8 +31,7 @@ def temp_dir():
     """Fixture to create and clean up a temporary directory for test datasets."""
     # this flag is necessary to prevent a bug where the simulation gets stuck randomly when running the
     # test on many environments.
-    carb_settings_iface = carb.settings.get_settings()
-    carb_settings_iface.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
     # create a temporary directory to store the test datasets
     temp_dir = tempfile.mkdtemp()
     yield temp_dir

--- a/source/isaaclab/test/sim/test_simulation_render_config.py
+++ b/source/isaaclab/test/sim/test_simulation_render_config.py
@@ -20,8 +20,7 @@ import flatdict
 import pytest
 import toml
 
-import carb
-
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.sim.simulation_cfg import RenderCfg, SimulationCfg
 from isaaclab.sim.simulation_context import SimulationContext
 from isaaclab.utils.version import get_isaac_sim_version
@@ -76,21 +75,17 @@ def test_render_cfg():
     assert sim.cfg.render.enable_shadows == enable_shadows
     assert sim.cfg.render.enable_ambient_occlusion == enable_ambient_occlusion
 
-    carb_settings_iface = carb.settings.get_settings()
-    assert carb_settings_iface.get("/rtx/translucency/enabled") == sim.cfg.render.enable_translucency
-    assert carb_settings_iface.get("/rtx/reflections/enabled") == sim.cfg.render.enable_reflections
-    assert carb_settings_iface.get("/rtx/indirectDiffuse/enabled") == sim.cfg.render.enable_global_illumination
-    assert carb_settings_iface.get("/rtx-transient/dlssg/enabled") == sim.cfg.render.enable_dlssg
-    assert carb_settings_iface.get("/rtx-transient/dldenoiser/enabled") == sim.cfg.render.enable_dl_denoiser
-    assert carb_settings_iface.get("/rtx/post/dlss/execMode") == sim.cfg.render.dlss_mode
-    assert carb_settings_iface.get("/rtx/directLighting/enabled") == sim.cfg.render.enable_direct_lighting
-    assert (
-        carb_settings_iface.get("/rtx/directLighting/sampledLighting/samplesPerPixel")
-        == sim.cfg.render.samples_per_pixel
-    )
-    assert carb_settings_iface.get("/rtx/shadows/enabled") == sim.cfg.render.enable_shadows
-    assert carb_settings_iface.get("/rtx/ambientOcclusion/enabled") == sim.cfg.render.enable_ambient_occlusion
-    assert carb_settings_iface.get("/rtx/post/aa/op") == 4  # dlss = 3, dlaa=4
+    assert sim.get_setting("/rtx/translucency/enabled") == sim.cfg.render.enable_translucency
+    assert sim.get_setting("/rtx/reflections/enabled") == sim.cfg.render.enable_reflections
+    assert sim.get_setting("/rtx/indirectDiffuse/enabled") == sim.cfg.render.enable_global_illumination
+    assert sim.get_setting("/rtx-transient/dlssg/enabled") == sim.cfg.render.enable_dlssg
+    assert sim.get_setting("/rtx-transient/dldenoiser/enabled") == sim.cfg.render.enable_dl_denoiser
+    assert sim.get_setting("/rtx/post/dlss/execMode") == sim.cfg.render.dlss_mode
+    assert sim.get_setting("/rtx/directLighting/enabled") == sim.cfg.render.enable_direct_lighting
+    assert sim.get_setting("/rtx/directLighting/sampledLighting/samplesPerPixel") == sim.cfg.render.samples_per_pixel
+    assert sim.get_setting("/rtx/shadows/enabled") == sim.cfg.render.enable_shadows
+    assert sim.get_setting("/rtx/ambientOcclusion/enabled") == sim.cfg.render.enable_ambient_occlusion
+    assert sim.get_setting("/rtx/post/aa/op") == 4  # dlss = 3, dlaa=4
 
 
 @pytest.mark.isaacsim_ci
@@ -130,21 +125,18 @@ def test_render_cfg_presets():
 
         SimulationContext(cfg)
 
-        carb_settings_iface = carb.settings.get_settings()
+        settings = get_settings_manager()
         for key, val in preset_dict.items():
-            setting_name = "/" + key.replace(".", "/")  # convert to carb setting format
+            setting_name = "/" + key.replace(".", "/")  # convert to setting path format
 
             if setting_name in carb_settings:
-                # grab groundtruth from carb setting dictionary overrides
                 setting_gt = carb_settings[setting_name]
             elif setting_name == dlss_mode[0]:
-                # grab groundtruth from user-friendly setting overrides
                 setting_gt = dlss_mode[1]
             else:
-                # grab groundtruth from preset
                 setting_gt = val
 
-            setting_val = carb_settings_iface.get(setting_name)
+            setting_val = settings.get(setting_name)
 
             assert setting_gt == setting_val, (
                 f"Mismatch for '{setting_name}' in mode '{rendering_mode}': "
@@ -201,18 +193,14 @@ def test_render_cfg_defaults():
     assert sim.cfg.render.enable_shadows == enable_shadows
     assert sim.cfg.render.enable_ambient_occlusion == enable_ambient_occlusion
 
-    carb_settings_iface = carb.settings.get_settings()
-    assert carb_settings_iface.get("/rtx/translucency/enabled") == sim.cfg.render.enable_translucency
-    assert carb_settings_iface.get("/rtx/reflections/enabled") == sim.cfg.render.enable_reflections
-    assert carb_settings_iface.get("/rtx/indirectDiffuse/enabled") == sim.cfg.render.enable_global_illumination
-    assert carb_settings_iface.get("/rtx-transient/dlssg/enabled") == sim.cfg.render.enable_dlssg
-    assert carb_settings_iface.get("/rtx-transient/dldenoiser/enabled") == sim.cfg.render.enable_dl_denoiser
-    assert carb_settings_iface.get("/rtx/post/dlss/execMode") == sim.cfg.render.dlss_mode
-    assert carb_settings_iface.get("/rtx/directLighting/enabled") == sim.cfg.render.enable_direct_lighting
-    assert (
-        carb_settings_iface.get("/rtx/directLighting/sampledLighting/samplesPerPixel")
-        == sim.cfg.render.samples_per_pixel
-    )
-    assert carb_settings_iface.get("/rtx/shadows/enabled") == sim.cfg.render.enable_shadows
-    assert carb_settings_iface.get("/rtx/ambientOcclusion/enabled") == sim.cfg.render.enable_ambient_occlusion
-    assert carb_settings_iface.get("/rtx/post/aa/op") == 3  # dlss = 3, dlaa=4
+    assert sim.get_setting("/rtx/translucency/enabled") == sim.cfg.render.enable_translucency
+    assert sim.get_setting("/rtx/reflections/enabled") == sim.cfg.render.enable_reflections
+    assert sim.get_setting("/rtx/indirectDiffuse/enabled") == sim.cfg.render.enable_global_illumination
+    assert sim.get_setting("/rtx-transient/dlssg/enabled") == sim.cfg.render.enable_dlssg
+    assert sim.get_setting("/rtx-transient/dldenoiser/enabled") == sim.cfg.render.enable_dl_denoiser
+    assert sim.get_setting("/rtx/post/dlss/execMode") == sim.cfg.render.dlss_mode
+    assert sim.get_setting("/rtx/directLighting/enabled") == sim.cfg.render.enable_direct_lighting
+    assert sim.get_setting("/rtx/directLighting/sampledLighting/samplesPerPixel") == sim.cfg.render.samples_per_pixel
+    assert sim.get_setting("/rtx/shadows/enabled") == sim.cfg.render.enable_shadows
+    assert sim.get_setting("/rtx/ambientOcclusion/enabled") == sim.cfg.render.enable_ambient_occlusion
+    assert sim.get_setting("/rtx/post/aa/op") == 3  # dlss = 3, dlaa=4

--- a/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
@@ -15,10 +15,10 @@ from typing import TYPE_CHECKING
 import torch
 import warp as wp
 
-import carb
 import omni.physics.tensors.impl.api as physx
 
 import isaaclab.sim as sim_utils
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.markers import VisualizationMarkers
 from isaaclab.sensors.contact_sensor import BaseContactSensor
 
@@ -91,8 +91,7 @@ class ContactSensor(BaseContactSensor):
         super().__init__(cfg)
 
         # Enable contact processing
-        carb_settings_iface = carb.settings.get_settings()
-        carb_settings_iface.set_bool("/physics/disableContactProcessing", False)
+        get_settings_manager().set_bool("/physics/disableContactProcessing", False)
 
         # Create empty variables for storing output data
         self._data: ContactSensorData = ContactSensorData()

--- a/source/isaaclab_physx/test/assets/test_deformable_object.py
+++ b/source/isaaclab_physx/test/assets/test_deformable_object.py
@@ -24,8 +24,6 @@ import warp as wp
 from flaky import flaky
 from isaaclab_physx.assets import DeformableObject, DeformableObjectCfg
 
-import carb
-
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
 from isaaclab.sim import build_simulation_context
@@ -265,8 +263,9 @@ def test_set_nodal_state(sim, num_cubes):
 @pytest.mark.isaacsim_ci
 def test_set_nodal_state_with_applied_transform(num_cubes, randomize_pos, randomize_rot):
     """Test setting the state of the deformable object with applied transform."""
-    carb_settings_iface = carb.settings.get_settings()
-    carb_settings_iface.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+    from isaaclab.app.settings_manager import get_settings_manager
+
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
 
     # Create simulation context with gravity disabled (no fixture needed)
     with build_simulation_context(auto_add_lighting=True, gravity_enabled=False) as sim:

--- a/source/isaaclab_rl/test/test_rl_games_wrapper.py
+++ b/source/isaaclab_rl/test/test_rl_games_wrapper.py
@@ -20,9 +20,8 @@ import gymnasium as gym
 import pytest
 import torch
 
-import carb
-
 import isaaclab.sim as sim_utils
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.envs import DirectMARLEnv, multi_agent_to_single_agent
 
 from isaaclab_rl.rl_games import RlGamesVecEnvWrapper
@@ -51,8 +50,7 @@ def registered_tasks():
 
     # this flag is necessary to prevent a bug where the simulation gets stuck randomly when running the
     # test on many environments.
-    carb_settings_iface = carb.settings.get_settings()
-    carb_settings_iface.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
 
     # print all existing task names
     print(">>> All registered environments:", registered_tasks)
@@ -70,7 +68,7 @@ def test_random_actions(registered_tasks):
         # create a new stage
         sim_utils.create_new_stage()
         # reset the rtx sensors carb setting to False
-        carb.settings.get_settings().set_bool("/isaaclab/render/rtx_sensors", False)
+        get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
         try:
             # parse configuration
             env_cfg = parse_env_cfg(task_name, device=device, num_envs=num_envs)

--- a/source/isaaclab_rl/test/test_rsl_rl_wrapper.py
+++ b/source/isaaclab_rl/test/test_rsl_rl_wrapper.py
@@ -19,9 +19,8 @@ import pytest
 import torch
 from tensordict import TensorDict
 
-import carb
-
 import isaaclab.sim as sim_utils
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.envs import DirectMARLEnv, multi_agent_to_single_agent
 
 from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
@@ -45,8 +44,7 @@ def registered_tasks():
 
     # this flag is necessary to prevent a bug where the simulation gets stuck randomly when running the
     # test on many environments.
-    carb_settings_iface = carb.settings.get_settings()
-    carb_settings_iface.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
 
     # print all existing task names
     print(">>> All registered environments:", registered_tasks)
@@ -64,7 +62,7 @@ def test_random_actions(registered_tasks):
         # create a new stage
         sim_utils.create_new_stage()
         # reset the rtx sensors carb setting to False
-        carb.settings.get_settings().set_bool("/isaaclab/render/rtx_sensors", False)
+        get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
         try:
             # parse configuration
             env_cfg = parse_env_cfg(task_name, device=device, num_envs=num_envs)

--- a/source/isaaclab_rl/test/test_sb3_wrapper.py
+++ b/source/isaaclab_rl/test/test_sb3_wrapper.py
@@ -19,9 +19,8 @@ import numpy as np
 import pytest
 import torch
 
-import carb
-
 import isaaclab.sim as sim_utils
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.envs import DirectMARLEnv, multi_agent_to_single_agent
 
 from isaaclab_rl.sb3 import Sb3VecEnvWrapper
@@ -45,8 +44,7 @@ def registered_tasks():
 
     # this flag is necessary to prevent a bug where the simulation gets stuck randomly when running the
     # test on many environments.
-    carb_settings_iface = carb.settings.get_settings()
-    carb_settings_iface.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
 
     # print all existing task names
     print(">>> All registered environments:", registered_tasks)
@@ -64,7 +62,7 @@ def test_random_actions(registered_tasks):
         # create a new stage
         sim_utils.create_new_stage()
         # reset the rtx sensors carb setting to False
-        carb.settings.get_settings().set_bool("/isaaclab/render/rtx_sensors", False)
+        get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
         try:
             # parse configuration
             env_cfg = parse_env_cfg(task_name, device=device, num_envs=num_envs)

--- a/source/isaaclab_rl/test/test_skrl_wrapper.py
+++ b/source/isaaclab_rl/test/test_skrl_wrapper.py
@@ -18,9 +18,8 @@ import gymnasium as gym
 import pytest
 import torch
 
-import carb
-
 import isaaclab.sim as sim_utils
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.envs import DirectMARLEnv, multi_agent_to_single_agent
 
 from isaaclab_rl.skrl import SkrlVecEnvWrapper
@@ -44,8 +43,7 @@ def registered_tasks():
 
     # this flag is necessary to prevent a bug where the simulation gets stuck randomly when running the
     # test on many environments.
-    carb_settings_iface = carb.settings.get_settings()
-    carb_settings_iface.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
 
     # print all existing task names
     print(">>> All registered environments:", registered_tasks)
@@ -63,7 +61,7 @@ def test_random_actions(registered_tasks):
         # create a new stage
         sim_utils.create_new_stage()
         # reset the rtx sensors carb setting to False
-        carb.settings.get_settings().set_bool("/isaaclab/render/rtx_sensors", False)
+        get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
         try:
             # parse configuration
             env_cfg = parse_env_cfg(task_name, device=device, num_envs=num_envs)

--- a/source/isaaclab_tasks/test/env_test_utils.py
+++ b/source/isaaclab_tasks/test/env_test_utils.py
@@ -12,9 +12,8 @@ import gymnasium as gym
 import pytest
 import torch
 
-import carb
-
 import isaaclab.sim as sim_utils
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.envs.utils.spaces import sample_space
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.version import get_isaac_sim_version
@@ -82,8 +81,8 @@ def setup_environment(
     # sort environments alphabetically
     registered_tasks.sort()
 
-    # this flag is necessary to prevent a bug where the simulation gets stuck randomy when running many environments
-    carb.settings.get_settings().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+    # this flag is necessary to prevent a bug where the simulation gets stuck randomly when running many environments
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
 
     print(">>> All registered environments:", registered_tasks)
 
@@ -192,8 +191,8 @@ def _check_random_actions(
     if not create_stage_in_memory:
         sim_utils.create_new_stage()
 
-    # reset the rtx sensors carb setting to False
-    carb.settings.get_settings().set_bool("/isaaclab/render/rtx_sensors", False)
+    # reset the rtx sensors setting to False
+    get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
     env = None
     try:
         # parse config

--- a/source/isaaclab_tasks/test/test_environment_determinism.py
+++ b/source/isaaclab_tasks/test/test_environment_determinism.py
@@ -18,8 +18,6 @@ import gymnasium as gym
 import pytest
 import torch
 
-import carb
-
 import isaaclab.sim as sim_utils
 
 import isaaclab_tasks  # noqa: F401
@@ -30,8 +28,9 @@ from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
 def setup_environment():
     # this flag is necessary to prevent a bug where the simulation gets stuck randomly when running the
     # test on many environments.
-    carb_settings_iface = carb.settings.get_settings()
-    carb_settings_iface.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+    from isaaclab.app.settings_manager import get_settings_manager
+
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
 
 
 @pytest.mark.parametrize(

--- a/source/isaaclab_tasks/test/test_rl_device_separation.py
+++ b/source/isaaclab_tasks/test/test_rl_device_separation.py
@@ -47,8 +47,6 @@ import gymnasium as gym
 import pytest
 import torch
 
-import carb
-
 import isaaclab.sim as sim_utils
 
 import isaaclab_tasks  # noqa: F401
@@ -70,8 +68,10 @@ def _create_env(sim_device: str):
     """
     # Create a new stage
     sim_utils.create_new_stage()
-    # Reset the rtx sensors carb setting to False
-    carb.settings.get_settings().set_bool("/isaaclab/render/rtx_sensors", False)
+    # Reset the rtx sensors setting to False
+    from isaaclab.app.settings_manager import get_settings_manager
+
+    get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
 
     try:
         env_cfg = parse_env_cfg(TEST_ENV, device=sim_device, num_envs=NUM_ENVS)


### PR DESCRIPTION
# Description


In multi back-end settings, carb won't be accessible when kit is not initialized, we need this settings manager to work in the presence of carb or without presense of carb. 

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
