### PR TITLE
Adds Commit ID-based Tags to Post-Merge Builds

### DIFF
--- a/.github/workflows/postmerge-ci.yml
+++ b/.github/workflows/postmerge-ci.yml
@@ -111,6 +111,8 @@ jobs:
           # Combine repo short name and branch name for the tag
           COMBINED_TAG="${REPO_SHORT_NAME}-${SAFE_BRANCH_NAME}-${IMAGE_BASE_VERSION}"
           BUILD_TAG="${COMBINED_TAG}-b${{ github.run_number }}"
+          COMMIT_TAG="${COMBINED_TAG}-${{ github.sha }}"
+          SHORT_COMMIT_TAG="${COMBINED_TAG}-${GITHUB_SHA::7}"
 
           # Determine if multiarch is supported by inspecting the base image manifest
           echo "Checking if base image supports multiarch..."
@@ -151,12 +153,14 @@ jobs:
           echo "Base image: $BASE_IMAGE_FULL"
           echo "Target platforms: $BUILD_PLATFORMS"
 
-          # Build Docker image once with both tags for multiple architectures
+          # Build Docker image once with all tags for multiple architectures
           docker buildx build \
             --platform $BUILD_PLATFORMS \
             --progress=plain \
             -t ${{ env.ISAACLAB_IMAGE_NAME }}:$COMBINED_TAG \
             -t ${{ env.ISAACLAB_IMAGE_NAME }}:$BUILD_TAG \
+            -t ${{ env.ISAACLAB_IMAGE_NAME }}:$COMMIT_TAG \
+            -t ${{ env.ISAACLAB_IMAGE_NAME }}:$SHORT_COMMIT_TAG \
             --build-arg ISAACSIM_BASE_IMAGE_ARG=${{ env.ISAACSIM_BASE_IMAGE }} \
             --build-arg ISAACSIM_VERSION_ARG=$IMAGE_BASE_VERSION \
             --build-arg ISAACSIM_ROOT_PATH_ARG=/isaac-sim \
@@ -169,4 +173,6 @@ jobs:
 
           echo "✅ Successfully built and pushed: ${{ env.ISAACLAB_IMAGE_NAME }}:$COMBINED_TAG (platforms: $BUILD_PLATFORMS)"
           echo "✅ Successfully built and pushed: ${{ env.ISAACLAB_IMAGE_NAME }}:$BUILD_TAG (platforms: $BUILD_PLATFORMS)"
+          echo "✅ Successfully built and pushed: ${{ env.ISAACLAB_IMAGE_NAME }}:$COMMIT_TAG (platforms: $BUILD_PLATFORMS)"
+          echo "✅ Successfully built and pushed: ${{ env.ISAACLAB_IMAGE_NAME }}:$SHORT_COMMIT_TAG (platforms: $BUILD_PLATFORMS)"
         done


### PR DESCRIPTION
# Description

Adds commit-ID-based image tags to the post-merge CI Docker build.

Atm post-merge images are tagged with:

- `{repo}-{branch}-{version}`
- `{repo}-{branch}-{version}-b{run_number}`

This adds two additional tags:
- `{repo}-{branch}-{version}-{full_sha}` - full 40-character commit SHA
- `{repo}-{branch}-{version}-{short_sha}` - short 7-character commit SHA

This makes it easy to pull the exact image for a given commit:

```sh
# Branch tag
docker pull isaac-lab-base:IsaacLab-develop-latest-release-6-0

# Build number tag
docker pull isaac-lab-base:IsaacLab-develop-latest-release-6-0-b42

# Full commit SHA tag
docker pull isaac-lab-base:IsaacLab-develop-latest-release-6-0-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2

# Short commit SHA tag
docker pull isaac-lab-base:IsaacLab-develop-latest-release-6-0-a1b2c3d
```

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [NA] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
