### PR TITLE
Adds configurable target coordinate frame for teleop output poses

### DIFF
--- a/source/isaaclab_teleop/config/extension.toml
+++ b/source/isaaclab_teleop/config/extension.toml
@@ -1,6 +1,6 @@
 [package]
 # Semantic Versioning is used: https://semver.org/
-version = "0.3.3"
+version = "0.3.4"
 
 # Description
 title =  "Isaac Lab Teleop"

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -1,11 +1,17 @@
 Changelog
 ---------
 
-0.3.4 (2026-03-16)
+0.3.4 (2026-03-17)
 ~~~~~~~~~~~~~~~~~~~
 
 Added
 ^^^^^
+
+* Added :attr:`~isaaclab_teleop.IsaacTeleopCfg.target_frame_prim_path` for
+  config-driven frame rebasing.  When set to a USD prim path, the device
+  automatically reads the prim's world transform each frame and uses its
+  inverse as the ``target_T_world`` rebase matrix, so all output poses are
+  expressed in the target frame (e.g. robot base link for IK).
 
 * Added ``target_T_world`` parameter to
   :meth:`~isaaclab_teleop.IsaacTeleopDevice.advance` for rebasing all output

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+0.3.4 (2026-03-16)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``target_T_world`` parameter to
+  :meth:`~isaaclab_teleop.IsaacTeleopDevice.advance` for rebasing all output
+  poses into an arbitrary target coordinate frame (e.g. robot base link for
+  IK).  Accepts :class:`numpy.ndarray`, :class:`torch.Tensor`, or
+  ``wp.array``.
+
+
 0.3.3 (2026-03-13)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_cfg.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_cfg.py
@@ -108,5 +108,26 @@ class IsaacTeleopCfg:
     If ``None``, the tuning UI will not be opened.
     """
 
+    target_frame_prim_path: str | None = None
+    """Optional USD prim path whose world frame becomes the target coordinate
+    frame for all output poses.
+
+    When set, the device automatically reads this prim's world transform each
+    frame and uses its inverse as the ``target_T_world`` rebase matrix in
+    :meth:`~isaaclab_teleop.IsaacTeleopDevice.advance`.  An explicit
+    ``target_T_world`` argument to :meth:`~isaaclab_teleop.IsaacTeleopDevice.advance`
+    takes precedence over this config.
+
+    Typical usage: set to the robot base link prim path so that an IK
+    controller receives end-effector poses in the robot's base frame.
+
+    Example::
+
+        IsaacTeleopCfg(
+            target_frame_prim_path="/World/envs/env_0/Robot/base_link",
+            ...
+        )
+    """
+
     app_name: str = "IsaacLabTeleop"
     """Application name for the IsaacTeleop session."""

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -17,6 +18,9 @@ from .command_handler import CommandHandler
 from .isaac_teleop_cfg import IsaacTeleopCfg
 from .session_lifecycle import TeleopSessionLifecycle
 from .xr_anchor_manager import XrAnchorManager
+
+if TYPE_CHECKING:
+    from .session_lifecycle import SupportsDLPack
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +50,17 @@ class IsaacTeleopDevice:
     Frame rebasing:
         By default, all output poses are expressed in the simulation world
         frame.  When an application needs poses in a different frame (e.g.
-        robot base link for IK), pass a ``target_T_world`` transform to
-        :meth:`advance`.  The device composes
+        robot base link for IK), there are two options:
+
+        * **Config-driven** (recommended): set
+          :attr:`~IsaacTeleopCfg.target_frame_prim_path` to the USD prim
+          whose frame the output should be expressed in.  The device reads
+          the prim's world transform each frame and applies the rebase
+          automatically.
+        * **Explicit**: pass a ``target_T_world`` matrix directly to
+          :meth:`advance`.
+
+        In both cases the device composes
         ``target_T_world @ world_T_anchor`` before feeding the matrix into
         the retargeting pipeline, so all resulting poses are expressed in the
         target frame.
@@ -70,7 +83,14 @@ class IsaacTeleopDevice:
                     action = device.advance()
                     env.step(action.repeat(num_envs, 1))
 
-            # Poses rebased into the robot base frame for IK
+            # Config-driven rebase into robot base frame
+            cfg.target_frame_prim_path = "/World/Robot/base_link"
+            with IsaacTeleopDevice(cfg) as device:
+                while running:
+                    action = device.advance()
+                    env.step(action.repeat(num_envs, 1))
+
+            # Explicit rebase into robot base frame
             with IsaacTeleopDevice(cfg) as device:
                 while running:
                     robot_T_world = get_robot_base_transform()
@@ -165,7 +185,7 @@ class IsaacTeleopDevice:
         """
         self._command_handler.add_callback(key, func)
 
-    def advance(self, target_T_world: np.ndarray | torch.Tensor | None = None) -> torch.Tensor | None:
+    def advance(self, target_T_world: np.ndarray | torch.Tensor | SupportsDLPack | None = None) -> torch.Tensor | None:
         """Process current device state and return control commands.
 
         If the IsaacTeleop session has not been started yet (because the OpenXR
@@ -185,8 +205,14 @@ class IsaacTeleopDevice:
                 controller receives end-effector poses in the robot's base
                 link frame.
 
-                Accepts :class:`numpy.ndarray`, :class:`torch.Tensor`, or any
-                object with a ``.numpy()`` method (e.g. ``wp.array``).
+                Accepts any object supporting the DLPack buffer protocol
+                (``__dlpack__``), including :class:`numpy.ndarray`,
+                :class:`torch.Tensor`, and ``wp.array``.
+
+                When ``None`` and
+                :attr:`~IsaacTeleopCfg.target_frame_prim_path` is set, the
+                transform is computed automatically by reading the prim's
+                world matrix from Fabric and inverting it.
 
         Returns:
             A flattened action :class:`torch.Tensor` ready for the Isaac Lab
@@ -196,6 +222,10 @@ class IsaacTeleopDevice:
         Raises:
             RuntimeError: If called outside of a context manager.
         """
+        # Auto-compute target_T_world from config if not explicitly provided
+        if target_T_world is None and self._cfg.target_frame_prim_path is not None:
+            target_T_world = self._get_target_frame_T_world()
+
         # Step the session (handles lazy start and action extraction)
         action = self._session_lifecycle.step(
             anchor_world_matrix_fn=self._anchor_manager.get_world_matrix,
@@ -207,6 +237,75 @@ class IsaacTeleopDevice:
             self._poll_buttons()
 
         return action
+
+    # ------------------------------------------------------------------
+    # Target frame transform (config-driven rebase)
+    # ------------------------------------------------------------------
+
+    def _get_target_frame_T_world(self) -> np.ndarray | None:
+        """Read the target-frame prim's world matrix from Fabric and return its inverse.
+
+        Uses USDRT to read the prim's hierarchical world matrix, matching the
+        pattern used by :class:`XrAnchorSynchronizer` for anchor prim reads.
+
+        Returns:
+            A (4, 4) float32 :class:`numpy.ndarray` representing the inverse
+            of the prim's world transform (i.e. ``target_T_world``), or
+            ``None`` if the prim cannot be read.
+        """
+        try:
+            import omni.usd
+            import usdrt
+            from pxr import UsdUtils
+            from usdrt import Rt
+
+            stage = omni.usd.get_context().get_stage()
+            stage_cache = UsdUtils.StageCache.Get()
+            stage_id = stage_cache.GetId(stage).ToLongInt()
+            if stage_id < 0:
+                stage_id = stage_cache.Insert(stage).ToLongInt()
+            rt_stage = usdrt.Usd.Stage.Attach(stage_id)
+            if rt_stage is None:
+                return None
+
+            rt_prim = rt_stage.GetPrimAtPath(self._cfg.target_frame_prim_path)
+            if not rt_prim.IsValid():
+                return None
+
+            rt_xformable = Rt.Xformable(rt_prim)
+            if not rt_xformable.GetPrim().IsValid():
+                return None
+
+            world_matrix_attr = rt_xformable.GetFabricHierarchyWorldMatrixAttr()
+            if world_matrix_attr is None:
+                return None
+
+            rt_matrix = world_matrix_attr.Get()
+            if rt_matrix is None:
+                return None
+
+            pos = rt_matrix.ExtractTranslation()
+            rt_quat = rt_matrix.ExtractRotationQuat()
+
+            from scipy.spatial.transform import Rotation
+
+            quat_xyzw = [
+                float(rt_quat.GetImaginary()[0]),
+                float(rt_quat.GetImaginary()[1]),
+                float(rt_quat.GetImaginary()[2]),
+                float(rt_quat.GetReal()),
+            ]
+
+            R = Rotation.from_quat(quat_xyzw).as_matrix().astype(np.float32)
+            t = np.array([float(pos[0]), float(pos[1]), float(pos[2])], dtype=np.float32)
+
+            inv_mat = np.eye(4, dtype=np.float32)
+            inv_mat[:3, :3] = R.T
+            inv_mat[:3, 3] = -(R.T @ t)
+            return inv_mat
+        except Exception as e:
+            logger.warning(f"Failed to read target frame prim '{self._cfg.target_frame_prim_path}': {e}")
+            return None
 
     # ------------------------------------------------------------------
     # Controller button polling (glue between session and anchor manager)

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 
+import numpy as np
 import torch
 
 from .command_handler import CommandHandler
@@ -42,6 +43,15 @@ class IsaacTeleopDevice:
     The device uses IsaacTeleop's TensorReorderer to flatten pipeline outputs
     into a single action tensor matching the environment's action space.
 
+    Frame rebasing:
+        By default, all output poses are expressed in the simulation world
+        frame.  When an application needs poses in a different frame (e.g.
+        robot base link for IK), pass a ``target_T_world`` transform to
+        :meth:`advance`.  The device composes
+        ``target_T_world @ world_T_anchor`` before feeding the matrix into
+        the retargeting pipeline, so all resulting poses are expressed in the
+        target frame.
+
     Teleop commands:
         The device supports callbacks for START, STOP, and RESET commands
         that can be triggered via XR controller buttons or the message bus.
@@ -54,9 +64,17 @@ class IsaacTeleopDevice:
                 sim_device="cuda:0",
             )
 
+            # Poses in world frame (default)
             with IsaacTeleopDevice(cfg) as device:
                 while running:
                     action = device.advance()
+                    env.step(action.repeat(num_envs, 1))
+
+            # Poses rebased into the robot base frame for IK
+            with IsaacTeleopDevice(cfg) as device:
+                while running:
+                    robot_T_world = get_robot_base_transform()
+                    action = device.advance(target_T_world=robot_T_world)
                     env.step(action.repeat(num_envs, 1))
     """
 
@@ -147,13 +165,28 @@ class IsaacTeleopDevice:
         """
         self._command_handler.add_callback(key, func)
 
-    def advance(self) -> torch.Tensor | None:
+    def advance(self, target_T_world: np.ndarray | torch.Tensor | None = None) -> torch.Tensor | None:
         """Process current device state and return control commands.
 
         If the IsaacTeleop session has not been started yet (because the OpenXR
         handles were not available at ``__enter__`` time), this method will
         attempt to start it on each call.  Once the user clicks "Start AR" and
         the handles become available, the session is created transparently.
+
+        Args:
+            target_T_world: Optional 4x4 transform matrix that rebases all
+                output poses into an arbitrary target coordinate frame.  When
+                provided, the matrix sent to the retargeting pipeline becomes
+                ``target_T_world @ world_T_anchor`` instead of just
+                ``world_T_anchor``, so all resulting poses are expressed in
+                the target frame rather than the simulation world frame.
+
+                Typical use case: pass ``robot_base_T_world`` so that an IK
+                controller receives end-effector poses in the robot's base
+                link frame.
+
+                Accepts :class:`numpy.ndarray`, :class:`torch.Tensor`, or any
+                object with a ``.numpy()`` method (e.g. ``wp.array``).
 
         Returns:
             A flattened action :class:`torch.Tensor` ready for the Isaac Lab
@@ -166,6 +199,7 @@ class IsaacTeleopDevice:
         # Step the session (handles lazy start and action extraction)
         action = self._session_lifecycle.step(
             anchor_world_matrix_fn=self._anchor_manager.get_world_matrix,
+            target_T_world=target_T_world,
         )
 
         if action is not None:

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
 import torch
@@ -21,17 +21,32 @@ if TYPE_CHECKING:
 
 from .isaac_teleop_cfg import IsaacTeleopCfg
 
+
+class SupportsDLPack(Protocol):
+    """Duck type for objects supporting the DLPack buffer protocol.
+
+    Satisfied by :class:`torch.Tensor`, :class:`numpy.ndarray` (>= 1.22),
+    ``wp.array``, CuPy arrays, JAX arrays, and other frameworks.
+    """
+
+    def __dlpack__(self, *, stream: Any = ...) -> Any: ...
+
+    def __dlpack_device__(self) -> tuple[int, int]: ...
+
+
 logger = logging.getLogger(__name__)
 
+_DLDEVICE_CPU = 1
 
-def _to_numpy_4x4(mat: np.ndarray | torch.Tensor) -> np.ndarray:
-    """Convert a 4x4 transform to a float32 numpy array.
 
