### PR TITLE
Fixes triple ast.parse() call in is_lambda_expression

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.54.3"
+version = "0.54.4"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.54.4 (2026-03-24)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.utils.string.is_lambda_expression` calling
+  ``ast.parse()`` three times per invocation instead of once, eliminating
+  redundant work on every configclass deserialization that checks for
+  lambda expressions.
+
+
 0.54.3 (2026-02-04)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -99,8 +99,8 @@ def is_lambda_expression(name: str) -> bool:
         Whether the input string is a lambda expression.
     """
     try:
-        ast.parse(name)
-        return isinstance(ast.parse(name).body[0], ast.Expr) and isinstance(ast.parse(name).body[0].value, ast.Lambda)
+        tree = ast.parse(name)
+        return bool(tree.body) and isinstance(tree.body[0], ast.Expr) and isinstance(tree.body[0].value, ast.Lambda)
     except SyntaxError:
         return False
 


### PR DESCRIPTION
# Description

`is_lambda_expression()` was calling `ast.parse()` three separate times per invocation instead of reusing the parse tree. This function is called during configclass deserialization for every string field that could be a lambda expression, so the redundant parsing adds measurable overhead.

This fix parses once and reuses the tree.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file