### PR TITLE
Adds convergence checking to benchmark scripts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@ Guidelines for modifications:
 * Jan Kerner
 * Jean Tampon
 * Jeonghwan Kim
+* Jessica Martinez
 * Ji Yuan Feng
 * Jia Lin Yuan
 * Jiakai Zhang

--- a/scripts/benchmarks/benchmark_rlgames.py
+++ b/scripts/benchmarks/benchmark_rlgames.py
@@ -43,6 +43,15 @@ parser.add_argument(
     help="Benchmarking backend options, defaults omniperf",
 )
 parser.add_argument("--output_path", type=str, default=".", help="Path to output benchmark results.")
+parser.add_argument(
+    "--reward_threshold", type=float, default=None, help="Reward threshold for convergence (overrides config)."
+)
+parser.add_argument(
+    "--check_convergence", action="store_true", help="Check reward convergence using thresholds from configs.yaml."
+)
+parser.add_argument(
+    "--convergence_config", type=str, default="full", help="Config mode for convergence thresholds (default: full)."
+)
 
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
@@ -87,6 +96,7 @@ from scripts.benchmarks.utils import (
     get_backend_type,
     get_preset_string,
     log_app_start_time,
+    log_convergence,
     log_python_imports_time,
     log_rl_policy_episode_lengths,
     log_rl_policy_rewards,
@@ -264,6 +274,15 @@ def main(
         log_runtime_step_times(benchmark, rl_training_times, compute_stats=True)
         log_rl_policy_rewards(benchmark, log_data["rewards/iter"])
         log_rl_policy_episode_lengths(benchmark, log_data["episode_lengths/iter"])
+        log_convergence(
+            benchmark,
+            log_data["rewards/iter"],
+            args_cli.task,
+            workflow="rl_games",
+            should_check_convergence=args_cli.check_convergence,
+            reward_threshold=args_cli.reward_threshold,
+            convergence_config=args_cli.convergence_config,
+        )
 
         benchmark._finalize_impl()
 

--- a/scripts/benchmarks/benchmark_rsl_rl.py
+++ b/scripts/benchmarks/benchmark_rsl_rl.py
@@ -46,6 +46,15 @@ parser.add_argument(
     help="Benchmarking backend options, defaults omniperf",
 )
 parser.add_argument("--output_path", type=str, default=".", help="Path to output benchmark results.")
+parser.add_argument(
+    "--reward_threshold", type=float, default=None, help="Reward threshold for convergence (overrides config)."
+)
+parser.add_argument(
+    "--check_convergence", action="store_true", help="Check reward convergence using thresholds from configs.yaml."
+)
+parser.add_argument(
+    "--convergence_config", type=str, default="full", help="Config mode for convergence thresholds (default: full)."
+)
 
 # append RSL-RL cli arguments
 cli_args.add_rsl_rl_args(parser)
@@ -89,6 +98,7 @@ from scripts.benchmarks.utils import (
     get_backend_type,
     get_preset_string,
     log_app_start_time,
+    log_convergence,
     log_python_imports_time,
     log_rl_policy_episode_lengths,
     log_rl_policy_rewards,
@@ -258,6 +268,16 @@ def main(
         log_runtime_step_times(benchmark, rl_training_times, compute_stats=True)
         log_rl_policy_rewards(benchmark, log_data["Train/mean_reward"])
         log_rl_policy_episode_lengths(benchmark, log_data["Train/mean_episode_length"])
+
+        log_convergence(
+            benchmark,
+            log_data["Train/mean_reward"],
+            args_cli.task,
+            workflow="rsl_rl",
+            should_check_convergence=args_cli.check_convergence,
+            reward_threshold=args_cli.reward_threshold,
+            convergence_config=args_cli.convergence_config,
+        )
 
         benchmark._finalize_impl()
 

--- a/scripts/benchmarks/utils.py
+++ b/scripts/benchmarks/utils.py
@@ -6,10 +6,18 @@
 
 import glob
 import os
+import statistics
+import sys
 
 from tensorboard.backend.event_processing import event_accumulator
 
 from isaaclab.test.benchmark import BaseIsaacLabBenchmark, DictMeasurement, ListMeasurement, SingleMeasurement
+
+# Path to configs.yaml and the config loader.
+_BENCHMARKING_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "source", "isaaclab_tasks", "test", "benchmarking"
+)
+_CONFIGS_YAML = os.path.join(_BENCHMARKING_DIR, "configs.yaml")
 
 
 def get_backend_type(cli_backend: str) -> str:
@@ -140,3 +148,90 @@ def log_rl_policy_episode_lengths(benchmark: BaseIsaacLabBenchmark, value: list)
     # log max episode length
     measurement = SingleMeasurement(name="Max Episode Lengths", value=max(value), unit="float")
     benchmark.add_measurement("train", measurement=measurement)
+
+
+def check_convergence(
+    rewards: list[float],
+    threshold: float,
+    window_pct: float = 0.2,
+    cv_threshold: float = 20.0,
+) -> dict:
+    """Check whether training rewards have converged.
+
+    Passes when the trailing window mean exceeds *threshold* and the
+    coefficient of variation (CV) is below *cv_threshold*.
+
+    Args:
+        rewards: Per-iteration mean reward values.
+        threshold: Minimum reward to pass.
+        window_pct: Fraction of iterations for the trailing window.
+        cv_threshold: Maximum CV (%) for stable convergence.
+
+    Returns:
+        Dict with ``tail_mean``, ``cv``, and ``passed``.
+    """
+    if not rewards:
+        return {"tail_mean": 0.0, "cv": 999.9, "passed": False}
+    window = max(1, int(len(rewards) * window_pct))
+    tail = rewards[-window:]
+    tail_mean = statistics.mean(tail)
+    tail_std = statistics.stdev(tail) if len(tail) > 1 else 0.0
+    cv = (tail_std / abs(tail_mean) * 100) if tail_mean != 0 else 999.9
+    passed = tail_mean >= threshold and cv <= cv_threshold
+    return {"tail_mean": round(tail_mean, 2), "cv": round(cv, 1), "passed": passed}
+
+
+def log_convergence(
+    benchmark: BaseIsaacLabBenchmark,
+    rewards: list[float],
+    task: str,
+    workflow: str = "",
+    should_check_convergence: bool = False,
+    reward_threshold: float | None = None,
+    convergence_config: str = "full",
+):
+    """Check reward convergence and log results to the benchmark backend.
+
+    No-op unless *check_convergence* is True. When enabled, the threshold
+    is loaded from ``configs.yaml``. *reward_threshold* overrides the config.
+
+    Args:
+        benchmark: Benchmark instance to log measurements to.
+        rewards: Per-iteration mean reward values.
+        task: Task name for config lookup.
+        workflow: RL workflow name (``rsl_rl``, ``rl_games``, etc.).
+        should_check_convergence: Whether ``--check_convergence`` was passed.
+        reward_threshold: Explicit threshold override.
+        convergence_config: Config section for threshold lookup (default: ``full``).
+    """
+    if not should_check_convergence:
+        return
+
+    threshold = reward_threshold
+    if threshold is None and os.path.exists(_CONFIGS_YAML):
+        if _BENCHMARKING_DIR not in sys.path:
+            sys.path.insert(0, _BENCHMARKING_DIR)
+        try:
+            from env_benchmark_test_utils import get_env_config, get_env_configs
+
+            entry = get_env_config(get_env_configs(_CONFIGS_YAML), convergence_config, workflow, task)
+        except (ImportError, ValueError):
+            entry = None
+        if entry:
+            threshold = entry.get("lower_thresholds", {}).get("reward")
+
+    if threshold is None:
+        print(
+            f"[WARNING] No reward threshold found for '{task}'"
+            f" in configs.yaml [{convergence_config}]. Skipping convergence check."
+        )
+        return
+
+    result = check_convergence(rewards, threshold)
+    benchmark.add_measurement(
+        "train", SingleMeasurement(name="Mean Reward (Converged)", value=result["tail_mean"], unit="float")
+    )
+    benchmark.add_measurement("train", SingleMeasurement(name="Reward CV %", value=result["cv"], unit="%"))
+    benchmark.add_measurement(
+        "train", SingleMeasurement(name="Convergence Passed", value=int(result["passed"]), unit="bool")
+    )

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.5.17"
+version = "4.5.18"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+4.5.18 (2026-03-11)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added reward convergence checking to benchmark scripts. New ``--check_convergence``
+  flag loads thresholds from ``configs.yaml`` automatically. Also accepts
+  ``--reward_threshold`` for manual override and ``--convergence_config`` to select
+  config section (default: ``full``). Adds ``check_convergence()`` and
+  ``log_convergence()`` to benchmark utils.
+
+
 4.5.17 (2026-03-11)
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Description

This adds reward convergence checking to the benchmark script. Computes trailing window mean reward and coefficient of variation (CV) over the last 20% of iterations. Training passes when mean >= threshold and CV <= 20%.

Hooked into both benchmark_rsl_rl.py and benchmark_rlgames.py via a new `--check_convergence` arg. When provided, three new measurements are added to the benchmark json output for the Grafana dashboard to ingest:
  - `Mean Reward (Converged)` - trailing window mean
  - `Reward CV %` - stability metric
  - `Convergence Passed` - 1 if converged, 0 if not

Thresholds are loaded from configs.yaml using the `full` config by default, but can be overridden via the `--convergence_config` arg. The reward threshold can be overridden by the `--reward_threshold` arg.

## Usage
```
python scripts/benchmarks/benchmark_rlgames.py \
  --task Isaac-Repose-Cube-Shadow-Vision-Direct-v0 \
  --max_iterations 3000 --headless \
  --benchmark_backend summary \
  --check_convergence \
  --reward_threshold 1000 \
  presets=physx
```

## Example output (Shadow Hand Vision, physx, 3000 iters)
```
{"name": "Mean Reward (Converged)", "value": 2806.34, "unit": "float"},
{"name": "Reward CV %", "value": 4.2, "unit": "%"},
{"name": "Convergence Passed", "value": 1, "unit": "bool"}
```

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation _(N/A - utility function in scripts/benchmarks, not a framework API change)_
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works _(manually tested)_
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
