### PR TITLE
Improves CLI install and environment setup commands

### DIFF
--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -16,6 +16,8 @@ if [ -n "$VIRTUAL_ENV" ]; then
     python_exe="$VIRTUAL_ENV/bin/python"
 elif [ -n "$CONDA_PREFIX" ]; then
     python_exe="$CONDA_PREFIX/bin/python"
+elif [ -f "$ISAACLAB_PATH/env_isaaclab/bin/python" ]; then
+    python_exe="$ISAACLAB_PATH/env_isaaclab/bin/python"
 elif [ -f "$ISAACLAB_PATH/_isaac_sim/python.sh" ]; then
     python_exe="$ISAACLAB_PATH/_isaac_sim/python.sh"
 else

--- a/source/isaaclab/isaaclab/cli/commands/envs.py
+++ b/source/isaaclab/isaaclab/cli/commands/envs.py
@@ -608,15 +608,20 @@ def _check_venv_python_version(env_path: Path, required_ver: str) -> None:
         text=True,
         check=False,
     )
-    if result.returncode == 0:
-        actual_ver = result.stdout.strip()
-        if actual_ver != required_ver:
-            print_error(f"Virtual environment Python is {actual_ver}, but Isaac Sim requires {required_ver}.")
-            print_error(
-                "Please recreate the environment with the correct Python version, e.g.:\n"
-                f"\tuv venv --python {required_ver} {env_path}"
-            )
-            sys.exit(1)
+    if result.returncode != 0:
+        print_warning(
+            f"Could not determine Python version in virtual environment at {env_path}. "
+            "The environment may be corrupted."
+        )
+        return
+    actual_ver = result.stdout.strip()
+    if actual_ver != required_ver:
+        print_error(f"Virtual environment Python is {actual_ver}, but Isaac Sim requires {required_ver}.")
+        print_error(
+            "Please recreate the environment with the correct Python version, e.g.:\n"
+            f"\tuv venv --python {required_ver} {env_path}"
+        )
+        sys.exit(1)
 
 
 def command_setup_uv(env_name: str) -> None:
@@ -674,7 +679,10 @@ def command_setup_uv(env_name: str) -> None:
 
         print_info("Added Isaac Lab environment hooks to the active virtual environment.")
         print_info("Deactivate and reactivate the environment for hooks to take effect:\n")
-        print("\t\tdeactivate && source " + str(env_path / "bin" / "activate"))
+        if is_windows():
+            print("\t\tdeactivate && " + str(env_path / "Scripts" / "activate"))
+        else:
+            print("\t\tdeactivate && source " + str(env_path / "bin" / "activate"))
         print("\n")
         return
 

--- a/source/isaaclab/isaaclab/cli/commands/envs.py
+++ b/source/isaaclab/isaaclab/cli/commands/envs.py
@@ -584,11 +584,49 @@ def command_setup_conda(env_name: str) -> None:
         print("\n")
 
 