-    Accepts :class:`numpy.ndarray`, :class:`torch.Tensor`, ``wp.array``,
-    or any object implementing a ``.numpy()`` method.
+def _to_numpy_4x4(mat: np.ndarray | torch.Tensor | SupportsDLPack) -> np.ndarray:
+    """Convert a (4, 4) transform to a float32 numpy array.
+
+    Prefers the DLPack buffer protocol (``__dlpack__``) for zero-copy
+    interop with torch, warp, cupy, jax, and other frameworks.
 
     Args:
-        mat: A (4, 4) transform matrix in any supported array type.
+        mat: A (4, 4) transform matrix.
 
     Returns:
         A (4, 4) float32 :class:`numpy.ndarray`.
@@ -39,9 +54,18 @@ def _to_numpy_4x4(mat: np.ndarray | torch.Tensor) -> np.ndarray:
     if isinstance(mat, np.ndarray):
         return np.asarray(mat, dtype=np.float32)
     if isinstance(mat, torch.Tensor):
-        return mat.detach().cpu().numpy().astype(np.float32)
+        return np.asarray(np.from_dlpack(mat.detach().cpu()), dtype=np.float32)
+    if hasattr(mat, "__dlpack_device__"):
+        device_type, _ = mat.__dlpack_device__()
+        if device_type == _DLDEVICE_CPU:
+            return np.asarray(np.from_dlpack(mat), dtype=np.float32)
+        # Non-CPU DLPack source (e.g. CUDA wp.array): .numpy() typically
+        # handles the device-to-host transfer internally.
+        if hasattr(mat, "numpy"):
+            return np.asarray(mat.numpy(), dtype=np.float32)  # type: ignore[union-attr]
+        raise TypeError(f"Cannot convert non-CPU DLPack array of type {type(mat).__name__} to numpy")
     if hasattr(mat, "numpy"):
-        return np.asarray(mat.numpy(), dtype=np.float32)
+        return np.asarray(mat.numpy(), dtype=np.float32)  # type: ignore[union-attr]
     return np.asarray(mat, dtype=np.float32)
 
 
@@ -330,7 +354,7 @@ class TeleopSessionLifecycle:
     def step(
         self,
         anchor_world_matrix_fn: Callable[[], np.ndarray] | None = None,
-        target_T_world: np.ndarray | torch.Tensor | None = None,
+        target_T_world: np.ndarray | torch.Tensor | SupportsDLPack | None = None,
     ) -> torch.Tensor | None:
         """Execute one step of the teleop session and return the action tensor.
 
@@ -352,9 +376,10 @@ class TeleopSessionLifecycle:
                 pipeline poses into a target coordinate frame.  When provided,
                 the anchor matrix is left-multiplied by this transform
                 (``target_T_world @ world_T_anchor``) so all output poses
-                are expressed in the target frame.  Accepts
-                :class:`numpy.ndarray`, :class:`torch.Tensor`, or any object
-                with a ``.numpy()`` method (e.g. ``wp.array``).
+                are expressed in the target frame.  Accepts any object
+                supporting the DLPack buffer protocol (``__dlpack__``),
+                including :class:`numpy.ndarray`, :class:`torch.Tensor`,
+                and ``wp.array``.
 
         Returns:
             A flattened action :class:`torch.Tensor` ready for the Isaac Lab
@@ -392,11 +417,12 @@ class TeleopSessionLifecycle:
         # Store the right controller TensorGroup for button polling
         self._last_right_controller = result.get(self._CONTROLLER_RIGHT_KEY)
 
-        # Extract the flattened action array from TensorReorderer output
-        action_np = result["action"][0]
-
-        # Convert to torch tensor and move to device
-        action = torch.from_numpy(np.asarray(action_np, dtype=np.float32)).to(self._device)
+        # Extract the flattened action array (DLPack-compatible) from
+        # TensorReorderer and move to the simulation device.
+        action_array = result["action"][0]
+        action = torch.from_dlpack(action_array).to(  # type: ignore[attr-defined]
+            dtype=torch.float32, device=self._device
+        )
 
         return action
 
