### PR TITLE
Fix path export command in source installation guide

### DIFF
--- a/docs/source/setup/installation/source_installation.rst
+++ b/docs/source/setup/installation/source_installation.rst
@@ -78,7 +78,7 @@ variables to your terminal for the remaining of the installation instructions:
       .. code:: bash
 
          # Isaac Sim root directory
-         export ISAACSIM_PATH="${pwd}/_build/linux-x86_64/release"
+         export ISAACSIM_PATH="$(pwd)/_build/linux-x86_64/release"
          # Isaac Sim python executable
          export ISAACSIM_PYTHON_EXE="${ISAACSIM_PATH}/python.sh"
 


### PR DESCRIPTION
ISAACSIM_PATH is wrong because ${pwd} is empty; only $PWD or $(pwd) or ${PWD} work.

## Type of change

- Documentation update


