### PR TITLE
Adds extended version tracking to benchmark output

### DIFF
--- a/source/isaaclab/isaaclab/test/benchmark/recorders/record_version_info.py
+++ b/source/isaaclab/isaaclab/test/benchmark/recorders/record_version_info.py
@@ -41,10 +41,11 @@ class VersionInfoRecorder(MeasurementDataRecorder):
         """Get version via importlib.metadata (pip package name, no module import)."""
         try:
             return importlib.metadata.version(pip_name)
-        except importlib.metadata.PackageNotFoundError:
+        except Exception:
             return None
 
     def _record(self, key: str, version: str | None) -> None:
+        """Store a version entry only if version is non-empty."""
         if version:
             self._version_info[key] = version
 


### PR DESCRIPTION
Add extended version tracking to benchmark output

# Description

Track additional package versions in benchmark JSON output to improve reproducibility and regression debugging. Adds isaaclab sub-packages (isaaclab_newton, isaaclab_physx, isaaclab_ov, isaaclab_tasks, isaaclab_rl), renderers/physics engines (ovrtx, newton, mujoco, mujoco-warp), RL frameworks (rl_games, rsl-rl, stable_baselines3, skrl), and key dependencies (gymnasium, cuda-bindings, usd-core). Uses importlib.metadata for safe version lookup without triggering module initialization side effects.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

- [x] I have done this task