@@ -430,7 +456,7 @@ class TeleopSessionLifecycle:
     def _build_external_inputs(
         self,
         anchor_world_matrix_fn: Callable[[], np.ndarray] | None,
-        target_T_world: np.ndarray | torch.Tensor | None = None,
+        target_T_world: np.ndarray | torch.Tensor | SupportsDLPack | None = None,
     ) -> dict | None:
         """Build external inputs for non-DeviceIO leaf nodes in the pipeline.
 

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -24,6 +24,27 @@ from .isaac_teleop_cfg import IsaacTeleopCfg
 logger = logging.getLogger(__name__)
 
 
+def _to_numpy_4x4(mat: np.ndarray | torch.Tensor) -> np.ndarray:
+    """Convert a 4x4 transform to a float32 numpy array.
+
+    Accepts :class:`numpy.ndarray`, :class:`torch.Tensor`, ``wp.array``,
+    or any object implementing a ``.numpy()`` method.
+
+    Args:
+        mat: A (4, 4) transform matrix in any supported array type.
+
+    Returns:
+        A (4, 4) float32 :class:`numpy.ndarray`.
+    """
+    if isinstance(mat, np.ndarray):
+        return np.asarray(mat, dtype=np.float32)
+    if isinstance(mat, torch.Tensor):
+        return mat.detach().cpu().numpy().astype(np.float32)
+    if hasattr(mat, "numpy"):
+        return np.asarray(mat.numpy(), dtype=np.float32)
+    return np.asarray(mat, dtype=np.float32)
+
+
 class TeleopSessionLifecycle:
     """Manages the IsaacTeleop session lifecycle.
 
@@ -306,7 +327,11 @@ class TeleopSessionLifecycle:
     # Stepping
     # ------------------------------------------------------------------
 
-    def step(self, anchor_world_matrix_fn: Callable[[], np.ndarray] | None = None) -> torch.Tensor | None:
+    def step(
+        self,
+        anchor_world_matrix_fn: Callable[[], np.ndarray] | None = None,
+        target_T_world: np.ndarray | torch.Tensor | None = None,
+    ) -> torch.Tensor | None:
         """Execute one step of the teleop session and return the action tensor.
 
         If the session has not been started yet (because OpenXR handles were
@@ -323,6 +348,13 @@ class TeleopSessionLifecycle:
             anchor_world_matrix_fn: Optional callable returning the (4, 4)
                 world-to-anchor transform.  Used to build external inputs
                 for ``ValueInput`` leaf nodes in the pipeline.
+            target_T_world: Optional (4, 4) transform matrix that rebases
+                pipeline poses into a target coordinate frame.  When provided,
+                the anchor matrix is left-multiplied by this transform
+                (``target_T_world @ world_T_anchor``) so all output poses
+                are expressed in the target frame.  Accepts
+                :class:`numpy.ndarray`, :class:`torch.Tensor`, or any object
+                with a ``.numpy()`` method (e.g. ``wp.array``).
 
         Returns:
             A flattened action :class:`torch.Tensor` ready for the Isaac Lab
@@ -342,7 +374,7 @@ class TeleopSessionLifecycle:
 
         # Build external inputs (e.g. world-to-anchor transform) if the
         # pipeline contains ValueInput leaf nodes.
-        external_inputs = self._build_external_inputs(anchor_world_matrix_fn)
+        external_inputs = self._build_external_inputs(anchor_world_matrix_fn, target_T_world)
 
         # Execute one step of the teleop session.
         # If the underlying OpenXR session was destroyed externally (e.g.
@@ -395,16 +427,27 @@ class TeleopSessionLifecycle:
     # External input building
     # ------------------------------------------------------------------
 
-    def _build_external_inputs(self, anchor_world_matrix_fn: Callable[[], np.ndarray] | None) -> dict | None:
+    def _build_external_inputs(
+        self,
+        anchor_world_matrix_fn: Callable[[], np.ndarray] | None,
+        target_T_world: np.ndarray | torch.Tensor | None = None,
+    ) -> dict | None:
         """Build external inputs for non-DeviceIO leaf nodes in the pipeline.
 
         Checks whether the active ``TeleopSession`` has external (non-DeviceIO)
         leaf nodes and, for each recognized leaf, constructs the corresponding
         ``TensorGroup`` data.
 
