### PR TITLE
Reverts success condition with packing_table in LocomanipulationG1EnvCfg

### DIFF
--- a/source/isaaclab_mimic/isaaclab_mimic/locomanipulation_sdg/envs/g1_locomanipulation_sdg_env.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/locomanipulation_sdg/envs/g1_locomanipulation_sdg_env.py
@@ -11,6 +11,7 @@ from isaaclab.assets import AssetBaseCfg
 from isaaclab.envs.common import ViewerCfg
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.sensors import CameraCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
@@ -21,6 +22,7 @@ from isaaclab_mimic.locomanipulation_sdg.data_classes import LocomanipulationSDG
 from isaaclab_mimic.locomanipulation_sdg.occupancy_map_utils import OccupancyMap
 from isaaclab_mimic.locomanipulation_sdg.scene_utils import HasPose, SceneBody, SceneFixture
 
+from isaaclab_tasks.manager_based.locomanipulation.pick_place import mdp as locomanip_mdp
 from isaaclab_tasks.manager_based.locomanipulation.pick_place.locomanipulation_g1_env_cfg import (
     LocomanipulationG1EnvCfg,
     LocomanipulationG1SceneCfg,
@@ -150,6 +152,16 @@ class G1LocomanipulationSDGEnvCfg(LocomanipulationG1EnvCfg, LocomanipulationSDGE
 
         # Retrieve local paths for the URDF and mesh files. Will be cached for call after the first time.
         self.actions.upper_body_ik.controller.urdf_path = retrieve_file_path(urdf_omniverse_path)
+
+        # Override success condition: check placement relative to the drop-off table (packing_table_2),
+        # since this env has two tables: packing_table (pick-up) and packing_table_2 (drop-off).
+        self.terminations.success = DoneTerm(
+            func=locomanip_mdp.task_done_pick_place_table_frame,
+            params={
+                "task_link_name": "right_wrist_yaw_link",
+                "table_cfg": SceneEntityCfg("packing_table_2"),
+            },
+        )
 
 
 class G1LocomanipulationSDGEnv(LocomanipulationSDGEnv):

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/locomanipulation_g1_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/locomanipulation_g1_env_cfg.py
@@ -392,10 +392,9 @@ class TerminationsCfg:
     )
 
     success = DoneTerm(
-        func=locomanip_mdp.task_done_pick_place_table_frame,
+        func=manip_mdp.task_done_pick_place,
         params={
             "task_link_name": "right_wrist_yaw_link",
-            "table_cfg": SceneEntityCfg("packing_table_2"),
         },
     )
 


### PR DESCRIPTION
# Description

This PR reverts the success condition with "packing_table" in LocomanipulationG1EnvCfg, and only uses "packing_table_2" for G1LocomanipulationSDGEnvCfg.

Fixes # (issue)

This PR is for fixing teleop issue related to "packing_table_2": 

`./isaaclab.sh -p scripts/tools/record_demos.py   --task Isaac-PickPlace-Locomanipulation-G1-Abs-v0   --num_demos 5   --xr --visualizer kit --info`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
