### PR TITLE
Add render flag to environment step() API

### DIFF
--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -9,6 +9,13 @@ Added
 
 * Added :meth:`~isaaclab.utils.wrench_composer.WrenchComposer.add_raw_buffers_from` to merge one composer's raw
   input buffers into another.
+* Added ``render_enabled`` property to all environment base classes
+  (:class:`~isaaclab.envs.ManagerBasedEnv`, :class:`~isaaclab.envs.ManagerBasedRLEnv`,
+  :class:`~isaaclab.envs.DirectRLEnv`, :class:`~isaaclab.envs.DirectMARLEnv`).
+  Setting ``env.render_enabled = False`` before calling ``step()`` skips all rendering calls
+  (GUI updates, RTX sensor rendering, post-reset re-renders) while physics simulation continues
+  normally.  The property can be toggled between steps for per-step control.  Defaults to ``True``
+  for full backward compatibility.
 
 Changed
 ^^^^^^^

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -12,10 +12,17 @@ Added
 * Added ``render_enabled`` property to all environment base classes
   (:class:`~isaaclab.envs.ManagerBasedEnv`, :class:`~isaaclab.envs.ManagerBasedRLEnv`,
   :class:`~isaaclab.envs.DirectRLEnv`, :class:`~isaaclab.envs.DirectMARLEnv`).
-  Setting ``env.render_enabled = False`` before calling ``step()`` skips all rendering calls
-  (GUI updates, RTX sensor rendering, post-reset re-renders) while physics simulation continues
-  normally.  The property can be toggled between steps for per-step control.  Defaults to ``True``
-  for full backward compatibility.
+  Setting ``env.render_enabled = False`` before calling ``step()`` skips the Kit app loop
+  (``app.update()``) and camera/RTX sensor rendering, while standalone visualizers (Newton,
+  Rerun, Viser) continue to update normally.  Kit bundles camera rendering with its app loop
+  so the two cannot be separated; non-Kit visualizers have independent ``step()`` methods and
+  are unaffected by this flag.  Post-reset re-renders for RTX sensors are also skipped when
+  disabled.  The property can be toggled between steps for per-step control.  Defaults to
+  ``True`` for full backward compatibility.
+* Added ``skip_app_pumping`` parameter to
+  :meth:`~isaaclab.sim.SimulationContext.render` and
+  :meth:`~isaaclab.sim.SimulationContext.update_visualizers` to selectively skip
+  visualizers that pump the Kit app loop (``pumps_app_update() == True``).
 
 Changed
 ^^^^^^^

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -217,6 +217,8 @@ class DirectMARLEnv(gym.Env):
         # initialize data and constants
         # -- counter for simulation steps
         self._sim_step_counter = 0
+        # -- whether step() performs rendering (set to False to skip all render calls)
+        self.render_enabled: bool = True
         # -- counter for curriculum
         self.common_step_counter = 0
         # -- init buffers
@@ -391,6 +393,8 @@ class DirectMARLEnv(gym.Env):
         5. Apply interval events if they are enabled.
         6. Compute observations.
 
+        Rendering can be controlled per-step via :attr:`render_enabled`.
+
         Args:
             actions: The actions to apply on the environment (keyed by the agent ID).
                 Shape of individual tensors is (num_envs, action_dim).
@@ -411,7 +415,7 @@ class DirectMARLEnv(gym.Env):
 
         # check if we need to do rendering within the physics loop
         # note: uses cached property to avoid settings lookup every step
-        is_rendering = self.sim.is_rendering
+        is_rendering = self.render_enabled and self.sim.is_rendering
 
         # perform physics stepping
         for _ in range(self.cfg.decimation):

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -217,7 +217,12 @@ class DirectMARLEnv(gym.Env):
         # initialize data and constants
         # -- counter for simulation steps
         self._sim_step_counter = 0
