### PR TITLE
Fixes XR rendering with deprecated --headless flag

### DIFF
--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -50,6 +50,7 @@ folders = [
     "${exe-path}/exts",  # kit extensions
     "${exe-path}/extscore",  # kit core extensions
     "${exe-path}/../exts",  # isaac extensions
+    "${exe-path}/../extsInternal",  # isaac internal extensions
     "${exe-path}/../extsDeprecated",  # deprecated isaac extensions
     "${exe-path}/../extscache",  # isaac cache extensions
     "${exe-path}/../extsPhysics",  # isaac physics extensions

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.5.19"
+version = "4.5.20"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,21 @@
 Changelog
 ---------
 
+4.5.20 (2026-03-12)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed XR rendering not producing output when the deprecated ``--headless``
+  CLI flag was combined with ``--xr``. The ``--headless`` flag unconditionally
+  disabled all visualizers and the active viewport, preventing the XR rendering
+  pipeline from producing frames for the headset. The fix overrides the
+  visualizer-disable in :meth:`~isaaclab.app.AppLauncher._resolve_xr_settings`
+  when XR is active, and keeps the viewport rendering enabled in
+  :meth:`~isaaclab.app.AppLauncher._resolve_viewport_settings` for XR sessions.
+
+
 4.5.19 (2026-03-11)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -827,6 +827,13 @@ class AppLauncher:
         else:
             self._xr = bool(xr_env)
 
+        # XR requires an active rendering pipeline even in headless mode (no desktop
+        # window but rendering to the XR device). Undo the blanket visualizer-disable
+        # that the deprecated --headless flag may have set.
+        if self._xr and self._cli_visualizer_disable_all:
+            logger.info("XR mode requires rendering; overriding visualizer-disable from deprecated '--headless' flag.")
+            self._cli_visualizer_disable_all = False
+
     def _resolve_viewport_settings(self, launcher_args: dict):
         """Resolve viewport related settings."""
         # Check if we can disable the viewport to improve performance
@@ -834,7 +841,7 @@ class AppLauncher:
         #   This is different from offscreen_render because this only affects the default viewport and
         #   not other render-products in the scene
         self._render_viewport = True
-        if self._headless and not self._livestream and not launcher_args.get("video", False):
+        if self._headless and not self._livestream and not launcher_args.get("video", False) and not self._xr:
             self._render_viewport = False
 
         # hide_ui flag

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -830,7 +830,7 @@ class AppLauncher:
         # XR requires an active rendering pipeline even in headless mode (no desktop
         # window but rendering to the XR device). Undo the blanket visualizer-disable
         # that the deprecated --headless flag may have set.
-        if self._xr and self._cli_visualizer_disable_all:
+        if self._xr and self._cli_visualizer_disable_all and not self._cli_visualizer_explicit:
             logger.info("XR mode requires rendering; overriding visualizer-disable from deprecated '--headless' flag.")
             self._cli_visualizer_disable_all = False
 

--- a/source/isaaclab_teleop/isaaclab_teleop/xr_anchor_manager.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/xr_anchor_manager.py
@@ -21,8 +21,9 @@ from .xr_cfg import XrCfg
 # Import XR components with fallback for testing
 XRCore = None
 XRCoreEventType = None
+XRSettings = None
 with contextlib.suppress(ModuleNotFoundError):
-    from omni.kit.xr.core import XRCore, XRCoreEventType
+    from omni.kit.xr.core import XRCore, XRCoreEventType, XRSettings
 
 with contextlib.suppress(ModuleNotFoundError):
     from isaacsim.core.prims import SingleXFormPrim
@@ -88,11 +89,21 @@ class XrAnchorManager:
         except Exception as e:
             logger.warning(f"Failed to create XR anchor prim: {e}")
 
-        # Configure carb settings for XR rendering
+        # Configure XR rendering settings.
+        # The XR core reads raw carb paths while the viewport controller reads
+        # through the XRSettings profile API (``profile/persistent/anchorMode``
+        # etc.).  We must set both so the viewport controller doesn't override
+        # the custom anchor with "active camera" and teleport to /OmniverseKit_Persp.
         if hasattr(carb, "settings"):
             carb.settings.get_settings().set_float("/persistent/xr/render/nearPlane", self._xr_cfg.near_plane)
             carb.settings.get_settings().set_string("/persistent/xr/anchorMode", "custom anchor")
             carb.settings.get_settings().set_string("/xrstage/customAnchor", self._xr_anchor_headset_path)
+
+        if XRSettings is not None:
+            xr_settings = XRSettings.get_singleton()
+            if xr_settings is not None:
+                xr_settings.set_setting("profile/persistent/anchorMode", "custom anchor")
+                xr_settings.set_setting("profile/stage/customAnchor", self._xr_anchor_headset_path)
 
         self._anchor_sync: XrAnchorSynchronizer | None = None
         if self._xr_core is not None:


### PR DESCRIPTION
# Description

When --headless was combined with --xr, the deprecated --headless flag unconditionally disabled all visualizers and the active viewport, preventing XR from producing frames for the headset. The fix makes _resolve_xr_settings override the blanket visualizer-disable when XR is active, and excludes XR sessions from the viewport-disable logic in _resolve_viewport_settings.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
