### PR TITLE
 Fixes viewport camera crash on teardown in generate_data.py

### DIFF
--- a/scripts/imitation_learning/locomanipulation_sdg/generate_data.py
+++ b/scripts/imitation_learning/locomanipulation_sdg/generate_data.py
@@ -1060,6 +1060,8 @@ if __name__ == "__main__":
                 print(f"Run {run_id} failed (demo={demo}), retrying...", flush=True)
 
         env.recorder_manager.close()
+        if env.viewport_camera_controller is not None:
+            env.viewport_camera_controller.update_view_to_world()
         env.close()
 
         simulation_app.close()


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->


Prevents an AttributeError during environment teardown when running the locomanipulation SDG data generation script. The ViewportCameraController keeps a post-update callback that tracks asset_body, and if that callback runs after env.close() invalidates the articulation’s root_view, it crashes when accessing body_names.

This change switches the viewer’s origin to "world" before env.close(), so the callback no longer touches asset properties during teardown. The fix is limited to generate_data.py and does not modify shared framework code.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
