### PR TITLE
Fixes conftest.py exclude pattern not splitting on commas

### DIFF
--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -301,7 +301,7 @@ def _collect_test_files(
                 if filter_pattern and filter_pattern not in full_path:
                     print(f"Skipping {full_path} (does not match include pattern: {filter_pattern})")
                     continue
-                if exclude_pattern and exclude_pattern in full_path:
+                if exclude_pattern and any(pat.strip() in full_path for pat in exclude_pattern.split(",")):
                     print(f"Skipping {full_path} (matches exclude pattern: {exclude_pattern})")
                     continue
                 if include_files and file not in include_files:


### PR DESCRIPTION
# Description

Same fix as #5090 but targeting `develop`.

The General Tests CI job passes a comma-separated exclude pattern like `isaaclab_tasks,isaaclab_newton,isaaclab_physx` via `TEST_EXCLUDE_PATTERN`. The conftest.py filter was checking whether the **entire** comma-separated string was a substring of the test file path, which never matches.

As a result, the General Tests job was accidentally running **all** tests instead of excluding the package-specific ones — causing longer runtimes and unrelated failures.

The fix splits on commas so each pattern is matched independently.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings