### PR TITLE
Fixes WristTiledCameraCfg simple_shading presets using wrong base config

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -184,6 +184,7 @@ Guidelines for modifications:
 * Yohan Choi
 * Yujian Zhang
 * Yun Liu
+* YuTeh Shen
 * Zehao Wang
 * Zijian Li
 * Ziqi Fan

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/config/kuka_allegro/camera_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/config/kuka_allegro/camera_cfg.py
@@ -101,27 +101,27 @@ class WristTiledCameraCfg(PresetCfg):
     albedo64 = WRIST_CAMERA_CFG.replace(data_types=["albedo"], width=64, height=64)
     albedo128 = WRIST_CAMERA_CFG.replace(data_types=["albedo"], width=128, height=128)
     albedo256 = WRIST_CAMERA_CFG.replace(data_types=["albedo"], width=256, height=256)
-    simple_shading_constant_diffuse64 = BASE_CAMERA_CFG.replace(
+    simple_shading_constant_diffuse64 = WRIST_CAMERA_CFG.replace(
         data_types=["simple_shading_constant_diffuse"], width=64, height=64
     )
-    simple_shading_constant_diffuse128 = BASE_CAMERA_CFG.replace(
+    simple_shading_constant_diffuse128 = WRIST_CAMERA_CFG.replace(
         data_types=["simple_shading_constant_diffuse"], width=128, height=128
     )
-    simple_shading_constant_diffuse256 = BASE_CAMERA_CFG.replace(
+    simple_shading_constant_diffuse256 = WRIST_CAMERA_CFG.replace(
         data_types=["simple_shading_constant_diffuse"], width=256, height=256
     )
-    simple_shading_diffuse_mdl64 = BASE_CAMERA_CFG.replace(
+    simple_shading_diffuse_mdl64 = WRIST_CAMERA_CFG.replace(
         data_types=["simple_shading_diffuse_mdl"], width=64, height=64
     )
-    simple_shading_diffuse_mdl128 = BASE_CAMERA_CFG.replace(
+    simple_shading_diffuse_mdl128 = WRIST_CAMERA_CFG.replace(
         data_types=["simple_shading_diffuse_mdl"], width=128, height=128
     )
-    simple_shading_diffuse_mdl256 = BASE_CAMERA_CFG.replace(
+    simple_shading_diffuse_mdl256 = WRIST_CAMERA_CFG.replace(
         data_types=["simple_shading_diffuse_mdl"], width=256, height=256
     )
-    simple_shading_full_mdl64 = BASE_CAMERA_CFG.replace(data_types=["simple_shading_full_mdl"], width=64, height=64)
-    simple_shading_full_mdl128 = BASE_CAMERA_CFG.replace(data_types=["simple_shading_full_mdl"], width=128, height=128)
-    simple_shading_full_mdl256 = BASE_CAMERA_CFG.replace(data_types=["simple_shading_full_mdl"], width=256, height=256)
+    simple_shading_full_mdl64 = WRIST_CAMERA_CFG.replace(data_types=["simple_shading_full_mdl"], width=64, height=64)
+    simple_shading_full_mdl128 = WRIST_CAMERA_CFG.replace(data_types=["simple_shading_full_mdl"], width=128, height=128)
+    simple_shading_full_mdl256 = WRIST_CAMERA_CFG.replace(data_types=["simple_shading_full_mdl"], width=256, height=256)
     default = rgb64
 
 


### PR DESCRIPTION

# Description

  Summary:                                                                                                                                                                                                                                                                                                       
  - WristTiledCameraCfg in camera_cfg.py had a copy-paste bug where simple_shading_* variants (lines 104-124) used BASE_CAMERA_CFG instead of WRIST_CAMERA_CFG
  - This caused both base_camera and wrist_camera to resolve to the same prim path (/World/envs/env_.*/Camera), resulting in ValueError: A prim already exists at path when using duo_camera with any simple_shading_* preset                                                                                    
  - Fix: Replace BASE_CAMERA_CFG → WRIST_CAMERA_CFG for all 9 simple_shading_* entries in WristTiledCameraCfg                                                                                                                
                                                                                                                                                                                                                                                                                                                 
  Affected presets: simple_shading_constant_diffuse{64,128,256}, simple_shading_diffuse_mdl{64,128,256}, simple_shading_full_mdl{64,128,256}                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                 
  Not affected: rgb*, depth*, albedo* presets were already correctly using WRIST_CAMERA_CFG
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
