### PR TITLE
Remove hardcoded camera prim paths from OVRTX renderer

### DIFF
--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -120,6 +120,7 @@ class OVRTXRenderer(BaseRenderer):
         self._initialized_scene = False
         self._sensor_ref: weakref.ref[object] | None = None
         self._exported_usd_path: str | None = None
+        self._camera_rel_path: str | None = None
 
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """Export the USD stage for OVRTX before create_render_data.
@@ -133,7 +134,7 @@ class OVRTXRenderer(BaseRenderer):
         use_cloning = self.cfg.use_cloning
 
         logger.info("Preparing stage for export (%d envs, cloning=%s)...", num_envs, use_cloning)
-        create_cloning_attributes(stage, "Camera", num_envs, use_cloning)
+        create_cloning_attributes(stage, num_envs, use_cloning)
 
         export_path = "/tmp/stage_before_ovrtx.usda"
         export_stage_for_ovrtx(stage, export_path, num_envs, use_cloning)
@@ -153,6 +154,12 @@ class OVRTXRenderer(BaseRenderer):
         height = sensor.cfg.height
         num_envs = sensor.num_instances
         data_types = sensor.cfg.data_types if sensor.cfg.data_types else ["rgb"]
+
+        env_0_prefix = "/World/envs/env_0/"
+        first_cam_path = sensor._view.prims[0].GetPath().pathString
+        if not first_cam_path.startswith(env_0_prefix):
+            raise RuntimeError(f"Expected camera prim under '{env_0_prefix}', got '{first_cam_path}'")
+        self._camera_rel_path = first_cam_path.removeprefix(env_0_prefix)
 
         usd_scene_path = self._exported_usd_path
         use_cloning = self.cfg.use_cloning
@@ -176,6 +183,7 @@ class OVRTXRenderer(BaseRenderer):
                 height=height,
                 num_envs=num_envs,
                 data_types=data_types,
+                camera_rel_path=self._camera_rel_path,
             )
             self._render_product_paths.append(render_product_path)
 
@@ -195,7 +203,7 @@ class OVRTXRenderer(BaseRenderer):
 
             self._initialized_scene = True
 
-            camera_paths = [f"/World/envs/env_{i}/Camera" for i in range(num_envs)]
+            camera_paths = [f"/World/envs/env_{i}/{self._camera_rel_path}" for i in range(num_envs)]
             self._camera_binding = self._renderer.bind_attribute(
                 prim_paths=camera_paths,
                 attribute_name="omni:xform",
@@ -237,7 +245,7 @@ class OVRTXRenderer(BaseRenderer):
         logger.info("Writing scene partitions for %d environments...", num_envs)
         partition_tokens = [f"env_{i}" for i in range(num_envs)]
         env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
-        camera_prim_paths = [f"/World/envs/env_{i}/Camera" for i in range(num_envs)]
+        camera_prim_paths = [f"/World/envs/env_{i}/{self._camera_rel_path}" for i in range(num_envs)]
 
         try:
             self._renderer.write_attribute(
@@ -280,7 +288,7 @@ class OVRTXRenderer(BaseRenderer):
             object_paths = []
             newton_indices = []
             for idx, path in enumerate(all_body_paths):
-                if "/World/envs/" in path and "Camera" not in path and "GroundPlane" not in path:
+                if "/World/envs/" in path and self._camera_rel_path not in path and "GroundPlane" not in path:
                     object_paths.append(path)
                     newton_indices.append(idx)
 

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pxr import Sdf, Usd
+from pxr import Sdf, Usd, UsdGeom
 
 if TYPE_CHECKING:
     from .ovrtx_renderer_cfg import OVRTXRendererCfg
@@ -94,6 +94,7 @@ def inject_cameras_into_usd(
     height: int,
     num_envs: int,
     data_types: list[str],
+    camera_rel_path: str = "Camera",
 ) -> tuple[str, str]:
     """Inject camera and render product definitions into an existing USD file.
 
@@ -107,6 +108,8 @@ def inject_cameras_into_usd(
         height: Tile height from sensor config.
         num_envs: Number of environments from scene.
         data_types: Data types from sensor config.
+        camera_rel_path: Camera prim path relative to the env root (e.g. ``"Camera"``
+            or ``"Robot/head_cam"``).
     """
     with open(usd_scene_path) as f:
         original_usd = f.read()
@@ -114,7 +117,7 @@ def inject_cameras_into_usd(
     data_types = data_types if data_types else ["rgb"]
     tiled_width, tiled_height = _tiled_resolution(num_envs, width, height)
 
-    camera_paths = [f"/World/envs/env_{i}/Camera" for i in range(num_envs)]
+    camera_paths = [f"/World/envs/env_{i}/{camera_rel_path}" for i in range(num_envs)]
     render_product_name = "RenderProduct"
     render_product_path = f"/Render/{render_product_name}"
 
@@ -140,18 +143,20 @@ def inject_cameras_into_usd(
     return temp_path, render_product_path
 
 
-def create_cloning_attributes(
-    stage, camera_prim_name: str = "Camera", num_envs: int = 1, use_cloning: bool = True
-) -> int:
+def create_cloning_attributes(stage, num_envs: int = 1, use_cloning: bool = True) -> int:
     """Create OVRTX cloning attributes (scene partition, xform) on env_0 only.
 
     Only env_0 is exported for OVRTX; env_1..env_{n-1} are deactivated before export.
     OVRTX clones env_0 internally and _update_scene_partitions_after_clone sets
     partition attributes on the clones. So we only need to set attributes on env_0 here.
 
+    Camera prims are discovered by USD type (``UsdGeom.Camera``) rather than by
+    name, so this works regardless of where the camera is placed in the hierarchy.
+
     Args:
         stage: USD stage to modify.
-        camera_prim_name: Name of the camera prim under each env (e.g. "Camera").
+        num_envs: Number of environments.
+        use_cloning: Whether OVRTX cloning is enabled.
 
     Returns:
         Total number of objects (non-camera prims) that received partition attributes.
@@ -167,15 +172,13 @@ def create_cloning_attributes(
         attr = env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token)
         attr.Set(partition_name)
         for prim in Usd.PrimRange(env_prim):
-            if prim.GetPath() == env_prim.GetPath() or "Camera" in prim.GetPath().pathString:
+            if prim.GetPath() == env_prim.GetPath():
                 continue
-            obj_attr = prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token)
-            obj_attr.Set(partition_name)
-            total_objects += 1
-        camera_path = f"{env_path}/{camera_prim_name}"
-        camera_prim = stage.GetPrimAtPath(camera_path)
-        if camera_prim.IsValid():
-            camera_prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(partition_name)
+            if prim.IsA(UsdGeom.Camera):
+                prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(partition_name)
+            else:
+                prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(partition_name)
+                total_objects += 1
     return total_objects
 
 


### PR DESCRIPTION
Remove hardcoded camera prim paths from OVRTX renderer

Derive the camera prim path from the sensor's resolved view prims
instead of assuming it is always "Camera". This fixes scenes where the
camera lives at a non-default path (e.g. Robot/ee_link/palm_link/Camera).

- Extract camera relative path from sensor._view at initialization
- Use it for camera bindings, scene partitions, object binding filter,
  and USD camera injection
- Discover cameras by USD type (UsdGeom.Camera) in create_cloning_attributes
  instead of matching on the "Camera" string
- Add ovrtx_renderer preset to cartpole camera presets env config