### PR TITLE
Installation guide - replace curly bracket with parantheses

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,8 +54,9 @@ Guidelines for modifications:
 * Brayden Zhang
 * Brian Bingham
 * Brian McCann
-* Cameron Upright
+* Caelan Garrett
 * Calvin Yu
+* Cameron Upright
 * Cathy Y. Li
 * Cheng-Rong Lai
 * Chenyu Yang

--- a/docs/source/experimental-features/newton-physics-integration/index.rst
+++ b/docs/source/experimental-features/newton-physics-integration/index.rst
@@ -1,34 +1,31 @@
 Newton Physics Integration
 ===========================
 
-`Newton <https://newton-physics.github.io/newton/guide/overview.html>`_ is a GPU-accelerated, extensible, and differentiable physics simulation engine designed for robotics, research,
+`Newton <https://newton-physics.github.io/newton/latest/guide/overview.html>`_ is a GPU-accelerated, extensible, and differentiable physics simulation engine designed for robotics, research,
 and advanced simulation workflows. Built on top of `NVIDIA Warp <https://nvidia.github.io/warp/>`_ and integrating MuJoCo Warp, Newton provides high-performance
 simulation, modern Python APIs, and a flexible architecture for both users and developers.
 
 Newton is an Open Source community-driven project with contributions from NVIDIA, Google Deep Mind, and Disney Research,
 managed through the Linux Foundation.
 
-This `experimental feature branch <https://github.com/isaac-sim/IsaacLab/tree/feature/newton>`_ of Isaac Lab provides an initial integration with the Newton Physics Engine, and is
+This integration is available on the `develop branch <https://github.com/isaac-sim/IsaacLab/tree/develop>`_ of Isaac Lab as part of Isaac Lab 3.0 Beta, and is
 under active development. Many features are not yet supported, and only a limited set of classic RL and flat terrain locomotion
 reinforcement learning examples are included at the moment.
 
-Both this Isaac Lab integration branch and Newton itself are under heavy development. We intend to support additional
+Both this Isaac Lab integration and Newton itself are under heavy development. We intend to support additional
 features for other reinforcement learning and imitation learning workflows in the future, but the above tasks should be
 a good lens through which to understand how Newton integration works in Isaac Lab.
 
 We have validated Newton simulation against PhysX by transferring learned policies from Newton to PhysX and vice versa
 Furthermore, we have also successfully deployed a Newton-trained locomotion policy to a G1 robot. Please see :ref:`here <sim2real>` for more information.
 
-Newton can support `multiple solvers <https://newton-physics.github.io/newton/api/newton_solvers.html>`_ for handling different types of physics simulation, but for the moment, the Isaac
+Newton can support `multiple solvers <https://newton-physics.github.io/newton/latest/api/newton_solvers.html>`_ for handling different types of physics simulation, but for the moment, the Isaac
 Lab integration focuses primarily on the MuJoCo-Warp solver.
 
-Future updates of this branch and Newton should include both ongoing improvements in performance as well as integration
+Future updates of Isaac Lab and Newton should include both ongoing improvements in performance as well as integration
 with additional solvers.
 
-Note that this branch does not include support for the PhysX physics engine - only Newton is supported. We are considering
-several possible paths to continue to support PhysX within Lab, and feedback from users about their needs around that would be appreciated.
-
-During the early development phase of both Newton and this Isaac Lab integration, you are likely to encounter breaking
+During the development phase of both Newton and this Isaac Lab integration, you are likely to encounter breaking
 changes as well as limited documentation. We do not expect to be able to provide official support or debugging assistance
 until the framework has reached an official release. We appreciate your understanding and patience as we work to deliver a robust and polished framework!
 

--- a/docs/source/experimental-features/newton-physics-integration/installation.rst
+++ b/docs/source/experimental-features/newton-physics-integration/installation.rst
@@ -1,62 +1,68 @@
 Installation
 ============
 
-Installing the Newton physics integration branch requires three things:
+Installing the Newton physics integration requires three things:
 
-1) The ``feature/newton`` branch of Isaac Lab
-2) Ubuntu 22.04 or 24.04 (Windows will be supported soon)
-3) [Optional] Isaac sim 5.1 (Isaac Sim is not required if the Omniverse visualizer is not used)
+1) The ``develop`` branch of Isaac Lab
+2) Ubuntu 22.04 or 24.04
+3) [Optional] Isaac Sim 6.0 (Isaac Sim is not required if the Omniverse visualizer is not used)
 
-To begin, verify the version of Isaac Sim by checking the title of the window created when launching the simulation app.  Alternatively, you can
-find more explicit version information under the ``Help -> About`` menu within the app.
-If your version is less than 5.1, you must first `update or reinstall Isaac Sim <https://docs.isaacsim.omniverse.nvidia.com/latest/installation/quick-install.html>`_ before
-you can proceed further.
+To begin, navigate to the root directory of your local copy of the Isaac Lab repository and open a terminal.
 
