### PR TITLE
Adds absolute named import support to lazy_export

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.5.23"
+version = "4.5.24"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+4.5.24 (2026-03-25)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added support for absolute named imports (``from pkg import a, b``) in
+  ``.pyi`` stubs processed by :func:`~isaaclab.utils.module.lazy_export`.
+  Previously only relative imports and absolute wildcard fallbacks were
+  handled; explicit names from absolute packages are now eagerly resolved
+  and re-exported.
+
+
 4.5.23 (2026-03-16)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/utils/module.py
+++ b/source/isaaclab/isaaclab/utils/module.py
@@ -18,11 +18,14 @@ from collections.abc import Callable
 import lazy_loader as lazy
 
 
-def _parse_stub(stub_file: str) -> tuple[str | None, list[str], list[str]]:
+def _parse_stub(
+    stub_file: str,
+) -> tuple[str | None, list[str], list[str], dict[str, list[str]]]:
     """Parse a ``.pyi`` stub in a single AST pass.
 
     Returns:
-        A 3-tuple of ``(filtered_path, fallback_packages, relative_wildcards)``.
+        A 4-tuple ``(filtered_path, fallback_packages, relative_wildcards,
+        absolute_named)``.
 
         *filtered_path* is a temporary ``.pyi`` containing only explicit
         relative imports (what ``lazy_loader`` can handle), or ``None`` when
@@ -36,6 +39,9 @@ def _parse_stub(stub_file: str) -> tuple[str | None, list[str], list[str]]:
 
         *relative_wildcards* lists submodule names extracted from relative
         wildcard imports (``from .mod import *``).
+
+        *absolute_named* maps fully-qualified package names to the list of
+        explicit names imported from them (``from pkg import a, b``).
     """
     with open(stub_file) as f:
         source = f.read()
@@ -44,6 +50,7 @@ def _parse_stub(stub_file: str) -> tuple[str | None, list[str], list[str]]:
 
     fallback_packages: list[str] = []
     relative_wildcards: list[str] = []
+    absolute_named: dict[str, list[str]] = {}
     filtered_body: list[ast.stmt] = []
     needs_filter = False
 
@@ -57,18 +64,21 @@ def _parse_stub(stub_file: str) -> tuple[str | None, list[str], list[str]]:
                 fallback_packages.append(node.module)
             elif node.level == 1 and is_star and node.module:
                 relative_wildcards.append(node.module)
+            elif node.level == 0 and not is_star and node.module:
+                names = [alias.name for alias in node.names]
+                absolute_named.setdefault(node.module, []).extend(names)
             needs_filter = True
         else:
             filtered_body.append(node)
 
     if not needs_filter:
-        return None, fallback_packages, relative_wildcards
+        return None, fallback_packages, relative_wildcards, absolute_named
 
     filtered = ast.Module(body=filtered_body, type_ignores=[])
     with tempfile.NamedTemporaryFile(mode="w", suffix=".pyi", delete=False) as tmp:
         tmp.write(ast.unparse(filtered))
 