-        # -- whether step() performs rendering (set to False to skip all render calls)
+        # -- controls camera/Kit rendering in step().
+        # When False, the Kit app loop (app.update()) and camera/RTX sensor updates are
+        # skipped, but standalone visualizers (Newton, Rerun, Viser) continue to update.
+        # This is because Kit bundles camera rendering with its app loop and the two
+        # cannot be separated.  Non-Kit visualizers have independent step() methods
+        # that do not trigger camera or GUI updates, so they remain active.
         self.render_enabled: bool = True
         # -- counter for curriculum
         self.common_step_counter = 0
@@ -395,6 +400,15 @@ class DirectMARLEnv(gym.Env):
 
         Rendering can be controlled per-step via :attr:`render_enabled`.
 
+        When ``render_enabled`` is False:
+
+        - The Kit app loop (``app.update()``) is **skipped**, which also disables
+          camera/RTX sensor rendering and GUI viewport updates.  Kit bundles these
+          operations together, so they cannot be separated.
+        - Standalone visualizers (Newton, Rerun, Viser) **continue to update**
+          normally because their ``step()`` methods are independent of the Kit
+          app loop.
+
         Args:
             actions: The actions to apply on the environment (keyed by the agent ID).
                 Shape of individual tensors is (num_envs, action_dim).
@@ -415,7 +429,7 @@ class DirectMARLEnv(gym.Env):
 
         # check if we need to do rendering within the physics loop
         # note: uses cached property to avoid settings lookup every step
-        is_rendering = self.render_enabled and self.sim.is_rendering
+        is_rendering = self.sim.is_rendering
 
         # perform physics stepping
         for _ in range(self.cfg.decimation):
@@ -426,11 +440,11 @@ class DirectMARLEnv(gym.Env):
             self.scene.write_data_to_sim()
             # simulate
             self.sim.step(render=False)
-            # render between steps only if the GUI or an RTX sensor needs it
-            # note: we assume the render interval to be the shortest accepted rendering interval.
-            #    If a camera needs rendering at a faster frequency, this will lead to unexpected behavior.
+            # render between steps only if the GUI or an RTX sensor needs it.
+            # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
+            # but standalone visualizers (Newton, Rerun, Viser) still update.
             if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
-                self.sim.render()
+                self.sim.render(skip_app_pumping=not self.render_enabled)
             # update buffers at sim dt
             self.scene.update(dt=self.physics_dt)
 

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -223,7 +223,12 @@ class DirectRLEnv(gym.Env):
         # initialize data and constants
         # -- counter for simulation steps
         self._sim_step_counter = 0
-        # -- whether step() performs rendering (set to False to skip all render calls)
+        # -- controls camera/Kit rendering in step().
+        # When False, the Kit app loop (app.update()) and camera/RTX sensor updates are
+        # skipped, but standalone visualizers (Newton, Rerun, Viser) continue to update.
+        # This is because Kit bundles camera rendering with its app loop and the two
+        # cannot be separated.  Non-Kit visualizers have independent step() methods
+        # that do not trigger camera or GUI updates, so they remain active.
         self.render_enabled: bool = True
         # -- counter for curriculum
         self.common_step_counter = 0
@@ -389,6 +394,16 @@ class DirectRLEnv(gym.Env):
 
         Rendering can be controlled per-step via :attr:`render_enabled`.
 
+        When ``render_enabled`` is False:
+
+        - The Kit app loop (``app.update()``) is **skipped**, which also disables
+          camera/RTX sensor rendering and GUI viewport updates.  Kit bundles these
+          operations together, so they cannot be separated.
+        - Standalone visualizers (Newton, Rerun, Viser) **continue to update**
+          normally because their ``step()`` methods are independent of the Kit
+          app loop.
+        - Post-reset re-renders for RTX sensors are also skipped.
+
         Args:
             action: The actions to apply on the environment. Shape is (num_envs, action_dim).
 
@@ -405,7 +420,7 @@ class DirectRLEnv(gym.Env):
 
         # check if we need to do rendering within the physics loop
         # note: uses cached property to avoid settings lookup every step
