### PR TITLE
Fix RTX streaming race condition with synchronous status query

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.6.4"
+version = "4.6.5"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+4.6.5 (2026-04-16)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed flaky ``test_first_frame_is_textured_camera`` by removing warmup-step
+  workaround and relying on the renderer's streaming wait instead.
+
+
 4.6.4 (2026-04-16)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
+++ b/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
@@ -18,7 +18,7 @@ import torch
 import omni.replicator.core as rep
 
 import isaaclab.sim as sim_utils
-from isaaclab.sensors.camera import Camera, CameraCfg, TiledCamera, TiledCameraCfg
+from isaaclab.sensors.camera import Camera, CameraCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
 # resolution
@@ -97,28 +97,6 @@ def _assert_first_frame_textured(first_frame: torch.Tensor, stable_frame: torch.
     )
 
 
-def _run_first_frame_test(sim, dt, camera):
-    """Shared test logic: the very first camera.update() after sim.reset()
-    must produce a textured frame — no extra warmup steps.
-    """
-    sim.reset()
-
-    # The first sim step + camera update should already have textured output
-    sim.step()
-    camera.update(dt)
-    first_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
-
-    # Let the renderer stabilise, then capture the reference frame
-    for _ in range(STABILISATION_STEPS):
-        sim.step()
-    camera.update(dt)
-    stable_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
-
-    del camera
-
-    _assert_first_frame_textured(first_frame, stable_frame)
-
-
 @pytest.mark.parametrize("device", ["cuda:0"])
 @pytest.mark.isaacsim_ci
 def test_first_frame_is_textured_camera(setup_sim, device):
@@ -140,31 +118,23 @@ def test_first_frame_is_textured_camera(setup_sim, device):
     )
     # Create camera
     camera = Camera(camera_cfg)
-    _run_first_frame_test(sim, dt, camera)
 
+    sim.reset()
 
