### PR TITLE
Fixes arm64 docker build failure

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -103,10 +103,12 @@ RUN touch /bin/nvidia-smi && \
 # On arm64, pre-install nlopt 2.6.2 (transitively pinned by isaacteleop[retargeters]).
 # There is no aarch64 wheel for this version, and pip's isolated build env hides the
 # system numpy from nlopt's cmake-based build, so we install it manually with
-# --no-build-isolation. The subsequent isaaclab.sh --install will see nlopt as
-# already satisfied and skip the from-source rebuild that would otherwise fail.
+# --no-build-isolation. setuptools+wheel+numpy must be importable in the host Python
+# for that mode (PEP 517 backend lookup). The subsequent isaaclab.sh --install then
+# sees nlopt as already satisfied and skips the from-source rebuild that would fail.
 RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
     if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel numpy && \
         ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
     fi
 

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -151,10 +151,12 @@ RUN rm -rf ${ISAACSIM_ROOT_PATH}/kit/python/lib/python3.12/site-packages/pip* &&
 # On arm64, pre-install nlopt 2.6.2 (transitively pinned by isaacteleop[retargeters]).
 # There is no aarch64 wheel for this version, and pip's isolated build env hides the
 # system numpy from nlopt's cmake-based build, so we install it manually with
-# --no-build-isolation. The subsequent isaaclab.sh --install will see nlopt as
-# already satisfied and skip the from-source rebuild that would otherwise fail.
+# --no-build-isolation. setuptools+wheel+numpy must be importable in the host Python
+# for that mode (PEP 517 backend lookup). The subsequent isaaclab.sh --install then
+# sees nlopt as already satisfied and skips the from-source rebuild that would fail.
 RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
     if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel numpy && \
         ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
     fi
 


### PR DESCRIPTION
# Description

Follow-up to #5408. After that merged, the arm64 build still fails on the nlopt step with BackendUnavailable: Cannot import 'setuptools.build_meta'. With --no-build-isolation, pip uses the host Python to resolve the PEP 517 build backend, and IsaacSim's bundled arm64 Python does not expose setuptools.build_meta in that scope.

Fix: pre-install setuptools, wheel, and numpy in IsaacSim's Python before the nlopt install step. Same change applied to Dockerfile.base and Dockerfile.curobo.

Verified locally in a QEMU arm64 python:3.12-slim container: reproduced the BackendUnavailable error after pip uninstall setuptools wheel, then confirmed the install succeeds when those packages are pre-installed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with ./isaaclab.sh --format
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's config/extension.toml file
- [x] I have added my name to the CONTRIBUTORS.md or my name already exists there