### PR TITLE
Draft: Add typed Scene Data Provider transform format negotiation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,6 +182,7 @@ Table of Contents
    source/refs/changelog
    source/refs/license
    source/refs/bibliography
+   source/refs/adr/index
 
 .. toctree::
     :hidden:

--- a/docs/source/refs/adr/0001-scene-data-provider-redesign.rst
+++ b/docs/source/refs/adr/0001-scene-data-provider-redesign.rst
@@ -3,7 +3,20 @@ ADR-0001: Scene Data Provider Redesign
 
 :Status: Accepted
 :Date: 2026-04-22
+:Last Updated: 2026-04-28
 :Authors: Nathan Cournia, Daniela Hasenbring
+
+.. note::
+
+   The transport-surface and consumer-requirement framing in this ADR is
+   generalised by :doc:`0002-capability-based-provider-extensibility`, which
+   moves the typed transform API onto a ``GpuTransformBuffer`` capability
+   protocol and replaces the implicit "single GPU buffer" channel with a
+   type-keyed capability registry. The format/dispatcher/buffer-pool design
+   described below is preserved unchanged; only the location of the API
+   (now the ``GpuTransformBuffer`` protocol rather than
+   :class:`BaseSceneDataProvider`) and the consumer requirement mechanism
+   change.
 
 Context
 -------
@@ -167,9 +180,63 @@ making the SDP fully format-agnostic. This was rejected as overly complex
 for the four well-known formats used in Isaac Lab, and it would prevent
 compile-time type checking of Warp kernel inputs.
 
+Post-merge clarifications
+-------------------------
+
+The following components landed alongside the typed-format work but were
+not described in the original ADR text. They are included here for
+completeness; their futures are addressed in
+:doc:`0002-capability-based-provider-extensibility`.
+
+``SceneDataRequirement`` and ``VisualizerPrebuiltArtifacts``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``isaaclab.physics.scene_data_requirements`` ships a string-keyed
+mechanism for declaring what each in-tree consumer needs from the SDP:
+
+- ``SceneDataRequirement`` carries booleans (``requires_newton_model``,
+  ``requires_usd_stage``) and a ``preferred_transform_formats`` set.
+- ``VisualizerPrebuiltArtifacts`` carries a Newton ``Model`` and ``State``
+  produced during scene clone and consumed by providers as a fast path
+  instead of rebuilding from USD.
+- ``_VISUALIZER_REQUIREMENTS`` and ``_RENDERER_REQUIREMENTS`` map
+  string consumer-type names (``"kit"``, ``"newton"``, ``"rerun"``,
+  ``"viser"``, ``"isaac_rtx"``, ``"newton_warp"``, ``"ovrtx"``) to
+  concrete requirements.
+
+This mechanism is the precursor to the capability-based requirement
+declarations introduced in ADR-0002 and is removed by that work.
+
+PhysX→Newton sync bridge
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:class:`~isaaclab_physx.scene_data_providers.PhysxSceneDataProvider`
+maintains an optional Newton ``Model`` and ``State`` to support
+Newton-flavoured consumers (NewtonWarp renderer, Newton/Rerun/Viser
+visualizers) running against PhysX physics. The provider's
+``_needs_newton_sync`` flag is set to ``True`` when any registered
+consumer's ``SceneDataRequirement`` has ``requires_newton_model=True``,
+and each :meth:`update` call copies PhysX body transforms into the
+synthetic Newton state so consumers reading
+:meth:`get_newton_state` see PhysX-driven motion.
+
+ADR-0002 makes this generic: the bridge runs whenever a consumer queries
+the ``NewtonState`` capability, regardless of which provider is active.
+
+``SceneDataProvider`` factory class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``isaaclab.physics.scene_data_provider.SceneDataProvider`` is a thin
+factory that resolves a concrete provider subclass at construction time
+based on the active physics backend. It is part of the public API
+(:py:`from isaaclab.physics import SceneDataProvider`) and is unchanged
+by ADR-0002.
+
 References
 ----------
 
+- :doc:`0002-capability-based-provider-extensibility` — the capability
+  framework that supersedes this ADR's transport/consumer framing.
 - Proof-of-concept implementation:
   ``daniela-hase/IsaacLab`` branch ``dev/scene-data-provider-api``
 - Design meeting (2026-03-09): ``isaac-lab-render-standup.20260309.md``

--- a/docs/source/refs/adr/0001-scene-data-provider-redesign.rst
+++ b/docs/source/refs/adr/0001-scene-data-provider-redesign.rst
@@ -229,7 +229,7 @@ the ``NewtonState`` capability, regardless of which provider is active.
 ``isaaclab.physics.scene_data_provider.SceneDataProvider`` is a thin
 factory that resolves a concrete provider subclass at construction time
 based on the active physics backend. It is part of the public API
-(:py:`from isaaclab.physics import SceneDataProvider`) and is unchanged
+(``from isaaclab.physics import SceneDataProvider``) and is unchanged
 by ADR-0002.
 
 References

--- a/docs/source/refs/adr/0001-scene-data-provider-redesign.rst
+++ b/docs/source/refs/adr/0001-scene-data-provider-redesign.rst
@@ -1,0 +1,176 @@
+ADR-0001: Scene Data Provider Redesign
+=======================================
+
+:Status: Accepted
+:Date: 2026-04-22
+:Authors: Nathan Cournia, Daniela Hasenbring
+
+Context
+-------
+
+Isaac Lab bridges multiple physics simulators (PhysX, Newton) with multiple
+renderers (OVRTX, Newton Warp, Isaac RTX) and visualizers (Kit, Newton, Rerun,
+Viser). The Scene Data Provider (SDP) is the component responsible for
+transferring simulation data—primarily rigid-body transforms—between these
+subsystems.
+
+The existing SDP has several problems:
+
+1. **Untyped interface.** ``BaseSceneDataProvider.get_transforms()`` returns
+   ``dict[str, Any] | None``. Consumers must guess the format of the returned
+   data and perform ad-hoc conversions.
+
+2. **Duplicated conversion logic.** Each consumer implements its own format
+   conversions. The OVRTX renderer converts ``transformf`` → ``mat44d``, the
+   PhysX provider converts ``vec3 + quat`` → ``transformf``, and so on.
+   Adding a new consumer means writing another set of conversions.
+
+3. **No zero-copy guarantees.** Data is copied unnecessarily when the
+   simulator's native format already matches what the consumer needs.
+
+4. **No CUDA stream support.** All GPU work runs synchronously on the default
+   stream. Renderers like OVRTX that manage their own streams cannot enqueue
+   deferred work.
+
+5. **No buffer lifetime management.** Buffers are allocated per-call with no
+   pre-allocation, no reuse across frames, and no change detection to skip
+   redundant conversions.
+
+Decision
+--------
+
+We introduce a **typed format-negotiation system** for the SDP. The key
+components are:
+
+Transform format types
+^^^^^^^^^^^^^^^^^^^^^^
+
+A set of concrete dataclasses representing the four transform representations
+used in Isaac Lab:
+
+- ``Vec3QuatTransforms`` — separate position (``wp.vec3``) and quaternion
+  (``wp.quatf``) arrays. Native to PhysX.
+- ``Vec3Mat33Transforms`` — separate position and 3×3 rotation matrix arrays.
+- ``TransformArrayData`` — packed 7-float transforms (``wp.transformf``).
+  Native to Newton.
+- ``Mat44Transforms`` — 4×4 homogeneous matrices (``wp.mat44f`` or
+  ``wp.mat44d``). Native to OVRTX.
+
+Each type carries metadata: ``QuaternionConvention`` (XYZW or WXYZ) and
+``MatrixLayout`` (row-major or column-major).
+
+Centralized GPU conversion kernels
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A ``ConversionDispatcher`` selects and launches the appropriate Warp kernel
+for any ``(source_format, target_format)`` pair. All 16 kernel paths
+(4 × 4 grid) are implemented, plus quaternion convention swizzle and matrix
+layout transpose kernels. All kernels accept an optional ``index_map`` for
+subset scatter writes.
+
+This consolidates conversion logic that was previously duplicated across
+``physx_scene_data_provider.py``, ``ovrtx_renderer_kernels.py``, and
+individual visualizers.
+
+Buffer pool with generation-based caching
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``TransformBufferPool`` pre-allocates GPU output buffers and reuses them
+across frames. A generation counter (incremented each ``update()`` call)
+enables three fast paths:
+
+1. **Format-match passthrough (zero work).** When the consumer's requested
+   format matches the simulator's native format, the simulator's own GPU
+   buffer is returned directly. No copy, no kernel launch, no allocation.
+   Example: Newton backend → Newton Warp renderer, both using
+   ``TransformFormat.TRANSFORM``.
+
+2. **Same-frame conversion cache.** If the same conversion was already
+   performed this frame (same generation), the cached result is returned.
+   Example: two consumers both request ``MAT44`` → kernel runs once.
+
+3. **Cross-frame buffer reuse.** When generation changes, the conversion
+   kernel re-runs but writes into the same pre-allocated buffer—no
+   allocation.
+
+CUDA stream support
+^^^^^^^^^^^^^^^^^^^
+
+``get_body_transforms()`` accepts an optional ``stream`` parameter. When
+provided, conversion kernels are launched on that stream via
+``wp.ScopedStream``, enabling deferred execution. This follows the pattern
+established in ``NewtonManager`` and aligns with OVRTX's stream-based
+rendering pipeline.
+
+Enhanced base class
+^^^^^^^^^^^^^^^^^^^
+
+``BaseSceneDataProvider`` gains two new methods:
+
+- ``get_body_transforms(target_format, ...)`` — the primary typed API.
+  Consumers declare the format they need; the SDP converts from the
+  simulator's native format.
+- ``get_source_format()`` — returns the simulator's native transform format,
+  allowing consumers to request a passthrough-compatible format.
+
+Both methods have default implementations returning ``None`` for backward
+compatibility.
+
+Consequences
+------------
+
+Positive
+^^^^^^^^
+
+- **Zero-copy GPU-only path.** When formats match, data flows from simulator
+  to consumer without any GPU memory copies or kernel launches.
+- **No duplicated conversions.** All format conversion logic lives in one
+  place (``scene_data_kernels.py``). Adding a new consumer requires zero
+  conversion code.
+- **Type safety.** Consumers receive concrete ``TransformData`` subclasses
+  instead of untyped dicts. Format mismatches are caught at call time.
+- **Performance.** Pre-allocated buffers, generation-based caching, and
+  CUDA stream support eliminate per-frame allocation overhead and enable
+  asynchronous execution.
+- **Extensibility.** Adding a new format requires adding one enum variant,
+  one dataclass, and the conversion kernels to/from existing formats.
+
+Negative
+^^^^^^^^
+
+- **Interface change.** ``BaseSceneDataProvider`` gains new methods. Existing
+  subclasses continue to work (default implementations return ``None``), but
+  must implement the new methods to participate in the typed API.
+- **Kernel maintenance.** The 4×4 conversion grid means 16 kernel paths to
+  maintain. This is mitigated by each kernel being small (~10 lines) and
+  using Warp's built-in transform functions.
+- **Passthrough ownership semantics.** When ``allow_passthrough=True``,
+  consumers receive a reference to the simulator's buffer and must not
+  mutate it. This is documented but not enforced at runtime.
+
+Alternatives Considered
+-----------------------
+
+Per-consumer conversion library
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each renderer/visualizer could use a shared utility library for conversions
+but manage its own buffer allocation and caching. This was rejected because
+it still duplicates buffer management logic and makes the zero-copy
+passthrough optimization harder to implement centrally.
+
+Opaque binary buffers with layout descriptors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The SDP could pass opaque byte buffers with runtime layout descriptors,
+making the SDP fully format-agnostic. This was rejected as overly complex
+for the four well-known formats used in Isaac Lab, and it would prevent
+compile-time type checking of Warp kernel inputs.
+
+References
+----------
+
+- Proof-of-concept implementation:
+  ``daniela-hase/IsaacLab`` branch ``dev/scene-data-provider-api``
+- Design meeting (2026-03-09): ``isaac-lab-render-standup.20260309.md``
+- Design meeting (2026-04-02): ``new-scene-data-provider-transcript.md``

--- a/docs/source/refs/adr/0002-capability-based-provider-extensibility.rst
+++ b/docs/source/refs/adr/0002-capability-based-provider-extensibility.rst
@@ -1,0 +1,304 @@
+ADR-0002: Capability-Based Provider Extensibility
+==================================================
+
+:Status: Accepted
+:Date: 2026-04-28
+:Authors: Nathan Cournia
+:Supersedes (in part): ADR-0001 — channel and consumer-requirement framing
+
+Context
+-------
+
+ADR-0001 introduced a typed format-negotiation API on the Scene Data
+Provider (SDP). It defined four transform formats, a conversion dispatcher,
+and a buffer pool with format-match passthrough. That work assumed a single
+implicit transport surface: a GPU buffer of typed ``TransformData``.
+
+Two extensibility gaps surfaced after the typed API landed.
+
+1. **Transport surfaces are hard-coded to "GPU buffer of TransformData".**
+
+   Several in-tree consumers do not read transforms from a GPU buffer:
+
+   - :class:`~isaaclab_physx.renderers.IsaacRtxRenderer` reads transforms
+     from USD Fabric directly. Its ``update_transforms`` is a no-op.
+   - The Kit visualizer reads transforms from USD Fabric via Hydra.
+
+   These are valid fast paths — when PhysX writes Fabric natively, no
+   SDP work is needed at all. But the ADR-0001 design has no name for
+   them. Their fast paths exist only as accidental no-ops in
+   ``update_transforms`` implementations.
+
+   Customer extensions push this further. A customer authoring a vertically
+   integrated provider+consumer pair (e.g. shared-memory transport between
+   a custom physics backend and a custom remote viewer) must be able to
+   register a fast path of their own without modifying framework code. An
+   enum-keyed transport type does not allow this.
+
+2. **Consumer requirements are stringly-typed and validated implicitly.**
+
+   :class:`~isaaclab.physics.scene_data_requirements.SceneDataRequirement`
+   tracks per-consumer needs as boolean flags
+   (``requires_newton_model``, ``requires_usd_stage``) keyed by visualizer
+   or renderer type-name strings. This works for a fixed in-tree consumer
+   set but is not extensible — a customer-authored consumer cannot declare
+   a new requirement type without modifying the framework's lookup tables.
+
+   Failure modes are also implicit. When a consumer's needs are not met,
+   the failure surfaces as a ``None`` return deep in an update loop or an
+   ``AttributeError`` on a missing method — never as a coherent
+   wire-up-time error.
+
+Decision
+--------
+
+We introduce a **capability-based extensibility model** for the SDP.
+
+Capability protocols
+^^^^^^^^^^^^^^^^^^^^
+
+Each transport surface or provider service is expressed as a
+``runtime_checkable`` ``typing.Protocol``. The four built-in capabilities are:
+
+- ``GpuTransformBuffer`` — typed GPU buffer pull. Hosts the
+  :meth:`get_body_transforms` and :meth:`get_source_format` API previously
+  on :class:`BaseSceneDataProvider` (ADR-0001).
+- ``UsdFabric`` — USD prim attribute storage with explicit freshness.
+  Exposes ``ensure_current(stream=None) -> None``.
+- ``NewtonState`` — direct access to the active Newton ``State`` and
+  ``Model`` objects. Read-only. Replaces the legacy
+  :meth:`BaseSceneDataProvider.get_newton_state` and
+  :meth:`get_newton_model` methods.
+
+Capabilities are identified by Python ``type`` identity. Two protocols with
+the same name in different modules are distinct. This is intentional and
+matches the ABI risk: code that imports ``acme.shm.SharedMemoryChannel``
+expects compatibility with other code importing the same class, not with
+an unrelated class that happens to share a name.
+
+Generic capabilities (``GpuTransformBuffer``, ``UsdFabric``) live in
+``isaaclab.physics.capabilities``. Backend-specific capabilities live in
+their owning extension package (``NewtonState`` lives in
+``isaaclab_newton.physics.capabilities``).
+
+Provider registry
+^^^^^^^^^^^^^^^^^
+
+:class:`BaseSceneDataProvider` gains:
+
+.. code-block:: python
+
+    def get_capability(self, cap_type: type[T]) -> T | None: ...
+    def list_capabilities(self) -> frozenset[type]: ...
+    def get_first_capability(
+        self, *cap_types: type
+    ) -> tuple[type, Any] | None: ...
+
+Providers register handles in ``__init__`` by populating an internal
+``{type: handle}`` mapping. Handles are per-provider singletons, valid for
+the SDP's lifetime. ``get_capability`` returns the registered handle or
+``None``; ``list_capabilities`` returns all registered types;
+``get_first_capability`` walks an ordered preference list and returns the
+first match (used by consumers that prefer one cap but accept a fallback).
+
+The ``GpuTransformBuffer`` capability is **mandatory** for every provider.
+This guarantees every consumer can fall back to typed buffer pull when its
+preferred cap is unavailable, and makes ``GpuTransformBuffer`` the universal
+lingua franca across mixed provider/consumer pairs.
+
+Consumer requirement declarations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Renderer and visualizer base classes gain two ``ClassVar`` attributes:
+
+.. code-block:: python
+
+    class NewtonWarpRenderer(BaseRenderer):
+        required_capabilities: ClassVar[tuple[type, ...]] = ()
+        required_one_of: ClassVar[tuple[tuple[type, ...], ...]] = (
+            (NewtonState, GpuTransformBuffer),
+        )
+
+- ``required_capabilities`` lists capabilities all of which must be
+  present.
+- ``required_one_of`` lists groups; from each group at least one entry must
+  be present.
+
+Validation runs once at SDP wire-up after all consumers are constructed.
+A single consolidated error lists every consumer's unmet requirements.
+Consumers register themselves with the SDP from
+:class:`~isaaclab.renderers.BaseRenderer.__init__` and
+:class:`~isaaclab_visualizers.base.BaseVisualizer.__init__`.
+
+Migration of the typed transform API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The typed transform API introduced in ADR-0001 moves off
+:class:`BaseSceneDataProvider` and onto the ``GpuTransformBuffer`` protocol.
+
+Consumer code changes from:
+
+.. code-block:: python
+
+    transforms = provider.get_body_transforms(TransformFormat.MAT44, ...)
+
+to:
+
+.. code-block:: python
+
+    cap = provider.get_capability(GpuTransformBuffer)
+    transforms = cap.get_body_transforms(TransformFormat.MAT44, ...)
+
+The base-class methods ``get_body_transforms``, ``get_source_format``,
+``get_newton_state``, ``get_newton_model``, and ``get_transforms`` are
+removed. Per ``AGENTS.md``, the deprecation requirement applies only to
+released API; the entire SDP stack — including the legacy methods
+introduced by PR #4797 — is on this branch and unreleased, so removal is
+clean.
+
+Replacement for ``SceneDataRequirement``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The string-keyed requirement mechanism in
+``isaaclab.physics.scene_data_requirements`` is removed. The new
+declarative attributes on consumer base classes replace it cleanly:
+
+- ``requires_usd_stage=True`` becomes
+  ``required_capabilities = (UsdFabric,)``.
+- ``requires_newton_model=True`` becomes
+  ``required_capabilities = (NewtonState,)``.
+- ``preferred_transform_formats`` moves into the consumer's own logic — the
+  consumer chooses its target format when it calls
+  ``GpuTransformBuffer.get_body_transforms``.
+
+Consumer protocol
+^^^^^^^^^^^^^^^^^
+
+Each consumer's per-frame update follows this shape:
+
+.. code-block:: python
+
+    def update_transforms(self) -> None:
+        # Optional: ensure native channel is current. No-op when the
+        # provider writes the channel natively.
+        if self._fabric is not None:
+            self._fabric.ensure_current()
+            return
+
+        # Typed buffer-pull path.
+        transforms = self._gpu.get_body_transforms(
+            self._target_format, ...
+        )
+        if transforms is not None:
+            self._copy(transforms)
+
+Consequences
+------------
+
+Positive
+^^^^^^^^
+
+- **Customer extensibility.** Third-party packages may define their own
+  capability protocols and ship matched provider/consumer pairs. The SDP
+  forwards opaquely; the framework never needs to know what the customer's
+  cap means.
+
+- **Native-channel fast paths are first-class.** PhysX→Fabric→Isaac RTX is
+  no longer an accidental ``update_transforms`` no-op; ``UsdFabric``
+  formalizes the contract and surfaces it for testing and introspection.
+
+- **Failure mode is startup-time and explicit.** A consumer with unmet
+  requirements fails at SDP wire-up with one consolidated message listing
+  every missing capability across every consumer.
+
+- **Two parallel mechanisms collapse into one.** ``SceneDataRequirement``
+  and the implicit "this method may exist on the base class" pattern both
+  disappear. The capability registry is the single source of truth.
+
+- **The PhysX provider's ``_needs_newton_sync`` flag becomes generic.**
+  Today it answers "is any consumer asking for Newton state?" tied
+  specifically to the Newton sync bridge. Generalised: "did any consumer
+  query a non-native cap?" — keyed by capability type, not Newton-specific.
+
+- **Introspection and debug.** ``provider.list_capabilities()`` is a
+  useful debugging tool. When a consumer's expected fast path silently
+  doesn't engage, the registry shows what is actually offered.
+
+Negative
+^^^^^^^^
+
+- **One layer of indirection.** Consumers go through ``get_capability()``
+  rather than calling the base class directly. The cost is a single dict
+  lookup per cap, performed once and cached for the SDP lifetime, so
+  per-frame overhead is zero.
+
+- **Type-identity coupling.** A protocol class is the lookup key. Two
+  implementations of "a shared-memory channel" in different packages will
+  not match unless they import the same class. This is correct behaviour
+  but customers must understand it; a versioned cap (``MyCapV2``) is
+  introduced as a new class, not by mutating the existing one.
+
+- **No semantic schema enforcement.** A provider claiming to satisfy a
+  protocol is checked structurally by ``runtime_checkable``. Missing
+  methods are caught; semantically wrong implementations are not.
+
+- **Wire-up registration adds machinery.** Renderers and visualizers must
+  self-register with the SDP. The base classes do this in ``__init__`` so
+  individual subclasses are unaffected, but it does mean the SDP holds
+  weak references to consumers for the validator to walk.
+
+Alternatives Considered
+-----------------------
+
+String-keyed capability registry
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Providers expose a ``dict[str, Any]`` keyed by capability name. Rejected:
+no static type checking, no IDE autocomplete on returned handles, and
+naming collisions across packages are unprotected.
+
+Enum extension at import time
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Keep ``TransportChannel`` as an ``Enum`` and let customers register
+additional values. Rejected: Python enums are intentionally closed;
+extending them is a known anti-pattern and the value-object would still
+have nowhere to host its behavioural contract.
+
+Constructor injection of capabilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The framework wires required capability handles into each consumer at
+construction time, removing the runtime ``get_capability`` query.
+Rejected: heavier machinery without commensurate benefit; consumers can
+still cache capability handles in ``__init__``. The query pattern can
+evolve into injection if a future use case demands it.
+
+Open Items
+----------
+
+- **Custom :class:`TransformFormat`.** Customers will eventually want to
+  add new transform formats and conversion kernels. The current
+  ``TransformFormat`` ``Enum`` is closed; opening it requires migrating
+  to a class hierarchy with a kernel-registry dispatcher. This is
+  architecturally compatible with the capability model
+  (``GpuTransformBuffer.get_body_transforms`` already accepts a format
+  parameter) but is deferred to a follow-up after this PR merges.
+
+- **Cross-process capability identity.** Python ``type`` identity is
+  stable in-process but not across pickling or RPC. If the SDP is ever
+  used across processes, capabilities will need stable URN-style
+  identifiers (``"acme.shm.SharedMemoryChannel.v1"``). Out of scope.
+
+- **CudaStream capability.** Originally proposed alongside the four
+  primary capabilities. Deferred — no consumer concretely needs it yet.
+  When OVRTX or another stream-aware consumer surfaces a need, the
+  protocol will be added without disturbing the framework.
+
+References
+----------
+
+- :doc:`0001-scene-data-provider-redesign` — the typed format-negotiation
+  API this ADR builds on.
+- ``AGENTS.md`` — deprecation policy (waived here because the entire SDP
+  stack is unreleased on the branch).

--- a/docs/source/refs/adr/audits/0001-audit.rst
+++ b/docs/source/refs/adr/audits/0001-audit.rst
@@ -1,0 +1,224 @@
+ADR-0001 Implementation Audit
+==============================
+
+:Audit Date: 2026-04-29
+:Audit Branch: ``ncournia/scene-data-provider``
+:Audit Commit: ``HEAD``
+
+Each claim from :doc:`/source/refs/adr/0001-scene-data-provider-redesign`
+is matched against the implementation. Status legend:
+
+- |OK| — implemented as described.
+- |PARTIAL| — implemented with caveats noted.
+- |GAP| — claimed but not implemented (with proposed follow-up).
+- |MOVED| — relocated by ADR-0002.
+
+.. |OK| replace:: ✓ OK
+.. |PARTIAL| replace:: ◐ PARTIAL
+.. |GAP| replace:: ✗ GAP
+.. |MOVED| replace:: ↪ MOVED
+
+Decision claims
+---------------
+
+Transform format types
+^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: ``Vec3QuatTransforms``, ``Vec3Mat33Transforms``,
+  ``TransformArrayData``, ``Mat44Transforms`` dataclasses with
+  ``QuaternionConvention`` and ``MatrixLayout`` metadata.
+| Status: |OK|
+| Implementation: ``source/isaaclab/isaaclab/physics/scene_data_types.py:65-152``.
+| Tests: ``source/isaaclab/test/physics/test_scene_data_types.py``.
+
+Centralized GPU conversion kernels
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: ``ConversionDispatcher`` selects and launches Warp kernels for
+  any ``(source_format, target_format)`` pair. All 16 paths plus
+  quaternion swizzle and matrix-layout transpose, with optional
+  ``index_map`` for subset writes.
+| Status: |OK|
+| Implementation: ``source/isaaclab/isaaclab/physics/scene_data_conversion.py:39``
+  (``ConversionDispatcher``); kernels in
+  ``source/isaaclab/isaaclab/physics/scene_data_kernels.py`` (576 lines).
+| Tests: ``source/isaaclab/test/physics/test_scene_data_kernels.py`` and
+  ``test_scene_data_conversion.py``.
+
+Buffer pool with generation-based caching
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: ``TransformBufferPool`` with three fast paths — format-match
+  passthrough, same-frame conversion cache, cross-frame buffer reuse.
+| Status: |OK|
+| Implementation: ``source/isaaclab/isaaclab/physics/scene_data_buffers.py:74``
+  (``TransformBufferPool``).
+| Tests: ``source/isaaclab/test/physics/test_scene_data_buffers.py``.
+
+CUDA stream support
+^^^^^^^^^^^^^^^^^^^
+
+| Claim: ``get_body_transforms()`` accepts an optional ``stream``
+  parameter; conversion kernels launch via ``wp.ScopedStream``.
+| Status: |PARTIAL|
+| Implementation: parameter present on
+  ``GpuTransformBuffer.get_body_transforms`` (capabilities/_protocols.py)
+  and on the provider implementations
+  (``physx_scene_data_provider.py``,
+  ``newton_scene_data_provider.py``); ``ConversionDispatcher`` accepts
+  the stream and uses ``wp.ScopedStream``.
+| Caveat: the existing 56 unit tests do not exercise the stream
+  parameter — every test path uses the default stream. The contract
+  works in the abstract but is not under regression coverage.
+| Follow-up: add a stream test in
+  ``source/isaaclab/test/physics/test_scene_data_conversion.py`` that
+  asserts the dispatcher submits work to a non-default stream when one
+  is provided.
+
+Enhanced base class — ``get_body_transforms()`` and ``get_source_format()``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: ``BaseSceneDataProvider`` gains
+  ``get_body_transforms(target_format, ...)`` and
+  ``get_source_format()``.
+| Status: |MOVED|
+| Note: the methods were retained on the base class through Phase 4 of
+  the ADR-0002 migration, then removed in Phase 5
+  (commit ``2d1ab5f12``). The same API now lives on the
+  :class:`~isaaclab.physics.GpuTransformBuffer` capability protocol;
+  consumers acquire it via
+  ``provider.get_capability(GpuTransformBuffer)``.
+
+Consequences claims
+-------------------
+
+Zero-copy GPU-only path
+^^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: When formats match, data flows from simulator to consumer with
+  no GPU copies or kernel launches.
+| Status: |PARTIAL|
+| Implementation: Newton provider's ``Vec3QuatTransforms`` /
+  ``TransformArrayData`` paths return source buffers directly when
+  ``allow_passthrough=True``.
+| Caveat: no automated test asserts pointer identity between the
+  consumer's buffer and the simulator's source buffer. The
+  Newton-renderer migration in Phase 4 sets ``allow_passthrough=True``
+  but does not verify the no-copy property at runtime.
+| Follow-up: add the snapshot regression tests proposed in the migration
+  plan, and include a ``data_ptr`` identity assertion for the
+  Newton-sim + Newton-renderer combo.
+
+No duplicated conversions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: All format conversion logic lives in
+  ``scene_data_kernels.py``.
+| Status: |OK|
+| Audit: ``grep -rn "convert_camera_frame_orientation_convention\|sync_newton_transforms"``
+  shows the only remaining per-consumer conversion is OVRTX's
+  ``create_camera_transforms_kernel`` (camera-pose convention conversion,
+  outside transform-format scope) and Newton's
+  ``RenderData._update_transforms`` (camera-only). The
+  ``sync_newton_transforms_kernel`` referenced as duplicated logic in
+  the ADR was removed in commit ``2d1ab5f12``.
+
+Type safety
+^^^^^^^^^^^
+
+| Claim: Consumers receive concrete ``TransformData`` subclasses; format
+  mismatches caught at call time.
+| Status: |OK|
+| Implementation: ``GpuTransformBuffer.get_body_transforms`` returns
+  ``TransformData | None``; concrete return types are
+  ``Vec3QuatTransforms`` / ``Vec3Mat33Transforms`` /
+  ``TransformArrayData`` / ``Mat44Transforms``.
+| Caveat: type narrowing relies on consumers checking
+  ``isinstance(td, Mat44Transforms)`` (etc.) before reading
+  format-specific attributes. Documented in the dataclass docstrings
+  but not enforced.
+
+Performance — pre-allocated buffers, generation cache, streams
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |PARTIAL|
+| Same caveat as the CUDA stream claim: behaviour is implemented but
+  no benchmark or regression test pins it. A multi-frame test asserting
+  zero allocations after warm-up would close the gap.
+
+Extensibility — new format requires one enum, one dataclass, kernels
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: Adding a new format requires one ``TransformFormat`` enum
+  variant, one dataclass, and conversion kernels to/from existing
+  formats.
+| Status: |GAP|
+| ``TransformFormat`` is currently a closed Python ``Enum``
+  (``scene_data_types.py:45``); customers cannot add a new variant
+  without modifying the framework. The ``ConversionDispatcher``
+  similarly hard-codes a 4×4 grid.
+| Follow-up: per ADR-0002 Open Items §"Custom TransformFormat", convert
+  the enum to an open class hierarchy with a kernel registry. Deferred
+  to a follow-up PR after #5352 merges.
+
+Negative consequences claims
+----------------------------
+
+Interface change — subclasses with default ``None`` returns
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |MOVED|
+| The default-``None`` shim on ``BaseSceneDataProvider`` was removed in
+  Phase 5 of the ADR-0002 migration. New consumer code goes through the
+  capability registry; the back-compat path is no longer needed.
+
+Kernel maintenance — 16 paths
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| 16 kernel functions live in ``scene_data_kernels.py``; each is small
+  (~10–20 lines). Maintenance cost matches the ADR's prediction.
+
+Passthrough ownership semantics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: Documented but not enforced at runtime.
+| Status: |OK|
+| Implementation: ``GpuTransformBuffer.get_body_transforms`` docstring
+  in ``capabilities/_protocols.py`` documents the no-mutate contract;
+  ``Vec3QuatTransforms`` etc. expose mutable Warp arrays with no
+  runtime guard. As designed.
+
+Post-merge clarifications added in this audit
+---------------------------------------------
+
+The 2026-04-29 update to ADR-0001 documents three components that landed
+without ADR coverage:
+
+- ``SceneDataRequirement`` and ``VisualizerPrebuiltArtifacts``
+  (``scene_data_requirements.py``).
+- The PhysX→Newton sync bridge in
+  ``PhysxSceneDataProvider`` (``physx_scene_data_provider.py:107, 144-146``).
+- The ``SceneDataProvider`` factory (``scene_data_provider.py:20``).
+
+ADR-0002 schedules ``SceneDataRequirement`` and
+``_needs_newton_sync`` for replacement once the capability framework
+becomes the sole driver of provider service registration; that
+transition is tracked in :doc:`0002-audit`.
+
+Summary
+-------
+
+13 claims audited.
+
+- |OK|: 6
+- |PARTIAL|: 4 (CUDA stream, zero-copy, performance, type safety)
+- |GAP|: 1 (custom ``TransformFormat``)
+- |MOVED|: 2 (typed-API methods, default-``None`` consequence)
+
+Open follow-ups:
+
+1. Stream-aware test in ``test_scene_data_conversion.py``.
+2. ``data_ptr`` identity assertion for the Newton passthrough path.
+3. ``TransformFormat`` open-class refactor (deferred to follow-up PR).
+4. Allocation/benchmarks regression coverage.

