### PR TITLE
Filters Isaac Sim prebundled paths from PYTHONPATH during install

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,6 +38,7 @@ Guidelines for modifications:
 * Sheikh Dawood
 * Ossama Ahmed
 * Greg Attra
+* Gavriel State
 
 ## Contributors
 
@@ -185,7 +186,6 @@ Guidelines for modifications:
 * Ajay Mandlekar
 * Animesh Garg
 * Buck Babich
-* Gavriel State
 * Hammad Mazhar
 * Marco Hutter
 * Yan Chang

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -220,6 +220,27 @@ def command_install(install_type: str = "all") -> None:
         print_info("ARM install sandbox: temporarily unsetting LD_PRELOAD for installation.")
         saved_ld_preload = os.environ.pop("LD_PRELOAD")
 
+    # Temporarily filter Isaac Sim pre-bundled package paths from PYTHONPATH during all pip operations.
+    # This prevents pip from scanning and managing packages in Isaac Sim's pip_prebundle directories,
+    # which can cause those packages to be deleted or modified. This is especially important
+    # in conda environments where Isaac Sim setup scripts add these paths to PYTHONPATH.
+    saved_pythonpath = None
+    filtered_pythonpath = None
+    if "PYTHONPATH" in os.environ:
+        saved_pythonpath = os.environ["PYTHONPATH"]
+        # Filter out any paths containing pip_prebundle (pre-bundled packages that pip shouldn't manage)
+        paths = saved_pythonpath.split(os.pathsep)
+        filtered_paths = [p for p in paths if p and "pip_prebundle" not in p]
+
+        if len(filtered_paths) != len(paths):
+            filtered_pythonpath = os.pathsep.join(filtered_paths)
+            os.environ["PYTHONPATH"] = filtered_pythonpath
+            filtered_count = len(paths) - len(filtered_paths)
+            print_info(
+                f"Temporarily filtering {filtered_count} Isaac Sim pre-bundled package path(s) from PYTHONPATH "
+                "during pip operations to prevent interference with pre-bundled packages."
+            )
+
     try:
         # Upgrade pip first to avoid compatibility issues.
         print_info("Upgrading pip...")
@@ -243,6 +264,9 @@ def command_install(install_type: str = "all") -> None:
         # Restore LD_PRELOAD if we cleared it.
         if saved_ld_preload:
             os.environ["LD_PRELOAD"] = saved_ld_preload
+        # Restore PYTHONPATH if we filtered it.
+        if saved_pythonpath is not None:
+            os.environ["PYTHONPATH"] = saved_pythonpath
 
     # Install vscode update unless we're in docker.
     if not (os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")):


### PR DESCRIPTION
# Description

Recent changes to the installation setup cause issues when using an Isaac Sim source build. To avoid these, we need to filter out any PYTHONPATH entries that are inside Isaac Sim's various `pip_prebundle` directories so that pip does not try to manage them. This avoids inappropriate deletion of critical packages Isaac Sim requires

## Type of change

- Bug fix 

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there