### PR TITLE
Fixes torch version check during install to avoid double installation

### DIFF
--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -66,28 +66,32 @@ def _ensure_cuda_torch() -> None:
 
     want_torch = f"{torch_ver}+{cuda_tag}"
 
-    # Check current torch version (may be empty).
+    # Check current torch version using pip show (includes build tags).
     current_ver = ""
     try:
-        # Run python to check torch version.
         result = run_command(
             [
                 python_exe,
-                "-c",
-                "import torch; print(torch.__version__, end='')",
+                "-m",
+                "pip",
+                "show",
+                "torch",
             ],
             capture_output=True,
             text=True,
             check=False,
         )
         if result.returncode == 0:
-            current_ver = result.stdout.strip()
+            for line in result.stdout.split("\n"):
+                if line.startswith("Version: "):
+                    current_ver = line.split("Version: ", 1)[1].strip()
+                    break
     except Exception:
         pass
 
-    # Skip install if version is already satisfied.
+    # Skip install if version already matches (including CUDA build tag).
     if current_ver == want_torch:
-        # print(f"[INFO] PyTorch {want_torch} already installed.")
+        print_info(f"PyTorch {want_torch} already installed.")
         return
 
     # Clean install torch.


### PR DESCRIPTION
# Description

The check of torch version wasn't correctly matching already installed versions with the ones we want to install, which triggered an unnecessary step to uninstall and re-install torch. Fixing the check to hopefully read the correct versions.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
