### PR TITLE
Supports hydra presetting scalar values

### DIFF
--- a/docs/source/features/hydra.rst
+++ b/docs/source/features/hydra.rst
@@ -171,12 +171,15 @@ combinations early with clear error messages.
 Preset System
 -------------
 
-The preset system lets you swap out entire config sections with a single command line argument.
-Instead of overriding individual fields, you select a named preset that **completely replaces** the
-config section (no field merging).
+The preset system lets you swap out entire config sections -- or individual scalar
+values -- with a single command line argument. Instead of overriding individual
+fields, you select a named preset that **completely replaces** the config section
+(no field merging).
 
-Presets are defined directly on config classes using a ``presets`` attribute. The system recursively
-discovers all presets from nested configs automatically.
+Presets are declared by subclassing :class:`~isaaclab_tasks.utils.hydra.PresetCfg`
+or by using the :func:`~isaaclab_tasks.utils.hydra.preset` convenience factory. The
+system recursively discovers all presets from nested configs automatically,
+including presets inside dict-valued fields (e.g. ``actuators``).
 
 
 Override Order
@@ -184,71 +187,18 @@ Override Order
 
 Overrides are applied in sequence:
 
-1. **Auto-default**: Configs with a ``"default"`` preset auto-apply without CLI args
-2. **Global presets**: ``presets=inference,newton`` applies to ALL matching configs
-3. **Path presets**: ``env.actions.arm_action=relative_joint_position`` replaces specific section
+1. **Auto-default**: Configs with a ``"default"`` field auto-apply without CLI args
+2. **Global presets**: ``presets=newton,inference`` applies to ALL matching configs
+3. **Path presets**: ``env.backend=newton`` replaces a specific section
 4. **Scalar overrides**: ``env.sim.dt=0.001`` modifies individual fields
 
 
-Defining Presets
-^^^^^^^^^^^^^^^^
+Defining Presets with PresetCfg
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are four styles for defining presets:
-
-**Style 1: Inheritance** - Default values from base class, presets for alternatives:
-
-.. code-block:: python
-
-    @configclass
-    class FrankaArmActionCfg(mdp.JointPositionActionCfg):
-        """Franka arm action config with presets for different action types."""
-
-        presets = {
-            "joint_position_to_limit": mdp.JointPositionToLimitsActionCfg(
-                asset_name="robot", joint_names=["panda_joint.*"]
-            ),
-            "relative_joint_position": mdp.RelativeJointPositionActionCfg(
-                asset_name="robot", joint_names=["panda_joint.*"], scale=0.2
-            ),
-        }
-
-**Style 2: Inner class** - Self-contained with nested preset definitions:
-
-.. code-block:: python
-
-    @configclass
-    class SimCfg:
-        """Simulation config with physics backend presets."""
-
-        backend: str = "physx"
-        dt: float = 0.005
-        substeps: int = 2
-
-        @configclass
-        class Newton:
-            backend: str = "newton"
-            dt: float = 0.002
-            substeps: int = 4
-            solver_iterations: int = 8
-
-        presets = {"newton": Newton()}
-
-**Style 3: Preset-only with auto-default** - Pure composition, no default fields:
-
-.. code-block:: python
-
-    @configclass
-    class ObservationsCfg:
-        """Observation specifications with presets."""
-
-        presets = {
-            "default": DefaultObservationsCfg(),
-            "noise_less": NoiselessObservationsCfg(),
-        }
-
-With Style 3, the ``"default"`` preset is automatically applied when no preset is selected.
-
-**Style 4: PresetCfg class** - Declarative, class-based preset definitions:
+Create a :class:`~isaaclab_tasks.utils.hydra.PresetCfg` subclass where each field
+is a named alternative. The ``default`` field is the config used when no CLI
+override is given:
 
 .. code-block:: python
 
@@ -256,28 +206,20 @@ With Style 3, the ``"default"`` preset is automatically applied when no preset i
 
     @configclass
     class PhysicsCfg(PresetCfg):
-        """Physics backend presets using class-based pattern."""
-
         default: PhysxCfg = PhysxCfg()
         newton: NewtonCfg = NewtonCfg()
 
     @configclass
-    class SimCfg:
+    class MyEnvCfg:
         physics: PhysicsCfg = PhysicsCfg()
-
-With Style 4, each field on the ``PresetCfg`` subclass is a named preset. The ``default`` field
-holds the config instance used when no CLI override is given. ``collect_presets`` automatically
-discovers ``PresetCfg`` subclasses and converts their fields into a presets dict, so no
-``presets`` attribute is needed. CLI usage is the same as other styles:
 
 .. code-block:: bash
 
     # Use Newton physics backend
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        env.sim.physics=newton
+    python train.py --task=Isaac-Reach-Franka-v0 env.physics=newton
 
-The ``default`` field can be set to ``None`` to make an optional feature that is disabled unless
-explicitly selected on the command line:
+The ``default`` field can be set to ``None`` to make an optional feature that is
+disabled unless explicitly selected:
 
 .. code-block:: python
 
@@ -291,108 +233,128 @@ explicitly selected on the command line:
     class SceneCfg:
         camera: CameraPresetCfg = CameraPresetCfg()
 
-When no CLI argument is given, ``camera`` resolves to ``None`` (no camera):
-
 .. code-block:: bash
 
