### PR TITLE
Add target_T_world parameter to IsaacTeleopDevice.advance() for frame

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.5.22"
+version = "4.5.23"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+4.5.23 (2026-03-16)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :attr:`~isaaclab.envs.mdp.actions.PinkInverseKinematicsActionCfg.expect_base_link_frame`
+  flag.  When ``True``, incoming action poses are assumed to already be in the
+  robot base link frame and the internal world-to-base-link transform in
+  :meth:`~isaaclab.envs.mdp.actions.PinkInverseKinematicsAction.process_actions`
+  is skipped.
+
+
 4.5.22 (2026-03-16)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/envs/mdp/actions/pink_actions_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/pink_actions_cfg.py
@@ -43,3 +43,14 @@ class PinkInverseKinematicsActionCfg(ActionTermCfg):
     This dictionary should map the task names (e.g., 'left_wrist', 'right_wrist') to the
     corresponding link names in the URDF that will be controlled by the IK solver.
     """
+
+    expect_base_link_frame: bool = False
+    """When ``True``, incoming action poses are assumed to already be in the
+    robot base link frame and the internal world-to-base-link transform is
+    skipped.
+
+    Set this to ``True`` when the teleop device applies the rebase transform
+    itself (e.g. via :attr:`~isaaclab_teleop.IsaacTeleopCfg.target_frame_prim_path`
+    or an explicit ``target_T_world`` argument to
+    :meth:`~isaaclab_teleop.IsaacTeleopDevice.advance`).
+    """

--- a/source/isaaclab/isaaclab/envs/mdp/actions/pink_task_space_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/pink_task_space_actions.py
@@ -192,7 +192,11 @@ class PinkInverseKinematicsAction(ActionTerm):
         """Process the input actions and set targets for each task.
 
         Args:
