### PR TITLE
Replaces deprecated TiledCamera with Camera in visuotactile sensor

### DIFF
--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -12,6 +12,13 @@ Added
   joints with zero stiffness and damping receive a minimal stiffness so that
   backends like Newton recognise the drive as active.
 
+Fixed
+^^^^^
+
+* Fixed ``AttributeError`` in :meth:`Camera.__del__` when the constructor raised
+  before ``_renderer`` was assigned. Data attributes are now initialized early in
+  ``__init__`` so cleanup is always safe.
+
 
 4.6.0 (2026-04-13)
 ~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -116,6 +116,14 @@ class Camera(SensorBase):
         # initialize base class
         super().__init__(cfg)
 
+        # UsdGeom Camera prim for the sensor
+        self._sensor_prims: list[UsdGeom.Camera] = list()
+        # Create empty variables for storing output data
+        self._data = CameraData()
+        # Renderer and render data — assigned in _initialize_impl.
+        self._renderer: BaseRenderer | None = None
+        self._render_data = None
+
         # toggle rendering of rtx sensors as True
         # this flag is read by SimulationContext to determine if rtx sensors should be rendered
         settings = get_settings_manager()
@@ -151,14 +159,6 @@ class Camera(SensorBase):
         matching_prims = sim_utils.find_matching_prims(check_path)
         if len(matching_prims) == 0:
             raise RuntimeError(f"Could not find prim with path {check_path}.")
-
-        # UsdGeom Camera prim for the sensor
-        self._sensor_prims: list[UsdGeom.Camera] = list()
-        # Create empty variables for storing output data
-        self._data = CameraData()
-        # Renderer and render data — assigned in _initialize_impl.
-        self._renderer: BaseRenderer | None = None
-        self._render_data = None
 
         if not has_kit():
             return

--- a/source/isaaclab_contrib/config/extension.toml
+++ b/source/isaaclab_contrib/config/extension.toml
@@ -1,6 +1,6 @@
 [package]
 # Semantic Versioning is used: https://semver.org/
-version = "0.3.0"
+version = "0.3.1"
 
 # Description
 title =  "Isaac Lab External Contributions"

--- a/source/isaaclab_contrib/docs/CHANGELOG.rst
+++ b/source/isaaclab_contrib/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.3.1 (2026-04-14)
+~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Replaced deprecated :class:`~isaaclab.sensors.camera.TiledCamera` and
+  :class:`~isaaclab.sensors.camera.TiledCameraCfg` with :class:`~isaaclab.sensors.camera.Camera`
+  and :class:`~isaaclab.sensors.camera.CameraCfg` in the visuotactile sensor.
+
+
 0.3.0 (2026-02-13)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_contrib/docs/README.md
