### PR TITLE
Add kit-less benchmark runner

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -130,6 +130,7 @@ Guidelines for modifications:
 * Oyindamola Omotuyi
 * Özhan Özen
 * Patrick Yin
+* Paul Reeves
 * Peter Du
 * Philipp Reist
 * Pulkit Goyal

--- a/docs/source/testing/benchmarks.rst
+++ b/docs/source/testing/benchmarks.rst
@@ -34,7 +34,7 @@ The benchmarking framework consists of several key components:
 - **Metadata**: Data classes for recording context (hardware, versions, parameters)
 - **TestPhase**: Container for organizing measurements into logical groups
 - **Recorders**: System information collectors (CPU, GPU, memory, versions)
-- **Backends**: Output formatters (JSON, Osmo, OmniPerf)
+- **Backends**: Output formatters (JSON, Osmo, OmniPerf, Summary)
 
 .. seealso::
 
@@ -169,7 +169,7 @@ Common Arguments
      - Description
    * - ``--benchmark_backend``
      - ``json``
-     - Output backend: ``json``, ``osmo``, or ``omniperf``
+     - Output backend: ``json``, ``osmo``, ``omniperf``, or ``summary``
    * - ``--output_path``
      - ``./``
      - Directory for output files
@@ -396,6 +396,20 @@ Output structure:
      }
    }
 
+Summary Backend
+~~~~~~~~~~~~~~~
+
+Human-readable console report plus JSON file. Prints a formatted summary (runtime,
+startup, train, frametime, and system info) to the terminal while also writing
+the same data as JSON. Use when you want a quick readout without opening the JSON:
+
+.. code-block:: bash
+
+   ./isaaclab.sh -p ... --benchmark_backend summary --output_path ./results
+
+When ``summary`` is selected, frametime recorders are enabled automatically when
+running with Isaac Sim (Kit).
+
 BenchmarkMonitor
 ----------------
 
@@ -585,7 +599,7 @@ Ensure ``_finalize_impl()`` is called before the script exits:
 Backend Not Recognized
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Valid backend types are: ``json``, ``osmo``, ``omniperf``
+Valid backend types are: ``json``, ``osmo``, ``omniperf``, ``summary``
 
 .. code-block:: bash
 

--- a/scripts/benchmarks/benchmark_cameras.py
+++ b/scripts/benchmarks/benchmark_cameras.py
@@ -228,7 +228,7 @@ parser.add_argument(
     "--benchmark_backend",
     type=str,
     default="omniperf",
-    choices=["json", "osmo", "omniperf"],
+    choices=["json", "osmo", "omniperf", "summary"],
     help="Benchmarking backend options, defaults omniperf",
 )
 parser.add_argument("--output_path", type=str, default=".", help="Path to output benchmark results.")
@@ -768,11 +768,13 @@ def main():
         num_cameras = args_cli.num_ray_caster_cameras
 
     # Create the benchmark
