### PR TITLE
Pins Sphinx <8 for sphinx-multiversion compatibility

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # for building the docs
-sphinx>=7.0,<9
+sphinx>=7.0,<8  # sphinx-multiversion 0.2.4 incompatible with Sphinx 8.x
 sphinx-book-theme>=1.1
 myst-parser
 sphinxcontrib-bibtex==2.5.0


### PR DESCRIPTION
## Description

Fixes the docs build failure that started on April 8-9, causing `develop` and `release/3.0.0-beta` to disappear from the published docs.

### Root Cause

`sphinx-multiversion==0.2.4` is not compatible with Sphinx 8.x due to changes in the `Config.read()` signature. The build was failing with:

```
TypeError: Config.read() takes 2 positional arguments but 3 were given
```

This happened because `sphinx>=7.0,<9` allowed Sphinx 8.x to be installed.

### Fix

Pin Sphinx to `<8` until `sphinx-multiversion` is updated or replaced with a compatible alternative.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the contribution guidelines