+        When *target_T_world* is provided, the anchor matrix is left-multiplied
+        by the rebase transform so that all pipeline poses are expressed in
+        the target coordinate frame:
+        ``target_T_world @ world_T_anchor = target_T_anchor``.
+
         Args:
             anchor_world_matrix_fn: Callable returning the (4, 4)
                 world-to-anchor transform matrix.
+            target_T_world: Optional (4, 4) rebase transform.  See
+                :meth:`step` for details.
 
         Returns:
             A dict suitable for ``TeleopSession.step(external_inputs=...)``,
@@ -425,6 +468,8 @@ class TeleopSessionLifecycle:
                     anchor_matrix = anchor_world_matrix_fn()
                 else:
                     anchor_matrix = np.eye(4, dtype=np.float32)
+                if target_T_world is not None:
+                    anchor_matrix = _to_numpy_4x4(target_T_world) @ anchor_matrix
                 xform_tg = TensorGroup(TransformMatrix())
                 xform_tg[0] = anchor_matrix
                 external_inputs[leaf_name] = {ValueInput.VALUE: xform_tg}

--- a/source/isaaclab_teleop/test/test_target_frame_rebase.py
+++ b/source/isaaclab_teleop/test/test_target_frame_rebase.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# pyright: reportPrivateUsage=none
+
+"""Tests for the target-frame rebase logic and _to_numpy_4x4 helper.
+
+These tests exercise pure math (no Omniverse/Isaac Sim stack required).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from isaaclab_teleop.session_lifecycle import _to_numpy_4x4
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def identity_4x4() -> np.ndarray:
+    return np.eye(4, dtype=np.float32)
+
+
+@pytest.fixture
+def translation_matrix() -> np.ndarray:
+    """A pure translation of (1, 2, 3)."""
+    mat = np.eye(4, dtype=np.float32)
+    mat[:3, 3] = [1.0, 2.0, 3.0]
+    return mat
+
+
+@pytest.fixture
+def rotation_90z_matrix() -> np.ndarray:
+    """90-degree rotation about Z axis."""
+    mat = np.eye(4, dtype=np.float32)
+    mat[0, 0] = 0.0
+    mat[0, 1] = -1.0
+    mat[1, 0] = 1.0
+    mat[1, 1] = 0.0
+    return mat
+
+
+# ---------------------------------------------------------------------------
+# _to_numpy_4x4 conversion tests
+# ---------------------------------------------------------------------------
+
+
+class TestToNumpy4x4:
+    def test_from_ndarray_float32(self, identity_4x4: np.ndarray):
+        result = _to_numpy_4x4(identity_4x4)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_equal(result, identity_4x4)
+
+    def test_from_ndarray_float64_casts(self):
+        mat = np.eye(4, dtype=np.float64)
+        result = _to_numpy_4x4(mat)
+        assert result.dtype == np.float32
+        np.testing.assert_array_almost_equal(result, np.eye(4, dtype=np.float32))
+
+    def test_from_torch_cpu(self, translation_matrix: np.ndarray):
+        tensor = torch.from_numpy(translation_matrix.copy())
+        result = _to_numpy_4x4(tensor)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_almost_equal(result, translation_matrix)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_from_torch_gpu(self, translation_matrix: np.ndarray):
+        tensor = torch.from_numpy(translation_matrix.copy()).cuda()
+        result = _to_numpy_4x4(tensor)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_almost_equal(result, translation_matrix)
+
+    def test_from_duck_typed_numpy(self, rotation_90z_matrix: np.ndarray):
+        """Simulates a wp.array or similar object with a .numpy() method."""
+
+        class FakeWarpArray:
+            def __init__(self, data: np.ndarray):
+                self._data = data
+
+            def numpy(self) -> np.ndarray:
+                return self._data
+
+        fake = FakeWarpArray(rotation_90z_matrix.copy())
+        result = _to_numpy_4x4(fake)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_almost_equal(result, rotation_90z_matrix)
+
+    def test_from_list(self):
+        data = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
+        result = _to_numpy_4x4(data)
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float32
+        np.testing.assert_array_equal(result, np.eye(4, dtype=np.float32))
+
+
+# ---------------------------------------------------------------------------
+# Matrix multiplication (rebase) tests
+# ---------------------------------------------------------------------------
+
+
+class TestRebaseMultiplication:
+    def test_rebase_identity_is_noop(self, translation_matrix: np.ndarray):
+        """target_T_world = I should leave anchor_matrix unchanged."""
+        identity = np.eye(4, dtype=np.float32)
+        result = _to_numpy_4x4(identity) @ translation_matrix
+        np.testing.assert_array_almost_equal(result, translation_matrix)
+
+    def test_rebase_translation(self, identity_4x4: np.ndarray):
+        """Rebasing by a pure translation offsets the origin."""
+        target_T_world = np.eye(4, dtype=np.float32)
+        target_T_world[:3, 3] = [10.0, 20.0, 30.0]
+
+        world_T_anchor = np.eye(4, dtype=np.float32)
+        world_T_anchor[:3, 3] = [1.0, 2.0, 3.0]
+
+        result = _to_numpy_4x4(target_T_world) @ world_T_anchor
+        np.testing.assert_array_almost_equal(result[:3, 3], [11.0, 22.0, 33.0])
+
+    def test_rebase_rotation(self, rotation_90z_matrix: np.ndarray):
+        """A 90-deg Z rotation rebase should rotate the anchor translation."""
+        world_T_anchor = np.eye(4, dtype=np.float32)
+        world_T_anchor[:3, 3] = [1.0, 0.0, 0.0]
+
+        result = _to_numpy_4x4(rotation_90z_matrix) @ world_T_anchor
+
+        # After 90-deg Z rotation: (1,0,0) -> (0,1,0)
+        np.testing.assert_array_almost_equal(result[:3, 3], [0.0, 1.0, 0.0])
+        # Rotation part should match the 90-deg Z rotation
+        np.testing.assert_array_almost_equal(result[:3, :3], rotation_90z_matrix[:3, :3])
+
+    def test_rebase_with_torch_tensor(self, translation_matrix: np.ndarray):
+        """target_T_world as a torch.Tensor should work identically."""
+        target_T_world = torch.eye(4, dtype=torch.float32)
+        target_T_world[:3, 3] = torch.tensor([5.0, 5.0, 5.0])
+
+        result = _to_numpy_4x4(target_T_world) @ translation_matrix
+
+        expected = np.eye(4, dtype=np.float32)
+        expected[:3, 3] = [6.0, 7.0, 8.0]
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_none_target_leaves_anchor_unchanged(self, translation_matrix: np.ndarray):
+        """When target_T_world is None, the calling code should skip multiplication."""
+        target_T_world = None
+        anchor_matrix = translation_matrix.copy()
+
+        if target_T_world is not None:
+            anchor_matrix = _to_numpy_4x4(target_T_world) @ anchor_matrix
+
+        np.testing.assert_array_equal(anchor_matrix, translation_matrix)
+
+    def test_inverse_rebase_recovers_identity(self):
+        """target_T_world = inv(world_T_anchor) should yield identity."""
+        world_T_anchor = np.array(
+            [
+                [0.0, -1.0, 0.0, 3.0],
+                [1.0, 0.0, 0.0, -1.0],
+                [0.0, 0.0, 1.0, 2.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+        target_T_world = np.linalg.inv(world_T_anchor).astype(np.float32)
+
+        result = _to_numpy_4x4(target_T_world) @ world_T_anchor
+        np.testing.assert_array_almost_equal(result, np.eye(4, dtype=np.float32), decimal=5)

--- a/source/isaaclab_teleop/test/test_target_frame_rebase.py
+++ b/source/isaaclab_teleop/test/test_target_frame_rebase.py
@@ -5,7 +5,7 @@
 
 # pyright: reportPrivateUsage=none
 
-"""Tests for the target-frame rebase logic and _to_numpy_4x4 helper.
+"""Tests for the target-frame rebase logic, _to_numpy_4x4 helper, and config-driven auto-selection.
 
 These tests exercise pure math (no Omniverse/Isaac Sim stack required).
 """
