### PR TITLE
Remove sync_usd_on_fabric_write workaround (OMPE-85872 fixed in Kit 110.1)

### DIFF
--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -417,9 +417,8 @@ class Camera(SensorBase):
         self._renderer.prepare_stage(self.stage, self._num_envs)
 
         # Create a view for the sensor with Fabric enabled for fast pose queries.
-        # TODO: remove sync_usd_on_fabric_write=True once the GPU Fabric sync bug is fixed.
         self._view = XformPrimView(
-            self.cfg.prim_path, device=self._device, stage=self.stage, sync_usd_on_fabric_write=True
+            self.cfg.prim_path, device=self._device, stage=self.stage
         )
         # Check that sizes are correct
         if self._view.count != self._num_envs:

--- a/source/isaaclab/isaaclab/sim/views/xform_prim_view.py
+++ b/source/isaaclab/isaaclab/sim/views/xform_prim_view.py
@@ -51,8 +51,8 @@ class XformPrimView:
 
         When Fabric is enabled, this view ensures prims have the required Fabric hierarchy
         attributes (``omni:fabric:localMatrix`` and ``omni:fabric:worldMatrix``). On first Fabric
-        read, USD-authored transforms initialize Fabric state. Fabric writes can optionally
-        be mirrored back to USD via :attr:`sync_usd_on_fabric_write`.
+        read, USD-authored transforms initialize Fabric state. Fabric writes remain
+        GPU-resident and are not mirrored back to USD.
 
         For more information, see the `Fabric Hierarchy documentation`_.
 
@@ -85,7 +85,6 @@ class XformPrimView:
         prim_path: str,
         device: str = "cpu",
         validate_xform_ops: bool = True,
