### PR TITLE
Adds prebundle package repointing during installation

### DIFF
--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -5,13 +5,16 @@
 
 import os
 import shutil
+from pathlib import Path
 
 from ..utils import (
     ISAACLAB_ROOT,
+    extract_isaacsim_path,
     extract_python_exe,
     get_pip_command,
     is_arm,
     is_windows,
+    print_debug,
     print_info,
     print_warning,
     run_command,
@@ -321,6 +324,98 @@ def _install_extra_frameworks(framework_name: str = "all") -> None:
     run_command(pip_cmd + ["install", "-e", f"{ISAACLAB_ROOT}/source/isaaclab_mimic{extras}"])
 
 
+_PREBUNDLE_REPOINT_PACKAGES: list[str] = [
+    "torch",
+    "torchvision",
+    "torchaudio",
+    "nvidia",
+    "newton",
+    "newton_actuators",
+    "warp",
+    "mujoco_warp",
+]
+"""Package directory names in Isaac Sim prebundle directories to repoint.
+
+When a local ``_isaac_sim`` symlink exists, its ``setup_conda_env.sh`` injects
+``pip_prebundle`` paths into ``PYTHONPATH``.  These prebundled copies can shadow
+the versions installed in the active conda/uv environment (e.g. ``torch+cu128``
+overriding the ``torch+cu130`` the user installed).
+
+After installation we replace each prebundled copy with a symlink that points
+back to the environment's ``site-packages``, so the *same* version is loaded
+regardless of import path order.
+"""
+
+
+def _repoint_prebundle_packages() -> None:
+    """Replace prebundled packages in Isaac Sim with symlinks to the active environment.
+
+    Scans every ``pip_prebundle`` directory under the Isaac Sim installation
+    for package directories listed in :data:`_PREBUNDLE_REPOINT_PACKAGES`.
+    When the same package exists in the active environment's ``site-packages``,
+    the prebundled copy is moved to ``<name>.bak`` and replaced with a symlink.
+
+    This is idempotent — existing symlinks that already point to the correct
+    target are left untouched.
+    """
+    isaacsim_path = extract_isaacsim_path(required=False)
+    if isaacsim_path is None or not isaacsim_path.exists():
+        print_debug("No Isaac Sim installation found — skipping prebundle repoint.")
+        return
+
+    python_exe = extract_python_exe()
+    result = run_command(
+        [python_exe, "-c", "import site; print(site.getsitepackages()[0])"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print_warning("Could not determine site-packages path — skipping prebundle repoint.")
+        return
+    site_packages = Path(result.stdout.strip())
+    if not site_packages.is_dir():
+        print_warning(f"site-packages directory not found: {site_packages} — skipping prebundle repoint.")
+        return
+
+    prebundle_dirs = list(isaacsim_path.rglob("pip_prebundle"))
+    if not prebundle_dirs:
+        print_debug("No pip_prebundle directories found under Isaac Sim.")
+        return
+
+    repointed = 0
+    for prebundle_dir in prebundle_dirs:
+        for pkg_name in _PREBUNDLE_REPOINT_PACKAGES:
+            prebundled = prebundle_dir / pkg_name
+            venv_pkg = site_packages / pkg_name
+
+            if not venv_pkg.exists():
+                continue
+            if not prebundled.exists() and not prebundled.is_symlink():
+                continue
+
+            if prebundled.is_symlink():
+                if prebundled.resolve() == venv_pkg.resolve():
+                    continue
+                prebundled.unlink()
+            else:
+                backup = prebundle_dir / f"{pkg_name}.bak"
+                if backup.exists():
+                    shutil.rmtree(backup) if backup.is_dir() else backup.unlink()
+                prebundled.rename(backup)
+
+            prebundled.symlink_to(venv_pkg)
+            repointed += 1
+            print_debug(f"Repointed {prebundled} -> {venv_pkg}")
+
+    if repointed:
+        print_info(
+            f"Repointed {repointed} prebundled package(s) in Isaac Sim to the active environment's site-packages."
+        )
+    else:
+        print_debug("All prebundled packages already up-to-date — nothing to repoint.")
+
+
 def command_install(install_type: str = "all") -> None:
     """Install Isaac Lab extensions and optional sub-packages.
 
@@ -486,6 +581,11 @@ def command_install(install_type: str = "all") -> None:
         # In some rare cases, torch might not be installed properly by setup.py, add one more check here.
         # Can prevent that from happening.
         _ensure_cuda_torch()
+
+        # Repoint prebundled packages in Isaac Sim to the environment's copies so
+        # the active venv/conda versions are always loaded regardless of PYTHONPATH
+        # ordering (e.g. torch+cu130 in venv vs torch+cu128 in prebundle on aarch64).
+        _repoint_prebundle_packages()
 
     finally:
         # Restore LD_PRELOAD if we cleared it.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -358,6 +358,8 @@ def _repoint_prebundle_packages() -> None:
     This is idempotent — existing symlinks that already point to the correct
     target are left untouched.
     """
+    use_symlinks = not is_windows()
+
     isaacsim_path = extract_isaacsim_path(required=False)
     if isaacsim_path is None or not isaacsim_path.exists():
         print_debug("No Isaac Sim installation found — skipping prebundle repoint.")
@@ -394,19 +396,25 @@ def _repoint_prebundle_packages() -> None:
             if not prebundled.exists() and not prebundled.is_symlink():
                 continue
 
-            if prebundled.is_symlink():
-                if prebundled.resolve() == venv_pkg.resolve():
-                    continue
-                prebundled.unlink()
-            else:
-                backup = prebundle_dir / f"{pkg_name}.bak"
-                if backup.exists():
-                    shutil.rmtree(backup) if backup.is_dir() else backup.unlink()
-                prebundled.rename(backup)
+            try:
+                if prebundled.is_symlink():
+                    if prebundled.resolve() == venv_pkg.resolve():
+                        continue
+                    prebundled.unlink()
+                else:
+                    backup = prebundle_dir / f"{pkg_name}.bak"
+                    if backup.exists() or backup.is_symlink():
+                        shutil.rmtree(backup) if backup.is_dir() else backup.unlink()
+                    prebundled.rename(backup)
 
-            prebundled.symlink_to(venv_pkg)
-            repointed += 1
-            print_debug(f"Repointed {prebundled} -> {venv_pkg}")
+                if use_symlinks:
+                    prebundled.symlink_to(venv_pkg)
+                else:
+                    shutil.copytree(venv_pkg, prebundled)
+                repointed += 1
+                print_debug(f"Repointed {prebundled} -> {venv_pkg}")
+            except OSError as exc:
+                print_warning(f"Could not repoint {prebundled}: {exc} — skipping.")
 
     if repointed:
         print_info(

--- a/source/isaaclab/isaaclab/cli/utils.py
+++ b/source/isaaclab/isaaclab/cli/utils.py
@@ -209,11 +209,7 @@ def get_pip_command(python_exe: str | None = None) -> list[str]:
         python_exe: Python executable path.  Resolved via
             :func:`extract_python_exe` when ``None``.
     """
-    in_venv = bool(
-        os.environ.get("VIRTUAL_ENV")
-        or os.environ.get("CONDA_PREFIX")
-        or (sys.prefix != sys.base_prefix)
-    )
+    in_venv = bool(os.environ.get("VIRTUAL_ENV") or os.environ.get("CONDA_PREFIX") or (sys.prefix != sys.base_prefix))
     if shutil.which("uv") and in_venv:
         return ["uv", "pip"]
 


### PR DESCRIPTION
# Description
Isaac Sim ships prebundled copies of packages (torch, warp, newton, etc.) inside `pip_prebundle` directories. Whether Isaac Sim is installed via pip or via a local symlink (`_isaac_sim`), these prebundled copies can shadow the versions installed in the active conda/uv environment (e.g. `torch+cu128` overriding the `torch+cu130` the user installed on aarch64), causing version mismatches or native crashes during Kit startup.
This PR adds `_repoint_prebundle_packages()` which runs at the end of `command_install` and replaces prebundled package directories with symlinks pointing to the active environment's `site-packages`. Original copies are preserved as `.bak` for recovery. The operation is idempotent.
## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
## Checklist
- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there