### PR TITLE
Improves debugging experience for cfg logging

### DIFF
--- a/scripts/reinforcement_learning/rl_games/train.py
+++ b/scripts/reinforcement_learning/rl_games/train.py
@@ -137,9 +137,6 @@ def main():
         wandb_project = config_name if args_cli.wandb_project_name is None else args_cli.wandb_project_name
         experiment_name = log_dir if args_cli.wandb_name is None else args_cli.wandb_name
 
-        # dump the configuration into log-directory
-        dump_yaml(os.path.join(log_root_path, log_dir, "params", "env.yaml"), env_cfg)
-        dump_yaml(os.path.join(log_root_path, log_dir, "params", "agent.yaml"), agent_cfg)
         print(f"Exact experiment name requested from command line: {os.path.join(log_root_path, log_dir)}")
 
         # read configurations about the agent-training
@@ -163,6 +160,11 @@ def main():
 
         # create isaac environment
         env = gym.make(args_cli.task, cfg=env_cfg, render_mode="rgb_array" if args_cli.video else None)
+
+        # dump the configuration into log-directory (after gym.make so
+        # resolved values from __post_init__ and env setup are captured)
+        dump_yaml(os.path.join(log_root_path, log_dir, "params", "env.yaml"), env_cfg)
+        dump_yaml(os.path.join(log_root_path, log_dir, "params", "agent.yaml"), agent_cfg)
 
         # convert to single-agent instance if required by the RL algorithm
         if isinstance(env.unwrapped.cfg, DirectMARLEnvCfg):

--- a/scripts/reinforcement_learning/sb3/train.py
+++ b/scripts/reinforcement_learning/sb3/train.py
@@ -113,9 +113,6 @@ def main():
         print(f"[INFO] Logging experiment in directory: {log_root_path}")
         print(f"Exact experiment name requested from command line: {run_info}")
         log_dir = os.path.join(log_root_path, run_info)
-        # dump the configuration into log-directory
-        dump_yaml(os.path.join(log_dir, "params", "env.yaml"), env_cfg)
-        dump_yaml(os.path.join(log_dir, "params", "agent.yaml"), agent_cfg)
 
         # save command used to run the script
         command = " ".join(sys.orig_argv)
@@ -141,6 +138,11 @@ def main():
 
         # create isaac environment
         env = gym.make(args_cli.task, cfg=env_cfg, render_mode="rgb_array" if args_cli.video else None)
+
+        # dump the configuration into log-directory (after gym.make so
+        # resolved values from __post_init__ and env setup are captured)
+        dump_yaml(os.path.join(log_dir, "params", "env.yaml"), env_cfg)
+        dump_yaml(os.path.join(log_dir, "params", "agent.yaml"), agent_cfg)
 
         # convert to single-agent instance if required by the RL algorithm
         if isinstance(env.unwrapped.cfg, DirectMARLEnvCfg):

--- a/scripts/reinforcement_learning/skrl/train.py
+++ b/scripts/reinforcement_learning/skrl/train.py
@@ -161,10 +161,6 @@ def main():
         agent_cfg["agent"]["experiment"]["experiment_name"] = log_dir
         log_dir = os.path.join(log_root_path, log_dir)
 
-        # dump the configuration into log-directory
-        dump_yaml(os.path.join(log_dir, "params", "env.yaml"), env_cfg)
-        dump_yaml(os.path.join(log_dir, "params", "agent.yaml"), agent_cfg)
-
         # get checkpoint path (to resume training)
         resume_path = retrieve_file_path(args_cli.checkpoint) if args_cli.checkpoint else None
 
@@ -182,6 +178,11 @@ def main():
 
         # create isaac environment
         env = gym.make(args_cli.task, cfg=env_cfg, render_mode="rgb_array" if args_cli.video else None)
+
+        # dump the configuration into log-directory (after gym.make so
+        # resolved values from __post_init__ and env setup are captured)
+        dump_yaml(os.path.join(log_dir, "params", "env.yaml"), env_cfg)
+        dump_yaml(os.path.join(log_dir, "params", "agent.yaml"), agent_cfg)
 
         # convert to single-agent instance if required by the RL algorithm
         if isinstance(env.unwrapped.cfg, DirectMARLEnvCfg) and algorithm in ["ppo"]:

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -14,19 +14,16 @@ Added
   a ``FutureWarning`` because this path is temporary until neutral USD materials
   replace OmniPBR in content.
 * Added ``test_newton_model_utils`` tests for the Newton shape color pass.
