### PR TITLE
Fixes articulation root prim discovery

### DIFF
--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.10"
+version = "0.5.11"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.5.11 (2026-03-13)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed articulation root prim discovery failing when the
+  ``physxArticulation:articulationEnabled`` attribute is not authored on the
+  USD prim. The predicate now treats an unset attribute as enabled (the PhysX
+  default) instead of rejecting the prim.
+
+
 0.5.10 (2026-03-13)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -3597,7 +3597,7 @@ class Articulation(BaseArticulation):
             first_env_root_prims = get_all_matching_child_prims(
                 first_env_matching_prim_path,
                 predicate=lambda prim: prim.HasAPI(UsdPhysics.ArticulationRootAPI)
-                and prim.GetAttribute("physxArticulation:articulationEnabled").Get(),
+                and prim.GetAttribute("physxArticulation:articulationEnabled").Get() is not False,
                 traverse_instance_prims=False,
             )
             if len(first_env_root_prims) == 0:


### PR DESCRIPTION
# Description

Fixed articulation root prim discovery failing when the `physxArticulation:articulationEnabled` attribute is not authored on the USD prim.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there