-            actions: The input actions tensor.
+            actions: The input actions tensor.  Poses are expected in the
+                simulation world frame by default.  When
+                :attr:`~PinkInverseKinematicsActionCfg.expect_base_link_frame`
+                is ``True``, poses must already be in the robot base link
+                frame (the internal world-to-base-link transform is skipped).
         """
         # Store raw actions
         self._raw_actions[:] = actions
@@ -200,12 +204,15 @@ class PinkInverseKinematicsAction(ActionTerm):
         # Extract hand joint positions directly (no cloning needed)
         self._target_hand_joint_positions = actions[:, -self.hand_joint_dim :]
 
-        # Get base link frame transformation
-        self.base_link_frame_in_world_rf = self._get_base_link_frame_transform()
-
         # Process controlled frame poses (pass original actions, no clone needed)
         controlled_frame_poses = self._extract_controlled_frame_poses(actions)
-        transformed_poses = self._transform_poses_to_base_link_frame(controlled_frame_poses)
+
+        if self.cfg.expect_base_link_frame:
+            positions, rotation_matrices = math_utils.unmake_pose(controlled_frame_poses)
+            transformed_poses = (positions, rotation_matrices)
+        else:
+            self.base_link_frame_in_world_rf = self._get_base_link_frame_transform()
+            transformed_poses = self._transform_poses_to_base_link_frame(controlled_frame_poses)
 
         # Set targets for all tasks
         self._set_task_targets(transformed_poses)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/locomanipulation_g1_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/locomanipulation_g1_env_cfg.py
@@ -429,6 +429,10 @@ class LocomanipulationG1EnvCfg(ManagerBasedRLEnvCfg):
         # Set the URDF path for the IK controller. Path resolution (Nucleus → local) happens at runtime.
         self.actions.upper_body_ik.controller.urdf_path = f"{ISAACLAB_NUCLEUS_DIR}/Controllers/LocomanipulationAssets/unitree_g1_kinematics_asset/g1_29dof_with_hand_only_kinematics.urdf"  # noqa: E501
 
+        # IsaacTeleop rebases poses into the pelvis frame via target_frame_prim_path,
+        # so the IK action term can skip its internal world-to-base-link transform.
+        self.actions.upper_body_ik.expect_base_link_frame = True
+
         self.xr = XrCfg(
             anchor_pos=(0.0, 0.0, -0.95),
             anchor_rot=(0.0, 0.0, 0.0, 1.0),
@@ -441,4 +445,5 @@ class LocomanipulationG1EnvCfg(ManagerBasedRLEnvCfg):
             pipeline_builder=_build_g1_locomanipulation_pipeline,
             sim_device=self.sim.device,
             xr_cfg=self.xr,
+            target_frame_prim_path="/World/envs/env_0/Robot/pelvis",
         )

--- a/source/isaaclab_teleop/config/extension.toml
+++ b/source/isaaclab_teleop/config/extension.toml
@@ -1,6 +1,6 @@
 [package]
 # Semantic Versioning is used: https://semver.org/
-version = "0.3.3"
+version = "0.3.4"
 
 # Description
 title =  "Isaac Lab Teleop"

--- a/source/isaaclab_teleop/config/extension.toml
+++ b/source/isaaclab_teleop/config/extension.toml
@@ -1,6 +1,6 @@
 [package]
 # Semantic Versioning is used: https://semver.org/
-version = "0.3.4"
+version = "0.3.5"
 
 # Description
 title =  "Isaac Lab Teleop"

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+0.3.5 (2026-03-16)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_teleop.IsaacTeleopCfg.target_frame_prim_path` for
+  config-driven frame rebasing.  When set to a USD prim path, the device
+  automatically reads the prim's world transform each frame and uses its
+  inverse as the ``target_T_world`` rebase matrix, so all output poses are
+  expressed in the target frame (e.g. robot base link for IK).
+
+
 0.3.4 (2026-03-16)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+0.3.4 (2026-03-16)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``target_T_world`` parameter to
+  :meth:`~isaaclab_teleop.IsaacTeleopDevice.advance` for rebasing all output
+  poses into an arbitrary target coordinate frame (e.g. robot base link for
+  IK).  Accepts :class:`numpy.ndarray`, :class:`torch.Tensor`, or
+  ``wp.array``.
+
+
 0.3.3 (2026-03-13)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_cfg.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_cfg.py
@@ -108,5 +108,26 @@ class IsaacTeleopCfg:
     If ``None``, the tuning UI will not be opened.
     """
 
+    target_frame_prim_path: str | None = None
+    """Optional USD prim path whose world frame becomes the target coordinate
+    frame for all output poses.
+
+    When set, the device automatically reads this prim's world transform each
+    frame and uses its inverse as the ``target_T_world`` rebase matrix in
+    :meth:`~isaaclab_teleop.IsaacTeleopDevice.advance`.  An explicit
+    ``target_T_world`` argument to :meth:`~isaaclab_teleop.IsaacTeleopDevice.advance`
+    takes precedence over this config.
+
+    Typical usage: set to the robot base link prim path so that an IK
+    controller receives end-effector poses in the robot's base frame.
+
+    Example::
+
+        IsaacTeleopCfg(
+            target_frame_prim_path="/World/envs/env_0/Robot/base_link",
+            ...
+        )
+    """
+
     app_name: str = "IsaacLabTeleop"
     """Application name for the IsaacTeleop session."""

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -46,8 +46,17 @@ class IsaacTeleopDevice:
     Frame rebasing:
         By default, all output poses are expressed in the simulation world
         frame.  When an application needs poses in a different frame (e.g.
-        robot base link for IK), pass a ``target_T_world`` transform to
-        :meth:`advance`.  The device composes
+        robot base link for IK), there are two options:
+
+        * **Config-driven** (recommended): set
+          :attr:`~IsaacTeleopCfg.target_frame_prim_path` to the USD prim
+          whose frame the output should be expressed in.  The device reads
+          the prim's world transform each frame and applies the rebase
+          automatically.
+        * **Explicit**: pass a ``target_T_world`` matrix directly to
+          :meth:`advance`.
+
+        In both cases the device composes
         ``target_T_world @ world_T_anchor`` before feeding the matrix into
         the retargeting pipeline, so all resulting poses are expressed in the
         target frame.
