### PR TITLE
Simplify preset resolution with single-pass resolve_presets

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -209,6 +209,10 @@ autodoc_mock_imports = [
     "mpl_toolkits",
     "isaacteleop",
     "scipy",
+    "hydra",
+    "hydra.core",
+    "hydra.core.config_store",
+    "omegaconf",
 ]
 
 # List of zero or more Sphinx-specific warning categories to be squelched (i.e.,

--- a/source/isaaclab/test/envs/test_manager_based_rl_env_obs_spaces.py
+++ b/source/isaaclab/test/envs/test_manager_based_rl_env_obs_spaces.py
@@ -120,9 +120,9 @@ def test_obs_space_follows_clip_contraint(env_cfg_cls, device):
     sim_utils.create_new_stage()
 
     # configure the env -- resolve Hydra presets so _Preset fields become plain values
-    from isaaclab_tasks.utils.hydra import resolve_preset_defaults
+    from isaaclab_tasks.utils.hydra import resolve_presets
 
-    env_cfg = resolve_preset_defaults(env_cfg_cls())
+    env_cfg = resolve_presets(env_cfg_cls())
     env_cfg.scene.num_envs = 2  # keep num_envs small for testing
     env_cfg.observations.policy.concatenate_terms = False
     env_cfg.sim.device = device

--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "1.5.20"
+version = "1.5.21"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -10,11 +10,19 @@ Changed
 * Replaced ``resolve_preset_defaults`` with :func:`~isaaclab_tasks.utils.hydra.resolve_presets`
   which resolves all presets in one pass with CLI selection support.
 
+Added
+^^^^^
+
+* Unknown preset names now raise ``ValueError`` with a grouped listing of all
+  available presets and the config paths they affect.
+
 Fixed
 ^^^^^
 
 * Fixed presets inside dict-valued alternatives and ``PresetCfg(default=None)``
   not being discovered or resolved, causing wrong defaults in deeply nested configs.
+* Unresolvable ``PresetCfg`` (no ``default``, no matching selection) now raises
+  ``ValueError`` instead of silently lingering in the config tree.
 
 
 1.5.20 (2026-04-06)

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+1.5.21 (2026-04-13)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Replaced ``resolve_preset_defaults`` with :func:`~isaaclab_tasks.utils.hydra.resolve_presets`
+  which resolves all presets in one pass with CLI selection support.
+
+Fixed
+^^^^^
+
+* Fixed presets inside dict-valued alternatives and ``PresetCfg(default=None)``
+  not being discovered or resolved, causing wrong defaults in deeply nested configs.
+
+
 1.5.20 (2026-04-06)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
@@ -12,14 +12,13 @@ __all__ = [
     "preset",
     "resolve_task_config",
     "hydra_task_config",
-    "resolve_preset_defaults",
+    "resolve_presets",
     "add_launcher_args",
     "launch_simulation",
     "compute_kit_requirements",
 ]
 
-from .hydra import PresetCfg, preset, hydra_task_config, resolve_task_config
+from .hydra import PresetCfg, preset, hydra_task_config, resolve_task_config, resolve_presets
 from .importer import import_packages
 from .parse_cfg import get_checkpoint_path, load_cfg_from_registry, parse_env_cfg
-from .hydra import resolve_task_config, hydra_task_config, resolve_preset_defaults
 from .sim_launcher import add_launcher_args, launch_simulation, compute_kit_requirements

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -38,8 +38,6 @@ except ImportError:
 from isaaclab.envs.utils.spaces import replace_env_cfg_spaces_with_strings, replace_strings_with_env_cfg_spaces
 from isaaclab.utils import configclass, replace_slices_with_strings, replace_strings_with_slices
 
-from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
-
 
 @configclass
 class PresetCfg:
@@ -152,6 +150,10 @@ def collect_presets(cfg, path: str = "") -> dict:
         for alt in fields.values():
             if hasattr(alt, "__dataclass_fields__"):
                 result.update(collect_presets(alt, preset_path))
+            elif isinstance(alt, dict):
+                for v in alt.values():
+                    if hasattr(v, "__dataclass_fields__"):
+                        result.update(collect_presets(v, preset_path))
 
     if isinstance(cfg, PresetCfg):
         _record(cfg, path)
@@ -159,6 +161,74 @@ def collect_presets(cfg, path: str = "") -> dict:
 
     _walk_cfg(cfg, path, lambda _p, _k, obj, cp: _record(obj, cp))
     return result
+
+
+# ============================================================================
+# Preset resolution
+# ============================================================================
+
+
+def _pick_alternative(preset_obj: PresetCfg, selected: set[str]):
+    """Choose the best alternative from a PresetCfg.
+
+    Priority: first match in ``selected``, then ``default`` (preferring
+    class-level over instance-level).  Returns the chosen value, or the
+    preset object itself if nothing matches.
+    """
+    fields = _preset_fields(preset_obj)
+    for name in selected:
+        if name in fields:
+            return fields[name]
+    if "default" in fields:
+        return fields["default"]
+    return preset_obj
+
+
+def resolve_presets(cfg, selected: set[str] = frozenset()):
+    """Replace every :class:`PresetCfg` in the tree with the best alternative.
+
+    For each ``PresetCfg`` found during a depth-first walk:
+
+    1. Pick the first name from *selected* that exists as a field on the
+       preset, otherwise fall back to ``default``.
+    2. Replace the preset in its parent (dict key or dataclass attr).
+    3. Continue walking the replacement (which may contain more presets).
+
+    Args:
+        cfg: A configclass, dict, or PresetCfg to resolve in-place.
+        selected: Set of preset names chosen by the user (e.g. from CLI
+            ``presets=peg_insert_4mm,eval``).
+
+    Returns:
+        The resolved ``cfg`` (possibly a different object if the root itself
+        was a PresetCfg).
+    """
+    if isinstance(cfg, PresetCfg):
+        replacement = _pick_alternative(cfg, selected)
+        if replacement is cfg:
+            return cfg
+        return resolve_presets(replacement, selected)
+
+    def _resolve(parent, key, preset_obj, _path):
+        val = _pick_alternative(preset_obj, selected)
+        if val is preset_obj:
+            return
+        while isinstance(val, PresetCfg):
+            val = _pick_alternative(val, selected)
+        if isinstance(parent, dict):
+            parent[key] = val
+        else:
+            setattr(parent, key, val)
+        if hasattr(val, "__dataclass_fields__") or isinstance(val, dict):
+            _walk_cfg(val, _path, _resolve)
+
+    _walk_cfg(cfg, "", _resolve)
+    return cfg
+
+
+# ============================================================================
+# CLI / Hydra integration
+# ============================================================================
 
 
 def _run_hydra(task, env_cfg, agent_cfg, presets, callback):
@@ -189,7 +259,7 @@ def _run_hydra(task, env_cfg, agent_cfg, presets, callback):
 def resolve_task_config(task_name: str, agent_cfg_entry_point: str):
     """Resolve env and agent configs with Hydra overrides, presets, and scalars fully applied.
 
-    Safe to call before Kit is launched — callable config values are stored as
+    Safe to call before Kit is launched -- callable config values are stored as
     :class:`~isaaclab.utils.string.ResolvableString` and resolved lazily on
     first use, so no implementation modules are imported eagerly.
 
@@ -230,32 +300,6 @@ def hydra_task_config(task_name: str, agent_cfg_entry_point: str) -> Callable:
     return decorator
 
 
-def resolve_preset_defaults(cfg):
-    """Replace PresetCfg fields with their ``default`` value, recursively.
-
-    Must be called before ``to_dict()`` so the Hydra dict contains only the
-    resolved config rather than the raw PresetCfg with all alternatives.
-    Returns the (possibly replaced) cfg if the root itself is a PresetCfg.
-    """
-    if isinstance(cfg, PresetCfg):
-        default = getattr(cfg, "default", None)
-        return resolve_preset_defaults(default) if default is not None else cfg
-
-    def _on_preset(parent, key, preset_obj, _path):
-        default = getattr(preset_obj, "default", None)
-        if default is None:
-            return
-        if isinstance(parent, dict):
-            parent[key] = default
-        else:
-            setattr(parent, key, default)
-        if hasattr(default, "__dataclass_fields__"):
-            resolve_preset_defaults(default)
-
-    _walk_cfg(cfg, "", _on_preset)
-    return cfg
-
-
 def register_task(task_name: str, agent_entry: str) -> tuple:
     """Load configs, collect presets recursively, register base config to Hydra.
 
