### PR TITLE
Caches warp-to-torch views to deduplicate conversions per step

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.6.1"
+version = "4.6.2"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -173,6 +173,18 @@ Added
 
 * Added release version to
   :class:`~isaaclab.test.benchmark.recorders.VersionInfoRecorder` output.
+* Added :func:`~isaaclab.utils.warp_torch_cache.warp_to_torch` utility for cached
+  :func:`warp.to_torch` views on asset data, sensor data, and frame-transformer
+  objects, keyed by ``_sim_timestamp`` or buffer pointer.  Caching can be disabled
+  via :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache` to fall back to
+  plain ``wp.to_torch()``.
+
+Changed
+^^^^^^^
+
+* Changed all built-in observation, reward, and termination terms in
+  :mod:`isaaclab.envs.mdp` to use :func:`~isaaclab.utils.warp_torch_cache.warp_to_torch`
+  instead of calling :func:`warp.to_torch` on every evaluation.
 
 
 4.5.26 (2026-04-08)

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -175,9 +175,12 @@ Added
   :class:`~isaaclab.test.benchmark.recorders.VersionInfoRecorder` output.
 * Added :func:`~isaaclab.utils.warp_torch_cache.warp_to_torch` utility for cached
   :func:`warp.to_torch` views on asset data, sensor data, and frame-transformer
-  objects, keyed by ``_sim_timestamp`` or buffer pointer.  Caching can be disabled
-  via :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache` to fall back to
-  plain ``wp.to_torch()``.
+  objects, keyed by the Warp array's memory pointer.  Because ``wp.to_torch``
+  returns a zero-copy view, in-place updates are automatically reflected without
+  cache invalidation; a new conversion only occurs when the buffer is reallocated.
+  Caching can be disabled via
+  :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache`.
+
 Changed
 ^^^^^^^
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -178,7 +178,6 @@ Added
   objects, keyed by ``_sim_timestamp`` or buffer pointer.  Caching can be disabled
   via :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache` to fall back to
   plain ``wp.to_torch()``.
-
 Changed
 ^^^^^^^
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+4.6.2 (2026-04-14)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :func:`~isaaclab.utils.warp_torch_cache.clear_warp_torch_cache` to
+  flush all cached ``wp.to_torch()`` tensor views. The function is registered
+  automatically on :attr:`~isaaclab.physics.PhysicsEvent.STOP` so that stale
+  views do not survive a simulation teardown or scene change.
+
 4.6.1 (2026-04-14)
 ~~~~~~~~~~~~~~~~~~
 
@@ -51,6 +62,12 @@ Removed
 * Removed :attr:`~isaaclab.sensors.camera.Camera.render_product_paths`. Render products are
   now managed internally by the renderer backend and are not part of the public API.
 
+=======
+* Added :func:`~isaaclab.utils.warp_torch_cache.clear_warp_torch_cache` to
+  flush all cached ``wp.to_torch()`` tensor views. The function is registered
+  automatically on :attr:`~isaaclab.physics.PhysicsEvent.STOP` so that stale
+  views do not survive a simulation teardown or scene change.
+>>>>>>> f2cc4bcd818 (Add cache invalidation for warp_to_torch on simulation teardown)
 
 4.5.33 (2026-04-13)
 ~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -14,12 +14,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 import isaaclab.utils.math as math_utils
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers.manager_base import ManagerTermBase
 from isaaclab.managers.manager_term_cfg import ObservationTermCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation, RigidObject
