### PR TITLE
Adds async retarget to IsaacTeleopDevice (on by default)

### DIFF
--- a/source/isaaclab_teleop/config/extension.toml
+++ b/source/isaaclab_teleop/config/extension.toml
@@ -1,6 +1,6 @@
 [package]
 # Semantic Versioning is used: https://semver.org/
-version = "0.3.8"
+version = "0.3.9"
 
 # Description
 title =  "Isaac Lab Teleop"

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -8,14 +8,22 @@ Added
 ^^^^^
 
 * Added :class:`~isaaclab_teleop.async_retarget_loop.AsyncRetargetLoop` for background-threaded
-  retargeting with consumption-gated, EMA-paced scheduling, so retarget work
+  retargeting with consumption-gated, paced scheduling, so retarget work
   overlaps with ``env.step()`` instead of blocking the render path.  The
-  consumption gate enforces a strict 1:1 retarget-to-advance ratio while the
-  EMA pacer delays input reads until just before the predicted deadline for
-  maximum freshness.
+  consumption gate enforces a strict 1:1 retarget-to-advance ratio while a
+  pluggable :class:`~isaaclab_teleop.async_retarget_loop.TimingEstimator`
+  delays input reads until just before the predicted deadline for maximum
+  freshness.
+
+* Added :class:`~isaaclab_teleop.async_retarget_loop.TimingEstimator` ABC and
+  :class:`~isaaclab_teleop.async_retarget_loop.TimingEstimatorCfg` base config
+  for pluggable timing strategies.  The default
+  :class:`~isaaclab_teleop.async_retarget_loop.EmaTimingEstimator` uses
+  Exponential Moving Average to predict consume cadence and retarget cost.
 
 * Added :meth:`~isaaclab_teleop.IsaacTeleopDevice.set_async` to toggle between
-  synchronous and asynchronous retargeting at runtime.  Async mode is enabled
+  synchronous and asynchronous retargeting at runtime.  Pass a custom
+  ``timing_cfg`` to use a different estimation strategy.  Async mode is enabled
   by default.
 
 Changed

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -8,8 +8,11 @@ Added
 ^^^^^
 
 * Added :class:`~isaaclab_teleop.async_retarget_loop.AsyncRetargetLoop` for background-threaded
-  retargeting with EMA-paced scheduling, so retarget work overlaps with
-  ``env.step()`` instead of blocking the render path.
+  retargeting with consumption-gated, EMA-paced scheduling, so retarget work
+  overlaps with ``env.step()`` instead of blocking the render path.  The
+  consumption gate enforces a strict 1:1 retarget-to-advance ratio while the
+  EMA pacer delays input reads until just before the predicted deadline for
+  maximum freshness.
 
 * Added :meth:`~isaaclab_teleop.IsaacTeleopDevice.set_async` to toggle between
   synchronous and asynchronous retargeting at runtime.  Async mode is enabled

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Added
 ^^^^^
 
-* Added :class:`~isaaclab_teleop.AsyncRetargetLoop` for background-threaded
+* Added :class:`~isaaclab_teleop.async_retarget_loop.AsyncRetargetLoop` for background-threaded
   retargeting with EMA-paced scheduling, so retarget work overlaps with
   ``env.step()`` instead of blocking the render path.
 

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -1,6 +1,32 @@
 Changelog
 ---------
 