-    return tmp.name, fallback_packages, relative_wildcards
+    return tmp.name, fallback_packages, relative_wildcards, absolute_named
 
 
 def lazy_export(
@@ -84,6 +94,8 @@ def lazy_export(
       local submodule (existing ``lazy_loader`` behaviour).
     * ``from .rewards import *`` — eagerly imports the submodule and
       re-exports all of its public names at ``lazy_export()`` time.
+    * ``from isaaclab.envs.mdp import foo, bar`` — eagerly re-exports
+      specific names from an absolute package.
     * ``from isaaclab.envs.mdp import *`` — sets up a lazy fallback so that
       any name not found locally is resolved from the specified package.
 
@@ -123,9 +135,10 @@ def lazy_export(
 
     fallback_packages: list[str] = list(packages) if packages else []
     relative_wildcards: list[str] = []
+    absolute_named: dict[str, list[str]] = {}
 
     if has_stub:
-        filtered_path, stub_fallbacks, relative_wildcards = _parse_stub(stub_file)
+        filtered_path, stub_fallbacks, relative_wildcards, absolute_named = _parse_stub(stub_file)
         if stub_fallbacks:
             fallback_packages = list(dict.fromkeys(fallback_packages + stub_fallbacks))
 
@@ -137,6 +150,14 @@ def lazy_export(
         __all__: list[str] = []
 
     mod = sys.modules[package_name]
+
+    # -- Eagerly resolve absolute named imports (from pkg import a, b) -----
+    for abs_pkg, names in absolute_named.items():
+        pkg_mod = importlib.import_module(abs_pkg)
+        for name in names:
+            mod.__dict__[name] = getattr(pkg_mod, name)
+            if name not in __all__:
+                __all__.append(name)
 
     # -- Eagerly resolve relative wildcard imports (from .X import *) ------
     for rel_mod_name in relative_wildcards:

--- a/source/isaaclab_tasks/test/test_lazy_export_stubs.py
+++ b/source/isaaclab_tasks/test/test_lazy_export_stubs.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Verify that lazy_export() call sites use no arguments.
+"""Verify lazy_export() call-site conventions and _parse_stub behaviour.
 
 Every ``__init__.py`` that calls ``lazy_export()`` should pass no arguments.
 Fallback packages and wildcard re-exports are inferred from the ``.pyi``
@@ -15,9 +15,12 @@ This test is purely static (AST-based) and requires no simulator.
 
 import ast
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
+
+from isaaclab.utils.module import _parse_stub
 
 _SOURCE_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -80,3 +83,114 @@ def test_no_lazy_export_violations_found():
         if f == "__init__.py" and "lazy_export" in (Path(root) / f).read_text(errors="ignore")
     )
     assert init_count > 0, "No __init__.py files with lazy_export() found — discovery may be broken"
+
+
+# ---------------------------------------------------------------------------
+# _parse_stub unit tests
+# ---------------------------------------------------------------------------
+
+
+def _write_stub(content: str) -> str:
+    """Write *content* to a temporary ``.pyi`` file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".pyi")
+    with os.fdopen(fd, "w") as f:
+        f.write(content)
+    return path
+
+
+class TestParseStubAbsoluteNamed:
+    """Tests for absolute named import extraction in _parse_stub."""
+
+    def test_single_absolute_named_import(self):
+        stub = _write_stub("from some.package import alpha, beta\n")
+        try:
+            _, _, _, absolute_named = _parse_stub(stub)
+        finally:
+            os.unlink(stub)
+
+        assert "some.package" in absolute_named
+        assert absolute_named["some.package"] == ["alpha", "beta"]
+
+    def test_multiple_absolute_named_imports(self):
+        stub = _write_stub("from pkg_a import foo\nfrom pkg_b import bar, baz\n")
+        try:
+            _, _, _, absolute_named = _parse_stub(stub)
+        finally:
+            os.unlink(stub)
+
+        assert absolute_named["pkg_a"] == ["foo"]
+        assert absolute_named["pkg_b"] == ["bar", "baz"]
+
+    def test_same_package_multiple_lines_accumulates(self):
+        stub = _write_stub("from pkg import a\nfrom pkg import b, c\n")
+        try:
+            _, _, _, absolute_named = _parse_stub(stub)
+        finally:
+            os.unlink(stub)
+
+        assert absolute_named["pkg"] == ["a", "b", "c"]
+
+    def test_absolute_wildcard_not_in_absolute_named(self):
+        stub = _write_stub("from some.package import *\n")
+        try:
+            _, fallbacks, _, absolute_named = _parse_stub(stub)
+        finally:
+            os.unlink(stub)
+
+        assert "some.package" in fallbacks
+        assert absolute_named == {}
+
+    def test_relative_import_not_in_absolute_named(self):
+        stub = _write_stub("from .sub import foo, bar\n")
+        try:
+            _, _, _, absolute_named = _parse_stub(stub)
+        finally:
+            os.unlink(stub)
+
+        assert absolute_named == {}
+
+    def test_mixed_import_kinds(self):
+        """All four import kinds in one stub are routed correctly."""
+        stub = _write_stub(
+            "from .local import thing\nfrom .wildmod import *\nfrom abs.pkg import *\nfrom abs.other import x, y\n"
+        )
+        try:
+            filtered_path, fallbacks, rel_wildcards, absolute_named = _parse_stub(stub)
+        finally:
+            if filtered_path is not None:
+                os.unlink(filtered_path)
+            os.unlink(stub)
+
+        assert fallbacks == ["abs.pkg"]
+        assert rel_wildcards == ["wildmod"]
+        assert absolute_named == {"abs.other": ["x", "y"]}
+        assert filtered_path is not None
+
+    def test_no_imports_returns_empty(self):
+        stub = _write_stub("X: int\n")
+        try:
+            filtered_path, fallbacks, rel_wildcards, absolute_named = _parse_stub(stub)
+        finally:
+            os.unlink(stub)
+
+        assert filtered_path is None
+        assert fallbacks == []
+        assert rel_wildcards == []
+        assert absolute_named == {}
+
+    def test_filtered_stub_excludes_absolute_named(self):
+        """Absolute named imports must not leak into the filtered stub
+        passed to lazy_loader (it only handles relative named imports)."""
+        stub = _write_stub("from .local import thing\nfrom abs.pkg import alpha\n")
+        try:
+            filtered_path, _, _, _ = _parse_stub(stub)
+            assert filtered_path is not None
+            with open(filtered_path) as f:
+                content = f.read()
+            assert "alpha" not in content
+            assert "abs" not in content
+            assert "thing" in content
+        finally:
+            if filtered_path is not None:
+                os.unlink(filtered_path)
+            os.unlink(stub)

--- a/source/isaaclab_tasks/test/test_lazy_export_stubs.py
+++ b/source/isaaclab_tasks/test/test_lazy_export_stubs.py
@@ -98,99 +98,111 @@ def _write_stub(content: str) -> str:
     return path
 
 
-class TestParseStubAbsoluteNamed:
-    """Tests for absolute named import extraction in _parse_stub."""
+def test_parse_stub_single_absolute_named_import():
+    """Test single absolute named import extraction."""
+    stub = _write_stub("from some.package import alpha, beta\n")
+    try:
+        _, _, _, absolute_named = _parse_stub(stub)
+    finally:
+        os.unlink(stub)
 
-    def test_single_absolute_named_import(self):
-        stub = _write_stub("from some.package import alpha, beta\n")
-        try:
-            _, _, _, absolute_named = _parse_stub(stub)
-        finally:
-            os.unlink(stub)
+    assert "some.package" in absolute_named
+    assert absolute_named["some.package"] == ["alpha", "beta"]
 
-        assert "some.package" in absolute_named
-        assert absolute_named["some.package"] == ["alpha", "beta"]
 
-    def test_multiple_absolute_named_imports(self):
-        stub = _write_stub("from pkg_a import foo\nfrom pkg_b import bar, baz\n")
-        try:
-            _, _, _, absolute_named = _parse_stub(stub)
-        finally:
-            os.unlink(stub)
+def test_parse_stub_multiple_absolute_named_imports():
+    """Test multiple absolute named imports from different packages."""
+    stub = _write_stub("from pkg_a import foo\nfrom pkg_b import bar, baz\n")
+    try:
+        _, _, _, absolute_named = _parse_stub(stub)
+    finally:
+        os.unlink(stub)
 
-        assert absolute_named["pkg_a"] == ["foo"]
-        assert absolute_named["pkg_b"] == ["bar", "baz"]
+    assert absolute_named["pkg_a"] == ["foo"]
+    assert absolute_named["pkg_b"] == ["bar", "baz"]
 
-    def test_same_package_multiple_lines_accumulates(self):
-        stub = _write_stub("from pkg import a\nfrom pkg import b, c\n")
-        try:
-            _, _, _, absolute_named = _parse_stub(stub)
-        finally:
-            os.unlink(stub)
 
-        assert absolute_named["pkg"] == ["a", "b", "c"]
+def test_parse_stub_same_package_multiple_lines_accumulates():
+    """Test that imports from the same package on multiple lines accumulate."""
+    stub = _write_stub("from pkg import a\nfrom pkg import b, c\n")
+    try:
+        _, _, _, absolute_named = _parse_stub(stub)
+    finally:
+        os.unlink(stub)
 
-    def test_absolute_wildcard_not_in_absolute_named(self):
-        stub = _write_stub("from some.package import *\n")
-        try:
-            _, fallbacks, _, absolute_named = _parse_stub(stub)
-        finally:
-            os.unlink(stub)
+    assert absolute_named["pkg"] == ["a", "b", "c"]
 
-        assert "some.package" in fallbacks
-        assert absolute_named == {}
 
-    def test_relative_import_not_in_absolute_named(self):
-        stub = _write_stub("from .sub import foo, bar\n")
-        try:
-            _, _, _, absolute_named = _parse_stub(stub)
-        finally:
-            os.unlink(stub)
+def test_parse_stub_absolute_wildcard_not_in_absolute_named():
+    """Test that absolute wildcard imports go to fallbacks, not absolute_named."""
+    stub = _write_stub("from some.package import *\n")
+    try:
+        _, fallbacks, _, absolute_named = _parse_stub(stub)
+    finally:
+        os.unlink(stub)
 
-        assert absolute_named == {}
+    assert "some.package" in fallbacks
+    assert absolute_named == {}
 
-    def test_mixed_import_kinds(self):
-        """All four import kinds in one stub are routed correctly."""
-        stub = _write_stub(
-            "from .local import thing\nfrom .wildmod import *\nfrom abs.pkg import *\nfrom abs.other import x, y\n"
-        )
-        try:
-            filtered_path, fallbacks, rel_wildcards, absolute_named = _parse_stub(stub)
-        finally:
-            if filtered_path is not None:
-                os.unlink(filtered_path)
-            os.unlink(stub)
 
-        assert fallbacks == ["abs.pkg"]
-        assert rel_wildcards == ["wildmod"]
-        assert absolute_named == {"abs.other": ["x", "y"]}
+def test_parse_stub_relative_import_not_in_absolute_named():
+    """Test that relative imports are not included in absolute_named."""
+    stub = _write_stub("from .sub import foo, bar\n")
+    try:
+        _, _, _, absolute_named = _parse_stub(stub)
+    finally:
+        os.unlink(stub)
+
+    assert absolute_named == {}
+
+
+def test_parse_stub_mixed_import_kinds():
+    """All four import kinds in one stub are routed correctly."""
+    stub = _write_stub(
+        "from .local import thing\nfrom .wildmod import *\nfrom abs.pkg import *\nfrom abs.other import x, y\n"
+    )
+    try:
+        filtered_path, fallbacks, rel_wildcards, absolute_named = _parse_stub(stub)
+    finally:
+        if filtered_path is not None:
+            os.unlink(filtered_path)
+        os.unlink(stub)
+
+    assert fallbacks == ["abs.pkg"]
+    assert rel_wildcards == ["wildmod"]
+    assert absolute_named == {"abs.other": ["x", "y"]}
+    assert filtered_path is not None
+
+
+def test_parse_stub_no_imports_returns_empty():
+    """Test that a stub with no imports returns empty collections."""
+    stub = _write_stub("X: int\n")
+    try:
+        filtered_path, fallbacks, rel_wildcards, absolute_named = _parse_stub(stub)
+    finally:
+        os.unlink(stub)
+
+    assert filtered_path is None
+    assert fallbacks == []
+    assert rel_wildcards == []
+    assert absolute_named == {}
+
+
+def test_parse_stub_filtered_stub_excludes_absolute_named():
+    """Absolute named imports must not leak into the filtered stub.
+
+    The filtered stub is passed to lazy_loader which only handles relative named imports.
+    """
+    stub = _write_stub("from .local import thing\nfrom abs.pkg import alpha\n")
+    try:
+        filtered_path, _, _, _ = _parse_stub(stub)
         assert filtered_path is not None
-
-    def test_no_imports_returns_empty(self):
-        stub = _write_stub("X: int\n")
-        try:
-            filtered_path, fallbacks, rel_wildcards, absolute_named = _parse_stub(stub)
-        finally:
-            os.unlink(stub)
-
-        assert filtered_path is None
-        assert fallbacks == []
-        assert rel_wildcards == []
-        assert absolute_named == {}
-
-    def test_filtered_stub_excludes_absolute_named(self):
-        """Absolute named imports must not leak into the filtered stub
-        passed to lazy_loader (it only handles relative named imports)."""
-        stub = _write_stub("from .local import thing\nfrom abs.pkg import alpha\n")
-        try:
-            filtered_path, _, _, _ = _parse_stub(stub)
-            assert filtered_path is not None
-            with open(filtered_path) as f:
-                content = f.read()
-            assert "alpha" not in content
-            assert "abs" not in content
-            assert "thing" in content
-        finally:
-            if filtered_path is not None:
-                os.unlink(filtered_path)
-            os.unlink(stub)
+        with open(filtered_path) as f:
+            content = f.read()
+        assert "alpha" not in content
+        assert "abs" not in content
+        assert "thing" in content
+    finally:
+        if filtered_path is not None:
+            os.unlink(filtered_path)
+        os.unlink(stub)


### PR DESCRIPTION
# Description

Extend `_parse_stub` and `lazy_export` to handle absolute named imports
(e.g. `from isaaclab.envs.mdp import foo, bar`) in `.pyi` stubs. Previously only
relative imports and absolute wildcard fallbacks were supported. Explicit names from
absolute packages are now eagerly resolved and re-exported at `lazy_export()` time.

## Type of change

- Bug Fix

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there