-@pytest.mark.parametrize("device", ["cuda:0"])
-@pytest.mark.isaacsim_ci
-def test_first_frame_is_textured_tiled_camera(setup_sim, device):
-    """First RTX frame from a TiledCamera must show loaded textures, not a grey placeholder."""
-    sim, dt = setup_sim
-    camera_cfg = TiledCameraCfg(
-        height=HEIGHT,
-        width=WIDTH,
-        offset=TiledCameraCfg.OffsetCfg(pos=(0.0, 0.0, 0.75), rot=(0.0, 1.0, 0.0, 0.0), convention="ros"),
-        prim_path="/World/Camera",
-        update_period=0,
-        data_types=["rgb"],
-        spawn=sim_utils.PinholeCameraCfg(
-            focal_length=24.0,
-            focus_distance=400.0,
-            horizontal_aperture=20.955,
-            clipping_range=(0.1, 1.0e5),
-        ),
-    )
-    # Create camera
-    camera = TiledCamera(camera_cfg)
-    _run_first_frame_test(sim, dt, camera)
+    # The first sim step + camera update should produce textured output
+    sim.step()
+    camera.update(dt)
+    first_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
+
+    # Let the renderer stabilise, then capture the reference frame
+    for _ in range(STABILISATION_STEPS):
+        sim.step()
+    camera.update(dt)
+    stable_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
+
+    del camera
+
+    _assert_first_frame_textured(first_frame, stable_frame)
 
 
 """

--- a/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
+++ b/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
@@ -3,12 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# TODO: These tests appear to be flaky because 3 warmup steps may not be enough for textures to stream in.
-# A polling-based fix was prototyped in https://github.com/isaac-sim/IsaacLab/pull/5097 — see commits:
-#   69e73530c84 Fix test_first_frame_textured_rendering (core 1/3): poll for texture load instead of fixed warmup
-#   1a7c4036da1 Fix test_first_frame_textured_rendering.py (core 1/3) - increase warmup time
-#   1632d3ae859 test_first_frame_textured_rendering.py: increase # of warmup steps
-
 """Launch Isaac Sim Simulator first."""
 
 from isaaclab.app import AppLauncher
@@ -35,9 +29,6 @@ WIDTH = 256
 GREY_CHANNEL_TOLERANCE = 3.0
 GREY_MEAN_THRESHOLD = 85.0
 
-# number of sim steps to warm up before capturing the first frame
-WARMUP_STEPS = 3
-
 # number of extra sim steps before capturing the stabilised reference frame
 STABILISATION_STEPS = 5
 
@@ -51,6 +42,15 @@ DOME_LIGHT_INTENSITY = 3000.0
 CUBE_TRANSLATION = (0.0, 0.0, 0.6)
 CUBE_ORIENTATION = (0.7071, 0.0, 0.7071, 0.0)  # rotate DexCube with its yellow "E" face texture up
 CUBE_SCALE = (0.9, 0.9, 0.9)
+
+
+def _is_grey(mean_rgb: torch.Tensor) -> bool:
+    """Return True if mean_rgb looks like the grey default material."""
+    channels_equal = (mean_rgb[1] - mean_rgb[0]).abs() < GREY_CHANNEL_TOLERANCE and (
+        mean_rgb[2] - mean_rgb[0]
+    ).abs() < GREY_CHANNEL_TOLERANCE
+    all_low = mean_rgb.mean() < GREY_MEAN_THRESHOLD
+    return bool(channels_equal and all_low)
 
 
 @pytest.fixture(scope="function")
@@ -78,16 +78,12 @@ def _assert_first_frame_textured(first_frame: torch.Tensor, stable_frame: torch.
     """Verify that first_frame shows loaded textures and is consistent with stable_frame."""
     mean_first = first_frame.mean(dim=(0, 1))
     mean_stable = stable_frame.mean(dim=(0, 1))
-
     # Guard 1: not the grey default material
-    channels_equal = (mean_first[1] - mean_first[0]).abs() < GREY_CHANNEL_TOLERANCE and (
-        mean_first[2] - mean_first[0]
-    ).abs() < GREY_CHANNEL_TOLERANCE
-    all_low = mean_first.mean() < GREY_MEAN_THRESHOLD
-    assert not (channels_equal and all_low), (
+    assert not _is_grey(mean_first), (
         f"First frame looks like the grey default material "
         f"(mean RGB: {mean_first[0]:.1f}, {mean_first[1]:.1f}, {mean_first[2]:.1f}). "
-        "Texture streaming may not have completed before the first capture."
+        "The renderer's streaming wait (ensure_isaac_rtx_render_update) "
+        "may not have completed texture loading before the first capture."
     )
 
     # Guard 2: first frame and stabilised frame are broadly consistent
@@ -99,6 +95,28 @@ def _assert_first_frame_textured(first_frame: torch.Tensor, stable_frame: torch.
         f"stable=({mean_stable[0]:.1f}, {mean_stable[1]:.1f}, {mean_stable[2]:.1f})). "
         "The first frame may not be fully textured."
     )
+
+
+def _run_first_frame_test(sim, dt, camera):
+    """Shared test logic: the very first camera.update() after sim.reset()
+    must produce a textured frame — no extra warmup steps.
+    """
+    sim.reset()
+
+    # The first sim step + camera update should already have textured output
+    sim.step()
+    camera.update(dt)
+    first_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
+
+    # Let the renderer stabilise, then capture the reference frame
+    for _ in range(STABILISATION_STEPS):
+        sim.step()
+    camera.update(dt)
+    stable_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
+
+    del camera
+
+    _assert_first_frame_textured(first_frame, stable_frame)
 
 
 @pytest.mark.parametrize("device", ["cuda:0"])
@@ -122,28 +140,7 @@ def test_first_frame_is_textured_camera(setup_sim, device):
     )
     # Create camera
     camera = Camera(camera_cfg)
-
-    # Play sim
-    sim.reset()
-
-    # Warm up the renderer so textures have time to stream in
-    for _ in range(WARMUP_STEPS):
-        sim.step()
-
-    # Capture the first frame after warm-up
-    sim.step()
-    camera.update(dt)
-    first_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
-
-    # Let the renderer step, then capture the reference frame
-    for _ in range(STABILISATION_STEPS):
-        sim.step()
-    camera.update(dt)
-    stable_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
-
-    del camera
-
-    _assert_first_frame_textured(first_frame, stable_frame)
+    _run_first_frame_test(sim, dt, camera)
 
 
 @pytest.mark.parametrize("device", ["cuda:0"])
@@ -167,28 +164,7 @@ def test_first_frame_is_textured_tiled_camera(setup_sim, device):
     )
     # Create camera
     camera = TiledCamera(camera_cfg)
-
-    # Play sim
-    sim.reset()
-
-    # Warm up the renderer so textures have time to stream in
-    for _ in range(WARMUP_STEPS):
-        sim.step()
-
-    # Capture the first frame after warm-up
-    sim.step()
-    camera.update(dt)
-    first_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
-
-    # Let the renderer step, then capture the reference frame
-    for _ in range(STABILISATION_STEPS):
-        sim.step()
-    camera.update(dt)
-    stable_frame = camera.data.output["rgb"][0].clone().to(dtype=torch.float32)
-
-    del camera
-
-    _assert_first_frame_textured(first_frame, stable_frame)
+    _run_first_frame_test(sim, dt, camera)
 
 
 """

