### PR TITLE
Adjustment of SAC action space in SB3 implementation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -168,6 +168,7 @@ Guidelines for modifications:
 * Yohan Choi
 * Yujian Zhang
 * Yun Liu
+* Zachary Tang
 * Zehao Wang
 * Zijian Li
 * Ziqi Fan

--- a/scripts/reinforcement_learning/sb3/play.py
+++ b/scripts/reinforcement_learning/sb3/play.py
@@ -151,8 +151,12 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
         print("[INFO] Recording videos during training.")
         print_dict(video_kwargs, nesting=4)
         env = gym.wrappers.RecordVideo(env, **video_kwargs)
+    # extract action bounds from agent config (useful for off-policy algorithms like SAC)
+    action_low = agent_cfg.pop("action_low", None)
+    action_high = agent_cfg.pop("action_high", None)
+
     # wrap around environment for stable baselines
-    env = Sb3VecEnvWrapper(env, fast_variant=not args_cli.keep_all_info)
+    env = Sb3VecEnvWrapper(env, fast_variant=not args_cli.keep_all_info, action_low=action_low, action_high=action_high)
 
     vec_norm_path = checkpoint_path.replace("/model", "/model_vecnormalize").replace(".zip", ".pkl")
     vec_norm_path = Path(vec_norm_path)

--- a/scripts/reinforcement_learning/sb3/train.py
+++ b/scripts/reinforcement_learning/sb3/train.py
@@ -180,8 +180,12 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
 
     start_time = time.time()
 
+    # extract action bounds from agent config (useful for off-policy algorithms like SAC)
+    action_low = agent_cfg.pop("action_low", None)
+    action_high = agent_cfg.pop("action_high", None)
+
     # wrap around environment for stable baselines
-    env = Sb3VecEnvWrapper(env, fast_variant=not args_cli.keep_all_info)
+    env = Sb3VecEnvWrapper(env, fast_variant=not args_cli.keep_all_info, action_low=action_low, action_high=action_high)
 
     norm_keys = {"normalize_input", "normalize_value", "clip_obs"}
     norm_args = {}

--- a/source/isaaclab_rl/isaaclab_rl/sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/sb3.py
@@ -347,7 +347,7 @@ class Sb3VecEnvWrapper(VecEnv):
             warnings.warn(
                 "The environment has an unbounded action space. Clamping to [-1, 1] for SB3 compatibility. "
                 "For best results, define bounded action spaces in your environment config.",
-                stacklevel=2,
+                stacklevel=3,
             )
             action_space = gym.spaces.Box(low=-1.0, high=1.0, shape=action_space.shape)
 

--- a/source/isaaclab_rl/isaaclab_rl/sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/sb3.py
@@ -135,13 +135,21 @@ class Sb3VecEnvWrapper(VecEnv):
 
     """
 
-    def __init__(self, env: ManagerBasedRLEnv | DirectRLEnv, fast_variant: bool = True):
+    def __init__(
+        self,
+        env: ManagerBasedRLEnv | DirectRLEnv,
+        fast_variant: bool = True,
+        action_low: float | None = None,
+        action_high: float | None = None,
+    ):
         """Initialize the wrapper.
 
         Args:
             env: The environment to wrap around.
             fast_variant: Use fast variant for processing info
                 (Only episodic reward, lengths and truncation info are included)