+++ b/source/isaaclab_contrib/docs/README.md
@@ -256,7 +256,7 @@ The TacSL tactile sensor system includes:
 
 ```python
 import isaaclab.sim as sim_utils
-from isaaclab.sensors import TiledCameraCfg
+from isaaclab.sensors import CameraCfg
 
 from isaaclab_contrib.sensors.tacsl_sensor import VisuoTactileSensorCfg
 
@@ -288,7 +288,7 @@ tactile_sensor_cfg = VisuoTactileSensorCfg(
     tangential_stiffness=0.1,        # Tangential stiffness
 
     # Camera configuration (must match render_cfg dimensions)
-    camera_cfg=TiledCameraCfg(
+    camera_cfg=CameraCfg(
         prim_path="{ENV_REGEX_NS}/Robot/elastomer_tip/cam",
         height=GELSIGHT_R15_CFG.image_height,
         width=GELSIGHT_R15_CFG.image_width,

--- a/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_sensor.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_sensor.py
@@ -20,7 +20,7 @@ from pxr import Usd, UsdGeom, UsdPhysics
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
 from isaaclab.markers import VisualizationMarkers
-from isaaclab.sensors.camera import Camera, TiledCamera
+from isaaclab.sensors.camera import Camera
 from isaaclab.sensors.sensor_base import SensorBase
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.math import quat_apply, quat_inv
@@ -66,7 +66,7 @@ class VisuoTactileSensor(SensorBase):
         The following requirements must be satisfied for proper sensor operation:
 
         **Camera Tactile Imaging**
-            If ``enable_camera_tactile=True``, a valid ``camera_cfg`` (TiledCameraCfg) must be
+            If ``enable_camera_tactile=True``, a valid ``camera_cfg`` (CameraCfg) must be
             provided with appropriate camera parameters.
 
         **Force Field Computation**
@@ -98,7 +98,7 @@ class VisuoTactileSensor(SensorBase):
         self._data: VisuoTactileSensorData = VisuoTactileSensorData()
 
         # Camera-based tactile sensing
-        self._camera_sensor: Camera | TiledCamera | None = None
+        self._camera_sensor: Camera | None = None
         self._nominal_tactile: dict | None = None
 
         # Force field tactile sensing
@@ -262,7 +262,7 @@ class VisuoTactileSensor(SensorBase):
         self._tactile_rgb_render = GelsightRender(self.cfg.render_cfg, device=self.device)
 
         # Create camera sensor
-        self._camera_sensor = TiledCamera(self.cfg.camera_cfg)
+        self._camera_sensor = Camera(self.cfg.camera_cfg)
 
         # Initialize camera
         if not self._camera_sensor.is_initialized:

--- a/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_sensor_cfg.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_sensor_cfg.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 from isaaclab.markers import VisualizationMarkersCfg
 from isaaclab.markers.config import VISUO_TACTILE_SENSOR_MARKER_CFG
-from isaaclab.sensors import SensorBaseCfg, TiledCameraCfg
+from isaaclab.sensors import CameraCfg, SensorBaseCfg
 from isaaclab.utils import configclass
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 
@@ -171,7 +171,7 @@ class VisuoTactileSensorCfg(SensorBaseCfg):
     tangential_stiffness: float = 0.1
     """Tangential stiffness for shear forces."""
 
-    camera_cfg: TiledCameraCfg | None = None
+    camera_cfg: CameraCfg | None = None
     """Camera configuration for tactile RGB/depth sensing.
 
     If None, camera-based sensing will be disabled even if :attr:`enable_camera_tactile` is True.

--- a/source/isaaclab_contrib/test/sensors/test_visuotactile_sensor.py
+++ b/source/isaaclab_contrib/test/sensors/test_visuotactile_sensor.py
@@ -25,7 +25,7 @@ import omni.replicator.core as rep
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import Articulation, ArticulationCfg, RigidObject, RigidObjectCfg
-from isaaclab.sensors.camera import TiledCameraCfg
+from isaaclab.sensors.camera import CameraCfg
 from isaaclab.terrains.trimesh.utils import make_plane
 from isaaclab.terrains.utils import create_prim_from_mesh
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
@@ -69,7 +69,7 @@ def get_sensor_cfg_by_type(sensor_type: str) -> VisuoTactileSensorCfg:
         return VisuoTactileSensorCfg(
             prim_path="/World/Robot/elastomer/tactile_cam",
             enable_force_field=False,
-            camera_cfg=TiledCameraCfg(
+            camera_cfg=CameraCfg(
                 height=320,
                 width=240,
                 prim_path="/World/Robot/elastomer_tip/cam",
@@ -89,7 +89,7 @@ def get_sensor_cfg_by_type(sensor_type: str) -> VisuoTactileSensorCfg:
             debug_vis=False,
             enable_camera_tactile=True,
             enable_force_field=True,
-            camera_cfg=TiledCameraCfg(
+            camera_cfg=CameraCfg(
                 height=320,
                 width=240,
                 prim_path="/World/Robot/elastomer_tip/cam",


### PR DESCRIPTION

# Description

TiledCamera was merged into Camera in #5162, leaving TiledCamera as a deprecated wrapper. The visuotactile sensor still used the old classes, which caused CI failures due to the extra deprecation layer interacting poorly with the refactored Camera renderer/Fabric initialization.

Also fix Camera.__del__ crash when __init__ raises before _renderer is assigned by moving data attribute initialization earlier in __init__.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there