-        is_rendering = self.render_enabled and self.sim.is_rendering
+        is_rendering = self.sim.is_rendering
 
         # perform physics stepping
         for _ in range(self.cfg.decimation):
@@ -416,11 +431,11 @@ class DirectRLEnv(gym.Env):
             self.scene.write_data_to_sim()
             # simulate
             self.sim.step(render=False)
-            # render between steps only if the GUI or an RTX sensor needs it
-            # note: we assume the render interval to be the shortest accepted rendering interval.
-            #    If a camera needs rendering at a faster frequency, this will lead to unexpected behavior.
+            # render between steps only if the GUI or an RTX sensor needs it.
+            # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
+            # but standalone visualizers (Newton, Rerun, Viser) still update.
             if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
-                self.sim.render()
+                self.sim.render(skip_app_pumping=not self.render_enabled)
             # update buffers at sim dt
             self.scene.update(dt=self.physics_dt)
 
@@ -438,7 +453,7 @@ class DirectRLEnv(gym.Env):
         if len(reset_env_ids) > 0:
             self._reset_idx(reset_env_ids)
             # if sensors are added to the scene, make sure we render to reflect changes in reset
-            if is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
+            if self.render_enabled and is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):
                     self.sim.render()
 

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -223,6 +223,8 @@ class DirectRLEnv(gym.Env):
         # initialize data and constants
         # -- counter for simulation steps
         self._sim_step_counter = 0
+        # -- whether step() performs rendering (set to False to skip all render calls)
+        self.render_enabled: bool = True
         # -- counter for curriculum
         self.common_step_counter = 0
         # -- init buffers
@@ -385,6 +387,8 @@ class DirectRLEnv(gym.Env):
         5. Apply interval events if they are enabled.
         6. Compute observations.
 
+        Rendering can be controlled per-step via :attr:`render_enabled`.
+
         Args:
             action: The actions to apply on the environment. Shape is (num_envs, action_dim).
 
@@ -401,7 +405,7 @@ class DirectRLEnv(gym.Env):
 
         # check if we need to do rendering within the physics loop
         # note: uses cached property to avoid settings lookup every step
-        is_rendering = self.sim.is_rendering
+        is_rendering = self.render_enabled and self.sim.is_rendering
 
         # perform physics stepping
         for _ in range(self.cfg.decimation):
@@ -434,7 +438,7 @@ class DirectRLEnv(gym.Env):
         if len(reset_env_ids) > 0:
             self._reset_idx(reset_env_ids)
             # if sensors are added to the scene, make sure we render to reflect changes in reset
-            if self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
+            if is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):
                     self.sim.render()
 

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -153,7 +153,12 @@ class ManagerBasedEnv:
         # counter for simulation steps
         self._sim_step_counter = 0
 
-        # -- whether step() performs rendering (set to False to skip all render calls)
+        # -- controls camera/Kit rendering in step().
+        # When False, the Kit app loop (app.update()) and camera/RTX sensor updates are
+        # skipped, but standalone visualizers (Newton, Rerun, Viser) continue to update.
+        # This is because Kit bundles camera rendering with its app loop and the two
+        # cannot be separated.  Non-Kit visualizers have independent step() methods
+        # that do not trigger camera or GUI updates, so they remain active.
         self.render_enabled: bool = True
 
         # allocate dictionary to store metrics
@@ -499,6 +504,15 @@ class ManagerBasedEnv:
 
         Rendering can be controlled per-step via :attr:`render_enabled`.
 
+        When ``render_enabled`` is False:
+
+        - The Kit app loop (``app.update()``) is **skipped**, which also disables
+          camera/RTX sensor rendering and GUI viewport updates.  Kit bundles these
+          operations together, so they cannot be separated.
+        - Standalone visualizers (Newton, Rerun, Viser) **continue to update**
+          normally because their ``step()`` methods are independent of the Kit
+          app loop.
+
         Args:
             action: The actions to apply on the environment. Shape is (num_envs, action_dim).
 
@@ -512,7 +526,7 @@ class ManagerBasedEnv:
 
         # check if we need to do rendering within the physics loop
         # note: uses cached property to avoid settings lookup every step
-        is_rendering = self.render_enabled and self.sim.is_rendering
+        is_rendering = self.sim.is_rendering
 
         # perform physics stepping
         for _ in range(self.cfg.decimation):
@@ -523,11 +537,11 @@ class ManagerBasedEnv:
             self.scene.write_data_to_sim()
             # simulate
             self.sim.step(render=False)
-            # render between steps only if the GUI or an RTX sensor needs it
-            # note: we assume the render interval to be the shortest accepted rendering interval.
-            #    If a camera needs rendering at a faster frequency, this will lead to unexpected behavior.
+            # render between steps only if the GUI or an RTX sensor needs it.
+            # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
+            # but standalone visualizers (Newton, Rerun, Viser) still update.
             if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
-                self.sim.render()
+                self.sim.render(skip_app_pumping=not self.render_enabled)
             # update buffers at sim dt
             self.scene.update(dt=self.physics_dt)
 

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -153,6 +153,9 @@ class ManagerBasedEnv:
         # counter for simulation steps
         self._sim_step_counter = 0
 
+        # -- whether step() performs rendering (set to False to skip all render calls)
+        self.render_enabled: bool = True
+
         # allocate dictionary to store metrics
         self.extras = {}
 
@@ -494,6 +497,8 @@ class ManagerBasedEnv:
         simulation steps per environment step) and the :attr:`ManagerBasedEnvCfg.sim.dt` (physics time-step).
         Based on these parameters, the environment time-step is computed as the product of the two.
 
+        Rendering can be controlled per-step via :attr:`render_enabled`.
+
         Args:
             action: The actions to apply on the environment. Shape is (num_envs, action_dim).
 
@@ -507,7 +512,7 @@ class ManagerBasedEnv:
 
         # check if we need to do rendering within the physics loop
         # note: uses cached property to avoid settings lookup every step
-        is_rendering = self.sim.is_rendering
+        is_rendering = self.render_enabled and self.sim.is_rendering
 
         # perform physics stepping
         for _ in range(self.cfg.decimation):

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -173,6 +173,16 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
 
         Rendering can be controlled per-step via :attr:`render_enabled`.
 
+        When ``render_enabled`` is False:
+
+        - The Kit app loop (``app.update()``) is **skipped**, which also disables
+          camera/RTX sensor rendering and GUI viewport updates.  Kit bundles these
+          operations together, so they cannot be separated.
+        - Standalone visualizers (Newton, Rerun, Viser) **continue to update**
+          normally because their ``step()`` methods are independent of the Kit
+          app loop.
+        - Post-reset re-renders for RTX sensors are also skipped.
+
         Args:
             action: The actions to apply on the environment. Shape is (num_envs, action_dim).
 
@@ -186,7 +196,7 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
 
         # check if we need to do rendering within the physics loop
         # note: uses cached property to avoid settings lookup every step
-        is_rendering = self.render_enabled and self.sim.is_rendering
+        is_rendering = self.sim.is_rendering
 
         # perform physics stepping
         for _ in range(self.cfg.decimation):
@@ -198,11 +208,11 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
             # simulate
             self.sim.step(render=False)
             self.recorder_manager.record_post_physics_decimation_step()
-            # render between steps only if the GUI or an RTX sensor needs it
-            # note: we assume the render interval to be the shortest accepted rendering interval.
-            #    If a camera needs rendering at a faster frequency, this will lead to unexpected behavior.
+            # render between steps only if the GUI or an RTX sensor needs it.
+            # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
+            # but standalone visualizers (Newton, Rerun, Viser) still update.
             if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
-                self.sim.render()
+                self.sim.render(skip_app_pumping=not self.render_enabled)
             # update buffers at sim dt
             self.scene.update(dt=self.physics_dt)
 
@@ -231,7 +241,7 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
             self._reset_idx(reset_env_ids)
 
             # if sensors are added to the scene, make sure we render to reflect changes in reset
