### PR TITLE
Add agentic installation guide to AGENTS.md

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -101,6 +101,7 @@ jobs:
           --exclude 'huggingface\.co/nvidia/X-Mobility'
           --exclude 'openusd\.org'
           --exclude 'ubuntu\.com/server/docs'
+          --exclude 'docs\.conda\.io'
           --max-retries 5
           --retry-wait-time 10
           --timeout 20

--- a/.github/workflows/license-exceptions.json
+++ b/.github/workflows/license-exceptions.json
@@ -492,5 +492,10 @@
     "package": "omniverseclient",
     "license": "NVIDIA Proprietary Software, https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-software-license-agreement/",
     "comment": "NVIDIA"
+  },
+  {
+    "package": "ovphysx",
+    "license": "LicenseRef-NVIDIA-Omniverse",
+    "comment": "NVIDIA"
   }
 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,46 @@
 # IsaacLab Guidelines
 
+## Installation (agentic setup)
+
+Isaac Lab can run **without Isaac Sim** using the Newton physics backend.
+This is the fastest path to a working environment.
+
+Follow the steps in `docs/source/setup/quick_installation.rst` to install.
+The short version: install uv, clone the repo, run `./isaaclab.sh -u` to
+create the environment, activate it, then `./isaaclab.sh -i` to install.
+
+### Verify
+
+```bash
+./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+  --task Isaac-Cartpole-Direct-v0 --num_envs 1024 --max_iterations 50 \
+  presets=newton
+```
+
+**Expected:** mean reward climbs to ~290, episode length reaches ~295
+(max 300). Training completes in <60s. First run is slower (~90s) due
+to one-time Warp kernel compilation and CUDA graph capture.
+
+### Common automation mistakes
+
+| Mistake | Consequence | Correct approach |
+|---------|------------|------------------|
+| `uv pip install torch` before `--install` | Wrong CUDA build tag | Let `./isaaclab.sh --install` handle PyTorch |
+| `uv venv env_isaaclab` manually | Missing Python version pin and activation hooks | Use `./isaaclab.sh -u` |
+| Cherry-picking submodules (`--install newton,tasks`) | `ModuleNotFoundError` from implicit cross-deps | Use `--install` (installs all submodules) |
+| Writing a custom test script | Misses Hydra config resolution, fragile | Use the existing `rsl_rl/train.py` |
+| Omitting `presets=newton` | `No module named 'omni.physics'` | Required when Isaac Sim is not installed |
+| `pip3 install uv` | Stale version | Use official installer: `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+
+### Adding Isaac Sim (optional)
+
+Only needed for PhysX, RTX rendering, cameras, or ROS integration:
+
+```bash
+export OMNI_KIT_ACCEPT_EULA=y   # required — process hangs without it
+./isaaclab.sh --install isaacsim
+```
+
 ## Breaking API changes
 
 - **Breaking changes require a deprecation first.** Do not remove or rename public API symbols without deprecating them in a prior release.

--- a/docs/source/setup/quick_installation.rst
+++ b/docs/source/setup/quick_installation.rst
@@ -14,9 +14,11 @@ Quick Installation
    git clone https://github.com/isaac-sim/IsaacLab.git
    cd IsaacLab
 
-   # Create environment and install
-   uv venv .venv --python 3.12
-   source .venv/bin/activate
+   # Create environment (pins Python 3.12, adds activation hooks)
+   ./isaaclab.sh -u
+   source env_isaaclab/bin/activate
+
+   # Install all submodules + RL frameworks
    ./isaaclab.sh -i
 
    # Run training (Newton backend, 16 envs)


### PR DESCRIPTION
## Summary
- Adds an installation section to `AGENTS.md` with agent-specific guidance: verification expectations with quantitative thresholds, a common automation mistakes table, and the `OMNI_KIT_ACCEPT_EULA` environment variable warning.
- `AGENTS.md` references `quick_installation.rst` for canonical install steps instead of duplicating them, reducing maintenance burden.
- Updates `quick_installation.rst` to use `./isaaclab.sh -u` instead of manual `uv venv` creation, which pins Python 3.12 and adds activation hooks — aligning with the recommended approach already documented in other installation guides.

## Test plan
- [x] Clean clone from this branch, followed updated `quick_installation.rst` steps exactly
- [x] `./isaaclab.sh -u` created env with Python 3.12
- [x] `./isaaclab.sh -i` installed all 14 submodules + RL frameworks
- [x] Verification training (`Isaac-Cartpole-Direct-v0`, 1024 envs, 50 iterations, Newton backend) completed in ~8s on L40 GPU with mean reward ~290 and episode length ~295, matching documented expectations