### PR TITLE
Remove stale nvidia.srl symlink hack from Dockerfiles

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -109,6 +109,10 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog
 ENV PYTHONPATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle:${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib/python3.12/site-packages:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib:${LD_LIBRARY_PATH}"
 
+# HACK: nvidia-srl-usd-to-urdf was previously bundled in Kit python but has been
+# removed from the latest-develop Isaac Sim image. Install it explicitly for Pink IK.
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install nvidia-srl-usd-to-urdf
+
 # aliasing isaaclab.sh and python for convenience
 RUN echo "export ISAACLAB_PATH=${ISAACLAB_PATH}" >> ${HOME}/.bashrc && \
     echo "alias isaaclab=${ISAACLAB_PATH}/isaaclab.sh" >> ${HOME}/.bashrc && \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -109,10 +109,6 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog
 ENV PYTHONPATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle:${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib/python3.12/site-packages:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib:${LD_LIBRARY_PATH}"
 
-# HACK: Expose nvidia.srl from Kit python into the ml_archive nvidia namespace
-RUN ln -s ${ISAACSIM_ROOT_PATH}/kit/python/lib/python3.12/site-packages/nvidia/srl \
-    ${ISAACSIM_ROOT_PATH}/exts/omni.isaac.ml_archive/pip_prebundle/nvidia/srl
-
 # aliasing isaaclab.sh and python for convenience
 RUN echo "export ISAACLAB_PATH=${ISAACLAB_PATH}" >> ${HOME}/.bashrc && \
     echo "alias isaaclab=${ISAACLAB_PATH}/isaaclab.sh" >> ${HOME}/.bashrc && \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -109,6 +109,14 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog
 ENV PYTHONPATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle:${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib/python3.12/site-packages:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib:${LD_LIBRARY_PATH}"
 
+# HACK: nvidia-srl-usd-to-urdf was previously bundled in the Isaac Sim image but has
+# been removed. Install with --no-deps to avoid lxml<5 conflict with dex-retargeting.
+# Then symlink nvidia.srl into the ml_archive nvidia namespace so Python can find it
+# (the deprecated ml_archive prebundle shadows site-packages for the nvidia namespace).
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-deps nvidia-srl-usd-to-urdf \
+    && ln -s ${ISAACSIM_ROOT_PATH}/kit/python/lib/python3.12/site-packages/nvidia/srl \
+       ${ISAACSIM_ROOT_PATH}/extsDeprecated/omni.isaac.ml_archive/pip_prebundle/nvidia/srl
+
 # aliasing isaaclab.sh and python for convenience
 RUN echo "export ISAACLAB_PATH=${ISAACLAB_PATH}" >> ${HOME}/.bashrc && \
     echo "alias isaaclab=${ISAACLAB_PATH}/isaaclab.sh" >> ${HOME}/.bashrc && \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -109,10 +109,6 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog
 ENV PYTHONPATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle:${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib/python3.12/site-packages:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib:${LD_LIBRARY_PATH}"
 
-# HACK: nvidia-srl-usd-to-urdf was previously bundled in Kit python but has been
-# removed from the latest-develop Isaac Sim image. Install it explicitly for Pink IK.
-RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install nvidia-srl-usd-to-urdf
-
 # aliasing isaaclab.sh and python for convenience
 RUN echo "export ISAACLAB_PATH=${ISAACLAB_PATH}" >> ${HOME}/.bashrc && \
     echo "alias isaaclab=${ISAACLAB_PATH}/isaaclab.sh" >> ${HOME}/.bashrc && \

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -157,6 +157,10 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog
 ENV PYTHONPATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle:${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib/python3.12/site-packages:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib:${LD_LIBRARY_PATH}"
 
+# HACK: nvidia-srl-usd-to-urdf was previously bundled in Kit python but has been
+# removed from the latest-develop Isaac Sim image. Install it explicitly for Pink IK.
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install nvidia-srl-usd-to-urdf
+
 # Install cuRobo from source (pinned commit); needs CUDA env and Torch
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation \
     "nvidia-curobo @ git+https://github.com/NVlabs/curobo.git@ebb71702f3f70e767f40fd8e050674af0288abe8"

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -157,10 +157,6 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog
 ENV PYTHONPATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle:${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib/python3.12/site-packages:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib:${LD_LIBRARY_PATH}"
 
-# HACK: Expose nvidia.srl from Kit python into the ml_archive nvidia namespace
-RUN ln -s ${ISAACSIM_ROOT_PATH}/kit/python/lib/python3.12/site-packages/nvidia/srl \
-    ${ISAACSIM_ROOT_PATH}/exts/omni.isaac.ml_archive/pip_prebundle/nvidia/srl
-
 # Install cuRobo from source (pinned commit); needs CUDA env and Torch
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation \
     "nvidia-curobo @ git+https://github.com/NVlabs/curobo.git@ebb71702f3f70e767f40fd8e050674af0288abe8"

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -157,10 +157,6 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog
 ENV PYTHONPATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle:${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib/python3.12/site-packages:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib:${LD_LIBRARY_PATH}"
 
-# HACK: nvidia-srl-usd-to-urdf was previously bundled in Kit python but has been
-# removed from the latest-develop Isaac Sim image. Install it explicitly for Pink IK.
-RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install nvidia-srl-usd-to-urdf
-
 # Install cuRobo from source (pinned commit); needs CUDA env and Torch
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation \
     "nvidia-curobo @ git+https://github.com/NVlabs/curobo.git@ebb71702f3f70e767f40fd8e050674af0288abe8"

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -157,6 +157,14 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog
 ENV PYTHONPATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle:${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib/python3.12/site-packages:${PYTHONPATH}"
 ENV LD_LIBRARY_PATH="${ISAACSIM_ROOT_PATH}/exts/isaacsim.robot_motion.pink/pip_prebundle/cmeel.prefix/lib:${LD_LIBRARY_PATH}"
 
+# HACK: nvidia-srl-usd-to-urdf was previously bundled in the Isaac Sim image but has
+# been removed. Install with --no-deps to avoid lxml<5 conflict with dex-retargeting.
+# Then symlink nvidia.srl into the ml_archive nvidia namespace so Python can find it
+# (the deprecated ml_archive prebundle shadows site-packages for the nvidia namespace).
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-deps nvidia-srl-usd-to-urdf \
+    && ln -s ${ISAACSIM_ROOT_PATH}/kit/python/lib/python3.12/site-packages/nvidia/srl \
+       ${ISAACSIM_ROOT_PATH}/extsDeprecated/omni.isaac.ml_archive/pip_prebundle/nvidia/srl
+
 # Install cuRobo from source (pinned commit); needs CUDA env and Torch
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation \
     "nvidia-curobo @ git+https://github.com/NVlabs/curobo.git@ebb71702f3f70e767f40fd8e050674af0288abe8"

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -66,6 +66,8 @@ INSTALL_REQUIRES += [
     # required by isaaclab.isaaclab.controllers.pink_ik
     f"pin-pink==3.1.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
     f"daqp==0.7.2 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
+    # required by isaaclab.isaaclab.controllers.utils (convert_usd_to_urdf)
+    f"nvidia-srl-usd-to-urdf ; ({SUPPORTED_ARCHS})",
     # required by isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1_t2_dex_retargeting_utils
     f"dex-retargeting==0.5.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
 ]

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -66,8 +66,6 @@ INSTALL_REQUIRES += [
     # required by isaaclab.isaaclab.controllers.pink_ik
     f"pin-pink==3.1.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
     f"daqp==0.7.2 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
-    # required by isaaclab.isaaclab.controllers.utils (convert_usd_to_urdf)
-    f"nvidia-srl-usd-to-urdf ; ({SUPPORTED_ARCHS})",
     # required by isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1_t2_dex_retargeting_utils
     f"dex-retargeting==0.5.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
 ]


### PR DESCRIPTION
# Description

The omni.isaac.ml_archive extension and nvidia.srl have been removed from the latest-develop Isaac Sim image, causing Docker builds to fail on the ln -s step. The symlink is no longer needed since nvidia.srl is no longer bundled in Kit python site-packages.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there