### PR TITLE
Removes  Docker image pruning in CI workflow (already automated on GH runners)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,10 +61,6 @@ jobs:
         dockerfile-path: docker/Dockerfile.base
         cache-tag: cache-base
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
   build-curobo:
     name: Build cuRobo Docker image
@@ -85,10 +81,6 @@ jobs:
         dockerfile-path: docker/Dockerfile.curobo
         cache-tag: cache-curobo
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
 
   test-isaaclab-tasks:
@@ -154,10 +146,6 @@ jobs:
           exit 1
         fi
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
   test-isaaclab-tasks-2:
     name: IsaacLab Tasks Tests 2/2
@@ -223,10 +211,6 @@ jobs:
           exit 1
         fi
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
   test-general:
     name: General Tests
@@ -284,10 +268,6 @@ jobs:
           exit 1
         fi
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
   test-newton:
     name: Newton Tests
@@ -344,10 +324,6 @@ jobs:
           exit 1
         fi
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
   test-physx:
     name: PhysX Tests
@@ -404,10 +380,6 @@ jobs:
           exit 1
         fi
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
   test-curobo:
     name: cuRobo and SkillGen Tests
@@ -466,10 +438,6 @@ jobs:
           exit 1
         fi
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
   test-quarantined:
     name: "Quarantined Tests"
@@ -528,10 +496,6 @@ jobs:
           exit 1
         fi
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
   test-environments-training:
     name: "test_environments_training.py"
@@ -589,10 +553,6 @@ jobs:
           exit 1
         fi
 
-    # ECR images must be pruned with a lifecycle policy.
-    - name: Clean up stale Docker images
-      if: always()
-      run: docker image prune -f --filter "until=24h" || true
 
   combine-results:
     needs: [build, build-curobo, test-isaaclab-tasks, test-isaaclab-tasks-2, test-general, test-newton, test-physx, test-curobo, test-quarantined, test-environments-training]


### PR DESCRIPTION
# Description

Removes  "Clean up stale Docker images" steps from `build.yaml`.

These `docker image prune` steps are unnecessary because our self-hosted runners already handle Docker image cleanup. (ECR images are pruned with a lifecycle policy.) THis will help to increase local Docker cache hits on the runners, hopefully making our CI a little bit faster.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
