### PR TITLE
Adds back optional Teleop hand joint visualization

### DIFF
--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_cfg.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_cfg.py
@@ -108,7 +108,7 @@ class IsaacTeleopCfg:
     If ``None``, the tuning UI will not be opened.
     """
 
-    enable_visualization: bool = False
+    enable_visualization: bool = True
     """When True, auto-discover hand tracking data in the pipeline and render
     red sphere markers at each OpenXR hand joint for debug visualization."""
 

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_cfg.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_cfg.py
@@ -108,5 +108,9 @@ class IsaacTeleopCfg:
     If ``None``, the tuning UI will not be opened.
     """
 
+    enable_visualization: bool = False
+    """When True, auto-discover hand tracking data in the pipeline and render
+    red sphere markers at each OpenXR hand joint for debug visualization."""
+
     app_name: str = "IsaacLabTeleop"
     """Application name for the IsaacTeleop session."""

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -16,6 +17,9 @@ from .command_handler import CommandHandler
 from .isaac_teleop_cfg import IsaacTeleopCfg
 from .session_lifecycle import TeleopSessionLifecycle
 from .xr_anchor_manager import XrAnchorManager
+
+if TYPE_CHECKING:
+    from .visualizers.hand_joint_visualizer import HandJointVisualizer
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +82,10 @@ class IsaacTeleopDevice:
 
         # Controller button polling state (edge detection for right 'A')
         self._prev_right_a_pressed = False
+
+        # Hand debug visualizer (lazily created on first frame with hand data).
+        self._hand_visualizer: HandJointVisualizer | None = None
+        self._hand_visualizer_failed = False
 
     def __del__(self):
         """Clean up resources when the object is destroyed."""
@@ -171,8 +179,39 @@ class IsaacTeleopDevice:
         if action is not None:
             # Poll controller buttons (e.g. toggle anchor rotation on right 'A' press)
             self._poll_buttons()
+            if self._cfg.enable_visualization:
+                self._update_hand_debug()
 
         return action
+
+    # ------------------------------------------------------------------
+    # Hand debug visualization
+    # ------------------------------------------------------------------
+
+    def _update_hand_debug(self) -> None:
+        """Lazily create and update the hand joint debug visualizer.
+
+        On the first frame where ``hand_left`` or ``hand_right`` appears in
+        the pipeline step result, a :class:`HandJointVisualizer` is created
+        (red sphere markers at each OpenXR hand joint).  Subsequent frames
+        simply update marker positions.
+        """
+        result = self._session_lifecycle.last_step_result
+        if result is None:
+            return
+        if "hand_left" not in result and "hand_right" not in result:
+            return
+        if self._hand_visualizer is None and not self._hand_visualizer_failed:
+            try:
+                from .visualizers.hand_joint_visualizer import HandJointVisualizer
+
+                self._hand_visualizer = HandJointVisualizer()
+            except Exception:
+                logger.debug("HandJointVisualizer creation failed; disabling hand debug", exc_info=True)
+                self._hand_visualizer_failed = True
+                return
+        if self._hand_visualizer is not None:
+            self._hand_visualizer.update(result)
 
     # ------------------------------------------------------------------
     # Controller button polling (glue between session and anchor manager)

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -58,6 +58,7 @@ class TeleopSessionLifecycle:
         self._session: TeleopSession | None = None
         self._pipeline = None
         self._last_right_controller = None
+        self._last_step_result: dict | None = None
         self._session_start_deferred_logged = False
 
         # Retargeting tuning UI (created in start, closed in stop)