-Next, navigate to the root directory of your local copy of the Isaac Lab repository and open a terminal.
-
-Make sure we are on the ``feature/newton`` branch by running the following command:
+Make sure we are on the ``develop`` branch by running the following command:
 
 .. code-block:: bash
 
-    git checkout feature/newton
-
-Below, we provide instructions for installing Isaac Sim through pip.
+    git checkout develop
 
 
-Pip Installation
-----------------
+Installation
+------------
 
-We recommend using conda for managing your python environments. Conda can be downloaded and installed from `here <https://docs.conda.io/en/latest/miniconda.html>`_.
+We recommend using **uv** as the package manager — it is significantly faster than pip and conda.
+To install ``uv``, please follow the instructions `here <https://docs.astral.sh/uv/getting-started/installation/>`__.
 
 If you previously already have a virtual environment for Isaac Lab, please ensure to start from a fresh environment to avoid any dependency conflicts.
 If you have installed earlier versions of mujoco, mujoco-warp, or newton packages through pip, we recommend first
 cleaning your pip cache with ``pip cache purge`` to remove any cache of earlier versions that may be conflicting with the latest.
 
-Create a new conda environment:
+Create a new virtual environment with Python 3.12:
 
 .. code-block:: bash
 
-    conda create -n env_isaaclab python=3.11
+    uv venv --python 3.12 --seed env_isaaclab
 
 Activate the environment:
 
 .. code-block:: bash
 
-    conda activate env_isaaclab
+    source env_isaaclab/bin/activate
+
+.. note::
+
+   If you are using ``pip`` directly instead of ``uv pip``, replace ``uv pip`` with ``pip`` in the commands below.
+
+
+Ensure pip is up to date:
+
+.. code-block:: bash
+
+    uv pip install --upgrade pip
+
+[Optional] Install Isaac Sim 6.0:
+
+.. code-block:: bash
+
+    uv pip install "isaacsim[all,extscache]==6.0.0" --extra-index-url https://pypi.nvidia.com
+
 
 Install the correct version of torch and torchvision:
 
 .. code-block:: bash
 
-    pip install -U torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+    uv pip install -U torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cu128
 
-[Optional] Install Isaac Sim 5.1:
-
-.. code-block:: bash
-
-    pip install "isaacsim[all,extscache]==5.1.0" --extra-index-url https://pypi.nvidia.com
-
-Install Isaac Lab extensions and dependencies:
+Install Isaac Lab extensions and dependencies (this includes Newton 1.0):
 
 .. code-block:: bash
 
@@ -71,8 +77,3 @@ To verify that the installation was successful, run the following command from t
 .. code-block:: bash
 
     ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Cartpole-Direct-v0 --num_envs 128
-
-
-Note that since Newton requires a more recent version of Warp than Isaac Sim 5.1, there may be some incompatibility issues
-that could result in errors such as ``ModuleNotFoundError: No module named 'warp.sim'``. These are ok to ignore and should not
-impact usability.

--- a/docs/source/experimental-features/newton-physics-integration/isaaclab_newton-beta-2.rst
+++ b/docs/source/experimental-features/newton-physics-integration/isaaclab_newton-beta-2.rst
@@ -1,11 +1,11 @@
-Isaac Lab - Newton Beta 2
-=========================
+Isaac Lab 3.0 Beta
+==================
 
-Isaac Lab - Newton Beta 2 (feature/newton branch) provides Newton physics engine integration for Isaac Lab. We refactored our code so that we can not only support PhysX and Newton, but
+Isaac Lab 3.0 Beta (develop branch) provides Newton physics engine integration for Isaac Lab. We refactored our code so that we can not only support PhysX and Newton, but
 any other physics engine, enabling users to bring their own physics engine to Isaac Lab if they desire. To enable this, we introduce base implementations of
 our ``simulation interfaces``, :class:`~isaaclab.assets.articulation.Articulation` or :class:`~isaaclab.sensors.ContactSensor` for instance. These provide a
 set of abstract methods that all physics engines must implement. In turn this allows all of the default Isaac Lab environments to work with any physics engine.
-This also allows us to ensure that Isaac Lab - Newton Beta 2 is backwards compatible with Isaac Lab 2.X. For engine specific calls, users could get the underlying view of
+This also allows us to ensure that Isaac Lab 3.0 Beta is backwards compatible with Isaac Lab 2.X. For engine specific calls, users could get the underlying view of
 the physics engine and call the engine specific APIs directly.
 
 However, as we are refactoring the code, we are also looking at ways to limit the overhead of Isaac Lab's. In an effort to minimize the overhead, we are moving
@@ -13,7 +13,7 @@ all our low level code away from torch, and instead will rely heavily on warp. T
 to take advantage of the cuda-graphing. However, this means that the ``data classes`` such as :class:`~isaaclab.assets.articulation.ArticulationData` or
 :class:`~isaaclab.sensors.ContactSensorData` will only return warp arrays. Users will hence have to call ``wp.to_torch`` to convert them to torch tensors if they desire.
 Our setters/writers will support both warp arrays and torch tensors, and will use the most optimal strategy to update the warp arrays under the hood. This minimizes the
