### PR TITLE
Caches string_to_callable module lookups with functools.cache

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.54.3"
+version = "0.54.4"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.54.4 (2026-03-24)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Cached :func:`~isaaclab.utils.string.string_to_callable` for
+  ``module:attribute`` references via ``functools.cache``, avoiding repeated
+  ``importlib.import_module`` calls when the same callable string is resolved
+  multiple times (e.g. across environment resets or multi-env setups).
+
+
 0.54.3 (2026-02-04)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -6,6 +6,7 @@
 """Sub-module containing utilities for transforming strings and regular expressions."""
 
 import ast
+import functools
 import importlib
 import inspect
 import re
@@ -135,6 +136,22 @@ def callable_to_string(value: Callable) -> str:
         return f"{module_name}:{function_name}"
 
 
+@functools.cache
+def _resolve_module_callable(name: str) -> Callable:
+    """Resolve a ``module:attribute`` string to a callable, with caching.
+
+    This is the cached inner implementation used by :func:`string_to_callable`
+    for non-lambda references. Repeated lookups (e.g. across environment resets
+    or multi-env setups) skip the ``importlib`` overhead.
+    """
+    mod_name, attr_name = name.split(":")
+    mod = importlib.import_module(mod_name)
+    callable_object = getattr(mod, attr_name)
+    if callable(callable_object):
+        return callable_object
+    raise AttributeError(f"The imported object is not callable: '{name}'")
+
+
 def string_to_callable(name: str) -> Callable:
     """Resolves the module and function names to return the function.
 
@@ -152,16 +169,11 @@ def string_to_callable(name: str) -> Callable:
     try:
         if is_lambda_expression(name):
             callable_object = eval(name)
-        else:
-            mod_name, attr_name = name.split(":")
-            mod = importlib.import_module(mod_name)
-            callable_object = getattr(mod, attr_name)
-        # check if attribute is callable
-        if callable(callable_object):
-            return callable_object
-        else:
+            if callable(callable_object):
+                return callable_object
             raise AttributeError(f"The imported object is not callable: '{name}'")
-    except (ValueError, ModuleNotFoundError) as e:
+        return _resolve_module_callable(name)
+    except (ValueError, ModuleNotFoundError, AttributeError) as e:
         msg = (
             f"Could not resolve the input string '{name}' into callable object."
             " The format of input should be 'module:attribute_name'.\n"


### PR DESCRIPTION
# Description

`string_to_callable()` is called during manager initialization and configclass deserialization to resolve `module:attribute` strings into callables. Each call runs `importlib.import_module()` even when the same string has been resolved before.

This PR extracts the non-lambda resolution path into `_resolve_module_callable()` and decorates it with `functools.cache`, so repeated lookups (e.g. across environment resets or multi-env setups) skip the import overhead.

Lambda expressions are **not** cached since they are `eval()`'d fresh each time by design.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file