### PR TITLE
Fix usd-core 25.8 / usd-exchange ABI conflict by relaxing version pin

### DIFF
--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -70,7 +70,7 @@ INSTALL_REQUIRES += [
 ]
 # Adds OpenUSD dependencies based on architecture for Kit less mode.
 INSTALL_REQUIRES += [
-    f"usd-core==25.8.0 ; ({SUPPORTED_ARCHS})",
+    f"usd-core>=25.8.0,<26.0.0 ; ({SUPPORTED_ARCHS})",
     f"usd-exchange>=2.2 ; ({SUPPORTED_ARCHS_ARM})",
 ]
 


### PR DESCRIPTION
# Description

Bug: `usd-core==25.8.0` conflicts with `usd-exchange` due to overlapping `pxr/` modules         
                                               
  ### Environment                                                                                    
   
  - Isaac Lab: `develop` branch, `isaaclab 4.6.12`                                                   
  - Python: 3.12.12                                               
  - OS: Ubuntu (x86_64)                                                                              
  - Install method: `./isaaclab.sh --install`                                                        
                                                                                                     
  ### Problem                                                                                        
                                                                                                     
  Training scripts fail at startup with:                          
                                                                                                     
  ```                                                             
  RuntimeError: extension class wrapper for base class                                               
  pxrInternal_v0_25_8__pxrReserved__::Tf_PyEnumWrapper has not been created yet                      
  ```                                                                                                
                                                                                                     
  Import chain: `cartpole_env.py` → `isaaclab.assets.Articulation` →                                 
  `isaaclab.sim.simulation_context` → `from pxr import Usd` → crash                                  
                                                                  
  ### Root Cause                                                                                     
                                                                                                     
  Both `usd-core` 25.8.0 and `usd-exchange` 2.2.2 **ship identical `pxr/` Python modules** (`.py`, 
  `.pyc`, `.so` files). When installed together via `pip install -e`, the later-installed package    
  overwrites the former's `.so` files, causing ABI incompatibility.
                                                                                                     
  | File | usd-core 25.8 built from | usd-exchange 2.2.2 built from |
  |------|--------------------------|-------------------------------|                                
  | `pxr/Tf/_tf.so` | `/opt/USD/` | `/builds/omniverse/usd-ci/USD/` |                                
  | `pxr/Usd/_usd.so` | `/opt/USD/` | `/builds/omniverse/usd-ci/USD/` |                              
  | ... (all `pxr/` modules) | | |                                                                   
                                                                                                     
  `usd-exchange`'s `_tf.so` overwrites `usd-core`'s, but `usd-core`'s monolithic `libusd_ms.so` still
   links against its own ABI. The Boost.Python converter registration fails due to the mismatch.     
                                                                                                     
  **Verified:**                                                                                      
   
  ```bash                                                                                            
  # usd-core 25.8 + usd-exchange 2.2.2 → FAILS                    
  python -c "from pxr import Usd"  # RuntimeError                                                    
                                                                                                     
  # usd-core 25.11 + usd-exchange 2.2.2 → OK                                                         
  pip install usd-core==25.11                                                                        
  python -c "from pxr import Usd"  # works                                                           
  ```                                                                                                
                                                                                                     
  `usd-core` 25.11+ is ABI-compatible with `usd-exchange` 2.2.2. Only 25.8 triggers the conflict.    
                                                                                                     
  ### Current Constraints                                                                            
                                                                  
  `source/isaaclab/setup.py:73`:                                                                     
                                                                  
  ```python                                                                                          
  f"usd-core==25.8.0 ; ({SUPPORTED_ARCHS})",                      
  f"usd-exchange>=2.2 ; ({SUPPORTED_ARCHS_ARM})",                                                    
  ```                                                                                                
                                                                                                     
  `usd-core` is pinned to exactly 25.8.0, while `usd-exchange>=2.2` allows 2.2.2 (which is           
  incompatible with 25.8).                                                                           
                                                                                                     
  ### Fix                                                         

  Relax the version constraint:

  ```diff                                                                                            
  -    f"usd-core==25.8.0 ; ({SUPPORTED_ARCHS})",
  +    f"usd-core>=25.8.0,<26.0.0 ; ({SUPPORTED_ARCHS})",                                            
  ```                                                                                                
                                                                                                     
  ### Long-term Recommendations                                                                      
                                                                  
  1. **`usd-exchange` should not ship `pxr/` modules** — it should depend on `usd-core` instead of   
  repackaging the same files. This is a packaging issue on NVIDIA's side.
  2. **Pin compatible version pairs** — `usd-core` and `usd-exchange` should be constrained to       
  known-compatible combinations.                                                                     
  3. **CI smoke test** — verify `from pxr import Usd` works after install.

Fixes #5025 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
