### PR TITLE
Removes unnecessary AppLauncher from pure-Python tests

### DIFF
--- a/source/isaaclab/test/envs/test_null_command_term.py
+++ b/source/isaaclab/test/envs/test_null_command_term.py
@@ -3,14 +3,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Launch Isaac Sim Simulator first."""
+"""Tests for the NullCommandTerm.
 
-from isaaclab.app import AppLauncher
-
-# launch omniverse app
-simulation_app = AppLauncher(headless=True).app
-
-"""Rest everything follows."""
+These tests are pure-Python and do not require Isaac Sim or a GPU.
+"""
 
 from collections import namedtuple
 

--- a/source/isaaclab/test/envs/test_spaces_utils.py
+++ b/source/isaaclab/test/envs/test_spaces_utils.py
@@ -6,16 +6,12 @@
 # ignore private usage of variables warning
 # pyright: reportPrivateUsage=none
 
+"""Tests for space utility functions.
+
+These tests require torch but do not require Isaac Sim or a GPU.
+"""
+
 from __future__ import annotations
-
-"""Launch Isaac Sim Simulator first."""
-
-from isaaclab.app import AppLauncher
-
-# launch omniverse app
-simulation_app = AppLauncher(headless=True).app
-
-"""Rest everything follows."""
 
 import numpy as np
 import torch

--- a/source/isaaclab/test/utils/test_configclass.py
+++ b/source/isaaclab/test/utils/test_configclass.py
@@ -3,18 +3,12 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+"""Tests for the configclass decorator and utilities.
+
+These tests are pure-Python and do not require Isaac Sim or a GPU.
+"""
+
 from __future__ import annotations
-
-# NOTE: While we don't actually use the simulation app in this test, we still need to launch it
-#       because warp is only available in the context of a running simulation
-"""Launch Isaac Sim Simulator first."""
-
-from isaaclab.app import AppLauncher
-
-# launch omniverse app
-simulation_app = AppLauncher(headless=True).app
-
-"""Rest everything follows."""
 
 import copy
 import os

--- a/source/isaaclab/test/utils/test_dict.py
+++ b/source/isaaclab/test/utils/test_dict.py
@@ -3,16 +3,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# NOTE: While we don't actually use the simulation app in this test, we still need to launch it
-#       because warp is only available in the context of a running simulation
-"""Launch Isaac Sim Simulator first."""
+"""Tests for dictionary utility functions.
 
-from isaaclab.app import AppLauncher
-
-# launch omniverse app
-simulation_app = AppLauncher(headless=True).app
-
-"""Rest everything follows."""
+These tests are pure-Python and do not require Isaac Sim or a GPU.
+"""
 
 import random
 

--- a/source/isaaclab/test/utils/test_logger.py
+++ b/source/isaaclab/test/utils/test_logger.py
@@ -3,16 +3,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Tests for logging utilities."""
+"""Tests for logging utilities.
 
-"""Launch Isaac Sim Simulator first."""
-
-from isaaclab.app import AppLauncher
-
-# launch omniverse app
-simulation_app = AppLauncher(headless=True).app
-
-"""Rest everything follows."""
+These tests are pure-Python and do not require Isaac Sim or a GPU.
+"""
 
 import logging
 import os

--- a/source/isaaclab/test/utils/test_string.py
+++ b/source/isaaclab/test/utils/test_string.py
@@ -3,16 +3,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# NOTE: While we don't actually use the simulation app in this test, we still need to launch it
-#       because warp is only available in the context of a running simulation
-"""Launch Isaac Sim Simulator first."""
+"""Tests for string utility functions.
 
-from isaaclab.app import AppLauncher
-
-# launch omniverse app
-simulation_app = AppLauncher(headless=True).app
-
-"""Rest everything follows."""
+These tests are pure-Python and do not require Isaac Sim or a GPU.
+"""
 
 import random
 


### PR DESCRIPTION
# Description

Six test files were launching the full Isaac Sim AppLauncher despite not using warp, simulation, or any Isaac Sim API. They test pure-Python utility functions:

- `test_string.py` — string manipulation utilities
- `test_dict.py` — dictionary utilities  
- `test_configclass.py` — configclass decorator
- `test_logger.py` — logging utilities
- `test_version.py` — version comparison
- `test_spaces_utils.py` — gymnasium space utilities

The AppLauncher was a leftover from the convention of launching the simulator at the top of every test file, with comments like *"While we don't actually use the simulation app in this test, we still need to launch it because warp is only available in the context of a running simulation"* — but these tests don't use warp either.

**Benefits:**
- These tests can now run **without Isaac Sim installed**
- Makes them candidates for lightweight CI on standard ubuntu runners (no GPU)  
- Significantly faster local execution (no Kit startup overhead)
- Reduces GPU runner time by ~6 × Kit startup time per CI run

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings