### PR TITLE
fix: correct inverted preserve_order docstring in resolve_matching_names functions

### DIFF
--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -183,10 +183,10 @@ def resolve_matching_names(
     When a list of query regular expressions is provided, the function checks each target string against each
     query regular expression and returns the indices of the matched strings and the matched strings.
 
-If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
+        If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
     of the provided list of query regular expressions.
 
-    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
+        If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
     of the provided list of strings. This means that the ordering is dictated by the order of the target strings
     and not the order of the query regular expressions.
 
@@ -281,11 +281,11 @@ def resolve_matching_names_values(
     the matched indices, names, and values.
 
     If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
-    of the provided list of strings. This means that the ordering is dictated by the order of the target strings
-    and not the order of the query regular expressions.
+    of the provided list of query regular expressions.
 
     If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
-    of the provided list of query regular expressions.
+    of the provided list of strings. This means that the ordering is dictated by the order of the target strings
+    and not the order of the query regular expressions.
 
     For example, consider the dictionary is {"a|d|e": 1, "b|c": 2}, the list of strings is ['a', 'b', 'c', 'd', 'e'].
     If :attr:`preserve_order` is False, then the function will return the indices of the matched strings, the

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -183,12 +183,12 @@ def resolve_matching_names(
     When a list of query regular expressions is provided, the function checks each target string against each
     query regular expression and returns the indices of the matched strings and the matched strings.
 
-    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
-    of the provided list of strings. This means that the ordering is dictated by the order of the target strings
-    and not the order of the query regular expressions.
+If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
+    of the provided list of query regular expressions.
 
     If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
-    of the provided list of query regular expressions.
+    of the provided list of strings. This means that the ordering is dictated by the order of the target strings
+    and not the order of the query regular expressions.
 
     For example, consider the list of strings is ['a', 'b', 'c', 'd', 'e'] and the regular expressions are ['a|c', 'b'].
     If :attr:`preserve_order` is False, then the function will return the indices of the matched strings and the


### PR DESCRIPTION
## Description
The `preserve_order` parameter descriptions were inverted in the docstrings
of `resolve_matching_names` and `resolve_matching_names_values` in
`source/isaaclab/isaaclab/utils/string.py`.

The code logic and examples were already correct — only the prose descriptions
were swapped.

Fixes #5146

## Type of change
- Documentation update

## Checklist
- [x] I have read and understood the contribution guidelines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings