### PR TITLE
ray can now find log_dir that has run name

### DIFF
--- a/scripts/reinforcement_learning/rsl_rl/train.py
+++ b/scripts/reinforcement_learning/rsl_rl/train.py
@@ -151,12 +151,10 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
     print(f"[INFO] Logging experiment in directory: {log_root_path}")
     # specify directory for logging runs: {time-stamp}_{run_name}
     log_dir = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    # The Ray Tune workflow extracts experiment name using the logging line below, hence, do not
-    # change it (see PR #2346, comment-2819298849)
     if agent_cfg.run_name:
         log_dir += f"_{agent_cfg.run_name}"
-
-    # so that ray can see logdir including agent_cfg.run_name!!
+    # The Ray Tune workflow extracts experiment name using the logging line below, hence, do not
+    # change it (see PR #2346, comment-2819298849)
     print(f"Exact experiment name requested from command line: {log_dir}")
 
     log_dir = os.path.join(log_root_path, log_dir)

--- a/scripts/reinforcement_learning/rsl_rl/train.py
+++ b/scripts/reinforcement_learning/rsl_rl/train.py
@@ -153,9 +153,12 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
     log_dir = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     # The Ray Tune workflow extracts experiment name using the logging line below, hence, do not
     # change it (see PR #2346, comment-2819298849)
-    print(f"Exact experiment name requested from command line: {log_dir}")
     if agent_cfg.run_name:
         log_dir += f"_{agent_cfg.run_name}"
+
+    # so that ray can see logdir including agent_cfg.run_name!!
+    print(f"Exact experiment name requested from command line: {log_dir}")
+
     log_dir = os.path.join(log_root_path, log_dir)
 
     # set the IO descriptors export flag if requested

--- a/scripts/reinforcement_learning/skrl/train.py
+++ b/scripts/reinforcement_learning/skrl/train.py
@@ -170,9 +170,9 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
     log_dir = datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + f"_{algorithm}_{args_cli.ml_framework}"
     # The Ray Tune workflow extracts experiment name using the logging line below, hence,
     # do not change it (see PR #2346, comment-2819298849)
-    print(f"Exact experiment name requested from command line: {log_dir}")
     if agent_cfg["agent"]["experiment"]["experiment_name"]:
         log_dir += f"_{agent_cfg['agent']['experiment']['experiment_name']}"
+    print(f"Exact experiment name requested from command line: {log_dir}")
     # set directory into agent config
     agent_cfg["agent"]["experiment"]["directory"] = log_root_path
     agent_cfg["agent"]["experiment"]["experiment_name"] = log_dir

--- a/scripts/reinforcement_learning/skrl/train.py
+++ b/scripts/reinforcement_learning/skrl/train.py
@@ -168,10 +168,10 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
     print(f"[INFO] Logging experiment in directory: {log_root_path}")
     # specify directory for logging runs: {time-stamp}_{run_name}
     log_dir = datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + f"_{algorithm}_{args_cli.ml_framework}"
-    # The Ray Tune workflow extracts experiment name using the logging line below, hence,
-    # do not change it (see PR #2346, comment-2819298849)
     if agent_cfg["agent"]["experiment"]["experiment_name"]:
         log_dir += f"_{agent_cfg['agent']['experiment']['experiment_name']}"
+    # The Ray Tune workflow extracts experiment name using the logging line below, hence,
+    # do not change it (see PR #2346, comment-2819298849)
     print(f"Exact experiment name requested from command line: {log_dir}")
     # set directory into agent config
     agent_cfg["agent"]["experiment"]["directory"] = log_root_path


### PR DESCRIPTION
# Description

This PR fixes a small issue in the `rsl_rl/train.py` script related to Ray Tune log directory detection when `agent_cfg.run_name` is provided.

Previously, the line

```python
print(f"Exact experiment name requested from command line: {log_dir}")
```

was executed before:

```python
if agent_cfg.run_name:
    log_dir += f"_{agent_cfg.run_name}"
```

As a result, when `run_name` was set, the printed experiment name did not match the actual final `log_dir`. Since the Ray Tune workflow parses this printed line to locate the log directory, Ray could fail to find the correct directory.

This PR moves the print statement to after the `run_name` suffix is appended, so the printed experiment name matches the actual log directory.

For example, if `run_name=seed_xx`, the final log directory becomes:

```text
YYYY-MM-DD_HH-MM-SS_seed_xx
```

and Ray can now correctly detect it.

Fixes # (issue)

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

* [x] I have read and understood the contribution guidelines
* [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
* [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