+0.3.9 (2026-04-28)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :class:`~isaaclab_teleop.AsyncRetargetLoop` for background-threaded
+  retargeting with EMA-paced scheduling, so retarget work overlaps with
+  ``env.step()`` instead of blocking the render path.
+
+* Added :meth:`~isaaclab_teleop.IsaacTeleopDevice.set_async` to toggle between
+  synchronous and asynchronous retargeting at runtime.  Async mode is enabled
+  by default.
+
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_teleop.IsaacTeleopDevice` to run retargeting
+  asynchronously by default.  Call ``device.set_async(False)`` to revert to
+  synchronous behavior.
+
+* Changed :class:`~isaaclab_teleop.session_lifecycle.TeleopSessionLifecycle` to
+  support :meth:`~isaaclab_teleop.session_lifecycle.TeleopSessionLifecycle.add_on_stop_callback`
+  for registering cleanup callbacks invoked when the session stops.
+
+
 0.3.8 (2026-04-24)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""EMA-paced, consumption-gated background retarget loop for :class:`IsaacTeleopDevice`.
+"""Consumption-gated background retarget loop with pluggable timing estimation.
 
 The background thread produces exactly one retarget result per
 :meth:`consume` call.  After posting a result it waits for the main
@@ -11,15 +11,18 @@ thread to consume it before retargeting again, ensuring the retarget
 pipeline is invoked at the same cadence as ``advance()`` (just like the
 synchronous path).
 
-Within each cycle the thread uses an Exponential Moving Average (EMA)
-to predict *when* the next :meth:`consume` will happen, then delays
-reading inputs and retargeting until just before that deadline.  This
-maximises input freshness while still overlapping the retarget
-computation with ``env.step()``.
+Within each cycle a :class:`TimingEstimator` predicts *when* the next
+:meth:`consume` will happen and delays reading inputs until just before
+that deadline.  The default strategy uses Exponential Moving Average
+(EMA) via :class:`EmaTimingEstimator`.  To swap in a different
+prediction algorithm, subclass :class:`TimingEstimator` and
+:class:`TimingEstimatorCfg`, then pass the custom cfg to
+:class:`AsyncRetargetLoop`.
 """
 
 from __future__ import annotations
 
+import abc
 import logging
 import threading
 import time
@@ -28,7 +31,186 @@ from collections.abc import Callable
 import numpy as np
 import torch
 
+from isaaclab.utils import configclass
+
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Timing estimator interface + default EMA implementation
+# ---------------------------------------------------------------------------
+
+
+class TimingEstimator(abc.ABC):
+    """Base class for retarget-loop timing estimators.
+
+    Subclasses predict *when* to start each retarget cycle so the result
+    is ready just before the consumer calls :meth:`consume`.
+
+    Subclass both this class and :class:`TimingEstimatorCfg` to
+    implement a custom estimation strategy.
+    """
+
+    def __init__(self, cfg: TimingEstimatorCfg):
+        """Initialize the estimator.
+
+        Args:
+            cfg: Configuration for this estimator instance.
+        """
+
+    @abc.abstractmethod
+    def reset(self) -> None:
+        """Reset to initial state (no timing data)."""
+
+    @abc.abstractmethod
+    def record_consume(self, timestamp: float) -> None:
+        """Record a consume() call, updating the step-period estimate.
+
+        Args:
+            timestamp: :func:`time.monotonic` value at the consume call.
+        """
+
+    @abc.abstractmethod
+    def record_retarget(self, duration_s: float) -> None:
+        """Record a completed retarget, updating the cost estimate.
+
+        Args:
+            duration_s: Wall-clock time [s] of the retarget computation.
+        """
+
+    @abc.abstractmethod
+    def compute_sleep(self, now: float) -> float:
+        """Return how long to sleep before starting the next retarget [s].
+
+        Returns ``0.0`` when no timing data is available yet (first
+        iteration), signalling that the caller should proceed immediately.
+
+        Args:
+            now: Current :func:`time.monotonic` value.
+        """
+
+
+@configclass
+class TimingEstimatorCfg:
+    """Base configuration for :class:`TimingEstimator` subclasses.
+
+    Subclass to add parameters for a custom estimation strategy and set
+    :attr:`class_type` to the corresponding :class:`TimingEstimator`
+    subclass.
+    """
+
+    class_type: type[TimingEstimator] | None = None
+    """The :class:`TimingEstimator` subclass to instantiate.  Must be
+    set by concrete cfg subclasses."""
+
+
+class EmaTimingEstimator(TimingEstimator):
+    """Timing estimator using Exponential Moving Average (EMA).
+
+    Tracks two quantities via EMA:
+
+    * **Step period** -- interval between consecutive consumer calls
+      (i.e. how often a fresh result is needed).
+    * **Retarget duration** -- wall-clock cost of one retarget computation.
+
+    :meth:`compute_sleep` combines both estimates to return how long the
+    background thread should sleep before starting the next retarget,
+    aiming to finish just before the consumer arrives.
+    """
+
+    _MIN_SLEEP = 0.001  # 1 ms floor to prevent busy-spinning
+
+    def __init__(self, cfg: EmaTimingEstimatorCfg):
+        """Initialize the EMA estimator.
+
+        Args:
+            cfg: Configuration for this estimator instance.
+        """
+        super().__init__(cfg)
+        self._alpha = cfg.ema_alpha
+        self._margin_s = cfg.margin_s
+        # Seed estimates assume ~45 Hz consume cadence and ~5 ms retarget
+        # cost.  The EMA converges within a few frames regardless of the
+        # actual rates, so these only affect the first 2-3 pacing decisions.
+        self._step_period = 0.022
+        self._retarget_dur = 0.005
+        self._last_consume = 0.0
+
+    @property
+    def step_period(self) -> float:
+        """Current estimate of the consumer call interval [s]."""
+        return self._step_period
+
+    @property
+    def retarget_dur(self) -> float:
+        """Current estimate of the retarget computation cost [s]."""
+        return self._retarget_dur
+
+    def reset(self) -> None:
+        """Reset to initial state (no timing data)."""
+        self._last_consume = 0.0
+
+    def record_consume(self, timestamp: float) -> None:
+        """Record a consume() call, updating the step-period estimate.
+
+        Args:
+            timestamp: :func:`time.monotonic` value at the consume call.
+        """
+        if self._last_consume > 0:
+            dt = timestamp - self._last_consume
+            if 0.001 < dt < 1.0:
+                self._step_period = self._alpha * dt + (1 - self._alpha) * self._step_period
+        self._last_consume = timestamp
+
+    def record_retarget(self, duration_s: float) -> None:
+        """Record a completed retarget, updating the cost estimate.
+
+        Args:
+            duration_s: Wall-clock time [s] of the retarget computation.
+        """
+        self._retarget_dur = self._alpha * duration_s + (1 - self._alpha) * self._retarget_dur
+
+    def compute_sleep(self, now: float) -> float:
+        """Return how long to sleep before starting the next retarget [s].
+
+        Returns ``0.0`` when no timing data is available yet (first
+        iteration), signalling that the caller should proceed immediately.
+
+        Args:
+            now: Current :func:`time.monotonic` value.
+        """
+        if self._last_consume <= 0:
+            return 0.0
+        elapsed_since_consume = now - self._last_consume
+        time_until_next = self._step_period - elapsed_since_consume
+        ideal = time_until_next - self._retarget_dur - self._margin_s
+        return max(ideal, self._MIN_SLEEP)
+
+
+@configclass
+class EmaTimingEstimatorCfg(TimingEstimatorCfg):
+    """Configuration for :class:`EmaTimingEstimator`."""
+
+    class_type: type = EmaTimingEstimator
+    """The estimator class to instantiate."""
+
+    ema_alpha: float = 0.3
+    """EMA smoothing factor in ``(0, 1]``.  Higher values adapt faster
+    but are more sensitive to jitter.  The default 0.3 gives a half-life
+    of ~2 samples (``ln2 / ln(1 / 0.7) ≈ 1.9``)."""
+
+    margin_s: float = 0.005
+    """Safety margin [s] subtracted from the predicted deadline so the
+    retarget finishes slightly early."""
+
+    def __post_init__(self):
+        if not (0.0 < self.ema_alpha <= 1.0):
+            raise ValueError(f"ema_alpha must be in (0, 1], got {self.ema_alpha}")
+
+
+# ---------------------------------------------------------------------------
+# Async retarget loop
+# ---------------------------------------------------------------------------
 
 
 class AsyncRetargetLoop:
@@ -39,30 +221,26 @@ class AsyncRetargetLoop:
     1. **Consumption gate** -- after posting a result the thread blocks
        until :meth:`consume` has read it, preventing more than one
        retarget per ``advance()`` call.
-    2. **EMA pacer** -- once the gate opens, the thread sleeps until the
-       optimal moment to start retargeting so inputs are as fresh as
-       possible when read.
+    2. **Timing estimator** -- once the gate opens, the estimator sleeps
+       until the optimal moment to start retargeting so inputs are as
+       fresh as possible when read.
 
-    The EMA tracks two quantities:
+    Timeline (one cycle, time flows left → right)::
 
-    * **step period** -- time between consecutive :meth:`consume` calls
-      (i.e. the main loop's frame period).
-    * **retarget duration** -- wall-clock cost of one ``step_fn`` call.
+        main  ──consume()──env.step()────────────────────consume()──
+                  ↑                                         ↑
+                  │                                         │
+        bg    ──[gate]──|                              |──[gate]──
+                        ├────────sleep──────┤          │
+                                            ├─retarget─┤
+                                                       │
+                                                    result ready
 
-    With those estimates the pacer computes::
-
-        sleep = predicted_next_consume - now - retarget_duration - margin
-
-    so it wakes up just early enough to finish retargeting right before
-    the caller needs the result.
-
-    Timeline sketch (one consume-to-consume period)::
-
-        main: advance() → update_inputs() → consume(block) [waits] →
-                                                      gets result → env.step()
-
-        bg:   [gate: wait consumed] → [ema sleep] → read inputs →
-                                       retarget → post result → [gate] …
+    When :meth:`consume` is called with ``block=True`` (the default), it
+    waits until the background thread has produced a fresh result since
+    the previous :meth:`consume`.  Because the pacer aims to finish
+    just in time, the wait is almost always instantaneous; the block acts
+    as a safety net when retarget occasionally runs longer than predicted.
 
     Thread-safety contract:
         All USD/Kit/Omniverse API calls must stay on the main thread.
@@ -73,14 +251,12 @@ class AsyncRetargetLoop:
     """
 
     _MAX_CONSECUTIVE_FAILURES = 5
-    _MIN_LOOP_PERIOD = 0.001  # 1 ms floor to prevent busy-spinning
 
     def __init__(
         self,
         step_fn: Callable[[np.ndarray, np.ndarray | torch.Tensor | None], torch.Tensor | None],
         *,
-        ema_alpha: float = 0.3,
-        margin_s: float = 0.005,
+        timing_cfg: TimingEstimatorCfg | None = None,
     ):
         """Create a new loop (stopped).  Call :meth:`start` to begin.
 
@@ -89,14 +265,16 @@ class AsyncRetargetLoop:
                 ``(anchor_matrix, target_T_world)`` and returning an
                 action tensor or ``None``.  **Called from a background
                 thread**; must not touch USD/Kit/Omniverse APIs directly.
-            ema_alpha: EMA smoothing factor in ``(0, 1]``.
-            margin_s: Safety margin [s] subtracted from the predicted
-                deadline.
+            timing_cfg: Configuration for the timing estimator.  Defaults
+                to :class:`EmaTimingEstimatorCfg` when ``None``.
         """
-        if not (0.0 < ema_alpha <= 1.0):
-            raise ValueError(f"ema_alpha must be in (0, 1], got {ema_alpha}")
+        if timing_cfg is None:
+            timing_cfg = EmaTimingEstimatorCfg()
+        if timing_cfg.class_type is None:
+            raise ValueError("timing_cfg.class_type must be set to a TimingEstimator subclass")
 
         self._step_fn = step_fn
+        self._timing: TimingEstimator = timing_cfg.class_type(timing_cfg)
 
         self._lock = threading.Lock()
         self._cond = threading.Condition(self._lock)
@@ -113,12 +291,6 @@ class AsyncRetargetLoop:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 
-        self._ema_alpha = ema_alpha
-        self._margin_s = margin_s
-        self._step_period = 0.022
-        self._retarget_dur = 0.005
-        self._last_consume = 0.0
-
     def start(self) -> None:
         """Start the retarget loop in a daemon thread."""
         self._stop.clear()
@@ -127,7 +299,7 @@ class AsyncRetargetLoop:
             self._consumed_gen = 0
             self._latest = None
             self._exc = None
-        self._last_consume = 0.0
+        self._timing.reset()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
@@ -171,8 +343,8 @@ class AsyncRetargetLoop:
     def consume(self, block: bool = True) -> tuple[torch.Tensor | None, bool]:
         """Read the most recent retarget result.
 
-        Updates the EMA estimate of the consumer's call period so the
-        pacer can predict the next deadline.
+        Updates the timing estimator so the pacer can predict the next
+        deadline.
 
         Args:
             block: When ``True`` (default), wait until the background
@@ -195,14 +367,7 @@ class AsyncRetargetLoop:
                         break
                     self._cond.wait(timeout=0.1)
 
-            now = time.monotonic()
-            if self._last_consume > 0:
-                dt = now - self._last_consume
-                if 0.001 < dt < 1.0:
-                    self._step_period = (
-                        self._ema_alpha * dt + (1 - self._ema_alpha) * self._step_period
-                    )
-            self._last_consume = now
+            self._timing.record_consume(time.monotonic())
 
             exc = self._exc
             self._exc = None
@@ -233,9 +398,9 @@ class AsyncRetargetLoop:
             if self._stop.is_set():
                 break
 
-            # EMA pace: delay reading inputs until just before the
-            # predicted next consume() so that inputs are as fresh as
-            # possible.
+            # Timing estimator pace: delay reading inputs until just
+            # before the predicted next consume() so that inputs are as
+            # fresh as possible.
             self._pace()
             if self._stop.is_set():
                 break
@@ -266,9 +431,7 @@ class AsyncRetargetLoop:
                 continue
             elapsed = time.monotonic() - t0
 
-            self._retarget_dur = (
-                self._ema_alpha * elapsed + (1 - self._ema_alpha) * self._retarget_dur
-            )
+            self._timing.record_retarget(elapsed)
 
             if action is not None:
                 action = action.clone()
@@ -283,20 +446,15 @@ class AsyncRetargetLoop:
     def _pace(self) -> None:
         """Sleep until the optimal moment to begin the next retarget.
 
-        Goal: read inputs and start retargeting as late as possible
-        while still finishing before the predicted next :meth:`consume`.
-        If there is no timing data yet (first iteration), return
-        immediately so the first result is produced as fast as possible.
+        Delegates to :meth:`TimingEstimator.compute_sleep` for the
+        actual duration.  If there is no timing data yet (first
+        iteration), returns immediately so the first result is produced
+        as fast as possible.
 
         The consumption gate in :meth:`_run` guarantees at most one
         retarget per consume, so this method never needs to worry about
         a second retarget sneaking in.
         """
-        if self._last_consume <= 0:
-            return
-
-        elapsed_since_consume = time.monotonic() - self._last_consume
-        time_until_next = self._step_period - elapsed_since_consume
-        ideal_sleep = time_until_next - self._retarget_dur - self._margin_s
-
-        self._stop.wait(timeout=max(ideal_sleep, self._MIN_LOOP_PERIOD))
+        sleep = self._timing.compute_sleep(time.monotonic())
+        if sleep > 0:
+            self._stop.wait(timeout=sleep)

--- a/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
@@ -199,7 +199,7 @@ class EmaTimingEstimatorCfg(TimingEstimatorCfg):
     but are more sensitive to jitter.  The default 0.3 gives a half-life
     of ~2 samples (``ln2 / ln(1 / 0.7) ≈ 1.9``)."""
 
-    margin_s: float = 0.005
+    margin_s: float = 0.015
     """Safety margin [s] subtracted from the predicted deadline so the
     retarget finishes slightly early."""
 

--- a/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""EMA-paced background retarget loop used by :class:`IsaacTeleopDevice`."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncRetargetLoop:
+    """Background loop that retargets with EMA-paced scheduling.
+
+    The loop runs continuously in a background thread and uses an
+    Exponential Moving Average (EMA) to predict *when* the next
+    :meth:`consume` will happen and *how long* retargeting takes.  The
+    EMA is a weighted running average where each new sample contributes
+    ``alpha`` and the accumulated history contributes ``1 - alpha``,
+    giving a smooth estimate that adapts to changing timing without
+    reacting to every jitter spike.
+
+    With those two estimates the loop computes::
+
+        sleep = predicted_next_consume - now - retarget_duration - margin
+
+    so it wakes up just early enough to finish retargeting right before
+    the caller needs the result.
+
+    Timeline sketch (one consume-to-consume period)::
+
+        last_consume                        next_consume (predicted)
+            |                                       |
+            |-------sleep--------->|--retarget--|   |
+                                   ^            ^   ^
+                                wake here    ready  consume
+
+    When :meth:`consume` is called with ``block=True`` (the default), it
+    waits until the background thread has produced a fresh result since
+    the previous :meth:`consume`.  Because the EMA pacer aims to finish
+    just in time, the wait is almost always instantaneous; the block acts
+    as a safety net when retarget occasionally runs longer than predicted.
+
+    Thread-safety contract:
+        All USD/Kit/Omniverse API calls must stay on the main thread.
+        The main thread pushes pre-computed inputs (anchor matrix,
+        target-frame transform) via :meth:`update_inputs`, and the
+        background thread only runs the retarget computation with those
+        inputs.
+    """
+
+    _MAX_CONSECUTIVE_FAILURES = 5
+    _MIN_LOOP_PERIOD = 0.001  # 1 ms floor to prevent busy-spinning
+
+    def __init__(
+        self,
+        step_fn: Callable[[np.ndarray, np.ndarray | torch.Tensor | None], torch.Tensor | None],
+        *,
+        ema_alpha: float = 0.3,
+        margin_s: float = 0.005,
+    ):
+        # alpha=0.3 gives an EMA half-life of ~2 samples (ln2/ln(1/0.7)≈1.9).
+        # At a 45 Hz target frame rate that adapts within ~44 ms — fast
+        # enough to track frame-rate changes (e.g. VSync toggle, workload
+        # shifts) while still filtering single-frame timing jitter.
+        self._step_fn = step_fn
+
+        # Result state protected by a Condition rather than a bare Event to
+        # avoid a TOCTOU (Time-of-Check-to-Time-of-Use) race: with Event the
+        # consumer would check is_set() then separately read _latest, but
+        # the producer could overwrite _latest between those two steps.
+        # Condition bundles the "is there a new result?" check and the read
+        # under a single lock acquisition.
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._gen = 0
+        self._consumed_gen = 0
+        self._latest: torch.Tensor | None = None
+        self._exc: BaseException | None = None
+
+        # Input state: written by main thread, read by background thread.
+        self._input_lock = threading.Lock()
+        self._anchor_matrix: np.ndarray = np.eye(4, dtype=np.float32)
+        self._target_T_world: np.ndarray | torch.Tensor | None = None
+
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+        self._ema_alpha = ema_alpha
+        self._margin_s = margin_s
+        self._step_period = 0.022
+        self._retarget_dur = 0.020
+        self._last_consume = 0.0
+
+    def start(self) -> None:
+        """Start the retarget loop in a daemon thread."""
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the loop to exit and wait for the thread to finish."""
+        self._stop.set()
+        with self._cond:
+            self._cond.notify_all()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            if self._thread.is_alive():
+                logger.error(
+                    "Background retarget thread did not exit within 2 s; "
+                    "it will continue running as a daemon until interpreter exit."
+                )
+            self._thread = None
+
+    def update_inputs(
+        self,
+        anchor_matrix: np.ndarray,
+        target_T_world: np.ndarray | torch.Tensor | None = None,
+    ) -> None:
+        """Push updated inputs from the main thread.
+
+        Called every frame before :meth:`consume` so the background
+        thread always has fresh USD-derived data without touching
+        USD/Kit APIs itself.
+
+        Args:
+            anchor_matrix: The (4, 4) world-to-anchor transform [m].
+            target_T_world: Optional (4, 4) rebase transform [m].
+        """
+        with self._input_lock:
+            self._anchor_matrix = np.array(anchor_matrix, dtype=np.float32, copy=True)
+            if isinstance(target_T_world, np.ndarray):
+                target_T_world = np.array(target_T_world, dtype=np.float32, copy=True)
+            self._target_T_world = target_T_world
+
+    def consume(self, block: bool = True) -> tuple[torch.Tensor | None, bool]:
+        """Read the most recent retarget result.
+
+        Updates the EMA estimate of the consumer's call period so the
+        pacer can predict the next deadline.
+
+        Args:
+            block: When ``True`` (default), wait until the background
+                thread has produced a fresh result since the last
+                :meth:`consume`.  When ``False``, return immediately
+                with whatever result is available (may be stale).
+
+        Returns:
+            ``(action, is_fresh)`` where *is_fresh* is ``True`` when the
+            result has been updated since the last :meth:`consume`.
+
+        Raises:
+            Exception: Re-raises any exception that killed the background
+                thread, chained under a :class:`RuntimeError`.
+        """
+        if block:
+            with self._cond:
+                while not self._stop.is_set() and self._gen == self._consumed_gen:
+                    self._cond.wait(timeout=0.1)
+
+        now = time.monotonic()
+        if self._last_consume > 0:
+            dt = now - self._last_consume
+            if 0.001 < dt < 1.0:
+                # EMA update: blend the new measurement (dt) at weight alpha
+                # with the running estimate at weight (1 - alpha).  With the
+                # default alpha=0.3 the effective window is ~1/alpha ≈ 3
+                # samples, so the estimate tracks frame-rate changes within
+                # 2-3 frames while filtering single-frame jitter.
+                self._step_period = self._ema_alpha * dt + (1 - self._ema_alpha) * self._step_period
+        self._last_consume = now
+
+        with self._cond:
+            exc = self._exc
+            self._exc = None
+            fresh = self._gen != self._consumed_gen
+            self._consumed_gen = self._gen
+            result = self._latest
+
+        if exc is not None:
+            raise RuntimeError("Background retarget thread failed") from exc
+
+        return result, fresh
+
+    # ------------------------------------------------------------------
+
+    def _run(self) -> None:
+        consecutive_failures = 0
+        while not self._stop.is_set():
+            self._pace()
+            if self._stop.is_set():
+                break
+
+            with self._input_lock:
+                anchor_matrix = self._anchor_matrix
+                target_T_world = self._target_T_world
+
+            t0 = time.monotonic()
+            try:
+                action = self._step_fn(anchor_matrix, target_T_world)
+                consecutive_failures = 0
+            except Exception as exc:
+                consecutive_failures += 1
+                if consecutive_failures >= self._MAX_CONSECUTIVE_FAILURES:
+                    with self._cond:
+                        self._exc = exc
+                        self._gen += 1
+                        self._cond.notify_all()
+                    return
+                logger.warning(
+                    "Retarget failed (%d/%d), retrying: %s",
+                    consecutive_failures,
+                    self._MAX_CONSECUTIVE_FAILURES,
+                    exc,
+                )
+                self._stop.wait(timeout=min(0.1 * consecutive_failures, 0.5))
+                continue
+            elapsed = time.monotonic() - t0
+
+            # Same EMA formula as _step_period but applied to retarget
+            # wall-clock duration, so the pacer knows how much lead time
+            # to reserve before the next predicted consume().
+            self._retarget_dur = self._ema_alpha * elapsed + (1 - self._ema_alpha) * self._retarget_dur
+
+            if action is not None:
+                action = action.clone()
+                if action.is_cuda:
+                    torch.cuda.current_stream(action.device).synchronize()
+
+            with self._cond:
+                self._latest = action
+                self._gen += 1
+                self._cond.notify_all()
+
+    def _pace(self) -> None:
+        """Sleep until the optimal moment to begin the next retarget.
+
+        Goal: finish retargeting just before the predicted next
+        :meth:`consume` call.  If there is no timing data yet (first
+        iteration), return immediately so the first result is produced
+        as fast as possible.
+
+
+        ``margin_s`` is subtracted so we wake slightly *early* rather
+        than risk finishing late.  ``_MIN_LOOP_PERIOD`` clamps the sleep
+        to at least 1 ms to prevent busy-spinning when the deadline has
+        already passed.
+        """
+        if self._last_consume <= 0:
+            return
+
+        # How much time has already elapsed since the last consume().
+        elapsed_since_consume = time.monotonic() - self._last_consume
+        # EMA-predicted time remaining until the next consume() call.
+        time_until_next = self._step_period - elapsed_since_consume
+        # Subtract the predicted retarget cost and a safety margin so we
+        # wake up just early enough to have a fresh result ready.
+        ideal_sleep = time_until_next - self._retarget_dur - self._margin_s
+
+        self._stop.wait(timeout=max(ideal_sleep, self._MIN_LOOP_PERIOD))

--- a/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
@@ -3,7 +3,20 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""EMA-paced background retarget loop used by :class:`IsaacTeleopDevice`."""
+"""EMA-paced, consumption-gated background retarget loop for :class:`IsaacTeleopDevice`.
+
+The background thread produces exactly one retarget result per
+:meth:`consume` call.  After posting a result it waits for the main
+thread to consume it before retargeting again, ensuring the retarget
+pipeline is invoked at the same cadence as ``advance()`` (just like the
+synchronous path).
+
+Within each cycle the thread uses an Exponential Moving Average (EMA)
+to predict *when* the next :meth:`consume` will happen, then delays
+reading inputs and retargeting until just before that deadline.  This
+maximises input freshness while still overlapping the retarget
+computation with ``env.step()``.
+"""
 
 from __future__ import annotations
 
@@ -19,17 +32,24 @@ logger = logging.getLogger(__name__)
 
 
 class AsyncRetargetLoop:
-    """Background loop that retargets with EMA-paced scheduling.
+    """Background loop that retargets once per :meth:`consume` call.
 
-    The loop runs continuously in a background thread and uses an
-    Exponential Moving Average (EMA) to predict *when* the next
-    :meth:`consume` will happen and *how long* retargeting takes.  The
-    EMA is a weighted running average where each new sample contributes
-    ``alpha`` and the accumulated history contributes ``1 - alpha``,
-    giving a smooth estimate that adapts to changing timing without
-    reacting to every jitter spike.
+    The loop runs in a daemon thread and combines two mechanisms:
 
-    With those two estimates the loop computes::
+    1. **Consumption gate** -- after posting a result the thread blocks
+       until :meth:`consume` has read it, preventing more than one
+       retarget per ``advance()`` call.
+    2. **EMA pacer** -- once the gate opens, the thread sleeps until the
+       optimal moment to start retargeting so inputs are as fresh as
+       possible when read.
+
+    The EMA tracks two quantities:
+
+    * **step period** -- time between consecutive :meth:`consume` calls
+      (i.e. the main loop's frame period).
+    * **retarget duration** -- wall-clock cost of one ``step_fn`` call.
+
+    With those estimates the pacer computes::
 
         sleep = predicted_next_consume - now - retarget_duration - margin
 
@@ -38,17 +58,11 @@ class AsyncRetargetLoop:
 
     Timeline sketch (one consume-to-consume period)::
 
-        last_consume                        next_consume (predicted)
-            |                                       |
-            |-------sleep--------->|--retarget--|   |
-                                   ^            ^   ^
-                                wake here    ready  consume
+        main: advance() → update_inputs() → consume(block) [waits] →
+                                                      gets result → env.step()
 
-    When :meth:`consume` is called with ``block=True`` (the default), it
-    waits until the background thread has produced a fresh result since
-    the previous :meth:`consume`.  Because the EMA pacer aims to finish
-    just in time, the wait is almost always instantaneous; the block acts
-    as a safety net when retarget occasionally runs longer than predicted.
+        bg:   [gate: wait consumed] → [ema sleep] → read inputs →
+                                       retarget → post result → [gate] …
 
     Thread-safety contract:
         All USD/Kit/Omniverse API calls must stay on the main thread.
@@ -82,18 +96,8 @@ class AsyncRetargetLoop:
         if not (0.0 < ema_alpha <= 1.0):
             raise ValueError(f"ema_alpha must be in (0, 1], got {ema_alpha}")
 
-        # alpha=0.3 gives an EMA half-life of ~2 samples (ln2/ln(1/0.7)≈1.9).
-        # At a 45 Hz target frame rate that adapts within ~44 ms — fast
-        # enough to track frame-rate changes (e.g. VSync toggle, workload
-        # shifts) while still filtering single-frame timing jitter.
         self._step_fn = step_fn
 
-        # Result state protected by a Condition rather than a bare Event to
-        # avoid a TOCTOU (Time-of-Check-to-Time-of-Use) race: with Event the
-        # consumer would check is_set() then separately read _latest, but
-        # the producer could overwrite _latest between those two steps.
-        # Condition bundles the "is there a new result?" check and the read
-        # under a single lock acquisition.
         self._lock = threading.Lock()
         self._cond = threading.Condition(self._lock)
         self._gen = 0
@@ -112,7 +116,7 @@ class AsyncRetargetLoop:
         self._ema_alpha = ema_alpha
         self._margin_s = margin_s
         self._step_period = 0.022
-        self._retarget_dur = 0.020
+        self._retarget_dur = 0.005
         self._last_consume = 0.0
 
     def start(self) -> None:
@@ -184,7 +188,6 @@ class AsyncRetargetLoop:
             Exception: Re-raises any exception that killed the background
                 thread, chained under a :class:`RuntimeError`.
         """
-        now = time.monotonic()
         with self._cond:
             if block:
                 while not self._stop.is_set() and self._gen == self._consumed_gen:
@@ -192,15 +195,13 @@ class AsyncRetargetLoop:
                         break
                     self._cond.wait(timeout=0.1)
 
+            now = time.monotonic()
             if self._last_consume > 0:
                 dt = now - self._last_consume
                 if 0.001 < dt < 1.0:
-                    # EMA update: blend the new measurement (dt) at weight alpha
-                    # with the running estimate at weight (1 - alpha).  With the
-                    # default alpha=0.3 the effective window is ~1/alpha ≈ 3
-                    # samples, so the estimate tracks frame-rate changes within
-                    # 2-3 frames while filtering single-frame jitter.
-                    self._step_period = self._ema_alpha * dt + (1 - self._ema_alpha) * self._step_period
+                    self._step_period = (
+                        self._ema_alpha * dt + (1 - self._ema_alpha) * self._step_period
+                    )
             self._last_consume = now
 
             exc = self._exc
@@ -208,6 +209,8 @@ class AsyncRetargetLoop:
             fresh = self._gen != self._consumed_gen
             self._consumed_gen = self._gen
             result = self._latest
+            # Wake the BG thread now that we have consumed the result.
+            self._cond.notify_all()
 
         if exc is not None:
             raise RuntimeError("Background retarget thread failed") from exc
@@ -222,6 +225,17 @@ class AsyncRetargetLoop:
     def _run(self) -> None:
         consecutive_failures = 0
         while not self._stop.is_set():
+            # Gate: wait until the previous result has been consumed so
+            # the pipeline is invoked exactly once per advance() call.
+            with self._cond:
+                while not self._stop.is_set() and self._gen > self._consumed_gen:
+                    self._cond.wait(timeout=0.1)
+            if self._stop.is_set():
+                break
+
+            # EMA pace: delay reading inputs until just before the
+            # predicted next consume() so that inputs are as fresh as
+            # possible.
             self._pace()
             if self._stop.is_set():
                 break
@@ -252,10 +266,9 @@ class AsyncRetargetLoop:
                 continue
             elapsed = time.monotonic() - t0
 
-            # Same EMA formula as _step_period but applied to retarget
-            # wall-clock duration, so the pacer knows how much lead time
-            # to reserve before the next predicted consume().
-            self._retarget_dur = self._ema_alpha * elapsed + (1 - self._ema_alpha) * self._retarget_dur
+            self._retarget_dur = (
+                self._ema_alpha * elapsed + (1 - self._ema_alpha) * self._retarget_dur
+            )
 
             if action is not None:
                 action = action.clone()
@@ -270,29 +283,20 @@ class AsyncRetargetLoop:
     def _pace(self) -> None:
         """Sleep until the optimal moment to begin the next retarget.
 
-        Goal: finish retargeting just before the predicted next
-        :meth:`consume` call.  If there is no timing data yet (first
-        iteration), return immediately so the first result is produced
-        as fast as possible.
+        Goal: read inputs and start retargeting as late as possible
+        while still finishing before the predicted next :meth:`consume`.
+        If there is no timing data yet (first iteration), return
+        immediately so the first result is produced as fast as possible.
 
-        ``margin_s`` is subtracted so we wake slightly *early* rather
-        than risk finishing late.  ``_MIN_LOOP_PERIOD`` clamps the sleep
-        to at least 1 ms to prevent busy-spinning when the deadline has
-        already passed.
+        The consumption gate in :meth:`_run` guarantees at most one
+        retarget per consume, so this method never needs to worry about
+        a second retarget sneaking in.
         """
         if self._last_consume <= 0:
             return
 
-        # _step_period, _retarget_dur, and _last_consume are read without
-        # _cond here (benign race): float assignment is atomic under CPython's
-        # GIL, and the EMA tolerates values stale by at most one sample.
-
-        # How much time has already elapsed since the last consume().
         elapsed_since_consume = time.monotonic() - self._last_consume
-        # EMA-predicted time remaining until the next consume() call.
         time_until_next = self._step_period - elapsed_since_consume
-        # Subtract the predicted retarget cost and a safety margin so we
-        # wake up just early enough to have a fresh result ready.
         ideal_sleep = time_until_next - self._retarget_dur - self._margin_s
 
         self._stop.wait(timeout=max(ideal_sleep, self._MIN_LOOP_PERIOD))

--- a/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/async_retarget_loop.py
@@ -68,6 +68,20 @@ class AsyncRetargetLoop:
         ema_alpha: float = 0.3,
         margin_s: float = 0.005,
     ):
+        """Create a new loop (stopped).  Call :meth:`start` to begin.
+
+        Args:
+            step_fn: Retarget function called each iteration with
+                ``(anchor_matrix, target_T_world)`` and returning an
+                action tensor or ``None``.  **Called from a background
+                thread**; must not touch USD/Kit/Omniverse APIs directly.
+            ema_alpha: EMA smoothing factor in ``(0, 1]``.
+            margin_s: Safety margin [s] subtracted from the predicted
+                deadline.
+        """
+        if not (0.0 < ema_alpha <= 1.0):
+            raise ValueError(f"ema_alpha must be in (0, 1], got {ema_alpha}")
+
         # alpha=0.3 gives an EMA half-life of ~2 samples (ln2/ln(1/0.7)≈1.9).
         # At a 45 Hz target frame rate that adapts within ~44 ms — fast
         # enough to track frame-rate changes (e.g. VSync toggle, workload
@@ -104,6 +118,12 @@ class AsyncRetargetLoop:
     def start(self) -> None:
         """Start the retarget loop in a daemon thread."""
         self._stop.clear()
+        with self._cond:
+            self._gen = 0
+            self._consumed_gen = 0
+            self._latest = None
+            self._exc = None
+        self._last_consume = 0.0
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
@@ -140,6 +160,8 @@ class AsyncRetargetLoop:
             self._anchor_matrix = np.array(anchor_matrix, dtype=np.float32, copy=True)
             if isinstance(target_T_world, np.ndarray):
                 target_T_world = np.array(target_T_world, dtype=np.float32, copy=True)
+            elif isinstance(target_T_world, torch.Tensor):
+                target_T_world = target_T_world.clone()
             self._target_T_world = target_T_world
 
     def consume(self, block: bool = True) -> tuple[torch.Tensor | None, bool]:
@@ -162,24 +184,25 @@ class AsyncRetargetLoop:
             Exception: Re-raises any exception that killed the background
                 thread, chained under a :class:`RuntimeError`.
         """
-        if block:
-            with self._cond:
+        now = time.monotonic()
+        with self._cond:
+            if block:
                 while not self._stop.is_set() and self._gen == self._consumed_gen:
+                    if self._thread is not None and not self._thread.is_alive():
+                        break
                     self._cond.wait(timeout=0.1)
 
-        now = time.monotonic()
-        if self._last_consume > 0:
-            dt = now - self._last_consume
-            if 0.001 < dt < 1.0:
-                # EMA update: blend the new measurement (dt) at weight alpha
-                # with the running estimate at weight (1 - alpha).  With the
-                # default alpha=0.3 the effective window is ~1/alpha ≈ 3
-                # samples, so the estimate tracks frame-rate changes within
-                # 2-3 frames while filtering single-frame jitter.
-                self._step_period = self._ema_alpha * dt + (1 - self._ema_alpha) * self._step_period
-        self._last_consume = now
+            if self._last_consume > 0:
+                dt = now - self._last_consume
+                if 0.001 < dt < 1.0:
+                    # EMA update: blend the new measurement (dt) at weight alpha
+                    # with the running estimate at weight (1 - alpha).  With the
+                    # default alpha=0.3 the effective window is ~1/alpha ≈ 3
+                    # samples, so the estimate tracks frame-rate changes within
+                    # 2-3 frames while filtering single-frame jitter.
+                    self._step_period = self._ema_alpha * dt + (1 - self._ema_alpha) * self._step_period
+            self._last_consume = now
 
-        with self._cond:
             exc = self._exc
             self._exc = None
             fresh = self._gen != self._consumed_gen
@@ -188,6 +211,9 @@ class AsyncRetargetLoop:
 
         if exc is not None:
             raise RuntimeError("Background retarget thread failed") from exc
+
+        if block and not fresh and self._thread is not None and not self._thread.is_alive():
+            raise RuntimeError("Background retarget thread died unexpectedly")
 
         return result, fresh
 
@@ -249,7 +275,6 @@ class AsyncRetargetLoop:
         iteration), return immediately so the first result is produced
         as fast as possible.
 
-
         ``margin_s`` is subtracted so we wake slightly *early* rather
         than risk finishing late.  ``_MIN_LOOP_PERIOD`` clamps the sleep
         to at least 1 ms to prevent busy-spinning when the deadline has
@@ -257,6 +282,10 @@ class AsyncRetargetLoop:
         """
         if self._last_consume <= 0:
             return
+
+        # _step_period, _retarget_dur, and _last_consume are read without
+        # _cond here (benign race): float assignment is atomic under CPython's
+        # GIL, and the EMA tolerates values stale by at most one sample.
 
         # How much time has already elapsed since the last consume().
         elapsed_since_consume = time.monotonic() - self._last_consume

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -241,16 +241,19 @@ class IsaacTeleopDevice:
     ) -> None:
         """Enable or disable asynchronous advance mode.
 
-        When enabled, retargeting runs in a background thread with
-        EMA (Exponential Moving Average)-based pacing that predicts
-        when the next :meth:`advance` call will happen and starts each
-        retarget just early enough to finish in time.
+        When enabled, retargeting runs in a background thread that
+        combines a **consumption gate** with **EMA-paced scheduling**:
+
+        1. After producing a result the thread waits for
+           :meth:`advance` to consume it, guaranteeing a strict 1:1
+           ratio between retarget invocations and ``advance()`` calls.
+        2. Once the gate opens the thread sleeps until the EMA-predicted
+           optimal moment, then reads inputs and retargets, delivering
+           the freshest possible result just before the next
+           :meth:`advance`.
 
         With ``blocking=True`` (default), :meth:`advance` waits for the
         background thread to produce a fresh result before returning.
-        Because the EMA pacer aims to finish just in time, the wait is
-        almost always instantaneous; the block acts as a safety net when
-        retarget occasionally runs longer than predicted.
 
         With ``blocking=False``, :meth:`advance` returns immediately
         with whatever result is available (may be stale if the background
@@ -265,17 +268,12 @@ class IsaacTeleopDevice:
                 until a fresh result is available.  When ``False``,
                 returns immediately (possibly stale).  Ignored when
                 *enabled* is ``False``.
-            ema_alpha: EMA smoothing factor for timing prediction in
-                ``(0, 1]``.  Higher values adapt faster to timing
-                changes but are more sensitive to jitter.  The default
-                0.3 gives a half-life of ~2 samples, adapting within
-                ~44 ms at 45 Hz — empirically a good balance for
-                typical teleop frame rates (45-90 Hz).
+            ema_alpha: EMA smoothing factor in ``(0, 1]`` for predicting
+                the consumer's call period and retarget cost.
             margin_s: Safety margin [s] subtracted from the predicted
-                deadline.  Increase if retarget occasionally misses the
-                deadline.
+                deadline to avoid late delivery.
         """
-        if not (0.0 < ema_alpha <= 1.0):
+        if enabled and not (0.0 < ema_alpha <= 1.0):
             raise ValueError(f"ema_alpha must be in (0, 1], got {ema_alpha}")
 
         needs_restart = (
@@ -306,12 +304,12 @@ class IsaacTeleopDevice:
         the handles become available, the session is created transparently.
 
         When async mode is enabled (see :meth:`set_async`), the retargeting
-        pipeline runs in a background thread with EMA (Exponential Moving
-        Average)-based pacing.  By
-        default the call blocks until a fresh result is ready (the block
-        is almost always instantaneous because the pacer finishes just in
-        time).  This lets retargeting overlap with ``env.step()`` while
-        guaranteeing up-to-date data every frame.
+        pipeline runs in a background thread with consumption-gated,
+        EMA-paced scheduling.  By default the call blocks until a fresh
+        result is ready (the block is almost always instantaneous because
+        the pacer finishes just in time).  This lets retargeting overlap
+        with ``env.step()`` while guaranteeing exactly one retarget per
+        ``advance()`` call with inputs as fresh as possible.
 
         Args:
             target_T_world: Optional 4x4 transform matrix that rebases all
@@ -364,7 +362,7 @@ class IsaacTeleopDevice:
         return action
 
     def _advance_async(self, target_T_world=None) -> torch.Tensor | None:
-        """Async advance: read from the EMA-paced background retarget loop.
+        """Async advance: read from the EMA-paced, consumption-gated loop.
 
         All USD/Kit interactions (anchor matrix, target-frame transform,
         button polling) run on the calling (main) thread.  Only the

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -400,7 +400,10 @@ class IsaacTeleopDevice:
             ``True`` when the loop is running and cache is seeded; ``False``
             when no synchronous action was produced yet.
         """
-        action = self._advance_sync(target_T_world)
+        action = self._session_lifecycle.step(
+            anchor_world_matrix_fn=self._anchor_manager.get_world_matrix,
+            target_T_world=target_T_world,
+        )
         if action is None:
             return False
         self._cached_action = action

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 
+from .async_retarget_loop import AsyncRetargetLoop
 from .command_handler import CommandHandler
 from .control_events import ControlEvents
 from .isaac_teleop_cfg import IsaacTeleopCfg
@@ -131,6 +132,20 @@ class IsaacTeleopDevice:
         self._prev_right_a_pressed = False
         self._prev_control_is_active: bool | None = None
 
+        # Async advance state: background retarget loop with EMA pacing
+        # that produces results consumed by advance().
+        self._async_enabled = True
+        self._async_blocking = True
+        self._async_ema_alpha = 0.3
+        self._async_margin_s = 0.005
+        self._retarget_loop: AsyncRetargetLoop | None = None
+        self._cached_action: torch.Tensor | None = None
+
+        # Ensure the retarget loop is stopped before the lifecycle clears
+        # session/pipeline state (covers _on_pre_shutdown and other external
+        # shutdown paths that bypass __exit__).
+        self._session_lifecycle.add_on_stop_callback(self._stop_retarget_loop)
+
     def __del__(self):
         """Clean up resources when the object is destroyed."""
         if hasattr(self, "_command_handler"):
@@ -179,6 +194,8 @@ class IsaacTeleopDevice:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Exit the context manager and clean up the IsaacTeleop session."""
+        self._stop_retarget_loop()
+        self._async_enabled = False
         self._anchor_manager.cleanup()
         self._session_lifecycle.stop(exc_type, exc_val, exc_tb)
         return False
@@ -213,6 +230,69 @@ class IsaacTeleopDevice:
         """
         self._command_handler.add_callback(key, func)
 
+    def set_async(
+        self,
+        enabled: bool = True,
+        blocking: bool = True,
+        *,
+        ema_alpha: float = 0.3,
+        margin_s: float = 0.005,
+    ) -> None:
+        """Enable or disable asynchronous advance mode.
+
+        When enabled, retargeting runs in a background thread with
+        EMA (Exponential Moving Average)-based pacing that predicts
+        when the next :meth:`advance` call will happen and starts each
+        retarget just early enough to finish in time.
+
+        With ``blocking=True`` (default), :meth:`advance` waits for the
+        background thread to produce a fresh result before returning.
+        Because the EMA pacer aims to finish just in time, the wait is
+        almost always instantaneous; the block acts as a safety net when
+        retarget occasionally runs longer than predicted.
+
+        With ``blocking=False``, :meth:`advance` returns immediately
+        with whatever result is available (may be stale if the background
+        thread hasn't finished yet).
+
+        The first call after enabling always runs synchronously to seed
+        the pipeline.
+
+        Args:
+            enabled: Whether to enable async mode.
+            blocking: When ``True`` (default), :meth:`advance` blocks
+                until a fresh result is available.  When ``False``,
+                returns immediately (possibly stale).  Ignored when
+                *enabled* is ``False``.
+            ema_alpha: EMA smoothing factor for timing prediction in
+                ``(0, 1]``.  Higher values adapt faster to timing
+                changes but are more sensitive to jitter.  The default
+                0.3 gives a half-life of ~2 samples, adapting within
+                ~44 ms at 45 Hz — empirically a good balance for
+                typical teleop frame rates (45-90 Hz).
+            margin_s: Safety margin [s] subtracted from the predicted
+                deadline.  Increase if retarget occasionally misses the
+                deadline.
+        """
+        needs_restart = (
+            enabled != self._async_enabled
+            or (enabled and blocking != self._async_blocking)
+            or (enabled and ema_alpha != self._async_ema_alpha)
+            or (enabled and margin_s != self._async_margin_s)
+        )
+        if not needs_restart:
+            return
+        self._stop_retarget_loop()
+        self._async_enabled = enabled
+        self._async_blocking = blocking
+        self._async_ema_alpha = ema_alpha
+        self._async_margin_s = margin_s
+        self._cached_action = None
+        mode = "off"
+        if enabled:
+            mode = "blocking" if blocking else "non-blocking"
+        logger.info("IsaacTeleop async advance: %s", mode)
+
     def advance(self, target_T_world: np.ndarray | torch.Tensor | SupportsDLPack | None = None) -> torch.Tensor | None:
         """Process current device state and return control commands.
 
@@ -220,6 +300,14 @@ class IsaacTeleopDevice:
         handles were not available at ``__enter__`` time), this method will
         attempt to start it on each call.  Once the user clicks "Start AR" and
         the handles become available, the session is created transparently.
+
+        When async mode is enabled (see :meth:`set_async`), the retargeting
+        pipeline runs in a background thread with EMA (Exponential Moving
+        Average)-based pacing.  By
+        default the call blocks until a fresh result is ready (the block
+        is almost always instantaneous because the pacer finishes just in
+        time).  This lets retargeting overlap with ``env.step()`` while
+        guaranteeing up-to-date data every frame.
 
         Args:
             target_T_world: Optional 4x4 transform matrix that rebases all
@@ -254,19 +342,91 @@ class IsaacTeleopDevice:
         if target_T_world is None and self._cfg.target_frame_prim_path is not None:
             target_T_world = self._get_target_frame_T_world()
 
-        # Step the session (handles lazy start and action extraction)
+        if self._async_enabled:
+            return self._advance_async(target_T_world)
+        return self._advance_sync(target_T_world)
+
+    def _advance_sync(self, target_T_world=None) -> torch.Tensor | None:
+        """Synchronous (original) advance path."""
         action = self._session_lifecycle.step(
             anchor_world_matrix_fn=self._anchor_manager.get_world_matrix,
             target_T_world=target_T_world,
         )
-
         if action is not None:
-            # Poll controller buttons (e.g. toggle anchor rotation on right 'A' press)
             self._poll_buttons()
 
         self._dispatch_control_callbacks()
 
         return action
+
+    def _advance_async(self, target_T_world=None) -> torch.Tensor | None:
+        """Async advance: read from the EMA-paced background retarget loop.
+
+        All USD/Kit interactions (anchor matrix, target-frame transform,
+        button polling) run on the calling (main) thread.  Only the
+        retarget computation runs in the background.
+
+        First call runs synchronously to seed the cache and starts the
+        background loop only once the session is confirmed alive.
+        Subsequent calls push fresh inputs from the main thread and
+        consume the latest result, blocking for freshness when
+        ``self._async_blocking`` is set.
+
+        If the background thread died with an exception, it is re-raised
+        here on the main thread after cleaning up the loop.
+        """
+        if self._retarget_loop is None:
+            action = self._advance_sync(target_T_world)
+            if action is None:
+                return None
+            self._cached_action = action
+            self._retarget_loop = AsyncRetargetLoop(
+                step_fn=lambda am, ttw: self._session_lifecycle.step(
+                    anchor_world_matrix_fn=lambda: am,
+                    target_T_world=ttw,
+                ),
+                ema_alpha=self._async_ema_alpha,
+                margin_s=self._async_margin_s,
+            )
+            self._retarget_loop.update_inputs(
+                self._anchor_manager.get_world_matrix(),
+                target_T_world,
+            )
+            self._retarget_loop.start()
+            return action
+
+        # Push current inputs from main thread so the background thread
+        # never touches USD/Kit APIs.
+        self._retarget_loop.update_inputs(
+            self._anchor_manager.get_world_matrix(),
+            target_T_world,
+        )
+
+        try:
+            action, fresh = self._retarget_loop.consume(block=self._async_blocking)
+        except Exception:
+            self._stop_retarget_loop()
+            raise
+
+        if action is not None:
+            self._cached_action = action
+            self._poll_buttons()
+        elif fresh:
+            # Background thread explicitly produced None (session down).
+            # Stop the loop so the next advance() re-enters the sync seed
+            # path, keeping session management on the main thread.
+            self._cached_action = None
+            self._stop_retarget_loop()
+
+        self._dispatch_control_callbacks()
+
+        return self._cached_action
+
+    def _stop_retarget_loop(self) -> None:
+        """Stop and discard the background retarget loop (idempotent)."""
+        if self._retarget_loop is not None:
+            self._retarget_loop.stop()
+            self._retarget_loop = None
 
     # ------------------------------------------------------------------
     # Control event -> callback bridge

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -189,13 +189,14 @@ class IsaacTeleopDevice:
         Returns:
             Self for context manager protocol.
         """
+        self._saved_async_enabled = self._async_enabled
         self._session_lifecycle.start()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Exit the context manager and clean up the IsaacTeleop session."""
         self._stop_retarget_loop()
-        self._async_enabled = False
+        self._async_enabled = self._saved_async_enabled
         self._anchor_manager.cleanup()
         self._session_lifecycle.stop(exc_type, exc_val, exc_tb)
         return False
@@ -274,6 +275,9 @@ class IsaacTeleopDevice:
                 deadline.  Increase if retarget occasionally misses the
                 deadline.
         """
+        if not (0.0 < ema_alpha <= 1.0):
+            raise ValueError(f"ema_alpha must be in (0, 1], got {ema_alpha}")
+
         needs_restart = (
             enabled != self._async_enabled
             or (enabled and blocking != self._async_blocking)
@@ -410,13 +414,15 @@ class IsaacTeleopDevice:
 
         if action is not None:
             self._cached_action = action
-            self._poll_buttons()
         elif fresh:
             # Background thread explicitly produced None (session down).
             # Stop the loop so the next advance() re-enters the sync seed
             # path, keeping session management on the main thread.
             self._cached_action = None
             self._stop_retarget_loop()
+
+        if self._cached_action is not None:
+            self._poll_buttons()
 
         self._dispatch_control_callbacks()
 

--- a/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/isaac_teleop_device.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 
-from .async_retarget_loop import AsyncRetargetLoop
+from .async_retarget_loop import AsyncRetargetLoop, EmaTimingEstimatorCfg, TimingEstimatorCfg
 from .command_handler import CommandHandler
 from .control_events import ControlEvents
 from .isaac_teleop_cfg import IsaacTeleopCfg
@@ -132,12 +132,11 @@ class IsaacTeleopDevice:
         self._prev_right_a_pressed = False
         self._prev_control_is_active: bool | None = None
 
-        # Async advance state: background retarget loop with EMA pacing
-        # that produces results consumed by advance().
+        # Async advance state: background retarget loop with paced
+        # scheduling that produces results consumed by advance().
         self._async_enabled = True
         self._async_blocking = True
-        self._async_ema_alpha = 0.3
-        self._async_margin_s = 0.005
+        self._async_timing_cfg: TimingEstimatorCfg = EmaTimingEstimatorCfg()
         self._retarget_loop: AsyncRetargetLoop | None = None
         self._cached_action: torch.Tensor | None = None
 
@@ -236,18 +235,17 @@ class IsaacTeleopDevice:
         enabled: bool = True,
         blocking: bool = True,
         *,
-        ema_alpha: float = 0.3,
-        margin_s: float = 0.005,
+        timing_cfg: TimingEstimatorCfg | None = None,
     ) -> None:
         """Enable or disable asynchronous advance mode.
 
         When enabled, retargeting runs in a background thread that
-        combines a **consumption gate** with **EMA-paced scheduling**:
+        combines a **consumption gate** with **paced scheduling**:
 
         1. After producing a result the thread waits for
            :meth:`advance` to consume it, guaranteeing a strict 1:1
            ratio between retarget invocations and ``advance()`` calls.
-        2. Once the gate opens the thread sleeps until the EMA-predicted
+        2. Once the gate opens the thread sleeps until the predicted
            optimal moment, then reads inputs and retargets, delivering
            the freshest possible result just before the next
            :meth:`advance`.
@@ -268,27 +266,25 @@ class IsaacTeleopDevice:
                 until a fresh result is available.  When ``False``,
                 returns immediately (possibly stale).  Ignored when
                 *enabled* is ``False``.
-            ema_alpha: EMA smoothing factor in ``(0, 1]`` for predicting
-                the consumer's call period and retarget cost.
-            margin_s: Safety margin [s] subtracted from the predicted
-                deadline to avoid late delivery.
+            timing_cfg: Configuration for the timing estimator used by the
+                background loop.  Defaults to :class:`EmaTimingEstimatorCfg`
+                when ``None``.  Pass a subclass to use a different
+                estimation strategy.
         """
-        if enabled and not (0.0 < ema_alpha <= 1.0):
-            raise ValueError(f"ema_alpha must be in (0, 1], got {ema_alpha}")
+        if timing_cfg is None:
+            timing_cfg = self._async_timing_cfg
 
         needs_restart = (
             enabled != self._async_enabled
             or (enabled and blocking != self._async_blocking)
-            or (enabled and ema_alpha != self._async_ema_alpha)
-            or (enabled and margin_s != self._async_margin_s)
+            or (enabled and timing_cfg != self._async_timing_cfg)
         )
         if not needs_restart:
             return
         self._stop_retarget_loop()
         self._async_enabled = enabled
         self._async_blocking = blocking
-        self._async_ema_alpha = ema_alpha
-        self._async_margin_s = margin_s
+        self._async_timing_cfg = timing_cfg
         self._cached_action = None
         mode = "off"
         if enabled:
@@ -304,12 +300,11 @@ class IsaacTeleopDevice:
         the handles become available, the session is created transparently.
 
         When async mode is enabled (see :meth:`set_async`), the retargeting
-        pipeline runs in a background thread with consumption-gated,
-        EMA-paced scheduling.  By default the call blocks until a fresh
-        result is ready (the block is almost always instantaneous because
-        the pacer finishes just in time).  This lets retargeting overlap
-        with ``env.step()`` while guaranteeing exactly one retarget per
-        ``advance()`` call with inputs as fresh as possible.
+        pipeline runs in a background thread with paced scheduling.  By
+        default the call blocks until a fresh result is ready (the block
+        is almost always instantaneous because the pacer finishes just in
+        time).  This lets retargeting overlap with ``env.step()`` while
+        guaranteeing exactly one retarget per ``advance()`` call.
 
         Args:
             target_T_world: Optional 4x4 transform matrix that rebases all
@@ -362,7 +357,7 @@ class IsaacTeleopDevice:
         return action
 
     def _advance_async(self, target_T_world=None) -> torch.Tensor | None:
-        """Async advance: read from the EMA-paced, consumption-gated loop.
+        """Async advance: read from the paced, consumption-gated loop.
 
         All USD/Kit interactions (anchor matrix, target-frame transform,
         button polling) run on the calling (main) thread.  Only the
@@ -378,46 +373,18 @@ class IsaacTeleopDevice:
         here on the main thread after cleaning up the loop.
         """
         if self._retarget_loop is None:
-            action = self._advance_sync(target_T_world)
-            if action is None:
+            if not self._seed_async_loop(target_T_world):
                 return None
-            self._cached_action = action
-            self._retarget_loop = AsyncRetargetLoop(
-                step_fn=lambda am, ttw: self._session_lifecycle.step(
-                    anchor_world_matrix_fn=lambda: am,
-                    target_T_world=ttw,
-                ),
-                ema_alpha=self._async_ema_alpha,
-                margin_s=self._async_margin_s,
-            )
-            self._retarget_loop.update_inputs(
-                self._anchor_manager.get_world_matrix(),
-                target_T_world,
-            )
-            self._retarget_loop.start()
-            return action
-
-        # Push current inputs from main thread so the background thread
-        # never touches USD/Kit APIs.
-        self._retarget_loop.update_inputs(
-            self._anchor_manager.get_world_matrix(),
-            target_T_world,
-        )
-
-        try:
-            action, fresh = self._retarget_loop.consume(block=self._async_blocking)
-        except Exception:
-            self._stop_retarget_loop()
-            raise
-
-        if action is not None:
-            self._cached_action = action
-        elif fresh:
-            # Background thread explicitly produced None (session down).
-            # Stop the loop so the next advance() re-enters the sync seed
-            # path, keeping session management on the main thread.
-            self._cached_action = None
-            self._stop_retarget_loop()
+        else:
+            action, fresh = self._consume_async_loop(target_T_world)
+            if action is not None:
+                self._cached_action = action
+            elif fresh:
+                # Background thread explicitly produced None (session down).
+                # Stop the loop so the next advance() re-enters the sync seed
+                # path, keeping session management on the main thread.
+                self._cached_action = None
+                self._stop_retarget_loop()
 
         if self._cached_action is not None:
             self._poll_buttons()
@@ -425,6 +392,48 @@ class IsaacTeleopDevice:
         self._dispatch_control_callbacks()
 
         return self._cached_action
+
+    def _seed_async_loop(self, target_T_world=None) -> bool:
+        """Run sync once to seed cache, then create/start background loop.
+
+        Returns:
+            ``True`` when the loop is running and cache is seeded; ``False``
+            when no synchronous action was produced yet.
+        """
+        action = self._advance_sync(target_T_world)
+        if action is None:
+            return False
+        self._cached_action = action
+        self._retarget_loop = AsyncRetargetLoop(
+            step_fn=lambda anchor_matrix, target_transform: self._session_lifecycle.step(
+                anchor_world_matrix_fn=lambda: anchor_matrix,
+                target_T_world=target_transform,
+            ),
+            timing_cfg=self._async_timing_cfg,
+        )
+        self._retarget_loop.update_inputs(
+            self._anchor_manager.get_world_matrix(),
+            target_T_world,
+        )
+        self._retarget_loop.start()
+        return True
+
+    def _consume_async_loop(self, target_T_world=None) -> tuple[torch.Tensor | None, bool]:
+        """Push main-thread inputs and consume latest result from loop."""
+        loop = self._retarget_loop
+        if loop is None:
+            raise RuntimeError("Async retarget loop is not initialized")
+        # Push current inputs from main thread so the background thread
+        # never touches USD/Kit APIs.
+        loop.update_inputs(
+            self._anchor_manager.get_world_matrix(),
+            target_T_world,
+        )
+        try:
+            return loop.consume(block=self._async_blocking)
+        except Exception:
+            self._stop_retarget_loop()
+            raise
 
     def _stop_retarget_loop(self) -> None:
         """Stop and discard the background retarget loop (idempotent)."""

--- a/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/session_lifecycle.py
@@ -146,6 +146,11 @@ class TeleopSessionLifecycle:
         # CloudXR runtime launcher (created in start if configured, stopped in stop)
         self._cloudxr_launcher: CloudXRLauncher | None = None
 
+        # Callbacks fired at the top of stop(), before any state is cleared.
+        # Allows owners (e.g. IsaacTeleopDevice) to stop background threads
+        # that depend on the session being alive.
+        self._on_stop_callbacks: list[Callable[[], None]] = []
+
         # Retargeting tuning UI (created in start, closed in stop)
         self._retargeting_ui_ctx: MultiRetargeterTuningUIImGui | None = None
         self._retargeting_ui = None
@@ -198,6 +203,18 @@ class TeleopSessionLifecycle:
     def is_active(self) -> bool:
         """Whether the teleop session is currently running."""
         return self._session is not None
+
+    def add_on_stop_callback(self, fn: Callable[[], None]) -> None:
+        """Register a callback to be invoked at the start of :meth:`stop`.
+
+        Callbacks run *before* any session state is cleared, so dependents
+        (e.g. background threads that call :meth:`step`) can be shut down
+        while the pipeline and session are still in a valid state.
+
+        Args:
+            fn: A no-argument callable.
+        """
+        self._on_stop_callbacks.append(fn)
 
     @property
     def pipeline(self):
@@ -316,8 +333,10 @@ class TeleopSessionLifecycle:
     def stop(self, exc_type=None, exc_val=None, exc_tb=None) -> None:
         """Shut down the session and clean up resources.
 
-        Closes the retargeting tuning UI and exits the ``TeleopSession``
-        context manager.  If the underlying OpenXR session was already torn
+        Fires registered on-stop callbacks first (so background consumers
+        can shut down while state is still valid), then closes the
+        retargeting tuning UI and exits the ``TeleopSession`` context
+        manager.  If the underlying OpenXR session was already torn
         down externally (e.g. "Stop AR"), cleanup errors are suppressed.
 
         Args:
@@ -325,6 +344,12 @@ class TeleopSessionLifecycle:
             exc_val: Exception value.
             exc_tb: Exception traceback.
         """
+        for fn in self._on_stop_callbacks:
+            try:
+                fn()
+            except Exception:
+                logger.debug("on-stop callback failed", exc_info=True)
+
         # Close the retargeting tuning UI first
         if self._retargeting_ui_ctx is not None:
             self._retargeting_ui_ctx.__exit__(exc_type, exc_val, exc_tb)

--- a/source/isaaclab_teleop/test/test_async_retarget_loop.py
+++ b/source/isaaclab_teleop/test/test_async_retarget_loop.py
@@ -163,6 +163,20 @@ class TestErrorPropagation:
 
         assert isinstance(exc_info.value.__cause__, ValueError)
 
+    def test_dead_thread_raises_instead_of_deadlock(self, make_loop):
+        def _raise_base_exception(_a, _t):
+            raise KeyboardInterrupt("simulated")
+
+        loop = make_loop(_raise_base_exception)
+        loop.start()
+
+        # Give the thread time to die.
+        time.sleep(0.3)
+        assert not loop._thread.is_alive()
+
+        with pytest.raises(RuntimeError, match="died unexpectedly"):
+            loop.consume(block=True)
+
     def test_transient_failures_recover(self, make_loop):
         call_count = 0
         lock = threading.Lock()
@@ -208,6 +222,18 @@ class TestInputIsolation:
             loop._anchor_matrix[:3, 3],
             [0.0, 0.0, 0.0],
         )
+
+    def test_update_inputs_clones_tensor(self, make_loop):
+        loop = make_loop(_constant_step_fn)
+
+        original = torch.eye(4)
+        loop.update_inputs(np.eye(4, dtype=np.float32), target_T_world=original)
+
+        original[0, 3] = 99.0
+
+        stored = loop._target_T_world
+        assert isinstance(stored, torch.Tensor)
+        assert stored[0, 3].item() == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab_teleop/test/test_async_retarget_loop.py
+++ b/source/isaaclab_teleop/test/test_async_retarget_loop.py
@@ -15,7 +15,7 @@ import time
 import numpy as np
 import pytest
 import torch
-from isaaclab_teleop.async_retarget_loop import AsyncRetargetLoop
+from isaaclab_teleop.async_retarget_loop import AsyncRetargetLoop, EmaTimingEstimatorCfg
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -123,24 +123,24 @@ class TestNonBlockingConsume:
 class TestEMAConvergence:
     def test_step_period_converges(self, make_loop):
         cadence_s = 0.020
-        loop = make_loop(_constant_step_fn, ema_alpha=0.3)
+        loop = make_loop(_constant_step_fn, timing_cfg=EmaTimingEstimatorCfg(ema_alpha=0.3))
         loop.start()
 
         for _ in range(20):
             loop.consume(block=True)
             time.sleep(cadence_s)
 
-        assert loop._step_period == pytest.approx(cadence_s, rel=0.5)
+        assert loop._timing.step_period == pytest.approx(cadence_s, rel=0.5)
 
     def test_retarget_dur_converges(self, make_loop):
         sleep_s = 0.005
-        loop = make_loop(_sleeping_step_fn(sleep_s=sleep_s), ema_alpha=0.3)
+        loop = make_loop(_sleeping_step_fn(sleep_s=sleep_s), timing_cfg=EmaTimingEstimatorCfg(ema_alpha=0.3))
         loop.start()
 
         for _ in range(20):
             loop.consume(block=True)
 
-        assert loop._retarget_dur == pytest.approx(sleep_s, rel=0.5)
+        assert loop._timing.retarget_dur == pytest.approx(sleep_s, rel=0.5)
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +163,7 @@ class TestErrorPropagation:
 
         assert isinstance(exc_info.value.__cause__, ValueError)
 
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
     def test_dead_thread_raises_instead_of_deadlock(self, make_loop):
         def _raise_base_exception(_a, _t):
             raise KeyboardInterrupt("simulated")

--- a/source/isaaclab_teleop/test/test_async_retarget_loop.py
+++ b/source/isaaclab_teleop/test/test_async_retarget_loop.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# pyright: reportPrivateUsage=none
+
+"""Tests for :class:`AsyncRetargetLoop` (pure Python, no Omniverse required)."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import numpy as np
+import pytest
+import torch
+from isaaclab_teleop.async_retarget_loop import AsyncRetargetLoop
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_EXPECTED = torch.ones(3)
+
+
+@pytest.fixture
+def make_loop():
+    """Factory fixture: creates a loop, yields it, and guarantees stop() on teardown."""
+    loops: list[AsyncRetargetLoop] = []
+
+    def _factory(step_fn, **kwargs) -> AsyncRetargetLoop:
+        loop = AsyncRetargetLoop(step_fn, **kwargs)
+        loops.append(loop)
+        return loop
+
+    yield _factory
+
+    for loop in loops:
+        loop.stop()
+
+
+def _constant_step_fn(
+    _anchor: np.ndarray,
+    _target: np.ndarray | torch.Tensor | None,
+) -> torch.Tensor:
+    return torch.ones(3)
+
+
+def _sleeping_step_fn(sleep_s: float = 0.005):
+    """Return a step_fn that sleeps for a fixed duration before returning."""
+
+    def _fn(
+        _anchor: np.ndarray,
+        _target: np.ndarray | torch.Tensor | None,
+    ) -> torch.Tensor:
+        time.sleep(sleep_s)
+        return torch.ones(3)
+
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# TestBlockingConsume
+# ---------------------------------------------------------------------------
+
+
+class TestBlockingConsume:
+    def test_consume_returns_fresh_result(self, make_loop):
+        loop = make_loop(_constant_step_fn)
+        loop.start()
+
+        action, fresh = loop.consume(block=True)
+
+        assert fresh
+        assert action is not None
+        torch.testing.assert_close(action, _EXPECTED)
+
+    def test_second_consume_waits_for_new_generation(self, make_loop):
+        loop = make_loop(_constant_step_fn)
+        loop.start()
+
+        _, fresh1 = loop.consume(block=True)
+        assert fresh1
+
+        gen_before = loop._consumed_gen
+        _, fresh2 = loop.consume(block=True)
+        assert fresh2
+        assert loop._consumed_gen > gen_before
+
+
+# ---------------------------------------------------------------------------
+# TestNonBlockingConsume
+# ---------------------------------------------------------------------------
+
+
+class TestNonBlockingConsume:
+    def test_non_blocking_returns_immediately(self, make_loop):
+        loop = make_loop(_sleeping_step_fn(sleep_s=0.5))
+        loop.start()
+
+        t0 = time.monotonic()
+        _action, _fresh = loop.consume(block=False)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 0.1
+
+    def test_non_blocking_stale_flag(self, make_loop):
+        loop = make_loop(_sleeping_step_fn(sleep_s=0.02))
+        loop.start()
+
+        loop.consume(block=True)
+
+        _action, fresh = loop.consume(block=False)
+        assert not fresh
+
+
+# ---------------------------------------------------------------------------
+# TestEMAConvergence
+# ---------------------------------------------------------------------------
+
+
+class TestEMAConvergence:
+    def test_step_period_converges(self, make_loop):
+        cadence_s = 0.020
+        loop = make_loop(_constant_step_fn, ema_alpha=0.3)
+        loop.start()
+
+        for _ in range(20):
+            loop.consume(block=True)
+            time.sleep(cadence_s)
+
+        assert loop._step_period == pytest.approx(cadence_s, rel=0.5)
+
+    def test_retarget_dur_converges(self, make_loop):
+        sleep_s = 0.005
+        loop = make_loop(_sleeping_step_fn(sleep_s=sleep_s), ema_alpha=0.3)
+        loop.start()
+
+        for _ in range(20):
+            loop.consume(block=True)
+
+        assert loop._retarget_dur == pytest.approx(sleep_s, rel=0.5)
+
+
+# ---------------------------------------------------------------------------
+# TestErrorPropagation
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPropagation:
+    def test_persistent_failure_surfaces_after_max(self, make_loop):
+        def _always_fail(_a, _t):
+            raise ValueError("boom")
+
+        loop = make_loop(_always_fail)
+        loop.start()
+
+        with pytest.raises(RuntimeError, match="Background retarget thread failed") as exc_info:
+            for _ in range(20):
+                loop.consume(block=True)
+                time.sleep(0.05)
+
+        assert isinstance(exc_info.value.__cause__, ValueError)
+
+    def test_transient_failures_recover(self, make_loop):
+        call_count = 0
+        lock = threading.Lock()
+
+        def _fail_then_succeed(_a, _t):
+            nonlocal call_count
+            with lock:
+                call_count += 1
+                n = call_count
+            if n <= 2:
+                raise ValueError(f"transient failure {n}")
+            return torch.ones(3)
+
+        loop = make_loop(_fail_then_succeed)
+        loop.start()
+
+        deadline = time.monotonic() + 5.0
+        action = None
+        while time.monotonic() < deadline:
+            action, fresh = loop.consume(block=True)
+            if fresh and action is not None:
+                break
+
+        assert action is not None
+        torch.testing.assert_close(action, _EXPECTED)
+
+
+# ---------------------------------------------------------------------------
+# TestInputIsolation
+# ---------------------------------------------------------------------------
+
+
+class TestInputIsolation:
+    def test_update_inputs_copies_arrays(self, make_loop):
+        loop = make_loop(_constant_step_fn)
+
+        original = np.eye(4, dtype=np.float32)
+        loop.update_inputs(original)
+
+        original[:3, 3] = [99.0, 99.0, 99.0]
+
+        np.testing.assert_array_equal(
+            loop._anchor_matrix[:3, 3],
+            [0.0, 0.0, 0.0],
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestLifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_stop_is_idempotent(self, make_loop):
+        loop = make_loop(_constant_step_fn)
+        loop.start()
+        loop.consume(block=True)
+
+        loop.stop()
+        loop.stop()
+
+    def test_start_after_stop(self, make_loop):
+        loop = make_loop(_constant_step_fn)
+
+        loop.start()
+        action1, _ = loop.consume(block=True)
+        loop.stop()
+
+        loop.start()
+        action2, _ = loop.consume(block=True)
+        loop.stop()
+
+        assert action1 is not None
+        assert action2 is not None
+        torch.testing.assert_close(action1, _EXPECTED)
+        torch.testing.assert_close(action2, _EXPECTED)
+
+    def test_action_is_cloned(self, make_loop):
+        shared_tensor = torch.ones(3)
+
+        def _return_shared(_a, _t):
+            return shared_tensor
+
+        loop = make_loop(_return_shared)
+        loop.start()
+
+        action, _ = loop.consume(block=True)
+
+        assert action is not shared_tensor
+        assert action.data_ptr() != shared_tensor.data_ptr()
+        torch.testing.assert_close(action, shared_tensor)


### PR DESCRIPTION
# Description

Retargeting now runs asynchronously by default so work overlaps with env.step() instead of blocking the render path. This PR also hardens async scheduling by combining a consumption gate (strict 1:1 retarget-to-advance() cadence) with paced timing, and then refactors pacing into a pluggable estimator interface (EMA remains the default).

To disable async and use synchronous retargeting:

device.set_async(False)

Key changes:
Added AsyncRetargetLoop and wired IsaacTeleopDevice to use async retargeting by default.
Added consumption-gated pacing to prevent double-retargets and keep inputs fresh.
Refactored pacing into pluggable TimingEstimator / TimingEstimatorCfg with EmaTimingEstimator as default.

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
