### PR TITLE
Updates Newton Renderer Cfg to include qualitative settings

### DIFF
--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -170,7 +170,19 @@ class NewtonWarpRenderer(BaseRenderer):
                 "Check the log for earlier Newton model build errors."
             )
 
-        self.newton_sensor = newton.sensors.SensorTiledCamera(newton_model)
+        self.newton_sensor = newton.sensors.SensorTiledCamera(
+            newton_model,
+            config=newton.sensors.SensorTiledCamera.RenderConfig(
+                enable_textures=cfg.enable_textures,
+                enable_shadows=cfg.enable_shadows,
+                enable_ambient_lighting=cfg.enable_ambient_lighting,
+                enable_backface_culling=cfg.enable_backface_culling,
+                max_distance=cfg.max_distance,
+            ),
+        )
+
+        if cfg.create_default_light:
+            self.newton_sensor.utils.create_default_light(enable_shadows=cfg.enable_shadows)
 
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """No-op for Newton Warp - uses Newton scene directly without stage export.

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
@@ -32,4 +32,4 @@ class NewtonWarpRendererCfg(RendererCfg):
     """Maximum ray distance [m]."""
 
     create_default_light: bool = True
-    """Create default light."""
+    """Create a default directional light source in the scene."""

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
@@ -15,3 +15,21 @@ class NewtonWarpRendererCfg(RendererCfg):
 
     renderer_type: str = "newton_warp"
     """Type identifier for Newton Warp renderer."""
+
+    enable_textures: bool = True
+    """Enable texture-mapped rendering for meshes."""
+
+    enable_shadows: bool = False
+    """Enable shadow rays for directional lights."""
+
+    enable_ambient_lighting: bool = True
+    """Enable ambient lighting for the scene."""
+
+    enable_backface_culling: bool = True
+    """Cull back-facing triangles."""
+
+    max_distance: float = 1000.0
+    """Maximum ray distance [m]."""
+
+    create_default_light: bool = True
+    """Create default light."""


### PR DESCRIPTION
## Summary

Expose Newton Warp renderer settings through `NewtonWarpRendererCfg` so users can configure rendering behavior (textures, shadows, lighting, culling, ray distance) without modifying source code. Previously `SensorTiledCamera` was constructed with no configuration, using only Newton's internal defaults.

## Changes

**`NewtonWarpRendererCfg`** (`newton_warp_renderer_cfg.py`)

Added 6 configurable fields with sensible defaults:

| Field | Type | Default | Description |
|---|---|---|---|
| `enable_textures` | `bool` | `True` | Texture-mapped rendering for meshes |
| `enable_shadows` | `bool` | `False` | Shadow rays for directional lights |
| `enable_ambient_lighting` | `bool` | `True` | Ambient lighting for the scene |
| `enable_backface_culling` | `bool` | `True` | Cull back-facing triangles |
| `max_distance` | `float` | `1000.0` | Maximum ray distance [m] |
| `create_default_light` | `bool` | `True` | Create a default light source |

**`NewtonWarpRenderer`** (`newton_warp_renderer.py`)

- Passes cfg fields into `SensorTiledCamera.RenderConfig(...)` at construction instead of using a bare `SensorTiledCamera(newton_model)` call.
- When `cfg.create_default_light` is `True`, creates a default light via `newton_sensor.utils.create_default_light()`, respecting the shadow setting.

## Test plan

- [ ] Verify default behavior is unchanged (all defaults match Newton's previous implicit behavior).
- [ ] Test toggling each setting individually (e.g., `enable_shadows=True`, `enable_textures=False`) and confirm the rendered output reflects the change.
- [ ] Confirm `create_default_light=False` produces an unlit scene (no automatic light added).
- [ ] Validate `max_distance` correctly limits ray tracing range.