### PR TITLE
Fixes Newton GUI after Update

### DIFF
--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -48,7 +48,7 @@ class NewtonViewerGL(ViewerGL):
         self._metadata = metadata or {}
         self._fallback_draw_controls = False
         self._update_frequency = update_frequency
-        self._color_edit3_accepts_sequence: bool | None = None
+        self._color_edit3_prefers_sequence: bool | None = None
 
         try:
             self.register_ui_callback(self._render_training_controls, position="side")
@@ -124,23 +124,23 @@ class NewtonViewerGL(ViewerGL):
     def _color_edit3_compat(self, imgui, label: str, color):
         """
         # Handle imgui.color_edit3 API differences between bindings.
-        # Some require a Sequence[float], others accept vector-like objects.
+        # Some require vector-like objects, others require a Sequence[float].
         # This method tries both approaches, caching the one that works to avoid repeated exceptions.
         # NOTE: This is a compatibility workaround, perhaps we can address the issue more directly.
         """
         color_tuple = self._coerce_color3(color)
         sequence_color = [color_tuple[0], color_tuple[1], color_tuple[2]]
-        if self._color_edit3_accepts_sequence is not False:
+        if self._color_edit3_prefers_sequence is not True:
             try:
-                changed, edited = imgui.color_edit3(label, sequence_color)
-                self._color_edit3_accepts_sequence = True
+                imvec4 = imgui.ImVec4(sequence_color[0], sequence_color[1], sequence_color[2], 1.0)
+                changed, edited = imgui.color_edit3(label, imvec4)
+                self._color_edit3_prefers_sequence = False
                 return changed, self._coerce_color3(edited)
-            except TypeError:
-                self._color_edit3_accepts_sequence = False
+            except Exception:
+                self._color_edit3_prefers_sequence = True
 
         try:
-            imvec4 = imgui.ImVec4(sequence_color[0], sequence_color[1], sequence_color[2], 1.0)
-            changed, edited = imgui.color_edit3(label, imvec4)
+            changed, edited = imgui.color_edit3(label, sequence_color)
             return changed, self._coerce_color3(edited)
         except Exception as exc:
             logger.debug("[NewtonVisualizer] color_edit3 failed for '%s': %s", label, exc)
@@ -323,9 +323,10 @@ class NewtonVisualizer(BaseVisualizer):
             self._viewer.renderer.draw_sky = self.cfg.enable_sky
             self._viewer.renderer.draw_wireframe = self.cfg.enable_wireframe
 
-            self._viewer.renderer.sky_upper = self.cfg.sky_upper_color
-            self._viewer.renderer.sky_lower = self.cfg.sky_lower_color
-            self._viewer.renderer._light_color = self.cfg.light_color
+            # Accept list/tuple/array-like config colors and provide a stable tuple for nanobind conversion.
+            self._viewer.renderer.sky_upper = self._viewer._coerce_color3(self.cfg.sky_upper_color)
+            self._viewer.renderer.sky_lower = self._viewer._coerce_color3(self.cfg.sky_lower_color)
+            self._viewer.renderer._light_color = self._viewer._coerce_color3(self.cfg.light_color)
 
         num_visualized_envs = len(self._env_ids) if self._env_ids is not None else int(metadata.get("num_envs", 0))
         self._log_initialization_table(


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Fixes Newton GUI Imvec4 issue after newton update.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