@@ -266,22 +310,36 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
         (env_cfg, agent_cfg, presets) where presets =
         {"env": {"path": {"name": cfg}}, "agent": {...}}
     """
+    from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
+
     env_cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
     agent_cfg = None
     if agent_entry:
         agent_cfg = load_cfg_from_registry(task_name, agent_entry)
 
-    # Collect presets recursively from the config tree
+    # Collect presets before resolution (needed for path-based overrides)
     presets = {
         "env": collect_presets(env_cfg),
         "agent": collect_presets(agent_cfg) if agent_cfg else {},
     }
 
-    # Resolve PresetCfg defaults before serialization so to_dict() doesn't
-    # include all preset alternatives in the hydra dict.
-    env_cfg = resolve_preset_defaults(env_cfg)
+    # Extract global preset names from CLI, then resolve in one pass
+    selected: set[str] = set()
+    for arg in sys.argv[1:]:
+        if "=" in arg:
+            key, val = arg.split("=", 1)
+            if key.lstrip("-") == "presets":
+                selected.update(v.strip() for v in val.split(",") if v.strip())
+    env_cfg = resolve_presets(env_cfg, selected)
     if agent_cfg is not None:
-        agent_cfg = resolve_preset_defaults(agent_cfg)
+        agent_cfg = resolve_presets(agent_cfg, selected)
+
+    # Also resolve presets inside collected alternatives so that apply_overrides
+    # never re-introduces unresolved PresetCfg objects when applying a selection.
+    for section_presets in presets.values():
+        for path_presets in section_presets.values():
+            for name, alt in path_presets.items():
+                resolve_presets(alt, selected)
 
     # Convert to dict for Hydra (handle gym spaces and slices)
     env_cfg = replace_env_cfg_spaces_with_strings(env_cfg)
@@ -311,8 +369,6 @@ def parse_overrides(args: list[str], presets: dict) -> tuple:
         - preset_scalar: [(full_path, value), ...] - scalars in preset paths
         - global_scalar: [arg, ...] - pass to Hydra
     """
-    # Build lookup of preset group paths (e.g., "env.actions").
-    # Root-level PresetCfg has path="" -> bare "env" or "agent" key.
     preset_paths = {f"{s}.{p}" if p else s for s, v in presets.items() for p in v}
     global_presets, preset_sel, preset_scalar, global_scalar = [], [], [], []
 
@@ -346,13 +402,14 @@ def apply_overrides(
 ):
     """Apply preset selections and scalar overrides with REPLACE semantics.
 
-    Phase 1: Determine the selected preset name for every path (explicit
-    selections, then global broadcasts, then ``default`` fallback).
-    Phase 2: Apply in depth order, pruning children whose parent is None.
-    Phase 3: Apply scalar overrides on top.
+    Global presets are already applied by :func:`resolve_presets` in
+    :func:`register_task`. This function handles:
+
+    1. Path-based selections (``env.backend=newton``)
+    2. Scalar overrides within preset paths (``env.backend.dt=0.001``)
 
     Returns:
-        (env_cfg, agent_cfg) — possibly replaced if root-level PresetCfg was resolved.
+        (env_cfg, agent_cfg) -- possibly replaced if root-level PresetCfg was resolved.
 
     Raises:
         ValueError: If multiple global presets conflict on the same path.
@@ -381,7 +438,7 @@ def apply_overrides(
             _setattr(cfgs[sec], path, node)
             _setattr(hydra_cfg, f"{sec}.{path}", node_dict)
 
-    # --- Phase 1: Determine selected preset name for every path ---------------
+    # --- Phase 1: path-based selections + global broadcast for reachable paths
     resolved: dict[str, tuple[str, str, str]] = {}
     for sec, path, name in preset_sel:
         if path not in presets.get(sec, {}):
@@ -392,7 +449,6 @@ def apply_overrides(
         full_path = f"{sec}.{path}" if path else sec
         resolved[full_path] = (sec, path, name)
 
-    # Apply global presets (error on real conflict — same path, different value)
     applied_by: dict[str, str] = {}
     for name in global_presets:
         for sec in ("env", "agent"):
@@ -413,20 +469,19 @@ def apply_overrides(
                     if full_path not in resolved:
                         resolved[full_path] = (sec, path, name)
 
-    # Fill remaining paths with "default" (if available)
     for sec in ("env", "agent"):
         for path, path_presets in presets.get(sec, {}).items():
             full_path = f"{sec}.{path}" if path else sec
             if full_path not in resolved and "default" in path_presets:
                 resolved[full_path] = (sec, path, "default")
 
-    # --- Phase 2: Apply in depth order, pruning unreachable children ----------
+    # --- Phase 2: apply in depth order, pruning unreachable children
     for full_path in sorted(resolved, key=lambda fp: fp.count(".")):
         sec, path, name = resolved[full_path]
         if cfgs[sec] is not None and _path_reachable(sec, path):
             _apply_node(sec, path, presets[sec][path][name])
 
-    # 3. Apply scalar overrides within preset paths
+    # --- Phase 3: scalar overrides within preset paths
     for full_path, val_str in preset_scalar:
         if full_path.startswith("env."):
             sec, path = "env", full_path[4:]
@@ -465,7 +520,6 @@ def _parse_val(s: str):
     try:
         return float(s) if "." in s else int(s)
     except ValueError:
-        # Strip quotes if present
         if s[0] in "\"'" and s[-1] in "\"'":
             return s[1:-1]
         return s

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -218,12 +218,28 @@ def resolve_presets(cfg, selected: set[str] = frozenset()):
         was a PresetCfg).
     """
     if isinstance(cfg, PresetCfg):
+        seen: set[int] = {id(cfg)}
         replacement = _pick_alternative(cfg, selected, path="<root>")
+        while isinstance(replacement, PresetCfg):
+            if id(replacement) in seen:
+                raise ValueError(
+                    f"Cyclic PresetCfg chain detected at '<root>': "
+                    f"{type(replacement).__name__} was already visited."
+                )
+            seen.add(id(replacement))
+            replacement = _pick_alternative(replacement, selected, path="<root>")
         return resolve_presets(replacement, selected)
 
     def _resolve(parent, key, preset_obj, _path):
+        seen: set[int] = {id(preset_obj)}
         val = _pick_alternative(preset_obj, selected, path=_path)
         while isinstance(val, PresetCfg):
+            if id(val) in seen:
+                raise ValueError(
+                    f"Cyclic PresetCfg chain detected at '{_path}': "
+                    f"{type(val).__name__} was already visited."
+                )
+            seen.add(id(val))
             val = _pick_alternative(val, selected, path=_path)
         if isinstance(parent, dict):
             parent[key] = val

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -312,6 +312,30 @@ def _extract_preset_names(args: list[str]) -> set[str]:
     return selected
 
 
+def _format_unknown_presets_error(unknown: set[str], name_to_paths: dict[str, list[str]], max_paths: int = 5) -> str:
+    """Build a readable error message grouping presets by identical path fingerprints."""
+    fingerprint_to_names: dict[tuple[str, ...], list[str]] = {}
+    for name, paths in name_to_paths.items():
+        key = tuple(sorted(paths))
+        fingerprint_to_names.setdefault(key, []).append(name)
+
+    lines = [f"Unknown preset(s): {', '.join(sorted(unknown))}", "", "Available presets (grouped by affected paths):", ""]
+    for paths_tuple in sorted(fingerprint_to_names, key=lambda k: fingerprint_to_names[k][0]):
+        names = sorted(fingerprint_to_names[paths_tuple])
+        if len(names) <= 30:
+            lines.append(f"  {', '.join(names)}")
+        else:
+            lines.append(f"  {', '.join(names[:25])}, ... ({len(names)} total)")
+        shown = list(paths_tuple[:max_paths])
+        for p in shown:
+            lines.append(f"    -> {p}")
+        remaining = len(paths_tuple) - len(shown)
+        if remaining > 0:
+            lines.append(f"    ... ({remaining} more)")
+        lines.append("")
+    return "\n".join(lines)
+
+
 def register_task(task_name: str, agent_entry: str) -> tuple:
     """Load configs, collect presets recursively, register base config to Hydra.
 
@@ -347,13 +371,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
                         name_to_paths.setdefault(name, []).append(full)
         unknown = selected - set(name_to_paths)
         if unknown:
-            lines = [f"Unknown preset(s): {', '.join(sorted(unknown))}", "", "Available presets:"]
-            for name in sorted(name_to_paths):
-                paths = name_to_paths[name]
-                lines.append(f"  {name}")
-                for p in paths:
-                    lines.append(f"    -> {p}")
-            raise ValueError("\n".join(lines))
+            raise ValueError(_format_unknown_presets_error(unknown, name_to_paths))
 
     env_cfg = resolve_presets(env_cfg, selected)
     if agent_cfg is not None:

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -37,6 +37,7 @@ from isaaclab.utils import configclass, replace_slices_with_strings, replace_str
 
 _LITERAL_MAP = {"true": True, "false": False, "none": None, "null": None}
 
+
 @configclass
 class PresetCfg:
     """Base class for declarative preset definitions.
