### PR TITLE
[Newton] Fix kit-less mode and Newton v0.2.2 compatibility

### DIFF
--- a/source/isaaclab/isaaclab/envs/__init__.py
+++ b/source/isaaclab/isaaclab/envs/__init__.py
@@ -42,7 +42,12 @@ For more information about the workflow design patterns, see the `Task Design Wo
 .. _`Task Design Workflows`: https://isaac-sim.github.io/IsaacLab/source/features/task_workflows.html
 """
 
-from . import mdp, ui
+from . import mdp
+
+try:
+    from . import ui
+except ModuleNotFoundError:
+    pass
 from .common import VecEnvObs, VecEnvStepReturn, ViewerCfg
 from .direct_rl_env import DirectRLEnv
 from .direct_rl_env_cfg import DirectRLEnvCfg

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -28,7 +28,10 @@ from isaaclab.utils.timer import Timer
 
 from .common import VecEnvObs, VecEnvStepReturn
 from .direct_rl_env_cfg import DirectRLEnvCfg
-from .ui import ViewportCameraController
+try:
+    from .ui import ViewportCameraController
+except ModuleNotFoundError:
+    ViewportCameraController = None
 from .utils.spaces import sample_space, spec_to_gym_space
 
 # import logger

--- a/source/isaaclab/isaaclab/envs/direct_rl_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env_cfg.py
@@ -11,7 +11,10 @@ from isaaclab.utils import configclass
 from isaaclab.utils.noise import NoiseModelCfg
 
 from .common import SpaceType, ViewerCfg
-from .ui import BaseEnvWindow
+try:
+    from .ui import BaseEnvWindow
+except ModuleNotFoundError:
+    BaseEnvWindow = None
 
 
 @configclass

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -15,13 +15,19 @@ from isaaclab.managers import ActionManager, EventManager, ObservationManager, R
 from isaaclab.scene import InteractiveScene
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils import use_stage
-from isaaclab.ui.widgets import ManagerLiveVisualizer
+try:
+    from isaaclab.ui.widgets import ManagerLiveVisualizer
+except ModuleNotFoundError:
+    ManagerLiveVisualizer = None
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
 
 from .common import VecEnvObs
 from .manager_based_env_cfg import ManagerBasedEnvCfg
-from .ui import ViewportCameraController
+try:
+    from .ui import ViewportCameraController
+except ModuleNotFoundError:
+    ViewportCameraController = None
 from .utils.io_descriptors import export_articulations_data, export_scene_data
 
 logger = logging.getLogger(__name__)

--- a/source/isaaclab/isaaclab/envs/manager_based_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env_cfg.py
@@ -19,7 +19,10 @@ from isaaclab.sim import SimulationCfg
 from isaaclab.utils import configclass
 
 from .common import ViewerCfg
-from .ui import BaseEnvWindow
+try:
+    from .ui import BaseEnvWindow
+except ModuleNotFoundError:
+    BaseEnvWindow = None
 
 
 @configclass

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -14,7 +14,10 @@ from collections.abc import Sequence
 from typing import Any, ClassVar
 
 from isaaclab.managers import CommandManager, CurriculumManager, RewardManager, TerminationManager
-from isaaclab.ui.widgets import ManagerLiveVisualizer
+try:
+    from isaaclab.ui.widgets import ManagerLiveVisualizer
+except ModuleNotFoundError:
+    ManagerLiveVisualizer = None
 from isaaclab.utils.timer import Timer
 
 from .common import VecEnvStepReturn

--- a/source/isaaclab/isaaclab/sim/__init__.py
+++ b/source/isaaclab/isaaclab/sim/__init__.py
@@ -34,7 +34,10 @@ from .simulation_cfg import RenderCfg, SimulationCfg  # noqa: F401, F403
 from .simulation_context import SimulationContext, build_simulation_context  # noqa: F401, F403
 from .spawners import *  # noqa: F401, F403
 from .utils import *  # noqa: F401, F403
-from .views import *  # noqa: F401, F403
+try:
+    from .views import *  # noqa: F401, F403
+except ModuleNotFoundError:
+    pass
 
 # Deprecated alias for PhysxCfg -> PhysxCfg
 # This supports old code that uses `from isaaclab.sim import PhysxCfg`

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -201,6 +201,10 @@ class SimulationContext:
         """Returns whether GUI is enabled (cached at init)."""
         return self._has_gui
 
+    def has_rtx_sensors(self) -> bool:
+        """Returns whether RTX sensors are available. Always False in kit-less mode."""
+        return False
+
     @property
     def has_offscreen_render(self) -> bool:
         """Returns whether offscreen rendering is enabled (cached at init)."""

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -145,7 +145,8 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
                     import urllib.request
 
                     try:
-                        urllib.request.urlretrieve(cur_url, target_path)
+                        with urllib.request.urlopen(cur_url) as resp, open(target_path, "wb") as f:
+                            f.write(resp.read())
                     except Exception as e:
                         raise RuntimeError(f"Unable to download file: '{cur_url}'. Error: {e}")
                 else:

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -22,10 +22,21 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
-import omni.client
+try:
+    import omni.client
+
+    _OMNI_AVAILABLE = True
+except ModuleNotFoundError:
+    _OMNI_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
-from pxr import Sdf
+
+try:
+    from pxr import Sdf
+
+    _PXR_AVAILABLE = True
+except ModuleNotFoundError:
+    _PXR_AVAILABLE = False
 
 NUCLEUS_ASSET_ROOT_DIR = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/5.1"
 """Path to the root directory on the cloud storage."""
@@ -57,9 +68,19 @@ def check_file_path(path: str) -> Literal[0, 1, 2]:
     """
     if os.path.isfile(path):
         return 1
-    # we need to convert backslash to forward slash on Windows for omni.client API
-    elif omni.client.stat(path.replace(os.sep, "/"))[0] == omni.client.Result.OK:
+    elif _OMNI_AVAILABLE and omni.client.stat(path.replace(os.sep, "/"))[0] == omni.client.Result.OK:
         return 2
+    elif not _OMNI_AVAILABLE and path.startswith(("http://", "https://")):
+        import urllib.request
+
+        try:
+            req = urllib.request.Request(path, method="HEAD")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                if resp.status == 200:
+                    return 2
+        except Exception:
+            pass
+        return 0
     else:
         return 0
 
@@ -116,9 +137,19 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
             os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
             if not os.path.isfile(target_path) or force_download:
-                result = omni.client.copy(cur_url, target_path, omni.client.CopyBehavior.OVERWRITE)
-                if result != omni.client.Result.OK and force_download:
-                    raise RuntimeError(f"Unable to copy file: '{cur_url}'. Is the Nucleus Server running?")
+                if _OMNI_AVAILABLE:
+                    result = omni.client.copy(cur_url, target_path, omni.client.CopyBehavior.OVERWRITE)
+                    if result != omni.client.Result.OK and force_download:
+                        raise RuntimeError(f"Unable to copy file: '{cur_url}'. Is the Nucleus Server running?")
+                elif cur_url.startswith(("http://", "https://")):
+                    import urllib.request
+
+                    try:
+                        urllib.request.urlretrieve(cur_url, target_path)
+                    except Exception as e:
+                        raise RuntimeError(f"Unable to download file: '{cur_url}'. Error: {e}")
+                else:
+                    raise RuntimeError(f"Unable to copy file: '{cur_url}'. omni.client not available.")
 
             if local_root is None:
                 local_root = target_path
@@ -153,8 +184,14 @@ def read_file(path: str) -> io.BytesIO:
         with open(path, "rb") as f:
             return io.BytesIO(f.read())
     elif file_status == 2:
-        file_content = omni.client.read_file(path.replace(os.sep, "/"))[2]
-        return io.BytesIO(memoryview(file_content).tobytes())
+        if _OMNI_AVAILABLE:
+            file_content = omni.client.read_file(path.replace(os.sep, "/"))[2]
+            return io.BytesIO(memoryview(file_content).tobytes())
+        else:
+            import urllib.request
+
+            with urllib.request.urlopen(path) as resp:
+                return io.BytesIO(resp.read())
     else:
         raise FileNotFoundError(f"Unable to find the file: {path}")
 
@@ -176,6 +213,8 @@ def _is_downloadable_asset(path: str) -> bool:
 
 def _find_usd_references(local_usd_path: str) -> set[str]:
     """Use Sdf API to collect referenced assets from a USD layer."""
+    if not _PXR_AVAILABLE:
+        return set()
     try:
         layer = Sdf.Layer.FindOrOpen(local_usd_path)
     except Exception:

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -40,8 +40,6 @@ INSTALL_REQUIRES = [
     "pillow==11.2.1",
     # livestream
     "starlette==0.45.3",
-    # assets
-    "omniverseclient",
     # testing
     "pytest",
     "pytest-mock",

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
@@ -677,7 +677,7 @@ class DirectRLEnvWarp(gym.Env):
             env_ids: List of environment ids which must be reset
         """
 
-        self.scene.reset(env_ids=None, mask=mask)
+        self.scene.reset(env_ids=None, env_mask=mask)
 
         # apply events such as randomization for environments that need a reset
         # if self.cfg.events:

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
@@ -28,12 +28,18 @@ import warp as wp
 
 from isaaclab.envs.common import VecEnvObs
 from isaaclab.envs.manager_based_env_cfg import ManagerBasedEnvCfg
-from isaaclab.envs.ui import ViewportCameraController
+try:
+    from isaaclab.envs.ui import ViewportCameraController
+except ModuleNotFoundError:
+    ViewportCameraController = None
 from isaaclab.envs.utils.io_descriptors import export_articulations_data, export_scene_data
 from isaaclab.scene import InteractiveScene
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils import use_stage
-from isaaclab.ui.widgets import ManagerLiveVisualizer
+try:
+    from isaaclab.ui.widgets import ManagerLiveVisualizer
+except ModuleNotFoundError:
+    ManagerLiveVisualizer = None
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
 from isaaclab.utils.warp.utils import resolve_1d_mask

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_rl_env_warp.py
@@ -25,7 +25,10 @@ from isaaclab_experimental.utils.torch_utils import clone_obs_buffer
 
 from isaaclab.envs.common import VecEnvStepReturn
 from isaaclab.envs.manager_based_rl_env_cfg import ManagerBasedRLEnvCfg
-from isaaclab.ui.widgets import ManagerLiveVisualizer
+try:
+    from isaaclab.ui.widgets import ManagerLiveVisualizer
+except ModuleNotFoundError:
+    ManagerLiveVisualizer = None
 from isaaclab.utils.timer import Timer
 
 from .manager_based_env_warp import ManagerBasedEnvWarp, ManagerCallMode

--- a/source/isaaclab_experimental/setup.py
+++ b/source/isaaclab_experimental/setup.py
@@ -19,7 +19,7 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 INSTALL_REQUIRES = [
     # generic
     "numpy>2",
-    "warp-lang>=1.9.0.dev20250825",  # TODO: update to 1.11.0
+    "warp-lang==1.11.1",
     "torch>=2.7",
     "prettytable==3.3.0",
     "toml",

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -2240,16 +2240,19 @@ class ArticulationData(BaseArticulationData):
         n_dof = self._root_view.joint_dof_count
 
         # -- root properties
+        root_transforms = self._root_view.get_root_transforms(NewtonManager.get_state_0())
         if self._root_view.is_fixed_base:
-            self._sim_bind_root_link_pose_w = self._root_view.get_root_transforms(NewtonManager.get_state_0())[:, 0, 0]
+            self._sim_bind_root_link_pose_w = root_transforms[(slice(None),) + (0,) * (root_transforms.ndim - 1)]
         else:
-            self._sim_bind_root_link_pose_w = self._root_view.get_root_transforms(NewtonManager.get_state_0())[:, 0]
-        self._sim_bind_root_com_vel_w = self._root_view.get_root_velocities(NewtonManager.get_state_0())
-        if self._sim_bind_root_com_vel_w is not None:
+            self._sim_bind_root_link_pose_w = root_transforms[:, 0] if root_transforms.ndim > 1 else root_transforms
+        root_velocities = self._root_view.get_root_velocities(NewtonManager.get_state_0())
+        if root_velocities is not None:
             if self._root_view.is_fixed_base:
-                self._sim_bind_root_com_vel_w = self._sim_bind_root_com_vel_w[:, 0, 0]
+                self._sim_bind_root_com_vel_w = root_velocities[(slice(None),) + (0,) * (root_velocities.ndim - 1)]
             else:
-                self._sim_bind_root_com_vel_w = self._sim_bind_root_com_vel_w[:, 0]
+                self._sim_bind_root_com_vel_w = root_velocities[:, 0] if root_velocities.ndim > 1 else root_velocities
+        else:
+            self._sim_bind_root_com_vel_w = None
         # -- body properties
         self._sim_bind_body_com_pos_b = self._root_view.get_attribute("body_com", NewtonManager.get_model())[:, 0]
         self._sim_bind_body_link_pose_w = self._root_view.get_link_transforms(NewtonManager.get_state_0())[:, 0]

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -27,7 +27,7 @@ INSTALL_REQUIRES = [
     # newton
     "mujoco>=3.5.0",
     "mujoco-warp>=3.5.0",
-    "newton @ git+https://github.com/newton-physics/newton.git@51ce35e8def843377546764033edc33a0b479d65",
+    "newton @ git+https://github.com/newton-physics/newton.git@v0.2.2",
     "imgui-bundle==1.92.0",
     "PyOpenGL-accelerate==3.1.10",
 ]

--- a/source/isaaclab_tasks_experimental/setup.py
+++ b/source/isaaclab_tasks_experimental/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = [
     # generic
     "numpy>2",
     "torch>=2.7",
-    "warp-lang>=1.9.0.dev20250825",  # TODO: update to 1.11.0
+    "warp-lang==1.11.1",
     "torchvision>=0.14.1",  # ensure compatibility with torch 1.13.1
     "protobuf>=3.20.2,!=5.26.0",
     # basic logger


### PR DESCRIPTION
The `dev/newton` branch supports running Isaac Lab without Omniverse (kit-less mode using the Newton physics backend), but several issues prevent it from working outside of Isaac Sim's bundled Python environment. Two fixes:

- Guard unconditional `import omni` statements that crash at import time when Omniverse is not installed. Add HTTPS fallback for downloading S3-hosted USD assets without `omni.client`. Remove `omniverseclient` from `setup.py` (never imported). Fix stale `warp-lang` dev pins.
- Pin Newton to v0.2.2 (the pinned commit `51ce35e8` lacks `body_label` used by `newton_replicate.py`). Fix API mismatches: `articulation_data.py` tensor indexing, `direct_rl_env_warp.py` kwarg name (`mask` -> `env_mask`), add `has_rtx_sensors()` stub.

All changes are backwards-compatible - when Omniverse is available, behavior is unchanged.

## Context

The Newton kit-less mode is a key feature of Isaac Lab 3.0 Beta, but the `dev/newton` branch currently crashes on import without Omniverse installed. These fixes enable headless RL training on HPC clusters using only CUDA (no Omniverse/Isaac Sim).

Tested environments (training + Newton OpenGL visualization):
- `Isaac-Cartpole-Direct-Warp-v0` (direct workflow)
- `Isaac-Reach-Franka-Warp-v0` (manager-based warp workflow)
- `Isaac-Open-Drawer-Franka-v0` (manager-based standard workflow)
