### PR TITLE
Improves AGENTS.md review workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ Proper workflow:
 - Don't commit first and then run pre-commit (requires amending commits)
 - Do run pre-commit before committing (clean workflow)
 
+**When reviewing code** (e.g. via a code-reviewer agent), always run `./isaaclab.sh -f` as part of the review to catch formatting or lint issues early.
+
 ## Changelog
 
 - **Update `CHANGELOG.rst` for every change** targeting the source directory. Each extension has its own changelog at `source/<package>/docs/CHANGELOG.rst` (e.g. `source/isaaclab/docs/CHANGELOG.rst`, `source/isaaclab_physx/docs/CHANGELOG.rst`).


### PR DESCRIPTION
# Description

When calling things like:

```
/requesting-code-review against develop
```

The agent will now run the pre-commits check everytime.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there