@@ -128,6 +129,16 @@ class TeleopSessionLifecycle:
         """
         return self._last_right_controller
 
+    @property
+    def last_step_result(self) -> dict | None:
+        """Full pipeline output from the most recent :meth:`step`, or ``None``.
+
+        Contains at least ``"action"`` and ``"_controller_right"``.  When the
+        pipeline graph contains a ``HandsSource``, ``"hand_left"`` and
+        ``"hand_right"`` are auto-discovered and included as well.
+        """
+        return self._last_step_result
+
     # ------------------------------------------------------------------
     # Lifecycle: start / stop
     # ------------------------------------------------------------------
@@ -150,14 +161,18 @@ class TeleopSessionLifecycle:
         user_pipeline = self._cfg.pipeline_builder()
         self._session_start_deferred_logged = False
         self._last_right_controller = None
+        self._last_step_result = None
 
         button_controllers = ControllersSource("_button_controllers")
-        self._pipeline = OutputCombiner(
-            {
-                "action": user_pipeline.output("action"),
-                self._CONTROLLER_RIGHT_KEY: button_controllers.output(ControllersSource.RIGHT),
-            }
-        )
+        output_mapping = {
+            "action": user_pipeline.output("action"),
+            self._CONTROLLER_RIGHT_KEY: button_controllers.output(ControllersSource.RIGHT),
+        }
+
+        if self._cfg.enable_visualization:
+            self._chain_hand_debug_outputs(user_pipeline, output_mapping)
+
+        self._pipeline = OutputCombiner(output_mapping)
 
         # Try to start the session now; it may be deferred
         self._try_start_session()
@@ -340,7 +355,10 @@ class TeleopSessionLifecycle:
         except Exception as e:
             logger.warning(f"IsaacTeleop session step failed (XR session likely torn down): {e}")
             self._teardown_dead_session()
+            self._last_step_result = None
             return None
+
+        self._last_step_result = result
 
         # Store the right controller TensorGroup for button polling
         self._last_right_controller = result.get(self._CONTROLLER_RIGHT_KEY)
@@ -352,6 +370,42 @@ class TeleopSessionLifecycle:
         action = torch.from_numpy(np.asarray(action_np, dtype=np.float32)).to(self._device)
 
         return action
+
+    # ------------------------------------------------------------------
+    # Hand debug output chaining
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _chain_hand_debug_outputs(user_pipeline, output_mapping: dict) -> None:
+        """Auto-discover ``HandsSource`` in the pipeline and chain hand outputs.
+
+        Walks the leaf nodes of *user_pipeline*.  If a ``HandsSource`` and a
+        ``ValueInput("world_T_anchor")`` are both present, a lightweight
+        ``HandTransform`` subgraph is created from them and its
+        ``hand_left`` / ``hand_right`` outputs are added to *output_mapping*
+        so they appear in the step result for debug visualization.
+
+        Args:
+            user_pipeline: The pipeline returned by ``pipeline_builder()``.
+            output_mapping: Mutable dict of output-name to ``OutputSelector``
+                being assembled for the final ``OutputCombiner``.
+        """
+        from isaacteleop.retargeting_engine.deviceio_source_nodes import HandsSource
+        from isaacteleop.retargeting_engine.interface import ValueInput
+
+        hands_source = None
+        value_input = None
+        for leaf in user_pipeline.get_leaf_nodes():
+            if isinstance(leaf, HandsSource) and hands_source is None:
+                hands_source = leaf
+            elif isinstance(leaf, ValueInput) and leaf.name == TeleopSessionLifecycle.WORLD_T_ANCHOR_INPUT_NAME:
+                value_input = leaf
+        if hands_source is None or value_input is None:
+            return
+        transformed = hands_source.transformed(value_input.output(ValueInput.VALUE))
+        output_mapping[HandsSource.LEFT] = transformed.output(HandsSource.LEFT)
+        output_mapping[HandsSource.RIGHT] = transformed.output(HandsSource.RIGHT)
+        logger.debug("Auto-discovered HandsSource; chaining hand_left/hand_right for debug visualization")
 
     # ------------------------------------------------------------------
     # Dead session teardown
@@ -374,6 +428,7 @@ class TeleopSessionLifecycle:
                 logger.debug(f"Suppressed error tearing down dead session: {e}")
             self._session = None
         self._session_start_deferred_logged = False
+        self._last_step_result = None
         logger.info("IsaacTeleop session torn down after external XR shutdown")
 
     # ------------------------------------------------------------------

--- a/source/isaaclab_teleop/isaaclab_teleop/visualizers/__init__.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/visualizers/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Visualizers for teleop debug data (e.g. hand joint markers)."""
+
+from .hand_joint_visualizer import HandJointVisualizer
+
+__all__ = ["HandJointVisualizer"]

