### PR TITLE
Adds support for requesting required  OpenXR extensions at runtime

### DIFF
--- a/apps/isaaclab.python.xr.openxr.kit
+++ b/apps/isaaclab.python.xr.openxr.kit
@@ -73,6 +73,7 @@ folders = [
     "${exe-path}/exts",  # kit extensions
     "${exe-path}/extscore",  # kit core extensions
     "${exe-path}/../exts",  # isaac extensions
+    "${exe-path}/../extsInternal",  # isaac internal extensions
     "${exe-path}/../extsDeprecated",  # deprecated isaac extensions
     "${exe-path}/../extscache",  # isaac cache extensions
     "${exe-path}/../extsPhysics",  # isaac physics extensions

--- a/source/isaaclab_teleop/config/extension.toml
+++ b/source/isaaclab_teleop/config/extension.toml
@@ -1,6 +1,6 @@
 [package]
 # Semantic Versioning is used: https://semver.org/
-version = "0.1.0"
+version = "0.2.0"
 
 # Description
 title =  "Isaac Lab Teleop"

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -1,7 +1,15 @@
 Changelog
 ---------
 
+0.2.0 (2026-02-24)
+~~~~~~~~~~~~~~~~~~~
 
+Added
+^^^^^
+
+* Added :meth:`~isaaclab_teleop.session_lifecycle.SessionLifecycle._on_request_required_extensions` to request required 
+  OpenXR extensions at runtime based on Teleop devices needed for the specified environment.
+the
 0.1.0 (2026-02-18)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -7,9 +7,9 @@ Changelog
 Added
 ^^^^^
 
-* Added :meth:`~isaaclab_teleop.session_lifecycle.SessionLifecycle._on_request_required_extensions` to request required 
+* Added :meth:`~isaaclab_teleop.session_lifecycle.SessionLifecycle._on_request_required_extensions` to request required
   OpenXR extensions at runtime based on Teleop devices needed for the specified environment.
-the
+
 0.1.0 (2026-02-18)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Added
 ^^^^^
 
-* Added :meth:`~isaaclab_teleop.session_lifecycle.SessionLifecycle._on_request_required_extensions` to request required
+* Added :meth:`~isaaclab_teleop.session_lifecycle.TeleopSessionLifecycle._on_request_required_extensions` to request required
   OpenXR extensions at runtime based on Teleop devices needed for the specified environment.
 
 0.1.0 (2026-02-18)

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -381,7 +381,7 @@ class TeleopSessionLifecycle:
         return external_inputs if external_inputs else None
 
     # ------------------------------------------------------------------
-    # Tracker discovery
+    # Controller tracker discovery
     # ------------------------------------------------------------------
 
     @staticmethod

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -62,6 +62,7 @@ class TeleopSessionLifecycle:
         self._retargeting_ui = None
 
         try:
+            # Importing bridge also performs polyfill of missing omni.kit.xr.system.openxr functions.
             import isaacsim.kit.xr.teleop.bridge as bridge
 
             subscribe_required_extensions = getattr(bridge, "subscribe_required_extensions", None)
@@ -490,10 +491,9 @@ class TeleopSessionLifecycle:
             extension is not available (e.g. running outside Isaac Sim).
         """
         try:
-            import isaacsim.kit.xr.teleop.bridge  # Performs polyfill of openxr functions.
             import omni.kit.xr.system.openxr as openxr
         except (ImportError, ModuleNotFoundError):
-            logger.info("omni.kit.xr.system.openxr or isaacsim.kit.xr.teleop.bridge not available; IsaacTeleop will create its own OpenXR session")
+            logger.info("omni.kit.xr.system.openxr not available; IsaacTeleop will create its own OpenXR session")
             return None
 
         instance = openxr.get_instance_handle()

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -61,6 +61,22 @@ class TeleopSessionLifecycle:
         self._retargeting_ui_ctx: MultiRetargeterTuningUIImGui | None = None
         self._retargeting_ui = None
 
+        try:
+            import isaacsim.kit.xr.teleop.bridge as bridge
+
+            subscribe_required_extensions = getattr(bridge, "subscribe_required_extensions", None)
+            if callable(subscribe_required_extensions):
+                self._required_extensions_subscription = subscribe_required_extensions(
+                    self._on_request_required_extensions
+                )
+            else:
+                logger.info(
+                    "isaacsim.kit.xr.teleop.bridge.subscribe_required_extensions not available; "
+                    "skipping required extensions subscription"
+                )
+        except (ImportError, ModuleNotFoundError):
+            logger.info("isaacsim.kit.xr.teleop.bridge not available; IsaacTeleop will create its own OpenXR session")
+
     @property
     def is_active(self) -> bool:
         """Whether the teleop session is currently running."""
@@ -151,6 +167,25 @@ class TeleopSessionLifecycle:
             self._pipeline = None
         logger.info("IsaacTeleop session ended")
 
+    def _on_request_required_extensions(self) -> list[str]:
+        """Callback for required extensions subscription.
+
+        Returns:
+            A list of required extensions.
+        """
+        from isaacteleop import deviceio
+
+        trackers = self._collect_trackers_from_pipeline(self._pipeline)
+
+        # Include fallback/manual tracker when present and not already collected.
+        if self._controller_tracker is not None and all(t is not self._controller_tracker for t in trackers):
+            trackers.append(self._controller_tracker)
+
+        required_extensions = deviceio.DeviceIOSession.get_required_extensions(trackers)
+        logger.info(f"Required extensions: {required_extensions}")
+        # Keep extension order deterministic while removing duplicates.
+        return list(dict.fromkeys(required_extensions))
+
     # ------------------------------------------------------------------
     # Deferred session creation
     # ------------------------------------------------------------------
@@ -166,7 +201,7 @@ class TeleopSessionLifecycle:
     def _try_start_session(self) -> bool:
         """Attempt to create and start the IsaacTeleop session.
 
-        Tries to acquire OpenXR handles from Kit's XR bridge.  If the handles
+        Tries to acquire OpenXR handles from Kit's XR.  If the handles
         are available, creates and enters the ``TeleopSession``.  If not (e.g.
         the user hasn't started AR yet), the attempt is silently deferred and
         will be retried on the next :meth:`step` call.
@@ -349,8 +384,42 @@ class TeleopSessionLifecycle:
         return external_inputs if external_inputs else None
 
     # ------------------------------------------------------------------
-    # Controller tracker discovery
+    # Tracker discovery
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _collect_trackers_from_pipeline(pipeline) -> list:
+        """Collect all tracker objects from pipeline DeviceIO source nodes.
+
+        Returns:
+            A de-duplicated list of trackers discovered in pipeline leaf nodes.
+        """
+        from isaacteleop.retargeting_engine.deviceio_source_nodes import IDeviceIOSource
+
+        if pipeline is None:
+            return []
+
+        try:
+            leaf_nodes = pipeline.get_leaf_nodes()
+        except AttributeError:
+            return []
+
+        trackers = []
+        for node in leaf_nodes:
+            if isinstance(node, IDeviceIOSource):
+                tracker = node.get_tracker()
+                if tracker is not None:
+                    trackers.append(tracker)
+
+        # De-duplicate by object identity while preserving discovery order.
+        deduped_trackers = []
+        seen_ids: set[int] = set()
+        for tracker in trackers:
+            tracker_id = id(tracker)
+            if tracker_id not in seen_ids:
+                seen_ids.add(tracker_id)
+                deduped_trackers.append(tracker)
+        return deduped_trackers
 
     @staticmethod
     def _find_controller_tracker_in(pipeline):
@@ -407,7 +476,7 @@ class TeleopSessionLifecycle:
     def _acquire_kit_oxr_handles(handles_cls: type[OpenXRSessionHandles]) -> OpenXRSessionHandles | None:
         """Acquire OpenXR session handles from Kit's XR bridge extension.
 
-        Imports ``isaacsim.kit.xr.teleop.bridge`` and reads the four raw handle
+        Imports ``omni.kit.xr.openxr`` and reads the four raw handle
         values (XrInstance, XrSession, XrSpace, xrGetInstanceProcAddr) that Kit's
         OpenXR system exposes.  The handles are returned as an
         ``OpenXRSessionHandles`` instance ready for ``DeviceIOSession.run()``.
@@ -421,15 +490,16 @@ class TeleopSessionLifecycle:
             extension is not available (e.g. running outside Isaac Sim).
         """
         try:
-            import isaacsim.kit.xr.teleop.bridge as xr_bridge
+            import isaacsim.kit.xr.teleop.bridge  # Performs polyfill of openxr functions.
+            import omni.kit.xr.system.openxr as openxr
         except (ImportError, ModuleNotFoundError):
-            logger.info("isaacsim.kit.xr.teleop.bridge not available; IsaacTeleop will create its own OpenXR session")
+            logger.info("omni.kit.xr.system.openxr or isaacsim.kit.xr.teleop.bridge not available; IsaacTeleop will create its own OpenXR session")
             return None
 
-        instance = xr_bridge.get_instance_handle()
-        session = xr_bridge.get_session_handle()
-        space = xr_bridge.get_stage_space_handle()
-        proc_addr = xr_bridge.get_instance_proc_addr()
+        instance = openxr.get_instance_handle()
+        session = openxr.get_session_handle()
+        space = openxr.get_stage_space_handle()
+        proc_addr = openxr.get_instance_proc_addr()
 
         if not all((instance, session, space, proc_addr)):
             logger.debug(

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -174,18 +174,14 @@ class TeleopSessionLifecycle:
         Returns:
             A list of required extensions.
         """
-        from isaacteleop import deviceio
+        from isaacteleop.teleop_session_manager.helpers import get_required_oxr_extensions_from_pipeline
 
-        trackers = self._collect_trackers_from_pipeline(self._pipeline)
+        required_extensions = (
+            get_required_oxr_extensions_from_pipeline(self._pipeline) if self._pipeline is not None else []
+        )
 
-        # Include fallback/manual tracker when present and not already collected.
-        if self._controller_tracker is not None and all(t is not self._controller_tracker for t in trackers):
-            trackers.append(self._controller_tracker)
-
-        required_extensions = deviceio.DeviceIOSession.get_required_extensions(trackers)
         logger.info(f"Required extensions: {required_extensions}")
-        # Keep extension order deterministic while removing duplicates.
-        return list(dict.fromkeys(required_extensions))
+        return required_extensions
 
     # ------------------------------------------------------------------
     # Deferred session creation
@@ -387,40 +383,6 @@ class TeleopSessionLifecycle:
     # ------------------------------------------------------------------
     # Tracker discovery
     # ------------------------------------------------------------------
-
-    @staticmethod
-    def _collect_trackers_from_pipeline(pipeline) -> list:
-        """Collect all tracker objects from pipeline DeviceIO source nodes.
-
-        Returns:
-            A de-duplicated list of trackers discovered in pipeline leaf nodes.
-        """
-        from isaacteleop.retargeting_engine.deviceio_source_nodes import IDeviceIOSource
-
-        if pipeline is None:
-            return []
-
-        try:
-            leaf_nodes = pipeline.get_leaf_nodes()
-        except AttributeError:
-            return []
-
-        trackers = []
-        for node in leaf_nodes:
-            if isinstance(node, IDeviceIOSource):
-                tracker = node.get_tracker()
-                if tracker is not None:
-                    trackers.append(tracker)
-
-        # De-duplicate by object identity while preserving discovery order.
-        deduped_trackers = []
-        seen_ids: set[int] = set()
-        for tracker in trackers:
-            tracker_id = id(tracker)
-            if tracker_id not in seen_ids:
-                seen_ids.add(tracker_id)
-                deduped_trackers.append(tracker)
-        return deduped_trackers
 
     @staticmethod
     def _find_controller_tracker_in(pipeline):


### PR DESCRIPTION
# Description

Added support for requesting required  OpenXR extensions at runtime based on Teleop devices needed for the specified  environment. Different devices require different OpenXR extensions. Previously, the list of required extensions was hard coded in the isaacsim.kit.xr.teleop.bridge extension making it inflexible. Now, the bridge extension has a  callback for required extensions that the application can subscribe to and fill depending on Teleop devices needed.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
