### PR TITLE
Fixes arm64 docker build failure

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -46,12 +46,15 @@ RUN apt-get update && \
     git \
     wget
 
-# Install packages needed to build imgui-bundle on arm64 as no prebuilt pip wheel is provided
+# arm64-only build deps:
+# - imgui-bundle has no prebuilt arm64 wheel; needs GL/X11 dev headers.
+# - swig is required for the nlopt source build (see arm64 nlopt step below).
 RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
         apt-get update && \
         apt-get install -y --no-install-recommends \
         libgl1-mesa-dev libopengl-dev libglx-dev \
-        libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev; \
+        libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev \
+        swig; \
     fi
 
 # copy files necessary for installing Isaac Lab and its dependencies
@@ -96,6 +99,16 @@ RUN touch /bin/nvidia-smi && \
     touch /etc/localtime && \
     mkdir -p /var/run/nvidia-persistenced && \
     touch /var/run/nvidia-persistenced/socket
+
+# On arm64, pre-install nlopt 2.6.2 (transitively pinned by isaacteleop[retargeters]).
+# There is no aarch64 wheel for this version, and pip's isolated build env hides the
+# system numpy from nlopt's cmake-based build, so we install it manually with
+# --no-build-isolation. The subsequent isaaclab.sh --install will see nlopt as
+# already satisfied and skip the from-source rebuild that would otherwise fail.
+RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
+    if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
+    fi
 
 # installing Isaac Lab dependencies
 # use pip caching to avoid reinstalling large packages

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -46,12 +46,15 @@ RUN apt-get update && \
     git \
     wget
 
-# Install packages needed to build imgui-bundle on arm64 as no prebuilt pip wheel is provided
+# arm64-only build deps:
+# - imgui-bundle has no prebuilt arm64 wheel; needs GL/X11 dev headers.
+# - swig is required for the nlopt source build (see arm64 nlopt step below).
 RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
         apt-get update && \
         apt-get install -y --no-install-recommends \
         libgl1-mesa-dev libopengl-dev libglx-dev \
-        libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev; \
+        libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev \
+        swig; \
     fi
 
 # Detect Ubuntu version and install CUDA 12.8 via NVIDIA network repo (cuda-keyring)
@@ -144,6 +147,16 @@ RUN rm -rf ${ISAACSIM_ROOT_PATH}/kit/python/lib/python3.12/site-packages/pip* &&
     wget -q https://bootstrap.pypa.io/get-pip.py && \
     ${ISAACLAB_PATH}/_isaac_sim/kit/python/bin/python3 get-pip.py && \
     rm get-pip.py
+
+# On arm64, pre-install nlopt 2.6.2 (transitively pinned by isaacteleop[retargeters]).
+# There is no aarch64 wheel for this version, and pip's isolated build env hides the
+# system numpy from nlopt's cmake-based build, so we install it manually with
+# --no-build-isolation. The subsequent isaaclab.sh --install will see nlopt as
+# already satisfied and skip the from-source rebuild that would otherwise fail.
+RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
+    if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
+    fi
 
 # installing Isaac Lab dependencies
 # use pip caching to avoid reinstalling large packages


### PR DESCRIPTION
# Description

Post-merge CI on develop has been failing on arm64. The chain is: isaaclab_teleop pulls isaacteleop[retargeters], which transitively pins nlopt==2.6.2, and nlopt 2.6.2 has no aarch64 wheel.

Fix: add swig to apt deps and pre-install nlopt 2.6.2 with --no-build-isolation on arm64 before isaaclab.sh --install runs. The later install sees nlopt as already satisfied. Same change applied to Dockerfile.base and Dockerfile.curobo.

Verified locally in a QEMU arm64 python:3.12-slim container running the same install path.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with ./isaaclab.sh --format
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's config/extension.toml file
- [x] I have added my name to the CONTRIBUTORS.md or my name already exists there