@@ -70,7 +79,14 @@ class IsaacTeleopDevice:
                     action = device.advance()
                     env.step(action.repeat(num_envs, 1))
 
-            # Poses rebased into the robot base frame for IK
+            # Config-driven rebase into robot base frame
+            cfg.target_frame_prim_path = "/World/Robot/base_link"
+            with IsaacTeleopDevice(cfg) as device:
+                while running:
+                    action = device.advance()
+                    env.step(action.repeat(num_envs, 1))
+
+            # Explicit rebase into robot base frame
             with IsaacTeleopDevice(cfg) as device:
                 while running:
                     robot_T_world = get_robot_base_transform()
@@ -188,6 +204,11 @@ class IsaacTeleopDevice:
                 Accepts :class:`numpy.ndarray`, :class:`torch.Tensor`, or any
                 object with a ``.numpy()`` method (e.g. ``wp.array``).
 
+                When ``None`` and
+                :attr:`~IsaacTeleopCfg.target_frame_prim_path` is set, the
+                transform is computed automatically by reading the prim's
+                world matrix from Fabric and inverting it.
+
         Returns:
             A flattened action :class:`torch.Tensor` ready for the Isaac Lab
             environment, or ``None`` if the session has not started yet
@@ -196,6 +217,10 @@ class IsaacTeleopDevice:
         Raises:
             RuntimeError: If called outside of a context manager.
         """
+        # Auto-compute target_T_world from config if not explicitly provided
+        if target_T_world is None and self._cfg.target_frame_prim_path is not None:
+            target_T_world = self._get_target_frame_T_world()
+
         # Step the session (handles lazy start and action extraction)
         action = self._session_lifecycle.step(
             anchor_world_matrix_fn=self._anchor_manager.get_world_matrix,
@@ -207,6 +232,69 @@ class IsaacTeleopDevice:
             self._poll_buttons()
 
         return action
+
+    # ------------------------------------------------------------------
+    # Target frame transform (config-driven rebase)
+    # ------------------------------------------------------------------
+
+    def _get_target_frame_T_world(self) -> np.ndarray | None:
+        """Read the target-frame prim's world matrix from Fabric and return its inverse.
+
+        Uses USDRT to read the prim's hierarchical world matrix, matching the
+        pattern used by :class:`XrAnchorSynchronizer` for anchor prim reads.
+
+        Returns:
+            A (4, 4) float32 :class:`numpy.ndarray` representing the inverse
+            of the prim's world transform (i.e. ``target_T_world``), or
+            ``None`` if the prim cannot be read.
+        """
+        try:
+            import usdrt
+            from usdrt import Rt
+
+            from isaaclab.sim.utils.stage import get_current_stage_id
+
+            stage_id = get_current_stage_id()
+            rt_stage = usdrt.Usd.Stage.Attach(stage_id)
+            if rt_stage is None:
+                return None
+
+            rt_prim = rt_stage.GetPrimAtPath(self._cfg.target_frame_prim_path)
+            if rt_prim is None:
+                return None
+
+            rt_xformable = Rt.Xformable(rt_prim)
+            if rt_xformable is None:
+                return None
+
+            world_matrix_attr = rt_xformable.GetFabricHierarchyWorldMatrixAttr()
+            if world_matrix_attr is None:
+                return None
+
+            rt_matrix = world_matrix_attr.Get()
+            if rt_matrix is None:
+                return None
+
+            pos = rt_matrix.ExtractTranslation()
+            rt_quat = rt_matrix.ExtractRotationQuat()
+
+            from scipy.spatial.transform import Rotation
+
+            quat_xyzw = [
+                float(rt_quat.GetImaginary()[0]),
+                float(rt_quat.GetImaginary()[1]),
+                float(rt_quat.GetImaginary()[2]),
+                float(rt_quat.GetReal()),
+            ]
+
+            mat = np.eye(4, dtype=np.float32)
+            mat[:3, :3] = Rotation.from_quat(quat_xyzw).as_matrix()
+            mat[:3, 3] = [float(pos[0]), float(pos[1]), float(pos[2])]
+
+            return np.linalg.inv(mat).astype(np.float32)
+        except Exception as e:
+            logger.warning(f"Failed to read target frame prim '{self._cfg.target_frame_prim_path}': {e}")
+            return None
 
     # ------------------------------------------------------------------
     # Controller button polling (glue between session and anchor manager)

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 
+import numpy as np
 import torch
 
 from .command_handler import CommandHandler
@@ -42,6 +43,15 @@ class IsaacTeleopDevice:
     The device uses IsaacTeleop's TensorReorderer to flatten pipeline outputs
     into a single action tensor matching the environment's action space.
 
+    Frame rebasing:
+        By default, all output poses are expressed in the simulation world
+        frame.  When an application needs poses in a different frame (e.g.
+        robot base link for IK), pass a ``target_T_world`` transform to
+        :meth:`advance`.  The device composes
+        ``target_T_world @ world_T_anchor`` before feeding the matrix into
+        the retargeting pipeline, so all resulting poses are expressed in the
+        target frame.
+
     Teleop commands:
         The device supports callbacks for START, STOP, and RESET commands
         that can be triggered via XR controller buttons or the message bus.
@@ -54,9 +64,17 @@ class IsaacTeleopDevice:
                 sim_device="cuda:0",
             )
 
+            # Poses in world frame (default)
             with IsaacTeleopDevice(cfg) as device:
                 while running:
                     action = device.advance()
+                    env.step(action.repeat(num_envs, 1))
+
+            # Poses rebased into the robot base frame for IK
+            with IsaacTeleopDevice(cfg) as device:
+                while running:
+                    robot_T_world = get_robot_base_transform()
+                    action = device.advance(target_T_world=robot_T_world)
                     env.step(action.repeat(num_envs, 1))
     """
 
