### PR TITLE
docs: add NCCL troubleshooting notes for multi-GPU training

### DIFF
--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -128,11 +128,10 @@ Troubleshooting NCCL Errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On some Linux multi-GPU systems, distributed training may fail with
-``CUDA error: an illegal memory access was encountered`` reported by
-``ProcessGroupNCCL`` during or shortly after communicator initialization.
+``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``
+during or shortly after communicator initialization.
 
-If this occurs, try disabling the NCCL shared-memory transport before
-launching training:
+If this occurs, try disabling the NCCL shared-memory transport before launching training:
 
 .. code-block:: bash
 
@@ -149,9 +148,9 @@ Then relaunch the distributed training command as usual.
 
 .. note::
 
-    These variables are NCCL-level workarounds intended for affected systems.
-    They are not required on all machines, and may change communication
-    behavior or performance depending on the hardware topology.
+    These variables are NCCL-level workarounds intended for affected systems. They are not
+    required on all machines, and may change communication behavior or performance depending
+    on the hardware topology.
 
 Multi-Node Training
 -------------------

--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -124,6 +124,8 @@ To train with multiple GPUs, use the following command, where ``--nproc_per_node
 
                     python -m skrl.utils.distributed.jax --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole-v0 --headless --distributed --ml_framework jax
 
+.. _multi-gpu-nccl-troubleshooting:
+
 Troubleshooting NCCL Errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -125,7 +125,7 @@ To train with multiple GPUs, use the following command, where ``--nproc_per_node
                     python -m skrl.utils.distributed.jax --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole-v0 --headless --distributed --ml_framework jax
 
 Troubleshooting NCCL Errors
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On some Linux multi-GPU systems, distributed training may fail with
 ``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``

--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -133,13 +133,13 @@ during or shortly after communicator initialization.
 
 If this occurs, try disabling the NCCL shared-memory transport before launching training:
 
-.. code-block:: bash
+.. code-block:: shell
 
     export NCCL_SHM_DISABLE=1
 
 If the issue persists, additional NCCL fallbacks that may help are:
 
-.. code-block:: bash
+.. code-block:: shell
 
     export NCCL_IB_DISABLE=1
     export NCCL_ALGO=Ring

--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -124,6 +124,35 @@ To train with multiple GPUs, use the following command, where ``--nproc_per_node
 
                     python -m skrl.utils.distributed.jax --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole-v0 --headless --distributed --ml_framework jax
 
+Troubleshooting NCCL Errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On some Linux multi-GPU systems, distributed training may fail with
+``CUDA error: an illegal memory access was encountered`` reported by
+``ProcessGroupNCCL`` during or shortly after communicator initialization.
+
+If this occurs, try disabling the NCCL shared-memory transport before
+launching training:
+
+.. code-block:: bash
+
+    export NCCL_SHM_DISABLE=1
+
+If the issue persists, additional NCCL fallbacks that may help are:
+
+.. code-block:: bash
+
+    export NCCL_IB_DISABLE=1
+    export NCCL_ALGO=Ring
+
+Then relaunch the distributed training command as usual.
+
+.. note::
+
+    These variables are NCCL-level workarounds intended for affected systems.
+    They are not required on all machines, and may change communication
+    behavior or performance depending on the hardware topology.
+
 Multi-Node Training
 -------------------
 

--- a/docs/source/refs/troubleshooting.rst
+++ b/docs/source/refs/troubleshooting.rst
@@ -9,6 +9,14 @@ Tricks and Troubleshooting
     assistance.
 
 
+Troubleshooting distributed training NCCL errors
+------------------------------------------------
+
+On some Linux multi-GPU systems, distributed training may fail with
+``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``.
+For documented NCCL workarounds, see :ref:`multi-gpu-nccl-troubleshooting`.
+
+
 Debugging physics simulation stability issues
 ---------------------------------------------
 


### PR DESCRIPTION
## Description

Adds a troubleshooting note to the multi-GPU training docs for Linux systems
where distributed training may fail with `CUDA error: an illegal memory access was encountered`
reported by `ProcessGroupNCCL`.

This PR is documentation-only. It does not change the default distributed training behavior
in IsaacLab or `rsl_rl`. The note documents NCCL environment-variable workarounds that were
observed to restore stability on some affected systems:

- `NCCL_SHM_DISABLE=1`
- `NCCL_IB_DISABLE=1`
- `NCCL_ALGO=Ring`

The motivation for this change is to provide an official troubleshooting path for users who
hit NCCL transport/algo issues on specific Linux multi-GPU setups. In our local reproduction,
the failure was not caused by IsaacLab task logic itself, but occurred in the distributed
training stack when using NCCL with humanoid locomotion workloads.

Dependencies: none.

Refs #4011
Refs #2756

## Type of change

- Documentation update

## Screenshots

N/A

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Context

Local reproduction environment:
- Ubuntu 22.04.5
- RTX 5090 x2
- Isaac Sim / IsaacLab multi-GPU training
- official distributed minimal reproduction with `Isaac-Velocity-Flat-G1-v0`

Observed behavior:
- the default distributed launch failed with NCCL illegal memory access
- `NCCL_SHM_DISABLE=1` was sufficient to make the official dual-GPU minimal reproduction pass
- `NCCL_SHM_DISABLE=1 NCCL_IB_DISABLE=1 NCCL_ALGO=Ring` also restored stability in a longer validation run

This PR documents those workarounds without changing defaults, since the NCCL transport/algo
selection is handled below the IsaacLab task layer.