### PR TITLE
Pins sphinx<9 to fix sphinx-multiversion compatibility

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # for building the docs
-sphinx>=7.0
+sphinx>=7.0,<9
 sphinx-book-theme>=1.1
 myst-parser
 sphinxcontrib-bibtex==2.5.0


### PR DESCRIPTION
## Description

Sphinx 9.0 changed `Config.read()` to use keyword-only parameters (`overrides` and `tags`), breaking `sphinx-multiversion==0.2.4` which passes arguments positionally. This causes the multi-version docs CI build to fail with:

```
TypeError: Config.read() takes 2 positional arguments but 3 were given
```

The `develop` branch has `sphinx>=7.0` with no upper bound, so CI (Python 3.12) resolves to Sphinx 9.1.0 which introduced the breaking API change.

## Fix

Pin `sphinx>=7.0,<9` in `docs/requirements.txt` to keep Sphinx on the 8.x line until `sphinx-multiversion` is updated or replaced with a maintained fork.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)