@@ -522,7 +523,9 @@ def apply_overrides(
         sec, path, name = resolved[full_path]
         if cfgs[sec] is not None and _path_reachable(sec, path):
             node = presets[sec][path][name]
-            node_dict = node.to_dict() if hasattr(node, "to_dict") else dict(node) if isinstance(node, Mapping) else node
+            node_dict = (
+                node.to_dict() if hasattr(node, "to_dict") else dict(node) if isinstance(node, Mapping) else node
+            )
             if not path:
                 cfgs[sec], hydra_cfg[sec] = node, node_dict
             else:
@@ -534,7 +537,7 @@ def apply_overrides(
         sec = full_path.split(".", 1)[0]
         if sec not in cfgs:
             continue
-        path = full_path[len(sec) + 1:]
+        path = full_path[len(sec) + 1 :]
         if cfgs[sec] is not None:
             val = _parse_val(val_str)
             _setattr(cfgs[sec], path, val)

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -43,6 +43,7 @@ def _require_hydra():
     if not _HYDRA_AVAILABLE:
         raise ImportError("Hydra not installed. Run: pip install hydra-core")
 
+
 from isaaclab.envs.utils.spaces import replace_env_cfg_spaces_with_strings, replace_strings_with_env_cfg_spaces
 from isaaclab.utils import configclass, replace_slices_with_strings, replace_strings_with_slices
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -381,11 +381,11 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
             for path, fields in sec_presets.items():
                 full = f"{sec}.{path}" if path else sec
                 for name in fields:
-                    if name != "default":
-                        name_to_paths.setdefault(name, []).append(full)
+                    name_to_paths.setdefault(name, []).append(full)
         unknown = selected - set(name_to_paths)
         if unknown:
-            raise ValueError(_format_unknown_presets_error(unknown, name_to_paths))
+            display = {n: p for n, p in name_to_paths.items() if n != "default"}
+            raise ValueError(_format_unknown_presets_error(unknown, display))
 
     env_cfg = resolve_presets(env_cfg, selected)
     if agent_cfg is not None:

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -319,7 +319,12 @@ def _format_unknown_presets_error(unknown: set[str], name_to_paths: dict[str, li
         key = tuple(sorted(paths))
         fingerprint_to_names.setdefault(key, []).append(name)
 
-    lines = [f"Unknown preset(s): {', '.join(sorted(unknown))}", "", "Available presets (grouped by affected paths):", ""]
+    lines = [
+        f"Unknown preset(s): {', '.join(sorted(unknown))}",
+        "",
+        "Available presets (grouped by affected paths):",
+        "",
+    ]
     for paths_tuple in sorted(fingerprint_to_names, key=lambda k: fingerprint_to_names[k][0]):
         names = sorted(fingerprint_to_names[paths_tuple])
         if len(names) <= 30:

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -168,12 +168,14 @@ def collect_presets(cfg, path: str = "") -> dict:
 # ============================================================================
 
 
-def _pick_alternative(preset_obj: PresetCfg, selected: set[str]):
+def _pick_alternative(preset_obj: PresetCfg, selected: set[str], path: str = ""):
     """Choose the best alternative from a PresetCfg.
 
     Priority: first match in ``selected``, then ``default`` (preferring
-    class-level over instance-level).  Returns the chosen value, or the
-    preset object itself if nothing matches.
+    class-level over instance-level).
+
+    Raises:
+        ValueError: If no matching name and no ``default`` field exists.
     """
     fields = _preset_fields(preset_obj)
     for name in selected:
@@ -181,7 +183,10 @@ def _pick_alternative(preset_obj: PresetCfg, selected: set[str]):
             return fields[name]
     if "default" in fields:
         return fields["default"]
-    return preset_obj
+    raise ValueError(
+        f"PresetCfg {type(preset_obj).__name__} at '{path}' has no 'default' field "
+        f"and none of the selected presets {selected} match its fields {set(fields.keys())}."
+    )
 
 
 def resolve_presets(cfg, selected: set[str] = frozenset()):
@@ -204,17 +209,13 @@ def resolve_presets(cfg, selected: set[str] = frozenset()):
         was a PresetCfg).
     """
     if isinstance(cfg, PresetCfg):
-        replacement = _pick_alternative(cfg, selected)
-        if replacement is cfg:
-            return cfg
+        replacement = _pick_alternative(cfg, selected, path="<root>")
         return resolve_presets(replacement, selected)
 
     def _resolve(parent, key, preset_obj, _path):
-        val = _pick_alternative(preset_obj, selected)
-        if val is preset_obj:
-            return
+        val = _pick_alternative(preset_obj, selected, path=_path)
         while isinstance(val, PresetCfg):
-            val = _pick_alternative(val, selected)
+            val = _pick_alternative(val, selected, path=_path)
         if isinstance(parent, dict):
             parent[key] = val
         else:
@@ -300,6 +301,17 @@ def hydra_task_config(task_name: str, agent_cfg_entry_point: str) -> Callable:
     return decorator
 
 
+def _extract_preset_names(args: list[str]) -> set[str]:
+    """Extract global preset names from a list of CLI args."""
+    selected: set[str] = set()
+    for arg in args:
+        if "=" in arg:
+            key, val = arg.split("=", 1)
+            if key.lstrip("-") == "presets":
+                selected.update(v.strip() for v in val.split(",") if v.strip())
+    return selected
+
+
 def register_task(task_name: str, agent_entry: str) -> tuple:
     """Load configs, collect presets recursively, register base config to Hydra.
 
@@ -323,13 +335,26 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
         "agent": collect_presets(agent_cfg) if agent_cfg else {},
     }
 
-    # Extract global preset names from CLI, then resolve in one pass
-    selected: set[str] = set()
-    for arg in sys.argv[1:]:
-        if "=" in arg:
-            key, val = arg.split("=", 1)
-            if key.lstrip("-") == "presets":
-                selected.update(v.strip() for v in val.split(",") if v.strip())
+    selected = _extract_preset_names(sys.argv[1:])
+
+    if selected:
+        name_to_paths: dict[str, list[str]] = {}
+        for sec, sec_presets in presets.items():
+            for path, fields in sec_presets.items():
+                full = f"{sec}.{path}" if path else sec
+                for name in fields:
+                    if name != "default":
+                        name_to_paths.setdefault(name, []).append(full)
+        unknown = selected - set(name_to_paths)
+        if unknown:
+            lines = [f"Unknown preset(s): {', '.join(sorted(unknown))}", "", "Available presets:"]
+            for name in sorted(name_to_paths):
+                paths = name_to_paths[name]
+                lines.append(f"  {name}")
+                for p in paths:
+                    lines.append(f"    -> {p}")
+            raise ValueError("\n".join(lines))
+
     env_cfg = resolve_presets(env_cfg, selected)
     if agent_cfg is not None:
         agent_cfg = resolve_presets(agent_cfg, selected)

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -32,8 +32,16 @@ try:
     import hydra
     from hydra.core.config_store import ConfigStore
     from omegaconf import OmegaConf
+
+    _HYDRA_AVAILABLE = True
 except ImportError:
-    raise ImportError("Hydra not installed. Run: pip install hydra-core")
+    _HYDRA_AVAILABLE = False
+
+
+def _require_hydra():
+    """Raise a clear error if hydra-core is not installed."""
+    if not _HYDRA_AVAILABLE:
+        raise ImportError("Hydra not installed. Run: pip install hydra-core")
 
 from isaaclab.envs.utils.spaces import replace_env_cfg_spaces_with_strings, replace_strings_with_env_cfg_spaces
 from isaaclab.utils import configclass, replace_slices_with_strings, replace_strings_with_slices
@@ -234,6 +242,7 @@ def resolve_presets(cfg, selected: set[str] = frozenset()):
 
 def _run_hydra(task, env_cfg, agent_cfg, presets, callback):
     """Shared Hydra entry point for :func:`resolve_task_config` and :func:`hydra_task_config`."""
+    _require_hydra()
     global_presets, preset_sel, preset_scalar, global_scalar = parse_overrides(sys.argv[1:], presets)
     original_argv, sys.argv = sys.argv, [sys.argv[0]] + global_scalar
 
@@ -399,6 +408,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
     cfg_dict = replace_slices_with_strings({"env": env_dict, "agent": agent_dict})
 
     # Register plain config (no groups) - Hydra only handles global scalars
+    _require_hydra()
     ConfigStore.instance().store(name=task_name, node=OmegaConf.create(cfg_dict))
     return env_cfg, agent_cfg, presets
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -28,25 +28,14 @@ import functools
 import sys
 from collections.abc import Callable, Mapping
 
-try:
-    import hydra
-    from hydra.core.config_store import ConfigStore
-    from omegaconf import OmegaConf
-
-    _HYDRA_AVAILABLE = True
-except ImportError:
-    _HYDRA_AVAILABLE = False
-
-
-def _require_hydra():
-    """Raise a clear error if hydra-core is not installed."""
-    if not _HYDRA_AVAILABLE:
-        raise ImportError("Hydra not installed. Run: pip install hydra-core")
-
+import hydra
+from hydra.core.config_store import ConfigStore
+from omegaconf import OmegaConf
 
 from isaaclab.envs.utils.spaces import replace_env_cfg_spaces_with_strings, replace_strings_with_env_cfg_spaces
 from isaaclab.utils import configclass, replace_slices_with_strings, replace_strings_with_slices
 
+_LITERAL_MAP = {"true": True, "false": False, "none": None, "null": None}
 
 @configclass
 class PresetCfg:
@@ -223,8 +212,7 @@ def resolve_presets(cfg, selected: set[str] = frozenset()):
         while isinstance(replacement, PresetCfg):
             if id(replacement) in seen:
                 raise ValueError(
-                    f"Cyclic PresetCfg chain detected at '<root>': "
-                    f"{type(replacement).__name__} was already visited."
+                    f"Cyclic PresetCfg chain detected at '<root>': {type(replacement).__name__} was already visited."
                 )
             seen.add(id(replacement))
             replacement = _pick_alternative(replacement, selected, path="<root>")
@@ -236,8 +224,7 @@ def resolve_presets(cfg, selected: set[str] = frozenset()):
         while isinstance(val, PresetCfg):
             if id(val) in seen:
                 raise ValueError(
-                    f"Cyclic PresetCfg chain detected at '{_path}': "
-                    f"{type(val).__name__} was already visited."
+                    f"Cyclic PresetCfg chain detected at '{_path}': {type(val).__name__} was already visited."
                 )
             seen.add(id(val))
             val = _pick_alternative(val, selected, path=_path)
@@ -259,7 +246,6 @@ def resolve_presets(cfg, selected: set[str] = frozenset()):
 
 def _run_hydra(task, env_cfg, agent_cfg, presets, callback):
     """Shared Hydra entry point for :func:`resolve_task_config` and :func:`hydra_task_config`."""
-    _require_hydra()
     global_presets, preset_sel, preset_scalar, global_scalar = parse_overrides(sys.argv[1:], presets)
     original_argv, sys.argv = sys.argv, [sys.argv[0]] + global_scalar
 
@@ -327,17 +313,6 @@ def hydra_task_config(task_name: str, agent_cfg_entry_point: str) -> Callable:
     return decorator
 
 
-def _extract_preset_names(args: list[str]) -> set[str]:
-    """Extract global preset names from a list of CLI args."""
-    selected: set[str] = set()
-    for arg in args:
-        if "=" in arg:
-            key, val = arg.split("=", 1)
-            if key.lstrip("-") == "presets":
-                selected.update(v.strip() for v in val.split(",") if v.strip())
-    return selected
-
-
 def _format_unknown_presets_error(unknown: set[str], name_to_paths: dict[str, list[str]], max_paths: int = 5) -> str:
     """Build a readable error message grouping presets by identical path fingerprints."""
     fingerprint_to_names: dict[tuple[str, ...], list[str]] = {}
@@ -380,9 +355,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
     from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
 
     env_cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
-    agent_cfg = None
-    if agent_entry:
-        agent_cfg = load_cfg_from_registry(task_name, agent_entry)
+    agent_cfg = load_cfg_from_registry(task_name, agent_entry) if agent_entry else None
 
     # Collect presets before resolution (needed for path-based overrides)
     presets = {
@@ -390,7 +363,15 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
         "agent": collect_presets(agent_cfg) if agent_cfg else {},
     }
 
-    selected = _extract_preset_names(sys.argv[1:])
+    selected = {
+        v.strip()
+        for arg in sys.argv[1:]
+        if "=" in arg
+        for key, val in [arg.split("=", 1)]
+        if key.lstrip("-") == "presets"
+        for v in val.split(",")
+        if v.strip()
+    }
 
     if selected:
         name_to_paths: dict[str, list[str]] = {}
@@ -417,15 +398,11 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
 
     # Convert to dict for Hydra (handle gym spaces and slices)
     env_cfg = replace_env_cfg_spaces_with_strings(env_cfg)
-    if agent_cfg is not None and hasattr(agent_cfg, "to_dict"):
-        agent_dict = agent_cfg.to_dict()
-    else:
-        agent_dict = agent_cfg
+    agent_dict = agent_cfg.to_dict() if agent_cfg is not None and hasattr(agent_cfg, "to_dict") else agent_cfg
     env_dict = env_cfg.to_dict()  # type: ignore[union-attr]
     cfg_dict = replace_slices_with_strings({"env": env_dict, "agent": agent_dict})
 
     # Register plain config (no groups) - Hydra only handles global scalars
-    _require_hydra()
     ConfigStore.instance().store(name=task_name, node=OmegaConf.create(cfg_dict))
     return env_cfg, agent_cfg, presets
 
@@ -504,15 +481,6 @@ def apply_overrides(
                 return False
         return True
 
-    def _apply_node(sec: str, path: str, node):
-        node_dict = node.to_dict() if hasattr(node, "to_dict") else dict(node) if isinstance(node, Mapping) else node
-        if path == "":
-            cfgs[sec] = node
-            hydra_cfg[sec] = node_dict
-        else:
-            _setattr(cfgs[sec], path, node)
-            _setattr(hydra_cfg, f"{sec}.{path}", node_dict)
-
     # --- Phase 1: path-based selections + global broadcast for reachable paths
     resolved: dict[str, tuple[str, str, str]] = {}
     for sec, path, name in preset_sel:
@@ -541,29 +509,32 @@ def apply_overrides(
                             )
                     else:
                         applied_by[full_path] = name
-                    if full_path not in resolved:
-                        resolved[full_path] = (sec, path, name)
+                    resolved.setdefault(full_path, (sec, path, name))
 
     for sec in ("env", "agent"):
         for path, path_presets in presets.get(sec, {}).items():
-            full_path = f"{sec}.{path}" if path else sec
-            if full_path not in resolved and "default" in path_presets:
-                resolved[full_path] = (sec, path, "default")
+            if "default" in path_presets:
+                full_path = f"{sec}.{path}" if path else sec
+                resolved.setdefault(full_path, (sec, path, "default"))
 
     # --- Phase 2: apply in depth order, pruning unreachable children
     for full_path in sorted(resolved, key=lambda fp: fp.count(".")):
         sec, path, name = resolved[full_path]
         if cfgs[sec] is not None and _path_reachable(sec, path):
-            _apply_node(sec, path, presets[sec][path][name])
+            node = presets[sec][path][name]
+            node_dict = node.to_dict() if hasattr(node, "to_dict") else dict(node) if isinstance(node, Mapping) else node
+            if not path:
+                cfgs[sec], hydra_cfg[sec] = node, node_dict
+            else:
+                _setattr(cfgs[sec], path, node)
+                _setattr(hydra_cfg, f"{sec}.{path}", node_dict)
 
     # --- Phase 3: scalar overrides within preset paths
     for full_path, val_str in preset_scalar:
-        if full_path.startswith("env."):
-            sec, path = "env", full_path[4:]
-        elif full_path.startswith("agent."):
-            sec, path = "agent", full_path[6:]
-        else:
+        sec = full_path.split(".", 1)[0]
+        if sec not in cfgs:
             continue
+        path = full_path[len(sec) + 1:]
         if cfgs[sec] is not None:
             val = _parse_val(val_str)
             _setattr(cfgs[sec], path, val)
@@ -585,16 +556,9 @@ def _setattr(obj, path: str, val):
 
 def _parse_val(s: str):
     """Parse string to Python value (bool, None, int, float, or str)."""
-    low = s.lower()
-    if low == "true":
-        return True
-    if low == "false":
-        return False
-    if low in ("none", "null"):
-        return None
+    if s.lower() in _LITERAL_MAP:
+        return _LITERAL_MAP[s.lower()]
     try:
         return float(s) if "." in s else int(s)
     except ValueError:
-        if s[0] in "\"'" and s[-1] in "\"'":
-            return s[1:-1]
-        return s
+        return s[1:-1] if len(s) >= 2 and s[0] in "\"'" and s[-1] in "\"'" else s

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 import gymnasium as gym
 import yaml
 
+from isaaclab_tasks.utils.hydra import resolve_presets
+
 if TYPE_CHECKING:
     from isaaclab.envs import DirectRLEnvCfg, ManagerBasedRLEnvCfg
 
@@ -141,8 +143,6 @@ def parse_env_cfg(
         RuntimeError: If the configuration for the task is not a class. We assume users always use a class for the
             environment configuration.
     """
-    from isaaclab_tasks.utils.hydra import resolve_preset_defaults
-
     # load the default configuration
     cfg = load_cfg_from_registry(task_name.split(":")[-1], "env_cfg_entry_point")
 
@@ -156,7 +156,7 @@ def parse_env_cfg(
     # Must happen BEFORE attribute overrides, otherwise overrides on PresetCfg wrapper
     # fields (e.g. cfg.scene when scene is a PresetCfg) get discarded when the wrapper
     # is replaced by its .default.
-    cfg = resolve_preset_defaults(cfg)
+    cfg = resolve_presets(cfg)
 
     # simulation device
     cfg.sim.device = device

--- a/source/isaaclab_tasks/test/test_hydra.py
+++ b/source/isaaclab_tasks/test/test_hydra.py
@@ -1164,3 +1164,53 @@ def test_resolve_presets_idempotent():
     assert isinstance(second.backend, PhysxCfg)
     assert isinstance(second.observations, NoiselessObservationsCfg)
     assert second.backend.dt == first.backend.dt
+
+
+def test_unknown_global_preset_name_detected():
+    """A selected preset name that doesn't match any PresetCfg field is detected.
+
+    This catches typos like presets=peg_insrt_4mm (missing 'e'). The validation
+    in register_task raises ValueError before resolution begins.
+    """
+    cfg = PresetCfgEnvCfg()
+    presets = {"env": collect_presets(cfg), "agent": {}}
+    all_known = {name for alts in presets.values() for fields in alts.values() for name in fields if name != "default"}
+
+    assert "newton" in all_known
+    assert "typo_preset" not in all_known
+
+
+def test_resolve_presets_errors_on_no_default():
+    """A PresetCfg with no 'default' field and no matching selected name
+    must raise ValueError, not silently linger or infinite loop."""
+
+    @configclass
+    class NoDefaultPreset(PresetCfg):
+        option_a: int = 1
+
+    @configclass
+    class EnvCfg:
+        mode: NoDefaultPreset = NoDefaultPreset()
+
+    with pytest.raises(ValueError, match="no 'default' field"):
+        resolve_presets(EnvCfg())
+
+
+def test_resolve_presets_errors_on_chained_no_default():
+    """A PresetCfg whose default is another PresetCfg with no 'default'
+    must raise ValueError on the inner preset."""
+
+    @configclass
+    class InnerNoDefault(PresetCfg):
+        option_a: int = 1
+
+    @configclass
+    class OuterPreset(PresetCfg):
+        default: InnerNoDefault = InnerNoDefault()
+
+    @configclass
+    class EnvCfg:
+        mode: OuterPreset = OuterPreset()
+
+    with pytest.raises(ValueError, match="no 'default' field"):
+        resolve_presets(EnvCfg())

--- a/source/isaaclab_tasks/test/test_hydra.py
+++ b/source/isaaclab_tasks/test/test_hydra.py
@@ -19,7 +19,7 @@ from isaaclab_tasks.utils.hydra import (
     collect_presets,
     parse_overrides,
     preset,
-    resolve_preset_defaults,
+    resolve_presets,
 )
 
 # =============================================================================
@@ -116,7 +116,7 @@ class PresetCfgAgentCfg:
 
 @configclass
 class RootAgentCfg(PresetCfg):
-    """Root-level PresetCfg — the agent config itself is a PresetCfg."""
+    """Root-level PresetCfg -- the agent config itself is a PresetCfg."""
 
     default: SampleAgentCfg = SampleAgentCfg()
     fast: SampleAgentCfg = SampleAgentCfg(max_iterations=100, learning_rate=1e-3)
@@ -160,6 +160,147 @@ class ScenePresetCfg(PresetCfg):
 class NestedPresetEnvCfg:
     decimation: int = 4
     scene: ScenePresetCfg = ScenePresetCfg()
+
+
+# -- Scalar PresetCfg and actuator configs (shared by scalar + dict sections) --
+
+
+@configclass
+class ScalarPresetCfg(PresetCfg):
+    default: float = 0.0
+    newton: float = 0.01
+
+
+@configclass
+class ActuatorWithPresetCfg:
+    joint_names: list = [".*"]
+    stiffness: float = 40.0
+    damping: float = 5.0
+    armature: ScalarPresetCfg = ScalarPresetCfg()
+
+
+# -- Deep-nested dict configs (event term params pattern) --
+
+
+@configclass
+class OffsetCfg(PresetCfg):
+    """Mimics task-specific offset presets (e.g., AssembledOffsetCfg)."""
+
+    task_a: tuple = (0.0, 0.0, 0.01)
+    task_b: tuple = (0.02, 0.0, 0.005)
+    default: tuple = task_a
+
+
+@configclass
+class FractionCfg(PresetCfg):
+    task_a: tuple = (0.05, 0.5)
+    task_b: tuple = (0.3, 1.0)
+    default: tuple = task_a
+
+
+@configclass
+class JointNamesCfg(PresetCfg):
+    default: list[str] | None = None
+    robot_a: list[str] = None
+    robot_b: list[str] = None
+
+
+@configclass
+class EntityCfg:
+    """Mimics SceneEntityCfg with a preset-valued field."""
+
+    name: str = "robot"
+    joint_names: list[str] | None = None
+
+
+@configclass
+class InnerTermCfg:
+    """Mimics an EventTermCfg with params containing presets."""
+
+    func: str = "reset_fn"
+    params: dict = None
+
+    def __post_init__(self):
+        if self.params is None:
+            self.params = {
+                "offset": OffsetCfg(),
+                "fraction": FractionCfg(),
+                "robot_cfg": EntityCfg(name="robot", joint_names=JointNamesCfg()),
+            }
+
+
+@configclass
+class OuterTermCfg:
+    """Mimics a chained reset term with nested terms dict."""
+
+    func: str = "chain_fn"
+    params: dict = None
+
+    def __post_init__(self):
+        if self.params is None:
+            self.params = {
+                "terms": {
+                    "step_one": InnerTermCfg(),
+                }
+            }
+
+
+@configclass
+class DeepDictEnvCfg:
+    decimation: int = 4
+    events: OuterTermCfg = OuterTermCfg()
+
+
+@configclass
+class DictPresetTermCfg:
+    """Outer term where the terms dict is itself a preset (resolves to a dict)."""
+
+    func: str = "term_choice"
+    params: dict = None
+
+    def __post_init__(self):
+        if self.params is None:
+            self.params = {
+                "terms": preset(
+                    default={
+                        "strategy_a": InnerTermCfg(),
+                        "strategy_b": InnerTermCfg(),
+                    },
+                    alt={
+                        "strategy_a": InnerTermCfg(),
+                    },
+                ),
+            }
+
+
+@configclass
+class PresetResolvesToDictEnvCfg:
+    decimation: int = 4
+    events: DictPresetTermCfg = DictPresetTermCfg()
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _apply(env_cfg, agent_cfg=None, global_presets=None, preset_sel=None, preset_scalar=None):
+    """Collect presets, resolve defaults, build hydra dict, and apply overrides."""
+    if agent_cfg is None:
+        agent_cfg = PresetCfgAgentCfg()
+    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
+    env_cfg = resolve_presets(env_cfg)
+    agent_cfg = resolve_presets(agent_cfg)
+    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
+    return apply_overrides(
+        env_cfg,
+        agent_cfg,
+        hydra_cfg,
+        global_presets or [],
+        preset_sel or [],
+        preset_scalar or [],
+        presets,
+    )
 
 
 # =============================================================================
@@ -229,7 +370,7 @@ def test_parse_overrides_root_preset():
 
 
 # =============================================================================
-# Tests: apply_overrides — PresetCfg (nested + broadcast + root)
+# Tests: apply_overrides -- PresetCfg (nested + broadcast + root)
 # =============================================================================
 
 
@@ -273,22 +414,14 @@ def test_presetcfg_path_selection_others_default(class_presets):
 
 def test_root_presetcfg_auto_default():
     """Root-level PresetCfg auto-applies 'default'."""
-    agent_cfg = RootAgentCfg()
-    env_cfg = SampleEnvCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    env_cfg, agent_cfg = apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [], [], presets)
+    env_cfg, agent_cfg = _apply(SampleEnvCfg(), RootAgentCfg())
     assert isinstance(agent_cfg, SampleAgentCfg)
     assert agent_cfg.max_iterations == 1000
 
 
 def test_root_presetcfg_cli_selection():
     """Root-level PresetCfg resolved via path selection."""
-    agent_cfg = RootAgentCfg()
-    env_cfg = SampleEnvCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    env_cfg, agent_cfg = apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [("agent", "", "fast")], [], presets)
+    env_cfg, agent_cfg = _apply(SampleEnvCfg(), RootAgentCfg(), preset_sel=[("agent", "", "fast")])
     assert isinstance(agent_cfg, SampleAgentCfg)
     assert agent_cfg.max_iterations == 100
     assert agent_cfg.learning_rate == 1e-3
@@ -296,11 +429,7 @@ def test_root_presetcfg_cli_selection():
 
 def test_root_presetcfg_global_preset():
     """Root-level PresetCfg resolved via global preset."""
-    agent_cfg = RootAgentCfg()
-    env_cfg = SampleEnvCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    env_cfg, agent_cfg = apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["fast"], [], [], presets)
+    env_cfg, agent_cfg = _apply(SampleEnvCfg(), RootAgentCfg(), global_presets=["fast"])
     assert isinstance(agent_cfg, SampleAgentCfg)
     assert agent_cfg.max_iterations == 100
 
@@ -315,7 +444,6 @@ def test_collect_nested_presetcfg():
     presets = collect_presets(NestedPresetEnvCfg())
     assert "scene" in presets
     assert set(presets["scene"].keys()) == {"default", "with_camera"}
-    # camera preset discovered inside with_camera alternative
     assert "scene.camera" in presets
     assert set(presets["scene.camera"].keys()) == {"small", "large", "default"}
     assert isinstance(presets["scene.camera"]["small"], CameraSmallCfg)
@@ -324,24 +452,14 @@ def test_collect_nested_presetcfg():
 
 def test_nested_presetcfg_pruned_when_parent_has_none():
     """When scene auto-defaults to default (camera=None), nested camera preset is pruned."""
-    env_cfg = NestedPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    # No CLI args → scene resolves to default (camera=None), camera preset must NOT apply
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [], [], presets)
+    env_cfg, _ = _apply(NestedPresetEnvCfg())
     assert isinstance(env_cfg.scene, BaseSceneCfg)
     assert env_cfg.scene.camera is None
 
 
 def test_nested_presetcfg_auto_default_with_camera():
     """When with_camera scene is selected, camera auto-defaults to small (the default)."""
-    env_cfg = NestedPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    # Only select with_camera scene, camera should auto-default to small
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["with_camera"], [], [], presets)
+    env_cfg, _ = _apply(NestedPresetEnvCfg(), global_presets=["with_camera"])
     assert isinstance(env_cfg.scene, BaseSceneCfg)
     assert isinstance(env_cfg.scene.camera, CameraSmallCfg)
     assert env_cfg.scene.camera.width == 64
@@ -349,12 +467,7 @@ def test_nested_presetcfg_auto_default_with_camera():
 
 def test_nested_presetcfg_global_broadcast():
     """Global preset resolves both outer and nested PresetCfg."""
-    env_cfg = NestedPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    # "with_camera" selects the scene, "large" selects the camera
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["with_camera", "large"], [], [], presets)
+    env_cfg, _ = _apply(NestedPresetEnvCfg(), global_presets=["with_camera", "large"])
     assert isinstance(env_cfg.scene, BaseSceneCfg)
     assert isinstance(env_cfg.scene.camera, CameraLargeCfg)
     assert env_cfg.scene.camera.width == 256
@@ -362,12 +475,8 @@ def test_nested_presetcfg_global_broadcast():
 
 def test_nested_presetcfg_path_selection():
     """Path selection on nested PresetCfg resolves correctly."""
-    env_cfg = NestedPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
     sel = [("env", "scene", "with_camera"), ("env", "scene.camera", "large")]
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], sel, [], presets)
+    env_cfg, _ = _apply(NestedPresetEnvCfg(), preset_sel=sel)
     assert isinstance(env_cfg.scene, BaseSceneCfg)
     assert isinstance(env_cfg.scene.camera, CameraLargeCfg)
     assert env_cfg.scene.camera.width == 256
@@ -434,8 +543,8 @@ def test_root_presetcfg_with_nested_preset_collect():
 
 
 def test_root_presetcfg_resolve_defaults():
-    """resolve_preset_defaults resolves nested PresetCfg inside root."""
-    resolved = resolve_preset_defaults(RootPresetEnvCfg())
+    """resolve_presets resolves nested PresetCfg inside root."""
+    resolved = resolve_presets(RootPresetEnvCfg())
     assert isinstance(resolved, RootEnvBaseCfg)
     assert isinstance(resolved.sensor, SensorBaseCfg)
     assert resolved.sensor.data_types == ["rgb"]
@@ -463,11 +572,7 @@ class EnvWithOptionalFeatureCfg:
 
 def test_presetcfg_none_default_auto_applies():
     """PresetCfg with default=None auto-applies None without crashing."""
-    env_cfg = EnvWithOptionalFeatureCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [], [], presets)
+    env_cfg, _ = _apply(EnvWithOptionalFeatureCfg())
     assert env_cfg.optional_feature is None
 
 
@@ -485,17 +590,7 @@ def test_presetcfg_none_default_cli_selects_enabled():
 
 def test_root_presetcfg_global_depth_resolves_nested():
     """Global preset=depth on root PresetCfg also resolves nested sensor and renderer."""
-    env_cfg = RootPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg_resolved = resolve_preset_defaults(agent_cfg)
-
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg_resolved.to_dict()}
-
-    env_cfg, agent_cfg = apply_overrides(env_cfg, agent_cfg_resolved, hydra_cfg, ["depth"], [], [], presets)
-
+    env_cfg, _ = _apply(RootPresetEnvCfg(), global_presets=["depth"])
     assert isinstance(env_cfg, RootEnvBaseCfg)
     assert env_cfg.obs_shape == [100, 100, 1]
     assert isinstance(env_cfg.sensor, SensorBaseCfg), (
@@ -513,23 +608,9 @@ def test_root_presetcfg_global_depth_resolves_nested():
 
 
 @configclass
-class ScalarPresetCfg(PresetCfg):
-    default: float = 0.0
-    newton: float = 0.01
-
-
-@configclass
-class ActuatorWithScalarPresetCfg:
-    joint_names: list = [".*"]
-    stiffness: float = 40.0
-    damping: float = 5.0
-    armature: ScalarPresetCfg = ScalarPresetCfg()
-
-
-@configclass
 class ScalarPresetEnvCfg:
     decimation: int = 4
-    actuator: ActuatorWithScalarPresetCfg = ActuatorWithScalarPresetCfg()
+    actuator: ActuatorWithPresetCfg = ActuatorWithPresetCfg()
 
 
 def test_scalar_presetcfg_collect():
@@ -541,62 +622,35 @@ def test_scalar_presetcfg_collect():
 
 
 def test_scalar_presetcfg_resolve_default():
-    """resolve_preset_defaults replaces scalar PresetCfg with its default value."""
+    """resolve_presets replaces scalar PresetCfg with its default value."""
     cfg = ScalarPresetEnvCfg()
-    resolved = resolve_preset_defaults(cfg)
+    resolved = resolve_presets(cfg)
     assert resolved.actuator.armature == 0.0
     assert not isinstance(resolved.actuator.armature, PresetCfg)
 
 
 def test_scalar_presetcfg_auto_default():
     """Scalar PresetCfg auto-applies default=0.0 when no CLI override."""
-    env_cfg = ScalarPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [], [], presets)
+    env_cfg, _ = _apply(ScalarPresetEnvCfg())
     assert env_cfg.actuator.armature == 0.0
 
 
 def test_scalar_presetcfg_global_newton():
     """Global preset=newton replaces scalar PresetCfg with newton value."""
-    env_cfg = ScalarPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["newton"], [], [], presets)
+    env_cfg, _ = _apply(ScalarPresetEnvCfg(), global_presets=["newton"])
     assert env_cfg.actuator.armature == 0.01
 
 
 def test_scalar_presetcfg_path_selection():
     """Path selection replaces scalar PresetCfg with chosen value."""
-    env_cfg = ScalarPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    sel = [("env", "actuator.armature", "newton")]
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], sel, [], presets)
+    env_cfg, _ = _apply(ScalarPresetEnvCfg(), preset_sel=[("env", "actuator.armature", "newton")])
     assert env_cfg.actuator.armature == 0.01
-    assert env_cfg.actuator.stiffness == 40.0  # other fields untouched
+    assert env_cfg.actuator.stiffness == 40.0
 
 
 # =============================================================================
 # Tests: PresetCfg inside dict values (e.g., actuators["legs"].armature)
 # =============================================================================
-
-
-@configclass
-class ActuatorCfgWithPreset:
-    joint_names: list = [".*"]
-    stiffness: float = 40.0
-    damping: float = 5.0
-    armature: ScalarPresetCfg = ScalarPresetCfg()
 
 
 @configclass
@@ -606,7 +660,7 @@ class RobotCfg:
 
     def __post_init__(self):
         if self.actuators is None:
-            self.actuators = {"legs": ActuatorCfgWithPreset()}
+            self.actuators = {"legs": ActuatorWithPresetCfg()}
 
 
 @configclass
@@ -624,48 +678,29 @@ def test_collect_presets_traverses_dict_values():
     assert presets["robot.actuators.legs.armature"]["newton"] == 0.01
 
 
-def test_resolve_preset_defaults_traverses_dict_values():
-    """resolve_preset_defaults resolves PresetCfg inside dict-held configclass values."""
+def test_resolve_presets_traverses_dict_values():
+    """resolve_presets resolves PresetCfg inside dict-held configclass values."""
     cfg = DictPresetEnvCfg()
-    resolved = resolve_preset_defaults(cfg)
+    resolved = resolve_presets(cfg)
     assert resolved.robot.actuators["legs"].armature == 0.0
     assert not isinstance(resolved.robot.actuators["legs"].armature, PresetCfg)
 
 
 def test_dict_preset_auto_default():
     """Dict-held PresetCfg auto-applies default when no CLI override."""
-    env_cfg = DictPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [], [], presets)
+    env_cfg, _ = _apply(DictPresetEnvCfg())
     assert env_cfg.robot.actuators["legs"].armature == 0.0
 
 
 def test_dict_preset_global_newton():
     """Global preset=newton replaces dict-held scalar PresetCfg."""
-    env_cfg = DictPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["newton"], [], [], presets)
+    env_cfg, _ = _apply(DictPresetEnvCfg(), global_presets=["newton"])
     assert env_cfg.robot.actuators["legs"].armature == 0.01
 
 
 def test_dict_preset_path_selection():
     """Path selection replaces dict-held scalar PresetCfg."""
-    env_cfg = DictPresetEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    sel = [("env", "robot.actuators.legs.armature", "newton")]
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], sel, [], presets)
+    env_cfg, _ = _apply(DictPresetEnvCfg(), preset_sel=[("env", "robot.actuators.legs.armature", "newton")])
     assert env_cfg.robot.actuators["legs"].armature == 0.01
     assert env_cfg.robot.actuators["legs"].stiffness == 40.0
 
@@ -707,61 +742,8 @@ def test_dict_preset_with_factory():
 # =============================================================================
 
 
-@configclass
-class OffsetCfg(PresetCfg):
-    """Mimics task-specific offset presets (e.g., AssembledOffsetCfg)."""
-
-    task_a: tuple = (0.0, 0.0, 0.01)
-    task_b: tuple = (0.02, 0.0, 0.005)
-    default: tuple = task_a
-
-
-@configclass
-class FractionCfg(PresetCfg):
-    task_a: tuple = (0.05, 0.5)
-    task_b: tuple = (0.3, 1.0)
-    default: tuple = task_a
-
-
-@configclass
-class InnerTermCfg:
-    """Mimics an EventTermCfg with params containing presets."""
-
-    func: str = "reset_fn"
-    params: dict = None
-
-    def __post_init__(self):
-        if self.params is None:
-            self.params = {
-                "offset": OffsetCfg(),
-                "fraction": FractionCfg(),
-            }
-
-
-@configclass
-class OuterTermCfg:
-    """Mimics a chained reset term with nested terms dict."""
-
-    func: str = "chain_fn"
-    params: dict = None
-
-    def __post_init__(self):
-        if self.params is None:
-            self.params = {
-                "terms": {
-                    "step_one": InnerTermCfg(),
-                }
-            }
-
-
-@configclass
-class DeepDictEnvCfg:
-    decimation: int = 4
-    events: OuterTermCfg = OuterTermCfg()
-
-
 def test_collect_presets_deep_nested_dicts():
-    """collect_presets discovers PresetCfg inside dict→dict→configclass→dict chains."""
+    """collect_presets discovers PresetCfg inside dict->dict->configclass->dict chains."""
     cfg = DeepDictEnvCfg()
     presets = collect_presets(cfg)
     offset_path = "events.params.terms.step_one.params.offset"
@@ -774,26 +756,22 @@ def test_collect_presets_deep_nested_dicts():
     assert presets[fraction_path]["task_b"] == (0.3, 1.0)
 
 
-def test_resolve_preset_defaults_deep_nested_dicts():
-    """resolve_preset_defaults resolves presets inside deeply nested dicts."""
+def test_resolve_presets_deep_nested_dicts():
+    """resolve_presets resolves presets inside deeply nested dicts."""
     cfg = DeepDictEnvCfg()
-    resolved = resolve_preset_defaults(cfg)
+    resolved = resolve_presets(cfg)
     inner = resolved.events.params["terms"]["step_one"]
     assert inner.params["offset"] == (0.0, 0.0, 0.01)
     assert inner.params["fraction"] == (0.05, 0.5)
     assert not isinstance(inner.params["offset"], PresetCfg)
     assert not isinstance(inner.params["fraction"], PresetCfg)
+    assert inner.params["robot_cfg"].joint_names is None
+    assert not isinstance(inner.params["robot_cfg"].joint_names, PresetCfg)
 
 
 def test_deep_nested_dict_auto_default():
     """Deeply nested dict presets auto-apply default when no CLI override."""
-    env_cfg = DeepDictEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], [], [], presets)
+    env_cfg, _ = _apply(DeepDictEnvCfg())
     inner = env_cfg.events.params["terms"]["step_one"]
     assert inner.params["offset"] == (0.0, 0.0, 0.01)
     assert inner.params["fraction"] == (0.05, 0.5)
@@ -801,13 +779,7 @@ def test_deep_nested_dict_auto_default():
 
 def test_deep_nested_dict_global_preset():
     """Global preset=task_b replaces deeply nested dict presets."""
-    env_cfg = DeepDictEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["task_b"], [], [], presets)
+    env_cfg, _ = _apply(DeepDictEnvCfg(), global_presets=["task_b"])
     inner = env_cfg.events.params["terms"]["step_one"]
     assert inner.params["offset"] == (0.02, 0.0, 0.005), f"offset should be task_b value, got {inner.params['offset']}"
     assert inner.params["fraction"] == (0.3, 1.0), f"fraction should be task_b value, got {inner.params['fraction']}"
@@ -815,32 +787,111 @@ def test_deep_nested_dict_global_preset():
 
 def test_deep_nested_dict_path_selection():
     """Path selection replaces a specific deeply nested dict preset."""
-    env_cfg = DeepDictEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
     sel = [("env", "events.params.terms.step_one.params.offset", "task_b")]
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, [], sel, [], presets)
+    env_cfg, _ = _apply(DeepDictEnvCfg(), preset_sel=sel)
     inner = env_cfg.events.params["terms"]["step_one"]
     assert inner.params["offset"] == (0.02, 0.0, 0.005)
-    assert inner.params["fraction"] == (0.05, 0.5)  # untouched
+    assert inner.params["fraction"] == (0.05, 0.5)
 
 
 def test_deep_nested_dict_mixed_global_and_path():
     """Global preset applies to nested dicts, path selection overrides one."""
-    env_cfg = DeepDictEnvCfg()
-    agent_cfg = PresetCfgAgentCfg()
-    presets = {"env": collect_presets(env_cfg), "agent": collect_presets(agent_cfg)}
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
-    hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
     sel = [("env", "events.params.terms.step_one.params.fraction", "task_a")]
-    apply_overrides(env_cfg, agent_cfg, hydra_cfg, ["task_b"], sel, [], presets)
+    env_cfg, _ = _apply(DeepDictEnvCfg(), global_presets=["task_b"], preset_sel=sel)
     inner = env_cfg.events.params["terms"]["step_one"]
-    assert inner.params["offset"] == (0.02, 0.0, 0.005)  # from global task_b
-    assert inner.params["fraction"] == (0.05, 0.5)  # path override keeps task_a
+    assert inner.params["offset"] == (0.02, 0.0, 0.005)
+    assert inner.params["fraction"] == (0.05, 0.5)
+
+
+# =============================================================================
+# Tests: preset resolving to dict containing further presets
+# =============================================================================
+
+
+def test_collect_presets_discovers_presets_inside_dict_valued_alternatives():
+    """collect_presets must recurse into dict-valued preset alternatives to
+    discover further PresetCfg nodes nested inside them.
+    """
+    cfg = PresetResolvesToDictEnvCfg()
+    presets = collect_presets(cfg)
+    offset_paths = [p for p in presets if "offset" in p]
+    fraction_paths = [p for p in presets if "fraction" in p]
+    assert len(offset_paths) > 0, (
+        f"OffsetCfg inside dict-valued preset alternative not discovered. Found: {list(presets.keys())}"
+    )
+    assert len(fraction_paths) > 0, (
+        f"FractionCfg inside dict-valued preset alternative not discovered. Found: {list(presets.keys())}"
+    )
+
+
+def test_resolve_preset_resolving_to_dict_walks_contents():
+    """When a preset resolves to a dict, presets inside that dict are also resolved.
+
+    Also verifies that PresetCfg(default=None) nested inside the resolved dict
+    correctly resolves to None (not skipped).
+    """
+    cfg = PresetResolvesToDictEnvCfg()
+    resolved = resolve_presets(cfg)
+
+    terms = resolved.events.params["terms"]
+    assert isinstance(terms, dict), f"Expected dict, got {type(terms)}"
+    assert not isinstance(terms, PresetCfg), "Top-level preset was not resolved"
+
+    for name, term in terms.items():
+        entity = term.params["robot_cfg"]
+        assert not isinstance(entity.joint_names, PresetCfg), (
+            f"PresetCfg leaked into {name}.params.robot_cfg.joint_names"
+        )
+        assert entity.joint_names is None
+        assert not isinstance(term.params["offset"], PresetCfg)
+        assert not isinstance(term.params["fraction"], PresetCfg)
+
+
+def test_resolve_preset_uses_class_level_override():
+    """When a robot-specific module overrides PresetCfg.default at class level
+    after instances are created, resolve_presets picks up the override."""
+
+    @configclass
+    class BodyNameCfg(PresetCfg):
+        default: str = "generic_body"
+
+    @configclass
+    class TermWithBody:
+        func: str = "some_fn"
+        params: dict = None
+
+        def __post_init__(self):
+            if self.params is None:
+                self.params = {"cfg": EntityCfg(name="robot", joint_names=BodyNameCfg())}
+
+    @configclass
+    class EnvWithBody:
+        events: TermWithBody = TermWithBody()
+
+    BodyNameCfg.default = "robot_specific_body"
+
+    cfg = EnvWithBody()
+    resolved = resolve_presets(cfg)
+    assert resolved.events.params["cfg"].joint_names == "robot_specific_body"
+    assert not isinstance(resolved.events.params["cfg"].joint_names, PresetCfg)
+
+
+def test_resolve_presets_with_selected_name_in_deeply_nested_dict():
+    """resolve_presets(cfg, {"task_b"}) must select task_b alternatives
+    for PresetCfg instances nested inside dict-valued preset alternatives.
+    """
+    cfg = PresetResolvesToDictEnvCfg()
+    resolved = resolve_presets(cfg, {"task_b"})
+
+    terms = resolved.events.params["terms"]
+    assert isinstance(terms, dict)
+    for name, term in terms.items():
+        assert term.params["offset"] == (0.02, 0.0, 0.005), (
+            f"{name}: offset should be task_b, got {term.params['offset']}"
+        )
+        assert term.params["fraction"] == (0.3, 1.0), (
+            f"{name}: fraction should be task_b, got {term.params['fraction']}"
+        )
 
 
 # =============================================================================
@@ -1083,8 +1134,8 @@ def test_parse_val_types():
 def test_scalar_override_within_preset_path(class_presets):
     """Scalar overrides within preset paths are applied on top of the preset."""
     env_cfg, agent_cfg, presets = class_presets
-    env_cfg = resolve_preset_defaults(env_cfg)
-    agent_cfg = resolve_preset_defaults(agent_cfg)
+    env_cfg = resolve_presets(env_cfg)
+    agent_cfg = resolve_presets(agent_cfg)
     hydra_cfg = {"env": env_cfg.to_dict(), "agent": agent_cfg.to_dict()}
     apply_overrides(
         env_cfg,
@@ -1096,20 +1147,20 @@ def test_scalar_override_within_preset_path(class_presets):
         presets,
     )
     assert isinstance(env_cfg.backend, NewtonCfg)
-    assert env_cfg.backend.dt == 0.001  # overridden from 0.002
-    assert env_cfg.backend.substeps == 4  # untouched
+    assert env_cfg.backend.dt == 0.001
+    assert env_cfg.backend.substeps == 4
 
 
 # =============================================================================
-# Tests: resolve_preset_defaults idempotency
+# Tests: resolve_presets idempotency
 # =============================================================================
 
 
-def test_resolve_preset_defaults_idempotent():
-    """Calling resolve_preset_defaults twice yields the same result."""
+def test_resolve_presets_idempotent():
+    """Calling resolve_presets twice yields the same result."""
     cfg = PresetCfgEnvCfg()
-    first = resolve_preset_defaults(cfg)
-    second = resolve_preset_defaults(first)
+    first = resolve_presets(cfg)
+    second = resolve_presets(first)
     assert isinstance(second.backend, PhysxCfg)
     assert isinstance(second.observations, NoiselessObservationsCfg)
     assert second.backend.dt == first.backend.dt

--- a/source/isaaclab_tasks/test/test_hydra.py
+++ b/source/isaaclab_tasks/test/test_hydra.py
@@ -1214,3 +1214,44 @@ def test_resolve_presets_errors_on_chained_no_default():
 
     with pytest.raises(ValueError, match="no 'default' field"):
         resolve_presets(EnvCfg())
+
+
+def test_resolve_presets_errors_on_cyclic_preset():
+    """Cyclic PresetCfg chain (A.default -> B, B.default -> A) must raise
+    ValueError instead of looping forever."""
+
+    @configclass
+    class CyclicB(PresetCfg):
+        pass
+
+    @configclass
+    class CyclicA(PresetCfg):
+        default: CyclicB = CyclicB()
+
+    CyclicA.default = CyclicB()
+    CyclicB.default = CyclicA()
+
+    @configclass
+    class EnvCfg:
+        mode: CyclicA = CyclicA()
+
+    with pytest.raises(ValueError, match="[Cc]ycl"):
+        resolve_presets(EnvCfg())
+
+
+def test_resolve_presets_errors_on_cyclic_preset_at_root():
+    """Cyclic PresetCfg at root level must raise ValueError, not RecursionError."""
+
+    @configclass
+    class RootCyclicB(PresetCfg):
+        pass
+
+    @configclass
+    class RootCyclicA(PresetCfg):
+        default: RootCyclicB = RootCyclicB()
+
+    RootCyclicA.default = RootCyclicB()
+    RootCyclicB.default = RootCyclicA()
+
+    with pytest.raises(ValueError, match="[Cc]ycl"):
+        resolve_presets(RootCyclicA())

--- a/source/isaaclab_tasks/test/test_shadow_hand_vision_presets.py
+++ b/source/isaaclab_tasks/test/test_shadow_hand_vision_presets.py
@@ -41,7 +41,7 @@ from isaaclab_tasks.direct.shadow_hand.shadow_hand_vision_env_cfg import (  # no
     ShadowHandVisionBenchmarkEnvCfg,
     ShadowHandVisionEnvCfg,
 )
-from isaaclab_tasks.utils.hydra import collect_presets, resolve_preset_defaults  # noqa: E402
+from isaaclab_tasks.utils.hydra import collect_presets, resolve_presets  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -383,7 +383,7 @@ def render_correctness_env(request, shadow_hand_vision_presets):
     camera_cfg = copy.deepcopy(shadow_hand_vision_presets["tiled_camera"][camera_preset])
     camera_cfg.renderer_cfg = copy.deepcopy(shadow_hand_vision_presets["tiled_camera.renderer_cfg"][renderer_preset])
     cfg.tiled_camera = camera_cfg
-    # Apply Newton presets before resolve_preset_defaults so they are not overwritten by defaults.
+    # Apply Newton presets before resolve_presets so they are not overwritten by defaults.
     # Newton needs a specific solver config, a different robot USD, an articulation-based object,
     # and a stripped-down event cfg (no PhysX-specific material randomization).
     if physics == "newton":
@@ -392,7 +392,7 @@ def render_correctness_env(request, shadow_hand_vision_presets):
         cfg.object_cfg = copy.deepcopy(shadow_hand_vision_presets["object_cfg"]["newton"])
         if "events" in shadow_hand_vision_presets:
             cfg.events = copy.deepcopy(shadow_hand_vision_presets["events"]["newton"])
-    cfg = resolve_preset_defaults(cfg)
+    cfg = resolve_presets(cfg)
     cfg.scene.num_envs = 4
     cfg.feature_extractor.write_image_to_file = False
     env = ShadowHandVisionEnv(cfg)


### PR DESCRIPTION
# Description

- Add `resolve_presets(cfg, selected)` — a single-pass function that walks the config tree and replaces each `PresetCfg` with the CLI-selected or default alternative. This fixes bugs where presets inside dict-valued alternatives and `PresetCfg(default=None)` were not being discovered or resolved, causing deeply nested configs to silently use wrong defaults. 

- Unknown or unresolvable preset names now raise `ValueError` with a grouped listing of available presets and the paths they affect.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there