### PR TITLE
Fixes Post-Merge-CI, again :scream_cat: 

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -70,7 +70,7 @@ RUN ln -sf ${ISAACSIM_ROOT_PATH} ${ISAACLAB_PATH}/_isaac_sim
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install toml
 
 # Install apt dependencies for extensions that declare them in their extension.toml
-RUN ${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/tools/install_deps.py apt ${ISAACLAB_PATH}/source 
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/tools/install_deps.py apt ${ISAACLAB_PATH}/source
 
 # Apt Cleanup
 RUN apt-get -y autoremove && apt-get clean && \


### PR DESCRIPTION
# Description

This tries to fix cache issues we're seeing with concurrent docker builds: https://github.com/isaac-sim/IsaacLab/actions/runs/22424928169/job/64930859377