-    # camera is None — no camera overhead
+    # camera is None -- no camera overhead
     python train.py --task=Isaac-Reach-Franka-v0
 
     # activate camera with the "large" preset
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        env.scene.camera=large
+    python train.py --task=Isaac-Reach-Franka-v0 env.scene.camera=large
+
+
+Inline Presets with preset()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For simple values (scalars, lists) that don't warrant a full subclass, use the
+:func:`~isaaclab_tasks.utils.hydra.preset` factory. It dynamically creates a
+``PresetCfg`` instance from keyword arguments:
+
+.. code-block:: python
+
+    from isaaclab_tasks.utils.hydra import preset
+
+    # Scalar preset -- one line, no boilerplate class
+    self.scene.robot.actuators["legs"].armature = preset(default=0.0, newton=0.01, physx=0.0)
+
+This is equivalent to defining a ``PresetCfg`` subclass with three ``float``
+fields, but without the ceremony. The ``default`` keyword is required.
+
+``preset()`` works for any value type -- scalars, lists, or even config
+instances:
+
+.. code-block:: python
+
+    # Resolution preset on a camera config field
+    width = preset(default=64, res128=128, res256=256)
+
+    # List preset for camera data types
+    @configclass
+    class DataTypeCfg(PresetCfg):
+        default: list = ["rgb"]
+        depth: list = ["depth"]
+        albedo: list = ["albedo"]
+
+Use ``preset()`` when the definition fits on a single line.  Use a
+``PresetCfg`` subclass when the options are verbose enough to benefit from
+type annotations and multiline formatting.
+
+The preset system discovers ``preset()`` values anywhere in the config tree,
+including inside dict-valued fields such as ``actuators``:
+
+.. code-block:: bash
+
+    # Select newton preset globally -- sets armature to 0.01
+    python train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 presets=newton
 
 
 Using Presets
 ^^^^^^^^^^^^^
 
-**Path presets** - Select a specific preset for one config path:
+**Path presets** -- select a specific preset for one config path:
 
 .. code-block:: bash
 
-    # Use relative joint position action
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        env.actions.arm_action=relative_joint_position
+    python train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 \
+        env.events=newton
 
-    # Use noiseless observations
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        env.observations=noise_less
-
-**Path preset + scalar override** - Select preset then modify a field:
+**Global presets** -- apply the same preset name everywhere it exists:
 
 .. code-block:: bash
 
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        env.actions.arm_action=relative_joint_position \
-        env.actions.arm_action.scale=0.5
+    # Apply "newton" preset to all configs that define it
+    python train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 \
+        presets=newton
 
-**Global presets** - Apply the same preset name everywhere it exists:
-
-.. code-block:: bash
-
-    # Apply "inference" preset to all configs that define it
-    # (e.g., observations, policy, etc.)
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        presets=inference
-
-**Multiple global presets** - Apply several non-conflicting presets:
+**Multiple global presets** -- apply several non-conflicting presets:
 
 .. code-block:: bash
 
-    # Newton physics backend + inference mode
-    python train.py --task=Isaac-Reach-Franka-v0 \
+    python train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 \
         presets=newton,inference
 
-**Combined** - Global presets + path presets + scalar overrides:
+**Combined** -- global presets + scalar overrides:
 
 .. code-block:: bash
 
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        presets=inference \
-        env.actions.arm_action=relative_joint_position \
-        env.actions.arm_action.scale=0.5 \
+    python train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 \
+        presets=newton \
         env.sim.dt=0.002
 
 
 Global Preset Conflict Detection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If multiple global presets define the same path, an error is raised:
+If two global presets both match the same config path, an error is raised
+so the ambiguity is caught early:
 
-.. code-block:: bash
+.. code-block:: text
 
-    # ERROR: both "fast" and "noise_less" define env.observations
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        presets=fast,noise_less
-
-    # ValueError: Conflicting global presets: 'fast' and 'noise_less'
-    #             both define preset for 'env.observations'
+    ValueError: Conflicting global presets: 'foo' and 'bar'
+                both define preset for 'env.events'
 
 
 Real-World Example
 ^^^^^^^^^^^^^^^^^^
 
-The Franka Reach environment demonstrates presets in practice:
+The ANYmal-C locomotion environment shows both ``PresetCfg`` and ``preset()``
+working together:
 
-.. literalinclude:: ../../../source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/config/franka/joint_pos_env_cfg.py
+.. literalinclude:: ../../../source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/rough_env_cfg.py
     :language: python
-    :start-at: @configclass
-    :end-before: class FrankaReachEnvCfg_PLAY
+    :lines: 21-42
 
-This allows users to switch action types:
+A single ``presets=newton`` on the command line resolves every ``PresetCfg``
+and ``preset()`` that defines a ``newton`` field: the physics engine is swapped
+to Newton, ``AnymalCEventsCfg`` selects Newton-compatible events, and the
+actuator armature is set to ``0.01``.
 
 .. code-block:: bash
 
-    # Default: JointPositionActionCfg (from inheritance)
-    python train.py --task=Isaac-Reach-Franka-v0
+    # Default (PhysX events, armature=0.0)
+    python train.py --task=Isaac-Velocity-Rough-Anymal-C-v0
 
-    # Switch to relative joint position
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        env.actions.arm_action=relative_joint_position
-
-    # Switch to joint position with limits
-    python train.py --task=Isaac-Reach-Franka-v0 \
-        env.actions.arm_action=joint_position_to_limit
+    # Newton (Newton events, armature=0.01)
+    python train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 presets=newton
 
 
 Summary
@@ -409,10 +371,10 @@ Summary
      - ``env.sim.dt=0.001``
      - Modify single field
    * - Path preset
-     - ``env.actions.arm_action=relative``
+     - ``env.events=newton``
      - Replace entire section
    * - Global preset
-     - ``presets=inference``
+     - ``presets=newton``
      - Apply everywhere matching
    * - Combined
      - ``presets=newton env.sim.dt=0.001``

--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "1.5.10"
+version = "1.5.11"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+1.5.11 (2026-03-13)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Simplified the Hydra preset system by removing the dict-style ``presets = {...}``
+  attribute in favor of :class:`~isaaclab_tasks.utils.hydra.PresetCfg` subclasses
+  and the new :func:`~isaaclab_tasks.utils.hydra.preset` factory for inline scalar
+  overrides.
+
+
 1.5.10 (2026-03-12)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
@@ -19,7 +19,7 @@ class PhysicsCfg(PresetCfg):
     default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
     newton = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