@@ -46,7 +46,7 @@ def base_pos_z(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg(
     """Root height in the simulation world frame."""
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.root_pos_w)[:, 2].unsqueeze(-1)
+    return warp_to_torch(asset.data, "root_pos_w")[:, 2].unsqueeze(-1)
 
 
 @generic_io_descriptor(
@@ -56,7 +56,7 @@ def base_lin_vel(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCf
     """Root linear velocity in the asset's root frame."""
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.root_lin_vel_b)
+    return warp_to_torch(asset.data, "root_lin_vel_b")
 
 
 @generic_io_descriptor(
@@ -66,7 +66,7 @@ def base_ang_vel(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCf
     """Root angular velocity in the asset's root frame."""
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.root_ang_vel_b)
+    return warp_to_torch(asset.data, "root_ang_vel_b")
 
 
 @generic_io_descriptor(
@@ -76,7 +76,7 @@ def projected_gravity(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEnt
     """Gravity projection on the asset's root frame."""
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.projected_gravity_b)
+    return warp_to_torch(asset.data, "projected_gravity_b")
 
 
 @generic_io_descriptor(
@@ -86,7 +86,7 @@ def root_pos_w(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg(
     """Asset root position in the environment frame."""
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.root_pos_w) - env.scene.env_origins
+    return warp_to_torch(asset.data, "root_pos_w") - env.scene.env_origins
 
 
 @generic_io_descriptor(
@@ -104,7 +104,7 @@ def root_quat_w(
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
 
-    quat = wp.to_torch(asset.data.root_quat_w)
+    quat = warp_to_torch(asset.data, "root_quat_w")
     # make the quaternion real-part positive if configured
     return math_utils.quat_unique(quat) if make_quat_unique else quat
 
@@ -116,7 +116,7 @@ def root_lin_vel_w(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntity
     """Asset root linear velocity in the environment frame."""
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.root_lin_vel_w)
+    return warp_to_torch(asset.data, "root_lin_vel_w")
 
 
 @generic_io_descriptor(
@@ -126,7 +126,7 @@ def root_ang_vel_w(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntity
     """Asset root angular velocity in the environment frame."""
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.root_ang_vel_w)
+    return warp_to_torch(asset.data, "root_ang_vel_w")
 
 
 """
@@ -155,7 +155,7 @@ def body_pose_w(
     asset: Articulation = env.scene[asset_cfg.name]
 
     # access the body poses in world frame
-    pose = wp.to_torch(asset.data.body_pose_w)[:, asset_cfg.body_ids, :7]
+    pose = warp_to_torch(asset.data, "body_pose_w")[:, asset_cfg.body_ids, :7]
     if isinstance(asset_cfg.body_ids, (slice, int)):
         pose = pose.clone()  # if slice or int, make a copy to avoid modifying original data
     pose[..., :3] = pose[..., :3] - env.scene.env_origins.unsqueeze(1)
@@ -182,8 +182,8 @@ def body_projected_gravity_b(
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
 
-    body_quat = wp.to_torch(asset.data.body_quat_w)[:, asset_cfg.body_ids]
-    gravity_dir = wp.to_torch(asset.data.GRAVITY_VEC_W).unsqueeze(1)
+    body_quat = warp_to_torch(asset.data, "body_quat_w")[:, asset_cfg.body_ids]
+    gravity_dir = warp_to_torch(asset.data, "GRAVITY_VEC_W").unsqueeze(1)
     return math_utils.quat_apply_inverse(body_quat, gravity_dir).view(env.num_envs, -1)
 
 
@@ -202,7 +202,7 @@ def joint_pos(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("
     """
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids]
+    return warp_to_torch(asset.data, "joint_pos")[:, asset_cfg.joint_ids]
 
 
 @generic_io_descriptor(
@@ -218,8 +218,8 @@ def joint_pos_rel(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityC
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     return (
-        wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids]
-        - wp.to_torch(asset.data.default_joint_pos)[:, asset_cfg.joint_ids]
+        warp_to_torch(asset.data, "joint_pos")[:, asset_cfg.joint_ids]
+        - warp_to_torch(asset.data, "default_joint_pos")[:, asset_cfg.joint_ids]
     )
 
 
@@ -233,10 +233,11 @@ def joint_pos_limit_normalized(
     """
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
+    limits = warp_to_torch(asset.data, "soft_joint_pos_limits")
     return math_utils.scale_transform(
-        wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids],
-        wp.to_torch(asset.data.soft_joint_pos_limits)[:, asset_cfg.joint_ids, 0],
-        wp.to_torch(asset.data.soft_joint_pos_limits)[:, asset_cfg.joint_ids, 1],
+        warp_to_torch(asset.data, "joint_pos")[:, asset_cfg.joint_ids],
+        limits[:, asset_cfg.joint_ids, 0],
+        limits[:, asset_cfg.joint_ids, 1],
     )
 
 
@@ -250,7 +251,7 @@ def joint_vel(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("
     """
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.joint_vel)[:, asset_cfg.joint_ids]
+    return warp_to_torch(asset.data, "joint_vel")[:, asset_cfg.joint_ids]
 
 
 @generic_io_descriptor(
@@ -266,8 +267,8 @@ def joint_vel_rel(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityC
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     return (
-        wp.to_torch(asset.data.joint_vel)[:, asset_cfg.joint_ids]
-        - wp.to_torch(asset.data.default_joint_vel)[:, asset_cfg.joint_ids]
+        warp_to_torch(asset.data, "joint_vel")[:, asset_cfg.joint_ids]
+        - warp_to_torch(asset.data, "default_joint_vel")[:, asset_cfg.joint_ids]
     )
 
 
@@ -288,7 +289,7 @@ def joint_effort(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCf
     """
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.applied_torque)[:, asset_cfg.joint_ids]
+    return warp_to_torch(asset.data, "applied_torque")[:, asset_cfg.joint_ids]
 
 
 """
@@ -315,7 +316,7 @@ def body_incoming_wrench(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg) -> tor
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # obtain the link incoming forces in world frame
-    body_incoming_joint_wrench_b = wp.to_torch(asset.data.body_incoming_joint_wrench_b)[:, asset_cfg.body_ids]
+    body_incoming_joint_wrench_b = warp_to_torch(asset.data, "body_incoming_joint_wrench_b")[:, asset_cfg.body_ids]
     return body_incoming_joint_wrench_b.view(env.num_envs, -1)
 
 
@@ -330,7 +331,7 @@ def pva_orientation(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntit
         Orientation in the world frame in (x, y, z, w) quaternion form. Shape is (num_envs, 4).
     """
     asset: Pva = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.quat_w)
+    return warp_to_torch(asset.data, "quat_w")
 
 
 def pva_projected_gravity(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("pva")) -> torch.Tensor:
@@ -344,7 +345,7 @@ def pva_projected_gravity(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = Scen
         Gravity projected on sensor frame, shape of torch.tensor is (num_env, 3).
     """
     asset: Pva = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.projected_gravity_b)
+    return warp_to_torch(asset.data, "projected_gravity_b")
 
 
 def imu_ang_vel(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("imu")) -> torch.Tensor:
@@ -358,7 +359,7 @@ def imu_ang_vel(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg
         The angular velocity [rad/s] in the sensor frame. Shape is (num_envs, 3).
     """
     asset: Imu = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.ang_vel_b)
+    return warp_to_torch(asset.data, "ang_vel_b")
 
 
 def imu_lin_acc(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("imu")) -> torch.Tensor:
@@ -372,7 +373,7 @@ def imu_lin_acc(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg
         The linear acceleration [m/s^2] in the sensor frame. Shape is (num_envs, 3).
     """
     asset: Imu = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.lin_acc_b)
+    return warp_to_torch(asset.data, "lin_acc_b")
 
 
 def image(

--- a/source/isaaclab/isaaclab/envs/mdp/rewards.py
+++ b/source/isaaclab/isaaclab/envs/mdp/rewards.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers.manager_base import ManagerTermBase
 from isaaclab.managers.manager_term_cfg import RewardTermCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation, RigidObject
@@ -79,14 +79,14 @@ def lin_vel_z_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntity
     """Penalize z-axis base linear velocity using L2 squared kernel."""
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return torch.square(wp.to_torch(asset.data.root_lin_vel_b)[:, 2])
+    return torch.square(warp_to_torch(asset.data, "root_lin_vel_b")[:, 2])
 
 
 def ang_vel_xy_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
     """Penalize xy-axis base angular velocity using L2 squared kernel."""
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return torch.sum(torch.square(wp.to_torch(asset.data.root_ang_vel_b)[:, :2]), dim=1)
+    return torch.sum(torch.square(warp_to_torch(asset.data, "root_ang_vel_b")[:, :2]), dim=1)
 
 
 def flat_orientation_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
@@ -96,7 +96,7 @@ def flat_orientation_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = Scen
     """
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return torch.sum(torch.square(wp.to_torch(asset.data.projected_gravity_b)[:, :2]), dim=1)
+    return torch.sum(torch.square(warp_to_torch(asset.data, "projected_gravity_b")[:, :2]), dim=1)
 
 
 def base_height_l2(
@@ -121,13 +121,15 @@ def base_height_l2(
         # Use the provided target height directly for flat terrain
         adjusted_target_height = target_height
     # Compute the L2 squared penalty
-    return torch.square(wp.to_torch(asset.data.root_pos_w)[:, 2] - adjusted_target_height)
+    return torch.square(warp_to_torch(asset.data, "root_pos_w")[:, 2] - adjusted_target_height)
 
 
 def body_lin_acc_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
     """Penalize the linear acceleration of bodies using L2-kernel."""
     asset: Articulation = env.scene[asset_cfg.name]
-    return torch.sum(torch.linalg.norm(wp.to_torch(asset.data.body_lin_acc_w)[:, asset_cfg.body_ids, :], dim=-1), dim=1)
+    return torch.sum(
+        torch.linalg.norm(warp_to_torch(asset.data, "body_lin_acc_w")[:, asset_cfg.body_ids, :], dim=-1), dim=1
+    )
 
 
 """
@@ -144,14 +146,14 @@ def joint_torques_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEn
     """
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
-    return torch.sum(torch.square(wp.to_torch(asset.data.applied_torque)[:, asset_cfg.joint_ids]), dim=1)
+    return torch.sum(torch.square(warp_to_torch(asset.data, "applied_torque")[:, asset_cfg.joint_ids]), dim=1)
 
 
 def joint_vel_l1(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
     """Penalize joint velocities on the articulation using an L1-kernel."""
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
-    return torch.sum(torch.abs(wp.to_torch(asset.data.joint_vel)[:, asset_cfg.joint_ids]), dim=1)
+    return torch.sum(torch.abs(warp_to_torch(asset.data, "joint_vel")[:, asset_cfg.joint_ids]), dim=1)
 
 
 def joint_vel_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
@@ -163,7 +165,7 @@ def joint_vel_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntity
     """
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
-    return torch.sum(torch.square(wp.to_torch(asset.data.joint_vel)[:, asset_cfg.joint_ids]), dim=1)
+    return torch.sum(torch.square(warp_to_torch(asset.data, "joint_vel")[:, asset_cfg.joint_ids]), dim=1)
 
 
 def joint_acc_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
@@ -175,7 +177,7 @@ def joint_acc_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntity
     """
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
-    return torch.sum(torch.square(wp.to_torch(asset.data.joint_acc)[:, asset_cfg.joint_ids]), dim=1)
+    return torch.sum(torch.square(warp_to_torch(asset.data, "joint_acc")[:, asset_cfg.joint_ids]), dim=1)
 
 
 def joint_deviation_l1(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
@@ -184,8 +186,8 @@ def joint_deviation_l1(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = Scene
     asset: Articulation = env.scene[asset_cfg.name]
     # compute out of limits constraints
     angle = (
-        wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids]
-        - wp.to_torch(asset.data.default_joint_pos)[:, asset_cfg.joint_ids]
+        warp_to_torch(asset.data, "joint_pos")[:, asset_cfg.joint_ids]
+        - warp_to_torch(asset.data, "default_joint_pos")[:, asset_cfg.joint_ids]
     )
     return torch.sum(torch.abs(angle), dim=1)
 
@@ -198,14 +200,10 @@ def joint_pos_limits(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEn
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # compute out of limits constraints
-    out_of_limits = -(
-        wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids]
-        - wp.to_torch(asset.data.soft_joint_pos_limits)[:, asset_cfg.joint_ids, 0]
-    ).clip(max=0.0)
-    out_of_limits += (
-        wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids]
-        - wp.to_torch(asset.data.soft_joint_pos_limits)[:, asset_cfg.joint_ids, 1]
-    ).clip(min=0.0)
+    jp = warp_to_torch(asset.data, "joint_pos")[:, asset_cfg.joint_ids]
+    limits = warp_to_torch(asset.data, "soft_joint_pos_limits")[:, asset_cfg.joint_ids]
+    out_of_limits = -(jp - limits[..., 0]).clip(max=0.0)
+    out_of_limits += (jp - limits[..., 1]).clip(min=0.0)
     return torch.sum(out_of_limits, dim=1)
 
 
@@ -223,8 +221,8 @@ def joint_vel_limits(
     asset: Articulation = env.scene[asset_cfg.name]
     # compute out of limits constraints
     out_of_limits = (
-        torch.abs(wp.to_torch(asset.data.joint_vel)[:, asset_cfg.joint_ids])
-        - wp.to_torch(asset.data.soft_joint_vel_limits)[:, asset_cfg.joint_ids] * soft_ratio
+        torch.abs(warp_to_torch(asset.data, "joint_vel")[:, asset_cfg.joint_ids])
+        - warp_to_torch(asset.data, "soft_joint_vel_limits")[:, asset_cfg.joint_ids] * soft_ratio
     )
     # clip to max error = 1 rad/s per joint to avoid huge penalties
     out_of_limits = out_of_limits.clip_(min=0.0, max=1.0)
@@ -250,8 +248,8 @@ def applied_torque_limits(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = Sc
     # compute out of limits constraints
     # TODO: We need to fix this to support implicit joints.
     out_of_limits = torch.abs(
-        wp.to_torch(asset.data.applied_torque)[:, asset_cfg.joint_ids]
-        - wp.to_torch(asset.data.computed_torque)[:, asset_cfg.joint_ids]
+        warp_to_torch(asset.data, "applied_torque")[:, asset_cfg.joint_ids]
+        - warp_to_torch(asset.data, "computed_torque")[:, asset_cfg.joint_ids]
     )
     return torch.sum(out_of_limits, dim=1)
 
@@ -276,7 +274,7 @@ def undesired_contacts(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: Sce
     # extract the used quantities (to enable type-hinting)
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
     # check if contact force is above threshold
-    net_contact_forces = wp.to_torch(contact_sensor.data.net_forces_w_history)
+    net_contact_forces = warp_to_torch(contact_sensor.data, "net_forces_w_history")
     is_contact = (
         torch.max(torch.linalg.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > threshold
     )
@@ -288,7 +286,9 @@ def desired_contacts(env, sensor_cfg: SceneEntityCfg, threshold: float = 1.0) ->
     """Penalize if none of the desired contacts are present."""
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
     contacts = (
-        wp.to_torch(contact_sensor.data.net_forces_w_history)[:, :, sensor_cfg.body_ids, :].norm(dim=-1).max(dim=1)[0]
+        warp_to_torch(contact_sensor.data, "net_forces_w_history")[:, :, sensor_cfg.body_ids, :]
+        .norm(dim=-1)
+        .max(dim=1)[0]
         > threshold
     )
     zero_contact = (~contacts).all(dim=1)
@@ -299,7 +299,7 @@ def contact_forces(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: SceneEn
     """Penalize contact forces as the amount of violations of the net contact force."""
     # extract the used quantities (to enable type-hinting)
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
-    net_contact_forces = wp.to_torch(contact_sensor.data.net_forces_w_history)
+    net_contact_forces = warp_to_torch(contact_sensor.data, "net_forces_w_history")
     # compute the violation
     violation = (
         torch.max(torch.linalg.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] - threshold
@@ -322,7 +322,7 @@ def track_lin_vel_xy_exp(
     # compute the error
     lin_vel_error = torch.sum(
         torch.square(
-            env.command_manager.get_command(command_name)[:, :2] - wp.to_torch(asset.data.root_lin_vel_b)[:, :2]
+            env.command_manager.get_command(command_name)[:, :2] - warp_to_torch(asset.data, "root_lin_vel_b")[:, :2]
         ),
         dim=1,
     )
@@ -337,6 +337,6 @@ def track_ang_vel_z_exp(
     asset: RigidObject = env.scene[asset_cfg.name]
     # compute the error
     ang_vel_error = torch.square(
-        env.command_manager.get_command(command_name)[:, 2] - wp.to_torch(asset.data.root_ang_vel_b)[:, 2]
+        env.command_manager.get_command(command_name)[:, 2] - warp_to_torch(asset.data, "root_ang_vel_b")[:, 2]
     )
     return torch.exp(-ang_vel_error / std**2)

--- a/source/isaaclab/isaaclab/envs/mdp/terminations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/terminations.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation, RigidObject
@@ -58,7 +58,7 @@ def bad_orientation(
     """
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return torch.acos(-wp.to_torch(asset.data.projected_gravity_b)[:, 2]).abs() > limit_angle
+    return torch.acos(-warp_to_torch(asset.data, "projected_gravity_b")[:, 2]).abs() > limit_angle
 
 
 def root_height_below_minimum(
@@ -71,7 +71,7 @@ def root_height_below_minimum(
     """
     # extract the used quantities (to enable type-hinting)
     asset: RigidObject = env.scene[asset_cfg.name]
-    return wp.to_torch(asset.data.root_pos_w)[:, 2] < minimum_height
+    return warp_to_torch(asset.data, "root_pos_w")[:, 2] < minimum_height
 
 
 """
@@ -86,9 +86,10 @@ def joint_pos_out_of_limit(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = S
     if asset_cfg.joint_ids is None:
         asset_cfg.joint_ids = slice(None)
 
-    limits = wp.to_torch(asset.data.soft_joint_pos_limits)[:, asset_cfg.joint_ids]
-    out_of_upper_limits = torch.any(wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids] > limits[..., 1], dim=1)
-    out_of_lower_limits = torch.any(wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids] < limits[..., 0], dim=1)
+    limits = warp_to_torch(asset.data, "soft_joint_pos_limits")[:, asset_cfg.joint_ids]
+    jp = warp_to_torch(asset.data, "joint_pos")[:, asset_cfg.joint_ids]
+    out_of_upper_limits = torch.any(jp > limits[..., 1], dim=1)
+    out_of_lower_limits = torch.any(jp < limits[..., 0], dim=1)
     return torch.logical_or(out_of_upper_limits, out_of_lower_limits)
 
 
@@ -105,8 +106,9 @@ def joint_pos_out_of_manual_limit(
     if asset_cfg.joint_ids is None:
         asset_cfg.joint_ids = slice(None)
     # compute any violations
-    out_of_upper_limits = torch.any(wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids] > bounds[1], dim=1)
-    out_of_lower_limits = torch.any(wp.to_torch(asset.data.joint_pos)[:, asset_cfg.joint_ids] < bounds[0], dim=1)
+    jp = warp_to_torch(asset.data, "joint_pos")[:, asset_cfg.joint_ids]
+    out_of_upper_limits = torch.any(jp > bounds[1], dim=1)
+    out_of_lower_limits = torch.any(jp < bounds[0], dim=1)
     return torch.logical_or(out_of_upper_limits, out_of_lower_limits)
 
 
@@ -115,9 +117,10 @@ def joint_vel_out_of_limit(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = S
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # compute any violations
-    limits = wp.to_torch(asset.data.soft_joint_vel_limits)
+    limits = warp_to_torch(asset.data, "soft_joint_vel_limits")
     return torch.any(
-        torch.abs(wp.to_torch(asset.data.joint_vel)[:, asset_cfg.joint_ids]) > limits[:, asset_cfg.joint_ids], dim=1
+        torch.abs(warp_to_torch(asset.data, "joint_vel")[:, asset_cfg.joint_ids]) > limits[:, asset_cfg.joint_ids],
+        dim=1,
     )
 
 
@@ -128,7 +131,7 @@ def joint_vel_out_of_manual_limit(
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # compute any violations
-    return torch.any(torch.abs(wp.to_torch(asset.data.joint_vel)[:, asset_cfg.joint_ids]) > max_velocity, dim=1)
+    return torch.any(torch.abs(warp_to_torch(asset.data, "joint_vel")[:, asset_cfg.joint_ids]) > max_velocity, dim=1)
 
 
 def joint_effort_out_of_limit(
@@ -144,8 +147,8 @@ def joint_effort_out_of_limit(
     asset: Articulation = env.scene[asset_cfg.name]
     # check if any joint effort is out of limit
     out_of_limits = ~torch.isclose(
-        wp.to_torch(asset.data.computed_torque)[:, asset_cfg.joint_ids],
-        wp.to_torch(asset.data.applied_torque)[:, asset_cfg.joint_ids],
+        warp_to_torch(asset.data, "computed_torque")[:, asset_cfg.joint_ids],
+        warp_to_torch(asset.data, "applied_torque")[:, asset_cfg.joint_ids],
     )
     return torch.any(out_of_limits, dim=1)
 
@@ -159,7 +162,7 @@ def illegal_contact(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: SceneE
     """Terminate when the contact force on the sensor exceeds the force threshold."""
     # extract the used quantities (to enable type-hinting)
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
-    net_contact_forces = wp.to_torch(contact_sensor.data.net_forces_w_history)
+    net_contact_forces = warp_to_torch(contact_sensor.data, "net_forces_w_history")
     # check if any contact force exceeds the threshold
     return torch.any(
         torch.max(torch.linalg.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > threshold, dim=1

--- a/source/isaaclab/isaaclab/managers/observation_manager.py
+++ b/source/isaaclab/isaaclab/managers/observation_manager.py
@@ -389,6 +389,10 @@ class ObservationManager(ManagerBase):
         # read attributes for each term
         obs_terms = zip(group_term_names, self._group_obs_term_cfgs[group_name])
 
+        # pre-resolve lazy-loaded types so isinstance checks skip __getattr__ per iteration
+        _NoiseCfg = noise.NoiseCfg
+        _NoiseModelCfg = noise.NoiseModelCfg
+
         # evaluate terms: compute, add noise, clip, scale, custom modifiers
         for term_name, term_cfg in obs_terms:
             # compute term's value
@@ -397,9 +401,9 @@ class ObservationManager(ManagerBase):
             if term_cfg.modifiers is not None:
                 for modifier in term_cfg.modifiers:
                     obs = modifier.func(obs, **modifier.params)
-            if isinstance(term_cfg.noise, noise.NoiseCfg):
+            if isinstance(term_cfg.noise, _NoiseCfg):
                 obs = term_cfg.noise.func(obs, term_cfg.noise)
-            elif isinstance(term_cfg.noise, noise.NoiseModelCfg) and term_cfg.noise.func is not None:
+            elif isinstance(term_cfg.noise, _NoiseModelCfg) and term_cfg.noise.func is not None:
                 obs = term_cfg.noise.func(obs)
             if term_cfg.clip:
                 obs = obs.clip_(min=term_cfg.clip[0], max=term_cfg.clip[1])

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -260,5 +260,14 @@ class SimulationCfg:
     If None, the logs will be saved to the temp directory.
     """
 
+    enable_warp_torch_cache: bool = True
+    """Cache :func:`warp.to_torch` views within each simulation step. Default is True.
+
+    When enabled, :func:`~isaaclab.utils.warp_torch_cache.warp_to_torch` deduplicates
+    ``wp.to_torch()`` calls so at most one conversion is performed per field per step.
+    Set to ``False`` to fall back to plain ``wp.to_torch()`` on every call (useful for
+    debugging or benchmarking the cache overhead).
+    """
+
     visualizer_cfgs: list[VisualizerCfg] | VisualizerCfg = []
     """The visualizer configuration(s). Default is an empty list."""

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -261,10 +261,13 @@ class SimulationCfg:
     """
 
     enable_warp_torch_cache: bool = True
-    """Cache :func:`warp.to_torch` views within each simulation step. Default is True.
+    """Cache :func:`warp.to_torch` views using buffer-pointer identity. Default is True.
 
-    When enabled, :func:`~isaaclab.utils.warp_torch_cache.warp_to_torch` deduplicates
-    ``wp.to_torch()`` calls so at most one conversion is performed per field per step.
+    When enabled, :func:`~isaaclab.utils.warp_torch_cache.warp_to_torch` caches
+    ``wp.to_torch()`` results keyed by the Warp array's memory pointer.  Because
+    ``wp.to_torch`` returns a zero-copy view, in-place updates to the Warp buffer
+    are automatically reflected in the cached tensor without invalidation.  A new
+    conversion is only performed when the underlying buffer is reallocated.
     Set to ``False`` to fall back to plain ``wp.to_torch()`` on every call (useful for
     debugging or benchmarking the cache overhead).
     """

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -176,6 +176,11 @@ class SimulationContext:
         physics_dt = getattr(self.cfg.physics, "dt", None)
         self._viz_dt = (physics_dt if physics_dt is not None else self.cfg.dt) * self.cfg.render_interval
 
+        # Apply warp-to-torch cache setting
+        from isaaclab.utils.warp_torch_cache import set_caching_enabled
+
+        set_caching_enabled(self.cfg.enable_warp_torch_cache)
+
         # Cache commonly-used settings (these don't change during runtime)
         self._has_gui = bool(self.get_setting("/isaaclab/has_gui"))
         self._has_offscreen_render = bool(self.get_setting("/isaaclab/render/offscreen"))

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -176,10 +176,17 @@ class SimulationContext:
         physics_dt = getattr(self.cfg.physics, "dt", None)
         self._viz_dt = (physics_dt if physics_dt is not None else self.cfg.dt) * self.cfg.render_interval
 
-        # Apply warp-to-torch cache setting
-        from isaaclab.utils.warp_torch_cache import set_caching_enabled
+        # Apply warp-to-torch cache setting and register STOP callback to flush
+        # all cached wp.to_torch tensors when the simulation is torn down.
+        from isaaclab.physics import PhysicsEvent
+        from isaaclab.utils.warp_torch_cache import clear_warp_torch_cache, set_caching_enabled
 
+        # Defensive clear in case a prior session exited without dispatching STOP.
+        clear_warp_torch_cache()
         set_caching_enabled(self.cfg.enable_warp_torch_cache)
+        self.physics_manager.register_callback(
+            lambda _: clear_warp_torch_cache(), PhysicsEvent.STOP, order=0, wrap_weak_ref=False
+        )
 
         # Cache commonly-used settings (these don't change during runtime)
         self._has_gui = bool(self.get_setting("/isaaclab/has_gui"))

--- a/source/isaaclab/isaaclab/utils/__init__.pyi
+++ b/source/isaaclab/isaaclab/utils/__init__.pyi
@@ -55,6 +55,8 @@ __all__ = [
     "compare_versions",
     "configclass",
     "resolve_cfg_presets",
+    "warp_to_torch",
+    "set_caching_enabled",
 ]
 
 from .timer import Timer
@@ -105,3 +107,4 @@ from .string import (
 from .types import ArticulationActions
 from .version import has_kit, get_isaac_sim_version, compare_versions
 from .configclass import configclass, resolve_cfg_presets
+from .warp_torch_cache import warp_to_torch, set_caching_enabled

--- a/source/isaaclab/isaaclab/utils/__init__.pyi
+++ b/source/isaaclab/isaaclab/utils/__init__.pyi
@@ -57,6 +57,7 @@ __all__ = [
     "resolve_cfg_presets",
     "warp_to_torch",
     "set_caching_enabled",
+    "clear_warp_torch_cache",
 ]
 
 from .timer import Timer
@@ -107,4 +108,4 @@ from .string import (
 from .types import ArticulationActions
 from .version import has_kit, get_isaac_sim_version, compare_versions
 from .configclass import configclass, resolve_cfg_presets
-from .warp_torch_cache import warp_to_torch, set_caching_enabled
+from .warp_torch_cache import warp_to_torch, set_caching_enabled, clear_warp_torch_cache

--- a/source/isaaclab/isaaclab/utils/warp_torch_cache.py
+++ b/source/isaaclab/isaaclab/utils/warp_torch_cache.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Helpers to reuse :func:`warp.to_torch` views across hot paths (e.g. observation terms)."""
+
+from __future__ import annotations
+
+import torch
+import warp as wp
+
+_CACHING_ENABLED: bool = True
+
+
+def set_caching_enabled(enabled: bool) -> None:
+    """Enable or disable the per-step :func:`warp.to_torch` cache.
+
+    Called by :class:`~isaaclab.sim.SimulationContext` at init based on
+    :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache`.
+
+    Args:
+        enabled: Whether to cache ``wp.to_torch()`` views.
+    """
+    global _CACHING_ENABLED
+    _CACHING_ENABLED = enabled
+
+
+def warp_to_torch(owner_or_array: object, field_name: str | None = None) -> torch.Tensor:
+    """Return a PyTorch tensor view, optionally caching per simulation step.
+
+    Two calling conventions are supported:
+
+    - ``warp_to_torch(owner, "field_name")`` — resolves
+      ``getattr(owner, field_name)`` and caches the result on *owner* so at most
+      one :func:`warp.to_torch` call is performed per field per step.
+    - ``warp_to_torch(warp_array)`` — plain :func:`warp.to_torch` with no caching.
+
+    The cache is invalidated each physics substep via the owner's
+    ``_sim_timestamp``, or by a change in the Warp buffer pointer for owners
+    that lack a timestamp (e.g. sensor data with fixed Warp storage).
+
+    Caching can be disabled globally via
+    :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache`.
+
+    Args:
+        owner_or_array: Either the object that owns the Warp-backed property
+            (when *field_name* is given) or a raw :class:`wp.array` to convert
+            directly.
+        field_name: Attribute name on *owner_or_array* that returns a
+            :class:`wp.array` (e.g. ``"joint_pos"``, ``"root_pos_w"``).
+
+    Returns:
+        PyTorch tensor sharing memory with the underlying Warp buffer.
+    """
+    if field_name is None:
+        return wp.to_torch(owner_or_array)
+
+    owner = owner_or_array
+    warp_array = getattr(owner, field_name)
+
+    if not _CACHING_ENABLED:
+        return wp.to_torch(warp_array)
+
+    cache = getattr(owner, "_warp_torch_cache", None)
+    if cache is None:
+        cache = {}
+        object.__setattr__(owner, "_warp_torch_cache", cache)
+
+    sim_ts = getattr(owner, "_sim_timestamp", None)
+
+    if sim_ts is not None:
+        entry = cache.get(field_name)
+        if entry is None or entry[0] != sim_ts:
+            cache[field_name] = (sim_ts, wp.to_torch(warp_array))
+        return cache[field_name][1]
+
+    ptr = int(warp_array.ptr)
+    entry = cache.get(field_name)
+    if entry is None or entry[0] != ptr:
+        cache[field_name] = (ptr, wp.to_torch(warp_array))
+    return cache[field_name][1]

--- a/source/isaaclab/isaaclab/utils/warp_torch_cache.py
+++ b/source/isaaclab/isaaclab/utils/warp_torch_cache.py
@@ -3,7 +3,14 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Helpers to reuse :func:`warp.to_torch` views across hot paths (e.g. observation terms)."""
+"""Helpers to reuse :func:`warp.to_torch` views across hot paths (e.g. observation terms).
+
+Because :func:`warp.to_torch` returns a zero-copy tensor that shares the
+underlying GPU buffer, in-place modifications to the Warp array are
+automatically visible through the cached tensor.  The cache only needs to
+be invalidated when the Warp array is **reassigned** to a different buffer
+(i.e. its memory pointer changes).
+"""
 
 from __future__ import annotations
 
@@ -14,7 +21,7 @@ _CACHING_ENABLED: bool = True
 
 
 def set_caching_enabled(enabled: bool) -> None:
-    """Enable or disable the per-step :func:`warp.to_torch` cache.
+    """Enable or disable the :func:`warp.to_torch` pointer-based cache.
 
     Called by :class:`~isaaclab.sim.SimulationContext` at init based on
     :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache`.
@@ -26,38 +33,27 @@ def set_caching_enabled(enabled: bool) -> None:
     _CACHING_ENABLED = enabled
 
 
-def warp_to_torch(owner_or_array: object, field_name: str | None = None) -> torch.Tensor:
-    """Return a PyTorch tensor view, optionally caching per simulation step.
+def warp_to_torch(owner: object, field_name: str) -> torch.Tensor:
+    """Return a cached PyTorch tensor view of a Warp-backed attribute on *owner*.
 
-    Two calling conventions are supported:
-
-    - ``warp_to_torch(owner, "field_name")`` — resolves
-      ``getattr(owner, field_name)`` and caches the result on *owner* so at most
-      one :func:`warp.to_torch` call is performed per field per step.
-    - ``warp_to_torch(warp_array)`` — plain :func:`warp.to_torch` with no caching.
-
-    The cache is invalidated each physics substep via the owner's
-    ``_sim_timestamp``, or by a change in the Warp buffer pointer for owners
-    that lack a timestamp (e.g. sensor data with fixed Warp storage).
+    Resolves ``getattr(owner, field_name)`` and caches the resulting
+    :func:`warp.to_torch` tensor on *owner*.  The cached tensor is reused as
+    long as the Warp array's memory pointer (:attr:`wp.array.ptr`) is unchanged.
+    Since ``wp.to_torch`` produces a zero-copy view, in-place updates to the
+    Warp buffer are automatically reflected in the cached tensor without
+    invalidation.
 
     Caching can be disabled globally via
     :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache`.
 
     Args:
-        owner_or_array: Either the object that owns the Warp-backed property
-            (when *field_name* is given) or a raw :class:`wp.array` to convert
-            directly.
-        field_name: Attribute name on *owner_or_array* that returns a
+        owner: The object that owns the Warp-backed property.
+        field_name: Attribute name on *owner* that returns a
             :class:`wp.array` (e.g. ``"joint_pos"``, ``"root_pos_w"``).
 
     Returns:
         PyTorch tensor sharing memory with the underlying Warp buffer.
     """
-    if field_name is None:
-        return wp.to_torch(owner_or_array)  # type: ignore[arg-type]
-
-    owner = owner_or_array
-
     if not _CACHING_ENABLED:
         return wp.to_torch(getattr(owner, field_name))
 
@@ -69,21 +65,13 @@ def warp_to_torch(owner_or_array: object, field_name: str | None = None) -> torc
     except (AttributeError, TypeError):
         return wp.to_torch(getattr(owner, field_name))
 
-    sim_ts = getattr(owner, "_sim_timestamp", None)
-
-    if sim_ts is not None:
-        entry = cache.get(field_name)
-        if entry is not None and entry[0] == sim_ts:
-            return entry[1]
-
     warp_array = getattr(owner, field_name)
+    current_ptr = int(warp_array.ptr)
 
-    if sim_ts is not None:
-        cache[field_name] = (sim_ts, wp.to_torch(warp_array))
-        return cache[field_name][1]
-
-    ptr = int(warp_array.ptr)
     entry = cache.get(field_name)
-    if entry is None or entry[0] != ptr:
-        cache[field_name] = (ptr, wp.to_torch(warp_array))
-    return cache[field_name][1]
+    if entry is not None and entry[0] == current_ptr:
+        return entry[1]
+
+    new_tensor = wp.to_torch(warp_array)
+    cache[field_name] = (current_ptr, new_tensor)
+    return new_tensor

--- a/source/isaaclab/isaaclab/utils/warp_torch_cache.py
+++ b/source/isaaclab/isaaclab/utils/warp_torch_cache.py
@@ -54,25 +54,32 @@ def warp_to_torch(owner_or_array: object, field_name: str | None = None) -> torc
         PyTorch tensor sharing memory with the underlying Warp buffer.
     """
     if field_name is None:
-        return wp.to_torch(owner_or_array)
+        return wp.to_torch(owner_or_array)  # type: ignore[arg-type]
 
     owner = owner_or_array
-    warp_array = getattr(owner, field_name)
 
     if not _CACHING_ENABLED:
-        return wp.to_torch(warp_array)
+        return wp.to_torch(getattr(owner, field_name))
 
-    cache = getattr(owner, "_warp_torch_cache", None)
-    if cache is None:
-        cache = {}
-        object.__setattr__(owner, "_warp_torch_cache", cache)
+    try:
+        cache = getattr(owner, "_warp_torch_cache", None)
+        if cache is None:
+            cache = {}
+            object.__setattr__(owner, "_warp_torch_cache", cache)
+    except (AttributeError, TypeError):
+        return wp.to_torch(getattr(owner, field_name))
 
     sim_ts = getattr(owner, "_sim_timestamp", None)
 
     if sim_ts is not None:
         entry = cache.get(field_name)
-        if entry is None or entry[0] != sim_ts:
-            cache[field_name] = (sim_ts, wp.to_torch(warp_array))
+        if entry is not None and entry[0] == sim_ts:
+            return entry[1]
+
+    warp_array = getattr(owner, field_name)
+
+    if sim_ts is not None:
+        cache[field_name] = (sim_ts, wp.to_torch(warp_array))
         return cache[field_name][1]
 
     ptr = int(warp_array.ptr)

--- a/source/isaaclab/isaaclab/utils/warp_torch_cache.py
+++ b/source/isaaclab/isaaclab/utils/warp_torch_cache.py
@@ -10,26 +10,52 @@ underlying GPU buffer, in-place modifications to the Warp array are
 automatically visible through the cached tensor.  The cache only needs to
 be invalidated when the Warp array is **reassigned** to a different buffer
 (i.e. its memory pointer changes).
+
+All caches are automatically flushed on :attr:`~isaaclab.physics.PhysicsEvent.STOP`
+so that no stale tensor views survive a simulation teardown or scene change.
 """
 
 from __future__ import annotations
+
+import weakref
 
 import torch
 import warp as wp
 
 _CACHING_ENABLED: bool = True
+_CACHED_OWNERS: list[weakref.ref] = []
+
+
+def clear_warp_torch_cache() -> None:
+    """Clear all cached :func:`warp.to_torch` tensors across every tracked owner.
+
+    This is registered as a :attr:`~isaaclab.physics.PhysicsEvent.STOP` callback
+    by :class:`~isaaclab.sim.SimulationContext` so that stale tensor views do not
+    survive a simulation teardown or scene change.  It can also be called manually.
+    """
+    for ref in _CACHED_OWNERS:
+        obj = ref()
+        if obj is not None:
+            try:
+                delattr(obj, "_warp_torch_cache")
+            except (AttributeError, TypeError):
+                pass
+    _CACHED_OWNERS.clear()
 
 
 def set_caching_enabled(enabled: bool) -> None:
-    """Enable or disable the :func:`warp.to_torch` pointer-based cache.
+    """Enable or disable the :func:`warp.to_torch` cache.
 
     Called by :class:`~isaaclab.sim.SimulationContext` at init based on
-    :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache`.
+    :attr:`~isaaclab.sim.SimulationCfg.enable_warp_torch_cache`.  Flushes
+    all existing cached entries when the setting changes.
 
     Args:
         enabled: Whether to cache ``wp.to_torch()`` views.
     """
     global _CACHING_ENABLED
+    if enabled != _CACHING_ENABLED:
+        clear_warp_torch_cache()
     _CACHING_ENABLED = enabled
 
 
@@ -38,7 +64,8 @@ def warp_to_torch(owner: object, field_name: str) -> torch.Tensor:
 
     Resolves ``getattr(owner, field_name)`` and caches the resulting
     :func:`warp.to_torch` tensor on *owner*.  The cached tensor is reused as
-    long as the Warp array's memory pointer (:attr:`wp.array.ptr`) is unchanged.
+    long as the Warp array's identity token (pointer, shape, dtype, strides,
+    and device) is unchanged.
     Since ``wp.to_torch`` produces a zero-copy view, in-place updates to the
     Warp buffer are automatically reflected in the cached tensor without
     invalidation.
@@ -60,18 +87,31 @@ def warp_to_torch(owner: object, field_name: str) -> torch.Tensor:
     try:
         cache = getattr(owner, "_warp_torch_cache", None)
         if cache is None:
+            try:
+                owner_ref = weakref.ref(owner)
+            except TypeError:
+                # Owner cannot be weak-referenced, so we cannot guarantee global
+                # cache clearing on STOP. Fall back to uncached conversion.
+                return wp.to_torch(getattr(owner, field_name))
             cache = {}
             object.__setattr__(owner, "_warp_torch_cache", cache)
+            _CACHED_OWNERS.append(owner_ref)
     except (AttributeError, TypeError):
         return wp.to_torch(getattr(owner, field_name))
 
     warp_array = getattr(owner, field_name)
-    current_ptr = int(warp_array.ptr)
+    current_token = (
+        warp_array.ptr,
+        warp_array.shape,
+        warp_array.dtype,
+        warp_array.strides,
+        warp_array.device,
+    )
 
     entry = cache.get(field_name)
-    if entry is not None and entry[0] == current_ptr:
+    if entry is not None and entry[0] == current_token:
         return entry[1]
 
     new_tensor = wp.to_torch(warp_array)
-    cache[field_name] = (current_ptr, new_tensor)
+    cache[field_name] = (current_token, new_tensor)
     return new_tensor

--- a/source/isaaclab/test/sim/test_simulation_context.py
+++ b/source/isaaclab/test/sim/test_simulation_context.py
@@ -16,12 +16,33 @@ import weakref
 
 import numpy as np
 import pytest
+import torch
+import warp as wp
 from isaaclab_physx.physics import IsaacEvents, PhysxCfg, PhysxManager
 
 import omni.timeline
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
+from isaaclab.utils.warp_torch_cache import warp_to_torch
+
+
+class _MockWarpArray:
+    """Lightweight stand-in for a ``wp.array`` used by cache tests."""
+
+    def __init__(self, ptr: int = 0):
+        self.ptr = ptr
+        self.shape = (2,)
+        self.dtype = "float32"
+        self.strides = (1,)
+        self.device = "cpu"
+
+
+class _MockCacheOwner:
+    """Minimal owner that holds a single Warp-like attribute."""
+
+    def __init__(self, joint_pos):
+        self.joint_pos = joint_pos
 
 
 @pytest.fixture(autouse=True)
@@ -97,6 +118,33 @@ def test_instance_before_creation():
 
     # accessing instance before creation should return None
     assert SimulationContext.instance() is None
+
+
+@pytest.mark.isaacsim_ci
+def test_init_clears_stale_warp_torch_cache(monkeypatch: pytest.MonkeyPatch):
+    """SimulationContext init clears stale cached warp-to-torch entries."""
+    monkeypatch.setattr(wp, "to_torch", lambda arr: torch.empty(arr.shape))
+
+    owner = _MockCacheOwner(_MockWarpArray(ptr=123))
+    warp_to_torch(owner, "joint_pos")
+    assert hasattr(owner, "_warp_torch_cache")
+
+    SimulationContext(cfg=SimulationCfg(device="cpu"))
+    assert not hasattr(owner, "_warp_torch_cache")
+
+
+@pytest.mark.isaacsim_ci
+def test_teardown_clears_warp_torch_cache_via_stop_callback(monkeypatch: pytest.MonkeyPatch):
+    """SimulationContext teardown clears caches via STOP callback."""
+    monkeypatch.setattr(wp, "to_torch", lambda arr: torch.empty(arr.shape))
+
+    sim = SimulationContext(cfg=SimulationCfg(device="cpu"))
+    owner = _MockCacheOwner(_MockWarpArray(ptr=456))
+    warp_to_torch(owner, "joint_pos")
+    assert hasattr(owner, "_warp_torch_cache")
+
+    sim.clear_instance()
+    assert not hasattr(owner, "_warp_torch_cache")
 
 
 @pytest.mark.isaacsim_ci

--- a/source/isaaclab/test/utils/test_warp_torch_cache.py
+++ b/source/isaaclab/test/utils/test_warp_torch_cache.py
@@ -9,7 +9,7 @@ import warp as wp
 
 wp.init()
 
-from isaaclab.utils.warp_torch_cache import set_caching_enabled, warp_to_torch
+from isaaclab.utils.warp_torch_cache import clear_warp_torch_cache, set_caching_enabled, warp_to_torch
 
 
 class _Owner:
@@ -29,11 +29,32 @@ class _FrozenOwner:
         self.joint_pos = joint_pos
 
 
+class _FakeWarpArray:
+    """Lightweight warp-array stand-in for cache-key edge-case tests."""
+
+    def __init__(self, ptr: int, shape: tuple[int, ...], dtype: object, strides: tuple[int, ...], device: object):
+        self.ptr = ptr
+        self.shape = shape
+        self.dtype = dtype
+        self.strides = strides
+        self.device = device
+
+
+class _NoWeakrefOwner:
+    """Owner that allows cache attr writes but cannot be weak-referenced."""
+
+    __slots__ = ("joint_pos", "_warp_torch_cache")
+
+    def __init__(self, joint_pos):
+        self.joint_pos = joint_pos
+
+
 @pytest.fixture(autouse=True)
 def _enable_cache():
-    """Ensure caching is enabled before each test and restored afterwards."""
+    """Ensure caching is enabled during each test and cleared afterwards."""
     set_caching_enabled(True)
     yield
+    clear_warp_torch_cache()
     set_caching_enabled(True)
 
 
@@ -145,3 +166,74 @@ def test_frozen_owner_fallback():
 
     t = warp_to_torch(owner, "joint_pos")
     torch.testing.assert_close(t, torch.full((3,), 5.0))
+
+
+def test_non_weakref_owner_fallback_uncached():
+    """Owners that reject weakref fallback to uncached conversions."""
+    owner = _NoWeakrefOwner(joint_pos=_make_warp_array(4, value=5.0))
+
+    t1 = warp_to_torch(owner, "joint_pos")
+    t2 = warp_to_torch(owner, "joint_pos")
+
+    assert t1 is not t2
+    assert not hasattr(owner, "_warp_torch_cache")
+    torch.testing.assert_close(t1, torch.full((4,), 5.0))
+    torch.testing.assert_close(t2, torch.full((4,), 5.0))
+
+
+# --------------------------------------------------------------------------- #
+# clear_warp_torch_cache
+# --------------------------------------------------------------------------- #
+
+
+def test_clear_cache_flushes_all_owners():
+    """After clear_warp_torch_cache(), subsequent calls return new tensor objects."""
+    owner_a = _Owner(joint_pos=_make_warp_array(4, value=1.0))
+    owner_b = _Owner(joint_pos=_make_warp_array(4, value=2.0))
+
+    t_a = warp_to_torch(owner_a, "joint_pos")
+    t_b = warp_to_torch(owner_b, "joint_pos")
+
+    # Sanity: cache hits before clearing.
+    assert warp_to_torch(owner_a, "joint_pos") is t_a
+    assert warp_to_torch(owner_b, "joint_pos") is t_b
+
+    clear_warp_torch_cache()
+
+    # After clearing, new tensors are created (same data, different objects).
+    t_a2 = warp_to_torch(owner_a, "joint_pos")
+    t_b2 = warp_to_torch(owner_b, "joint_pos")
+    assert t_a2 is not t_a
+    assert t_b2 is not t_b
+    torch.testing.assert_close(t_a2, torch.full((4,), 1.0))
+    torch.testing.assert_close(t_b2, torch.full((4,), 2.0))
+
+
+def test_clear_cache_handles_dead_refs():
+    """clear_warp_torch_cache() does not crash when owners have been garbage-collected."""
+    owner = _Owner(joint_pos=_make_warp_array(4, value=1.0))
+    warp_to_torch(owner, "joint_pos")
+
+    del owner
+    # Should not raise even though the weak reference is now dead.
+    clear_warp_torch_cache()
+
+
+def test_cache_miss_when_ptr_matches_but_metadata_changes(monkeypatch: pytest.MonkeyPatch):
+    """Cache token includes metadata, not only pointer address."""
+    owner = _Owner(data=_FakeWarpArray(ptr=0, shape=(0,), dtype="float32", strides=(1,), device="cpu"))
+
+    def _fake_to_torch(arr):
+        return torch.empty(arr.shape)
+
+    monkeypatch.setattr(wp, "to_torch", _fake_to_torch)
+
+    t1 = warp_to_torch(owner, "data")
+
+    # Same pointer, different shape/dtype metadata should force a cache miss.
+    owner.data = _FakeWarpArray(ptr=0, shape=(0, 3), dtype="int32", strides=(3, 1), device="cpu")
+    t2 = warp_to_torch(owner, "data")
+
+    assert t1 is not t2
+    assert tuple(t1.shape) == (0,)
+    assert tuple(t2.shape) == (0, 3)

--- a/source/isaaclab/test/utils/test_warp_torch_cache.py
+++ b/source/isaaclab/test/utils/test_warp_torch_cache.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+import torch
+import warp as wp
+
+wp.init()
+
+from isaaclab.utils.warp_torch_cache import set_caching_enabled, warp_to_torch
+
+
+class _Owner:
+    """Minimal stub that holds Warp arrays as attributes."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class _FrozenOwner:
+    """Owner that rejects arbitrary attribute writes via __slots__."""
+
+    __slots__ = ("joint_pos",)
+
+    def __init__(self, joint_pos):
+        self.joint_pos = joint_pos
+
+
+@pytest.fixture(autouse=True)
+def _enable_cache():
+    """Ensure caching is enabled before each test and restored afterwards."""
+    set_caching_enabled(True)
+    yield
+    set_caching_enabled(True)
+
+
+def _make_warp_array(n: int = 4, value: float = 1.0) -> wp.array:
+    return wp.from_torch(torch.full((n,), value, dtype=torch.float32, device="cpu"))
+
+
+# --------------------------------------------------------------------------- #
+# Cache hit / identity
+# --------------------------------------------------------------------------- #
+
+
+def test_cache_hit_returns_same_object():
+    """Repeated calls with the same Warp buffer return the identical tensor."""
+    owner = _Owner(joint_pos=_make_warp_array())
+    t1 = warp_to_torch(owner, "joint_pos")
+    t2 = warp_to_torch(owner, "joint_pos")
+    assert t1 is t2
+
+
+# --------------------------------------------------------------------------- #
+# Zero-copy: in-place mutations visible through cached tensor
+# --------------------------------------------------------------------------- #
+
+
+def test_zero_copy_inplace_update():
+    """In-place write to the Warp array is reflected in the cached tensor."""
+    arr = _make_warp_array(4, value=0.0)
+    owner = _Owner(data=arr)
+
+    cached = warp_to_torch(owner, "data")
+    assert cached.sum().item() == 0.0
+
+    arr.numpy()[:] = 7.0
+    # Re-fetch — should be same tensor object, now showing updated values.
+    cached2 = warp_to_torch(owner, "data")
+    assert cached2 is cached
+    assert cached.sum().item() == pytest.approx(28.0)
+
+
+# --------------------------------------------------------------------------- #
+# Cache miss on buffer reallocation (pointer change)
+# --------------------------------------------------------------------------- #
+
+
+def test_cache_miss_on_reallocation():
+    """Replacing the Warp array with a new buffer triggers a fresh conversion."""
+    owner = _Owner(joint_pos=_make_warp_array(4, value=1.0))
+    t_old = warp_to_torch(owner, "joint_pos")
+
+    owner.joint_pos = _make_warp_array(4, value=2.0)
+    t_new = warp_to_torch(owner, "joint_pos")
+
+    assert t_old is not t_new
+    torch.testing.assert_close(t_old, torch.full((4,), 1.0))
+    torch.testing.assert_close(t_new, torch.full((4,), 2.0))
+
+
+# --------------------------------------------------------------------------- #
+# Multiple fields on the same owner
+# --------------------------------------------------------------------------- #
+
+
+def test_multiple_fields_independent():
+    """Different field names are cached independently on the same owner."""
+    owner = _Owner(
+        joint_pos=_make_warp_array(3, value=1.0),
+        joint_vel=_make_warp_array(3, value=2.0),
+    )
+
+    t_pos = warp_to_torch(owner, "joint_pos")
+    t_vel = warp_to_torch(owner, "joint_vel")
+
+    assert t_pos is not t_vel
+    torch.testing.assert_close(t_pos, torch.full((3,), 1.0))
+    torch.testing.assert_close(t_vel, torch.full((3,), 2.0))
+
+    # Each field still cache-hits independently.
+    assert warp_to_torch(owner, "joint_pos") is t_pos
+    assert warp_to_torch(owner, "joint_vel") is t_vel
+
+
+# --------------------------------------------------------------------------- #
+# Caching disabled
+# --------------------------------------------------------------------------- #
+
+
+def test_disabled_cache_returns_fresh_tensor():
+    """With caching off, every call creates a new tensor (still correct data)."""
+    set_caching_enabled(False)
+
+    owner = _Owner(joint_pos=_make_warp_array(4, value=3.0))
+    t1 = warp_to_torch(owner, "joint_pos")
+    t2 = warp_to_torch(owner, "joint_pos")
+
+    assert t1 is not t2
+    torch.testing.assert_close(t1, t2)
+
+
+# --------------------------------------------------------------------------- #
+# Frozen / unsettable owner fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_frozen_owner_fallback():
+    """Owners that reject __setattr__ still return correct data without error."""
+    arr = _make_warp_array(3, value=5.0)
+    owner = _FrozenOwner(joint_pos=arr)
+
+    t = warp_to_torch(owner, "joint_pos")
+    torch.testing.assert_close(t, torch.full((3,), 5.0))

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -30,6 +30,7 @@ from isaaclab.sim.utils.queries import find_first_matching_prim, get_all_matchin
 from isaaclab.utils.string import resolve_matching_names, resolve_matching_names_values
 from isaaclab.utils.types import ArticulationActions
 from isaaclab.utils.version import get_isaac_sim_version, has_kit
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 from isaaclab.utils.wrench_composer import WrenchComposer
 
 from isaaclab_newton.assets import kernels as shared_kernels
@@ -3484,21 +3485,28 @@ class Articulation(BaseArticulation):
         The actions are first processed using actuator models. Depending on the robot configuration,
         the actuator models compute the joint level simulation commands and sets them into the PhysX buffers.
         """
+        # cache torch views of warp arrays outside the actuator loop to avoid
+        # repeated wp.to_torch() calls when multiple actuator groups exist
+        joint_pos_target = warp_to_torch(self._data, "joint_pos_target")
+        joint_vel_target = warp_to_torch(self._data, "joint_vel_target")
+        joint_effort_target = warp_to_torch(self._data, "joint_effort_target")
+        joint_pos = warp_to_torch(self._data, "joint_pos")
+        joint_vel = warp_to_torch(self._data, "joint_vel")
         # process actions per group
         for actuator in self.actuators.values():
             # prepare input for actuator model based on cached data
             # TODO : A tensor dict would be nice to do the indexing of all tensors together
             control_action = ArticulationActions(
-                joint_positions=wp.to_torch(self._data.joint_pos_target)[:, actuator.joint_indices],
-                joint_velocities=wp.to_torch(self._data.joint_vel_target)[:, actuator.joint_indices],
-                joint_efforts=wp.to_torch(self._data.joint_effort_target)[:, actuator.joint_indices],
+                joint_positions=joint_pos_target[:, actuator.joint_indices],
+                joint_velocities=joint_vel_target[:, actuator.joint_indices],
+                joint_efforts=joint_effort_target[:, actuator.joint_indices],
                 joint_indices=actuator.joint_indices,
             )
             # compute joint command from the actuator model
             control_action = actuator.compute(
                 control_action,
-                joint_pos=wp.to_torch(self._data.joint_pos)[:, actuator.joint_indices],
-                joint_vel=wp.to_torch(self._data.joint_vel)[:, actuator.joint_indices],
+                joint_pos=joint_pos[:, actuator.joint_indices],
+                joint_vel=joint_vel[:, actuator.joint_indices],
             )
             # update targets (these are set into the simulation)
             joint_indices = actuator.joint_indices

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -26,6 +26,7 @@ from isaaclab.sim.utils.queries import find_first_matching_prim, get_all_matchin
 from isaaclab.utils.string import resolve_matching_names, resolve_matching_names_values
 from isaaclab.utils.types import ArticulationActions
 from isaaclab.utils.version import get_isaac_sim_version, has_kit
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 from isaaclab.utils.wrench_composer import WrenchComposer
 
 from isaaclab_physx.assets import kernels as shared_kernels
@@ -3952,21 +3953,28 @@ class Articulation(BaseArticulation):
         The actions are first processed using actuator models. Depending on the robot configuration,
         the actuator models compute the joint level simulation commands and sets them into the PhysX buffers.
         """
+        # cache torch views of warp arrays outside the actuator loop to avoid
+        # repeated wp.to_torch() calls when multiple actuator groups exist
+        joint_pos_target = warp_to_torch(self._data, "joint_pos_target")
+        joint_vel_target = warp_to_torch(self._data, "joint_vel_target")
+        joint_effort_target = warp_to_torch(self._data, "joint_effort_target")
+        joint_pos = warp_to_torch(self._data, "joint_pos")
+        joint_vel = warp_to_torch(self._data, "joint_vel")
         # process actions per group
         for actuator in self.actuators.values():
             # prepare input for actuator model based on cached data
             # TODO : A tensor dict would be nice to do the indexing of all tensors together
             control_action = ArticulationActions(
-                joint_positions=wp.to_torch(self._data.joint_pos_target)[:, actuator.joint_indices],
-                joint_velocities=wp.to_torch(self._data.joint_vel_target)[:, actuator.joint_indices],
-                joint_efforts=wp.to_torch(self._data.joint_effort_target)[:, actuator.joint_indices],
+                joint_positions=joint_pos_target[:, actuator.joint_indices],
+                joint_velocities=joint_vel_target[:, actuator.joint_indices],
+                joint_efforts=joint_effort_target[:, actuator.joint_indices],
                 joint_indices=actuator.joint_indices,
             )
             # compute joint command from the actuator model
             control_action = actuator.compute(
                 control_action,
-                joint_pos=wp.to_torch(self._data.joint_pos)[:, actuator.joint_indices],
-                joint_vel=wp.to_torch(self._data.joint_vel)[:, actuator.joint_indices],
+                joint_pos=joint_pos[:, actuator.joint_indices],
+                joint_vel=joint_vel[:, actuator.joint_indices],
             )
             # update targets (these are set into the simulation)
             joint_indices = actuator.joint_indices

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -32,6 +32,10 @@ Changed
 ^^^^^^^
 
 * Change Franka visuomotor and GR1T2 nut pouring environments to use TiledCamera.
+* Changed task-specific observation and termination terms across humanoid, drone,
+  locomanipulation, cabinet, deploy, dexsuite, inhand, lift, pick-place, place, and
+  stack environments to use :func:`~isaaclab.utils.warp_torch_cache.warp_to_torch`
+  instead of calling :func:`warp.to_torch` on every evaluation.
 
 
 1.5.19 (2026-04-06)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/mdp/observations.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 import isaaclab.utils.math as math_utils
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation
@@ -23,7 +23,7 @@ def base_yaw_roll(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityC
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # extract euler angles (in world frame)
-    roll, _, yaw = math_utils.euler_xyz_from_quat(wp.to_torch(asset.data.root_quat_w))
+    roll, _, yaw = math_utils.euler_xyz_from_quat(warp_to_torch(asset.data, "root_quat_w"))
     # normalize angle to [-pi, pi]
     roll = torch.atan2(torch.sin(roll), torch.cos(roll))
     yaw = torch.atan2(torch.sin(yaw), torch.cos(yaw))
@@ -36,7 +36,7 @@ def base_up_proj(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntityCf
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # compute base up vector
-    base_up_vec = -wp.to_torch(asset.data.projected_gravity_b)
+    base_up_vec = -warp_to_torch(asset.data, "projected_gravity_b")
 
     return base_up_vec[:, 2].unsqueeze(-1)
 
@@ -48,11 +48,13 @@ def base_heading_proj(
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # compute desired heading direction
-    to_target_pos = torch.tensor(target_pos, device=env.device) - wp.to_torch(asset.data.root_pos_w)[:, :3]
+    to_target_pos = torch.tensor(target_pos, device=env.device) - warp_to_torch(asset.data, "root_pos_w")[:, :3]
     to_target_pos[:, 2] = 0.0
     to_target_dir = math_utils.normalize(to_target_pos)
     # compute base forward vector
-    heading_vec = math_utils.quat_apply(wp.to_torch(asset.data.root_quat_w), wp.to_torch(asset.data.FORWARD_VEC_B))
+    heading_vec = math_utils.quat_apply(
+        warp_to_torch(asset.data, "root_quat_w"), warp_to_torch(asset.data, "FORWARD_VEC_B")
+    )
     # compute dot product between heading and target direction
     heading_proj = torch.bmm(heading_vec.view(env.num_envs, 1, 3), to_target_dir.view(env.num_envs, 3, 1))
 
@@ -66,10 +68,10 @@ def base_angle_to_target(
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # compute desired heading direction
-    to_target_pos = torch.tensor(target_pos, device=env.device) - wp.to_torch(asset.data.root_pos_w)[:, :3]
+    to_target_pos = torch.tensor(target_pos, device=env.device) - warp_to_torch(asset.data, "root_pos_w")[:, :3]
     walk_target_angle = torch.atan2(to_target_pos[:, 1], to_target_pos[:, 0])
     # compute base forward vector
-    _, _, yaw = math_utils.euler_xyz_from_quat(wp.to_torch(asset.data.root_quat_w))
+    _, _, yaw = math_utils.euler_xyz_from_quat(warp_to_torch(asset.data, "root_quat_w"))
     # normalize angle to target to [-pi, pi]
     angle_to_target = walk_target_angle - yaw
     angle_to_target = torch.atan2(torch.sin(angle_to_target), torch.cos(angle_to_target))

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/mdp/observations.py
@@ -14,10 +14,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 import isaaclab.utils.math as math_utils
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation
@@ -50,7 +50,7 @@ def base_roll_pitch(env: ManagerBasedEnv, asset_cfg: SceneEntityCfg = SceneEntit
     # extract the used quantities (to enable type-hinting)
     asset: Articulation = env.scene[asset_cfg.name]
     # extract euler angles (in world frame)
-    roll, pitch, _ = math_utils.euler_xyz_from_quat(wp.to_torch(asset.data.root_quat_w))
+    roll, pitch, _ = math_utils.euler_xyz_from_quat(warp_to_torch(asset.data, "root_quat_w"))
     # normalize angle to [-pi, pi]
     roll = math_utils.wrap_to_pi(roll)
     pitch = math_utils.wrap_to_pi(pitch)
@@ -94,10 +94,10 @@ def generated_drone_commands(
         - A small epsilon (1e-8) is used to guard against zero-length direction vectors.
     """
     asset: Multirotor = env.scene[asset_cfg.name]
-    current_position_w = wp.to_torch(asset.data.root_pos_w) - env.scene.env_origins
+    current_position_w = warp_to_torch(asset.data, "root_pos_w") - env.scene.env_origins
     command = env.command_manager.get_command(command_name)
     current_position_b = math_utils.quat_apply_inverse(
-        wp.to_torch(asset.data.root_link_quat_w), command[:, :3] - current_position_w
+        warp_to_torch(asset.data, "root_link_quat_w"), command[:, :3] - current_position_w
     )
     current_position_b_dir = current_position_b / (torch.linalg.norm(current_position_b, dim=-1, keepdim=True) + 1e-8)
     current_position_b_mag = torch.linalg.norm(current_position_b, dim=-1, keepdim=True)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomanipulation/pick_place/mdp/observations.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 if TYPE_CHECKING:
     from isaaclab.envs import ManagerBasedRLEnv
 
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 
 def upper_body_last_action(
@@ -22,7 +22,7 @@ def upper_body_last_action(
 ) -> torch.Tensor:
     """Extract the last action of the upper body."""
     asset = env.scene[asset_cfg.name]
-    joint_pos_target = wp.to_torch(asset.data.joint_pos_target)
+    joint_pos_target = warp_to_torch(asset.data, "joint_pos_target")
 
     # Use joint_names from asset_cfg to find indices
     joint_names = asset_cfg.joint_names if hasattr(asset_cfg, "joint_names") else None

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/mdp/observations.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 import isaaclab.utils.math as math_utils
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import ArticulationData
@@ -23,7 +23,7 @@ def rel_ee_object_distance(env: ManagerBasedRLEnv) -> torch.Tensor:
     ee_tf_data: FrameTransformerData = env.scene["ee_frame"].data
     object_data: ArticulationData = env.scene["object"].data
 
-    return wp.to_torch(object_data.root_pos_w) - wp.to_torch(ee_tf_data.target_pos_w)[..., 0, :]
+    return warp_to_torch(object_data, "root_pos_w") - warp_to_torch(ee_tf_data, "target_pos_w")[..., 0, :]
 
 
 def rel_ee_drawer_distance(env: ManagerBasedRLEnv) -> torch.Tensor:
@@ -31,13 +31,15 @@ def rel_ee_drawer_distance(env: ManagerBasedRLEnv) -> torch.Tensor:
     ee_tf_data: FrameTransformerData = env.scene["ee_frame"].data
     cabinet_tf_data: FrameTransformerData = env.scene["cabinet_frame"].data
 
-    return wp.to_torch(cabinet_tf_data.target_pos_w)[..., 0, :] - wp.to_torch(ee_tf_data.target_pos_w)[..., 0, :]
+    return (
+        warp_to_torch(cabinet_tf_data, "target_pos_w")[..., 0, :] - warp_to_torch(ee_tf_data, "target_pos_w")[..., 0, :]
+    )
 
 
 def fingertips_pos(env: ManagerBasedRLEnv) -> torch.Tensor:
     """The position of the fingertips relative to the environment origins."""
     ee_tf_data: FrameTransformerData = env.scene["ee_frame"].data
-    fingertips_pos = wp.to_torch(ee_tf_data.target_pos_w)[..., 1:, :] - env.scene.env_origins.unsqueeze(1)
+    fingertips_pos = warp_to_torch(ee_tf_data, "target_pos_w")[..., 1:, :] - env.scene.env_origins.unsqueeze(1)
 
     return fingertips_pos.view(env.num_envs, -1)
 
@@ -45,7 +47,7 @@ def fingertips_pos(env: ManagerBasedRLEnv) -> torch.Tensor:
 def ee_pos(env: ManagerBasedRLEnv) -> torch.Tensor:
     """The position of the end-effector relative to the environment origins."""
     ee_tf_data: FrameTransformerData = env.scene["ee_frame"].data
-    ee_pos = wp.to_torch(ee_tf_data.target_pos_w)[..., 0, :] - env.scene.env_origins
+    ee_pos = warp_to_torch(ee_tf_data, "target_pos_w")[..., 0, :] - env.scene.env_origins
 
     return ee_pos
 
@@ -56,6 +58,6 @@ def ee_quat(env: ManagerBasedRLEnv, make_quat_unique: bool = True) -> torch.Tens
     If :attr:`make_quat_unique` is True, the quaternion is made unique by ensuring the real part is positive.
     """
     ee_tf_data: FrameTransformerData = env.scene["ee_frame"].data
-    ee_quat = wp.to_torch(ee_tf_data.target_quat_w)[..., 0, :]
+    ee_quat = warp_to_torch(ee_tf_data, "target_quat_w")[..., 0, :]
     # make first element of quaternion positive
     return math_utils.quat_unique(ee_quat) if make_quat_unique else ee_quat

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/mdp/observations.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 from isaaclab.managers import ManagerTermBase, ObservationTermCfg, SceneEntityCfg
 from isaaclab.utils.math import combine_frame_transforms
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import RigidObject
@@ -128,8 +128,8 @@ class gear_shaft_pos_w(ManagerTermBase):
         gear_type_indices = gear_type_manager.get_all_gear_type_indices()
 
         # Get base gear position and orientation
-        base_pos = wp.to_torch(self.asset.data.root_pos_w)
-        base_quat = wp.to_torch(self.asset.data.root_quat_w)
+        base_pos = warp_to_torch(self.asset.data, "root_pos_w")
+        base_quat = warp_to_torch(self.asset.data, "root_quat_w")
 
         # Update offsets using vectorized indexing
         self.offsets_buffer = self.gear_offsets_stacked[gear_type_indices]
@@ -182,7 +182,7 @@ class gear_shaft_quat_w(ManagerTermBase):
             Gear shaft orientation tensor of shape (num_envs, 4)
         """
         # Get base quaternion
-        base_quat = wp.to_torch(self.asset.data.root_quat_w)
+        base_quat = warp_to_torch(self.asset.data, "root_quat_w")
 
         # Ensure w component is positive (q and -q represent the same rotation)
         # Pick one canonical form to reduce observation variation seen by the policy
@@ -250,9 +250,9 @@ class gear_pos_w(ManagerTermBase):
         # Stack all gear positions
         all_gear_positions = torch.stack(
             [
-                wp.to_torch(self.gear_assets["gear_small"].data.root_pos_w),
-                wp.to_torch(self.gear_assets["gear_medium"].data.root_pos_w),
-                wp.to_torch(self.gear_assets["gear_large"].data.root_pos_w),
+                warp_to_torch(self.gear_assets["gear_small"].data, "root_pos_w"),
+                warp_to_torch(self.gear_assets["gear_medium"].data, "root_pos_w"),
+                warp_to_torch(self.gear_assets["gear_large"].data, "root_pos_w"),
             ],
             dim=1,
         )
@@ -323,9 +323,9 @@ class gear_quat_w(ManagerTermBase):
         # Stack all gear quaternions
         all_gear_quat = torch.stack(
             [
-                wp.to_torch(self.gear_assets["gear_small"].data.root_quat_w),
-                wp.to_torch(self.gear_assets["gear_medium"].data.root_quat_w),
-                wp.to_torch(self.gear_assets["gear_large"].data.root_quat_w),
+                warp_to_torch(self.gear_assets["gear_small"].data, "root_quat_w"),
+                warp_to_torch(self.gear_assets["gear_medium"].data, "root_quat_w"),
+                warp_to_torch(self.gear_assets["gear_large"].data, "root_quat_w"),
             ],
             dim=1,
         )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/mdp/observations.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 from isaaclab.managers import ManagerTermBase, SceneEntityCfg
 from isaaclab.utils.math import quat_apply, quat_apply_inverse, quat_inv, quat_mul, subtract_frame_transforms
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation, RigidObject
@@ -37,7 +37,8 @@ def object_pos_b(
     robot: RigidObject = env.scene[robot_cfg.name]
     object: RigidObject = env.scene[object_cfg.name]
     return quat_apply_inverse(
-        wp.to_torch(robot.data.root_quat_w), wp.to_torch(object.data.root_pos_w) - wp.to_torch(robot.data.root_pos_w)
+        warp_to_torch(robot.data, "root_quat_w"),
+        warp_to_torch(object.data, "root_pos_w") - warp_to_torch(robot.data, "root_pos_w"),
     )
 
 
@@ -58,7 +59,7 @@ def object_quat_b(
     """
     robot: RigidObject = env.scene[robot_cfg.name]
     object: RigidObject = env.scene[object_cfg.name]
-    return quat_mul(quat_inv(wp.to_torch(robot.data.root_quat_w)), wp.to_torch(object.data.root_quat_w))
+    return quat_mul(quat_inv(warp_to_torch(robot.data, "root_quat_w")), warp_to_torch(object.data, "root_quat_w"))
 
 
 def body_state_b(
@@ -82,17 +83,17 @@ def body_state_b(
     body_asset: Articulation = env.scene[body_asset_cfg.name]
     base_asset: Articulation = env.scene[base_asset_cfg.name]
     # get world pose of bodies
-    body_pos_w = wp.to_torch(body_asset.data.body_pos_w)[:, body_asset_cfg.body_ids].view(-1, 3)
-    body_quat_w = wp.to_torch(body_asset.data.body_quat_w)[:, body_asset_cfg.body_ids].view(-1, 4)
-    body_lin_vel_w = wp.to_torch(body_asset.data.body_lin_vel_w)[:, body_asset_cfg.body_ids].view(-1, 3)
-    body_ang_vel_w = wp.to_torch(body_asset.data.body_ang_vel_w)[:, body_asset_cfg.body_ids].view(-1, 3)
+    body_pos_w = warp_to_torch(body_asset.data, "body_pos_w")[:, body_asset_cfg.body_ids].view(-1, 3)
+    body_quat_w = warp_to_torch(body_asset.data, "body_quat_w")[:, body_asset_cfg.body_ids].view(-1, 4)
+    body_lin_vel_w = warp_to_torch(body_asset.data, "body_lin_vel_w")[:, body_asset_cfg.body_ids].view(-1, 3)
+    body_ang_vel_w = warp_to_torch(body_asset.data, "body_ang_vel_w")[:, body_asset_cfg.body_ids].view(-1, 3)
     num_bodies = int(body_pos_w.shape[0] / env.num_envs)
     # get world pose of base frame
     root_pos_w = (
-        wp.to_torch(base_asset.data.root_link_pos_w).unsqueeze(1).repeat_interleave(num_bodies, dim=1).view(-1, 3)
+        warp_to_torch(base_asset.data, "root_link_pos_w").unsqueeze(1).repeat_interleave(num_bodies, dim=1).view(-1, 3)
     )
     root_quat_w = (
-        wp.to_torch(base_asset.data.root_link_quat_w).unsqueeze(1).repeat_interleave(num_bodies, dim=1).view(-1, 4)
+        warp_to_torch(base_asset.data, "root_link_quat_w").unsqueeze(1).repeat_interleave(num_bodies, dim=1).view(-1, 4)
     )
     # transform from world body pose to local body pose
     body_pos_b, body_quat_b = subtract_frame_transforms(root_pos_w, root_quat_w, body_pos_w, body_quat_w)
@@ -170,11 +171,11 @@ class object_point_cloud_b(ManagerTermBase):
         Returns:
             Tensor of shape ``(num_envs, num_points, 3)`` or flattened if requested.
         """
-        ref_pos_w = wp.to_torch(self.ref_asset.data.root_pos_w).unsqueeze(1).repeat(1, num_points, 1)
-        ref_quat_w = wp.to_torch(self.ref_asset.data.root_quat_w).unsqueeze(1).repeat(1, num_points, 1)
+        ref_pos_w = warp_to_torch(self.ref_asset.data, "root_pos_w").unsqueeze(1).repeat(1, num_points, 1)
+        ref_quat_w = warp_to_torch(self.ref_asset.data, "root_quat_w").unsqueeze(1).repeat(1, num_points, 1)
 
-        object_pos_w = wp.to_torch(self.object.data.root_pos_w).unsqueeze(1).repeat(1, num_points, 1)
-        object_quat_w = wp.to_torch(self.object.data.root_quat_w).unsqueeze(1).repeat(1, num_points, 1)
+        object_pos_w = warp_to_torch(self.object.data, "root_pos_w").unsqueeze(1).repeat(1, num_points, 1)
+        object_quat_w = warp_to_torch(self.object.data, "root_quat_w").unsqueeze(1).repeat(1, num_points, 1)
         # apply rotation + translation
         self.points_w = quat_apply(object_quat_w, self.points_local) + object_pos_w
         if visualize:
@@ -200,11 +201,12 @@ def fingers_contact_force_b(
         ``[fx, fy, fz]`` per sensor.
     """
     force_w = [
-        wp.to_torch(env.scene.sensors[name].data.force_matrix_w).view(env.num_envs, 3) for name in contact_sensor_names
+        warp_to_torch(env.scene.sensors[name].data, "force_matrix_w").view(env.num_envs, 3)
+        for name in contact_sensor_names
     ]
     force_w = torch.stack(force_w, dim=1)
     robot: Articulation = env.scene[asset_cfg.name]
-    root_link_quat_w = wp.to_torch(robot.data.root_link_quat_w)
+    root_link_quat_w = warp_to_torch(robot.data, "root_link_quat_w")
     forces_b = quat_apply_inverse(root_link_quat_w.unsqueeze(1).repeat(1, force_w.shape[1], 1), force_w)
     return forces_b.view(env.num_envs, -1)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/inhand/mdp/observations.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 import isaaclab.utils.math as math_utils
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import RigidObject
@@ -35,7 +35,7 @@ def goal_quat_diff(
 
     # obtain the orientations
     goal_quat_w = command_term.command[:, 3:7]
-    asset_quat_w = wp.to_torch(asset.data.root_quat_w)
+    asset_quat_w = warp_to_torch(asset.data, "root_quat_w")
 
     # compute quaternion difference
     quat = math_utils.quat_mul(asset_quat_w, math_utils.quat_conjugate(goal_quat_w))

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/lift/mdp/observations.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.utils.math import subtract_frame_transforms
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import RigidObject
@@ -26,8 +26,8 @@ def object_position_in_robot_root_frame(
     """The position of the object in the robot's root frame."""
     robot: RigidObject = env.scene[robot_cfg.name]
     object: RigidObject = env.scene[object_cfg.name]
-    object_pos_w = wp.to_torch(object.data.root_pos_w)[:, :3]
+    object_pos_w = warp_to_torch(object.data, "root_pos_w")[:, :3]
     object_pos_b, _ = subtract_frame_transforms(
-        wp.to_torch(robot.data.root_pos_w), wp.to_torch(robot.data.root_quat_w), object_pos_w
+        warp_to_torch(robot.data, "root_pos_w"), warp_to_torch(robot.data, "root_quat_w"), object_pos_w
     )
     return object_pos_b

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/mdp/observations.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
+
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.envs import ManagerBasedRLEnv
@@ -19,22 +20,15 @@ def object_obs(
     left_eef_link_name: str,
     right_eef_link_name: str,
 ) -> torch.Tensor:
-    """
-    Object observations (in world frame):
-        object pos,
-        object quat,
-        left_eef to object,
-        right_eef_to object,
-    """
-
-    body_pos_w = wp.to_torch(env.scene["robot"].data.body_pos_w)
+    """Object observations (in world frame): pos, quat, left_eef-to-object, right_eef-to-object."""
+    body_pos_w = warp_to_torch(env.scene["robot"].data, "body_pos_w")
     left_eef_idx = env.scene["robot"].data.body_names.index(left_eef_link_name)
     right_eef_idx = env.scene["robot"].data.body_names.index(right_eef_link_name)
     left_eef_pos = body_pos_w[:, left_eef_idx] - env.scene.env_origins
     right_eef_pos = body_pos_w[:, right_eef_idx] - env.scene.env_origins
 
-    object_pos = wp.to_torch(env.scene["object"].data.root_pos_w) - env.scene.env_origins
-    object_quat = wp.to_torch(env.scene["object"].data.root_quat_w)
+    object_pos = warp_to_torch(env.scene["object"].data, "root_pos_w") - env.scene.env_origins
+    object_quat = warp_to_torch(env.scene["object"].data, "root_quat_w")
 
     left_eef_to_object = object_pos - left_eef_pos
     right_eef_to_object = object_pos - right_eef_pos
@@ -51,37 +45,27 @@ def object_obs(
 
 
 def get_eef_pos(env: ManagerBasedRLEnv, link_name: str) -> torch.Tensor:
-    body_pos_w = wp.to_torch(env.scene["robot"].data.body_pos_w)
+    body_pos_w = warp_to_torch(env.scene["robot"].data, "body_pos_w")
     left_eef_idx = env.scene["robot"].data.body_names.index(link_name)
-    left_eef_pos = body_pos_w[:, left_eef_idx] - env.scene.env_origins
-
-    return left_eef_pos
+    return body_pos_w[:, left_eef_idx] - env.scene.env_origins
 
 
 def get_eef_quat(env: ManagerBasedRLEnv, link_name: str) -> torch.Tensor:
-    body_quat_w = wp.to_torch(env.scene["robot"].data.body_quat_w)
+    body_quat_w = warp_to_torch(env.scene["robot"].data, "body_quat_w")
     left_eef_idx = env.scene["robot"].data.body_names.index(link_name)
-    left_eef_quat = body_quat_w[:, left_eef_idx]
-
-    return left_eef_quat
+    return body_quat_w[:, left_eef_idx]
 
 
 def get_robot_joint_state(
     env: ManagerBasedRLEnv,
     joint_names: list[str],
 ) -> torch.Tensor:
-    # hand_joint_names is a list of regex, use find_joints
     indexes, _ = env.scene["robot"].find_joints(joint_names)
     indexes = torch.tensor(indexes, dtype=torch.long)
-    robot_joint_states = wp.to_torch(env.scene["robot"].data.joint_pos)[:, indexes]
-
-    return robot_joint_states
+    return warp_to_torch(env.scene["robot"].data, "joint_pos")[:, indexes]
 
 
 def get_all_robot_link_state(
     env: ManagerBasedRLEnv,
 ) -> torch.Tensor:
-    body_pos_w = wp.to_torch(env.scene["robot"].data.body_link_state_w)[:, :, :]
-    all_robot_link_pos = body_pos_w
-
-    return all_robot_link_pos
+    return warp_to_torch(env.scene["robot"].data, "body_link_state_w")[:, :, :]

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/mdp/terminations.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-import warp as wp
 
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import RigidObject
@@ -63,14 +63,13 @@ def task_done_pick_place(
     # Get object entity from the scene
     object: RigidObject = env.scene[object_cfg.name]
 
-    # Extract wheel position relative to environment origin
-    object_x = wp.to_torch(object.data.root_pos_w)[:, 0] - env.scene.env_origins[:, 0]
-    object_y = wp.to_torch(object.data.root_pos_w)[:, 1] - env.scene.env_origins[:, 1]
-    object_height = wp.to_torch(object.data.root_pos_w)[:, 2] - env.scene.env_origins[:, 2]
-    object_vel = torch.abs(wp.to_torch(object.data.root_vel_w))
+    obj_pos = warp_to_torch(object.data, "root_pos_w")
+    object_x = obj_pos[:, 0] - env.scene.env_origins[:, 0]
+    object_y = obj_pos[:, 1] - env.scene.env_origins[:, 1]
+    object_height = obj_pos[:, 2] - env.scene.env_origins[:, 2]
+    object_vel = torch.abs(warp_to_torch(object.data, "root_vel_w"))
 
-    # Get right wrist position relative to environment origin
-    robot_body_pos_w = wp.to_torch(env.scene["robot"].data.body_pos_w)
+    robot_body_pos_w = warp_to_torch(env.scene["robot"].data, "body_pos_w")
     right_eef_idx = env.scene["robot"].data.body_names.index(task_link_name)
     right_wrist_x = robot_body_pos_w[:, right_eef_idx, 0] - env.scene.env_origins[:, 0]
 
@@ -140,11 +139,11 @@ def task_done_nut_pour(
     sorting_bin: RigidObject = env.scene[sorting_bin_cfg.name]
 
     # Get positions relative to environment origin
-    scale_pos = wp.to_torch(sorting_scale.data.root_pos_w) - env.scene.env_origins
-    bowl_pos = wp.to_torch(sorting_bowl.data.root_pos_w) - env.scene.env_origins
-    sorting_beaker_pos = wp.to_torch(sorting_beaker.data.root_pos_w) - env.scene.env_origins
-    nut_pos = wp.to_torch(factory_nut.data.root_pos_w) - env.scene.env_origins
-    bin_pos = wp.to_torch(sorting_bin.data.root_pos_w) - env.scene.env_origins
+    scale_pos = warp_to_torch(sorting_scale.data, "root_pos_w") - env.scene.env_origins
+    bowl_pos = warp_to_torch(sorting_bowl.data, "root_pos_w") - env.scene.env_origins
+    sorting_beaker_pos = warp_to_torch(sorting_beaker.data, "root_pos_w") - env.scene.env_origins
+    nut_pos = warp_to_torch(factory_nut.data, "root_pos_w") - env.scene.env_origins
+    bin_pos = warp_to_torch(sorting_bin.data, "root_pos_w") - env.scene.env_origins
 
     # nut to bowl
     nut_to_bowl_x = torch.abs(nut_pos[:, 0] - bowl_pos[:, 0])
@@ -207,8 +206,8 @@ def task_done_exhaust_pipe(
     blue_sorting_bin: RigidObject = env.scene[blue_sorting_bin_cfg.name]
 
     # Get positions relative to environment origin
-    blue_exhaust_pipe_pos = wp.to_torch(blue_exhaust_pipe.data.root_pos_w) - env.scene.env_origins
-    blue_sorting_bin_pos = wp.to_torch(blue_sorting_bin.data.root_pos_w) - env.scene.env_origins
+    blue_exhaust_pipe_pos = warp_to_torch(blue_exhaust_pipe.data, "root_pos_w") - env.scene.env_origins
+    blue_sorting_bin_pos = warp_to_torch(blue_sorting_bin.data, "root_pos_w") - env.scene.env_origins
 
     # blue exhaust to bin
     blue_exhaust_to_bin_x = torch.abs(blue_exhaust_pipe_pos[:, 0] - blue_sorting_bin_pos[:, 0])

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/mdp/observations.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 import torch
-import warp as wp
 
 import isaaclab.utils.math as math_utils
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation, RigidObject
@@ -28,13 +28,13 @@ def object_poses_in_base_frame(
     """The pose of the object in the robot base frame."""
     object: RigidObject = env.scene[object_cfg.name]
 
-    pos_object_world = wp.to_torch(object.data.root_pos_w)
-    quat_object_world = wp.to_torch(object.data.root_quat_w)
+    pos_object_world = warp_to_torch(object.data, "root_pos_w")
+    quat_object_world = warp_to_torch(object.data, "root_quat_w")
 
     """The position of the robot in the world frame."""
     robot: Articulation = env.scene[robot_cfg.name]
-    root_pos_w = wp.to_torch(robot.data.root_pos_w)
-    root_quat_w = wp.to_torch(robot.data.root_quat_w)
+    root_pos_w = warp_to_torch(robot.data, "root_pos_w")
+    root_quat_w = warp_to_torch(robot.data, "root_quat_w")
 
     pos_object_base, quat_object_base = math_utils.subtract_frame_transforms(
         root_pos_w, root_quat_w, pos_object_world, quat_object_world
@@ -65,14 +65,13 @@ def object_grasped(
     ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
     object: RigidObject = env.scene[object_cfg.name]
 
-    object_pos = wp.to_torch(object.data.root_pos_w)
-    end_effector_pos = wp.to_torch(ee_frame.data.target_pos_w)[:, 0, :]
+    object_pos = warp_to_torch(object.data, "root_pos_w")
+    end_effector_pos = warp_to_torch(ee_frame.data, "target_pos_w")[:, 0, :]
     pose_diff = torch.linalg.vector_norm(object_pos - end_effector_pos, dim=1)
 
     if "contact_grasp" in env.scene.keys() and env.scene["contact_grasp"] is not None:
-        contact_force_grasp = wp.to_torch(
-            env.scene["contact_grasp"].data.net_forces_w
-        )  # shape:(N, 2, 3) for two fingers
+        contact_grasp = env.scene["contact_grasp"]
+        contact_force_grasp = warp_to_torch(contact_grasp.data, "net_forces_w")  # shape:(N, 2, 3) for two fingers
         contact_force_norm = torch.linalg.vector_norm(
             contact_force_grasp, dim=2
         )  # shape:(N, 2) - force magnitude per finger
@@ -84,9 +83,8 @@ def object_grasped(
         f"contact_grasp_{object_cfg.name}" in env.scene.keys()
         and env.scene[f"contact_grasp_{object_cfg.name}"] is not None
     ):
-        contact_force_object = wp.to_torch(
-            env.scene[f"contact_grasp_{object_cfg.name}"].data.net_forces_w
-        )  # shape:(N, 2, 3) for two fingers
+        contact_grasp_obj = env.scene[f"contact_grasp_{object_cfg.name}"]
+        contact_force_object = warp_to_torch(contact_grasp_obj.data, "net_forces_w")  # shape:(N, 2, 3) for two fingers
         contact_force_norm = torch.linalg.vector_norm(
             contact_force_object, dim=2
         )  # shape:(N, 2) - force magnitude per finger
@@ -99,7 +97,7 @@ def object_grasped(
 
     if hasattr(env.scene, "surface_grippers") and len(env.scene.surface_grippers) > 0:
         surface_gripper = env.scene.surface_grippers["surface_gripper"]
-        suction_cup_status = wp.to_torch(surface_gripper.state).view(-1, 1)  # 1: closed, 0: closing, -1: open
+        suction_cup_status = warp_to_torch(surface_gripper, "state").view(-1, 1)  # 1: closed, 0: closing, -1: open
         suction_cup_is_closed = (suction_cup_status == 1).to(torch.float32)
         grasped = torch.logical_and(suction_cup_is_closed, pose_diff < diff_threshold)
 
@@ -109,14 +107,16 @@ def object_grasped(
             grasped = torch.logical_and(
                 grasped,
                 torch.abs(
-                    torch.abs(wp.to_torch(robot.data.joint_pos)[:, gripper_joint_ids[0]]) - env.cfg.gripper_open_val
+                    torch.abs(warp_to_torch(robot.data, "joint_pos")[:, gripper_joint_ids[0]])
+                    - env.cfg.gripper_open_val
                 )
                 > env.cfg.gripper_threshold,
             )
             grasped = torch.logical_and(
                 grasped,
                 torch.abs(
-                    torch.abs(wp.to_torch(robot.data.joint_pos)[:, gripper_joint_ids[1]]) - env.cfg.gripper_open_val
+                    torch.abs(warp_to_torch(robot.data, "joint_pos")[:, gripper_joint_ids[1]])
+                    - env.cfg.gripper_open_val
                 )
                 > env.cfg.gripper_threshold,
             )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/observations.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 import torch
-import warp as wp
 
 import isaaclab.utils.math as math_utils
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.warp_torch_cache import warp_to_torch
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation, RigidObject, RigidObjectCollection
@@ -31,7 +31,11 @@ def cube_positions_in_world_frame(
     cube_3: RigidObject = env.scene[cube_3_cfg.name]
 
     return torch.cat(
-        (wp.to_torch(cube_1.data.root_pos_w), wp.to_torch(cube_2.data.root_pos_w), wp.to_torch(cube_3.data.root_pos_w)),
+        (
+            warp_to_torch(cube_1.data, "root_pos_w"),
+            warp_to_torch(cube_2.data, "root_pos_w"),
+            warp_to_torch(cube_3.data, "root_pos_w"),
+        ),
         dim=1,
     )
 
@@ -54,9 +58,15 @@ def instance_randomize_cube_positions_in_world_frame(
     cube_2_pos_w = []
     cube_3_pos_w = []
     for env_id in range(env.num_envs):
-        cube_1_pos_w.append(wp.to_torch(cube_1.data.body_link_pos_w)[env_id, env.rigid_objects_in_focus[env_id][0], :3])
-        cube_2_pos_w.append(wp.to_torch(cube_2.data.body_link_pos_w)[env_id, env.rigid_objects_in_focus[env_id][1], :3])
-        cube_3_pos_w.append(wp.to_torch(cube_3.data.body_link_pos_w)[env_id, env.rigid_objects_in_focus[env_id][2], :3])
+        cube_1_pos_w.append(
+            warp_to_torch(cube_1.data, "body_link_pos_w")[env_id, env.rigid_objects_in_focus[env_id][0], :3]
+        )
+        cube_2_pos_w.append(
+            warp_to_torch(cube_2.data, "body_link_pos_w")[env_id, env.rigid_objects_in_focus[env_id][1], :3]
+        )
+        cube_3_pos_w.append(
+            warp_to_torch(cube_3.data, "body_link_pos_w")[env_id, env.rigid_objects_in_focus[env_id][2], :3]
+        )
     cube_1_pos_w = torch.stack(cube_1_pos_w)
     cube_2_pos_w = torch.stack(cube_2_pos_w)
     cube_3_pos_w = torch.stack(cube_3_pos_w)
@@ -77,9 +87,9 @@ def cube_orientations_in_world_frame(
 
     return torch.cat(
         (
-            wp.to_torch(cube_1.data.root_quat_w),
-            wp.to_torch(cube_2.data.root_quat_w),
-            wp.to_torch(cube_3.data.root_quat_w),
+            warp_to_torch(cube_1.data, "root_quat_w"),
+            warp_to_torch(cube_2.data, "root_quat_w"),
+            warp_to_torch(cube_3.data, "root_quat_w"),
         ),
         dim=1,
     )
@@ -104,13 +114,13 @@ def instance_randomize_cube_orientations_in_world_frame(
     cube_3_quat_w = []
     for env_id in range(env.num_envs):
         cube_1_quat_w.append(
-            wp.to_torch(cube_1.data.body_link_quat_w)[env_id, env.rigid_objects_in_focus[env_id][0], :4]
+            warp_to_torch(cube_1.data, "body_link_quat_w")[env_id, env.rigid_objects_in_focus[env_id][0], :4]
         )
         cube_2_quat_w.append(
-            wp.to_torch(cube_2.data.body_link_quat_w)[env_id, env.rigid_objects_in_focus[env_id][1], :4]
+            warp_to_torch(cube_2.data, "body_link_quat_w")[env_id, env.rigid_objects_in_focus[env_id][1], :4]
         )
         cube_3_quat_w.append(
-            wp.to_torch(cube_3.data.body_link_quat_w)[env_id, env.rigid_objects_in_focus[env_id][2], :4]
+            warp_to_torch(cube_3.data, "body_link_quat_w")[env_id, env.rigid_objects_in_focus[env_id][2], :4]
         )
     cube_1_quat_w = torch.stack(cube_1_quat_w)
     cube_2_quat_w = torch.stack(cube_2_quat_w)
@@ -146,16 +156,16 @@ def object_obs(
     cube_3: RigidObject = env.scene[cube_3_cfg.name]
     ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
 
-    cube_1_pos_w = wp.to_torch(cube_1.data.root_pos_w)
-    cube_1_quat_w = wp.to_torch(cube_1.data.root_quat_w)
+    cube_1_pos_w = warp_to_torch(cube_1.data, "root_pos_w")
+    cube_1_quat_w = warp_to_torch(cube_1.data, "root_quat_w")
 
-    cube_2_pos_w = wp.to_torch(cube_2.data.root_pos_w)
-    cube_2_quat_w = wp.to_torch(cube_2.data.root_quat_w)
+    cube_2_pos_w = warp_to_torch(cube_2.data, "root_pos_w")
+    cube_2_quat_w = warp_to_torch(cube_2.data, "root_quat_w")
 
-    cube_3_pos_w = wp.to_torch(cube_3.data.root_pos_w)
-    cube_3_quat_w = wp.to_torch(cube_3.data.root_quat_w)
+    cube_3_pos_w = warp_to_torch(cube_3.data, "root_pos_w")
+    cube_3_quat_w = warp_to_torch(cube_3.data, "root_quat_w")
 
-    ee_pos_w = wp.to_torch(ee_frame.data.target_pos_w)[:, 0, :]
+    ee_pos_w = warp_to_torch(ee_frame.data, "target_pos_w")[:, 0, :]
     gripper_to_cube_1 = cube_1_pos_w - ee_pos_w
     gripper_to_cube_2 = cube_2_pos_w - ee_pos_w
     gripper_to_cube_3 = cube_3_pos_w - ee_pos_w
@@ -220,17 +230,23 @@ def instance_randomize_object_obs(
     cube_2_quat_w = []
     cube_3_quat_w = []
     for env_id in range(env.num_envs):
-        cube_1_pos_w.append(wp.to_torch(cube_1.data.body_link_pos_w)[env_id, env.rigid_objects_in_focus[env_id][0], :3])
-        cube_2_pos_w.append(wp.to_torch(cube_2.data.body_link_pos_w)[env_id, env.rigid_objects_in_focus[env_id][1], :3])
-        cube_3_pos_w.append(wp.to_torch(cube_3.data.body_link_pos_w)[env_id, env.rigid_objects_in_focus[env_id][2], :3])
+        cube_1_pos_w.append(
+            warp_to_torch(cube_1.data, "body_link_pos_w")[env_id, env.rigid_objects_in_focus[env_id][0], :3]
+        )
+        cube_2_pos_w.append(
+            warp_to_torch(cube_2.data, "body_link_pos_w")[env_id, env.rigid_objects_in_focus[env_id][1], :3]
+        )
+        cube_3_pos_w.append(
+            warp_to_torch(cube_3.data, "body_link_pos_w")[env_id, env.rigid_objects_in_focus[env_id][2], :3]
+        )
         cube_1_quat_w.append(
-            wp.to_torch(cube_1.data.body_link_quat_w)[env_id, env.rigid_objects_in_focus[env_id][0], :4]
+            warp_to_torch(cube_1.data, "body_link_quat_w")[env_id, env.rigid_objects_in_focus[env_id][0], :4]
         )
         cube_2_quat_w.append(
-            wp.to_torch(cube_2.data.body_link_quat_w)[env_id, env.rigid_objects_in_focus[env_id][1], :4]
+            warp_to_torch(cube_2.data, "body_link_quat_w")[env_id, env.rigid_objects_in_focus[env_id][1], :4]
         )
         cube_3_quat_w.append(
-            wp.to_torch(cube_3.data.body_link_quat_w)[env_id, env.rigid_objects_in_focus[env_id][2], :4]
+            warp_to_torch(cube_3.data, "body_link_quat_w")[env_id, env.rigid_objects_in_focus[env_id][2], :4]
         )
     cube_1_pos_w = torch.stack(cube_1_pos_w)
     cube_2_pos_w = torch.stack(cube_2_pos_w)
@@ -239,7 +255,7 @@ def instance_randomize_object_obs(
     cube_2_quat_w = torch.stack(cube_2_quat_w)
     cube_3_quat_w = torch.stack(cube_3_quat_w)
 
-    ee_pos_w = wp.to_torch(ee_frame.data.target_pos_w)[:, 0, :]
+    ee_pos_w = warp_to_torch(ee_frame.data, "target_pos_w")[:, 0, :]
     gripper_to_cube_1 = cube_1_pos_w - ee_pos_w
     gripper_to_cube_2 = cube_2_pos_w - ee_pos_w
     gripper_to_cube_3 = cube_3_pos_w - ee_pos_w
@@ -269,14 +285,14 @@ def instance_randomize_object_obs(
 
 def ee_frame_pos(env: ManagerBasedRLEnv, ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame")) -> torch.Tensor:
     ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
-    ee_frame_pos = wp.to_torch(ee_frame.data.target_pos_w)[:, 0, :] - env.scene.env_origins[:, 0:3]
+    ee_frame_pos = warp_to_torch(ee_frame.data, "target_pos_w")[:, 0, :] - env.scene.env_origins[:, 0:3]
 
     return ee_frame_pos
 
 
 def ee_frame_quat(env: ManagerBasedRLEnv, ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame")) -> torch.Tensor:
     ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
-    ee_frame_quat = wp.to_torch(ee_frame.data.target_quat_w)[:, 0, :]
+    ee_frame_quat = warp_to_torch(ee_frame.data, "target_quat_w")[:, 0, :]
 
     return ee_frame_quat
 
@@ -294,7 +310,7 @@ def gripper_pos(
         # Handle multiple surface grippers by concatenating their states
         gripper_states = []
         for gripper_name, surface_gripper in env.scene.surface_grippers.items():
-            gripper_states.append(wp.to_torch(surface_gripper.state).view(-1, 1))
+            gripper_states.append(warp_to_torch(surface_gripper, "state").view(-1, 1))
 
         if len(gripper_states) == 1:
             return gripper_states[0]
@@ -305,8 +321,8 @@ def gripper_pos(
         if hasattr(env.cfg, "gripper_joint_names"):
             gripper_joint_ids, _ = robot.find_joints(env.cfg.gripper_joint_names)
             assert len(gripper_joint_ids) == 2, "Observation gripper_pos only support parallel gripper for now"
-            finger_joint_1 = wp.to_torch(robot.data.joint_pos)[:, gripper_joint_ids[0]].clone().unsqueeze(1)
-            finger_joint_2 = -1 * wp.to_torch(robot.data.joint_pos)[:, gripper_joint_ids[1]].clone().unsqueeze(1)
+            finger_joint_1 = warp_to_torch(robot.data, "joint_pos")[:, gripper_joint_ids[0]].clone().unsqueeze(1)
+            finger_joint_2 = -1 * warp_to_torch(robot.data, "joint_pos")[:, gripper_joint_ids[1]].clone().unsqueeze(1)
             return torch.cat((finger_joint_1, finger_joint_2), dim=1)
         else:
             raise NotImplementedError("[Error] Cannot find gripper_joint_names in the environment config")
@@ -325,13 +341,13 @@ def object_grasped(
     ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
     object: RigidObject = env.scene[object_cfg.name]
 
-    object_pos = wp.to_torch(object.data.root_pos_w)
-    end_effector_pos = wp.to_torch(ee_frame.data.target_pos_w)[:, 0, :]
+    object_pos = warp_to_torch(object.data, "root_pos_w")
+    end_effector_pos = warp_to_torch(ee_frame.data, "target_pos_w")[:, 0, :]
     pose_diff = torch.linalg.vector_norm(object_pos - end_effector_pos, dim=1)
 
     if hasattr(env.scene, "surface_grippers") and len(env.scene.surface_grippers) > 0:
         surface_gripper = env.scene.surface_grippers["surface_gripper"]
-        suction_cup_status = wp.to_torch(surface_gripper.state).view(-1, 1)  # 1: closed, 0: closing, -1: open
+        suction_cup_status = warp_to_torch(surface_gripper, "state").view(-1, 1)  # 1: closed, 0: closing, -1: open
         suction_cup_is_closed = (suction_cup_status == 1).to(torch.float32)
         grasped = torch.logical_and(suction_cup_is_closed, pose_diff < diff_threshold)
 
@@ -343,7 +359,7 @@ def object_grasped(
             grasped = torch.logical_and(
                 pose_diff < diff_threshold,
                 torch.abs(
-                    wp.to_torch(robot.data.joint_pos)[:, gripper_joint_ids[0]]
+                    warp_to_torch(robot.data, "joint_pos")[:, gripper_joint_ids[0]]
                     - torch.tensor(env.cfg.gripper_open_val, dtype=torch.float32).to(env.device)
                 )
                 > env.cfg.gripper_threshold,
@@ -351,7 +367,7 @@ def object_grasped(
             grasped = torch.logical_and(
                 grasped,
                 torch.abs(
-                    wp.to_torch(robot.data.joint_pos)[:, gripper_joint_ids[1]]
+                    warp_to_torch(robot.data, "joint_pos")[:, gripper_joint_ids[1]]
                     - torch.tensor(env.cfg.gripper_open_val, dtype=torch.float32).to(env.device)
                 )
                 > env.cfg.gripper_threshold,
@@ -375,7 +391,7 @@ def object_stacked(
     upper_object: RigidObject = env.scene[upper_object_cfg.name]
     lower_object: RigidObject = env.scene[lower_object_cfg.name]
 
-    pos_diff = wp.to_torch(upper_object.data.root_pos_w) - wp.to_torch(lower_object.data.root_pos_w)
+    pos_diff = warp_to_torch(upper_object.data, "root_pos_w") - warp_to_torch(lower_object.data, "root_pos_w")
     height_dist = torch.linalg.vector_norm(pos_diff[:, 2:], dim=1)
     xy_dist = torch.linalg.vector_norm(pos_diff[:, :2], dim=1)
 
@@ -383,7 +399,7 @@ def object_stacked(
 
     if hasattr(env.scene, "surface_grippers") and len(env.scene.surface_grippers) > 0:
         surface_gripper = env.scene.surface_grippers["surface_gripper"]
-        suction_cup_status = wp.to_torch(surface_gripper.state).view(-1, 1)  # 1: closed, 0: closing, -1: open
+        suction_cup_status = warp_to_torch(surface_gripper, "state").view(-1, 1)  # 1: closed, 0: closing, -1: open
         suction_cup_is_open = (suction_cup_status == -1).to(torch.float32)
         stacked = torch.logical_and(suction_cup_is_open, stacked)
 
@@ -393,7 +409,7 @@ def object_stacked(
             assert len(gripper_joint_ids) == 2, "Observations only support parallel gripper for now"
             stacked = torch.logical_and(
                 torch.isclose(
-                    wp.to_torch(robot.data.joint_pos)[:, gripper_joint_ids[0]],
+                    warp_to_torch(robot.data, "joint_pos")[:, gripper_joint_ids[0]],
                     torch.tensor(env.cfg.gripper_open_val, dtype=torch.float32).to(env.device),
                     atol=1e-4,
                     rtol=1e-4,
@@ -402,7 +418,7 @@ def object_stacked(
             )
             stacked = torch.logical_and(
                 torch.isclose(
-                    wp.to_torch(robot.data.joint_pos)[:, gripper_joint_ids[1]],
+                    warp_to_torch(robot.data, "joint_pos")[:, gripper_joint_ids[1]],
                     torch.tensor(env.cfg.gripper_open_val, dtype=torch.float32).to(env.device),
                     atol=1e-4,
                     rtol=1e-4,
@@ -429,17 +445,17 @@ def cube_poses_in_base_frame(
     cube_2: RigidObject = env.scene[cube_2_cfg.name]
     cube_3: RigidObject = env.scene[cube_3_cfg.name]
 
-    pos_cube_1_world = wp.to_torch(cube_1.data.root_pos_w)
-    pos_cube_2_world = wp.to_torch(cube_2.data.root_pos_w)
-    pos_cube_3_world = wp.to_torch(cube_3.data.root_pos_w)
+    pos_cube_1_world = warp_to_torch(cube_1.data, "root_pos_w")
+    pos_cube_2_world = warp_to_torch(cube_2.data, "root_pos_w")
+    pos_cube_3_world = warp_to_torch(cube_3.data, "root_pos_w")
 
-    quat_cube_1_world = wp.to_torch(cube_1.data.root_quat_w)
-    quat_cube_2_world = wp.to_torch(cube_2.data.root_quat_w)
-    quat_cube_3_world = wp.to_torch(cube_3.data.root_quat_w)
+    quat_cube_1_world = warp_to_torch(cube_1.data, "root_quat_w")
+    quat_cube_2_world = warp_to_torch(cube_2.data, "root_quat_w")
+    quat_cube_3_world = warp_to_torch(cube_3.data, "root_quat_w")
 
     robot: Articulation = env.scene[robot_cfg.name]
-    root_pos_w = wp.to_torch(robot.data.root_pos_w)
-    root_quat_w = wp.to_torch(robot.data.root_quat_w)
+    root_pos_w = warp_to_torch(robot.data, "root_pos_w")
+    root_quat_w = warp_to_torch(robot.data, "root_quat_w")
 
     pos_cube_1_base, quat_cube_1_base = math_utils.subtract_frame_transforms(
         root_pos_w, root_quat_w, pos_cube_1_world, quat_cube_1_world
@@ -488,17 +504,17 @@ def object_abs_obs_in_base_frame(
     ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
     robot: Articulation = env.scene[robot_cfg.name]
 
-    root_pos_w = wp.to_torch(robot.data.root_pos_w)
-    root_quat_w = wp.to_torch(robot.data.root_quat_w)
+    root_pos_w = warp_to_torch(robot.data, "root_pos_w")
+    root_quat_w = warp_to_torch(robot.data, "root_quat_w")
 
-    cube_1_pos_w = wp.to_torch(cube_1.data.root_pos_w)
-    cube_1_quat_w = wp.to_torch(cube_1.data.root_quat_w)
+    cube_1_pos_w = warp_to_torch(cube_1.data, "root_pos_w")
+    cube_1_quat_w = warp_to_torch(cube_1.data, "root_quat_w")
 
-    cube_2_pos_w = wp.to_torch(cube_2.data.root_pos_w)
-    cube_2_quat_w = wp.to_torch(cube_2.data.root_quat_w)
+    cube_2_pos_w = warp_to_torch(cube_2.data, "root_pos_w")
+    cube_2_quat_w = warp_to_torch(cube_2.data, "root_quat_w")
 
-    cube_3_pos_w = wp.to_torch(cube_3.data.root_pos_w)
-    cube_3_quat_w = wp.to_torch(cube_3.data.root_quat_w)
+    cube_3_pos_w = warp_to_torch(cube_3.data, "root_pos_w")
+    cube_3_quat_w = warp_to_torch(cube_3.data, "root_quat_w")
 
     pos_cube_1_base, quat_cube_1_base = math_utils.subtract_frame_transforms(
         root_pos_w, root_quat_w, cube_1_pos_w, cube_1_quat_w
@@ -510,8 +526,8 @@ def object_abs_obs_in_base_frame(
         root_pos_w, root_quat_w, cube_3_pos_w, cube_3_quat_w
     )
 
-    ee_pos_w = wp.to_torch(ee_frame.data.target_pos_w)[:, 0, :]
-    ee_quat_w = wp.to_torch(ee_frame.data.target_quat_w)[:, 0, :]
+    ee_pos_w = warp_to_torch(ee_frame.data, "target_pos_w")[:, 0, :]
+    ee_quat_w = warp_to_torch(ee_frame.data, "target_quat_w")[:, 0, :]
     ee_pos_base, ee_quat_base = math_utils.subtract_frame_transforms(root_pos_w, root_quat_w, ee_pos_w, ee_quat_w)
 
     return torch.cat(
@@ -539,12 +555,12 @@ def ee_frame_pose_in_base_frame(
     The end effector pose in the robot base frame.
     """
     ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
-    ee_frame_pos_w = wp.to_torch(ee_frame.data.target_pos_w)[:, 0, :]
-    ee_frame_quat_w = wp.to_torch(ee_frame.data.target_quat_w)[:, 0, :]
+    ee_frame_pos_w = warp_to_torch(ee_frame.data, "target_pos_w")[:, 0, :]
+    ee_frame_quat_w = warp_to_torch(ee_frame.data, "target_quat_w")[:, 0, :]
 
     robot: Articulation = env.scene[robot_cfg.name]
-    root_pos_w = wp.to_torch(robot.data.root_pos_w)
-    root_quat_w = wp.to_torch(robot.data.root_quat_w)
+    root_pos_w = warp_to_torch(robot.data, "root_pos_w")
+    root_quat_w = warp_to_torch(robot.data, "root_quat_w")
     ee_pos_in_base, ee_quat_in_base = math_utils.subtract_frame_transforms(
         root_pos_w, root_quat_w, ee_frame_pos_w, ee_frame_quat_w
     )


### PR DESCRIPTION
Adds warp_to_torch(owner, field_name) utility that caches wp.to_torch() results using the Warp array's memory pointer as the cache key. Since wp.to_torch() returns a zero-copy view sharing the same GPU buffer, in-place updates are automatically reflected in the cached tensor without invalidation. A new conversion only occurs when the underlying buffer is reallocated (pointer change). This eliminates hundreds of redundant wp.to_torch() calls per frame in observation, reward, and termination functions.

Caching is enabled by default and can be toggled via SimulationCfg.enable_warp_torch_cache.

Migrate all built-in and task-specific MDP terms in isaaclab.envs.mdp and isaaclab_tasks to use warp_to_torch instead of raw wp.to_torch.

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
