### PR TITLE
Adds UJITSO flags for gaussian rendering support

### DIFF
--- a/apps/isaaclab.python.headless.rendering.kit
+++ b/apps/isaaclab.python.headless.rendering.kit
@@ -155,6 +155,10 @@ folders = [
     "${app}/../source", # needed to find extensions in Isaac Lab
 ]
 
+[settings.persistent]
+UJITSO.geometry = true
+UJITSO.enabled = true
+
 # Asset path
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets

--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -235,6 +235,8 @@ renderer.startupMessageDisplayed = true # hides the IOMMU popup window
 resourcemonitor.timeBetweenQueries = 100 # improves performance
 simulation.defaultMetersPerUnit = 1.0 # Meters default
 omni.replicator.captureOnPlay = true
+UJITSO.geometry = true
+UJITSO.enabled = true
 
 [settings]
 ### async rendering settings

--- a/apps/isaaclab.python.rendering.kit
+++ b/apps/isaaclab.python.rendering.kit
@@ -141,6 +141,10 @@ folders = [
     "${app}/../source", # needed to find extensions in Isaac Lab
 ]
 
+[settings.persistent]
+UJITSO.geometry = true
+UJITSO.enabled = true
+
 # Asset path
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets

--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -58,6 +58,10 @@ folders = [
     "${app}/../source", # needed to find extensions in Isaac Lab
 ]
 
+[settings.persistent]
+UJITSO.geometry = true
+UJITSO.enabled = true
+
 [settings]
 persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
 persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"

--- a/apps/isaaclab.python.xr.openxr.kit
+++ b/apps/isaaclab.python.xr.openxr.kit
@@ -85,6 +85,10 @@ folders = [
     "${app}/../source", # needed to find extensions in Isaac Lab
 ]
 
+[settings.persistent]
+UJITSO.geometry = true
+UJITSO.enabled = true
+
 # Asset path
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets


### PR DESCRIPTION
# Description

In Kit 110, RTX renderer will be able to trace Gaussians representations, but requires enabling UJITSO geometry.
We are adding this setting into the app files as the default to support Gaussians out of the box.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