-            njmax=50,
+            njmax=120,
             nconmax=15,
             cone="elliptic",
             impratio=100,

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/rough_env_cfg.py
@@ -10,7 +10,7 @@ from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     StartupEventsCfg,
 )
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 ##
 # Pre-defined configs
@@ -39,6 +39,7 @@ class AnymalCRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
         super().__post_init__()
         # switch robot to anymal-c
         self.scene.robot = ANYMAL_C_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+        self.scene.robot.actuators["legs"].armature = preset(default=0.0, newton=0.01, physx=0.0)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/velocity_env_cfg.py
@@ -20,13 +20,14 @@ from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
-from isaaclab.sensors import ContactSensorCfg, RayCasterCfg, patterns
+from isaaclab.sensors import RayCasterCfg, patterns
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 import isaaclab_tasks.manager_based.locomotion.velocity.mdp as mdp
+from isaaclab_tasks.utils import PresetCfg
 
 ##
 # Pre-defined configs
@@ -40,11 +41,10 @@ from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG  # isort: skip
 
 
 @configclass
-class VelocityEnvContactSensorCfg:
-    presets: dict[str, ContactSensorCfg] = {
-        "default": PhysXContactSensorCfg(prim_path="{ENV_REGEX_NS}/Robot/.*", history_length=3, track_air_time=True),
-        "newton": NewtonContactSensorCfg(prim_path="{ENV_REGEX_NS}/Robot/.*", history_length=3, track_air_time=True),
-    }
+class VelocityEnvContactSensorCfg(PresetCfg):
+    default = PhysXContactSensorCfg(prim_path="{ENV_REGEX_NS}/Robot/.*", history_length=3, track_air_time=True)
+    newton = NewtonContactSensorCfg(prim_path="{ENV_REGEX_NS}/Robot/.*", history_length=3, track_air_time=True)
+    physx = default
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
@@ -9,6 +9,7 @@ __all__ = [
     "load_cfg_from_registry",
     "parse_env_cfg",
     "PresetCfg",
+    "preset",
     "resolve_task_config",
     "hydra_task_config",
     "resolve_preset_defaults",
@@ -17,7 +18,7 @@ __all__ = [
     "compute_kit_requirements",
 ]
 
-from .hydra import PresetCfg, hydra_task_config, resolve_task_config
+from .hydra import PresetCfg, preset, hydra_task_config, resolve_task_config
 from .importer import import_packages
 from .parse_cfg import get_checkpoint_path, load_cfg_from_registry, parse_env_cfg
 from .hydra import resolve_task_config, hydra_task_config, resolve_preset_defaults

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -7,23 +7,23 @@
 
 This module bypasses Hydra's default MERGE behavior for config groups.
 Instead, when a preset is selected, the entire config section is REPLACED
-with the preset - no field merging.
+with the preset -- no field merging.
 
-Presets are defined on individual configclasses using a `presets` dict.
-The system recursively discovers all presets and their paths automatically.
+Presets are declared by subclassing :class:`PresetCfg` (or using the
+:func:`preset` factory for scalars). The system recursively discovers all
+presets and their paths automatically, including inside dict-valued fields.
 
 Override categories (applied in order):
-    1. Global presets: `presets=inference,newton` -> apply everywhere matching
-    2. Path presets: `env.actions=joint_control` -> REPLACE specific section
-    3. Preset-path scalars: `env.actions.scale=5.0` -> handled by us
-    4. Global scalars: `env.sim.dt=0.01` -> handled by Hydra
+    1. Global presets: ``presets=inference,newton`` -- apply everywhere matching
+    2. Path presets: ``env.backend=newton`` -- REPLACE specific section
+    3. Preset-path scalars: ``env.backend.dt=0.001`` -- handled by us
+    4. Global scalars: ``env.decimation=10`` -- handled by Hydra
 
-Example usage:
-    # Apply "inference" preset everywhere it exists, then override scale
-    presets=inference env.actions.arm_action.scale=0.5 env.sim.dt=0.01
+Example usage::
+
+    presets=newton env.backend.dt=0.001 env.decimation=10
 """
 
-import contextlib
 import functools
 import sys
 from collections.abc import Callable, Mapping
@@ -61,37 +61,60 @@ class PresetCfg:
     pass
 
 
+def preset(**options) -> PresetCfg:
+    """Create a :class:`PresetCfg` instance from keyword arguments.
+
+    A convenience factory that dynamically builds a ``PresetCfg`` subclass
+    with one field per keyword argument, then returns an instance of it.
+    The caller **must** supply a ``default`` key.
+
+    Example::
+
+        armature = preset(default=0.0, newton=0.01)
+        # Equivalent to:
+        # @configclass
+        # class _Preset(PresetCfg):
+        #     default: float = 0.0
+        #     newton: float = 0.01
+        # armature = _Preset()
+
+    Args:
+        **options: Preset alternatives keyed by name.  Must include ``default``.
+
+    Returns:
+        A ``PresetCfg`` instance whose fields are the supplied options.
+
+    Raises:
+        ValueError: If ``default`` is not provided.
+    """
+    if "default" not in options:
+        raise ValueError("preset() requires a 'default' keyword argument.")
+    annotations = {k: type(v) if v is not None else object for k, v in options.items()}
+    ns = {"__annotations__": annotations, **options}
+    cls = configclass(type("_Preset", (PresetCfg,), ns))
+    return cls()
+
+
 def collect_presets(cfg, path: str = "") -> dict:
-    """Recursively walk config tree and collect presets with auto-discovered paths.
+    """Recursively walk config tree and collect :class:`PresetCfg` fields.
 
-    Each configclass can define a `presets` dict attribute. Presets are collected
-    at the path where they're found. The dict can have two formats:
-
-    1. Simple format (presets for the current field):
-       presets = {"preset_name": ConfigInstance(), ...}
-       -> Collected at current path
-
-    2. Nested format (presets for child fields, legacy support):
-       presets = {"child.path": {"preset_name": ConfigInstance()}, ...}
-       -> Collected at specified sub-path
+    Presets are defined by subclassing :class:`PresetCfg` with typed fields for
+    each alternative, or by using the :func:`preset` factory for scalar values.
+    This function discovers them at every level of the config tree, including
+    inside dict-valued fields (e.g. ``actuators``).
 
     Args:
         cfg: A configclass instance to walk.
         path: Current path prefix (used during recursion).
 
     Returns:
-        Dict mapping paths to preset dicts, e.g.:
-        {"actions.arm_action": {"relative_joint_position": <cfg>, ...}}
+        Dict mapping dotted paths to preset dicts, e.g.:
+        ``{"backend": {"default": PhysxCfg(), "newton": NewtonCfg()}}``
     """
     result = {}
 
     # Root-level PresetCfg: the cfg itself is a PresetCfg subclass
     if isinstance(cfg, PresetCfg) and hasattr(cfg, "__dataclass_fields__"):
-        if getattr(cfg, "presets", None):
-            raise ValueError(
-                f"PresetCfg subclass at '{path or '<root>'}' must not define a 'presets' attribute. "
-                "Use typed fields instead (e.g., default: MyCfg = MyCfg())."
-            )
         preset_dict = {}
         for field_name in cfg.__dataclass_fields__:
             preset_dict[field_name] = getattr(cfg, field_name)
@@ -101,51 +124,32 @@ def collect_presets(cfg, path: str = "") -> dict:
                 result.update(collect_presets(alt, path))
         return result
 
-    # Check if this config has presets
-    presets = getattr(cfg, "presets", None)
-    if presets and isinstance(presets, dict):
-        # Check format: simple (values are configs) or nested (values are dicts)
-        first_val = next(iter(presets.values()), None) if presets else None
-        is_nested_format = isinstance(first_val, dict)
-
-        if is_nested_format:
-            # Nested format: {"field.path": {"name": cfg}}
-            for sub_path, sub_presets in presets.items():
-                full_path = f"{path}.{sub_path}" if path else sub_path
-                result[full_path] = sub_presets
-        else:
-            # Simple format: {"name": cfg} - presets for current field
-            if path:
-                result[path] = presets
-
     # Recurse into nested configclass attributes
     for name in dir(cfg):
-        if name.startswith("_") or name == "presets":
+        if name.startswith("_"):
             continue
         try:
             value = getattr(cfg, name)
         except Exception:
             continue
 
-        # Check if it's a configclass (has __dataclass_fields__)
+        child_path = f"{path}.{name}" if path else name
+
         if hasattr(value, "__dataclass_fields__"):
-            child_path = f"{path}.{name}" if path else name
             if isinstance(value, PresetCfg):
-                if getattr(value, "presets", None):
-                    raise ValueError(
-                        f"PresetCfg subclass at '{child_path}' must not define a 'presets' attribute. "
-                        "Use typed fields instead (e.g., default: MyCfg = MyCfg())."
-                    )
                 preset_dict = {}
                 for field_name in value.__dataclass_fields__:
                     preset_dict[field_name] = getattr(value, field_name)
                 result[child_path] = preset_dict
-                # Recurse into each alternative to find nested PresetCfg
                 for alt in preset_dict.values():
                     if hasattr(alt, "__dataclass_fields__"):
                         result.update(collect_presets(alt, child_path))
             else:
                 result.update(collect_presets(value, child_path))
+        elif isinstance(value, dict):
+            for dict_key, dict_val in value.items():
+                if hasattr(dict_val, "__dataclass_fields__"):
+                    result.update(collect_presets(dict_val, f"{child_path}.{dict_key}"))
 
     return result
 
@@ -179,9 +183,6 @@ def resolve_task_config(task_name: str, agent_cfg_entry_point: str):
         env_cfg, agent_cfg = apply_overrides(
             env_cfg, agent_cfg, hydra_cfg, global_presets, preset_sel, preset_scalar, presets
         )
-        _cleanup_presets(env_cfg)
-        _cleanup_presets(agent_cfg)
-        _cleanup_presets_dict(hydra_cfg)
         env_cfg.from_dict(hydra_cfg["env"])
         env_cfg = replace_strings_with_env_cfg_spaces(env_cfg)
         if isinstance(agent_cfg, dict) or agent_cfg is None:
@@ -228,9 +229,6 @@ def hydra_task_config(task_name: str, agent_cfg_entry_point: str) -> Callable:
                 env_cfg, agent_cfg = apply_overrides(
                     env_cfg, agent_cfg, hydra_cfg, global_presets, preset_sel, preset_scalar, presets
                 )
-                _cleanup_presets(env_cfg)
-                _cleanup_presets(agent_cfg)
-                _cleanup_presets_dict(hydra_cfg)
                 env_cfg.from_dict(hydra_cfg["env"])
                 env_cfg = replace_strings_with_env_cfg_spaces(env_cfg)
                 if isinstance(agent_cfg, dict) or agent_cfg is None:
@@ -271,9 +269,14 @@ def resolve_preset_defaults(cfg):
             default = getattr(value, "default", None)
             if default is not None:
                 setattr(cfg, name, default)
-                resolve_preset_defaults(default)
+                if hasattr(default, "__dataclass_fields__"):
+                    resolve_preset_defaults(default)
         elif hasattr(value, "__dataclass_fields__"):
             resolve_preset_defaults(value)
+        elif isinstance(value, dict):
+            for dict_val in value.values():
+                if hasattr(dict_val, "__dataclass_fields__"):
+                    resolve_preset_defaults(dict_val)
     return cfg
 
 
@@ -402,8 +405,11 @@ def apply_overrides(
         obj = cfgs[sec]
         for part in path.split("."):
             try:
-                obj = getattr(obj, part)
-            except (AttributeError, TypeError):
+                if isinstance(obj, dict):
+                    obj = obj[part]
+                else:
+                    obj = getattr(obj, part)
+            except (AttributeError, TypeError, KeyError):
                 return False
             if obj is None:
                 return False
@@ -415,8 +421,10 @@ def apply_overrides(
             node_dict = None
         elif hasattr(node, "to_dict"):
             node_dict = node.to_dict()
-        else:
+        elif isinstance(node, Mapping):
             node_dict = dict(node)
+        else:
+            node_dict = node
         if path == "":
             cfgs[sec] = node
             hydra_cfg[sec] = node_dict
@@ -479,39 +487,6 @@ def apply_overrides(
             _setattr(hydra_cfg, full_path, val)
 
     return cfgs["env"], cfgs["agent"]
-
-
-def _cleanup_presets(cfg):
-    """Recursively remove ``presets`` fields from a config tree after resolution.
-
-    Once all presets have been selected and applied, the ``presets`` metadata
-    is no longer needed and would confuse downstream managers that expect every
-    field to be a term config.
-    """
-    if cfg is None:
-        return
-    if hasattr(cfg, "presets"):
-        with contextlib.suppress(Exception):
-            delattr(cfg, "presets")
-    for name in list(getattr(cfg, "__dataclass_fields__", {}).keys()):
-        if name == "presets":
-            continue
-        try:
-            value = getattr(cfg, name)
-        except Exception:
-            continue
-        if hasattr(value, "__dataclass_fields__"):
-            _cleanup_presets(value)
-
-
-def _cleanup_presets_dict(d: dict):
-    """Recursively remove ``presets`` keys from a nested dict."""
-    if not isinstance(d, dict):
-        return
-    d.pop("presets", None)
-    for v in d.values():
-        if isinstance(v, dict):
-            _cleanup_presets_dict(v)
 
 
 def _setattr(obj, path: str, val):

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -50,18 +50,23 @@ def _resolve_presets_to_default(cfg: object) -> object:
         return cfg
     for field_name in list(cfg.__dataclass_fields__):
         value = getattr(cfg, field_name, None)
-        if value is None or not hasattr(value, "__dataclass_fields__"):
+        if value is None:
             continue
-        if _is_preset_cfg(value):
-            resolved = value.default
-            setattr(cfg, field_name, resolved)
-            _resolve_presets_to_default(resolved)
-        elif _is_old_style_preset(value):
-            resolved = value.presets["default"]
-            setattr(cfg, field_name, resolved)
-            _resolve_presets_to_default(resolved)
-        else:
-            _resolve_presets_to_default(value)
+        if hasattr(value, "__dataclass_fields__"):
+            if _is_preset_cfg(value):
+                resolved = value.default
+                setattr(cfg, field_name, resolved)
+                _resolve_presets_to_default(resolved)
+            elif _is_old_style_preset(value):
+                resolved = value.presets["default"]
+                setattr(cfg, field_name, resolved)
+                _resolve_presets_to_default(resolved)
+            else:
+                _resolve_presets_to_default(value)
+        elif isinstance(value, dict):
+            for dict_val in value.values():
+                if hasattr(dict_val, "__dataclass_fields__"):
+                    _resolve_presets_to_default(dict_val)
     return cfg
 
 
@@ -85,22 +90,32 @@ def apply_named_preset(env_cfg: object, raw_cfg: object, preset_name: str) -> No
         return
     for field_name in raw_cfg.__dataclass_fields__:
         raw_value = getattr(raw_cfg, field_name, None)
-        if raw_value is None or not hasattr(raw_value, "__dataclass_fields__"):
+        if raw_value is None:
             continue
-        if _is_preset_cfg(raw_value):
-            if hasattr(raw_value, preset_name):
-                resolved = getattr(raw_value, preset_name)
-                setattr(env_cfg, field_name, resolved)
-                apply_named_preset(resolved, resolved, preset_name)
-        elif _is_old_style_preset(raw_value):
-            if preset_name in raw_value.presets:
-                resolved = raw_value.presets[preset_name]
-                setattr(env_cfg, field_name, resolved)
-                apply_named_preset(resolved, resolved, preset_name)
-        else:
-            env_value = getattr(env_cfg, field_name, None)
-            if env_value is not None and hasattr(env_value, "__dataclass_fields__"):
-                apply_named_preset(env_value, raw_value, preset_name)
+        if hasattr(raw_value, "__dataclass_fields__"):
+            if _is_preset_cfg(raw_value):
+                if hasattr(raw_value, preset_name):
+                    resolved = getattr(raw_value, preset_name)
+                    setattr(env_cfg, field_name, resolved)
+                    apply_named_preset(resolved, resolved, preset_name)
+            elif _is_old_style_preset(raw_value):
+                if preset_name in raw_value.presets:
+                    resolved = raw_value.presets[preset_name]
+                    setattr(env_cfg, field_name, resolved)
+                    apply_named_preset(resolved, resolved, preset_name)
+            else:
+                env_value = getattr(env_cfg, field_name, None)
+                if env_value is not None and hasattr(env_value, "__dataclass_fields__"):
+                    apply_named_preset(env_value, raw_value, preset_name)
+        elif isinstance(raw_value, dict):
+            env_dict = getattr(env_cfg, field_name, None)
+            if not isinstance(env_dict, dict):
+                continue
+            for key, raw_dict_val in raw_value.items():
+                if hasattr(raw_dict_val, "__dataclass_fields__") and key in env_dict:
+                    env_dict_val = env_dict[key]
+                    if hasattr(env_dict_val, "__dataclass_fields__"):
+                        apply_named_preset(env_dict_val, raw_dict_val, preset_name)
 
 
 def load_cfg_from_registry(task_name: str, entry_point_key: str) -> dict | object:

--- a/source/isaaclab_tasks/test/test_hydra.py
+++ b/source/isaaclab_tasks/test/test_hydra.py
@@ -18,38 +18,13 @@ from isaaclab_tasks.utils.hydra import (
     apply_overrides,
     collect_presets,
     parse_overrides,
+    preset,
     resolve_preset_defaults,
 )
 
 # =============================================================================
 # Leaf config classes (reused across all test sections)
 # =============================================================================
-
-
-@configclass
-class JointPositionActionCfg:
-    class_type: str = "JointPositionAction"
-    asset_name: str = "robot"
-    joint_names: list = [".*"]
-    scale: float = 1.0
-    offset: float = 0.0
-
-
-@configclass
-class RelativeJointPositionActionCfg:
-    class_type: str = "RelativeJointPositionAction"
-    asset_name: str = "robot"
-    joint_names: list = [".*"]
-    scale: float = 0.2
-    offset: float = 0.0
-    use_zero_offset: bool = True
-
-
-@configclass
-class VelocityActionCfg:
-    class_type: str = "VelocityAction"
-    asset_name: str = "robot"
-    velocity_scale: float = 1.0
 
 
 @configclass
@@ -87,87 +62,25 @@ class SmallPolicyCfg:
 
 
 @configclass
-class LargePolicyCfg:
-    actor_hidden_dims: list = [512, 256, 128]
-
-
-@configclass
 class FastPolicyCfg:
     actor_hidden_dims: list = [32, 16]
 
 
 # =============================================================================
-# Composite configs using presets dict (Style 1-3)
+# Composite configs using PresetCfg
 # =============================================================================
-
-
-@configclass
-class ArmActionCfg:
-    presets = {
-        "default": JointPositionActionCfg(),
-        "joint_position": JointPositionActionCfg(),
-        "relative_joint_position": RelativeJointPositionActionCfg(),
-    }
-
-
-@configclass
-class JointControlActionsCfg:
-    arm_action: ArmActionCfg = ArmActionCfg()
-
-
-@configclass
-class VelocityControlActionsCfg:
-    velocity_command: VelocityActionCfg = VelocityActionCfg()
-
-
-@configclass
-class ObservationsCfg:
-    enable_corruption: bool = True
-    concatenate_terms: bool = True
-    noise_scale: float = 0.1
-    presets = {
-        "noise_less": NoiselessObservationsCfg(),
-        "fast": FastObservationsCfg(),
-    }
-
-
-@configclass
-class ActionsCfg:
-    arm_action: ArmActionCfg = ArmActionCfg()
-    presets = {
-        "joint_control": JointControlActionsCfg(),
-        "velocity_control": VelocityControlActionsCfg(),
-    }
-
-
-@configclass
-class PolicyCfg:
-    actor_hidden_dims: list = [256, 128]
-    presets = {
-        "small_network": SmallPolicyCfg(),
-        "large_network": LargePolicyCfg(),
-        "fast": FastPolicyCfg(),
-    }
 
 
 @configclass
 class SampleEnvCfg:
     decimation: int = 4
     sim_dt: float = 0.005
-    observations: ObservationsCfg = ObservationsCfg()
-    actions: ActionsCfg = ActionsCfg()
 
 
 @configclass
 class SampleAgentCfg:
     max_iterations: int = 1000
     learning_rate: float = 3e-4
-    policy: PolicyCfg = PolicyCfg()
-
-
-# =============================================================================
-# Composite configs using PresetCfg (Style 4)
-# =============================================================================
 
 
 @configclass
@@ -255,15 +168,6 @@ class NestedPresetEnvCfg:
 
 
 @pytest.fixture
-def dict_presets():
-    """Fresh configs using presets dict pattern."""
-    env_cfg = SampleEnvCfg()
-    agent_cfg = SampleAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    return env_cfg, agent_cfg, presets
-
-
-@pytest.fixture
 def class_presets():
     """Fresh configs using PresetCfg pattern."""
     env_cfg = PresetCfgEnvCfg()
@@ -275,17 +179,6 @@ def class_presets():
 # =============================================================================
 # Tests: collect_presets
 # =============================================================================
-
-
-def test_collect_presets_dict_style():
-    """presets dict discovered at correct paths."""
-    presets = collect_presets(SampleEnvCfg())
-    assert "observations" in presets
-    assert "actions" in presets
-    assert "actions.arm_action" in presets
-    assert "noise_less" in presets["observations"]
-    assert "velocity_control" in presets["actions"]
-    assert "relative_joint_position" in presets["actions.arm_action"]
 
 
 def test_collect_presets_class_style():
@@ -306,52 +199,26 @@ def test_collect_presets_root_level():
     assert presets[""]["fast"].max_iterations == 100
 
 
-def test_collect_presets_class_with_presets_attr_raises():
-    """PresetCfg subclass with a 'presets' attribute raises ValueError."""
-
-    @configclass
-    class BadCfg(PresetCfg):
-        default: PhysxCfg = PhysxCfg()
-        presets = {"extra": PhysxCfg()}
-
-    @configclass
-    class WrapperCfg:
-        child: BadCfg = BadCfg()
-
-    with pytest.raises(ValueError, match="must not define a 'presets' attribute"):
-        collect_presets(WrapperCfg())
-
-
 # =============================================================================
 # Tests: parse_overrides
 # =============================================================================
 
 
-def test_parse_overrides_mixed(dict_presets):
+def test_parse_overrides_mixed():
     """All override types categorized correctly."""
-    _, _, presets = dict_presets
+    env_cfg = PresetCfgEnvCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": {}}
     args = [
         "presets=fast",
         "env.decimation=10",
-        "env.observations=noise_less",
-        "env.actions.arm_action=relative_joint_position",
-        "env.actions.arm_action.scale=2.0",
+        "env.backend=newton",
+        "env.backend.dt=0.001",
     ]
     global_p, sel, scalar, glob = parse_overrides(args, presets)
     assert global_p == ["fast"]
-    assert ("env", "observations", "noise_less") in sel
-    assert ("env", "actions.arm_action", "relative_joint_position") in sel
-    assert ("env.actions.arm_action.scale", "2.0") in scalar
+    assert ("env", "backend", "newton") in sel
+    assert ("env.backend.dt", "0.001") in scalar
     assert "env.decimation=10" in glob
-
-
-def test_parse_overrides_sorted_by_depth(dict_presets):
-    """Parent presets applied before children."""
-    _, _, presets = dict_presets
-    args = ["env.actions.arm_action=relative_joint_position", "env.actions=joint_control"]
-    _, sel, _, _ = parse_overrides(args, presets)
-    assert sel[0] == ("env", "actions", "joint_control")
-    assert sel[1] == ("env", "actions.arm_action", "relative_joint_position")
 
 
 def test_parse_overrides_root_preset():
@@ -359,77 +226,6 @@ def test_parse_overrides_root_preset():
     presets = {"env": {}, "agent": collect_presets(RootAgentCfg())}
     _, sel, _, _ = parse_overrides(["agent=fast"], presets)
     assert sel == [("agent", "", "fast")]
-
-
-# =============================================================================
-# Tests: apply_overrides — presets dict
-# =============================================================================
-
-
-def test_apply_global_preset(dict_presets):
-    """Global preset applies to all matching paths."""
-    env_cfg, agent_cfg, presets = dict_presets
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["fast"], [], [], presets)
-    assert env_cfg.observations.enable_corruption is False
-    assert agent_cfg.policy.actor_hidden_dims == [32, 16]
-
-
-def test_apply_multiple_global_presets(dict_presets):
-    """Non-conflicting global presets all apply."""
-    env_cfg, agent_cfg, presets = dict_presets
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["noise_less", "large_network"], [], [], presets)
-    assert env_cfg.observations.noise_scale == 0.0
-    assert agent_cfg.policy.actor_hidden_dims == [512, 256, 128]
-
-
-def test_apply_conflicting_global_raises(dict_presets):
-    """Conflicting global presets raise ValueError."""
-    env_cfg, agent_cfg, presets = dict_presets
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    with pytest.raises(ValueError, match="Conflicting global presets"):
-        apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["fast", "noise_less"], [], [], presets)
-
-
-def test_apply_preset_with_scalars(dict_presets):
-    """Preset selection + scalar overrides."""
-    env_cfg, agent_cfg, presets = dict_presets
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    sel = [("env", "actions.arm_action", "relative_joint_position")]
-    scalars = [("env.actions.arm_action.scale", "5.0"), ("env.actions.arm_action.use_zero_offset", "false")]
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], sel, scalars, presets)
-    assert env_cfg.actions.arm_action.scale == 5.0
-    assert env_cfg.actions.arm_action.use_zero_offset is False
-
-
-def test_apply_nested_groups(dict_presets):
-    """Select parent group, then nested group, then scalar."""
-    env_cfg, agent_cfg, presets = dict_presets
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    sel = [("env", "actions", "joint_control"), ("env", "actions.arm_action", "relative_joint_position")]
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], sel, [("env.actions.arm_action.scale", "7.0")], presets)
-    assert isinstance(env_cfg.actions, JointControlActionsCfg)
-    assert env_cfg.actions.arm_action.scale == 7.0
-
-
-def test_apply_structural_replacement(dict_presets):
-    """Selecting velocity_control replaces structure."""
-    env_cfg, agent_cfg, presets = dict_presets
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [("env", "actions", "velocity_control")], [], presets)
-    assert isinstance(env_cfg.actions, VelocityControlActionsCfg)
-    assert hasattr(env_cfg.actions, "velocity_command")
-
-
-def test_apply_unknown_raises(dict_presets):
-    """Unknown preset group or name raises ValueError."""
-    env_cfg, agent_cfg, presets = dict_presets
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    with pytest.raises(ValueError, match="Unknown preset group"):
-        apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [("env", "nonexistent", "x")], [], presets)
-    with pytest.raises(ValueError, match="Unknown preset"):
-        apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [("env", "observations", "bad")], [], presets)
 
 
 # =============================================================================
