### PR TITLE
Fix prebundle repoint across filesystem boundaries in Docker

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.6.1"
+version = "4.6.2"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+4.6.2 (2026-04-15)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed prebundle repoint failing in Docker builds with ``[Errno 18] Invalid
+  cross-device link``. Replaced ``Path.rename()`` with ``shutil.move()`` so the
+  backup step works across filesystem boundaries (e.g. overlay layers).
+
+
 4.6.1 (2026-04-14)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -377,7 +377,7 @@ def _repoint_prebundle_packages() -> None:
                     backup = prebundle_dir / f"{pkg_name}.bak"
                     if backup.exists() or backup.is_symlink():
                         shutil.rmtree(backup) if backup.is_dir() else backup.unlink()
-                    prebundled.rename(backup)
+                    shutil.move(str(prebundled), str(backup))
 
                 if use_symlinks:
                     prebundled.symlink_to(venv_pkg)


### PR DESCRIPTION
## Summary

* `Path.rename()` in `_repoint_prebundle_packages()` raises `EXDEV` (errno 18) in Docker overlay layers because the prebundled package lives on a lower read-only layer while the backup target is on the upper writable layer.
* Replaced with `shutil.move()` which falls back to copy+delete across mount points.
* This was causing repoint of `newton`, `mujoco_warp`, `torch`, and other prebundled packages to silently fail in Docker builds, allowing stale prebundled versions from the Isaac Sim base image to shadow the environment's installed versions.

**Root cause of Newton CI failures:** the `latest-develop` Isaac Sim image ships a newer newton with a breaking change in `solver_mujoco.py` (`geom_dataid` became 2D). The repoint mechanism was supposed to replace it with the pinned version, but failed silently due to this bug.

## Test plan

- [ ] Verify Docker + Tests CI passes (newton tests in particular)
- [ ] Verify the repoint log no longer shows `[Errno 18]` warnings during Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)