### PR TITLE
[CAREFUL|Not Sure] Moves local import of pxr and omniclient in asset.py to top import 

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.4.0"
+version = "4.5.0"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+4.5.0 (2026-02-27)
+~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Replaced ``omni.kit.commands`` and async Nucleus calls in asset utilities, prim
+  helpers.
+
+
 4.4.0 (2026-02-26)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/controllers/config/rmp_flow.py
+++ b/source/isaaclab/isaaclab/controllers/config/rmp_flow.py
@@ -6,7 +6,7 @@
 import os
 
 from isaaclab.controllers.rmp_flow_cfg import RmpFlowControllerCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 # Directory on Nucleus Server for RMP-Flow assets (URDFs, collision models, etc.)
 ISAACLAB_NUCLEUS_RMPFLOW_DIR = os.path.join(ISAACLAB_NUCLEUS_DIR, "Controllers", "RmpFlowAssets")

--- a/source/isaaclab/isaaclab/markers/config/__init__.py
+++ b/source/isaaclab/isaaclab/markers/config/__init__.py
@@ -5,7 +5,7 @@
 
 import isaaclab.sim as sim_utils
 from isaaclab.markers.visualization_markers_cfg import VisualizationMarkersCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Sensors.

--- a/source/isaaclab/isaaclab/sim/spawners/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/__init__.py
@@ -16,7 +16,7 @@ There are two main ways of using the spawners:
    .. code-block:: python
 
     import isaaclab.sim as sim_utils
-    from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+    from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
     # spawn from USD file
     cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd")
@@ -30,7 +30,7 @@ There are two main ways of using the spawners:
    .. code-block:: python
 
     import isaaclab.sim as sim_utils
-    from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+    from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
     # spawn from USD file
     cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd")

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-import omni.kit.commands
-from pxr import Gf, Sdf, Usd
+from pxr import Gf, Sdf, Usd, UsdGeom
 
 from isaaclab.sim import converters, schemas
 from isaaclab.sim.spawners.materials import RigidBodyMaterialCfg
@@ -25,7 +24,8 @@ from isaaclab.sim.utils import (
     select_usd_variants,
     set_prim_visibility,
 )
-from isaaclab.utils.assets import check_usd_path_with_timeout
+from isaaclab.utils.assets import check_file_path, retrieve_file_path
+from isaaclab.utils.version import has_kit
 
 if TYPE_CHECKING:
     from . import from_files_cfg
@@ -238,9 +238,12 @@ def spawn_ground_plane(
             stage=stage,
             type_to_create_if_not_exist=Sdf.ValueTypeNames.Color3f,
         )
-    # Remove the light from the ground plane
+    # Remove the light from the ground plane (USD API, works without Kit/Newton)
     # It isn't bright enough and messes up with the user's lighting settings
-    omni.kit.commands.execute("ToggleVisibilitySelectedPrims", selected_paths=[f"{prim_path}/SphereLight"], stage=stage)
+    light_prim = stage.GetPrimAtPath(f"{prim_path}/SphereLight")
+    if light_prim.IsValid():
+        imageable = UsdGeom.Imageable(light_prim)
+        imageable.MakeInvisible()
 
     prim = stage.GetPrimAtPath(prim_path)
     # Apply semantic tags