-* Added :meth:`~isaaclab.utils.configclass.post_init_diff` method to all
-  ``@configclass`` instances, returning a dict of scalar fields changed by
-  ``__post_init__``.  Helps users discover silent config overrides.
 * Added debug-level logging of the ``__post_init__`` call chain in
   ``@configclass`` so that ``ISAACLAB_LOG_LEVEL=DEBUG`` reveals which classes
   modify fields during initialization.
-* Added automatic dump of the fully-resolved env config to
-  ``<log_dir>/params/resolved_env.yaml`` from
-  :class:`~isaaclab.envs.ManagerBasedEnv`,
+* Added :func:`~isaaclab.utils.io.dump_resolved_cfg` standalone utility for
+  writing ``<log_dir>/params/resolved_env.yaml``.  All env base classes
+  (:class:`~isaaclab.envs.ManagerBasedEnv`,
   :class:`~isaaclab.envs.DirectRLEnv`, and
-  :class:`~isaaclab.envs.DirectMARLEnv` at the end of ``__init__``.  This
-  gives users a single source of truth for the values the environment actually
-  uses.
+  :class:`~isaaclab.envs.DirectMARLEnv`) now call this at the end of
+  ``__init__``, giving users a single source of truth for the values the
+  environment actually uses.
 
 Changed
 ^^^^^^^

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -14,6 +14,27 @@ Added
   a ``FutureWarning`` because this path is temporary until neutral USD materials
   replace OmniPBR in content.
 * Added ``test_newton_model_utils`` tests for the Newton shape color pass.
+* Added :meth:`~isaaclab.utils.configclass.post_init_diff` method to all
+  ``@configclass`` instances, returning a dict of scalar fields changed by
+  ``__post_init__``.  Helps users discover silent config overrides.
+* Added debug-level logging of the ``__post_init__`` call chain in
+  ``@configclass`` so that ``ISAACLAB_LOG_LEVEL=DEBUG`` reveals which classes
+  modify fields during initialization.
+* Added automatic dump of the fully-resolved env config to
+  ``<log_dir>/params/resolved_env.yaml`` from
+  :class:`~isaaclab.envs.ManagerBasedEnv`,
+  :class:`~isaaclab.envs.DirectRLEnv`, and
+  :class:`~isaaclab.envs.DirectMARLEnv` at the end of ``__init__``.  This
+  gives users a single source of truth for the values the environment actually
+  uses.
+
+Changed
+^^^^^^^
+
+* Changed ``dump_yaml`` calls in ``sb3/train.py``, ``skrl/train.py``, and
+  ``rl_games/train.py`` training scripts to execute **after** ``gym.make()``
+  instead of before, so that ``params/env.yaml`` reflects all
+  ``__post_init__`` and env-construction-time mutations.
 
 Fixed
 ^^^^^

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -28,6 +28,7 @@ from isaaclab.scene import InteractiveScene
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils.stage import use_stage
 from isaaclab.utils.configclass import resolve_cfg_presets
+from isaaclab.utils.io import dump_yaml
 from isaaclab.utils.noise import NoiseModel
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
@@ -248,6 +249,11 @@ class DirectMARLEnv(gym.Env):
             if "startup" in self.event_manager.available_modes:
                 self.event_manager.apply(mode="startup")
         self.has_rtx_sensors = self.sim.get_setting("/isaaclab/render/rtx_sensors")
+
+        # dump the fully-resolved env config so users have a single source of
+        # truth for what values the environment is actually using
+        self._dump_resolved_cfg()
+
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
 
@@ -603,6 +609,24 @@ class DirectMARLEnv(gym.Env):
     """
     Helper functions.
     """
