### PR TITLE
Extracts Failing CI Tests in Groups to Fix

### DIFF
--- a/.github/actions/ecr-build-push-pull/action.yml
+++ b/.github/actions/ecr-build-push-pull/action.yml
@@ -191,7 +191,6 @@ runs:
           "${{ inputs.dockerfile-path }}"
           isaaclab.sh
           environment.yml
-          tools
           source/isaaclab/isaaclab/cli
         )
         # Manifest files matched repo-wide via git ls-files.

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -128,8 +128,11 @@ runs:
           fi
 
           if [ -n "$include_files" ]; then
-            docker_env_vars="$docker_env_vars -e TEST_INCLUDE_FILES=$include_files"
-            echo "Setting TEST_INCLUDE_FILES=$include_files"
+            # Strip spaces so the value is safe to embed in an unquoted docker_env_vars string.
+            # conftest.py splits on commas and strips whitespace, so compact form works fine.
+            include_files_compact="${include_files// /}"
+            docker_env_vars="$docker_env_vars -e TEST_INCLUDE_FILES=$include_files_compact"
+            echo "Setting TEST_INCLUDE_FILES=$include_files_compact"
           fi
 
           if [ -n "$filter_pattern" ]; then

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -39,6 +39,14 @@ inputs:
     description: 'Run only tests with known CUDA issues (isolated from general tests)'
     default: 'false'
     required: false
+  flaky-only:
+    description: 'Run only clearly flaky tests (<60% pass rate); these are skipped in normal jobs'
+    default: 'false'
+    required: false
+  slightly-flaky-only:
+    description: 'Run only mildly flaky tests (96%+ pass rate); these are skipped in normal jobs'
+    default: 'false'
+    required: false
   include-files:
     description: 'Comma-separated list of specific test file paths to include (e.g., source/pkg/test/test_a.py,source/pkg/test/test_b.py)'
     default: ''
@@ -62,6 +70,8 @@ runs:
           local curobo_only="$8"
           local cuda_issue_only="$9"
           local include_files="${10}"
+          local flaky_only="${11}"
+          local slightly_flaky_only="${12}"
 
           echo "Running tests in: $test_path"
           if [ -n "$pytest_options" ]; then
@@ -105,6 +115,16 @@ runs:
           if [ "$cuda_issue_only" = "true" ]; then
             docker_env_vars="$docker_env_vars -e TEST_CUDA_ISSUE_ONLY=true"
             echo "Setting TEST_CUDA_ISSUE_ONLY=true"
+          fi
+
+          if [ "$flaky_only" = "true" ]; then
+            docker_env_vars="$docker_env_vars -e TEST_FLAKY_ONLY=true"
+            echo "Setting TEST_FLAKY_ONLY=true"
+          fi
+
+          if [ "$slightly_flaky_only" = "true" ]; then
+            docker_env_vars="$docker_env_vars -e TEST_SLIGHTLY_FLAKY_ONLY=true"
+            echo "Setting TEST_SLIGHTLY_FLAKY_ONLY=true"
           fi
 
           if [ -n "$include_files" ]; then
@@ -193,4 +213,4 @@ runs:
         }
 
         # Call the function with provided parameters
-        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "${{ inputs.pytest-options }}" "${{ inputs.filter-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.cuda-issue-only }}" "${{ inputs.include-files }}"
+        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "${{ inputs.pytest-options }}" "${{ inputs.filter-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.cuda-issue-only }}" "${{ inputs.include-files }}" "${{ inputs.flaky-only }}" "${{ inputs.slightly-flaky-only }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,6 +89,7 @@ jobs:
 
 
   test-isaaclab-tasks:
+    name: IsaacLab Tasks Tests 1/2
     runs-on: [self-hosted, gpu]
     timeout-minutes: 180
     continue-on-error: true
@@ -110,7 +111,7 @@ jobs:
         dockerfile-path: docker/Dockerfile.base
         cache-tag: cache-base
 
-    - name: Run IsaacLab Tasks Tests
+    - name: Run IsaacLab Tasks Tests 1/2
       uses: ./.github/actions/run-tests
       with:
         test-path: "tools"
@@ -156,6 +157,7 @@ jobs:
       run: docker image prune -f --filter "until=24h" || true
 
   test-isaaclab-tasks-2:
+    name: IsaacLab Tasks Tests 2/2
     runs-on: [self-hosted, gpu]
     timeout-minutes: 180
     continue-on-error: true
@@ -177,7 +179,7 @@ jobs:
         dockerfile-path: docker/Dockerfile.base
         cache-tag: cache-base
 
-    - name: Run IsaacLab Tasks Tests 2
+    - name: Run IsaacLab Tasks Tests 2/2
       uses: ./.github/actions/run-tests
       with:
         test-path: "tools"
@@ -224,6 +226,7 @@ jobs:
       run: docker image prune -f --filter "until=24h" || true
 
   test-general:
+    name: General Tests
     runs-on: [self-hosted, gpu]
     timeout-minutes: 180
     needs: build
@@ -284,6 +287,7 @@ jobs:
       run: docker image prune -f --filter "until=24h" || true
 
   test-curobo:
+    name: cuRobo and SkillGen Tests
     runs-on: [self-hosted, gpu]
     timeout-minutes: 120
     continue-on-error: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   build:
-    name: Build base Docker image
+    name: Build Base Docker image
     runs-on: [self-hosted, gpu]
     steps:
     - name: Checkout Code
@@ -349,7 +349,7 @@ jobs:
       run: docker image prune -f --filter "until=24h" || true
 
   test-flaky:
-    name: Flaky Tests
+    name: "⚠️ Very Flaky Tests"
     runs-on: [self-hosted, gpu]
     timeout-minutes: 180
     continue-on-error: true
@@ -410,7 +410,7 @@ jobs:
       run: docker image prune -f --filter "until=24h" || true
 
   test-slightly-flaky:
-    name: Slightly Flaky Tests
+    name: "⚠️ Less Flaky Tests"
     runs-on: [self-hosted, gpu]
     timeout-minutes: 60
     continue-on-error: true