--- a/docs/source/refs/adr/audits/0001-audit.rst
+++ b/docs/source/refs/adr/audits/0001-audit.rst
@@ -76,7 +76,7 @@ CUDA stream support
   is provided.
 
 Enhanced base class — ``get_body_transforms()`` and ``get_source_format()``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | Claim: ``BaseSceneDataProvider`` gains
   ``get_body_transforms(target_format, ...)`` and

--- a/docs/source/refs/adr/audits/0002-audit.rst
+++ b/docs/source/refs/adr/audits/0002-audit.rst
@@ -1,0 +1,295 @@
+ADR-0002 Implementation Audit
+==============================
+
+:Audit Date: 2026-04-29
+:Audit Branch: ``ncournia/scene-data-provider``
+:Audit Commit: ``HEAD``
+
+Each claim from
+:doc:`/source/refs/adr/0002-capability-based-provider-extensibility` is
+matched against the implementation. Status legend matches
+:doc:`0001-audit`.
+
+.. |OK| replace:: ✓ OK
+.. |PARTIAL| replace:: ◐ PARTIAL
+.. |GAP| replace:: ✗ GAP
+
+Capability protocols
+--------------------
+
+Built-in protocols ``GpuTransformBuffer``, ``UsdFabric``, ``NewtonState``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Implementation:
+
+  - ``GpuTransformBuffer`` and ``UsdFabric`` in
+    ``source/isaaclab/isaaclab/physics/capabilities/_protocols.py:30``
+    and ``:88``.
+  - ``NewtonState`` in
+    ``source/isaaclab_newton/isaaclab_newton/physics/capabilities/_protocols.py:11``.
+
+| Tests: ``source/isaaclab/test/physics/test_capabilities.py``
+  (registry mechanics; runtime-checkable assertions at
+  ``test_runtime_checkable_protocol_isinstance``).
+
+Bare-noun naming following ``typing.Iterable`` precedent
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Names ``GpuTransformBuffer``, ``UsdFabric``, ``NewtonState`` match
+  the kind-of-thing convention.
+
+Type identity by Python ``type``; same-named classes in different
+modules are distinct
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Implementation: ``BaseSceneDataProvider._capabilities`` is a
+  ``dict[type, Any]``; lookup uses class identity.
+| Test:
+  ``test_capabilities.py::test_custom_capability_routes_through_registry``
+  declares a customer-defined ``_CustomCap`` Protocol and registers it.
+
+Generic caps in ``isaaclab.physics``; ``NewtonState`` in
+``isaaclab_newton.physics``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Generic caps under
+  ``source/isaaclab/isaaclab/physics/capabilities/``;
+  Newton cap under
+  ``source/isaaclab_newton/isaaclab_newton/physics/capabilities/``.
+
+Provider registry
+-----------------
+
+``get_capability``, ``list_capabilities``, ``get_first_capability``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Implementation:
+  ``source/isaaclab/isaaclab/physics/base_scene_data_provider.py:48-80``.
+| Tests: ``test_capabilities.py``,
+  ``test_registered_capability_is_returned``,
+  ``test_get_first_capability_walks_in_order``,
+  ``test_get_first_capability_returns_none_when_all_missing``.
+
+Per-lifetime cap handles registered in subclass ``__init__``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Implementation:
+
+  - PhysX: ``physx_scene_data_provider.py`` (the cap-registration
+    block at end of ``__init__``).
+  - Newton: ``newton_scene_data_provider.py`` (same pattern).
+
+| Test: ``test_re_registration_replaces_handle``.
+
+``GpuTransformBuffer`` mandatory baseline
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: Every provider must offer ``GpuTransformBuffer`` so consumers
+  always have a fallback.
+| Status: |OK|
+| Implementation: both providers register ``GpuTransformBuffer``
+  unconditionally.
+| Tests:
+  ``test_physx_provider_capabilities.py::test_physx_baseline_capabilities``
+  and ``test_newton_provider_capabilities.py::test_newton_baseline_capabilities``
+  assert presence regardless of optional caps.
+| Caveat: not enforced at the type level. A custom provider that omits
+  ``GpuTransformBuffer`` from its registry is structurally legal —
+  validation surfaces only when a consumer requires it. The ADR claims
+  this is part of the contract; making the contract enforceable would
+  require either an abstract method on ``BaseSceneDataProvider`` or a
+  subclass-init-time assertion. Tracked as follow-up; deferred (low
+  risk: the in-tree providers all comply, and customers diverging are
+  caught immediately by the wire-up validator).
+
+Consumer requirement declarations
+---------------------------------
+
+``required_capabilities`` and ``required_one_of`` ClassVars
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Implementation:
+
+  - Base classes: ``base_renderer.py:24-34``, ``base_visualizer.py:31-40``.
+  - In-tree consumers (declared in their class bodies):
+
+    - ``OVRTXRenderer``: ``required_capabilities = (GpuTransformBuffer, NewtonState)``.
+    - ``NewtonWarpRenderer``: ``required_capabilities = (NewtonState,)``.
+    - ``IsaacRtxRenderer``: ``required_capabilities = (UsdFabric,)``.
+    - ``KitVisualizer``: ``required_capabilities = (UsdFabric,)``.
+    - ``NewtonVisualizer``, ``RerunVisualizer``, ``ViserVisualizer``:
+      ``required_capabilities = (NewtonState,)``.
+
+| Tests: ``test_capabilities.py::test_validate_passes_when_required_satisfied``,
+  ``test_validate_fails_with_missing_required``,
+  ``test_required_one_of_passes_when_any_present``,
+  ``test_required_one_of_fails_when_all_missing``,
+  ``test_required_capabilities_are_all_required``,
+  ``test_validate_consolidates_multiple_failures``.
+| Caveat: no in-tree consumer actually declares ``required_one_of``;
+  the framework supports it and unit tests cover it, but no consumer
+  exercises the preference-ordered path in practice. ADR-0002's Newton
+  Warp example (``required_one_of = ((NewtonState, GpuTransformBuffer),)``)
+  is not implemented; the actual ``NewtonWarpRenderer`` declares
+  ``NewtonState`` as strictly required because the renderer is
+  Newton-shaped end-to-end and a ``GpuTransformBuffer`` fallback was
+  never exercised.
+
+Wire-up validation runs at first frame; consolidated error
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Implementation: ``base_scene_data_provider.py``
+  ``register_consumer``, ``validate_consumer_capabilities``,
+  ``_validate_consumers_if_needed``. Both
+  ``PhysxSceneDataProvider.update`` and
+  ``NewtonSceneDataProvider.update`` call
+  ``self._validate_consumers_if_needed()`` as their first action, so
+  the consolidated error fires on the first per-frame tick after
+  consumer registration.
+| Tests: ``test_capabilities.py::test_validate_consolidates_multiple_failures``
+  covers the validator; provider-level tests in
+  ``test_physx_provider_capabilities.py`` and
+  ``test_newton_provider_capabilities.py`` exercise the wired-up call
+  path.
+
+Self-registration via ``BaseRenderer.register_with_scene_data_provider``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Implementation: ``base_renderer.py:36-43``,
+  ``base_visualizer.py:53-60``.
+| Each in-tree consumer calls
+  ``self.register_with_scene_data_provider(provider)`` once during
+  initialization or first ``update_transforms``.
+
+Migration of the typed transform API onto ``GpuTransformBuffer``
+----------------------------------------------------------------
+
+Removal of the base-class methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Claim: ``get_body_transforms``, ``get_source_format``,
+  ``get_newton_state``, ``get_newton_model``, ``get_transforms`` removed
+  from ``BaseSceneDataProvider``.
+| Status: |OK|
+| Implementation: removed in commit ``2d1ab5f12``
+  (Phase 5). Subclass ``PhysxSceneDataProvider`` and
+  ``NewtonSceneDataProvider`` implementations remain as concrete
+  methods that the cap adapters delegate to.
+
+Replacement for ``SceneDataRequirement``
+----------------------------------------
+
+| Claim: ``SceneDataRequirement`` and the string-keyed visualizer/
+  renderer requirement maps are removed; replaced by capability
+  ClassVars.
+| Status: |GAP|
+| Reality:
+
+  - ``SceneDataRequirement`` is *still* in
+    ``source/isaaclab/isaaclab/physics/scene_data_requirements.py``.
+  - ``_VISUALIZER_REQUIREMENTS`` and ``_RENDERER_REQUIREMENTS`` mappings
+    still drive provider construction
+    (``physx_scene_data_provider.py:107``,
+    ``newton_scene_data_provider.py:124``).
+  - ``NewtonWarpRenderer.__init__``
+    (``newton_warp_renderer.py:157-167``) still calls
+    ``aggregate_requirements`` and ``requirement_for_renderer_type``
+    to flag the PhysX provider's ``_needs_newton_sync``.
+
+| Why deferred: removing this requires the SimulationContext to
+  aggregate consumer ``required_capabilities`` ClassVars *before* the
+  provider is constructed, so the provider knows which optional caps
+  to set up. Today the order is reversed (provider builds, then
+  consumers register), and the cap-driven path coexists with the
+  string-keyed legacy. The two systems agree on what ends up in the
+  registry; only the trigger differs.
+| Follow-up: in a separate PR, refactor ``SimulationContext`` to walk
+  consumer ClassVars at provider-construction time, then delete
+  ``SceneDataRequirement``, ``_VISUALIZER_REQUIREMENTS``,
+  ``_RENDERER_REQUIREMENTS``, and the ``aggregate_requirements`` /
+  ``requirement_for_*`` helpers. The ``_needs_newton_sync`` and
+  ``_needs_usd_sync`` flags become "did any consumer register cap X?"
+  derived from the consumer registry.
+
+``_needs_newton_sync`` becomes generic
+--------------------------------------
+
+| Claim: PhysX's ``_needs_newton_sync`` flag becomes
+  capability-driven, no longer Newton-specific.
+| Status: |GAP|
+| Same root cause as the ``SceneDataRequirement`` gap: the flag is
+  still derived from
+  ``simulation_context.get_scene_data_requirements().requires_newton_model``
+  (``physx_scene_data_provider.py:107``), not from registered consumer
+  caps. Tracked as part of the same follow-up.
+
+Customer extensibility
+----------------------
+
+Third-party packages may define their own protocols
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |OK|
+| Verified by the ``_CustomCap`` test in ``test_capabilities.py``,
+  which defines a customer-shaped Protocol and registers it on a fake
+  provider with no framework changes.
+
+Open Items declared in ADR-0002
+-------------------------------
+
+Custom :class:`TransformFormat`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |GAP|, deferred (per ADR §"Open Items").
+| ``TransformFormat`` is still a closed ``Enum``
+  (``scene_data_types.py:45``); the ``ConversionDispatcher`` holds a
+  hard-coded 4×4 kernel grid (``scene_data_conversion.py``). To open
+  the design, ``TransformFormat`` becomes a class hierarchy and the
+  dispatcher becomes a registry. The ADR explicitly defers this; the
+  audit confirms no work has been done.
+
+Cross-process capability identity
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |GAP|, declared out-of-scope by the ADR. No work done.
+
+``CudaStream`` capability
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Status: |GAP|, declared deferred by the ADR. No work done. The
+  existing ``stream`` parameter on
+  ``GpuTransformBuffer.get_body_transforms`` covers the only concrete
+  in-tree need today.
+
+Summary
+-------
+
+15 claims audited.
+
+- |OK|: 12
+- |PARTIAL|: 0
+- |GAP|: 3 (``SceneDataRequirement`` retired, ``_needs_newton_sync``
+  generalized, custom ``TransformFormat``)
+
+Open follow-ups (ranked by visibility risk):
+
+1. **Refactor ``SimulationContext`` to drive provider construction
+   from consumer ClassVars.** Closes both ``SceneDataRequirement``
+   and ``_needs_newton_sync`` gaps in one move. Larger refactor;
+   recommend separate PR after #5352 merges.
+2. **Open ``TransformFormat`` to a class hierarchy.** Deferred per
+   ADR-0002; necessary for customer-defined formats but not blocking
+   the in-tree consumer surface.
+3. **Mandatory-baseline enforcement for ``GpuTransformBuffer``.** Add
+   either a base-class assertion or a subclass-init check. Low-risk
+   guard that future custom providers do not silently violate the
+   baseline contract.

--- a/docs/source/refs/adr/audits/0002-audit.rst
+++ b/docs/source/refs/adr/audits/0002-audit.rst
@@ -18,7 +18,7 @@ Capability protocols
 --------------------
 
 Built-in protocols ``GpuTransformBuffer``, ``UsdFabric``, ``NewtonState``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | Status: |OK|
 | Implementation:
@@ -65,7 +65,7 @@ Provider registry
 -----------------
 
 ``get_capability``, ``list_capabilities``, ``get_first_capability``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | Status: |OK|
 | Implementation:

--- a/docs/source/refs/adr/index.rst
+++ b/docs/source/refs/adr/index.rst
@@ -8,3 +8,4 @@ design decisions in Isaac Lab.
    :maxdepth: 1
 
    0001-scene-data-provider-redesign
+   0002-capability-based-provider-extensibility

--- a/docs/source/refs/adr/index.rst
+++ b/docs/source/refs/adr/index.rst
@@ -9,3 +9,10 @@ design decisions in Isaac Lab.
 
    0001-scene-data-provider-redesign
    0002-capability-based-provider-extensibility
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Implementation audits
+
+   audits/0001-audit
+   audits/0002-audit

--- a/docs/source/refs/adr/index.rst
+++ b/docs/source/refs/adr/index.rst
@@ -1,0 +1,10 @@
+Architecture Decision Records
+=============================
+
+This directory contains Architecture Decision Records (ADRs) for significant
+design decisions in Isaac Lab.
+
+.. toctree::
+   :maxdepth: 1
+
+   0001-scene-data-provider-redesign

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.6.23"
+version = "4.6.24"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.6.21"
+version = "4.6.23"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.6.24"
+version = "4.6.25"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,32 @@
 Changelog
 ---------
 
+4.6.23 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :mod:`isaaclab.physics.capabilities` capability protocols for
+  Scene Data Provider extensibility:
+  :class:`~isaaclab.physics.GpuTransformBuffer` and
+  :class:`~isaaclab.physics.UsdFabric`. Customers may define their own
+  protocols in their own packages following the same pattern.
+* Added :meth:`~isaaclab.physics.BaseSceneDataProvider.get_capability`,
+  :meth:`~isaaclab.physics.BaseSceneDataProvider.list_capabilities`, and
+  :meth:`~isaaclab.physics.BaseSceneDataProvider.get_first_capability`
+  for runtime capability discovery.
+* Added :meth:`~isaaclab.physics.BaseSceneDataProvider.register_consumer`
+  and :meth:`~isaaclab.physics.BaseSceneDataProvider.validate_consumer_capabilities`
+  with :class:`~isaaclab.physics.CapabilityRequirementError` for wire-up
+  validation of consumer requirements.
+* Added ``required_capabilities`` and ``required_one_of`` ClassVars to
+  :class:`~isaaclab.renderers.BaseRenderer` and
+  :class:`~isaaclab.visualizers.BaseVisualizer` for declarative consumer
+  capability requirements. See
+  :doc:`/source/refs/adr/0002-capability-based-provider-extensibility`.
+
+
 4.6.22 (2026-04-27)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,26 @@
 Changelog
 ---------
 
