### PR TITLE
Replaces deprecated --headless with --viz none in mimic tests

### DIFF
--- a/source/isaaclab_mimic/config/extension.toml
+++ b/source/isaaclab_mimic/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Semantic Versioning is used: https://semver.org/
-version = "1.2.4"
+version = "1.2.5"
 
 # Description
 category = "isaaclab"

--- a/source/isaaclab_mimic/docs/CHANGELOG.rst
+++ b/source/isaaclab_mimic/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+1.2.5 (2026-04-23)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^
+
+* Replaced the deprecated ``--headless`` CLI flag with ``--viz none`` in the dataset-generation
+  tests under ``isaaclab_mimic/test/`` to silence the ``AppLauncher`` deprecation warning.
+
+
 1.2.4 (2026-04-06)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_mimic/docs/CHANGELOG.rst
+++ b/source/isaaclab_mimic/docs/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~~
 
 Changed
-^^^^^
+^^^^^^^
 
 * Replaced the deprecated ``--headless`` CLI flag with ``--viz none`` in the dataset-generation
   tests under ``isaaclab_mimic/test/`` to silence the ``AppLauncher`` deprecation warning.

--- a/source/isaaclab_mimic/test/test_generate_dataset_franka_state.py
+++ b/source/isaaclab_mimic/test/test_generate_dataset_franka_state.py
@@ -75,7 +75,8 @@ def setup_test_environment():
         "--output_file",
         annotated_output_path,
         "--auto",
-        "--headless",
+        "--viz",
+        "none",
     ]
     print(config_command)
 
@@ -139,7 +140,8 @@ def _run_generation(workflow_root: str, input_file: str, output_file: str, num_e
         str(num_envs),
         "--generation_num_trials",
         "1",
-        "--headless",
+        "--viz",
+        "none",
     ]
 
     result = run_script(command, timeout=_SUBPROCESS_TIMEOUT)

--- a/source/isaaclab_mimic/test/test_generate_dataset_franka_visuomotor.py
+++ b/source/isaaclab_mimic/test/test_generate_dataset_franka_visuomotor.py
@@ -75,7 +75,8 @@ def _run_generation(workflow_root: str, input_file: str, output_file: str, num_e
         "--generation_num_trials",
         "1",
         "--enable_cameras",
-        "--headless",
+        "--viz",
+        "none",
     ]
 
     result = run_script(command)

--- a/source/isaaclab_mimic/test/test_generate_dataset_gr1t2_nutpour.py
+++ b/source/isaaclab_mimic/test/test_generate_dataset_gr1t2_nutpour.py
@@ -75,7 +75,8 @@ def _run_generation(workflow_root: str, input_file: str, output_file: str, num_e
         "--generation_num_trials",
         "1",
         "--enable_cameras",
-        "--headless",
+        "--viz",
+        "none",
     ]
 
     result = run_script(command)

--- a/source/isaaclab_mimic/test/test_generate_dataset_gr1t2_pickplace.py
+++ b/source/isaaclab_mimic/test/test_generate_dataset_gr1t2_pickplace.py
@@ -74,7 +74,8 @@ def _run_generation(workflow_root: str, input_file: str, output_file: str, num_e
         str(num_envs),
         "--generation_num_trials",
         "1",
-        "--headless",
+        "--viz",
+        "none",
     ]
 
     result = run_script(command)

--- a/source/isaaclab_mimic/test/test_generate_dataset_skillgen.py
+++ b/source/isaaclab_mimic/test/test_generate_dataset_skillgen.py
@@ -85,7 +85,8 @@ def test_generate_dataset_skillgen(setup_skillgen_test_environment):
         "--generation_num_trials",
         "1",
         "--use_skillgen",
-        "--headless",
+        "--viz",
+        "none",
         "--task",
         "Isaac-Stack-Cube-Franka-IK-Rel-Skillgen-v0",
     ]


### PR DESCRIPTION
# Description

This PR replaces `--headless` with `--viz none` in the subprocess command built by each test.
Files updated:

- `source/isaaclab_mimic/test/test_generate_dataset_franka_state.py` (2 occurrences)
- `source/isaaclab_mimic/test/test_generate_dataset_franka_visuomotor.py` (1 occurrence)
- `source/isaaclab_mimic/test/test_generate_dataset_gr1t2_nutpour.py` (1 occurrence)
- `source/isaaclab_mimic/test/test_generate_dataset_gr1t2_pickplace.py` (1 occurrence)
- `source/isaaclab_mimic/test/test_generate_dataset_skillgen.py` (1 occurrence)

Total: 5 files, 6 subprocess commands updated.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there