@@ -296,15 +299,15 @@ def _spawn_from_usd_file(
     Raises:
         FileNotFoundError: If the USD file does not exist at the given path.
     """
-    # check if usd path exists with periodic logging until timeout
-    if not check_usd_path_with_timeout(usd_path):
-        if "4.5" in usd_path:
-            usd_5_0_path = usd_path.replace("http", "https").replace("/4.5", "/5.0")
-            if not check_usd_path_with_timeout(usd_5_0_path):
-                raise FileNotFoundError(f"USD file not found at path at either: '{usd_path}' or '{usd_5_0_path}'.")
-            usd_path = usd_5_0_path
-        else:
-            raise FileNotFoundError(f"USD file not found at path at: '{usd_path}'.")
+    # check file path exists (supports local paths, S3, HTTP/HTTPS URLs)
+    # check_file_path returns: 0 (not found), 1 (local), 2 (remote)
+    file_status = check_file_path(usd_path)
+    if file_status == 0:
+        raise FileNotFoundError(f"USD file not found at path: '{usd_path}'.")
+
+    # Download remote files (S3, HTTP, HTTPS) to local cache
+    if file_status == 2:
+        usd_path = retrieve_file_path(usd_path, force_download=False)
 
     # Obtain current stage
     stage = get_current_stage()
@@ -356,6 +359,9 @@ def _spawn_from_usd_file(
 
     # apply visual material
     if cfg.visual_material is not None:
+        if not has_kit():
+            logger.warning("Skipping visual material application for '%s' in kitless mode.", prim_path)
+            return stage.GetPrimAtPath(prim_path)
         if not cfg.visual_material_path.startswith("/"):
             material_path = f"{prim_path}/{cfg.visual_material_path}"
         else:

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
@@ -12,7 +12,7 @@ from isaaclab.sim import converters, schemas
 from isaaclab.sim.spawners import materials
 from isaaclab.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg, RigidObjectSpawnerCfg, SpawnerCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 
 @configclass

--- a/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
@@ -12,7 +12,7 @@ from pxr import Usd, UsdShade
 
 from isaaclab.sim.utils import clone, safe_set_attribute_on_usd_prim
 from isaaclab.sim.utils.stage import get_current_stage
-from isaaclab.utils.assets import NVIDIA_NUCLEUS_DIR
+from isaaclab.utils import NVIDIA_NUCLEUS_DIR
 from isaaclab.utils.version import has_kit
 
 if TYPE_CHECKING:

--- a/source/isaaclab/isaaclab/sim/utils/prims.py
+++ b/source/isaaclab/isaaclab/sim/utils/prims.py
@@ -214,18 +214,12 @@ def delete_prim(prim_path: str | Sequence[str], stage: Usd.Stage | None = None) 
     if stage_id < 0:
         stage_id = stage_cache.Insert(stage).ToLongInt()
 
-    if has_kit():
-        # delete prims
-        import omni.kit.commands
-
-        success, _ = omni.kit.commands.execute(
-            "DeletePrimsCommand",
-            paths=prim_path,
-            stage=stage,
-        )
-        return success
-    return True
-
+    # delete prims via the Sdf API directly
+    success = True
+    for path in prim_path:
+        if not stage.RemovePrim(path):
+            success = False
+    return success
 
 """
 USD Prim properties and attributes.

--- a/source/isaaclab/isaaclab/sim/utils/prims.py
+++ b/source/isaaclab/isaaclab/sim/utils/prims.py
@@ -16,15 +16,15 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
-import omni.kit.commands
 from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade, UsdUtils
 
+from isaaclab.utils.assets import check_file_path, retrieve_file_path
 from isaaclab.utils.string import to_camel_case
-from isaaclab.utils.version import get_isaac_sim_version
+from isaaclab.utils.version import has_kit
 
 from .queries import find_matching_prim_paths
 from .semantics import add_labels
-from .stage import get_current_stage, get_current_stage_id, resolve_paths
+from .stage import get_current_stage, resolve_paths
 from .transforms import convert_world_pose_to_local, standardize_xform_ops
 
 if TYPE_CHECKING:
@@ -213,13 +213,17 @@ def delete_prim(prim_path: str | Sequence[str], stage: Usd.Stage | None = None) 
     stage_id = stage_cache.GetId(stage).ToLongInt()
     if stage_id < 0:
         stage_id = stage_cache.Insert(stage).ToLongInt()
-    # delete prims
-    success, _ = omni.kit.commands.execute(
-        "DeletePrimsCommand",
-        paths=prim_path,
-        stage=stage,
-    )
-    return success
+
+    if has_kit():
+        # delete prims
+        import omni.kit.commands
+
+        success, _ = omni.kit.commands.execute(
+            "DeletePrimsCommand",
+            paths=prim_path,
+            stage=stage,
+        )
+        return success
 
 
 """
@@ -700,12 +704,21 @@ def clone(func: Callable) -> Callable:
                 # deal with spaces by replacing them with underscores
                 semantic_type_sanitized = semantic_type.replace(" ", "_")
                 semantic_value_sanitized = semantic_value.replace(" ", "_")
-                # add labels to the prim
-                add_labels(
-                    prim, labels=[semantic_value_sanitized], instance_name=semantic_type_sanitized, overwrite=False
-                )
+                instance_name = f"{semantic_type_sanitized}_{semantic_value_sanitized}"
+
+                type_attr_name = f"semantic:{instance_name}:semantic:type"
+                type_attr = prim.GetAttribute(type_attr_name)
+                if not type_attr:
+                    type_attr = prim.CreateAttribute(type_attr_name, Sdf.ValueTypeNames.String)
+                type_attr.Set(semantic_type)
+
+                data_attr_name = f"semantic:{instance_name}:semantic:data"
+                data_attr = prim.GetAttribute(data_attr_name)
+                if not data_attr:
+                    data_attr = prim.CreateAttribute(data_attr_name, Sdf.ValueTypeNames.String)
+                data_attr.Set(semantic_value)
         # activate rigid body contact sensors (lazy import to avoid circular import with schemas)
-        if hasattr(cfg, "activate_contact_sensors") and cfg.activate_contact_sensors:  # type: ignore
+        if hasattr(cfg, "activate_contact_sensors") and cfg.activate_contact_sensors:
             from ..schemas import schemas as _schemas
 
             _schemas.activate_contact_sensors(prim_spawn_path)
@@ -757,6 +770,8 @@ def bind_visual_material(
     Raises:
         ValueError: If the provided prim paths do not exist on stage.
     """
+    if not has_kit():
+        return None
     # get stage handle
     if stage is None:
         stage = get_current_stage()
@@ -775,6 +790,8 @@ def bind_visual_material(
         binding_strength = "weakerThanDescendants"
     # obtain material binding API
     # note: we prefer using the command here as it is more robust than the USD API
+    import omni.kit.commands
+
     success, _ = omni.kit.commands.execute(
         "BindMaterialCommand",
         prim_path=prim_path,
@@ -888,6 +905,16 @@ def add_usd_reference(
     Raises:
         FileNotFoundError: When the input USD file is not found at the specified path.
     """
+    # resolve remote USD paths to local (same as Newton / add_reference_to_stage)
+    file_status = check_file_path(usd_path)
+    if file_status == 0:
+        raise FileNotFoundError(f"Unable to open the usd file at path: {usd_path}")
+    if file_status == 2:
+        try:
+            usd_path = retrieve_file_path(usd_path, force_download=False)
+        except Exception as e:
+            raise FileNotFoundError(f"Failed to retrieve USD file from {usd_path}") from e
+
     # get current stage
     stage = get_current_stage() if stage is None else stage
     # get prim at path
@@ -904,32 +931,6 @@ def add_usd_reference(
             )
         return prim
 
-    # Compatibility with Isaac Sim 4.5 where omni.metrics is not available
-    if get_isaac_sim_version().major < 5:
-        return _add_reference_to_prim(prim)
-
-    # check if the USD file is valid and add reference to the prim
-    sdf_layer = Sdf.Layer.FindOrOpen(usd_path)
-    if not sdf_layer:
-        raise FileNotFoundError(f"Unable to open the usd file at path: {usd_path}")
-
-    # import metrics assembler interface
-    # note: this is only available in Isaac Sim 5.0 and above
-    from omni.metrics.assembler.core import get_metrics_assembler_interface
-
-    # obtain the stage ID
-    stage_id = get_current_stage_id()
-    # check if the layers are compatible (i.e. the same units)
-    ret_val = get_metrics_assembler_interface().check_layers(
-        stage.GetRootLayer().identifier, sdf_layer.identifier, stage_id
-    )
-    # log that metric assembler did not detect any issues
-    if ret_val["ret_val"]:
-        logger.info(
-            "Metric assembler detected no issues between the current stage and the referenced USD file at path:"
-            f" {usd_path}"
-        )
-    # add reference to the prim
     return _add_reference_to_prim(prim)
 
 

--- a/source/isaaclab/isaaclab/sim/utils/prims.py
+++ b/source/isaaclab/isaaclab/sim/utils/prims.py
@@ -224,6 +224,7 @@ def delete_prim(prim_path: str | Sequence[str], stage: Usd.Stage | None = None) 
             stage=stage,
         )
         return success
+    return True
 
 
 """

--- a/source/isaaclab/isaaclab/sim/utils/prims.py
+++ b/source/isaaclab/isaaclab/sim/utils/prims.py
@@ -221,6 +221,7 @@ def delete_prim(prim_path: str | Sequence[str], stage: Usd.Stage | None = None) 
             success = False
     return success
 
+
 """
 USD Prim properties and attributes.
 """

--- a/source/isaaclab/isaaclab/utils/__init__.py
+++ b/source/isaaclab/isaaclab/utils/__init__.py
@@ -5,8 +5,36 @@
 
 """Sub-package containing utilities for common operations and helper functions."""
 
+import os as _os
+import re as _re
+
 from .configclass import configclass
 
 import lazy_loader as lazy
 
 __getattr__, __dir__, __all__ = lazy.attach_stub(__name__, __file__)
+
+
+def _parse_kit_asset_root() -> str:
+    """Parse ``persistent.isaac.asset_root.cloud`` from ``apps/isaaclab.python.kit``."""
+    root = _os.path.join(_os.path.dirname(__file__), *([".."] * 4))
+    kit_path = _os.path.normpath(_os.path.join(root, "apps", "isaaclab.python.kit"))
+    with open(kit_path) as f:
+        for line in reversed(f.readlines()):
+            m = _re.match(r'\s*persistent\.isaac\.asset_root\.cloud\s*=\s*"([^"]*)"', line)
+            if m:
+                return m.group(1)
+    return ""
+
+
+NUCLEUS_ASSET_ROOT_DIR: str = _parse_kit_asset_root()
+"""Path to the root directory on the Nucleus Server."""
+
+NVIDIA_NUCLEUS_DIR: str = f"{NUCLEUS_ASSET_ROOT_DIR}/NVIDIA"
+"""Path to the root directory on the NVIDIA Nucleus Server."""
+
+ISAAC_NUCLEUS_DIR: str = f"{NUCLEUS_ASSET_ROOT_DIR}/Isaac"
+"""Path to the ``Isaac`` directory on the NVIDIA Nucleus Server."""
+
+ISAACLAB_NUCLEUS_DIR: str = f"{ISAAC_NUCLEUS_DIR}/IsaacLab"
+"""Path to the ``Isaac/IsaacLab`` directory on the NVIDIA Nucleus Server."""

--- a/source/isaaclab/isaaclab/utils/__init__.pyi
+++ b/source/isaaclab/isaaclab/utils/__init__.pyi
@@ -54,6 +54,10 @@ __all__ = [
     "get_isaac_sim_version",
     "compare_versions",
     "configclass",
+    "NUCLEUS_ASSET_ROOT_DIR",
+    "NVIDIA_NUCLEUS_DIR",
+    "ISAAC_NUCLEUS_DIR",
+    "ISAACLAB_NUCLEUS_DIR",
 ]
 
 from .timer import Timer
@@ -104,3 +108,8 @@ from .string import (
 from .types import ArticulationActions
 from .version import has_kit, get_isaac_sim_version, compare_versions
 from .configclass import configclass
+
+NUCLEUS_ASSET_ROOT_DIR: str
+NVIDIA_NUCLEUS_DIR: str
+ISAAC_NUCLEUS_DIR: str
+ISAACLAB_NUCLEUS_DIR: str

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -17,20 +17,20 @@ import io
 import logging
 import os
 import posixpath
+import re
 import tempfile
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
 import omni.client
+from pxr import Sdf
 
 logger = logging.getLogger(__name__)
 
 
 def _parse_kit_asset_root() -> str:
     """Parse ``persistent.isaac.asset_root.cloud`` from ``apps/isaaclab.python.kit``."""
-    import re
-
     _ISAACLAB_ROOT = os.path.join(os.path.dirname(__file__), *([".."] * 4))
     kit_path = os.path.normpath(os.path.join(_ISAACLAB_ROOT, "apps", "isaaclab.python.kit"))
     with open(kit_path) as f:
@@ -105,8 +105,6 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
     if file_status == 1:
         return os.path.abspath(path)
     elif file_status == 2:
-        import omni.client
-
         # resolve download directory
         if download_dir is None:
             download_dir = tempfile.gettempdir()
@@ -169,8 +167,6 @@ def read_file(path: str) -> io.BytesIO:
         with open(path, "rb") as f:
             return io.BytesIO(f.read())
     elif file_status == 2:
-        import omni.client
-
         file_content = omni.client.read_file(path.replace(os.sep, "/"))[2]
         return io.BytesIO(memoryview(file_content).tobytes())
     else:
@@ -194,8 +190,6 @@ def _is_downloadable_asset(path: str) -> bool:
 
 def _find_usd_references(local_usd_path: str) -> set[str]:
     """Use Sdf API to collect referenced assets from a USD layer."""
-    from pxr import Sdf
-
     try:
         layer = Sdf.Layer.FindOrOpen(local_usd_path)
     except Exception:

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -23,9 +23,6 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
-import omni.client
-from pxr import Sdf
-
 logger = logging.getLogger(__name__)
 
 
@@ -72,6 +69,8 @@ def check_file_path(path: str) -> Literal[0, 1, 2]:
     if os.path.isfile(path):
         return 1
 
+    import omni.client  # noqa: PLC0415
+
     if omni.client.stat(path.replace(os.sep, "/"))[0] == omni.client.Result.OK:
         return 2
     else:
@@ -105,6 +104,8 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
     if file_status == 1:
         return os.path.abspath(path)
     elif file_status == 2:
+        import omni.client  # noqa: PLC0415
+
         # resolve download directory
         if download_dir is None:
             download_dir = tempfile.gettempdir()
@@ -167,6 +168,8 @@ def read_file(path: str) -> io.BytesIO:
         with open(path, "rb") as f:
             return io.BytesIO(f.read())
     elif file_status == 2:
+        import omni.client  # noqa: PLC0415
+
         file_content = omni.client.read_file(path.replace(os.sep, "/"))[2]
         return io.BytesIO(memoryview(file_content).tobytes())
     else:
@@ -190,6 +193,8 @@ def _is_downloadable_asset(path: str) -> bool:
 
 def _find_usd_references(local_usd_path: str) -> set[str]:
     """Use Sdf API to collect referenced assets from a USD layer."""
+    from pxr import Sdf  # noqa: PLC0415
+
     try:
         layer = Sdf.Layer.FindOrOpen(local_usd_path)
     except Exception:

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -16,8 +16,13 @@ For more information, please check information on `Omniverse Nucleus`_.
 import io
 import logging
 import os
+import posixpath
 import tempfile
+from pathlib import Path
 from typing import Literal
+from urllib.parse import urlparse
+
+import omni.client
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +53,8 @@ ISAAC_NUCLEUS_DIR: str = f"{NUCLEUS_ASSET_ROOT_DIR}/Isaac"
 ISAACLAB_NUCLEUS_DIR: str = f"{ISAAC_NUCLEUS_DIR}/IsaacLab"
 """Path to the ``Isaac/IsaacLab`` directory on the NVIDIA Nucleus Server."""
 
+USD_EXTENSIONS = {".usd", ".usda", ".usdz"}
+
 
 def check_file_path(path: str) -> Literal[0, 1, 2]:
     """Checks if a file exists on the Nucleus Server or locally.
@@ -64,9 +71,7 @@ def check_file_path(path: str) -> Literal[0, 1, 2]:
     """
     if os.path.isfile(path):
         return 1
-    import omni.client
 
-    # we need to convert backslash to forward slash on Windows for omni.client API
     if omni.client.stat(path.replace(os.sep, "/"))[0] == omni.client.Result.OK:
         return 2
     else:
@@ -100,6 +105,8 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
     if file_status == 1:
         return os.path.abspath(path)
     elif file_status == 2:
+        import omni.client
+
         # resolve download directory
         if download_dir is None:
             download_dir = tempfile.gettempdir()
@@ -108,18 +115,38 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
         # create download directory if it does not exist
         if not os.path.exists(download_dir):
             os.makedirs(download_dir)
-        import omni.client
+        # recursive download: mirror remote tree under download_dir
+        remote_url = path.replace(os.sep, "/")
+        to_visit = [remote_url]
+        visited = set()
+        local_root = None
 
-        # download file in temp directory using os
-        file_name = os.path.basename(omni.client.break_url(path.replace(os.sep, "/")).path)
-        target_path = os.path.join(download_dir, file_name)
-        # check if file already exists locally
-        if not os.path.isfile(target_path) or force_download:
-            # copy file to local machine
-            result = omni.client.copy(path.replace(os.sep, "/"), target_path, omni.client.CopyBehavior.OVERWRITE)
-            if result != omni.client.Result.OK and force_download:
-                raise RuntimeError(f"Unable to copy file: '{path}'. Is the Nucleus Server running?")
-        return os.path.abspath(target_path)
+        while to_visit:
+            cur_url = to_visit.pop()
+            if cur_url in visited:
+                continue
+            visited.add(cur_url)
+
+            cur_rel = urlparse(cur_url).path.lstrip("/")
+            target_path = os.path.join(download_dir, cur_rel)
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
+
+            if not os.path.isfile(target_path) or force_download:
+                result = omni.client.copy(cur_url, target_path, omni.client.CopyBehavior.OVERWRITE)
+                if result != omni.client.Result.OK and force_download:
+                    raise RuntimeError(f"Unable to copy file: '{cur_url}'. Is the Nucleus Server running?")
+
+            if local_root is None:
+                local_root = target_path
+
+            # recurse into USD dependencies and referenced assets
+            if Path(target_path).suffix.lower() in USD_EXTENSIONS:
+                for ref in _find_usd_references(target_path):
+                    ref_url = _resolve_reference_url(cur_url, ref)
+                    if ref_url and ref_url not in visited:
+                        to_visit.append(ref_url)
+
+        return os.path.abspath(local_root)
     else:
         raise FileNotFoundError(f"Unable to find the file: {path}")
 
@@ -150,84 +177,109 @@ def read_file(path: str) -> io.BytesIO:
         raise FileNotFoundError(f"Unable to find the file: {path}")
 
 
-"""
-Nucleus Connection.
-"""
+def _is_downloadable_asset(path: str) -> bool:
+    """Return True for USD or other asset types we mirror locally (textures, etc.)."""
+    clean = path.split("?", 1)[0].split("#", 1)[0]
+    suffix = Path(clean).suffix.lower()
+
+    if suffix == ".mdl":
+        # MDL modules (OmniPBR.mdl, OmniSurface.mdl, ...) come from MDL search paths
+        return False
+    if not suffix:
+        return False
+    if suffix not in {".usd", ".usda", ".usdz", ".png", ".jpg", ".jpeg", ".exr", ".hdr", ".tif", ".tiff"}:
+        return False
+    return True
 
 
-def check_usd_path_with_timeout(usd_path: str, timeout: float = 300, log_interval: float = 30) -> bool:
-    """Checks whether the given USD file path is available on the NVIDIA Nucleus server.
-
-    This function synchronously runs an asynchronous USD path availability check,
-    logging progress periodically until it completes. The file is available on the server
-    if the HTTP status code is 200. Otherwise, the file is not available on the server.
-
-    This is useful for checking server responsiveness before attempting to load a remote
-    asset. It will block execution until the check completes or times out.
-
-    Args:
-        usd_path: The remote USD file path to check.
-        timeout: Maximum time (in seconds) to wait for the server check.
-        log_interval: Interval (in seconds) at which progress is logged.
-
-    Returns:
-        Whether the given USD path is available on the server.
-    """
-    import asyncio
-    import time
-
-    start_time = time.time()
-    loop = asyncio.get_event_loop()
-
-    coroutine = _is_usd_path_available(usd_path, timeout)
-    task = asyncio.ensure_future(coroutine)
-
-    next_log_time = start_time + log_interval
-
-    first_log = True
-    while not task.done():
-        now = time.time()
-        if now >= next_log_time:
-            elapsed = int(now - start_time)
-            if first_log:
-                logger.warning(f"Checking server availability for USD path: {usd_path} (timeout: {timeout}s)")
-                first_log = False
-            logger.warning(f"Waiting for server response... ({elapsed}s elapsed)")
-            next_log_time += log_interval
-        loop.run_until_complete(asyncio.sleep(0.1))  # Yield to allow async work
-
-    return task.result()
-
-
-"""
-Helper functions.
-"""
-
-
-async def _is_usd_path_available(usd_path: str, timeout: float) -> bool:
-    """Checks whether the given USD path is available on the Omniverse Nucleus server.
-
-    This function is a asynchronous routine to check the availability of the given USD path on
-    the Omniverse Nucleus server. It will return True if the USD path is available on the server,
-    False otherwise.
-
-    Args:
-        usd_path: The remote or local USD file path to check.
-        timeout: Timeout in seconds for the async stat call.
-
-    Returns:
-        Whether the given USD path is available on the server.
-    """
-    import asyncio
-
-    import omni.client
+def _find_usd_references(local_usd_path: str) -> set[str]:
+    """Use Sdf API to collect referenced assets from a USD layer."""
+    from pxr import Sdf
 
     try:
-        result, _ = await asyncio.wait_for(omni.client.stat_async(usd_path), timeout=timeout)
-        return result == omni.client.Result.OK
-    except asyncio.TimeoutError:
-        logger.warning(f"Timed out after {timeout}s while checking for USD: {usd_path}")
-        return False
-    except Exception as ex:
-        logger.warning(f"Exception during USD file check: {type(ex).__name__}: {ex}")
-        return False
+        layer = Sdf.Layer.FindOrOpen(local_usd_path)
+    except Exception:
+        logger.warning("Failed to open USD layer: %s", local_usd_path, exc_info=True)
+        return set()
+
+    if layer is None:
+        return set()
+
+    refs: set[str] = set()
+
+    # Sublayers
+    for sub_path in getattr(layer, "subLayerPaths", []) or []:
+        if sub_path and _is_downloadable_asset(sub_path):
+            refs.add(str(sub_path))
+
+    def _walk_prim(prim_spec: Sdf.PrimSpec) -> None:
+        # References
+        ref_list = prim_spec.referenceList
+        for field in ("addedItems", "prependedItems", "appendedItems", "explicitItems"):
+            items = getattr(ref_list, field, None)
+            if not items:
+                continue
+            for ref in items:
+                asset_path = getattr(ref, "assetPath", None)
+                if asset_path and _is_downloadable_asset(asset_path):
+                    refs.add(str(asset_path))
+
+        # Payloads
+        payload_list = prim_spec.payloadList
+        for field in ("addedItems", "prependedItems", "appendedItems", "explicitItems"):
+            items = getattr(payload_list, field, None)
+            if not items:
+                continue
+            for payload in items:
+                asset_path = getattr(payload, "assetPath", None)
+                if asset_path and _is_downloadable_asset(asset_path):
+                    refs.add(str(asset_path))
+
+        # AssetPath-valued attributes (this is where OmniPBR.mdl, textures, etc. show up)
+        for attr_spec in prim_spec.attributes.values():
+            default = attr_spec.default
+            if isinstance(default, Sdf.AssetPath):
+                if default.path and _is_downloadable_asset(default.path):
+                    refs.add(default.path)
+            elif isinstance(default, Sdf.AssetPathArray):
+                for ap in default:
+                    if ap.path and _is_downloadable_asset(ap.path):
+                        refs.add(ap.path)
+
+        # Variants - each variant set can have multiple variants with their own prim content
+        for variant_set_spec in prim_spec.variantSets.values():
+            for variant_spec in variant_set_spec.variants.values():
+                variant_prim_spec = variant_spec.primSpec
+                if variant_prim_spec is not None:
+                    _walk_prim(variant_prim_spec)
+
+        for child in prim_spec.nameChildren.values():
+            _walk_prim(child)
+
+    for root_prim in layer.rootPrims.values():
+        _walk_prim(root_prim)
+
+    return refs
+
+
+def _resolve_reference_url(base_url: str, ref: str) -> str:
+    """Resolve a USD asset reference against a base URL (http/local)."""
+    ref = ref.strip()
+    if not ref:
+        return ref
+
+    parsed_ref = urlparse(ref)
+    if parsed_ref.scheme:
+        return ref
+
+    base = urlparse(base_url)
+    if base.scheme == "":
+        base_dir = os.path.dirname(base_url)
+        return os.path.normpath(os.path.join(base_dir, ref))
+
+    base_dir = posixpath.dirname(base.path)
+    if ref.startswith("/"):
+        new_path = posixpath.normpath(ref)
+    else:
+        new_path = posixpath.normpath(posixpath.join(base_dir, ref))
+    return f"{base.scheme}://{base.netloc}{new_path}"

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -22,6 +22,9 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
+import omni.client
+from pxr import Sdf
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,8 +43,6 @@ def check_file_path(path: str) -> Literal[0, 1, 2]:
     """
     if os.path.isfile(path):
         return 1
-
-    import omni.client  # noqa: PLC0415
 
     if omni.client.stat(path.replace(os.sep, "/"))[0] == omni.client.Result.OK:
         return 2
@@ -76,8 +77,6 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
     if file_status == 1:
         return os.path.abspath(path)
     elif file_status == 2:
-        import omni.client  # noqa: PLC0415
-
         # resolve download directory
         if download_dir is None:
             download_dir = tempfile.gettempdir()
@@ -140,8 +139,6 @@ def read_file(path: str) -> io.BytesIO:
         with open(path, "rb") as f:
             return io.BytesIO(f.read())
     elif file_status == 2:
-        import omni.client  # noqa: PLC0415
-
         file_content = omni.client.read_file(path.replace(os.sep, "/"))[2]
         return io.BytesIO(memoryview(file_content).tobytes())
     else:
@@ -165,8 +162,6 @@ def _is_downloadable_asset(path: str) -> bool:
 
 def _find_usd_references(local_usd_path: str) -> set[str]:
     """Use Sdf API to collect referenced assets from a USD layer."""
-    from pxr import Sdf  # noqa: PLC0415
-
     try:
         layer = Sdf.Layer.FindOrOpen(local_usd_path)
     except Exception:

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -78,7 +78,7 @@ def check_file_path(path: str) -> Literal[0, 1, 2]:
         return 0
 
 
-def retrieve_file_path(path: str, download_dir: str | None = None, force_download: bool = True) -> str:
+def retrieve_file_path(path: str, download_dir: str | None = None, force_download: bool = False) -> str:
     """Retrieves the path to a file on the Nucleus Server or locally.
 
     If the file exists locally, then the absolute path to the file is returned.
@@ -90,7 +90,7 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
         download_dir: The directory where the file should be downloaded. Defaults to None, in which
             case the file is downloaded to the system's temporary directory.
         force_download: Whether to force download the file from the Nucleus Server. This will overwrite
-            the local file if it exists. Defaults to True.
+            the local file if it exists. Defaults to False.
 
     Returns:
         The path to the file on the local machine.

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -17,40 +17,12 @@ import io
 import logging
 import os
 import posixpath
-import re
 import tempfile
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
-
-
-def _parse_kit_asset_root() -> str:
-    """Parse ``persistent.isaac.asset_root.cloud`` from ``apps/isaaclab.python.kit``."""
-    _ISAACLAB_ROOT = os.path.join(os.path.dirname(__file__), *([".."] * 4))
-    kit_path = os.path.normpath(os.path.join(_ISAACLAB_ROOT, "apps", "isaaclab.python.kit"))
-    with open(kit_path) as f:
-        for line in reversed(f.readlines()):  # read from the last line since it's the last setting defined
-            m = re.match(r'\s*persistent\.isaac\.asset_root\.cloud\s*=\s*"([^"]*)"', line)
-            if m:
-                return m.group(1)
-    return ""
-
-
-NUCLEUS_ASSET_ROOT_DIR: str = _parse_kit_asset_root()
-"""Path to the root directory on the Nucleus Server."""
-
-NVIDIA_NUCLEUS_DIR: str = f"{NUCLEUS_ASSET_ROOT_DIR}/NVIDIA"
-"""Path to the root directory on the NVIDIA Nucleus Server."""
-
-ISAAC_NUCLEUS_DIR: str = f"{NUCLEUS_ASSET_ROOT_DIR}/Isaac"
-"""Path to the ``Isaac`` directory on the NVIDIA Nucleus Server."""
-
-ISAACLAB_NUCLEUS_DIR: str = f"{ISAAC_NUCLEUS_DIR}/IsaacLab"
-"""Path to the ``Isaac/IsaacLab`` directory on the NVIDIA Nucleus Server."""
-
-USD_EXTENSIONS = {".usd", ".usda", ".usdz"}
 
 
 def check_file_path(path: str) -> Literal[0, 1, 2]:
@@ -139,7 +111,7 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
                 local_root = target_path
 
             # recurse into USD dependencies and referenced assets
-            if Path(target_path).suffix.lower() in USD_EXTENSIONS:
+            if Path(target_path).suffix.lower() in {".usd", ".usda", ".usdz"}:
                 for ref in _find_usd_references(target_path):
                     ref_url = _resolve_reference_url(cur_url, ref)
                     if ref_url and ref_url not in visited:

--- a/source/isaaclab/test/controllers/test_controller_utils.py
+++ b/source/isaaclab/test/controllers/test_controller_utils.py
@@ -21,7 +21,8 @@ import pytest
 import torch
 
 from isaaclab.controllers.utils import change_revolute_to_fixed, change_revolute_to_fixed_regex
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 from isaaclab.utils.io.torchscript import load_torchscript_model
 
 

--- a/source/isaaclab/test/envs/check_manager_based_env_anymal_locomotion.py
+++ b/source/isaaclab/test/envs/check_manager_based_env_anymal_locomotion.py
@@ -47,7 +47,8 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import RayCasterCfg, patterns
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, NVIDIA_NUCLEUS_DIR, check_file_path, read_file
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR, NVIDIA_NUCLEUS_DIR
+from isaaclab.utils.assets import check_file_path, read_file
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 ##

--- a/source/isaaclab/test/envs/test_texture_randomization.py
+++ b/source/isaaclab/test/envs/test_texture_randomization.py
@@ -30,7 +30,7 @@ from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import NVIDIA_NUCLEUS_DIR
+from isaaclab.utils import NVIDIA_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.classic.cartpole.cartpole_env_cfg import CartpoleSceneCfg
 

--- a/source/isaaclab/test/scene/test_interactive_scene.py
+++ b/source/isaaclab/test/scene/test_interactive_scene.py
@@ -22,7 +22,7 @@ from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sim import build_simulation_context
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 
 @configclass

--- a/source/isaaclab/test/sensors/check_multi_mesh_ray_caster.py
+++ b/source/isaaclab/test/sensors/check_multi_mesh_ray_caster.py
@@ -55,7 +55,7 @@ from isaaclab.sensors.ray_caster import MultiMeshRayCaster, MultiMeshRayCasterCf
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG
 from isaaclab.terrains.terrain_importer import TerrainImporter
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.math import quat_from_euler_xyz
 from isaaclab.utils.timer import Timer
 

--- a/source/isaaclab/test/sensors/check_ray_caster.py
+++ b/source/isaaclab/test/sensors/check_ray_caster.py
@@ -50,7 +50,7 @@ from isaaclab.sensors.ray_caster import RayCaster, RayCasterCfg, patterns
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG
 from isaaclab.terrains.terrain_importer import TerrainImporter
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.timer import Timer
 
 

--- a/source/isaaclab/test/sensors/test_tiled_camera.py
+++ b/source/isaaclab/test/sensors/test_tiled_camera.py
@@ -28,7 +28,7 @@ from pxr import Gf, UsdGeom, UsdPhysics
 
 import isaaclab.sim as sim_utils
 from isaaclab.sensors.camera import Camera, CameraCfg, TiledCamera, TiledCameraCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.timer import Timer
 
 

--- a/source/isaaclab/test/sim/test_mesh_converter.py
+++ b/source/isaaclab/test/sim/test_mesh_converter.py
@@ -25,7 +25,8 @@ import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.sim.converters import MeshConverter, MeshConverterCfg
 from isaaclab.sim.schemas import MESH_APPROXIMATION_TOKENS, schemas_cfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 
 def random_quaternion():

--- a/source/isaaclab/test/sim/test_schemas.py
+++ b/source/isaaclab/test/sim/test_schemas.py
@@ -21,7 +21,7 @@ from pxr import UsdPhysics
 import isaaclab.sim as sim_utils
 import isaaclab.sim.schemas as schemas
 from isaaclab.sim import SimulationCfg, SimulationContext
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.string import to_camel_case
 
 

--- a/source/isaaclab/test/sim/test_simulation_stage_in_memory.py
+++ b/source/isaaclab/test/sim/test_simulation_stage_in_memory.py
@@ -25,7 +25,7 @@ from isaacsim.core.cloner import GridCloner
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim.simulation_context import SimulationCfg, SimulationContext
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 from isaaclab.utils.version import get_isaac_sim_version
 
 

--- a/source/isaaclab/test/sim/test_spawn_from_files.py
+++ b/source/isaaclab/test/sim/test_spawn_from_files.py
@@ -18,7 +18,7 @@ import omni.kit.app
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 
 @pytest.fixture

--- a/source/isaaclab/test/sim/test_spawn_materials.py
+++ b/source/isaaclab/test/sim/test_spawn_materials.py
@@ -19,7 +19,7 @@ from pxr import UsdPhysics, UsdShade
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
-from isaaclab.utils.assets import NVIDIA_NUCLEUS_DIR
+from isaaclab.utils import NVIDIA_NUCLEUS_DIR
 
 
 @pytest.fixture

--- a/source/isaaclab/test/sim/test_spawn_wrappers.py
+++ b/source/isaaclab/test/sim/test_spawn_wrappers.py
@@ -17,7 +17,7 @@ import pytest
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 
 @pytest.fixture

--- a/source/isaaclab/test/sim/test_utils_prims.py
+++ b/source/isaaclab/test/sim/test_utils_prims.py
@@ -23,7 +23,7 @@ from pxr import Gf, Sdf, Usd, UsdGeom
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim.utils.prims import _to_tuple  # type: ignore[reportPrivateUsage]
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR, retrieve_file_path
 
 
 @pytest.fixture(autouse=True)
@@ -93,7 +93,8 @@ def test_create_prim():
     for prim_spec in prim.GetPrimStack():
         references.extend(prim_spec.referenceList.prependedItems)
     assert len(references) == 1
-    assert str(references[0].assetPath) == franka_usd
+    expected_path = retrieve_file_path(franka_usd)
+    assert str(references[0].assetPath) == expected_path
 
     # check adding semantic label
     prim = sim_utils.create_prim(
@@ -361,10 +362,11 @@ def test_get_usd_references():
     # Create a prim with a USD reference
     franka_usd = f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
     sim_utils.create_prim("/World/WithReference", usd_path=franka_usd, stage=stage)
-    # Check that it has the expected reference
+    # Check that it has the expected reference (remote URLs are resolved to local paths)
     refs = sim_utils.get_usd_references("/World/WithReference", stage=stage)
     assert len(refs) == 1
-    assert refs == [franka_usd]
+    expected_path = retrieve_file_path(franka_usd)
+    assert refs == [expected_path]
 
     # Test with invalid prim path
     with pytest.raises(ValueError, match="not valid"):

--- a/source/isaaclab/test/sim/test_utils_prims.py
+++ b/source/isaaclab/test/sim/test_utils_prims.py
@@ -23,7 +23,8 @@ from pxr import Gf, Sdf, Usd, UsdGeom
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim.utils.prims import _to_tuple  # type: ignore[reportPrivateUsage]
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 
 @pytest.fixture(autouse=True)

--- a/source/isaaclab/test/sim/test_utils_queries.py
+++ b/source/isaaclab/test/sim/test_utils_queries.py
@@ -18,7 +18,7 @@ import pytest
 from pxr import UsdPhysics
 
 import isaaclab.sim as sim_utils
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 
 @pytest.fixture(autouse=True)

--- a/source/isaaclab/test/sim/test_views_xform_prim.py
+++ b/source/isaaclab/test/sim/test_views_xform_prim.py
@@ -23,7 +23,7 @@ except (ModuleNotFoundError, ImportError):
 
 import isaaclab.sim as sim_utils  # noqa: E402
 from isaaclab.sim.views import XformPrimView as XformPrimView  # noqa: E402
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR  # noqa: E402
+from isaaclab.utils import ISAAC_NUCLEUS_DIR  # noqa: E402
 
 
 @pytest.fixture(autouse=True)

--- a/source/isaaclab/test/terrains/check_terrain_importer.py
+++ b/source/isaaclab/test/terrains/check_terrain_importer.py
@@ -71,7 +71,7 @@ import isaaclab.terrains as terrain_gen
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG
 from isaaclab.terrains.terrain_importer import TerrainImporter
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 
 def main():

--- a/source/isaaclab/test/terrains/test_terrain_importer.py
+++ b/source/isaaclab/test/terrains/test_terrain_importer.py
@@ -28,7 +28,7 @@ import isaaclab.terrains as terrain_gen
 from isaaclab.sim import PreviewSurfaceCfg, SimulationContext, build_simulation_context, get_first_matching_child_prim
 from isaaclab.terrains import TerrainImporter, TerrainImporterCfg
 from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -6,14 +6,6 @@
 from __future__ import annotations
 
 """Launch Isaac Sim Simulator first."""
-
-from isaaclab.app import AppLauncher
-
-# launch omniverse app
-simulation_app = AppLauncher(headless=True).app
-
-"""Rest everything follows."""
-
 import isaaclab.utils.assets as assets_utils
 
 
@@ -37,16 +29,3 @@ def test_check_file_path_invalid():
     usd_path = f"{assets_utils.ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_xyz.usd"
     # check file path
     assert assets_utils.check_file_path(usd_path) == 0
-
-
-def test_check_usd_path_with_timeout():
-    """Test checking a USD path with timeout."""
-    # robot file path
-    usd_path = f"{assets_utils.ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
-    # check file path
-    assert assets_utils.check_usd_path_with_timeout(usd_path) is True
-
-    # invalid file path
-    usd_path = f"{assets_utils.ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_xyz.usd"
-    # check file path
-    assert assets_utils.check_usd_path_with_timeout(usd_path) is False

--- a/source/isaaclab_assets/isaaclab_assets/robots/agibot.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/agibot.py
@@ -15,7 +15,7 @@ The following configurations are available:
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/agility.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/agility.py
@@ -6,7 +6,7 @@
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 LEG_JOINT_NAMES = [
     ".*_hip_roll",

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -20,7 +20,7 @@ import math
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/ant.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/ant.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/anymal.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/anymal.py
@@ -23,7 +23,7 @@ import isaaclab.sim as sim_utils
 from isaaclab.actuators import ActuatorNetLSTMCfg, DCMotorCfg
 from isaaclab.assets.articulation import ArticulationCfg
 from isaaclab.sensors import RayCasterCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_assets.sensors.velodyne import VELODYNE_VLP_16_RAYCASTER_CFG
 

--- a/source/isaaclab_assets/isaaclab_assets/robots/arl_robot_1.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/arl_robot_1.py
@@ -11,7 +11,7 @@ The following configuration parameters are available:
 """
 
 import isaaclab.sim as sim_utils
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from isaaclab_contrib.actuators import ThrusterCfg
 from isaaclab_contrib.assets import MultirotorCfg

--- a/source/isaaclab_assets/isaaclab_assets/robots/cart_double_pendulum.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/cart_double_pendulum.py
@@ -8,7 +8,7 @@
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/cartpole.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/cartpole.py
@@ -8,7 +8,7 @@
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/cassie.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/cassie.py
@@ -15,7 +15,7 @@ Reference: https://github.com/UMich-BipedLab/Cassie_Model/blob/master/urdf/cassi
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/fourier.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/fourier.py
@@ -19,7 +19,7 @@ import torch
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/franka.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/franka.py
@@ -17,7 +17,7 @@ Reference: https://github.com/frankaemika/franka_ros
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/galbot.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/galbot.py
@@ -15,7 +15,7 @@ The following configuration parameters are available:
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/humanoid.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/humanoid.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/humanoid_28.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/humanoid_28.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/kinova.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/kinova.py
@@ -17,7 +17,7 @@ Reference: https://github.com/Kinovarobotics/kinova-ros
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/kuka_allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/kuka_allegro.py
@@ -19,7 +19,7 @@ Reference:
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/openarm.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/openarm.py
@@ -29,7 +29,7 @@ Motor spec sheets:
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 OPENARM_BI_CFG = ArticulationCfg(
     spawn=sim_utils.UsdFileCfg(

--- a/source/isaaclab_assets/isaaclab_assets/robots/pick_and_place.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/pick_and_place.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/quadcopter.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/quadcopter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/ridgeback_franka.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/ridgeback_franka.py
@@ -15,7 +15,7 @@ Reference: https://github.com/ridgeback/ridgeback_manipulation
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/sawyer.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/sawyer.py
@@ -15,7 +15,7 @@ Reference: https://github.com/RethinkRobotics/sawyer_robot
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -18,7 +18,7 @@ Reference:
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_assets/isaaclab_assets/robots/spot.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/spot.py
@@ -14,7 +14,7 @@ The following configuration parameters are available:
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import DelayedPDActuatorCfg, RemotizedPDActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 # Note: This data was collected by the Boston Dynamics AI Institute.
 joint_parameter_lookup = [

--- a/source/isaaclab_assets/isaaclab_assets/robots/unitree.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/unitree.py
@@ -23,7 +23,7 @@ Reference: https://github.com/unitreerobotics/unitree_ros
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ActuatorNetMLPCfg, DCMotorCfg, ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration - Actuators.

--- a/source/isaaclab_assets/isaaclab_assets/robots/universal_robots.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/universal_robots.py
@@ -18,7 +18,7 @@ Reference: https://github.com/ros-industrial/universal_robot
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 ##
 # Configuration

--- a/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_sensor_cfg.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_sensor_cfg.py
@@ -14,7 +14,7 @@ from isaaclab.markers import VisualizationMarkersCfg
 from isaaclab.markers.config import VISUO_TACTILE_SENSOR_MARKER_CFG
 from isaaclab.sensors import SensorBaseCfg, TiledCameraCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 if TYPE_CHECKING:
     from .visuotactile_sensor import VisuoTactileSensor

--- a/source/isaaclab_contrib/test/sensors/test_visuotactile_sensor.py
+++ b/source/isaaclab_contrib/test/sensors/test_visuotactile_sensor.py
@@ -28,7 +28,7 @@ from isaaclab.assets import Articulation, ArticulationCfg, RigidObject, RigidObj
 from isaaclab.sensors.camera import TiledCameraCfg
 from isaaclab.terrains.trimesh.utils import make_plane
 from isaaclab.terrains.utils import create_prim_from_mesh
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_contrib.sensors.tacsl_sensor import VisuoTactileSensor, VisuoTactileSensorCfg
 from isaaclab_contrib.sensors.tacsl_sensor.visuotactile_sensor_cfg import GelSightRenderCfg

--- a/source/isaaclab_mimic/isaaclab_mimic/locomanipulation_sdg/envs/g1_locomanipulation_sdg_env.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/locomanipulation_sdg/envs/g1_locomanipulation_sdg_env.py
@@ -15,7 +15,8 @@ from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.sensors import CameraCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 from isaaclab.utils.datasets import EpisodeData
 
 from isaaclab_mimic.locomanipulation_sdg.data_classes import LocomanipulationSDGInputData

--- a/source/isaaclab_mimic/isaaclab_mimic/motion_planners/curobo/curobo_planner_cfg.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/motion_planners/curobo/curobo_planner_cfg.py
@@ -12,7 +12,8 @@ from curobo.geom.sdf.world import CollisionCheckerType
 from curobo.geom.types import WorldConfig
 from curobo.util_file import get_robot_configs_path, get_world_configs_path, join_path, load_yaml
 
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 from isaaclab.utils.configclass import configclass
 
 

--- a/source/isaaclab_mimic/test/test_generate_dataset.py
+++ b/source/isaaclab_mimic/test/test_generate_dataset.py
@@ -16,7 +16,8 @@ import tempfile
 
 import pytest
 
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 DATASETS_DOWNLOAD_DIR = tempfile.mkdtemp(suffix="_Isaac-Stack-Cube-Franka-IK-Rel-Mimic-v0")
 NUCLEUS_DATASET_PATH = os.path.join(ISAACLAB_NUCLEUS_DIR, "Tests", "Mimic", "dataset.hdf5")

--- a/source/isaaclab_mimic/test/test_generate_dataset_skillgen.py
+++ b/source/isaaclab_mimic/test/test_generate_dataset_skillgen.py
@@ -16,7 +16,8 @@ import tempfile
 
 import pytest
 
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 DATASETS_DOWNLOAD_DIR = tempfile.mkdtemp(suffix="_Isaac-Stack-Cube-Franka-IK-Rel-Skillgen-v0")
 NUCLEUS_SKILLGEN_ANNOTATED_DATASET_PATH = os.path.join(

--- a/source/isaaclab_physx/test/assets/test_articulation.py
+++ b/source/isaaclab_physx/test/assets/test_articulation.py
@@ -32,7 +32,7 @@ from isaaclab.assets import ArticulationCfg
 from isaaclab.envs.mdp.terminations import joint_effort_out_of_limit
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.sim import build_simulation_context
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.version import get_isaac_sim_version, has_kit
 
 ##

--- a/source/isaaclab_physx/test/assets/test_rigid_object.py
+++ b/source/isaaclab_physx/test/assets/test_rigid_object.py
@@ -29,7 +29,7 @@ import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
 from isaaclab.sim import build_simulation_context
 from isaaclab.sim.spawners import materials
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 from isaaclab.utils.math import (
     combine_frame_transforms,
     default_orientation,

--- a/source/isaaclab_physx/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab_physx/test/assets/test_rigid_object_collection.py
@@ -26,7 +26,7 @@ from isaaclab_physx.assets import RigidObjectCollection
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg, RigidObjectCollectionCfg
 from isaaclab.sim import build_simulation_context
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.math import (
     combine_frame_transforms,
     default_orientation,

--- a/source/isaaclab_physx/test/assets/test_surface_gripper.py
+++ b/source/isaaclab_physx/test/assets/test_surface_gripper.py
@@ -30,7 +30,7 @@ from isaaclab.assets import (
     RigidObjectCfg,
 )
 from isaaclab.sim import build_simulation_context
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 from isaaclab.utils.version import get_isaac_sim_version, has_kit
 
 # from isaacsim.robot.surface_gripper import GripperView

--- a/source/isaaclab_physx/test/sensors/check_imu_sensor.py
+++ b/source/isaaclab_physx/test/sensors/check_imu_sensor.py
@@ -50,7 +50,7 @@ from isaaclab.sensors.imu import Imu, ImuCfg
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG
 from isaaclab.terrains.terrain_importer import TerrainImporter
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.timer import Timer
 
 # import logger

--- a/source/isaaclab_physx/test/sensors/test_imu.py
+++ b/source/isaaclab_physx/test/sensors/test_imu.py
@@ -34,7 +34,7 @@ from isaaclab.utils import configclass
 # Pre-defined configs
 ##
 from isaaclab_assets.robots.anymal import ANYMAL_C_CFG  # isort: skip
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR  # isort: skip
+from isaaclab.utils import ISAAC_NUCLEUS_DIR  # isort: skip
 
 # offset of imu_link from base_link on anymal_c
 POS_OFFSET = (0.2488, 0.00835, 0.04628)

--- a/source/isaaclab_rl/isaaclab_rl/utils/pretrained_checkpoint.py
+++ b/source/isaaclab_rl/isaaclab_rl/utils/pretrained_checkpoint.py
@@ -11,7 +11,8 @@ import os
 
 import carb.settings
 
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry  # noqa: F401
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/allegro_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/allegro_hand/allegro_hand_env_cfg.py
@@ -14,7 +14,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.sim.spawners.materials.physics_materials_cfg import RigidBodyMaterialCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from isaaclab_assets.robots.allegro import ALLEGRO_HAND_CFG
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env.py
@@ -14,7 +14,8 @@ import isaaclab.sim as sim_utils
 from isaaclab.assets import Articulation, RigidObject
 from isaaclab.envs import DirectRLEnv
 from isaaclab.sim.spawners.from_files import GroundPlaneCfg, spawn_ground_plane
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 from isaaclab.utils.math import (
     axis_angle_from_quat,
     combine_frame_transforms,

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_tasks_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_tasks_cfg.py
@@ -6,7 +6,7 @@
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ASSET_DIR = f"{ISAACLAB_NUCLEUS_DIR}/AutoMate"
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env.py
@@ -14,7 +14,8 @@ import isaaclab.sim as sim_utils
 from isaaclab.assets import Articulation, RigidObject
 from isaaclab.envs import DirectRLEnv
 from isaaclab.sim.spawners.from_files import GroundPlaneCfg, spawn_ground_plane
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 from isaaclab.utils.math import (
     axis_angle_from_quat,
     combine_frame_transforms,

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_tasks_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_tasks_cfg.py
@@ -6,7 +6,7 @@
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ASSET_DIR = f"{ISAACLAB_NUCLEUS_DIR}/AutoMate"
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_env.py
@@ -14,7 +14,7 @@ from isaaclab.assets import Articulation
 from isaaclab.envs import DirectRLEnv
 from isaaclab.sim.spawners.from_files import GroundPlaneCfg, spawn_ground_plane
 from isaaclab.utils import math as torch_utils
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from . import factory_control, factory_utils
 from .factory_env_cfg import OBS_DIM_CFG, STATE_DIM_CFG, FactoryEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_tasks_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/factory/factory_tasks_cfg.py
@@ -6,7 +6,7 @@
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 ASSET_DIR = f"{ISAACLAB_NUCLEUS_DIR}/Factory"
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/franka_cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/franka_cabinet_env_cfg.py
@@ -13,7 +13,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
@@ -16,7 +16,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.sim.spawners.materials.physics_materials_cfg import RigidBodyMaterialCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.noise import GaussianNoiseCfg, NoiseModelWithAdditiveBiasCfg
 
 from isaaclab_assets.robots.shadow_hand import SHADOW_HAND_CFG

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/track_position_state_based/config/arl_robot_1/track_position_state_based_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/track_position_state_based/config/arl_robot_1/track_position_state_based_env_cfg.py
@@ -19,7 +19,7 @@ from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 from isaaclab_contrib.assets import MultirotorCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/fixed_base_upper_body_ik_g1_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/fixed_base_upper_body_ik_g1_env_cfg.py
@@ -18,7 +18,7 @@ from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.locomanipulation.pick_place import mdp as locomanip_mdp
 from isaaclab_tasks.manager_based.manipulation.pick_place import mdp as manip_mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/locomanipulation_g1_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/locomanipulation_g1_env_cfg.py
@@ -25,7 +25,7 @@ from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.locomanipulation.pick_place import mdp as locomanip_mdp
 from isaaclab_tasks.manager_based.locomanipulation.pick_place.configs.action_cfg import AgileBasedLowerBodyActionCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
@@ -13,7 +13,7 @@ from isaaclab.managers import RewardTermCfg, SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 import isaaclab_tasks.manager_based.locomotion.velocity.config.spot.mdp as spot_mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
@@ -22,7 +22,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import ContactSensorCfg, RayCasterCfg, patterns
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 import isaaclab_tasks.manager_based.locomotion.velocity.mdp as mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/cabinet_env_cfg.py
@@ -22,7 +22,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import FrameTransformerCfg
 from isaaclab.sensors.frame_transformer import OffsetCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from . import mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/openarm/cabinet_openarm_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/config/openarm/cabinet_openarm_env_cfg.py
@@ -26,7 +26,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import FrameTransformerCfg
 from isaaclab.sensors.frame_transformer import OffsetCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 ##
 # Pre-defined configs

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/gear_assembly/gear_assembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/gear_assembly/gear_assembly_env_cfg.py
@@ -21,7 +21,7 @@ from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim.simulation_cfg import SimulationCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg
 
 import isaaclab_tasks.manager_based.manipulation.deploy.mdp as mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/reach/reach_env_cfg.py
@@ -17,7 +17,7 @@ from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 import isaaclab_tasks.manager_based.manipulation.deploy.mdp as mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/dexsuite_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/dexsuite_env_cfg.py
@@ -19,7 +19,7 @@ from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import CapsuleCfg, ConeCfg, CuboidCfg, RigidBodyMaterialCfg, SphereCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 from . import mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/mdp/commands/pose_commands_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/mdp/commands/pose_commands_cfg.py
@@ -10,7 +10,7 @@ import isaaclab.sim as sim_utils
 from isaaclab.managers import CommandTermCfg
 from isaaclab.markers import VisualizationMarkersCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 if TYPE_CHECKING:
     from .pose_commands import ObjectUniformPoseCommand

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/inhand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/inhand_env_cfg.py
@@ -22,7 +22,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim.simulation_cfg import SimulationCfg
 from isaaclab.sim.spawners.materials import RigidBodyMaterialCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.noise import GaussianNoiseCfg as Gnoise
 
 import isaaclab_tasks.manager_based.manipulation.inhand.mdp as mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/commands_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/commands/commands_cfg.py
@@ -9,7 +9,7 @@ import isaaclab.sim as sim_utils
 from isaaclab.managers import CommandTermCfg
 from isaaclab.markers import VisualizationMarkersCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/ik_abs_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/ik_abs_env_cfg.py
@@ -11,7 +11,7 @@ from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.sim.spawners import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 import isaaclab_tasks.manager_based.manipulation.lift.mdp as mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/franka/joint_pos_env_cfg.py
@@ -9,7 +9,7 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.lift import mdp
 from isaaclab_tasks.manager_based.manipulation.lift.lift_env_cfg import LiftEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/openarm/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/openarm/joint_pos_env_cfg.py
@@ -11,7 +11,7 @@ from isaaclab.sensors import FrameTransformerCfg
 from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.lift import mdp
 from isaaclab_tasks.manager_based.manipulation.lift.config.openarm.lift_openarm_env_cfg import LiftEnvCfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/openarm/lift_openarm_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/config/openarm/lift_openarm_env_cfg.py
@@ -27,7 +27,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransformerCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from ... import mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/lift_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/lift_env_cfg.py
@@ -22,7 +22,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransformerCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from . import mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/exhaustpipe_gr1t2_base_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/exhaustpipe_gr1t2_base_env_cfg.py
@@ -32,7 +32,7 @@ from isaaclab.sensors import CameraCfg
 # from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 from . import mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/nutpour_gr1t2_base_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/nutpour_gr1t2_base_env_cfg.py
@@ -32,7 +32,7 @@ from isaaclab.sensors import CameraCfg
 # from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 from . import mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_gr1t2_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_gr1t2_env_cfg.py
@@ -22,7 +22,8 @@ from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 from . import mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_unitree_g1_inspire_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_unitree_g1_inspire_hand_env_cfg.py
@@ -24,7 +24,8 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim.schemas.schemas_cfg import MassPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 from . import mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
@@ -24,7 +24,7 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import MassPropertiesCfg, RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.place import mdp as place_mdp
 from isaaclab_tasks.manager_based.manipulation.stack import mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/config/agibot/place_upright_mug_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/config/agibot/place_upright_mug_rmp_rel_env_cfg.py
@@ -21,7 +21,7 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.place import mdp as place_mdp
 from isaaclab_tasks.manager_based.manipulation.place.config.agibot import place_toy2box_rmp_rel_env_cfg

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/openarm/unimanual/reach_openarm_uni_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/openarm/unimanual/reach_openarm_uni_env_cfg.py
@@ -23,7 +23,7 @@ from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 import isaaclab_tasks.manager_based.manipulation.reach.mdp as mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/reach_env_cfg.py
@@ -22,7 +22,7 @@ from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 import isaaclab_tasks.manager_based.manipulation.reach.mdp as mdp

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/bin_stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/bin_stack_joint_pos_env_cfg.py
@@ -13,7 +13,7 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.stack import mdp
 from isaaclab_tasks.manager_based.manipulation.stack.mdp import franka_stack_events

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_visuomotor_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_visuomotor_env_cfg.py
@@ -12,7 +12,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.sensors import CameraCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, NVIDIA_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR, NVIDIA_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.stack import mdp
 from isaaclab_tasks.manager_based.manipulation.stack.mdp import franka_stack_events

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_joint_pos_env_cfg.py
@@ -11,7 +11,7 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.stack import mdp
 from isaaclab_tasks.manager_based.manipulation.stack.mdp import franka_stack_events

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_joint_pos_instance_randomize_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_joint_pos_instance_randomize_env_cfg.py
@@ -13,7 +13,7 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.stack import mdp
 from isaaclab_tasks.manager_based.manipulation.stack.mdp import franka_stack_events

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_joint_pos_env_cfg.py
@@ -28,7 +28,7 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import CollisionPropertiesCfg, RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.stack import mdp
 from isaaclab_tasks.manager_based.manipulation.stack.mdp import franka_stack_events

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/ur10_gripper/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/ur10_gripper/stack_joint_pos_env_cfg.py
@@ -14,7 +14,7 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from isaaclab_tasks.manager_based.manipulation.stack import mdp
 from isaaclab_tasks.manager_based.manipulation.stack.mdp import franka_stack_events

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_env_cfg.py
@@ -19,7 +19,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransformerCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from . import mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_instance_randomize_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/stack_instance_randomize_env_cfg.py
@@ -17,7 +17,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransformerCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils import ISAAC_NUCLEUS_DIR
 
 from . import mdp
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/navigation_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/navigation_env_cfg.py
@@ -13,7 +13,7 @@ from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.utils import configclass
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
 
 import isaaclab_tasks.manager_based.navigation.mdp as mdp
 from isaaclab_tasks.manager_based.locomotion.velocity.config.anymal_c.flat_env_cfg import AnymalCFlatEnvCfg

--- a/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/retargeters/humanoid/fourier/gr1_t2_dex_retargeting_utils.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/retargeters/humanoid/fourier/gr1_t2_dex_retargeting_utils.py
@@ -12,7 +12,8 @@ import yaml
 from dex_retargeting.retargeting_config import RetargetingConfig
 from scipy.spatial.transform import Rotation as R
 
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 # import logger
 logger = logging.getLogger(__name__)

--- a/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/retargeters/humanoid/unitree/inspire/g1_dex_retargeting_utils.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/retargeters/humanoid/unitree/inspire/g1_dex_retargeting_utils.py
@@ -12,7 +12,8 @@ import yaml
 from dex_retargeting.retargeting_config import RetargetingConfig
 from scipy.spatial.transform import Rotation as R
 
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 # import logger
 logger = logging.getLogger(__name__)

--- a/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/retargeters/humanoid/unitree/trihand/g1_dex_retargeting_utils.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/retargeters/humanoid/unitree/trihand/g1_dex_retargeting_utils.py
@@ -12,7 +12,8 @@ import yaml
 from dex_retargeting.retargeting_config import RetargetingConfig
 from scipy.spatial.transform import Rotation as R
 
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, retrieve_file_path
+from isaaclab.utils import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import retrieve_file_path
 
 # import logger
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Description

Currently our asset.py as a very aggressive import chain if top import. 

NUCLEUS_ASSET_ROOT_DIR is required for the most basic asset path readying and is purely kit independent, but to access it from asset.py require import pxr and omni.client. VERY VERY BAD

The foundamental issue if that data only variable like NUCLEUS_ASSET_ROOT_DIR is living together with dependency heavy  `retrieve_file_path`



the solution is very tricky, if we want to do it properly, we need to separate NUCLEUS_ASSET_ROOT_DIR from `retrieve_file_path` we will break a lot of user code because, vvv will not work

`from isaaclab.utils.asset import NUCLEUS_ASSET_ROOT_DIR, retrieve_file_path`


Or we just stay local import. Which means we don't merge this PR : D


But on the other side of coin, if we are moving toward major release which we are going to break things, why don't we do it properly here and break once, document in migration guide. The migration for this change shouldn't be hard either (compared to xyzw) especially with all the help of AI.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