-amount of changes required for users to migrate to Isaac Lab - Newton Beta 2.
+amount of changes required for users to migrate to Isaac Lab 3.0 Beta.
 
 Another new feature of the writers and setters is the ability to provide them with masks and complete data (as opposed to indices and partial data in Isaac Lab 2.X).
 Note that this feature will be available along with the ability to provide indices and partial data, and that the default behavior will still be to provide indices and partial data.
@@ -41,12 +41,3 @@ we are introducing cuda-graphing support for direct rl tasks. This drastically r
 .. code-block:: bash
 
     ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Humanoid-Direct-Warp-v0 --num_envs 4096 --headless
-
-
-What's Next?
-============
-
-Isaac Lab 3.0 is the upcoming release of Isaac Lab, which will be compatible with Isaac Sim 6.0, and at the same time will support the new Newton physics engine.
-This will allow users to train policies on the Newton physics engine, or PhysX. To accommodate this major code refactoring are required. In this section, we
-will go over some of the changes, how that will affect Isaac Lab 2.X users, and how to migrate to Isaac Lab 3.0. The current branch of ``feature/newton`` gives
-a glance of what is to come. While the changes to the internal code structure are significant, the changes to the user API are minimal.

--- a/docs/source/experimental-features/newton-physics-integration/training-environments.rst
+++ b/docs/source/experimental-features/newton-physics-integration/training-environments.rst
@@ -7,16 +7,15 @@ The currently supported tasks are as follows:
 
 * Isaac-Cartpole-Direct-v0
 * Isaac-Cartpole-v0
-* Isaac-Cartpole-RGB-Camera-Direct-v0
-* Isaac-Cartpole-Depth-Camera-Direct-v0
+* Isaac-Cartpole-Camera-Presets-Direct-v0
 * Isaac-Ant-Direct-v0
 * Isaac-Ant-v0
+* Isaac-Dexsuite-Kuka-Allegro-Lift-v0
 * Isaac-Humanoid-Direct-v0
 * Isaac-Humanoid-v0
 * Isaac-Velocity-Flat-Anymal-B-v0
 * Isaac-Velocity-Flat-Anymal-C-v0
 * Isaac-Velocity-Flat-Anymal-D-v0
-* Isaac-Velocity-Flat-Cassie-v0
 * Isaac-Velocity-Flat-G1-v0
 * Isaac-Velocity-Flat-G1-v1 (Sim-to-Real tested)
 * Isaac-Velocity-Flat-H1-v0

--- a/docs/source/experimental-features/newton-physics-integration/visualization.rst
+++ b/docs/source/experimental-features/newton-physics-integration/visualization.rst
@@ -59,8 +59,8 @@ Launch visualizers from the command line with ``--visualizer``:
 
 .. code-block:: bash
 
-    # Launch all visualizers
-    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-v0 --visualizer omniverse newton rerun
+    # Launch all visualizers (comma-delimited list, no spaces)
+    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-v0 --visualizer kit,newton,rerun
 
     # Launch just newton visualizer
     python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-v0 --visualizer newton
@@ -77,18 +77,20 @@ If ``--headless`` is given, no visualizers will be launched.
 Configuration
 ~~~~~~~~~~~~~
 
-Launching visualizers with the command line will use default visualizer configurations. Default configs can be found and edited in ``source/isaaclab/isaaclab/visualizers``.
+Launching visualizers with the command line will use default visualizer configurations. Visualizer backends live in the ``isaaclab_visualizers`` package (e.g. ``source/isaaclab_visualizers/isaaclab_visualizers/kit``, ``newton``, ``rerun``).
 
-You can also configure custom visualizers in the code by defining new ``VisualizerCfg`` instances for the ``SimulationCfg``, for example:
+You can also configure custom visualizers in the code by defining ``VisualizerCfg`` instances for the ``SimulationCfg``, for example:
 
 .. code-block:: python
 
     from isaaclab.sim import SimulationCfg
