### PR TITLE
Compute mass from collision shapes for zero-mass moving bodies in Newton

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -116,6 +116,7 @@ Guidelines for modifications:
 * Manuel Schweiger
 * Masoud Moghani
 * Mateo Guaman Castro
+* Matěj Kripner
 * Maurice Rahme
 * Michael Gussert
 * Michael Lin

--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.10"
+version = "0.5.11"
 
 # Description
 title = "Newton simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_newton/docs/CHANGELOG.rst
+++ b/source/isaaclab_newton/docs/CHANGELOG.rst
@@ -1,6 +1,26 @@
 Changelog
 ---------
 
+0.5.11 (2026-04-08)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed zero-mass moving bodies in :class:`~isaaclab_newton.physics.NewtonManager`.
+  Some USD assets (e.g. Franka ``panda_leftfinger`` / ``panda_rightfinger``,
+  OpenArm hand link) have zero authored mass because they rely on Isaac Sim's
+  PhysX "auto-compute mass from collider" feature, which Newton's USD importer
+  does not replicate. Newton's ``bound_mass`` validator only floors *positive*
+  masses, so these bodies would either fail the MuJoCo solver's positivity
+  check at finalize, or get a near-zero epsilon mass that made them physically
+  meaningless (e.g. a microgram-mass gripper finger could not transmit force
+  to a 200 g cube). Mass and inertia are now computed from the body's
+  collision shapes via :func:`newton._src.geometry.inertia.compute_inertia_shape`
+  with a default density of 1000 kg/m^3, falling back to a small default for
+  bodies without any usable shape.
+
+
 0.5.10 (2026-04-05)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -417,6 +417,13 @@ class NewtonManager(PhysicsManager):
         device = PhysicsManager._device
         logger.info(f"Finalizing model on device: {device}")
         cls._builder.up_axis = Axis.from_string(cls._up_axis)
+        # The MuJoCo solver requires moving bodies (those with non-fixed joints) to have
+        # positive mass. Some USD assets (e.g. Franka panda finger, OpenArm hand link)
+        # have zero mass authored because they rely on Isaac Sim's "auto-compute mass
+        # from collider" PhysX feature, which Newton's USD importer does not replicate.
+        # Newton's bound_mass validator only floors *positive* masses, so we explicitly
+        # compute mass for those bodies here, before finalize.
+        cls._fix_zero_mass_moving_bodies()
         # Set smaller contact margin for manipulation examples (default 10cm is too large)
         with Timer(name="newton_finalize_builder", msg="Finalize builder took:"):
             cls._model = cls._builder.finalize(device=device)
@@ -521,6 +528,109 @@ class NewtonManager(PhysicsManager):
             cls._num_envs = len(env_paths)
 
         cls.set_builder(builder)
+
+    @classmethod
+    def _fix_zero_mass_moving_bodies(cls) -> None:
+        """Compute physical mass for moving bodies with zero/negative mass authored.
+
+        Some USD assets (e.g. Franka panda finger, OpenArm hand link) have
+        invalid mass on intermediate bodies because the asset relies on
+        Isaac Sim's "auto-compute mass from collider" PhysX feature, which
+        Newton's USD importer does not replicate.
+
+        Newton's :attr:`~newton.ModelBuilder.bound_mass` validator only floors
+        *positive* masses below the bound -- zero/negative is treated as a
+        "static body". The MuJoCo solver requires positive mass for any body
+        with a non-fixed joint, so the asset would otherwise fail at finalize
+        with an ``mjMINVAL`` check. Even when the solver does not reject it,
+        a near-zero mass on a moving body is physically meaningless: a
+        microgram-mass gripper finger cannot transmit force to a 200 g cube
+        and the manipulator simply passes through it.
+
+        We compute a reasonable mass from the body's collision shapes using
+        :func:`newton._src.geometry.inertia.compute_inertia_shape` with a
+        default density of 1000 kg/m^3 (water / light plastic). For a Franka
+        ``panda_leftfinger`` this yields ~22 g, close to the real spec
+        (~15 g). Bodies without any usable collision shape fall back to a
+        small default mass and inertia.
+        """
+        from newton import JointType
+        from newton._src.geometry.inertia import compute_inertia_shape
+
+        builder = cls._builder
+        if builder is None or len(builder.body_mass) == 0:
+            return
+
+        # Identify bodies that are the child of a non-fixed joint (moving bodies).
+        moving_bodies: set[int] = set()
+        for j in range(len(builder.joint_type)):
+            if builder.joint_type[j] == JointType.FIXED:
+                continue
+            child = builder.joint_child[j]
+            if child >= 0:
+                moving_bodies.add(child)
+
+        # Default density for shape-based mass computation [kg/m^3].
+        default_density = 1000.0
+        # Fallback mass [kg] and inertia scalar [kg*m^2] for bodies without any usable shape.
+        fallback_mass = 0.01
+        fallback_inertia_scalar = 1e-5
+
+        num_fixed = 0
+        for b in moving_bodies:
+            if builder.body_mass[b] > 0.0:
+                continue
+
+            # Try to compute mass from the body's collision shapes.
+            total_mass = 0.0
+            total_inertia = wp.mat33(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+            shape_indices = builder.body_shapes.get(b, [])
+            for s in shape_indices:
+                shape_type = builder.shape_type[s]
+                shape_scale = builder.shape_scale[s]
+                shape_src = builder.shape_source[s] if hasattr(builder, "shape_source") else None
+                try:
+                    shape_mass, _com, shape_inertia = compute_inertia_shape(
+                        type=shape_type,
+                        scale=shape_scale,
+                        src=shape_src,
+                        density=default_density,
+                    )
+                except Exception:
+                    continue
+                if shape_mass > 0.0:
+                    total_mass += shape_mass
+                    for i in range(3):
+                        for k in range(3):
+                            total_inertia[i, k] = total_inertia[i, k] + shape_inertia[i, k]
+
+            if total_mass <= 0.0:
+                # No valid shape -- use fallback values.
+                total_mass = fallback_mass
+                total_inertia = wp.mat33(
+                    fallback_inertia_scalar,
+                    0.0,
+                    0.0,
+                    0.0,
+                    fallback_inertia_scalar,
+                    0.0,
+                    0.0,
+                    0.0,
+                    fallback_inertia_scalar,
+                )
+
+            builder.body_mass[b] = total_mass
+            builder.body_inv_mass[b] = 1.0 / total_mass
+            builder.body_inertia[b] = total_inertia
+            builder.body_inv_inertia[b] = wp.inverse(total_inertia)
+            num_fixed += 1
+
+        if num_fixed > 0:
+            logger.warning(
+                f"Computed mass from collision shapes (density={default_density} kg/m^3) "
+                f"for {num_fixed} zero-mass moving body(ies). Newton's USD importer does "
+                f"not auto-compute mass from colliders the way Isaac Sim PhysX does."
+            )
 
     @classmethod
     def _initialize_contacts(cls) -> None:


### PR DESCRIPTION
Some USD assets - including stock Isaac Lab assets like Franka `panda_leftfinger` / `panda_rightfinger` and the OpenArm hand link - declare zero mass on intermediate moving bodies. This is not an authoring mistake: those assets rely on Isaac Sim's PhysX "auto-compute mass from collider" feature, which Newton's USD importer does not replicate.

The bug: Newton's `bound_mass` validator only floors positive masses below the bound; zero / negative is treated as a "static body". For any body that is the child of a non-fixed joint, the MuJoCo solver then rejects the model with an `mjMINVAL` check at finalize, because it requires positive mass for every non-fixed joint. Manipulation tasks that use these assets (e.g. Isaac-Lift-Cube-Franka-v0) cannot start at all.

The fix: Compute mass and inertia from the body's own collision shapes, before `finalize`.

The obvious alternative is to floor zero-mass moving bodies at some small epsilon (e.g. 1e-6 kg). This makes the solver accept the model, but the result is physically meaningless: a microgram-mass gripper finger cannot transmit contact force to a 200 g cube - the manipulator simply passes through it. The task starts, but no policy can ever solve it. The fix has to give the body a physically reasonable mass, not just a non-zero one.

## How

A new private method `NewtonManager._fix_zero_mass_moving_bodies()` runs once in `_finalize_model`, immediately before `builder.finalize`:

1. Identify all bodies that are the child of a non-fixed joint.
2. For each such body whose authored mass is `<= 0`, walk its collision shapes and call [`newton._src.geometry.inertia.compute_inertia_shape`](https://github.com/newton-physics/newton) on each one with a default density of **1000 kg/m³**. Sum the per-shape masses and inertia tensors.
3. Bodies without any usable collision shape fall back to a small default (`fallback_mass = 0.01 kg`, `fallback_inertia_scalar = 1e-5 kg·m²`) so the solver still has positive values to work with.
4. Write the computed mass / inertia (and their inverses) back into the builder, and emit a single warning summarizing how many bodies were patched.

The fix is non-invasive - bodies with valid authored mass are completely untouched.

## Validation

For a Franka `panda_leftfinger`, the fix computes ~22 g, which is close to the manufacturer spec (~15 g) - close enough that the gripper can actually grip a cube. With this fix in place, the lift / stack manipulation tasks train cleanly under PPO with `presets=newton`. Without it, the same tasks either crash at finalize or never converge because contact forces through the fingers are effectively zero.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (the fix itself emits an informational warning summarizing what was patched)
- [ ] I have added tests that prove my fix is effective or that my feature works *(see note below)*
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md`

**Note on tests:** the failure mode is asset-specific (it requires a USD asset that uses PhysX auto-mass-from-collider, which means a real Franka / OpenArm USD or a fixture that mimics one). I'd welcome guidance on where the right home for such a regression test would be. Manually validated against `Isaac-Lift-Cube-Franka-v0`.
