### PR TITLE
Update Visualizer CLI usage in doc to align with 3.0 behavior

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,6 +56,7 @@ Guidelines for modifications:
 * Ashwin Varghese Kuruttukulam
 * Bikram Pandit
 * Bingjie Tang
+* Bocheng Zou
 * Brayden Zhang
 * Brian Bingham
 * Brian McCann

--- a/docs/source/setup/installation/include/src_verify_isaaclab.rst
+++ b/docs/source/setup/installation/include/src_verify_isaaclab.rst
@@ -14,10 +14,10 @@ top of the repository:
 
          # Option 1: Using the isaaclab.sh executable
          # note: this works for both the bundled python and the virtual environment
-         ./isaaclab.sh -p scripts/tutorials/00_sim/create_empty.py
+         ./isaaclab.sh -p scripts/tutorials/00_sim/create_empty.py --viz kit
 
          # Option 2: Using python in your virtual environment
-         python scripts/tutorials/00_sim/create_empty.py
+         python scripts/tutorials/00_sim/create_empty.py --viz kit
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows
       :sync: windows
@@ -26,10 +26,10 @@ top of the repository:
 
          :: Option 1: Using the isaaclab.bat executable
          :: note: this works for both the bundled python and the virtual environment
-         isaaclab.bat -p scripts\tutorials\00_sim\create_empty.py
+         isaaclab.bat -p scripts\tutorials\00_sim\create_empty.py --viz kit
 
          :: Option 2: Using python in your virtual environment
-         python scripts\tutorials\00_sim\create_empty.py
+         python scripts\tutorials\00_sim\create_empty.py --viz kit
 
 
 The above command should launch the simulator and display a window with a black

--- a/docs/source/tutorials/00_sim/create_empty.rst
+++ b/docs/source/tutorials/00_sim/create_empty.rst
@@ -156,7 +156,7 @@ following:
 
 .. code-block:: bash
 
-   ./isaaclab.sh -p scripts/tutorials/00_sim/create_empty.py
+   ./isaaclab.sh -p scripts/tutorials/00_sim/create_empty.py --viz none
 
 
 Now that we have a basic understanding of how to run a simulation, let's move on to the

--- a/docs/source/tutorials/00_sim/create_empty.rst
+++ b/docs/source/tutorials/00_sim/create_empty.rst
@@ -139,7 +139,7 @@ Now that we have gone through the code, let's run the script and see the result:
 
 .. code-block:: bash
 
-   ./isaaclab.sh -p scripts/tutorials/00_sim/create_empty.py
+   ./isaaclab.sh -p scripts/tutorials/00_sim/create_empty.py --viz kit
 
 
 The simulation should be playing, and the stage should be rendering. To stop the simulation,
@@ -156,7 +156,7 @@ following:
 
 .. code-block:: bash
 
-   ./isaaclab.sh -p scripts/tutorials/00_sim/create_empty.py --headless
+   ./isaaclab.sh -p scripts/tutorials/00_sim/create_empty.py
 
 
 Now that we have a basic understanding of how to run a simulation, let's move on to the


### PR DESCRIPTION
# Description

According to https://isaac-sim.github.io/IsaacLab/develop/source/migration/migrating_to_isaaclab_3-0.html, IsaacLab 3.0 has deprecated the `--headless` parameter, and requires explicit `--viz` parameter to enable visualization. 

This update the command in the installation document to add `--viz` so that it can align with the later description

> The above command should launch the simulator and display a window with a black viewport.

## Type of change

- Documentation update

## Checklist

- [X] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [X] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
