### PR TITLE
Change Flexiv Reach ROS env config to reflect robot mounting pose in …

### DIFF
--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "1.5.18"
+version = "1.5.19"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+1.5.19 (2026-04-06)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Aligned :class:`~isaaclab_tasks.manager_based.manipulation.deploy.reach.config.rizon_4s.ros_inference_env_cfg.Rizon4sReachROSInferenceEnvCfg`
+  with the Flexiv Rizon 4s mount and workspace at NVIDIA Hubble Lab.
+
+
 1.5.18 (2026-04-02)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/reach/config/rizon_4s/ros_inference_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/reach/config/rizon_4s/ros_inference_env_cfg.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import math
+
 from isaaclab.utils import configclass
 
 from .joint_pos_env_cfg import Rizon4sReachEnvCfg
@@ -10,11 +12,65 @@ from .joint_pos_env_cfg import Rizon4sReachEnvCfg
 
 @configclass
 class Rizon4sReachROSInferenceEnvCfg(Rizon4sReachEnvCfg):
-    """Exposing variables for ROS inferences"""
+    """ROS / Isaac Manipulator inference fields plus deployment alignment for NVIDIA Hubble Lab.
+
+    The Hubble-specific block in this config matches how the Flexiv Rizon 4s is mounted there.
+    """
 
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
+
+        # --- NVIDIA Hubble Lab: Flexiv Rizon 4s mount and workspace ---
+        # Remove vertical mount stand since Hubble deployment does not use the sim stand asset
+        self.scene.table = None
+
+        # Lab home joint pose (radians); aligns sim defaults / reset with the physical stand
+        self.scene.robot.init_state.joint_pos = {
+            "joint1": math.radians(-90.0),
+            "joint2": math.radians(90.0),
+            "joint3": 0.0,
+            "joint4": math.radians(90.0),
+            "joint5": 0.0,
+            "joint6": 0.0,
+            "joint7": 0.0,
+        }
+
+        # Orientation of robot is based on the Flexiv Rizon 4s mount in the Hubble Lab
+        self.scene.robot.init_state.pos = (0.0, 0.0, 0.0)
+        self.scene.robot.init_state.rot = (0.5, 0.5, 0.5, 0.5)
+
+        # end-effector is along z-direction for Rizon 4s
+        self.target_pos_centre = (0.0, 0.3, 0.9)
+        self.target_pos_range = (0.4, 0.4, 0.4)
+        self.commands.ee_pose.body_name = "flange"
+        self.commands.ee_pose.ranges.pos_x = (
+            self.target_pos_centre[0] - self.target_pos_range[0],
+            self.target_pos_centre[0] + self.target_pos_range[0],
+        )
+        self.commands.ee_pose.ranges.pos_y = (
+            self.target_pos_centre[1] - self.target_pos_range[1],
+            self.target_pos_centre[1] + self.target_pos_range[1],
+        )
+        self.commands.ee_pose.ranges.pos_z = (
+            self.target_pos_centre[2] - self.target_pos_range[2],
+            self.target_pos_centre[2] + self.target_pos_range[2],
+        )
+
+        self.target_rot_centre = (math.pi / 2, math.pi / 2, 0.0)  # end-effector facing down
+        self.target_rot_range = (math.pi / 2, math.pi / 2, math.pi)
+        self.commands.ee_pose.ranges.roll = (
+            self.target_rot_centre[0] - self.target_rot_range[0],
+            self.target_rot_centre[0] + self.target_rot_range[0],
+        )
+        self.commands.ee_pose.ranges.pitch = (
+            self.target_rot_centre[1] - self.target_rot_range[1],
+            self.target_rot_centre[1] + self.target_rot_range[1],
+        )
+        self.commands.ee_pose.ranges.yaw = (
+            self.target_rot_centre[2] - self.target_rot_range[2],
+            self.target_rot_centre[2] + self.target_rot_range[2],
+        )
 
         # Variables used by Isaac Manipulator for on robot inference
         # TODO: @ashwinvk: Remove these from env cfg once the generic inference node has been implemented

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/reach/config/rizon_4s/ros_inference_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/reach/config/rizon_4s/ros_inference_env_cfg.py
@@ -41,8 +41,10 @@ class Rizon4sReachROSInferenceEnvCfg(Rizon4sReachEnvCfg):
         self.scene.robot.init_state.rot = (0.5, 0.5, 0.5, 0.5)
 
         # end-effector is along z-direction for Rizon 4s
+        # target_pos_centre and target_rot_centre are approzimately the end effector pose when
+        # the robot is in the self.scene.robot.init_state.joint_pos pose
         self.target_pos_centre = (0.0, 0.3, 0.9)
-        self.target_pos_range = (0.4, 0.4, 0.4)
+        self.target_pos_range = (0.4, 0.4, 0.35)
         self.commands.ee_pose.body_name = "flange"
         self.commands.ee_pose.ranges.pos_x = (
             self.target_pos_centre[0] - self.target_pos_range[0],

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/reach/config/rizon_4s/ros_inference_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/reach/config/rizon_4s/ros_inference_env_cfg.py
@@ -41,7 +41,7 @@ class Rizon4sReachROSInferenceEnvCfg(Rizon4sReachEnvCfg):
         self.scene.robot.init_state.rot = (0.5, 0.5, 0.5, 0.5)
 
         # end-effector is along z-direction for Rizon 4s
-        # target_pos_centre and target_rot_centre are approzimately the end effector pose when
+        # target_pos_centre and target_rot_centre are approximately the end effector pose when
         # the robot is in the self.scene.robot.init_state.joint_pos pose
         self.target_pos_centre = (0.0, 0.3, 0.9)
         self.target_pos_range = (0.4, 0.4, 0.35)


### PR DESCRIPTION
# Description

Updates `Rizon4sReachROSInferenceEnvCfg` so the Flexiv Rizon 4s ROS / Isaac Manipulator inference setup matches the new Robot mounts in the Hubble Lab

**Motivation:** Align sim defaults and command sampling with the physical robot and workspace for on-robot inference at Hubble.

**Dependencies:** None (standard library `math` only).

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there