### PR TITLE
Fixes typo in cxr install docs

### DIFF
--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -69,7 +69,7 @@ Install Isaac Teleop
 
    .. code-block:: bash
 
-      echo "NV_CXR_ENABLE_PUSH_DEVICES=0" > deps/cloudxr/cxr.env
+      echo "NV_CXR_ENABLE_PUSH_DEVICES=0" > deps/cloudxr/.env
 
 #. Activate the **same** virtual environment you use for Isaac Lab, then install the
    ``isaacteleop`` package:


### PR DESCRIPTION
# Description

Fixes typo in isaac teleop installation docs where the env file was not getting picked up and HMD optical hand tracking will not work.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there