### PR TITLE
Adds passive damping to Newton ImplicitActuator; enables training Ant and Humanoid

### DIFF
--- a/source/isaaclab_assets/isaaclab_assets/robots/ant.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/ant.py
@@ -48,7 +48,7 @@ ANT_CFG = ArticulationCfg(
         "body": ImplicitActuatorCfg(
             joint_names_expr=[".*"],
             stiffness=0.0,
-            damping=0.0,
+            damping=0.5,
             effort_limit_sim=30.0,
         ),
     },

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -17,6 +17,7 @@ import numpy as np
 import torch
 import warp as wp
 from newton import JointType
+from newton import Model as NewtonModel
 from newton.selection import ArticulationView
 from newton.solvers import SolverNotifyFlags
 from prettytable import PrettyTable
@@ -3381,6 +3382,11 @@ class Articulation(BaseArticulation):
                 # the gains and limits are set into the simulation since actuator model is implicit
                 self.write_joint_stiffness_to_sim_index(stiffness=actuator.stiffness, joint_ids=actuator.joint_indices)
                 self.write_joint_damping_to_sim_index(damping=actuator.damping, joint_ids=actuator.joint_indices)
+                # write_joint_damping_to_sim_index updates joint_target_kd, which only applies
+                # to joints with an existing velocity actuator (VELOCITY or POSITION_VELOCITY mode).
+                # For joints in EFFORT or NONE mode, passive damping must be written to
+                # model.mujoco.dof_passive_damping so the MuJoCo solver can apply it.
+                self._write_passive_damping_to_mujoco(actuator.damping, actuator.joint_indices)
             else:
                 # the gains and limits are processed by the actuator model
                 # we set gains to zero, and torque limit to a high value in simulation to avoid any interference
@@ -3477,6 +3483,92 @@ class Articulation(BaseArticulation):
                         t.add_row([actuator_group_str, property_str, *fmt])
                         group_count += 1
             logger.warning(f"\nActuatorCfg-USD Value Discrepancy Resolution (matching values are skipped): \n{t}")
