### PR TITLE
Moves gravity compensation from schemas to MDP event

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.5.25"
+version = "4.5.26"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+4.5.26 (2026-04-08)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :func:`~isaaclab.envs.mdp.events.set_gravity_compensation` MDP event for
+  setting body-level (``mjc:gravcomp``) and joint-level (``mjc:actuatorgravcomp``)
+  gravity compensation USD attributes at environment prestartup. This is a
+  Newton/MuJoCo-only feature.
+
+
 4.5.25 (2026-04-01)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/envs/mdp/__init__.pyi
+++ b/source/isaaclab/isaaclab/envs/mdp/__init__.pyi
@@ -58,6 +58,7 @@ __all__ = [
     "randomize_rigid_body_mass",
     "randomize_rigid_body_material",
     "randomize_rigid_body_scale",
+    "set_gravity_compensation",
     "randomize_visual_color",
     "randomize_visual_texture_material",
     "reset_joints_by_offset",

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -151,7 +151,7 @@ def randomize_rigid_body_scale(
                 op_order_spec.default = Vt.TokenArray(["xformOp:translate", "xformOp:orient", "xformOp:scale"])
 
 
-def set_gravity_compensation(
+def set_newton_gravity_compensation(
     env: ManagerBasedEnv,
     env_ids: torch.Tensor | None,
     asset_cfg: SceneEntityCfg,

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -151,6 +151,105 @@ def randomize_rigid_body_scale(
                 op_order_spec.default = Vt.TokenArray(["xformOp:translate", "xformOp:orient", "xformOp:scale"])
 
 
+def set_gravity_compensation(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor | None,
+    asset_cfg: SceneEntityCfg,
+    body_gravity_compensation_scale: float | dict[str, float] | None = None,
+    joint_gravity_compensation: list[str] | None = None,
+):
+    """Write MuJoCo gravity-compensation USD attributes on an asset's prims.
+
+    This event writes ``mjc:gravcomp`` on rigid-body prims and
+    ``mjc:actuatorgravcomp`` on joint prims so that Newton's MuJoCo solver
+    applies gravity compensation when the simulation starts.
+
+    .. note::
+        This is a Newton/MuJoCo-only feature. The attributes are silently
+        ignored by other physics backends (e.g. PhysX).
+
+    .. attention::
+        Since this function writes USD attributes that are consumed when the
+        physics model is built, the event **must** run in ``"prestartup"`` mode
+        (before ``sim.reset()``).
+
+    Args:
+        env: The environment instance.
+        env_ids: The environment indices. If None, all environments are used.
+        asset_cfg: The asset configuration specifying which asset to modify.
+        body_gravity_compensation_scale: Gravity compensation scale for rigid
+            bodies.  A single float applies to **all** bodies. A dict maps
+            body regex patterns to per-body scales
+            (e.g. ``{".*link[0-3]": 1.0, ".*link4": 0.5}``).
+            ``0.0`` means no compensation, ``1.0`` means full compensation.
+        joint_gravity_compensation: List of joint name regex patterns whose
+            matching joints will have ``mjc:actuatorgravcomp`` set to ``True``.
+            If ``None``, no joint-level attribute is written.
+    """
+    if env.sim.is_playing():
+        raise RuntimeError(
+            "set_gravity_compensation writes USD attributes that are consumed at model-build time."
+            " It must run before the simulation starts (use 'prestartup' event mode)."
+        )
+
+    if body_gravity_compensation_scale is None and joint_gravity_compensation is None:
+        return
+
+    asset: Articulation | RigidObject = env.scene[asset_cfg.name]
+    prim_paths = sim_utils.find_matching_prim_paths(asset.cfg.prim_path)
+
+    # resolve environment ids
+    if env_ids is None:
+        env_ids = torch.arange(env.scene.num_envs, device="cpu")
+    else:
+        env_ids = env_ids.cpu()
+
+    from pxr import Usd, UsdPhysics  # noqa: PLC0415
+
+    stage = env.sim.stage
+
+    _JOINT_TYPES = frozenset(
+        {"PhysicsRevoluteJoint", "PhysicsPrismaticJoint", "PhysicsSphericalJoint", "PhysicsD6Joint"}
+    )
+
+    for env_id in env_ids:
+        root_prim = stage.GetPrimAtPath(prim_paths[env_id])
+        if not root_prim.IsValid():
+            continue
+
+        # --- body-level: mjc:gravcomp ---
+        if body_gravity_compensation_scale is not None:
+            # collect all rigid-body prims under this asset
+            body_prims = [p for p in Usd.PrimRange(root_prim) if UsdPhysics.RigidBodyAPI(p)]
+
+            if isinstance(body_gravity_compensation_scale, dict):
+                # per-body pattern matching
+                for body_prim in body_prims:
+                    body_name = body_prim.GetName()
+                    for pattern, scale in body_gravity_compensation_scale.items():
+                        if re.fullmatch(pattern, body_name):
+                            sim_utils.safe_set_attribute_on_usd_prim(body_prim, "mjc:gravcomp", scale, camel_case=False)
+                            break
+            else:
+                # uniform scale for all bodies
+                for body_prim in body_prims:
+                    sim_utils.safe_set_attribute_on_usd_prim(
+                        body_prim, "mjc:gravcomp", body_gravity_compensation_scale, camel_case=False
+                    )
+
+        # --- joint-level: mjc:actuatorgravcomp ---
+        if joint_gravity_compensation is not None:
+            joint_prims = [p for p in Usd.PrimRange(root_prim) if p.GetTypeName() in _JOINT_TYPES]
+            for joint_prim in joint_prims:
+                joint_name = joint_prim.GetName()
+                for pattern in joint_gravity_compensation:
+                    if re.fullmatch(pattern, joint_name):
+                        sim_utils.safe_set_attribute_on_usd_prim(
+                            joint_prim, "mjc:actuatorgravcomp", True, camel_case=False
+                        )
+                        break
+
+
 class randomize_rigid_body_material(ManagerTermBase):
     """Randomize the physics materials on all geometries of the asset.
 

--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.10"
+version = "0.5.11"
 
 # Description
 title = "Newton simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_newton/docs/CHANGELOG.rst
+++ b/source/isaaclab_newton/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.5.11 (2026-04-08)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added gravity compensation end-to-end tests verifying
+  ``mjc:gravcomp`` and ``mjc:actuatorgravcomp`` USD attributes
+  propagate through Newton to MJCF XML. Tests run without Isaac Sim
+  using pure USD + Newton + MuJoCo.
+
+
 0.5.10 (2026-04-05)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_newton/docs/CHANGELOG.rst
+++ b/source/isaaclab_newton/docs/CHANGELOG.rst
@@ -12,6 +12,15 @@ Added
   propagate through Newton to MJCF XML. Tests run without Isaac Sim
   using pure USD + Newton + MuJoCo.
 
+Fixed
+^^^^^
+
+* Fixed MuJoCo custom attributes (``mjc:gravcomp``, ``mjc:actuatorgravcomp``)
+  not being parsed from USD in
+  :meth:`~isaaclab_newton.physics.NewtonManager.instantiate_builder_from_stage`.
+  ``SolverMuJoCo.register_custom_attributes()`` is now called before
+  ``builder.add_usd()`` so the builder knows to read ``mjc:`` prefixed attributes.
+
 
 0.5.10 (2026-04-05)
 ~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -482,6 +482,10 @@ class NewtonManager(PhysicsManager):
 
         builder = ModelBuilder(up_axis=up_axis)
 
+        # Register MuJoCo custom attributes (gravcomp, jnt_actgravcomp, etc.)
+        # before add_usd() so the builder knows to parse mjc: prefixed attributes.
+        SolverMuJoCo.register_custom_attributes(builder)
+
         schema_resolvers = [SchemaResolverNewton(), SchemaResolverPhysx()]
 
         if not env_paths:

--- a/source/isaaclab_newton/test/test_actuator_gravity_comp.py
+++ b/source/isaaclab_newton/test/test_actuator_gravity_comp.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for gravity compensation USD attributes and their propagation to Newton/MJCF.
+
+These tests verify the full pipeline: USD attributes -> Newton ModelBuilder -> MuJoCo solver -> MJCF XML.
+They do NOT require Isaac Sim / Omniverse Kit -- only ``pxr`` (OpenUSD), ``newton``, and ``mujoco``.
+"""
+
+import unittest.mock as mock
+from types import SimpleNamespace
+
+import newton
+import numpy as np
+import pytest
+import torch
+from newton.solvers import SolverMuJoCo
+
+from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _create_two_body_articulation(stage):
+    """Create a minimal two-body articulation on *stage* and return key prims."""
+    UsdPhysics.Scene.Define(stage, "/World/physicsScene")
+
+    root = UsdGeom.Xform.Define(stage, "/World/Robot")
+    UsdPhysics.ArticulationRootAPI.Apply(root.GetPrim())
+
+    # Body1: rigid body + collision cube
+    body1_xf = UsdGeom.Xform.Define(stage, "/World/Robot/Body1")
+    body1 = body1_xf.GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(body1)
+    mass1 = UsdPhysics.MassAPI.Apply(body1)
+    mass1.GetMassAttr().Set(1.0)
+    col1 = UsdGeom.Cube.Define(stage, "/World/Robot/Body1/Collision")
+    UsdPhysics.CollisionAPI.Apply(col1.GetPrim())
+
+    # Body2: rigid body + collision sphere
+    body2_xf = UsdGeom.Xform.Define(stage, "/World/Robot/Body2")
+    body2 = body2_xf.GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(body2)
+    mass2 = UsdPhysics.MassAPI.Apply(body2)
+    mass2.GetMassAttr().Set(1.0)
+    col2 = UsdGeom.Sphere.Define(stage, "/World/Robot/Body2/Collision")
+    UsdPhysics.CollisionAPI.Apply(col2.GetPrim())
+
+    # Joint1: world -> Body1
+    joint1 = UsdPhysics.RevoluteJoint.Define(stage, "/World/Robot/Joint1")
+    joint1.GetBody0Rel().SetTargets(["/World/Robot/Body1"])
+    joint1.GetAxisAttr().Set("Z")
+    joint1.GetLocalPos0Attr().Set(Gf.Vec3f(0, 0, 0))
+    joint1.GetLocalPos1Attr().Set(Gf.Vec3f(0, 0, 0))
+    joint1.GetLocalRot0Attr().Set(Gf.Quatf(1, 0, 0, 0))
+    joint1.GetLocalRot1Attr().Set(Gf.Quatf(1, 0, 0, 0))
+
+    # Joint2: Body1 -> Body2
+    joint2 = UsdPhysics.RevoluteJoint.Define(stage, "/World/Robot/Joint2")
+    joint2.GetBody0Rel().SetTargets(["/World/Robot/Body1"])
+    joint2.GetBody1Rel().SetTargets(["/World/Robot/Body2"])
+    joint2.GetAxisAttr().Set("Y")
+    joint2.GetLocalPos0Attr().Set(Gf.Vec3f(0, 0, 0))
+    joint2.GetLocalPos1Attr().Set(Gf.Vec3f(0, 0, 0))
+    joint2.GetLocalRot0Attr().Set(Gf.Quatf(1, 0, 0, 0))
+    joint2.GetLocalRot1Attr().Set(Gf.Quatf(1, 0, 0, 0))
+
+    return body1, body2, joint1.GetPrim(), joint2.GetPrim()
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+def _make_mock_env(stage, prim_paths):
+    """Build a minimal mock env that satisfies set_gravity_compensation's interface.
+
+    The function accesses:
+      - env.sim.is_playing()  -> False (prestartup)
+      - env.sim.stage         -> the USD stage
+      - env.scene[name]       -> an object with cfg.prim_path
+      - env.scene.num_envs    -> len(prim_paths)
+    """
+    asset = SimpleNamespace(cfg=SimpleNamespace(prim_path="/World/Robot"))
+    scene = mock.MagicMock()
+    scene.__getitem__ = mock.MagicMock(return_value=asset)
+    scene.num_envs = len(prim_paths)
+    sim = SimpleNamespace(is_playing=lambda: False, stage=stage)
+    return SimpleNamespace(sim=sim, scene=scene)
+
+
+def _make_asset_cfg(name="robot"):
+    return SimpleNamespace(name=name)
+
+
+@pytest.mark.isaacsim_ci
+class TestSetGravityCompensationEvent:
+    """Test the set_gravity_compensation MDP event function directly."""
+
+    def test_uniform_body_gravcomp(self):
+        """Uniform float scale sets mjc:gravcomp on all rigid bodies."""
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        body1, body2, _, _ = _create_two_body_articulation(stage)
+
+        env = _make_mock_env(stage, ["/World/Robot"])
+
+        from isaaclab.envs.mdp.events import set_gravity_compensation
+
+        with mock.patch("isaaclab.sim.find_matching_prim_paths", return_value=["/World/Robot"]):
+            set_gravity_compensation(env, None, _make_asset_cfg(), body_gravity_compensation_scale=0.75)
+
+        assert body1.GetAttribute("mjc:gravcomp").Get() == pytest.approx(0.75)
+        assert body2.GetAttribute("mjc:gravcomp").Get() == pytest.approx(0.75)
+
+    def test_dict_body_gravcomp_with_regex(self):
+        """Dict form applies different scales based on body name regex."""
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        body1, body2, _, _ = _create_two_body_articulation(stage)
+
+        env = _make_mock_env(stage, ["/World/Robot"])
+
+        from isaaclab.envs.mdp.events import set_gravity_compensation
+
+        with mock.patch("isaaclab.sim.find_matching_prim_paths", return_value=["/World/Robot"]):
+            set_gravity_compensation(
+                env,
+                None,
+                _make_asset_cfg(),
+                body_gravity_compensation_scale={"Body1": 1.0, "Body2": 0.3},
+            )
+
+        assert body1.GetAttribute("mjc:gravcomp").Get() == pytest.approx(1.0)
+        assert body2.GetAttribute("mjc:gravcomp").Get() == pytest.approx(0.3)
+
+    def test_joint_gravcomp_with_regex(self):
+        """Joint regex patterns set mjc:actuatorgravcomp on matching joints only."""
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        _, _, joint1_prim, joint2_prim = _create_two_body_articulation(stage)
+
+        env = _make_mock_env(stage, ["/World/Robot"])
+
+        from isaaclab.envs.mdp.events import set_gravity_compensation
+
+        with mock.patch("isaaclab.sim.find_matching_prim_paths", return_value=["/World/Robot"]):
+            set_gravity_compensation(
+                env,
+                None,
+                _make_asset_cfg(),
+                joint_gravity_compensation=["Joint1"],
+            )
+
+        assert joint1_prim.GetAttribute("mjc:actuatorgravcomp").Get() is True
+        assert not joint2_prim.GetAttribute("mjc:actuatorgravcomp").IsValid()
+
+    def test_env_ids_limits_which_envs_are_modified(self):
+        """Only the environments in env_ids should be modified."""
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+
+        # Create two "environments" with separate robot prims
+        for env_idx in range(2):
+            prefix = f"/World/Env_{env_idx}/Robot"
+            root = UsdGeom.Xform.Define(stage, prefix)
+            UsdPhysics.ArticulationRootAPI.Apply(root.GetPrim())
+            body_xf = UsdGeom.Xform.Define(stage, f"{prefix}/Body")
+            body = body_xf.GetPrim()
+            UsdPhysics.RigidBodyAPI.Apply(body)
+            mass = UsdPhysics.MassAPI.Apply(body)
+            mass.GetMassAttr().Set(1.0)
+
+        env = _make_mock_env(stage, ["/World/Env_0/Robot", "/World/Env_1/Robot"])
+
+        from isaaclab.envs.mdp.events import set_gravity_compensation
+
+        # Only modify env 0
+        with mock.patch(
+            "isaaclab.sim.find_matching_prim_paths", return_value=["/World/Env_0/Robot", "/World/Env_1/Robot"]
+        ):
+            set_gravity_compensation(
+                env,
+                torch.tensor([0]),
+                _make_asset_cfg(),
+                body_gravity_compensation_scale=1.0,
+            )
+
+        env0_body = stage.GetPrimAtPath("/World/Env_0/Robot/Body")
+        env1_body = stage.GetPrimAtPath("/World/Env_1/Robot/Body")
+        assert env0_body.GetAttribute("mjc:gravcomp").Get() == pytest.approx(1.0)
+        assert not env1_body.GetAttribute("mjc:gravcomp").IsValid(), "env_id=1 should not be modified"
+
+    def test_raises_when_sim_is_playing(self):
+        """Should raise RuntimeError if called after simulation starts."""
+        stage = Usd.Stage.CreateInMemory()
+        sim = SimpleNamespace(is_playing=lambda: True, stage=stage)
+        env = SimpleNamespace(sim=sim, scene=mock.MagicMock())
+
+        from isaaclab.envs.mdp.events import set_gravity_compensation
+
+        with pytest.raises(RuntimeError, match="prestartup"):
+            set_gravity_compensation(env, None, _make_asset_cfg(), body_gravity_compensation_scale=1.0)
+
+    def test_noop_when_both_params_none(self):
+        """Should return immediately without touching USD when both params are None."""
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        body1, _, _, _ = _create_two_body_articulation(stage)
+
+        env = _make_mock_env(stage, ["/World/Robot"])
+
+        from isaaclab.envs.mdp.events import set_gravity_compensation
+
+        # Neither param set — should be a no-op
+        set_gravity_compensation(env, None, _make_asset_cfg())
+
+        assert not body1.GetAttribute("mjc:gravcomp").IsValid()
+
+
+def _build_newton_model(stage):
+    """Build a Newton model from a USD stage with MuJoCo solver custom attributes."""
+    builder = newton.ModelBuilder()
+    SolverMuJoCo.register_custom_attributes(builder)
+    builder.add_usd(stage)
+    return builder.finalize()
+
+
+@pytest.mark.isaacsim_ci
+class TestGravityCompensationNewtonModel:
+    """End-to-end: set_gravity_compensation -> Newton model has correct gravcomp values."""
+
+    def test_body_gravcomp_in_newton_model(self):
+        """Body gravcomp written by the event propagates to Newton model.mujoco.gravcomp."""
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        body1, body2, _, _ = _create_two_body_articulation(stage)
+
+        env = _make_mock_env(stage, ["/World/Robot"])
+
+        from isaaclab.envs.mdp.events import set_gravity_compensation
+
+        with mock.patch("isaaclab.sim.find_matching_prim_paths", return_value=["/World/Robot"]):
+            set_gravity_compensation(
+                env,
+                None,
+                _make_asset_cfg(),
+                body_gravity_compensation_scale={"Body1": 0.75, "Body2": 0.3},
+            )
+
+        model = _build_newton_model(stage)
+
+        assert hasattr(model.mujoco, "gravcomp"), "Newton model missing mujoco.gravcomp"
+        gravcomp = model.mujoco.gravcomp.numpy()
+        # body_label tells us the index order
+        body_idx = {label.split("/")[-1]: i for i, label in enumerate(model.body_label)}
+        assert gravcomp[body_idx["Body1"]] == pytest.approx(0.75)
+        assert gravcomp[body_idx["Body2"]] == pytest.approx(0.3)
+
+    def test_joint_actgravcomp_in_newton_model(self):
+        """Joint actuatorgravcomp written by the event propagates to Newton model.mujoco.jnt_actgravcomp."""
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        _, _, joint1_prim, joint2_prim = _create_two_body_articulation(stage)
+
+        env = _make_mock_env(stage, ["/World/Robot"])
+
+        from isaaclab.envs.mdp.events import set_gravity_compensation
+
+        with mock.patch("isaaclab.sim.find_matching_prim_paths", return_value=["/World/Robot"]):
+            set_gravity_compensation(
+                env,
+                None,
+                _make_asset_cfg(),
+                body_gravity_compensation_scale=1.0,
+                joint_gravity_compensation=["Joint1"],
+            )
+
+        model = _build_newton_model(stage)
+
+        assert hasattr(model.mujoco, "jnt_actgravcomp"), "Newton model missing mujoco.jnt_actgravcomp"
+        jnt_actgravcomp = model.mujoco.jnt_actgravcomp.numpy()
+        joint_idx = {label.split("/")[-1]: i for i, label in enumerate(model.joint_label)}
+        assert jnt_actgravcomp[joint_idx["Joint1"]] is np.True_
+        assert jnt_actgravcomp[joint_idx["Joint2"]] is np.False_
+
+    def test_no_gravcomp_in_newton_model_when_not_set(self):
+        """Newton model has zero gravcomp when the event is not called."""
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        _create_two_body_articulation(stage)
+
+        model = _build_newton_model(stage)
+
+        if hasattr(model.mujoco, "gravcomp"):
+            assert np.allclose(model.mujoco.gravcomp.numpy(), 0.0)


### PR DESCRIPTION
# Description

Adds gravity compensation support for the Newton/MuJoCo backend as an MDP event, addressing review feedback from @ooctipus on #4847 to keep Newton-specific attributes out of the PhysX schema layer.

**New MDP event:** `set_gravity_compensation()` writes `mjc:gravcomp` (body-level) and `mjc:actuatorgravcomp` (joint-level) USD attributes at `prestartup` time. This follows the same pattern as existing USD-modifying events like `randomize_rigid_body_scale`.

**Bug fix:** `SolverMuJoCo.register_custom_attributes(builder)` was missing from `NewtonManager.instantiate_builder_from_stage()`, causing all `mjc:` prefixed custom attributes (gravcomp, actuatorgravcomp, etc.) to be silently ignored when parsing USD. The cloning path (`newton_replicate.py`) already had this call — it was only missing from the normal path.

**Usage example:**
```python
events = {
    "gravity_compensation": EventTermCfg(
        func=mdp.set_gravity_compensation,
        mode="prestartup",
        params={
            "asset_cfg": SceneEntityCfg("robot"),
            "body_gravity_compensation_scale": 1.0,          # uniform for all bodies
            # or per-body: {".*link[0-3]": 1.0, ".*link4": 0.5}
            "joint_gravity_compensation": [".*"],             # regex patterns for joints
        },
    ),
}
```

The pipeline: IsaacLab config → USD attributes → Newton ModelBuilder → MuJoCo solver / MJCF XML.

Supersedes #4847

## Type of change

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there