### PR TITLE
fix: multi-GPU support for Newton physics with camera rendering

### DIFF
--- a/scripts/reinforcement_learning/rsl_rl/train.py
+++ b/scripts/reinforcement_learning/rsl_rl/train.py
@@ -132,8 +132,16 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
         if args_cli.distributed:
             local_rank = int(os.getenv("LOCAL_RANK", "0"))
             global_rank = int(os.getenv("RANK", "0"))
-            env_cfg.sim.device = f"cuda:{local_rank}"
-            agent_cfg.device = f"cuda:{local_rank}"
+            from isaaclab.utils.distributed import resolve_cuda_device
+
+            env_cfg.sim.device, _ = resolve_cuda_device(local_rank)
+            agent_cfg.device = env_cfg.sim.device
+
+            # Set current CUDA device here because in the kitless Newton path,
+            # AppLauncher may not have run (launch_simulation skips it), so this
+            # is the only place the current CUDA device gets set.
+            if "cuda" in env_cfg.sim.device:
+                torch.cuda.set_device(env_cfg.sim.device)
 
             # use global rank for seed diversity across all nodes
             seed = agent_cfg.seed + global_rank

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -12,6 +12,14 @@ Added
   joints with zero stiffness and damping receive a minimal stiffness so that
   backends like Newton recognise the drive as active.
 
+Fixed
+^^^^^
+
+* Fixed multi-GPU device assignment for distributed training. ``resolve_cuda_device()``
+  now compares ``local_rank`` against ``torch.cuda.device_count()`` instead of
+  ``WORLD_SIZE``, correctly handling single-node, multi-node, and
+  ``CUDA_VISIBLE_DEVICES``-restricted scenarios. Also calls ``torch.cuda.set_device()``
+  early in ``AppLauncher`` so physics backends allocate on the correct GPU.
 
 4.6.0 (2026-04-13)
 ~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -906,8 +906,9 @@ class AppLauncher:
             # global rank (GPU id) in multi-gpu multi-node mode
             self.global_rank = int(os.getenv("RANK", "0")) + int(os.getenv("JAX_RANK", "0"))
 
-            self.device_id = self.local_rank
-            device = "cuda:" + str(self.device_id)
+            from isaaclab.utils.distributed import resolve_cuda_device
+
+            device, self.device_id = resolve_cuda_device(self.local_rank)
             launcher_args["multi_gpu"] = False
             # limit CPU threads to minimize thread context switching
             # this ensures processes do not take up all available threads and fight for resources
@@ -923,6 +924,13 @@ class AppLauncher:
         # as the active_gpu device. Setting physics_gpu explicitly may result in a different device to be used.
         launcher_args["physics_gpu"] = self.device_id
         launcher_args["active_gpu"] = self.device_id
+
+        # Set the current CUDA device early so that physics backends (e.g. Newton/Warp)
+        # that allocate on the "current" device during initialization get the correct GPU.
+        if "cuda" in device:
+            import torch
+
+            torch.cuda.set_device(self.device_id)
 
         logger.info("Using device: %s", device)
 

--- a/source/isaaclab/isaaclab/utils/distributed.py
+++ b/source/isaaclab/isaaclab/utils/distributed.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Utilities for multi-GPU distributed training."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+
+def resolve_cuda_device(local_rank: int) -> tuple[str, int]:
+    """Determine the correct CUDA device for the current process in distributed training.
+
+    When ``CUDA_VISIBLE_DEVICES`` restricts each process to a single GPU (common in
+    SLURM/Kubernetes), ``local_rank`` may exceed the visible device count. In that
+    case we fall back to ``cuda:0`` since the process can only see one GPU.
+
+    Args:
+        local_rank: The local rank of the current process.
+
+    Returns:
+        A tuple of ``(device_string, device_id)`` — e.g. ``("cuda:0", 0)`` or
+        ``("cuda:2", 2)``.
+    """
+    num_visible = torch.cuda.device_count()
+    world_size = int(os.getenv("WORLD_SIZE", "1"))
+    if num_visible >= world_size:
+        device_id = local_rank
+    else:
+        device_id = 0
+    return f"cuda:{device_id}", device_id

--- a/source/isaaclab/isaaclab/utils/distributed.py
+++ b/source/isaaclab/isaaclab/utils/distributed.py
@@ -7,8 +7,6 @@
 
 from __future__ import annotations
 
-import os
-
 import torch
 
 
