### PR TITLE
 Fix headless visualizer runtime in SimulationContext and DirectRLEnvWarp

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.5.25"
+version = "4.5.26"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,21 @@
 Changelog
 ---------
 
+4.5.26 (2026-04-06)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed compatibility for environments still reading the legacy
+  ``/isaaclab/visualizer`` setting. Isaac Lab now mirrors resolved
+  visualizer enablement to that key so visualizer-only runs continue
+  to render correctly when using :class:`~isaaclab.sim.SimulationContext`.
+* Fixed :class:`~isaaclab.envs.ui.base_env_window.BaseEnvWindow` cleanup after
+  partial initialization failures so teardown no longer raises ``AttributeError``
+  when the UI window was never created.
+
+
 4.5.25 (2026-04-01)
 ~~~~~~~~~~~~~~~~~~~
 
@@ -32,7 +47,6 @@ Fixed
   for floating-base articulations. Replaced with ``self._jacobi_joint_idx`` which correctly
   applies the +6 offset for floating-base robots and is identical to ``self._joint_ids`` for
   fixed-base robots.
-
 
 4.5.23 (2026-03-16)
 ~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/isaaclab/envs/ui/base_env_window.py
+++ b/source/isaaclab/isaaclab/envs/ui/base_env_window.py
@@ -54,6 +54,7 @@ class BaseEnvWindow:
         """
         # store inputs
         self.env = env
+        self.ui_window = None
         # prepare the list of assets that can be followed by the viewport camera
         # note that the first two options are "World" and "Env" which are special cases
         self._viewer_assets_options = [
@@ -100,9 +101,10 @@ class BaseEnvWindow:
     def __del__(self):
         """Destructor for the window."""
         # destroy the window
-        if self.ui_window is not None:
-            self.ui_window.visible = False
-            self.ui_window.destroy()
+        ui_window = getattr(self, "ui_window", None)
+        if ui_window is not None:
+            ui_window.visible = False
+            ui_window.destroy()
             self.ui_window = None
 
     """

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -165,6 +165,7 @@ class SimulationContext:
         self.physics_manager: type[PhysicsManager] = self._physics.class_type
         self.physics_manager.initialize(self)
         self._apply_render_cfg_settings()
+        self._sync_legacy_visualizer_setting()
 
         # Initialize visualizer state (provider/visualizers are created lazily during initialize_visualizers()).
         self._scene_data_provider: BaseSceneDataProvider | None = None
@@ -764,10 +765,16 @@ class SimulationContext:
     def set_setting(self, name: str, value: Any) -> None:
         """Set a setting value."""
         self._settings_helper.set(name, value)
+        if name.startswith("/isaaclab/visualizer/") and name != "/isaaclab/visualizer/max_worlds":
+            self._sync_legacy_visualizer_setting()
 
     def get_setting(self, name: str) -> Any:
         """Get a setting value."""
         return self._settings_helper.get(name)
+
+    def _sync_legacy_visualizer_setting(self) -> None:
+        """Mirror resolved visualizer enablement to the legacy setting path."""
+        self._settings_helper.set("/isaaclab/visualizer", bool(self.resolve_visualizer_types()))
 
     @classmethod
     def clear_instance(cls) -> None:

--- a/source/isaaclab/test/envs/test_direct_rl_env_warp_ui.py
+++ b/source/isaaclab/test/envs/test_direct_rl_env_warp_ui.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab.envs.ui.base_env_window import BaseEnvWindow
 from isaaclab_experimental.envs.direct_rl_env_warp import DirectRLEnvWarp
+
+from isaaclab.envs.ui.base_env_window import BaseEnvWindow
 
 
 def test_direct_rl_env_warp_ui_window_requires_gui():

