### PR TITLE
Fixes incorrect device being used when reordering arrays in RigidObjectCollection

### DIFF
--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.8"
+version = "0.5.9"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+0.5.9 (2026-03-11)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed device mismatch in
+  :class:`~isaaclab_physx.assets.RigidObjectCollectionData` where
+  ``_reshape_view_to_data_2d`` and ``_reshape_view_to_data_3d`` created
+  strided pointer views with the target GPU device instead of the source
+  array's device. PhysX returns masses, COMs, and inertias on CPU, so the
+  strided view incorrectly claimed a CPU pointer lived on GPU. This caused
+  ``CUDA error 1: invalid argument`` during ``wp.clone`` on GPUs without
+  HMM (Heterogeneous Memory Management).
+
+
 0.5.8 (2026-03-10)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -632,16 +632,17 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
         # The view returns data ordered as (body0_env0, body0_env1, ..., body1_env0, body1_env1, ...)
         # i.e. shape (num_bodies, num_instances) when reshaped.
         # We need (num_instances, num_bodies) so we create a strided view with transposed strides.
+        # Use data.device for the strided view (PhysX returns masses/coms/inertias on CPU),
+        # then clone to self.device (handles both contiguity and device transfer).
         element_size = wp.types.type_size_in_bytes(data.dtype)
         strided_view = wp.array(
             ptr=data.ptr,
             shape=(self.num_instances, self.num_bodies),
             dtype=data.dtype,
             strides=(element_size, self.num_instances * element_size),
-            device=self.device,
+            device=data.device,
         )
-        # Clone to make contiguous
-        return wp.clone(strided_view)
+        return wp.clone(strided_view, self.device)
 
     def _reshape_view_to_data_3d(self, data: wp.array, data_dim: int) -> wp.array:
         """Reshapes and arranges 2D view data to (num_instances, num_bodies, data_dim).
@@ -655,6 +656,8 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
         """
         # The view returns data ordered as (body0_env0, body0_env1, ..., body1_env0, body1_env1, ...)
         # We need (num_instances, num_bodies, data_dim), so stride through the flat float32 data.
+        # Use data.device for the strided view (PhysX returns masses/coms/inertias on CPU),
+        # then clone to self.device (handles both contiguity and device transfer).
         element_size = wp.types.type_size_in_bytes(wp.float32)
         row_size = element_size * data_dim
         strided_view = wp.array(
@@ -662,9 +665,9 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
             shape=(self.num_instances, self.num_bodies, data_dim),
             dtype=wp.float32,
             strides=(row_size, self.num_instances * row_size, element_size),
-            device=self.device,
+            device=data.device,
         )
-        return wp.clone(strided_view)
+        return wp.clone(strided_view, self.device)
 
     def _get_pos_from_transform(self, transform: wp.array) -> wp.array:
         """Generates a position array from a transform array."""


### PR DESCRIPTION
# Description

_reshape_view_to_data_2d/_3d created strided views with device=self.device (GPU) on pointers from CPU arrays.

This could not be reproduced locally because our GPUs allowed for this using heterogeneous memory management, but the CI machine did no allow for this.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there