### PR TITLE
Fixes exception during io_descriptors creation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -116,6 +116,7 @@ Guidelines for modifications:
 * Manuel Schweiger
 * Masoud Moghani
 * Mateo Guaman Castro
+* Matteo Princisgh
 * Maurice Rahme
 * Michael Gussert
 * Michael Lin

--- a/source/isaaclab/isaaclab/envs/utils/io_descriptors.py
+++ b/source/isaaclab/isaaclab/envs/utils/io_descriptors.py
@@ -358,25 +358,25 @@ def export_articulations_data(env: ManagerBasedEnv) -> dict[str, dict[str, list[
         articulation_joint_data[articulation_name] = {}
         articulation_joint_data[articulation_name]["joint_names"] = articulation.joint_names
         articulation_joint_data[articulation_name]["default_joint_pos"] = (
-            articulation.data.default_joint_pos[0].detach().cpu().numpy().tolist()
+            wp.to_torch(articulation.data.default_joint_pos)[0].detach().cpu().numpy().tolist()
         )
         articulation_joint_data[articulation_name]["default_joint_vel"] = (
-            articulation.data.default_joint_vel[0].detach().cpu().numpy().tolist()
+            wp.to_torch(articulation.data.default_joint_vel)[0].detach().cpu().numpy().tolist()
         )
         articulation_joint_data[articulation_name]["default_joint_pos_limits"] = (
-            articulation.data.default_joint_pos_limits[0].detach().cpu().numpy().tolist()
+            wp.to_torch(articulation.data.default_joint_pos_limits)[0].detach().cpu().numpy().tolist()
         )
         articulation_joint_data[articulation_name]["default_joint_damping"] = (
-            articulation.data.joint_damping[0].detach().cpu().numpy().tolist()
+            wp.to_torch(articulation.data.joint_damping)[0].detach().cpu().numpy().tolist()
         )
         articulation_joint_data[articulation_name]["default_joint_stiffness"] = (
-            articulation.data.joint_stiffness[0].detach().cpu().numpy().tolist()
+            wp.to_torch(articulation.data.joint_stiffness)[0].detach().cpu().numpy().tolist()
         )
         articulation_joint_data[articulation_name]["default_joint_friction"] = (
-            articulation.data.joint_friction_coeff[0].detach().cpu().numpy().tolist()
+            wp.to_torch(articulation.data.joint_friction_coeff)[0].detach().cpu().numpy().tolist()
         )
         articulation_joint_data[articulation_name]["default_joint_armature"] = (
-            articulation.data.joint_armature[0].detach().cpu().numpy().tolist()
+            wp.to_torch(articulation.data.joint_armature)[0].detach().cpu().numpy().tolist()
         )
     return articulation_joint_data
 


### PR DESCRIPTION
# Description

Added `wp.to_torch` wrappers needed for io_descriptors creation in ManagerBasedEnv.

This PR partially fixes #5057 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