--- a/source/isaaclab/test/envs/test_direct_rl_env_warp_ui.py
+++ b/source/isaaclab/test/envs/test_direct_rl_env_warp_ui.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.envs.ui.base_env_window import BaseEnvWindow
+from isaaclab_experimental.envs.direct_rl_env_warp import DirectRLEnvWarp
+
+
+def test_direct_rl_env_warp_ui_window_requires_gui():
+    env = object.__new__(DirectRLEnvWarp)
+    env.sim = type("Sim", (), {"has_gui": False})()
+    env.cfg = type("Cfg", (), {"ui_window_class_type": object})()
+
+    assert env._should_create_ui_window() is False
+
+
+def test_direct_rl_env_warp_ui_window_created_when_gui_and_window_type_exist():
+    env = object.__new__(DirectRLEnvWarp)
+    env.sim = type("Sim", (), {"has_gui": True})()
+    env.cfg = type("Cfg", (), {"ui_window_class_type": object})()
+
+    assert env._should_create_ui_window() is True
+
+
+def test_direct_rl_env_warp_ui_window_skipped_without_window_type():
+    env = object.__new__(DirectRLEnvWarp)
+    env.sim = type("Sim", (), {"has_gui": True})()
+    env.cfg = type("Cfg", (), {"ui_window_class_type": None})()
+
+    assert env._should_create_ui_window() is False
+
+
+def test_base_env_window_destructor_tolerates_partial_initialization():
+    window = object.__new__(BaseEnvWindow)
+    window.__del__()

--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -34,6 +34,17 @@ class _FakeProvider:
         self.update_calls.append(env_ids)
 
 
+class _FakeSettingsHelper:
+    def __init__(self, values: dict[str, Any] | None = None):
+        self.values = {} if values is None else dict(values)
+
+    def set(self, name: str, value: Any) -> None:
+        self.values[name] = value
+
+    def get(self, name: str) -> Any:
+        return self.values.get(name)
+
+
 class _FakeVisualizer:
     def __init__(
         self,
@@ -430,6 +441,46 @@ def test_is_rendering_false_when_cli_disable_all_even_with_cfg_visualizer():
     }
     ctx = _make_context_with_settings(settings, visualizer_cfgs=[cfg_visualizer])
     assert ctx.is_rendering is False
+
+
+def test_sync_legacy_visualizer_setting_tracks_cfg_visualizers():
+    cfg_visualizer = type("CfgVisualizer", (), {"visualizer_type": "newton"})()
+    cfg = type("Cfg", (), {"visualizer_cfgs": [cfg_visualizer]})()
+
+    ctx = object.__new__(SimulationContext)
+    ctx.cfg = cfg
+    ctx._settings_helper = _FakeSettingsHelper(
+        {
+            "/isaaclab/visualizer/types": "",
+            "/isaaclab/visualizer/explicit": False,
+            "/isaaclab/visualizer/disable_all": False,
+        }
+    )
+
+    ctx._sync_legacy_visualizer_setting()
+
+    assert ctx.get_setting("/isaaclab/visualizer") is True
+
+
+def test_set_setting_updates_legacy_visualizer_flag_for_cli_visualizers():
+    cfg = type("Cfg", (), {"visualizer_cfgs": []})()
+
+    ctx = object.__new__(SimulationContext)
+    ctx.cfg = cfg
+    ctx._settings_helper = _FakeSettingsHelper(
+        {
+            "/isaaclab/visualizer/types": "",
+            "/isaaclab/visualizer/explicit": False,
+            "/isaaclab/visualizer/disable_all": False,
+        }
+    )
+
+    ctx.set_setting("/isaaclab/visualizer/explicit", True)
+    ctx.set_setting("/isaaclab/visualizer/types", "rerun")
+    assert ctx.get_setting("/isaaclab/visualizer") is True
+
+    ctx.set_setting("/isaaclab/visualizer/disable_all", True)
+    assert ctx.get_setting("/isaaclab/visualizer") is False
 
 
 def test_explicit_unknown_visualizer_type_raises():

--- a/source/isaaclab_experimental/config/extension.toml
+++ b/source/isaaclab_experimental/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.0.2"
+version = "0.0.3"
 
 # Description
 title = "Experimental playground for upcoming IsaacLab features"

