### PR TITLE
Remove libcarb.so LD_PRELOAD workaround from isaaclab.sh

### DIFF
--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -26,27 +26,5 @@ fi
 # Add source/isaaclab to PYTHONPATH so we can import isaaclab.cli.
 export PYTHONPATH="$ISAACLAB_PATH/source/isaaclab:$PYTHONPATH"
 
-# On Linux, preload libcarb.so so the dynamic linker reserves its static-TLS
-# slot before other large native extensions (e.g. PyTorch) exhaust the surplus.
-# Without this, importing omni.client later can fail with:
-#   "cannot allocate memory in static TLS block"
-if [ "$(uname -s)" = "Linux" ]; then
-    _libcarb="$("$python_exe" -c "
-import sys, os
-for p in sys.path:
-    f = os.path.join(p, 'omni', 'client', 'libcarb.so')
-    if os.path.isfile(f):
-        print(f)
-        break
-" 2>/dev/null)"
-    if [ -n "$_libcarb" ] && [ -r "$_libcarb" ]; then
-        case ":${LD_PRELOAD:-}:" in
-            *":$_libcarb:"*) ;;
-            *) export LD_PRELOAD="${_libcarb}${LD_PRELOAD:+:$LD_PRELOAD}";;
-        esac
-    fi
-    unset _libcarb
-fi
-
 # Execute CLI.
 exec "$python_exe" -c "from isaaclab.cli import cli; cli()" "$@"


### PR DESCRIPTION
## Summary

* Removes the Linux-specific `libcarb.so` static-TLS `LD_PRELOAD` workaround from `isaaclab.sh`, as it has issues on DGX Sprark with uv environments. 

* Users can follow the terminal prompt to manually `export LD_PRELOAD="$LD_PRELOAD:/lib/aarch64-linux-gnu/libgomp.so.1"`

## Test plan

- [ ] Run `./isaaclab.sh -p` on Linux and verify no `libcarb.so`-related errors
- [ ] Verify `omni.client` imports correctly without the preload
