### PR TITLE
Fixes keyboard and spacemouse teleop options for the galbot rel tasks

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -228,16 +228,6 @@ pipeline, what input mode it expects, and how the operator interacts with the ro
      - Right
      - **Arm:** right controller grip pose drives end-effector.
        **Gripper:** right trigger.
-   * - ``Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-RmpFlow-v0``
-     - Hand tracking
-     - Left
-     - **Arm:** left hand wrist position drives end-effector.
-       **Gripper:** thumb-index pinch distance.
-   * - ``Isaac-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow-v0``
-     - Hand tracking
-     - Right
-     - **Arm:** right hand wrist position drives end-effector.
-       **Gripper:** thumb-index pinch distance.
    * - ``Isaac-PickPlace-GR1T2-Abs-v0``
      - Hand tracking
      - Both
@@ -547,11 +537,24 @@ uses ``create_isaac_teleop_device()`` -- no ``--teleop_device`` flag is needed:
        --visualizer kit \
        --xr
 
+Some environments use the legacy ``teleop_devices`` configuration instead of ``isaac_teleop``
+(e.g. the Galbot RmpFlow relative-mode tasks). For these, pass ``--teleop_device`` to select
+the input device:
+
+.. code-block:: bash
+
+   ./isaaclab.sh -p scripts/tools/record_demos.py \
+       --task Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-RmpFlow-v0 \
+       --visualizer kit \
+       --teleop_device keyboard
+
 The workflow is:
 
-#. Configure your environment with ``IsaacTeleopCfg`` (see :ref:`isaac-teleop-env-config`).
+#. Configure your environment with ``IsaacTeleopCfg`` (see :ref:`isaac-teleop-env-config`)
+   or ``teleop_devices`` for legacy devices (keyboard, spacemouse).
 #. Run ``record_demos.py`` with the task name.
-#. Start AR, connect your XR device, and teleoperate.
+#. For XR tasks: start AR, connect your XR device, and teleoperate.
+   For legacy tasks: use the configured input device directly.
 #. Demonstrations are recorded to HDF5 files.
 #. Use the recorded data with Isaac Lab Mimic or other imitation learning frameworks.
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_rmp_rel_env_cfg.py
@@ -58,20 +58,22 @@ class RmpFlowGalbotLeftArmCubeStackEnvCfg(stack_joint_pos_env_cfg.GalbotLeftArmC
             use_relative_mode=self.use_relative_mode,
         )
 
-        # RmpFlow rel envs use legacy teleop (keyboard/spacemouse) instead of XR
-        self.isaac_teleop = None
-        self.teleop_devices = DevicesCfg(
-            devices={
-                "keyboard": Se3KeyboardCfg(
-                    pos_sensitivity=0.05,
-                    rot_sensitivity=0.05,
-                ),
-                "spacemouse": Se3SpaceMouseCfg(
-                    pos_sensitivity=0.05,
-                    rot_sensitivity=0.05,
-                ),
-            }
-        )
+        # Relative mode uses legacy teleop (keyboard/spacemouse) instead of XR;
+        # absolute mode keeps the inherited XR isaac_teleop pipeline.
+        if self.use_relative_mode:
+            self.isaac_teleop = None
+            self.teleop_devices = DevicesCfg(
+                devices={
+                    "keyboard": Se3KeyboardCfg(
+                        pos_sensitivity=0.05,
+                        rot_sensitivity=0.05,
+                    ),
+                    "spacemouse": Se3SpaceMouseCfg(
+                        pos_sensitivity=0.05,
+                        rot_sensitivity=0.05,
+                    ),
+                }
+            )
 
         # Set the simulation parameters
         self.sim.dt = 1 / 60
@@ -106,20 +108,22 @@ class RmpFlowGalbotRightArmCubeStackEnvCfg(stack_joint_pos_env_cfg.GalbotRightAr
             use_relative_mode=self.use_relative_mode,
         )
 
-        # RmpFlow rel envs use legacy teleop (keyboard/spacemouse) instead of XR
-        self.isaac_teleop = None
-        self.teleop_devices = DevicesCfg(
-            devices={
-                "keyboard": Se3KeyboardCfg(
-                    pos_sensitivity=0.05,
-                    rot_sensitivity=0.05,
-                ),
-                "spacemouse": Se3SpaceMouseCfg(
-                    pos_sensitivity=0.05,
-                    rot_sensitivity=0.05,
-                ),
-            }
-        )
+        # Relative mode uses legacy teleop (keyboard/spacemouse) instead of XR;
+        # absolute mode keeps the inherited XR isaac_teleop pipeline.
+        if self.use_relative_mode:
+            self.isaac_teleop = None
+            self.teleop_devices = DevicesCfg(
+                devices={
+                    "keyboard": Se3KeyboardCfg(
+                        pos_sensitivity=0.05,
+                        rot_sensitivity=0.05,
+                    ),
+                    "spacemouse": Se3SpaceMouseCfg(
+                        pos_sensitivity=0.05,
+                        rot_sensitivity=0.05,
+                    ),
+                }
+            )
 
         # Set the simulation parameters
         self.sim.dt = 1 / 120

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_rmp_rel_env_cfg.py
@@ -9,6 +9,9 @@ import os
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
+from isaaclab.devices.device_base import DevicesCfg
+from isaaclab.devices.keyboard import Se3KeyboardCfg
+from isaaclab.devices.spacemouse import Se3SpaceMouseCfg
 from isaaclab.envs.mdp.actions.rmpflow_actions_cfg import RMPFlowActionCfg
 from isaaclab.sensors import CameraCfg, FrameTransformerCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
@@ -55,6 +58,21 @@ class RmpFlowGalbotLeftArmCubeStackEnvCfg(stack_joint_pos_env_cfg.GalbotLeftArmC
             use_relative_mode=self.use_relative_mode,
         )
 
+        # RmpFlow rel envs use legacy teleop (keyboard/spacemouse) instead of XR
+        self.isaac_teleop = None
+        self.teleop_devices = DevicesCfg(
+            devices={
+                "keyboard": Se3KeyboardCfg(
+                    pos_sensitivity=0.05,
+                    rot_sensitivity=0.05,
+                ),
+                "spacemouse": Se3SpaceMouseCfg(
+                    pos_sensitivity=0.05,
+                    rot_sensitivity=0.05,
+                ),
+            }
+        )
+
         # Set the simulation parameters
         self.sim.dt = 1 / 60
         self.sim.render_interval = 6
@@ -87,6 +105,22 @@ class RmpFlowGalbotRightArmCubeStackEnvCfg(stack_joint_pos_env_cfg.GalbotRightAr
             body_offset=RMPFlowActionCfg.OffsetCfg(pos=[0.0, 0.0, 0.0]),
             use_relative_mode=self.use_relative_mode,
         )
+
+        # RmpFlow rel envs use legacy teleop (keyboard/spacemouse) instead of XR
+        self.isaac_teleop = None
+        self.teleop_devices = DevicesCfg(
+            devices={
+                "keyboard": Se3KeyboardCfg(
+                    pos_sensitivity=0.05,
+                    rot_sensitivity=0.05,
+                ),
+                "spacemouse": Se3SpaceMouseCfg(
+                    pos_sensitivity=0.05,
+                    rot_sensitivity=0.05,
+                ),
+            }
+        )
+
         # Set the simulation parameters
         self.sim.dt = 1 / 120
         self.sim.render_interval = 6


### PR DESCRIPTION
# Description

The Galbot RmpFlow (relative mode) env configs inherit isaac_teleop from the base joint-pos configs, which sets up an absolute-pose XR pipeline producing 8D actions. This mismatches the RMPFlowAction in relative mode, which expects 7D (6D delta + 1D gripper), causing a ValueError: Invalid action shape, expected: 7, received: 8 at runtime.
This PR clears the inherited isaac_teleop and adds teleop_devices with keyboard and spacemouse configs to both RmpFlowGalbotLeftArmCubeStackEnvCfg and RmpFlowGalbotRightArmCubeStackEnvCfg, restoring the legacy teleop support that was present in release/2.3.0.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there