### PR TITLE
Fix flatdict version pin to allow 4.1.0+ (develop)

### DIFF
--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -50,7 +50,7 @@ INSTALL_REQUIRES = [
     "junitparser",
     "coverage==7.6.1",
     "debugpy>=1.8.20",
-    "flatdict==4.0.0",
+    "flatdict>=4.0.0",
     "flaky",
     "packaging",
     "psutil",

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -50,7 +50,7 @@ INSTALL_REQUIRES = [
     "junitparser",
     "coverage==7.6.1",
     "debugpy>=1.8.20",
-    "flatdict>=4.0.0",
+    "flatdict>=4.1.0",
     "flaky",
     "packaging",
     "psutil",


### PR DESCRIPTION
## Description

Relaxes the `flatdict` version pin from `==4.0.0` to `>=4.0.0` in `source/isaaclab/setup.py`.

## Motivation

`flatdict==4.0.0` (and 4.0.1) are source distributions (`.tar.gz`) that require `pkg_resources` during the build step. On modern Python (3.10+) with newer pip/setuptools, the build isolation environment often lacks `pkg_resources`, causing installation to fail with:

```
ModuleNotFoundError: No module named 'pkg_resources'
ERROR: Failed to build 'flatdict' when getting requirements to build wheel
```

`flatdict 4.1.0` ships as a pre-built wheel (`.whl`) and installs cleanly without any build step.

## Changes

- `source/isaaclab/setup.py`: Changed `flatdict==4.0.0` → `flatdict>=4.0.0`

## Verification

The `FlatDict` API used in isaaclab (`FlatDict(dict, delimiter='.')` in `simulation_context.py` and `test_simulation_render_config.py`) is fully compatible across 4.0.0 → 4.1.0. Tested both the constructor and nested dict flattening.

Fixes #4576