### PR TITLE
Fixes conftest.py exclude pattern not splitting on commas

### DIFF
--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -310,7 +310,7 @@ def pytest_sessionstart(session):
                         continue
 
                     # Apply exclude filter
-                    if exclude_pattern and exclude_pattern in full_path:
+                    if exclude_pattern and any(pat.strip() in full_path for pat in exclude_pattern.split(",")):
                         print(f"Skipping {full_path} (matches exclude pattern: {exclude_pattern})")
                         continue
 


### PR DESCRIPTION
# Description

The General Tests CI job passes a comma-separated exclude pattern like `isaaclab_tasks,isaaclab_newton,isaaclab_physx` via `TEST_EXCLUDE_PATTERN`. The conftest.py filter was checking whether the **entire** comma-separated string was a substring of the test file path, which never matches any path. 

As a result, the General Tests job was accidentally running **all** tests including isaaclab_tasks, isaaclab_newton, and isaaclab_physx tests — causing longer runtimes and unrelated failures bleeding into the General Tests job.

The fix splits on commas so each pattern is matched independently.

**Before:** `"isaaclab_tasks,isaaclab_newton,isaaclab_physx" in full_path` → always False
**After:** `any(pat in full_path for pat in ["isaaclab_tasks", "isaaclab_newton", "isaaclab_physx"])` → correctly excludes

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings