### PR TITLE
Pins Isaac Sim docker in postmerge-ci.yaml to the same commit as in build.yaml

### DIFF
--- a/.github/workflows/postmerge-ci.yml
+++ b/.github/workflows/postmerge-ci.yml
@@ -25,7 +25,7 @@ env:
   NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
   # On merge to main defaults will point to "nvcr.io/nvidia/isaac-sim:6.0.0"
   ISAACSIM_BASE_IMAGE: 'nvcr.io/nvidian/isaac-sim' # ${{ vars.ISAACSIM_BASE_IMAGE || 'nvcr.io/nvidia/isaac-sim' }}
-  ISAACSIM_BASE_VERSIONS_STRING: 'latest-develop@sha256:f085fb5b6899511bb19abdf18121bfc469901334aefb029d0def56d4fef79c58' # ${{ vars.ISAACSIM_BASE_VERSIONS_STRING || '6.0.0' }}
+  ISAACSIM_BASE_VERSIONS_STRING: 'latest-develop@sha256:f085fb5b6899511bb19abdf18121bfc469901334aefb029d0def56d4fef79c58' # Pinned to the Apr 8 nightly digest that last passed CI, while latest-develop is broken. TODO: Revert to 'latest-develop' once the nightly is fixed. # ${{ vars.ISAACSIM_BASE_VERSIONS_STRING || '6.0.0' }}
   ISAACLAB_IMAGE_NAME: ${{ vars.ISAACLAB_IMAGE_NAME || 'isaac-lab-base' }}
 
 jobs:

--- a/.github/workflows/postmerge-ci.yml
+++ b/.github/workflows/postmerge-ci.yml
@@ -25,7 +25,7 @@ env:
   NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
   # On merge to main defaults will point to "nvcr.io/nvidia/isaac-sim:6.0.0"
   ISAACSIM_BASE_IMAGE: 'nvcr.io/nvidian/isaac-sim' # ${{ vars.ISAACSIM_BASE_IMAGE || 'nvcr.io/nvidia/isaac-sim' }}
-  ISAACSIM_BASE_VERSIONS_STRING: 'latest-release-6-0' # ${{ vars.ISAACSIM_BASE_VERSIONS_STRING || '6.0.0' }}
+  ISAACSIM_BASE_VERSIONS_STRING: 'latest-develop@sha256:f085fb5b6899511bb19abdf18121bfc469901334aefb029d0def56d4fef79c58' # ${{ vars.ISAACSIM_BASE_VERSIONS_STRING || '6.0.0' }}
   ISAACLAB_IMAGE_NAME: ${{ vars.ISAACLAB_IMAGE_NAME || 'isaac-lab-base' }}
 
 jobs:


### PR DESCRIPTION
# Description

Pins the Isaac Sim docker image in postmerge-ci.yml to a same tag as in build.yaml.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