+
+    def _dump_resolved_cfg(self):
+        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
+
+        This runs after all ``__post_init__`` hooks, preset resolution, and
+        any training-script mutations, giving users a single source of truth
+        for the values the environment actually uses.
+        """
+        import os
+
+        if self.cfg.log_dir is None:
+            return
+        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
+        try:
+            dump_yaml(resolved_path, self.cfg)
+            logger.info("Resolved env config written to %s", resolved_path)
+        except Exception:
+            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _configure_env_spaces(self):
         """Configure the spaces for the environment."""

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -28,7 +28,7 @@ from isaaclab.scene import InteractiveScene
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils.stage import use_stage
 from isaaclab.utils.configclass import resolve_cfg_presets
-from isaaclab.utils.io import dump_yaml
+from isaaclab.utils.io import dump_resolved_cfg
 from isaaclab.utils.noise import NoiseModel
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
@@ -250,9 +250,7 @@ class DirectMARLEnv(gym.Env):
                 self.event_manager.apply(mode="startup")
         self.has_rtx_sensors = self.sim.get_setting("/isaaclab/render/rtx_sensors")
 
-        # dump the fully-resolved env config so users have a single source of
-        # truth for what values the environment is actually using
-        self._dump_resolved_cfg()
+        dump_resolved_cfg(self.cfg, getattr(self.cfg, "log_dir", None), logger)
 
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
@@ -609,24 +607,6 @@ class DirectMARLEnv(gym.Env):
     """
     Helper functions.
     """
-
-    def _dump_resolved_cfg(self):
-        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
-
-        This runs after all ``__post_init__`` hooks, preset resolution, and
-        any training-script mutations, giving users a single source of truth
-        for the values the environment actually uses.
-        """
-        import os
-
-        if self.cfg.log_dir is None:
-            return
-        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
-        try:
-            dump_yaml(resolved_path, self.cfg)
-            logger.info("Resolved env config written to %s", resolved_path)
-        except Exception:
-            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _configure_env_spaces(self):
         """Configure the spaces for the environment."""

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -24,6 +24,7 @@ from isaaclab.scene import InteractiveScene
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils.stage import use_stage
 from isaaclab.utils.configclass import resolve_cfg_presets
+from isaaclab.utils.io import dump_yaml
 from isaaclab.utils.noise import NoiseModel
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
@@ -269,6 +270,10 @@ class DirectRLEnv(gym.Env):
             )
             if self.cfg.num_rerenders_on_reset == 0:
                 self.cfg.num_rerenders_on_reset = 1
+
+        # dump the fully-resolved env config so users have a single source of
+        # truth for what values the environment is actually using
+        self._dump_resolved_cfg()
 
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
@@ -572,6 +577,24 @@ class DirectRLEnv(gym.Env):
     """
     Helper functions.
     """
+
+    def _dump_resolved_cfg(self):
+        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
+
+        This runs after all ``__post_init__`` hooks, preset resolution, and
+        any training-script mutations, giving users a single source of truth
+        for the values the environment actually uses.
+        """
+        import os
+
+        if self.cfg.log_dir is None:
+            return
+        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
+        try:
+            dump_yaml(resolved_path, self.cfg)
+            logger.info("Resolved env config written to %s", resolved_path)
+        except Exception:
+            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _configure_gym_env_spaces(self):
         """Configure the action and observation spaces for the Gym environment."""

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -24,7 +24,7 @@ from isaaclab.scene import InteractiveScene
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils.stage import use_stage
 from isaaclab.utils.configclass import resolve_cfg_presets
-from isaaclab.utils.io import dump_yaml
+from isaaclab.utils.io import dump_resolved_cfg
 from isaaclab.utils.noise import NoiseModel
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
@@ -271,9 +271,7 @@ class DirectRLEnv(gym.Env):
             if self.cfg.num_rerenders_on_reset == 0:
                 self.cfg.num_rerenders_on_reset = 1
 
-        # dump the fully-resolved env config so users have a single source of
-        # truth for what values the environment is actually using
-        self._dump_resolved_cfg()
+        dump_resolved_cfg(self.cfg, getattr(self.cfg, "log_dir", None), logger)
 
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
@@ -577,24 +575,6 @@ class DirectRLEnv(gym.Env):
     """
     Helper functions.
     """
-
-    def _dump_resolved_cfg(self):
-        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
-
-        This runs after all ``__post_init__`` hooks, preset resolution, and
-        any training-script mutations, giving users a single source of truth
-        for the values the environment actually uses.
-        """
-        import os
-
-        if self.cfg.log_dir is None:
-            return
-        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
-        try:
-            dump_yaml(resolved_path, self.cfg)
-            logger.info("Resolved env config written to %s", resolved_path)
-        except Exception:
-            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _configure_gym_env_spaces(self):
         """Configure the action and observation spaces for the Gym environment."""

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -19,6 +19,7 @@ from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils.stage import use_stage
 from isaaclab.ui.widgets import ManagerLiveVisualizer
 from isaaclab.utils.configclass import resolve_cfg_presets
+from isaaclab.utils.io import dump_yaml
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
 
@@ -240,6 +241,10 @@ class ManagerBasedEnv:
             )
             if self.cfg.num_rerenders_on_reset == 0:
                 self.cfg.num_rerenders_on_reset = 1
