### PR TITLE
Fixes benchmarking long tear down time.

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.5.16"
+version = "4.5.17"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,21 @@
 Changelog
 ---------
 
+4.5.17 (2026-03-11)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed simulation hanging on exit by removing the prim-by-prim
+  ``clear_stage()`` call from :meth:`~isaaclab.sim.SimulationContext.clear_instance`.
+  The subsequent :func:`~isaaclab.sim.utils.close_stage` and app shutdown already
+  tear down the entire stage, making the per-prim deletion redundant and slow.
+* Fixed ``close_stage()`` ordering so that Kit's USD context is closed before
+  the stage cache is cleared, preventing the ``Removal of UsdStage from cache
+  failed`` error.
+
+
 4.5.16 (2026-03-10)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -704,9 +704,6 @@ class SimulationContext:
             # This must happen before clearing USD prims to avoid PhysX cleanup errors
             cls._instance.physics_manager.close()
 
-            # Now safe to clear stage contents (PhysX is detached)
-            cls.clear_stage()
-
             # Close all visualizers
             for viz in cls._instance._visualizers:
                 viz.close()
@@ -717,7 +714,8 @@ class SimulationContext:
                     close_provider()
                 cls._instance._scene_data_provider = None
 
-            # Close the stage (clears cache, thread-local context, and Kit USD context)
+            # Tear down the stage. We skip clear_stage() (prim-by-prim deletion) since
+            # close_stage() + app shutdown destroy the entire stage at once.
             stage_utils.close_stage()
 
             # Clear instance

--- a/source/isaaclab/isaaclab/sim/utils/stage.py
+++ b/source/isaaclab/isaaclab/sim/utils/stage.py
@@ -369,10 +369,11 @@ def save_stage(usd_path: str, save_and_reload_in_place: bool = True) -> bool:
 
 
 def close_stage() -> bool:
-    """Closes the current USD stage by clearing the stage cache.
+    """Closes the current USD stage.
 
-    If Kit is running, this also closes the stage attached to the Kit USD context
-    (``omni.usd.get_context().close_stage()``).
+    If Kit is running, this first closes the stage via the Kit USD context
+    (``omni.usd.get_context().close_stage()``), then clears the stage cache.
+    Without Kit, only the stage cache is cleared.
 
     .. note::
 
@@ -388,14 +389,17 @@ def close_stage() -> bool:
         >>> sim_utils.close_stage()
         True
     """
-    stage_cache = UsdUtils.StageCache.Get()
-    stage_cache.Clear()
-    _context.stage = None
-
+    # Close Kit's USD context first (while the stage is still in the cache),
+    # then clear the cache. Reversing this order causes Kit to fail with
+    # "Removal of UsdStage from cache failed" and can hang during teardown.
     if has_kit():
         import omni.usd
 
         omni.usd.get_context().close_stage()
+
+    stage_cache = UsdUtils.StageCache.Get()
+    stage_cache.Clear()
+    _context.stage = None
 
     return True
 


### PR DESCRIPTION
# Description

Running the benchmarks, I noticed the `SimulationContext` tear-down time was long or even hanging indefinitely. 

This PR skips clear_stage() when calling clear_instance(). The idea is that we likely don't need to clear the stage when we clear the instance, we already call close stage + app shutdown?  Hopefully this also helps with the CI times that are getting out of hand....

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there