### PR TITLE
Fixes default shape margin field name in Newton manager

### DIFF
--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.15"
+version = "0.5.16"
 
 # Description
 title = "Newton simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_newton/docs/CHANGELOG.rst
+++ b/source/isaaclab_newton/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+0.5.16 (2026-04-17)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed incorrect attribute name ``contact_margin`` on Newton
+  ``ShapeConfig`` in
+  :meth:`~isaaclab_newton.physics.NewtonManager.create_builder`. The
+  field was renamed to ``gap`` in Newton PR #1732. The typo created a
+  dead attribute so the intended 1 cm default shape gap was never applied.
+
+
 0.5.15 (2026-04-16)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -426,10 +426,10 @@ class NewtonManager(PhysicsManager):
             **kwargs: Forwarded to :class:`ModelBuilder`.
 
         Returns:
-            New builder with up-axis and contact margin defaults applied.
+            New builder with up-axis and gap defaults applied.
         """
         builder = ModelBuilder(up_axis=up_axis or cls._up_axis, **kwargs)
-        builder.default_shape_cfg.contact_margin = 0.01
+        builder.default_shape_cfg.gap = 0.01
         return builder
 
     @classmethod


### PR DESCRIPTION
## Summary

Fix incorrect attribute name `contact_margin` → `gap` on Newton `ShapeConfig` in `NewtonManager.create_builder()`.

Newton PR #1732 renamed `contact_margin` to `gap` (broad-phase AABB expansion). The IsaacLab code was never updated, creating a dead attribute that Python silently accepted. The intended 1 cm default shape gap was never applied.

## Newton PR #1732 rename mapping

| Old field | New field | Semantics |
|-----------|-----------|-----------|
| `thickness` | `margin` | Shape surface extension (affects contact forces) |
| `contact_margin` | **`gap`** | Broad-phase AABB expansion (detection range only) |
| `rigid_contact_margin` | `rigid_gap` | Builder-level default gap (already 0.1) |

## Timeline

| Date | Newton | IsaacLab | `contact_margin` valid? |
|------|--------|----------|------------------------|
| Feb 19 | pin: `51ce35e` (has `contact_margin`) | #4646 adds `contact_margin = 0.01` | Yes |
| Feb 24 | **PR #1732 renames `contact_margin` → `gap`** | — | — |
| Mar 2 | pin updated to `v0.2.3` (after rename) | #4761 keeps `contact_margin` | **No — broken** |
| Mar 9 | — | #4883 removes the line | Removed |
| Apr 13 | — | #4822 re-adds `contact_margin` | **No — still broken** |

## Ablation: gap vs margin

We conducted an ablation study to understand the impact. Note: `margin` (shape surface
extension) is a different field from `gap` (broad-phase range). The original code intended
to set `gap`, but setting `margin` also has a significant positive effect on training for
rough terrain locomotion.

| Setting | `gap` | `margin` | Go1 Reward (300 iter) | Effect |
|---------|-------|----------|----------------------|--------|
| Dead field (baseline) | 0.1 (default) | 0.0 | ~1.0 | — |
| `gap=0.01` only | 0.01 | 0.0 | 0.66 | No training improvement |
| `margin=0.01` only | 0.1 (default) | 0.01 | 18.77 | Major improvement |
| `gap=0.01` + `margin=0.01` | 0.01 | 0.01 | 16.54 | Similar to margin-only |

**This PR fixes the correct field migration** (`contact_margin` → `gap`). The `margin` setting
for rough terrain contact quality will be addressed separately in the rough terrain env PR
(#5248) via a new `default_shape_margin` config field on `NewtonCfg`.

## Test plan

- [x] Verified `contact_margin` is not a field on `ShapeConfig` (Newton 1.1.0.dev0)
- [x] Verified `gap` is the correct replacement field per Newton PR #1732
- [x] Confirmed by camevor (Newton developer)
- [x] Ablation study: gap alone doesn't change training, so existing tests should pass