+def _check_venv_python_version(env_path: Path, required_ver: str) -> None:
+    """Validate that a virtual environment's Python matches the required version.
+
+    Args:
+        env_path: Root path of the virtual environment.
+        required_ver: Required Python minor version string (e.g. "3.12").
+
+    Raises:
+        SystemExit: If the Python version does not match.
+    """
+    if is_windows():
+        python_exe = env_path / "Scripts" / "python.exe"
+    else:
+        python_exe = env_path / "bin" / "python"
+
+    if not python_exe.exists():
+        return
+
+    result = run_command(
+        [str(python_exe), "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        actual_ver = result.stdout.strip()
+        if actual_ver != required_ver:
+            print_error(f"Virtual environment Python is {actual_ver}, but Isaac Sim requires {required_ver}.")
+            print_error(
+                "Please recreate the environment with the correct Python version, e.g.:\n"
+                f"\tuv venv --python {required_ver} {env_path}"
+            )
+            sys.exit(1)
+
+
 def command_setup_uv(env_name: str) -> None:
     """setup uv environment for Isaac Lab
 
     Args:
         env_name: Name for the uv environment directory to create or reuse.
+            If a virtual environment is already active (VIRTUAL_ENV is set),
+            the active environment is configured for Isaac Lab instead of
+            creating a new one.
     """
     # Check if uv is installed.
     if not shutil.which("uv"):
@@ -596,9 +634,6 @@ def command_setup_uv(env_name: str) -> None:
         print_error("uv can be installed here:")
         print_error("https://docs.astral.sh/uv/getting-started/installation/")
         sys.exit(1)
-
-    # Check if already in a uv environment - use precise pattern matching.
-    # (In Python we check environments differently or assume env_name is new).
 
     # Check if _isaac_sim symlink exists and isaacsim is not importable.
     if not (ISAACLAB_ROOT / "_isaac_sim").is_symlink():
@@ -621,10 +656,29 @@ def command_setup_uv(env_name: str) -> None:
         except Exception:
             pass
 
-    env_path = ISAACLAB_ROOT / env_name
-
     # Determine appropriate python version based on Isaac Sim version.
     py_ver = determine_python_version()
+
+    # If a virtual environment is already active, configure it for Isaac Lab
+    # instead of creating a new one.
+    active_venv = os.environ.get("VIRTUAL_ENV")
+    if active_venv:
+        env_path = Path(active_venv)
+        print_info(f"Detected active virtual environment: {env_path}")
+
+        # Validate Python version.
+        _check_venv_python_version(env_path, py_ver)
+
+        # Inject Isaac Lab hooks into the existing environment.
+        _write_uv_env_hooks(env_path)
+
+        print_info("Added Isaac Lab environment hooks to the active virtual environment.")
+        print_info("Deactivate and reactivate the environment for hooks to take effect:\n")
+        print("\t\tdeactivate && source " + str(env_path / "bin" / "activate"))
+        print("\n")
+        return
+
+    env_path = ISAACLAB_ROOT / env_name
 
     # Check if the environment exists.
     if not env_path.exists():
@@ -632,6 +686,8 @@ def command_setup_uv(env_name: str) -> None:
         run_command(["uv", "venv", "--clear", "--seed", "--python", py_ver, str(env_path)])
     else:
         print_info(f"uv environment '{env_name}' already exists.")
+        # Validate Python version of existing environment.
+        _check_venv_python_version(env_path, py_ver)
 
     # Setup Isaac Lab and Isaac Sim environment variables through uv activation hooks.
     _write_uv_env_hooks(env_path)

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -5,6 +5,7 @@
 
 import os
 import shutil
+import sys
 from pathlib import Path
 
 from ..utils import (
@@ -47,6 +48,33 @@ def _install_system_deps() -> None:
             "build-essential",
         ]
         run_command(["sudo"] + cmd if os.geteuid() != 0 else cmd)
+
+    # On ARM Linux (e.g. DGX Spark), Python dev headers (Python.h) are needed
+    # to build C extensions such as quadprog. They are typically pre-installed
+    # in x86 Docker images but missing on bare-metal ARM systems.
+    if is_arm():
+        python_dev_pkg = f"python{sys.version_info.major}.{sys.version_info.minor}-dev"
+        try:
+            import sysconfig
+
+            if sysconfig.get_path("include") and os.path.isfile(
+                os.path.join(sysconfig.get_path("include"), "Python.h")
+            ):
+                print_info("Python dev headers are already installed.")
+            else:
+                raise FileNotFoundError
+        except (FileNotFoundError, AttributeError):
+            print_info(f"Installing {python_dev_pkg} (required for building C extensions on ARM)...")
+            cmd = ["apt-get", "update"]
+            run_command(["sudo"] + cmd if os.geteuid() != 0 else cmd)
+            cmd = [
+                "apt-get",
+                "install",
+                "-y",
+                "--no-install-recommends",
+                python_dev_pkg,
+            ]
+            run_command(["sudo"] + cmd if os.geteuid() != 0 else cmd)
 
 
 def _ensure_cuda_torch() -> None:

--- a/source/isaaclab/isaaclab/cli/commands/misc.py
+++ b/source/isaaclab/isaaclab/cli/commands/misc.py
@@ -9,6 +9,7 @@ from ..utils import (
     ISAACLAB_ROOT,
     extract_isaacsim_exe,
     extract_python_exe,
+    get_pip_command,
     is_windows,
     print_info,
     print_warning,
@@ -82,8 +83,9 @@ def command_build_docs() -> None:
     docs_dir = ISAACLAB_ROOT / "docs"
 
     # Install reqs.
+    pip_cmd = get_pip_command(python_exe)
     run_command(
-        [python_exe, "-m", "pip", "install", "-r", "requirements.txt"],
+        pip_cmd + ["install", "-r", "requirements.txt"],
         cwd=docs_dir,
     )
 

--- a/source/isaaclab/isaaclab/cli/utils.py
+++ b/source/isaaclab/isaaclab/cli/utils.py
@@ -258,6 +258,18 @@ def extract_python_exe() -> str:
         else:
             print_debug("extract_python_exe(): No CONDA_PREFIX found.")
 
+    # Try the default Isaac Lab uv venv (env_isaaclab/) in the repo root.
+    if not python_exe or not Path(python_exe).exists():
+        default_venv = ISAACLAB_ROOT / "env_isaaclab"
+        if default_venv.is_dir():
+            if is_windows():
+                candidate = default_venv / "Scripts" / "python.exe"
+            else:
+                candidate = default_venv / "bin" / "python"
+            if candidate.exists():
+                print_debug(f"extract_python_exe(): Found default venv python: {candidate}")
+                python_exe = candidate
+
     # Try kit python.
     if not python_exe or not Path(python_exe).exists():
         print_debug("extract_python_exe(): Checking for Kit python...")


### PR DESCRIPTION
## Summary
- Add Python version validation for existing virtual environments
- Support reusing an active virtual environment with `isaaclab.sh -uv`
- Install `python-dev` headers on ARM (e.g. DGX Spark) for building C extensions
- Use environment pip for doc builds

Split from #4966 per reviewer feedback (CLI changes only).

## Test plan
- [ ] Run `./isaaclab.sh -uv` with an active venv and verify it configures hooks
- [ ] Run `./isaaclab.sh -uv` with a mismatched Python version venv and verify error
- [ ] Run `./isaaclab.sh -i` on ARM and verify python-dev installation
- [ ] Run `./isaaclab.sh -d` and verify doc build uses correct pip