### PR TITLE
Save final checkpoint after skrl training completes

### DIFF
--- a/scripts/reinforcement_learning/skrl/train.py
+++ b/scripts/reinforcement_learning/skrl/train.py
@@ -211,6 +211,13 @@ def main():
         try:
             runner.run()
             print(f"Training time: {round(time.time() - start_time, 2)} seconds")
+
+            # skrl only saves checkpoints at checkpoint_interval multiples during training,
+            # so save a final checkpoint to ensure at least one always exists
+            total_timesteps = agent_cfg["trainer"]["timesteps"]
+            os.makedirs(os.path.join(log_dir, "checkpoints"), exist_ok=True)
+            runner.agent.write_checkpoint(timestep=total_timesteps, timesteps=total_timesteps)
+            print(f"[INFO] Saved final agent checkpoint to: {log_dir}/checkpoints")
             # close the simulator
             env.close()
         except KeyboardInterrupt:


### PR DESCRIPTION
# Description

skrl only writes checkpoints at `checkpoint_interval` multiples during training (in `Agent.post_interaction`). When using short training runs (e.g. `--max_iterations 5` with `rollouts=32` gives 160 timesteps vs `checkpoint_interval=3200`), no checkpoint file is ever saved. This causes SQA validation to fail because no `.pt` files are found in the `checkpoints/` directory.

This PR adds an explicit `write_checkpoint` call after `runner.run()` completes to ensure at least one checkpoint always exists. This is consistent with how the sb3 training script already saves a final model after training.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there