### PR TITLE
fix(newton): use correct kernel launch dim in actuator effort copy

### DIFF
--- a/source/isaaclab_newton/isaaclab_newton/actuators/actuator_pd.py
+++ b/source/isaaclab_newton/isaaclab_newton/actuators/actuator_pd.py
@@ -154,7 +154,7 @@ class ImplicitActuator(ActuatorBase):
         # update the joint effort
         wp.launch(
             update_array2D_with_array2D_masked,
-            dim=(self._num_envs, self.num_joints),
+            dim=(self._num_envs, self._num_joints),
             inputs=[
                 self.data._actuator_effort_target,
                 self.data.joint_effort,
@@ -228,7 +228,7 @@ class IdealPDActuator(ActuatorBase):
         # update the joint effort
         wp.launch(
             update_array2D_with_array2D_masked,
-            dim=(self._num_envs, self.num_joints),
+            dim=(self._num_envs, self._num_joints),
             inputs=[
                 self.data._applied_effort,
                 self.data.joint_effort,


### PR DESCRIPTION
## Summary
- Fix kernel launch dimension bug in `ImplicitActuator.compute()` and `IdealPDActuator.compute()` (Newton backend)
- The `update_array2D_with_array2D_masked` kernel was launched with `self.num_joints` (group size) instead of `self._num_joints` (total joints), preventing effort from being written to joints with indices >= group size
- This caused explicit actuators (DelayedPD, IdealPD, DCMotor) to produce zero torque on most joints when multiple actuator groups are defined

## Impact
Any robot using **multiple explicit actuator groups** on the Newton backend is affected. Robots with a single actuator group (all joints in one group) are not affected, nor are robots using only implicit actuators (Newton handles PD internally).

Example: A quadruped with 4 actuator groups (rockers, hips, front_knees, rear_knees) of 4 joints each across 16 total joints. The kernel iterates `joint_index = 0..3` but `joint_mask` has True entries at positions like [6, 11, 12, 14] — these are never reached, producing zero torque.

## Fix
`self.num_joints` → `self._num_joints` on 2 lines in `source/isaaclab_newton/isaaclab_newton/actuators/actuator_pd.py`. This is consistent with the other kernel launches (`compute_pd_actuator`, `_clip_effort`) in the same methods, which already use `self._num_joints`.

## Test plan
- [ ] Verified on Artaban v0.3 quadruped (4 groups × 4 joints) — robot was collapsing with zero torque on 9/12 actuated joints, now squats correctly
- [ ] Existing CI tests should pass — the fix only affects robots with multiple explicit actuator groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)