### PR TITLE
Fix Newton renderer scene data provider initialization

### DIFF
--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.6"
+version = "0.5.7"
 
 # Description
 title = "Newton simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_newton/docs/CHANGELOG.rst
+++ b/source/isaaclab_newton/docs/CHANGELOG.rst
@@ -2,6 +2,20 @@ Changelog
 ---------
 
 
+0.5.7 (2026-03-10)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_newton.renderers.NewtonWarpRenderer` failing with
+  ``RuntimeError: NewtonWarpRenderer requires a Newton model`` when the
+  renderer was instantiated after the scene data provider.  The renderer now
+  proactively updates the global :class:`~isaaclab.sim.SimulationContext`
+  scene-data requirements before querying the provider, ensuring the Newton
+  model is built.
+
+
 0.5.6 (2026-03-10)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -146,6 +146,18 @@ class NewtonWarpRenderer(BaseRenderer):
     RenderData = RenderData
 
     def __init__(self, cfg: NewtonWarpRendererCfg):
+        from isaaclab.physics.scene_data_requirements import (
+            aggregate_requirements,
+            requirement_for_renderer_type,
+        )
+
+        sim = SimulationContext.instance()
+        current_req = sim.get_scene_data_requirements()
+        renderer_req = requirement_for_renderer_type("newton_warp")
+        merged = aggregate_requirements([current_req, renderer_req])
+        if merged != current_req:
+            sim.update_scene_data_requirements(merged)
+
         newton_model = self.get_scene_data_provider().get_newton_model()
         if newton_model is None:
             raise RuntimeError(

--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.8"
+version = "0.5.9"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+0.5.9 (2026-03-10)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed native ``malloc(): invalid size`` crash in
+  :class:`~isaaclab_physx.scene_data_providers.PhysxSceneDataProvider` caused
+  by passing articulation root prim paths to PhysX ``create_rigid_body_view``.
+  Prebuilt Newton artifacts now use only rigid body link paths for the view,
+  as articulation root prims are not valid rigid body entries.
+
+
 0.5.8 (2026-03-10)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
+++ b/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
@@ -216,14 +216,6 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
         self._newton_model = model
         self._newton_state = state
         body_paths = list(artifact.rigid_body_paths) or self._model_body_paths(model)
-        # Merge articulation root paths into rigid body paths (deduplicated) so the
-        # RigidBodyView covers all bodies without needing a separate ArticulationView.
-        if artifact.articulation_paths:
-            seen = set(body_paths)
-            for path in artifact.articulation_paths:
-                if path not in seen:
-                    body_paths.append(path)
-                    seen.add(path)
         self._rigid_body_paths = body_paths
         self._xform_views.clear()
         self._view_body_index_map = {}


### PR DESCRIPTION
## Summary

- **NewtonWarpRenderer** now proactively updates the global `SimulationContext` scene-data requirements before querying the scene data provider, fixing `RuntimeError: NewtonWarpRenderer requires a Newton model but the scene data provider returned None`.
- **PhysxSceneDataProvider** no longer merges articulation root prim paths into the rigid body paths list when using prebuilt Newton artifacts. Articulation root prims are not valid rigid body entries and caused a native `malloc(): invalid size (unsorted)` crash in PhysX `create_rigid_body_view`.
