### PR TITLE
Adds --prerelease and --index-strategy to pip/uv install docs

### DIFF
--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -64,6 +64,7 @@ Isaac Lab sub-packages:
          uv pip install "isaaclab[isaacsim]" --index-strategy unsafe-best-match --prerelease=allow
 
          # Isaac Lab + specific sub-package(s)
+         # Note: flags above are only needed when installing the isaacsim extra
          uv pip install "isaaclab[assets]"
          uv pip install "isaaclab[rl,tasks]"
 
@@ -82,6 +83,7 @@ Isaac Lab sub-packages:
          pip install "isaaclab[isaacsim]" --extra-index-url https://pypi.nvidia.com --pre
 
          # Isaac Lab + specific sub-package(s)
+         # Note: flags above are only needed when installing the isaacsim extra
          pip install "isaaclab[assets]"
          pip install "isaaclab[rl,tasks]"
 

--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -61,14 +61,14 @@ Isaac Lab sub-packages:
          uv pip install isaaclab==3.0.0 # specific version
 
          # Isaac Lab + Isaac Sim
-         uv pip install "isaaclab[isaacsim]"
+         uv pip install "isaaclab[isaacsim]" --index-strategy unsafe-best-match --prerelease=allow
 
          # Isaac Lab + specific sub-package(s)
          uv pip install "isaaclab[assets]"
          uv pip install "isaaclab[rl,tasks]"
 
          # Isaac Lab + Isaac Sim + all sub-packages
-         uv pip install "isaaclab[isaacsim,all]"
+         uv pip install "isaaclab[isaacsim,all]" --index-strategy unsafe-best-match --prerelease=allow
 
    .. tab-item:: pip
 
@@ -79,14 +79,14 @@ Isaac Lab sub-packages:
          pip install isaaclab==3.0.0 # specific version
 
          # Isaac Lab + Isaac Sim
-         pip install "isaaclab[isaacsim]" --extra-index-url https://pypi.nvidia.com
+         pip install "isaaclab[isaacsim]" --extra-index-url https://pypi.nvidia.com --pre
 
          # Isaac Lab + specific sub-package(s)
          pip install "isaaclab[assets]"
          pip install "isaaclab[rl,tasks]"
 
          # Isaac Lab + Isaac Sim + all Isaac Lab sub-packages
-         pip install "isaaclab[isaacsim,all]" --extra-index-url https://pypi.nvidia.com
+         pip install "isaaclab[isaacsim,all]" --extra-index-url https://pypi.nvidia.com --pre
 
 Installing dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -51,7 +51,7 @@ Installing dependencies
 
    .. code-block:: bash
 
-      uv pip install "isaacsim[all,extscache]==6.0.0" --extra-index-url https://pypi.nvidia.com
+      uv pip install "isaacsim[all,extscache]==6.0.0" --extra-index-url https://pypi.nvidia.com --index-strategy unsafe-best-match --prerelease=allow
 
 -  Install a CUDA-enabled PyTorch build that matches your system architecture:
 

--- a/docs/source/setup/quickstart.rst
+++ b/docs/source/setup/quickstart.rst
@@ -98,7 +98,7 @@ and now we can install the Isaac Sim packages.
 
 .. code-block:: bash
 
-    uv pip install "isaacsim[all,extscache]==6.0.0" --extra-index-url https://pypi.nvidia.com
+    uv pip install "isaacsim[all,extscache]==6.0.0" --extra-index-url https://pypi.nvidia.com --index-strategy unsafe-best-match --prerelease=allow
 
 Finally, we can install Isaac Lab.  To start, clone the repository using the following
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ explicit = false
 # that only publish pre-release wheels (e.g. tinyobjloader==2.0.0rc13).
 [tool.uv]
 index-strategy = "unsafe-best-match"
+prerelease = "allow"
 
 [tool.uv.pip]
 index-strategy = "unsafe-best-match"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,4 +155,5 @@ explicit = false
 index-strategy = "unsafe-best-match"
 
 [tool.uv.pip]
+index-strategy = "unsafe-best-match"
 prerelease = "allow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,3 +146,13 @@ markers = [
 [[tool.uv.index]]
 url = "https://pypi.nvidia.com"
 explicit = false
+
+# Some Isaac Sim dependencies (e.g. mujoco-usd-converter, tinyobjloader) have
+# mismatched versions across pypi.nvidia.com and PyPI.  unsafe-best-match lets uv
+# resolve the correct version from any index, and prerelease=allow covers packages
+# that only publish pre-release wheels (e.g. tinyobjloader==2.0.0rc13).
+[tool.uv]
+index-strategy = "unsafe-best-match"
+
+[tool.uv.pip]
+prerelease = "allow"


### PR DESCRIPTION
## Description

When installing Isaac Sim packages via pip or uv, some dependencies have mismatched versions across pypi.nvidia.com and PyPI (`mujoco-usd-converter`), or only publish pre-release wheels (`tinyobjloader`).

This causes install failures without the right flags.

This PR adds the necessary flags to all install commands in the docs and configures the same defaults in pyproject.toml for uv users:

- `--prerelease=allow` / `--pre` to allow pre-release wheels
- `--index-strategy unsafe-best-match` to let uv resolve across indexes

## Type of change

- Documentation update


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there