@@ -147,13 +165,28 @@ class IsaacTeleopDevice:
         """
         self._command_handler.add_callback(key, func)
 
-    def advance(self) -> torch.Tensor | None:
+    def advance(self, target_T_world: np.ndarray | torch.Tensor | None = None) -> torch.Tensor | None:
         """Process current device state and return control commands.
 
         If the IsaacTeleop session has not been started yet (because the OpenXR
         handles were not available at ``__enter__`` time), this method will
         attempt to start it on each call.  Once the user clicks "Start AR" and
         the handles become available, the session is created transparently.
+
+        Args:
+            target_T_world: Optional 4x4 transform matrix that rebases all
+                output poses into an arbitrary target coordinate frame.  When
+                provided, the matrix sent to the retargeting pipeline becomes
+                ``target_T_world @ world_T_anchor`` instead of just
+                ``world_T_anchor``, so all resulting poses are expressed in
+                the target frame rather than the simulation world frame.
+
+                Typical use case: pass ``robot_base_T_world`` so that an IK
+                controller receives end-effector poses in the robot's base
+                link frame.
+
+                Accepts :class:`numpy.ndarray`, :class:`torch.Tensor`, or any
+                object with a ``.numpy()`` method (e.g. ``wp.array``).
 
         Returns:
             A flattened action :class:`torch.Tensor` ready for the Isaac Lab
@@ -166,6 +199,7 @@ class IsaacTeleopDevice:
         # Step the session (handles lazy start and action extraction)
         action = self._session_lifecycle.step(
             anchor_world_matrix_fn=self._anchor_manager.get_world_matrix,
+            target_T_world=target_T_world,
         )
 
         if action is not None:

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -24,6 +24,27 @@ from .isaac_teleop_cfg import IsaacTeleopCfg
 logger = logging.getLogger(__name__)
 
 
