### PR TITLE
Fix randomize_actuator_gains zeroing explicit actuator gains

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.5.31"
+version = "4.5.32"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+4.5.32 (2026-04-13)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.envs.mdp.events.randomize_actuator_gains` producing zero
+  stiffness and damping for explicit actuators. The default gains were read from
+  ``asset.data.joint_stiffness``, which is zeroed out at the sim level for explicit
+  actuator models. The defaults are now patched with the actual actuator PD gains.
+
+
 4.5.31 (2026-04-13)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -1135,6 +1135,14 @@ class randomize_actuator_gains(ManagerTermBase):
         self.default_joint_stiffness = wp.to_torch(self.asset.data.joint_stiffness).clone()
         self.default_joint_damping = wp.to_torch(self.asset.data.joint_damping).clone()
 
+        # For explicit actuators the sim-level stiffness/damping is zeroed out, so patch
+        # the defaults with the actual actuator PD gains.
+        for actuator in self.asset.actuators.values():
+            if not isinstance(actuator, ImplicitActuator):
+                joint_ids = actuator.joint_indices
+                self.default_joint_stiffness[:, joint_ids] = actuator.stiffness
+                self.default_joint_damping[:, joint_ids] = actuator.damping
+
         # check for valid operation
         if cfg.params["operation"] == "scale":
             if "stiffness_distribution_params" in cfg.params:


### PR DESCRIPTION
# Description

`randomize_actuator_gains` reads its default stiffness/damping baseline from `asset.data.joint_stiffness`, which is intentionally zeroed at the sim level for explicit actuators (e.g., `IdealPDActuator`, `DCMotor`, `ActuatorNetLSTM`). This causes `scale` and `add` randomization to produce zero gains, making the robot go limp.

After reading the sim-level defaults, the fix patches explicit-actuator joints with the actual PD gains from `actuator.stiffness` / `actuator.damping`.

Fixes #5106

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there