+
+    def _write_passive_damping_to_mujoco(
+        self,
+        damping: torch.Tensor | wp.array | float,
+        joint_ids: Sequence[int] | torch.Tensor | wp.array | None,
+    ) -> None:
+        """Write passive joint damping to the MuJoCo solver's dof_passive_damping array.
+
+        :meth:`write_joint_damping_to_sim_index` updates ``joint_target_kd``, which only takes
+        effect for joints that have a velocity actuator (VELOCITY or POSITION_VELOCITY drive mode).
+        For joints in EFFORT or NONE mode (no velocity actuator is created), the MuJoCo solver
+        reads passive joint damping from ``model.mujoco.dof_passive_damping`` instead.
+        This method writes the damping value to that array so it is applied during simulation.
+
+        .. note::
+            This method assumes each selected joint contributes exactly one DOF (i.e., revolute or
+            prismatic joints). Multi-DOF joints (e.g., spherical) are not supported.
+
+        Args:
+            damping: Joint damping [N·m·s/rad or N·s/m]. Scalar or shape (num_instances, num_joints).
+            joint_ids: Joint indices. If None, all joints are used.
+        """
+        model = SimulationManager.get_model()
+        mujoco_attrs = getattr(model, "mujoco", None)
+        if mujoco_attrs is None:
+            return
+        dof_passive_damping = getattr(mujoco_attrs, "dof_passive_damping", None)
+        if dof_passive_damping is None:
+            return
+
+        # Get the JOINT_DOF frequency layout to map view-local joint indices to flat DOF indices.
+        # layout.offset: first DOF index for this view's joints (instance 0).
+        # layout.stride_between_worlds: DOF stride between instances in the flat array.
+        # layout.slice / layout.indices: maps view-local joint position -> relative DOF (from offset).
+        layout = self._root_view.frequency_layouts.get(NewtonModel.AttributeFrequency.JOINT_DOF)
+        if layout is None:
+            return
+
+        # Resolve joint IDs; ensure it's a Warp array throughout.
+        resolved = self._resolve_joint_ids(joint_ids)
+        if not isinstance(resolved, wp.array):
+            resolved = wp.from_torch(resolved.to(torch.int32).contiguous())
+        num_joints = resolved.shape[0]
+        if num_joints == 0:
+            return
+
+        # Compute the relative DOF index for each actuator joint (relative to layout.offset).
+        # Contiguous: dof_rel = layout.slice.start + joint_id.
+        # Non-contiguous: dof_rel = layout.indices[joint_id] (gather).
+        dof_rels = wp.empty((num_joints,), dtype=wp.int32, device=self.device)
+        if layout.is_contiguous:
+            wp.launch(
+                articulation_kernels.offset_indices,
+                dim=num_joints,
+                inputs=[resolved, layout.slice.start],
+                outputs=[dof_rels],
+                device=self.device,
+            )
+        else:
+            wp.launch(
+                articulation_kernels.gather_indices,
+                dim=num_joints,
+                inputs=[resolved, layout.indices],
+                outputs=[dof_rels],
+                device=self.device,
+            )
+
+        # Build a Warp array of damping values (one per actuator joint, same for all instances).
+        if isinstance(damping, (int, float)):
+            damping_wp = wp.full((num_joints,), float(damping), dtype=wp.float32, device=self.device)
+        elif isinstance(damping, wp.array):
+            damping_wp = wp.from_torch(wp.to_torch(damping)[0].contiguous(), dtype=wp.float32)
+        else:
+            damping_wp = wp.from_torch(damping[0].contiguous(), dtype=wp.float32)
+
+        # Write damping to all instances via a Warp kernel.
+        # dof_passive_damping is per-instance: flat index = layout.offset + w * stride + dof_rel.
+        stride = layout.stride_between_worlds
+        num_worlds = self.num_instances if stride > 0 else 1
+        wp.launch(
+            articulation_kernels.write_passive_damping,
+            dim=(num_worlds, num_joints),
+            inputs=[dof_rels, damping_wp, layout.offset, stride],
+            outputs=[dof_passive_damping],
+            device=self.device,
+        )
 
     def _process_tendons(self):
         """Process fixed and spatial tendons."""

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/kernels.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/kernels.py
@@ -557,3 +557,62 @@ def concat_joint_pos_limits_lower_and_upper(
     """
     i, j = wp.tid()
     joint_pos_limits[i, j] = wp.vec2f(joint_pos_limits_lower[i, j], joint_pos_limits_upper[i, j])
+
+
+@wp.kernel
+def offset_indices(
+    indices: wp.array(dtype=wp.int32),
+    offset: int,
+    result: wp.array(dtype=wp.int32),
+):
+    """Add a scalar offset to each element of an index array.
+
+    Args:
+        indices: Input index array.
+        offset: Scalar value to add to each element.
+        result: Output array of offset indices.
+    """
+    i = wp.tid()
+    result[i] = indices[i] + offset
+
+
+@wp.kernel
+def gather_indices(
+    indices: wp.array(dtype=wp.int32),
+    source: wp.array(dtype=wp.int32),
+    result: wp.array(dtype=wp.int32),
+):
+    """Gather values from source using indices as a lookup.
+
+    Args:
+        indices: Array of lookup positions into source.
+        source: Array to gather from.
+        result: Output array where result[i] = source[indices[i]].
+    """
+    i = wp.tid()
+    result[i] = source[indices[i]]
+
+
+@wp.kernel
+def write_passive_damping(
+    dof_rels: wp.array(dtype=wp.int32),
+    damping_values: wp.array(dtype=wp.float32),
+    layout_offset: int,
+    stride_between_worlds: int,
+    dof_passive_damping: wp.array(dtype=wp.float32),
+):
+    """Write per-joint passive damping to all instances in the flat dof_passive_damping array.
+
+    Launched with dim=(num_instances, num_actuator_joints).
+
+    Args:
+        dof_rels: Relative DOF index for each actuator joint (relative to layout_offset).
+            Shape is (num_actuator_joints,).
+        damping_values: Damping value for each actuator joint. Shape is (num_actuator_joints,).
+        layout_offset: Flat-array offset for instance 0's first DOF in this view.
+        stride_between_worlds: Flat-array stride between consecutive instances.
+        dof_passive_damping: Output flat array of passive DOF damping values for the Newton model.
+    """
+    world, pos = wp.tid()
+    dof_global = layout_offset + world * stride_between_worlds + dof_rels[pos]
+    dof_passive_damping[dof_global] = damping_values[pos]


### PR DESCRIPTION
# Description

Mujoco has a concept of passive damping for implicit actuators. In Newton's MuJoCo implicitfast integrator, with no damping, joint velocities grow without bound under constant effort, causing Ants to fly away.

In PhysX, `solver_velocity_iteration_count=0` means PhysX skips velocity correction passes and prevents the centripetal runaway. Newton (MuJoCo) computes full nonlinear dynamics including Coriolis terms correctly.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