+
+        # dump the fully-resolved env config so users have a single source of
+        # truth for what values the environment is actually using
+        self._dump_resolved_cfg()
 
     def __del__(self):
         """Cleanup for the environment."""
@@ -582,6 +587,24 @@ class ManagerBasedEnv:
     """
     Helper functions.
     """
+
+    def _dump_resolved_cfg(self):
+        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
+
+        This runs after all ``__post_init__`` hooks, preset resolution, and
+        any training-script mutations, giving users a single source of truth
+        for the values the environment actually uses.
+        """
+        import os
+
+        if self.cfg.log_dir is None:
+            return
+        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
+        try:
+            dump_yaml(resolved_path, self.cfg)
+            logger.info("Resolved env config written to %s", resolved_path)
+        except Exception:
+            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _reset_idx(self, env_ids: Sequence[int]):
         """Reset environments based on specified indices.

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -19,7 +19,7 @@ from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils.stage import use_stage
 from isaaclab.ui.widgets import ManagerLiveVisualizer
 from isaaclab.utils.configclass import resolve_cfg_presets
-from isaaclab.utils.io import dump_yaml
+from isaaclab.utils.io import dump_resolved_cfg
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
 
@@ -242,9 +242,7 @@ class ManagerBasedEnv:
             if self.cfg.num_rerenders_on_reset == 0:
                 self.cfg.num_rerenders_on_reset = 1
 
-        # dump the fully-resolved env config so users have a single source of
-        # truth for what values the environment is actually using
-        self._dump_resolved_cfg()
+        dump_resolved_cfg(self.cfg, getattr(self.cfg, "log_dir", None), logger)
 
     def __del__(self):
         """Cleanup for the environment."""
@@ -587,24 +585,6 @@ class ManagerBasedEnv:
     """
     Helper functions.
     """
-
-    def _dump_resolved_cfg(self):
-        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
-
-        This runs after all ``__post_init__`` hooks, preset resolution, and
-        any training-script mutations, giving users a single source of truth
-        for the values the environment actually uses.
-        """
-        import os
-
-        if self.cfg.log_dir is None:
-            return
-        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
-        try:
-            dump_yaml(resolved_path, self.cfg)
-            logger.info("Resolved env config written to %s", resolved_path)
-        except Exception:
-            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _reset_idx(self, env_ids: Sequence[int]):
         """Reset environments based on specified indices.

--- a/source/isaaclab/isaaclab/utils/configclass.py
+++ b/source/isaaclab/isaaclab/utils/configclass.py
@@ -6,6 +6,7 @@
 """Sub-module that provides a wrapper around the Python 3.7 onwards ``dataclasses`` module."""
 
 import inspect
+import logging
 import re
 import types
 from collections.abc import Callable
@@ -16,10 +17,12 @@ from typing import Any, ClassVar
 from .dict import class_to_dict, update_class_from_dict
 from .string import ResolvableString
 
+_logger = logging.getLogger(__name__)
+
 _CALLABLE_STR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_\\.]*:[A-Za-z_][A-Za-z0-9_]*$")
 _CALLABLE_STR_WITH_DIR_RE = re.compile(r"^\{DIR\}(?:\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_]*$")
 
-_CONFIGCLASS_METHODS = ["to_dict", "from_dict", "replace", "copy", "validate"]
+_CONFIGCLASS_METHODS = ["to_dict", "from_dict", "replace", "copy", "validate", "post_init_diff"]
 """List of class methods added at runtime to dataclass."""
 
 """
@@ -110,6 +113,7 @@ def configclass(cls, **kwargs):
     setattr(cls, "replace", _replace_class_with_kwargs)
     setattr(cls, "copy", _copy_class)
     setattr(cls, "validate", _validate)
+    setattr(cls, "post_init_diff", _post_init_diff)
     # wrap around dataclass
     cls = dataclass(cls, **kwargs)
     # return wrapped class
@@ -478,6 +482,7 @@ def _custom_post_init(obj):
     proxy type i.e. a read only proxy for mapping objects. The error is thrown when using hierarchical data-classes
     for configuration.
     """
+    _logger.debug("Running _custom_post_init for %s", type(obj).__name__)
     for key in dir(obj):
         # skip dunder members
         if key.startswith("__"):
@@ -493,20 +498,30 @@ def _custom_post_init(obj):
 
 
 def _combined_function(f1: Callable, f2: Callable) -> Callable:
-    """Combine two functions into one.
+    """Combine a user ``__post_init__`` with the configclass deep-copy hook.
+
+    Before *f1* (the user hook) runs, a shallow snapshot of every scalar/tuple
+    field is taken.  After both hooks finish, the snapshot is stored on the
+    object so that :meth:`post_init_diff` can report which fields were silently
+    changed by ``__post_init__``.
 
     Args:
-        f1: The first function.
-        f2: The second function.
+        f1: The user-defined ``__post_init__``.
+        f2: The configclass ``_custom_post_init`` (deep-copy + ResolvableString wrapping).
 
     Returns:
         The combined function.
     """
 
     def _combined(*args, **kwargs):
-        # call both functions
+        obj = args[0]
+        # Snapshot scalar / tuple field values before the user hook runs.
+        before = _snapshot_fields(obj)
+        _logger.debug("Running __post_init__ for %s", type(obj).__name__)
         f1(*args, **kwargs)
         f2(*args, **kwargs)
+        after = _snapshot_fields(obj)
+        obj.__post_init_field_diff__ = _compute_field_diff(before, after)
 
     return _combined
 
@@ -590,6 +605,53 @@ def _return_f(f: Any) -> Callable[[], Any]:
             return deepcopy(f)
 
     return _wrap
+
+
+"""
+Post-init diff helpers.
+"""
+
+
+def _snapshot_fields(obj: object, prefix: str = "") -> dict[str, Any]:
+    """Capture a flat ``{dotted.path: value}`` snapshot of scalar and tuple fields.
+
+    Nested configclass objects are walked recursively so that changes at any
+    depth are captured.
+    """
+    snap: dict[str, Any] = {}
+    for key in list(getattr(obj, "__dataclass_fields__", {})):
+        value = getattr(obj, key, MISSING)
+        if value is MISSING:
+            continue
+        full_key = f"{prefix}{key}"
+        if hasattr(value, "__dataclass_fields__"):
+            snap.update(_snapshot_fields(value, prefix=f"{full_key}."))
+        elif isinstance(value, (int, float, bool, str, type(None), tuple)):
+            snap[full_key] = value
+    return snap
+
+
+def _compute_field_diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, tuple[Any, Any]]:
+    """Return ``{field: (old_value, new_value)}`` for fields that changed."""
+    diff: dict[str, tuple[Any, Any]] = {}
+    for key in before:
+        if key in after and before[key] != after[key]:
+            diff[key] = (before[key], after[key])
+    return diff
+
+
+def _post_init_diff(obj: object) -> dict[str, tuple[Any, Any]]:
+    """Return fields changed by ``__post_init__`` as ``{field: (before, after)}``.
+
+    Only scalar and tuple fields are tracked (mutable containers like lists and
+    dicts are excluded because their identity changes during deep-copy).
+
+    Returns:
+        A dictionary mapping dotted field paths to ``(old_value, new_value)``
+        tuples.  Empty when no ``__post_init__`` was defined or no scalar
+        fields were modified.
+    """
+    return getattr(obj, "__post_init_field_diff__", {})
 
 
 def resolve_cfg_presets(cfg: object) -> object:

--- a/source/isaaclab/isaaclab/utils/configclass.py
+++ b/source/isaaclab/isaaclab/utils/configclass.py
@@ -22,7 +22,7 @@ _logger = logging.getLogger(__name__)
 _CALLABLE_STR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_\\.]*:[A-Za-z_][A-Za-z0-9_]*$")
 _CALLABLE_STR_WITH_DIR_RE = re.compile(r"^\{DIR\}(?:\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_]*$")
 
-_CONFIGCLASS_METHODS = ["to_dict", "from_dict", "replace", "copy", "validate", "post_init_diff"]
+_CONFIGCLASS_METHODS = ["to_dict", "from_dict", "replace", "copy", "validate"]
 """List of class methods added at runtime to dataclass."""
 
 """
@@ -113,7 +113,6 @@ def configclass(cls, **kwargs):
     setattr(cls, "replace", _replace_class_with_kwargs)
     setattr(cls, "copy", _copy_class)
     setattr(cls, "validate", _validate)
-    setattr(cls, "post_init_diff", _post_init_diff)
     # wrap around dataclass
     cls = dataclass(cls, **kwargs)
     # return wrapped class
@@ -498,30 +497,20 @@ def _custom_post_init(obj):
 
 
 def _combined_function(f1: Callable, f2: Callable) -> Callable:
-    """Combine a user ``__post_init__`` with the configclass deep-copy hook.
-
-    Before *f1* (the user hook) runs, a shallow snapshot of every scalar/tuple
-    field is taken.  After both hooks finish, the snapshot is stored on the
-    object so that :meth:`post_init_diff` can report which fields were silently
-    changed by ``__post_init__``.
+    """Combine two functions into one by calling them sequentially.
 
     Args:
-        f1: The user-defined ``__post_init__``.
-        f2: The configclass ``_custom_post_init`` (deep-copy + ResolvableString wrapping).
+        f1: The first function to call (user-defined ``__post_init__``).
+        f2: The second function to call (configclass ``_custom_post_init``).
 
     Returns:
         The combined function.
     """
 
     def _combined(*args, **kwargs):
-        obj = args[0]
-        # Snapshot scalar / tuple field values before the user hook runs.
-        before = _snapshot_fields(obj)
-        _logger.debug("Running __post_init__ for %s", type(obj).__name__)
+        _logger.debug("Running __post_init__ for %s", type(args[0]).__name__)
         f1(*args, **kwargs)
         f2(*args, **kwargs)
-        after = _snapshot_fields(obj)
-        obj.__post_init_field_diff__ = _compute_field_diff(before, after)
 
     return _combined
 
@@ -605,53 +594,6 @@ def _return_f(f: Any) -> Callable[[], Any]:
             return deepcopy(f)
 
     return _wrap
-
-
-"""
-Post-init diff helpers.
-"""
-
-
-def _snapshot_fields(obj: object, prefix: str = "") -> dict[str, Any]:
-    """Capture a flat ``{dotted.path: value}`` snapshot of scalar and tuple fields.
-
-    Nested configclass objects are walked recursively so that changes at any
-    depth are captured.
-    """
-    snap: dict[str, Any] = {}
-    for key in list(getattr(obj, "__dataclass_fields__", {})):
-        value = getattr(obj, key, MISSING)
-        if value is MISSING:
-            continue
-        full_key = f"{prefix}{key}"
-        if hasattr(value, "__dataclass_fields__"):
-            snap.update(_snapshot_fields(value, prefix=f"{full_key}."))
-        elif isinstance(value, (int, float, bool, str, type(None), tuple)):
-            snap[full_key] = value
-    return snap
-
-
-def _compute_field_diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, tuple[Any, Any]]:
-    """Return ``{field: (old_value, new_value)}`` for fields that changed."""
-    diff: dict[str, tuple[Any, Any]] = {}
-    for key in before:
-        if key in after and before[key] != after[key]:
-            diff[key] = (before[key], after[key])
-    return diff
-
-
-def _post_init_diff(obj: object) -> dict[str, tuple[Any, Any]]:
-    """Return fields changed by ``__post_init__`` as ``{field: (before, after)}``.
-
-    Only scalar and tuple fields are tracked (mutable containers like lists and
-    dicts are excluded because their identity changes during deep-copy).
-
-    Returns:
-        A dictionary mapping dotted field paths to ``(old_value, new_value)``
-        tuples.  Empty when no ``__post_init__`` was defined or no scalar
-        fields were modified.
-    """
-    return getattr(obj, "__post_init_field_diff__", {})
 
 
 def resolve_cfg_presets(cfg: object) -> object:

--- a/source/isaaclab/isaaclab/utils/io/yaml.py
+++ b/source/isaaclab/isaaclab/utils/io/yaml.py
@@ -5,6 +5,7 @@
 
 """Utilities for file I/O with yaml."""
 
+import logging
 import os
 
 import yaml
@@ -54,3 +55,30 @@ def dump_yaml(filename: str, data: dict | object, sort_keys: bool = False):
     # save data
     with open(filename, "w") as f:
         yaml.dump(data, f, default_flow_style=False, sort_keys=sort_keys)
+
+
+def dump_resolved_cfg(cfg: object, log_dir: str | None, logger: logging.Logger | None = None):
+    """Dump a fully-resolved config to ``<log_dir>/params/resolved_env.yaml``.
+
+    This is intended to be called at the end of environment ``__init__``
+    after all ``__post_init__`` hooks, preset resolution, and training-script
+    mutations have been applied, giving users a single source of truth for the
+    values the environment actually uses.
+
+    Args:
+        cfg: The config object to serialize (typically ``self.cfg``).
+        log_dir: The logging directory. When ``None``, the dump is silently
+            skipped.
+        logger: Optional logger for status messages. When ``None``, messages
+            are suppressed.
+    """
+    if log_dir is None:
+        return
+    resolved_path = os.path.join(log_dir, "params", "resolved_env.yaml")
+    try:
+        dump_yaml(resolved_path, cfg)
+        if logger is not None:
+            logger.info("Resolved env config written to %s", resolved_path)
+    except Exception:
+        if logger is not None:
+            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)

--- a/source/isaaclab_experimental/config/extension.toml
+++ b/source/isaaclab_experimental/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.0.2"
+version = "0.0.3"
 
 # Description
 title = "Experimental playground for upcoming IsaacLab features"

--- a/source/isaaclab_experimental/docs/CHANGELOG.rst
+++ b/source/isaaclab_experimental/docs/CHANGELOG.rst
@@ -11,7 +11,8 @@ Added
   ``<log_dir>/params/resolved_env.yaml`` from
   :class:`~isaaclab_experimental.envs.ManagerBasedEnvWarp` and
   :class:`~isaaclab_experimental.envs.DirectRLEnvWarp` at the end of
-  ``__init__``, matching the stable env base classes.
+  ``__init__`` via the shared :func:`~isaaclab.utils.io.dump_resolved_cfg`
+  utility, matching the stable env base classes.
 
 
 0.0.2 (2026-03-16)

--- a/source/isaaclab_experimental/docs/CHANGELOG.rst
+++ b/source/isaaclab_experimental/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+0.0.3 (2026-04-20)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added automatic dump of the fully-resolved env config to
+  ``<log_dir>/params/resolved_env.yaml`` from
+  :class:`~isaaclab_experimental.envs.ManagerBasedEnvWarp` and
+  :class:`~isaaclab_experimental.envs.DirectRLEnvWarp` at the end of
+  ``__init__``, matching the stable env base classes.
+
+
 0.0.2 (2026-03-16)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
@@ -33,6 +33,7 @@ from isaaclab.envs.utils.spaces import sample_space, spec_to_gym_space
 from isaaclab.managers import EventManager
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils import use_stage
+from isaaclab.utils.io import dump_yaml
 from isaaclab.utils.noise import NoiseModel
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
@@ -269,6 +270,10 @@ class DirectRLEnvWarp(DirectRLEnv):
         # set the framerate of the gym video recorder wrapper so that the playback speed of the produced
         # video matches the simulation
         self.metadata["render_fps"] = 1 / self.step_dt
+
+        # dump the fully-resolved env config so users have a single source of
+        # truth for what values the environment is actually using
+        self._dump_resolved_cfg()
 
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
@@ -679,6 +684,22 @@ class DirectRLEnvWarp(DirectRLEnv):
     """
     Helper functions.
     """
+
+    def _dump_resolved_cfg(self):
+        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
+
+        This runs after all ``__post_init__`` hooks, preset resolution, and
+        any training-script mutations, giving users a single source of truth
+        for the values the environment actually uses.
+        """
+        if self.cfg.log_dir is None:
+            return
+        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
+        try:
+            dump_yaml(resolved_path, self.cfg)
+            logger.info("Resolved env config written to %s", resolved_path)
+        except Exception:
+            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _configure_gym_env_spaces(self):
         """Configure the action and observation spaces for the Gym environment."""

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
@@ -33,7 +33,7 @@ from isaaclab.envs.utils.spaces import sample_space, spec_to_gym_space
 from isaaclab.managers import EventManager
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils import use_stage
-from isaaclab.utils.io import dump_yaml
+from isaaclab.utils.io import dump_resolved_cfg
 from isaaclab.utils.noise import NoiseModel
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
@@ -271,9 +271,7 @@ class DirectRLEnvWarp(DirectRLEnv):
         # video matches the simulation
         self.metadata["render_fps"] = 1 / self.step_dt
 
