### PR TITLE
fix: remove deprecated 'name' argument and update hardcoded shader path in spawn_preview_surface for Omniverse Kit >= 1.13.17

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -177,6 +177,7 @@ Guidelines for modifications:
 * Weihua Zhang
 * Tsz Ki GAO
 * Anke Zhao
+* Harshith Deshalli Ravi
 
 ## Acknowledgements
 

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.54.3"
+version = "0.54.4"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
@@ -65,7 +65,6 @@ def spawn_preview_surface(prim_path: str, cfg: visual_materials_cfg.PreviewSurfa
                 parent_path=prim_path,
                 identifier="UsdPreviewSurface",
                 stage_or_context=stage,
-                name="Shader",
             ).do()
             # bind the shader graph to the material
             if shader_prim:
@@ -82,7 +81,7 @@ def spawn_preview_surface(prim_path: str, cfg: visual_materials_cfg.PreviewSurfa
         raise ValueError(f"A prim already exists at path: '{prim_path}'.")
 
     # obtain prim
-    prim = stage.GetPrimAtPath(f"{prim_path}/Shader")
+    prim = stage.GetPrimAtPath(f"{prim_path}/UsdPreviewSurface")
     # check prim is valid
     if not prim.IsValid():
         raise ValueError(f"Failed to create preview surface material at path: '{prim_path}'.")


### PR DESCRIPTION
# Description

Fixes #5122

In Omniverse Kit >= 1.13.17, `CreateShaderPrimFromSdrCommand` no longer accepts 
a `name` keyword argument. This caused an immediate `TypeError` when spawning any 
primitive with a visual material (e.g., `PreviewSurfaceCfg`).

Additionally, the new API creates the shader prim under the name `UsdPreviewSurface` 
instead of `Shader`. The downstream prim lookup was hardcoded to `{prim_path}/Shader`, 
which silently failed and raised a `ValueError` even after removing the `name` argument.

This PR fixes both issues in 
`source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py`:

1. Removes the deprecated `name="Shader"` argument from `CreateShaderPrimFromSdrCommand`
2. Updates the hardcoded prim path lookup from `{prim_path}/Shader` to 
   `{prim_path}/UsdPreviewSurface` to match the new default naming behavior

**Change 1:**
```python
# Before
shader_prim = CreateShaderPrimFromSdrCommand(
    parent_path=prim_path,
    identifier="UsdPreviewSurface",
    stage_or_context=stage,
    name="Shader",  # removed in Kit >= 1.13.17
).do()

# After
shader_prim = CreateShaderPrimFromSdrCommand(
    parent_path=prim_path,
    identifier="UsdPreviewSurface",
    stage_or_context=stage,
).do()
```

**Change 2:**
```python
# Before
prim = stage.GetPrimAtPath(f"{prim_path}/Shader")

# After
prim = stage.GetPrimAtPath(f"{prim_path}/UsdPreviewSurface")
```

The fix was confirmed by inspecting the prim tree at runtime:
```
child path: /World/Objects/Cone1/geometry/material/UsdPreviewSurface, name: UsdPreviewSurface
shader_prim returned: UsdShade.Shader(Usd.Prim(</World/Objects/Cone1/geometry/material/UsdPreviewSurface>))
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there