### PR TITLE
Updates flatdict from 4.0.0 to 4.1.0

### DIFF
--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -42,7 +42,7 @@ INSTALL_REQUIRES = [
     "pytest",
     "pytest-mock",
     "junitparser",
-    "flatdict==4.0.0",
+    "flatdict==4.1.0",
     "flaky",
     "packaging",
 ]


### PR DESCRIPTION
## Description

Update `flatdict` dependency from `4.0.0` to `4.1.0`.

`flatdict 4.0.1` (and `4.0.0` when built from source) fails to build because its `setup.py` imports `pkg_resources`, which is no longer bundled with recent `setuptools` versions. This causes installation failures for users who don't have `pkg_resources` available in their build environment.

`flatdict 4.1.0` resolves this build issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Fixes

Fixes #4576