+def _to_numpy_4x4(mat: np.ndarray | torch.Tensor) -> np.ndarray:
+    """Convert a 4x4 transform to a float32 numpy array.
+
+    Accepts :class:`numpy.ndarray`, :class:`torch.Tensor`, ``wp.array``,
+    or any object implementing a ``.numpy()`` method.
+
+    Args:
+        mat: A (4, 4) transform matrix in any supported array type.
+
+    Returns:
+        A (4, 4) float32 :class:`numpy.ndarray`.
+    """
+    if isinstance(mat, np.ndarray):
+        return np.asarray(mat, dtype=np.float32)
+    if isinstance(mat, torch.Tensor):
+        return mat.detach().cpu().numpy().astype(np.float32)
+    if hasattr(mat, "numpy"):
+        return np.asarray(mat.numpy(), dtype=np.float32)
+    return np.asarray(mat, dtype=np.float32)
+
+
 class TeleopSessionLifecycle:
     """Manages the IsaacTeleop session lifecycle.
 
@@ -306,7 +327,11 @@ class TeleopSessionLifecycle:
     # Stepping
     # ------------------------------------------------------------------
 
-    def step(self, anchor_world_matrix_fn: Callable[[], np.ndarray] | None = None) -> torch.Tensor | None:
+    def step(
+        self,
+        anchor_world_matrix_fn: Callable[[], np.ndarray] | None = None,
+        target_T_world: np.ndarray | torch.Tensor | None = None,
+    ) -> torch.Tensor | None:
         """Execute one step of the teleop session and return the action tensor.
 
         If the session has not been started yet (because OpenXR handles were
@@ -323,6 +348,13 @@ class TeleopSessionLifecycle:
             anchor_world_matrix_fn: Optional callable returning the (4, 4)
                 world-to-anchor transform.  Used to build external inputs
                 for ``ValueInput`` leaf nodes in the pipeline.
+            target_T_world: Optional (4, 4) transform matrix that rebases
+                pipeline poses into a target coordinate frame.  When provided,
+                the anchor matrix is left-multiplied by this transform
+                (``target_T_world @ world_T_anchor``) so all output poses
+                are expressed in the target frame.  Accepts
+                :class:`numpy.ndarray`, :class:`torch.Tensor`, or any object
+                with a ``.numpy()`` method (e.g. ``wp.array``).
 
         Returns:
             A flattened action :class:`torch.Tensor` ready for the Isaac Lab
@@ -342,7 +374,7 @@ class TeleopSessionLifecycle:
 
         # Build external inputs (e.g. world-to-anchor transform) if the
         # pipeline contains ValueInput leaf nodes.
-        external_inputs = self._build_external_inputs(anchor_world_matrix_fn)
+        external_inputs = self._build_external_inputs(anchor_world_matrix_fn, target_T_world)
 
         # Execute one step of the teleop session.
         # If the underlying OpenXR session was destroyed externally (e.g.
@@ -395,16 +427,27 @@ class TeleopSessionLifecycle:
     # External input building
     # ------------------------------------------------------------------
 
-    def _build_external_inputs(self, anchor_world_matrix_fn: Callable[[], np.ndarray] | None) -> dict | None:
+    def _build_external_inputs(
+        self,
+        anchor_world_matrix_fn: Callable[[], np.ndarray] | None,
+        target_T_world: np.ndarray | torch.Tensor | None = None,
+    ) -> dict | None:
         """Build external inputs for non-DeviceIO leaf nodes in the pipeline.
 
         Checks whether the active ``TeleopSession`` has external (non-DeviceIO)
         leaf nodes and, for each recognized leaf, constructs the corresponding
         ``TensorGroup`` data.
 
+        When *target_T_world* is provided, the anchor matrix is left-multiplied
+        by the rebase transform so that all pipeline poses are expressed in
+        the target coordinate frame:
+        ``target_T_world @ world_T_anchor = target_T_anchor``.
+
         Args:
             anchor_world_matrix_fn: Callable returning the (4, 4)
                 world-to-anchor transform matrix.
+            target_T_world: Optional (4, 4) rebase transform.  See
+                :meth:`step` for details.
 
         Returns:
             A dict suitable for ``TeleopSession.step(external_inputs=...)``,
@@ -425,6 +468,8 @@ class TeleopSessionLifecycle:
                     anchor_matrix = anchor_world_matrix_fn()
                 else:
                     anchor_matrix = np.eye(4, dtype=np.float32)
+                if target_T_world is not None:
+                    anchor_matrix = _to_numpy_4x4(target_T_world) @ anchor_matrix
                 xform_tg = TensorGroup(TransformMatrix())
                 xform_tg[0] = anchor_matrix
                 external_inputs[leaf_name] = {ValueInput.VALUE: xform_tg}

--- a/source/isaaclab_teleop/test/test_target_frame_rebase.py
+++ b/source/isaaclab_teleop/test/test_target_frame_rebase.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# pyright: reportPrivateUsage=none
+
+"""Tests for the target-frame rebase logic and _to_numpy_4x4 helper.
+
+These tests exercise pure math (no Omniverse/Isaac Sim stack required).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from isaaclab_teleop.session_lifecycle import _to_numpy_4x4
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def identity_4x4() -> np.ndarray:
+    return np.eye(4, dtype=np.float32)
+
+
+@pytest.fixture
+def translation_matrix() -> np.ndarray:
+    """A pure translation of (1, 2, 3)."""
+    mat = np.eye(4, dtype=np.float32)
+    mat[:3, 3] = [1.0, 2.0, 3.0]
+    return mat
+
+
+@pytest.fixture
+def rotation_90z_matrix() -> np.ndarray:
+    """90-degree rotation about Z axis."""
+    mat = np.eye(4, dtype=np.float32)
+    mat[0, 0] = 0.0
+    mat[0, 1] = -1.0
+    mat[1, 0] = 1.0
+    mat[1, 1] = 0.0
+    return mat
+
+
+# ---------------------------------------------------------------------------
+# _to_numpy_4x4 conversion tests
+# ---------------------------------------------------------------------------
+
+
+class TestToNumpy4x4:
+    def test_from_ndarray_float32(self, identity_4x4: np.ndarray):
+        result = _to_numpy_4x4(identity_4x4)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_equal(result, identity_4x4)
+
+    def test_from_ndarray_float64_casts(self):
+        mat = np.eye(4, dtype=np.float64)
+        result = _to_numpy_4x4(mat)
+        assert result.dtype == np.float32
+        np.testing.assert_array_almost_equal(result, np.eye(4, dtype=np.float32))
+
+    def test_from_torch_cpu(self, translation_matrix: np.ndarray):
+        tensor = torch.from_numpy(translation_matrix.copy())
+        result = _to_numpy_4x4(tensor)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_almost_equal(result, translation_matrix)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_from_torch_gpu(self, translation_matrix: np.ndarray):
+        tensor = torch.from_numpy(translation_matrix.copy()).cuda()
+        result = _to_numpy_4x4(tensor)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_almost_equal(result, translation_matrix)
+
+    def test_from_duck_typed_numpy(self, rotation_90z_matrix: np.ndarray):
+        """Simulates a wp.array or similar object with a .numpy() method."""
+
+        class FakeWarpArray:
+            def __init__(self, data: np.ndarray):
+                self._data = data
+
+            def numpy(self) -> np.ndarray:
+                return self._data
+
+        fake = FakeWarpArray(rotation_90z_matrix.copy())
+        result = _to_numpy_4x4(fake)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_almost_equal(result, rotation_90z_matrix)
+
+    def test_from_list(self):
+        data = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
+        result = _to_numpy_4x4(data)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_equal(result, np.eye(4, dtype=np.float32))
+
+
+# ---------------------------------------------------------------------------
+# Matrix multiplication (rebase) tests
+# ---------------------------------------------------------------------------
+
+
+class TestRebaseMultiplication:
+    def test_rebase_identity_is_noop(self, translation_matrix: np.ndarray):
+        """target_T_world = I should leave anchor_matrix unchanged."""
+        identity = np.eye(4, dtype=np.float32)
+        result = _to_numpy_4x4(identity) @ translation_matrix
+        np.testing.assert_array_almost_equal(result, translation_matrix)
+
+    def test_rebase_translation(self, identity_4x4: np.ndarray):
+        """Rebasing by a pure translation offsets the origin."""
+        target_T_world = np.eye(4, dtype=np.float32)
+        target_T_world[:3, 3] = [10.0, 20.0, 30.0]
+
+        world_T_anchor = np.eye(4, dtype=np.float32)
+        world_T_anchor[:3, 3] = [1.0, 2.0, 3.0]
+
+        result = _to_numpy_4x4(target_T_world) @ world_T_anchor
+        np.testing.assert_array_almost_equal(result[:3, 3], [11.0, 22.0, 33.0])
+
+    def test_rebase_rotation(self, rotation_90z_matrix: np.ndarray):
+        """A 90-deg Z rotation rebase should rotate the anchor translation."""
+        world_T_anchor = np.eye(4, dtype=np.float32)
+        world_T_anchor[:3, 3] = [1.0, 0.0, 0.0]
+
+        result = _to_numpy_4x4(rotation_90z_matrix) @ world_T_anchor
+
+        # After 90-deg Z rotation: (1,0,0) -> (0,1,0)
+        np.testing.assert_array_almost_equal(result[:3, 3], [0.0, 1.0, 0.0])
+        # Rotation part should match the 90-deg Z rotation
+        np.testing.assert_array_almost_equal(result[:3, :3], rotation_90z_matrix[:3, :3])
+
+    def test_rebase_with_torch_tensor(self, translation_matrix: np.ndarray):
+        """target_T_world as a torch.Tensor should work identically."""
+        target_T_world = torch.eye(4, dtype=torch.float32)
+        target_T_world[:3, 3] = torch.tensor([5.0, 5.0, 5.0])
+
+        result = _to_numpy_4x4(target_T_world) @ translation_matrix
+
+        expected = np.eye(4, dtype=np.float32)
+        expected[:3, 3] = [6.0, 7.0, 8.0]
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_none_target_leaves_anchor_unchanged(self, translation_matrix: np.ndarray):
+        """When target_T_world is None, the calling code should skip multiplication."""
+        target_T_world = None
+        anchor_matrix = translation_matrix.copy()
+
+        if target_T_world is not None:
+            anchor_matrix = _to_numpy_4x4(target_T_world) @ anchor_matrix
+
+        np.testing.assert_array_equal(anchor_matrix, translation_matrix)
+
+    def test_inverse_rebase_recovers_identity(self):
+        """target_T_world = inv(world_T_anchor) should yield identity."""
+        world_T_anchor = np.array(
+            [
+                [0.0, -1.0, 0.0, 3.0],
+                [1.0, 0.0, 0.0, -1.0],
+                [0.0, 0.0, 1.0, 2.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+        target_T_world = np.linalg.inv(world_T_anchor).astype(np.float32)
+
+        result = _to_numpy_4x4(target_T_world) @ world_T_anchor
+        np.testing.assert_array_almost_equal(result, np.eye(4, dtype=np.float32), decimal=5)

--- a/source/isaaclab_teleop/test/test_target_frame_rebase.py
+++ b/source/isaaclab_teleop/test/test_target_frame_rebase.py
@@ -5,7 +5,7 @@
 
 # pyright: reportPrivateUsage=none
 
-"""Tests for the target-frame rebase logic and _to_numpy_4x4 helper.
+"""Tests for the target-frame rebase logic, _to_numpy_4x4 helper, and config-driven auto-selection.
 
 These tests exercise pure math (no Omniverse/Isaac Sim stack required).
 """
@@ -15,9 +15,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 import torch
-
 from isaaclab_teleop.session_lifecycle import _to_numpy_4x4
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -176,3 +174,91 @@ class TestRebaseMultiplication:
 
         result = _to_numpy_4x4(target_T_world) @ world_T_anchor
         np.testing.assert_array_almost_equal(result, np.eye(4, dtype=np.float32), decimal=5)
+
+
+# ---------------------------------------------------------------------------
+# Config-driven auto-selection tests
+# ---------------------------------------------------------------------------
+
+
+def _simulate_advance_selection(
+    target_T_world: np.ndarray | None,
+    target_frame_prim_path: str | None,
+    auto_read_result: np.ndarray | None = None,
+) -> tuple[np.ndarray | None, bool]:
+    """Replicate the auto-selection logic from IsaacTeleopDevice.advance().
+
+    Returns the target_T_world that would be passed to step(), and whether
+    _get_target_frame_T_world would have been called.
+    """
+    auto_read_called = False
+
+    def fake_get_target_frame_T_world():
+        nonlocal auto_read_called
+        auto_read_called = True
+        return auto_read_result
+
+    if target_T_world is None and target_frame_prim_path is not None:
+        target_T_world = fake_get_target_frame_T_world()
+
+    return target_T_world, auto_read_called
+
+
+class TestConfigDrivenAutoSelection:
+    """Tests for the advance() auto-selection logic between explicit target_T_world
+    and config-driven target_frame_prim_path.
+
+    These tests replicate the branching logic from advance() without importing
+    the full IsaacTeleopDevice (which requires Isaac Sim runtime dependencies).
+    """
+
+    def test_no_config_no_explicit_passes_none(self):
+        """When neither config nor explicit target_T_world is set, step() receives None."""
+        result, called = _simulate_advance_selection(target_T_world=None, target_frame_prim_path=None)
+        assert result is None
+        assert not called
+
+    def test_explicit_target_is_passed_through(self):
+        """An explicit target_T_world should be passed directly to step()."""
+        explicit = np.eye(4, dtype=np.float32)
+        explicit[:3, 3] = [1.0, 2.0, 3.0]
+
+        result, called = _simulate_advance_selection(target_T_world=explicit, target_frame_prim_path=None)
+        np.testing.assert_array_equal(result, explicit)
+        assert not called
+
+    def test_config_prim_triggers_auto_read(self):
+        """When target_frame_prim_path is set, _get_target_frame_T_world is called."""
+        auto_matrix = np.eye(4, dtype=np.float32)
+        auto_matrix[:3, 3] = [9.0, 8.0, 7.0]
+
+        result, called = _simulate_advance_selection(
+            target_T_world=None,
+            target_frame_prim_path="/World/Robot/base_link",
+            auto_read_result=auto_matrix,
+        )
+        assert called
+        np.testing.assert_array_equal(result, auto_matrix)
+
+    def test_explicit_overrides_config(self):
+        """An explicit target_T_world takes precedence over config prim path."""
+        explicit = np.eye(4, dtype=np.float32)
+        explicit[:3, 3] = [42.0, 0.0, 0.0]
+
+        result, called = _simulate_advance_selection(
+            target_T_world=explicit,
+            target_frame_prim_path="/World/Robot/base_link",
+            auto_read_result=np.eye(4, dtype=np.float32),
+        )
+        assert not called
+        np.testing.assert_array_equal(result, explicit)
+
+    def test_config_prim_returns_none_passes_none(self):
+        """If the prim read fails (returns None), step() receives None."""
+        result, called = _simulate_advance_selection(
+            target_T_world=None,
+            target_frame_prim_path="/World/Robot/base_link",
+            auto_read_result=None,
+        )
+        assert called
+        assert result is None


### PR DESCRIPTION
# Description

Add an optional target_T_world parameter to IsaacTeleopDevice.advance() that left-multiplies the world-to-anchor matrix before it enters the retargeting pipeline, allowing applications to receive all teleop poses in an arbitrary target frame (e.g. robot base link for IK controllers).
Support np.ndarray, torch.Tensor, and wp.array (via duck-typed .numpy()) as input types for the transform matrix.
Add unit tests for the _to_numpy_4x4 conversion helper and the rebase matrix multiplication logic.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