-            if is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
+            if self.render_enabled and is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):
                     self.sim.render()
 

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -171,6 +171,8 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         6. Compute the observations.
         7. Return the observations, rewards, resets and extras.
 
+        Rendering can be controlled per-step via :attr:`render_enabled`.
+
         Args:
             action: The actions to apply on the environment. Shape is (num_envs, action_dim).
 
@@ -184,7 +186,7 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
 
         # check if we need to do rendering within the physics loop
         # note: uses cached property to avoid settings lookup every step
-        is_rendering = self.sim.is_rendering
+        is_rendering = self.render_enabled and self.sim.is_rendering
 
         # perform physics stepping
         for _ in range(self.cfg.decimation):
@@ -229,7 +231,7 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
             self._reset_idx(reset_env_ids)
 
             # if sensors are added to the scene, make sure we render to reflect changes in reset
-            if self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
+            if is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):
                     self.sim.render()
 

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -696,7 +696,7 @@ class SimulationContext:
         if render and self.is_rendering:
             self.render()
 
-    def render(self, mode: int | None = None) -> None:
+    def render(self, mode: int | None = None, skip_app_pumping: bool = False) -> None:
         """Update visualizers and render the scene.
 
         Calls update_visualizers() so visualizers run at the render cadence (not at
@@ -704,9 +704,24 @@ class SimulationContext:
         fetching data. Recording-related follow-up (Kit/RTX headless video, Newton GL
         video, etc.) runs in :mod:`isaaclab.envs.utils.recording_hooks` so it is not tied to a
         specific :class:`~isaaclab.physics.PhysicsManager` subclass.
+
+        **Kit vs. standalone visualizers:**  The Kit app loop (``app.update()``) is the
+        only way to drive camera/RTX sensor rendering and viewport GUI updates; it
+        cannot be split into "cameras only" and "GUI only".  Standalone visualizers
+        (Newton, Rerun, Viser) have self-contained ``step()`` methods that never call
+        ``app.update()``, so they can run independently of camera rendering.  The
+        ``skip_app_pumping`` flag exploits this distinction: when True, Kit is skipped
+        while standalone visualizers continue to update.
+
+        Args:
+            mode: Unused. Kept for backward compatibility.
+            skip_app_pumping: When True, skip visualizers whose :meth:`~BaseVisualizer.pumps_app_update`
+                returns True (e.g. KitVisualizer).  This disables the Kit app loop and camera
+                updates while still stepping standalone visualizers (Newton, Rerun, Viser).
+                Used by environment ``step()`` when ``render_enabled`` is False.
         """
         self.physics_manager.pre_render()
-        self.update_visualizers(self.get_rendering_dt())
+        self.update_visualizers(self.get_rendering_dt(), skip_app_pumping=skip_app_pumping)
         self.physics_manager.after_visualizers_render()
         run_recording_hooks_after_visualizers(self)
         self._render_generation += 1
@@ -716,8 +731,16 @@ class SimulationContext:
             for callback in self._render_callbacks.values():
                 callback(None)  # Pass None as event data
 
-    def update_visualizers(self, dt: float) -> None:
-        """Update visualizers without triggering renderer/GUI."""
+    def update_visualizers(self, dt: float, skip_app_pumping: bool = False) -> None:
+        """Update visualizers without triggering renderer/GUI.
+
+        Args:
+            dt: Simulation time-step in seconds.
+            skip_app_pumping: When True, skip visualizers whose :meth:`~BaseVisualizer.pumps_app_update`
+                returns True (e.g. KitVisualizer). This is used when the environment's ``render_enabled``
+                flag is False — cameras and the Kit app loop are skipped, but standalone visualizers
+                (Newton, Rerun, Viser) still receive updates.
+        """
         if not self._visualizers:
             return
 
@@ -726,6 +749,9 @@ class SimulationContext:
         visualizers_to_remove = []
         for viz in self._visualizers:
             try:
+                # When skip_app_pumping is set, skip Kit-like visualizers that call app.update()
+                if skip_app_pumping and viz.pumps_app_update():
+                    continue
                 if viz.is_closed or not viz.is_running():
                     if viz.is_closed:
                         logger.info("Visualizer closed: %s", type(viz).__name__)

--- a/source/isaaclab/test/envs/test_env_rendering_logic.py
+++ b/source/isaaclab/test/envs/test_env_rendering_logic.py
@@ -79,20 +79,29 @@ def create_manager_based_rl_env(render_interval: int):
     return ManagerBasedRLEnv(cfg=EnvCfg())
 
 
-def create_direct_rl_env(render_interval: int):
-    """Create a direct RL environment."""
+def create_direct_rl_env(render_interval: int, episode_length_steps: int | None = None):
+    """Create a direct RL environment.
+
+    Args:
+        render_interval: Render interval in physics steps.
+        episode_length_steps: If provided, the episode terminates (via time-out) after this
+            many *env* steps.  Useful for testing post-reset re-render paths.
+    """
+    # Compute episode_length_s from step count when requested
+    _dt = 0.005
+    _decimation = 4
+    _step_dt = _dt * _decimation
+    _episode_length_s = (episode_length_steps * _step_dt) if episode_length_steps is not None else 100.0
 
     @configclass
     class EnvCfg(DirectRLEnvCfg):
         """Configuration for the test environment."""
 
-        decimation: int = 4
+        decimation: int = _decimation
         action_space: int = 0
         observation_space: int = 0
-        episode_length_s: float = 100.0
-        sim: SimulationCfg = SimulationCfg(
-            dt=0.005, render_interval=render_interval, visualizer_cfgs=KitVisualizerCfg()
-        )
+        episode_length_s: float = _episode_length_s
+        sim: SimulationCfg = SimulationCfg(dt=_dt, render_interval=render_interval, visualizer_cfgs=KitVisualizerCfg())
         scene: InteractiveSceneCfg = InteractiveSceneCfg(num_envs=1, env_spacing=1.0)
 
     class Env(DirectRLEnv):
@@ -111,7 +120,8 @@ def create_direct_rl_env(render_interval: int):
             return {}
 
         def _get_dones(self):
-            return torch.zeros(1, dtype=torch.bool), torch.zeros(1, dtype=torch.bool)
+            time_out = self.episode_length_buf >= self.max_episode_length
+            return torch.zeros_like(time_out), time_out
 
     return Env(cfg=EnvCfg())
 
