### PR TITLE
fix: add missing viewport.window + hydra_texture deps for headless rendering

### DIFF
--- a/apps/isaaclab.python.headless.rendering.kit
+++ b/apps/isaaclab.python.headless.rendering.kit
@@ -22,6 +22,10 @@ keywords = ["experience", "app", "isaaclab", "python", "camera", "minimal"]
 # Rendering
 "omni.kit.material.library" = {}
 "omni.kit.viewport.rtx" = {}
+# Headless viewport + texture support — required for annotators/render-products
+# without a visible window (e.g. DGX Cloud, CI containers).
+"omni.kit.viewport.window" = {}
+"omni.kit.hydra_texture" = {}
 
 [settings.isaaclab]
 # This is used to check that this experience file is loaded when using cameras


### PR DESCRIPTION
## Description

The headless rendering experience file (`isaaclab.python.headless.rendering.kit`) is missing two extensions required for the annotator/render-product pipeline to function in environments without a display (DGX Cloud, CI containers, SSH sessions):

- **`omni.kit.viewport.window`**: provides viewport infrastructure needed by `rep.create.render_product_tiled()` to create render products headlessly. Without it, `rep.orchestrator.step()` triggers an infinite `createViewport` loop, and annotators produce empty buffers.
- **`omni.kit.hydra_texture`**: provides the HydraTexture backend that replicator annotators rely on to extract rendered pixel data. While transitively pulled via `omni.replicator.core → omni.syntheticdata`, the load order in headless mode causes `omni.hydratexture` to be imported before the extension has started, making `ht_available = False` permanently.

The non-headless experience file (`isaaclab.python.kit`) already includes `omni.kit.viewport.window`. Adding both as explicit dependencies ensures correct startup ordering.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Reproduction

Any `Camera`/`TiledCamera` test that actually renders in headless mode fails:

```bash
# On a headless machine (no DISPLAY, no nvidia_drm):
DISPLAY= python -m pytest source/isaaclab/test/sensors/test_tiled_camera.py -v
# test_tiled_camera_basic_functionality[cuda:0] → FAILED (cudaErrorIllegalAddress)
```

## Fix

```diff
 # Rendering
 "omni.kit.material.library" = {}
 "omni.kit.viewport.rtx" = {}
+# Headless viewport + texture support — required for annotators/render-products
+# without a visible window (e.g. DGX Cloud, CI containers).
+"omni.kit.viewport.window" = {}
+"omni.kit.hydra_texture" = {}
```

## Testing

After the fix, all 8 tiled camera test variants pass:

```
test_tiled_camera_deprecation_warning[cuda:0]    PASSED
test_tiled_camera_deprecation_warning[cpu]        PASSED
test_tiled_camera_cfg_deprecation_warning[cuda:0] PASSED
test_tiled_camera_cfg_deprecation_warning[cpu]    PASSED
test_tiled_camera_is_camera_subclass[cuda:0]      PASSED
test_tiled_camera_is_camera_subclass[cpu]         PASSED
test_tiled_camera_basic_functionality[cuda:0]     PASSED
test_tiled_camera_basic_functionality[cpu]        PASSED
```

Tested on DGX Cloud (2x L40, Kit 110.1.1, Isaac Sim v6.0.0-alpha.183, Vulkan headless).