@@ -15,9 +15,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 import torch
-
 from isaaclab_teleop.session_lifecycle import _to_numpy_4x4
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -176,3 +174,91 @@ class TestRebaseMultiplication:
 
         result = _to_numpy_4x4(target_T_world) @ world_T_anchor
         np.testing.assert_array_almost_equal(result, np.eye(4, dtype=np.float32), decimal=5)
+
+
+# ---------------------------------------------------------------------------
+# Config-driven auto-selection tests
+# ---------------------------------------------------------------------------
+
+
+def _simulate_advance_selection(
+    target_T_world: np.ndarray | None,
+    target_frame_prim_path: str | None,
+    auto_read_result: np.ndarray | None = None,
+) -> tuple[np.ndarray | None, bool]:
+    """Replicate the auto-selection logic from IsaacTeleopDevice.advance().
+
+    Returns the target_T_world that would be passed to step(), and whether
+    _get_target_frame_T_world would have been called.
+    """
+    auto_read_called = False
+
+    def fake_get_target_frame_T_world():
+        nonlocal auto_read_called
+        auto_read_called = True
+        return auto_read_result
+
+    if target_T_world is None and target_frame_prim_path is not None:
+        target_T_world = fake_get_target_frame_T_world()
+
+    return target_T_world, auto_read_called
+
+
+class TestConfigDrivenAutoSelection:
+    """Tests for the advance() auto-selection logic between explicit target_T_world
+    and config-driven target_frame_prim_path.
+
+    These tests replicate the branching logic from advance() without importing
+    the full IsaacTeleopDevice (which requires Isaac Sim runtime dependencies).
+    """
+
+    def test_no_config_no_explicit_passes_none(self):
+        """When neither config nor explicit target_T_world is set, step() receives None."""
+        result, called = _simulate_advance_selection(target_T_world=None, target_frame_prim_path=None)
+        assert result is None
+        assert not called
+
+    def test_explicit_target_is_passed_through(self):
+        """An explicit target_T_world should be passed directly to step()."""
+        explicit = np.eye(4, dtype=np.float32)
+        explicit[:3, 3] = [1.0, 2.0, 3.0]
+
+        result, called = _simulate_advance_selection(target_T_world=explicit, target_frame_prim_path=None)
+        np.testing.assert_array_equal(result, explicit)
+        assert not called
+
+    def test_config_prim_triggers_auto_read(self):
+        """When target_frame_prim_path is set, _get_target_frame_T_world is called."""
+        auto_matrix = np.eye(4, dtype=np.float32)
+        auto_matrix[:3, 3] = [9.0, 8.0, 7.0]
+
+        result, called = _simulate_advance_selection(
+            target_T_world=None,
+            target_frame_prim_path="/World/Robot/base_link",
+            auto_read_result=auto_matrix,
+        )
+        assert called
+        np.testing.assert_array_equal(result, auto_matrix)
+
+    def test_explicit_overrides_config(self):
+        """An explicit target_T_world takes precedence over config prim path."""
+        explicit = np.eye(4, dtype=np.float32)
+        explicit[:3, 3] = [42.0, 0.0, 0.0]
+
+        result, called = _simulate_advance_selection(
+            target_T_world=explicit,
+            target_frame_prim_path="/World/Robot/base_link",
+            auto_read_result=np.eye(4, dtype=np.float32),
+        )
+        assert not called
+        np.testing.assert_array_equal(result, explicit)
+
+    def test_config_prim_returns_none_passes_none(self):
+        """If the prim read fails (returns None), step() receives None."""
+        result, called = _simulate_advance_selection(
+            target_T_world=None,
+            target_frame_prim_path="/World/Robot/base_link",
+            auto_read_result=None,
+        )
+        assert called
+        assert result is None


### PR DESCRIPTION
# Description

Add a target_T_world parameter to IsaacTeleopDevice.advance() and TeleopSessionLifecycle.step() that left-multiplies the anchor matrix to rebase all output poses into an arbitrary target coordinate frame (e.g. robot base link for IK).
Add a config-driven alternative via IsaacTeleopCfg.target_frame_prim_path: when set to a USD prim path, the device automatically reads the prim's world transform each frame via USDRT/Fabric and uses its inverse as the rebase matrix, removing the need for callers to compute it manually.
Add _to_numpy_4x4 helper that accepts np.ndarray, torch.Tensor, wp.array, or any duck-typed .numpy() object and normalizes to float32 NumPy.
Add comprehensive unit tests for the conversion helper, matrix rebase math, and config-vs-explicit auto-selection logic.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there