-        sync_usd_on_fabric_write: bool = False,
         stage: Usd.Stage | None = None,
     ):
         """Initialize the view with matching prims.
@@ -107,9 +106,6 @@ class XformPrimView:
                 ``"cuda:0"``. Defaults to ``"cpu"``.
             validate_xform_ops: Whether to validate that the prims have standard xform operations.
                 Defaults to True.
-            sync_usd_on_fabric_write: Whether to mirror Fabric transform writes back to USD.
-                When True, transform updates are synchronized to USD so that USD data readers (e.g., rendering
-                cameras) can observe these changes. Defaults to False for better performance.
             stage: USD stage to search for prims. Defaults to None, in which case the current active stage
                 from the simulation context is used.
 
@@ -166,10 +162,6 @@ class XformPrimView:
         # Create indices buffer
         # Since we iterate over the indices, we need to use range instead of torch tensor
         self._ALL_INDICES = list(range(len(self._prims)))
-
-        # Some prims (e.g., Cameras) require USD-authored transforms for rendering.
-        # When enabled, mirror Fabric pose writes to USD for those prims.
-        self._sync_usd_on_fabric_write = sync_usd_on_fabric_write
 
         # Fabric batch infrastructure (initialized lazily on first use)
         self._fabric_initialized = False
@@ -771,11 +763,6 @@ class XformPrimView:
         self._fabric_hierarchy.update_world_xforms()
         # Fabric now has authoritative data; skip future USD syncs
         self._fabric_usd_sync_done = True
-        # Mirror to USD for renderer-facing prims when enabled.
-        if self._sync_usd_on_fabric_write:
-            self._set_world_poses_usd(positions, orientations, indices)
-
-        # Fabric writes are GPU-resident; local pose operations still use USD.
 
     def _set_local_poses_fabric(
         self,
@@ -842,9 +829,6 @@ class XformPrimView:
         self._fabric_hierarchy.update_world_xforms()
         # Fabric now has authoritative data; skip future USD syncs
         self._fabric_usd_sync_done = True
-        # Mirror to USD for renderer-facing prims when enabled.
-        if self._sync_usd_on_fabric_write:
-            self._set_scales_usd(scales, indices)
 
     def _get_world_poses_fabric(self, indices: Sequence[int] | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         """Get world poses from Fabric using GPU batch operations."""
@@ -1122,11 +1106,8 @@ class XformPrimView:
         positions_usd, orientations_usd = self._get_world_poses_usd()
         scales_usd = self._get_scales_usd()
 
-        prev_sync = self._sync_usd_on_fabric_write
-        self._sync_usd_on_fabric_write = False
         self._set_world_poses_fabric(positions_usd, orientations_usd)
         self._set_scales_fabric(scales_usd)
-        self._sync_usd_on_fabric_write = prev_sync
 
         self._fabric_usd_sync_done = True
 

--- a/source/isaaclab/test/sim/test_views_xform_prim.py
+++ b/source/isaaclab/test/sim/test_views_xform_prim.py
@@ -1513,3 +1513,75 @@ def test_fabric_usd_consistency(device):
     pos_fabric_after, quat_fabric_after = view_fabric.get_world_poses()
     torch.testing.assert_close(pos_fabric_after, new_positions, atol=1e-4, rtol=0)
     torch.testing.assert_close(quat_fabric_after, new_orientations, atol=1e-4, rtol=0)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_fabric_writes_do_not_sync_to_usd(device):
+    """Test that Fabric world-pose writes are NOT mirrored back to USD.
+
+    The old workaround (sync_usd_on_fabric_write=True) used to double-write every
+    Fabric pose change back to USD so that USD data readers (cameras, renderers)
+    could observe them.  With the Kit PrepareForReuse fix (OMPE-85872), the renderer
+    picks up GPU-resident Fabric transforms directly, so the USD sync is no longer
+    needed.  This test verifies the sync is truly gone: after a Fabric write, USD
+    xformOp attributes must still contain their original values.
+    """
+    _skip_if_backend_unavailable("fabric", device)
+
+    stage = sim_utils.get_current_stage()
+
+    # Create camera prims with known USD-authored positions
+    num_prims = 3
+    original_positions = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)]
+    for i, pos in enumerate(original_positions):
+        sim_utils.create_prim(f"/World/Cam_{i}", "Camera", translation=pos, stage=stage)
+
+    # Create a Fabric-backed view
+    view = _create_view("/World/Cam_.*", device=device, backend="fabric")
+
+    # Write completely different positions via Fabric
+    new_positions = torch.tensor(
+        [[100.0, 200.0, 300.0], [400.0, 500.0, 600.0], [700.0, 800.0, 900.0]],
+        dtype=torch.float32,
+        device=device,
+    )
+    new_orientations = torch.tensor(
+        [[0.0, 0.0, 0.7071068, 0.7071068]] * num_prims,
+        dtype=torch.float32,
+        device=device,
+    )
+    view.set_world_poses(new_positions, new_orientations)
+
+    # Verify Fabric read returns the new values
+    fabric_pos, _ = view.get_world_poses()
+    torch.testing.assert_close(fabric_pos, new_positions, atol=1e-4, rtol=0)
+
+    # Verify USD xformOp:translate was NOT updated (still has the original values)
+    for i, expected_pos in enumerate(original_positions):
+        prim = stage.GetPrimAtPath(f"/World/Cam_{i}")
+        usd_translate = prim.GetAttribute("xformOp:translate").Get()
+        assert usd_translate is not None, f"Prim /World/Cam_{i} should have xformOp:translate"
+        usd_pos = (usd_translate[0], usd_translate[1], usd_translate[2])
+        assert abs(usd_pos[0] - expected_pos[0]) < 1e-5, (
+            f"USD xformOp:translate should NOT be updated by Fabric write. "
+            f"Expected {expected_pos}, got {usd_pos}"
+        )
+        assert abs(usd_pos[1] - expected_pos[1]) < 1e-5
+        assert abs(usd_pos[2] - expected_pos[2]) < 1e-5
+
+    # Also verify USD orientation was NOT updated (should still be identity)
+    for i in range(num_prims):
+        prim = stage.GetPrimAtPath(f"/World/Cam_{i}")
+        usd_orient = prim.GetAttribute("xformOp:orient").Get()
+        assert usd_orient is not None
+        # Original orientation is identity (w=1, x=0, y=0, z=0)
+        real = usd_orient.GetReal()
+        imag = usd_orient.GetImaginary()
+        assert abs(real - 1.0) < 1e-5, (
+            f"USD xformOp:orient should NOT be updated by Fabric write. "
+            f"Expected identity quaternion, got real={real}, imag={imag}"
+        )
+        assert abs(imag[0]) < 1e-5 and abs(imag[1]) < 1e-5 and abs(imag[2]) < 1e-5, (
+            f"USD xformOp:orient should NOT be updated by Fabric write. "
+            f"Expected identity quaternion, got real={real}, imag={imag}"
+        )


### PR DESCRIPTION
## Summary

Removes the `sync_usd_on_fabric_write` workaround from `XformPrimView` and the Camera sensor. This double-write hack is no longer needed now that the Kit `PrepareForReuse` fix properly dirties Fabric attributes for the GPU renderer.

## Background

When `XformPrimView` writes transforms to Fabric via `SelectPrims` + Warp kernels, the data is GPU-resident on `omni:fabric:worldMatrix`. Prior to the Kit 110.1 fix, the RTX renderer did not pick up these GPU-resident changes because Fabric didn't signal attribute dirtiness at the device level (OMPE-85872).

The workaround was `sync_usd_on_fabric_write=True`, which mirrored every Fabric pose write back to USD — effectively double-writing transforms (GPU Fabric + CPU USD). This defeated the performance benefit of Fabric for any prim that needed to be visible to the renderer (e.g., cameras).

The `PrepareForReuse` fix in Kit 110.1 resolves this at the Fabric level using `dirtyAttribute` (CPU) and `getAttributeArrayMGpu` / `getArrayAttributeArrayWithSizesMGpu` (GPU) to properly signal changes to downstream consumers.

## Changes

**`source/isaaclab/isaaclab/sim/views/xform_prim_view.py`**
- Removed `sync_usd_on_fabric_write` constructor parameter
- Removed `self._sync_usd_on_fabric_write` field
- Removed conditional USD mirror writes from `_set_world_poses_fabric()` and `_set_scales_fabric()`
- Simplified `_sync_fabric_from_usd_once()` (no more save/restore of sync flag)
- Updated docstring to reflect Fabric writes are purely GPU-resident

**`source/isaaclab/isaaclab/sensors/camera/camera.py`**
- Removed `sync_usd_on_fabric_write=True` and the associated TODO comment

**`source/isaaclab/test/sim/test_views_xform_prim.py`**
- Added `test_fabric_writes_do_not_sync_to_usd` regression test: writes via Fabric, then verifies USD `xformOp:translate` and `xformOp:orient` still hold their original values

## Impact

- **Performance**: Eliminates redundant CPU-side USD writes for camera prims (the only caller using `sync_usd_on_fabric_write=True`)
- **API**: Removes `sync_usd_on_fabric_write` parameter from `XformPrimView.__init__()`. This is a breaking change for any external code passing this argument, but it defaulted to `False` so only the internal Camera sensor was affected.
- **Compatibility**: Requires Kit 110.1+ with the `PrepareForReuse` cross-device fix

## Test Plan

- Existing `test_views_xform_prim.py` tests pass (they never set `sync_usd_on_fabric_write=True`)
- New `test_fabric_writes_do_not_sync_to_usd` validates Fabric/USD isolation