@@ -471,7 +471,7 @@ jobs:
       run: docker image prune -f --filter "until=24h" || true
 
   test-environments-training:
-    name: Environments Training Tests
+    name: "⚠️ test_environments_training.py"
     runs-on: [self-hosted, gpu]
     timeout-minutes: 300
     continue-on-error: true
@@ -535,6 +535,7 @@ jobs:
     needs: [build, build-curobo, test-isaaclab-tasks, test-isaaclab-tasks-2, test-general, test-curobo, test-flaky, test-slightly-flaky, test-environments-training]
     runs-on: ubuntu-latest
     if: always()
+    name: Combine Results
 
     steps:
     - name: Checkout Code

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,7 +119,15 @@ jobs:
         image-tag: ${{ env.DOCKER_IMAGE_TAG }}
         pytest-options: ""
         filter-pattern: "isaaclab_tasks"
-        include-files: "test_multi_agent_environments.py,test_pickplace_stack_environments.py,test_environments.py,test_environments_newton.py,test_factory_environments.py,test_environments_training.py,test_cartpole_showcase_environments.py,test_teleop_environments.py"
+        include-files: >-
+            test_multi_agent_environments.py,
+            test_pickplace_stack_environments.py,
+            test_environments.py,
+            test_environments_newton.py,
+            test_factory_environments.py,
+            test_environments_training.py,
+            test_cartpole_showcase_environments.py,
+            test_teleop_environments.py
 
     - name: Upload IsaacLab Tasks Test Results
       uses: actions/upload-artifact@v4
@@ -180,7 +188,16 @@ jobs:
         image-tag: ${{ env.DOCKER_IMAGE_TAG }}
         pytest-options: ""
         filter-pattern: "isaaclab_tasks"
-        include-files: "test_teleop_environments_with_stage_in_memory.py,test_lift_teddy_bear.py,test_environment_determinism.py,test_hydra.py,test_env_cfg_no_forbidden_imports.py,test_rl_device_separation.py,test_cartpole_showcase_environments_with_stage_in_memory.py,test_environments_with_stage_in_memory.py,test_shadow_hand_vision_presets.py,test_rendering_correctness.py"
+        include-files: >-
+          test_teleop_environments_with_stage_in_memory.py,
+          test_lift_teddy_bear.py,
+          test_environment_determinism.py,
+          test_hydra.py,
+          test_env_cfg_no_forbidden_imports.py,
+          test_rl_device_separation.py,
+          test_cartpole_showcase_environments_with_stage_in_memory.py,
+          test_environments_with_stage_in_memory.py,
+          test_shadow_hand_vision_presets.py
 
     - name: Upload IsaacLab Tasks 2 Test Results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,9 +123,7 @@ jobs:
             test_multi_agent_environments.py,
             test_pickplace_stack_environments.py,
             test_environments.py,
-            test_environments_newton.py,
             test_factory_environments.py,
-            test_environments_training.py,
             test_cartpole_showcase_environments.py,
             test_teleop_environments.py
 
@@ -193,11 +191,9 @@ jobs:
           test_lift_teddy_bear.py,
           test_environment_determinism.py,
           test_hydra.py,
-          test_env_cfg_no_forbidden_imports.py,
           test_rl_device_separation.py,
           test_cartpole_showcase_environments_with_stage_in_memory.py,
-          test_environments_with_stage_in_memory.py,
-          test_shadow_hand_vision_presets.py
+          test_environments_with_stage_in_memory.py
 
     - name: Upload IsaacLab Tasks 2 Test Results
       uses: actions/upload-artifact@v4
@@ -348,8 +344,191 @@ jobs:
       if: always()
       run: docker image prune -f --filter "until=24h" || true
 
