### PR TITLE
Updated to latest newton/main version

### DIFF
--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -46,8 +46,8 @@ class RenderData:
         normals_image: wp.array(dtype=wp.vec3f, ndim=4) = None
         instance_segmentation_image: wp.array(dtype=wp.uint32, ndim=4) = None
 
-    def __init__(self, render_context: newton.sensors.SensorTiledCamera.RenderContext, sensor: SensorBase):
-        self.render_context = render_context
+    def __init__(self, newton_sensor: newton.sensors.SensorTiledCamera, sensor: SensorBase):
+        self.newton_sensor = newton_sensor
 
         # Currently camera owns the renderer and render data. By holding full
         # reference of the sensor, we create a circular reference between the
@@ -98,20 +98,20 @@ class RenderData:
         )
 
         self.camera_transforms = wp.empty(
-            (1, self.render_context.world_count), dtype=wp.transformf, device=self.render_context.device
+            (1, self.newton_sensor.model.world_count), dtype=wp.transformf, device=self.newton_sensor.model.device
         )
         wp.launch(
             RenderData._update_transforms,
-            self.render_context.world_count,
+            self.newton_sensor.model.world_count,
             [positions, converted_orientations, self.camera_transforms],
-            device=self.render_context.device,
+            device=self.newton_sensor.model.device,
         )
 
-        if self.render_context is not None:
+        if self.camera_rays is None:
             first_focal_length = intrinsics[:, 1, 1][0:1]
             fov_radians_all = 2.0 * torch.atan(self.height / (2.0 * first_focal_length))
 
-            self.camera_rays = self.render_context.utils.compute_pinhole_camera_rays(
+            self.camera_rays = self.newton_sensor.utils.compute_pinhole_camera_rays(
                 self.width, self.height, wp.from_torch(fov_radians_all, dtype=wp.float32)
             )
 
@@ -121,14 +121,14 @@ class RenderData:
             return wp.array(
                 ptr=torch_array.ptr,
                 dtype=dtype,
-                shape=(self.render_context.world_count, self.num_cameras, self.height, self.width),
+                shape=(self.newton_sensor.model.world_count, self.num_cameras, self.height, self.width),
                 device=torch_array.device,
                 copy=False,
             )
 
         logger.warning("NewtonWarpRenderer - torch output array is non-contiguous")
         return wp.zeros(
-            (self.render_context.world_count, self.num_cameras, self.height, self.width),
+            (self.newton_sensor.model.world_count, self.num_cameras, self.height, self.width),
             dtype=dtype,
             device=torch_array.device,
         )
@@ -169,6 +169,7 @@ class NewtonWarpRenderer(BaseRenderer):
                 "(e.g., unsupported PhysX schemas such as tendons). "
                 "Check the log for earlier Newton model build errors."
             )
+
         self.newton_sensor = newton.sensors.SensorTiledCamera(newton_model)
 
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
@@ -179,7 +180,7 @@ class NewtonWarpRenderer(BaseRenderer):
     def create_render_data(self, sensor: SensorBase) -> RenderData:
         """Create render data for the Newton tiled camera.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.create_render_data`."""
-        return RenderData(self.newton_sensor.render_context, sensor)
+        return RenderData(self.newton_sensor, sensor)
 
     def set_outputs(self, render_data: RenderData, output_data: dict[str, torch.Tensor]):
         """Store output buffers. See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.set_outputs`."""

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -45,7 +45,7 @@ EXTRAS_REQUIRE = {
         "mujoco==3.5.0",
         "mujoco-warp==3.5.0.2",
         "PyOpenGL-accelerate==3.1.10",
-        "newton==1.0.0",
+        "newton @ git+https://github.com/newton-physics/newton.git@2684d75bfa4bb8b058a93b81c458a74b7701c997",
     ],
 }
 


### PR DESCRIPTION
## Summary

- **Pin the `newton` dependency to commit [`2684d75`](https://github.com/newton-physics/newton.git/commit/2684d75bfa4bb8b058a93b81c458a74b7701c997)** across all dependency manifests (`setup.py`), replacing the previous `newton==1.0.0` PyPI pin.
- **Adapt `NewtonWarpRenderer` to upstream API changes.** The newton library replaced `SensorTiledCamera.RenderContext` with direct access via the `SensorTiledCamera` object. `RenderData` now holds a reference to the `newton_sensor` instead of the removed `render_context`, and attribute accesses (`world_count`, `device`, `utils`) are updated accordingly.

## Test Plan

- [x] CLI install unit tests pass (14/14)
- [x] Newton mock interface tests pass (46/46)
- [ ] Run `./isaaclab.sh --install` in a clean environment and verify `newton` resolves to commit `2684d75`
- [ ] Verify `NewtonWarpRenderer` initializes correctly with a tiled camera sensor in a Newton simulation