### PR TITLE
Applies world scale to mesh transformation correctly in MeshRayCaster

### DIFF
--- a/source/isaaclab/isaaclab/sensors/ray_caster/multi_mesh_ray_caster.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/multi_mesh_ray_caster.py
@@ -228,17 +228,18 @@ class MultiMeshRayCaster(RayCaster):
                         mesh = create_trimesh_from_geom_mesh(mesh_prim)
                     else:
                         mesh = create_trimesh_from_geom_shape(mesh_prim)
-                    scale = sim_utils.resolve_prim_scale(mesh_prim)
-                    mesh.apply_scale(scale)
 
                     relative_pos, relative_quat = sim_utils.resolve_prim_pose(mesh_prim, target_prim)
                     relative_pos = torch.tensor(relative_pos, dtype=torch.float32)
                     relative_quat = torch.tensor(relative_quat, dtype=torch.float32)
 
+                    world_scale = sim_utils.resolve_prim_scale(mesh_prim)
+
                     rotation = matrix_from_quat(relative_quat)
                     transform = np.eye(4)
                     transform[:3, :3] = rotation.numpy()
                     transform[:3, 3] = relative_pos.numpy()
+                    transform[:3, :3] = transform[:3, :3] @ np.diag(world_scale)
                     mesh.apply_transform(transform)
 
                     # add to list of parsed meshes


### PR DESCRIPTION
# Description

Previously, the transforms were applied in the order (scale, transform, rotate). However, in Isaac Sim, the correct transformation order is (transform, rotate, scale). This MR fixes this issue by applying scale later.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there