### PR TITLE
Restrict pyglet to <3 to fix Newton viewer

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.6.3"
+version = "4.6.4"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+4.6.4 (2026-04-16)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed Newton viewer compatibility by restricting ``pyglet`` to ``<3``.
+
+
 4.6.3 (2026-04-16)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     "gymnasium==1.2.1",
     # procedural-generation
     "trimesh",
-    "pyglet>=2.1.6",
+    "pyglet>=2.1.6,<3",
     "mujoco==3.5.0",
     "mujoco-warp==3.5.0.2",
     # image processing


### PR DESCRIPTION
# Description

pyglet 3.x introduces breaking changes that prevent the Newton viewer from functioning correctly. Pin the upper bound to maintain compatibility.

The pyglet version was already constrained in the newton[examples] dependencies, but IsaacLab does not install these dependencies when doing `./isaaclab.sh --install rsl_rl` and having `uv .. --prerelease=allow`.  See Cursor's analysis at the bottom.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Extra
Here is Cursor's analysis, which I found quite clear:
```
1. Newton’s <3 is only on the examples extra
In Newton’s pyproject.toml, pyglet>=2.1.6,<3 lives under [project.optional-dependencies] → examples, not under the core package:


pyproject.toml
Lines 74-84
# Examples dependencies including visualization
examples = [
    "newton[sim]",          # include simulation dependencies
    "newton[importers]",    # include import dependencies
    "pyglet>=2.1.6,<3",     # for OpenGL viewer
    ...
]
The default dependencies are only:


pyproject.toml
Lines 30-32
dependencies = [
    "warp-lang>=1.12.0",
]
So a plain newton install does not apply any pyglet upper bound. The <3 rule only applies when something installs newton[examples] (or another extra that pulls that group in).

2. Isaac Lab pins pyglet with no <3
Core Isaac Lab declares an open lower bound:


setup.py
Lines 30-33
    # procedural-generation
    "trimesh",
    "pyglet>=2.1.6",
    "mujoco>=3.5",
So the resolver is explicitly allowed to pick any pyglet that satisfies >=2.1.6, including 3.x pre-releases.

3. isaaclab_newton does not pull Newton’s optional deps by default
isaaclab_newton has empty install_requires and puts newton (git) under extras_require["all"] only:


setup.py
Lines 36-49
INSTALL_REQUIRES = [
    # INTENTIONALLY disabled to avoid circular dependency with isaaclab_physx, which also depends on isaaclab_newton.
    ...
]
EXTRAS_REQUIRE = {
    "all": [
        ...
        "newton @ git+https://github.com/newton-physics/newton.git@...",
    ],
}
A normal ./isaaclab.sh --install rsl_rl installs isaaclab_newton as editable without [all], so that git newton extra (and thus any PyPI newton[examples]-style constraint) is not part of the solve.

4. --prerelease=allow makes 3.0.dev2 eligible
Your install.sh installs Isaac Sim with:


install.sh
Lines 102-105
uv pip install "isaacsim[all,extscache]==6.0.0" \
    --extra-index-url https://pypi.nvidia.com \
    --index-strategy unsafe-best-match \
    --prerelease=allow
With prereleases allowed, pyglet 3.0.dev2 can be chosen to satisfy pyglet>=2.1.6 from Isaac Lab.

Bottom line: You still get pyglet 3.x because Isaac Lab’s direct requirement allows it, Newton’s <3 only applies to newton[examples], and your install path does not merge that optional Newton constraint into the environment. To align behavior you’d need something that actually constrains pyglet in the same environment (e.g. cap it in Isaac Lab’s setup.py, or install newton[examples] / pin pyglet<3 explicitly), and avoid broad --prerelease=allow if you don’t want dev releases of unrelated packages.
```