@@ -392,6 +402,74 @@ def test_env_render_flag_mixed_steps(env_type, physics_callback, render_callback
             _, num_render_steps = get_render_stats()
             assert num_render_steps == expected_render_steps, (
                 f"Render steps mismatch at step {i}: expected {expected_render_steps}, got {num_render_steps}"
+            )
+
+    finally:
+        if viz is not None and original_step is not None:
+            viz.step = original_step
+        if physics_handle is not None:
+            physics_handle.deregister()
+        if env is not None:
+            env.close()
+        else:
+            SimulationContext.clear_instance()
+
+
+def test_env_render_false_with_resets(physics_callback, render_callback):
+    """Test that render_enabled=False skips post-reset re-renders during short episodes.
+
+    Uses a direct RL env with a 3-step episode so that resets occur during the
+    test loop, exercising the post-reset re-render gate.
+    """
+    physics_cb, get_physics_stats = physics_callback
+    render_cb, get_render_stats = render_callback
+
+    env = None
+    physics_handle = None
+    original_step = None
+    viz = None
+
+    try:
+        sim_utils.create_new_stage()
+
+        # 3-step episode: resets will occur at steps 3, 6, 9, ...
+        env = create_direct_rl_env(render_interval=1, episode_length_steps=3)
+
+        env.sim.set_setting("/isaaclab/render/rtx_sensors", True)
+        env.sim._app_control_on_stop_handle = None  # type: ignore
+
+        env.reset()
+        assert isinstance(env.sim.visualizers[0], KitVisualizer)
+
+        physics_handle = env.sim.physics_manager.register_callback(
+            physics_cb, IsaacEvents.POST_PHYSICS_STEP, name="physics_step"
+        )
+
+        viz = env.sim.visualizers[0]
+        original_step = viz.step
+        render_dt = env.cfg.sim.dt * env.cfg.sim.render_interval
+
+        def wrapped_step(dt):
+            original_step(dt)
+            render_cb(render_dt)
+
+        viz.step = wrapped_step
+
+        actions = torch.zeros((env.num_envs, 0), device=env.device)
+
+        # Disable rendering and run past several episode boundaries
+        env.render_enabled = False
+        for i in range(10):
+            env.step(action=actions)
+
+            # Physics always advances
+            _, num_physics_steps = get_physics_stats()
+            assert num_physics_steps == (i + 1) * env.cfg.decimation, f"Physics steps mismatch at step {i} with resets"
+
+            # No Kit rendering should occur — including post-reset re-renders
+            _, num_render_steps = get_render_stats()
+            assert num_render_steps == 0, (
+                f"Expected 0 render steps with render_enabled=False and resets, got {num_render_steps} at step {i}"
             )
 
     finally:

--- a/source/isaaclab/test/envs/test_env_rendering_logic.py
+++ b/source/isaaclab/test/envs/test_env_rendering_logic.py
@@ -239,3 +239,167 @@ def test_env_rendering_logic(env_type, render_interval, physics_callback, render
         else:
             # If env creation failed, still clear the singleton
             SimulationContext.clear_instance()
+
+
+@pytest.mark.parametrize("env_type", ["manager_based_env", "manager_based_rl_env", "direct_rl_env"])
+def test_env_render_false_skips_rendering(env_type, physics_callback, render_callback):
+    """Test that setting render_enabled=False skips all rendering while physics continues."""
+    physics_cb, get_physics_stats = physics_callback
+    render_cb, get_render_stats = render_callback
+
+    env = None
+    physics_handle = None
+    original_step = None
+    viz = None
+
+    try:
+        # create a new stage
+        sim_utils.create_new_stage()
+
+        # create environment with render_interval=1 so rendering would happen every physics step
+        if env_type == "manager_based_env":
+            env = create_manager_based_env(render_interval=1)
+        elif env_type == "manager_based_rl_env":
+            env = create_manager_based_rl_env(render_interval=1)
+        else:
+            env = create_direct_rl_env(render_interval=1)
+
+        # enable the flag to render the environment
+        env.sim.set_setting("/isaaclab/render/rtx_sensors", True)
+
+        # disable the app from shutting down when the environment is closed
+        env.sim._app_control_on_stop_handle = None  # type: ignore
+
+        # Reset to initialize visualizers
+        env.reset()
+
+        # Ensure the default Kit visualizer is active for rendering callbacks.
+        assert isinstance(env.sim.visualizers[0], KitVisualizer)
+
+        # add physics callback
+        physics_handle = env.sim.physics_manager.register_callback(
+            physics_cb, IsaacEvents.POST_PHYSICS_STEP, name="physics_step"
+        )
+
+        # Wrap visualizer step to track render calls
+        viz = env.sim.visualizers[0]
+        original_step = viz.step
+        render_dt = env.cfg.sim.dt * env.cfg.sim.render_interval
+
+        def wrapped_step(dt):
+            original_step(dt)
+            render_cb(render_dt)
+
+        viz.step = wrapped_step
+
+        # create a zero action tensor for stepping the environment
+        actions = torch.zeros((env.num_envs, 0), device=env.device)
+
+        # Step with render_enabled=False for several steps
+        env.render_enabled = False
+        for i in range(10):
+            env.step(action=actions)
+
+            # Physics should still advance normally
+            _, num_physics_steps = get_physics_stats()
+            assert num_physics_steps == (i + 1) * env.cfg.decimation, "Physics steps mismatch with render_enabled=False"
+
+            # No rendering should have occurred
+            _, num_render_steps = get_render_stats()
+            assert num_render_steps == 0, f"Expected 0 render steps with render_enabled=False, got {num_render_steps}"
+
+    finally:
+        if viz is not None and original_step is not None:
+            viz.step = original_step
+        if physics_handle is not None:
+            physics_handle.deregister()
+        if env is not None:
+            env.close()
+        else:
+            SimulationContext.clear_instance()
+
+
+@pytest.mark.parametrize("env_type", ["manager_based_env", "manager_based_rl_env", "direct_rl_env"])
+def test_env_render_flag_mixed_steps(env_type, physics_callback, render_callback):
+    """Test that render_enabled can be toggled between steps and rendering counts are correct."""
+    physics_cb, get_physics_stats = physics_callback
+    render_cb, get_render_stats = render_callback
+
+    env = None
+    physics_handle = None
+    original_step = None
+    viz = None
+
+    try:
+        # create a new stage
+        sim_utils.create_new_stage()
+
+        # create environment with render_interval=1 so every decimation step renders
+        if env_type == "manager_based_env":
+            env = create_manager_based_env(render_interval=1)
+        elif env_type == "manager_based_rl_env":
+            env = create_manager_based_rl_env(render_interval=1)
+        else:
+            env = create_direct_rl_env(render_interval=1)
+
+        # enable the flag to render the environment
+        env.sim.set_setting("/isaaclab/render/rtx_sensors", True)
+
+        # disable the app from shutting down when the environment is closed
+        env.sim._app_control_on_stop_handle = None  # type: ignore
+
+        # Reset to initialize visualizers
+        env.reset()
+
+        # Ensure the default Kit visualizer is active for rendering callbacks.
+        assert isinstance(env.sim.visualizers[0], KitVisualizer)
+
+        # add physics callback
+        physics_handle = env.sim.physics_manager.register_callback(
+            physics_cb, IsaacEvents.POST_PHYSICS_STEP, name="physics_step"
+        )
+
+        # Wrap visualizer step to track render calls
+        viz = env.sim.visualizers[0]
+        original_step = viz.step
+        render_dt = env.cfg.sim.dt * env.cfg.sim.render_interval
+
+        def wrapped_step(dt):
+            original_step(dt)
+            render_cb(render_dt)
+
+        viz.step = wrapped_step
+
+        # create a zero action tensor for stepping the environment
+        actions = torch.zeros((env.num_envs, 0), device=env.device)
+
+        expected_render_steps = 0
+
+        # Step 5 times with render_enabled=True, then 5 with render_enabled=False
+        for i in range(10):
+            should_render = i < 5
+            env.render_enabled = should_render
+            env.step(action=actions)
+
+            # Physics always advances
+            _, num_physics_steps = get_physics_stats()
+            assert num_physics_steps == (i + 1) * env.cfg.decimation, "Physics steps mismatch in mixed test"
+
+            # Rendering only happens in the first 5 steps
+            if should_render:
+                expected_render_steps += env.cfg.decimation  # render_interval=1, so renders every decimation step
+
+            _, num_render_steps = get_render_stats()
+            assert num_render_steps == expected_render_steps, (
+                f"Render steps mismatch at step {i}: expected {expected_render_steps}, got {num_render_steps}"
+            )
+
+    finally:
+        if viz is not None and original_step is not None:
+            viz.step = original_step
+        if physics_handle is not None:
+            physics_handle.deregister()
+        if env is not None:
+            env.close()
+        else:
+            SimulationContext.clear_instance()


### PR DESCRIPTION
Expose a render: bool = True parameter on the step() method of all environment base classes (ManagerBasedEnv, ManagerBasedRLEnv, DirectRLEnv, DirectMARLEnv) and the MARL utility wrappers.

When render=False is passed, all rendering calls are skipped:
- GUI / RTX sensor renders inside the decimation loop
- Post-reset re-renders for RTX sensors

Physics simulation continues normally regardless of the flag. This allows user workflows that do not need rendering every step (e.g. headless RL training, fast rollouts) to opt out per-step.

Also adds unit tests for render=False and mixed render flag stepping.

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
