### PR TITLE
Fixes windows batch command inline comment syntax

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,7 @@
+# CI Workflows
+
+`schedule:` and `workflow_dispatch:` triggers fire **only from the default
+branch (`main`)**. A workflow YAML must live on `main` for its cron to
+register — the same file on other branches has no effect. `pull_request:`
+and `push:` triggers fire from the event branch's file and work normally
+on `develop`.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,15 +3,18 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-name: Build & deploy docs
+name: Docs
 
 on:
   push:
     branches:
       - main
-      - devel
+      - develop
       - 'release/**'
+      - 'feature/isaacsim-6-0'
   pull_request:
+    # we're skipping the branches and paths filter to allow docs to be built on any PR because heredoc is used
+    # additionally, we have a check that determines what version of docs will be built
     types: [opened, synchronize, reopened]
 
 concurrency:
@@ -19,50 +22,91 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-secrets:
-    name: Check secrets
+  doc-build-type:
+    name: Detect Doc Build Type
     runs-on: ubuntu-latest
     outputs:
       trigger-deploy: ${{ steps.trigger-deploy.outputs.defined }}
     steps:
+    - id: info
+      run: echo "repo=github.repository=${{ github.repository }}, ref=github.ref=${{ github.ref }}"
     - id: trigger-deploy
       env:
         REPO_NAME: ${{ secrets.REPO_NAME }}
-      if: "${{ github.repository == env.REPO_NAME && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/heads/release/')) }}"
-      run: echo "defined=true" >> "$GITHUB_OUTPUT"
+      # develop, main, release/ trigger multi-version build, then deployment to gh-pages
+      # all others - just the current docs without deployment
+      if: "${{ github.repository == env.REPO_NAME && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')) }}"
+      run: echo "defined=true" >> "$GITHUB_OUTPUT"; echo "Docs will be built multi-version and deployed"
 
-  build-docs:
-    name: Build Docs
+  build-latest-docs:
+    name: Build Latest Docs
     runs-on: ubuntu-latest
-    needs: [check-secrets]
+    needs: [doc-build-type]
+    # run on non-deploy branches to build current version docs only
+    if: needs.doc-build-type.outputs.trigger-deploy != 'true'
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
         architecture: x64
 
     - name: Install dev requirements
       working-directory: ./docs
       run: pip install -r requirements.txt
 
-    - name: Check branch docs building
+    - name: Build current version docs
       working-directory: ./docs
-      if: needs.check-secrets.outputs.trigger-deploy != 'true'
       run: make current-docs
+
+    - name: Upload docs artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: docs-html
+        path: ./docs/_build
+
+  build-multi-docs:
+    name: Build Multi-Version Docs
+    runs-on: ubuntu-latest
+    needs: [doc-build-type]
+    # run on deploy branches to create multi-version docs
+    if: needs.doc-build-type.outputs.trigger-deploy == 'true'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        architecture: x64
+
+    - name: Install dev requirements
+      working-directory: ./docs
+      run: pip install -r requirements.txt
 
     - name: Generate multi-version docs
       working-directory: ./docs
+      env:
+        # "deploy" branches build the full set of versions so every page
+        # has a complete version dropdown: main, develop, tags >= v2.0.0
+        # (including pre-release suffixes like -beta or -rc1). v1.x tags and
+        # release/ branches are excluded.
+        SMV_BRANCH_WHITELIST: '^(main|develop)$'
+        SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+(-[A-Za-z0-9.]+)?$'
       run: |
         git fetch --prune --unshallow --tags
+        git checkout --detach HEAD
+        git for-each-ref --format="%(refname:short)" refs/heads/ | xargs -r git branch -D
         make multi-docs
 
     - name: Upload docs artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: docs-html
         path: ./docs/_build
@@ -70,18 +114,21 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     runs-on: ubuntu-latest
-    needs: [check-secrets, build-docs]
-    if: needs.check-secrets.outputs.trigger-deploy == 'true'
+    needs: [doc-build-type, build-multi-docs]
+    # deploy only on "deploy" branches
+    if: needs.doc-build-type.outputs.trigger-deploy == 'true'
 
     steps:
     - name: Download docs artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: docs-html
         path: ./docs/_build
 
     - name: Deploy to gh-pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build
+        keep_files: false
+        force_orphan: true

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -1,0 +1,123 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Nightly auto-compile: rolls accumulated fragments under
+# ``source/<pkg>/changelog.d/`` into per-package ``CHANGELOG.rst`` entries,
+# bumps each ``extension.toml``, deletes consumed fragments, and pushes the
+# result back to ``develop``. Keeps the develop branch's changelog current
+# without requiring a maintainer to run ``compile`` by hand.
+#
+# Scheduled workflow — must live on the default branch (``main``) for the
+# cron to register. See ``.github/workflows/README.md``.
+#
+# The push uses ``CHANGELOG_PAT`` (a personal access token / fine-grained
+# GitHub App token with ``contents:write`` on this repo) when it's
+# available so downstream CI runs on the auto-commit. Falls back to
+# ``GITHUB_TOKEN`` — sufficient for the push itself, but pushes signed
+# with ``GITHUB_TOKEN`` do not trigger workflow runs on the resulting
+# commit, which is by design (avoids infinite loops) but means the
+# Docker / docs rebuild won't re-trigger off the nightly's auto-commit.
+
+name: Nightly Changelog Compilation
+
+on:
+  schedule:
+    # Run nightly at 5 AM UTC (one hour after daily-compatibility, so we
+    # don't compete for runner capacity).
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview only — do not commit / push'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  # Only one nightly compile may be in flight at a time. ``cancel-in-progress``
+  # is intentionally false: if a previous run is still finishing its push, we
+  # queue rather than abort it mid-commit.
+  group: nightly-changelog
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  compile-changelog:
+    name: Compile changelog fragments
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          # Operate on develop, not the repo's default branch. Scheduled
+          # workflows fire from the default branch's workflow file by
+          # default, but we want the *checkout* to be develop so the
+          # compile sees develop's accumulated fragments and the push
+          # writes back to develop.
+          ref: develop
+          # Use a PAT so the auto-commit triggers downstream CI; falls back
+          # to GITHUB_TOKEN which is sufficient for the push itself.
+          token: ${{ secrets.CHANGELOG_PAT || secrets.GITHUB_TOKEN }}
+          # Full history so the compiler can resolve each fragment's merge
+          # time via ``git log --diff-filter=A --first-parent``.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Compile fragments
+        run: |
+          ARGS="--all"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          echo "Running: python3 tools/changelog/cli.py compile $ARGS"
+          python3 tools/changelog/cli.py compile $ARGS
+
+      - name: Commit and push if fragments were compiled
+        if: inputs.dry_run != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add source/*/changelog.d/ \
+                  source/*/docs/CHANGELOG.rst \
+                  source/*/config/extension.toml
+          if git diff --staged --quiet; then
+            echo "No changelog fragments found — nothing to commit."
+          else
+            # Convention for CI-driven auto-commits on this repo:
+            #   [CI][<Specific Action>] <one-line summary>
+            # The leading ``[CI]`` tag groups every machine-driven commit
+            # (so future automations — auto image rebuilds, auto publish,
+            # etc. — all share the prefix and are easy to find/filter in
+            # ``git log --grep``). The second tag names the specific
+            # action. The trigger event suffix (``schedule`` vs
+            # ``workflow_dispatch``) is preserved for traceability.
+            #
+            # The body lists every package that bumped, derived from the
+            # staged ``extension.toml`` diff so the entries are accurate
+            # regardless of which packages happen to have pending
+            # fragments this run.
+            MSG_FILE=$(mktemp)
+            {
+              echo "[CI][Auto Version Bump] Compile changelog fragments (${{ github.event_name }})"
+              echo
+              echo "Bumped packages:"
+              for tom in $(git diff --staged --name-only -- 'source/*/config/extension.toml'); do
+                pkg=$(echo "$tom" | sed -E 's|source/([^/]+)/config/extension.toml|\1|')
+                old=$(git diff --staged "$tom" | awk -F'"' '/^-version/{print $2; exit}')
+                new=$(git diff --staged "$tom" | awk -F'"' '/^\+version/{print $2; exit}')
+                echo "- $pkg: $old → $new"
+              done
+            } > "$MSG_FILE"
+            git commit -F "$MSG_FILE"
+            # Push explicitly to develop so we don't accidentally write
+            # to the source ref of a workflow_dispatch run.
+            git push origin HEAD:develop
+          fi

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -63,7 +63,9 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.CHANGELOG_APP_ID }}
+          # ``client-id`` (the App's OAuth client ID, ``Iv23...``) supersedes
+          # the deprecated ``app-id`` integer input as of v3.x.
+          client-id: ${{ secrets.CHANGELOG_APP_CLIENT_ID }}
           private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
           # Declare the scope the App must have so token mint fails loudly
           # if the App is misconfigured, instead of failing silently at the
@@ -86,7 +88,7 @@ jobs:
           # time via ``git log --diff-filter=A --first-parent``.
           fetch-depth: 0
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -12,13 +12,15 @@
 # Scheduled workflow — must live on the default branch (``main``) for the
 # cron to register. See ``.github/workflows/README.md``.
 #
-# The push uses ``CHANGELOG_PAT`` (a personal access token / fine-grained
-# GitHub App token with ``contents:write`` on this repo) when it's
-# available so downstream CI runs on the auto-commit. Falls back to
-# ``GITHUB_TOKEN`` — sufficient for the push itself, but pushes signed
-# with ``GITHUB_TOKEN`` do not trigger workflow runs on the resulting
-# commit, which is by design (avoids infinite loops) but means the
-# Docker / docs rebuild won't re-trigger off the nightly's auto-commit.
+# The push uses a short-lived GitHub App installation token minted from
+# ``CHANGELOG_APP_ID`` + ``CHANGELOG_APP_PRIVATE_KEY`` (repo secrets). The
+# App must be installed on this repository with ``contents: write`` and
+# added to the bypass-actor list of ``develop``'s branch ruleset so the
+# auto-commit can push directly without satisfying required-checks /
+# required-approval gates.
+# Commits signed by an App token (unlike ``GITHUB_TOKEN``) are treated as
+# external pushes, so they DO trigger downstream workflow runs (Docker
+# rebuild, docs, etc.) without needing a separate PAT.
 
 name: Nightly Changelog Compilation
 
@@ -43,7 +45,9 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  # Reduced: the App installation token below carries its own write scope.
+  # GITHUB_TOKEN only needs read access for the standard checkout machinery.
+  contents: read
 
 jobs:
   compile-changelog:
@@ -52,6 +56,20 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # Mint a short-lived (1 h) installation access token for the
+      # ``isaaclab-bot`` GitHub App. The App is on develop's branch-ruleset
+      # bypass list, so its push lands without needing the standard
+      # required-checks / required-approval pipeline.
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.CHANGELOG_APP_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+          # Declare the scope the App must have so token mint fails loudly
+          # if the App is misconfigured, instead of failing silently at the
+          # push step.
+          permission-contents: write
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           # Operate on develop, not the repo's default branch. Scheduled
@@ -60,9 +78,10 @@ jobs:
           # compile sees develop's accumulated fragments and the push
           # writes back to develop.
           ref: develop
-          # Use a PAT so the auto-commit triggers downstream CI; falls back
-          # to GITHUB_TOKEN which is sufficient for the push itself.
-          token: ${{ secrets.CHANGELOG_PAT || secrets.GITHUB_TOKEN }}
+          # App token (vs. GITHUB_TOKEN) means the push is signed by
+          # ``isaaclab-bot`` — the bypass identity — and downstream CI
+          # workflows DO trigger on the resulting commit.
+          token: ${{ steps.app-token.outputs.token }}
           # Full history so the compiler can resolve each fragment's merge
           # time via ``git log --diff-filter=A --first-parent``.
           fetch-depth: 0
@@ -81,10 +100,12 @@ jobs:
           python3 tools/changelog/cli.py compile $ARGS
 
       - name: Commit and push if fragments were compiled
-        if: inputs.dry_run != 'true'
+        if: ${{ !inputs.dry_run }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Author commits as the App's bot user so the GitHub UI attributes
+          # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
+          git config user.name "isaaclab-bot[bot]"
+          git config user.email "282401363+isaaclab-bot[bot]@users.noreply.github.com"
           git add source/*/changelog.d/ \
                   source/*/docs/CHANGELOG.rst \
                   source/*/config/extension.toml
@@ -117,6 +138,11 @@ jobs:
               done
             } > "$MSG_FILE"
             git commit -F "$MSG_FILE"
+            # Rebase onto develop's current tip in case a human commit
+            # landed during this run (~2 min window between checkout and
+            # push). Without this the push fails non-fast-forward and the
+            # batch waits for the next run.
+            git pull --rebase origin develop
             # Push explicitly to develop so we don't accidentally write
             # to the source ref of a workflow_dispatch run.
             git push origin HEAD:develop

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,8 +54,9 @@ Guidelines for modifications:
 * Brayden Zhang
 * Brian Bingham
 * Brian McCann
-* Cameron Upright
+* Caelan Garrett
 * Calvin Yu
+* Cameron Upright
 * Cathy Y. Li
 * Cheng-Rong Lai
 * Chenyu Yang

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,7 +139,7 @@ templates_path = []
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "_redirect", "_templates", "Thumbs.db", ".DS_Store", "README.md", "licenses/*"]
+exclude_patterns = ["_build", "_redirect", "_templates", "Thumbs.db", ".DS_Store", "README.md", "licenses/*", "plans"]
 
 # Mock out modules that are not available on RTD
 autodoc_mock_imports = [
@@ -176,6 +176,7 @@ autodoc_mock_imports = [
     "omni.timeline",
     "omni.ui",
     "gym",
+    "gymnasium",
     "skrl",
     "stable_baselines3",
     "rsl_rl",
@@ -287,9 +288,11 @@ templates_path = [
 # Whitelist pattern for remotes
 smv_remote_whitelist = r"^.*$"
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = os.getenv("SMV_BRANCH_WHITELIST", r"^(main|devel|release/.*)$")
-# Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = os.getenv("SMV_TAG_WHITELIST", r"^v[1-9]\d*\.\d+\.\d+$")
+smv_branch_whitelist = os.getenv("SMV_BRANCH_WHITELIST", r"^(main|develop|release/.*)$")
+# Whitelist pattern for tags (set to None to ignore all tags).
+# Matches vMAJOR.MINOR.PATCH with an optional pre-release suffix like -beta or -rc1,
+# so tags like v3.0.0-beta show up in the version selector.
+smv_tag_whitelist = os.getenv("SMV_TAG_WHITELIST", r"^v[1-9]\d*\.\d+\.\d+(-[A-Za-z0-9.]+)?$")
 html_sidebars = {
     "**": ["navbar-logo.html", "versioning.html", "icon-links.html", "search-field.html", "sbt-sidebar-nav.html"]
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,8 @@ intersphinx_mapping = {
     "torch": ("https://docs.pytorch.org/docs/stable/", None),
     "isaacsim": ("https://docs.isaacsim.omniverse.nvidia.com/5.1.0/py/", None),
     "gymnasium": ("https://gymnasium.farama.org/", None),
-    "warp": ("https://nvidia.github.io/warp/", None),
+    # NOTE: pinned to /stable/ because /objects.inv at the root currently 404s
+    "warp": ("https://nvidia.github.io/warp/stable/", None),
     "omniverse": ("https://docs.omniverse.nvidia.com/dev-guide/latest", None),
 }
 

--- a/docs/source/api/lab/isaaclab.app.rst
+++ b/docs/source/api/lab/isaaclab.app.rst
@@ -111,5 +111,5 @@ Simulation App Launcher
    :members:
 
 
-.. _livestream: https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/manual_livestream_clients.html
+.. _livestream: https://docs.isaacsim.omniverse.nvidia.com/latest/installation/manual_livestream_clients.html
 .. _`WebRTC Livestream`: https://docs.isaacsim.omniverse.nvidia.com/latest/installation/manual_livestream_clients.html#isaac-sim-short-webrtc-streaming-client

--- a/docs/source/experimental-features/newton-physics-integration/index.rst
+++ b/docs/source/experimental-features/newton-physics-integration/index.rst
@@ -1,34 +1,31 @@
 Newton Physics Integration
 ===========================
 
-`Newton <https://newton-physics.github.io/newton/guide/overview.html>`_ is a GPU-accelerated, extensible, and differentiable physics simulation engine designed for robotics, research,
+`Newton <https://newton-physics.github.io/newton/latest/guide/overview.html>`_ is a GPU-accelerated, extensible, and differentiable physics simulation engine designed for robotics, research,
 and advanced simulation workflows. Built on top of `NVIDIA Warp <https://nvidia.github.io/warp/>`_ and integrating MuJoCo Warp, Newton provides high-performance
 simulation, modern Python APIs, and a flexible architecture for both users and developers.
 
 Newton is an Open Source community-driven project with contributions from NVIDIA, Google Deep Mind, and Disney Research,
 managed through the Linux Foundation.
 
-This `experimental feature branch <https://github.com/isaac-sim/IsaacLab/tree/feature/newton>`_ of Isaac Lab provides an initial integration with the Newton Physics Engine, and is
+This integration is available on the `develop branch <https://github.com/isaac-sim/IsaacLab/tree/develop>`_ of Isaac Lab as part of Isaac Lab 3.0 Beta, and is
 under active development. Many features are not yet supported, and only a limited set of classic RL and flat terrain locomotion
 reinforcement learning examples are included at the moment.
 
-Both this Isaac Lab integration branch and Newton itself are under heavy development. We intend to support additional
+Both this Isaac Lab integration and Newton itself are under heavy development. We intend to support additional
 features for other reinforcement learning and imitation learning workflows in the future, but the above tasks should be
 a good lens through which to understand how Newton integration works in Isaac Lab.
 
 We have validated Newton simulation against PhysX by transferring learned policies from Newton to PhysX and vice versa
 Furthermore, we have also successfully deployed a Newton-trained locomotion policy to a G1 robot. Please see :ref:`here <sim2real>` for more information.
 
-Newton can support `multiple solvers <https://newton-physics.github.io/newton/api/newton_solvers.html>`_ for handling different types of physics simulation, but for the moment, the Isaac
+Newton can support `multiple solvers <https://newton-physics.github.io/newton/latest/api/newton_solvers.html>`_ for handling different types of physics simulation, but for the moment, the Isaac
 Lab integration focuses primarily on the MuJoCo-Warp solver.
 
-Future updates of this branch and Newton should include both ongoing improvements in performance as well as integration
+Future updates of Isaac Lab and Newton should include both ongoing improvements in performance as well as integration
 with additional solvers.
 
-Note that this branch does not include support for the PhysX physics engine - only Newton is supported. We are considering
-several possible paths to continue to support PhysX within Lab, and feedback from users about their needs around that would be appreciated.
-
-During the early development phase of both Newton and this Isaac Lab integration, you are likely to encounter breaking
+During the development phase of both Newton and this Isaac Lab integration, you are likely to encounter breaking
 changes as well as limited documentation. We do not expect to be able to provide official support or debugging assistance
 until the framework has reached an official release. We appreciate your understanding and patience as we work to deliver a robust and polished framework!
 

--- a/docs/source/experimental-features/newton-physics-integration/installation.rst
+++ b/docs/source/experimental-features/newton-physics-integration/installation.rst
@@ -1,62 +1,68 @@
 Installation
 ============
 
-Installing the Newton physics integration branch requires three things:
+Installing the Newton physics integration requires three things:
 
-1) The ``feature/newton`` branch of Isaac Lab
-2) Ubuntu 22.04 or 24.04 (Windows will be supported soon)
-3) [Optional] Isaac sim 5.1 (Isaac Sim is not required if the Omniverse visualizer is not used)
+1) The ``develop`` branch of Isaac Lab
+2) Ubuntu 22.04 or 24.04
+3) [Optional] Isaac Sim 6.0 (Isaac Sim is not required if the Omniverse visualizer is not used)
 
-To begin, verify the version of Isaac Sim by checking the title of the window created when launching the simulation app.  Alternatively, you can
-find more explicit version information under the ``Help -> About`` menu within the app.
-If your version is less than 5.1, you must first `update or reinstall Isaac Sim <https://docs.isaacsim.omniverse.nvidia.com/latest/installation/quick-install.html>`_ before
-you can proceed further.
+To begin, navigate to the root directory of your local copy of the Isaac Lab repository and open a terminal.
 
-Next, navigate to the root directory of your local copy of the Isaac Lab repository and open a terminal.
-
-Make sure we are on the ``feature/newton`` branch by running the following command:
+Make sure we are on the ``develop`` branch by running the following command:
 
 .. code-block:: bash
 
-    git checkout feature/newton
-
-Below, we provide instructions for installing Isaac Sim through pip.
+    git checkout develop
 
 
-Pip Installation
-----------------
+Installation
+------------
 
-We recommend using conda for managing your python environments. Conda can be downloaded and installed from `here <https://docs.conda.io/en/latest/miniconda.html>`_.
+We recommend using **uv** as the package manager — it is significantly faster than pip and conda.
+To install ``uv``, please follow the instructions `here <https://docs.astral.sh/uv/getting-started/installation/>`__.
 
 If you previously already have a virtual environment for Isaac Lab, please ensure to start from a fresh environment to avoid any dependency conflicts.
 If you have installed earlier versions of mujoco, mujoco-warp, or newton packages through pip, we recommend first
 cleaning your pip cache with ``pip cache purge`` to remove any cache of earlier versions that may be conflicting with the latest.
 
-Create a new conda environment:
+Create a new virtual environment with Python 3.12:
 
 .. code-block:: bash
 
-    conda create -n env_isaaclab python=3.11
+    uv venv --python 3.12 --seed env_isaaclab
 
 Activate the environment:
 
 .. code-block:: bash
 
-    conda activate env_isaaclab
+    source env_isaaclab/bin/activate
+
+.. note::
+
+   If you are using ``pip`` directly instead of ``uv pip``, replace ``uv pip`` with ``pip`` in the commands below.
+
+
+Ensure pip is up to date:
+
+.. code-block:: bash
+
+    uv pip install --upgrade pip
+
+[Optional] Install Isaac Sim 6.0:
+
+.. code-block:: bash
+
+    uv pip install "isaacsim[all,extscache]==6.0.0" --extra-index-url https://pypi.nvidia.com
+
 
 Install the correct version of torch and torchvision:
 
 .. code-block:: bash
 
-    pip install -U torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+    uv pip install -U torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cu128
 
-[Optional] Install Isaac Sim 5.1:
-
-.. code-block:: bash
-
-    pip install "isaacsim[all,extscache]==5.1.0" --extra-index-url https://pypi.nvidia.com
-
-Install Isaac Lab extensions and dependencies:
+Install Isaac Lab extensions and dependencies (this includes Newton 1.0):
 
 .. code-block:: bash
 
@@ -71,8 +77,3 @@ To verify that the installation was successful, run the following command from t
 .. code-block:: bash
 
     ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Cartpole-Direct-v0 --num_envs 128
-
-
-Note that since Newton requires a more recent version of Warp than Isaac Sim 5.1, there may be some incompatibility issues
-that could result in errors such as ``ModuleNotFoundError: No module named 'warp.sim'``. These are ok to ignore and should not
-impact usability.

--- a/docs/source/experimental-features/newton-physics-integration/isaaclab_newton-beta-2.rst
+++ b/docs/source/experimental-features/newton-physics-integration/isaaclab_newton-beta-2.rst
@@ -1,11 +1,11 @@
-Isaac Lab - Newton Beta 2
-=========================
+Isaac Lab 3.0 Beta
+==================
 
-Isaac Lab - Newton Beta 2 (feature/newton branch) provides Newton physics engine integration for Isaac Lab. We refactored our code so that we can not only support PhysX and Newton, but
+Isaac Lab 3.0 Beta (develop branch) provides Newton physics engine integration for Isaac Lab. We refactored our code so that we can not only support PhysX and Newton, but
 any other physics engine, enabling users to bring their own physics engine to Isaac Lab if they desire. To enable this, we introduce base implementations of
 our ``simulation interfaces``, :class:`~isaaclab.assets.articulation.Articulation` or :class:`~isaaclab.sensors.ContactSensor` for instance. These provide a
 set of abstract methods that all physics engines must implement. In turn this allows all of the default Isaac Lab environments to work with any physics engine.
-This also allows us to ensure that Isaac Lab - Newton Beta 2 is backwards compatible with Isaac Lab 2.X. For engine specific calls, users could get the underlying view of
+This also allows us to ensure that Isaac Lab 3.0 Beta is backwards compatible with Isaac Lab 2.X. For engine specific calls, users could get the underlying view of
 the physics engine and call the engine specific APIs directly.
 
 However, as we are refactoring the code, we are also looking at ways to limit the overhead of Isaac Lab's. In an effort to minimize the overhead, we are moving
@@ -13,7 +13,7 @@ all our low level code away from torch, and instead will rely heavily on warp. T
 to take advantage of the cuda-graphing. However, this means that the ``data classes`` such as :class:`~isaaclab.assets.articulation.ArticulationData` or
 :class:`~isaaclab.sensors.ContactSensorData` will only return warp arrays. Users will hence have to call ``wp.to_torch`` to convert them to torch tensors if they desire.
 Our setters/writers will support both warp arrays and torch tensors, and will use the most optimal strategy to update the warp arrays under the hood. This minimizes the
-amount of changes required for users to migrate to Isaac Lab - Newton Beta 2.
+amount of changes required for users to migrate to Isaac Lab 3.0 Beta.
 
 Another new feature of the writers and setters is the ability to provide them with masks and complete data (as opposed to indices and partial data in Isaac Lab 2.X).
 Note that this feature will be available along with the ability to provide indices and partial data, and that the default behavior will still be to provide indices and partial data.
@@ -41,12 +41,3 @@ we are introducing cuda-graphing support for direct rl tasks. This drastically r
 .. code-block:: bash
 
     ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Humanoid-Direct-Warp-v0 --num_envs 4096 --headless
-
-
-What's Next?
-============
-
-Isaac Lab 3.0 is the upcoming release of Isaac Lab, which will be compatible with Isaac Sim 6.0, and at the same time will support the new Newton physics engine.
-This will allow users to train policies on the Newton physics engine, or PhysX. To accommodate this major code refactoring are required. In this section, we
-will go over some of the changes, how that will affect Isaac Lab 2.X users, and how to migrate to Isaac Lab 3.0. The current branch of ``feature/newton`` gives
-a glance of what is to come. While the changes to the internal code structure are significant, the changes to the user API are minimal.

--- a/docs/source/experimental-features/newton-physics-integration/training-environments.rst
+++ b/docs/source/experimental-features/newton-physics-integration/training-environments.rst
@@ -7,16 +7,15 @@ The currently supported tasks are as follows:
 
 * Isaac-Cartpole-Direct-v0
 * Isaac-Cartpole-v0
-* Isaac-Cartpole-RGB-Camera-Direct-v0
-* Isaac-Cartpole-Depth-Camera-Direct-v0
+* Isaac-Cartpole-Camera-Presets-Direct-v0
 * Isaac-Ant-Direct-v0
 * Isaac-Ant-v0
+* Isaac-Dexsuite-Kuka-Allegro-Lift-v0
 * Isaac-Humanoid-Direct-v0
 * Isaac-Humanoid-v0
 * Isaac-Velocity-Flat-Anymal-B-v0
 * Isaac-Velocity-Flat-Anymal-C-v0
 * Isaac-Velocity-Flat-Anymal-D-v0
-* Isaac-Velocity-Flat-Cassie-v0
 * Isaac-Velocity-Flat-G1-v0
 * Isaac-Velocity-Flat-G1-v1 (Sim-to-Real tested)
 * Isaac-Velocity-Flat-H1-v0

--- a/docs/source/experimental-features/newton-physics-integration/visualization.rst
+++ b/docs/source/experimental-features/newton-physics-integration/visualization.rst
@@ -59,8 +59,8 @@ Launch visualizers from the command line with ``--visualizer``:
 
 .. code-block:: bash
 
-    # Launch all visualizers
-    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-v0 --visualizer omniverse newton rerun
+    # Launch all visualizers (comma-delimited list, no spaces)
+    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-v0 --visualizer kit,newton,rerun
 
     # Launch just newton visualizer
     python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-v0 --visualizer newton
@@ -77,18 +77,20 @@ If ``--headless`` is given, no visualizers will be launched.
 Configuration
 ~~~~~~~~~~~~~
 
-Launching visualizers with the command line will use default visualizer configurations. Default configs can be found and edited in ``source/isaaclab/isaaclab/visualizers``.
+Launching visualizers with the command line will use default visualizer configurations. Visualizer backends live in the ``isaaclab_visualizers`` package (e.g. ``source/isaaclab_visualizers/isaaclab_visualizers/kit``, ``newton``, ``rerun``).
 
-You can also configure custom visualizers in the code by defining new ``VisualizerCfg`` instances for the ``SimulationCfg``, for example:
+You can also configure custom visualizers in the code by defining ``VisualizerCfg`` instances for the ``SimulationCfg``, for example:
 
 .. code-block:: python
 
     from isaaclab.sim import SimulationCfg
-    from isaaclab.visualizers import NewtonVisualizerCfg, OVVisualizerCfg, RerunVisualizerCfg
+    from isaaclab_visualizers.kit import KitVisualizerCfg
+    from isaaclab_visualizers.newton import NewtonVisualizerCfg
+    from isaaclab_visualizers.rerun import RerunVisualizerCfg
 
     sim_cfg = SimulationCfg(
         visualizer_cfgs=[
-            OVVisualizerCfg(
+            KitVisualizerCfg(
                 viewport_name="Visualizer Viewport",
                 create_viewport=True,
                 dock_position="SAME",
@@ -128,9 +130,9 @@ Omniverse Visualizer
 
 .. code-block:: python
 
-    from isaaclab.visualizers import OVVisualizerCfg
+    from isaaclab_visualizers.kit import KitVisualizerCfg
 
-    visualizer_cfg = OVVisualizerCfg(
+    visualizer_cfg = KitVisualizerCfg(
         # Viewport settings
         viewport_name="Visualizer Viewport",      # Viewport window name
         create_viewport=True,                     # Create new viewport vs. use existing
@@ -176,8 +178,6 @@ Newton Visualizer
      - Look around
    * - **Mouse Scroll**
      - Zoom in/out
-   * - **Space**
-     - Pause/resume rendering (physics continues)
    * - **H**
      - Toggle UI sidebar
    * - **ESC**
@@ -187,7 +187,7 @@ Newton Visualizer
 
 .. code-block:: python
 
-    from isaaclab.visualizers import NewtonVisualizerCfg
+    from isaaclab_visualizers.newton import NewtonVisualizerCfg
 
     visualizer_cfg = NewtonVisualizerCfg(
         # Window settings
@@ -233,12 +233,14 @@ Rerun Visualizer
 
 .. code-block:: python
 
-    from isaaclab.visualizers import RerunVisualizerCfg
+    from isaaclab_visualizers.rerun import RerunVisualizerCfg
 
     visualizer_cfg = RerunVisualizerCfg(
         # Server settings
         app_id="isaaclab-simulation",             # Application identifier for viewer
+        grpc_port=9876,                           # gRPC endpoint for logging SDK connection
         web_port=9090,                            # Port for local web viewer (launched in browser)
+        bind_address="0.0.0.0",                  # Endpoint host formatting/reuse checks
 
         # Camera settings
         camera_position=(8.0, 8.0, 3.0),         # Initial camera position (x, y, z)
@@ -251,6 +253,10 @@ Rerun Visualizer
         # Recording
         record_to_rrd="recording.rrd",            # Path to save .rrd file (None = no recording)
     )
+
+Rerun startup uses the Python SDK through ``newton.viewer.ViewerRerun`` (no external ``rerun`` CLI process
+management). If ``grpc_port`` is already active, Isaac Lab reuses that server. If ``web_port`` is occupied while
+starting a new server, initialization fails with a clear port-conflict error.
 
 
 Performance Note

--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -124,6 +124,36 @@ To train with multiple GPUs, use the following command, where ``--nproc_per_node
 
                     python -m skrl.utils.distributed.jax --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole-v0 --headless --distributed --ml_framework jax
 
+.. _multi-gpu-nccl-troubleshooting:
+
+Troubleshooting NCCL Errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On some Linux multi-GPU systems, distributed training may fail with
+``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``
+during or shortly after communicator initialization.
+
+If this occurs, try disabling the NCCL shared-memory transport before launching training:
+
+.. code-block:: shell
+
+    export NCCL_SHM_DISABLE=1
+
+If the issue persists, additional NCCL fallbacks that may help are:
+
+.. code-block:: shell
+
+    export NCCL_IB_DISABLE=1
+    export NCCL_ALGO=Ring
+
+Then relaunch the distributed training command as usual.
+
+.. note::
+
+    These variables are NCCL-level workarounds intended for affected systems. They are not
+    required on all machines, and may change communication behavior or performance depending
+    on the hardware topology.
+
 Multi-Node Training
 -------------------
 

--- a/docs/source/how-to/optimize_stage_creation.rst
+++ b/docs/source/how-to/optimize_stage_creation.rst
@@ -9,7 +9,7 @@ What These Features Do
 
 **Fabric Cloning**
 
-- Clones environments using Fabric library (see `USD Fabric USDRT Documentation <https://docs.omniverse.nvidia.com/kit/docs/usdrt/latest/docs/usd_fabric_usdrt.html>`_)
+- Clones environments using Fabric library (see `USD Fabric USDRT Documentation <https://docs.omniverse.nvidia.com/kit/docs/usdrt.scenegraph/latest/usd_fabric_usdrt.html>`_)
 - Partially supported and enabled by default on some environments (see `Limitations`_ section for a list)
 
 **Stage in Memory**
@@ -47,8 +47,8 @@ Stage in memory can be toggled by setting the :attr:`isaaclab.sim.SimulationCfg.
     # create env with stage in memory
     env = ManagerBasedRLEnv(cfg=cfg)
 
-Note, if stage in memory is enabled without using an existing RL environment class, a few more steps are need.
-The stage creation steps should be wrapped in a :py:keyword:`with` statement to set the stage context.
+Note, if stage in memory is enabled without using an existing RL environment class, a few more steps are needed.
+The stage creation steps should be wrapped in a ``with`` statement to set the stage context.
 If the stage needs to be attached, the :meth:`~isaaclab.sim.utils.attach_stage_to_usd_context` function should
 be called after the stage is created.
 

--- a/docs/source/how-to/record_animation.rst
+++ b/docs/source/how-to/record_animation.rst
@@ -122,6 +122,6 @@ After the stop time is reached, a file will be saved to:
 
 
 .. _Stage Recorder: https://docs.omniverse.nvidia.com/extensions/latest/ext_animation_stage-recorder.html
-.. _Fabric: https://docs.omniverse.nvidia.com/kit/docs/usdrt/latest/docs/usd_fabric_usdrt.html
+.. _Fabric: https://docs.omniverse.nvidia.com/kit/docs/usdrt.scenegraph/latest/usd_fabric_usdrt.html
 .. _Omniverse Launcher: https://docs.omniverse.nvidia.com/launcher/latest/index.html
 .. _tutorial on layering in Omniverse: https://www.youtube.com/watch?v=LTwmNkSDh-c&ab_channel=NVIDIAOmniverse

--- a/docs/source/overview/developer-guide/development.rst
+++ b/docs/source/overview/developer-guide/development.rst
@@ -68,12 +68,12 @@ python package to build the python module provided by the extensions. This is do
 .. note::
 
    The ``setup.py`` file is not required for extensions that are only loaded into Omniverse
-   using the `Extension Manager <https://docs.omniverse.nvidia.com/prod_extensions/prod_extensions/ext_extension-manager.html>`__.
+   using the `Extension Manager <https://docs.omniverse.nvidia.com/extensions/latest/ext_extension-manager.html>`__.
 
 Lastly, the ``tests`` directory contains the unit tests for the extension. These are written
 using the `unittest <https://docs.python.org/3/library/unittest.html>`__ framework. It is
 important to note that Omniverse also provides a similar
-`testing framework <https://docs.omniverse.nvidia.com/kit/docs/kit-manual/104.0/guide/testing_exts_python.html>`__.
+`testing framework <https://docs.omniverse.nvidia.com/kit/docs/kit-manual/latest/guide/testing_exts_python.html>`__.
 However, it requires going through the build process and does not support testing of the python module in
 standalone applications.
 

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -74,7 +74,7 @@ If you use an instanceable assets for markers, the marker class removes all the 
 This is then replicated across other references of the same asset since physics properties of instanceable assets
 are stored in the instanceable asset's USD file and not in its stage reference's USD file.
 
-.. _instanceable assets: https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/tutorial_gym_instanceable_assets.html
+.. _instanceable assets: https://docs.isaacsim.omniverse.nvidia.com/latest/isaac_lab_tutorials/tutorial_instanceable_assets.html
 .. _Omniverse Isaac Sim documentation: https://docs.isaacsim.omniverse.nvidia.com/latest/overview/known_issues.html#
 
 

--- a/docs/source/refs/troubleshooting.rst
+++ b/docs/source/refs/troubleshooting.rst
@@ -9,6 +9,14 @@ Tricks and Troubleshooting
     assistance.
 
 
+Troubleshooting distributed training NCCL errors
+------------------------------------------------
+
+On some Linux multi-GPU systems, distributed training may fail with
+``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``.
+For documented NCCL workarounds, see :ref:`multi-gpu-nccl-troubleshooting`.
+
+
 Debugging physics simulation stability issues
 ---------------------------------------------
 

--- a/docs/source/setup/installation/include/src_build_isaaclab.rst
+++ b/docs/source/setup/installation/include/src_build_isaaclab.rst
@@ -26,7 +26,7 @@ Installation
 
          .. code:: batch
 
-            isaaclab.bat --install :: or "isaaclab.bat -i"
+            isaaclab.bat --install
 
 
    By default, the above will install **all** the learning frameworks. These include
@@ -50,7 +50,7 @@ Installation
 
          .. code:: batch
 
-            isaaclab.bat --install rl_games :: or "isaaclab.bat -i rl_games"
+            isaaclab.bat --install rl_games
 
    The valid options are ``all``, ``rl_games``, ``rsl_rl``, ``sb3``, ``skrl``, ``robomimic``,
    and ``none``. If ``none`` is passed, then no learning frameworks will be installed.

--- a/docs/source/tutorials/00_sim/create_empty.rst
+++ b/docs/source/tutorials/00_sim/create_empty.rst
@@ -69,7 +69,7 @@ Configuring the simulation context
 
 When launching the simulator from a standalone script, the user has complete control over playing,
 pausing and stepping the simulator. All these operations are handled through the **simulation
-context**. It takes care of various timeline events and also configures the `physics scene`_ for
+context**. It takes care of various timeline events and also configures the physics scene for
 simulation.
 
 In Isaac Lab, the :class:`sim.SimulationContext` class inherits from Isaac Sim's
@@ -164,4 +164,3 @@ following tutorial where we will learn how to add assets to the stage.
 
 .. _`Isaac Sim Workflows`: https://docs.isaacsim.omniverse.nvidia.com/latest/introduction/workflows.html
 .. _carb: https://docs.omniverse.nvidia.com/kit/docs/carbonite/latest/index.html
-.. _`physics scene`: https://docs.omniverse.nvidia.com/prod_extensions/prod_extensions/ext_physics.html#physics-scene

--- a/docs/source/tutorials/00_sim/spawn_prims.rst
+++ b/docs/source/tutorials/00_sim/spawn_prims.rst
@@ -188,5 +188,5 @@ demonstrates the basic concepts of scene designing in Isaac Lab and how to use t
 we will now look at how to interact with the scene and the simulation.
 
 
-.. _`USD documentation`: https://graphics.pixar.com/usd/docs/index.html
+.. _`USD documentation`: https://openusd.org/release/index.html
 .. _`different light prims`: https://youtu.be/c7qyI8pZvF4?feature=shared

--- a/scripts/reinforcement_learning/skrl/play.py
+++ b/scripts/reinforcement_learning/skrl/play.py
@@ -46,15 +46,17 @@ parser.add_argument(
     "--ml_framework",
     type=str,
     default="torch",
-    choices=["torch", "jax", "jax-numpy"],
+    choices=["torch", "jax"],
     help="The ML framework used for training the skrl agent.",
 )
 parser.add_argument(
     "--algorithm",
     type=str,
     default="PPO",
-    choices=["AMP", "PPO", "IPPO", "MAPPO"],
-    help="The RL algorithm used for training the skrl agent.",
+    help=(
+        "Name of the RL algorithm to use (e.g. AMP, DDPG, IPPO, MAPPO, PPO, SAC, TD3, etc.) "
+        "when several algorithms exist for the same task. For a more specific selection, use the argument --agent."
+    ),
 )
 parser.add_argument("--real-time", action="store_true", default=False, help="Run in real-time, if possible.")
 
@@ -84,7 +86,7 @@ import torch
 from packaging import version
 
 # check for minimum supported skrl version
-SKRL_VERSION = "1.4.3"
+SKRL_VERSION = "2.0.0"
 if version.parse(skrl.__version__) < version.parse(SKRL_VERSION):
     skrl.logger.error(
         f"Unsupported skrl version: {skrl.__version__}. "
@@ -207,10 +209,11 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, expe
     print(f"[INFO] Loading model checkpoint from: {resume_path}")
     runner.agent.load(resume_path)
     # set agent to evaluation mode
-    runner.agent.set_running_mode("eval")
+    runner.agent.enable_training_mode(False, apply_to_models=True)
 
     # reset environment
     obs, _ = env.reset()
+    states = env.state()
     timestep = 0
     # simulate environment
     while simulation_app.is_running():
@@ -219,7 +222,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, expe
         # run everything in inference mode
         with torch.inference_mode():
             # agent stepping
-            outputs = runner.agent.act(obs, timestep=0, timesteps=0)
+            outputs = runner.agent.act(obs, states, timestep=0, timesteps=0)
             # - multi-agent (deterministic) actions
             if hasattr(env, "possible_agents"):
                 actions = {a: outputs[-1][a].get("mean_actions", outputs[0][a]) for a in env.possible_agents}
@@ -228,6 +231,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, expe
                 actions = outputs[-1].get("mean_actions", outputs[0])
             # env stepping
             obs, _, _, _, _ = env.step(actions)
+            states = env.state()
         if args_cli.video:
             timestep += 1
             # exit the play loop after recording one video

--- a/scripts/reinforcement_learning/skrl/train.py
+++ b/scripts/reinforcement_learning/skrl/train.py
@@ -44,15 +44,17 @@ parser.add_argument(
     "--ml_framework",
     type=str,
     default="torch",
-    choices=["torch", "jax", "jax-numpy"],
+    choices=["torch", "jax"],
     help="The ML framework used for training the skrl agent.",
 )
 parser.add_argument(
     "--algorithm",
     type=str,
     default="PPO",
-    choices=["AMP", "PPO", "IPPO", "MAPPO"],
-    help="The RL algorithm used for training the skrl agent.",
+    help=(
+        "Name of the RL algorithm to use (e.g. AMP, DDPG, IPPO, MAPPO, PPO, SAC, TD3, etc.) "
+        "when several algorithms exist for the same task. For a more specific selection, use the argument --agent."
+    ),
 )
 parser.add_argument(
     "--ray-proc-id", "-rid", type=int, default=None, help="Automatically configured by Ray integration, otherwise None."
@@ -85,7 +87,7 @@ import skrl
 from packaging import version
 
 # check for minimum supported skrl version
-SKRL_VERSION = "1.4.3"
+SKRL_VERSION = "2.0.0"
 if version.parse(skrl.__version__) < version.parse(SKRL_VERSION):
     skrl.logger.error(
         f"Unsupported skrl version: {skrl.__version__}. "

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -42,7 +42,7 @@ INSTALL_REQUIRES = [
     "pytest",
     "pytest-mock",
     "junitparser",
-    "flatdict==4.0.0",
+    "flatdict>=4.1.0",
     "flaky",
     "packaging",
 ]

--- a/source/isaaclab_rl/config/extension.toml
+++ b/source/isaaclab_rl/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.0"
+version = "0.5.1"
 
 # Description
 title = "Isaac Lab RL"

--- a/source/isaaclab_rl/docs/CHANGELOG.rst
+++ b/source/isaaclab_rl/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.5.1 (2026-04-21)
+~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Updated skrl wrapper to support the new version of skrl 2.0.
+
 0.5.0 (2026-3-04)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/distillation_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/distillation_cfg.py
@@ -22,7 +22,7 @@ class RslRlDistillationAlgorithmCfg:
     """Configuration for the distillation algorithm."""
 
     class_name: str = "Distillation"
-    """The algorithm class name. Default is Distillation."""
+    """The algorithm class name. Defaults to Distillation."""
 
     num_learning_epochs: int = MISSING
     """The number of updates performed with each sample."""
@@ -34,13 +34,13 @@ class RslRlDistillationAlgorithmCfg:
     """The number of environment steps the gradient flows back."""
 
     max_grad_norm: None | float = None
-    """The maximum norm the gradient is clipped to."""
+    """The maximum norm the gradient is clipped to. Defaults to None."""
 
     optimizer: Literal["adam", "adamw", "sgd", "rmsprop"] = "adam"
-    """The optimizer to use for the student policy."""
+    """The optimizer to use for the student policy. Defaults to adam."""
 
     loss_type: Literal["mse", "huber"] = "mse"
-    """The loss type to use for the student policy."""
+    """The loss type to use for the student policy. Defaults to mse."""
 
 
 #########################
@@ -53,7 +53,7 @@ class RslRlDistillationRunnerCfg(RslRlBaseRunnerCfg):
     """Configuration of the runner for distillation algorithms."""
 
     class_name: str = "DistillationRunner"
-    """The runner class name. Default is DistillationRunner."""
+    """The runner class name. Defaults to DistillationRunner."""
 
     student: RslRlMLPModelCfg = MISSING
     """The student configuration."""
@@ -85,13 +85,13 @@ class RslRlDistillationStudentTeacherCfg:
     """
 
     class_name: str = "StudentTeacher"
-    """The policy class name. Default is StudentTeacher."""
+    """The policy class name. Defaults to StudentTeacher."""
 
     init_noise_std: float = MISSING
     """The initial noise standard deviation for the student policy."""
 
     noise_std_type: Literal["scalar", "log"] = "scalar"
-    """The type of noise standard deviation for the policy. Default is scalar."""
+    """The type of noise standard deviation for the policy. Defaults to scalar."""
 
     student_obs_normalization: bool = MISSING
     """Whether to normalize the observation for the student network."""
@@ -117,7 +117,7 @@ class RslRlDistillationStudentTeacherRecurrentCfg(RslRlDistillationStudentTeache
     """
 
     class_name: str = "StudentTeacherRecurrent"
-    """The policy class name. Default is StudentTeacherRecurrent."""
+    """The policy class name. Defaults to StudentTeacherRecurrent."""
 
     rnn_type: str = MISSING
     """The type of the RNN network. Either "lstm" or "gru"."""

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
@@ -23,7 +23,7 @@ class RslRlMLPModelCfg:
     """Configuration for the MLP model."""
 
     class_name: str = "MLPModel"
-    """The model class name. Default is MLPModel."""
+    """The model class name. Defaults to MLPModel."""
 
     hidden_dims: list[int] = MISSING
     """The hidden dimensions of the MLP network."""
@@ -32,10 +32,10 @@ class RslRlMLPModelCfg:
     """The activation function for the MLP network."""
 
     obs_normalization: bool = False
-    """Whether to normalize the observation for the model. Default is False."""
+    """Whether to normalize the observation for the model. Defaults to False."""
 
     distribution_cfg: DistributionCfg | None = None
-    """The configuration for the output distribution. Default is None, in which case no distribution is used."""
+    """The configuration for the output distribution. Defaults to None, in which case no distribution is used."""
 
     @configclass
     class DistributionCfg:
@@ -79,14 +79,14 @@ class RslRlMLPModelCfg:
     """
 
     noise_std_type: Literal["scalar", "log"] = "scalar"
-    """The type of noise standard deviation for the model. Default is scalar.
+    """The type of noise standard deviation for the model. Defaults to scalar.
 
     For rsl-rl >= 5.0.0, this configuration is is deprecated. Please use `distribution_cfg` instead and use the
     `std_type` field of the distribution configuration to specify the type of noise standard deviation.
     """
 
     state_dependent_std: bool = False
-    """Whether to use state-dependent standard deviation for the policy. Default is False.
+    """Whether to use state-dependent standard deviation for the policy. Defaults to False.
 
     For rsl-rl >= 5.0.0, this configuration is is deprecated. Please use `distribution_cfg` instead and use
     the `HeteroscedasticGaussianDistributionCfg` if state-dependent standard deviation is desired.
@@ -98,7 +98,7 @@ class RslRlRNNModelCfg(RslRlMLPModelCfg):
     """Configuration for RNN model."""
 
     class_name: str = "RNNModel"
-    """The model class name. Default is RNNModel."""
+    """The model class name. Defaults to RNNModel."""
 
     rnn_type: str = MISSING
     """The type of RNN to use. Either "lstm" or "gru"."""
@@ -115,7 +115,7 @@ class RslRlCNNModelCfg(RslRlMLPModelCfg):
     """Configuration for CNN model."""
 
     class_name: str = "CNNModel"
-    """The model class name. Default is CNNModel."""
+    """The model class name. Defaults to CNNModel."""
 
     @configclass
     class CNNCfg:
@@ -126,28 +126,28 @@ class RslRlCNNModelCfg(RslRlMLPModelCfg):
         """The kernel size for the CNN."""
 
         stride: int | tuple[int] | list[int] = 1
-        """The stride for the CNN."""
+        """The stride for the CNN. Defaults to 1."""
 
         dilation: int | tuple[int] | list[int] = 1
-        """The dilation for the CNN."""
+        """The dilation for the CNN. Defaults to 1."""
 
         padding: Literal["none", "zeros", "reflect", "replicate", "circular"] = "none"
-        """The padding for the CNN."""
+        """The padding for the CNN. Defaults to none."""
 
         norm: Literal["none", "batch", "layer"] | tuple[str] | list[str] = "none"
-        """The normalization for the CNN."""
+        """The normalization for the CNN. Defaults to none."""
 
         activation: str = MISSING
         """The activation function for the CNN."""
 
         max_pool: bool | tuple[bool] | list[bool] = False
-        """Whether to use max pooling for the CNN."""
+        """Whether to use max pooling for the CNN. Defaults to False."""
 
         global_pool: Literal["none", "max", "avg"] = "none"
-        """The global pooling for the CNN."""
+        """The global pooling for the CNN. Defaults to none."""
 
         flatten: bool = True
-        """Whether to flatten the output of the CNN."""
+        """Whether to flatten the output of the CNN. Defaults to True."""
 
     cnn_cfg: CNNCfg = MISSING
     """The configuration for the CNN(s)."""
@@ -163,7 +163,7 @@ class RslRlPpoAlgorithmCfg:
     """Configuration for the PPO algorithm."""
 
     class_name: str = "PPO"
-    """The algorithm class name. Default is PPO."""
+    """The algorithm class name. Defaults to PPO."""
 
     num_learning_epochs: int = MISSING
     """The number of learning epochs per update."""
@@ -193,7 +193,7 @@ class RslRlPpoAlgorithmCfg:
     """The maximum gradient norm."""
 
     optimizer: Literal["adam", "adamw", "sgd", "rmsprop"] = "adam"
-    """The optimizer to use."""
+    """The optimizer to use. Defaults to adam."""
 
     value_loss_coef: float = MISSING
     """The coefficient for the value loss."""
@@ -205,7 +205,7 @@ class RslRlPpoAlgorithmCfg:
     """The clipping parameter for the policy."""
 
     normalize_advantage_per_mini_batch: bool = False
-    """Whether to normalize the advantage per mini-batch. Default is False.
+    """Whether to normalize the advantage per mini-batch. Defaults to False.
 
     If True, the advantage is normalized over the mini-batches only.
     Otherwise, the advantage is normalized over the entire collected trajectories.
@@ -215,10 +215,10 @@ class RslRlPpoAlgorithmCfg:
     """Whether to share the CNN networks between actor and critic, in case CNNModels are used. Defaults to False."""
 
     rnd_cfg: RslRlRndCfg | None = None
-    """The RND configuration. Default is None, in which case RND is not used."""
+    """The RND configuration. Defaults to None, in which case RND is not used."""
 
     symmetry_cfg: RslRlSymmetryCfg | None = None
-    """The symmetry configuration. Default is None, in which case symmetry is not used."""
+    """The symmetry configuration. Defaults to None, in which case symmetry is not used."""
 
 
 #########################
@@ -231,10 +231,10 @@ class RslRlBaseRunnerCfg:
     """Base configuration of the runner."""
 
     seed: int = 42
-    """The seed for the experiment. Default is 42."""
+    """The seed for the experiment. Defaults to 42."""
 
     device: str = "cuda:0"
-    """The device for the rl-agent. Default is cuda:0."""
+    """The device for the rl-agent. Defaults to cuda:0."""
 
     num_steps_per_env: int = MISSING
     """The number of steps per environment per update."""
@@ -288,7 +288,7 @@ class RslRlBaseRunnerCfg:
     """The experiment name."""
 
     run_name: str = ""
-    """The run name. Default is empty string.
+    """The run name. Defaults to empty string.
 
     The name of the run directory is typically the time-stamp at execution. If the run name is not empty,
     then it is appended to the run directory's name, i.e. the logging directory's name will become
@@ -296,28 +296,28 @@ class RslRlBaseRunnerCfg:
     """
 
     logger: Literal["tensorboard", "neptune", "wandb"] = "tensorboard"
-    """The logger to use. Default is tensorboard."""
+    """The logger to use. Defaults to tensorboard."""
 
     neptune_project: str = "isaaclab"
-    """The neptune project name. Default is "isaaclab"."""
+    """The neptune project name. Defaults to "isaaclab"."""
 
     wandb_project: str = "isaaclab"
-    """The wandb project name. Default is "isaaclab"."""
+    """The wandb project name. Defaults to "isaaclab"."""
 
     resume: bool = False
-    """Whether to resume a previous training. Default is False.
+    """Whether to resume a previous training. Defaults to False.
 
     This flag will be ignored for distillation.
     """
 
     load_run: str = ".*"
-    """The run directory to load. Default is ".*" (all).
+    """The run directory to load. Defaults to ".*" (all).
 
     If regex expression, the latest (alphabetical order) matching run will be loaded.
     """
 
     load_checkpoint: str = "model_.*.pt"
-    """The checkpoint file to load. Default is ``"model_.*.pt"`` (all).
+    """The checkpoint file to load. Defaults to ``"model_.*.pt"`` (all).
 
     If regex expression, the latest (alphabetical order) matching file will be loaded.
     """
@@ -328,7 +328,7 @@ class RslRlOnPolicyRunnerCfg(RslRlBaseRunnerCfg):
     """Configuration of the runner for on-policy algorithms."""
 
     class_name: str = "OnPolicyRunner"
-    """The runner class name. Default is OnPolicyRunner."""
+    """The runner class name. Defaults to OnPolicyRunner."""
 
     actor: RslRlMLPModelCfg = MISSING
     """The actor configuration."""
@@ -360,16 +360,16 @@ class RslRlPpoActorCriticCfg:
     """
 
     class_name: str = "ActorCritic"
-    """The policy class name. Default is ActorCritic."""
+    """The policy class name. Defaults to ActorCritic."""
 
     init_noise_std: float = MISSING
     """The initial noise standard deviation for the policy."""
 
     noise_std_type: Literal["scalar", "log"] = "scalar"
-    """The type of noise standard deviation for the policy. Default is scalar."""
+    """The type of noise standard deviation for the policy. Defaults to scalar."""
 
     state_dependent_std: bool = False
-    """Whether to use state-dependent standard deviation for the policy. Default is False."""
+    """Whether to use state-dependent standard deviation for the policy. Defaults to False."""
 
     actor_obs_normalization: bool = MISSING
     """Whether to normalize the observation for the actor network."""
@@ -395,7 +395,7 @@ class RslRlPpoActorCriticRecurrentCfg(RslRlPpoActorCriticCfg):
     """
 
     class_name: str = "ActorCriticRecurrent"
-    """The policy class name. Default is ActorCriticRecurrent."""
+    """The policy class name. Defaults to ActorCriticRecurrent."""
 
     rnn_type: str = MISSING
     """The type of RNN to use. Either "lstm" or "gru"."""

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rnd_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rnd_cfg.py
@@ -20,7 +20,7 @@ class RslRlRndCfg:
         """Configuration for the weight schedule."""
 
         mode: str = "constant"
-        """The type of weight schedule. Default is "constant"."""
+        """The type of weight schedule. Defaults to "constant"."""
 
     @configclass
     class LinearWeightScheduleCfg(WeightScheduleCfg):
@@ -31,6 +31,7 @@ class RslRlRndCfg:
         """
 
         mode: str = "linear"
+        """The type of weight schedule. Defaults to "linear"."""
 
         final_value: float = MISSING
         """The final value of the weight parameter."""
@@ -55,6 +56,7 @@ class RslRlRndCfg:
         """
 
         mode: str = "step"
+        """The type of weight schedule. Defaults to "step"."""
 
         final_step: int = MISSING
         """The final step of the weight schedule.
@@ -66,34 +68,34 @@ class RslRlRndCfg:
         """The final value of the weight parameter."""
 
     weight: float = 0.0
-    """The weight for the RND reward (also known as intrinsic reward). Default is 0.0.
+    """The weight for the RND reward (also known as intrinsic reward). Defaults to 0.0.
 
     Similar to other reward terms, the RND reward is scaled by this weight.
     """
 
     weight_schedule: WeightScheduleCfg | None = None
-    """The weight schedule for the RND reward. Default is None, which means the weight is constant."""
+    """The weight schedule for the RND reward. Defaults to None, which means the weight is constant."""
 
     reward_normalization: bool = False
-    """Whether to normalize the RND reward. Default is False."""
+    """Whether to normalize the RND reward. Defaults to False."""
 
     state_normalization: bool = False
-    """Whether to normalize the RND state. Default is False."""
+    """Whether to normalize the RND state. Defaults to False."""
 
     learning_rate: float = 1e-3
-    """The learning rate for the RND module. Default is 1e-3."""
+    """The learning rate for the RND module. Defaults to 1e-3."""
 
     num_outputs: int = 1
-    """The number of outputs for the RND module. Default is 1."""
+    """The number of outputs for the RND module. Defaults to 1."""
 
     predictor_hidden_dims: list[int] = [-1]
-    """The hidden dimensions for the RND predictor network. Default is [-1].
+    """The hidden dimensions for the RND predictor network. Defaults to [-1].
 
     If the list contains -1, then the hidden dimensions are the same as the input dimensions.
     """
 
     target_hidden_dims: list[int] = [-1]
-    """The hidden dimensions for the RND target network. Default is [-1].
+    """The hidden dimensions for the RND target network. Defaults to [-1].
 
     If the list contains -1, then the hidden dimensions are the same as the input dimensions.
     """

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/symmetry_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/symmetry_cfg.py
@@ -26,10 +26,10 @@ class RslRlSymmetryCfg:
     """
 
     use_data_augmentation: bool = False
-    """Whether to use symmetry-based data augmentation. Default is False."""
+    """Whether to use symmetry-based data augmentation. Defaults to False."""
 
     use_mirror_loss: bool = False
-    """Whether to use the symmetry-augmentation loss. Default is False."""
+    """Whether to use the symmetry-augmentation loss. Defaults to False."""
 
     data_augmentation_func: callable = MISSING
     """The symmetry data augmentation function.
@@ -48,4 +48,4 @@ class RslRlSymmetryCfg:
     """
 
     mirror_loss_coeff: float = 0.0
-    """The weight for the symmetry-mirror loss. Default is 0.0."""
+    """The weight for the symmetry-mirror loss. Defaults to 0.0."""

--- a/source/isaaclab_rl/isaaclab_rl/skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/skrl.py
@@ -38,7 +38,7 @@ Vectorized environment wrapper.
 
 def SkrlVecEnvWrapper(
     env: ManagerBasedRLEnv | DirectRLEnv | DirectMARLEnv,
-    ml_framework: Literal["torch", "jax", "jax-numpy"] = "torch",
+    ml_framework: Literal["torch", "jax", "warp"] = "torch",
     wrapper: Literal["auto", "isaaclab", "isaaclab-single-agent", "isaaclab-multi-agent"] = "isaaclab",
 ):
     """Wraps around Isaac Lab environment for skrl.
@@ -77,9 +77,11 @@ def SkrlVecEnvWrapper(
         from skrl.envs.wrappers.torch import wrap_env
     elif ml_framework.startswith("jax"):
         from skrl.envs.wrappers.jax import wrap_env
+    elif ml_framework.startswith("warp"):
+        from skrl.envs.wrappers.warp import wrap_env
     else:
-        ValueError(
-            f"Invalid ML framework for skrl: {ml_framework}. Available options are: 'torch', 'jax' or 'jax-numpy'"
+        raise ValueError(
+            f"Invalid ML framework for skrl: {ml_framework}. Available options are: 'torch', 'jax', 'warp'"
         )
 
     # wrap and return the environment

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -41,7 +41,7 @@ PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu128"]
 # Extra dependencies for RL agents
 EXTRAS_REQUIRE = {
     "sb3": ["stable-baselines3>=2.6", "tqdm", "rich"],  # tqdm/rich for progress bar
-    "skrl": ["skrl>=1.4.3"],
+    "skrl": ["skrl>=2.0.0"],
     "rl-games": [
         "rl-games @ git+https://github.com/isaac-sim/rl_games.git@python3.11",
         "gym",

--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.11.14"
+version = "0.11.16"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.11.15 (2026-03-07)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``Isaac-Stack-Cube-RedGreen-Franka-IK-Rel-v0``, ``Isaac-Stack-Cube-RedGreenBlue-Franka-IK-Rel-v0``,
+  ``Isaac-Stack-Cube-BlueGreen-Franka-IK-Rel-v0``, and ``Isaac-Stack-Cube-BlueGreenRed-Franka-IK-Rel-v0`` environments.
+
+
 0.11.14 (2026-02-27)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.11.16 (2026-04-21)
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Updated some agents' configuration files for the skrl library to support the new version of skrl 2.0.
+
 0.11.15 (2026-03-07)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/skrl_ippo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/skrl_ippo_cfg.yaml
@@ -54,7 +54,9 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.008
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/skrl_mappo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/skrl_mappo_cfg.yaml
@@ -28,7 +28,7 @@ models:
     clip_actions: False
     network:
       - name: net
-        input: OBSERVATIONS
+        input: STATES
         layers: [32, 32]
         activations: elu
     output: ONE
@@ -54,10 +54,10 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.008
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
   state_preprocessor: RunningStandardScaler
   state_preprocessor_kwargs: null
-  shared_state_preprocessor: RunningStandardScaler
-  shared_state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
   random_timesteps: 0

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_dance_amp_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_dance_amp_cfg.yaml
@@ -75,12 +75,14 @@ agent:
   learning_rate: 5.0e-05
   learning_rate_scheduler: null
   learning_rate_scheduler_kwargs: null
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
-  amp_state_preprocessor: RunningStandardScaler
-  amp_state_preprocessor_kwargs: null
+  amp_observation_preprocessor: RunningStandardScaler
+  amp_observation_preprocessor_kwargs: null
   random_timesteps: 0
   learning_starts: 0
   grad_norm_clip: 0.0
@@ -91,10 +93,9 @@ agent:
   value_loss_scale: 2.5
   discriminator_loss_scale: 5.0
   amp_batch_size: 512
-  task_reward_weight: 0.0
-  style_reward_weight: 1.0
+  task_reward_scale: 0.0
+  style_reward_scale: 2.0
   discriminator_batch_size: 4096
-  discriminator_reward_scale: 2.0
   discriminator_logit_regularization_scale: 0.05
   discriminator_gradient_penalty_scale: 5.0
   discriminator_weight_decay_scale: 1.0e-04

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_run_amp_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_run_amp_cfg.yaml
@@ -75,12 +75,14 @@ agent:
   learning_rate: 5.0e-05
   learning_rate_scheduler: null
   learning_rate_scheduler_kwargs: null
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
-  amp_state_preprocessor: RunningStandardScaler
-  amp_state_preprocessor_kwargs: null
+  amp_observation_preprocessor: RunningStandardScaler
+  amp_observation_preprocessor_kwargs: null
   random_timesteps: 0
   learning_starts: 0
   grad_norm_clip: 0.0
@@ -91,10 +93,9 @@ agent:
   value_loss_scale: 2.5
   discriminator_loss_scale: 5.0
   amp_batch_size: 512
-  task_reward_weight: 0.0
-  style_reward_weight: 1.0
+  task_reward_scale: 0.0
+  style_reward_scale: 2.0
   discriminator_batch_size: 4096
-  discriminator_reward_scale: 2.0
   discriminator_logit_regularization_scale: 0.05
   discriminator_gradient_penalty_scale: 5.0
   discriminator_weight_decay_scale: 1.0e-04

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_walk_amp_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_walk_amp_cfg.yaml
@@ -75,12 +75,14 @@ agent:
   learning_rate: 5.0e-05
   learning_rate_scheduler: null
   learning_rate_scheduler_kwargs: null
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
-  amp_state_preprocessor: RunningStandardScaler
-  amp_state_preprocessor_kwargs: null
+  amp_observation_preprocessor: RunningStandardScaler
+  amp_observation_preprocessor_kwargs: null
   random_timesteps: 0
   learning_starts: 0
   grad_norm_clip: 0.0
@@ -91,10 +93,9 @@ agent:
   value_loss_scale: 2.5
   discriminator_loss_scale: 5.0
   amp_batch_size: 512
-  task_reward_weight: 0.0
-  style_reward_weight: 1.0
+  task_reward_scale: 0.0
+  style_reward_scale: 2.0
   discriminator_batch_size: 4096
-  discriminator_reward_scale: 2.0
   discriminator_logit_regularization_scale: 0.05
   discriminator_gradient_penalty_scale: 5.0
   discriminator_weight_decay_scale: 1.0e-04

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/skrl_ippo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/skrl_ippo_cfg.yaml
@@ -54,7 +54,9 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.016
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/skrl_mappo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/skrl_mappo_cfg.yaml
@@ -28,7 +28,7 @@ models:
     clip_actions: False
     network:
       - name: net
-        input: OBSERVATIONS
+        input: STATES
         layers: [512, 512, 256, 128]
         activations: elu
     output: ONE
@@ -54,10 +54,10 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.016
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
   state_preprocessor: RunningStandardScaler
   state_preprocessor_kwargs: null
-  shared_state_preprocessor: RunningStandardScaler
-  shared_state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
   random_timesteps: 0

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
@@ -72,6 +72,47 @@ gym.register(
 )
 
 gym.register(
+    id="Isaac-Stack-Cube-RedGreen-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackRedGreenEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
+    id="Isaac-Stack-Cube-RedGreenBlue-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackRedGreenBlueEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+
+gym.register(
+    id="Isaac-Stack-Cube-BlueGreen-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackBlueGreenEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
+    id="Isaac-Stack-Cube-BlueGreenRed-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackBlueGreenRedEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
     id="Isaac-Stack-Cube-Franka-IK-Abs-v0",
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_env_cfg.py
@@ -10,7 +10,11 @@ from isaaclab.devices.openxr.openxr_device import OpenXRDeviceCfg
 from isaaclab.devices.openxr.retargeters.manipulator.gripper_retargeter import GripperRetargeterCfg
 from isaaclab.devices.openxr.retargeters.manipulator.se3_rel_retargeter import Se3RelRetargeterCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.utils import configclass
+
+from isaaclab_tasks.manager_based.manipulation.stack.stack_env_cfg import mdp
 
 from . import stack_joint_pos_env_cfg
 
@@ -66,4 +70,60 @@ class FrankaCubeStackEnvCfg(stack_joint_pos_env_cfg.FrankaCubeStackEnvCfg):
                     sim_device=self.sim.device,
                 ),
             }
+        )
+
+
+@configclass
+class FrankaCubeStackRedGreenEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={"cube_1_cfg": SceneEntityCfg("cube_2"), "cube_2_cfg": SceneEntityCfg("cube_3"), "cube_3_cfg": None},
+        )
+
+
+@configclass
+class FrankaCubeStackRedGreenBlueEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={
+                "cube_1_cfg": SceneEntityCfg("cube_2"),
+                "cube_2_cfg": SceneEntityCfg("cube_3"),
+                "cube_3_cfg": SceneEntityCfg("cube_1"),
+            },
+        )
+
+
+@configclass
+class FrankaCubeStackBlueGreenEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={"cube_1_cfg": SceneEntityCfg("cube_1"), "cube_2_cfg": SceneEntityCfg("cube_3"), "cube_3_cfg": None},
+        )
+
+
+@configclass
+class FrankaCubeStackBlueGreenRedEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={
+                "cube_1_cfg": SceneEntityCfg("cube_1"),
+                "cube_2_cfg": SceneEntityCfg("cube_3"),
+                "cube_3_cfg": SceneEntityCfg("cube_2"),
+            },
         )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
@@ -27,35 +27,44 @@ def cubes_stacked(
     robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
     cube_1_cfg: SceneEntityCfg = SceneEntityCfg("cube_1"),
     cube_2_cfg: SceneEntityCfg = SceneEntityCfg("cube_2"),
-    cube_3_cfg: SceneEntityCfg = SceneEntityCfg("cube_3"),
+    cube_3_cfg: SceneEntityCfg | None = SceneEntityCfg("cube_3"),
     xy_threshold: float = 0.04,
     height_threshold: float = 0.005,
     height_diff: float = 0.0468,
-    atol=0.0001,
-    rtol=0.0001,
-):
+    atol: float = 0.0001,
+    rtol: float = 0.0001,
+) -> torch.Tensor:
     robot: Articulation = env.scene[robot_cfg.name]
     cube_1: RigidObject = env.scene[cube_1_cfg.name]
     cube_2: RigidObject = env.scene[cube_2_cfg.name]
-    cube_3: RigidObject = env.scene[cube_3_cfg.name]
 
     pos_diff_c12 = cube_1.data.root_pos_w - cube_2.data.root_pos_w
-    pos_diff_c23 = cube_2.data.root_pos_w - cube_3.data.root_pos_w
 
     # Compute cube position difference in x-y plane
     xy_dist_c12 = torch.norm(pos_diff_c12[:, :2], dim=1)
-    xy_dist_c23 = torch.norm(pos_diff_c23[:, :2], dim=1)
 
     # Compute cube height difference
     h_dist_c12 = torch.norm(pos_diff_c12[:, 2:], dim=1)
-    h_dist_c23 = torch.norm(pos_diff_c23[:, 2:], dim=1)
 
     # Check cube positions
-    stacked = torch.logical_and(xy_dist_c12 < xy_threshold, xy_dist_c23 < xy_threshold)
+    stacked = xy_dist_c12 < xy_threshold
     stacked = torch.logical_and(h_dist_c12 - height_diff < height_threshold, stacked)
     stacked = torch.logical_and(pos_diff_c12[:, 2] < 0.0, stacked)
-    stacked = torch.logical_and(h_dist_c23 - height_diff < height_threshold, stacked)
-    stacked = torch.logical_and(pos_diff_c23[:, 2] < 0.0, stacked)
+
+    if cube_3_cfg is not None:
+        cube_3: RigidObject = env.scene[cube_3_cfg.name]
+        pos_diff_c23 = cube_2.data.root_pos_w - cube_3.data.root_pos_w
+
+        # Compute cube position difference in x-y plane
+        xy_dist_c23 = torch.norm(pos_diff_c23[:, :2], dim=1)
+
+        # Compute cube height difference
+        h_dist_c23 = torch.norm(pos_diff_c23[:, 2:], dim=1)
+
+        # Check cube positions
+        stacked = torch.logical_and(xy_dist_c23 < xy_threshold, stacked)
+        stacked = torch.logical_and(h_dist_c23 - height_diff < height_threshold, stacked)
+        stacked = torch.logical_and(pos_diff_c23[:, 2] < 0.0, stacked)
 
     # Check gripper positions
     if hasattr(env.scene, "surface_grippers") and len(env.scene.surface_grippers) > 0:


### PR DESCRIPTION
The Windows batch commands in the installation docs had inline comments 
using `::` which cause errors when copy-pasted:

isaaclab.bat --install :: or "isaaclab.bat -i"

The `::` is not valid as an inline comment in batch — it breaks the command.

Fix: removed the inline comments, keeping only the clean commands:

isaaclab.bat --install
isaaclab.bat --install rl_games

Fixes #5086