### PR TITLE
Adds more published docker image tags

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -114,6 +114,7 @@ jobs:
         case "$BRANCH_NAME" in
           develop)
             TAGS+=("$IMAGE:latest-develop")
+            TAGS+=("$IMAGE:latest-develop-${{ github.run_number }}-${SHA:0:8}")
             ;;
           main)
             TAGS+=("$IMAGE:latest")

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -130,6 +130,7 @@ jobs:
             # Sanitize the part after release/ for use as a Docker tag suffix.
             RELEASE_SUFFIX=$(echo "${BRANCH_NAME#release/}" | sed 's/[^a-zA-Z0-9._-]/-/g')
             TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX")
+            TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX-${{ github.run_number }}-${SHA:0:8}")
             ;;
           *)
             # Other tracked branches only get the immutable sha tag.

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -109,7 +109,7 @@ jobs:
         #   - Push to release/X:  $IMAGE:latest-release-X       (moves to newest build on that release branch)
         #   - Push to main:       $IMAGE:latest                 (moves to newest main build)
         #                         $IMAGE:v<VERSION>             (from the VERSION file, e.g. v3.0.0)
-        TAGS=("$IMAGE:$SHA")
+        TAGS=()
 
         case "$BRANCH_NAME" in
           develop)
@@ -133,8 +133,8 @@ jobs:
             TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX-${{ github.run_number }}-${SHA:0:8}")
             ;;
           *)
-            # Other tracked branches only get the immutable sha tag.
-            echo "Branch '$BRANCH_NAME' has no moving tag; only $IMAGE:$SHA will be published."
+            echo "Branch '$BRANCH_NAME' is not configured for publishing; skipping."
+            exit 0
             ;;
         esac
 

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -104,11 +104,12 @@ jobs:
         # Build the list of tags based on the branch.
         #
         # Tagging scheme:
-        #   - Every build:        $IMAGE:<full-sha>             (immutable, retained for re-testing)
-        #   - Push to develop:    $IMAGE:latest-develop         (moves to newest develop build)
-        #   - Push to release/X:  $IMAGE:latest-release-X       (moves to newest build on that release branch)
-        #   - Push to main:       $IMAGE:latest                 (moves to newest main build)
-        #                         $IMAGE:v<VERSION>             (from the VERSION file, e.g. v3.0.0)
+        #   - Push to develop:    $IMAGE:latest-develop                          (moves to newest develop build)
+        #                         $IMAGE:latest-develop-<run#>-<sha-stub>        (immutable per-build)
+        #   - Push to release/X:  $IMAGE:latest-release-X                        (moves to newest build on that release branch)
+        #                         $IMAGE:latest-release-X-<run#>-<sha-stub>      (immutable per-build)
+        #   - Push to main:       $IMAGE:latest                                  (moves to newest main build)
+        #                         $IMAGE:v<VERSION>                              (from the VERSION file, e.g. v3.0.0)
         TAGS=()
 
         case "$BRANCH_NAME" in


### PR DESCRIPTION
# Description

Adds per-build immutable tags to the Docker images published by [.github/workflows/publish-images.yaml](.github/workflows/publish-images.yaml), and drops the bare commit-SHA tag (now redundant).

New tags published:

- `develop` builds: `$IMAGE:latest-develop-<run#>-<sha-stub>` (in addition to the existing `$IMAGE:latest-develop`)
- `release/X` builds: `$IMAGE:latest-release-X-<run#>-<sha-stub>` (in addition to the existing `$IMAGE:latest-release-X`)

Removed: `$IMAGE:<full-sha>`. The new run-number + short-SHA tags provide the same per-build immutability with a more readable tag name.

`main` tagging (`$IMAGE:latest`, `$IMAGE:v<VERSION>`) is unchanged aside from the dropped SHA tag.

The tagging-scheme comment in the workflow was updated to match.

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there