### PR TITLE
Fixes broken VideoRecorder test imports and config field names

### DIFF
--- a/source/isaaclab/test/envs/test_video_recorder.py
+++ b/source/isaaclab/test/envs/test_video_recorder.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """Unit tests for VideoRecorder."""
 
-import importlib.util
-import pathlib
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -13,22 +11,16 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-_spec = importlib.util.spec_from_file_location("_vr", pathlib.Path(__file__).parent / "video_recorder.py")
-_module = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_module)
-VideoRecorder = _module.VideoRecorder
-_video_recorder_module = _module
+from isaaclab.envs.utils import video_recorder as _video_recorder_module
+from isaaclab.envs.utils.video_recorder import VideoRecorder
 
 _BLANK_720p = np.zeros((720, 1280, 3), dtype=np.uint8)
 _DEFAULT_CFG = dict(
-    render_mode="rgb_array",
-    video_mode="perspective",
-    fallback_camera_cfg=None,
-    video_num_tiles=-1,
-    camera_eye=(7.5, 7.5, 7.5),
-    camera_lookat=(0.0, 0.0, 0.0),
-    gl_viewer_width=1280,
-    gl_viewer_height=720,
+    env_render_mode="rgb_array",
+    camera_position=(7.5, 7.5, 7.5),
+    camera_target=(0.0, 0.0, 0.0),
+    window_width=1280,
+    window_height=720,
 )
 
 
@@ -52,15 +44,21 @@ def test_init_perspective_mode_creates_kit_capture():
     scene = MagicMock()
     scene.sensors = {}
     scene.num_envs = 1
-    cfg = SimpleNamespace(**{**_DEFAULT_CFG, "fallback_camera_cfg": MagicMock()})
+    cfg = SimpleNamespace(**_DEFAULT_CFG)
     fake_capture = MagicMock()
+    kit_mod = MagicMock()
+    kit_mod.create_isaacsim_kit_perspective_video = MagicMock(return_value=fake_capture)
     with patch.object(_video_recorder_module, "_resolve_video_backend", return_value="kit"):
-        with patch(
-            "isaaclab_physx.video_recording.isaacsim_kit_perspective_video.create_isaacsim_kit_perspective_video",
-            return_value=fake_capture,
-        ) as mock_create:
+        with patch.dict(
+            sys.modules,
+            {
+                "isaaclab_physx.video_recording": MagicMock(),
+                "isaaclab_physx.video_recording.isaacsim_kit_perspective_video": kit_mod,
+                "isaaclab_physx.video_recording.isaacsim_kit_perspective_video_cfg": MagicMock(),
+            },
+        ):
             vr = VideoRecorder(cfg, scene)
-    mock_create.assert_called_once()
+    kit_mod.create_isaacsim_kit_perspective_video.assert_called_once()
     assert vr._capture is fake_capture
 
 
@@ -69,14 +67,20 @@ def test_init_newton_backend_creates_newton_capture():
     scene = MagicMock()
     cfg = SimpleNamespace(**_DEFAULT_CFG)
     fake_capture = MagicMock()
-    with patch.dict(sys.modules, {"pyglet": MagicMock()}):
-        with patch.object(_video_recorder_module, "_resolve_video_backend", return_value="newton_gl"):
-            with patch(
-                "isaaclab_newton.video_recording.newton_gl_perspective_video.create_newton_gl_perspective_video",
-                return_value=fake_capture,
-            ) as mock_create:
-                vr = VideoRecorder(cfg, scene)
-    mock_create.assert_called_once()
+    newton_mod = MagicMock()
+    newton_mod.create_newton_gl_perspective_video = MagicMock(return_value=fake_capture)
+    with patch.object(_video_recorder_module, "_resolve_video_backend", return_value="newton_gl"):
+        with patch.dict(
+            sys.modules,
+            {
+                "pyglet": MagicMock(),
+                "isaaclab_newton.video_recording": MagicMock(),
+                "isaaclab_newton.video_recording.newton_gl_perspective_video": newton_mod,
+                "isaaclab_newton.video_recording.newton_gl_perspective_video_cfg": MagicMock(),
+            },
+        ):
+            vr = VideoRecorder(cfg, scene)
+    newton_mod.create_newton_gl_perspective_video.assert_called_once()
     assert vr._capture is fake_capture
 
 
@@ -89,8 +93,8 @@ def test_render_rgb_array_delegates_to_capture():
 
 
 def test_render_rgb_array_none_when_no_backend():
-    """Without rgb_array render_mode, _capture is None and render returns None."""
-    recorder = _create_recorder(render_mode=None)
+    """Without rgb_array env_render_mode, _capture is None and render returns None."""
+    recorder = _create_recorder(env_render_mode=None)
     recorder._backend = None
     recorder._capture = None
     assert recorder.render_rgb_array() is None


### PR DESCRIPTION
The test file added in #5011 was broken at collection time: it used importlib to load a nonexistent sibling file, referenced obsolete config field names, and used patch() targets that cannot resolve when the video_recording subpackages are not installed.

- Replace importlib file loader with normal package import
- Rename config fields to match VideoRecorderCfg (env_render_mode, camera_position, camera_target, window_width, window_height)
- Use patch.dict(sys.modules) instead of patch() for optional dep

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there