--- a/source/isaaclab_experimental/docs/CHANGELOG.rst
+++ b/source/isaaclab_experimental/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.0.3 (2026-04-06)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_experimental.envs.direct_rl_env_warp.DirectRLEnvWarp`
+  creating a Kit UI window for headless visualizer-only runs. The warp environment
+  now only instantiates the UI window when GUI support is actually available, while
+  continuing to render through :attr:`~isaaclab.sim.SimulationContext.is_rendering`.
+
+
 0.0.2 (2026-03-16)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
@@ -213,7 +213,7 @@ class DirectRLEnvWarp(DirectRLEnv):
         # extend UI elements
         # we need to do this here after all the managers are initialized
         # this is because they dictate the sensors and commands right now
-        if bool(self.sim.settings.get("/isaaclab/visualizer")) and self.cfg.ui_window_class_type is not None:
+        if self._should_create_ui_window():
             self._window = self.cfg.ui_window_class_type(self, window_name="IsaacLab")
         else:
             # if no window, then we don't need to store the window
@@ -321,6 +321,10 @@ class DirectRLEnvWarp(DirectRLEnv):
         """The maximum episode length in steps adjusted from s."""
         return math.ceil(self.max_episode_length_s / (self.cfg.sim.dt * self.cfg.decimation))
 
+    def _should_create_ui_window(self) -> bool:
+        """Return whether the environment should create a Kit UI window."""
+        return self.sim.has_gui and self.cfg.ui_window_class_type is not None
+
     @property
     def episode_length_buf(self) -> torch.Tensor:
         """The episode length buffer as a torch tensor.
@@ -417,8 +421,7 @@ class DirectRLEnvWarp(DirectRLEnv):
 
         # check if we need to do rendering within the physics loop
         # note: checked here once to avoid multiple checks within the loop
-        _has_rtx = hasattr(self.sim, "has_rtx_sensors") and self.sim.has_rtx_sensors()
-        is_rendering = bool(self.sim.settings.get("/isaaclab/visualizer")) or _has_rtx
+        is_rendering = self.sim.is_rendering
 
         # perform physics stepping
         with Timer(name="physics_loop", msg="Physics loop took:", enable=DEBUG_TIMERS):


### PR DESCRIPTION
## Description

  Follow-up to #4948.

  This PR fixes a regression in headless visualizer-only runs. After the
  visualizer resolution changes, some existing environment paths still read the
  legacy `/isaaclab/visualizer` boolean instead of the resolved visualizer
  state. As a result, rendering could remain disabled even when a visualizer was
  active.

  This change:
  - mirrors the resolved visualizer enablement back to `/isaaclab/visualizer` in
  `SimulationContext`, preserving compatibility for existing code paths that
  still read the legacy key;
  - updates `DirectRLEnvWarp` to use `SimulationContext.is_rendering` for render
  decisions;
  - prevents `DirectRLEnvWarp` from creating a Kit UI window unless a real GUI
  is available;
  - hardens `BaseEnvWindow` teardown so partial initialization failures do not
  raise `AttributeError`;
  - adds regression tests covering the legacy visualizer path and the headless
  UI-window behavior.

  User-visible impact:
  - headless visualizer-only runs render correctly again in existing environment
  paths;
  - `DirectRLEnvWarp` no longer attempts to create a Kit UI window during
  headless visualizer-only runs;
  - partially initialized UI windows now clean up safely.

  Related to #5015 and #5056.

  ## Type of change

  - Bug fix (non-breaking change which fixes an issue)

  ## Test plan

  - `./isaaclab.sh -p -m pytest source/isaaclab/test/sim/
  test_simulation_context_visualizers.py`
  - `./isaaclab.sh -p -m pytest source/isaaclab/test/envs/
  test_direct_rl_env_warp_ui.py`

  Manual verification:
  - Launch a headless visualizer-only warp environment and verify rendering
  still updates.
  - Verify no Kit UI window is created when GUI support is unavailable.