### PR TITLE
Fixes Direct cartpole envs to use scene-config cloning path

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env.py
@@ -53,8 +53,6 @@ class CartpoleCameraEnv(DirectRLEnv):
         super().__init__(cfg, render_mode, **kwargs)
 
         self._cartpole = self.scene["robot"]
-        self._tiled_camera = TiledCamera(self.cfg.tiled_camera)
-        self.scene.sensors["tiled_camera"] = self._tiled_camera
 
         self._cart_dof_idx, _ = self._cartpole.find_joints(self.cfg.cart_dof_name)
         self._pole_dof_idx, _ = self._cartpole.find_joints(self.cfg.pole_dof_name)
@@ -74,8 +72,13 @@ class CartpoleCameraEnv(DirectRLEnv):
         super().close()
 
     def _setup_scene(self):
-        """Scene is set up from the scene config. Camera is added in __init__."""
-        pass
+        """Scene is set up from the scene config. Camera is added here.
+
+        The TiledCamera must be created before ``sim.reset()`` fires
+        ``PHYSICS_READY`` so it can register its initialization callback.
+        """
+        self._tiled_camera = TiledCamera(self.cfg.tiled_camera)
+        self.scene.sensors["tiled_camera"] = self._tiled_camera
 
     def _pre_physics_step(self, actions: torch.Tensor) -> None:
         self.actions = self.action_scale * actions.clone()

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env.py
@@ -12,8 +12,6 @@ from typing import TYPE_CHECKING
 import torch
 import warp as wp
 
-import isaaclab.sim as sim_utils
-from isaaclab.assets import Articulation
 from isaaclab.envs import DirectRLEnv
 from isaaclab.sensors import TiledCamera, save_images_to_file
 from isaaclab.utils.math import sample_uniform
@@ -54,6 +52,10 @@ class CartpoleCameraEnv(DirectRLEnv):
     ):
         super().__init__(cfg, render_mode, **kwargs)
 
+        self._cartpole = self.scene["robot"]
+        self._tiled_camera = TiledCamera(self.cfg.tiled_camera)
+        self.scene.sensors["tiled_camera"] = self._tiled_camera
+
         self._cart_dof_idx, _ = self._cartpole.find_joints(self.cfg.cart_dof_name)
         self._pole_dof_idx, _ = self._cartpole.find_joints(self.cfg.pole_dof_name)
         self.action_scale = self.cfg.action_scale
@@ -72,22 +74,8 @@ class CartpoleCameraEnv(DirectRLEnv):
         super().close()
 
     def _setup_scene(self):
-        """Setup the scene with the cartpole and camera."""
-        self._cartpole = Articulation(self.cfg.robot_cfg)
-        self._tiled_camera = TiledCamera(self.cfg.tiled_camera)
-
-        # clone and replicate
-        self.scene.clone_environments(copy_from_source=False)
-        if self.device == "cpu":
-            # we need to explicitly filter collisions for CPU simulation
-            self.scene.filter_collisions(global_prim_paths=[])
-
-        # add articulation and sensors to scene
-        self.scene.articulations["cartpole"] = self._cartpole
-        self.scene.sensors["tiled_camera"] = self._tiled_camera
-        # add lights
-        light_cfg = sim_utils.DomeLightCfg(intensity=2000.0, color=(0.75, 0.75, 0.75))
-        light_cfg.func("/World/Light", light_cfg)
+        """Scene is set up from the scene config. Camera is added in __init__."""
+        pass
 
     def _pre_physics_step(self, actions: torch.Tensor) -> None:
         self.actions = self.action_scale * actions.clone()

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_env_cfg.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import isaaclab.sim as sim_utils
-from isaaclab.assets import ArticulationCfg
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
 from isaaclab.envs import DirectRLEnvCfg, ViewerCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import TiledCameraCfg
@@ -16,6 +16,17 @@ from isaaclab.utils import configclass
 from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
 
 from isaaclab_assets.robots.cartpole import CARTPOLE_CFG
+
+
+@configclass
+class CartpoleCameraSceneCfg(InteractiveSceneCfg):
+    """Configuration for the cartpole camera scene."""
+
+    robot: ArticulationCfg = CARTPOLE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    dome_light = AssetBaseCfg(
+        prim_path="/World/DomeLight",
+        spawn=sim_utils.DomeLightCfg(intensity=2000.0, color=(0.75, 0.75, 0.75)),
+    )
 
 
 @configclass
@@ -29,7 +40,6 @@ class CartpoleRGBCameraEnvCfg(DirectRLEnvCfg):
     sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation)
 
     # robot
-    robot_cfg: ArticulationCfg = CARTPOLE_CFG.replace(prim_path="/World/envs/env_.*/Robot")
     cart_dof_name = "slider_to_cart"
     pole_dof_name = "cart_to_pole"
 
@@ -56,7 +66,7 @@ class CartpoleRGBCameraEnvCfg(DirectRLEnvCfg):
     viewer = ViewerCfg(eye=(20.0, 20.0, 20.0))
 
     # scene
-    scene: InteractiveSceneCfg = InteractiveSceneCfg(num_envs=512, env_spacing=20.0, replicate_physics=True)
+    scene: CartpoleCameraSceneCfg = CartpoleCameraSceneCfg(num_envs=512, env_spacing=20.0, replicate_physics=True)
 
     # reset
     max_cart_pos = 3.0  # the cart is reset if it exceeds that position [m]

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_presets_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_presets_env_cfg.py
@@ -9,7 +9,7 @@ from isaaclab_newton.physics import NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
-from isaaclab.assets import ArticulationCfg
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
 from isaaclab.envs import DirectRLEnvCfg, ViewerCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import TiledCameraCfg
@@ -56,6 +56,17 @@ class MultiDataTypeCartpoleTiledCameraCfg(PresetCfg):
 
 
 @configclass
+class CartpolePresetsSceneCfg(InteractiveSceneCfg):
+    """Configuration for the cartpole camera presets scene."""
+
+    robot: ArticulationCfg = CARTPOLE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    dome_light = AssetBaseCfg(
+        prim_path="/World/DomeLight",
+        spawn=sim_utils.DomeLightCfg(intensity=2000.0, color=(0.75, 0.75, 0.75)),
+    )
+
+
+@configclass
 class CartpoleCameraPresetsEnvCfg(PresetCfg):
     @configclass
     class BaseCartpoleCameraEnvCfg(DirectRLEnvCfg):
@@ -68,7 +79,6 @@ class CartpoleCameraPresetsEnvCfg(PresetCfg):
         sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=PhysicsCfg())
 
         # robot
-        robot_cfg: ArticulationCfg = CARTPOLE_CFG.replace(prim_path="/World/envs/env_.*/Robot")
         cart_dof_name = "slider_to_cart"
         pole_dof_name = "cart_to_pole"
 
@@ -85,7 +95,7 @@ class CartpoleCameraPresetsEnvCfg(PresetCfg):
         viewer = ViewerCfg(eye=(20.0, 20.0, 20.0))
 
         # scene
-        scene: InteractiveSceneCfg = InteractiveSceneCfg(num_envs=512, env_spacing=20.0, replicate_physics=True)
+        scene: CartpolePresetsSceneCfg = CartpolePresetsSceneCfg(num_envs=512, env_spacing=20.0, replicate_physics=True)
 
         # reset
         max_cart_pos = 3.0  # the cart is reset if it exceeds that position [m]

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env.py
@@ -12,10 +12,7 @@ from typing import TYPE_CHECKING
 import torch
 import warp as wp
 
-import isaaclab.sim as sim_utils
-from isaaclab.assets import Articulation
 from isaaclab.envs import DirectRLEnv
-from isaaclab.sim.spawners.from_files import GroundPlaneCfg, spawn_ground_plane
 from isaaclab.utils.math import sample_uniform
 
 if TYPE_CHECKING:
@@ -28,6 +25,7 @@ class CartpoleEnv(DirectRLEnv):
     def __init__(self, cfg: CartpoleEnvCfg, render_mode: str | None = None, **kwargs):
         super().__init__(cfg, render_mode, **kwargs)
 
+        self.cartpole = self.scene["robot"]
         self._cart_dof_idx, _ = self.cartpole.find_joints(self.cfg.cart_dof_name)
         self._pole_dof_idx, _ = self.cartpole.find_joints(self.cfg.pole_dof_name)
         self.action_scale = self.cfg.action_scale
@@ -36,19 +34,8 @@ class CartpoleEnv(DirectRLEnv):
         self.joint_vel = wp.to_torch(self.cartpole.data.joint_vel)
 
     def _setup_scene(self):
-        self.cartpole = Articulation(self.cfg.robot_cfg)
-        # add ground plane
-        spawn_ground_plane(prim_path="/World/ground", cfg=GroundPlaneCfg())
-        # clone and replicate
-        self.scene.clone_environments(copy_from_source=False)
-        # we need to explicitly filter collisions for CPU simulation
-        if self.device == "cpu":
-            self.scene.filter_collisions(global_prim_paths=[])
-        # add articulation to scene
-        self.scene.articulations["cartpole"] = self.cartpole
-        # add lights
-        light_cfg = sim_utils.DomeLightCfg(intensity=2000.0, color=(0.75, 0.75, 0.75))
-        light_cfg.func("/World/Light", light_cfg)
+        """Scene is set up from the scene config."""
+        pass
 
     def _pre_physics_step(self, actions: torch.Tensor) -> None:
         self.actions = self.action_scale * actions.clone()

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_env_cfg.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
-from isaaclab.assets import ArticulationCfg
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
 from isaaclab.envs import DirectRLEnvCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
@@ -38,6 +39,21 @@ class CartpolePhysicsCfg(PresetCfg):
 
 
 @configclass
+class CartpoleSceneCfg(InteractiveSceneCfg):
+    """Configuration for the cartpole scene."""
+
+    robot: ArticulationCfg = CARTPOLE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    ground = AssetBaseCfg(
+        prim_path="/World/ground",
+        spawn=sim_utils.GroundPlaneCfg(size=(100.0, 100.0)),
+    )
+    dome_light = AssetBaseCfg(
+        prim_path="/World/DomeLight",
+        spawn=sim_utils.DomeLightCfg(intensity=2000.0, color=(0.75, 0.75, 0.75)),
+    )
+
+
+@configclass
 class CartpoleEnvCfg(DirectRLEnvCfg):
     # env
     decimation = 2
@@ -51,12 +67,11 @@ class CartpoleEnvCfg(DirectRLEnvCfg):
     sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=CartpolePhysicsCfg())
 
     # robot
-    robot_cfg: ArticulationCfg = CARTPOLE_CFG.replace(prim_path="/World/envs/env_.*/Robot")
     cart_dof_name = "slider_to_cart"
     pole_dof_name = "cart_to_pole"
 
     # scene
-    scene: InteractiveSceneCfg = InteractiveSceneCfg(
+    scene: CartpoleSceneCfg = CartpoleSceneCfg(
         num_envs=4096, env_spacing=4.0, replicate_physics=True, clone_in_fabric=True
     )
 


### PR DESCRIPTION
# Description

Move robot, ground plane, and light definitions from manual _setup_scene into scene config dataclasses so the InteractiveScene uses the template-based cloning path (clone_from_template). The legacy cloning path produces a PhysX simulation where joint actuation forces are silently ineffective on the cartpole's prismatic joint.

Hacks around #5302

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there