### PR TITLE
Fixes false conflict error for aliased global presets in Hydra

### DIFF
--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "1.5.15"
+version = "1.5.17"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+1.5.17 (2026-03-30)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab_tasks.utils.hydra.apply_overrides` raising a false
+  conflict error when two global presets resolve to the same value for a path
+  (e.g. ``newton`` aliased to ``cube``).
+
+
 1.5.16 (2026-03-24)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -392,7 +392,7 @@ def apply_overrides(
         full_path = f"{sec}.{path}" if path else sec
         resolved[full_path] = (sec, path, name)
 
-    # Apply global presets (error on conflict)
+    # Apply global presets (error on real conflict — same path, different value)
     applied_by: dict[str, str] = {}
     for name in global_presets:
         for sec in ("env", "agent"):
@@ -400,11 +400,16 @@ def apply_overrides(
                 if name in path_presets:
                     full_path = f"{sec}.{path}" if path else sec
                     if full_path in applied_by:
-                        raise ValueError(
-                            f"Conflicting global presets: '{applied_by[full_path]}' and '{name}' "
-                            f"both define preset for '{full_path}'"
-                        )
-                    applied_by[full_path] = name
+                        prev_name = applied_by[full_path]
+                        prev_val = path_presets[prev_name]
+                        cur_val = path_presets[name]
+                        if prev_val is not cur_val and prev_val != cur_val:
+                            raise ValueError(
+                                f"Conflicting global presets: '{prev_name}' and '{name}' "
+                                f"both define preset for '{full_path}'"
+                            )
+                    else:
+                        applied_by[full_path] = name
                     if full_path not in resolved:
                         resolved[full_path] = (sec, path, name)
 

--- a/source/isaaclab_tasks/test/test_hydra.py
+++ b/source/isaaclab_tasks/test/test_hydra.py
@@ -983,6 +983,40 @@ def test_apply_overrides_conflicting_globals_raises():
         apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["opt_a", "opt_b"], [], [], presets)
 
 
+def test_apply_overrides_aliased_globals_no_conflict():
+    """Two global presets resolving to equal values do not raise.
+
+    Mirrors the dexsuite ObjectCfg pattern where ``newton = cube`` creates
+    separate but equal dataclass instances after @configclass processing.
+    """
+
+    @configclass
+    class SharedCfg:
+        value: int = 42
+
+    cube_val = SharedCfg()
+    newton_val = SharedCfg()
+
+    @configclass
+    class AliasedPresetCfg(PresetCfg):
+        default: str = "d"
+        cube: SharedCfg = cube_val
+        newton: SharedCfg = newton_val
+
+    @configclass
+    class AliasedEnvCfg:
+        mode: AliasedPresetCfg = AliasedPresetCfg()
+
+    env_cfg = AliasedEnvCfg()
+    agent_cfg = PresetCfgAgentCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
+    assert presets["env"]["mode"]["cube"] is not presets["env"]["mode"]["newton"]
+    assert presets["env"]["mode"]["cube"] == presets["env"]["mode"]["newton"]
+    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
+    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["cube", "newton"], [], [], presets)
+    assert env_cfg.mode == SharedCfg()
+
+
 # =============================================================================
 # Tests: parse_overrides edge cases
 # =============================================================================


### PR DESCRIPTION
# Description

 Fixed :func:`~isaaclab_tasks.utils.hydra.apply_overrides` raising a false conflict error when two global presets resolve to the same value for a path (e.g. ``newton`` aliased to ``cube``).


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