+            action_low: Lower bound for clamping unbounded action spaces. Defaults to -100.
+            action_high: Upper bound for clamping unbounded action spaces. Defaults to 100.
         Raises:
             ValueError: When the environment is not an instance of :class:`ManagerBasedRLEnv` or :class:`DirectRLEnv`.
         """
@@ -154,6 +162,8 @@ class Sb3VecEnvWrapper(VecEnv):
         # initialize the wrapper
         self.env = env
         self.fast_variant = fast_variant
+        self._action_low = action_low if action_low is not None else -100.0
+        self._action_high = action_high if action_high is not None else 100.0
         # collect common information
         self.num_envs = self.unwrapped.num_envs
         self.sim_device = self.unwrapped.device
@@ -340,16 +350,18 @@ class Sb3VecEnvWrapper(VecEnv):
 
         # obtain gym spaces
         # note: stable-baselines3 does not like when we have unbounded action space so
-        #   we clamp to [-1, 1]. Using large bounds (e.g. [-100, 100]) breaks off-policy
-        #   algorithms like SAC, which rescale actions to fill the full [low, high] range.
+        #   we set it to some value here. The default [-100, 100] works for on-policy algorithms
+        #   like PPO. For off-policy algorithms like SAC, use action_low/action_high to set
+        #   tighter bounds (e.g. [-1, 1]) since SAC rescales actions to fill the full range.
         action_space = self.unwrapped.single_action_space
         if isinstance(action_space, gym.spaces.Box) and not action_space.is_bounded("both"):
             warnings.warn(
-                "The environment has an unbounded action space. Clamping to [-1, 1] for SB3 compatibility. "
-                "For best results, define bounded action spaces in your environment config.",
+                f"The environment has an unbounded action space. Clamping to [{self._action_low}, {self._action_high}]"
+                " for SB3 compatibility. For best results, define bounded action spaces in your environment config"
+                " or set action_low/action_high in the agent yaml.",
                 stacklevel=3,
             )
-            action_space = gym.spaces.Box(low=-1.0, high=1.0, shape=action_space.shape)
+            action_space = gym.spaces.Box(low=self._action_low, high=self._action_high, shape=action_space.shape)
 
         # initialize vec-env
         VecEnv.__init__(self, self.num_envs, observation_space, action_space)

--- a/source/isaaclab_rl/isaaclab_rl/sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/sb3.py
@@ -340,10 +340,16 @@ class Sb3VecEnvWrapper(VecEnv):
 
         # obtain gym spaces
         # note: stable-baselines3 does not like when we have unbounded action space so
-        #   we set it to some high value here. Maybe this is not general but something to think about.
+        #   we clamp to [-1, 1]. Using large bounds (e.g. [-100, 100]) breaks off-policy
+        #   algorithms like SAC, which rescale actions to fill the full [low, high] range.
         action_space = self.unwrapped.single_action_space
         if isinstance(action_space, gym.spaces.Box) and not action_space.is_bounded("both"):
-            action_space = gym.spaces.Box(low=-100, high=100, shape=action_space.shape)
+            warnings.warn(
+                "The environment has an unbounded action space. Clamping to [-1, 1] for SB3 compatibility. "
+                "For best results, define bounded action spaces in your environment config.",
+                stacklevel=2,
+            )
+            action_space = gym.spaces.Box(low=-1.0, high=1.0, shape=action_space.shape)
 
         # initialize vec-env
         VecEnv.__init__(self, self.num_envs, observation_space, action_space)


### PR DESCRIPTION
Solves #5080 

## Description

The SB3 `VecEnv` wrapper clamps unbounded action spaces to `[-100, 100]`, which breaks off-policy algorithms like SAC. SAC squashes actions through `tanh()` then rescales to the full `[low, high]` range via `unscale_action()`, so `[-100, 100]` bounds produce an initial action distribution completely misaligned with the useful range.

This change reduces the fallback bounds to `[-1, 1]` and adds a warning encouraging users to define proper bounded action spaces in their environment configs.

Reference: https://araffin.github.io/post/sac-massive-sim/

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

SAC trained for 1M steps on 3 environments, comparing `[-100, 100]` (current) vs `[-1, 1]` (fix):

| Env | `[-100, 100]` final reward | `[-1, 1]` final reward |
|---|---|---|
| Isaac-Ant-v0 | -1,786 | **-1.5** |
| Isaac-Humanoid-v0 | -7.87 trillion  | **+1.92** |
| Isaac-Cartpole-v0 | -1.071 | **4.341** |

Ant reward graph: 
<img width="1349" height="497" alt="image" src="https://github.com/user-attachments/assets/fa9c4428-fc53-43db-be8e-69dae8fb4568" />

Humanoid reward graph:
<img width="1351" height="497" alt="image" src="https://github.com/user-attachments/assets/aa25db36-ad09-4aea-bf2d-c35956c7c89c" />

Cartpole reward graph: 
<img width="1352" height="500" alt="Image" src="https://github.com/user-attachments/assets/d88f0dd1-02f9-4b0c-a98b-d83dac085f7e" />

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there