@@ -27,9 +25,10 @@ def resolve_cuda_device(local_rank: int) -> tuple[str, int]:
         ``("cuda:2", 2)``.
     """
     num_visible = torch.cuda.device_count()
-    world_size = int(os.getenv("WORLD_SIZE", "1"))
-    if num_visible >= world_size:
+    if local_rank < num_visible:
         device_id = local_rank
     else:
+        # CUDA_VISIBLE_DEVICES restricts this process to fewer GPUs than
+        # local_rank implies — fall back to cuda:0.
         device_id = 0
     return f"cuda:{device_id}", device_id

--- a/source/isaaclab/test/test_multigpu_newton.py
+++ b/source/isaaclab/test/test_multigpu_newton.py
@@ -19,41 +19,69 @@ def _get_num_gpus() -> int:
     return torch.cuda.device_count()
 
 
-@pytest.mark.skipif(_get_num_gpus() < 2, reason="Requires at least 2 GPUs")
-class TestMultiGPUDeviceAssignment:
-    """Tests for multi-GPU device assignment in distributed training."""
+class TestResolveCudaDevice:
+    """Tests for resolve_cuda_device across different GPU visibility scenarios."""
 
-    def test_resolve_cuda_device_full_visibility(self):
+    def test_full_visibility(self):
         """When all GPUs are visible, each rank gets its own device."""
         from isaaclab.utils.distributed import resolve_cuda_device
 
-        # Simulate 4 visible GPUs, world_size=4
-        with unittest.mock.patch("torch.cuda.device_count", return_value=4), \
-             unittest.mock.patch.dict(os.environ, {"WORLD_SIZE": "4"}):
+        with unittest.mock.patch("torch.cuda.device_count", return_value=4):
             for local_rank in range(4):
                 device, device_id = resolve_cuda_device(local_rank)
                 assert device == f"cuda:{local_rank}"
                 assert device_id == local_rank
 
-    def test_resolve_cuda_device_restricted_visibility(self):
+    def test_restricted_visibility(self):
         """When CUDA_VISIBLE_DEVICES restricts each process to 1 GPU, all ranks use cuda:0."""
         from isaaclab.utils.distributed import resolve_cuda_device
 
-        # Simulate 1 visible GPU (CUDA_VISIBLE_DEVICES restricted), world_size=4
-        with unittest.mock.patch("torch.cuda.device_count", return_value=1), \
-             unittest.mock.patch.dict(os.environ, {"WORLD_SIZE": "4"}):
+        with unittest.mock.patch("torch.cuda.device_count", return_value=1):
             for local_rank in range(4):
                 device, device_id = resolve_cuda_device(local_rank)
                 assert device == "cuda:0"
                 assert device_id == 0
 
+    def test_multi_node(self):
+        """Multi-node: 4 visible GPUs per node, world_size=8, each rank gets its own GPU."""
+        from isaaclab.utils.distributed import resolve_cuda_device
+
+        with unittest.mock.patch("torch.cuda.device_count", return_value=4):
+            for local_rank in range(4):
+                device, device_id = resolve_cuda_device(local_rank)
+                assert device == f"cuda:{local_rank}", (
+                    f"Multi-node: local_rank={local_rank} should map to cuda:{local_rank}"
+                )
+
+    def test_local_rank_exceeds_visible(self):
+        """When local_rank >= num_visible, fall back to cuda:0."""
+        from isaaclab.utils.distributed import resolve_cuda_device
+
+        with unittest.mock.patch("torch.cuda.device_count", return_value=2):
+            device, device_id = resolve_cuda_device(5)
+            assert device == "cuda:0"
+            assert device_id == 0
+
+
+@pytest.mark.skipif(_get_num_gpus() < 2, reason="Requires at least 2 GPUs")
+class TestMultiGPUDeviceAssignment:
+    """Integration tests for multi-GPU training."""
+
     def test_cartpole_newton_multigpu(self):
         """Test that multi-GPU cartpole training with Newton physics runs without error."""
         num_gpus = min(_get_num_gpus(), 4)
 
-        # Run a quick 2-iteration training to verify setup works
+        # Use torchrun from the same Python environment as the test runner
+        import shutil
+        import sys
+
+        torchrun = shutil.which("torchrun", path=os.path.dirname(sys.executable))
+        if torchrun is None:
+            torchrun = shutil.which("torchrun")
+        assert torchrun is not None, "torchrun not found — is torch installed?"
+
         cmd = [
-            "torchrun",
+            torchrun,
             f"--nproc_per_node={num_gpus}",
             "scripts/reinforcement_learning/rsl_rl/train.py",
             "--task", "Isaac-Cartpole-Direct-v0",
@@ -65,12 +93,9 @@ class TestMultiGPUDeviceAssignment:
         ]
 
         env = os.environ.copy()
-        # Required for containers with IOMMU where P2P transport fails,
-        # and for environments without InfiniBand.
         env["NCCL_P2P_DISABLE"] = "1"
         env["NCCL_IB_DISABLE"] = "1"
 
-        # Resolve IsaacLab root from test file location
         test_dir = os.path.dirname(os.path.abspath(__file__))
         isaaclab_root = os.path.dirname(os.path.dirname(os.path.dirname(test_dir)))
 
@@ -83,7 +108,6 @@ class TestMultiGPUDeviceAssignment:
             cwd=isaaclab_root,
         )
 
-        # Verify training actually ran (not just a clean exit from early skip)
         has_training_output = "Learning iteration 1" in result.stdout
         no_cuda_errors = "CUDA error" not in result.stderr
         assert result.returncode == 0 and has_training_output and no_cuda_errors, (
@@ -97,42 +121,25 @@ class TestMultiGPUDeviceAssignment:
 class TestMultiGPUCameraRendering:
     """Tests for multi-GPU training with camera observations."""
 
-    def test_preset_renderer_matching(self):
-        """Test that newton preset correctly matches the renderer."""
+    def test_preset_renderer_has_newton_renderer_field(self):
+        """Test that MultiBackendRendererCfg has newton_renderer field."""
         from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
 
         cfg = MultiBackendRendererCfg()
-        assert hasattr(cfg, "newton"), "MultiBackendRendererCfg should have 'newton' field"
-        assert "NewtonWarp" in type(cfg.newton).__name__, (
-            f"newton field should be NewtonWarpRendererCfg, got {type(cfg.newton).__name__}"
+        assert hasattr(cfg, "newton_renderer"), (
+            "MultiBackendRendererCfg should have 'newton_renderer' field"
+        )
+        assert "NewtonWarp" in type(cfg.newton_renderer).__name__, (
+            f"newton_renderer should be NewtonWarpRendererCfg, got {type(cfg.newton_renderer).__name__}"
         )
 
-    def test_physx_preset_is_independent_instance(self):
-        """Test that physx preset is a separate instance from default (not a shared alias)."""
+    def test_alias_fields_are_independent_instances(self):
+        """Test that aliased fields are separate instances (not shared mutable references)."""
         from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
 
         cfg = MultiBackendRendererCfg()
-        assert cfg.physx is not cfg.default, (
-            "physx and default should be independent instances, not shared aliases"
-        )
-
-    def test_camera_not_kit_with_preset_renderer(self):
-        """Test that PresetCfg renderers are not detected as Kit cameras."""
-        from isaaclab.sensors import TiledCameraCfg
-        from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
-        from isaaclab_tasks.utils.sim_launcher import _is_kit_camera
-
-        cam = TiledCameraCfg(
-            prim_path="/test",
-            data_types=["rgb"],
-            width=64,
-            height=64,
-            renderer_cfg=MultiBackendRendererCfg(),
-        )
-
-        # PresetCfg renderers resolve to match the physics backend, so not necessarily Kit
-        assert not _is_kit_camera(cam), (
-            "Camera with PresetCfg renderer should not be detected as Kit camera"
+        assert cfg.isaacsim_rtx_renderer is not cfg.default, (
+            "isaacsim_rtx_renderer and default should be independent instances"
         )
 
 

--- a/source/isaaclab/test/test_multigpu_newton.py
+++ b/source/isaaclab/test/test_multigpu_newton.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+"""Test multi-GPU device assignment for Newton physics."""
+
+import os
+import subprocess
+import unittest.mock
+
+import pytest
+import torch
+
+
+def _get_num_gpus() -> int:
+    """Return number of available CUDA GPUs."""
+    if not torch.cuda.is_available():
+        return 0
+    return torch.cuda.device_count()
+
+
+@pytest.mark.skipif(_get_num_gpus() < 2, reason="Requires at least 2 GPUs")
+class TestMultiGPUDeviceAssignment:
+    """Tests for multi-GPU device assignment in distributed training."""
+
+    def test_resolve_cuda_device_full_visibility(self):
+        """When all GPUs are visible, each rank gets its own device."""
+        from isaaclab.utils.distributed import resolve_cuda_device
+
+        # Simulate 4 visible GPUs, world_size=4
+        with unittest.mock.patch("torch.cuda.device_count", return_value=4), \
+             unittest.mock.patch.dict(os.environ, {"WORLD_SIZE": "4"}):
+            for local_rank in range(4):
+                device, device_id = resolve_cuda_device(local_rank)
+                assert device == f"cuda:{local_rank}"
+                assert device_id == local_rank
+
+    def test_resolve_cuda_device_restricted_visibility(self):
+        """When CUDA_VISIBLE_DEVICES restricts each process to 1 GPU, all ranks use cuda:0."""
+        from isaaclab.utils.distributed import resolve_cuda_device
+
+        # Simulate 1 visible GPU (CUDA_VISIBLE_DEVICES restricted), world_size=4
+        with unittest.mock.patch("torch.cuda.device_count", return_value=1), \
+             unittest.mock.patch.dict(os.environ, {"WORLD_SIZE": "4"}):
+            for local_rank in range(4):
+                device, device_id = resolve_cuda_device(local_rank)
+                assert device == "cuda:0"
+                assert device_id == 0
+
+    def test_cartpole_newton_multigpu(self):
+        """Test that multi-GPU cartpole training with Newton physics runs without error."""
+        num_gpus = min(_get_num_gpus(), 4)
+
+        # Run a quick 2-iteration training to verify setup works
+        cmd = [
+            "torchrun",
+            f"--nproc_per_node={num_gpus}",
+            "scripts/reinforcement_learning/rsl_rl/train.py",
+            "--task", "Isaac-Cartpole-Direct-v0",
+            "--num_envs", "64",
+            "--max_iterations", "2",
+            "--headless",
+            "--distributed",
+            "presets=newton",
+        ]
+
+        env = os.environ.copy()
+        # Required for containers with IOMMU where P2P transport fails,
+        # and for environments without InfiniBand.
+        env["NCCL_P2P_DISABLE"] = "1"
+        env["NCCL_IB_DISABLE"] = "1"
+
+        # Resolve IsaacLab root from test file location
+        test_dir = os.path.dirname(os.path.abspath(__file__))
+        isaaclab_root = os.path.dirname(os.path.dirname(os.path.dirname(test_dir)))
+
+        result = subprocess.run(
+            cmd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            cwd=isaaclab_root,
+        )
+
+        # Verify training actually ran (not just a clean exit from early skip)
+        has_training_output = "Learning iteration 1" in result.stdout
+        no_cuda_errors = "CUDA error" not in result.stderr
+        assert result.returncode == 0 and has_training_output and no_cuda_errors, (
+            f"Multi-GPU training failed (rc={result.returncode}):\n"
+            f"stdout (last 2000): {result.stdout[-2000:]}\n"
+            f"stderr (last 2000): {result.stderr[-2000:]}"
+        )
+
+
+@pytest.mark.skipif(_get_num_gpus() < 2, reason="Requires at least 2 GPUs")
+class TestMultiGPUCameraRendering:
+    """Tests for multi-GPU training with camera observations."""
+
+    def test_preset_renderer_matching(self):
+        """Test that newton preset correctly matches the renderer."""
+        from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
+
+        cfg = MultiBackendRendererCfg()
+        assert hasattr(cfg, "newton"), "MultiBackendRendererCfg should have 'newton' field"
+        assert "NewtonWarp" in type(cfg.newton).__name__, (
+            f"newton field should be NewtonWarpRendererCfg, got {type(cfg.newton).__name__}"
+        )
+
+    def test_physx_preset_is_independent_instance(self):
+        """Test that physx preset is a separate instance from default (not a shared alias)."""
+        from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
+
+        cfg = MultiBackendRendererCfg()
+        assert cfg.physx is not cfg.default, (
+            "physx and default should be independent instances, not shared aliases"
+        )
+
+    def test_camera_not_kit_with_preset_renderer(self):
+        """Test that PresetCfg renderers are not detected as Kit cameras."""
+        from isaaclab.sensors import TiledCameraCfg
+        from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
+        from isaaclab_tasks.utils.sim_launcher import _is_kit_camera
+
+        cam = TiledCameraCfg(
+            prim_path="/test",
+            data_types=["rgb"],
+            width=64,
+            height=64,
+            renderer_cfg=MultiBackendRendererCfg(),
+        )
+
+        # PresetCfg renderers resolve to match the physics backend, so not necessarily Kit
+        assert not _is_kit_camera(cam), (
+            "Camera with PresetCfg renderer should not be detected as Kit camera"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "1.5.21"
+version = "1.5.22"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+1.5.22 (2026-04-13)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed ``isaacsim_rtx_renderer`` field in ``MultiBackendRendererCfg`` to use proper
+  type annotation, preventing shared mutable instance across all config objects.
+
 1.5.21 (2026-04-13)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/presets.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/presets.py
@@ -15,9 +15,6 @@ from isaaclab_tasks.utils import PresetCfg
 @configclass
 class MultiBackendRendererCfg(PresetCfg):
     default: IsaacRtxRendererCfg = IsaacRtxRendererCfg()
-    newton: NewtonWarpRendererCfg = NewtonWarpRendererCfg()
     newton_renderer: NewtonWarpRendererCfg = NewtonWarpRendererCfg()
     ovrtx_renderer: OVRTXRendererCfg = OVRTXRendererCfg()
     isaacsim_rtx_renderer: IsaacRtxRendererCfg = IsaacRtxRendererCfg()
-    # PhysX uses RTX rendering by default in Isaac Lab.
-    physx: IsaacRtxRendererCfg = IsaacRtxRendererCfg()

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/presets.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/presets.py
@@ -15,6 +15,9 @@ from isaaclab_tasks.utils import PresetCfg
 @configclass
 class MultiBackendRendererCfg(PresetCfg):
     default: IsaacRtxRendererCfg = IsaacRtxRendererCfg()
+    newton: NewtonWarpRendererCfg = NewtonWarpRendererCfg()
     newton_renderer: NewtonWarpRendererCfg = NewtonWarpRendererCfg()
     ovrtx_renderer: OVRTXRendererCfg = OVRTXRendererCfg()
-    isaacsim_rtx_renderer = default
+    isaacsim_rtx_renderer: IsaacRtxRendererCfg = IsaacRtxRendererCfg()
+    # PhysX uses RTX rendering by default in Isaac Lab.
+    physx: IsaacRtxRendererCfg = IsaacRtxRendererCfg()

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
@@ -122,12 +122,6 @@ def _is_kit_camera(node) -> bool:
         return True
     if isinstance(renderer_cfg, RendererCfg):
         return renderer_cfg.renderer_type in ("default", "isaac_rtx")
-    # PresetCfg renderers (e.g. MultiBackendRendererCfg) are resolved later;
-    # assume they will match the physics backend, so not necessarily Kit.
-    from isaaclab_tasks.utils import PresetCfg
-
-    if isinstance(renderer_cfg, PresetCfg):
-        return False
     # Unknown renderer type — conservatively assume Kit is required.
     return True
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
@@ -122,6 +122,13 @@ def _is_kit_camera(node) -> bool:
         return True
     if isinstance(renderer_cfg, RendererCfg):
         return renderer_cfg.renderer_type in ("default", "isaac_rtx")
+    # PresetCfg renderers (e.g. MultiBackendRendererCfg) are resolved later;
+    # assume they will match the physics backend, so not necessarily Kit.
+    from isaaclab_tasks.utils import PresetCfg
+
+    if isinstance(renderer_cfg, PresetCfg):
+        return False
+    # Unknown renderer type — conservatively assume Kit is required.
     return True
 
 


### PR DESCRIPTION
## Description

Fixes bugs preventing multi-GPU distributed training with Newton physics and camera observations:

1. **Device assignment**: When `CUDA_VISIBLE_DEVICES` restricts each process to a single GPU (common in SLURM/Kubernetes), `local_rank` may exceed the visible device count. Added `resolve_cuda_device()` utility that compares `local_rank` against `torch.cuda.device_count()` and falls back to `cuda:0` when restricted. Works correctly for single-node, multi-node, and per-process GPU restriction.

2. **Preset alias fix**: `isaacsim_rtx_renderer` in `MultiBackendRendererCfg` was an unannotated bare assignment sharing a mutable instance with `default`. Fixed to use proper type annotation so `@configclass` creates independent instances.

3. **Early device selection**: `torch.cuda.set_device()` is now called early in both `AppLauncher` and the training script so that physics backends (Newton/Warp) that allocate on the "current" CUDA device during initialization get the correct GPU.

## Testing

- Includes unit tests in `source/isaaclab/test/test_multigpu_newton.py`:
  - `TestResolveCudaDevice`: tests `resolve_cuda_device()` with mocked device counts for full visibility, restricted visibility, multi-node, and out-of-bounds local_rank
  - `TestMultiGPUDeviceAssignment`: integration test for multi-GPU cartpole training with Newton physics (requires 2+ GPUs)
  - `TestMultiGPUCameraRendering`: verifies preset renderer fields and alias independence
- Validated on 4×L40 system with DexSuite Kuka-Allegro lift task (4096 envs/GPU, camera observations)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New tests added

## Checklist

- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have added tests that prove my fix is effective
- [x] I have updated the changelog and added documentation in relevant places