### PR TITLE
Add test detecting overlapping pxr/ files across distributions

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "4.6.12"
+version = "4.6.13"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Changelog
 ---------
 
+4.6.13 (2026-04-24)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``test/install_ci/test_usd_pxr_file_clashes.py`` to detect ABI-clash
+  risk from multiple installed distributions shipping overlapping ``pxr/``
+  files. The test fails if any path under ``pxr/`` is claimed by more than one
+  distribution's ``RECORD``, catching packaging conflicts (e.g. between
+  ``usd-core`` and ``usd-exchange``) before they surface as machine-specific
+  runtime crashes such as ``Tf_PyEnumWrapper has not been created yet``.
+
+
 4.6.12 (2026-04-23)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/test/install_ci/test_usd_pxr_file_clashes.py
+++ b/source/isaaclab/test/install_ci/test_usd_pxr_file_clashes.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Detect ABI-clash risk from multiple distributions shipping overlapping ``pxr/`` files.
+
+When two distributions (e.g. ``usd-core`` and ``usd-exchange``) both ship files
+under ``pxr/``, the later-installed package silently overwrites the earlier
+one's files on disk while each dist-info's RECORD keeps its own entries. Which
+``_*.so`` "wins" on disk depends on install order, wheel selection, and the
+pip resolver version, so the same version pins can produce a working import
+tree on one machine and crash with ``Tf_PyEnumWrapper has not been created
+yet`` on another.
+
+A strict, packaging-level detector is more reliable than trying to observe the
+runtime crash: any ``pxr/`` path claimed by more than one distribution is a
+potential ABI mismatch, regardless of whether the current env happens to have
+picked a working "winner".
+
+Regression for GitHub PR #5386 / issue #5025: ``usd-core==25.8.0`` and
+``usd-exchange==2.2.2`` both ship the entire ``pxr/`` tree.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as md
+from collections import defaultdict
+
+import pytest
+
+
+def _pxr_file_owners() -> dict[str, list[str]]:
+    """Return a map of ``pxr/`` paths to the distributions that claim to own them."""
+    owners: dict[str, set[str]] = defaultdict(set)
+    for dist in md.distributions():
+        if dist.name is None or dist.files is None:
+            continue
+        for f in dist.files:
+            path = str(f)
+            if path == "pxr" or path.startswith("pxr/"):
+                owners[path].add(dist.name)
+    return {p: sorted(ns) for p, ns in owners.items()}
+
+
+def test_no_pxr_file_owner_overlap():
+    """No path under ``pxr/`` should be claimed by more than one installed distribution."""
+    try:
+        md.distribution("usd-core")
+    except md.PackageNotFoundError:
+        pytest.skip("usd-core is not installed in this environment")
+
+    owners = _pxr_file_owners()
+    clashes = {p: ns for p, ns in owners.items() if len(ns) > 1}
+
+    if clashes:
+        lines = [f"Found {len(clashes)} pxr/ path(s) claimed by multiple distributions:"]
+        for path, dist_names in sorted(clashes.items()):
+            lines.append(f"  {path} -> {dist_names}")
+        lines.append(
+            "\nWhichever distribution pip installs last overwrites the other's files on"
+            " disk, while each dist-info still references its own binaries. If the two"
+            " were built against different USD ABIs, the resulting mix crashes at"
+            " import time (e.g. 'Tf_PyEnumWrapper has not been created yet'). See"
+            " GitHub PR #5386 / issue #5025 for the usd-core/usd-exchange case."
+        )
+        raise AssertionError("\n".join(lines))


### PR DESCRIPTION
## Summary

Adds a strict, packaging-level detector under `source/isaaclab/test/install_ci/` that fails if any path under `pxr/` is claimed by more than one installed distribution's `RECORD`.

This is intentionally opened **without** the fix from #5386, so CI fires and proves the detector works on the current broken state (`usd-core==25.8.0` pinned alongside `usd-exchange>=2.2`, both of which ship the entire `pxr/` tree — 81 overlapping paths in a fresh install).

## Motivation

Two distributions shipping the same file paths is a silent packaging bug: whichever pip installs last overwrites the other's `.so` files on disk, while each `dist-info` keeps its own `RECORD` hashes. If the two were built against different USD ABIs, you get machine-specific crashes like `Tf_PyEnumWrapper has not been created yet` (see #5025). A runtime `from pxr import Usd` check is an unreliable detector — whether it crashes depends on install order, wheel resolution, and pip version, so the same pins work on one machine and fail on another. File-ownership overlap is the stable, environment-independent signal.

## Expectations

- **`install-ci` job is expected to fail** on this PR. That's the demonstration — the detector correctly flags the current `develop` state as broken.
- Once #5386 merges, the detector may still fire if the pip resolver picks `usd-core==25.8.0` within the relaxed `>=25.8.0,<26.0.0` range. If so, that's a signal the fix should be narrowed to exclude the overlapping versions (or that `usd-exchange`'s packaging should stop shipping `pxr/`).
- Scoped to `pxr/` only; can be generalized to any shared top-level package later.

## Test plan

- [ ] `install-ci` workflow runs and `test_no_pxr_file_owner_overlap` fails with the expected list of overlapping `pxr/` paths and their owning distributions.
- [ ] After #5386 lands and the resolver picks a non-clashing `usd-core` version, re-running this test passes.

Related: #5025, #5386