### PR TITLE
Updates task deprecation call sites

### DIFF
--- a/source/isaaclab_contrib/changelog.d/pr-5410-task-deprecation-warning-cleanup.rst
+++ b/source/isaaclab_contrib/changelog.d/pr-5410-task-deprecation-warning-cleanup.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Updated TacSL visuotactile sensor camera configuration and examples to use
+  :class:`~isaaclab.sensors.CameraCfg` and :class:`~isaaclab.sensors.Camera`
+  instead of deprecated tiled-camera aliases.

--- a/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_sensor.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_sensor.py
@@ -66,7 +66,8 @@ class VisuoTactileSensor(SensorBase):
         The following requirements must be satisfied for proper sensor operation:
 
         **Camera Tactile Imaging**
-            If ``enable_camera_tactile=True``, a valid ``camera_cfg`` (CameraCfg) must be
+            If ``enable_camera_tactile=True``, a valid ``camera_cfg``
+            (:class:`~isaaclab.sensors.CameraCfg`) must be
             provided with appropriate camera parameters.
 
         **Force Field Computation**

--- a/source/isaaclab_tasks/changelog.d/pr-5410-task-deprecation-warning-cleanup.rst
+++ b/source/isaaclab_tasks/changelog.d/pr-5410-task-deprecation-warning-cleanup.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Updated task camera configs and environments to use
+  :class:`~isaaclab.sensors.CameraCfg` and :class:`~isaaclab.sensors.Camera`
+  instead of deprecated tiled-camera aliases.
+* Updated task state and write call sites to use explicit state properties and
+  indexed simulation write APIs.

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/inhand_manipulation_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/inhand_manipulation_env.py
@@ -85,20 +85,12 @@ class InHandManipulationEnv(DirectRLEnv):
         self.y_unit_tensor = torch.tensor([0, 1, 0], dtype=torch.float, device=self.device).repeat((self.num_envs, 1))
         self.z_unit_tensor = torch.tensor([0, 0, 1], dtype=torch.float, device=self.device).repeat((self.num_envs, 1))
 
-        # bind backend-optimal write methods (Newton prefers mask-based, PhysX prefers indexed)
-        use_mask = "newton" in self.sim.physics_manager.__name__.lower()
-        if use_mask:
-            self._set_joint_pos_target = self.hand.set_joint_position_target
-            self._write_obj_root_pose = self.object.write_root_pose_to_sim
-            self._write_obj_root_vel = self.object.write_root_velocity_to_sim
-            self._write_hand_joint_pos = self.hand.write_joint_position_to_sim
-            self._write_hand_joint_vel = self.hand.write_joint_velocity_to_sim
-        else:
-            self._set_joint_pos_target = self.hand.set_joint_position_target_index
-            self._write_obj_root_pose = self.object.write_root_pose_to_sim_index
-            self._write_obj_root_vel = self.object.write_root_velocity_to_sim_index
-            self._write_hand_joint_pos = self.hand.write_joint_position_to_sim_index
-            self._write_hand_joint_vel = self.hand.write_joint_velocity_to_sim_index
+        # bind write methods
+        self._set_joint_pos_target = self.hand.set_joint_position_target_index
+        self._write_obj_root_pose = self.object.write_root_pose_to_sim_index
+        self._write_obj_root_vel = self.object.write_root_velocity_to_sim_index
+        self._write_hand_joint_pos = self.hand.write_joint_position_to_sim_index
+        self._write_hand_joint_vel = self.hand.write_joint_velocity_to_sim_index
 
     def _setup_scene(self):
         # add hand, in-hand object, and goal object


### PR DESCRIPTION
## Summary
- Migrates task/contrib camera callers from TiledCamera aliases to Camera.
- Updates task state reads and in-hand write/target helper calls to explicit APIs.
- Bumps task/contrib changelogs and extension versions for touched packages.

## Verification
- ./isaaclab.sh -f
- Scoped deprecated-call-site search: concrete task/contrib deprecated calls removed.

Rebased onto develop after PR #5304 merged.