--- a/source/isaaclab_teleop/isaaclab_teleop/visualizers/hand_joint_visualizer.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/visualizers/hand_joint_visualizer.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Red sphere markers at each OpenXR hand joint for teleop debug visualization."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+
+import isaaclab.sim as sim_utils
+from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+if TYPE_CHECKING:
+    from isaacteleop.retargeting_engine.interface import OptionalTensorGroup
+
+logger = logging.getLogger(__name__)
+
+
+class HandJointVisualizer:
+    """Red sphere markers at each OpenXR hand joint (26 per hand).
+
+    Created lazily by :class:`~isaaclab_teleop.isaac_teleop_device.IsaacTeleopDevice`
+    when the pipeline step result first contains ``hand_left`` or ``hand_right``.
+    Call :meth:`update` each frame with the step result dict.
+    """
+
+    def __init__(self):
+        marker_cfg = VisualizationMarkersCfg(
+            prim_path="/Visuals/HandJointMarkers",
+            markers={
+                "joint": sim_utils.SphereCfg(
+                    radius=0.005,
+                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0)),
+                ),
+            },
+        )
+        self._markers = VisualizationMarkers(marker_cfg)
+        self._markers.set_visibility(True)
+        self._logged_error = False
+
+    def update(self, result: dict[str, OptionalTensorGroup]) -> None:
+        """Update marker positions from a pipeline step result.
+
+        Args:
+            result: The pipeline output dict from the most recent step.
+        """
+        try:
+            from isaacteleop.retargeting_engine.tensor_types import HandInputIndex
+
+            parts: list[torch.Tensor] = []
+            if "hand_left" in result and not result["hand_left"].is_none:
+                left_pos = result["hand_left"][HandInputIndex.JOINT_POSITIONS]
+                if not isinstance(left_pos, torch.Tensor):
+                    left_pos = torch.as_tensor(left_pos, dtype=torch.float32)
+                parts.append(left_pos)
+            if "hand_right" in result and not result["hand_right"].is_none:
+                right_pos = result["hand_right"][HandInputIndex.JOINT_POSITIONS]
+                if not isinstance(right_pos, torch.Tensor):
+                    right_pos = torch.as_tensor(right_pos, dtype=torch.float32)
+                parts.append(right_pos)
+            if not parts:
+                return
+            positions = torch.cat(parts, dim=0).reshape(-1, 3)
+        except Exception:
+            if not self._logged_error:
+                logger.exception("HandJointVisualizer: error extracting hand joint positions")
+                self._logged_error = True
+            return
+
+        self._markers.visualize(translations=positions)


### PR DESCRIPTION
# Description

Auto-discover HandsSource in the retargeting pipeline and render red
sphere markers at each OpenXR hand joint.  The feature is centralized
in isaaclab_teleop so individual env_cfg files are untouched:

- session_lifecycle: chain hand_left/hand_right outputs into the
  pipeline OutputCombiner via _chain_hand_debug_outputs(); expose
  last_step_result property.
- isaac_teleop_device: lazily create HandJointVisualizer on the first
  frame with hand data; gate everything behind enable_visualization.
- isaac_teleop_cfg: add enable_visualization flag (default True).
- visualizers/hand_joint_visualizer: new HandJointVisualizer class
  that draws per-joint red spheres, handling one or both hands.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
