### PR TITLE
Reduces logging verbosity and fixes replicator issue on Spark

### DIFF
--- a/apps/isaaclab.python.headless.kit
+++ b/apps/isaaclab.python.headless.kit
@@ -16,6 +16,8 @@ app.versionFile = "${exe-path}/VERSION"
 app.folder = "${exe-path}/"
 app.name = "IsaacLab"
 app.version = "3.0.0"
+log.level = "Warn" # Suppress third-party debug/info noise
+log.outputStreamLevel = "Warn"
 
 ##################################
 # Omniverse related dependencies #

--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -127,6 +127,8 @@ rtx.hydra.mdlMaterialWarmup = true # start loading the MDL shaders needed before
 omni.replicator.asyncRendering = false # Async rendering must be disabled for SDG
 exts."omni.kit.test".includeTests = ["*isaac*"] # Add isaac tests to test runner
 foundation.verifyOsVersion.enabled = false
+log.level = "Warn" # Suppress third-party debug/info noise
+log.outputStreamLevel = "Warn"
 
 # disable the metrics assembler change listener, we don't want to do any runtime changes
 metricsAssembler.changeListenerEnabled = false

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -32,8 +32,10 @@ from isaaclab.app.settings_manager import get_settings_manager, initialize_carb_
 # import logger
 logger = logging.getLogger(__name__)
 
-# Suppress noisy debug-level websocket frame logs from the Kit LiveSync server
+# Suppress noisy debug-level logs from third-party libraries
 logging.getLogger("websockets").setLevel(logging.WARNING)
+logging.getLogger("matplotlib").setLevel(logging.WARNING)
+logging.getLogger("h5py").setLevel(logging.WARNING)
 
 
 class ExplicitAction(argparse.Action):
@@ -1036,6 +1038,10 @@ class AppLauncher:
         # These have to be loaded after SimulationApp is initialized.
         # Use SettingsManager (backs onto carb when in Omniverse after initialize_carb_settings).
         initialize_carb_settings()
+
+        # After SimulationApp starts, Kit installs its Python log bridge at DEBUG level.
+        # Re-apply root logger level to WARNING to suppress third-party and verbose debug/info noise.
+        logging.getLogger().setLevel(logging.WARNING)
         settings = get_settings_manager()
 
         # set setting to indicate Isaac Lab's offscreen_render pipeline should be enabled

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -540,7 +540,7 @@ class ManagerBasedEnv:
             import omni.replicator.core as rep
 
             rep.set_global_seed(seed)
-        except ModuleNotFoundError:
+        except (ModuleNotFoundError, AttributeError):
             pass
         # set seed for torch and other libraries
         return configure_seed(seed)

--- a/source/isaaclab/isaaclab/utils/logger.py
+++ b/source/isaaclab/isaaclab/utils/logger.py
@@ -58,8 +58,9 @@ def configure_logging(
         The root logger.
     """
     root_logger = logging.getLogger()
-    # the root logger must be the lowest level to ensure that all messages are logged
-    root_logger.setLevel(logging.DEBUG)
+    # set root logger to the configured level to suppress third-party debug/info noise;
+    # isaaclab's own loggers inherit this level unless overridden
+    root_logger.setLevel(logging_level)
 
     # remove existing handlers
     # Note: iterate over a copy [:] to avoid modifying list during iteration

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -40,7 +40,7 @@ INSTALL_REQUIRES = [
     # make sure this is consistent with isaac sim version
     "pillow==12.0.0",
     # required by omni.replicator.core S3 backend
-    "botocore==1.47.66",
+    "botocore",
     # livestream
     "starlette==0.49.1",
     "omniverseclient",

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -39,6 +39,8 @@ INSTALL_REQUIRES = [
     "matplotlib>=3.10.3",  # minimum version for Python 3.12 support
     # make sure this is consistent with isaac sim version
     "pillow==12.0.0",
+    # required by omni.replicator.core S3 backend
+    "botocore==1.47.66",
     # livestream
     "starlette==0.49.1",
     "omniverseclient",


### PR DESCRIPTION
# Description

There was too much logging being printed so we default logging verbosity to warnings.
Also replicator was failing due to missing botocore package on Spark, so adding botocore as a dependency.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
