### PR TITLE
Fixes crashes when Stop XR is pressed and when Kit is closed while Teleop is running

### DIFF
--- a/source/isaaclab_teleop/config/extension.toml
+++ b/source/isaaclab_teleop/config/extension.toml
@@ -1,6 +1,6 @@
 [package]
 # Semantic Versioning is used: https://semver.org/
-version = "0.3.0"
+version = "0.3.1"
 
 # Description
 title =  "Isaac Lab Teleop"

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -9,6 +9,7 @@ Fixed
 
 * Update Isaac Teleop API usage for querying controller button states.
 
+
 0.2.0 (2026-02-24)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.3.1 (2026-02-26)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Add cleanup for Isaac Teleop session when Stop XR button is clicked and when Kit is closed.
+
+
 0.3.0 (2026-02-26)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -81,6 +81,34 @@ class TeleopSessionLifecycle:
         except (ImportError, ModuleNotFoundError):
             logger.info("isaacsim.kit.xr.teleop.bridge not available; IsaacTeleop will create its own OpenXR session")
 
+        try:
+            import carb.settings
+
+            # Subscribe to the setting (may not fire when Kit closes; see pre-shutdown below)
+            self._xr_enabled_subscription = carb.settings.get_settings().subscribe_to_node_change_events(
+                "/xr/enabled",
+                self._on_xr_enabled_changed,
+            )
+        except (ImportError, ModuleNotFoundError):
+            logger.info("carb.settings not available; IsaacTeleop will not be able to detect XR enabled state")
+
+        try:
+            import omni.kit.app
+            from carb.eventdispatcher import get_eventdispatcher
+
+            # Subscribe to Kit pre-shutdown so we tear down our session before XRCore
+            # tears down the OpenXR instance/session (XRCore uses order=0; lowest runs first).
+            # The /xr/enabled setting often does not fire on close, so this is required.
+            self._pre_shutdown_subscription = get_eventdispatcher().observe_event(
+                event_name=omni.kit.app.GLOBAL_EVENT_PRE_SHUTDOWN,
+                on_event=self._on_pre_shutdown,
+                observer_name="IsaacTeleop session lifecycle",
+                order=-100,
+            )
+        except (ImportError, ModuleNotFoundError):
+            logger.info("omni.kit.app/carb.eventdispatcher not available; IsaacTeleop will not clean up on Kit close")
+            self._pre_shutdown_subscription = None
+
     @property
     def is_active(self) -> bool:
         """Whether the teleop session is currently running."""
@@ -189,6 +217,20 @@ class TeleopSessionLifecycle:
 
         logger.info(f"Required extensions: {required_extensions}")
         return required_extensions
+
+    def _on_xr_enabled_changed(self, item, event_type):
+        import carb.settings
+
+        enabled = carb.settings.get_settings().get("/xr/enabled")
+        logger.info(f"XR enabled changed to: {enabled}")
+
+        if not enabled:
+            self._teardown_dead_session()
+
+    def _on_pre_shutdown(self, _event):
+        """Called when Kit is closing; run full cleanup since the app is exiting."""
+        logger.info("Shutting down IsaacTeleop session due to Kit close")
+        self.stop()
 
     # ------------------------------------------------------------------
     # Deferred session creation

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -107,7 +107,6 @@ class TeleopSessionLifecycle:
             )
         except (ImportError, ModuleNotFoundError):
             logger.info("omni.kit.app/carb.eventdispatcher not available; IsaacTeleop will not clean up on Kit close")
-            self._pre_shutdown_subscription = None
 
     @property
     def is_active(self) -> bool:
@@ -230,6 +229,8 @@ class TeleopSessionLifecycle:
     def _on_pre_shutdown(self, _event):
         """Called when Kit is closing; run full cleanup since the app is exiting."""
         logger.info("Shutting down IsaacTeleop session due to Kit close")
+        self._pre_shutdown_subscription.unsubscribe()
+        self._pre_shutdown_subscription = None
         self.stop()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
# Description

Before Kit tears down the OpenXR instance and session, we need to cleanup IsaacTeleop as the cached handles will become invalidated on Kit cleanup.

Stop XR: In the /xr/enabled callback, call _teardown_dead_session() instead of stop(). Only the session is torn down; pipeline and retargeting UI stay. step() then returns None (same as deferred start), the recording loop keeps rendering, and starting XR again works without restarting the script.

Kit close: Subscribe to GLOBAL_EVENT_PRE_SHUTDOWN with order=-100 so our cleanup runs before XRCore (order=0). We release our session and stop using our cached OpenXR handles before Kit XR tears down the OpenXR instance/session, avoiding use of invalid handles.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
