### PR TITLE
Guards nvidia-srl-usd-to-urdf from aarch64 installation since it doesn't have aarch64 wheels

### DIFF
--- a/source/isaaclab_mimic/setup.py
+++ b/source/isaaclab_mimic/setup.py
@@ -24,9 +24,11 @@ INSTALL_REQUIRES = [
     "ipywidgets==8.1.5",
     # data collection
     "h5py",
-    # humanoid support
-    "nvidia-srl-usd-to-urdf",
 ]
+
+# nvidia-srl-usd-to-urdf depends on usd-core which has no aarch64 wheels
+if platform.machine() != "aarch64":
+    INSTALL_REQUIRES.append("nvidia-srl-usd-to-urdf")
 
 # Extra dependencies for IL agents
 EXTRAS_REQUIRE = {"robomimic": []}

--- a/source/isaaclab_teleop/setup.py
+++ b/source/isaaclab_teleop/setup.py
@@ -6,6 +6,7 @@
 """Installation script for the 'isaaclab_teleop' python package."""
 
 import os
+import platform
 
 import toml
 from setuptools import find_packages, setup
@@ -16,10 +17,11 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
 # Minimum dependencies required prior to installation
-INSTALL_REQUIRES = [
-    # humanoid support
-    "nvidia-srl-usd-to-urdf",
-]
+INSTALL_REQUIRES = []
+
+# nvidia-srl-usd-to-urdf depends on usd-core which has no aarch64 wheels
+if platform.machine() != "aarch64":
+    INSTALL_REQUIRES.append("nvidia-srl-usd-to-urdf")
 
 # Installation operation
 setup(


### PR DESCRIPTION
# Description

This PR guards nvidia-srl-usd-to-urdf from aarch64 installation since it doesn't have aarch64 wheels. The bug is introduced in #4979

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
