### PR TITLE
Fix RTX color rendering disabled for albedo and simple-shading cameras

### DIFF
--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.16"
+version = "0.5.17"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.5.17 (2026-04-14)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_physx.renderers.IsaacRtxRenderer` incorrectly
+  disabling RTX color rendering for ``"albedo"`` and simple-shading camera
+  data types. This caused CUDA illegal memory access errors when using
+  camera environments with these data types.
+
 0.5.16 (2026-04-13)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -89,7 +89,12 @@ class IsaacRtxRenderer(BaseRenderer):
         isaac_sim_version = get_isaac_sim_version()
 
         if isaac_sim_version.major >= 6:
-            needs_color_render = "rgb" in sensor.cfg.data_types or "rgba" in sensor.cfg.data_types
+            needs_color_render = (
+                "rgb" in sensor.cfg.data_types
+                or "rgba" in sensor.cfg.data_types
+                or "albedo" in sensor.cfg.data_types
+                or any(dt in SIMPLE_SHADING_MODES for dt in sensor.cfg.data_types)
+            )
             if not needs_color_render:
                 settings.set_bool("/rtx/sdg/force/disableColorRender", True)
             if settings.get("/isaaclab/has_gui"):


### PR DESCRIPTION
# Description

The TiledCamera-to-Camera merge (b1aba48) moved a disableColorRender optimization into IsaacRtxRenderer.create_render_data. The old TiledCamera never had this optimization, so albedo and simple-shading camera types now incorrectly have color rendering disabled, causing CUDA illegal memory access when the annotator returns invalid buffers.

Expand the needs_color_render check to include "albedo" and simple-shading data types that also require RTX color rendering.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
