### PR TITLE
Fixes missing unpack of tuple in teleop config

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/fixed_base_upper_body_ik_g1_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/fixed_base_upper_body_ik_g1_env_cfg.py
@@ -3,9 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-
-from isaaclab_teleop.isaac_teleop_cfg import IsaacTeleopCfg
-from isaaclab_teleop.xr_cfg import XrCfg
+from isaaclab_teleop import IsaacTeleopCfg, XrCfg
 
 import isaaclab.envs.mdp as base_mdp
 import isaaclab.sim as sim_utils
@@ -39,8 +37,10 @@ def _build_g1_upper_body_pipeline():
     via TensorReorderer.
 
     Returns:
-        OutputCombiner with a single "action" output containing the flattened
-        28D action tensor: [left_wrist(7), right_wrist(7), hand_joints(14)].
+        Tuple of (OutputCombiner, list): the pipeline with a single "action"
+        output containing the flattened 28D action tensor
+        [left_wrist(7), right_wrist(7), hand_joints(14)], and the list of
+        retargeter instances [left_se3, right_se3] for tuning UI.
     """
     from isaacteleop.retargeters import (
         Se3AbsRetargeter,
@@ -391,8 +391,10 @@ class FixedBaseUpperBodyIKG1EnvCfg(ManagerBasedRLEnvCfg):
             anchor_pos=(0.0, 0.0, -0.45),
             anchor_rot=(0.0, 0.0, 0.0, 1.0),
         )
+
         self.isaac_teleop = IsaacTeleopCfg(
-            pipeline_builder=_build_g1_upper_body_pipeline,
+            pipeline_builder=lambda: _build_g1_upper_body_pipeline()[0],
+            # retargeters_to_tune=lambda: _build_g1_upper_body_pipeline()[1],
             sim_device=self.sim.device,
             xr_cfg=self.xr,
         )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/locomanipulation_g1_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/locomanipulation_g1_env_cfg.py
@@ -3,16 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import logging
-
-try:
-    import isaacteleop  # noqa: F401  -- pipeline builders need isaacteleop at runtime
-    from isaaclab_teleop import IsaacTeleopCfg, XrAnchorRotationMode, XrCfg
-
-    _TELEOP_AVAILABLE = True
-except ImportError:
-    _TELEOP_AVAILABLE = False
-    logging.getLogger(__name__).warning("isaaclab_teleop is not installed. XR teleoperation features will be disabled.")
+from isaaclab_teleop import IsaacTeleopCfg, XrAnchorRotationMode, XrCfg
 
 import isaaclab.envs.mdp as base_mdp
 import isaaclab.sim as sim_utils
@@ -438,17 +429,16 @@ class LocomanipulationG1EnvCfg(ManagerBasedRLEnvCfg):
         # Set the URDF path for the IK controller. Path resolution (Nucleus → local) happens at runtime.
         self.actions.upper_body_ik.controller.urdf_path = f"{ISAACLAB_NUCLEUS_DIR}/Controllers/LocomanipulationAssets/unitree_g1_kinematics_asset/g1_29dof_with_hand_only_kinematics.urdf"  # noqa: E501
 
-        if _TELEOP_AVAILABLE:
-            self.xr = XrCfg(
-                anchor_pos=(0.0, 0.0, -0.95),
-                anchor_rot=(0.0, 0.0, 0.0, 1.0),
-            )
-            self.xr.anchor_prim_path = "/World/envs/env_0/Robot/pelvis"
-            self.xr.fixed_anchor_height = True
-            self.xr.anchor_rotation_mode = XrAnchorRotationMode.FOLLOW_PRIM_SMOOTHED
+        self.xr = XrCfg(
+            anchor_pos=(0.0, 0.0, -0.95),
+            anchor_rot=(0.0, 0.0, 0.0, 1.0),
+        )
+        self.xr.anchor_prim_path = "/World/envs/env_0/Robot/pelvis"
+        self.xr.fixed_anchor_height = True
+        self.xr.anchor_rotation_mode = XrAnchorRotationMode.FOLLOW_PRIM_SMOOTHED
 
-            self.isaac_teleop = IsaacTeleopCfg(
-                pipeline_builder=_build_g1_locomanipulation_pipeline,
-                sim_device=self.sim.device,
-                xr_cfg=self.xr,
-            )
+        self.isaac_teleop = IsaacTeleopCfg(
+            pipeline_builder=_build_g1_locomanipulation_pipeline,
+            sim_device=self.sim.device,
+            xr_cfg=self.xr,
+        )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_joint_pos_env_cfg.py
@@ -4,18 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-import logging
-
 from isaaclab_physx.assets import SurfaceGripperCfg
-
-try:
-    import isaacteleop  # noqa: F401  -- pipeline builders need isaacteleop at runtime
-    from isaaclab_teleop import IsaacTeleopCfg
-
-    _TELEOP_AVAILABLE = True
-except ImportError:
-    _TELEOP_AVAILABLE = False
-    logging.getLogger(__name__).warning("isaaclab_teleop is not installed. XR teleoperation features will be disabled.")
+from isaaclab_teleop import IsaacTeleopCfg
 
 from isaaclab.assets import RigidObjectCfg
 from isaaclab.envs.mdp.actions.actions_cfg import SurfaceGripperBinaryActionCfg
@@ -334,13 +324,11 @@ class GalbotLeftArmCubeStackEnvCfg(StackEnvCfg):
         )
 
         # IsaacTeleop-based teleoperation pipeline (left hand)
-        if _TELEOP_AVAILABLE:
-            pipeline = _build_se3_abs_gripper_pipeline(hand_side="left")
-            self.isaac_teleop = IsaacTeleopCfg(
-                pipeline_builder=lambda: pipeline,
-                sim_device=self.sim.device,
-                xr_cfg=self.xr,
-            )
+        self.isaac_teleop = IsaacTeleopCfg(
+            pipeline_builder=lambda: _build_se3_abs_gripper_pipeline(hand_side="left"),
+            sim_device=self.sim.device,
+            xr_cfg=self.xr,
+        )
 
 
 @configclass
@@ -377,10 +365,8 @@ class GalbotRightArmCubeStackEnvCfg(GalbotLeftArmCubeStackEnvCfg):
         self.scene.ee_frame.target_frames[0].prim_path = "{ENV_REGEX_NS}/Robot/right_suction_cup_tcp_link"
 
         # IsaacTeleop-based teleoperation pipeline (right hand)
-        if _TELEOP_AVAILABLE:
-            pipeline = _build_se3_abs_gripper_pipeline(hand_side="right")
-            self.isaac_teleop = IsaacTeleopCfg(
-                pipeline_builder=lambda: pipeline,
-                sim_device=self.sim.device,
-                xr_cfg=self.xr,
-            )
+        self.isaac_teleop = IsaacTeleopCfg(
+            pipeline_builder=lambda: _build_se3_abs_gripper_pipeline(hand_side="right"),
+            sim_device=self.sim.device,
+            xr_cfg=self.xr,
+        )


### PR DESCRIPTION
# Description

Fixes missing tuple unpack in g1 fixed base teleop config. The env cfg contains the functionality to highlight how a user could enable the Isaac Teleop tuning UI, however that introduced a bug when not in use.

Also fixes eager calling of pipeline builder in a few env cfgs causing import errors when optional isaacteleop module is not installed.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
