### PR TITLE
Fix Newton model not built for sensors added in _setup_scene()

### DIFF
--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -149,6 +149,12 @@ class DirectRLEnv(gym.Env):
             with use_stage(self.sim.stage):
                 self.scene = InteractiveScene(self.cfg.scene)
                 self._setup_scene()
+        # InteractiveScene.__init__() resolves renderer requirements from sensors
+        # declared in the scene config, but sensors added programmatically in
+        # _setup_scene() (the standard DirectRLEnv pattern) are missed. Re-scan
+        # all scene sensors and merge their requirements so that the scene data
+        # provider (constructed later) knows it needs a Newton model.
+        self._update_scene_data_requirements_from_sensors()
         print("[INFO]: Scene manager: ", self.scene)
 
         # set up camera viewport controller
@@ -656,6 +662,31 @@ class DirectRLEnv(gym.Env):
         any explicit scene setup, the function can be left empty.
         """
         pass
+
+    def _update_scene_data_requirements_from_sensors(self):
+        """Re-scan scene sensors and update simulation context requirements.
+
+        ``InteractiveScene.__init__()`` resolves renderer requirements from
+        sensors declared in the scene *config*, but sensors added
+        programmatically in :meth:`_setup_scene` (the standard ``DirectRLEnv``
+        pattern) are missed.  This method re-scans all scene sensors after
+        ``_setup_scene()`` returns and merges their renderer requirements into
+        the simulation context so that ``PhysxSceneDataProvider`` (constructed
+        later) knows whether it needs to build a Newton model.
+        """
+        from isaaclab.physics.scene_data_requirements import (
+            aggregate_requirements,
+            resolve_scene_data_requirements,
+        )
+
+        renderer_types = self.scene._sensor_renderer_types()
+        if not renderer_types:
+            return
+        sensor_req = resolve_scene_data_requirements(visualizer_types=[], renderer_types=renderer_types)
+        current_req = self.sim.get_scene_data_requirements()
+        merged = aggregate_requirements([current_req, sensor_req])
+        if merged != current_req:
+            self.sim.update_scene_data_requirements(merged)
 
     @abstractmethod
     def _pre_physics_step(self, actions: torch.Tensor):


### PR DESCRIPTION
InteractiveScene.__init__() resolves renderer requirements from sensors declared in the scene config, but DirectRLEnv environments add sensors programmatically in _setup_scene() after the scene is constructed. This means PhysxSceneDataProvider is never told it needs a Newton model, so get_newton_model() returns None and Newton-based renderers/visualizers get a black screen.

Add _update_scene_data_requirements_from_sensors() to DirectRLEnv which re-scans all scene sensors after _setup_scene() and merges their renderer requirements into the simulation context before the provider is constructed.

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