+  test-flaky:
+    name: Flaky Tests
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 180
+    continue-on-error: true
+    needs: build
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        lfs: true
+
+    - name: Pull image from ECR
+      uses: ./.github/actions/ecr-build-push-pull
+      with:
+        image-tag: ${{ env.DOCKER_IMAGE_TAG }}
+        isaacsim-base-image: ${{ env.ISAACSIM_BASE_IMAGE }}
+        isaacsim-version: ${{ env.ISAACSIM_BASE_VERSION }}
+        dockerfile-path: docker/Dockerfile.base
+        cache-tag: cache-base
+
+    - name: Run Flaky Tests
+      uses: ./.github/actions/run-tests
+      with:
+        test-path: "tools"
+        result-file: "${{ github.job }}-report.xml"
+        container-name: "isaac-lab-flaky-test-${{ github.run_id }}-${{ github.run_attempt }}"
+        image-tag: ${{ env.DOCKER_IMAGE_TAG }}
+        pytest-options: ""
+        filter-pattern: ""
+        flaky-only: "true"
+
+    - name: Upload Flaky Test Results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: flaky-test-results
+        path: reports/${{ github.job }}-report.xml
+        retention-days: 1
+        compression-level: 9
+
+    - name: Check Test Results for Fork PRs
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      run: |
+        if [ -f "reports/${{ github.job }}-report.xml" ]; then
+          if grep -q 'failures="[1-9]' reports/${{ github.job }}-report.xml || grep -q 'errors="[1-9]' reports/${{ github.job }}-report.xml; then
+            echo "Tests failed for PR from fork. The test report is in the logs. Failing the job."
+            exit 1
+          fi
+        else
+          echo "No test results file found. This might indicate test execution failed."
+          exit 1
+        fi
+
+    # ECR images must be pruned with a lifecycle policy.
+    - name: Clean up stale Docker images
+      if: always()
+      run: docker image prune -f --filter "until=24h" || true
+
+  test-slightly-flaky:
+    name: Slightly Flaky Tests
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 60
+    continue-on-error: true
+    needs: build
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        lfs: true
+
+    - name: Pull image from ECR
+      uses: ./.github/actions/ecr-build-push-pull
+      with:
+        image-tag: ${{ env.DOCKER_IMAGE_TAG }}
+        isaacsim-base-image: ${{ env.ISAACSIM_BASE_IMAGE }}
+        isaacsim-version: ${{ env.ISAACSIM_BASE_VERSION }}
+        dockerfile-path: docker/Dockerfile.base
+        cache-tag: cache-base
+
+    - name: Run Slightly Flaky Tests
+      uses: ./.github/actions/run-tests
+      with:
+        test-path: "tools"
+        result-file: "${{ github.job }}-report.xml"
+        container-name: "isaac-lab-slightly-flaky-test-${{ github.run_id }}-${{ github.run_attempt }}"
+        image-tag: ${{ env.DOCKER_IMAGE_TAG }}
+        pytest-options: ""
+        filter-pattern: ""
+        slightly-flaky-only: "true"
+
+    - name: Upload Slightly Flaky Test Results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: slightly-flaky-test-results
+        path: reports/${{ github.job }}-report.xml
+        retention-days: 1
+        compression-level: 9
+
+    - name: Check Test Results for Fork PRs
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      run: |
+        if [ -f "reports/${{ github.job }}-report.xml" ]; then
+          if grep -q 'failures="[1-9]' reports/${{ github.job }}-report.xml || grep -q 'errors="[1-9]' reports/${{ github.job }}-report.xml; then
+            echo "Tests failed for PR from fork. The test report is in the logs. Failing the job."
+            exit 1
+          fi
+        else
+          echo "No test results file found. This might indicate test execution failed."
+          exit 1
+        fi
+
+    # ECR images must be pruned with a lifecycle policy.
+    - name: Clean up stale Docker images
+      if: always()
+      run: docker image prune -f --filter "until=24h" || true
+
+  test-environments-training:
+    name: Environments Training Tests
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 300
+    continue-on-error: true
+    needs: build
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        lfs: true
+
+    - name: Pull image from ECR
+      uses: ./.github/actions/ecr-build-push-pull
+      with:
+        image-tag: ${{ env.DOCKER_IMAGE_TAG }}
+        isaacsim-base-image: ${{ env.ISAACSIM_BASE_IMAGE }}
+        isaacsim-version: ${{ env.ISAACSIM_BASE_VERSION }}
+        dockerfile-path: docker/Dockerfile.base
+        cache-tag: cache-base
+
+    - name: Run Environments Training Tests
+      uses: ./.github/actions/run-tests
+      with:
+        test-path: "tools"
+        result-file: "${{ github.job }}-report.xml"
+        container-name: "isaac-lab-environments-training-test-${{ github.run_id }}-${{ github.run_attempt }}"
+        image-tag: ${{ env.DOCKER_IMAGE_TAG }}
+        pytest-options: ""
+        filter-pattern: "isaaclab_tasks"
+        include-files: "test_environments_training.py"
+
+    - name: Upload Environments Training Test Results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: environments-training-test-results
+        path: reports/${{ github.job }}-report.xml
+        retention-days: 1
+        compression-level: 9
+
+    - name: Check Test Results for Fork PRs
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      run: |
+        if [ -f "reports/${{ github.job }}-report.xml" ]; then
+          if grep -q 'failures="[1-9]' reports/${{ github.job }}-report.xml || grep -q 'errors="[1-9]' reports/${{ github.job }}-report.xml; then
+            echo "Tests failed for PR from fork. The test report is in the logs. Failing the job."
+            exit 1
+          fi
+        else
+          echo "No test results file found. This might indicate test execution failed."
+          exit 1
+        fi
+
+    # ECR images must be pruned with a lifecycle policy.
+    - name: Clean up stale Docker images
+      if: always()
+      run: docker image prune -f --filter "until=24h" || true
+
   combine-results:
-    needs: [build, build-curobo, test-isaaclab-tasks, test-isaaclab-tasks-2, test-general, test-curobo]
+    needs: [build, build-curobo, test-isaaclab-tasks, test-isaaclab-tasks-2, test-general, test-curobo, test-flaky, test-slightly-flaky, test-environments-training]
     runs-on: ubuntu-latest
     if: always()
 
@@ -392,6 +571,27 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: curobo-test-results
+        path: reports/
+      continue-on-error: true
+
+    - name: Download Flaky Test Results
+      uses: actions/download-artifact@v4
+      with:
+        name: flaky-test-results
+        path: reports/
+      continue-on-error: true
+
+    - name: Download Slightly Flaky Test Results
+      uses: actions/download-artifact@v4
+      with:
+        name: slightly-flaky-test-results
+        path: reports/
+      continue-on-error: true
+
+    - name: Download Environments Training Test Results
+      uses: actions/download-artifact@v4
+      with:
+        name: environments-training-test-results
         path: reports/
       continue-on-error: true
 