-    from isaaclab.visualizers import NewtonVisualizerCfg, OVVisualizerCfg, RerunVisualizerCfg
+    from isaaclab_visualizers.kit import KitVisualizerCfg
+    from isaaclab_visualizers.newton import NewtonVisualizerCfg
+    from isaaclab_visualizers.rerun import RerunVisualizerCfg
 
     sim_cfg = SimulationCfg(
         visualizer_cfgs=[
-            OVVisualizerCfg(
+            KitVisualizerCfg(
                 viewport_name="Visualizer Viewport",
                 create_viewport=True,
                 dock_position="SAME",
@@ -128,9 +130,9 @@ Omniverse Visualizer
 
 .. code-block:: python
 
-    from isaaclab.visualizers import OVVisualizerCfg
+    from isaaclab_visualizers.kit import KitVisualizerCfg
 
-    visualizer_cfg = OVVisualizerCfg(
+    visualizer_cfg = KitVisualizerCfg(
         # Viewport settings
         viewport_name="Visualizer Viewport",      # Viewport window name
         create_viewport=True,                     # Create new viewport vs. use existing
@@ -176,8 +178,6 @@ Newton Visualizer
      - Look around
    * - **Mouse Scroll**
      - Zoom in/out
-   * - **Space**
-     - Pause/resume rendering (physics continues)
    * - **H**
      - Toggle UI sidebar
    * - **ESC**
@@ -187,7 +187,7 @@ Newton Visualizer
 
 .. code-block:: python
 
-    from isaaclab.visualizers import NewtonVisualizerCfg
+    from isaaclab_visualizers.newton import NewtonVisualizerCfg
 
     visualizer_cfg = NewtonVisualizerCfg(
         # Window settings
@@ -233,12 +233,14 @@ Rerun Visualizer
 
 .. code-block:: python
 
-    from isaaclab.visualizers import RerunVisualizerCfg
+    from isaaclab_visualizers.rerun import RerunVisualizerCfg
 
     visualizer_cfg = RerunVisualizerCfg(
         # Server settings
         app_id="isaaclab-simulation",             # Application identifier for viewer
+        grpc_port=9876,                           # gRPC endpoint for logging SDK connection
         web_port=9090,                            # Port for local web viewer (launched in browser)
+        bind_address="0.0.0.0",                  # Endpoint host formatting/reuse checks
 
         # Camera settings
         camera_position=(8.0, 8.0, 3.0),         # Initial camera position (x, y, z)
@@ -251,6 +253,10 @@ Rerun Visualizer
         # Recording
         record_to_rrd="recording.rrd",            # Path to save .rrd file (None = no recording)
     )
+
+Rerun startup uses the Python SDK through ``newton.viewer.ViewerRerun`` (no external ``rerun`` CLI process
+management). If ``grpc_port`` is already active, Isaac Lab reuses that server. If ``web_port`` is occupied while
+starting a new server, initialization fails with a clear port-conflict error.
 
 
 Performance Note

--- a/docs/source/setup/installation/source_installation.rst
+++ b/docs/source/setup/installation/source_installation.rst
@@ -78,7 +78,7 @@ variables to your terminal for the remaining of the installation instructions:
       .. code:: bash
 
          # Isaac Sim root directory
-         export ISAACSIM_PATH="${pwd}/_build/linux-x86_64/release"
+         export ISAACSIM_PATH="$(pwd)/_build/linux-x86_64/release"
          # Isaac Sim python executable
          export ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/distillation_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/distillation_cfg.py
@@ -22,7 +22,7 @@ class RslRlDistillationAlgorithmCfg:
     """Configuration for the distillation algorithm."""
 
     class_name: str = "Distillation"
-    """The algorithm class name. Default is Distillation."""
+    """The algorithm class name. Defaults to Distillation."""
 
     num_learning_epochs: int = MISSING
     """The number of updates performed with each sample."""
@@ -34,13 +34,13 @@ class RslRlDistillationAlgorithmCfg:
     """The number of environment steps the gradient flows back."""
 
     max_grad_norm: None | float = None
-    """The maximum norm the gradient is clipped to."""
+    """The maximum norm the gradient is clipped to. Defaults to None."""
 
     optimizer: Literal["adam", "adamw", "sgd", "rmsprop"] = "adam"
-    """The optimizer to use for the student policy."""
+    """The optimizer to use for the student policy. Defaults to adam."""
 
     loss_type: Literal["mse", "huber"] = "mse"
-    """The loss type to use for the student policy."""
+    """The loss type to use for the student policy. Defaults to mse."""
 
 
 #########################
@@ -53,7 +53,7 @@ class RslRlDistillationRunnerCfg(RslRlBaseRunnerCfg):
     """Configuration of the runner for distillation algorithms."""
 
     class_name: str = "DistillationRunner"
-    """The runner class name. Default is DistillationRunner."""
+    """The runner class name. Defaults to DistillationRunner."""
 
     student: RslRlMLPModelCfg = MISSING
     """The student configuration."""
@@ -85,13 +85,13 @@ class RslRlDistillationStudentTeacherCfg:
     """
 
     class_name: str = "StudentTeacher"
-    """The policy class name. Default is StudentTeacher."""
+    """The policy class name. Defaults to StudentTeacher."""
 
     init_noise_std: float = MISSING
     """The initial noise standard deviation for the student policy."""
 
     noise_std_type: Literal["scalar", "log"] = "scalar"
-    """The type of noise standard deviation for the policy. Default is scalar."""
+    """The type of noise standard deviation for the policy. Defaults to scalar."""
 
     student_obs_normalization: bool = MISSING
     """Whether to normalize the observation for the student network."""
@@ -117,7 +117,7 @@ class RslRlDistillationStudentTeacherRecurrentCfg(RslRlDistillationStudentTeache
     """
 
     class_name: str = "StudentTeacherRecurrent"
-    """The policy class name. Default is StudentTeacherRecurrent."""
+    """The policy class name. Defaults to StudentTeacherRecurrent."""
 
     rnn_type: str = MISSING
     """The type of the RNN network. Either "lstm" or "gru"."""

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
@@ -23,7 +23,7 @@ class RslRlMLPModelCfg:
     """Configuration for the MLP model."""
 
     class_name: str = "MLPModel"
-    """The model class name. Default is MLPModel."""
+    """The model class name. Defaults to MLPModel."""
 
     hidden_dims: list[int] = MISSING
     """The hidden dimensions of the MLP network."""
@@ -32,10 +32,10 @@ class RslRlMLPModelCfg:
     """The activation function for the MLP network."""
 
     obs_normalization: bool = False
-    """Whether to normalize the observation for the model. Default is False."""
+    """Whether to normalize the observation for the model. Defaults to False."""
 
     distribution_cfg: DistributionCfg | None = None
-    """The configuration for the output distribution. Default is None, in which case no distribution is used."""
+    """The configuration for the output distribution. Defaults to None, in which case no distribution is used."""
 
     @configclass
     class DistributionCfg:
@@ -79,14 +79,14 @@ class RslRlMLPModelCfg:
     """
 
     noise_std_type: Literal["scalar", "log"] = "scalar"
-    """The type of noise standard deviation for the model. Default is scalar.
+    """The type of noise standard deviation for the model. Defaults to scalar.
 
     For rsl-rl >= 5.0.0, this configuration is is deprecated. Please use `distribution_cfg` instead and use the
     `std_type` field of the distribution configuration to specify the type of noise standard deviation.
     """
 
     state_dependent_std: bool = False
-    """Whether to use state-dependent standard deviation for the policy. Default is False.
+    """Whether to use state-dependent standard deviation for the policy. Defaults to False.
 
     For rsl-rl >= 5.0.0, this configuration is is deprecated. Please use `distribution_cfg` instead and use
     the `HeteroscedasticGaussianDistributionCfg` if state-dependent standard deviation is desired.
@@ -98,7 +98,7 @@ class RslRlRNNModelCfg(RslRlMLPModelCfg):
     """Configuration for RNN model."""
 
     class_name: str = "RNNModel"
-    """The model class name. Default is RNNModel."""
+    """The model class name. Defaults to RNNModel."""
 
     rnn_type: str = MISSING
     """The type of RNN to use. Either "lstm" or "gru"."""
@@ -115,7 +115,7 @@ class RslRlCNNModelCfg(RslRlMLPModelCfg):
     """Configuration for CNN model."""
 
     class_name: str = "CNNModel"
-    """The model class name. Default is CNNModel."""
+    """The model class name. Defaults to CNNModel."""
 
     @configclass
     class CNNCfg:
@@ -126,28 +126,28 @@ class RslRlCNNModelCfg(RslRlMLPModelCfg):
         """The kernel size for the CNN."""
 
         stride: int | tuple[int] | list[int] = 1
-        """The stride for the CNN."""
+        """The stride for the CNN. Defaults to 1."""
 
         dilation: int | tuple[int] | list[int] = 1
-        """The dilation for the CNN."""
+        """The dilation for the CNN. Defaults to 1."""
 
         padding: Literal["none", "zeros", "reflect", "replicate", "circular"] = "none"
-        """The padding for the CNN."""
+        """The padding for the CNN. Defaults to none."""
 
         norm: Literal["none", "batch", "layer"] | tuple[str] | list[str] = "none"
-        """The normalization for the CNN."""
+        """The normalization for the CNN. Defaults to none."""
 
         activation: str = MISSING
         """The activation function for the CNN."""
 
         max_pool: bool | tuple[bool] | list[bool] = False
-        """Whether to use max pooling for the CNN."""
+        """Whether to use max pooling for the CNN. Defaults to False."""
 
         global_pool: Literal["none", "max", "avg"] = "none"
-        """The global pooling for the CNN."""
+        """The global pooling for the CNN. Defaults to none."""
 
         flatten: bool = True
-        """Whether to flatten the output of the CNN."""
+        """Whether to flatten the output of the CNN. Defaults to True."""
 
     cnn_cfg: CNNCfg = MISSING
     """The configuration for the CNN(s)."""
@@ -163,7 +163,7 @@ class RslRlPpoAlgorithmCfg:
     """Configuration for the PPO algorithm."""
 
     class_name: str = "PPO"
-    """The algorithm class name. Default is PPO."""
+    """The algorithm class name. Defaults to PPO."""
 
     num_learning_epochs: int = MISSING
     """The number of learning epochs per update."""
@@ -193,7 +193,7 @@ class RslRlPpoAlgorithmCfg:
     """The maximum gradient norm."""
 
     optimizer: Literal["adam", "adamw", "sgd", "rmsprop"] = "adam"
-    """The optimizer to use."""
+    """The optimizer to use. Defaults to adam."""
 
     value_loss_coef: float = MISSING
     """The coefficient for the value loss."""
@@ -205,7 +205,7 @@ class RslRlPpoAlgorithmCfg:
     """The clipping parameter for the policy."""
 
     normalize_advantage_per_mini_batch: bool = False
-    """Whether to normalize the advantage per mini-batch. Default is False.
+    """Whether to normalize the advantage per mini-batch. Defaults to False.
 
     If True, the advantage is normalized over the mini-batches only.
     Otherwise, the advantage is normalized over the entire collected trajectories.
@@ -215,10 +215,10 @@ class RslRlPpoAlgorithmCfg:
     """Whether to share the CNN networks between actor and critic, in case CNNModels are used. Defaults to False."""
 
     rnd_cfg: RslRlRndCfg | None = None
-    """The RND configuration. Default is None, in which case RND is not used."""
+    """The RND configuration. Defaults to None, in which case RND is not used."""
 
     symmetry_cfg: RslRlSymmetryCfg | None = None
-    """The symmetry configuration. Default is None, in which case symmetry is not used."""
+    """The symmetry configuration. Defaults to None, in which case symmetry is not used."""
 
 
 #########################
@@ -231,10 +231,10 @@ class RslRlBaseRunnerCfg:
     """Base configuration of the runner."""
 
     seed: int = 42
-    """The seed for the experiment. Default is 42."""
+    """The seed for the experiment. Defaults to 42."""
 
     device: str = "cuda:0"
-    """The device for the rl-agent. Default is cuda:0."""
+    """The device for the rl-agent. Defaults to cuda:0."""
 
     num_steps_per_env: int = MISSING
     """The number of steps per environment per update."""
@@ -288,7 +288,7 @@ class RslRlBaseRunnerCfg:
     """The experiment name."""
 
     run_name: str = ""
-    """The run name. Default is empty string.
+    """The run name. Defaults to empty string.
 
     The name of the run directory is typically the time-stamp at execution. If the run name is not empty,
     then it is appended to the run directory's name, i.e. the logging directory's name will become
@@ -296,28 +296,28 @@ class RslRlBaseRunnerCfg:
     """
 
     logger: Literal["tensorboard", "neptune", "wandb"] = "tensorboard"
-    """The logger to use. Default is tensorboard."""
+    """The logger to use. Defaults to tensorboard."""
 
     neptune_project: str = "isaaclab"
-    """The neptune project name. Default is "isaaclab"."""
+    """The neptune project name. Defaults to "isaaclab"."""
 
     wandb_project: str = "isaaclab"
-    """The wandb project name. Default is "isaaclab"."""
+    """The wandb project name. Defaults to "isaaclab"."""
 
     resume: bool = False
-    """Whether to resume a previous training. Default is False.
+    """Whether to resume a previous training. Defaults to False.
 
     This flag will be ignored for distillation.
     """
 
     load_run: str = ".*"
-    """The run directory to load. Default is ".*" (all).
+    """The run directory to load. Defaults to ".*" (all).
 
     If regex expression, the latest (alphabetical order) matching run will be loaded.
     """
 
     load_checkpoint: str = "model_.*.pt"
-    """The checkpoint file to load. Default is ``"model_.*.pt"`` (all).
+    """The checkpoint file to load. Defaults to ``"model_.*.pt"`` (all).
 
     If regex expression, the latest (alphabetical order) matching file will be loaded.
     """
@@ -328,7 +328,7 @@ class RslRlOnPolicyRunnerCfg(RslRlBaseRunnerCfg):
     """Configuration of the runner for on-policy algorithms."""
 
     class_name: str = "OnPolicyRunner"
-    """The runner class name. Default is OnPolicyRunner."""
+    """The runner class name. Defaults to OnPolicyRunner."""
 
     actor: RslRlMLPModelCfg = MISSING
     """The actor configuration."""
@@ -360,16 +360,16 @@ class RslRlPpoActorCriticCfg:
     """
 
     class_name: str = "ActorCritic"
-    """The policy class name. Default is ActorCritic."""
+    """The policy class name. Defaults to ActorCritic."""
 
     init_noise_std: float = MISSING
     """The initial noise standard deviation for the policy."""
 
     noise_std_type: Literal["scalar", "log"] = "scalar"
-    """The type of noise standard deviation for the policy. Default is scalar."""
+    """The type of noise standard deviation for the policy. Defaults to scalar."""
 
     state_dependent_std: bool = False
-    """Whether to use state-dependent standard deviation for the policy. Default is False."""
+    """Whether to use state-dependent standard deviation for the policy. Defaults to False."""
 
     actor_obs_normalization: bool = MISSING
     """Whether to normalize the observation for the actor network."""
@@ -395,7 +395,7 @@ class RslRlPpoActorCriticRecurrentCfg(RslRlPpoActorCriticCfg):
     """
 
     class_name: str = "ActorCriticRecurrent"
-    """The policy class name. Default is ActorCriticRecurrent."""
+    """The policy class name. Defaults to ActorCriticRecurrent."""
 
     rnn_type: str = MISSING
     """The type of RNN to use. Either "lstm" or "gru"."""

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rnd_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rnd_cfg.py
@@ -20,7 +20,7 @@ class RslRlRndCfg:
         """Configuration for the weight schedule."""
 
         mode: str = "constant"
-        """The type of weight schedule. Default is "constant"."""
+        """The type of weight schedule. Defaults to "constant"."""
 
     @configclass
     class LinearWeightScheduleCfg(WeightScheduleCfg):
@@ -31,6 +31,7 @@ class RslRlRndCfg:
         """
 
         mode: str = "linear"
+        """The type of weight schedule. Defaults to "linear"."""
 
         final_value: float = MISSING
         """The final value of the weight parameter."""
@@ -55,6 +56,7 @@ class RslRlRndCfg:
         """
 
         mode: str = "step"
+        """The type of weight schedule. Defaults to "step"."""
 
         final_step: int = MISSING
         """The final step of the weight schedule.
@@ -66,34 +68,34 @@ class RslRlRndCfg:
         """The final value of the weight parameter."""
 
     weight: float = 0.0
-    """The weight for the RND reward (also known as intrinsic reward). Default is 0.0.
+    """The weight for the RND reward (also known as intrinsic reward). Defaults to 0.0.
 
     Similar to other reward terms, the RND reward is scaled by this weight.
     """
 
     weight_schedule: WeightScheduleCfg | None = None
-    """The weight schedule for the RND reward. Default is None, which means the weight is constant."""
+    """The weight schedule for the RND reward. Defaults to None, which means the weight is constant."""
 
     reward_normalization: bool = False
-    """Whether to normalize the RND reward. Default is False."""
+    """Whether to normalize the RND reward. Defaults to False."""
 
     state_normalization: bool = False
-    """Whether to normalize the RND state. Default is False."""
+    """Whether to normalize the RND state. Defaults to False."""
 
     learning_rate: float = 1e-3
-    """The learning rate for the RND module. Default is 1e-3."""
+    """The learning rate for the RND module. Defaults to 1e-3."""
 
     num_outputs: int = 1
-    """The number of outputs for the RND module. Default is 1."""
+    """The number of outputs for the RND module. Defaults to 1."""
 
     predictor_hidden_dims: list[int] = [-1]
-    """The hidden dimensions for the RND predictor network. Default is [-1].
+    """The hidden dimensions for the RND predictor network. Defaults to [-1].
 
     If the list contains -1, then the hidden dimensions are the same as the input dimensions.
     """
 
     target_hidden_dims: list[int] = [-1]
-    """The hidden dimensions for the RND target network. Default is [-1].
+    """The hidden dimensions for the RND target network. Defaults to [-1].
 
     If the list contains -1, then the hidden dimensions are the same as the input dimensions.
     """

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/symmetry_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/symmetry_cfg.py
@@ -26,10 +26,10 @@ class RslRlSymmetryCfg:
     """
 
     use_data_augmentation: bool = False
-    """Whether to use symmetry-based data augmentation. Default is False."""
+    """Whether to use symmetry-based data augmentation. Defaults to False."""
 
     use_mirror_loss: bool = False
-    """Whether to use the symmetry-augmentation loss. Default is False."""
+    """Whether to use the symmetry-augmentation loss. Defaults to False."""
 
     data_augmentation_func: callable = MISSING
     """The symmetry data augmentation function.
@@ -48,4 +48,4 @@ class RslRlSymmetryCfg:
     """
 
     mirror_loss_coeff: float = 0.0
-    """The weight for the symmetry-mirror loss. Default is 0.0."""
+    """The weight for the symmetry-mirror loss. Defaults to 0.0."""

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.11.15 (2026-03-07)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``Isaac-Stack-Cube-RedGreen-Franka-IK-Rel-v0``, ``Isaac-Stack-Cube-RedGreenBlue-Franka-IK-Rel-v0``,
+  ``Isaac-Stack-Cube-BlueGreen-Franka-IK-Rel-v0``, and ``Isaac-Stack-Cube-BlueGreenRed-Franka-IK-Rel-v0`` environments.
+
+
 0.11.14 (2026-02-27)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
@@ -72,6 +72,47 @@ gym.register(
 )
 
 gym.register(
+    id="Isaac-Stack-Cube-RedGreen-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackRedGreenEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
+    id="Isaac-Stack-Cube-RedGreenBlue-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackRedGreenBlueEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+
+gym.register(
+    id="Isaac-Stack-Cube-BlueGreen-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackBlueGreenEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
+    id="Isaac-Stack-Cube-BlueGreenRed-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackBlueGreenRedEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
     id="Isaac-Stack-Cube-Franka-IK-Abs-v0",
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_env_cfg.py
@@ -10,7 +10,11 @@ from isaaclab.devices.openxr.openxr_device import OpenXRDeviceCfg
 from isaaclab.devices.openxr.retargeters.manipulator.gripper_retargeter import GripperRetargeterCfg
 from isaaclab.devices.openxr.retargeters.manipulator.se3_rel_retargeter import Se3RelRetargeterCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.utils import configclass
+
+from isaaclab_tasks.manager_based.manipulation.stack.stack_env_cfg import mdp
 
 from . import stack_joint_pos_env_cfg
 
@@ -66,4 +70,60 @@ class FrankaCubeStackEnvCfg(stack_joint_pos_env_cfg.FrankaCubeStackEnvCfg):
                     sim_device=self.sim.device,
                 ),
             }
+        )
+
+
+@configclass
+class FrankaCubeStackRedGreenEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={"cube_1_cfg": SceneEntityCfg("cube_2"), "cube_2_cfg": SceneEntityCfg("cube_3"), "cube_3_cfg": None},
+        )
+
+
+@configclass
+class FrankaCubeStackRedGreenBlueEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={
+                "cube_1_cfg": SceneEntityCfg("cube_2"),
+                "cube_2_cfg": SceneEntityCfg("cube_3"),
+                "cube_3_cfg": SceneEntityCfg("cube_1"),
+            },
+        )
+
+
+@configclass
+class FrankaCubeStackBlueGreenEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={"cube_1_cfg": SceneEntityCfg("cube_1"), "cube_2_cfg": SceneEntityCfg("cube_3"), "cube_3_cfg": None},
+        )
+
+
+@configclass
+class FrankaCubeStackBlueGreenRedEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={
+                "cube_1_cfg": SceneEntityCfg("cube_1"),
+                "cube_2_cfg": SceneEntityCfg("cube_3"),
+                "cube_3_cfg": SceneEntityCfg("cube_2"),
+            },
         )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
@@ -27,35 +27,44 @@ def cubes_stacked(
     robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
     cube_1_cfg: SceneEntityCfg = SceneEntityCfg("cube_1"),
     cube_2_cfg: SceneEntityCfg = SceneEntityCfg("cube_2"),
-    cube_3_cfg: SceneEntityCfg = SceneEntityCfg("cube_3"),
+    cube_3_cfg: SceneEntityCfg | None = SceneEntityCfg("cube_3"),
     xy_threshold: float = 0.04,
     height_threshold: float = 0.005,
     height_diff: float = 0.0468,
-    atol=0.0001,
-    rtol=0.0001,
-):
+    atol: float = 0.0001,
+    rtol: float = 0.0001,
+) -> torch.Tensor:
     robot: Articulation = env.scene[robot_cfg.name]
     cube_1: RigidObject = env.scene[cube_1_cfg.name]
     cube_2: RigidObject = env.scene[cube_2_cfg.name]
-    cube_3: RigidObject = env.scene[cube_3_cfg.name]
 
     pos_diff_c12 = cube_1.data.root_pos_w - cube_2.data.root_pos_w
-    pos_diff_c23 = cube_2.data.root_pos_w - cube_3.data.root_pos_w
 
     # Compute cube position difference in x-y plane
     xy_dist_c12 = torch.norm(pos_diff_c12[:, :2], dim=1)
-    xy_dist_c23 = torch.norm(pos_diff_c23[:, :2], dim=1)
 
     # Compute cube height difference
     h_dist_c12 = torch.norm(pos_diff_c12[:, 2:], dim=1)
-    h_dist_c23 = torch.norm(pos_diff_c23[:, 2:], dim=1)
 
     # Check cube positions
-    stacked = torch.logical_and(xy_dist_c12 < xy_threshold, xy_dist_c23 < xy_threshold)
+    stacked = xy_dist_c12 < xy_threshold
     stacked = torch.logical_and(h_dist_c12 - height_diff < height_threshold, stacked)
     stacked = torch.logical_and(pos_diff_c12[:, 2] < 0.0, stacked)
-    stacked = torch.logical_and(h_dist_c23 - height_diff < height_threshold, stacked)
-    stacked = torch.logical_and(pos_diff_c23[:, 2] < 0.0, stacked)
+
+    if cube_3_cfg is not None:
+        cube_3: RigidObject = env.scene[cube_3_cfg.name]
+        pos_diff_c23 = cube_2.data.root_pos_w - cube_3.data.root_pos_w
+
+        # Compute cube position difference in x-y plane
+        xy_dist_c23 = torch.norm(pos_diff_c23[:, :2], dim=1)
+
+        # Compute cube height difference
+        h_dist_c23 = torch.norm(pos_diff_c23[:, 2:], dim=1)
+
+        # Check cube positions
+        stacked = torch.logical_and(xy_dist_c23 < xy_threshold, stacked)
+        stacked = torch.logical_and(h_dist_c23 - height_diff < height_threshold, stacked)
+        stacked = torch.logical_and(pos_diff_c23[:, 2] < 0.0, stacked)
 
     # Check gripper positions
     if hasattr(env.scene, "surface_grippers") and len(env.scene.surface_grippers) > 0:


### PR DESCRIPTION
To correctly set the path for the environment variable, the pwk command must be enclosed in parantheses rather than curly brackets.

## Type of change

- Documentation update