-        # dump the fully-resolved env config so users have a single source of
-        # truth for what values the environment is actually using
-        self._dump_resolved_cfg()
+        dump_resolved_cfg(self.cfg, getattr(self.cfg, "log_dir", None), logger)
 
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
@@ -684,22 +682,6 @@ class DirectRLEnvWarp(DirectRLEnv):
     """
     Helper functions.
     """
-
-    def _dump_resolved_cfg(self):
-        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
-
-        This runs after all ``__post_init__`` hooks, preset resolution, and
-        any training-script mutations, giving users a single source of truth
-        for the values the environment actually uses.
-        """
-        if self.cfg.log_dir is None:
-            return
-        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
-        try:
-            dump_yaml(resolved_path, self.cfg)
-            logger.info("Resolved env config written to %s", resolved_path)
-        except Exception:
-            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _configure_gym_env_spaces(self):
         """Configure the action and observation spaces for the Gym environment."""

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
@@ -31,6 +31,7 @@ from isaaclab.envs.utils.io_descriptors import export_articulations_data, export
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils import use_stage
 from isaaclab.ui.widgets import ManagerLiveVisualizer
+from isaaclab.utils.io import dump_yaml
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
 
@@ -226,6 +227,10 @@ class ManagerBasedEnvWarp:
             )
             if self.cfg.num_rerenders_on_reset == 0:
                 self.cfg.num_rerenders_on_reset = 1
+
+        # dump the fully-resolved env config so users have a single source of
+        # truth for what values the environment is actually using
+        self._dump_resolved_cfg()
 
     def __del__(self):
         """Cleanup for the environment."""
@@ -596,6 +601,24 @@ class ManagerBasedEnvWarp:
     """
     Helper functions.
     """
+
+    def _dump_resolved_cfg(self):
+        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
+
+        This runs after all ``__post_init__`` hooks, preset resolution, and
+        any training-script mutations, giving users a single source of truth
+        for the values the environment actually uses.
+        """
+        import os
+
+        if self.cfg.log_dir is None:
+            return
+        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
+        try:
+            dump_yaml(resolved_path, self.cfg)
+            logger.info("Resolved env config written to %s", resolved_path)
+        except Exception:
+            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _resolve_stable_cfg_counterpart(self) -> ManagerBasedEnvCfg | None:
         """Resolve a stable task config counterpart for the current experimental task config.

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
@@ -31,7 +31,7 @@ from isaaclab.envs.utils.io_descriptors import export_articulations_data, export
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils import use_stage
 from isaaclab.ui.widgets import ManagerLiveVisualizer
-from isaaclab.utils.io import dump_yaml
+from isaaclab.utils.io import dump_resolved_cfg
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
 
@@ -228,9 +228,7 @@ class ManagerBasedEnvWarp:
             if self.cfg.num_rerenders_on_reset == 0:
                 self.cfg.num_rerenders_on_reset = 1
 
-        # dump the fully-resolved env config so users have a single source of
-        # truth for what values the environment is actually using
-        self._dump_resolved_cfg()
+        dump_resolved_cfg(self.cfg, getattr(self.cfg, "log_dir", None), logger)
 
     def __del__(self):
         """Cleanup for the environment."""
@@ -601,24 +599,6 @@ class ManagerBasedEnvWarp:
     """
     Helper functions.
     """
-
-    def _dump_resolved_cfg(self):
-        """Dump the fully-resolved env config to ``<log_dir>/params/resolved_env.yaml``.
-
-        This runs after all ``__post_init__`` hooks, preset resolution, and
-        any training-script mutations, giving users a single source of truth
-        for the values the environment actually uses.
-        """
-        import os
-
-        if self.cfg.log_dir is None:
-            return
-        resolved_path = os.path.join(self.cfg.log_dir, "params", "resolved_env.yaml")
-        try:
-            dump_yaml(resolved_path, self.cfg)
-            logger.info("Resolved env config written to %s", resolved_path)
-        except Exception:
-            logger.warning("Failed to dump resolved env config to %s", resolved_path, exc_info=True)
 
     def _resolve_stable_cfg_counterpart(self) -> ManagerBasedEnvCfg | None:
         """Resolve a stable task config counterpart for the current experimental task config.


### PR DESCRIPTION
# Description

Debugging IsaacLab environment configurations is difficult because `__post_init__` overrides can silently change values set by users or Hydra, and there is no single reliable file that captures the fully-resolved config the environment actually uses. The existing `params/env.yaml` dump is inconsistent across RL frameworks (some dump before `gym.make`, missing post-init values).

This PR addresses these issues with three changes:

1. **Auto-dump `resolved_env.yaml` from all env base classes** — `ManagerBasedEnv`, `DirectRLEnv`, `DirectMARLEnv`, and the experimental Warp variants now write `<log_dir>/params/resolved_env.yaml` at the end of `__init__`. This is the single source of truth for the config the environment actually uses, regardless of entry point.

2. **Fix `params/env.yaml` dump timing** — Moved `dump_yaml` calls in `sb3/train.py`, `skrl/train.py`, and `rl_games/train.py` to execute **after** `gym.make()` instead of before, so they capture post-init values (matching `rsl_rl/train.py` which was already correct).

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Screenshots

N/A — infrastructure/debugging change, no visual impact.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there