### PR TITLE
Fixes standard xform ops order (#4696)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,6 +42,7 @@ Guidelines for modifications:
 
 * Alessandro Assirelli
 * Alex Omar
+* Alexander Millane
 * Alice Zhou
 * Amr Mousa
 * Andrej Orsula

--- a/source/isaaclab/isaaclab/sim/utils/transforms.py
+++ b/source/isaaclab/isaaclab/sim/utils/transforms.py
@@ -171,6 +171,19 @@ def standardize_xform_ops(
 
     # Verify if xform stack is reset
     has_reset = xformable.GetResetXformStack()
+
+    # Ensure the prim has an "over" spec on the edit target layer. Prims from
+    # referenced USD files may only exist in the reference layer with no spec on
+    # the edit target. Inside an Sdf.ChangeBlock, AddXformOp calls CreateAttribute
+    # which needs an existing prim spec on the edit target — it cannot create one
+    # while stage recomposition is deferred.
+    edit_layer = prim.GetStage().GetEditTarget().GetLayer()
+    if not edit_layer.GetPrimAtPath(prim.GetPath()):
+        for prefix in prim.GetPath().GetPrefixes():
+            if not edit_layer.GetPrimAtPath(prefix):
+                parent_spec = edit_layer.GetPrimAtPath(prefix.GetParentPath()) or edit_layer.pseudoRoot
+                Sdf.PrimSpec(parent_spec, prefix.name, Sdf.SpecifierOver)
+
     # Batch the operations
     with Sdf.ChangeBlock():
         # Clear the existing transform operation order

--- a/source/isaaclab/isaaclab/sim/views/xform_prim_view.py
+++ b/source/isaaclab/isaaclab/sim/views/xform_prim_view.py
@@ -129,6 +129,7 @@ class XformPrimView:
         # Validate all prims have standard xform operations
         if validate_xform_ops:
             for prim in self._prims:
+                sim_utils.standardize_xform_ops(prim)
                 if not sim_utils.validate_standard_xform_ops(prim):
                     raise ValueError(
                         f"Prim at path '{prim.GetPath().pathString}' is not a xformable prim with standard transform"

--- a/source/isaaclab/test/sim/test_views_xform_prim.py
+++ b/source/isaaclab/test/sim/test_views_xform_prim.py
@@ -200,20 +200,34 @@ def test_xform_prim_view_initialization_multiple_prims_order(device):
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
-def test_xform_prim_view_initialization_invalid_prim(device):
-    """Test XformPrimView initialization fails for non-xformable prims."""
-    # check if CUDA is available
+def test_xform_prim_view_standardizes_transform_op(device):
+    """Test that XformPrimView standardizes a prim with xformOp:transform to translate/orient/scale."""
+    from pxr import Gf, UsdGeom
+
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 
+    expected_pos = (3.0, -1.0, 0.5)
+    matrix = Gf.Matrix4d(1.0)
+    matrix.SetTranslateOnly(Gf.Vec3d(*expected_pos))
+
     stage = sim_utils.get_current_stage()
+    prim = stage.DefinePrim("/World/TransformPrim", "Xform")
+    UsdGeom.Xformable(prim).AddTransformOp().Set(matrix)
 
-    # Create a prim with non-standard xform operations
-    stage.DefinePrim("/World/InvalidPrim", "Xform")
+    view = XformPrimView("/World/TransformPrim", device=device)
 
-    # XformPrimView should raise ValueError because prim doesn't have standard operations
-    with pytest.raises(ValueError, match="not a xformable prim"):
-        XformPrimView("/World/InvalidPrim", device=device)
+    assert view.count == 1
+    assert sim_utils.validate_standard_xform_ops(view.prims[0])
+
+    xformable = UsdGeom.Xformable(view.prims[0])
+    ordered_ops = xformable.GetOrderedXformOps()
+    op_names = [op.GetOpName() for op in ordered_ops]
+    assert op_names == ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+    assert ordered_ops[0].Get() == Gf.Vec3d(*expected_pos)
+    assert ordered_ops[1].Get() == Gf.Quatd(1.0, 0.0, 0.0, 0.0)
+    assert ordered_ops[2].Get() == Gf.Vec3d(1.0, 1.0, 1.0)
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link:
https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Cherry-pick #4696 from develop to main branch.

This PR fixes an issue where AssetBaseCfgs that reference a prim inside another USD fail when the referenced prim has its pose specified as a transform matrix.

This MR introduces a change that `XformPrimView` converts matrices to `translation`, `rotation`, and `scale` ops, as required by lab. The function to do this conversion was also broken in the case of a referenced, rather than spawned, prim. This MR also fixes that function (`standardize_xform_ops`).

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

This screenshot shoes the type of prim that caused a crash and now no longer does. The cabinet inside this kitchen has its transform specified as a matrix. Before this MR creating an `AssetBaseCfg` pointing to this prim would crash lab.

<img width="914" height="503" alt="cabinet_4x4_transform" src="https://github.com/user-attachments/assets/fd7a7efe-3382-4aae-bd44-4792dc1553b1" />

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task -->

---------



(cherry picked from commit 3333dfed5c8649c47552e7331af0b69642d4b250)