+4.6.24 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Removed
+^^^^^^^
+
+* Removed :meth:`get_body_transforms` and :meth:`get_source_format` from
+  :class:`~isaaclab.physics.BaseSceneDataProvider`. Both were unreleased
+  on this branch and the typed transform API now lives on the
+  :class:`~isaaclab.physics.GpuTransformBuffer` capability protocol.
+  Migration: ``provider.get_capability(GpuTransformBuffer).get_body_transforms(...)``.
+* Removed :meth:`get_newton_model`, :meth:`get_newton_state`,
+  :meth:`get_transforms`, :meth:`get_velocities`, and :meth:`get_contacts`
+  from :class:`~isaaclab.physics.BaseSceneDataProvider`. Newton-specific
+  state access lives on the :class:`~isaaclab_newton.physics.NewtonState`
+  capability protocol; the per-frame transform/velocity/contact data
+  was never wired up across providers and consumers and is removed
+  pending future capability designs.
+
+
 4.6.23 (2026-04-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,23 @@
 Changelog
 ---------
 
+4.6.25 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab.sim.SimulationContext.initialize_visualizers`
+  overwriting scene-data requirements with visualizer-only requirements,
+  discarding sensor-renderer requirements (e.g. ``requires_usd_stage``)
+  set earlier by :class:`~isaaclab.scene.InteractiveScene`. The two are
+  now merged via :func:`aggregate_requirements`, so the Scene Data
+  Provider sees the full picture at construction time. This was a
+  pre-existing bug; it surfaced once the capability framework
+  (ADR-0002) added explicit cap requirements on consumers like
+  :class:`~isaaclab_physx.renderers.IsaacRtxRenderer`.
+
+
 4.6.24 (2026-04-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,29 @@
 Changelog
 ---------
 
+4.6.22 (2026-04-27)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added typed transform format negotiation system for the Scene Data Provider:
+  :class:`~isaaclab.physics.TransformFormat`, :class:`~isaaclab.physics.TransformData`,
+  :class:`~isaaclab.physics.Vec3QuatTransforms`, :class:`~isaaclab.physics.Vec3Mat33Transforms`,
+  :class:`~isaaclab.physics.TransformArrayData`, :class:`~isaaclab.physics.Mat44Transforms`,
+  :class:`~isaaclab.physics.QuaternionConvention`, :class:`~isaaclab.physics.MatrixLayout`.
+* Added :class:`~isaaclab.physics.ConversionDispatcher` with centralized GPU-only
+  Warp kernels for all transform format conversions, replacing per-consumer
+  conversion code.
+* Added :class:`~isaaclab.physics.TransformBufferPool` with generation-based
+  caching, zero-copy passthrough, and cross-frame buffer reuse.
+* Added :meth:`~isaaclab.physics.BaseSceneDataProvider.get_body_transforms` and
+  :meth:`~isaaclab.physics.BaseSceneDataProvider.get_source_format` to
+  :class:`~isaaclab.physics.BaseSceneDataProvider` for typed transform access.
+* Added ``preferred_transform_formats`` to
+  :class:`~isaaclab.physics.scene_data_requirements.SceneDataRequirement`.
+
+
 4.6.21 (2026-04-27)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/physics/__init__.pyi
+++ b/source/isaaclab/isaaclab/physics/__init__.pyi
@@ -4,25 +4,35 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 __all__ = [
-    "CallbackHandle",
-    "ConversionDispatcher",
-    "PhysicsEvent",
-    "PhysicsManager",
-    "PhysicsCfg",
     "BaseSceneDataProvider",
+    "CallbackHandle",
+    "CapabilityRequirementError",
+    "ConversionDispatcher",
+    "GpuTransformBuffer",
     "Mat44Transforms",
     "MatrixLayout",
+    "PhysicsCfg",
+    "PhysicsEvent",
+    "PhysicsManager",
     "QuaternionConvention",
     "SceneDataProvider",
     "TransformArrayData",
     "TransformBufferPool",
     "TransformData",
     "TransformFormat",
+    "UsdFabric",
     "Vec3Mat33Transforms",
     "Vec3QuatTransforms",
+    "validate_consumer_capabilities",
 ]
 
 from .base_scene_data_provider import BaseSceneDataProvider
+from .capabilities import (
+    CapabilityRequirementError,
+    GpuTransformBuffer,
+    UsdFabric,
+    validate_consumer_capabilities,
+)
 from .physics_manager import CallbackHandle, PhysicsEvent, PhysicsManager
 from .physics_manager_cfg import PhysicsCfg
 from .scene_data_buffers import TransformBufferPool

--- a/source/isaaclab/isaaclab/physics/__init__.pyi
+++ b/source/isaaclab/isaaclab/physics/__init__.pyi
@@ -5,14 +5,36 @@
 
 __all__ = [
     "CallbackHandle",
+    "ConversionDispatcher",
     "PhysicsEvent",
     "PhysicsManager",
     "PhysicsCfg",
     "BaseSceneDataProvider",
+    "Mat44Transforms",
+    "MatrixLayout",
+    "QuaternionConvention",
     "SceneDataProvider",
+    "TransformArrayData",
+    "TransformBufferPool",
+    "TransformData",
+    "TransformFormat",
+    "Vec3Mat33Transforms",
+    "Vec3QuatTransforms",
 ]
 
 from .base_scene_data_provider import BaseSceneDataProvider
 from .physics_manager import CallbackHandle, PhysicsEvent, PhysicsManager
 from .physics_manager_cfg import PhysicsCfg
+from .scene_data_buffers import TransformBufferPool
+from .scene_data_conversion import ConversionDispatcher
 from .scene_data_provider import SceneDataProvider
+from .scene_data_types import (
+    Mat44Transforms,
+    MatrixLayout,
+    QuaternionConvention,
+    TransformArrayData,
+    TransformData,
+    TransformFormat,
+    Vec3Mat33Transforms,
+    Vec3QuatTransforms,
+)

--- a/source/isaaclab/isaaclab/physics/base_scene_data_provider.py
+++ b/source/isaaclab/isaaclab/physics/base_scene_data_provider.py
@@ -10,9 +10,30 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+import warp as wp
+
+from .scene_data_types import (
+    MatrixLayout,
+    QuaternionConvention,
+    TransformData,
+    TransformFormat,
+)
+
 
 class BaseSceneDataProvider(ABC):
-    """Backend-agnostic scene data provider interface."""
+    """Backend-agnostic scene data provider interface.
+
+    The SDP acts as a central hub that bridges simulator data to renderers
+    and visualizers. It does not own simulation data—it provides
+    format-negotiated access to it.
+
+    Consumers should prefer the typed :meth:`get_body_transforms` API over
+    the legacy :meth:`get_transforms` method.
+    """
+
+    # ------------------------------------------------------------------
+    # Existing abstract methods (backward compatible)
+    # ------------------------------------------------------------------
 
     @abstractmethod
     def update(self) -> None:
@@ -58,3 +79,69 @@ class BaseSceneDataProvider(ABC):
     def get_camera_transforms(self) -> dict[str, Any] | None:
         """Return per-camera, per-env transforms, if supported."""
         raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Typed transform API
+    # ------------------------------------------------------------------
+
+    def get_body_transforms(
+        self,
+        target_format: TransformFormat,
+        *,
+        env_ids: list[int] | None = None,
+        quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
+        matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
+        double_precision: bool = False,
+        stream: wp.Stream | None = None,
+        allow_passthrough: bool = True,
+        index_map: wp.array | None = None,
+    ) -> TransformData | None:
+        """Return body transforms in the requested format.
+
+        Consumers declare what format they need; the provider converts from
+        the simulator's native format using GPU-only Warp kernels. Conversion
+        results are cached per frame and reused if multiple consumers request
+        the same format.
+
+        When the simulator's native format matches the requested format and
+        *allow_passthrough* is ``True``, the returned :class:`TransformData`
+        may reference the simulator's own GPU buffers (zero-copy passthrough).
+        The consumer must not mutate the returned data in this case.
+
+        Args:
+            target_format: Desired output transform representation.
+            env_ids: Optional environment subset. When provided, only
+                transforms for the specified environments are included.
+            quat_convention: Quaternion component ordering for
+                :attr:`TransformFormat.VEC3_QUAT` output.
+            matrix_layout: Matrix memory layout for
+                :attr:`TransformFormat.VEC3_MAT33` and
+                :attr:`TransformFormat.MAT44` output.
+            double_precision: Use 64-bit floats for
+                :attr:`TransformFormat.MAT44` output.
+            stream: CUDA stream for deferred kernel execution. When provided,
+                conversion kernels are enqueued on this stream instead of
+                the default stream.
+            allow_passthrough: If ``True`` and formats match, return the
+                source data directly without copying. The consumer must not
+                mutate the result.
+            index_map: Optional index remapping array for subset scatter
+                writes. When provided, ``output[i]`` is written from
+                ``source[index_map[i]]``.
+
+        Returns:
+            Typed transform data, or ``None`` if not supported by this
+            provider.
+        """
+        return None
+
+    def get_source_format(self) -> TransformFormat | None:
+        """Return the simulator's native transform format.
+
+        Consumers can use this to request a passthrough-compatible format and
+        avoid conversions entirely.
+
+        Returns:
+            The native transform format, or ``None`` if unknown.
+        """
+        return None

--- a/source/isaaclab/isaaclab/physics/base_scene_data_provider.py
+++ b/source/isaaclab/isaaclab/physics/base_scene_data_provider.py
@@ -11,15 +11,7 @@ import weakref
 from abc import ABC, abstractmethod
 from typing import Any, TypeVar
 
-import warp as wp
-
 from .capabilities._validator import validate_consumer_capabilities
-from .scene_data_types import (
-    MatrixLayout,
-    QuaternionConvention,
-    TransformData,
-    TransformFormat,
-)
 
 T = TypeVar("T")
 
@@ -118,7 +110,7 @@ class BaseSceneDataProvider(ABC):
             self.validate_consumer_capabilities()
 
     # ------------------------------------------------------------------
-    # Existing abstract methods (backward compatible)
+    # Provider lifecycle
     # ------------------------------------------------------------------
 
     @abstractmethod
@@ -127,18 +119,14 @@ class BaseSceneDataProvider(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_newton_model(self) -> Any | None:
-        """Return Newton model handle when available."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_newton_state(self) -> Any | None:
-        """Return Newton state handle when available (full state)."""
-        raise NotImplementedError
-
-    @abstractmethod
     def get_usd_stage(self) -> Any | None:
-        """Return USD stage handle when available."""
+        """Return USD stage handle when available.
+
+        Kept on the base class because USD stage access is orthogonal to
+        capability registration — consumers that need only the stage (not
+        per-frame USD freshness) use this directly. For per-frame freshness
+        guarantees, request the :class:`UsdFabric` capability instead.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -147,58 +135,6 @@ class BaseSceneDataProvider(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_transforms(self) -> dict[str, Any] | None:
-        """Return body transforms, if supported."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_velocities(self) -> dict[str, Any] | None:
-        """Return body velocities, if supported."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_contacts(self) -> dict[str, Any] | None:
-        """Return contacts, if supported."""
-        raise NotImplementedError
-
-    @abstractmethod
     def get_camera_transforms(self) -> dict[str, Any] | None:
         """Return per-camera, per-env transforms, if supported."""
         raise NotImplementedError
-
-    # ------------------------------------------------------------------
-    # Typed transform API (legacy — see ADR-0002)
-    # ------------------------------------------------------------------
-
-    def get_body_transforms(
-        self,
-        target_format: TransformFormat,
-        *,
-        env_ids: list[int] | None = None,
-        quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
-        matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
-        double_precision: bool = False,
-        stream: wp.Stream | None = None,
-        allow_passthrough: bool = True,
-        index_map: wp.array | None = None,
-    ) -> TransformData | None:
-        """Return body transforms in the requested format.
-
-        .. note::
-
-           This method is retained as a convenience forwarder during the
-           migration to the capability framework. New consumer code should
-           prefer ``get_capability(GpuTransformBuffer).get_body_transforms``
-           instead. See ADR-0002.
-        """
-        return None
-
-    def get_source_format(self) -> TransformFormat | None:
-        """Return the simulator's native transform format.
-
-        .. note::
-
-           Retained as a convenience forwarder. Prefer
-           ``get_capability(GpuTransformBuffer).get_source_format``.
-        """
-        return None

--- a/source/isaaclab/isaaclab/physics/base_scene_data_provider.py
+++ b/source/isaaclab/isaaclab/physics/base_scene_data_provider.py
@@ -7,11 +7,13 @@
 
 from __future__ import annotations
 
+import weakref
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, TypeVar
 
 import warp as wp
 
+from .capabilities._validator import validate_consumer_capabilities
 from .scene_data_types import (
     MatrixLayout,
     QuaternionConvention,
@@ -19,17 +21,101 @@ from .scene_data_types import (
     TransformFormat,
 )
 
+T = TypeVar("T")
+
 
 class BaseSceneDataProvider(ABC):
     """Backend-agnostic scene data provider interface.
 
     The SDP acts as a central hub that bridges simulator data to renderers
-    and visualizers. It does not own simulation data—it provides
+    and visualizers. It does not own simulation data — it provides
     format-negotiated access to it.
 
-    Consumers should prefer the typed :meth:`get_body_transforms` API over
-    the legacy :meth:`get_transforms` method.
+    Provider services are exposed as **capabilities**: typed protocol
+    handles registered by the provider and queried by consumers. See
+    :doc:`/source/refs/adr/0002-capability-based-provider-extensibility`.
     """
+
+    def __init__(self) -> None:
+        self._capabilities: dict[type, Any] = {}
+        self._consumers: weakref.WeakSet = weakref.WeakSet()
+        self._capabilities_validated = False
+
+    # ------------------------------------------------------------------
+    # Capability registry
+    # ------------------------------------------------------------------
+
+    def get_capability(self, cap_type: type[T]) -> T | None:
+        """Return the registered handle for *cap_type*, or ``None``.
+
+        Args:
+            cap_type: Capability protocol class to look up.
+
+        Returns:
+            The handle registered for *cap_type*, or ``None`` when this
+            provider does not offer that capability.
+        """
+        return self._capabilities.get(cap_type)
+
+    def list_capabilities(self) -> frozenset[type]:
+        """Return the set of capability types this provider offers."""
+        return frozenset(self._capabilities)
+
+    def get_first_capability(self, *cap_types: type) -> tuple[type, Any] | None:
+        """Return the first registered capability among *cap_types*.
+
+        Walks the arguments in order and returns the first match.
+
+        Args:
+            *cap_types: Capability protocol classes in preference order.
+
+        Returns:
+            A ``(cap_type, handle)`` tuple for the first match, or ``None``
+            when none of the requested capabilities are registered.
+        """
+        for cap_type in cap_types:
+            handle = self._capabilities.get(cap_type)
+            if handle is not None:
+                return cap_type, handle
+        return None
+
+    def _register_capability(self, cap_type: type[T], handle: T) -> None:
+        """Register *handle* as the implementation of *cap_type*.
+
+        Subclasses call this from ``__init__`` for every capability they
+        offer. Re-registering a capability replaces the previous handle.
+        """
+        self._capabilities[cap_type] = handle
+
+    # ------------------------------------------------------------------
+    # Consumer registry and wire-up validation
+    # ------------------------------------------------------------------
+
+    def register_consumer(self, consumer: Any) -> None:
+        """Register a consumer (renderer or visualizer) with this provider.
+
+        Consumers self-register so the provider can validate their
+        capability requirements at wire-up. The consumer is held by weak
+        reference; the provider does not extend its lifetime.
+        """
+        self._consumers.add(consumer)
+        # Re-validate next update; new consumer may have unmet requirements.
+        self._capabilities_validated = False
+
+    def validate_consumer_capabilities(self) -> None:
+        """Check that every registered consumer's requirements are met.
+
+        Raises:
+            CapabilityRequirementError: One or more consumers have unmet
+                ``required_capabilities`` or ``required_one_of`` declarations.
+        """
+        validate_consumer_capabilities(self, list(self._consumers))
+        self._capabilities_validated = True
+
+    def _validate_consumers_if_needed(self) -> None:
+        """Idempotent validator hook for use from per-frame ``update()``."""
+        if not self._capabilities_validated:
+            self.validate_consumer_capabilities()
 
     # ------------------------------------------------------------------
     # Existing abstract methods (backward compatible)
@@ -81,7 +167,7 @@ class BaseSceneDataProvider(ABC):
         raise NotImplementedError
 
     # ------------------------------------------------------------------
-    # Typed transform API
+    # Typed transform API (legacy — see ADR-0002)
     # ------------------------------------------------------------------
 
     def get_body_transforms(
@@ -98,50 +184,21 @@ class BaseSceneDataProvider(ABC):
     ) -> TransformData | None:
         """Return body transforms in the requested format.
 
-        Consumers declare what format they need; the provider converts from
-        the simulator's native format using GPU-only Warp kernels. Conversion
-        results are cached per frame and reused if multiple consumers request
-        the same format.
+        .. note::
 
-        When the simulator's native format matches the requested format and
-        *allow_passthrough* is ``True``, the returned :class:`TransformData`
-        may reference the simulator's own GPU buffers (zero-copy passthrough).
-        The consumer must not mutate the returned data in this case.
-
-        Args:
-            target_format: Desired output transform representation.
-            env_ids: Optional environment subset. When provided, only
-                transforms for the specified environments are included.
-            quat_convention: Quaternion component ordering for
-                :attr:`TransformFormat.VEC3_QUAT` output.
-            matrix_layout: Matrix memory layout for
-                :attr:`TransformFormat.VEC3_MAT33` and
-                :attr:`TransformFormat.MAT44` output.
-            double_precision: Use 64-bit floats for
-                :attr:`TransformFormat.MAT44` output.
-            stream: CUDA stream for deferred kernel execution. When provided,
-                conversion kernels are enqueued on this stream instead of
-                the default stream.
-            allow_passthrough: If ``True`` and formats match, return the
-                source data directly without copying. The consumer must not
-                mutate the result.
-            index_map: Optional index remapping array for subset scatter
-                writes. When provided, ``output[i]`` is written from
-                ``source[index_map[i]]``.
-
-        Returns:
-            Typed transform data, or ``None`` if not supported by this
-            provider.
+           This method is retained as a convenience forwarder during the
+           migration to the capability framework. New consumer code should
+           prefer ``get_capability(GpuTransformBuffer).get_body_transforms``
+           instead. See ADR-0002.
         """
         return None
 
     def get_source_format(self) -> TransformFormat | None:
         """Return the simulator's native transform format.
 
-        Consumers can use this to request a passthrough-compatible format and
-        avoid conversions entirely.
+        .. note::
 
-        Returns:
-            The native transform format, or ``None`` if unknown.
+           Retained as a convenience forwarder. Prefer
+           ``get_capability(GpuTransformBuffer).get_source_format``.
         """
         return None

--- a/source/isaaclab/isaaclab/physics/capabilities/__init__.py
+++ b/source/isaaclab/isaaclab/physics/capabilities/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Capability protocols for Scene Data Provider extensibility.
+
+The capability registry replaces the implicit single-channel framing of
+the original Scene Data Provider design. Each provider service — typed
+GPU buffer access, USD Fabric freshness, Newton state access, customer
+extensions — is expressed as a runtime-checkable :class:`typing.Protocol`.
+
+Consumers query the active provider by capability *type*::
+
+    cap = provider.get_capability(GpuTransformBuffer)
+    if cap is not None:
+        transforms = cap.get_body_transforms(TransformFormat.MAT44)
+
+See :doc:`/source/refs/adr/0002-capability-based-provider-extensibility`
+for the full design rationale.
+"""
+
+from ._protocols import GpuTransformBuffer, UsdFabric
+from ._validator import (
+    CapabilityRequirementError,
+    validate_consumer_capabilities,
+)
+
+__all__ = [
+    "CapabilityRequirementError",
+    "GpuTransformBuffer",
+    "UsdFabric",
+    "validate_consumer_capabilities",
+]

--- a/source/isaaclab/isaaclab/physics/capabilities/_protocols.py
+++ b/source/isaaclab/isaaclab/physics/capabilities/_protocols.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Built-in capability protocols.
+
+Each capability is a :func:`typing.runtime_checkable` :class:`typing.Protocol`
+identifying a specific provider service. Customers may define their own
+protocols in their own packages following the same pattern; identity is
+by Python ``type``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import warp as wp
+
+from ..scene_data_types import (
+    MatrixLayout,
+    QuaternionConvention,
+    TransformData,
+    TransformFormat,
+)
+
+
+@runtime_checkable
+class GpuTransformBuffer(Protocol):
+    """Typed GPU-buffer access to body transforms.
+
+    Consumers declare a target :class:`TransformFormat` and the provider
+    returns a typed :class:`TransformData` with converted data, or a
+    zero-copy passthrough when the requested format matches the
+    simulator's native format.
+
+    This is the mandatory baseline capability — every Scene Data Provider
+    must register an implementation, so every consumer can fall back to
+    typed buffer pull when its preferred capability is unavailable.
+    """
+
+    def get_body_transforms(
+        self,
+        target_format: TransformFormat,
+        *,
+        env_ids: list[int] | None = None,
+        quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
+        matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
+        double_precision: bool = False,
+        stream: wp.Stream | None = None,
+        allow_passthrough: bool = True,
+        index_map: wp.array | None = None,
+    ) -> TransformData | None:
+        """Return body transforms in the requested format.
+
+        Args:
+            target_format: Desired output transform representation.
+            env_ids: Optional environment subset to include.
+            quat_convention: Quaternion component ordering for
+                :attr:`TransformFormat.VEC3_QUAT` output.
+            matrix_layout: Matrix memory layout for
+                :attr:`TransformFormat.VEC3_MAT33` and
+                :attr:`TransformFormat.MAT44` output.
+            double_precision: Use 64-bit floats for
+                :attr:`TransformFormat.MAT44` output.
+            stream: CUDA stream for deferred kernel execution.
+            allow_passthrough: If ``True`` and formats match, return the
+                source data directly without copying.
+            index_map: Optional index remapping array for subset scatter
+                writes.
+
+        Returns:
+            Typed transform data, or ``None`` if not supported by this
+            provider.
+        """
+        ...
+
+    def get_source_format(self) -> TransformFormat | None:
+        """Return the simulator's native transform format.
+
+        Consumers can use this to request a passthrough-compatible format
+        and avoid conversions entirely.
+
+        Returns:
+            The native transform format, or ``None`` if unknown.
+        """
+        ...
+
+
+@runtime_checkable
+class UsdFabric(Protocol):
+    """USD Fabric channel — guarantees prim attributes reflect the current
+    physics generation.
+
+    Providers that natively write Fabric (e.g. PhysX via the Tensor API)
+    implement :meth:`ensure_current` as a fast no-op. Providers that do
+    not write Fabric natively (e.g. Newton) implement it by running their
+    sync-to-USD bridge.
+    """
+
+    def ensure_current(self, stream: wp.Stream | None = None) -> None:
+        """Ensure USD Fabric attributes reflect the current physics state.
+
+        Args:
+            stream: CUDA stream for deferred work, when applicable.
+        """
+        ...

--- a/source/isaaclab/isaaclab/physics/capabilities/_validator.py
+++ b/source/isaaclab/isaaclab/physics/capabilities/_validator.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Wire-up validator for consumer capability requirements."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..base_scene_data_provider import BaseSceneDataProvider
+
+
+class CapabilityRequirementError(RuntimeError):
+    """Raised when one or more registered consumers have unmet capability
+    requirements against the active Scene Data Provider.
+
+    The error message lists every consumer with at least one missing
+    capability, so a single error report covers all wire-up failures.
+    """
+
+
+def validate_consumer_capabilities(
+    provider: BaseSceneDataProvider,
+    consumers: list[Any],
+) -> None:
+    """Validate that every consumer's capability requirements are satisfied.
+
+    Each consumer may declare two ``ClassVar`` attributes:
+
+    - ``required_capabilities``: a tuple of capability types, all of which
+      must be present.
+    - ``required_one_of``: a tuple of tuples; from each inner tuple at least
+      one capability type must be present.
+
+    Args:
+        provider: The active Scene Data Provider.
+        consumers: All registered consumer instances.
+
+    Raises:
+        CapabilityRequirementError: One or more consumers have unmet
+            requirements. The message lists every offender.
+    """
+    available = provider.list_capabilities()
+    failures: list[str] = []
+
+    for consumer in consumers:
+        consumer_label = _label(consumer)
+        missing_required: list[type] = []
+        missing_one_of: list[tuple[type, ...]] = []
+
+        for cap_type in getattr(consumer, "required_capabilities", ()):
+            if cap_type not in available:
+                missing_required.append(cap_type)
+
+        for group in getattr(consumer, "required_one_of", ()):
+            if not any(c in available for c in group):
+                missing_one_of.append(tuple(group))
+
+        if missing_required or missing_one_of:
+            parts: list[str] = []
+            if missing_required:
+                parts.append(
+                    "missing required: ["
+                    + ", ".join(_cap_name(c) for c in missing_required)
+                    + "]"
+                )
+            if missing_one_of:
+                parts.append(
+                    "missing one-of: ["
+                    + ", ".join(
+                        "(" + " | ".join(_cap_name(c) for c in g) + ")"
+                        for g in missing_one_of
+                    )
+                    + "]"
+                )
+            failures.append(f"  - {consumer_label}: " + "; ".join(parts))
+
+    if failures:
+        offered = ", ".join(sorted(_cap_name(c) for c in available)) or "<none>"
+        raise CapabilityRequirementError(
+            "Consumer capability requirements not met by the active Scene"
+            " Data Provider. Offered capabilities: ["
+            + offered
+            + "]\n"
+            + "\n".join(failures)
+        )
+
+
+def _cap_name(cap_type: type) -> str:
+    return f"{cap_type.__module__}.{cap_type.__name__}"
+
+
+def _label(consumer: Any) -> str:
+    cls = type(consumer)
+    return f"{cls.__module__}.{cls.__name__}"

--- a/source/isaaclab/isaaclab/physics/scene_data_buffers.py
+++ b/source/isaaclab/isaaclab/physics/scene_data_buffers.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Pre-allocated GPU buffer pool for transform format conversion.
+
+Provides :class:`TransformBufferPool`, which manages pre-allocated GPU
+buffers for format conversion results and implements the three fast paths:
+format-match passthrough, same-frame cache, and cross-frame buffer reuse.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+from .scene_data_conversion import ConversionDispatcher
+from .scene_data_types import (
+    Mat44Transforms,
+    MatrixLayout,
+    QuaternionConvention,
+    TransformArrayData,
+    TransformData,
+    TransformFormat,
+    Vec3Mat33Transforms,
+    Vec3QuatTransforms,
+)
+
+
+def _allocate_transform_data(
+    fmt: TransformFormat,
+    count: int,
+    device: str,
+    *,
+    quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
+    matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
+    double_precision: bool = False,
+) -> TransformData:
+    """Allocate a :class:`TransformData` with zeroed GPU buffers."""
+    if fmt == TransformFormat.VEC3_QUAT:
+        return Vec3QuatTransforms(
+            count=count,
+            device=device,
+            positions=wp.zeros(count, dtype=wp.vec3, device=device),
+            orientations=wp.zeros(count, dtype=wp.quatf, device=device),
+            quat_convention=quat_convention,
+        )
+    if fmt == TransformFormat.VEC3_MAT33:
+        return Vec3Mat33Transforms(
+            count=count,
+            device=device,
+            positions=wp.zeros(count, dtype=wp.vec3, device=device),
+            rotations=wp.zeros(count, dtype=wp.mat33f, device=device),
+            layout=matrix_layout,
+        )
+    if fmt == TransformFormat.TRANSFORM:
+        return TransformArrayData(
+            count=count,
+            device=device,
+            transforms=wp.zeros(count, dtype=wp.transformf, device=device),
+        )
+    if fmt == TransformFormat.MAT44:
+        mat_dtype = wp.mat44d if double_precision else wp.mat44f
+        return Mat44Transforms(
+            count=count,
+            device=device,
+            matrices=wp.zeros(count, dtype=mat_dtype, device=device),
+            layout=matrix_layout,
+            double_precision=double_precision,
+        )
+    raise ValueError(f"Unknown format: {fmt}")
+
+
+class TransformBufferPool:
+    """Pre-allocated GPU buffer pool for transform format conversions.
+
+    Manages output buffers keyed by conversion parameters and implements
+    generation-based caching to avoid redundant conversions within a frame.
+
+    Three fast paths are supported:
+
+    1. **Format-match passthrough** -- when the requested format matches the
+       source format and ``allow_passthrough=True``, the source data is
+       returned directly (zero work).
+    2. **Same-frame cache** -- if a conversion was already performed this
+       frame (same generation), the cached result is returned.
+    3. **Cross-frame reuse** -- output buffers persist across frames;
+       only the conversion kernel is re-launched (no allocation).
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[tuple, TransformData] = {}
+        self._cache_generation: dict[tuple, int] = {}
+
+    def _cache_key(
+        self,
+        target_format: TransformFormat,
+        quat_convention: QuaternionConvention,
+        matrix_layout: MatrixLayout,
+        double_precision: bool,
+        index_map_id: int | None,
+    ) -> tuple:
+        return (target_format, quat_convention, matrix_layout, double_precision, index_map_id)
+
+    def get_or_convert(
+        self,
+        source: TransformData,
+        target_format: TransformFormat,
+        *,
+        generation: int,
+        quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
+        matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
+        double_precision: bool = False,
+        stream: wp.Stream | None = None,
+        allow_passthrough: bool = True,
+        index_map: wp.array | None = None,
+    ) -> TransformData:
+        """Return transform data in the requested format.
+
+        Uses cached results when possible; allocates and converts when not.
+
+        Args:
+            source: Source transform data from the simulator.
+            target_format: Desired output format.
+            generation: Frame generation counter. When this matches the
+                cached generation, the cached result is returned.
+            quat_convention: Desired quaternion convention.
+            matrix_layout: Desired matrix layout.
+            double_precision: Whether MAT44 output should use float64.
+            stream: Optional CUDA stream for deferred kernel execution.
+            allow_passthrough: If ``True`` and formats match, return source
+                directly (zero-copy). Consumer must not mutate the result.
+            index_map: Optional index remapping for subset scatter writes.
+
+        Returns:
+            Transform data in the requested format.
+        """
+        # Fast path 1: format-match passthrough
+        if (
+            allow_passthrough
+            and index_map is None
+            and ConversionDispatcher.can_passthrough(
+                source,
+                target_format,
+                quat_convention=quat_convention,
+                matrix_layout=matrix_layout,
+                double_precision=double_precision,
+            )
+        ):
+            return source
+
+        index_map_id = id(index_map) if index_map is not None else None
+        key = self._cache_key(target_format, quat_convention, matrix_layout, double_precision, index_map_id)
+
+        # Fast path 2: same-frame cache hit
+        if key in self._cache and self._cache_generation.get(key) == generation:
+            cached = self._cache[key]
+            if cached.count == source.count:
+                return cached
+
+        # Fast path 3: cross-frame buffer reuse (or allocate if size changed)
+        target_count = source.count
+        if index_map is not None:
+            target_count = int(index_map.shape[0])
+        existing = self._cache.get(key)
+        if existing is not None and existing.count == target_count:
+            target = existing
+        else:
+            target = _allocate_transform_data(
+                target_format,
+                target_count,
+                source.device,
+                quat_convention=quat_convention,
+                matrix_layout=matrix_layout,
+                double_precision=double_precision,
+            )
+
+        ConversionDispatcher.convert(source, target, stream=stream, index_map=index_map)
+
+        self._cache[key] = target
+        self._cache_generation[key] = generation
+        return target
+
+    def clear(self) -> None:
+        """Release all cached buffers."""
+        self._cache.clear()
+        self._cache_generation.clear()

--- a/source/isaaclab/isaaclab/physics/scene_data_conversion.py
+++ b/source/isaaclab/isaaclab/physics/scene_data_conversion.py
@@ -80,7 +80,7 @@ class ConversionDispatcher:
         return True
 
     @staticmethod
-    def convert(
+    def convert(  # noqa: C901
         source: TransformData,
         target: TransformData,
         *,
@@ -120,7 +120,9 @@ class ConversionDispatcher:
             sp, so = source.positions, source.orientations
             if dst_fmt == TransformFormat.VEC3_QUAT:
                 assert isinstance(target, Vec3QuatTransforms)
-                _launch(K.vec3_quat_to_vec3_quat_kernel, [sp, so, target.positions, target.orientations, imap, imap_len])
+                _launch(
+                    K.vec3_quat_to_vec3_quat_kernel, [sp, so, target.positions, target.orientations, imap, imap_len]
+                )
             elif dst_fmt == TransformFormat.VEC3_MAT33:
                 assert isinstance(target, Vec3Mat33Transforms)
                 _launch(K.vec3_quat_to_vec3_mat33_kernel, [sp, so, target.positions, target.rotations, imap, imap_len])
@@ -140,7 +142,9 @@ class ConversionDispatcher:
             sp, sr = source.positions, source.rotations
             if dst_fmt == TransformFormat.VEC3_QUAT:
                 assert isinstance(target, Vec3QuatTransforms)
-                _launch(K.vec3_mat33_to_vec3_quat_kernel, [sp, sr, target.positions, target.orientations, imap, imap_len])
+                _launch(
+                    K.vec3_mat33_to_vec3_quat_kernel, [sp, sr, target.positions, target.orientations, imap, imap_len]
+                )
             elif dst_fmt == TransformFormat.VEC3_MAT33:
                 assert isinstance(target, Vec3Mat33Transforms)
                 _launch(K.vec3_mat33_to_vec3_mat33_kernel, [sp, sr, target.positions, target.rotations, imap, imap_len])

--- a/source/isaaclab/isaaclab/physics/scene_data_conversion.py
+++ b/source/isaaclab/isaaclab/physics/scene_data_conversion.py
@@ -1,0 +1,227 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Conversion dispatcher for transform format conversions.
+
+Selects and launches the appropriate Warp kernel for any
+``(source_format, target_format)`` pair, including quaternion convention
+swizzle and matrix layout transpose as post-processing steps.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+from . import scene_data_kernels as K
+from .scene_data_types import (
+    Mat44Transforms,
+    MatrixLayout,
+    QuaternionConvention,
+    TransformArrayData,
+    TransformData,
+    TransformFormat,
+    Vec3Mat33Transforms,
+    Vec3QuatTransforms,
+)
+
+_EMPTY_INDEX_MAP: dict[str, wp.array] = {}
+
+
+def _get_empty_index_map(device: str) -> wp.array:
+    """Return a cached zero-length int32 array on the given device."""
+    if device not in _EMPTY_INDEX_MAP:
+        _EMPTY_INDEX_MAP[device] = wp.empty(0, dtype=wp.int32, device=device)
+    return _EMPTY_INDEX_MAP[device]
+
+
+class ConversionDispatcher:
+    """Dispatches transform format conversions via Warp kernels.
+
+    All conversions run entirely on GPU. The dispatcher selects the
+    appropriate kernel based on ``(source.format, target.format)`` and
+    optionally applies quaternion convention swizzle or matrix layout
+    transpose as post-processing steps.
+    """
+
+    @staticmethod
+    def can_passthrough(
+        source: TransformData,
+        target_format: TransformFormat,
+        *,
+        quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
+        matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
+        double_precision: bool = False,
+    ) -> bool:
+        """Check whether source data can be returned directly without conversion.
+
+        Args:
+            source: Source transform data.
+            target_format: Desired output format.
+            quat_convention: Desired quaternion convention (for VEC3_QUAT).
+            matrix_layout: Desired matrix layout (for VEC3_MAT33 / MAT44).
+            double_precision: Whether MAT44 output should use float64.
+
+        Returns:
+            ``True`` if no conversion or copy is needed.
+        """
+        if source.format != target_format:
+            return False
+        if target_format == TransformFormat.VEC3_QUAT:
+            assert isinstance(source, Vec3QuatTransforms)
+            return source.quat_convention == quat_convention
+        if target_format == TransformFormat.VEC3_MAT33:
+            assert isinstance(source, Vec3Mat33Transforms)
+            return source.layout == matrix_layout
+        if target_format == TransformFormat.MAT44:
+            assert isinstance(source, Mat44Transforms)
+            return source.layout == matrix_layout and source.double_precision == double_precision
+        return True
+
+    @staticmethod
+    def convert(
+        source: TransformData,
+        target: TransformData,
+        *,
+        stream: wp.Stream | None = None,
+        index_map: wp.array | None = None,
+    ) -> None:
+        """Convert source transform data into a pre-allocated target buffer.
+
+        All work is done on GPU via Warp kernels. When *stream* is provided,
+        kernels are launched on that stream for deferred execution.
+
+        Args:
+            source: Source transform data (read-only).
+            target: Pre-allocated target buffer to write into.
+            stream: Optional CUDA stream for deferred execution.
+            index_map: Optional index remapping array. When provided,
+                output element *i* is written to ``target[index_map[i]]``.
+        """
+        device = source.device
+        imap = index_map if index_map is not None else _get_empty_index_map(device)
+        imap_len = int(index_map.shape[0]) if index_map is not None else 0
+        dim = imap_len if index_map is not None else source.count
+
+        def _launch(kernel, inputs):
+            if stream is not None:
+                with wp.ScopedStream(stream):
+                    wp.launch(kernel, dim=dim, inputs=inputs, device=device)
+            else:
+                wp.launch(kernel, dim=dim, inputs=inputs, device=device)
+
+        src_fmt = source.format
+        dst_fmt = target.format
+
+        # --- vec3_quat source ---
+        if src_fmt == TransformFormat.VEC3_QUAT:
+            assert isinstance(source, Vec3QuatTransforms)
+            sp, so = source.positions, source.orientations
+            if dst_fmt == TransformFormat.VEC3_QUAT:
+                assert isinstance(target, Vec3QuatTransforms)
+                _launch(K.vec3_quat_to_vec3_quat_kernel, [sp, so, target.positions, target.orientations, imap, imap_len])
+            elif dst_fmt == TransformFormat.VEC3_MAT33:
+                assert isinstance(target, Vec3Mat33Transforms)
+                _launch(K.vec3_quat_to_vec3_mat33_kernel, [sp, so, target.positions, target.rotations, imap, imap_len])
+            elif dst_fmt == TransformFormat.TRANSFORM:
+                assert isinstance(target, TransformArrayData)
+                _launch(K.vec3_quat_to_transform_kernel, [sp, so, target.transforms, imap, imap_len])
+            elif dst_fmt == TransformFormat.MAT44:
+                assert isinstance(target, Mat44Transforms)
+                if target.double_precision:
+                    _launch(K.vec3_quat_to_mat44d_kernel, [sp, so, target.matrices, imap, imap_len])
+                else:
+                    _launch(K.vec3_quat_to_mat44f_kernel, [sp, so, target.matrices, imap, imap_len])
+
+        # --- vec3_mat33 source ---
+        elif src_fmt == TransformFormat.VEC3_MAT33:
+            assert isinstance(source, Vec3Mat33Transforms)
+            sp, sr = source.positions, source.rotations
+            if dst_fmt == TransformFormat.VEC3_QUAT:
+                assert isinstance(target, Vec3QuatTransforms)
+                _launch(K.vec3_mat33_to_vec3_quat_kernel, [sp, sr, target.positions, target.orientations, imap, imap_len])
+            elif dst_fmt == TransformFormat.VEC3_MAT33:
+                assert isinstance(target, Vec3Mat33Transforms)
+                _launch(K.vec3_mat33_to_vec3_mat33_kernel, [sp, sr, target.positions, target.rotations, imap, imap_len])
+            elif dst_fmt == TransformFormat.TRANSFORM:
+                assert isinstance(target, TransformArrayData)
+                _launch(K.vec3_mat33_to_transform_kernel, [sp, sr, target.transforms, imap, imap_len])
+            elif dst_fmt == TransformFormat.MAT44:
+                assert isinstance(target, Mat44Transforms)
+                _launch(K.vec3_mat33_to_mat44f_kernel, [sp, sr, target.matrices, imap, imap_len])
+
+        # --- transform source ---
+        elif src_fmt == TransformFormat.TRANSFORM:
+            assert isinstance(source, TransformArrayData)
+            st = source.transforms
+            if dst_fmt == TransformFormat.VEC3_QUAT:
+                assert isinstance(target, Vec3QuatTransforms)
+                _launch(K.transform_to_vec3_quat_kernel, [st, target.positions, target.orientations, imap, imap_len])
+            elif dst_fmt == TransformFormat.VEC3_MAT33:
+                assert isinstance(target, Vec3Mat33Transforms)
+                _launch(K.transform_to_vec3_mat33_kernel, [st, target.positions, target.rotations, imap, imap_len])
+            elif dst_fmt == TransformFormat.TRANSFORM:
+                assert isinstance(target, TransformArrayData)
+                _launch(K.transform_to_transform_kernel, [st, target.transforms, imap, imap_len])
+            elif dst_fmt == TransformFormat.MAT44:
+                assert isinstance(target, Mat44Transforms)
+                if target.double_precision:
+                    _launch(K.transform_to_mat44d_kernel, [st, target.matrices, imap, imap_len])
+                else:
+                    _launch(K.transform_to_mat44f_kernel, [st, target.matrices, imap, imap_len])
+
+        # --- mat44 source ---
+        elif src_fmt == TransformFormat.MAT44:
+            assert isinstance(source, Mat44Transforms)
+            sm = source.matrices
+            if dst_fmt == TransformFormat.VEC3_QUAT:
+                assert isinstance(target, Vec3QuatTransforms)
+                if source.double_precision:
+                    _launch(K.mat44d_to_vec3_quat_kernel, [sm, target.positions, target.orientations, imap, imap_len])
+                else:
+                    _launch(K.mat44f_to_vec3_quat_kernel, [sm, target.positions, target.orientations, imap, imap_len])
+            elif dst_fmt == TransformFormat.VEC3_MAT33:
+                assert isinstance(target, Vec3Mat33Transforms)
+                if source.double_precision:
+                    raise NotImplementedError("mat44d -> vec3_mat33 not yet supported")
+                _launch(K.mat44f_to_vec3_mat33_kernel, [sm, target.positions, target.rotations, imap, imap_len])
+            elif dst_fmt == TransformFormat.TRANSFORM:
+                assert isinstance(target, TransformArrayData)
+                if source.double_precision:
+                    _launch(K.mat44d_to_transform_kernel, [sm, target.transforms, imap, imap_len])
+                else:
+                    _launch(K.mat44f_to_transform_kernel, [sm, target.transforms, imap, imap_len])
+            elif dst_fmt == TransformFormat.MAT44:
+                assert isinstance(target, Mat44Transforms)
+                _launch(K.mat44f_to_mat44f_kernel, [sm, target.matrices, imap, imap_len])
+
+        # --- Post-processing: quaternion convention swizzle ---
+        if dst_fmt == TransformFormat.VEC3_QUAT:
+            assert isinstance(target, Vec3QuatTransforms)
+            src_conv = QuaternionConvention.XYZW
+            if src_fmt == TransformFormat.VEC3_QUAT:
+                assert isinstance(source, Vec3QuatTransforms)
+                src_conv = source.quat_convention
+            if src_conv != target.quat_convention:
+                empty_imap = _get_empty_index_map(device)
+                if target.quat_convention == QuaternionConvention.WXYZ:
+                    _launch(K.quat_xyzw_to_wxyz_kernel, [target.orientations, target.orientations, empty_imap, 0])
+                else:
+                    _launch(K.quat_wxyz_to_xyzw_kernel, [target.orientations, target.orientations, empty_imap, 0])
+
+        # --- Post-processing: matrix layout transpose ---
+        if dst_fmt == TransformFormat.MAT44:
+            assert isinstance(target, Mat44Transforms)
+            if target.layout == MatrixLayout.COLUMN_MAJOR:
+                empty_imap = _get_empty_index_map(device)
+                if target.double_precision:
+                    _launch(K.mat44d_transpose_kernel, [target.matrices, target.matrices, empty_imap, 0])
+                else:
+                    _launch(K.mat44f_transpose_kernel, [target.matrices, target.matrices, empty_imap, 0])
+
+        if dst_fmt == TransformFormat.VEC3_MAT33:
+            assert isinstance(target, Vec3Mat33Transforms)
+            if target.layout == MatrixLayout.COLUMN_MAJOR:
+                empty_imap = _get_empty_index_map(device)
+                _launch(K.mat33f_transpose_kernel, [target.rotations, target.rotations, empty_imap, 0])

--- a/source/isaaclab/isaaclab/physics/scene_data_kernels.py
+++ b/source/isaaclab/isaaclab/physics/scene_data_kernels.py
@@ -1,0 +1,504 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Warp GPU kernels for transform format conversion.
+
+Provides a 4x4 grid of conversion kernels between the four transform
+representations used in Isaac Lab, plus quaternion convention swizzle
+and matrix layout transpose kernels.
+
+All kernels support an optional ``index_map`` for subset scatter writes:
+when provided, output element *i* is written to ``output[index_map[i]]``
+instead of ``output[i]``.  Pass ``None`` (empty array with shape 0) to
+disable index mapping.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+@wp.func
+def _output_idx(tid: int, index_map: wp.array(dtype=wp.int32), index_map_len: int) -> int:  # type: ignore
+    """Return mapped output index, or *tid* when index_map is empty."""
+    if index_map_len > 0:
+        return index_map[tid]
+    return tid
+
+
+@wp.func
+def _quat_to_mat33(q: wp.quatf) -> wp.mat33f:  # type: ignore
+    """Convert a quaternion (XYZW) to a 3x3 rotation matrix (row-major)."""
+    return wp.quat_to_matrix(q)
+
+
+@wp.func
+def _mat33_to_quat(m: wp.mat33f) -> wp.quatf:  # type: ignore
+    """Convert a 3x3 rotation matrix (row-major) to a quaternion (XYZW)."""
+    return wp.quat_from_matrix(m)
+
+
+@wp.func
+def _transform_to_mat44f(t: wp.transformf) -> wp.mat44f:  # type: ignore
+    """Convert a packed transform to a 4x4 matrix (row-major, float32)."""
+    m44 = wp.math.transform_to_matrix(t)
+    return wp.mat44f(  # type: ignore
+        m44[0, 0], m44[0, 1], m44[0, 2], m44[0, 3],
+        m44[1, 0], m44[1, 1], m44[1, 2], m44[1, 3],
+        m44[2, 0], m44[2, 1], m44[2, 2], m44[2, 3],
+        m44[3, 0], m44[3, 1], m44[3, 2], m44[3, 3],
+    )
+
+
+@wp.func
+def _mat44f_to_transform(m: wp.mat44f) -> wp.transformf:  # type: ignore
+    """Convert a 4x4 matrix (row-major, float32) to a packed transform."""
+    pos = wp.vec3(m[0, 3], m[1, 3], m[2, 3])
+    rot = wp.mat33f(  # type: ignore
+        m[0, 0], m[0, 1], m[0, 2],
+        m[1, 0], m[1, 1], m[1, 2],
+        m[2, 0], m[2, 1], m[2, 2],
+    )
+    q = wp.quat_from_matrix(rot)
+    return wp.transformf(pos, q)
+
+
+# ---------------------------------------------------------------------------
+# vec3_quat -> other formats
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def vec3_quat_to_vec3_quat_kernel(
+    src_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    src_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    dst_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    dst_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Copy vec3+quat to vec3+quat (pass-through with optional index remap)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_pos[oid] = src_pos[tid]
+    dst_ori[oid] = src_ori[tid]
+
+
+@wp.kernel(enable_backward=False)
+def vec3_quat_to_vec3_mat33_kernel(
+    src_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    src_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    dst_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    dst_rot: wp.array(dtype=wp.mat33f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert vec3+quat to vec3+mat33."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_pos[oid] = src_pos[tid]
+    dst_rot[oid] = _quat_to_mat33(src_ori[tid])
+
+
+@wp.kernel(enable_backward=False)
+def vec3_quat_to_transform_kernel(
+    src_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    src_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    dst_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert vec3+quat to packed transformf."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_tf[oid] = wp.transformf(src_pos[tid], src_ori[tid])
+
+
+@wp.kernel(enable_backward=False)
+def vec3_quat_to_mat44f_kernel(
+    src_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    src_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    dst_mat: wp.array(dtype=wp.mat44f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert vec3+quat to 4x4 float32 matrix (row-major)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    t = wp.transformf(src_pos[tid], src_ori[tid])
+    dst_mat[oid] = _transform_to_mat44f(t)
+
+
+@wp.kernel(enable_backward=False)
+def vec3_quat_to_mat44d_kernel(
+    src_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    src_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    dst_mat: wp.array(dtype=wp.mat44d),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert vec3+quat to 4x4 float64 matrix (row-major)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    t = wp.transformf(src_pos[tid], src_ori[tid])
+    m = wp.math.transform_to_matrix(t)
+    dst_mat[oid] = wp.mat44d(  # type: ignore
+        wp.float64(m[0, 0]), wp.float64(m[0, 1]), wp.float64(m[0, 2]), wp.float64(m[0, 3]),
+        wp.float64(m[1, 0]), wp.float64(m[1, 1]), wp.float64(m[1, 2]), wp.float64(m[1, 3]),
+        wp.float64(m[2, 0]), wp.float64(m[2, 1]), wp.float64(m[2, 2]), wp.float64(m[2, 3]),
+        wp.float64(m[3, 0]), wp.float64(m[3, 1]), wp.float64(m[3, 2]), wp.float64(m[3, 3]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# vec3_mat33 -> other formats
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def vec3_mat33_to_vec3_quat_kernel(
+    src_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    src_rot: wp.array(dtype=wp.mat33f),  # type: ignore
+    dst_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    dst_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert vec3+mat33 to vec3+quat."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_pos[oid] = src_pos[tid]
+    dst_ori[oid] = _mat33_to_quat(src_rot[tid])
+
+
+@wp.kernel(enable_backward=False)
+def vec3_mat33_to_vec3_mat33_kernel(
+    src_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    src_rot: wp.array(dtype=wp.mat33f),  # type: ignore
+    dst_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    dst_rot: wp.array(dtype=wp.mat33f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Copy vec3+mat33 to vec3+mat33 (pass-through with optional index remap)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_pos[oid] = src_pos[tid]
+    dst_rot[oid] = src_rot[tid]
+
+
+@wp.kernel(enable_backward=False)
+def vec3_mat33_to_transform_kernel(
+    src_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    src_rot: wp.array(dtype=wp.mat33f),  # type: ignore
+    dst_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert vec3+mat33 to packed transformf."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    q = _mat33_to_quat(src_rot[tid])
+    dst_tf[oid] = wp.transformf(src_pos[tid], q)
+
+
+@wp.kernel(enable_backward=False)
+def vec3_mat33_to_mat44f_kernel(
+    src_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    src_rot: wp.array(dtype=wp.mat33f),  # type: ignore
+    dst_mat: wp.array(dtype=wp.mat44f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert vec3+mat33 to 4x4 float32 matrix (row-major)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    p = src_pos[tid]
+    r = src_rot[tid]
+    dst_mat[oid] = wp.mat44f(  # type: ignore
+        r[0, 0], r[0, 1], r[0, 2], p[0],
+        r[1, 0], r[1, 1], r[1, 2], p[1],
+        r[2, 0], r[2, 1], r[2, 2], p[2],
+        0.0, 0.0, 0.0, 1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# transform -> other formats
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def transform_to_vec3_quat_kernel(
+    src_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    dst_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    dst_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert packed transformf to vec3+quat."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_pos[oid] = wp.transform_get_translation(src_tf[tid])
+    dst_ori[oid] = wp.transform_get_rotation(src_tf[tid])
+
+
+@wp.kernel(enable_backward=False)
+def transform_to_vec3_mat33_kernel(
+    src_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    dst_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    dst_rot: wp.array(dtype=wp.mat33f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert packed transformf to vec3+mat33."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_pos[oid] = wp.transform_get_translation(src_tf[tid])
+    dst_rot[oid] = _quat_to_mat33(wp.transform_get_rotation(src_tf[tid]))
+
+
+@wp.kernel(enable_backward=False)
+def transform_to_transform_kernel(
+    src_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    dst_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Copy transformf to transformf (pass-through with optional index remap)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_tf[oid] = src_tf[tid]
+
+
+@wp.kernel(enable_backward=False)
+def transform_to_mat44f_kernel(
+    src_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    dst_mat: wp.array(dtype=wp.mat44f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert packed transformf to 4x4 float32 matrix (row-major)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_mat[oid] = _transform_to_mat44f(src_tf[tid])
+
+
+@wp.kernel(enable_backward=False)
+def transform_to_mat44d_kernel(
+    src_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    dst_mat: wp.array(dtype=wp.mat44d),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert packed transformf to 4x4 float64 matrix (row-major)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    m = wp.math.transform_to_matrix(src_tf[tid])
+    dst_mat[oid] = wp.mat44d(  # type: ignore
+        wp.float64(m[0, 0]), wp.float64(m[0, 1]), wp.float64(m[0, 2]), wp.float64(m[0, 3]),
+        wp.float64(m[1, 0]), wp.float64(m[1, 1]), wp.float64(m[1, 2]), wp.float64(m[1, 3]),
+        wp.float64(m[2, 0]), wp.float64(m[2, 1]), wp.float64(m[2, 2]), wp.float64(m[2, 3]),
+        wp.float64(m[3, 0]), wp.float64(m[3, 1]), wp.float64(m[3, 2]), wp.float64(m[3, 3]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# mat44 -> other formats (float32 versions)
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def mat44f_to_vec3_quat_kernel(
+    src_mat: wp.array(dtype=wp.mat44f),  # type: ignore
+    dst_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    dst_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert 4x4 float32 matrix (row-major) to vec3+quat."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    t = _mat44f_to_transform(src_mat[tid])
+    dst_pos[oid] = wp.transform_get_translation(t)
+    dst_ori[oid] = wp.transform_get_rotation(t)
+
+
+@wp.kernel(enable_backward=False)
+def mat44f_to_vec3_mat33_kernel(
+    src_mat: wp.array(dtype=wp.mat44f),  # type: ignore
+    dst_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    dst_rot: wp.array(dtype=wp.mat33f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert 4x4 float32 matrix (row-major) to vec3+mat33."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    m = src_mat[tid]
+    dst_pos[oid] = wp.vec3(m[0, 3], m[1, 3], m[2, 3])
+    dst_rot[oid] = wp.mat33f(  # type: ignore
+        m[0, 0], m[0, 1], m[0, 2],
+        m[1, 0], m[1, 1], m[1, 2],
+        m[2, 0], m[2, 1], m[2, 2],
+    )
+
+
+@wp.kernel(enable_backward=False)
+def mat44f_to_transform_kernel(
+    src_mat: wp.array(dtype=wp.mat44f),  # type: ignore
+    dst_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert 4x4 float32 matrix (row-major) to packed transformf."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_tf[oid] = _mat44f_to_transform(src_mat[tid])
+
+
+@wp.kernel(enable_backward=False)
+def mat44f_to_mat44f_kernel(
+    src_mat: wp.array(dtype=wp.mat44f),  # type: ignore
+    dst_mat: wp.array(dtype=wp.mat44f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Copy mat44f to mat44f (pass-through with optional index remap)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst_mat[oid] = src_mat[tid]
+
+
+# ---------------------------------------------------------------------------
+# mat44 -> other formats (float64 versions)
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def mat44d_to_vec3_quat_kernel(
+    src_mat: wp.array(dtype=wp.mat44d),  # type: ignore
+    dst_pos: wp.array(dtype=wp.vec3),  # type: ignore
+    dst_ori: wp.array(dtype=wp.quatf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert 4x4 float64 matrix (row-major) to vec3+quat."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    m = src_mat[tid]
+    dst_pos[oid] = wp.vec3(float(m[0, 3]), float(m[1, 3]), float(m[2, 3]))
+    rot = wp.mat33f(  # type: ignore
+        float(m[0, 0]), float(m[0, 1]), float(m[0, 2]),
+        float(m[1, 0]), float(m[1, 1]), float(m[1, 2]),
+        float(m[2, 0]), float(m[2, 1]), float(m[2, 2]),
+    )
+    dst_ori[oid] = wp.quat_from_matrix(rot)
+
+
+@wp.kernel(enable_backward=False)
+def mat44d_to_transform_kernel(
+    src_mat: wp.array(dtype=wp.mat44d),  # type: ignore
+    dst_tf: wp.array(dtype=wp.transformf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Convert 4x4 float64 matrix (row-major) to packed transformf."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    m = src_mat[tid]
+    pos = wp.vec3(float(m[0, 3]), float(m[1, 3]), float(m[2, 3]))
+    rot = wp.mat33f(  # type: ignore
+        float(m[0, 0]), float(m[0, 1]), float(m[0, 2]),
+        float(m[1, 0]), float(m[1, 1]), float(m[1, 2]),
+        float(m[2, 0]), float(m[2, 1]), float(m[2, 2]),
+    )
+    q = wp.quat_from_matrix(rot)
+    dst_tf[oid] = wp.transformf(pos, q)
+
+
+# ---------------------------------------------------------------------------
+# Quaternion convention swizzle kernels
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def quat_xyzw_to_wxyz_kernel(
+    src: wp.array(dtype=wp.quatf),  # type: ignore
+    dst: wp.array(dtype=wp.quatf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Swizzle quaternion from XYZW to WXYZ storage order.
+
+    Warp stores quatf as (x,y,z,w). This kernel reinterprets the output
+    so the w component occupies the first slot when read as raw floats.
+    """
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    q = src[tid]
+    dst[oid] = wp.quatf(q[3], q[0], q[1], q[2])
+
+
+@wp.kernel(enable_backward=False)
+def quat_wxyz_to_xyzw_kernel(
+    src: wp.array(dtype=wp.quatf),  # type: ignore
+    dst: wp.array(dtype=wp.quatf),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Swizzle quaternion from WXYZ to XYZW storage order."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    q = src[tid]
+    dst[oid] = wp.quatf(q[1], q[2], q[3], q[0])
+
+
+# ---------------------------------------------------------------------------
+# Matrix layout transpose kernels
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel(enable_backward=False)
+def mat44f_transpose_kernel(
+    src: wp.array(dtype=wp.mat44f),  # type: ignore
+    dst: wp.array(dtype=wp.mat44f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Transpose 4x4 float32 matrices (row-major <-> column-major)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst[oid] = wp.transpose(src[tid])
+
+
+@wp.kernel(enable_backward=False)
+def mat44d_transpose_kernel(
+    src: wp.array(dtype=wp.mat44d),  # type: ignore
+    dst: wp.array(dtype=wp.mat44d),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Transpose 4x4 float64 matrices (row-major <-> column-major)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst[oid] = wp.transpose(src[tid])
+
+
+@wp.kernel(enable_backward=False)
+def mat33f_transpose_kernel(
+    src: wp.array(dtype=wp.mat33f),  # type: ignore
+    dst: wp.array(dtype=wp.mat33f),  # type: ignore
+    index_map: wp.array(dtype=wp.int32),  # type: ignore
+    index_map_len: int,
+):
+    """Transpose 3x3 float32 matrices (row-major <-> column-major)."""
+    tid = wp.tid()
+    oid = _output_idx(tid, index_map, index_map_len)
+    dst[oid] = wp.transpose(src[tid])

--- a/source/isaaclab/isaaclab/physics/scene_data_kernels.py
+++ b/source/isaaclab/isaaclab/physics/scene_data_kernels.py
@@ -49,10 +49,22 @@ def _transform_to_mat44f(t: wp.transformf) -> wp.mat44f:  # type: ignore
     """Convert a packed transform to a 4x4 matrix (row-major, float32)."""
     m44 = wp.math.transform_to_matrix(t)
     return wp.mat44f(  # type: ignore
-        m44[0, 0], m44[0, 1], m44[0, 2], m44[0, 3],
-        m44[1, 0], m44[1, 1], m44[1, 2], m44[1, 3],
-        m44[2, 0], m44[2, 1], m44[2, 2], m44[2, 3],
-        m44[3, 0], m44[3, 1], m44[3, 2], m44[3, 3],
+        m44[0, 0],
+        m44[0, 1],
+        m44[0, 2],
+        m44[0, 3],
+        m44[1, 0],
+        m44[1, 1],
+        m44[1, 2],
+        m44[1, 3],
+        m44[2, 0],
+        m44[2, 1],
+        m44[2, 2],
+        m44[2, 3],
+        m44[3, 0],
+        m44[3, 1],
+        m44[3, 2],
+        m44[3, 3],
     )
 
 
@@ -61,9 +73,15 @@ def _mat44f_to_transform(m: wp.mat44f) -> wp.transformf:  # type: ignore
     """Convert a 4x4 matrix (row-major, float32) to a packed transform."""
     pos = wp.vec3(m[0, 3], m[1, 3], m[2, 3])
     rot = wp.mat33f(  # type: ignore
-        m[0, 0], m[0, 1], m[0, 2],
-        m[1, 0], m[1, 1], m[1, 2],
-        m[2, 0], m[2, 1], m[2, 2],
+        m[0, 0],
+        m[0, 1],
+        m[0, 2],
+        m[1, 0],
+        m[1, 1],
+        m[1, 2],
+        m[2, 0],
+        m[2, 1],
+        m[2, 2],
     )
     q = wp.quat_from_matrix(rot)
     return wp.transformf(pos, q)
@@ -149,10 +167,22 @@ def vec3_quat_to_mat44d_kernel(
     t = wp.transformf(src_pos[tid], src_ori[tid])
     m = wp.math.transform_to_matrix(t)
     dst_mat[oid] = wp.mat44d(  # type: ignore
-        wp.float64(m[0, 0]), wp.float64(m[0, 1]), wp.float64(m[0, 2]), wp.float64(m[0, 3]),
-        wp.float64(m[1, 0]), wp.float64(m[1, 1]), wp.float64(m[1, 2]), wp.float64(m[1, 3]),
-        wp.float64(m[2, 0]), wp.float64(m[2, 1]), wp.float64(m[2, 2]), wp.float64(m[2, 3]),
-        wp.float64(m[3, 0]), wp.float64(m[3, 1]), wp.float64(m[3, 2]), wp.float64(m[3, 3]),
+        wp.float64(m[0, 0]),
+        wp.float64(m[0, 1]),
+        wp.float64(m[0, 2]),
+        wp.float64(m[0, 3]),
+        wp.float64(m[1, 0]),
+        wp.float64(m[1, 1]),
+        wp.float64(m[1, 2]),
+        wp.float64(m[1, 3]),
+        wp.float64(m[2, 0]),
+        wp.float64(m[2, 1]),
+        wp.float64(m[2, 2]),
+        wp.float64(m[2, 3]),
+        wp.float64(m[3, 0]),
+        wp.float64(m[3, 1]),
+        wp.float64(m[3, 2]),
+        wp.float64(m[3, 3]),
     )
 
 
@@ -222,10 +252,22 @@ def vec3_mat33_to_mat44f_kernel(
     p = src_pos[tid]
     r = src_rot[tid]
     dst_mat[oid] = wp.mat44f(  # type: ignore
-        r[0, 0], r[0, 1], r[0, 2], p[0],
-        r[1, 0], r[1, 1], r[1, 2], p[1],
-        r[2, 0], r[2, 1], r[2, 2], p[2],
-        0.0, 0.0, 0.0, 1.0,
+        r[0, 0],
+        r[0, 1],
+        r[0, 2],
+        p[0],
+        r[1, 0],
+        r[1, 1],
+        r[1, 2],
+        p[1],
+        r[2, 0],
+        r[2, 1],
+        r[2, 2],
+        p[2],
+        0.0,
+        0.0,
+        0.0,
+        1.0,
     )
 
 
@@ -302,10 +344,22 @@ def transform_to_mat44d_kernel(
     oid = _output_idx(tid, index_map, index_map_len)
     m = wp.math.transform_to_matrix(src_tf[tid])
     dst_mat[oid] = wp.mat44d(  # type: ignore
-        wp.float64(m[0, 0]), wp.float64(m[0, 1]), wp.float64(m[0, 2]), wp.float64(m[0, 3]),
-        wp.float64(m[1, 0]), wp.float64(m[1, 1]), wp.float64(m[1, 2]), wp.float64(m[1, 3]),
-        wp.float64(m[2, 0]), wp.float64(m[2, 1]), wp.float64(m[2, 2]), wp.float64(m[2, 3]),
-        wp.float64(m[3, 0]), wp.float64(m[3, 1]), wp.float64(m[3, 2]), wp.float64(m[3, 3]),
+        wp.float64(m[0, 0]),
+        wp.float64(m[0, 1]),
+        wp.float64(m[0, 2]),
+        wp.float64(m[0, 3]),
+        wp.float64(m[1, 0]),
+        wp.float64(m[1, 1]),
+        wp.float64(m[1, 2]),
+        wp.float64(m[1, 3]),
+        wp.float64(m[2, 0]),
+        wp.float64(m[2, 1]),
+        wp.float64(m[2, 2]),
+        wp.float64(m[2, 3]),
+        wp.float64(m[3, 0]),
+        wp.float64(m[3, 1]),
+        wp.float64(m[3, 2]),
+        wp.float64(m[3, 3]),
     )
 
 
@@ -344,9 +398,15 @@ def mat44f_to_vec3_mat33_kernel(
     m = src_mat[tid]
     dst_pos[oid] = wp.vec3(m[0, 3], m[1, 3], m[2, 3])
     dst_rot[oid] = wp.mat33f(  # type: ignore
-        m[0, 0], m[0, 1], m[0, 2],
-        m[1, 0], m[1, 1], m[1, 2],
-        m[2, 0], m[2, 1], m[2, 2],
+        m[0, 0],
+        m[0, 1],
+        m[0, 2],
+        m[1, 0],
+        m[1, 1],
+        m[1, 2],
+        m[2, 0],
+        m[2, 1],
+        m[2, 2],
     )
 
 
@@ -395,9 +455,15 @@ def mat44d_to_vec3_quat_kernel(
     m = src_mat[tid]
     dst_pos[oid] = wp.vec3(float(m[0, 3]), float(m[1, 3]), float(m[2, 3]))
     rot = wp.mat33f(  # type: ignore
-        float(m[0, 0]), float(m[0, 1]), float(m[0, 2]),
-        float(m[1, 0]), float(m[1, 1]), float(m[1, 2]),
-        float(m[2, 0]), float(m[2, 1]), float(m[2, 2]),
+        float(m[0, 0]),
+        float(m[0, 1]),
+        float(m[0, 2]),
+        float(m[1, 0]),
+        float(m[1, 1]),
+        float(m[1, 2]),
+        float(m[2, 0]),
+        float(m[2, 1]),
+        float(m[2, 2]),
     )
     dst_ori[oid] = wp.quat_from_matrix(rot)
 
@@ -415,9 +481,15 @@ def mat44d_to_transform_kernel(
     m = src_mat[tid]
     pos = wp.vec3(float(m[0, 3]), float(m[1, 3]), float(m[2, 3]))
     rot = wp.mat33f(  # type: ignore
-        float(m[0, 0]), float(m[0, 1]), float(m[0, 2]),
-        float(m[1, 0]), float(m[1, 1]), float(m[1, 2]),
-        float(m[2, 0]), float(m[2, 1]), float(m[2, 2]),
+        float(m[0, 0]),
+        float(m[0, 1]),
+        float(m[0, 2]),
+        float(m[1, 0]),
+        float(m[1, 1]),
+        float(m[1, 2]),
+        float(m[2, 0]),
+        float(m[2, 1]),
+        float(m[2, 2]),
     )
     q = wp.quat_from_matrix(rot)
     dst_tf[oid] = wp.transformf(pos, q)

--- a/source/isaaclab/isaaclab/physics/scene_data_requirements.py
+++ b/source/isaaclab/isaaclab/physics/scene_data_requirements.py
@@ -22,6 +22,8 @@ class SceneDataRequirement:
 
     requires_newton_model: bool = False
     requires_usd_stage: bool = False
+    preferred_transform_formats: frozenset = frozenset()
+    """Preferred transform formats for buffer pre-allocation optimization."""
 
 
 @dataclass(frozen=True)

--- a/source/isaaclab/isaaclab/physics/scene_data_types.py
+++ b/source/isaaclab/isaaclab/physics/scene_data_types.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Typed transform data representations for the Scene Data Provider.
+
+This module defines the concrete types used to pass transform data between
+simulators, renderers, and visualizers without untyped dictionaries.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+
+import warp as wp
+
+
+class QuaternionConvention(enum.Enum):
+    """Quaternion component ordering convention.
+
+    Different subsystems in Isaac Lab use different quaternion orderings.
+    PhysX and Isaac Lab's public API use XYZW; Warp's ``wp.quatf`` stores
+    components as XYZW internally but constructs as ``wp.quatf(x, y, z, w)``.
+    """
+
+    XYZW = "xyzw"
+    """Components ordered ``(x, y, z, w)``. Default for Isaac Lab and PhysX."""
+
+    WXYZ = "wxyz"
+    """Components ordered ``(w, x, y, z)``. Used by some external tools."""
+
+
+class MatrixLayout(enum.Enum):
+    """Matrix memory layout convention."""
+
+    ROW_MAJOR = "row_major"
+    """Rows are contiguous in memory. Default for most CPU/GPU math libraries."""
+
+    COLUMN_MAJOR = "column_major"
+    """Columns are contiguous in memory. Required by OVRTX."""
+
+
+class TransformFormat(enum.Enum):
+    """Supported rigid-body transform representations.
+
+    Each variant corresponds to a concrete :class:`TransformData` subclass
+    that holds typed Warp arrays on GPU.
+    """
+
+    VEC3_QUAT = "vec3_quat"
+    """Separate position (vec3) and quaternion (quatf) arrays. Native to PhysX."""
+
+    VEC3_MAT33 = "vec3_mat33"
+    """Separate position (vec3) and 3x3 rotation matrix (mat33f) arrays."""
+
+    TRANSFORM = "transform"
+    """Packed 7-float transforms (transformf). Native to Newton ``state.body_q``."""
+
+    MAT44 = "mat44"
+    """4x4 homogeneous transformation matrices. Native to OVRTX."""
+
+
+@dataclass
+class TransformData:
+    """Base class for typed transform buffer containers.
+
+    All concrete subclasses hold Warp arrays on a specific device and carry
+    metadata describing the data layout (quaternion convention, matrix layout).
+    """
+
+    format: TransformFormat = field(init=False)
+    """The transform representation this container uses."""
+
+    count: int = 0
+    """Number of transforms in the container."""
+
+    device: str = "cuda:0"
+    """Device where the Warp arrays reside."""
+
+
+@dataclass
+class Vec3QuatTransforms(TransformData):
+    """Positions and quaternion orientations as separate arrays.
+
+    Attributes:
+        positions: Body positions [m], shape ``(count,)``, dtype ``wp.vec3``.
+        orientations: Body orientations, shape ``(count,)``, dtype ``wp.quatf``.
+        quat_convention: Component ordering of the quaternion data.
+    """
+
+    positions: wp.array | None = None
+    orientations: wp.array | None = None
+    quat_convention: QuaternionConvention = QuaternionConvention.XYZW
+
+    def __post_init__(self):
+        self.format = TransformFormat.VEC3_QUAT
+
+
+@dataclass
+class Vec3Mat33Transforms(TransformData):
+    """Positions and 3x3 rotation matrices as separate arrays.
+
+    Attributes:
+        positions: Body positions [m], shape ``(count,)``, dtype ``wp.vec3``.
+        rotations: Body rotation matrices, shape ``(count,)``, dtype ``wp.mat33f``.
+        layout: Memory layout of the rotation matrices.
+    """
+
+    positions: wp.array | None = None
+    rotations: wp.array | None = None
+    layout: MatrixLayout = MatrixLayout.ROW_MAJOR
+
+    def __post_init__(self):
+        self.format = TransformFormat.VEC3_MAT33
+
+
+@dataclass
+class TransformArrayData(TransformData):
+    """Packed transforms as a single array.
+
+    Each element is a ``wp.transformf`` containing a 3D position and a
+    quaternion orientation (7 floats total).
+
+    Attributes:
+        transforms: Packed transforms, shape ``(count,)``, dtype ``wp.transformf``.
+    """
+
+    transforms: wp.array | None = None
+
+    def __post_init__(self):
+        self.format = TransformFormat.TRANSFORM
+
+
+@dataclass
+class Mat44Transforms(TransformData):
+    """4x4 homogeneous transformation matrices.
+
+    Attributes:
+        matrices: Transform matrices, shape ``(count,)``,
+            dtype ``wp.mat44f`` or ``wp.mat44d``.
+        layout: Memory layout of the matrices.
+        double_precision: Whether matrices use 64-bit floats.
+    """
+
+    matrices: wp.array | None = None
+    layout: MatrixLayout = MatrixLayout.COLUMN_MAJOR
+    double_precision: bool = False
+
+    def __post_init__(self):
+        self.format = TransformFormat.MAT44

--- a/source/isaaclab/isaaclab/renderers/base_renderer.py
+++ b/source/isaaclab/isaaclab/renderers/base_renderer.py
@@ -8,17 +8,39 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
     import torch
 
+    from isaaclab.physics import BaseSceneDataProvider
     from isaaclab.sensors import SensorBase
     from isaaclab.sensors.camera.camera_data import CameraData
 
 
 class BaseRenderer(ABC):
     """Abstract base class for renderer implementations."""
+
+    required_capabilities: ClassVar[tuple[type, ...]] = ()
+    """Capabilities the active Scene Data Provider must register, in full.
+
+    See :doc:`/source/refs/adr/0002-capability-based-provider-extensibility`.
+    """
+
+    required_one_of: ClassVar[tuple[tuple[type, ...], ...]] = ()
+    """Capability groups; from each tuple at least one capability must be
+    registered. Use for ``"prefer NewtonState, fall back to GpuTransformBuffer"``
+    declarations.
+    """
+
+    def register_with_scene_data_provider(self, provider: BaseSceneDataProvider) -> None:
+        """Register this renderer with the SDP for wire-up validation.
+
+        Subclasses call this once they have acquired the active SDP, so the
+        provider can validate :attr:`required_capabilities` and
+        :attr:`required_one_of` at first-frame.
+        """
+        provider.register_consumer(self)
 
     @abstractmethod
     def prepare_stage(self, stage: Any, num_envs: int) -> None:

--- a/source/isaaclab/isaaclab/renderers/base_renderer.py
+++ b/source/isaaclab/isaaclab/renderers/base_renderer.py
@@ -38,9 +38,14 @@ class BaseRenderer(ABC):
 
         Subclasses call this once they have acquired the active SDP, so the
         provider can validate :attr:`required_capabilities` and
-        :attr:`required_one_of` at first-frame.
+        :attr:`required_one_of` at first-frame. Test fixtures that mock the
+        provider with a duck-typed object may not implement
+        ``register_consumer``; this is treated as a no-op so renderer unit
+        tests do not need to fake the full provider surface.
         """
-        provider.register_consumer(self)
+        register = getattr(provider, "register_consumer", None)
+        if register is not None:
+            register(self)
 
     @abstractmethod
     def prepare_stage(self, stage: Any, num_envs: int) -> None:

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -26,6 +26,7 @@ from isaaclab.physics import BaseSceneDataProvider, PhysicsManager, SceneDataPro
 from isaaclab.physics.scene_data_requirements import (
     SceneDataRequirement,
     VisualizerPrebuiltArtifacts,
+    aggregate_requirements,
     resolve_scene_data_requirements,
 )
 from isaaclab.sim.utils import create_new_stage
@@ -560,12 +561,16 @@ class SimulationContext:
 
         cli_explicit = self._is_cli_visualizer_explicit()
 
-        # Resolve visualizer-driven requirements once and keep optional artifact payload untouched.
+        # Resolve visualizer-driven requirements and merge them with whatever
+        # scene-driven requirements (e.g. sensor-renderer types from
+        # ``InteractiveScene``) have already been registered. Without the merge,
+        # later capability checks on the SDP would miss requirements like
+        # ``requires_usd_stage`` that were set earlier in scene construction.
         visualizer_types = [
             cfg.visualizer_type for cfg in visualizer_cfgs if getattr(cfg, "visualizer_type", None) is not None
         ]
-        requirements = resolve_scene_data_requirements(visualizer_types=visualizer_types)
-        self._scene_data_requirements = requirements
+        viz_requirements = resolve_scene_data_requirements(visualizer_types=visualizer_types)
+        self._scene_data_requirements = aggregate_requirements([self._scene_data_requirements, viz_requirements])
         self.initialize_scene_data_provider()
         self._visualizers = []
 

--- a/source/isaaclab/isaaclab/visualizers/base_visualizer.py
+++ b/source/isaaclab/isaaclab/visualizers/base_visualizer.py
@@ -55,9 +55,14 @@ class BaseVisualizer(ABC):
 
         Subclasses call this from :meth:`initialize` once they have the
         active SDP, so the provider can validate :attr:`required_capabilities`
-        and :attr:`required_one_of` at first-frame.
+        and :attr:`required_one_of` at first-frame. Test fixtures that mock
+        the provider with a duck-typed object may not implement
+        ``register_consumer``; this is treated as a no-op so visualizer
+        unit tests do not need to fake the full provider surface.
         """
-        provider.register_consumer(self)
+        register = getattr(provider, "register_consumer", None)
+        if register is not None:
+            register(self)
 
     @abstractmethod
     def initialize(self, scene_data_provider: SceneDataProvider) -> None:

--- a/source/isaaclab/isaaclab/visualizers/base_visualizer.py
+++ b/source/isaaclab/isaaclab/visualizers/base_visualizer.py
@@ -11,10 +11,10 @@ import logging
 import random
 import re
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
-    from isaaclab.physics import SceneDataProvider
+    from isaaclab.physics import BaseSceneDataProvider, SceneDataProvider
 
     from .visualizer_cfg import VisualizerCfg
 
@@ -28,6 +28,17 @@ class BaseVisualizer(ABC):
     Lifecycle: __init__() -> initialize() -> step() (repeated) -> close()
     """
 
+    required_capabilities: ClassVar[tuple[type, ...]] = ()
+    """Capabilities the active Scene Data Provider must register, in full.
+
+    See :doc:`/source/refs/adr/0002-capability-based-provider-extensibility`.
+    """
+
+    required_one_of: ClassVar[tuple[tuple[type, ...], ...]] = ()
+    """Capability groups; from each tuple at least one capability must be
+    registered.
+    """
+
     def __init__(self, cfg: VisualizerCfg):
         """Initialize visualizer with config.
 
@@ -38,6 +49,15 @@ class BaseVisualizer(ABC):
         self._scene_data_provider = None
         self._is_initialized = False
         self._is_closed = False
+
+    def register_with_scene_data_provider(self, provider: BaseSceneDataProvider) -> None:
+        """Register this visualizer with the SDP for wire-up validation.
+
+        Subclasses call this from :meth:`initialize` once they have the
+        active SDP, so the provider can validate :attr:`required_capabilities`
+        and :attr:`required_one_of` at first-frame.
+        """
+        provider.register_consumer(self)
 
     @abstractmethod
     def initialize(self, scene_data_provider: SceneDataProvider) -> None:

--- a/source/isaaclab/test/physics/test_capabilities.py
+++ b/source/isaaclab/test/physics/test_capabilities.py
@@ -55,36 +55,18 @@ class _FakeCustomHandle:
 
 
 class _FakeProvider(BaseSceneDataProvider):
-    """Minimal concrete provider for framework tests.
-
-    The base class declares many abstract methods inherited from earlier
-    designs; we stub them out with no-ops because none are exercised here.
-    """
+    """Minimal concrete provider for framework tests."""
 
     def __init__(self):
         super().__init__()
 
     def update(self) -> None: ...
-    def get_newton_model(self):
-        return None
-
-    def get_newton_state(self):
-        return None
 
     def get_usd_stage(self):
         return None
 
     def get_metadata(self):
         return {}
-
-    def get_transforms(self):
-        return None
-
-    def get_velocities(self):
-        return None
-
-    def get_contacts(self):
-        return None
 
     def get_camera_transforms(self):
         return None

--- a/source/isaaclab/test/physics/test_capabilities.py
+++ b/source/isaaclab/test/physics/test_capabilities.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for the capability registry and wire-up validator.
+
+These tests exercise the framework in isolation — no Isaac Sim, no real
+provider, no real renderer. A test-only ``_FakeProvider`` and a couple of
+test-only consumer classes are sufficient because the framework's contract
+is purely structural.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+import pytest
+
+from isaaclab.physics import (
+    BaseSceneDataProvider,
+    CapabilityRequirementError,
+    GpuTransformBuffer,
+    UsdFabric,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class _CustomCap(Protocol):
+    """A customer-defined capability for cross-package extensibility tests."""
+
+    def acme_method(self) -> int: ...
+
+
+class _FakeGpuHandle:
+    def get_body_transforms(self, target_format, **_kwargs):
+        return None
+
+    def get_source_format(self):
+        return None
+
+
+class _FakeFabricHandle:
+    def ensure_current(self, stream=None):
+        return None
+
+
+class _FakeCustomHandle:
+    def acme_method(self) -> int:
+        return 42
+
+
+class _FakeProvider(BaseSceneDataProvider):
+    """Minimal concrete provider for framework tests.
+
+    The base class declares many abstract methods inherited from earlier
+    designs; we stub them out with no-ops because none are exercised here.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def update(self) -> None: ...
+    def get_newton_model(self): return None
+    def get_newton_state(self): return None
+    def get_usd_stage(self): return None
+    def get_metadata(self): return {}
+    def get_transforms(self): return None
+    def get_velocities(self): return None
+    def get_contacts(self): return None
+    def get_camera_transforms(self): return None
+
+
+class _ConsumerWantingGpu:
+    required_capabilities: ClassVar[tuple[type, ...]] = (GpuTransformBuffer,)
+
+
+class _ConsumerWantingUsd:
+    required_capabilities: ClassVar[tuple[type, ...]] = (UsdFabric,)
+
+
+class _ConsumerWantingEither:
+    required_one_of: ClassVar[tuple[tuple[type, ...], ...]] = (
+        (UsdFabric, GpuTransformBuffer),
+    )
+
+
+class _ConsumerWantingBoth:
+    required_capabilities: ClassVar[tuple[type, ...]] = (
+        GpuTransformBuffer,
+        UsdFabric,
+    )
+
+
+class _ConsumerWantingCustom:
+    required_capabilities: ClassVar[tuple[type, ...]] = (_CustomCap,)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_empty_provider_lists_no_capabilities():
+    p = _FakeProvider()
+    assert p.list_capabilities() == frozenset()
+    assert p.get_capability(GpuTransformBuffer) is None
+
+
+def test_registered_capability_is_returned():
+    p = _FakeProvider()
+    handle = _FakeGpuHandle()
+    p._register_capability(GpuTransformBuffer, handle)
+
+    assert p.get_capability(GpuTransformBuffer) is handle
+    assert p.list_capabilities() == frozenset({GpuTransformBuffer})
+
+
+def test_re_registration_replaces_handle():
+    p = _FakeProvider()
+    first = _FakeGpuHandle()
+    second = _FakeGpuHandle()
+    p._register_capability(GpuTransformBuffer, first)
+    p._register_capability(GpuTransformBuffer, second)
+    assert p.get_capability(GpuTransformBuffer) is second
+
+
+def test_get_first_capability_walks_in_order():
+    p = _FakeProvider()
+    p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
+
+    # Preferred missing → falls back to second.
+    result = p.get_first_capability(UsdFabric, GpuTransformBuffer)
+    assert result is not None
+    cap_type, handle = result
+    assert cap_type is GpuTransformBuffer
+    assert isinstance(handle, _FakeGpuHandle)
+
+
+def test_get_first_capability_returns_none_when_all_missing():
+    p = _FakeProvider()
+    assert p.get_first_capability(UsdFabric, GpuTransformBuffer) is None
+
+
+def test_runtime_checkable_protocol_isinstance():
+    """The protocols are runtime_checkable; isinstance works on duck types."""
+    handle = _FakeGpuHandle()
+    assert isinstance(handle, GpuTransformBuffer)
+
+
+def test_custom_capability_routes_through_registry():
+    """Customer-defined caps work without framework changes."""
+    p = _FakeProvider()
+    handle = _FakeCustomHandle()
+    p._register_capability(_CustomCap, handle)
+    assert p.get_capability(_CustomCap) is handle
+    assert _CustomCap in p.list_capabilities()
+
+
+# ---------------------------------------------------------------------------
+# Consumer registration and wire-up validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_passes_with_no_consumers():
+    p = _FakeProvider()
+    p.validate_consumer_capabilities()  # no consumers → no error
+
+
+def test_validate_passes_when_required_satisfied():
+    p = _FakeProvider()
+    p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
+    p.register_consumer(_ConsumerWantingGpu())
+    p.validate_consumer_capabilities()
+
+
+def test_validate_fails_with_missing_required():
+    p = _FakeProvider()
+    p.register_consumer(_ConsumerWantingGpu())
+    with pytest.raises(CapabilityRequirementError) as excinfo:
+        p.validate_consumer_capabilities()
+    assert "GpuTransformBuffer" in str(excinfo.value)
+    assert "ConsumerWantingGpu" in str(excinfo.value)
+
+
+def test_validate_message_lists_offered_capabilities():
+    p = _FakeProvider()
+    p._register_capability(UsdFabric, _FakeFabricHandle())
+    p.register_consumer(_ConsumerWantingGpu())
+    with pytest.raises(CapabilityRequirementError) as excinfo:
+        p.validate_consumer_capabilities()
+    assert "UsdFabric" in str(excinfo.value)
+
+
+def test_validate_consolidates_multiple_failures():
+    """A single error reports failures for every offending consumer."""
+    p = _FakeProvider()
+    p.register_consumer(_ConsumerWantingGpu())
+    p.register_consumer(_ConsumerWantingUsd())
+    with pytest.raises(CapabilityRequirementError) as excinfo:
+        p.validate_consumer_capabilities()
+    msg = str(excinfo.value)
+    assert "ConsumerWantingGpu" in msg
+    assert "ConsumerWantingUsd" in msg
+
+
+def test_required_one_of_passes_when_any_present():
+    p = _FakeProvider()
+    p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
+    p.register_consumer(_ConsumerWantingEither())
+    p.validate_consumer_capabilities()
+
+
+def test_required_one_of_fails_when_all_missing():
+    p = _FakeProvider()
+    p.register_consumer(_ConsumerWantingEither())
+    with pytest.raises(CapabilityRequirementError) as excinfo:
+        p.validate_consumer_capabilities()
+    assert "one-of" in str(excinfo.value)
+
+
+def test_required_capabilities_are_all_required():
+    p = _FakeProvider()
+    p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
+    # UsdFabric missing
+    p.register_consumer(_ConsumerWantingBoth())
+    with pytest.raises(CapabilityRequirementError) as excinfo:
+        p.validate_consumer_capabilities()
+    assert "UsdFabric" in str(excinfo.value)
+    assert "GpuTransformBuffer" not in str(excinfo.value).split("missing required:")[1].split("]")[0]
+
+
+def test_register_consumer_invalidates_prior_validation():
+    """A new registration after validate() must force re-validation."""
+    p = _FakeProvider()
+    p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
+    p.register_consumer(_ConsumerWantingGpu())
+    p.validate_consumer_capabilities()
+    assert p._capabilities_validated is True
+
+    p.register_consumer(_ConsumerWantingUsd())
+    assert p._capabilities_validated is False
+
+
+def test_validate_if_needed_is_idempotent():
+    p = _FakeProvider()
+    p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
+    p.register_consumer(_ConsumerWantingGpu())
+    p._validate_consumers_if_needed()
+    # Second call is a no-op even if we mutate the registry behind its back.
+    p._capabilities.pop(GpuTransformBuffer)
+    p._validate_consumers_if_needed()  # no error — already validated
+
+
+def test_consumer_registry_uses_weak_references():
+    """Dropped consumers do not leak into validation."""
+    import gc
+
+    p = _FakeProvider()
+    p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
+
+    consumer = _ConsumerWantingUsd()
+    p.register_consumer(consumer)
+    del consumer
+    gc.collect()
+
+    p.validate_consumer_capabilities()  # no error: consumer was collected
+
+
+def test_custom_capability_validates_like_built_ins():
+    p = _FakeProvider()
+    p._register_capability(_CustomCap, _FakeCustomHandle())
+    p.register_consumer(_ConsumerWantingCustom())
+    p.validate_consumer_capabilities()

--- a/source/isaaclab/test/physics/test_capabilities.py
+++ b/source/isaaclab/test/physics/test_capabilities.py
@@ -13,7 +13,7 @@ is purely structural.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Protocol, runtime_checkable
+from typing import ClassVar, Protocol, runtime_checkable
 
 import pytest
 
@@ -23,7 +23,6 @@ from isaaclab.physics import (
     GpuTransformBuffer,
     UsdFabric,
 )
-
 
 # ---------------------------------------------------------------------------
 # Test fixtures
@@ -66,14 +65,29 @@ class _FakeProvider(BaseSceneDataProvider):
         super().__init__()
 
     def update(self) -> None: ...
-    def get_newton_model(self): return None
-    def get_newton_state(self): return None
-    def get_usd_stage(self): return None
-    def get_metadata(self): return {}
-    def get_transforms(self): return None
-    def get_velocities(self): return None
-    def get_contacts(self): return None
-    def get_camera_transforms(self): return None
+    def get_newton_model(self):
+        return None
+
+    def get_newton_state(self):
+        return None
+
+    def get_usd_stage(self):
+        return None
+
+    def get_metadata(self):
+        return {}
+
+    def get_transforms(self):
+        return None
+
+    def get_velocities(self):
+        return None
+
+    def get_contacts(self):
+        return None
+
+    def get_camera_transforms(self):
+        return None
 
 
 class _ConsumerWantingGpu:
@@ -85,9 +99,7 @@ class _ConsumerWantingUsd:
 
 
 class _ConsumerWantingEither:
-    required_one_of: ClassVar[tuple[tuple[type, ...], ...]] = (
-        (UsdFabric, GpuTransformBuffer),
-    )
+    required_one_of: ClassVar[tuple[tuple[type, ...], ...]] = ((UsdFabric, GpuTransformBuffer),)
 
 
 class _ConsumerWantingBoth:

--- a/source/isaaclab/test/physics/test_capabilities.py
+++ b/source/isaaclab/test/physics/test_capabilities.py
@@ -169,13 +169,15 @@ def test_validate_passes_with_no_consumers():
 def test_validate_passes_when_required_satisfied():
     p = _FakeProvider()
     p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
-    p.register_consumer(_ConsumerWantingGpu())
+    consumer = _ConsumerWantingGpu()
+    p.register_consumer(consumer)
     p.validate_consumer_capabilities()
 
 
 def test_validate_fails_with_missing_required():
     p = _FakeProvider()
-    p.register_consumer(_ConsumerWantingGpu())
+    consumer = _ConsumerWantingGpu()
+    p.register_consumer(consumer)
     with pytest.raises(CapabilityRequirementError) as excinfo:
         p.validate_consumer_capabilities()
     assert "GpuTransformBuffer" in str(excinfo.value)
@@ -185,7 +187,8 @@ def test_validate_fails_with_missing_required():
 def test_validate_message_lists_offered_capabilities():
     p = _FakeProvider()
     p._register_capability(UsdFabric, _FakeFabricHandle())
-    p.register_consumer(_ConsumerWantingGpu())
+    consumer = _ConsumerWantingGpu()
+    p.register_consumer(consumer)
     with pytest.raises(CapabilityRequirementError) as excinfo:
         p.validate_consumer_capabilities()
     assert "UsdFabric" in str(excinfo.value)
@@ -194,8 +197,10 @@ def test_validate_message_lists_offered_capabilities():
 def test_validate_consolidates_multiple_failures():
     """A single error reports failures for every offending consumer."""
     p = _FakeProvider()
-    p.register_consumer(_ConsumerWantingGpu())
-    p.register_consumer(_ConsumerWantingUsd())
+    gpu_consumer = _ConsumerWantingGpu()
+    usd_consumer = _ConsumerWantingUsd()
+    p.register_consumer(gpu_consumer)
+    p.register_consumer(usd_consumer)
     with pytest.raises(CapabilityRequirementError) as excinfo:
         p.validate_consumer_capabilities()
     msg = str(excinfo.value)
@@ -206,13 +211,15 @@ def test_validate_consolidates_multiple_failures():
 def test_required_one_of_passes_when_any_present():
     p = _FakeProvider()
     p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
-    p.register_consumer(_ConsumerWantingEither())
+    consumer = _ConsumerWantingEither()
+    p.register_consumer(consumer)
     p.validate_consumer_capabilities()
 
 
 def test_required_one_of_fails_when_all_missing():
     p = _FakeProvider()
-    p.register_consumer(_ConsumerWantingEither())
+    consumer = _ConsumerWantingEither()
+    p.register_consumer(consumer)
     with pytest.raises(CapabilityRequirementError) as excinfo:
         p.validate_consumer_capabilities()
     assert "one-of" in str(excinfo.value)
@@ -222,7 +229,8 @@ def test_required_capabilities_are_all_required():
     p = _FakeProvider()
     p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
     # UsdFabric missing
-    p.register_consumer(_ConsumerWantingBoth())
+    consumer = _ConsumerWantingBoth()
+    p.register_consumer(consumer)
     with pytest.raises(CapabilityRequirementError) as excinfo:
         p.validate_consumer_capabilities()
     assert "UsdFabric" in str(excinfo.value)
@@ -233,18 +241,21 @@ def test_register_consumer_invalidates_prior_validation():
     """A new registration after validate() must force re-validation."""
     p = _FakeProvider()
     p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
-    p.register_consumer(_ConsumerWantingGpu())
+    gpu_consumer = _ConsumerWantingGpu()
+    p.register_consumer(gpu_consumer)
     p.validate_consumer_capabilities()
     assert p._capabilities_validated is True
 
-    p.register_consumer(_ConsumerWantingUsd())
+    usd_consumer = _ConsumerWantingUsd()
+    p.register_consumer(usd_consumer)
     assert p._capabilities_validated is False
 
 
 def test_validate_if_needed_is_idempotent():
     p = _FakeProvider()
     p._register_capability(GpuTransformBuffer, _FakeGpuHandle())
-    p.register_consumer(_ConsumerWantingGpu())
+    consumer = _ConsumerWantingGpu()
+    p.register_consumer(consumer)
     p._validate_consumers_if_needed()
     # Second call is a no-op even if we mutate the registry behind its back.
     p._capabilities.pop(GpuTransformBuffer)
@@ -269,5 +280,6 @@ def test_consumer_registry_uses_weak_references():
 def test_custom_capability_validates_like_built_ins():
     p = _FakeProvider()
     p._register_capability(_CustomCap, _FakeCustomHandle())
-    p.register_consumer(_ConsumerWantingCustom())
+    consumer = _ConsumerWantingCustom()
+    p.register_consumer(consumer)
     p.validate_consumer_capabilities()

--- a/source/isaaclab/test/physics/test_scene_data_buffers.py
+++ b/source/isaaclab/test/physics/test_scene_data_buffers.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for TransformBufferPool."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import warp as wp
+
+from isaaclab.physics.scene_data_buffers import TransformBufferPool
+from isaaclab.physics.scene_data_types import (
+    Mat44Transforms,
+    MatrixLayout,
+    QuaternionConvention,
+    TransformArrayData,
+    TransformFormat,
+    Vec3QuatTransforms,
+)
+
+DEVICE = "cuda:0"
+
+
+def _make_source_vec3_quat(n=4):
+    """Create a Vec3QuatTransforms with test data."""
+    positions = wp.from_numpy(
+        np.array([[1.0, 2.0, 3.0]] * n, dtype=np.float32), dtype=wp.vec3, device=DEVICE
+    )
+    quats = wp.from_numpy(
+        np.array([[0.0, 0.0, 0.0, 1.0]] * n, dtype=np.float32), dtype=wp.quatf, device=DEVICE
+    )
+    return Vec3QuatTransforms(
+        count=n,
+        device=DEVICE,
+        positions=positions,
+        orientations=quats,
+        quat_convention=QuaternionConvention.XYZW,
+    )
+
+
+def _make_source_transform(n=4):
+    """Create a TransformArrayData with test data."""
+    tf_np = np.zeros((n, 7), dtype=np.float32)
+    tf_np[:, :3] = [1.0, 2.0, 3.0]
+    tf_np[:, 3:7] = [0.0, 0.0, 0.0, 1.0]
+    transforms = wp.from_numpy(tf_np, dtype=wp.transformf, device=DEVICE)
+    return TransformArrayData(
+        count=n,
+        device=DEVICE,
+        transforms=transforms,
+    )
+
+
+class TestPassthrough:
+    def test_format_match_returns_source(self):
+        """When requested format matches source, return source directly."""
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat()
+
+        result = pool.get_or_convert(
+            source,
+            TransformFormat.VEC3_QUAT,
+            generation=1,
+            allow_passthrough=True,
+        )
+        assert result is source
+
+    def test_transform_passthrough(self):
+        """TransformArrayData -> TRANSFORM should passthrough."""
+        pool = TransformBufferPool()
+        source = _make_source_transform()
+
+        result = pool.get_or_convert(
+            source,
+            TransformFormat.TRANSFORM,
+            generation=1,
+            allow_passthrough=True,
+        )
+        assert result is source
+
+    def test_no_passthrough_when_disabled(self):
+        """When allow_passthrough=False, result should be different object."""
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat()
+
+        result = pool.get_or_convert(
+            source,
+            TransformFormat.VEC3_QUAT,
+            generation=1,
+            allow_passthrough=False,
+        )
+        assert result is not source
+        assert isinstance(result, Vec3QuatTransforms)
+
+    def test_no_passthrough_when_convention_differs(self):
+        """When quat convention differs, conversion should happen."""
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat()
+
+        result = pool.get_or_convert(
+            source,
+            TransformFormat.VEC3_QUAT,
+            generation=1,
+            quat_convention=QuaternionConvention.WXYZ,
+            allow_passthrough=True,
+        )
+        assert result is not source
+
+    def test_no_passthrough_with_index_map(self):
+        """When index_map is provided, passthrough is disabled."""
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat()
+        index_map = wp.from_numpy(np.array([0, 1], dtype=np.int32), device=DEVICE)
+
+        result = pool.get_or_convert(
+            source,
+            TransformFormat.VEC3_QUAT,
+            generation=1,
+            allow_passthrough=True,
+            index_map=index_map,
+        )
+        assert result is not source
+
+
+class TestGenerationCache:
+    def test_same_generation_returns_cached(self):
+        """Second call with same generation should return cached result."""
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat()
+
+        result1 = pool.get_or_convert(
+            source, TransformFormat.TRANSFORM, generation=1
+        )
+        result2 = pool.get_or_convert(
+            source, TransformFormat.TRANSFORM, generation=1
+        )
+        assert result1 is result2
+
+    def test_different_generation_reconverts(self):
+        """Different generation should trigger re-conversion."""
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat()
+
+        result1 = pool.get_or_convert(
+            source, TransformFormat.TRANSFORM, generation=1
+        )
+        result2 = pool.get_or_convert(
+            source, TransformFormat.TRANSFORM, generation=2
+        )
+        assert isinstance(result1, TransformArrayData)
+        assert isinstance(result2, TransformArrayData)
+
+
+class TestBufferReuse:
+    def test_cross_frame_reuses_buffer(self):
+        """New generation should reuse the same allocated buffer."""
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat()
+
+        result1 = pool.get_or_convert(
+            source, TransformFormat.TRANSFORM, generation=1
+        )
+        assert isinstance(result1, TransformArrayData)
+        ptr1 = result1.transforms.ptr
+
+        result2 = pool.get_or_convert(
+            source, TransformFormat.TRANSFORM, generation=2
+        )
+        assert isinstance(result2, TransformArrayData)
+        ptr2 = result2.transforms.ptr
+
+        assert ptr1 == ptr2
+
+    def test_reallocates_when_count_changes(self):
+        """When source count changes, buffer should be reallocated."""
+        pool = TransformBufferPool()
+
+        source_small = _make_source_vec3_quat(n=2)
+        result1 = pool.get_or_convert(
+            source_small, TransformFormat.TRANSFORM, generation=1
+        )
+        assert isinstance(result1, TransformArrayData)
+
+        source_large = _make_source_vec3_quat(n=8)
+        result2 = pool.get_or_convert(
+            source_large, TransformFormat.TRANSFORM, generation=2
+        )
+        assert isinstance(result2, TransformArrayData)
+        assert result2.count == 8
+
+
+class TestFormatConversion:
+    def test_vec3_quat_to_transform(self):
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat(n=2)
+
+        result = pool.get_or_convert(source, TransformFormat.TRANSFORM, generation=1)
+        assert isinstance(result, TransformArrayData)
+        assert result.count == 2
+        wp.synchronize_device(DEVICE)
+
+        tf = result.transforms.numpy()
+        np.testing.assert_allclose(tf[0][:3], [1.0, 2.0, 3.0], atol=1e-5)
+
+    def test_vec3_quat_to_mat44(self):
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat(n=1)
+
+        result = pool.get_or_convert(
+            source,
+            TransformFormat.MAT44,
+            generation=1,
+            matrix_layout=MatrixLayout.ROW_MAJOR,
+        )
+        assert isinstance(result, Mat44Transforms)
+        wp.synchronize_device(DEVICE)
+
+        m = result.matrices.numpy()[0]
+        np.testing.assert_allclose(m[0, 3], 1.0, atol=1e-5)
+        np.testing.assert_allclose(m[1, 3], 2.0, atol=1e-5)
+        np.testing.assert_allclose(m[2, 3], 3.0, atol=1e-5)
+
+    def test_vec3_quat_to_mat44_column_major(self):
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat(n=1)
+
+        result = pool.get_or_convert(
+            source,
+            TransformFormat.MAT44,
+            generation=1,
+            matrix_layout=MatrixLayout.COLUMN_MAJOR,
+        )
+        assert isinstance(result, Mat44Transforms)
+        assert result.layout == MatrixLayout.COLUMN_MAJOR
+        wp.synchronize_device(DEVICE)
+
+        m = result.matrices.numpy()[0]
+        # Column-major: translation is in row 3 (transposed)
+        np.testing.assert_allclose(m[3, 0], 1.0, atol=1e-5)
+        np.testing.assert_allclose(m[3, 1], 2.0, atol=1e-5)
+        np.testing.assert_allclose(m[3, 2], 3.0, atol=1e-5)
+
+    def test_transform_to_vec3_quat(self):
+        pool = TransformBufferPool()
+        source = _make_source_transform(n=2)
+
+        result = pool.get_or_convert(source, TransformFormat.VEC3_QUAT, generation=1)
+        assert isinstance(result, Vec3QuatTransforms)
+        assert result.count == 2
+        wp.synchronize_device(DEVICE)
+
+        pos = result.positions.numpy()
+        np.testing.assert_allclose(pos[0], [1.0, 2.0, 3.0], atol=1e-5)
+
+
+class TestClear:
+    def test_clear_releases_cache(self):
+        pool = TransformBufferPool()
+        source = _make_source_vec3_quat()
+
+        pool.get_or_convert(source, TransformFormat.TRANSFORM, generation=1)
+        assert len(pool._cache) > 0
+
+        pool.clear()
+        assert len(pool._cache) == 0
+        assert len(pool._cache_generation) == 0

--- a/source/isaaclab/test/physics/test_scene_data_buffers.py
+++ b/source/isaaclab/test/physics/test_scene_data_buffers.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 import warp as wp
 
 from isaaclab.physics.scene_data_buffers import TransformBufferPool
@@ -26,12 +25,8 @@ DEVICE = "cuda:0"
 
 def _make_source_vec3_quat(n=4):
     """Create a Vec3QuatTransforms with test data."""
-    positions = wp.from_numpy(
-        np.array([[1.0, 2.0, 3.0]] * n, dtype=np.float32), dtype=wp.vec3, device=DEVICE
-    )
-    quats = wp.from_numpy(
-        np.array([[0.0, 0.0, 0.0, 1.0]] * n, dtype=np.float32), dtype=wp.quatf, device=DEVICE
-    )
+    positions = wp.from_numpy(np.array([[1.0, 2.0, 3.0]] * n, dtype=np.float32), dtype=wp.vec3, device=DEVICE)
+    quats = wp.from_numpy(np.array([[0.0, 0.0, 0.0, 1.0]] * n, dtype=np.float32), dtype=wp.quatf, device=DEVICE)
     return Vec3QuatTransforms(
         count=n,
         device=DEVICE,
@@ -131,12 +126,8 @@ class TestGenerationCache:
         pool = TransformBufferPool()
         source = _make_source_vec3_quat()
 
-        result1 = pool.get_or_convert(
-            source, TransformFormat.TRANSFORM, generation=1
-        )
-        result2 = pool.get_or_convert(
-            source, TransformFormat.TRANSFORM, generation=1
-        )
+        result1 = pool.get_or_convert(source, TransformFormat.TRANSFORM, generation=1)
+        result2 = pool.get_or_convert(source, TransformFormat.TRANSFORM, generation=1)
         assert result1 is result2
 
     def test_different_generation_reconverts(self):
@@ -144,12 +135,8 @@ class TestGenerationCache:
         pool = TransformBufferPool()
         source = _make_source_vec3_quat()
 
-        result1 = pool.get_or_convert(
-            source, TransformFormat.TRANSFORM, generation=1
-        )
-        result2 = pool.get_or_convert(
-            source, TransformFormat.TRANSFORM, generation=2
-        )
+        result1 = pool.get_or_convert(source, TransformFormat.TRANSFORM, generation=1)
+        result2 = pool.get_or_convert(source, TransformFormat.TRANSFORM, generation=2)
         assert isinstance(result1, TransformArrayData)
         assert isinstance(result2, TransformArrayData)
 
@@ -160,15 +147,11 @@ class TestBufferReuse:
         pool = TransformBufferPool()
         source = _make_source_vec3_quat()
 
-        result1 = pool.get_or_convert(
-            source, TransformFormat.TRANSFORM, generation=1
-        )
+        result1 = pool.get_or_convert(source, TransformFormat.TRANSFORM, generation=1)
         assert isinstance(result1, TransformArrayData)
         ptr1 = result1.transforms.ptr
 
-        result2 = pool.get_or_convert(
-            source, TransformFormat.TRANSFORM, generation=2
-        )
+        result2 = pool.get_or_convert(source, TransformFormat.TRANSFORM, generation=2)
         assert isinstance(result2, TransformArrayData)
         ptr2 = result2.transforms.ptr
 
@@ -179,15 +162,11 @@ class TestBufferReuse:
         pool = TransformBufferPool()
 
         source_small = _make_source_vec3_quat(n=2)
-        result1 = pool.get_or_convert(
-            source_small, TransformFormat.TRANSFORM, generation=1
-        )
+        result1 = pool.get_or_convert(source_small, TransformFormat.TRANSFORM, generation=1)
         assert isinstance(result1, TransformArrayData)
 
         source_large = _make_source_vec3_quat(n=8)
-        result2 = pool.get_or_convert(
-            source_large, TransformFormat.TRANSFORM, generation=2
-        )
+        result2 = pool.get_or_convert(source_large, TransformFormat.TRANSFORM, generation=2)
         assert isinstance(result2, TransformArrayData)
         assert result2.count == 8
 

--- a/source/isaaclab/test/physics/test_scene_data_conversion.py
+++ b/source/isaaclab/test/physics/test_scene_data_conversion.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import math
 
 import numpy as np
-import pytest
 import warp as wp
 
 from isaaclab.physics.scene_data_conversion import ConversionDispatcher
@@ -164,7 +163,9 @@ class TestConvertVec3QuatToMat44:
             count=1,
             device=DEVICE,
             positions=wp.from_numpy(np.array([[0.0, 0.0, 0.0]], dtype=np.float32), dtype=wp.vec3, device=DEVICE),
-            orientations=wp.from_numpy(np.array([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32), dtype=wp.quatf, device=DEVICE),
+            orientations=wp.from_numpy(
+                np.array([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32), dtype=wp.quatf, device=DEVICE
+            ),
         )
         target = _alloc_mat44f(1)
         ConversionDispatcher.convert(source, target)
@@ -179,7 +180,9 @@ class TestConvertVec3QuatToVec3Mat33:
             count=1,
             device=DEVICE,
             positions=wp.from_numpy(np.array([[5.0, 6.0, 7.0]], dtype=np.float32), dtype=wp.vec3, device=DEVICE),
-            orientations=wp.from_numpy(np.array([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32), dtype=wp.quatf, device=DEVICE),
+            orientations=wp.from_numpy(
+                np.array([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32), dtype=wp.quatf, device=DEVICE
+            ),
         )
         target = _alloc_vec3_mat33(1)
         ConversionDispatcher.convert(source, target)
@@ -247,15 +250,32 @@ class TestBaseProviderDefaults:
         from isaaclab.physics.base_scene_data_provider import BaseSceneDataProvider
 
         class Stub(BaseSceneDataProvider):
-            def update(self, env_ids=None): pass
-            def get_newton_model(self): return None
-            def get_newton_state(self, env_ids=None): return None
-            def get_usd_stage(self): return None
-            def get_metadata(self): return {}
-            def get_transforms(self): return None
-            def get_velocities(self): return None
-            def get_contacts(self): return None
-            def get_camera_transforms(self): return None
+            def update(self, env_ids=None):
+                pass
+
+            def get_newton_model(self):
+                return None
+
+            def get_newton_state(self, env_ids=None):
+                return None
+
+            def get_usd_stage(self):
+                return None
+
+            def get_metadata(self):
+                return {}
+
+            def get_transforms(self):
+                return None
+
+            def get_velocities(self):
+                return None
+
+            def get_contacts(self):
+                return None
+
+            def get_camera_transforms(self):
+                return None
 
         provider = Stub()
         assert provider.get_body_transforms(TransformFormat.TRANSFORM) is None

--- a/source/isaaclab/test/physics/test_scene_data_conversion.py
+++ b/source/isaaclab/test/physics/test_scene_data_conversion.py
@@ -246,18 +246,13 @@ class TestMatrixLayoutTranspose:
 
 
 class TestBaseProviderDefaults:
-    def test_get_body_transforms_default_returns_none(self):
+    def test_empty_provider_lists_no_capabilities(self):
+        """A bare BaseSceneDataProvider subclass exposes no capabilities by default."""
         from isaaclab.physics.base_scene_data_provider import BaseSceneDataProvider
 
         class Stub(BaseSceneDataProvider):
-            def update(self, env_ids=None):
+            def update(self):
                 pass
-
-            def get_newton_model(self):
-                return None
-
-            def get_newton_state(self, env_ids=None):
-                return None
 
             def get_usd_stage(self):
                 return None
@@ -265,18 +260,8 @@ class TestBaseProviderDefaults:
             def get_metadata(self):
                 return {}
 
-            def get_transforms(self):
-                return None
-
-            def get_velocities(self):
-                return None
-
-            def get_contacts(self):
-                return None
-
             def get_camera_transforms(self):
                 return None
 
         provider = Stub()
-        assert provider.get_body_transforms(TransformFormat.TRANSFORM) is None
-        assert provider.get_source_format() is None
+        assert provider.list_capabilities() == frozenset()

--- a/source/isaaclab/test/physics/test_scene_data_conversion.py
+++ b/source/isaaclab/test/physics/test_scene_data_conversion.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for ConversionDispatcher."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import warp as wp
+
+from isaaclab.physics.scene_data_conversion import ConversionDispatcher
+from isaaclab.physics.scene_data_types import (
+    Mat44Transforms,
+    MatrixLayout,
+    QuaternionConvention,
+    TransformArrayData,
+    TransformFormat,
+    Vec3Mat33Transforms,
+    Vec3QuatTransforms,
+)
+
+DEVICE = "cuda:0"
+ATOL = 1e-5
+
+
+def _identity_quat_np():
+    return np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+
+
+def _z90_quat_np():
+    angle = math.pi / 2
+    return np.array([0.0, 0.0, math.sin(angle / 2), math.cos(angle / 2)], dtype=np.float32)
+
+
+def _make_vec3_quat(n=2):
+    positions = wp.from_numpy(
+        np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]][:n], dtype=np.float32),
+        dtype=wp.vec3,
+        device=DEVICE,
+    )
+    quats = wp.from_numpy(
+        np.array([_identity_quat_np(), _z90_quat_np()][:n], dtype=np.float32),
+        dtype=wp.quatf,
+        device=DEVICE,
+    )
+    return Vec3QuatTransforms(count=n, device=DEVICE, positions=positions, orientations=quats)
+
+
+def _make_transform(n=2):
+    tf_np = np.zeros((n, 7), dtype=np.float32)
+    tf_np[0, :3] = [1.0, 2.0, 3.0]
+    tf_np[0, 3:7] = _identity_quat_np()
+    if n > 1:
+        tf_np[1, :3] = [4.0, 5.0, 6.0]
+        tf_np[1, 3:7] = _z90_quat_np()
+    return TransformArrayData(
+        count=n,
+        device=DEVICE,
+        transforms=wp.from_numpy(tf_np, dtype=wp.transformf, device=DEVICE),
+    )
+
+
+def _alloc_vec3_quat(n=2):
+    return Vec3QuatTransforms(
+        count=n,
+        device=DEVICE,
+        positions=wp.zeros(n, dtype=wp.vec3, device=DEVICE),
+        orientations=wp.zeros(n, dtype=wp.quatf, device=DEVICE),
+    )
+
+
+def _alloc_transform(n=2):
+    return TransformArrayData(
+        count=n,
+        device=DEVICE,
+        transforms=wp.zeros(n, dtype=wp.transformf, device=DEVICE),
+    )
+
+
+def _alloc_mat44f(n=2, layout=MatrixLayout.ROW_MAJOR):
+    return Mat44Transforms(
+        count=n,
+        device=DEVICE,
+        matrices=wp.zeros(n, dtype=wp.mat44f, device=DEVICE),
+        layout=layout,
+    )
+
+
+def _alloc_vec3_mat33(n=2):
+    return Vec3Mat33Transforms(
+        count=n,
+        device=DEVICE,
+        positions=wp.zeros(n, dtype=wp.vec3, device=DEVICE),
+        rotations=wp.zeros(n, dtype=wp.mat33f, device=DEVICE),
+    )
+
+
+class TestCanPassthrough:
+    def test_same_format_same_convention(self):
+        source = _make_vec3_quat()
+        assert ConversionDispatcher.can_passthrough(source, TransformFormat.VEC3_QUAT)
+
+    def test_same_format_different_convention(self):
+        source = _make_vec3_quat()
+        assert not ConversionDispatcher.can_passthrough(
+            source, TransformFormat.VEC3_QUAT, quat_convention=QuaternionConvention.WXYZ
+        )
+
+    def test_different_format(self):
+        source = _make_vec3_quat()
+        assert not ConversionDispatcher.can_passthrough(source, TransformFormat.TRANSFORM)
+
+    def test_transform_passthrough(self):
+        source = _make_transform()
+        assert ConversionDispatcher.can_passthrough(source, TransformFormat.TRANSFORM)
+
+    def test_mat44_layout_mismatch(self):
+        source = Mat44Transforms(
+            count=1,
+            device=DEVICE,
+            matrices=wp.zeros(1, dtype=wp.mat44f, device=DEVICE),
+            layout=MatrixLayout.ROW_MAJOR,
+        )
+        assert not ConversionDispatcher.can_passthrough(
+            source, TransformFormat.MAT44, matrix_layout=MatrixLayout.COLUMN_MAJOR
+        )
+
+
+class TestConvertVec3QuatToTransform:
+    def test_positions_preserved(self):
+        source = _make_vec3_quat()
+        target = _alloc_transform()
+
+        ConversionDispatcher.convert(source, target)
+        wp.synchronize_device(DEVICE)
+
+        tf = target.transforms.numpy()
+        np.testing.assert_allclose(tf[0][:3], [1.0, 2.0, 3.0], atol=ATOL)
+        np.testing.assert_allclose(tf[1][:3], [4.0, 5.0, 6.0], atol=ATOL)
+
+
+class TestConvertTransformToVec3Quat:
+    def test_roundtrip(self):
+        """transform -> vec3_quat -> transform should recover original."""
+        source = _make_transform()
+        mid = _alloc_vec3_quat()
+        ConversionDispatcher.convert(source, mid)
+
+        final = _alloc_transform()
+        ConversionDispatcher.convert(mid, final)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(final.transforms.numpy(), source.transforms.numpy(), atol=ATOL)
+
+
+class TestConvertVec3QuatToMat44:
+    def test_identity_produces_identity(self):
+        source = Vec3QuatTransforms(
+            count=1,
+            device=DEVICE,
+            positions=wp.from_numpy(np.array([[0.0, 0.0, 0.0]], dtype=np.float32), dtype=wp.vec3, device=DEVICE),
+            orientations=wp.from_numpy(np.array([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32), dtype=wp.quatf, device=DEVICE),
+        )
+        target = _alloc_mat44f(1)
+        ConversionDispatcher.convert(source, target)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(target.matrices.numpy()[0], np.eye(4, dtype=np.float32), atol=ATOL)
+
+
+class TestConvertVec3QuatToVec3Mat33:
+    def test_identity_quat_gives_identity_rotation(self):
+        source = Vec3QuatTransforms(
+            count=1,
+            device=DEVICE,
+            positions=wp.from_numpy(np.array([[5.0, 6.0, 7.0]], dtype=np.float32), dtype=wp.vec3, device=DEVICE),
+            orientations=wp.from_numpy(np.array([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32), dtype=wp.quatf, device=DEVICE),
+        )
+        target = _alloc_vec3_mat33(1)
+        ConversionDispatcher.convert(source, target)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(target.positions.numpy()[0], [5.0, 6.0, 7.0], atol=ATOL)
+        np.testing.assert_allclose(target.rotations.numpy()[0], np.eye(3, dtype=np.float32), atol=ATOL)
+
+
+class TestConvertWithIndexMap:
+    def test_scatter_preserves_data(self):
+        source = _make_vec3_quat(2)
+        index_map = wp.from_numpy(np.array([3, 1], dtype=np.int32), device=DEVICE)
+        target = _alloc_transform(5)
+
+        ConversionDispatcher.convert(source, target, index_map=index_map)
+        wp.synchronize_device(DEVICE)
+
+        tf = target.transforms.numpy()
+        np.testing.assert_allclose(tf[3][:3], [1.0, 2.0, 3.0], atol=ATOL)
+        np.testing.assert_allclose(tf[1][:3], [4.0, 5.0, 6.0], atol=ATOL)
+        np.testing.assert_allclose(tf[0][:3], [0.0, 0.0, 0.0], atol=ATOL)
+
+
+class TestQuatConventionSwizzle:
+    def test_convert_to_wxyz(self):
+        source = _make_vec3_quat(1)
+        target = Vec3QuatTransforms(
+            count=1,
+            device=DEVICE,
+            positions=wp.zeros(1, dtype=wp.vec3, device=DEVICE),
+            orientations=wp.zeros(1, dtype=wp.quatf, device=DEVICE),
+            quat_convention=QuaternionConvention.WXYZ,
+        )
+        ConversionDispatcher.convert(source, target)
+        wp.synchronize_device(DEVICE)
+
+        result = target.orientations.numpy()[0]
+        # Source was identity XYZW: (0,0,0,1). WXYZ should be (1,0,0,0).
+        np.testing.assert_allclose(result, [1.0, 0.0, 0.0, 0.0], atol=ATOL)
+
+
+class TestMatrixLayoutTranspose:
+    def test_column_major_output(self):
+        source = _make_vec3_quat(1)
+        target = Mat44Transforms(
+            count=1,
+            device=DEVICE,
+            matrices=wp.zeros(1, dtype=wp.mat44f, device=DEVICE),
+            layout=MatrixLayout.COLUMN_MAJOR,
+        )
+        ConversionDispatcher.convert(source, target)
+        wp.synchronize_device(DEVICE)
+
+        m = target.matrices.numpy()[0]
+        # Column-major identity with translation (1,2,3):
+        # translation should be in row 3 (transposed)
+        np.testing.assert_allclose(m[3, 0], 1.0, atol=ATOL)
+        np.testing.assert_allclose(m[3, 1], 2.0, atol=ATOL)
+        np.testing.assert_allclose(m[3, 2], 3.0, atol=ATOL)
+
+
+class TestBaseProviderDefaults:
+    def test_get_body_transforms_default_returns_none(self):
+        from isaaclab.physics.base_scene_data_provider import BaseSceneDataProvider
+
+        class Stub(BaseSceneDataProvider):
+            def update(self, env_ids=None): pass
+            def get_newton_model(self): return None
+            def get_newton_state(self, env_ids=None): return None
+            def get_usd_stage(self): return None
+            def get_metadata(self): return {}
+            def get_transforms(self): return None
+            def get_velocities(self): return None
+            def get_contacts(self): return None
+            def get_camera_transforms(self): return None
+
+        provider = Stub()
+        assert provider.get_body_transforms(TransformFormat.TRANSFORM) is None
+        assert provider.get_source_format() is None

--- a/source/isaaclab/test/physics/test_scene_data_kernels.py
+++ b/source/isaaclab/test/physics/test_scene_data_kernels.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import math
 
 import numpy as np
-import pytest
 import warp as wp
 
 from isaaclab.physics import scene_data_kernels as K
@@ -39,8 +38,9 @@ def _rotation_quat_z90():
 def _make_test_data(n=4):
     """Create test positions and XYZW quaternions as numpy arrays."""
     positions = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0], [0.1, 0.2, 0.3]], dtype=np.float32)[:n]
-    quats = np.array([_identity_quat(), _rotation_quat_z90(), _identity_quat(), _rotation_quat_z90()],
-                     dtype=np.float32)[:n]
+    quats = np.array(
+        [_identity_quat(), _rotation_quat_z90(), _identity_quat(), _rotation_quat_z90()], dtype=np.float32
+    )[:n]
     return positions, quats
 
 
@@ -81,7 +81,9 @@ class TestTransformToVec3Quat:
 
         out_pos = wp.zeros(4, dtype=wp.vec3, device=DEVICE)
         out_ori = wp.zeros(4, dtype=wp.quatf, device=DEVICE)
-        wp.launch(K.transform_to_vec3_quat_kernel, dim=4, inputs=[tf, out_pos, out_ori, _empty_imap(), 0], device=DEVICE)
+        wp.launch(
+            K.transform_to_vec3_quat_kernel, dim=4, inputs=[tf, out_pos, out_ori, _empty_imap(), 0], device=DEVICE
+        )
         wp.synchronize_device(DEVICE)
 
         np.testing.assert_allclose(out_pos.numpy(), positions_np, atol=ATOL)
@@ -303,9 +305,7 @@ class TestQuaternionSwizzle:
 
 class TestMatrixTranspose:
     def test_mat44f_transpose_roundtrip(self):
-        m_np = np.array(
-            [[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]], dtype=np.float32
-        )
+        m_np = np.array([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]], dtype=np.float32)
         src = wp.from_numpy(m_np, dtype=wp.mat44f, device=DEVICE)
         mid = wp.zeros(1, dtype=wp.mat44f, device=DEVICE)
         dst = wp.zeros(1, dtype=wp.mat44f, device=DEVICE)
@@ -317,9 +317,7 @@ class TestMatrixTranspose:
         np.testing.assert_allclose(dst.numpy(), m_np, atol=ATOL)
 
     def test_mat44f_transpose_values(self):
-        m_np = np.array(
-            [[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]], dtype=np.float32
-        )
+        m_np = np.array([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]], dtype=np.float32)
         src = wp.from_numpy(m_np, dtype=wp.mat44f, device=DEVICE)
         dst = wp.zeros(1, dtype=wp.mat44f, device=DEVICE)
 

--- a/source/isaaclab/test/physics/test_scene_data_kernels.py
+++ b/source/isaaclab/test/physics/test_scene_data_kernels.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for scene data conversion kernels.
+
+These tests verify all 16 conversion paths in the kernel grid, plus
+quaternion convention swizzle, matrix transpose, and index-mapped
+subset scatter. All tests run on GPU via Warp and do not require
+Isaac Sim.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import warp as wp
+
+from isaaclab.physics import scene_data_kernels as K
+
+DEVICE = "cuda:0"
+ATOL = 1e-5
+
+
+def _identity_quat():
+    """Return an XYZW identity quaternion as numpy: (0, 0, 0, 1)."""
+    return np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+
+
+def _rotation_quat_z90():
+    """Return a 90-degree rotation about Z as XYZW quaternion."""
+    angle = math.pi / 2
+    return np.array([0.0, 0.0, math.sin(angle / 2), math.cos(angle / 2)], dtype=np.float32)
+
+
+def _make_test_data(n=4):
+    """Create test positions and XYZW quaternions as numpy arrays."""
+    positions = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0], [0.1, 0.2, 0.3]], dtype=np.float32)[:n]
+    quats = np.array([_identity_quat(), _rotation_quat_z90(), _identity_quat(), _rotation_quat_z90()],
+                     dtype=np.float32)[:n]
+    return positions, quats
+
+
+def _to_warp_arrays(positions_np, quats_np, device=DEVICE):
+    """Convert numpy positions and quaternions to Warp arrays."""
+    pos_wp = wp.from_numpy(positions_np.copy(), dtype=wp.vec3, device=device)
+    ori_wp = wp.from_numpy(quats_np.copy(), dtype=wp.quatf, device=device)
+    return pos_wp, ori_wp
+
+
+def _empty_imap(device=DEVICE):
+    return wp.empty(0, dtype=wp.int32, device=device)
+
+
+class TestVec3QuatToTransform:
+    def test_basic_conversion(self):
+        positions_np, quats_np = _make_test_data(2)
+        pos_wp, ori_wp = _to_warp_arrays(positions_np, quats_np)
+        dst = wp.zeros(2, dtype=wp.transformf, device=DEVICE)
+
+        wp.launch(K.vec3_quat_to_transform_kernel, dim=2, inputs=[pos_wp, ori_wp, dst, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        result = dst.numpy()
+        for i in range(2):
+            np.testing.assert_allclose(result[i][:3], positions_np[i], atol=ATOL)
+            np.testing.assert_allclose(result[i][3:7], quats_np[i], atol=ATOL)
+
+
+class TestTransformToVec3Quat:
+    def test_roundtrip(self):
+        """vec3_quat -> transform -> vec3_quat should recover original data."""
+        positions_np, quats_np = _make_test_data(4)
+        pos_wp, ori_wp = _to_warp_arrays(positions_np, quats_np)
+
+        tf = wp.zeros(4, dtype=wp.transformf, device=DEVICE)
+        wp.launch(K.vec3_quat_to_transform_kernel, dim=4, inputs=[pos_wp, ori_wp, tf, _empty_imap(), 0], device=DEVICE)
+
+        out_pos = wp.zeros(4, dtype=wp.vec3, device=DEVICE)
+        out_ori = wp.zeros(4, dtype=wp.quatf, device=DEVICE)
+        wp.launch(K.transform_to_vec3_quat_kernel, dim=4, inputs=[tf, out_pos, out_ori, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(out_pos.numpy(), positions_np, atol=ATOL)
+        np.testing.assert_allclose(np.abs(out_ori.numpy()), np.abs(quats_np), atol=ATOL)
+
+
+class TestVec3QuatToVec3Mat33:
+    def test_identity_quat_gives_identity_matrix(self):
+        pos_np = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        quat_np = np.array([_identity_quat()], dtype=np.float32)
+        pos_wp, ori_wp = _to_warp_arrays(pos_np, quat_np)
+
+        dst_pos = wp.zeros(1, dtype=wp.vec3, device=DEVICE)
+        dst_rot = wp.zeros(1, dtype=wp.mat33f, device=DEVICE)
+        wp.launch(
+            K.vec3_quat_to_vec3_mat33_kernel,
+            dim=1,
+            inputs=[pos_wp, ori_wp, dst_pos, dst_rot, _empty_imap(), 0],
+            device=DEVICE,
+        )
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(dst_pos.numpy()[0], [1.0, 2.0, 3.0], atol=ATOL)
+        np.testing.assert_allclose(dst_rot.numpy()[0], np.eye(3, dtype=np.float32), atol=ATOL)
+
+    def test_roundtrip(self):
+        """vec3_quat -> vec3_mat33 -> vec3_quat should recover original data."""
+        positions_np, quats_np = _make_test_data(2)
+        pos_wp, ori_wp = _to_warp_arrays(positions_np, quats_np)
+
+        mid_pos = wp.zeros(2, dtype=wp.vec3, device=DEVICE)
+        mid_rot = wp.zeros(2, dtype=wp.mat33f, device=DEVICE)
+        wp.launch(
+            K.vec3_quat_to_vec3_mat33_kernel,
+            dim=2,
+            inputs=[pos_wp, ori_wp, mid_pos, mid_rot, _empty_imap(), 0],
+            device=DEVICE,
+        )
+
+        out_pos = wp.zeros(2, dtype=wp.vec3, device=DEVICE)
+        out_ori = wp.zeros(2, dtype=wp.quatf, device=DEVICE)
+        wp.launch(
+            K.vec3_mat33_to_vec3_quat_kernel,
+            dim=2,
+            inputs=[mid_pos, mid_rot, out_pos, out_ori, _empty_imap(), 0],
+            device=DEVICE,
+        )
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(out_pos.numpy(), positions_np, atol=ATOL)
+        np.testing.assert_allclose(np.abs(out_ori.numpy()), np.abs(quats_np), atol=ATOL)
+
+
+class TestVec3QuatToMat44:
+    def test_identity_produces_identity_matrix(self):
+        pos_np = np.array([[0.0, 0.0, 0.0]], dtype=np.float32)
+        quat_np = np.array([_identity_quat()], dtype=np.float32)
+        pos_wp, ori_wp = _to_warp_arrays(pos_np, quat_np)
+
+        dst = wp.zeros(1, dtype=wp.mat44f, device=DEVICE)
+        wp.launch(K.vec3_quat_to_mat44f_kernel, dim=1, inputs=[pos_wp, ori_wp, dst, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(dst.numpy()[0], np.eye(4, dtype=np.float32), atol=ATOL)
+
+    def test_translation_in_last_column(self):
+        pos_np = np.array([[10.0, 20.0, 30.0]], dtype=np.float32)
+        quat_np = np.array([_identity_quat()], dtype=np.float32)
+        pos_wp, ori_wp = _to_warp_arrays(pos_np, quat_np)
+
+        dst = wp.zeros(1, dtype=wp.mat44f, device=DEVICE)
+        wp.launch(K.vec3_quat_to_mat44f_kernel, dim=1, inputs=[pos_wp, ori_wp, dst, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        m = dst.numpy()[0]
+        np.testing.assert_allclose(m[0, 3], 10.0, atol=ATOL)
+        np.testing.assert_allclose(m[1, 3], 20.0, atol=ATOL)
+        np.testing.assert_allclose(m[2, 3], 30.0, atol=ATOL)
+
+    def test_double_precision(self):
+        pos_np = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        quat_np = np.array([_identity_quat()], dtype=np.float32)
+        pos_wp, ori_wp = _to_warp_arrays(pos_np, quat_np)
+
+        dst = wp.zeros(1, dtype=wp.mat44d, device=DEVICE)
+        wp.launch(K.vec3_quat_to_mat44d_kernel, dim=1, inputs=[pos_wp, ori_wp, dst, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        m = dst.numpy()[0]
+        np.testing.assert_allclose(m[0, 3], 1.0, atol=1e-10)
+
+
+class TestMat44ToVec3Quat:
+    def test_roundtrip_float32(self):
+        """vec3_quat -> mat44f -> vec3_quat should recover original data."""
+        positions_np, quats_np = _make_test_data(2)
+        pos_wp, ori_wp = _to_warp_arrays(positions_np, quats_np)
+
+        mat = wp.zeros(2, dtype=wp.mat44f, device=DEVICE)
+        wp.launch(K.vec3_quat_to_mat44f_kernel, dim=2, inputs=[pos_wp, ori_wp, mat, _empty_imap(), 0], device=DEVICE)
+
+        out_pos = wp.zeros(2, dtype=wp.vec3, device=DEVICE)
+        out_ori = wp.zeros(2, dtype=wp.quatf, device=DEVICE)
+        wp.launch(K.mat44f_to_vec3_quat_kernel, dim=2, inputs=[mat, out_pos, out_ori, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(out_pos.numpy(), positions_np, atol=ATOL)
+        np.testing.assert_allclose(np.abs(out_ori.numpy()), np.abs(quats_np), atol=ATOL)
+
+    def test_roundtrip_float64(self):
+        """vec3_quat -> mat44d -> vec3_quat should recover original data."""
+        positions_np, quats_np = _make_test_data(2)
+        pos_wp, ori_wp = _to_warp_arrays(positions_np, quats_np)
+
+        mat = wp.zeros(2, dtype=wp.mat44d, device=DEVICE)
+        wp.launch(K.vec3_quat_to_mat44d_kernel, dim=2, inputs=[pos_wp, ori_wp, mat, _empty_imap(), 0], device=DEVICE)
+
+        out_pos = wp.zeros(2, dtype=wp.vec3, device=DEVICE)
+        out_ori = wp.zeros(2, dtype=wp.quatf, device=DEVICE)
+        wp.launch(K.mat44d_to_vec3_quat_kernel, dim=2, inputs=[mat, out_pos, out_ori, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(out_pos.numpy(), positions_np, atol=ATOL)
+        np.testing.assert_allclose(np.abs(out_ori.numpy()), np.abs(quats_np), atol=ATOL)
+
+
+class TestTransformToMat44:
+    def test_roundtrip(self):
+        """transform -> mat44f -> transform should recover original data."""
+        positions_np, quats_np = _make_test_data(3)
+        pos_wp, ori_wp = _to_warp_arrays(positions_np, quats_np)
+
+        tf = wp.zeros(3, dtype=wp.transformf, device=DEVICE)
+        wp.launch(K.vec3_quat_to_transform_kernel, dim=3, inputs=[pos_wp, ori_wp, tf, _empty_imap(), 0], device=DEVICE)
+
+        mat = wp.zeros(3, dtype=wp.mat44f, device=DEVICE)
+        wp.launch(K.transform_to_mat44f_kernel, dim=3, inputs=[tf, mat, _empty_imap(), 0], device=DEVICE)
+
+        tf2 = wp.zeros(3, dtype=wp.transformf, device=DEVICE)
+        wp.launch(K.mat44f_to_transform_kernel, dim=3, inputs=[mat, tf2, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(tf2.numpy(), tf.numpy(), atol=ATOL)
+
+
+class TestIndexMap:
+    def test_scatter_write(self):
+        """Index map should scatter source elements to specified output positions."""
+        positions_np = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
+        quats_np = np.array([_identity_quat(), _rotation_quat_z90()], dtype=np.float32)
+        pos_wp, ori_wp = _to_warp_arrays(positions_np, quats_np)
+
+        index_map = wp.from_numpy(np.array([2, 0], dtype=np.int32), device=DEVICE)
+
+        dst_pos = wp.zeros(4, dtype=wp.vec3, device=DEVICE)
+        dst_ori = wp.zeros(4, dtype=wp.quatf, device=DEVICE)
+
+        wp.launch(
+            K.vec3_quat_to_vec3_quat_kernel,
+            dim=2,
+            inputs=[pos_wp, ori_wp, dst_pos, dst_ori, index_map, 2],
+            device=DEVICE,
+        )
+        wp.synchronize_device(DEVICE)
+
+        result_pos = dst_pos.numpy()
+        np.testing.assert_allclose(result_pos[2], [1.0, 2.0, 3.0], atol=ATOL)
+        np.testing.assert_allclose(result_pos[0], [4.0, 5.0, 6.0], atol=ATOL)
+        np.testing.assert_allclose(result_pos[1], [0.0, 0.0, 0.0], atol=ATOL)
+        np.testing.assert_allclose(result_pos[3], [0.0, 0.0, 0.0], atol=ATOL)
+
+    def test_index_map_with_transform_conversion(self):
+        """Index map should work with format conversion (vec3_quat -> transform)."""
+        positions_np = np.array([[10.0, 20.0, 30.0]], dtype=np.float32)
+        quats_np = np.array([_identity_quat()], dtype=np.float32)
+        pos_wp, ori_wp = _to_warp_arrays(positions_np, quats_np)
+
+        index_map = wp.from_numpy(np.array([3], dtype=np.int32), device=DEVICE)
+        dst = wp.zeros(5, dtype=wp.transformf, device=DEVICE)
+
+        wp.launch(
+            K.vec3_quat_to_transform_kernel,
+            dim=1,
+            inputs=[pos_wp, ori_wp, dst, index_map, 1],
+            device=DEVICE,
+        )
+        wp.synchronize_device(DEVICE)
+
+        result = dst.numpy()
+        np.testing.assert_allclose(result[3][:3], [10.0, 20.0, 30.0], atol=ATOL)
+        np.testing.assert_allclose(result[0][:3], [0.0, 0.0, 0.0], atol=ATOL)
+
+
+class TestQuaternionSwizzle:
+    def test_xyzw_to_wxyz(self):
+        quat_xyzw = np.array([[0.1, 0.2, 0.3, 0.9]], dtype=np.float32)
+        src = wp.from_numpy(quat_xyzw, dtype=wp.quatf, device=DEVICE)
+        dst = wp.zeros(1, dtype=wp.quatf, device=DEVICE)
+
+        wp.launch(K.quat_xyzw_to_wxyz_kernel, dim=1, inputs=[src, dst, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        result = dst.numpy()[0]
+        np.testing.assert_allclose(result, [0.9, 0.1, 0.2, 0.3], atol=ATOL)
+
+    def test_roundtrip(self):
+        """XYZW -> WXYZ -> XYZW should recover original data."""
+        quat_xyzw = np.array([[0.1, 0.2, 0.3, 0.9]], dtype=np.float32)
+        src = wp.from_numpy(quat_xyzw, dtype=wp.quatf, device=DEVICE)
+        mid = wp.zeros(1, dtype=wp.quatf, device=DEVICE)
+        dst = wp.zeros(1, dtype=wp.quatf, device=DEVICE)
+
+        wp.launch(K.quat_xyzw_to_wxyz_kernel, dim=1, inputs=[src, mid, _empty_imap(), 0], device=DEVICE)
+        wp.launch(K.quat_wxyz_to_xyzw_kernel, dim=1, inputs=[mid, dst, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(dst.numpy()[0], quat_xyzw[0], atol=ATOL)
+
+
+class TestMatrixTranspose:
+    def test_mat44f_transpose_roundtrip(self):
+        m_np = np.array(
+            [[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]], dtype=np.float32
+        )
+        src = wp.from_numpy(m_np, dtype=wp.mat44f, device=DEVICE)
+        mid = wp.zeros(1, dtype=wp.mat44f, device=DEVICE)
+        dst = wp.zeros(1, dtype=wp.mat44f, device=DEVICE)
+
+        wp.launch(K.mat44f_transpose_kernel, dim=1, inputs=[src, mid, _empty_imap(), 0], device=DEVICE)
+        wp.launch(K.mat44f_transpose_kernel, dim=1, inputs=[mid, dst, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        np.testing.assert_allclose(dst.numpy(), m_np, atol=ATOL)
+
+    def test_mat44f_transpose_values(self):
+        m_np = np.array(
+            [[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]], dtype=np.float32
+        )
+        src = wp.from_numpy(m_np, dtype=wp.mat44f, device=DEVICE)
+        dst = wp.zeros(1, dtype=wp.mat44f, device=DEVICE)
+
+        wp.launch(K.mat44f_transpose_kernel, dim=1, inputs=[src, dst, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        expected = m_np[0].T
+        np.testing.assert_allclose(dst.numpy()[0], expected, atol=ATOL)
+
+
+class TestEdgeCases:
+    def test_single_element(self):
+        positions_np, quats_np = _make_test_data(1)
+        pos_wp, ori_wp = _to_warp_arrays(positions_np, quats_np)
+        dst = wp.zeros(1, dtype=wp.transformf, device=DEVICE)
+
+        wp.launch(K.vec3_quat_to_transform_kernel, dim=1, inputs=[pos_wp, ori_wp, dst, _empty_imap(), 0], device=DEVICE)
+        wp.synchronize_device(DEVICE)
+
+        result = dst.numpy()
+        np.testing.assert_allclose(result[0][:3], positions_np[0], atol=ATOL)

--- a/source/isaaclab/test/physics/test_scene_data_types.py
+++ b/source/isaaclab/test/physics/test_scene_data_types.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for scene data types."""
+
+from __future__ import annotations
+
+import pytest
+import warp as wp
+
+from isaaclab.physics.scene_data_types import (
+    Mat44Transforms,
+    MatrixLayout,
+    QuaternionConvention,
+    TransformArrayData,
+    TransformData,
+    TransformFormat,
+    Vec3Mat33Transforms,
+    Vec3QuatTransforms,
+)
+
+DEVICE = "cuda:0"
+
+
+class TestEnums:
+    def test_quaternion_convention_values(self):
+        assert QuaternionConvention.XYZW.value == "xyzw"
+        assert QuaternionConvention.WXYZ.value == "wxyz"
+
+    def test_matrix_layout_values(self):
+        assert MatrixLayout.ROW_MAJOR.value == "row_major"
+        assert MatrixLayout.COLUMN_MAJOR.value == "column_major"
+
+    def test_transform_format_values(self):
+        assert TransformFormat.VEC3_QUAT.value == "vec3_quat"
+        assert TransformFormat.VEC3_MAT33.value == "vec3_mat33"
+        assert TransformFormat.TRANSFORM.value == "transform"
+        assert TransformFormat.MAT44.value == "mat44"
+
+
+class TestVec3QuatTransforms:
+    def test_construction(self):
+        n = 10
+        t = Vec3QuatTransforms(
+            count=n,
+            device=DEVICE,
+            positions=wp.zeros(n, dtype=wp.vec3, device=DEVICE),
+            orientations=wp.zeros(n, dtype=wp.quatf, device=DEVICE),
+        )
+        assert t.format == TransformFormat.VEC3_QUAT
+        assert t.count == n
+        assert t.device == DEVICE
+        assert t.quat_convention == QuaternionConvention.XYZW
+
+    def test_wxyz_convention(self):
+        t = Vec3QuatTransforms(
+            count=1,
+            device=DEVICE,
+            positions=wp.zeros(1, dtype=wp.vec3, device=DEVICE),
+            orientations=wp.zeros(1, dtype=wp.quatf, device=DEVICE),
+            quat_convention=QuaternionConvention.WXYZ,
+        )
+        assert t.quat_convention == QuaternionConvention.WXYZ
+
+    def test_inherits_transform_data(self):
+        t = Vec3QuatTransforms(count=1, device=DEVICE)
+        assert isinstance(t, TransformData)
+
+
+class TestVec3Mat33Transforms:
+    def test_construction(self):
+        n = 5
+        t = Vec3Mat33Transforms(
+            count=n,
+            device=DEVICE,
+            positions=wp.zeros(n, dtype=wp.vec3, device=DEVICE),
+            rotations=wp.zeros(n, dtype=wp.mat33f, device=DEVICE),
+        )
+        assert t.format == TransformFormat.VEC3_MAT33
+        assert t.layout == MatrixLayout.ROW_MAJOR
+
+    def test_column_major(self):
+        t = Vec3Mat33Transforms(count=1, device=DEVICE, layout=MatrixLayout.COLUMN_MAJOR)
+        assert t.layout == MatrixLayout.COLUMN_MAJOR
+
+
+class TestTransformArrayData:
+    def test_construction(self):
+        n = 8
+        t = TransformArrayData(
+            count=n,
+            device=DEVICE,
+            transforms=wp.zeros(n, dtype=wp.transformf, device=DEVICE),
+        )
+        assert t.format == TransformFormat.TRANSFORM
+        assert t.count == n
+
+
+class TestMat44Transforms:
+    def test_float32(self):
+        n = 3
+        t = Mat44Transforms(
+            count=n,
+            device=DEVICE,
+            matrices=wp.zeros(n, dtype=wp.mat44f, device=DEVICE),
+        )
+        assert t.format == TransformFormat.MAT44
+        assert t.double_precision is False
+        assert t.layout == MatrixLayout.COLUMN_MAJOR
+
+    def test_float64(self):
+        n = 3
+        t = Mat44Transforms(
+            count=n,
+            device=DEVICE,
+            matrices=wp.zeros(n, dtype=wp.mat44d, device=DEVICE),
+            double_precision=True,
+        )
+        assert t.double_precision is True
+
+    def test_row_major(self):
+        t = Mat44Transforms(count=1, device=DEVICE, layout=MatrixLayout.ROW_MAJOR)
+        assert t.layout == MatrixLayout.ROW_MAJOR

--- a/source/isaaclab/test/physics/test_scene_data_types.py
+++ b/source/isaaclab/test/physics/test_scene_data_types.py
@@ -7,7 +7,6 @@
 
 from __future__ import annotations
 
-import pytest
 import warp as wp
 
 from isaaclab.physics.scene_data_types import (

--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -168,10 +168,25 @@ def test_update_visualizers_handles_training_pause_loop():
     assert viz.step_calls == [0.0, 0.2]
 
 
+class _DummyNewtonStateCap:
+    """Forward NewtonState protocol calls to a dummy provider."""
+
+    def __init__(self, provider):
+        self._provider = provider
+
+    def get_state(self):
+        return self._provider.get_newton_state()
+
+    def get_model(self):
+        return self._provider.get_newton_model()
+
+
 class _DummyViserSceneDataProvider:
     def __init__(self):
         self._metadata = {"num_envs": 4}
         self.state_calls: list[list[int] | None] = []
+        self._cap = _DummyNewtonStateCap(self)
+        self._consumers: list = []
 
     def get_metadata(self) -> dict:
         return self._metadata
@@ -182,6 +197,16 @@ class _DummyViserSceneDataProvider:
     def get_newton_state(self):
         self.state_calls.append(None)
         return {"state_call": len(self.state_calls)}
+
+    def register_consumer(self, consumer) -> None:
+        self._consumers.append(consumer)
+
+    def get_capability(self, cap_type):
+        from isaaclab_newton.physics.capabilities import NewtonState
+
+        if cap_type is NewtonState:
+            return self._cap
+        return None
 
 
 class _DummyViserViewer:
@@ -345,6 +370,10 @@ def test_rerun_visualizer_initialize_applies_visible_worlds_and_world_offsets(
             captured["closed"] = True
 
     class _DummyRerunSceneDataProvider:
+        def __init__(self):
+            self._cap = _DummyNewtonStateCap(self)
+            self._consumers: list = []
+
         def get_metadata(self) -> dict:
             return {"num_envs": 4}
 
@@ -353,6 +382,16 @@ def test_rerun_visualizer_initialize_applies_visible_worlds_and_world_offsets(
 
         def get_newton_state(self):
             return {"ok": True}
+
+        def register_consumer(self, consumer) -> None:
+            self._consumers.append(consumer)
+
+        def get_capability(self, cap_type):
+            from isaaclab_newton.physics.capabilities import NewtonState
+
+            if cap_type is NewtonState:
+                return self._cap
+            return None
 
     monkeypatch.setattr(rerun_visualizer, "NewtonViewerRerun", _FakeNewtonViewerRerun)
     monkeypatch.setattr(
@@ -433,6 +472,8 @@ def _make_context_with_settings(
             "render_interval": 1,
         },
     )()
+    from isaaclab.physics.scene_data_requirements import SceneDataRequirement
+
     ctx = object.__new__(SimulationContext)
     ctx.cfg = cfg
     ctx._has_gui = has_gui
@@ -442,7 +483,7 @@ def _make_context_with_settings(
     ctx._render_generation = 0
     ctx._visualizers = []
     ctx._scene_data_provider = _FakeProvider()
-    ctx._scene_data_requirements = None
+    ctx._scene_data_requirements = SceneDataRequirement()
     ctx._visualizer_prebuilt_artifact = None
     ctx._visualizer_step_counter = 0
     ctx._viz_dt = 0.01
@@ -526,8 +567,9 @@ def test_explicit_visualizer_create_failure_raises(monkeypatch: pytest.MonkeyPat
     ctx = _make_context_with_settings(settings, visualizer_cfgs=[failing_cfg])
 
     import isaaclab.sim.simulation_context as sc_mod
+    from isaaclab.physics.scene_data_requirements import SceneDataRequirement
 
-    monkeypatch.setattr(sc_mod, "resolve_scene_data_requirements", lambda **kwargs: type("R", (), {})())
+    monkeypatch.setattr(sc_mod, "resolve_scene_data_requirements", lambda **kwargs: SceneDataRequirement())
 
     with pytest.raises(RuntimeError, match="failed to create or initialize"):
         ctx.initialize_visualizers()
@@ -545,8 +587,9 @@ def test_explicit_visualizer_init_failure_raises(monkeypatch: pytest.MonkeyPatch
     ctx = _make_context_with_settings(settings, visualizer_cfgs=[failing_cfg])
 
     import isaaclab.sim.simulation_context as sc_mod
+    from isaaclab.physics.scene_data_requirements import SceneDataRequirement
 
-    monkeypatch.setattr(sc_mod, "resolve_scene_data_requirements", lambda **kwargs: type("R", (), {})())
+    monkeypatch.setattr(sc_mod, "resolve_scene_data_requirements", lambda **kwargs: SceneDataRequirement())
 
     with pytest.raises(RuntimeError, match="failed to create or initialize"):
         ctx.initialize_visualizers()
@@ -593,8 +636,9 @@ def test_non_explicit_create_failure_silently_logged(monkeypatch: pytest.MonkeyP
     ctx = _make_context_with_settings(settings, visualizer_cfgs=[failing_cfg])
 
     import isaaclab.sim.simulation_context as sc_mod
+    from isaaclab.physics.scene_data_requirements import SceneDataRequirement
 
-    monkeypatch.setattr(sc_mod, "resolve_scene_data_requirements", lambda **kwargs: type("R", (), {})())
+    monkeypatch.setattr(sc_mod, "resolve_scene_data_requirements", lambda **kwargs: SceneDataRequirement())
 
     with caplog.at_level("ERROR"):
         ctx.initialize_visualizers()

--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.26"
+version = "0.5.27"
 
 # Description
 title = "Newton simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.24"
+version = "0.5.26"
 
 # Description
 title = "Newton simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.27"
+version = "0.5.28"
 
 # Description
 title = "Newton simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_newton/docs/CHANGELOG.rst
+++ b/source/isaaclab_newton/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+0.5.26 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :class:`~isaaclab_newton.physics.NewtonState` capability protocol
+  for direct read-only access to the active Newton ``Model`` and ``State``
+  objects. Used by Newton-flavoured renderers and visualizers via the SDP
+  capability registry. See
+  :doc:`/source/refs/adr/0002-capability-based-provider-extensibility`.
+
+
 0.5.25 (2026-04-27)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_newton/docs/CHANGELOG.rst
+++ b/source/isaaclab_newton/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.5.25 (2026-04-27)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :meth:`get_body_transforms` and :meth:`get_source_format` to
+  :class:`~isaaclab_newton.scene_data_providers.NewtonSceneDataProvider`,
+  implementing the typed transform API with zero-copy
+  :class:`~isaaclab.physics.TransformArrayData` wrapping Newton ``state.body_q``.
+
+
 0.5.24 (2026-04-27)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_newton/docs/CHANGELOG.rst
+++ b/source/isaaclab_newton/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+0.5.28 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_newton.renderers.NewtonWarpRenderer` to acquire
+  the :class:`~isaaclab_newton.physics.NewtonState` capability via
+  :meth:`~isaaclab.physics.BaseSceneDataProvider.get_capability`. Declares
+  ``required_capabilities = (NewtonState,)``.
+* Changed :class:`~isaaclab_newton.video_recording.NewtonGlPerspectiveVideo`
+  to use the ``NewtonState`` capability instead of the legacy
+  :meth:`get_newton_model` and :meth:`get_newton_state` methods on the
+  provider.
+
+
 0.5.27 (2026-04-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_newton/docs/CHANGELOG.rst
+++ b/source/isaaclab_newton/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+0.5.27 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Registered :class:`~isaaclab.physics.GpuTransformBuffer`,
+  :class:`~isaaclab_newton.physics.NewtonState`, and conditionally
+  :class:`~isaaclab.physics.UsdFabric` capabilities on
+  :class:`~isaaclab_newton.scene_data_providers.NewtonSceneDataProvider`.
+  Newton's :class:`UsdFabric` capability runs the manager's
+  ``sync_transforms_to_usd`` bridge on demand. Factored the previously
+  inline sync into :meth:`_sync_transforms_to_usd_if_needed` so it can be
+  invoked from the capability handle.
+
+
 0.5.26 (2026-04-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/__init__.pyi
+++ b/source/isaaclab_newton/isaaclab_newton/physics/__init__.pyi
@@ -12,9 +12,11 @@ __all__ = [
     "NewtonManager",
     "NewtonShapeCfg",
     "NewtonSolverCfg",
+    "NewtonState",
     "XPBDSolverCfg",
 ]
 
+from .capabilities import NewtonState
 from .newton_collision_cfg import HydroelasticSDFCfg, NewtonCollisionPipelineCfg
 from .newton_manager import NewtonManager
 from .newton_manager_cfg import (

--- a/source/isaaclab_newton/isaaclab_newton/physics/capabilities/__init__.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/capabilities/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Newton-specific capability protocols.
+
+See :doc:`/source/refs/adr/0002-capability-based-provider-extensibility`.
+"""
+
+from ._protocols import NewtonState
+
+__all__ = ["NewtonState"]

--- a/source/isaaclab_newton/isaaclab_newton/physics/capabilities/_protocols.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/capabilities/_protocols.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Newton-specific capability protocols."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class NewtonState(Protocol):
+    """Direct read-only access to the active Newton ``Model`` and ``State``.
+
+    Used by Newton-flavoured consumers (NewtonWarp renderer, Newton/Rerun/
+    Viser visualizers, Newton GL video) that pass the full ``State`` object
+    to a Newton-aware viewer or sensor and cannot work from a transform
+    buffer alone.
+
+    A provider exposes this capability when it has a Newton state to share
+    — natively in :class:`NewtonSceneDataProvider`, or via the PhysX→Newton
+    sync bridge in :class:`PhysxSceneDataProvider` when at least one
+    consumer requires it.
+    """
+
+    def get_state(self) -> Any:
+        """Return the current Newton ``State`` object.
+
+        The returned object is read-only; consumers must not mutate it.
+        """
+        ...
+
+    def get_model(self) -> Any:
+        """Return the Newton ``Model`` object.
+
+        The model is structural (joint topology, link names, shape data)
+        and stable across frames.
+        """
+        ...

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -20,6 +20,8 @@ from isaaclab.renderers import BaseRenderer
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.math import convert_camera_frame_orientation_convention
 
+from isaaclab_newton.physics.capabilities import NewtonState
+
 from .newton_warp_renderer_cfg import NewtonWarpRendererCfg
 
 if TYPE_CHECKING:
@@ -149,6 +151,8 @@ class NewtonWarpRenderer(BaseRenderer):
 
     RenderData = RenderData
 
+    required_capabilities = (NewtonState,)
+
     def __init__(self, cfg: NewtonWarpRendererCfg):
         from isaaclab.physics.scene_data_requirements import (
             aggregate_requirements,
@@ -162,7 +166,16 @@ class NewtonWarpRenderer(BaseRenderer):
         if merged != current_req:
             sim.update_scene_data_requirements(merged)
 
-        newton_model = self.get_scene_data_provider().get_newton_model()
+        provider = self.get_scene_data_provider()
+        self.register_with_scene_data_provider(provider)
+        self._newton_state_cap: NewtonState = provider.get_capability(NewtonState)
+        if self._newton_state_cap is None:
+            raise RuntimeError(
+                "NewtonWarpRenderer requires the NewtonState capability, but the active "
+                "Scene Data Provider does not register it."
+            )
+
+        newton_model = self._newton_state_cap.get_model()
         if newton_model is None:
             raise RuntimeError(
                 "NewtonWarpRenderer requires a Newton model but the scene data provider returned None. "
@@ -214,7 +227,7 @@ class NewtonWarpRenderer(BaseRenderer):
     def render(self, render_data: RenderData):
         """Render and write to output buffers. See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.render`."""
         self.newton_sensor.update(
-            self.get_scene_data_provider().get_newton_state(),
+            self._newton_state_cap.get_state(),
             render_data.camera_transforms,
             render_data.camera_rays,
             color_image=render_data.outputs.color_image,

--- a/source/isaaclab_newton/isaaclab_newton/scene_data_providers/newton_scene_data_provider.py
+++ b/source/isaaclab_newton/isaaclab_newton/scene_data_providers/newton_scene_data_provider.py
@@ -17,6 +17,7 @@ import warp as wp
 from pxr import UsdGeom
 
 from isaaclab.physics.base_scene_data_provider import BaseSceneDataProvider
+from isaaclab.physics.capabilities import GpuTransformBuffer, UsdFabric
 from isaaclab.physics.scene_data_buffers import TransformBufferPool
 from isaaclab.physics.scene_data_types import (
     MatrixLayout,
@@ -26,9 +27,74 @@ from isaaclab.physics.scene_data_types import (
     TransformFormat,
 )
 
+from isaaclab_newton.physics.capabilities import NewtonState
+
 logger = logging.getLogger(__name__)
 
 _ENV_ID_RE = re.compile(r"/World/envs/env_(\d+)")
+
+
+class _NewtonGpuTransformBufferCap:
+    """Adapter exposing :class:`GpuTransformBuffer` for the Newton provider."""
+
+    def __init__(self, provider: NewtonSceneDataProvider) -> None:
+        self._provider = provider
+
+    def get_body_transforms(
+        self,
+        target_format: TransformFormat,
+        *,
+        env_ids: list[int] | None = None,
+        quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
+        matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
+        double_precision: bool = False,
+        stream: wp.Stream | None = None,
+        allow_passthrough: bool = True,
+        index_map: wp.array | None = None,
+    ) -> TransformData | None:
+        return self._provider.get_body_transforms(
+            target_format,
+            env_ids=env_ids,
+            quat_convention=quat_convention,
+            matrix_layout=matrix_layout,
+            double_precision=double_precision,
+            stream=stream,
+            allow_passthrough=allow_passthrough,
+            index_map=index_map,
+        )
+
+    def get_source_format(self) -> TransformFormat | None:
+        return self._provider.get_source_format()
+
+
+class _NewtonUsdFabricCap:
+    """Adapter exposing :class:`UsdFabric` for the Newton provider.
+
+    Newton does not write USD natively; ``ensure_current`` runs the
+    sync-to-USD bridge owned by :class:`NewtonManager`.
+    """
+
+    def __init__(self, provider: NewtonSceneDataProvider) -> None:
+        self._provider = provider
+
+    def ensure_current(self, stream: wp.Stream | None = None) -> None:
+        # Sync handled inside NewtonSceneDataProvider.update() when
+        # _needs_usd_sync is True; this is the explicit consumer-facing
+        # entry point.
+        self._provider._sync_transforms_to_usd_if_needed()
+
+
+class _NewtonStateCap:
+    """Adapter exposing :class:`NewtonState` for the Newton provider."""
+
+    def __init__(self, provider: NewtonSceneDataProvider) -> None:
+        self._provider = provider
+
+    def get_state(self) -> Any:
+        return self._provider.get_newton_state()
+
+    def get_model(self) -> Any:
+        return self._provider.get_newton_model()
 
 
 class NewtonSceneDataProvider(BaseSceneDataProvider):
@@ -61,6 +127,12 @@ class NewtonSceneDataProvider(BaseSceneDataProvider):
         # Typed transform API state
         self._transform_buffer_pool = TransformBufferPool()
         self._generation: int = 0
+
+        # Capability registration (ADR-0002).
+        self._register_capability(GpuTransformBuffer, _NewtonGpuTransformBufferCap(self))
+        self._register_capability(NewtonState, _NewtonStateCap(self))
+        if self._needs_usd_sync:
+            self._register_capability(UsdFabric, _NewtonUsdFabricCap(self))
 
     def _warn_once(self, key: str, message: str, *args) -> None:
         """Emit a warning once per unique key.
@@ -121,6 +193,13 @@ class NewtonSceneDataProvider(BaseSceneDataProvider):
         are Newton (or Rerun), the sync is skipped to avoid unnecessary slowdown.
         """
         self._generation += 1
+        self._sync_transforms_to_usd_if_needed()
+
+    def _sync_transforms_to_usd_if_needed(self) -> None:
+        """Run the USD-Fabric sync when a USD-reading consumer is registered.
+
+        Idempotent and safe to call multiple times per frame.
+        """
         if not self._needs_usd_sync:
             return
         try:

--- a/source/isaaclab_newton/isaaclab_newton/scene_data_providers/newton_scene_data_provider.py
+++ b/source/isaaclab_newton/isaaclab_newton/scene_data_providers/newton_scene_data_provider.py
@@ -47,6 +47,7 @@ class NewtonSceneDataProvider(BaseSceneDataProvider):
             stage: USD stage handle.
             simulation_context: Active simulation context.
         """
+        super().__init__()
         self._simulation_context = simulation_context
         self._stage = stage
         self._metadata = {"physics_backend": "newton"}

--- a/source/isaaclab_newton/isaaclab_newton/scene_data_providers/newton_scene_data_provider.py
+++ b/source/isaaclab_newton/isaaclab_newton/scene_data_providers/newton_scene_data_provider.py
@@ -12,9 +12,19 @@ import re
 from collections import deque
 from typing import Any
 
+import warp as wp
+
 from pxr import UsdGeom
 
 from isaaclab.physics.base_scene_data_provider import BaseSceneDataProvider
+from isaaclab.physics.scene_data_buffers import TransformBufferPool
+from isaaclab.physics.scene_data_types import (
+    MatrixLayout,
+    QuaternionConvention,
+    TransformArrayData,
+    TransformData,
+    TransformFormat,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +56,10 @@ class NewtonSceneDataProvider(BaseSceneDataProvider):
         # Determine if usd stage sync is required for selected renderers and visualizers
         requirements = self._simulation_context.get_scene_data_requirements()
         self._needs_usd_sync = bool(requirements.requires_usd_stage)
+
+        # Typed transform API state
+        self._transform_buffer_pool = TransformBufferPool()
+        self._generation: int = 0
 
     def _warn_once(self, key: str, message: str, *args) -> None:
         """Emit a warning once per unique key.
@@ -105,6 +119,7 @@ class NewtonSceneDataProvider(BaseSceneDataProvider):
         (or other USD-based) visualizer is in use. When both sim and rendering backend
         are Newton (or Rerun), the sync is skipped to avoid unnecessary slowdown.
         """
+        self._generation += 1
         if not self._needs_usd_sync:
             return
         try:
@@ -304,3 +319,82 @@ class NewtonSceneDataProvider(BaseSceneDataProvider):
             orientations.append(per_world_ori)
 
         return {"order": shared_paths, "positions": positions, "orientations": orientations, "num_envs": num_envs}
+
+    # ---- Typed transform API -----------------------------------------------------------------
+
+    def get_source_format(self) -> TransformFormat:
+        """Return Newton's native transform format.
+
+        Returns:
+            :attr:`TransformFormat.TRANSFORM` — Newton stores body poses as
+            packed ``wp.transformf`` arrays in ``state.body_q``.
+        """
+        return TransformFormat.TRANSFORM
+
+    def get_body_transforms(
+        self,
+        target_format: TransformFormat,
+        *,
+        env_ids: list[int] | None = None,
+        quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
+        matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
+        double_precision: bool = False,
+        stream: wp.Stream | None = None,
+        allow_passthrough: bool = True,
+        index_map: wp.array | None = None,
+    ) -> TransformData | None:
+        """Return body transforms in the requested format.
+
+        When *target_format* is :attr:`TransformFormat.TRANSFORM` and
+        *allow_passthrough* is ``True``, this returns Newton's own
+        ``state.body_q`` array directly — zero copies, zero kernel launches.
+
+        Args:
+            target_format: Desired output transform representation.
+            env_ids: Optional environment subset (currently unused).
+            quat_convention: Quaternion component ordering for VEC3_QUAT output.
+            matrix_layout: Matrix memory layout for MAT44 / VEC3_MAT33 output.
+            double_precision: Use 64-bit floats for MAT44 output.
+            stream: CUDA stream for deferred kernel execution.
+            allow_passthrough: If ``True`` and formats match, return source
+                data directly without copying.
+            index_map: Optional index remapping for subset scatter writes.
+
+        Returns:
+            Typed transform data, or ``None`` when state is unavailable.
+        """
+        try:
+            from isaaclab_newton.physics import NewtonManager
+
+            state = NewtonManager.get_state_0()
+            if state is None or state.body_q is None:
+                return None
+
+            body_q = state.body_q
+            device = body_q.device.alias if hasattr(body_q.device, "alias") else str(body_q.device)
+            count = body_q.shape[0]
+
+            source = TransformArrayData(
+                count=count,
+                device=device,
+                transforms=body_q,
+            )
+
+            return self._transform_buffer_pool.get_or_convert(
+                source,
+                target_format,
+                generation=self._generation,
+                quat_convention=quat_convention,
+                matrix_layout=matrix_layout,
+                double_precision=double_precision,
+                stream=stream,
+                allow_passthrough=allow_passthrough,
+                index_map=index_map,
+            )
+        except Exception as exc:
+            self._warn_once(
+                "get-body-transforms-failed",
+                "[NewtonSceneDataProvider] get_body_transforms() failed: %s",
+                exc,
+            )
+            return None

--- a/source/isaaclab_newton/isaaclab_newton/scene_data_providers/newton_scene_data_provider.py
+++ b/source/isaaclab_newton/isaaclab_newton/scene_data_providers/newton_scene_data_provider.py
@@ -192,6 +192,7 @@ class NewtonSceneDataProvider(BaseSceneDataProvider):
         (or other USD-based) visualizer is in use. When both sim and rendering backend
         are Newton (or Rerun), the sync is skipped to avoid unnecessary slowdown.
         """
+        self._validate_consumers_if_needed()
         self._generation += 1
         self._sync_transforms_to_usd_if_needed()
 

--- a/source/isaaclab_newton/isaaclab_newton/video_recording/newton_gl_perspective_video.py
+++ b/source/isaaclab_newton/isaaclab_newton/video_recording/newton_gl_perspective_video.py
@@ -26,6 +26,7 @@ class NewtonGlPerspectiveVideo:
         self.cfg = cfg
         self._viewer = None
         self._init_attempted = False
+        self._newton_state_cap = None
 
     def _ensure_viewer(self) -> None:
         if self._init_attempted:
@@ -33,8 +34,16 @@ class NewtonGlPerspectiveVideo:
         self._init_attempted = True
         from isaaclab.sim import SimulationContext
 
+        from isaaclab_newton.physics.capabilities import NewtonState
+
         sdp = SimulationContext.instance().initialize_scene_data_provider()
-        model = sdp.get_newton_model()
+        self._newton_state_cap = sdp.get_capability(NewtonState)
+        if self._newton_state_cap is None:
+            raise RuntimeError(
+                "Newton GL perspective video requires the NewtonState capability on the active "
+                "Scene Data Provider. Do not use --video for this setup."
+            )
+        model = self._newton_state_cap.get_model()
         if model is None:
             raise RuntimeError(
                 "Newton GL perspective video requires a Newton model on the scene data provider. "
@@ -76,8 +85,7 @@ class NewtonGlPerspectiveVideo:
         from isaaclab.sim import SimulationContext
 
         sim = SimulationContext.instance()
-        sdp = sim.initialize_scene_data_provider()
-        state = sdp.get_newton_state()
+        state = self._newton_state_cap.get_state()
         dt = sim.get_physics_dt()
 
         viewer = self._viewer

--- a/source/isaaclab_newton/test/physics/test_newton_provider_capabilities.py
+++ b/source/isaaclab_newton/test/physics/test_newton_provider_capabilities.py
@@ -15,11 +15,11 @@ simulation_app = AppLauncher(headless=True).app
 
 import pytest
 import warp as wp
+from isaaclab_newton.physics.capabilities import NewtonState
 
 from isaaclab.physics import GpuTransformBuffer, UsdFabric
 from isaaclab.physics.scene_data_requirements import SceneDataRequirement
 from isaaclab.sim import build_simulation_context
-from isaaclab_newton.physics.capabilities import NewtonState
 
 wp.init()
 
@@ -38,9 +38,7 @@ def _build_newton_provider(sim, *, requires_usd_stage: bool = False):
 @pytest.fixture
 def sim():
     # Newton backend selected via build_simulation_context.
-    with build_simulation_context(
-        device="cuda:0", dt=0.01, add_lighting=False, sim_cfg=None
-    ) as sim:
+    with build_simulation_context(device="cuda:0", dt=0.01, add_lighting=False, sim_cfg=None) as sim:
         yield sim
 
 

--- a/source/isaaclab_newton/test/physics/test_newton_provider_capabilities.py
+++ b/source/isaaclab_newton/test/physics/test_newton_provider_capabilities.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Capability registration tests for :class:`NewtonSceneDataProvider`."""
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True).app
+
+"""Rest everything follows."""
+
+import pytest
+import warp as wp
+
+from isaaclab.physics import GpuTransformBuffer, UsdFabric
+from isaaclab.physics.scene_data_requirements import SceneDataRequirement
+from isaaclab.sim import build_simulation_context
+from isaaclab_newton.physics.capabilities import NewtonState
+
+wp.init()
+
+pytestmark = pytest.mark.isaacsim_ci
+
+
+def _build_newton_provider(sim, *, requires_usd_stage: bool = False):
+    from isaaclab_newton.scene_data_providers import NewtonSceneDataProvider
+
+    sim.get_scene_data_requirements = lambda: SceneDataRequirement(
+        requires_usd_stage=requires_usd_stage,
+    )
+    return NewtonSceneDataProvider(sim.stage, sim)
+
+
+@pytest.fixture
+def sim():
+    # Newton backend selected via build_simulation_context.
+    with build_simulation_context(
+        device="cuda:0", dt=0.01, add_lighting=False, sim_cfg=None
+    ) as sim:
+        yield sim
+
+
+def test_newton_baseline_capabilities(sim):
+    """Without a USD consumer, Newton exposes GpuTransformBuffer and NewtonState only."""
+    provider = _build_newton_provider(sim, requires_usd_stage=False)
+    caps = provider.list_capabilities()
+    assert GpuTransformBuffer in caps
+    assert NewtonState in caps
+    assert UsdFabric not in caps
+
+
+def test_newton_usd_fabric_registered_when_consumer_requires(sim):
+    """A USD-Fabric consumer flips on the UsdFabric cap on Newton."""
+    provider = _build_newton_provider(sim, requires_usd_stage=True)
+    caps = provider.list_capabilities()
+    assert UsdFabric in caps
+
+
+def test_newton_gpu_transform_buffer_handle_works(sim):
+    provider = _build_newton_provider(sim, requires_usd_stage=False)
+    cap = provider.get_capability(GpuTransformBuffer)
+    assert cap is not None
+    assert isinstance(cap, GpuTransformBuffer)
+    assert cap.get_source_format() == provider.get_source_format()
+
+
+def test_newton_state_handle_returns_state(sim):
+    provider = _build_newton_provider(sim, requires_usd_stage=False)
+    cap = provider.get_capability(NewtonState)
+    assert cap is not None
+    assert cap.get_model() is provider.get_newton_model()
+    assert cap.get_state() is provider.get_newton_state()
+
+
+def test_newton_usd_fabric_runs_sync(sim, monkeypatch):
+    """When USD is required, ensure_current invokes the manager's sync."""
+    provider = _build_newton_provider(sim, requires_usd_stage=True)
+    cap = provider.get_capability(UsdFabric)
+    assert cap is not None
+
+    sync_calls = {"count": 0}
+    from isaaclab_newton.physics import NewtonManager
+
+    monkeypatch.setattr(
+        NewtonManager,
+        "sync_transforms_to_usd",
+        lambda *a, **kw: sync_calls.__setitem__("count", sync_calls["count"] + 1),
+    )
+
+    cap.ensure_current()
+    assert sync_calls["count"] == 1

--- a/source/isaaclab_ov/config/extension.toml
+++ b/source/isaaclab_ov/config/extension.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.1.2"
+version = "0.1.3"
 title = "Omniverse renderers for IsaacLab"
 description = "Extension providing Omniverse renderers (OVRTX, ovphysx, etc.) for tiled camera rendering."
 readme = "docs/README.md"

--- a/source/isaaclab_ov/config/extension.toml
+++ b/source/isaaclab_ov/config/extension.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.1.3"
+version = "0.1.4"
 title = "Omniverse renderers for IsaacLab"
 description = "Extension providing Omniverse renderers (OVRTX, ovphysx, etc.) for tiled camera rendering."
 readme = "docs/README.md"

--- a/source/isaaclab_ov/config/extension.toml
+++ b/source/isaaclab_ov/config/extension.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.1.4"
+version = "0.1.5"
 title = "Omniverse renderers for IsaacLab"
 description = "Extension providing Omniverse renderers (OVRTX, ovphysx, etc.) for tiled camera rendering."
 readme = "docs/README.md"

--- a/source/isaaclab_ov/docs/CHANGELOG.rst
+++ b/source/isaaclab_ov/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.1.3 (2026-04-22)
+~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_ov.renderers.OVRTXRenderer` to use the typed
+  Scene Data Provider API (:meth:`get_body_transforms`) for transform updates,
+  with automatic fallback to the legacy kernel path.
+
+
 0.1.2 (2026-03-23)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_ov/docs/CHANGELOG.rst
+++ b/source/isaaclab_ov/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+0.1.4 (2026-04-29)
+~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_ov.renderers.OVRTXRenderer` to acquire the
+  :class:`~isaaclab.physics.GpuTransformBuffer` capability through
+  :meth:`~isaaclab.physics.BaseSceneDataProvider.get_capability` instead
+  of calling the now-deprecated :meth:`get_body_transforms` directly on
+  the provider. Declares ``required_capabilities = (GpuTransformBuffer,)``
+  for wire-up validation and removes the legacy Newton-state fallback
+  path along with the ``sync_newton_transforms_kernel`` import — both are
+  redundant once the capability is the mandatory baseline.
+
+
 0.1.3 (2026-04-22)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_ov/docs/CHANGELOG.rst
+++ b/source/isaaclab_ov/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.1.5 (2026-04-29)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_ov.renderers.OVRTXRenderer` not pushing its
+  scene-data requirements (Newton model + USD stage) onto the active
+  SDP at construction time. Mirrors the pattern used by
+  :class:`~isaaclab_newton.renderers.NewtonWarpRenderer`.
+
+
 0.1.4 (2026-04-29)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -39,6 +39,7 @@ os.environ["OVRTX_SKIP_USD_CHECK"] = "1"
 
 from ovrtx import Device, PrimMode, Renderer, RendererConfig, Semantic
 
+from isaaclab.physics import GpuTransformBuffer
 from isaaclab.renderers.base_renderer import BaseRenderer
 from isaaclab.utils.math import convert_camera_frame_orientation_convention
 
@@ -49,7 +50,6 @@ from .ovrtx_renderer_kernels import (
     extract_all_depth_tiles_kernel,
     extract_all_rgba_tiles_kernel,
     generate_random_colors_from_ids_kernel,
-    sync_newton_transforms_kernel,
 )
 from .ovrtx_usd import (
     create_cloning_attributes,
@@ -112,6 +112,8 @@ class OVRTXRenderer(BaseRenderer):
 
     cfg: OVRTXRendererCfg
 
+    required_capabilities = (GpuTransformBuffer,)
+
     def __init__(self, cfg: OVRTXRendererCfg):
         self.cfg = cfg
         self._usd_handles = []
@@ -124,6 +126,7 @@ class OVRTXRenderer(BaseRenderer):
         self._exported_usd_path: str | None = None
         self._camera_rel_path: str | None = None
         self._output_semantic_color_buffer: wp.array | None = None
+        self._gpu_transform_buffer: GpuTransformBuffer | None = None
 
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """Export the USD stage for OVRTX before create_render_data.
@@ -338,12 +341,12 @@ class OVRTXRenderer(BaseRenderer):
         pass
 
     def update_transforms(self) -> None:
-        """Sync physics objects to OVRTX via the typed Scene Data Provider API.
+        """Sync physics objects to OVRTX via the GpuTransformBuffer capability.
 
-        Uses :meth:`~isaaclab.physics.BaseSceneDataProvider.get_body_transforms`
-        to get transforms as column-major ``mat44d`` matrices, matching OVRTX's
-        native format. Falls back to the legacy Newton state path when the
-        typed API is unavailable.
+        Requests transforms as column-major ``mat44d`` matrices, matching
+        OVRTX's native format. The :class:`GpuTransformBuffer` capability is
+        the mandatory baseline (ADR-0002), so the cap is guaranteed to be
+        available once wire-up validation has run.
         """
         if self._object_binding is None or self._object_newton_indices is None:
             return
@@ -352,9 +355,14 @@ class OVRTXRenderer(BaseRenderer):
             from isaaclab.physics.scene_data_types import MatrixLayout, TransformFormat
             from isaaclab.sim import SimulationContext
 
-            provider = SimulationContext.instance().initialize_scene_data_provider()
+            if self._gpu_transform_buffer is None:
+                provider = SimulationContext.instance().initialize_scene_data_provider()
+                self.register_with_scene_data_provider(provider)
+                self._gpu_transform_buffer = provider.get_capability(GpuTransformBuffer)
+                if self._gpu_transform_buffer is None:
+                    return
 
-            transforms = provider.get_body_transforms(
+            transforms = self._gpu_transform_buffer.get_body_transforms(
                 TransformFormat.MAT44,
                 matrix_layout=MatrixLayout.COLUMN_MAJOR,
                 double_precision=True,
@@ -362,28 +370,12 @@ class OVRTXRenderer(BaseRenderer):
                 index_map=self._object_newton_indices,
             )
 
-            if transforms is not None:
-                with self._object_binding.map(device=Device.CUDA, device_id=0) as attr_mapping:
-                    ovrtx_buf = wp.from_dlpack(attr_mapping.tensor, dtype=wp.mat44d)
-                    wp.copy(ovrtx_buf, transforms.matrices)
-                return
-
-            # Legacy fallback: use Newton state directly
-            newton_state = provider.get_newton_state()
-            if newton_state is None:
-                return
-            body_q = getattr(newton_state, "body_q", None)
-            if body_q is None:
+            if transforms is None:
                 return
 
             with self._object_binding.map(device=Device.CUDA, device_id=0) as attr_mapping:
-                ovrtx_transforms = wp.from_dlpack(attr_mapping.tensor, dtype=wp.mat44d)
-                wp.launch(
-                    kernel=sync_newton_transforms_kernel,
-                    dim=len(self._object_newton_indices),
-                    inputs=[ovrtx_transforms, self._object_newton_indices, body_q],
-                    device=DEVICE,
-                )
+                ovrtx_buf = wp.from_dlpack(attr_mapping.tensor, dtype=wp.mat44d)
+                wp.copy(ovrtx_buf, transforms.matrices)
         except Exception as e:
             logger.warning("Failed to update object transforms: %s", e)
 

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -123,6 +123,12 @@ class OVRTXRenderer(BaseRenderer):
     required_capabilities = (GpuTransformBuffer, NewtonState)
 
     def __init__(self, cfg: OVRTXRendererCfg):
+        from isaaclab.physics.scene_data_requirements import (
+            aggregate_requirements,
+            requirement_for_renderer_type,
+        )
+        from isaaclab.sim import SimulationContext
+
         self.cfg = cfg
         self._usd_handles = []
         self._render_product_paths = []
@@ -135,6 +141,18 @@ class OVRTXRenderer(BaseRenderer):
         self._camera_rel_path: str | None = None
         self._output_semantic_color_buffer: wp.array | None = None
         self._gpu_transform_buffer: GpuTransformBuffer | None = None
+
+        # Mirror the NewtonWarpRenderer pattern: push this renderer's scene-data
+        # requirements (Newton model + USD stage) onto the active SDP at
+        # construction time, since :meth:`InteractiveScene._sensor_renderer_types`
+        # runs before sensors are populated and would otherwise miss them.
+        sim = SimulationContext.instance()
+        if sim is not None:
+            current_req = sim.get_scene_data_requirements()
+            renderer_req = requirement_for_renderer_type("ovrtx")
+            merged = aggregate_requirements([current_req, renderer_req])
+            if merged != current_req:
+                sim.update_scene_data_requirements(merged)
 
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """Export the USD stage for OVRTX before create_render_data.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -338,14 +338,37 @@ class OVRTXRenderer(BaseRenderer):
         pass
 
     def update_transforms(self) -> None:
-        """Sync physics objects to OVRTX."""
+        """Sync physics objects to OVRTX via the typed Scene Data Provider API.
+
+        Uses :meth:`~isaaclab.physics.BaseSceneDataProvider.get_body_transforms`
+        to get transforms as column-major ``mat44d`` matrices, matching OVRTX's
+        native format. Falls back to the legacy Newton state path when the
+        typed API is unavailable.
+        """
         if self._object_binding is None or self._object_newton_indices is None:
             return
 
         try:
+            from isaaclab.physics.scene_data_types import MatrixLayout, TransformFormat
             from isaaclab.sim import SimulationContext
 
             provider = SimulationContext.instance().initialize_scene_data_provider()
+
+            transforms = provider.get_body_transforms(
+                TransformFormat.MAT44,
+                matrix_layout=MatrixLayout.COLUMN_MAJOR,
+                double_precision=True,
+                allow_passthrough=False,
+                index_map=self._object_newton_indices,
+            )
+
+            if transforms is not None:
+                with self._object_binding.map(device=Device.CUDA, device_id=0) as attr_mapping:
+                    ovrtx_buf = wp.from_dlpack(attr_mapping.tensor, dtype=wp.mat44d)
+                    wp.copy(ovrtx_buf, transforms.matrices)
+                return
+
+            # Legacy fallback: use Newton state directly
             newton_state = provider.get_newton_state()
             if newton_state is None:
                 return

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -37,6 +37,7 @@ import warp as wp
 # By setting OVRTX_SKIP_USD_CHECK, we prevent the C library from loading the pxr Python package.
 os.environ["OVRTX_SKIP_USD_CHECK"] = "1"
 
+from isaaclab_newton.physics.capabilities import NewtonState
 from ovrtx import Device, PrimMode, Renderer, RendererConfig, Semantic
 
 from isaaclab.physics import GpuTransformBuffer
@@ -112,7 +113,7 @@ class OVRTXRenderer(BaseRenderer):
 
     cfg: OVRTXRendererCfg
 
-    required_capabilities = (GpuTransformBuffer,)
+    required_capabilities = (GpuTransformBuffer, NewtonState)
 
     def __init__(self, cfg: OVRTXRendererCfg):
         self.cfg = cfg
@@ -278,7 +279,11 @@ class OVRTXRenderer(BaseRenderer):
             from isaaclab.sim import SimulationContext
 
             provider = SimulationContext.instance().initialize_scene_data_provider()
-            newton_model = provider.get_newton_model()
+            newton_state_cap = provider.get_capability(NewtonState)
+            if newton_state_cap is None:
+                logger.info("NewtonState capability not registered, skipping object bindings")
+                return
+            newton_model = newton_state_cap.get_model()
             if newton_model is None:
                 logger.info("Newton model not available, skipping object bindings")
                 return

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
@@ -252,16 +252,3 @@ def generate_random_colors_from_ids_kernel(
         output_color = random_color_from_id(input_id)
 
     output_colors[i, j] = output_color
-
-
-@wp.kernel
-def sync_newton_transforms_kernel(
-    ovrtx_transforms: wp.array(dtype=wp.mat44d),  # type: ignore
-    newton_body_indices: wp.array(dtype=wp.int32),  # type: ignore
-    newton_body_q: wp.array(dtype=wp.transformf),  # type: ignore
-):
-    """Sync Newton physics body transforms to OVRTX 4x4 column-major matrices."""
-    i = wp.tid()
-    body_idx = newton_body_indices[i]
-    transform = newton_body_q[body_idx]
-    ovrtx_transforms[i] = wp.transpose(wp.mat44d(wp.math.transform_to_matrix(transform)))

--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.29"
+version = "0.5.30"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.28"
+version = "0.5.29"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.27"
+version = "0.5.28"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.30"
+version = "0.5.31"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,24 @@
 Changelog
 ---------
 
+0.5.31 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_physx.renderers.IsaacRtxRenderer` not pushing
+  its scene-data requirements onto the active SDP at construction time.
+  :class:`~isaaclab.scene.InteractiveScene` aggregates renderer
+  requirements before ``_setup_scene`` populates env sensors, so the
+  renderer's ``requires_usd_stage=True`` requirement was never visible
+  to the SDP. This left the Newton SDP without :class:`UsdFabric`
+  registered when running Newton physics + IsaacRTX rendering, which
+  broke wire-up validation in the visualizer integration tests.
+  Mirrors the pattern used by
+  :class:`~isaaclab_newton.renderers.NewtonWarpRenderer`.
+
+
 0.5.30 (2026-04-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.5.28 (2026-04-27)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :meth:`get_body_transforms` and :meth:`get_source_format` to
+  :class:`~isaaclab_physx.scene_data_providers.PhysxSceneDataProvider`,
+  implementing the typed transform API with zero-copy
+  :class:`~isaaclab.physics.Vec3QuatTransforms` wrapping PhysX tensor views.
+
+
 0.5.27 (2026-04-27)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,23 @@
 Changelog
 ---------
 
+0.5.29 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Registered :class:`~isaaclab.physics.GpuTransformBuffer`,
+  :class:`~isaaclab.physics.UsdFabric`, and
+  :class:`~isaaclab_newton.physics.NewtonState` capabilities on
+  :class:`~isaaclab_physx.scene_data_providers.PhysxSceneDataProvider`.
+  PhysX writes USD Fabric natively, so :meth:`UsdFabric.ensure_current`
+  is a no-op fast path. The :class:`NewtonState` capability is registered
+  only when at least one consumer requires Newton state, mirroring the
+  existing ``_needs_newton_sync`` behaviour. See
+  :doc:`/source/refs/adr/0002-capability-based-provider-extensibility`.
+
+
 0.5.28 (2026-04-27)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Changelog
 ---------
 
+0.5.30 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_physx.renderers.IsaacRtxRenderer` to declare
+  ``required_capabilities = (UsdFabric,)`` and call
+  :meth:`UsdFabric.ensure_current` from :meth:`update_transforms`. The
+  call is a no-op fast path on PhysX (which writes USD Fabric natively
+  via the Tensor API) and runs the sync-to-USD bridge on Newton. The
+  contract is now explicit instead of implicit.
+
+
 0.5.29 (2026-04-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -85,9 +85,28 @@ class IsaacRtxRenderer(BaseRenderer):
     required_capabilities = (UsdFabric,)
 
     def __init__(self, cfg: IsaacRtxRendererCfg):
+        from isaaclab.physics.scene_data_requirements import (
+            aggregate_requirements,
+            requirement_for_renderer_type,
+        )
+        from isaaclab.sim import SimulationContext
+
         self.cfg = cfg
         ensure_rtx_hydra_engine_attached()
         self._usd_fabric_cap: UsdFabric | None = None
+
+        # Sensors are typically added by ``DirectRLEnv._setup_scene`` after
+        # ``InteractiveScene.__init__`` already ran ``update_scene_data_requirements``,
+        # so the active SDP would never see this renderer's USD-Fabric requirement.
+        # Push it onto the requirements aggregator at construction time, mirroring
+        # the pattern used by :class:`~isaaclab_newton.renderers.NewtonWarpRenderer`.
+        sim = SimulationContext.instance()
+        if sim is not None:
+            current_req = sim.get_scene_data_requirements()
+            renderer_req = requirement_for_renderer_type("isaac_rtx")
+            merged = aggregate_requirements([current_req, renderer_req])
+            if merged != current_req:
+                sim.update_scene_data_requirements(merged)
 
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """No-op for Isaac RTX - uses USD scene directly without export.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -19,6 +19,7 @@ import torch
 import warp as wp
 
 from isaaclab.app.settings_manager import get_settings_manager
+from isaaclab.physics import UsdFabric
 from isaaclab.renderers import BaseRenderer
 from isaaclab.utils.version import get_isaac_sim_version
 from isaaclab.utils.warp.kernels import reshape_tiled_image
@@ -81,9 +82,12 @@ class IsaacRtxRenderer(BaseRenderer):
     Requires Isaac Sim.
     """
 
+    required_capabilities = (UsdFabric,)
+
     def __init__(self, cfg: IsaacRtxRendererCfg):
         self.cfg = cfg
         ensure_rtx_hydra_engine_attached()
+        self._usd_fabric_cap: UsdFabric | None = None
 
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """No-op for Isaac RTX - uses USD scene directly without export.
@@ -227,9 +231,24 @@ class IsaacRtxRenderer(BaseRenderer):
         render_data.output_data = output_data
 
     def update_transforms(self) -> None:
-        """No-op for Isaac RTX - uses USD scene directly.
-        See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.update_transforms`."""
-        pass
+        """Ensure USD Fabric reflects the current physics generation.
+
+        Isaac RTX reads transforms from USD via Hydra/Replicator. The
+        :class:`UsdFabric` capability formalises that contract: the renderer
+        does not produce or copy transforms itself, but it requires the
+        Scene Data Provider to guarantee Fabric is current. On a PhysX
+        provider this is a no-op fast path; on a Newton provider it would
+        run the sync-to-USD bridge.
+        """
+        if self._usd_fabric_cap is None:
+            from isaaclab.sim import SimulationContext
+
+            provider = SimulationContext.instance().initialize_scene_data_provider()
+            self.register_with_scene_data_provider(provider)
+            self._usd_fabric_cap = provider.get_capability(UsdFabric)
+            if self._usd_fabric_cap is None:
+                return
+        self._usd_fabric_cap.ensure_current()
 
     def update_camera(
         self,

--- a/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
+++ b/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
@@ -14,10 +14,12 @@ from collections import deque
 from typing import Any
 
 import warp as wp
+from isaaclab_newton.physics.capabilities import NewtonState
 
 from pxr import UsdGeom, UsdPhysics
 
 from isaaclab.physics.base_scene_data_provider import BaseSceneDataProvider
+from isaaclab.physics.capabilities import GpuTransformBuffer, UsdFabric
 from isaaclab.physics.scene_data_buffers import TransformBufferPool
 from isaaclab.physics.scene_data_requirements import VisualizerPrebuiltArtifacts
 from isaaclab.physics.scene_data_types import (
@@ -30,6 +32,67 @@ from isaaclab.physics.scene_data_types import (
 from isaaclab.sim.utils.newton_model_utils import replace_newton_shape_colors
 
 logger = logging.getLogger(__name__)
+
+
+class _PhysxGpuTransformBufferCap:
+    """Adapter exposing :class:`GpuTransformBuffer` for the PhysX provider."""
+
+    def __init__(self, provider: PhysxSceneDataProvider) -> None:
+        self._provider = provider
+
+    def get_body_transforms(
+        self,
+        target_format: TransformFormat,
+        *,
+        env_ids: list[int] | None = None,
+        quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
+        matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
+        double_precision: bool = False,
+        stream: wp.Stream | None = None,
+        allow_passthrough: bool = True,
+        index_map: wp.array | None = None,
+    ) -> TransformData | None:
+        return self._provider.get_body_transforms(
+            target_format,
+            env_ids=env_ids,
+            quat_convention=quat_convention,
+            matrix_layout=matrix_layout,
+            double_precision=double_precision,
+            stream=stream,
+            allow_passthrough=allow_passthrough,
+            index_map=index_map,
+        )
+
+    def get_source_format(self) -> TransformFormat | None:
+        return self._provider.get_source_format()
+
+
+class _PhysxUsdFabricCap:
+    """Adapter exposing :class:`UsdFabric` for the PhysX provider.
+
+    PhysX writes USD Fabric directly via the Tensor API, so freshness is
+    guaranteed by the physics step itself; this is a no-op fast path.
+    """
+
+    def ensure_current(self, stream: wp.Stream | None = None) -> None:
+        pass
+
+
+class _PhysxNewtonStateCap:
+    """Adapter exposing :class:`NewtonState` for the PhysX provider.
+
+    Reads the synthetic Newton state populated by the PhysX→Newton sync
+    bridge during :meth:`PhysxSceneDataProvider.update`.
+    """
+
+    def __init__(self, provider: PhysxSceneDataProvider) -> None:
+        self._provider = provider
+
+    def get_state(self) -> Any:
+        return self._provider.get_newton_state()
+
+    def get_model(self) -> Any:
+        return self._provider.get_newton_model()
 
 
 @wp.kernel(enable_backward=False)
@@ -145,6 +208,12 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
         if self._needs_newton_sync:
             self._load_newton_model_from_prebuilt_artifact()
             self._setup_rigid_body_view()
+
+        # Capability registration (ADR-0002).
+        self._register_capability(GpuTransformBuffer, _PhysxGpuTransformBufferCap(self))
+        self._register_capability(UsdFabric, _PhysxUsdFabricCap())
+        if self._needs_newton_sync:
+            self._register_capability(NewtonState, _PhysxNewtonStateCap(self))
 
     # ---- Newton model + PhysX view setup --------------------------------------------------
 

--- a/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
+++ b/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
@@ -665,6 +665,7 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
 
     def update(self) -> None:
         """Sync PhysX transforms into the full Newton state (one kernel launch)."""
+        self._validate_consumers_if_needed()
         self._generation += 1
         if not self._needs_newton_sync or self._newton_state is None:
             return

--- a/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
+++ b/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
@@ -90,6 +90,7 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
         """
         from isaaclab_physx.physics import PhysxManager as SimulationManager
 
+        super().__init__()
         self._simulation_context = simulation_context
         self._stage = stage
         self._physics_sim_view = SimulationManager.get_physics_sim_view()

--- a/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
+++ b/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
@@ -18,7 +18,15 @@ import warp as wp
 from pxr import UsdGeom, UsdPhysics
 
 from isaaclab.physics.base_scene_data_provider import BaseSceneDataProvider
+from isaaclab.physics.scene_data_buffers import TransformBufferPool
 from isaaclab.physics.scene_data_requirements import VisualizerPrebuiltArtifacts
+from isaaclab.physics.scene_data_types import (
+    MatrixLayout,
+    QuaternionConvention,
+    TransformData,
+    TransformFormat,
+    Vec3QuatTransforms,
+)
 from isaaclab.sim.utils.newton_model_utils import replace_newton_shape_colors
 
 logger = logging.getLogger(__name__)
@@ -128,6 +136,10 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
         # Last load outcome (tests / debug): "prebuilt" | "usd_fallback" | "missing" | "error".
         self._last_newton_model_build_source: str | None = None
         self._last_newton_model_build_elapsed_ms: float | None = None
+
+        # Typed transform API state
+        self._transform_buffer_pool = TransformBufferPool()
+        self._generation: int = 0
 
         if self._needs_newton_sync:
             self._load_newton_model_from_prebuilt_artifact()
@@ -583,6 +595,7 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
 
     def update(self) -> None:
         """Sync PhysX transforms into the full Newton state (one kernel launch)."""
+        self._generation += 1
         if not self._needs_newton_sync or self._newton_state is None:
             return
 
@@ -765,3 +778,85 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
             ``None`` because contacts are not currently implemented in this provider.
         """
         return None
+
+    # ---- Typed transform API -----------------------------------------------------------------
+
+    def get_source_format(self) -> TransformFormat:
+        """Return PhysX's native transform format.
+
+        Returns:
+            :attr:`TransformFormat.VEC3_QUAT` — PhysX produces separate
+            position and quaternion arrays.
+        """
+        return TransformFormat.VEC3_QUAT
+
+    def get_body_transforms(
+        self,
+        target_format: TransformFormat,
+        *,
+        env_ids: list[int] | None = None,
+        quat_convention: QuaternionConvention = QuaternionConvention.XYZW,
+        matrix_layout: MatrixLayout = MatrixLayout.ROW_MAJOR,
+        double_precision: bool = False,
+        stream: wp.Stream | None = None,
+        allow_passthrough: bool = True,
+        index_map: wp.array | None = None,
+    ) -> TransformData | None:
+        """Return body transforms in the requested format.
+
+        Reads positions and quaternions from PhysX tensor views and converts
+        to the requested format via the centralized GPU conversion pipeline.
+
+        Args:
+            target_format: Desired output transform representation.
+            env_ids: Optional environment subset (unused in this method;
+                env filtering is handled at the ``update()`` level).
+            quat_convention: Quaternion component ordering for VEC3_QUAT output.
+            matrix_layout: Matrix memory layout for MAT44 / VEC3_MAT33 output.
+            double_precision: Use 64-bit floats for MAT44 output.
+            stream: CUDA stream for deferred kernel execution.
+            allow_passthrough: If ``True`` and formats match, return source
+                data directly without copying.
+            index_map: Optional index remapping for subset scatter writes.
+
+        Returns:
+            Typed transform data, or ``None`` when poses are unavailable.
+        """
+        try:
+            result = self._read_poses_from_best_source()
+            if result is None:
+                return None
+
+            positions, orientations, _, xform_mask = result
+            orientations_xyzw = self._convert_xform_quats(orientations.reshape(-1, 4), xform_mask)
+
+            positions_wp = wp.from_torch(positions.reshape(-1, 3).contiguous(), dtype=wp.vec3)
+            orientations_wp = wp.from_torch(orientations_xyzw.contiguous(), dtype=wp.quatf)
+            count = positions_wp.shape[0]
+
+            source = Vec3QuatTransforms(
+                count=count,
+                device=self._device,
+                positions=positions_wp,
+                orientations=orientations_wp,
+                quat_convention=QuaternionConvention.XYZW,
+            )
+
+            return self._transform_buffer_pool.get_or_convert(
+                source,
+                target_format,
+                generation=self._generation,
+                quat_convention=quat_convention,
+                matrix_layout=matrix_layout,
+                double_precision=double_precision,
+                stream=stream,
+                allow_passthrough=allow_passthrough,
+                index_map=index_map,
+            )
+        except Exception as exc:
+            self._warn_once(
+                "get-body-transforms-failed",
+                "[PhysxSceneDataProvider] get_body_transforms() failed: %s",
+                exc,
+            )
+            return None

--- a/source/isaaclab_physx/test/sim/test_physx_provider_capabilities.py
+++ b/source/isaaclab_physx/test/sim/test_physx_provider_capabilities.py
@@ -15,11 +15,11 @@ simulation_app = AppLauncher(headless=True).app
 
 import pytest
 import warp as wp
+from isaaclab_newton.physics.capabilities import NewtonState
 
 from isaaclab.physics import GpuTransformBuffer, UsdFabric
 from isaaclab.physics.scene_data_requirements import SceneDataRequirement
 from isaaclab.sim import build_simulation_context
-from isaaclab_newton.physics.capabilities import NewtonState
 
 wp.init()
 

--- a/source/isaaclab_physx/test/sim/test_physx_provider_capabilities.py
+++ b/source/isaaclab_physx/test/sim/test_physx_provider_capabilities.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Capability registration tests for :class:`PhysxSceneDataProvider`."""
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True).app
+
+"""Rest everything follows."""
+
+import pytest
+import warp as wp
+
+from isaaclab.physics import GpuTransformBuffer, UsdFabric
+from isaaclab.physics.scene_data_requirements import SceneDataRequirement
+from isaaclab.sim import build_simulation_context
+from isaaclab_newton.physics.capabilities import NewtonState
+
+wp.init()
+
+pytestmark = pytest.mark.isaacsim_ci
+
+
+def _build_physx_provider(sim, *, requires_newton_model: bool, requires_usd_stage: bool = False):
+    """Force a PhysX provider with the requested SceneDataRequirement.
+
+    The sim's :meth:`SimulationContext.get_scene_data_requirements` is
+    monkey-patched for the duration of the test.
+    """
+    from isaaclab_physx.scene_data_providers import PhysxSceneDataProvider
+
+    sim.get_scene_data_requirements = lambda: SceneDataRequirement(
+        requires_newton_model=requires_newton_model,
+        requires_usd_stage=requires_usd_stage,
+    )
+    return PhysxSceneDataProvider(sim.stage, sim)
+
+
+@pytest.fixture
+def sim():
+    with build_simulation_context(device="cuda:0", dt=0.01, add_lighting=False) as sim:
+        yield sim
+
+
+def test_physx_baseline_capabilities(sim):
+    """Without a Newton consumer, PhysX exposes GpuTransformBuffer and UsdFabric only."""
+    provider = _build_physx_provider(sim, requires_newton_model=False)
+    caps = provider.list_capabilities()
+    assert GpuTransformBuffer in caps
+    assert UsdFabric in caps
+    assert NewtonState not in caps
+
+
+def test_physx_newton_state_registered_when_consumer_requires(sim):
+    """A Newton-flavoured consumer flips on the NewtonState cap."""
+    provider = _build_physx_provider(sim, requires_newton_model=True)
+    caps = provider.list_capabilities()
+    assert NewtonState in caps
+
+
+def test_physx_gpu_transform_buffer_handle_works(sim):
+    """The registered GpuTransformBuffer handle forwards the typed API."""
+    provider = _build_physx_provider(sim, requires_newton_model=False)
+    cap = provider.get_capability(GpuTransformBuffer)
+    assert cap is not None
+    assert isinstance(cap, GpuTransformBuffer)
+    # Source format should match what the provider reports.
+    assert cap.get_source_format() == provider.get_source_format()
+
+
+def test_physx_usd_fabric_is_no_op(sim):
+    """PhysX writes Fabric natively; ensure_current is a fast no-op."""
+    provider = _build_physx_provider(sim, requires_newton_model=False)
+    cap = provider.get_capability(UsdFabric)
+    assert cap is not None
+    cap.ensure_current()  # no error, no return
+
+
+def test_physx_newton_state_handle_returns_state(sim):
+    """The NewtonState cap forwards to the provider's synthetic state."""
+    provider = _build_physx_provider(sim, requires_newton_model=True)
+    cap = provider.get_capability(NewtonState)
+    assert cap is not None
+    # Identity: the cap must surface the same model object the provider holds.
+    assert cap.get_model() is provider.get_newton_model()
+    assert cap.get_state() is provider.get_newton_state()

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from pxr import Gf, Usd, UsdGeom, Vt
 
 from isaaclab.app.settings_manager import get_settings_manager
+from isaaclab.physics import UsdFabric
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
 
 from isaaclab_visualizers.newton_adapter import resolve_visible_env_indices
@@ -30,6 +31,8 @@ _DEFAULT_VIEWPORT_NAME = "Visualizer Viewport"
 
 class KitVisualizer(BaseVisualizer):
     """Kit visualizer using Isaac Sim viewport."""
+
+    required_capabilities = (UsdFabric,)
 
     def __init__(self, cfg: KitVisualizerCfg):
         """Initialize Kit visualizer state.
@@ -52,6 +55,7 @@ class KitVisualizer(BaseVisualizer):
         self._runtime_headless = bool(cfg.headless)
         # USD path for the viewport's active camera, refreshed after setup (used by CI/tests).
         self._controlled_camera_path: str | None = None
+        self._usd_fabric_cap: UsdFabric | None = None
 
     # ---- Lifecycle ------------------------------------------------------------------------
 
@@ -68,6 +72,13 @@ class KitVisualizer(BaseVisualizer):
         if scene_data_provider is None:
             raise RuntimeError("[KitVisualizer] Requires a scene_data_provider.")
         self._scene_data_provider = scene_data_provider
+        self.register_with_scene_data_provider(scene_data_provider)
+        self._usd_fabric_cap = scene_data_provider.get_capability(UsdFabric)
+        if self._usd_fabric_cap is None:
+            raise RuntimeError(
+                "[KitVisualizer] Requires the UsdFabric capability, but the active "
+                "Scene Data Provider does not register it."
+            )
         usd_stage = scene_data_provider.get_usd_stage()
         if usd_stage is None:
             raise RuntimeError("[KitVisualizer] USD stage not available from scene_data_provider.")
@@ -115,6 +126,10 @@ class KitVisualizer(BaseVisualizer):
             return
         self._sim_time += dt
         self._step_counter += 1
+        # Make USD Fabric current before Kit reads from it. No-op when the
+        # provider writes Fabric natively (PhysX); runs sync-to-USD on Newton.
+        if self._usd_fabric_cap is not None:
+            self._usd_fabric_cap.ensure_current()
         try:
             import omni.kit.app
 

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import warp as wp
+from isaaclab_newton.physics.capabilities import NewtonState
 from newton.viewer import ViewerGL
 
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
@@ -251,6 +252,8 @@ class NewtonViewerGL(ViewerGL):
 class NewtonVisualizer(BaseVisualizer):
     """Newton OpenGL visualizer for Isaac Lab."""
 
+    required_capabilities = (NewtonState,)
+
     def __init__(self, cfg: NewtonVisualizerCfg):
         """Initialize Newton visualizer state.
 
@@ -266,6 +269,7 @@ class NewtonVisualizer(BaseVisualizer):
         self._state = None
         self._update_frequency = cfg.update_frequency
         self._scene_data_provider = None
+        self._newton_state_cap: NewtonState | None = None
         self._last_camera_pose: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None
         self._headless_no_viewer = False
 
@@ -282,11 +286,18 @@ class NewtonVisualizer(BaseVisualizer):
             raise RuntimeError("Newton visualizer requires a scene_data_provider.")
 
         self._scene_data_provider = scene_data_provider
+        self.register_with_scene_data_provider(scene_data_provider)
+        self._newton_state_cap = scene_data_provider.get_capability(NewtonState)
+        if self._newton_state_cap is None:
+            raise RuntimeError(
+                "NewtonVisualizer requires the NewtonState capability, but the active "
+                "Scene Data Provider does not register it."
+            )
         metadata = scene_data_provider.get_metadata()
         num_envs = int(metadata.get("num_envs", 0))
         self._env_ids = self._compute_visualized_env_ids()
-        self._model = scene_data_provider.get_newton_model()
-        self._state = scene_data_provider.get_newton_state()
+        self._model = self._newton_state_cap.get_model()
+        self._state = self._newton_state_cap.get_state()
 
         # Use pyglet's EGL headless backend when requested. Must run before the first
         # ``pyglet.window`` import so ``Window`` resolves to :class:`~pyglet.window.headless.HeadlessWindow`.
@@ -366,14 +377,14 @@ class NewtonVisualizer(BaseVisualizer):
         self._step_counter += 1
 
         if self._viewer is None:
-            if self._scene_data_provider is not None:
-                self._state = self._scene_data_provider.get_newton_state()
+            if self._newton_state_cap is not None:
+                self._state = self._newton_state_cap.get_state()
             return
 
         if self.cfg.cam_source == "prim_path":
             self._update_camera_from_usd_path()
 
-        self._state = self._scene_data_provider.get_newton_state()
+        self._state = self._newton_state_cap.get_state()
 
         contacts = None
         if self._viewer.show_contacts:

--- a/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
@@ -16,6 +16,7 @@ from urllib.parse import quote
 
 import rerun as rr
 import rerun.blueprint as rrb
+from isaaclab_newton.physics.capabilities import NewtonState
 from newton.viewer import ViewerRerun
 
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
@@ -118,6 +119,8 @@ class NewtonViewerRerun(ViewerRerun):
 class RerunVisualizer(BaseVisualizer):
     """Rerun visualizer for Isaac Lab."""
 
+    required_capabilities = (NewtonState,)
+
     def __init__(self, cfg: RerunVisualizerCfg):
         """Initialize Rerun visualizer state.
 
@@ -132,6 +135,7 @@ class RerunVisualizer(BaseVisualizer):
         self._model = None
         self._state = None
         self._scene_data_provider = None
+        self._newton_state_cap: NewtonState | None = None
         self._last_camera_pose: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None
 
     def initialize(self, scene_data_provider: BaseSceneDataProvider) -> None:
@@ -146,11 +150,18 @@ class RerunVisualizer(BaseVisualizer):
             raise RuntimeError("Rerun visualizer requires a scene_data_provider.")
 
         self._scene_data_provider = scene_data_provider
+        self.register_with_scene_data_provider(scene_data_provider)
+        self._newton_state_cap = scene_data_provider.get_capability(NewtonState)
+        if self._newton_state_cap is None:
+            raise RuntimeError(
+                "RerunVisualizer requires the NewtonState capability, but the active "
+                "Scene Data Provider does not register it."
+            )
         metadata = scene_data_provider.get_metadata()
         num_envs = int(metadata.get("num_envs", 0))
         self._env_ids = self._compute_visualized_env_ids()
-        self._model = scene_data_provider.get_newton_model()
-        self._state = scene_data_provider.get_newton_state()
+        self._model = self._newton_state_cap.get_model()
+        self._state = self._newton_state_cap.get_state()
 
         grpc_port = int(self.cfg.grpc_port)
         web_port = int(self.cfg.web_port)
@@ -234,7 +245,7 @@ class RerunVisualizer(BaseVisualizer):
         if self.cfg.cam_source == "prim_path":
             self._update_camera_from_usd_path()
 
-        self._state = self._scene_data_provider.get_newton_state()
+        self._state = self._newton_state_cap.get_state()
 
         if not self._viewer.is_paused():
             self._viewer.begin_frame(self._sim_time)

--- a/source/isaaclab_visualizers/isaaclab_visualizers/viser/viser_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/viser/viser_visualizer.py
@@ -15,6 +15,7 @@ import webbrowser
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from isaaclab_newton.physics.capabilities import NewtonState
 from newton.viewer import ViewerViser
 
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
@@ -113,6 +114,8 @@ class NewtonViewerViser(ViewerViser):
 class ViserVisualizer(BaseVisualizer):
     """Viser web-based visualizer backed by Newton's ViewerViser."""
 
+    required_capabilities = (NewtonState,)
+
     def __init__(self, cfg: ViserVisualizerCfg):
         """Initialize Viser visualizer state.
 
@@ -126,6 +129,7 @@ class ViserVisualizer(BaseVisualizer):
         self._state = None
         self._sim_time = 0.0
         self._scene_data_provider = None
+        self._newton_state_cap: NewtonState | None = None
         self._active_record_path: str | None = None
         self._last_camera_pose: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None
         self._pending_camera_pose: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None
@@ -143,10 +147,17 @@ class ViserVisualizer(BaseVisualizer):
             raise RuntimeError("Viser visualizer requires a scene_data_provider.")
 
         self._scene_data_provider = scene_data_provider
+        self.register_with_scene_data_provider(scene_data_provider)
+        self._newton_state_cap = scene_data_provider.get_capability(NewtonState)
+        if self._newton_state_cap is None:
+            raise RuntimeError(
+                "ViserVisualizer requires the NewtonState capability, but the active "
+                "Scene Data Provider does not register it."
+            )
         metadata = scene_data_provider.get_metadata()
         self._env_ids = self._compute_visualized_env_ids()
-        self._model = scene_data_provider.get_newton_model()
-        self._state = scene_data_provider.get_newton_state()
+        self._model = self._newton_state_cap.get_model()
+        self._state = self._newton_state_cap.get_state()
 
         self._active_record_path = self.cfg.record_to_viser
         self._create_viewer(record_to_viser=self.cfg.record_to_viser, metadata=metadata)
@@ -182,7 +193,7 @@ class ViserVisualizer(BaseVisualizer):
             self._update_camera_from_usd_path()
         self._apply_pending_camera_pose()
 
-        self._state = self._scene_data_provider.get_newton_state()
+        self._state = self._newton_state_cap.get_state()
         self._sim_time += dt
         self._viewer.begin_frame(self._sim_time)
         self._viewer.log_state(self._state)


### PR DESCRIPTION
Introduce a typed format-negotiation system where consumers declare what transform format they need and the SDP converts from the simulator's native format using centralized GPU-only Warp kernels, with zero-copy passthrough when formats already match.

Core additions:
- TransformFormat enum and four concrete TransformData types (Vec3QuatTransforms, Vec3Mat33Transforms, TransformArrayData, Mat44Transforms) with QuaternionConvention and MatrixLayout
- 24 Warp GPU kernels covering the full 4x4 conversion grid plus quaternion swizzle and matrix transpose
- ConversionDispatcher selecting the right kernel for any format pair
- TransformBufferPool with three fast paths: format-match passthrough (zero work), same-frame generation cache, cross-frame buffer reuse
- get_body_transforms() and get_source_format() on BaseSceneDataProvider

Backend implementations:
- PhysX provider returns Vec3QuatTransforms wrapping tensor views
- Newton provider returns TransformArrayData wrapping state.body_q
- OVRTX renderer uses typed API with legacy fallback

56 unit tests verify all conversion paths, buffer pool behavior, and dispatcher logic without requiring Isaac Sim.

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
