### PR TITLE
Add Newton physics preset for Anymal-D rough terrain

### DIFF
--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -288,7 +288,21 @@ class NewtonManager(PhysicsManager):
         device = PhysicsManager._device
         logger.info(f"Finalizing model on device: {device}")
         cls._builder.up_axis = Axis.from_string(cls._up_axis)
-        # Set smaller contact margin for manipulation examples (default 10cm is too large)
+
+        # WAR: USD import produces shapes with zero contact margin. Zero margin causes
+        # CCD to use the is_discrete path (epsilon=0), where GJK fails to converge on
+        # mesh terrain, producing NaN in body_q/joint_q.
+        # TODO: file upstream Newton issue for USD importer zero-margin default.
+        contact_margin = 0.01
+        n_margin_fixed = 0
+        for i in range(len(cls._builder.shape_margin)):
+            if cls._builder.shape_margin[i] == 0.0:
+                cls._builder.shape_margin[i] = contact_margin
+                n_margin_fixed += 1
+        if n_margin_fixed > 0:
+            n_total = len(cls._builder.shape_margin)
+            logger.info(f"Set contact margin={contact_margin} on {n_margin_fixed}/{n_total} shapes with zero margin")
+
         with Timer(name="newton_finalize_builder", msg="Finalize builder took:"):
             cls._model = cls._builder.finalize(device=device)
             cls._model.set_gravity(cls._gravity_vector)
@@ -398,7 +412,12 @@ class NewtonManager(PhysicsManager):
         if cls._needs_collision_pipeline:
             # Newton collision pipeline: create pipeline and generate contacts
             if cls._collision_pipeline is None:
-                cls._collision_pipeline = CollisionPipeline(cls._model, broad_phase="explicit")
+                # WAR: default max_triangle_pairs (1M) overflows with mesh terrain at
+                # 4096+ envs (~2M triangle pairs). Overflow silently drops contacts.
+                # No upstream issue tracking auto-sizing yet.
+                cls._collision_pipeline = CollisionPipeline(
+                    cls._model, broad_phase="explicit", max_triangle_pairs=2_000_000
+                )
             if cls._contacts is None:
                 cls._contacts = cls._collision_pipeline.contacts()
 

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -42,10 +42,10 @@ INSTALL_REQUIRES = [
 EXTRAS_REQUIRE = {
     "all": [
         "prettytable==3.3.0",
-        "mujoco==3.5.0",
-        "mujoco-warp==3.5.0.2",
+        "mujoco==3.6.0",
+        "mujoco-warp==3.6.0",
         "PyOpenGL-accelerate==3.1.10",
-        "newton==1.0.0",
+        "newton @ git+https://github.com/newton-physics/newton.git@141baffff9",
     ],
 }
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_d/rough_env_cfg.py
@@ -3,6 +3,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_physx.physics import PhysxCfg
+
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils import configclass
 
 from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import (
@@ -10,12 +14,36 @@ from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     StartupEventsCfg,
 )
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 ##
 # Pre-defined configs
 ##
 from isaaclab_assets.robots.anymal import ANYMAL_D_CFG  # isort: skip
+
+
+@configclass
+class RoughPhysicsCfg(PresetCfg):
+    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    # WAR: Rough terrain requires pyramidal cone — elliptic cone + high impratio diverges
+    # in float32 with many mesh contacts due to MuJoCo Warp single-precision limitations.
+    # Upstream (open): https://github.com/google-deepmind/mujoco_warp/issues/1000
+    # Also uses Newton collision pipeline (use_mujoco_contacts=False) since MuJoCo's
+    # built-in collision does not support mesh terrain geometry.
+    newton = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=200,
+            nconmax=100,
+            cone="pyramidal",
+            impratio=1.0,
+            integrator="implicitfast",
+            use_mujoco_contacts=False,
+            ccd_iterations=100,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+    )
+    physx = default
 
 
 @configclass
@@ -32,6 +60,7 @@ class AnymalDEventsCfg(PresetCfg):
 
 @configclass
 class AnymalDRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=RoughPhysicsCfg())
     events: AnymalDEventsCfg = AnymalDEventsCfg()
 
     def __post_init__(self):
@@ -39,6 +68,9 @@ class AnymalDRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
         super().__post_init__()
         # switch robot to anymal-d
         self.scene.robot = ANYMAL_D_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+        # RayCaster height scanner requires Kit (omni.physics) — disable for Newton.
+        self.scene.height_scanner = preset(default=self.scene.height_scanner, newton=None)
+        self.observations.policy.height_scan = preset(default=self.observations.policy.height_scan, newton=None)
 
 
 @configclass


### PR DESCRIPTION
## Summary

Add `RoughPhysicsCfg` Newton preset enabling Anymal-D rough terrain locomotion training with the Newton physics backend. This is a small, self-contained change that makes the existing stable `Isaac-Velocity-Rough-Anymal-D-v0` task runnable with `presets=newton`.

Changes:
- Add `RoughPhysicsCfg(PresetCfg)` with Newton solver config tuned for mesh terrain
- Disable RayCaster height scanner for Newton (requires Kit via `omni.physics`)
- Fix zero contact margin from USD import that causes CCD divergence on mesh terrain
- Increase `CollisionPipeline` `max_triangle_pairs` to 2M for mesh terrain
- Bump `mujoco`/`mujoco-warp` to 3.6.0, pin Newton to `141baffff9`

## Upstream issues and workarounds

### Pyramidal cone for solver stability (WAR)
MuJoCo Warp uses float32 (vs float64 in MuJoCo C). The constraint solver diverges to NaN with elliptic cone + high impratio on mesh terrain contacts.
- Upstream (open): https://github.com/google-deepmind/mujoco_warp/issues/1000
- Workaround: `cone="pyramidal"`, `impratio=1.0`

### Zero contact margin from USD import (WAR)
Newton USD importer produces 100% of shapes with zero margin (225,281/225,281 at 4096 envs). Zero margin causes the CCD narrow phase to use a degenerate path where GJK fails to converge. Flat terrain is unaffected (plane geometry doesn't trigger this path); mesh terrain NaNs.
- TODO: file upstream Newton issue
- Workaround: enforce minimum margin of 0.01 before `ModelBuilder.finalize()`

### CollisionPipeline buffer overflow (WAR)
Default `max_triangle_pairs` (1M) overflows with mesh terrain at 4096 envs (~2M triangle pairs). Overflow silently drops contacts, causing robots to fall through terrain.
- No upstream issue tracking auto-sizing
- Workaround: increase `max_triangle_pairs` to 2M

## Related PRs

- https://github.com/isaac-sim/IsaacLab/pull/5088 — experimental warp rough terrain env (stacked on earlier PRs)

## Test plan

Tested on single GPU with `env_isaaclab_develop` conda env:

```bash
conda run -n env_isaaclab_develop python \
  scripts/reinforcement_learning/rsl_rl/train.py \
  --task Isaac-Velocity-Rough-Anymal-D-v0 \
  --num_envs 4096 --max_iterations 300 --headless presets=newton
```

Newton backend confirmed via log: `Registered backend 'newton' for factory Articulation`.

| Metric | Result | Benchmark (Anymal-C rough) |
|--------|--------|---------------------------|
| Reward | 13.33 | ≥ 7 |
| Episode length | 957 | ≥ 875 |
| time_out % | 89.7% | — |
| NaN | 0 | — |
| Training time | 14 min | — |

- [x] 300 iterations at 4096 envs with `presets=newton`, zero NaN
- [x] Multiple runs show consistent results (reward 11-13, episode length 940-970)
- [x] Pre-commit checks pass