### PR TITLE
Delegates close stage logic in SimulationContext to Stage utility

### DIFF
--- a/scripts/demos/sensors/multi_mesh_raycaster.py
+++ b/scripts/demos/sensors/multi_mesh_raycaster.py
@@ -49,7 +49,6 @@ import random
 import torch
 import warp as wp
 
-import omni.usd
 from pxr import Gf, Sdf
 
 import isaaclab.sim as sim_utils
@@ -202,8 +201,7 @@ class RaycasterSensorSceneCfg(InteractiveSceneCfg):
 def randomize_shape_color(prim_path_expr: str):
     """Randomize the color of the geometry."""
 
-    # acquire stage
-    stage = omni.usd.get_context().get_stage()
+    stage = sim_utils.get_current_stage()
     # resolve prim paths for spawning and cloning
     prim_paths = sim_utils.find_matching_prim_paths(prim_path_expr)
     # manually clone prims if the source prim path is a regex expression

--- a/scripts/demos/sensors/multi_mesh_raycaster_camera.py
+++ b/scripts/demos/sensors/multi_mesh_raycaster_camera.py
@@ -49,7 +49,6 @@ import random
 import torch
 import warp as wp
 
-import omni.usd
 from pxr import Gf, Sdf
 
 import isaaclab.sim as sim_utils
@@ -215,8 +214,7 @@ class RaycasterSensorSceneCfg(InteractiveSceneCfg):
 def randomize_shape_color(prim_path_expr: str):
     """Randomize the color of the geometry."""
 
-    # acquire stage
-    stage = omni.usd.get_context().get_stage()
+    stage = sim_utils.get_current_stage()
     # resolve prim paths for spawning and cloning
     prim_paths = sim_utils.find_matching_prim_paths(prim_path_expr)
     # manually clone prims if the source prim path is a regex expression

--- a/scripts/environments/teleoperation/teleop_se3_agent.py
+++ b/scripts/environments/teleoperation/teleop_se3_agent.py
@@ -72,8 +72,7 @@ import logging
 import gymnasium as gym
 import torch
 
-import omni.usd
-
+import isaaclab.sim as sim_utils
 from isaaclab.devices import Se3Gamepad, Se3GamepadCfg, Se3Keyboard, Se3KeyboardCfg, Se3SpaceMouse, Se3SpaceMouseCfg
 from isaaclab.devices.openxr import remove_camera_configs
 from isaaclab.devices.teleop_device_factory import create_teleop_device
@@ -319,7 +318,7 @@ if __name__ == "__main__":
     main()
     # Close the USD stage and pump the event loop so the viewport widget
     # processes the closure before the app teardown destroys it.
-    omni.usd.get_context().close_stage()
+    sim_utils.close_stage()
     simulation_app.update()
     # close sim app
     simulation_app.close()

--- a/scripts/imitation_learning/locomanipulation_sdg/generate_data.py
+++ b/scripts/imitation_learning/locomanipulation_sdg/generate_data.py
@@ -116,8 +116,7 @@ import random
 import gymnasium as gym
 import torch
 
-import omni.kit
-
+import isaaclab.sim as sim_utils
 from isaaclab.utils import configclass
 from isaaclab.utils.datasets import EpisodeData, HDF5DatasetFileHandler
 
@@ -663,7 +662,7 @@ def replay(
     if draw_visualization:
         occupancy_map_add_to_stage(
             occupancy_map,
-            stage=omni.usd.get_context().get_stage(),
+            stage=sim_utils.get_current_stage(),
             path="/OccupancyMap",
             z_offset=0.01,
             draw_path=base_path_helper.points,

--- a/scripts/tools/record_demos.py
+++ b/scripts/tools/record_demos.py
@@ -106,8 +106,8 @@ import gymnasium as gym
 import torch
 
 import omni.ui as ui
-import omni.usd
 
+import isaaclab.sim as sim_utils
 from isaaclab.devices import Se3Keyboard, Se3KeyboardCfg, Se3SpaceMouse, Se3SpaceMouseCfg
 from isaaclab.devices.openxr import remove_camera_configs
 from isaaclab.devices.teleop_device_factory import create_teleop_device
@@ -610,7 +610,7 @@ if __name__ == "__main__":
     main()
     # Close the USD stage and pump the event loop so the viewport widget
     # processes the closure before the app teardown destroys it.
-    omni.usd.get_context().close_stage()
+    sim_utils.close_stage()
     simulation_app.update()
     # close sim app
     simulation_app.close()

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "3.5.2"
+version = "3.5.3"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+
+
+3.5.3 (2026-02-22)
+~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Refactored ``SimulationContext.clear_instance`` to delegate stage teardown to
+  :func:`~isaaclab.sim.utils.close_stage` instead of manually clearing the stage cache,
+  thread-local context, and Kit USD context inline.
+* Updated :func:`~isaaclab.sim.utils.close_stage` to also close the Kit USD context stage
+  (``omni.usd.get_context().close_stage()``) when Kit is running, making it a complete
+  stage teardown function.
+
+
 3.5.2 (2026-02-23)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -600,21 +600,8 @@ class SimulationContext:
                     close_provider()
                 cls._instance._scene_data_provider = None
 
-            # Remove stage from cache
-            stage_cache = UsdUtils.StageCache.Get()
-            stage_id = stage_cache.GetId(cls._instance.stage).ToLongInt()  # type: ignore[union-attr]
-            if stage_id > 0:
-                stage_cache.Erase(cls._instance.stage)  # type: ignore[union-attr]
-
-            # Clear thread-local stage context
-            if hasattr(stage_utils._context, "stage"):
-                delattr(stage_utils._context, "stage")
-
-            # Close the USD context stage (symmetric with attach in __init__)
-            if sim_utils.has_kit():
-                import omni.usd
-
-                omni.usd.get_context().close_stage()
+            # Close the stage (clears cache, thread-local context, and Kit USD context)
+            stage_utils.close_stage()
 
             # Clear instance
             cls._instance = None

--- a/source/isaaclab/isaaclab/sim/utils/prims.py
+++ b/source/isaaclab/isaaclab/sim/utils/prims.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any
 import torch
 
 import omni.kit.commands
-import omni.usd
 from isaacsim.core.cloner import Cloner
 from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade, UsdUtils
 

--- a/source/isaaclab/isaaclab/sim/utils/stage.py
+++ b/source/isaaclab/isaaclab/sim/utils/stage.py
@@ -372,6 +372,9 @@ def save_stage(usd_path: str, save_and_reload_in_place: bool = True) -> bool:
 def close_stage() -> bool:
     """Closes the current USD stage by clearing the stage cache.
 
+    If Kit is running, this also closes the stage attached to the Kit USD context
+    (``omni.usd.get_context().close_stage()``).
+
     .. note::
 
         Once the stage is closed, it is necessary to open a new stage or create a
@@ -389,6 +392,12 @@ def close_stage() -> bool:
     stage_cache = UsdUtils.StageCache.Get()
     stage_cache.Clear()
     _context.stage = None
+
+    if has_kit():
+        import omni.usd
+
+        omni.usd.get_context().close_stage()
+
     return True
 
 


### PR DESCRIPTION
# Description

This PR refactors the code further

Removes remaining refactorable omni.usd usage 

Refactores `SimulationContext.clear_instance` to delegate stage teardown to
  `isaaclab.sim.utils.close_stage` instead of manually clearing the stage cache,
  thread-local context, and Kit USD context inline.

Updates `isaaclab.sim.utils.close_stage` to also close the Kit USD context stage
  (``omni.usd.get_context().close_stage()``) when Kit is running, making it a complete
  stage teardown function.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
-
## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
