### PR TITLE
Fixes failing Post-Merge-CI

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     build-essential \
     cmake \
     git \
-    # required to build imgui-bundle (use by usaaclab_newton)
+    # required to build imgui-bundle (use by isaaclab_newton)
     libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev \
     libglib2.0-0 \
     ncurses-term \


### PR DESCRIPTION
# Description

[Post-Merge-Ci can't build docker image for arm64 ](https://github.com/isaac-sim/IsaacLab/actions/runs/22324631546/job/64724469686) because `imgui-bundle` needs certain dev libraries to be built from source since pip wheel is missing for arm64 (used by isaaclab_newton).

This adds installation of libx11-dev, libxcursor-dev, libxi-dev, libxinerama-dev that are necessary to build  `imgui-bundle`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [NA] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
