### PR TITLE
Fix camera obs hang when xr is enabled

### DIFF
--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.27"
+version = "0.5.28"
 
 # Description
 title = "PhysX simulation interfaces for IsaacLab core package"

--- a/source/isaaclab_physx/docs/CHANGELOG.rst
+++ b/source/isaaclab_physx/docs/CHANGELOG.rst
@@ -1,6 +1,21 @@
 Changelog
 ---------
 
+0.5.28 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed camera observation hang when a visualizer (e.g. KitVisualizer for XR
+  teleop) is active and ``--enable_cameras`` is set.
+  :func:`~isaaclab_physx.renderers.isaac_rtx_renderer_utils.ensure_isaac_rtx_render_update`
+  now performs the initial ``app.update()`` on the very first call for a new
+  :class:`~isaaclab.sim.SimulationContext`, even when a visualizer reports that
+  it pumps the Kit app loop, because the visualizer has not had a chance to pump
+  yet at that point.
+
+
 0.5.27 (2026-04-27)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
@@ -127,7 +127,11 @@ def ensure_isaac_rtx_render_update() -> None:
         return  # Already pumped this step (by another camera or a visualizer)
 
     # If a visualizer already pumps the Kit app loop, mark as done and skip.
-    if any(viz.pumps_app_update() for viz in sim.visualizers):
+    # However, on the very first call for a new SimulationContext, the visualizer
+    # has not had a chance to pump yet (sim.render() was never called), so we
+    # must perform the initial app.update() ourselves to populate annotator buffers.
+    first_call_for_sim = _last_render_update_key[0] != id(sim)
+    if not first_call_for_sim and any(viz.pumps_app_update() for viz in sim.visualizers):
         _last_render_update_key = key
         return
 

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_utils.py
@@ -46,7 +46,7 @@ MOCK_ITERATIONS_BEFORE_IDLE = 3
 @pytest.fixture(autouse=True)
 def _reset_globals(monkeypatch):
     """Restore module-level state so tests are isolated."""
-    monkeypatch.setattr(rtx_utils, "_last_render_update_key", (0, -1))
+    monkeypatch.setattr(rtx_utils, "_last_render_update_key", (0, -1, -1))
 
 
 @pytest.fixture()
@@ -202,3 +202,132 @@ class TestWaitForStreamingComplete:
 
         mock_logger.info.assert_called_once()
         assert "RTX streaming completed in" in mock_logger.info.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# ensure_isaac_rtx_render_update
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureIsaacRtxRenderUpdate:
+    """Tests for :func:`ensure_isaac_rtx_render_update`.
+
+    Covers dedup logic, visualizer-skip behaviour, and the first-call-for-sim
+    guard that prevents annotator buffers from never being populated.
+    """
+
+    @pytest.fixture()
+    def mock_sim(self):
+        """A minimal mock of :class:`SimulationContext`."""
+        sim = MagicMock()
+        sim._physics_step_count = 0
+        sim._render_generation = 0
+        sim.render_generation = 0
+        sim.is_rendering = True
+        sim.visualizers = []
+        return sim
+
+    @pytest.fixture()
+    def pumping_visualizer(self):
+        """A visualizer that claims to pump ``app.update()``."""
+        viz = MagicMock()
+        viz.pumps_app_update.return_value = True
+        return viz
+
+    def test_first_call_with_visualizer_still_pumps(self, mock_sim, pumping_visualizer, mock_omni_kit_app):
+        """Regression: first call for a new sim must pump even with a visualizer.
+
+        Without the fix (commit 2e8ace7), a visualizer returning
+        ``pumps_app_update() == True`` caused the function to skip
+        ``app.update()`` on the very first call.  The visualizer had not
+        pumped yet (``sim.render()`` was never called), so annotator
+        buffers were never populated and cameras hung waiting for data.
+        """
+        mock_sim.visualizers = [pumping_visualizer]
+        mock_app = MagicMock()
+        mock_omni_kit_app.get_app.return_value = mock_app
+
+        with (
+            patch.object(
+                rtx_utils.sim_utils.SimulationContext,
+                "instance",
+                return_value=mock_sim,
+            ),
+            patch.object(rtx_utils, "_get_stage_streaming_busy", return_value=False),
+        ):
+            rtx_utils.ensure_isaac_rtx_render_update()
+
+        mock_app.update.assert_called_once()
+
+    def test_second_call_with_visualizer_skips_pump(self, mock_sim, pumping_visualizer, mock_omni_kit_app):
+        """After the first call, a visualizer that pumps causes the skip."""
+        mock_sim.visualizers = [pumping_visualizer]
+        mock_app = MagicMock()
+        mock_omni_kit_app.get_app.return_value = mock_app
+
+        with (
+            patch.object(
+                rtx_utils.sim_utils.SimulationContext,
+                "instance",
+                return_value=mock_sim,
+            ),
+            patch.object(rtx_utils, "_get_stage_streaming_busy", return_value=False),
+        ):
+            rtx_utils.ensure_isaac_rtx_render_update()
+            mock_app.update.assert_called_once()
+            mock_app.update.reset_mock()
+
+            mock_sim._physics_step_count = 1
+            rtx_utils.ensure_isaac_rtx_render_update()
+
+        mock_app.update.assert_not_called()
+
+    def test_no_sim_is_noop(self, mock_omni_kit_app):
+        """No-op when SimulationContext.instance() returns None."""
+        mock_app = MagicMock()
+        mock_omni_kit_app.get_app.return_value = mock_app
+
+        with patch.object(
+            rtx_utils.sim_utils.SimulationContext,
+            "instance",
+            return_value=None,
+        ):
+            rtx_utils.ensure_isaac_rtx_render_update()
+
+        mock_app.update.assert_not_called()
+
+    def test_dedup_same_step(self, mock_sim, mock_omni_kit_app):
+        """Second call in the same physics step is a no-op (dedup)."""
+        mock_app = MagicMock()
+        mock_omni_kit_app.get_app.return_value = mock_app
+
+        with (
+            patch.object(
+                rtx_utils.sim_utils.SimulationContext,
+                "instance",
+                return_value=mock_sim,
+            ),
+            patch.object(rtx_utils, "_get_stage_streaming_busy", return_value=False),
+        ):
+            rtx_utils.ensure_isaac_rtx_render_update()
+            mock_app.update.assert_called_once()
+            mock_app.update.reset_mock()
+
+            rtx_utils.ensure_isaac_rtx_render_update()
+
+        mock_app.update.assert_not_called()
+
+    def test_not_rendering_skips(self, mock_sim, mock_omni_kit_app):
+        """No ``app.update()`` when rendering is disabled."""
+        mock_sim.is_rendering = False
+        mock_app = MagicMock()
+        mock_omni_kit_app.get_app.return_value = mock_app
+
+        with patch.object(
+            rtx_utils.sim_utils.SimulationContext,
+            "instance",
+            return_value=mock_sim,
+        ):
+            rtx_utils.ensure_isaac_rtx_render_update()
+
+        mock_app.update.assert_not_called()


### PR DESCRIPTION
# Description

- Fix hang during `ObservationManager._prepare_terms()` when RTX cameras
  and XR are both active (e.g. `--enable_cameras --xr`). The
  `ensure_isaac_rtx_render_update()` helper was skipping the initial
  `app.update()` pump because a KitVisualizer was registered, but the
  visualizer had never been stepped yet — leaving annotator buffers
  uninitialized and causing the subsequent Warp kernel to block
  indefinitely.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there