--- a/.github/workflows/license-exceptions.json
+++ b/.github/workflows/license-exceptions.json
@@ -461,8 +461,8 @@
   },
   {
     "package": "typing_extensions",
-    "license": "PSF-2.0",
-    "comment": "PSF-2.0 / OSRB"
+    "license": "Python Software Foundation License",
+    "comment": "PSFL / OSRB"
   },
   {
     "package": "standard-distutils",

--- a/.github/workflows/license-exceptions.json
+++ b/.github/workflows/license-exceptions.json
@@ -461,8 +461,8 @@
   },
   {
     "package": "typing_extensions",
-    "license": "Python Software Foundation License",
-    "comment": "PSFL / OSRB"
+    "license": "PSF-2.0",
+    "comment": "PSF-2.0 / OSRB"
   },
   {
     "package": "standard-distutils",

--- a/source/isaaclab/test/cli/test_install.py
+++ b/source/isaaclab/test/cli/test_install.py
@@ -20,6 +20,19 @@ from isaaclab.cli.utils import (
     get_pip_command,
 )
 
+
+def _python_in_venv(venv: Path) -> Path:
+    if sys.platform == "win32":
+        return venv / "Scripts" / "python.exe"
+    return venv / "bin" / "python"
+
+
+def _python_for_conda(base: Path) -> Path:
+    if sys.platform == "win32":
+        return base / "python.exe"
+    return base / "bin" / "python"
+
+
 # ---------------------------------------------------------------------------
 # get_pip_command
 # ---------------------------------------------------------------------------
@@ -43,20 +56,16 @@ class TestGetPipCommand:
             result = get_pip_command(python_exe=fake_python)
             assert result == ["uv", "pip"]
 
-    def test_returns_python_pip_in_venv_with_pip_module(self, tmp_path):
-        """When VIRTUAL_ENV is set and pip module is available, return python -m pip."""
+    def test_returns_uv_pip_in_venv_with_uv(self, tmp_path):
+        """When VIRTUAL_ENV is set and uv is on PATH, always return uv pip."""
         fake_python = str(tmp_path / "python")
 
         with (
             mock.patch.dict(os.environ, {"VIRTUAL_ENV": str(tmp_path)}),
             mock.patch("isaaclab.cli.utils.shutil.which", return_value="/usr/bin/uv"),
-            mock.patch(
-                "isaaclab.cli.utils.subprocess.run",
-                return_value=subprocess.CompletedProcess(args=[], returncode=0),
-            ),
         ):
             result = get_pip_command(python_exe=fake_python)
-            assert result == [fake_python, "-m", "pip"]
+            assert result == ["uv", "pip"]
 
     def test_returns_python_pip_without_uv(self, tmp_path):
         """When uv is not installed, always return python -m pip."""
@@ -69,20 +78,19 @@ class TestGetPipCommand:
             result = get_pip_command(python_exe=fake_python)
             assert result == [fake_python, "-m", "pip"]
 
-    def test_returns_python_pip_in_conda(self, tmp_path):
-        """When VIRTUAL_ENV is not set (conda env), always return python -m pip."""
+    def test_returns_python_pip_in_conda_without_uv(self, tmp_path):
+        """When in a conda env and uv is not available, return python -m pip."""
         fake_python = str(tmp_path / "python")
 
+        env = os.environ.copy()
+        env.pop("VIRTUAL_ENV", None)
+        env["CONDA_PREFIX"] = str(tmp_path)
         with (
-            mock.patch.dict(os.environ, {}, clear=False),
-            mock.patch.dict(os.environ, {"CONDA_PREFIX": str(tmp_path)}, clear=False),
+            mock.patch.dict(os.environ, env, clear=True),
+            mock.patch("isaaclab.cli.utils.shutil.which", return_value=None),
         ):
-            # Remove VIRTUAL_ENV if present
-            env = os.environ.copy()
-            env.pop("VIRTUAL_ENV", None)
-            with mock.patch.dict(os.environ, env, clear=True):
-                result = get_pip_command(python_exe=fake_python)
-                assert result == [fake_python, "-m", "pip"]
+            result = get_pip_command(python_exe=fake_python)
+            assert result == [fake_python, "-m", "pip"]
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +138,7 @@ class TestExtractIsaacsimPath:
         with (
             mock.patch("isaaclab.cli.utils.DEFAULT_ISAAC_SIM_PATH", Path("/nonexistent/path")),
             mock.patch(
-                "isaaclab.cli.utils.run_command",
+                "isaaclab.cli.utils.subprocess.run",
                 return_value=subprocess.CompletedProcess(args=[], returncode=1),
             ),
         ):
@@ -142,7 +150,7 @@ class TestExtractIsaacsimPath:
         with (
             mock.patch("isaaclab.cli.utils.DEFAULT_ISAAC_SIM_PATH", Path("/nonexistent/path")),
             mock.patch(
-                "isaaclab.cli.utils.run_command",
+                "isaaclab.cli.utils.subprocess.run",
                 return_value=subprocess.CompletedProcess(args=[], returncode=1),
             ),
             pytest.raises(SystemExit),
@@ -214,166 +222,3 @@ class TestDeterminePythonVersion:
         ):
             result = determine_python_version()
             assert result == "3.11"
-
-
-# ---------------------------------------------------------------------------
-# Integration: uv venv install path
-# ---------------------------------------------------------------------------
-
-
-class TestUvInstallPath:
-    """Smoke tests verifying utility functions in the current venv."""
-
-    def test_get_pip_command_uses_uv_in_current_venv(self):
-        """In the current test venv (uv-managed), get_pip_command should return uv pip."""
-        if not os.environ.get("VIRTUAL_ENV"):
-            pytest.skip("Not running in a virtual environment")
-        if not __import__("shutil").which("uv"):
-            pytest.skip("uv not available")
-
-        result = get_pip_command(python_exe=sys.executable)
-        # In a uv venv without pip module, should return ["uv", "pip"]
-        # In a venv with pip, should return [python, "-m", "pip"]
-        assert len(result) >= 2
-        assert result[-1] == "pip"
-
-    def test_extract_python_exe_in_current_venv(self):
-        """extract_python_exe should find the current venv's Python."""
-        if not os.environ.get("VIRTUAL_ENV"):
-            pytest.skip("Not running in a virtual environment")
-
-        result = extract_python_exe()
-        # Should point into the current venv
-        assert os.environ["VIRTUAL_ENV"] in result
-
-    def test_determine_python_version_without_sim(self):
-        """Without Isaac Sim installed, should not crash and return a valid version."""
-        try:
-            from importlib.metadata import distribution
-
-            distribution("isaacsim")
-            pytest.skip("Isaac Sim is installed — this test is for the Kit-less path")
-        except Exception:
-            pass
-
-        version = determine_python_version()
-        major, minor = version.split(".")
-        assert int(major) == 3
-        assert int(minor) >= 10
-
-
-# ---------------------------------------------------------------------------
-# Integration: uv install into a fresh venv
-# ---------------------------------------------------------------------------
-
-# Resolve the Isaac Lab repo root once (source/isaaclab/test/cli/ -> repo root).
-_REPO_ROOT = Path(__file__).resolve().parents[4]
-
-
-def _uv(*args: str, **kwargs) -> subprocess.CompletedProcess:
-    """Run a uv command, raising on failure."""
-    return subprocess.run(["uv", *args], check=True, capture_output=True, text=True, **kwargs)
-
-
-def _python_in_venv(venv: Path) -> Path:
-    if sys.platform == "win32":
-        return venv / "Scripts" / "python.exe"
-    return venv / "bin" / "python"
-
-
-def _python_for_conda(base: Path) -> Path:
-    if sys.platform == "win32":
-        return base / "python.exe"
-    return base / "bin" / "python"
-
-
-def _run_in_venv(venv: Path, code: str) -> subprocess.CompletedProcess:
-    """Run a Python snippet inside the given venv."""
-    python = _python_in_venv(venv)
-    return subprocess.run([str(python), "-c", code], check=True, capture_output=True, text=True)
-
-
-@pytest.fixture(scope="module")
-def uv_venv(tmp_path_factory):
-    """Create a temporary uv venv and install the Newton sub-packages into it.
-
-    This fixture is module-scoped so the install only happens once for all
-    integration tests, keeping total runtime reasonable (~30s).
-    """
-    import shutil
-
-    if not shutil.which("uv"):
-        pytest.skip("uv is not installed")
-
-    venv_dir = tmp_path_factory.mktemp("isaaclab_test_venv")
-    py_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
-
-    # Create venv
-    _uv("venv", "--python", py_version, str(venv_dir))
-
-    # Install Isaac Lab core + Newton sub-packages (editable, from local source).
-    src = _REPO_ROOT / "source"
-    packages = [
-        f"-e{src / 'isaaclab'}",
-        f"-e{src / 'isaaclab_newton'}",
-        f"-e{src / 'isaaclab_physx'}",
-        f"-e{src / 'isaaclab_tasks'}",
-        f"-e{src / 'isaaclab_assets'}",
-        f"-e{src / 'isaaclab_visualizers'}",
-        f"-e{src / 'isaaclab_rl'}",
-    ]
-    _uv("pip", "install", *packages, "--python", str(_python_in_venv(venv_dir)))
-
-    return venv_dir
-
-
-class TestUvInstallIntegration:
-    """Integration tests that install Isaac Lab into a fresh uv venv."""
-
-    def test_isaaclab_importable(self, uv_venv):
-        """Core isaaclab package should be importable."""
-        _run_in_venv(uv_venv, "import isaaclab")
-
-    def test_newton_importable(self, uv_venv):
-        """isaaclab_newton should be importable."""
-        _run_in_venv(uv_venv, "import isaaclab_newton")
-
-    def test_physx_importable(self, uv_venv):
-        """isaaclab_physx should be importable."""
-        _run_in_venv(uv_venv, "import isaaclab_physx")
-
-    def test_tasks_importable(self, uv_venv):
-        """isaaclab_tasks should be importable."""
-        _run_in_venv(uv_venv, "import isaaclab_tasks")
-
-    def test_assets_importable(self, uv_venv):
-        """isaaclab_assets should be importable."""
-        _run_in_venv(uv_venv, "import isaaclab_assets")
-
-    def test_visualizers_importable(self, uv_venv):
-        """isaaclab_visualizers should be importable."""
-        _run_in_venv(uv_venv, "import isaaclab_visualizers")
-
-    def test_rl_importable(self, uv_venv):
-        """isaaclab_rl should be importable."""
-        _run_in_venv(uv_venv, "import isaaclab_rl")
-
-    def test_builtin_tasks_registered(self, uv_venv):
-        """Built-in gym environments should be registered after importing isaaclab_tasks."""
-        result = _run_in_venv(
-            uv_venv,
-            "import isaaclab_tasks; import gymnasium as gym; "
-            "envs = [s.id for s in gym.registry.values() if s.id.startswith('Isaac-')]; "
-            "print(len(envs))",
-        )
-        count = int(result.stdout.strip())
-        assert count > 50, f"Expected >50 built-in tasks, got {count}"
-
-    def test_cartpole_env_spec_resolves(self, uv_venv):
-        """The cartpole direct env should have a resolvable spec."""
-        _run_in_venv(
-            uv_venv,
-            "import isaaclab_tasks; import gymnasium as gym; "
-            "spec = gym.spec('Isaac-Cartpole-Direct-v0'); "
-            "assert spec.entry_point is not None",
-        )

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -272,6 +272,8 @@ def pytest_sessionstart(session):
     include_files_str = os.environ.get("TEST_INCLUDE_FILES", "")
     curobo_only = os.environ.get("TEST_CUROBO_ONLY", "false") == "true"
     cuda_issue_only = os.environ.get("TEST_CUDA_ISSUE_ONLY", "false") == "true"
+    flaky_only = os.environ.get("TEST_FLAKY_ONLY", "false") == "true"
+    slightly_flaky_only = os.environ.get("TEST_SLIGHTLY_FLAKY_ONLY", "false") == "true"
 
     isaacsim_ci = os.environ.get("ISAACSIM_CI_SHORT", "false") == "true"
 
@@ -297,11 +299,15 @@ def pytest_sessionstart(session):
     print(f"Include files: {include_files if include_files else 'none'}")
     print(f"Curobo-only mode: {curobo_only}")
     print(f"CUDA-issue-only mode: {cuda_issue_only}")
+    print(f"Flaky-only mode: {flaky_only}")
+    print(f"Slightly-flaky-only mode: {slightly_flaky_only}")
     print(f"TEST_FILTER_PATTERN env var: '{os.environ.get('TEST_FILTER_PATTERN', 'NOT_SET')}'")
     print(f"TEST_EXCLUDE_PATTERN env var: '{os.environ.get('TEST_EXCLUDE_PATTERN', 'NOT_SET')}'")
     print(f"TEST_INCLUDE_FILES env var: '{os.environ.get('TEST_INCLUDE_FILES', 'NOT_SET')}'")
     print(f"TEST_CUROBO_ONLY env var: '{os.environ.get('TEST_CUROBO_ONLY', 'NOT_SET')}'")
     print(f"TEST_CUDA_ISSUE_ONLY env var: '{os.environ.get('TEST_CUDA_ISSUE_ONLY', 'NOT_SET')}'")
+    print(f"TEST_FLAKY_ONLY env var: '{os.environ.get('TEST_FLAKY_ONLY', 'NOT_SET')}'")
+    print(f"TEST_SLIGHTLY_FLAKY_ONLY env var: '{os.environ.get('TEST_SLIGHTLY_FLAKY_ONLY', 'NOT_SET')}'")
     print("=" * 50)
 
     # Get all test files in the source directories
@@ -315,7 +321,19 @@ def pytest_sessionstart(session):
         for root, _, files in os.walk(source_dir):
             for file in files:
                 if file.startswith("test_") and file.endswith(".py"):
-                    if curobo_only:
+                    if flaky_only:
+                        # In flaky-only mode, run exclusively the clearly flaky tests.
+                        # The normal TESTS_TO_SKIP list is intentionally bypassed here so that
+                        # these tests (which are skipped in normal jobs) can execute.
+                        if file not in test_settings.FLAKY_TESTS:
+                            continue
+                    elif slightly_flaky_only:
+                        # In slightly-flaky-only mode, run exclusively the mildly flaky tests.
+                        # The normal TESTS_TO_SKIP list is intentionally bypassed here so that
+                        # these tests (which are skipped in normal jobs) can execute.
+                        if file not in test_settings.SLIGHTLY_FLAKY_TESTS:
+                            continue
+                    elif curobo_only:
                         # In curobo-only mode, run exclusively the cuRobo and SkillGen tests.
                         # The normal TESTS_TO_SKIP list is intentionally bypassed here so that
                         # these tests (which are skipped in base-image jobs) can execute.

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -257,6 +257,62 @@ def run_individual_tests(test_files, workspace_root, isaacsim_ci):
     return failed_tests, test_status
 
 
+def _collect_test_files(
+    source_dirs,
+    filter_pattern,
+    exclude_pattern,
+    include_files,
+    flaky_only,
+    slightly_flaky_only,
+    curobo_only,
+    cuda_issue_only,
+):
+    """Collect test files from source directories, applying all active filters."""
+    test_files = []
+    for source_dir in source_dirs:
+        if not os.path.exists(source_dir):
+            print(f"Error: source directory not found at {source_dir}")
+            pytest.exit("Source directory not found", returncode=1)
+
+        for root, _, files in os.walk(source_dir):
+            for file in files:
+                if not (file.startswith("test_") and file.endswith(".py")):
+                    continue
+
+                # Mode-exclusive filters (each bypasses TESTS_TO_SKIP)
+                if flaky_only:
+                    if file not in test_settings.FLAKY_TESTS:
+                        continue
+                elif slightly_flaky_only:
+                    if file not in test_settings.SLIGHTLY_FLAKY_TESTS:
+                        continue
+                elif curobo_only:
+                    if file not in test_settings.CUROBO_TESTS:
+                        continue
+                elif cuda_issue_only:
+                    if file not in test_settings.CUDA_ISSUE_TESTS:
+                        continue
+                else:
+                    if file in test_settings.TESTS_TO_SKIP:
+                        print(f"Skipping {file} as it's in the skip list")
+                        continue
+
+                full_path = os.path.join(root, file)
+
+                if filter_pattern and filter_pattern not in full_path:
+                    print(f"Skipping {full_path} (does not match include pattern: {filter_pattern})")
+                    continue
+                if exclude_pattern and exclude_pattern in full_path:
+                    print(f"Skipping {full_path} (matches exclude pattern: {exclude_pattern})")
+                    continue
+                if include_files and file not in include_files:
+                    print(f"Skipping {full_path} (not in include files list)")
+                    continue
+
+                test_files.append(full_path)
+    return test_files
+
+
 def pytest_sessionstart(session):
     """Intercept pytest startup to execute tests in the correct order."""
     # Get the workspace root directory (one level up from tools)
@@ -311,64 +367,16 @@ def pytest_sessionstart(session):
     print("=" * 50)
 
     # Get all test files in the source directories
-    test_files = []
-
-    for source_dir in source_dirs:
-        if not os.path.exists(source_dir):
-            print(f"Error: source directory not found at {source_dir}")
-            pytest.exit("Source directory not found", returncode=1)
-
-        for root, _, files in os.walk(source_dir):
-            for file in files:
-                if file.startswith("test_") and file.endswith(".py"):
-                    if flaky_only:
-                        # In flaky-only mode, run exclusively the clearly flaky tests.
-                        # The normal TESTS_TO_SKIP list is intentionally bypassed here so that
-                        # these tests (which are skipped in normal jobs) can execute.
-                        if file not in test_settings.FLAKY_TESTS:
-                            continue
-                    elif slightly_flaky_only:
-                        # In slightly-flaky-only mode, run exclusively the mildly flaky tests.
-                        # The normal TESTS_TO_SKIP list is intentionally bypassed here so that
-                        # these tests (which are skipped in normal jobs) can execute.
-                        if file not in test_settings.SLIGHTLY_FLAKY_TESTS:
-                            continue
-                    elif curobo_only:
-                        # In curobo-only mode, run exclusively the cuRobo and SkillGen tests.
-                        # The normal TESTS_TO_SKIP list is intentionally bypassed here so that
-                        # these tests (which are skipped in base-image jobs) can execute.
-                        if file not in test_settings.CUROBO_TESTS:
-                            continue
-                    elif cuda_issue_only:
-                        # In cuda-issue-only mode, run exclusively the CUDA issue tests.
-                        # The normal TESTS_TO_SKIP list is intentionally bypassed here so that
-                        # these tests (which are skipped in base-image jobs) can execute.
-                        if file not in test_settings.CUDA_ISSUE_TESTS:
-                            continue
-                    else:
-                        # Skip if the file is in TESTS_TO_SKIP
-                        if file in test_settings.TESTS_TO_SKIP:
-                            print(f"Skipping {file} as it's in the skip list")
-                            continue
-
-                    full_path = os.path.join(root, file)
-
-                    # Apply include filter
-                    if filter_pattern and filter_pattern not in full_path:
-                        print(f"Skipping {full_path} (does not match include pattern: {filter_pattern})")
-                        continue
-
-                    # Apply exclude filter
-                    if exclude_pattern and exclude_pattern in full_path:
-                        print(f"Skipping {full_path} (matches exclude pattern: {exclude_pattern})")
-                        continue
-
-                    # Apply include files filter
-                    if include_files and file not in include_files:
-                        print(f"Skipping {full_path} (not in include files list)")
-                        continue
-
-                    test_files.append(full_path)
+    test_files = _collect_test_files(
+        source_dirs,
+        filter_pattern,
+        exclude_pattern,
+        include_files,
+        flaky_only,
+        slightly_flaky_only,
+        curobo_only,
+        cuda_issue_only,
+    )
 
     if isaacsim_ci:
         new_test_files = []

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -293,7 +293,10 @@ def _collect_test_files(
                     if file not in test_settings.CUDA_ISSUE_TESTS:
                         continue
                 else:
-                    if file in test_settings.TESTS_TO_SKIP:
+                    # An explicit include_files entry overrides TESTS_TO_SKIP, allowing
+                    # dedicated jobs (e.g. test-environments-training) to run tests that
+                    # are otherwise excluded from general CI runs.
+                    if file in test_settings.TESTS_TO_SKIP and file not in include_files:
                         print(f"Skipping {file} as it's in the skip list")
                         continue
 

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -77,20 +77,20 @@ dedicated ``test-curobo`` CI job which uses the cuRobo Docker image.
 
 FLAKY_TESTS = [
     # Consistently failing or highly flaky (<60% pass rate across recent CI runs)
-    # "test_rigid_object_collection_iface.py",  # 0%
+    "test_rigid_object_collection_iface.py",  # 0%
     "test_environments_newton.py",  # 5.9%
-    # "test_articulation_iface.py",  # 7.7%
-    "test_articulation.py",  # 10.5%
+    "test_articulation_iface.py",  # 7.7%
+    # "test_articulation.py",  # 10.5%
     "test_rigid_object_iface.py",  # 23.1%
-    "test_rigid_object_collection.py",  # 26.7%
-    # "test_physx_scene_data_provider_visualizer_contract.py",  # 30.8%
-    # "test_shadow_hand_vision_presets.py",  # 47.4%
+    # "test_rigid_object_collection.py",  # 26.7%
+    "test_physx_scene_data_provider_visualizer_contract.py",  # 30.8%
+    "test_shadow_hand_vision_presets.py",  # 47.4%
     "test_mock_data_properties.py",  # 50.0%
-    "test_rigid_object.py",  # 57.7%
+    # "test_rigid_object.py",  # 57.7%
     # "test_contact_sensor.py",  # 60.0%
     "test_robot_load_performance.py",  # 60.0%
     # Failing in recent CI runs
-    "test_camera.py",
+    # "test_camera.py",
     "test_logger.py",
     "test_multirotor.py",
     "test_null_command_term.py",
@@ -107,7 +107,7 @@ These tests are skipped in normal CI runs and executed in the dedicated
 SLIGHTLY_FLAKY_TESTS = [
     # Mildly intermittent (96%+ pass rate across recent CI runs)
     # "test_multi_mesh_ray_caster_camera.py",  # 96.2%
-    "test_ray_caster_camera.py",  # 96.2%
+    # "test_ray_caster_camera.py",  # 96.2%
     "test_surface_gripper.py",  # 96.2%
     "test_env_cfg_no_forbidden_imports.py",  # 96.4%
 ]

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -89,6 +89,14 @@ FLAKY_TESTS = [
     "test_rigid_object.py",  # 57.7%
     "test_contact_sensor.py",  # 60.0%
     "test_robot_load_performance.py",  # 60.0%
+    # Failing in recent CI runs
+    "test_camera.py",
+    "test_logger.py",
+    "test_multirotor.py",
+    "test_null_command_term.py",
+    "test_sb3_wrapper.py",
+    "test_selection_strategy.py",
+    "test_spawn_lights.py",
 ]
 """A list of tests that are known to be flaky (< 60% pass rate).
 

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -77,17 +77,17 @@ dedicated ``test-curobo`` CI job which uses the cuRobo Docker image.
 
 FLAKY_TESTS = [
     # Consistently failing or highly flaky (<60% pass rate across recent CI runs)
-    "test_rigid_object_collection_iface.py",  # 0%
+    # "test_rigid_object_collection_iface.py",  # 0%
     "test_environments_newton.py",  # 5.9%
-    "test_articulation_iface.py",  # 7.7%
+    # "test_articulation_iface.py",  # 7.7%
     "test_articulation.py",  # 10.5%
     "test_rigid_object_iface.py",  # 23.1%
     "test_rigid_object_collection.py",  # 26.7%
-    "test_physx_scene_data_provider_visualizer_contract.py",  # 30.8%
-    "test_shadow_hand_vision_presets.py",  # 47.4%
+    # "test_physx_scene_data_provider_visualizer_contract.py",  # 30.8%
+    # "test_shadow_hand_vision_presets.py",  # 47.4%
     "test_mock_data_properties.py",  # 50.0%
     "test_rigid_object.py",  # 57.7%
-    "test_contact_sensor.py",  # 60.0%
+    # "test_contact_sensor.py",  # 60.0%
     "test_robot_load_performance.py",  # 60.0%
     # Failing in recent CI runs
     "test_camera.py",
@@ -106,7 +106,7 @@ These tests are skipped in normal CI runs and executed in the dedicated
 
 SLIGHTLY_FLAKY_TESTS = [
     # Mildly intermittent (96%+ pass rate across recent CI runs)
-    "test_multi_mesh_ray_caster_camera.py",  # 96.2%
+    # "test_multi_mesh_ray_caster_camera.py",  # 96.2%
     "test_ray_caster_camera.py",  # 96.2%
     "test_surface_gripper.py",  # 96.2%
     "test_env_cfg_no_forbidden_imports.py",  # 96.4%

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -77,18 +77,18 @@ dedicated ``test-curobo`` CI job which uses the cuRobo Docker image.
 
 FLAKY_TESTS = [
     # Consistently failing or highly flaky (<60% pass rate across recent CI runs)
-    "test_rigid_object_collection_iface.py",              # 0%
-    "test_environments_newton.py",                        # 5.9%
-    "test_articulation_iface.py",                         # 7.7%
-    "test_articulation.py",                               # 10.5%
-    "test_rigid_object_iface.py",                         # 23.1%
-    "test_rigid_object_collection.py",                    # 26.7%
+    "test_rigid_object_collection_iface.py",  # 0%
+    "test_environments_newton.py",  # 5.9%
+    "test_articulation_iface.py",  # 7.7%
+    "test_articulation.py",  # 10.5%
+    "test_rigid_object_iface.py",  # 23.1%
+    "test_rigid_object_collection.py",  # 26.7%
     "test_physx_scene_data_provider_visualizer_contract.py",  # 30.8%
-    "test_shadow_hand_vision_presets.py",                 # 47.4%
-    "test_mock_data_properties.py",                       # 50.0%
-    "test_rigid_object.py",                               # 57.7%
-    "test_contact_sensor.py",                             # 60.0%
-    "test_robot_load_performance.py",                     # 60.0%
+    "test_shadow_hand_vision_presets.py",  # 47.4%
+    "test_mock_data_properties.py",  # 50.0%
+    "test_rigid_object.py",  # 57.7%
+    "test_contact_sensor.py",  # 60.0%
+    "test_robot_load_performance.py",  # 60.0%
 ]
 """A list of tests that are known to be flaky (< 60% pass rate).
 
@@ -98,9 +98,9 @@ These tests are skipped in normal CI runs and executed in the dedicated
 
 SLIGHTLY_FLAKY_TESTS = [
     # Mildly intermittent (96%+ pass rate across recent CI runs)
-    "test_multi_mesh_ray_caster_camera.py",   # 96.2%
-    "test_ray_caster_camera.py",              # 96.2%
-    "test_surface_gripper.py",               # 96.2%
+    "test_multi_mesh_ray_caster_camera.py",  # 96.2%
+    "test_ray_caster_camera.py",  # 96.2%
+    "test_surface_gripper.py",  # 96.2%
     "test_env_cfg_no_forbidden_imports.py",  # 96.4%
 ]
 """A list of tests that are mildly flaky (96%+ pass rate).

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -75,6 +75,40 @@ These tests are skipped in the base image CI jobs and run separately in the
 dedicated ``test-curobo`` CI job which uses the cuRobo Docker image.
 """
 
+FLAKY_TESTS = [
+    # Consistently failing or highly flaky (<60% pass rate across recent CI runs)
+    "test_rigid_object_collection_iface.py",              # 0%
+    "test_environments_newton.py",                        # 5.9%
+    "test_articulation_iface.py",                         # 7.7%
+    "test_articulation.py",                               # 10.5%
+    "test_rigid_object_iface.py",                         # 23.1%
+    "test_rigid_object_collection.py",                    # 26.7%
+    "test_physx_scene_data_provider_visualizer_contract.py",  # 30.8%
+    "test_shadow_hand_vision_presets.py",                 # 47.4%
+    "test_mock_data_properties.py",                       # 50.0%
+    "test_rigid_object.py",                               # 57.7%
+    "test_contact_sensor.py",                             # 60.0%
+    "test_robot_load_performance.py",                     # 60.0%
+]
+"""A list of tests that are known to be flaky (< 60% pass rate).
+
+These tests are skipped in normal CI runs and executed in the dedicated
+``test-flaky`` CI job where failures do not block PR merges.
+"""
+
+SLIGHTLY_FLAKY_TESTS = [
+    # Mildly intermittent (96%+ pass rate across recent CI runs)
+    "test_multi_mesh_ray_caster_camera.py",   # 96.2%
+    "test_ray_caster_camera.py",              # 96.2%
+    "test_surface_gripper.py",               # 96.2%
+    "test_env_cfg_no_forbidden_imports.py",  # 96.4%
+]
+"""A list of tests that are mildly flaky (96%+ pass rate).
+
+These tests are skipped in normal CI runs and executed in the dedicated
+``test-slightly-flaky`` CI job where failures do not block PR merges.
+"""
+
 TESTS_TO_SKIP = [
     # lab
     "test_argparser_launch.py",  # app.close issue
@@ -87,6 +121,10 @@ TESTS_TO_SKIP = [
     "test_tiled_camera_env.py",  # Need to improve the logic
     # curobo / skillgen - require cuRobo installation; run via the test-curobo CI job
     *CUROBO_TESTS,
+    # flaky tests - run in dedicated CI jobs that do not block PR merges
+    *FLAKY_TESTS,
+    *SLIGHTLY_FLAKY_TESTS,
+    "test_environments_training.py",  # Long-running RL training test; runs in dedicated CI job
 ]
 """A list of tests to skip by run_tests.py"""
 


### PR DESCRIPTION
## Description

[ci_report.html](https://github.com/user-attachments/files/25947914/ci_report.html)

Based on last ~30 CI runs, this extracts tests that never/rarely succeed in 3 groups:

- Very Flaky (0 to 60% success rate) 
- Less Flaky (~90% success rate)
- `environments_training.py` (runs ~100 minutes, never succeeds)

Goals:

- Have some subset of tests that always pass we can rely on to detect broken code
- See and be motivated to fix of failing and very long running monolithic tests.
- Allocate CI runners in a more granular way to balance between multiple PRs better.

I will monitor our progress and re-group as needed.

Additionally this improves docker build caching logic for more cache hits.

# Fixes # (issue)

CI test not serving it's purpose of validating PRs and changes.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

<img width="1269" height="600" alt="image" src="https://github.com/user-attachments/assets/fab3c07b-85ae-482f-a862-c678d721da20" />

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [NA] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
