### PR TITLE
Add Visualizer Doc notes for launching Viser / Rerun in Docker container

### DIFF
--- a/docs/source/experimental-features/newton-physics-integration/visualization.rst
+++ b/docs/source/experimental-features/newton-physics-integration/visualization.rst
@@ -77,6 +77,12 @@ To run in headless mode, omit the ``--viz`` argument:
     The ``--headless`` argument is deprecated.
     For compatibility, ``--headless`` still takes precedence and disables all visualizers.
 
+.. note::
+
+    In Docker containers, browser auto-open for the web-based visualizers (Rerun and Viser)
+    may not work. If no browser tab opens automatically, use the ``viewer_url`` logged in
+    each visualizer's initialization block and open that URL manually from your host browser.
+
 
 .. _visualization-configuration:
 

--- a/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
@@ -72,12 +72,17 @@ def _ensure_rerun_server(app_id: str, bind_address: str, grpc_port: int, web_por
 
 def _open_rerun_web_viewer(host: str, web_port: int, connect_to: str) -> None:
     """Open rerun web UI and prefill endpoint connection URL."""
-    url = f"http://{host}:{int(web_port)}/?url={quote(connect_to, safe='')}"
+    url = _rerun_web_viewer_url(host, web_port, connect_to)
     try:
         if not webbrowser.open_new_tab(url):
             logger.info("[RerunVisualizer] Could not auto-open browser tab. Open manually: %s", url)
     except Exception:
         logger.info("[RerunVisualizer] Could not auto-open browser tab. Open manually: %s", url)
+
+
+def _rerun_web_viewer_url(host: str, web_port: int, connect_to: str) -> str:
+    """Return rerun web UI URL with prefilled endpoint."""
+    return f"http://{host}:{int(web_port)}/?url={quote(connect_to, safe='')}"
 
 
 class NewtonViewerRerun(ViewerRerun):
@@ -176,8 +181,10 @@ class RerunVisualizer(BaseVisualizer):
         )
         if start_server_in_viewer:
             rerun_address = getattr(self._viewer, "_grpc_server_uri", rerun_address)
+        viewer_host = _normalize_host(bind_address)
+        viewer_url = _rerun_web_viewer_url(viewer_host, web_port, rerun_address)
         if self.cfg.open_browser and not start_server_in_viewer:
-            _open_rerun_web_viewer(_normalize_host(bind_address), web_port, rerun_address)
+            _open_rerun_web_viewer(viewer_host, web_port, rerun_address)
         self._viewer.set_model(self._model, max_worlds=self.cfg.max_worlds)
         # Preserve simulation world positions (env_spacing) rather than adding viewer-side offsets.
         self._viewer.set_world_offsets((0.0, 0.0, 0.0))
@@ -195,7 +202,8 @@ class RerunVisualizer(BaseVisualizer):
                 ("camera_target", self.cfg.camera_target),
                 ("camera_source", self.cfg.camera_source),
                 ("num_visualized_envs", num_visualized_envs),
-                ("endpoint", f"http://{_normalize_host(bind_address)}:{web_port}"),
+                ("endpoint", f"http://{viewer_host}:{web_port}"),
+                ("viewer_url", viewer_url),
                 ("bind_address", bind_address),
                 ("grpc_port", grpc_port),
                 ("web_port", web_port),

--- a/source/isaaclab_visualizers/isaaclab_visualizers/viser/viser_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/viser/viser_visualizer.py
@@ -62,12 +62,17 @@ def _suppress_viser_startup_logs(enabled: bool):
 
 def _open_viser_web_viewer(port: int) -> None:
     """Open the local viser web UI in a browser."""
-    url = f"http://localhost:{int(port)}"
+    url = _viser_web_viewer_url(port)
     try:
         if not webbrowser.open_new_tab(url):
             logger.info("[ViserVisualizer] Could not auto-open browser tab. Open manually: %s", url)
     except Exception:
         logger.info("[ViserVisualizer] Could not auto-open browser tab. Open manually: %s", url)
+
+
+def _viser_web_viewer_url(port: int) -> str:
+    """Return local viser web UI URL."""
+    return f"http://localhost:{int(port)}"
 
 
 class NewtonViewerViser(ViewerViser):
@@ -152,6 +157,7 @@ class ViserVisualizer(BaseVisualizer):
         self._active_record_path = self.cfg.record_to_viser
         self._create_viewer(record_to_viser=self.cfg.record_to_viser, metadata=metadata)
         num_visualized_envs = len(self._env_ids) if self._env_ids is not None else int(metadata.get("num_envs", 0))
+        viewer_url = _viser_web_viewer_url(self.cfg.port)
         self._log_initialization_table(
             logger=logger,
             title="ViserVisualizer Configuration",
@@ -161,6 +167,7 @@ class ViserVisualizer(BaseVisualizer):
                 ("camera_source", self.cfg.camera_source),
                 ("num_visualized_envs", num_visualized_envs),
                 ("port", self.cfg.port),
+                ("viewer_url", viewer_url),
                 ("record_to_viser", self.cfg.record_to_viser or "<none>"),
             ],
         )


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Add Visualizer Doc notes for launching Viser / Rerun in Docker container

Now we log the URL for Viser and Rerun where the browser webviewer is hosted.
Users can use this log msg to manually open the webviewer when launching these 2 visualizers in docker containers.

Auto launching the browser window dependent on some dependencies like xdg-open, which the IL docker image doesn't currently support.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
