### PR TITLE
Fixes for the wrench composer

### DIFF
--- a/source/isaaclab/isaaclab/utils/warp/kernels.py
+++ b/source/isaaclab/isaaclab/utils/warp/kernels.py
@@ -310,6 +310,10 @@ wp.overload(
 def cast_to_link_frame(position: wp.vec3f, link_position: wp.vec3f, is_global: bool) -> wp.vec3f:
     """Casts a position to the link frame of the body.
 
+    .. deprecated::
+        This function only subtracts positions but does not rotate the offset
+        into the link frame.  Use :func:`cast_position_to_link_frame` instead.
+
     Args:
         position: The position to cast.
         link_position: The link frame position.
@@ -320,6 +324,27 @@ def cast_to_link_frame(position: wp.vec3f, link_position: wp.vec3f, is_global: b
     """
     if is_global:
         return position - link_position
+    else:
+        return position
+
+
+@wp.func
+def cast_position_to_link_frame(
+    position: wp.vec3f, link_position: wp.vec3f, link_quat: wp.quatf, is_global: bool
+) -> wp.vec3f:
+    """Casts a position to the link frame of the body.
+
+    Args:
+        position: The position to cast.
+        link_position: The link frame world position.
+        link_quat: The link frame world quaternion.
+        is_global: Whether the position is expressed in the global frame.
+
+    Returns:
+        The offset vector expressed in the link frame.
+    """
+    if is_global:
+        return wp.quat_rotate_inv(link_quat, position - link_position)
     else:
         return position
 
@@ -401,8 +426,11 @@ def add_forces_and_torques_at_position(
         # if there is a position offset, add a torque to the composed torque.
         if positions:
             composed_torques_b[env_ids[tid_env], body_ids[tid_body]] += wp.skew(
-                cast_to_link_frame(
-                    positions[tid_env, tid_body], link_positions[env_ids[tid_env], body_ids[tid_body]], is_global
+                cast_position_to_link_frame(
+                    positions[tid_env, tid_body],
+                    link_positions[env_ids[tid_env], body_ids[tid_body]],
+                    link_quaternions[env_ids[tid_env], body_ids[tid_body]],
+                    is_global,
                 )
             ) @ cast_force_to_link_frame(
                 forces[tid_env, tid_body], link_quaternions[env_ids[tid_env], body_ids[tid_body]], is_global
@@ -461,8 +489,11 @@ def set_forces_and_torques_at_position(
         # if there is a position offset, set the torque from the force at that position.
         if positions:
             composed_torques_b[env_ids[tid_env], body_ids[tid_body]] = wp.skew(
-                cast_to_link_frame(
-                    positions[tid_env, tid_body], link_positions[env_ids[tid_env], body_ids[tid_body]], is_global
+                cast_position_to_link_frame(
+                    positions[tid_env, tid_body],
+                    link_positions[env_ids[tid_env], body_ids[tid_body]],
+                    link_quaternions[env_ids[tid_env], body_ids[tid_body]],
+                    is_global,
                 )
             ) @ cast_force_to_link_frame(
                 forces[tid_env, tid_body], link_quaternions[env_ids[tid_env], body_ids[tid_body]], is_global

--- a/source/isaaclab/isaaclab/utils/warp/kernels.py
+++ b/source/isaaclab/isaaclab/utils/warp/kernels.py
@@ -479,6 +479,8 @@ def set_forces_and_torques_at_position(
         composed_torques_b[env_ids[tid_env], body_ids[tid_body]] = cast_torque_to_link_frame(
             torques[tid_env, tid_body], link_quaternions[env_ids[tid_env], body_ids[tid_body]], is_global
         )
+    else:
+        composed_torques_b[env_ids[tid_env], body_ids[tid_body]] = wp.vec3(0.0)
     # set the forces to the composed force, if the positions are provided, adds a torque to the composed torque
     # from the force at that position.
     if forces:
@@ -488,7 +490,7 @@ def set_forces_and_torques_at_position(
         )
         # if there is a position offset, set the torque from the force at that position.
         if positions:
-            composed_torques_b[env_ids[tid_env], body_ids[tid_body]] = wp.skew(
+            composed_torques_b[env_ids[tid_env], body_ids[tid_body]] += wp.skew(
                 cast_position_to_link_frame(
                     positions[tid_env, tid_body],
                     link_positions[env_ids[tid_env], body_ids[tid_body]],


### PR DESCRIPTION
# Description

The wrench composer currently has two bugs if I am not mistaken.

1. `cast_to_link_frame()` computes the position relative to a link frame's origin, but expressed in world frame with:
```
if is_global:
        return position - link_position
```
This position is then used in the cross product with the force from `cast_force_to_link_frame()` which is expressed in link frame:
```
if is_global:
        return wp.quat_rotate_inv(link_quat, position - link_position)
```
which is incorrect.

2. In `set_forces_and_torques_at_position()`, user-provided torques are overwritten when positions are provided.

Both issues are fixed in a separate commit.

## Type of change

- Bug fix (non-breaking change which fixes an issue)