### PR TITLE
Restores GR1T2 legacy teleop pipeline for teleop CI

### DIFF
--- a/scripts/environments/teleoperation/teleop_se3_agent.py
+++ b/scripts/environments/teleoperation/teleop_se3_agent.py
@@ -29,12 +29,11 @@ parser.add_argument("--num_envs", type=int, default=1, help="Number of environme
 parser.add_argument(
     "--teleop_device",
     type=str,
-    default="keyboard",
+    default=None,
     help=(
-        "Teleop device. Set here (legacy) or via the environment config. If using the environment config, pass the"
-        " device key/name defined under 'teleop_devices' (it can be a custom name, not necessarily 'handtracking')."
-        " Built-ins: keyboard, spacemouse, gamepad. Not all tasks support all built-ins."
-        " If env_cfg has isaac_teleop configured, this argument is ignored and IsaacTeleop stack is used."
+        "Legacy teleop device name. When omitted, the IsaacTeleop pipeline is used if configured in the env,"
+        " otherwise keyboard is used as fallback. When explicitly provided, the script uses the legacy"
+        " teleop_devices path and looks up this name in env_cfg.teleop_devices.devices."
     ),
 )
 parser.add_argument("--task", type=str, default=None, help="Name of the task.")
@@ -60,9 +59,6 @@ AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
 
 app_launcher_args = vars(args_cli)
-
-if "handtracking" in args_cli.teleop_device.lower():
-    app_launcher_args["xr"] = True
 
 # launch omniverse app
 app_launcher = AppLauncher(app_launcher_args)
@@ -107,6 +103,18 @@ def _resolve_cloudxr_env(value: str | None) -> str | None:
     return _CLOUDXR_ENV_SHORTHANDS.get(value.lower(), value)
 
 
+def _create_builtin_device(device_name: str, sensitivity: float) -> object | None:
+    """Create a built-in teleop device by name, or return None if unrecognized."""
+    name = device_name.lower()
+    if name == "keyboard":
+        return Se3Keyboard(Se3KeyboardCfg(pos_sensitivity=0.05 * sensitivity, rot_sensitivity=0.05 * sensitivity))
+    elif name == "spacemouse":
+        return Se3SpaceMouse(Se3SpaceMouseCfg(pos_sensitivity=0.05 * sensitivity, rot_sensitivity=0.05 * sensitivity))
+    elif name == "gamepad":
+        return Se3Gamepad(Se3GamepadCfg(pos_sensitivity=0.1 * sensitivity, rot_sensitivity=0.1 * sensitivity))
+    return None
+
+
 def main() -> None:
     """
     Run teleoperation with an Isaac Lab manipulation environment.
@@ -133,8 +141,12 @@ def main() -> None:
         # add termination condition for reaching the goal otherwise the environment won't reset
         env_cfg.terminations.object_reached_goal = DoneTerm(func=mdp.object_reached_goal)
 
-    # Check if IsaacTeleop is configured in the environment
-    use_isaac_teleop = hasattr(env_cfg, "isaac_teleop") and env_cfg.isaac_teleop is not None
+    # When --teleop_device is explicitly provided, use the legacy teleop_devices path
+    # even if isaac_teleop is configured. Otherwise prefer isaac_teleop when available.
+    teleop_device_explicitly_set = args_cli.teleop_device is not None
+    use_isaac_teleop = (
+        not teleop_device_explicitly_set and hasattr(env_cfg, "isaac_teleop") and env_cfg.isaac_teleop is not None
+    )
 
     if use_isaac_teleop or args_cli.xr:
         env_cfg = remove_camera_configs(env_cfg)
@@ -228,37 +240,36 @@ def main() -> None:
                 auto_launch_cloudxr=args_cli.auto_launch_cloudxr,
             )
 
-        elif hasattr(env_cfg, "teleop_devices") and args_cli.teleop_device in env_cfg.teleop_devices.devices:
-            # Use native Isaac Lab teleop stack
-            teleop_interface = create_teleop_device(
-                args_cli.teleop_device, env_cfg.teleop_devices.devices, teleoperation_callbacks
-            )
-        else:
-            logger.warning(
-                f"No teleop device '{args_cli.teleop_device}' found in environment config. Creating default."
-            )
-            # Create fallback teleop device
-            sensitivity = args_cli.sensitivity
-            if args_cli.teleop_device.lower() == "keyboard":
-                teleop_interface = Se3Keyboard(
-                    Se3KeyboardCfg(pos_sensitivity=0.05 * sensitivity, rot_sensitivity=0.05 * sensitivity)
-                )
-            elif args_cli.teleop_device.lower() == "spacemouse":
-                teleop_interface = Se3SpaceMouse(
-                    Se3SpaceMouseCfg(pos_sensitivity=0.05 * sensitivity, rot_sensitivity=0.05 * sensitivity)
-                )
-            elif args_cli.teleop_device.lower() == "gamepad":
-                teleop_interface = Se3Gamepad(
-                    Se3GamepadCfg(pos_sensitivity=0.1 * sensitivity, rot_sensitivity=0.1 * sensitivity)
+        elif teleop_device_explicitly_set:
+            device_name = args_cli.teleop_device
+            if hasattr(env_cfg, "teleop_devices") and device_name in env_cfg.teleop_devices.devices:
+                teleop_interface = create_teleop_device(
+                    device_name, env_cfg.teleop_devices.devices, teleoperation_callbacks
                 )
             else:
-                logger.error(f"Unsupported teleop device: {args_cli.teleop_device}")
-                logger.error("Configure the teleop device in the environment config.")
-                env.close()
-                simulation_app.close()
-                return
-
-            # Add callbacks to fallback device
+                teleop_interface = _create_builtin_device(device_name, args_cli.sensitivity)
+                if teleop_interface is None:
+                    logger.error(
+                        f"--teleop_device={device_name} was passed but no matching entry exists in"
+                        " env_cfg.teleop_devices and it is not a built-in device name. Either remove"
+                        " --teleop_device to use the IsaacTeleop pipeline, or add a"
+                        f" '{device_name}' entry under teleop_devices in the environment config."
+                        " Built-in devices: keyboard, spacemouse, gamepad."
+                    )
+                    env.close()
+                    simulation_app.close()
+                    return
+                for key, callback in teleoperation_callbacks.items():
+                    try:
+                        teleop_interface.add_callback(key, callback)
+                    except (ValueError, TypeError) as e:
+                        logger.warning(f"Failed to add callback for key {key}: {e}")
+        else:
+            # No --teleop_device and no isaac_teleop: fall back to keyboard
+            sensitivity = args_cli.sensitivity
+            teleop_interface = Se3Keyboard(
+                Se3KeyboardCfg(pos_sensitivity=0.05 * sensitivity, rot_sensitivity=0.05 * sensitivity)
+            )
             for key, callback in teleoperation_callbacks.items():
                 try:
                     teleop_interface.add_callback(key, callback)

--- a/scripts/tools/record_demos.py
+++ b/scripts/tools/record_demos.py
@@ -20,8 +20,8 @@ required arguments:
 
 optional arguments:
     -h, --help                Show this help message and exit
-    --teleop_device           Device for interacting with environment. (default: keyboard)
-                              If env_cfg has isaac_teleop configured, this argument is ignored.
+    --teleop_device           Legacy teleop device name. When omitted, IsaacTeleop is used if
+                              configured, otherwise keyboard. When set, forces the legacy path.
     --dataset_file            File path to export recorded demos. (default: "./datasets/dataset.hdf5")
     --step_hz                 Environment stepping rate in Hz. (default: 30)
     --num_demos               Number of demonstrations to record. (default: 0)
@@ -44,11 +44,11 @@ parser.add_argument("--task", type=str, required=True, help="Name of the task.")
 parser.add_argument(
     "--teleop_device",
     type=str,
-    default="keyboard",
+    default=None,
     help=(
-        "Teleop device. Set here (legacy) or via the environment config. If using the environment config, pass the"
-        " device key/name defined under 'teleop_devices' (it can be a custom name, not necessarily 'handtracking')."
-        " Built-ins: keyboard, spacemouse, gamepad. Not all tasks support all built-ins."
+        "Legacy teleop device name. When omitted, the IsaacTeleop pipeline is used if configured in the env,"
+        " otherwise keyboard is used as fallback. When explicitly provided, the script uses the legacy"
+        " teleop_devices path and looks up this name in env_cfg.teleop_devices.devices."
     ),
 )
 parser.add_argument(
@@ -90,9 +90,6 @@ if args_cli.task is None:
     parser.error("--task is required")
 
 app_launcher_args = vars(args_cli)
-
-if "handtracking" in args_cli.teleop_device.lower():
-    app_launcher_args["xr"] = True
 
 # launch the simulator
 app_launcher = AppLauncher(args_cli)
@@ -232,8 +229,12 @@ def create_environment_config(
         logger.error(f"Failed to parse environment configuration: {e}")
         exit(1)
 
-    # Check if IsaacTeleop is configured
-    use_isaac_teleop = hasattr(env_cfg, "isaac_teleop") and env_cfg.isaac_teleop is not None
+    # When --teleop_device is explicitly provided, use the legacy teleop_devices path
+    # even if isaac_teleop is configured. Otherwise prefer isaac_teleop when available.
+    teleop_device_explicitly_set = args_cli.teleop_device is not None
+    use_isaac_teleop = (
+        not teleop_device_explicitly_set and hasattr(env_cfg, "isaac_teleop") and env_cfg.isaac_teleop is not None
+    )
 
     # extract success checking function to invoke in the main loop
     success_term = None
@@ -286,6 +287,16 @@ def create_environment(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg) -> gym.En
         exit(1)
 
 
+def _create_builtin_device(device_name: str) -> object | None:
+    """Create a built-in teleop device by name, or return None if unrecognized."""
+    name = device_name.lower()
+    if name == "keyboard":
+        return Se3Keyboard(Se3KeyboardCfg(pos_sensitivity=0.2, rot_sensitivity=0.5))
+    elif name == "spacemouse":
+        return Se3SpaceMouse(Se3SpaceMouseCfg(pos_sensitivity=0.2, rot_sensitivity=0.5))
+    return None
+
+
 def setup_teleop_device(callbacks: dict[str, Callable], use_isaac_teleop: bool = False) -> object:
     """Set up the teleoperation device based on configuration.
 
@@ -303,6 +314,7 @@ def setup_teleop_device(callbacks: dict[str, Callable], use_isaac_teleop: bool =
     Raises:
         Exception: If teleop device creation fails
     """
+    teleop_device_explicitly_set = args_cli.teleop_device is not None
     teleop_interface = None
     try:
         if use_isaac_teleop:
@@ -316,23 +328,26 @@ def setup_teleop_device(callbacks: dict[str, Callable], use_isaac_teleop: bool =
                 auto_launch_cloudxr=args_cli.auto_launch_cloudxr,
             )
 
-        elif hasattr(env_cfg, "teleop_devices") and args_cli.teleop_device in env_cfg.teleop_devices.devices:
-            teleop_interface = create_teleop_device(args_cli.teleop_device, env_cfg.teleop_devices.devices, callbacks)
-        else:
-            logger.warning(
-                f"No teleop device '{args_cli.teleop_device}' found in environment config. Creating default."
-            )
-            # Create fallback teleop device
-            if args_cli.teleop_device.lower() == "keyboard":
-                teleop_interface = Se3Keyboard(Se3KeyboardCfg(pos_sensitivity=0.2, rot_sensitivity=0.5))
-            elif args_cli.teleop_device.lower() == "spacemouse":
-                teleop_interface = Se3SpaceMouse(Se3SpaceMouseCfg(pos_sensitivity=0.2, rot_sensitivity=0.5))
+        elif teleop_device_explicitly_set:
+            device_name = args_cli.teleop_device
+            if hasattr(env_cfg, "teleop_devices") and device_name in env_cfg.teleop_devices.devices:
+                teleop_interface = create_teleop_device(device_name, env_cfg.teleop_devices.devices, callbacks)
             else:
-                logger.error(f"Unsupported teleop device: {args_cli.teleop_device}")
-                logger.error("Supported devices: keyboard, spacemouse, handtracking")
-                exit(1)
-
-            # Add callbacks to fallback device
+                teleop_interface = _create_builtin_device(device_name)
+                if teleop_interface is None:
+                    logger.error(
+                        f"--teleop_device={device_name} was passed but no matching entry exists in"
+                        " env_cfg.teleop_devices and it is not a built-in device name. Either remove"
+                        " --teleop_device to use the IsaacTeleop pipeline, or add a"
+                        f" '{device_name}' entry under teleop_devices in the environment config."
+                        " Built-in devices: keyboard, spacemouse."
+                    )
+                    exit(1)
+                for key, callback in callbacks.items():
+                    teleop_interface.add_callback(key, callback)
+        else:
+            # No --teleop_device and no isaac_teleop: fall back to keyboard
+            teleop_interface = Se3Keyboard(Se3KeyboardCfg(pos_sensitivity=0.2, rot_sensitivity=0.5))
             for key, callback in callbacks.items():
                 teleop_interface.add_callback(key, callback)
     except Exception as e:

--- a/source/isaaclab_tasks/changelog.d/rwiltz-restore-legacy-teleop.rst
+++ b/source/isaaclab_tasks/changelog.d/rwiltz-restore-legacy-teleop.rst
@@ -1,0 +1,8 @@
+Added
+^^^^^
+
+* Added legacy ``teleop_devices`` configuration (``OpenXRDeviceCfg``,
+  ``ManusViveCfg``, ``GR1T2RetargeterCfg``) to
+  :class:`~isaaclab_tasks.manager_based.manipulation.pick_place.pickplace_gr1t2_env_cfg.PickPlaceGR1T2EnvCfg`
+  alongside the existing ``isaac_teleop`` pipeline, enabling CI validation
+  via ``--teleop_device=handtracking``.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_gr1t2_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_gr1t2_env_cfg.py
@@ -608,36 +608,45 @@ class PickPlaceGR1T2EnvCfg(ManagerBasedRLEnvCfg):
             xr_cfg=self.xr,
         )
 
-        # Legacy teleop devices (used when --teleop_device is explicitly passed).
-        from isaaclab.devices.device_base import DevicesCfg  # isort: skip
-        from isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1t2_retargeter import GR1T2RetargeterCfg  # isort: skip
-        from isaaclab.devices.openxr import ManusViveCfg, OpenXRDeviceCfg
+        # Legacy teleop devices are built lazily via __getattr__ to avoid
+        # importing runtime-only modules (carb, pxr) at config-load time.
+        del self.teleop_devices
 
-        self.teleop_devices = DevicesCfg(
-            devices={
-                "handtracking": OpenXRDeviceCfg(
-                    retargeters=[
-                        GR1T2RetargeterCfg(
-                            enable_visualization=True,
-                            num_open_xr_hand_joints=2 * 26,
-                            sim_device=self.sim.device,
-                            hand_joint_names=self.actions.upper_body_ik.hand_joint_names,
-                        ),
-                    ],
-                    sim_device=self.sim.device,
-                    xr_cfg=self.xr,
-                ),
-                "manusvive": ManusViveCfg(
-                    retargeters=[
-                        GR1T2RetargeterCfg(
-                            enable_visualization=True,
-                            num_open_xr_hand_joints=2 * 26,
-                            sim_device=self.sim.device,
-                            hand_joint_names=self.actions.upper_body_ik.hand_joint_names,
-                        ),
-                    ],
-                    sim_device=self.sim.device,
-                    xr_cfg=self.xr,
-                ),
-            }
-        )
+    def __getattr__(self, name: str):
+        if name == "teleop_devices":
+            from isaaclab.devices.device_base import DevicesCfg  # noqa: PLC0415
+            from isaaclab.devices.openxr import ManusViveCfg, OpenXRDeviceCfg  # noqa: PLC0415
+            from isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1t2_retargeter import (  # noqa: PLC0415
+                GR1T2RetargeterCfg,
+            )
+
+            self.teleop_devices = DevicesCfg(
+                devices={
+                    "handtracking": OpenXRDeviceCfg(
+                        retargeters=[
+                            GR1T2RetargeterCfg(
+                                enable_visualization=True,
+                                num_open_xr_hand_joints=2 * 26,
+                                sim_device=self.sim.device,
+                                hand_joint_names=self.actions.upper_body_ik.hand_joint_names,
+                            ),
+                        ],
+                        sim_device=self.sim.device,
+                        xr_cfg=self.xr,
+                    ),
+                    "manusvive": ManusViveCfg(
+                        retargeters=[
+                            GR1T2RetargeterCfg(
+                                enable_visualization=True,
+                                num_open_xr_hand_joints=2 * 26,
+                                sim_device=self.sim.device,
+                                hand_joint_names=self.actions.upper_body_ik.hand_joint_names,
+                            ),
+                        ],
+                        sim_device=self.sim.device,
+                        xr_cfg=self.xr,
+                    ),
+                }
+            )
+            return self.teleop_devices
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_gr1t2_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_gr1t2_env_cfg.py
@@ -607,3 +607,37 @@ class PickPlaceGR1T2EnvCfg(ManagerBasedRLEnvCfg):
             sim_device=self.sim.device,
             xr_cfg=self.xr,
         )
+
+        # Legacy teleop devices (used when --teleop_device is explicitly passed).
+        from isaaclab.devices.device_base import DevicesCfg  # isort: skip
+        from isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1t2_retargeter import GR1T2RetargeterCfg  # isort: skip
+        from isaaclab.devices.openxr import ManusViveCfg, OpenXRDeviceCfg
+
+        self.teleop_devices = DevicesCfg(
+            devices={
+                "handtracking": OpenXRDeviceCfg(
+                    retargeters=[
+                        GR1T2RetargeterCfg(
+                            enable_visualization=True,
+                            num_open_xr_hand_joints=2 * 26,
+                            sim_device=self.sim.device,
+                            hand_joint_names=self.actions.upper_body_ik.hand_joint_names,
+                        ),
+                    ],
+                    sim_device=self.sim.device,
+                    xr_cfg=self.xr,
+                ),
+                "manusvive": ManusViveCfg(
+                    retargeters=[
+                        GR1T2RetargeterCfg(
+                            enable_visualization=True,
+                            num_open_xr_hand_joints=2 * 26,
+                            sim_device=self.sim.device,
+                            hand_joint_names=self.actions.upper_body_ik.hand_joint_names,
+                        ),
+                    ],
+                    sim_device=self.sim.device,
+                    xr_cfg=self.xr,
+                ),
+            }
+        )

--- a/source/isaaclab_teleop/changelog.d/rwiltz-restore-legacy-teleop.rst
+++ b/source/isaaclab_teleop/changelog.d/rwiltz-restore-legacy-teleop.rst
@@ -1,0 +1,11 @@
+Changed
+^^^^^^^
+
+* Changed ``--teleop_device`` default to ``None`` in ``teleop_se3_agent.py``
+  and ``record_demos.py``. When omitted, the IsaacTeleop pipeline is used if
+  the env configures ``isaac_teleop``; otherwise keyboard is used as fallback.
+  When explicitly provided, the scripts use the legacy ``teleop_devices`` path
+  and error out if no matching entry exists.
+* Removed automatic ``--xr`` detection from ``--teleop_device`` containing
+  ``"handtracking"``. Users who need XR with the legacy path should pass
+  ``--xr`` explicitly.

--- a/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/openxr_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/openxr_device.py
@@ -338,8 +338,8 @@ class OpenXRDevice(DeviceBase):
                     quati = quat.GetImaginary()
                     quatw = quat.GetReal()
                 else:
-                    quatw = previous_joint_poses[joint_name][3]
-                    quati = previous_joint_poses[joint_name][4:]
+                    quati = previous_joint_poses[joint_name][3:6]
+                    quatw = previous_joint_poses[joint_name][6]
 
                 # Directly update the dictionary with new data
                 previous_joint_poses[joint_name] = np.array(

--- a/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/retargeters/humanoid/fourier/gr1_t2_dex_retargeting_utils.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/retargeters/humanoid/fourier/gr1_t2_dex_retargeting_utils.py
@@ -158,8 +158,8 @@ class GR1TR2DexRetargeting:
         # Convert hand pose to the canonical frame.
         joint_position = joint_position - joint_position[0:1, :]
         xr_wrist_quat = hand_poses.get("wrist")[3:]
-        # OpenXR hand uses w,x,y,z order for quaternions but scipy uses x,y,z,w order
-        wrist_rot = R.from_quat([xr_wrist_quat[1], xr_wrist_quat[2], xr_wrist_quat[3], xr_wrist_quat[0]]).as_matrix()
+        # OpenXR hand data is in xyzw order, matching scipy's convention
+        wrist_rot = R.from_quat(xr_wrist_quat).as_matrix()
 
         return joint_position @ wrist_rot @ operator2mano
 


### PR DESCRIPTION
# Description

- Restores legacy `teleop_devices` config (`OpenXRDeviceCfg` / `ManusViveCfg` + `GR1T2RetargeterCfg`) on `PickPlaceGR1T2EnvCfg` alongside the existing `isaac_teleop` pipeline, re-enabling CI validation via `--teleop_device=handtracking`.
- Updates `teleop_se3_agent.py` and `record_demos.py` to route between the two stacks: IsaacTeleop is used by default when configured; passing `--teleop_device` explicitly forces the legacy `teleop_devices` path (errors if no matching entry exists).
- Removes automatic `--xr` inference from `--teleop_device` containing `"handtracking"`. Users who need XR with the legacy path should pass `--xr` explicitly.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there