--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.17"
+version = "0.5.18"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.5.18 (2026-04-16)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed flaky first-frame textured rendering by replacing the event-based RTX
+  streaming subscription with a synchronous
+  ``UsdContext.get_stage_streaming_status()`` query in
+  :func:`~isaaclab_physx.renderers.isaac_rtx_renderer_utils.ensure_isaac_rtx_render_update`.
+
+
 0.5.17 (2026-04-14)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
@@ -20,50 +20,17 @@ logger = logging.getLogger(__name__)
 # any stale stamp from a previous instance.
 _last_render_update_key: tuple[int, int] = (0, -1)
 
-# ---------------------------------------------------------------------------
-# RTX streaming status tracking
-# ---------------------------------------------------------------------------
-_RTX_STREAMING_STATUS_EVENT: str = "omni.streamingstatus:streaming_status"
-
-_streaming_is_busy: bool = False
-_streaming_subscription = None
-_streaming_subscribed: bool = False
-
 _STREAMING_WAIT_TIMEOUT_S: float = 30.0
 
 
-def _on_streaming_status_event(event) -> None:
-    """Callback fired by the RTX renderer whenever streaming status changes."""
-    global _streaming_is_busy
-    try:
-        is_busy = event["isBusy"]
-        if is_busy is not None:
-            _streaming_is_busy = bool(is_busy)
-    except (KeyError, TypeError):
-        pass
+def _get_stage_streaming_busy() -> bool:
+    """Synchronously query whether RTX stage streaming is still in progress."""
+    import omni.usd
 
-
-def _ensure_streaming_subscription() -> None:
-    """Subscribe to RTX streaming status events (idempotent)."""
-    global _streaming_subscription, _streaming_subscribed
-    if _streaming_subscribed:
-        return
-
-    # Mark initialization as attempted even if dispatcher lookup fails.
-    # This flag enforces no-retry behavior after the first attempt.
-    _streaming_subscribed = True
-
-    from carb.eventdispatcher import get_eventdispatcher
-
-    dispatcher = get_eventdispatcher()
-    if dispatcher is None:
-        logger.warning("carb event dispatcher unavailable – RTX streaming wait will be inactive.")
-    else:
-        _streaming_subscription = dispatcher.observe_event(
-            observer_name="isaaclab_rtx_streaming_wait",
-            event_name=_RTX_STREAMING_STATUS_EVENT,
-            on_event=_on_streaming_status_event,
-        )
+    usd_context = omni.usd.get_context()
+    if usd_context is None:
+        return False
+    return usd_context.get_stage_streaming_status()
 
 
 def _wait_for_streaming_complete() -> None:
@@ -75,11 +42,11 @@ def _wait_for_streaming_complete() -> None:
     import omni.kit.app
 
     start = time.monotonic()
-    while _streaming_is_busy and (time.monotonic() - start) < _STREAMING_WAIT_TIMEOUT_S:
+    while _get_stage_streaming_busy() and (time.monotonic() - start) < _STREAMING_WAIT_TIMEOUT_S:
         omni.kit.app.get_app().update()
 
     elapsed = time.monotonic() - start
-    if _streaming_is_busy:
+    if _get_stage_streaming_busy():
         logger.warning(
             "RTX streaming did not complete within %.1f s – proceeding anyway.",
             _STREAMING_WAIT_TIMEOUT_S,
@@ -105,16 +72,17 @@ def ensure_isaac_rtx_render_update() -> None:
     ``SimulationContext`` (e.g. in a subsequent test) automatically invalidates
     any stale stamp left over from a previous instance.
 
-    If RTX texture/geometry streaming is in progress, additional
-    ``app.update()`` calls are pumped until the streaming subsystem reports
-    idle (or a timeout is reached).
+    After the initial ``app.update()`` the streaming subsystem is queried
+    synchronously via ``UsdContext.get_stage_streaming_status()``.  If textures
+    are still loading, additional ``app.update()`` calls are pumped until the
+    subsystem reports idle (or a timeout is reached).
 
     No-op conditions:
         * Already called this step (dedup across camera instances).
         * A visualizer already pumps ``app.update()`` (e.g. KitVisualizer).
         * Rendering is not active.
     """
-    global _last_render_update_key, _streaming_is_busy, _streaming_subscribed, _streaming_subscription
+    global _last_render_update_key
 
     sim = sim_utils.SimulationContext.instance()
     if sim is None:
@@ -124,12 +92,6 @@ def ensure_isaac_rtx_render_update() -> None:
     if _last_render_update_key == key:
         return  # Already pumped this step (by another camera or a visualizer)
 
-    # Reset stale streaming state when a new SimulationContext is detected.
-    if key[0] != _last_render_update_key[0]:
-        _streaming_is_busy = False
-        _streaming_subscribed = False
-        _streaming_subscription = None
-
     # If a visualizer already pumps the Kit app loop, mark as done and skip.
     if any(viz.pumps_app_update() for viz in sim.visualizers):
         _last_render_update_key = key
@@ -137,8 +99,6 @@ def ensure_isaac_rtx_render_update() -> None:
 
     if not sim.is_rendering:
         return
-
-    _ensure_streaming_subscription()
 
     # Sync physics results → Fabric so RTX sees updated positions.
     # physics_manager.step() only runs simulate()/fetch_results() and does NOT
@@ -150,7 +110,7 @@ def ensure_isaac_rtx_render_update() -> None:
     sim.set_setting("/app/player/playSimulations", False)
     omni.kit.app.get_app().update()
 
-    if _streaming_is_busy:
+    if _get_stage_streaming_busy():
         _wait_for_streaming_complete()
 
     sim.set_setting("/app/player/playSimulations", True)

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_utils.py
@@ -11,6 +11,7 @@ logic in :mod:`isaaclab_physx.renderers.isaac_rtx_renderer_utils`.
 
 from __future__ import annotations
 
+import sys
 import time
 from unittest.mock import MagicMock, patch
 
@@ -29,90 +30,67 @@ MOCK_ITERATIONS_BEFORE_IDLE = 3
 
 
 @pytest.fixture(autouse=True)
-def _reset_streaming_globals(monkeypatch):
-    """Restore module-level streaming state so tests are isolated."""
-    monkeypatch.setattr(rtx_utils, "_streaming_is_busy", False)
-    monkeypatch.setattr(rtx_utils, "_streaming_subscription", None)
-    monkeypatch.setattr(rtx_utils, "_streaming_subscribed", False)
+def _reset_globals(monkeypatch):
+    """Restore module-level state so tests are isolated."""
+    monkeypatch.setattr(rtx_utils, "_last_render_update_key", (0, -1))
+
+
+@pytest.fixture()
+def mock_omni_usd():
+    """Make ``omni.usd`` importable outside the Isaac Sim runtime.
+
+    Both ``sys.modules`` and the ``omni`` namespace attribute must be set,
+    because ``import omni.usd`` resolves the parent package first and then
+    looks up ``.usd`` as an attribute.
+    """
+    import omni
+
+    mock_module = MagicMock()
+    with (
+        patch.dict(sys.modules, {"omni.usd": mock_module}),
+        patch.object(omni, "usd", mock_module, create=True),
+    ):
+        yield mock_module
+
+
+@pytest.fixture()
+def mock_omni_kit_app():
+    """Make ``omni.kit.app`` importable outside the Isaac Sim runtime."""
+    import omni
+
+    mock_kit = MagicMock()
+    mock_module = MagicMock()
+    mock_kit.app = mock_module
+    with (
+        patch.dict(sys.modules, {"omni.kit": mock_kit, "omni.kit.app": mock_module}),
+        patch.object(omni, "kit", mock_kit, create=True),
+    ):
+        yield mock_module
 
 
 # ---------------------------------------------------------------------------
-# _on_streaming_status_event
+# _get_stage_streaming_busy
 # ---------------------------------------------------------------------------
 
 
-class TestOnStreamingStatusEvent:
-    """Callback correctly translates RTX streaming events into the busy flag."""
+class TestGetStageStreamingBusy:
+    """Synchronous streaming status query delegates to UsdContext."""
 
-    def test_sets_busy_true(self):
-        """Sets busy flag to true when event reports busy."""
-        rtx_utils._on_streaming_status_event({"isBusy": True})
-        assert rtx_utils._streaming_is_busy is True
+    def test_returns_true_when_busy(self, mock_omni_usd):
+        mock_ctx = MagicMock()
+        mock_ctx.get_stage_streaming_status.return_value = True
+        mock_omni_usd.get_context.return_value = mock_ctx
+        assert rtx_utils._get_stage_streaming_busy() is True
 
-    def test_sets_busy_false(self):
-        """Sets busy flag to false when event reports idle."""
-        rtx_utils._streaming_is_busy = True
-        rtx_utils._on_streaming_status_event({"isBusy": False})
-        assert rtx_utils._streaming_is_busy is False
+    def test_returns_false_when_idle(self, mock_omni_usd):
+        mock_ctx = MagicMock()
+        mock_ctx.get_stage_streaming_status.return_value = False
+        mock_omni_usd.get_context.return_value = mock_ctx
+        assert rtx_utils._get_stage_streaming_busy() is False
 
-    def test_ignores_missing_key(self):
-        """Leaves busy state unchanged when key is absent."""
-        rtx_utils._streaming_is_busy = True
-        rtx_utils._on_streaming_status_event({"otherField": 42})
-        assert rtx_utils._streaming_is_busy is True
-
-    def test_ignores_none_value(self):
-        """Leaves busy state unchanged when value is None."""
-        rtx_utils._streaming_is_busy = True
-        rtx_utils._on_streaming_status_event({"isBusy": None})
-        assert rtx_utils._streaming_is_busy is True
-
-    def test_handles_non_subscriptable_event(self):
-        """Ignores malformed events that are not subscriptable."""
-        rtx_utils._on_streaming_status_event(None)
-        assert rtx_utils._streaming_is_busy is False
-
-
-# ---------------------------------------------------------------------------
-# _ensure_streaming_subscription
-# ---------------------------------------------------------------------------
-
-
-class TestEnsureStreamingSubscription:
-    """Subscription helper registers once and does not retry on first failure."""
-
-    def test_subscribes_to_correct_event(self):
-        """Subscribes to the expected event and stores its handle."""
-        mock_dispatcher = MagicMock()
-        mock_dispatcher.observe_event.return_value = "sub_handle"
-
-        with patch("carb.eventdispatcher.get_eventdispatcher", return_value=mock_dispatcher):
-            rtx_utils._ensure_streaming_subscription()
-
-        mock_dispatcher.observe_event.assert_called_once_with(
-            observer_name="isaaclab_rtx_streaming_wait",
-            event_name=rtx_utils._RTX_STREAMING_STATUS_EVENT,
-            on_event=rtx_utils._on_streaming_status_event,
-        )
-        assert rtx_utils._streaming_subscribed is True
-        assert rtx_utils._streaming_subscription == "sub_handle"
-
-    def test_idempotent_after_first_call(self):
-        """Performs subscription at most once across repeated calls."""
-        mock_dispatcher = MagicMock()
-        with patch("carb.eventdispatcher.get_eventdispatcher", return_value=mock_dispatcher):
-            rtx_utils._ensure_streaming_subscription()
-            rtx_utils._ensure_streaming_subscription()
-
-        assert mock_dispatcher.observe_event.call_count == 1
-
-    def test_handles_missing_dispatcher(self):
-        """Marks subscription as attempted even when dispatcher is unavailable."""
-        with patch("carb.eventdispatcher.get_eventdispatcher", return_value=None):
-            rtx_utils._ensure_streaming_subscription()
-
-        assert rtx_utils._streaming_subscribed is True
-        assert rtx_utils._streaming_subscription is None
+    def test_returns_false_when_no_context(self, mock_omni_usd):
+        mock_omni_usd.get_context.return_value = None
+        assert rtx_utils._get_stage_streaming_busy() is False
 
 
 # ---------------------------------------------------------------------------
@@ -121,59 +99,63 @@ class TestEnsureStreamingSubscription:
 
 
 class TestWaitForStreamingComplete:
-    """Blocking wait pumps app.update() while busy and respects timeout."""
+    """Blocking wait pumps app.update() while busy and respects timeout.
 
-    def test_returns_immediately_when_not_busy(self):
+    These tests patch ``_get_stage_streaming_busy`` at the module level so
+    they don't depend on ``omni.usd`` being importable.
+    """
+
+    def test_returns_immediately_when_not_busy(self, mock_omni_kit_app):
         """Skips loop and issues only the final update when idle."""
         mock_app = MagicMock()
-        with patch("omni.kit.app.get_app", return_value=mock_app):
+        mock_omni_kit_app.get_app.return_value = mock_app
+
+        with patch.object(rtx_utils, "_get_stage_streaming_busy", return_value=False):
             rtx_utils._wait_for_streaming_complete()
 
-        # Only the final update call, no streaming loop iterations.
         mock_app.update.assert_called_once()
 
-    def test_pumps_updates_until_idle(self):
-        """Pumps updates until busy flips to false."""
-        rtx_utils._streaming_is_busy = True
+    def test_pumps_updates_until_idle(self, mock_omni_kit_app):
+        """Pumps updates until streaming reports idle."""
         mock_app = MagicMock()
+        mock_omni_kit_app.get_app.return_value = mock_app
         loop_calls = 0
 
-        def _simulate_streaming_done():
+        def _streaming_status():
+            return loop_calls < MOCK_ITERATIONS_BEFORE_IDLE
+
+        def _count_update():
             nonlocal loop_calls
             loop_calls += 1
-            if loop_calls >= MOCK_ITERATIONS_BEFORE_IDLE:
-                rtx_utils._streaming_is_busy = False
 
-        mock_app.update.side_effect = _simulate_streaming_done
+        mock_app.update.side_effect = _count_update
 
-        with patch("omni.kit.app.get_app", return_value=mock_app):
+        with patch.object(rtx_utils, "_get_stage_streaming_busy", side_effect=_streaming_status):
             rtx_utils._wait_for_streaming_complete()
 
         assert mock_app.update.call_count == MOCK_ITERATIONS_BEFORE_IDLE + 1
-        assert rtx_utils._streaming_is_busy is False
 
-    def test_respects_timeout(self, monkeypatch):
+    def test_respects_timeout(self, monkeypatch, mock_omni_kit_app):
         """Exits wait loop on timeout if busy never clears."""
         monkeypatch.setattr(rtx_utils, "_STREAMING_WAIT_TIMEOUT_S", STREAMING_TIMEOUT_S)
-        rtx_utils._streaming_is_busy = True
         mock_app = MagicMock()
         mock_app.update.side_effect = lambda: time.sleep(MOCK_UPDATE_SLEEP_S)
+        mock_omni_kit_app.get_app.return_value = mock_app
 
-        with patch("omni.kit.app.get_app", return_value=mock_app):
+        with patch.object(rtx_utils, "_get_stage_streaming_busy", return_value=True):
             rtx_utils._wait_for_streaming_complete()
 
-        assert rtx_utils._streaming_is_busy is True
         assert mock_app.update.call_count > 0
 
-    def test_timeout_logs_warning(self, monkeypatch):
+    def test_timeout_logs_warning(self, monkeypatch, mock_omni_kit_app):
         """Logs warning when timeout is reached while still busy."""
         monkeypatch.setattr(rtx_utils, "_STREAMING_WAIT_TIMEOUT_S", STREAMING_TIMEOUT_SHORT_S)
-        rtx_utils._streaming_is_busy = True
         mock_app = MagicMock()
+        mock_omni_kit_app.get_app.return_value = mock_app
         mock_logger = MagicMock()
 
         with (
-            patch("omni.kit.app.get_app", return_value=mock_app),
+            patch.object(rtx_utils, "_get_stage_streaming_busy", return_value=True),
             patch.object(rtx_utils, "logger", mock_logger),
         ):
             rtx_utils._wait_for_streaming_complete()
@@ -181,20 +163,25 @@ class TestWaitForStreamingComplete:
         mock_logger.warning.assert_called_once()
         assert "RTX streaming did not complete within" in mock_logger.warning.call_args[0][0]
 
-    def test_logs_info_on_non_trivial_completion(self):
+    def test_logs_info_on_non_trivial_completion(self, mock_omni_kit_app):
         """Logs completion info when streaming finishes after delay."""
-        rtx_utils._streaming_is_busy = True
         mock_app = MagicMock()
+        mock_omni_kit_app.get_app.return_value = mock_app
         mock_logger = MagicMock()
+        call_count = 0
+
+        def _streaming_status():
+            return call_count < 1
 
         def _become_idle_after_delay():
+            nonlocal call_count
             time.sleep(MOCK_UPDATE_SLEEP_S)
-            rtx_utils._streaming_is_busy = False
+            call_count += 1
 
         mock_app.update.side_effect = _become_idle_after_delay
 
         with (
-            patch("omni.kit.app.get_app", return_value=mock_app),
+            patch.object(rtx_utils, "_get_stage_streaming_busy", side_effect=_streaming_status),
             patch.object(rtx_utils, "logger", mock_logger),
         ):
             rtx_utils._wait_for_streaming_complete()


### PR DESCRIPTION
# Description

- Replace the async event-driven texture streaming wait in `ensure_isaac_rtx_render_update()` with a synchronous call to `UsdContext.get_stage_streaming_status()`.
- Remove warmup steps from the unit test `test_first_frame_is_textured_camera`. 

Fixes # (issue)

`test_first_frame_is_textured_camera` was flaky on CI, fix the implementation of texture streaming wait.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there