### PR TITLE
Pins hf-xet dependency to avoid broken tarball cached on NV Artifactory

### DIFF
--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -76,7 +76,7 @@ INSTALL_REQUIRES += [
 ]
 
 # Pin hf-xet to avoid broken tarball (hf_xet-1.1.8.dev2) cached on NVIDIA Artifactory.
-# (https://urm.nvidia.com/artifactory/api/pypi/ct-omniverse-pypi) that gets installed with --pre 
+# (https://urm.nvidia.com/artifactory/api/pypi/ct-omniverse-pypi) that gets installed with --pre
 # and --extra-index-url flags. The broken hf-xet-1.1.8.dev2 package is present as of Mar 12 2026.
 # TODO: Can be removed once the broken hf-xet-1.1.8.dev2 package is removed from NVIDIA Artifactory.
 # Issue: https://nvbugs/5974917 includes verification steps.

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -76,7 +76,7 @@ INSTALL_REQUIRES += [
 ]
 
 # Pin hf-xet to avoid broken tarball (hf_xet-1.1.8.dev2) cached on NVIDIA Artifactory.
-# (https://urm.nvidia.com/artifactory/api/pypi/ct-omniverse-pypi) that gets installed wth --pre 
+# (https://urm.nvidia.com/artifactory/api/pypi/ct-omniverse-pypi) that gets installed with --pre 
 # and --extra-index-url flags. The broken hf-xet-1.1.8.dev2 package is present as of Mar 12 2026.
 # TODO: Can be removed once the broken hf-xet-1.1.8.dev2 package is removed from NVIDIA Artifactory.
 # Issue: https://nvbugs/5974917 includes verification steps.

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -75,6 +75,16 @@ INSTALL_REQUIRES += [
     f"usd-exchange>=2.2 ; ({SUPPORTED_ARCHS_ARM})",
 ]
 
+# Pin hf-xet to avoid broken tarball (hf_xet-1.1.8.dev2) cached on NVIDIA Artifactory.
+# (https://urm.nvidia.com/artifactory/api/pypi/ct-omniverse-pypi) that gets installed wth --pre 
+# and --extra-index-url flags. The broken hf-xet-1.1.8.dev2 package is present as of Mar 12 2026.
+# TODO: Can be removed once the broken hf-xet-1.1.8.dev2 package is removed from NVIDIA Artifactory.
+# Issue: https://nvbugs/5974917 includes verification steps.
+INSTALL_REQUIRES += [
+    # 1.4.1 is latest as of Mar 12 2026
+    f"hf-xet>=1.4.1,<2.0.0 ; ({SUPPORTED_ARCHS_ARM})",
+]
+
 PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu128"]
 
 # Isaac Lab subpackages + Isaac Sim


### PR DESCRIPTION
# Description

NV Artifactory (urm.nvidia.com) is a caching proxy in front of PyPI, it automatically mirrors/caches anything that gets requested through it. `hf_xet-1.1.8.dev2` source tarball was likely published briefly on PyPI during development and later deleted. PyPI no longer serves it, but NV Artifactory cached it when it was still available and never purged it.

The issue will not be present when release of Isaac Lab is published and users do not use `--pre` flag.

This pins `hf-xet>=1.4.1,<2.0.0` - latest stable version atm.


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there