### PR TITLE
Fixes the height of the Isaac-PickPlace-FixedBaseUpperBodyIK-G1-Abs-v…

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/fixed_base_upper_body_ik_g1_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/fixed_base_upper_body_ik_g1_env_cfg.py
@@ -388,7 +388,7 @@ class FixedBaseUpperBodyIKG1EnvCfg(ManagerBasedRLEnvCfg):
 
         # IsaacTeleop-based teleoperation pipeline (resolved lazily at runtime).
         self.xr = XrCfg(
-            anchor_pos=(0.0, 0.0, -0.45),
+            anchor_pos=(0.0, 0.0, -0.30),
             anchor_rot=(0.0, 0.0, 0.0, 1.0),
         )
 


### PR DESCRIPTION
# Description

The starting height of the XR anchor was too high causing discomfort in the teleoperator experience. This change lowers the height to a more reasonable level.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
