### PR TITLE
Fixes M1 3.0 GA Issues

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -94,10 +94,11 @@ jobs:
       working-directory: ./docs
       env:
         # "deploy" branches build the full set of versions so every page
-        # has a complete version dropdown: main, develop, tags >= v2.0.0.
-        # v1.x tags and release/ branches are excluded to keep it lean and mean.
+        # has a complete version dropdown: main, develop, tags >= v2.0.0
+        # (including pre-release suffixes like -beta or -rc1). v1.x tags and
+        # release/ branches are excluded.
         SMV_BRANCH_WHITELIST: '^(main|develop)$'
-        SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+$'
+        SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+(-[A-Za-z0-9.]+)?$'
       run: |
         git fetch --prune --unshallow --tags
         git checkout --detach HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,9 @@ _build
 
 # Ruff cache
 **/.ruff_cache/
+
+# Dev-time files, generated stuff
+**/__*
+
+# Isaac Lab CI environments in native mode
+**/_isaaclab_install_ci_*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -304,8 +304,10 @@ templates_path = [
 smv_remote_whitelist = r"^.*$"
 # Whitelist pattern for branches (set to None to ignore all branches)
 smv_branch_whitelist = os.getenv("SMV_BRANCH_WHITELIST", r"^(main|develop|release/.*)$")
-# Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = os.getenv("SMV_TAG_WHITELIST", r"^v[1-9]\d*\.\d+\.\d+$")
+# Whitelist pattern for tags (set to None to ignore all tags).
+# Matches vMAJOR.MINOR.PATCH with an optional pre-release suffix like -beta or -rc1,
+# so tags like v3.0.0-beta show up in the version selector.
+smv_tag_whitelist = os.getenv("SMV_TAG_WHITELIST", r"^v[1-9]\d*\.\d+\.\d+(-[A-Za-z0-9.]+)?$")
 html_sidebars = {
     "**": ["navbar-logo.html", "versioning.html", "icon-links.html", "search-field.html", "sbt-sidebar-nav.html"]
 }

--- a/isaaclab.bat
+++ b/isaaclab.bat
@@ -26,6 +26,13 @@ if defined VIRTUAL_ENV (
 rem Add source/isaaclab to PYTHONPATH so we can import isaaclab.cli.
 set "PYTHONPATH=%ISAACLAB_PATH%\source\isaaclab;%PYTHONPATH%"
 
+rem If a local Isaac Sim binary is present, source its env setup so that
+rem PYTHONPATH/PATH/EXP_PATH are correct without depending on a conda
+rem activate.d hook (those don't fire under e.g. `conda run` on Windows).
+if exist "%ISAACLAB_PATH%\_isaac_sim\setup_conda_env.bat" (
+    call "%ISAACLAB_PATH%\_isaac_sim\setup_conda_env.bat" >NUL
+)
+
 rem Execute CLI.
 "%python_exe%" -c "from isaaclab.cli import cli; cli()" %*
 

--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -28,5 +28,13 @@ fi
 # Add source/isaaclab to PYTHONPATH so we can import isaaclab.cli.
 export PYTHONPATH="$ISAACLAB_PATH/source/isaaclab:$PYTHONPATH"
 
+# If a local Isaac Sim binary is present, source its env setup so that
+# PYTHONPATH/PATH/EXP_PATH are correct without depending on a conda
+# activate.d hook (those don't fire reliably under e.g. `conda run`).
+if [ -f "$ISAACLAB_PATH/_isaac_sim/setup_conda_env.sh" ]; then
+    # shellcheck disable=SC1091
+    . "$ISAACLAB_PATH/_isaac_sim/setup_conda_env.sh" >/dev/null 2>&1 || true
+fi
+
 # Execute CLI.
 exec "$python_exe" -c "from isaaclab.cli import cli; cli()" "$@"

--- a/source/isaaclab/isaaclab/cli/utils.py
+++ b/source/isaaclab/isaaclab/cli/utils.py
@@ -146,19 +146,16 @@ def _print_debug_env(prefix: str, env: dict[str, str] | None) -> None:
 _CMD_METACHARACTERS = frozenset("<>|&^")
 
 
-def _escape_for_cmd_exe(cmd: list[str] | tuple[str, ...]) -> str | list[str]:
+def _escape_for_cmd_exe(cmd: list[str] | tuple[str, ...]) -> list[str]:
+    """Wrap .bat/.cmd calls in cmd.exe /c so args with < > | & ^ stay literal
+    (otherwise Windows treats e.g. setuptools<82.0.0 as a redirection).
     """
-    Quote ``cmd.exe`` metacharacters when invoking ``.bat``/``.cmd`` files.
-
-    Returns a command string (not list) so ``subprocess.run`` bypasses
-    ``list2cmdline`` which doesn't escape cmd.exe metacharacters (<, >, |, &, ^).
-    """
-    # Only .bat/.cmd files are executed via cmd.exe.
+    # only .bat/.cmd needs wrapping
     exe = str(cmd[0]).lower()
     if not (exe.endswith(".bat") or exe.endswith(".cmd")):
         return list(cmd)
 
-    # Wrap args that contain metacharacters or whitespace in double quotes.
+    # quote anything with metacharacters or spaces
     parts: list[str] = []
     for arg in cmd:
         s = str(arg)
@@ -167,8 +164,7 @@ def _escape_for_cmd_exe(cmd: list[str] | tuple[str, ...]) -> str | list[str]:
         else:
             parts.append(s)
 
-    # Return a string so subprocess skips list2cmdline.
-    return " ".join(parts)
+    return ["cmd.exe", "/c", " ".join(parts)]
 
 
 def run_command(

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
@@ -190,12 +190,38 @@ def launch_simulation(
         import importlib.util
 
         if importlib.util.find_spec("omni.kit") is None:
+            # Print a more obvious hint when a local _isaac_sim symlink
+            # exists but its env wasn't sourced (typical on Win11 + conda
+            # when activate.d hooks didn't fire, e.g. under `conda run`).
+            import os
+            import sys
+
+            isaaclab_path = os.environ.get("ISAACLAB_PATH")
+            local_sim = os.path.join(isaaclab_path, "_isaac_sim") if isaaclab_path else None
+            extra_hint = ""
+            if local_sim and os.path.isdir(local_sim):
+                if sys.platform == "win32":
+                    extra_hint = (
+                        f"  Found a local Isaac Sim at {local_sim} but its environment is not active.\n"
+                        f"  Either run via `isaaclab.bat ...` (which now sources setup_conda_env.bat\n"
+                        f"  automatically), or in your current shell run:\n"
+                        f'    call "{local_sim}\\setup_conda_env.bat"\n'
+                    )
+                else:
+                    extra_hint = (
+                        f"  Found a local Isaac Sim at {local_sim} but its environment is not active.\n"
+                        f"  Either run via `./isaaclab.sh ...` (which now sources setup_conda_env.sh\n"
+                        f"  automatically), or in your current shell run:\n"
+                        f'    source "{local_sim}/setup_conda_env.sh"\n'
+                    )
+
             logger.error(
                 "\n[ERROR] Isaac Sim is not installed or not found on PYTHONPATH.\n"
                 "\n"
                 "  This environment requires Isaac Sim and Omniverse Kit.\n"
                 "    PhysX backend and Kit visualizer currently requires Isaac Sim.\n"
                 "\n"
+                f"{extra_hint}"
                 "  To fix this, ensure Isaac Sim is installed and available in the current environment.\n"
                 "\n"
                 "  See https://isaac-sim.github.io/IsaacLab/main/source/setup/installation for details.\n"


### PR DESCRIPTION
# Description

Fixes 3.0 GA M1 issues.

Code changes in this PR fix:

- NVBug 5985028 (also fixes 5984996) - Win11 isaaclab.bat install + Sim-binary detection on conda.
- NVBug 5992915 - docs version selector now picks up pre-release tags like v3.0.0-beta.

Triaged separately (no code changes needed in this PR):

- NVBug 5974917 - hf-xet pip metadata error: fixed via PR#4992 plus Artifactory cache purge.
- NVBug 5994306 - Docker image not found: already fixed in PR#5189 (ISAACSIM_VERSION=6.0.0-dev2).
- NVBug 5974684 - pip [newton] warp-lang conflict: already aligned (warp-lang==1.12.0 in tools/wheel_builder/res/python_packages.toml). Needs next-rc-wheel re-verify.
- NVBug 5983721 - pip pillow conflict: already aligned (pillow==12.1.1 in tools/wheel_builder/res/python_packages.toml). Needs next-rc-wheel re-verify.
- NVBug 5983082 - duplicate of 5979273 (Isaac Sim sensors.rtx Windows DLL chain).
- NVBug 5627823 - VDR docs feedback: item 1 already fixed on develop via -u/--uv; remaining items split into follow-ups.

This should complete M1 issues.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with ./isaaclab.sh --format
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's config/extension.toml file
- [x] I have added my name to the CONTRIBUTORS.md or my name already exists there
