### PR TITLE
[Newton] Fixes flatdict dependency to pkg_resources error

### DIFF
--- a/source/isaaclab_experimental/setup.py
+++ b/source/isaaclab_experimental/setup.py
@@ -23,11 +23,6 @@ INSTALL_REQUIRES = [
     "torch>=2.7",
     "prettytable==3.3.0",
     "toml",
-    # testing
-    "pytest",
-    "pytest-mock",
-    "junitparser",
-    "flatdict==4.0.1",
 ]
 
 

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -24,11 +24,6 @@ INSTALL_REQUIRES = [
     "toml",
     # reinforcement learning
     "pyglet>=2.1.6",
-    # testing
-    "pytest",
-    "pytest-mock",
-    "junitparser",
-    "flatdict==4.0.1",
     # newton
     "mujoco>=3.5.0",
     "mujoco-warp>=3.5.0",


### PR DESCRIPTION
# Description

Cleans up the flatdict dependency in multiple extensions since they are not needed.


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