+    backend_type = args_cli.benchmark_backend
     benchmark = BaseIsaacLabBenchmark(
         benchmark_name="benchmark_cameras",
-        backend_type=args_cli.benchmark_backend,
+        backend_type=backend_type,
         output_path=args_cli.output_path,
         use_recorders=True,
+        frametime_recorders=backend_type == "summary",
         output_prefix="benchmark_cameras",
         workflow_metadata={
             "metadata": [

--- a/scripts/benchmarks/benchmark_cameras.py
+++ b/scripts/benchmarks/benchmark_cameras.py
@@ -774,7 +774,7 @@ def main():
         backend_type=backend_type,
         output_path=args_cli.output_path,
         use_recorders=True,
-        frametime_recorders=backend_type == "summary",
+        frametime_recorders=backend_type in ("summary", "omniperf"),
         output_prefix="benchmark_cameras",
         workflow_metadata={
             "metadata": [

--- a/scripts/benchmarks/benchmark_kitless.py
+++ b/scripts/benchmarks/benchmark_kitless.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Kit-less benchmark harness for synthetic workloads.
+
+This script runs without Kit/Isaac Sim and emits benchmark JSON compatible with
+the existing metrics backends (OmniPerf/JSON/Osmo/Summary).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+# Ensure local IsaacLab sources are importable (avoid relying on installed package)
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+SOURCE_ROOT = os.path.join(REPO_ROOT, "source/isaaclab")
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+if SOURCE_ROOT not in sys.path:
+    sys.path.insert(0, SOURCE_ROOT)
+
+from isaaclab.test.benchmark import BaseIsaacLabBenchmark, BenchmarkMonitor, SingleMeasurement
+
+from scripts.benchmarks.utils import (
+    get_backend_type,
+    log_python_imports_time,
+    log_runtime_step_times,
+    log_task_start_time,
+    log_total_start_time,
+)
+
+
+def _cpu_spin(iterations: int) -> float:
+    """Simple CPU-bound loop to simulate work."""
+    acc = 0.0
+    for i in range(iterations):
+        acc += (i % 97) * 0.0001
+    return acc
+
+
+def _prepare_torch_workload(dim: int, device: str):
+    import torch
+
+    a = torch.randn((dim, dim), device=device)
+    b = torch.randn((dim, dim), device=device)
+    return a, b
+
+
+def _run_torch_workload(a, b, device: str):
+    import torch
+
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+    _ = a @ b
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Kit-less benchmark harness.")
+    parser.add_argument("--num_steps", type=int, default=100, help="Number of steps to run.")
+    parser.add_argument("--num_envs", type=int, default=1, help="Logical env count for throughput math.")
+    parser.add_argument(
+        "--workload",
+        type=str,
+        default="sleep",
+        choices=["sleep", "cpu_spin", "torch_matmul"],
+        help="Synthetic workload type.",
+    )
+    parser.add_argument("--sleep_ms", type=float, default=1.0, help="Sleep time per step (ms).")
+    parser.add_argument("--cpu_iterations", type=int, default=250000, help="CPU spin iterations per step.")
+    parser.add_argument("--torch_dim", type=int, default=512, help="Matrix dimension for torch_matmul.")
+    parser.add_argument("--device", type=str, default="cpu", help="Device for torch workload (cpu/cuda:0).")
+    parser.add_argument(
+        "--benchmark_backend",
+        type=str,
+        default="omniperf",
+        choices=[
+            "json",
+            "osmo",
+            "omniperf",
+            "summary",
+            "LocalLogMetrics",
+            "JSONFileMetrics",
+            "OsmoKPIFile",
+            "OmniPerfKPIFile",
+        ],
+        help="Benchmarking backend options, defaults omniperf.",
+    )
+    parser.add_argument("--output_path", type=str, default=".", help="Path to output benchmark results.")
+    parser.add_argument(
+        "--output_prefix",
+        type=str,
+        default="benchmark_kitless",
+        help="Output filename prefix (without extension).",
+    )
+    parser.add_argument(
+        "--monitor_interval",
+        type=float,
+        default=1.0,
+        help="Recorder update interval in seconds; set 0 to disable background monitor.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    script_start_ns = time.perf_counter_ns()
+    imports_time_begin = time.perf_counter_ns()
+
+    # Lazy imports for optional workloads
+    if args.workload == "torch_matmul":
+        import torch  # noqa: F401
+
+    imports_time_end = time.perf_counter_ns()
+
+    backend_type = get_backend_type(args.benchmark_backend)
+    benchmark = BaseIsaacLabBenchmark(
+        benchmark_name="benchmark_kitless",
+        backend_type=backend_type,
+        output_path=args.output_path,
+        use_recorders=True,
+        frametime_recorders=False,
+        output_prefix=args.output_prefix,
+        workflow_metadata={
+            "metadata": [
+                {"name": "kitless", "data": True},
+                {"name": "workload", "data": args.workload},
+                {"name": "num_steps", "data": args.num_steps},
+                {"name": "num_envs", "data": args.num_envs},
+                {"name": "sleep_ms", "data": args.sleep_ms},
+                {"name": "cpu_iterations", "data": args.cpu_iterations},
+                {"name": "torch_dim", "data": args.torch_dim},
+                {"name": "device", "data": args.device},
+            ]
+        },
+    )
+
+    workload_setup_begin = time.perf_counter_ns()
+    torch_buffers = None
+    if args.workload == "torch_matmul":
+        torch_buffers = _prepare_torch_workload(args.torch_dim, args.device)
+    workload_setup_end = time.perf_counter_ns()
+
+    step_times_ns: list[int] = []
+
+    def _run_step() -> None:
+        if args.workload == "sleep":
+            if args.sleep_ms > 0:
+                time.sleep(args.sleep_ms / 1000.0)
+        elif args.workload == "cpu_spin":
+            _cpu_spin(args.cpu_iterations)
+        elif args.workload == "torch_matmul":
+            if torch_buffers is None:
+                raise RuntimeError("Torch workload requested but buffers are not initialized.")
+            _run_torch_workload(torch_buffers[0], torch_buffers[1], args.device)
+
+    if args.monitor_interval > 0:
+        monitor_ctx = BenchmarkMonitor(benchmark, interval=args.monitor_interval)
+    else:
+        monitor_ctx = None
+
+    if monitor_ctx:
+        monitor_ctx.start()
+    try:
+        for _ in range(args.num_steps):
+            step_begin = time.perf_counter_ns()
+            _run_step()
+            step_end = time.perf_counter_ns()
+            step_times_ns.append(step_end - step_begin)
+    finally:
+        if monitor_ctx:
+            monitor_ctx.stop()
+
+    # Final recorder update after loop completes
+    benchmark.update_manual_recorders()
+
+    step_times_ms = [t / 1e6 for t in step_times_ns]
+    fps = [1000.0 / max(t, 1e-9) for t in step_times_ms]
+    effective_fps = [value * args.num_envs for value in fps]
+
+    step_metrics = {
+        "Kitless step times": step_times_ms,
+        "Kitless step FPS": fps,
+        "Kitless step effective FPS": effective_fps,
+    }
+
+    loop_start_ns = workload_setup_end
+    loop_end_ns = time.perf_counter_ns()
+
+    log_python_imports_time(benchmark, (imports_time_end - imports_time_begin) / 1e6)
+    log_task_start_time(benchmark, (workload_setup_end - workload_setup_begin) / 1e6)
+    log_total_start_time(benchmark, (loop_start_ns - script_start_ns) / 1e6)
+    log_runtime_step_times(benchmark, step_metrics, compute_stats=True)
+
+    # Add total runtime measurement for convenience
+    benchmark.add_measurement(
+        "runtime",
+        measurement=SingleMeasurement(
+            name="Kitless loop duration",
+            value=(loop_end_ns - loop_start_ns) / 1e6,
+            unit="ms",
+        ),
+    )
+
+    benchmark._finalize_impl()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/benchmark_load_robot.py
+++ b/scripts/benchmarks/benchmark_load_robot.py
@@ -82,7 +82,7 @@ benchmark = BaseIsaacLabBenchmark(
     backend_type=backend_type,
     output_path=args_cli.output_path,
     use_recorders=True,
-    frametime_recorders=backend_type == "summary",
+    frametime_recorders=backend_type in ("summary", "omniperf"),
     output_prefix="benchmark_load_robot",
     workflow_metadata={
         "metadata": [

--- a/scripts/benchmarks/benchmark_load_robot.py
+++ b/scripts/benchmarks/benchmark_load_robot.py
@@ -32,7 +32,7 @@ parser.add_argument(
     "--benchmark_backend",
     type=str,
     default="omniperf",
-    choices=["json", "osmo", "omniperf"],
+    choices=["json", "osmo", "omniperf", "summary"],
     help="Benchmarking backend options, defaults omniperf",
 )
 parser.add_argument("--output_path", type=str, default=".", help="Path to output benchmark results.")
@@ -76,11 +76,13 @@ from isaaclab_assets import ANYMAL_D_CFG, G1_MINIMAL_CFG, H1_MINIMAL_CFG  # isor
 imports_time_end = time.perf_counter_ns()
 
 # Create the benchmark
+backend_type = args_cli.benchmark_backend
 benchmark = BaseIsaacLabBenchmark(
     benchmark_name="benchmark_load_robot",
-    backend_type=args_cli.benchmark_backend,
+    backend_type=backend_type,
     output_path=args_cli.output_path,
     use_recorders=True,
+    frametime_recorders=backend_type == "summary",
     output_prefix="benchmark_load_robot",
     workflow_metadata={
         "metadata": [

--- a/scripts/benchmarks/benchmark_non_rl.py
+++ b/scripts/benchmarks/benchmark_non_rl.py
@@ -100,11 +100,13 @@ imports_time_end = time.perf_counter_ns()
 
 
 # Create the benchmark
+backend_type = get_backend_type(args_cli.benchmark_backend)
 benchmark = BaseIsaacLabBenchmark(
     benchmark_name="benchmark_non_rl",
-    backend_type=get_backend_type(args_cli.benchmark_backend),
+    backend_type=backend_type,
     output_path=args_cli.output_path,
     use_recorders=True,
+    frametime_recorders=backend_type == "summary",
     output_prefix=f"benchmark_non_rl_{args_cli.task}",
     workflow_metadata={
         "metadata": [
@@ -114,7 +116,6 @@ benchmark = BaseIsaacLabBenchmark(
             {"name": "num_frames", "data": args_cli.num_frames},
         ]
     },
-    frametime_recorders=True,
 )
 
 

--- a/scripts/benchmarks/benchmark_non_rl.py
+++ b/scripts/benchmarks/benchmark_non_rl.py
@@ -30,7 +30,16 @@ parser.add_argument(
     "--benchmark_backend",
     type=str,
     default="omniperf",
-    choices=["json", "osmo", "omniperf", "LocalLogMetrics", "JSONFileMetrics", "OsmoKPIFile", "OmniPerfKPIFile"],
+    choices=[
+        "json",
+        "osmo",
+        "omniperf",
+        "summary",
+        "LocalLogMetrics",
+        "JSONFileMetrics",
+        "OsmoKPIFile",
+        "OmniPerfKPIFile",
+    ],
     help="Benchmarking backend options, defaults omniperf",
 )
 parser.add_argument("--output_path", type=str, default=".", help="Path to output benchmark results.")

--- a/scripts/benchmarks/benchmark_non_rl.py
+++ b/scripts/benchmarks/benchmark_non_rl.py
@@ -106,7 +106,7 @@ benchmark = BaseIsaacLabBenchmark(
     backend_type=backend_type,
     output_path=args_cli.output_path,
     use_recorders=True,
-    frametime_recorders=backend_type == "summary",
+    frametime_recorders=backend_type in ("summary", "omniperf"),
     output_prefix=f"benchmark_non_rl_{args_cli.task}",
     workflow_metadata={
         "metadata": [

--- a/scripts/benchmarks/benchmark_rlgames.py
+++ b/scripts/benchmarks/benchmark_rlgames.py
@@ -30,7 +30,16 @@ parser.add_argument(
     "--benchmark_backend",
     type=str,
     default="omniperf",
-    choices=["json", "osmo", "omniperf", "LocalLogMetrics", "JSONFileMetrics", "OsmoKPIFile", "OmniPerfKPIFile"],
+    choices=[
+        "json",
+        "osmo",
+        "omniperf",
+        "summary",
+        "LocalLogMetrics",
+        "JSONFileMetrics",
+        "OsmoKPIFile",
+        "OmniPerfKPIFile",
+    ],
     help="Benchmarking backend options, defaults omniperf",
 )
 parser.add_argument("--output_path", type=str, default=".", help="Path to output benchmark results.")
@@ -105,11 +114,13 @@ torch.backends.cudnn.benchmark = False
 
 
 # Create the benchmark
+backend_type = get_backend_type(args_cli.benchmark_backend)
 benchmark = BaseIsaacLabBenchmark(
     benchmark_name="benchmark_rlgames_train",
-    backend_type=get_backend_type(args_cli.benchmark_backend),
+    backend_type=backend_type,
     output_path=args_cli.output_path,
     use_recorders=True,
+    frametime_recorders=backend_type == "summary",
     output_prefix=f"benchmark_rlgames_train_{args_cli.task}",
     workflow_metadata={
         "metadata": [

--- a/scripts/benchmarks/benchmark_rlgames.py
+++ b/scripts/benchmarks/benchmark_rlgames.py
@@ -120,7 +120,7 @@ benchmark = BaseIsaacLabBenchmark(
     backend_type=backend_type,
     output_path=args_cli.output_path,
     use_recorders=True,
-    frametime_recorders=backend_type == "summary",
+    frametime_recorders=backend_type in ("summary", "omniperf"),
     output_prefix=f"benchmark_rlgames_train_{args_cli.task}",
     workflow_metadata={
         "metadata": [

--- a/scripts/benchmarks/benchmark_rsl_rl.py
+++ b/scripts/benchmarks/benchmark_rsl_rl.py
@@ -33,7 +33,16 @@ parser.add_argument(
     "--benchmark_backend",
     type=str,
     default="omniperf",
-    choices=["json", "osmo", "omniperf", "LocalLogMetrics", "JSONFileMetrics", "OsmoKPIFile", "OmniPerfKPIFile"],
+    choices=[
+        "json",
+        "osmo",
+        "omniperf",
+        "summary",
+        "LocalLogMetrics",
+        "JSONFileMetrics",
+        "OsmoKPIFile",
+        "OmniPerfKPIFile",
+    ],
     help="Benchmarking backend options, defaults omniperf",
 )
 parser.add_argument("--output_path", type=str, default=".", help="Path to output benchmark results.")
@@ -104,11 +113,13 @@ torch.backends.cudnn.deterministic = False
 torch.backends.cudnn.benchmark = False
 
 # Create the benchmark
+backend_type = get_backend_type(args_cli.benchmark_backend)
 benchmark = BaseIsaacLabBenchmark(
     benchmark_name="benchmark_rsl_rl_train",
-    backend_type=get_backend_type(args_cli.benchmark_backend),
+    backend_type=backend_type,
     output_path=args_cli.output_path,
     use_recorders=True,
+    frametime_recorders=backend_type == "summary",
     output_prefix=f"benchmark_rsl_rl_train_{args_cli.task}",
     workflow_metadata={
         "metadata": [

--- a/scripts/benchmarks/benchmark_rsl_rl.py
+++ b/scripts/benchmarks/benchmark_rsl_rl.py
@@ -119,7 +119,7 @@ benchmark = BaseIsaacLabBenchmark(
     backend_type=backend_type,
     output_path=args_cli.output_path,
     use_recorders=True,
-    frametime_recorders=backend_type == "summary",
+    frametime_recorders=backend_type in ("summary", "omniperf"),
     output_prefix=f"benchmark_rsl_rl_train_{args_cli.task}",
     workflow_metadata={
         "metadata": [

--- a/scripts/benchmarks/utils.py
+++ b/scripts/benchmarks/utils.py
@@ -29,6 +29,7 @@ def get_backend_type(cli_backend: str) -> str:
         "omniperf": "omniperf",
         "json": "json",
         "osmo": "osmo",
+        "summary": "summary",
     }
     return mapping.get(cli_backend, "omniperf")
 
@@ -64,11 +65,12 @@ def parse_tf_logs(log_dir: str):
 
 def log_min_max_mean_stats(benchmark: BaseIsaacLabBenchmark, values: dict):
     for k, v in values.items():
-        measurement = SingleMeasurement(name=f"Min {k}", value=min(v), unit="ms")
+        unit = "FPS" if "FPS" in k else "ms" if "Time" in k or "time" in k else ""
+        measurement = SingleMeasurement(name=f"Min {k}", value=min(v), unit=unit)
         benchmark.add_measurement("runtime", measurement=measurement)
-        measurement = SingleMeasurement(name=f"Max {k}", value=max(v), unit="ms")
+        measurement = SingleMeasurement(name=f"Max {k}", value=max(v), unit=unit)
         benchmark.add_measurement("runtime", measurement=measurement)
-        measurement = SingleMeasurement(name=f"Mean {k}", value=sum(v) / len(v), unit="ms")
+        measurement = SingleMeasurement(name=f"Mean {k}", value=sum(v) / len(v), unit=unit)
         benchmark.add_measurement("runtime", measurement=measurement)
 
 

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.2.1"
+version = "4.2.2"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -267,6 +267,7 @@ Added
   * ``json``: Full JSON output with all phases, measurements, and metadata.
   * ``osmo``: Osmo KPI format for CI/CD integration.
   * ``omniperf``: OmniPerf format for database upload.
+  * ``summary``: Human-readable console summary plus JSON output.
 
 * Added system recorders in :mod:`isaaclab.test.benchmark.recorders`:
 
@@ -283,11 +284,20 @@ Added
   * ``scripts/benchmarks/run_physx_benchmarks.sh``: PhysX micro-benchmarks.
   * ``scripts/benchmarks/run_training_benchmarks.sh``: RL training benchmarks.
 
+* Added fallback in :mod:`isaaclab.test.benchmark.benchmark_core` for Isaac Sim packaging that
+  bundles frametime recorders in a single module, so frametime collection works across variants.
+
 Changed
 ^^^^^^^
 
 * Refactored benchmark scripts to use new :class:`~isaaclab.test.benchmark.BaseIsaacLabBenchmark`
   class instead of ``isaacsim.benchmark.services``.
+
+Fixed
+^^^^^
+
+* Fixed runtime stats in ``log_min_max_mean_stats`` (``scripts/benchmarks/utils.py``) so FPS
+  metrics are labeled with unit ``FPS`` and time metrics with ``ms`` instead of all being ``ms``.
 
 Removed
 ^^^^^^^

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,27 @@
 Changelog
 ---------
 
+4.2.2 (2026-02-26)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :class:`~isaaclab.test.benchmark.backends.SummaryMetrics` backend for benchmarks:
+  prints a human-readable boxed summary to the console while still writing full JSON output.
+  Use ``--benchmark_backend summary`` in benchmark scripts.
+
+Fixed
+^^^^^
+
+* Fixed runtime stats in benchmark scripts so FPS metrics (e.g. Collection FPS, Total FPS)
+  are labeled with unit "FPS" instead of "ms". Unit is now inferred from the metric
+  name in ``log_min_max_mean_stats`` (benchmark utils).
+
+* Enabled frametime recorders for the ``omniperf`` backend in benchmark scripts to
+  preserve Grafana metrics ingestion.
+
+
 4.2.1 (2026-02-25)
 ~~~~~~~~~~~~~~~~~~
 
@@ -219,20 +240,6 @@ Added
 
 * Added shared warp math kernels in :mod:`isaaclab.utils.warp.kernels` for quaternion
   operations, coordinate transforms, and velocity computations.
-
-* Added :class:`~isaaclab.test.benchmark.backends.SummaryMetrics` backend for benchmarks:
-  prints a human-readable boxed summary to the console while still writing full JSON output.
-  Use ``--benchmark_backend summary`` in benchmark scripts. Frametime recorders are
-  enabled automatically when the summary backend is selected, with a fallback for
-  bundled Isaac Sim packaging variants.
-
-Fixed
-^^^^^
-
-* Fixed runtime stats in benchmark scripts so FPS metrics (e.g. Collection FPS, Total FPS)
-  are labeled with unit "FPS" instead of "ms". Unit is now inferred from the metric
-  name in ``log_min_max_mean_stats`` (benchmark utils).
-
 
 3.2.0 (2026-02-06)
 ~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -220,6 +220,19 @@ Added
 * Added shared warp math kernels in :mod:`isaaclab.utils.warp.kernels` for quaternion
   operations, coordinate transforms, and velocity computations.
 
+* Added :class:`~isaaclab.test.benchmark.backends.SummaryMetrics` backend for benchmarks:
+  prints a human-readable boxed summary to the console while still writing full JSON output.
+  Use ``--benchmark_backend summary`` in benchmark scripts. Frametime recorders are
+  enabled automatically when the summary backend is selected, with a fallback for
+  bundled Isaac Sim packaging variants.
+
+Fixed
+^^^^^
+
+* Fixed runtime stats in benchmark scripts so FPS metrics (e.g. Collection FPS, Total FPS)
+  are labeled with unit "FPS" instead of "ms". Unit is now inferred from the metric
+  name in ``log_min_max_mean_stats`` (benchmark utils).
+
 
 3.2.0 (2026-02-06)
 ~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/isaaclab/test/benchmark/backends.py
+++ b/source/isaaclab/isaaclab/test/benchmark/backends.py
@@ -300,9 +300,7 @@ class SummaryMetrics(MetricsBackendInterface):
             return name, total_mem
         return None, None
 
-    def _print_optional_measurement(
-        self, phase: TestPhase, name: str, unit_fallback: str | None = None
-    ) -> None:
+    def _print_optional_measurement(self, phase: TestPhase, name: str, unit_fallback: str | None = None) -> None:
         measurement = self._get_single_measurement(phase, name)
         if measurement is None:
             return

--- a/source/isaaclab/isaaclab/test/benchmark/backends.py
+++ b/source/isaaclab/isaaclab/test/benchmark/backends.py
@@ -7,8 +7,10 @@ import copy
 import json
 import logging
 import os
+import textwrap
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import Any
 
 from .measurements import SingleMeasurement, StatisticalMeasurement, TestPhase, TestPhaseEncoder
 
@@ -74,6 +76,7 @@ class MetricsBackend:
                 "json": JSONFileMetrics,
                 "osmo": OsmoKPIFile,
                 "omniperf": OmniPerfKPIFile,
+                "summary": SummaryMetrics,
             }
             if instance_type not in backend_map:
                 raise ValueError(f"Unknown backend type: {instance_type}. Available: {list(backend_map.keys())}")
@@ -152,6 +155,244 @@ class JSONFileMetrics(MetricsBackendInterface):
         print(f"Results written to: {metrics_path}")
 
         self.data.clear()
+
+
+class SummaryMetrics(MetricsBackendInterface):
+    """Print a human-readable summary and write JSON metrics."""
+
+    def __init__(self) -> None:
+        self._phases: list[TestPhase] = []
+        self._json_backend = JSONFileMetrics()
+        self._report_width = 86
+
+    def add_metrics(self, test_phase: TestPhase) -> None:
+        self._phases.append(copy.deepcopy(test_phase))
+        self._json_backend.add_metrics(test_phase)
+
+    def finalize(self, output_path: str, output_filename: str, **kwargs) -> None:
+        self._json_backend.finalize(output_path, output_filename, **kwargs)
+        if self._phases:
+            self._print_summary()
+        self._phases.clear()
+
+    def _print_summary(self) -> None:
+        phases = self._merge_phases()
+        benchmark_info = phases.get("benchmark_info")
+        runtime_phase = phases.get("runtime")
+        startup_phase = phases.get("startup")
+        train_phase = phases.get("train")
+        frametime_phase = phases.get("frametime")
+        hardware_info = phases.get("hardware_info")
+        version_info = phases.get("version_info")
+
+        benchmark_meta = self._metadata_map(benchmark_info)
+        hardware_meta = self._metadata_map(hardware_info)
+        version_meta = self._metadata_map(version_info)
+        dev_meta = version_meta.get("dev", {}) if isinstance(version_meta.get("dev"), dict) else {}
+
+        workflow_name = benchmark_meta.get("workflow_name")
+        timestamp = benchmark_meta.get("timestamp")
+        task = benchmark_meta.get("task")
+        seed = benchmark_meta.get("seed")
+        num_envs = benchmark_meta.get("num_envs")
+        max_iterations = benchmark_meta.get("max_iterations")
+        num_cpus = hardware_meta.get("physical_cores")
+        commit = dev_meta.get("commit_hash_short") or dev_meta.get("commit_hash")
+        branch = dev_meta.get("branch")
+
+        gpu_name, gpu_total_mem = self._get_gpu_summary(hardware_meta)
+
+        print()
+        self._print_box_separator()
+        self._print_box_line("Summary Report".center(self._report_width - 4))
+        self._print_box_separator()
+        self._print_box_kv("workflow_name", workflow_name)
+        self._print_box_kv("timestamp", timestamp)
+        self._print_box_kv("task", task)
+        self._print_box_kv("seed", seed)
+        self._print_box_kv("num_envs", num_envs)
+        self._print_box_kv("max_iterations", max_iterations)
+        self._print_box_kv("num_cpus", num_cpus)
+        self._print_box_kv("commit", commit)
+        self._print_box_kv("branch", branch)
+        self._print_box_kv("gpu_name", gpu_name)
+        if gpu_total_mem is not None:
+            self._print_box_kv("gpu_total_memory_gb", gpu_total_mem)
+        self._print_box_separator()
+
+        if runtime_phase:
+            runtime_rows = self._summarize_runtime_metrics(runtime_phase.measurements)
+            self._print_box_line("Phase: runtime")
+            for row in runtime_rows:
+                self._print_box_line(row)
+            self._print_box_separator()
+
+        if startup_phase:
+            self._print_box_line("Phase: startup")
+            self._print_optional_measurement(startup_phase, "App Launch Time")
+            self._print_optional_measurement(startup_phase, "Python Imports Time")
+            self._print_optional_measurement(startup_phase, "Task Creation and Start Time")
+            self._print_optional_measurement(startup_phase, "Scene Creation Time")
+            self._print_optional_measurement(startup_phase, "Simulation Start Time")
+            self._print_optional_measurement(startup_phase, "Total Start Time (Launch to Train)")
+            self._print_box_separator()
+
+        if train_phase:
+            self._print_box_line("Phase: train")
+            self._print_optional_measurement(train_phase, "Max Rewards", unit_fallback="float")
+            self._print_optional_measurement(train_phase, "Max Episode Lengths", unit_fallback="float")
+            self._print_optional_measurement(train_phase, "Last Reward", unit_fallback="float")
+            self._print_optional_measurement(train_phase, "Last Episode Length", unit_fallback="float")
+            self._print_optional_measurement(train_phase, "EMA 0.95 Reward", unit_fallback="float")
+            self._print_optional_measurement(train_phase, "EMA 0.95 Episode Length", unit_fallback="float")
+            self._print_box_separator()
+
+        if frametime_phase and frametime_phase.measurements:
+            self._print_box_line("Phase: frametime")
+            for measurement in frametime_phase.measurements:
+                label = measurement.name
+                if isinstance(measurement, StatisticalMeasurement):
+                    value = f"{self._format_scalar(measurement.mean)} {measurement.unit}"
+                    value = f"{value} (std {self._format_scalar(measurement.std)})"
+                elif isinstance(measurement, SingleMeasurement):
+                    value = f"{self._format_scalar(measurement.value)} {measurement.unit}"
+                else:
+                    continue
+                self._print_box_line(f"{label}: {value}")
+            self._print_box_separator()
+
+        if hardware_meta:
+            self._print_box_line("System:")
+            self._print_box_kv("cpu_name", hardware_meta.get("cpu_name"))
+            self._print_box_kv("physical_cores", hardware_meta.get("physical_cores"))
+            self._print_box_kv("total_ram_gb", hardware_meta.get("total_ram_gb"))
+            self._print_box_kv("gpu_device_count", hardware_meta.get("gpu_device_count"))
+            self._print_box_kv("cuda_version", hardware_meta.get("cuda_version"))
+            self._print_box_separator()
+
+    def _merge_phases(self) -> dict[str, TestPhase]:
+        merged: dict[str, TestPhase] = {}
+        for phase in self._phases:
+            name = phase.phase_name
+            if name not in merged:
+                merged[name] = copy.deepcopy(phase)
+            else:
+                merged[name].measurements.extend(phase.measurements)
+                merged[name].metadata.extend(phase.metadata)
+        return merged
+
+    def _metadata_map(self, phase: TestPhase | None) -> dict[str, Any]:
+        if not phase:
+            return {}
+        metadata: dict[str, Any] = {}
+        for item in phase.metadata:
+            if hasattr(item, "data"):
+                metadata[item.name] = item.data
+        return metadata
+
+    def _get_gpu_summary(self, hardware_meta: dict[str, Any]) -> tuple[str | None, float | None]:
+        gpu_devices = hardware_meta.get("gpu_devices")
+        current_device = hardware_meta.get("gpu_current_device", 0)
+        if isinstance(gpu_devices, dict):
+            device = gpu_devices.get(str(current_device)) or next(iter(gpu_devices.values()), {})
+            name = device.get("name")
+            total_mem = device.get("total_memory_gb")
+            return name, total_mem
+        return None, None
+
+    def _print_optional_measurement(
+        self, phase: TestPhase, name: str, unit_fallback: str | None = None
+    ) -> None:
+        measurement = self._get_single_measurement(phase, name)
+        if measurement is None:
+            return
+        unit = measurement.unit or unit_fallback
+        suffix = f" {unit}" if unit else ""
+        self._print_box_line(f"{name}: {self._format_scalar(measurement.value)}{suffix}")
+
+    def _get_single_measurement(self, phase: TestPhase, name: str) -> SingleMeasurement | None:
+        for measurement in phase.measurements:
+            if isinstance(measurement, SingleMeasurement) and measurement.name == name:
+                return measurement
+        return None
+
+    def _summarize_runtime_metrics(self, measurements: list) -> list[str]:
+        series: dict[str, dict[str, float]] = {}
+        units: dict[str, str | None] = {}
+        for measurement in measurements:
+            if not isinstance(measurement, SingleMeasurement):
+                continue
+            name = measurement.name
+            value = measurement.value
+            unit = measurement.unit
+            if not isinstance(value, (int, float)):
+                continue
+            if name.startswith("Min "):
+                base = name[len("Min ") :]
+                series.setdefault(base, {})["min"] = float(value)
+                units.setdefault(base, unit)
+            elif name.startswith("Max "):
+                base = name[len("Max ") :]
+                series.setdefault(base, {})["max"] = float(value)
+                units.setdefault(base, unit)
+            elif name.startswith("Mean "):
+                base = name[len("Mean ") :]
+                series.setdefault(base, {})["mean"] = float(value)
+                units.setdefault(base, unit)
+
+        category_order = ["Collection", "Learning", "Step Times", "Throughput", "Other"]
+        categorized: dict[str, list[str]] = {key: [] for key in category_order}
+        for base, stats in series.items():
+            unit = units.get(base)
+            unit_suffix = f" {unit}" if unit else ""
+            min_val = self._format_scalar(stats.get("min", 0.0))
+            mean_val = self._format_scalar(stats.get("mean", 0.0))
+            max_val = self._format_scalar(stats.get("max", 0.0))
+            row = f"{base} (min/mean/max): {min_val} / {mean_val} / {max_val}{unit_suffix}"
+
+            if "Collection" in base:
+                categorized["Collection"].append(row)
+            elif "Learning" in base:
+                categorized["Learning"].append(row)
+            elif "step time" in base.lower():
+                categorized["Step Times"].append(row)
+            elif "FPS" in base or "Throughput" in base:
+                categorized["Throughput"].append(row)
+            else:
+                categorized["Other"].append(row)
+
+        rows: list[str] = []
+        for category in category_order:
+            if not categorized[category]:
+                continue
+            rows.append(f"{category}:")
+            rows.extend(f"  {entry}" for entry in categorized[category])
+        if not rows:
+            rows.append("No runtime metrics available.")
+        return rows
+
+    def _print_box_separator(self) -> None:
+        print("|" + "-" * (self._report_width - 2) + "|")
+
+    def _print_box_line(self, text: str) -> None:
+        inner_width = self._report_width - 4
+        if not text:
+            print(f"| {' ' * inner_width} |")
+            return
+        for line in textwrap.wrap(text, width=inner_width, break_long_words=False, break_on_hyphens=False):
+            print(f"| {line.ljust(inner_width)} |")
+
+    def _print_box_kv(self, key: str, value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, float):
+            value = self._format_scalar(value)
+        self._print_box_line(f"{key}: {value}")
+
+    def _format_scalar(self, value: float | int) -> str:
+        if isinstance(value, float):
+            return f"{value:.2f}"
+        return str(value)
 
 
 class OsmoKPIFile(MetricsBackendInterface):

--- a/source/isaaclab/isaaclab/test/benchmark/backends.py
+++ b/source/isaaclab/isaaclab/test/benchmark/backends.py
@@ -255,7 +255,8 @@ class SummaryMetrics(MetricsBackendInterface):
                     unit_str = f" {measurement.unit}" if measurement.unit else ""
                     value = f"{self._format_scalar(measurement.mean)}{unit_str}"
                 elif isinstance(measurement, SingleMeasurement):
-                    value = f"{self._format_scalar(measurement.value)} {measurement.unit}"
+                    unit_str = f" {measurement.unit}" if measurement.unit else ""
+                    value = f"{self._format_scalar(measurement.value)}{unit_str}"
                 else:
                     continue
                 self._print_box_line(f"{label}: {value}")

--- a/source/isaaclab/isaaclab/test/benchmark/backends.py
+++ b/source/isaaclab/isaaclab/test/benchmark/backends.py
@@ -252,8 +252,8 @@ class SummaryMetrics(MetricsBackendInterface):
             for measurement in frametime_phase.measurements:
                 label = measurement.name
                 if isinstance(measurement, StatisticalMeasurement):
-                    value = f"{self._format_scalar(measurement.mean)} {measurement.unit}"
-                    value = f"{value} (std {self._format_scalar(measurement.std)})"
+                    unit_str = f" {measurement.unit}" if measurement.unit else ""
+                    value = f"{self._format_scalar(measurement.mean)}{unit_str}"
                 elif isinstance(measurement, SingleMeasurement):
                     value = f"{self._format_scalar(measurement.value)} {measurement.unit}"
                 else:

--- a/source/isaaclab/isaaclab/test/benchmark/backends.py
+++ b/source/isaaclab/isaaclab/test/benchmark/backends.py
@@ -252,10 +252,10 @@ class SummaryMetrics(MetricsBackendInterface):
             for measurement in frametime_phase.measurements:
                 label = measurement.name
                 if isinstance(measurement, StatisticalMeasurement):
-                    unit_str = f" {measurement.unit}" if measurement.unit else ""
+                    unit_str = f" {measurement.unit.strip()}" if (measurement.unit and measurement.unit.strip()) else ""
                     value = f"{self._format_scalar(measurement.mean)}{unit_str}"
                 elif isinstance(measurement, SingleMeasurement):
-                    unit_str = f" {measurement.unit}" if measurement.unit else ""
+                    unit_str = f" {measurement.unit.strip()}" if (measurement.unit and measurement.unit.strip()) else ""
                     value = f"{self._format_scalar(measurement.value)}{unit_str}"
                 else:
                     continue
@@ -305,7 +305,7 @@ class SummaryMetrics(MetricsBackendInterface):
         measurement = self._get_single_measurement(phase, name)
         if measurement is None:
             return
-        unit = measurement.unit or unit_fallback
+        unit = (measurement.unit or unit_fallback or "").strip()
         suffix = f" {unit}" if unit else ""
         self._print_box_line(f"{name}: {self._format_scalar(measurement.value)}{suffix}")
 
@@ -342,7 +342,8 @@ class SummaryMetrics(MetricsBackendInterface):
         category_order = ["Collection", "Learning", "Step Times", "Throughput", "Other"]
         categorized: dict[str, list[str]] = {key: [] for key in category_order}
         for base, stats in series.items():
-            unit = units.get(base)
+            raw_unit = units.get(base)
+            unit = (raw_unit or "").strip() if isinstance(raw_unit, str) else ""
             unit_suffix = f" {unit}" if unit else ""
             min_val = self._format_scalar(stats.get("min", 0.0))
             mean_val = self._format_scalar(stats.get("mean", 0.0))

--- a/source/isaaclab/isaaclab/test/benchmark/backends.py
+++ b/source/isaaclab/isaaclab/test/benchmark/backends.py
@@ -161,21 +161,35 @@ class SummaryMetrics(MetricsBackendInterface):
     """Print a human-readable summary and write JSON metrics."""
 
     def __init__(self) -> None:
+        """Initialize internal phase storage and JSON backend."""
         self._phases: list[TestPhase] = []
         self._json_backend = JSONFileMetrics()
         self._report_width = 86
 
     def add_metrics(self, test_phase: TestPhase) -> None:
+        """Add metrics from a test phase; store for summary and forward to JSON backend.
+
+        Args:
+            test_phase: Test phase containing measurements and metadata.
+        """
         self._phases.append(copy.deepcopy(test_phase))
         self._json_backend.add_metrics(test_phase)
 
     def finalize(self, output_path: str, output_filename: str, **kwargs) -> None:
+        """Write JSON output and print human-readable summary to console.
+
+        Args:
+            output_path: Path to write output file(s).
+            output_filename: Base filename for the JSON file.
+            **kwargs: Additional options passed to the JSON backend.
+        """
         self._json_backend.finalize(output_path, output_filename, **kwargs)
         if self._phases:
             self._print_summary()
         self._phases.clear()
 
     def _print_summary(self) -> None:
+        """Format and print the boxed summary report to stdout."""
         phases = self._merge_phases()
         benchmark_info = phases.get("benchmark_info")
         runtime_phase = phases.get("runtime")
@@ -272,6 +286,11 @@ class SummaryMetrics(MetricsBackendInterface):
             self._print_box_separator()
 
     def _merge_phases(self) -> dict[str, TestPhase]:
+        """Merge all stored phases by name, combining measurements and metadata.
+
+        Returns:
+            Dictionary mapping phase name to a single merged TestPhase.
+        """
         merged: dict[str, TestPhase] = {}
         for phase in self._phases:
             name = phase.phase_name
@@ -283,6 +302,14 @@ class SummaryMetrics(MetricsBackendInterface):
         return merged
 
     def _metadata_map(self, phase: TestPhase | None) -> dict[str, Any]:
+        """Build a name -> data map from a phase's metadata list.
+
+        Args:
+            phase: Test phase, or None.
+
+        Returns:
+            Dictionary of metadata names to their data values.
+        """
         if not phase:
             return {}
         metadata: dict[str, Any] = {}
@@ -292,6 +319,14 @@ class SummaryMetrics(MetricsBackendInterface):
         return metadata
 
     def _get_gpu_summary(self, hardware_meta: dict[str, Any]) -> tuple[str | None, float | None]:
+        """Extract GPU name and total memory (GB) from hardware metadata.
+
+        Args:
+            hardware_meta: Metadata dict from the hardware_info phase.
+
+        Returns:
+            (gpu_name, total_memory_gb) or (None, None) if not available.
+        """
         gpu_devices = hardware_meta.get("gpu_devices")
         current_device = hardware_meta.get("gpu_current_device", 0)
         if isinstance(gpu_devices, dict):
@@ -302,6 +337,13 @@ class SummaryMetrics(MetricsBackendInterface):
         return None, None
 
     def _print_optional_measurement(self, phase: TestPhase, name: str, unit_fallback: str | None = None) -> None:
+        """Print a single measurement line if present in the phase.
+
+        Args:
+            phase: Test phase to look up the measurement.
+            name: Measurement name.
+            unit_fallback: Unit string to use when measurement has no unit.
+        """
         measurement = self._get_single_measurement(phase, name)
         if measurement is None:
             return
@@ -310,12 +352,29 @@ class SummaryMetrics(MetricsBackendInterface):
         self._print_box_line(f"{name}: {self._format_scalar(measurement.value)}{suffix}")
 
     def _get_single_measurement(self, phase: TestPhase, name: str) -> SingleMeasurement | None:
+        """Return the first SingleMeasurement in the phase with the given name.
+
+        Args:
+            phase: Test phase to search.
+            name: Measurement name.
+
+        Returns:
+            The matching SingleMeasurement, or None.
+        """
         for measurement in phase.measurements:
             if isinstance(measurement, SingleMeasurement) and measurement.name == name:
                 return measurement
         return None
 
     def _summarize_runtime_metrics(self, measurements: list) -> list[str]:
+        """Build min/mean/max summary rows from SingleMeasurement runtime metrics.
+
+        Args:
+            measurements: List of measurements (typically from the runtime phase).
+
+        Returns:
+            List of formatted lines, grouped by category (Collection, Learning, etc.).
+        """
         series: dict[str, dict[str, float]] = {}
         units: dict[str, str | None] = {}
         for measurement in measurements:
@@ -372,9 +431,11 @@ class SummaryMetrics(MetricsBackendInterface):
         return rows
 
     def _print_box_separator(self) -> None:
+        """Print a horizontal rule line for the summary box."""
         print("|" + "-" * (self._report_width - 2) + "|")
 
     def _print_box_line(self, text: str) -> None:
+        """Print a line of text inside the box, wrapping if needed."""
         inner_width = self._report_width - 4
         if not text:
             print(f"| {' ' * inner_width} |")
@@ -383,6 +444,7 @@ class SummaryMetrics(MetricsBackendInterface):
             print(f"| {line.ljust(inner_width)} |")
 
     def _print_box_kv(self, key: str, value: Any) -> None:
+        """Print a key-value line; skip if value is None."""
         if value is None:
             return
         if isinstance(value, float):
@@ -390,6 +452,7 @@ class SummaryMetrics(MetricsBackendInterface):
         self._print_box_line(f"{key}: {value}")
 
     def _format_scalar(self, value: float | int) -> str:
+        """Format a numeric value for display (two decimal places for floats)."""
         if isinstance(value, float):
             return f"{value:.2f}"
         return str(value)

--- a/source/isaaclab/isaaclab/test/benchmark/benchmark_core.py
+++ b/source/isaaclab/isaaclab/test/benchmark/benchmark_core.py
@@ -119,15 +119,25 @@ class BaseIsaacLabBenchmark:
 
                     enable_extension("isaacsim.benchmark.services")
 
-                    from isaacsim.benchmark.services.datarecorders.app_frametime import AppFrametimeRecorder
-                    from isaacsim.benchmark.services.datarecorders.gpu_frametime import GPUFrametimeRecorder
-                    from isaacsim.benchmark.services.datarecorders.physics_frametime import PhysicsFrametimeRecorder
-                    from isaacsim.benchmark.services.datarecorders.render_frametime import RenderFrametimeRecorder
+                    try:
+                        from isaacsim.benchmark.services.datarecorders.app_frametime import AppFrametimeRecorder
+                        from isaacsim.benchmark.services.datarecorders.gpu_frametime import GPUFrametimeRecorder
+                        from isaacsim.benchmark.services.datarecorders.physics_frametime import PhysicsFrametimeRecorder
+                        from isaacsim.benchmark.services.datarecorders.render_frametime import RenderFrametimeRecorder
 
-                    self._frametime_recorders["PhysicsFrametime"] = PhysicsFrametimeRecorder()
-                    self._frametime_recorders["RenderFrametime"] = RenderFrametimeRecorder()
-                    self._frametime_recorders["AppFrametime"] = AppFrametimeRecorder()
-                    self._frametime_recorders["GPUFrametime"] = GPUFrametimeRecorder()
+                        self._frametime_recorders["PhysicsFrametime"] = PhysicsFrametimeRecorder()
+                        self._frametime_recorders["RenderFrametime"] = RenderFrametimeRecorder()
+                        self._frametime_recorders["AppFrametime"] = AppFrametimeRecorder()
+                        self._frametime_recorders["GPUFrametime"] = GPUFrametimeRecorder()
+                    except ImportError:
+                        # Fallback for Isaac Sim packaging that bundles frametime recorders in a single module.
+                        from isaacsim.benchmark.services.datarecorders.interface import InputContext
+                        from isaacsim.benchmark.services.recorders import IsaacFrameTimeRecorder
+
+                        context = InputContext(phase="frametime")
+                        self._frametime_recorders["IsaacFrameTime"] = IsaacFrameTimeRecorder(
+                            context=context, gpu_frametime=False
+                        )
                 except ImportError as e:
                     logger.warning(
                         f"Could not import kit recorders: {e}. Kit related measurements will not be available."

--- a/source/isaaclab/isaaclab/test/benchmark/benchmark_core.py
+++ b/source/isaaclab/isaaclab/test/benchmark/benchmark_core.py
@@ -120,6 +120,16 @@ class BaseIsaacLabBenchmark:
                     enable_extension("isaacsim.benchmark.services")
 
                     try:
+                        # Try bundled/kit path first (Isaac Sim packaging that uses a single recorder module).
+                        from isaacsim.benchmark.services.datarecorders.interface import InputContext
+                        from isaacsim.benchmark.services.recorders import IsaacFrameTimeRecorder
+
+                        context = InputContext(phase="frametime")
+                        self._frametime_recorders["IsaacFrameTime"] = IsaacFrameTimeRecorder(
+                            context=context, gpu_frametime=False
+                        )
+                    except ImportError:
+                        # Fallback to individual datarecorder modules when not bundled.
                         from isaacsim.benchmark.services.datarecorders.app_frametime import AppFrametimeRecorder
                         from isaacsim.benchmark.services.datarecorders.gpu_frametime import GPUFrametimeRecorder
                         from isaacsim.benchmark.services.datarecorders.physics_frametime import PhysicsFrametimeRecorder
@@ -129,15 +139,6 @@ class BaseIsaacLabBenchmark:
                         self._frametime_recorders["RenderFrametime"] = RenderFrametimeRecorder()
                         self._frametime_recorders["AppFrametime"] = AppFrametimeRecorder()
                         self._frametime_recorders["GPUFrametime"] = GPUFrametimeRecorder()
-                    except ImportError:
-                        # Fallback for Isaac Sim packaging that bundles frametime recorders in a single module.
-                        from isaacsim.benchmark.services.datarecorders.interface import InputContext
-                        from isaacsim.benchmark.services.recorders import IsaacFrameTimeRecorder
-
-                        context = InputContext(phase="frametime")
-                        self._frametime_recorders["IsaacFrameTime"] = IsaacFrameTimeRecorder(
-                            context=context, gpu_frametime=False
-                        )
                 except ImportError as e:
                     logger.warning(
                         f"Could not import kit recorders: {e}. Kit related measurements will not be available."

--- a/source/isaaclab/isaaclab/test/benchmark/benchmark_core.py
+++ b/source/isaaclab/isaaclab/test/benchmark/benchmark_core.py
@@ -111,7 +111,11 @@ class BaseIsaacLabBenchmark:
                 "VersionInfo": VersionInfoRecorder(),
             }
 
-            # If we're using Kit, then we can use IsaacSim's benchmark services to peak into the frametimes.
+            # "Kit-full" means Isaac Sim (Kit) runtime is available, so benchmark services can
+            # provide frametime recorders. "Kit-less" means those services are absent; we should
+            # gracefully skip or fall back while still allowing mixed modes (e.g., kit-full physics
+            # with kit-less rendering).
+            # If we're using Kit, then we can use IsaacSim's benchmark services to peek into the frametimes.
             if self._use_frametime_recorders:
                 try:
                     # Enable the benchmark services extension first
@@ -119,26 +123,56 @@ class BaseIsaacLabBenchmark:
 
                     enable_extension("isaacsim.benchmark.services")
 
-                    try:
-                        # Try bundled/kit path first (Isaac Sim packaging that uses a single recorder module).
-                        from isaacsim.benchmark.services.datarecorders.interface import InputContext
-                        from isaacsim.benchmark.services.recorders import IsaacFrameTimeRecorder
+                    added_any = False
 
-                        context = InputContext(phase="frametime")
-                        self._frametime_recorders["IsaacFrameTime"] = IsaacFrameTimeRecorder(
-                            context=context, gpu_frametime=False
-                        )
-                    except ImportError:
-                        # Fallback to individual datarecorder modules when not bundled.
-                        from isaacsim.benchmark.services.datarecorders.app_frametime import AppFrametimeRecorder
-                        from isaacsim.benchmark.services.datarecorders.gpu_frametime import GPUFrametimeRecorder
+                    # Try individual recorders first so we can collect partial metrics when only some are available.
+                    try:
                         from isaacsim.benchmark.services.datarecorders.physics_frametime import PhysicsFrametimeRecorder
-                        from isaacsim.benchmark.services.datarecorders.render_frametime import RenderFrametimeRecorder
 
                         self._frametime_recorders["PhysicsFrametime"] = PhysicsFrametimeRecorder()
+                        added_any = True
+                    except (ImportError, Exception) as e:
+                        logger.debug(f"Physics frametime recorder unavailable: {e}")
+
+                    try:
+                        from isaacsim.benchmark.services.datarecorders.render_frametime import RenderFrametimeRecorder
+
                         self._frametime_recorders["RenderFrametime"] = RenderFrametimeRecorder()
+                        added_any = True
+                    except (ImportError, Exception) as e:
+                        logger.debug(f"Render frametime recorder unavailable: {e}")
+
+                    try:
+                        from isaacsim.benchmark.services.datarecorders.app_frametime import AppFrametimeRecorder
+
                         self._frametime_recorders["AppFrametime"] = AppFrametimeRecorder()
+                        added_any = True
+                    except (ImportError, Exception) as e:
+                        logger.debug(f"App frametime recorder unavailable: {e}")
+
+                    try:
+                        from isaacsim.benchmark.services.datarecorders.gpu_frametime import GPUFrametimeRecorder
+
                         self._frametime_recorders["GPUFrametime"] = GPUFrametimeRecorder()
+                        added_any = True
+                    except (ImportError, Exception) as e:
+                        logger.debug(f"GPU frametime recorder unavailable: {e}")
+
+                    if not added_any:
+                        # Fallback for Isaac Sim packaging that bundles frametime recorders in a single module.
+                        try:
+                            from isaacsim.benchmark.services.datarecorders.interface import InputContext
+                            from isaacsim.benchmark.services.recorders import IsaacFrameTimeRecorder
+
+                            context = InputContext(phase="frametime")
+                            self._frametime_recorders["IsaacFrameTime"] = IsaacFrameTimeRecorder(
+                                context=context, gpu_frametime=False
+                            )
+                        except ImportError as e:
+                            logger.warning(
+                                "Could not import bundled frametime recorder: "
+                                f"{e}. Frametime measurements will not be available."
+                            )
                 except ImportError as e:
                     logger.warning(
                         f"Could not import kit recorders: {e}. Kit related measurements will not be available."

--- a/source/isaaclab/test/benchmark/test_benchmark_core.py
+++ b/source/isaaclab/test/benchmark/test_benchmark_core.py
@@ -283,7 +283,7 @@ class TestMetricsBackendFactory:
     def test_summary_backend_finalize_writes_json(self, temp_output_dir):
         """Test that SummaryMetrics finalize writes JSON output (and does not raise)."""
         backend = backends.MetricsBackend.get_instance("summary")
-        from isaaclab.test.benchmark.measurements import TestPhase, StringMetadata
+        from isaaclab.test.benchmark.measurements import StringMetadata, TestPhase
 
         phase = TestPhase(phase_name="runtime")
         phase.measurements.append(SingleMeasurement(name="Test FPS", value=60.0, unit="FPS"))

--- a/source/isaaclab/test/benchmark/test_benchmark_core.py
+++ b/source/isaaclab/test/benchmark/test_benchmark_core.py
@@ -247,6 +247,12 @@ class TestBaseIsaacLabBenchmark:
 class TestMetricsBackendFactory:
     """Tests for MetricsBackend factory class."""
 
+    @pytest.fixture
+    def temp_output_dir(self):
+        """Create a temporary output directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield tmpdir
+
     @pytest.fixture(autouse=True)
     def reset_backends(self):
         """Reset backend instances before each test."""
@@ -269,6 +275,31 @@ class TestMetricsBackendFactory:
         backend = backends.MetricsBackend.get_instance("omniperf")
         assert isinstance(backend, backends.OmniPerfKPIFile)
 
+    def test_get_summary_backend(self):
+        """Test getting Summary backend instance."""
+        backend = backends.MetricsBackend.get_instance("summary")
+        assert isinstance(backend, backends.SummaryMetrics)
+
+    def test_summary_backend_finalize_writes_json(self, temp_output_dir):
+        """Test that SummaryMetrics finalize writes JSON output (and does not raise)."""
+        backend = backends.MetricsBackend.get_instance("summary")
+        from isaaclab.test.benchmark.measurements import TestPhase, StringMetadata
+
+        phase = TestPhase(phase_name="runtime")
+        phase.measurements.append(SingleMeasurement(name="Test FPS", value=60.0, unit="FPS"))
+        phase.metadata.append(StringMetadata(name="runtime workflow_name", data="summary_test"))
+        phase.metadata.append(StringMetadata(name="runtime phase", data="runtime"))
+        backend.add_metrics(phase)
+        output_path = temp_output_dir
+        output_filename = "summary_test"
+        backend.finalize(output_path, output_filename)
+        expected_path = os.path.join(output_path, f"{output_filename}.json")
+        assert os.path.exists(expected_path)
+        with open(expected_path) as f:
+            data = json.load(f)
+        assert isinstance(data, list) and len(data) >= 1
+        assert any(p.get("phase_name") == "runtime" for p in data)
+
     def test_invalid_backend_type_raises_error(self):
         """Test that invalid backend type raises ValueError."""
         with pytest.raises(ValueError, match="Unknown backend type"):
@@ -286,3 +317,7 @@ class TestMetricsBackendFactory:
         backends.MetricsBackend.reset_instances()
         backend2 = backends.MetricsBackend.get_instance("omniperf")
         assert backend1 is not backend2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--maxfail=1"])


### PR DESCRIPTION
## Summary
- add a kit-less benchmark runner that emits OmniPerf-compatible JSON without launching Kit
- include summary backend + frametime recorder fallback/unit fixes and benchmark script wiring from dev/preeves/benchmarking_summaries
- document summary backend usage and add tests for SummaryMetrics

## Test plan
- `python scripts/benchmarks/benchmark_kitless.py --num_steps 5 --workload sleep --sleep_ms 1 --output_path /tmp --output_prefix benchmark_kitless_smoke`
- not run: kit-full benchmark (blocked by PhysX SimulationView issue)


Made with [Cursor](https://cursor.com)