@@ -709,3 +505,198 @@ def test_root_presetcfg_global_depth_resolves_nested():
     assert isinstance(env_cfg.sensor.renderer, RendererACfg), (
         f"renderer should be RendererACfg (default), got {type(env_cfg.sensor.renderer).__name__}"
     )
+
+
+# =============================================================================
+# Tests: scalar PresetCfg (e.g., armature=PresetCfg(default=0.0, newton=0.01))
+# =============================================================================
+
+
+@configclass
+class ScalarPresetCfg(PresetCfg):
+    default: float = 0.0
+    newton: float = 0.01
+
+
+@configclass
+class ActuatorWithScalarPresetCfg:
+    joint_names: list = [".*"]
+    stiffness: float = 40.0
+    damping: float = 5.0
+    armature: ScalarPresetCfg = ScalarPresetCfg()
+
+
+@configclass
+class ScalarPresetEnvCfg:
+    decimation: int = 4
+    actuator: ActuatorWithScalarPresetCfg = ActuatorWithScalarPresetCfg()
+
+
+def test_scalar_presetcfg_collect():
+    """Scalar PresetCfg fields collected with correct values."""
+    presets = collect_presets(ScalarPresetEnvCfg())
+    assert "actuator.armature" in presets
+    assert presets["actuator.armature"]["default"] == 0.0
+    assert presets["actuator.armature"]["newton"] == 0.01
+
+
+def test_scalar_presetcfg_resolve_default():
+    """resolve_preset_defaults replaces scalar PresetCfg with its default value."""
+    cfg = ScalarPresetEnvCfg()
+    resolved = resolve_preset_defaults(cfg)
+    assert resolved.actuator.armature == 0.0
+    assert not isinstance(resolved.actuator.armature, PresetCfg)
+
+
+def test_scalar_presetcfg_auto_default():
+    """Scalar PresetCfg auto-applies default=0.0 when no CLI override."""
+    env_cfg = ScalarPresetEnvCfg()
+    agent_cfg = PresetCfgAgentCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
+    env_cfg = resolve_preset_defaults(env_cfg)
+    agent_cfg = resolve_preset_defaults(agent_cfg)
+    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
+    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [], [], presets)
+    assert env_cfg.actuator.armature == 0.0
+
+
+def test_scalar_presetcfg_global_newton():
+    """Global preset=newton replaces scalar PresetCfg with newton value."""
+    env_cfg = ScalarPresetEnvCfg()
+    agent_cfg = PresetCfgAgentCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
+    env_cfg = resolve_preset_defaults(env_cfg)
+    agent_cfg = resolve_preset_defaults(agent_cfg)
+    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
+    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["newton"], [], [], presets)
+    assert env_cfg.actuator.armature == 0.01
+
+
+def test_scalar_presetcfg_path_selection():
+    """Path selection replaces scalar PresetCfg with chosen value."""
+    env_cfg = ScalarPresetEnvCfg()
+    agent_cfg = PresetCfgAgentCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
+    env_cfg = resolve_preset_defaults(env_cfg)
+    agent_cfg = resolve_preset_defaults(agent_cfg)
+    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
+    sel = [("env", "actuator.armature", "newton")]
+    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], sel, [], presets)
+    assert env_cfg.actuator.armature == 0.01
+    assert env_cfg.actuator.stiffness == 40.0  # other fields untouched
+
+
+# =============================================================================
+# Tests: PresetCfg inside dict values (e.g., actuators["legs"].armature)
+# =============================================================================
+
+
+@configclass
+class ActuatorCfgWithPreset:
+    joint_names: list = [".*"]
+    stiffness: float = 40.0
+    damping: float = 5.0
+    armature: ScalarPresetCfg = ScalarPresetCfg()
+
+
+@configclass
+class RobotCfg:
+    prim_path: str = "/World/Robot"
+    actuators: dict = None
+
+    def __post_init__(self):
+        if self.actuators is None:
+            self.actuators = {"legs": ActuatorCfgWithPreset()}
+
+
+@configclass
+class DictPresetEnvCfg:
+    decimation: int = 4
+    robot: RobotCfg = RobotCfg()
+
+
+def test_collect_presets_traverses_dict_values():
+    """collect_presets finds PresetCfg inside dict-held configclass values."""
+    cfg = DictPresetEnvCfg()
+    presets = collect_presets(cfg)
+    assert "robot.actuators.legs.armature" in presets
+    assert presets["robot.actuators.legs.armature"]["default"] == 0.0
+    assert presets["robot.actuators.legs.armature"]["newton"] == 0.01
+
+
+def test_resolve_preset_defaults_traverses_dict_values():
+    """resolve_preset_defaults resolves PresetCfg inside dict-held configclass values."""
+    cfg = DictPresetEnvCfg()
+    resolved = resolve_preset_defaults(cfg)
+    assert resolved.robot.actuators["legs"].armature == 0.0
+    assert not isinstance(resolved.robot.actuators["legs"].armature, PresetCfg)
+
+
+def test_dict_preset_auto_default():
+    """Dict-held PresetCfg auto-applies default when no CLI override."""
+    env_cfg = DictPresetEnvCfg()
+    agent_cfg = PresetCfgAgentCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
+    env_cfg = resolve_preset_defaults(env_cfg)
+    agent_cfg = resolve_preset_defaults(agent_cfg)
+    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
+    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [], [], presets)
+    assert env_cfg.robot.actuators["legs"].armature == 0.0
+
+
+def test_dict_preset_global_newton():
+    """Global preset=newton replaces dict-held scalar PresetCfg."""
+    env_cfg = DictPresetEnvCfg()
+    agent_cfg = PresetCfgAgentCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
+    env_cfg = resolve_preset_defaults(env_cfg)
+    agent_cfg = resolve_preset_defaults(agent_cfg)
+    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
+    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["newton"], [], [], presets)
+    assert env_cfg.robot.actuators["legs"].armature == 0.01
+
+
+def test_dict_preset_path_selection():
+    """Path selection replaces dict-held scalar PresetCfg."""
+    env_cfg = DictPresetEnvCfg()
+    agent_cfg = PresetCfgAgentCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
+    env_cfg = resolve_preset_defaults(env_cfg)
+    agent_cfg = resolve_preset_defaults(agent_cfg)
+    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
+    sel = [("env", "robot.actuators.legs.armature", "newton")]
+    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], sel, [], presets)
+    assert env_cfg.robot.actuators["legs"].armature == 0.01
+    assert env_cfg.robot.actuators["legs"].stiffness == 40.0
+
+
+def test_dict_preset_with_factory():
+    """preset() factory works inside dict-held configclass values."""
+
+    @configclass
+    class ActuatorCfgFactory:
+        joint_names: list = [".*"]
+        armature: object = None
+
+        def __post_init__(self):
+            if self.armature is None:
+                self.armature = preset(default=0.0, newton=0.01, physx=0.0)
+
+    @configclass
+    class RobotCfgFactory:
+        actuators: dict = None
+
+        def __post_init__(self):
+            if self.actuators is None:
+                self.actuators = {"legs": ActuatorCfgFactory()}
+
+    @configclass
+    class EnvCfgFactory:
+        robot: RobotCfgFactory = RobotCfgFactory()
+
+    cfg = EnvCfgFactory()
+    presets = collect_presets(cfg)
+    assert "robot.actuators.legs.armature" in presets
+    assert presets["robot.actuators.legs.armature"]["default"] == 0.0
+    assert presets["robot.actuators.legs.armature"]["newton"] == 0.01
+    assert presets["robot.actuators.legs.armature"]["physx"] == 0.0


### PR DESCRIPTION
# Description

This PR enables hydra to preset scalar values,
this makes convenient for presetting field where it is not a configclass
 

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
