### PR TITLE
fix: correct inverted preserve_order docstring in resolve_matching_names

### DIFF
--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -183,17 +183,18 @@ def resolve_matching_names(
     When a list of query regular expressions is provided, the function checks each target string against each
     query regular expression and returns the indices of the matched strings and the matched strings.
 
-    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
-    of the provided list of strings. This means that the ordering is dictated by the order of the target strings
-    and not the order of the query regular expressions.
+    If the :attr:`preserve_order` is False (default), the ordering of the matched indices and names follows
+    the order of the provided list of strings. This means that the ordering is dictated by the order of the
+    target strings and not the order of the query regular expressions.
 
-    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
-    of the provided list of query regular expressions.
+    If the :attr:`preserve_order` is True, the ordering of the matched indices and names follows the order
+    of the query regular expressions.
 
     For example, consider the list of strings is ['a', 'b', 'c', 'd', 'e'] and the regular expressions are ['a|c', 'b'].
-    If :attr:`preserve_order` is False, then the function will return the indices of the matched strings and the
-    strings as: ([0, 1, 2], ['a', 'b', 'c']). When :attr:`preserve_order` is True, it will return them as:
-    ([0, 2, 1], ['a', 'c', 'b']).
+    If :attr:`preserve_order` is False (default), then the function will return the indices of the matched strings and
+    the strings as: ([0, 1, 2], ['a', 'b', 'c']) - following the order of list_of_strings. When
+    :attr:`preserve_order` is True, it will return them as:
+    ([0, 2, 1], ['a', 'c', 'b']) - following the order of the regex keys.
 
     Note:
         The function does not sort the indices. It returns the indices in the order they are found.


### PR DESCRIPTION
## Summary

Fix the inverted `preserve_order` parameter description in the `resolve_matching_names` docstring.

The docstring incorrectly stated that `preserve_order=True` returns results in list_of_strings order, and `preserve_order=False` returns in query-key order. The actual behavior is the opposite:

- `preserve_order=False` (default): results follow `list_of_strings` order
- `preserve_order=True`: results are reordered to follow query regex key order

This is the same bug that PR #4427 fixes for the sibling function `resolve_matching_names_values`. This PR addresses the remaining function noted in #4493.

Fixes #4493

## Changes

- Swapped the `True`/`False` descriptions in the `resolve_matching_names` docstring
- Added `(default)` annotation to the `False` case for clarity
- Added brief inline clarifications to the examples (matching PR #4427 style)

Signed-off-by: alltheseas <alltheseas@users.noreply.github.com>