### PR TITLE
[Newton] Add Shadow-Hand-Over MAPPO Newton backend (depends on #5433)

### DIFF
--- a/source/isaaclab_newton/changelog.d/jichuanh-newton-replicate-tendon-fix.rst
+++ b/source/isaaclab_newton/changelog.d/jichuanh-newton-replicate-tendon-fix.rst
@@ -1,0 +1,14 @@
+Fixed
+^^^^^
+
+* Fixed per-environment string identifiers (e.g. ``mujoco:tendon_label``)
+  keeping the source proto path after replication.
+  :func:`~isaaclab_newton.cloner.newton_replicate._rename_builder_labels`
+  now also walks string-typed custom-attribute columns whose frequency
+  declares a ``references="world"`` companion, rewriting their per-row
+  source-path prefix to the destination world root in the same pass that
+  handles built-in label arrays. Adds ``constraint_mimic`` and
+  ``equality_constraint`` to that built-in pass for completeness. The
+  prefix match uses a path-separator boundary so a source path that is a
+  string prefix of another (e.g. ``/Sources/protoA`` vs
+  ``/Sources/protoAB``) does not cross-contaminate during the rename.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
@@ -127,6 +127,15 @@ def _rename_builder_labels(
 ) -> None:
     """Rename builder labels/keys from source roots to destination roots.
 
+    Walks both built-in label arrays (``body``, ``joint``, ``shape``,
+    ``articulation``, ``constraint_mimic``, ``equality_constraint``) and any
+    string-typed custom-attribute column whose frequency declares a sibling
+    world column (``references="world"``).
+    The ``startswith(src_prefix)`` guard makes the rewrite a no-op for strings that
+    are not paths under the source, so non-path custom string columns are passed
+    through untouched and any future solver-registered string column is handled
+    automatically without changes here.
+
     Args:
         builder: Newton model builder to update in-place.
         sources: Source prim root paths.
@@ -136,21 +145,50 @@ def _rename_builder_labels(
     """
     # per-source, per-world renaming (strict prefix swap), compact style preserved
     for i, src_path in enumerate(sources):
-        src_prefix_len = len(src_path.rstrip("/"))
+        # Boundary-terminated prefix prevents over-matching when one source path is a
+        # prefix of another (e.g. ``/Sources/protoA`` vs ``/Sources/protoAB``).
+        src_prefix = src_path.rstrip("/") + "/"
+        src_prefix_len = len(src_prefix) - 1  # slice index keeps the leading "/" in the suffix
         swap = lambda name, new_root: new_root + name[src_prefix_len:]  # noqa: E731
         world_cols = torch.nonzero(mapping[i], as_tuple=True)[0].tolist()
         # Map Newton world IDs (sequential) to destination paths using env_ids
         world_roots = {int(env_ids[c]): destinations[i].format(int(env_ids[c])) for c in world_cols}
 
-        for t in ("body", "joint", "shape", "articulation"):
-            labels = getattr(builder, f"{t}_label", None)
-            if labels is None:
-                labels = getattr(builder, f"{t}_key")
-            worlds_arr = getattr(builder, f"{t}_world")
-            for k, w in enumerate(worlds_arr):
-                world_id = int(w)
-                if world_id in world_roots and labels[k].startswith(src_path):
-                    labels[k] = swap(labels[k], world_roots[world_id])
+        def _rename_pair(values, worlds):
+            if len(values) != len(worlds):
+                raise ValueError(f"label/world column length mismatch: {len(values)} vs {len(worlds)}")
+            for k in range(len(values)):
+                world_id = int(worlds[k])
+                if world_id in world_roots and isinstance(values[k], str) and values[k].startswith(src_prefix):
+                    values[k] = swap(values[k], world_roots[world_id])
+
+        # Pass 1: built-in label arrays. Each has a paired ``*_world`` int column.
+        for t in ("body", "joint", "shape", "articulation", "constraint_mimic", "equality_constraint"):
+            labels = getattr(builder, f"{t}_label", None) or getattr(builder, f"{t}_key", None)
+            worlds_arr = getattr(builder, f"{t}_world", None)
+            if labels is None or worlds_arr is None:
+                continue
+            _rename_pair(labels, worlds_arr)
+
+        # Pass 2: string-typed custom-attribute columns (e.g. ``mujoco:tendon_label``)
+        # paired with a world companion declared via ``references="world"``. Index
+        # world companions by frequency for O(1) lookup, then walk the str columns.
+        custom = builder.custom_attributes
+        world_by_freq: dict[str, ModelBuilder.CustomAttribute] = {}
+        for attr in custom.values():
+            if getattr(attr, "references", None) == "world":
+                world_by_freq[attr.frequency] = attr
+        for attr in custom.values():
+            if attr.dtype is not str:
+                continue
+            world_attr = world_by_freq.get(attr.frequency)
+            if world_attr is None:
+                continue
+            values = attr.values
+            worlds = world_attr.values
+            if not values or not worlds:
+                continue
+            _rename_pair(values, worlds)
 
 
 def newton_physics_replicate(

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
@@ -163,8 +163,13 @@ def _rename_builder_labels(
                     values[k] = swap(values[k], world_roots[world_id])
 
         # Pass 1: built-in label arrays. Each has a paired ``*_world`` int column.
+        # Use ``is None`` (not ``or``) so an empty-but-defined ``*_label`` column
+        # is recognized — falling through to ``*_key`` would over-match a
+        # builder that legitimately exposes both attributes.
         for t in ("body", "joint", "shape", "articulation", "constraint_mimic", "equality_constraint"):
-            labels = getattr(builder, f"{t}_label", None) or getattr(builder, f"{t}_key", None)
+            labels = getattr(builder, f"{t}_label", None)
+            if labels is None:
+                labels = getattr(builder, f"{t}_key", None)
             worlds_arr = getattr(builder, f"{t}_world", None)
             if labels is None or worlds_arr is None:
                 continue

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -8,7 +8,7 @@
 Covers both passes of the rewrite:
 
   * Pass 1 — built-in label arrays (``body``, ``joint``, ``shape``,
-    ``articulation``, ``constraint_mimic``).
+    ``articulation``, ``constraint_mimic``, ``equality_constraint``).
   * Pass 2 — any string-typed custom-attribute column whose frequency declares a
     sibling ``references="world"`` companion (e.g. ``mujoco:tendon_label``).
 
@@ -60,7 +60,9 @@ def _make_builder_with_entries(worlds: list[int]) -> newton.ModelBuilder:
     """Builder pre-populated with one row per world for every label class under test."""
     b = newton.ModelBuilder()
     SolverMuJoCo.register_custom_attributes(b)
-    _inject_builtins(b, ("body", "joint", "shape", "articulation", "constraint_mimic"), _SRC, worlds)
+    _inject_builtins(
+        b, ("body", "joint", "shape", "articulation", "constraint_mimic", "equality_constraint"), _SRC, worlds
+    )
     _inject_tendon_strings(b, _SRC, worlds)
     return b
 
@@ -84,7 +86,7 @@ class TestRenameBuilderLabels(unittest.TestCase):
     def test_builtin_labels_rewritten_per_world(self):
         b = _make_builder_with_entries(self.worlds)
         self._rename(b)
-        for t in ("body", "joint", "shape", "articulation", "constraint_mimic"):
+        for t in ("body", "joint", "shape", "articulation", "constraint_mimic", "equality_constraint"):
             labels = getattr(b, f"{t}_label")
             worlds_arr = getattr(b, f"{t}_world")
             for k, w in enumerate(worlds_arr):
@@ -111,7 +113,7 @@ class TestRenameBuilderLabels(unittest.TestCase):
         b = _make_builder_with_entries(self.worlds)
         self._rename(b)
         per_world = {int(w): _DST.format(int(w)) + "/" for w in self.env_ids.tolist()}
-        for t in ("body", "joint", "shape", "articulation", "constraint_mimic"):
+        for t in ("body", "joint", "shape", "articulation", "constraint_mimic", "equality_constraint"):
             for label, w in zip(getattr(b, f"{t}_label"), getattr(b, f"{t}_world")):
                 self.assertTrue(label.startswith(per_world[int(w)]), msg=f"{t}: {label!r}")
         tendon_labels = b.custom_attributes["mujoco:tendon_label"].values

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for ``_rename_builder_labels``.
+
+Covers both passes of the rewrite:
+
+  * Pass 1 — built-in label arrays (``body``, ``joint``, ``shape``,
+    ``articulation``, ``constraint_mimic``).
+  * Pass 2 — any string-typed custom-attribute column whose frequency declares a
+    sibling ``references="world"`` companion (e.g. ``mujoco:tendon_label``).
+
+The contract under test: every label whose row maps to a world in ``env_ids``
+and whose value starts with the source root is rewritten to the destination
+template's per-env path; everything else is left alone.
+"""
+
+import unittest
+
+import newton
+import torch
+from isaaclab_newton.cloner.newton_replicate import _rename_builder_labels
+from newton.solvers import SolverMuJoCo
+
+_TENDON_FREQ = "mujoco:tendon"
+_SRC = "/Sources/protoA"
+_DST = "/World/envs/env_{}"
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _inject_builtins(builder: newton.ModelBuilder, types: tuple[str, ...], src_path: str, worlds: list[int]) -> None:
+    """Append ``len(worlds)`` synthetic entries to each built-in ``*_label``/``*_world`` pair."""
+    for t in types:
+        labels = getattr(builder, f"{t}_label")
+        worlds_arr = getattr(builder, f"{t}_world")
+        for w in worlds:
+            labels.append(f"{src_path}/{t}_{w}")
+            worlds_arr.append(w)
+
+
+def _inject_tendon_strings(builder: newton.ModelBuilder, src_path: str, worlds: list[int]) -> None:
+    """Append synthetic ``mujoco:tendon_label`` + ``mujoco:tendon_world`` rows."""
+    label_attr = builder.custom_attributes["mujoco:tendon_label"]
+    world_attr = builder.custom_attributes["mujoco:tendon_world"]
+    if label_attr.values is None:
+        label_attr.values = []
+    if world_attr.values is None:
+        world_attr.values = []
+    for w in worlds:
+        label_attr.values.append(f"{src_path}/Tendon_{w}")
+        world_attr.values.append(w)
+    builder._custom_frequency_counts[_TENDON_FREQ] = builder._custom_frequency_counts.get(_TENDON_FREQ, 0) + len(worlds)
+
+
+def _make_builder_with_entries(worlds: list[int]) -> newton.ModelBuilder:
+    """Builder pre-populated with one row per world for every label class under test."""
+    b = newton.ModelBuilder()
+    SolverMuJoCo.register_custom_attributes(b)
+    _inject_builtins(b, ("body", "joint", "shape", "articulation", "constraint_mimic"), _SRC, worlds)
+    _inject_tendon_strings(b, _SRC, worlds)
+    return b
+
+
+# ─── tests ───────────────────────────────────────────────────────────────────
+
+
+class TestRenameBuilderLabels(unittest.TestCase):
+    """Both passes rewrite to the same per-env destination pattern."""
+
+    def setUp(self):
+        self.worlds = [0, 1, 2]
+        self.env_ids = torch.tensor(self.worlds, dtype=torch.int32)
+        self.mapping = torch.ones(1, len(self.worlds), dtype=torch.bool)
+
+    def _rename(self, builder):
+        _rename_builder_labels(builder, [_SRC], [_DST], self.env_ids, self.mapping)
+
+    # Pass 1 ---------------------------------------------------------------
+
+    def test_builtin_labels_rewritten_per_world(self):
+        b = _make_builder_with_entries(self.worlds)
+        self._rename(b)
+        for t in ("body", "joint", "shape", "articulation", "constraint_mimic"):
+            labels = getattr(b, f"{t}_label")
+            worlds_arr = getattr(b, f"{t}_world")
+            for k, w in enumerate(worlds_arr):
+                self.assertEqual(
+                    labels[k],
+                    f"{_DST.format(int(w))}/{t}_{int(w)}",
+                    msg=f"{t}_label[{k}] not rewritten correctly",
+                )
+
+    # Pass 2 ---------------------------------------------------------------
+
+    def test_tendon_label_string_custom_attr_rewritten(self):
+        b = _make_builder_with_entries(self.worlds)
+        self._rename(b)
+        labels = b.custom_attributes["mujoco:tendon_label"].values
+        worlds_arr = b.custom_attributes["mujoco:tendon_world"].values
+        for k, w in enumerate(worlds_arr):
+            self.assertEqual(labels[k], f"{_DST.format(int(w))}/Tendon_{int(w)}")
+
+    # Cross-pass consistency ----------------------------------------------
+
+    def test_all_renamed_labels_share_the_per_env_root(self):
+        """Every label written by either pass must live under ``/World/envs/env_<world>/``."""
+        b = _make_builder_with_entries(self.worlds)
+        self._rename(b)
+        per_world = {int(w): _DST.format(int(w)) + "/" for w in self.env_ids.tolist()}
+        for t in ("body", "joint", "shape", "articulation", "constraint_mimic"):
+            for label, w in zip(getattr(b, f"{t}_label"), getattr(b, f"{t}_world")):
+                self.assertTrue(label.startswith(per_world[int(w)]), msg=f"{t}: {label!r}")
+        tendon_labels = b.custom_attributes["mujoco:tendon_label"].values
+        tendon_worlds = b.custom_attributes["mujoco:tendon_world"].values
+        for label, w in zip(tendon_labels, tendon_worlds):
+            self.assertTrue(label.startswith(per_world[int(w)]), msg=f"tendon: {label!r}")
+
+    # Guards ---------------------------------------------------------------
+
+    def test_non_path_string_left_untouched(self):
+        """Strings that don't start with ``src_path`` must pass through unchanged."""
+        b = _make_builder_with_entries(self.worlds)
+        # Inject one tendon row whose label is an opaque identifier, not a path.
+        b.custom_attributes["mujoco:tendon_label"].values.append("named_tendon")
+        b.custom_attributes["mujoco:tendon_world"].values.append(self.worlds[0])
+        self._rename(b)
+        self.assertEqual(b.custom_attributes["mujoco:tendon_label"].values[-1], "named_tendon")
+
+    def test_world_outside_env_ids_left_untouched(self):
+        """A row whose world is not in ``env_ids`` must keep its original label."""
+        b = _make_builder_with_entries(self.worlds)
+        # Inject one extra row tagged with a world id not present in env_ids.
+        b.body_label.append(f"{_SRC}/body_99")
+        b.body_world.append(99)
+        self._rename(b)
+        self.assertEqual(b.body_label[-1], f"{_SRC}/body_99")
+
+    def test_sparse_env_ids(self):
+        """Non-contiguous ``env_ids`` (e.g. [10, 20, 30]) must rewrite using the right per-env root."""
+        worlds = [10, 20, 30]
+        b = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(b)
+        _inject_builtins(b, ("body",), _SRC, worlds)
+        env_ids = torch.tensor(worlds, dtype=torch.int32)
+        mapping = torch.ones(1, len(worlds), dtype=torch.bool)
+        _rename_builder_labels(b, [_SRC], [_DST], env_ids, mapping)
+        for k, w in enumerate(b.body_world):
+            self.assertEqual(b.body_label[k], f"/World/envs/env_{int(w)}/body_{int(w)}")
+
+
+class TestRenamePass2Generality(unittest.TestCase):
+    """Pass 2 must generalize across coexisting frequencies and multiple string columns."""
+
+    def setUp(self):
+        self.worlds = [0, 1]
+        self.env_ids = torch.tensor(self.worlds, dtype=torch.int32)
+        self.mapping = torch.ones(1, len(self.worlds), dtype=torch.bool)
+
+    def _register_synthetic_freq(self, builder, freq_name, world_attr_name, str_attr_names):
+        """Register a ``syn:<freq_name>`` frequency with one world int column and N string columns."""
+        freq = f"syn:{freq_name}"
+        builder.add_custom_frequency(newton.ModelBuilder.CustomFrequency(name=freq_name, namespace="syn"))
+        builder.add_custom_attribute(
+            newton.ModelBuilder.CustomAttribute(
+                name=world_attr_name,
+                frequency=freq,
+                dtype=int,
+                default=0,
+                namespace="syn",
+                references="world",
+            )
+        )
+        for n in str_attr_names:
+            builder.add_custom_attribute(
+                newton.ModelBuilder.CustomAttribute(
+                    name=n,
+                    frequency=freq,
+                    dtype=str,
+                    default="",
+                    namespace="syn",
+                )
+            )
+
+    def _populate(self, builder, freq, world_attr_name, str_attr_names, worlds):
+        wa = builder.custom_attributes[f"syn:{world_attr_name}"]
+        if wa.values is None:
+            wa.values = []
+        for w in worlds:
+            wa.values.append(w)
+        for n in str_attr_names:
+            sa = builder.custom_attributes[f"syn:{n}"]
+            if sa.values is None:
+                sa.values = []
+            for w in worlds:
+                sa.values.append(f"{_SRC}/{n}_{w}")
+        builder._custom_frequency_counts[freq] = builder._custom_frequency_counts.get(freq, 0) + len(worlds)
+
+    def test_two_coexisting_custom_frequencies(self):
+        """Each registered ``references='world'`` companion must drive its own frequency's str columns."""
+        b = newton.ModelBuilder()
+        self._register_synthetic_freq(b, "freqA", "freqA_world", ["freqA_label"])
+        self._register_synthetic_freq(b, "freqB", "freqB_world", ["freqB_label"])
+        self._populate(b, "syn:freqA", "freqA_world", ["freqA_label"], self.worlds)
+        self._populate(b, "syn:freqB", "freqB_world", ["freqB_label"], self.worlds)
+        _rename_builder_labels(b, [_SRC], [_DST], self.env_ids, self.mapping)
+        for n in ("freqA_label", "freqB_label"):
+            wa = b.custom_attributes[f"syn:{n.split('_')[0]}_world"].values
+            sa = b.custom_attributes[f"syn:{n}"].values
+            for k, w in enumerate(wa):
+                self.assertEqual(sa[k], f"/World/envs/env_{int(w)}/{n}_{int(w)}")
+
+    def test_multiple_string_columns_at_one_frequency(self):
+        """Two str columns sharing one frequency must both be rewritten using the shared world companion."""
+        b = newton.ModelBuilder()
+        self._register_synthetic_freq(b, "freqA", "freqA_world", ["freqA_label", "freqA_alt"])
+        self._populate(b, "syn:freqA", "freqA_world", ["freqA_label", "freqA_alt"], self.worlds)
+        _rename_builder_labels(b, [_SRC], [_DST], self.env_ids, self.mapping)
+        wa = b.custom_attributes["syn:freqA_world"].values
+        for n in ("freqA_label", "freqA_alt"):
+            sa = b.custom_attributes[f"syn:{n}"].values
+            for k, w in enumerate(wa):
+                self.assertEqual(sa[k], f"/World/envs/env_{int(w)}/{n}_{int(w)}")
+
+    def test_empty_values_pass_through(self):
+        """A registered-but-empty string column must not crash the rename pass."""
+        b = newton.ModelBuilder()
+        self._register_synthetic_freq(b, "freqA", "freqA_world", ["freqA_label"])
+        # values stay None (registered, never populated)
+        _rename_builder_labels(b, [_SRC], [_DST], self.env_ids, self.mapping)
+        # Fully populate after the no-op rename: ensures the early-return guard didn't corrupt state.
+        self._populate(b, "syn:freqA", "freqA_world", ["freqA_label"], self.worlds)
+        self.assertEqual(len(b.custom_attributes["syn:freqA_label"].values), len(self.worlds))
+
+
+class TestRenameMultiSource(unittest.TestCase):
+    """Multi-source handling must not cross-contaminate when source paths share a string prefix."""
+
+    def test_prefix_overlap_does_not_cross_contaminate(self):
+        """Sources whose paths share a string prefix and that both feed the same envs must not cross-rename.
+
+        Common IL pattern: a robot proto and an object proto both feed every env. If the two source
+        paths share a string prefix (``/Sources/protoA`` and ``/Sources/protoAB``), iter 0
+        (``src=protoA``) sees the protoAB rows for the same world ids it owns and would over-match
+        them under a non-boundary ``startswith``. The world-id guard alone does not catch this case
+        because both sources contribute to the same set of worlds.
+        """
+        sources = ["/Sources/protoA", "/Sources/protoAB"]
+        # 2 envs, both fed by both sources.
+        env_ids = torch.tensor([0, 1], dtype=torch.int32)
+        mapping = torch.tensor([[1, 1], [1, 1]], dtype=torch.bool)
+        b = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(b)
+        # One body row from each source per env: 4 rows total, world ids interleaved.
+        b.body_label.extend(
+            [
+                f"{sources[0]}/body",  # row 0: protoA, world 0
+                f"{sources[1]}/body",  # row 1: protoAB, world 0
+                f"{sources[0]}/body",  # row 2: protoA, world 1
+                f"{sources[1]}/body",  # row 3: protoAB, world 1
+            ]
+        )
+        b.body_world.extend([0, 0, 1, 1])
+        _rename_builder_labels(b, sources, ["/World/envs/env_{}", "/World/envs/env_{}"], env_ids, mapping)
+        # Each row must end up under its own per-env root with the suffix preserved verbatim.
+        # Without the "/" boundary on ``startswith``, iter 0 (src=protoA) would match rows 1 and 3
+        # because ``/Sources/protoAB/body``.startswith(``/Sources/protoA``) is True, rewriting them
+        # to ``/World/envs/env_<w>/B/body`` (wrong suffix).
+        self.assertEqual(b.body_label[0], "/World/envs/env_0/body")
+        self.assertEqual(b.body_label[1], "/World/envs/env_0/body")
+        self.assertEqual(b.body_label[2], "/World/envs/env_1/body")
+        self.assertEqual(b.body_label[3], "/World/envs/env_1/body")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/isaaclab_tasks/changelog.d/jichuanh-shadow-hand-newton-parity.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-shadow-hand-newton-parity.minor.rst
@@ -4,40 +4,13 @@ Added
 * Added Newton backend support for the multi-agent
   ``Isaac-Shadow-Hand-Over-Direct-v0`` (MAPPO/IPPO) env. Mirrors the
   single-agent Shadow Hand Newton port: per-hand
-  :class:`ImplicitActuatorCfg`, ``shadow_hand_instanceable_newton.usd``,
-  per-backend :class:`~isaaclab_tasks.utils.PresetCfg` wrappers for sim
-  physics, scene cloning (``clone_in_fabric=False`` on Newton), the
+  :class:`~isaaclab.actuators.ImplicitActuatorCfg`,
+  ``shadow_hand_instanceable_newton.usd``, per-backend
+  :class:`~isaaclab_tasks.utils.PresetCfg` wrappers for sim physics, the
   hand-over object (``RigidObjectCfg`` on both backends, dropping
   PhysX-only knobs on Newton), and the two robot configs. Selectable via
   ``--preset newton`` / Hydra preset resolution; PhysX behavior unchanged.
-
-Fixed
-^^^^^
-
-* Fixed Newton training failing to learn the catch in
-  ``Isaac-Shadow-Hand-Over-Direct-v0`` MAPPO. Two Newton-side
-  :class:`~isaaclab.actuators.ImplicitActuatorCfg` overrides are added:
-
-  * ``fingers`` (wrist + per-finger joints): ``stiffness=20.0`` /
-    ``damping=2.0``, vs PhysX's ``5.0`` / ``0.5`` on wrists and
-    ``1.0`` / ``0.1`` on fingers. PhysX layers
-    ``fixed_tendons_props(limit_stiffness=30, damping=0.1)`` on top of
-    the implicit drive and runs ``solver_position_iteration_count=8``
-    per substep — both amplify the effective torque per unit nominal
-    gain. Newton's MJWarp implicit-PD path has neither, so larger
-    nominal gains are needed for comparable joint authority.
-  * ``distal_passive`` (the four ``robot0_(FF|MF|RF|LF)J0`` joints):
-    ``stiffness=10.0`` / ``damping=0.1``. The Newton USD bakes
-    ``stiffness=286`` / ``damping=57`` on these joints from the
-    MJCF→USD translation, which fights the ``MjcTendon`` coupling and
-    bounces the ball. ``stiffness=10`` (~1/3 of PhysX
-    ``limit_stiffness=30``) keeps the joints near-passive while the
-    tendon constraint dominates. PhysX uses tendon coupling on these
-    joints directly and does not need an analogous override.
-
-  At iter 200 / 2048 envs, MAPPO ``Reward / Total reward (mean)``:
-  PhysX baseline **246.7**, Newton at ``stiffness=1.0`` / ``damping=0.1``
-  (no catch learned) **23.4**, Newton at the new gains **777.1**.
-  Newton learns the catch reliably; longer runs and behavior-level
-  comparison (catch / drop rate, ball trajectory) are follow-ups.
-  PhysX path is unchanged.
+  Migration details (Newton-side actuator gain overrides for ``fingers``
+  and ``distal_passive``, and the ``ccd_iterations`` bump for multi-finger
+  contacts) live in
+  ``source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env_cfg.py``.

--- a/source/isaaclab_tasks/changelog.d/jichuanh-shadow-hand-newton-parity.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-shadow-hand-newton-parity.minor.rst
@@ -1,0 +1,43 @@
+Added
+^^^^^
+
+* Added Newton backend support for the multi-agent
+  ``Isaac-Shadow-Hand-Over-Direct-v0`` (MAPPO/IPPO) env. Mirrors the
+  single-agent Shadow Hand Newton port: per-hand
+  :class:`ImplicitActuatorCfg`, ``shadow_hand_instanceable_newton.usd``,
+  per-backend :class:`~isaaclab_tasks.utils.PresetCfg` wrappers for sim
+  physics, scene cloning (``clone_in_fabric=False`` on Newton), the
+  hand-over object (``RigidObjectCfg`` on both backends, dropping
+  PhysX-only knobs on Newton), and the two robot configs. Selectable via
+  ``--preset newton`` / Hydra preset resolution; PhysX behavior unchanged.
+
+Fixed
+^^^^^
+
+* Fixed Newton training failing to learn the catch in
+  ``Isaac-Shadow-Hand-Over-Direct-v0`` MAPPO. Two Newton-side
+  :class:`~isaaclab.actuators.ImplicitActuatorCfg` overrides are added:
+
+  * ``fingers`` (wrist + per-finger joints): ``stiffness=20.0`` /
+    ``damping=2.0``, vs PhysX's ``5.0`` / ``0.5`` on wrists and
+    ``1.0`` / ``0.1`` on fingers. PhysX layers
+    ``fixed_tendons_props(limit_stiffness=30, damping=0.1)`` on top of
+    the implicit drive and runs ``solver_position_iteration_count=8``
+    per substep — both amplify the effective torque per unit nominal
+    gain. Newton's MJWarp implicit-PD path has neither, so larger
+    nominal gains are needed for comparable joint authority.
+  * ``distal_passive`` (the four ``robot0_(FF|MF|RF|LF)J0`` joints):
+    ``stiffness=10.0`` / ``damping=0.1``. The Newton USD bakes
+    ``stiffness=286`` / ``damping=57`` on these joints from the
+    MJCF→USD translation, which fights the ``MjcTendon`` coupling and
+    bounces the ball. ``stiffness=10`` (~1/3 of PhysX
+    ``limit_stiffness=30``) keeps the joints near-passive while the
+    tendon constraint dominates. PhysX uses tendon coupling on these
+    joints directly and does not need an analogous override.
+
+  At iter 200 / 2048 envs, MAPPO ``Reward / Total reward (mean)``:
+  PhysX baseline **246.7**, Newton at ``stiffness=1.0`` / ``damping=0.1``
+  (no catch learned) **23.4**, Newton at the new gains **777.1**.
+  Newton learns the catch reliably; longer runs and behavior-level
+  comparison (catch / drop rate, ball trajectory) are follow-ups.
+  PhysX path is unchanged.

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env.py
@@ -64,7 +64,7 @@ class ShadowHandOverEnv(DirectMARLEnv):
         self.num_fingertips = len(self.finger_bodies)
 
         # joint limits
-        joint_pos_limits = wp.to_torch(self.right_hand.root_view.get_dof_limits()).to(self.device)
+        joint_pos_limits = wp.to_torch(self.right_hand.data.joint_limits).to(self.device)
         self.hand_dof_lower_limits = joint_pos_limits[..., 0]
         self.hand_dof_upper_limits = joint_pos_limits[..., 1]
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env.py
@@ -10,7 +10,6 @@ from collections.abc import Sequence
 
 import numpy as np
 import torch
-import warp as wp
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import Articulation, RigidObject
@@ -64,7 +63,7 @@ class ShadowHandOverEnv(DirectMARLEnv):
         self.num_fingertips = len(self.finger_bodies)
 
         # joint limits
-        joint_pos_limits = wp.to_torch(self.right_hand.data.joint_limits).to(self.device)
+        joint_pos_limits = self.right_hand.data.joint_limits.torch.to(self.device)
         self.hand_dof_lower_limits = joint_pos_limits[..., 0]
         self.hand_dof_upper_limits = joint_pos_limits[..., 1]
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env_cfg.py
@@ -20,7 +20,7 @@ from isaaclab.sim.spawners.materials.physics_materials_cfg import RigidBodyMater
 from isaaclab.utils import configclass
 
 from isaaclab_tasks.direct.shadow_hand.shadow_hand_env_cfg import ShadowHandRobotCfg
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from isaaclab_assets.robots.shadow_hand import SHADOW_HAND_CFG
 
@@ -131,12 +131,19 @@ class EventCfg:
 _SHADOW_HAND_NEWTON_CFG = ShadowHandRobotCfg().newton_mjwarp
 
 
-def _newton_shadow_hand_cfg(
-    prim_path: str, init_pos: tuple[float, float, float], init_rot: tuple[float, float, float, float]
-) -> ArticulationCfg:
-    """Newton Shadow Hand cfg parameterized by per-robot ``prim_path`` and init pose.
+def _shadow_hand_cfg(
+    prim_path: str,
+    init_pos: tuple[float, float, float],
+    init_rot: tuple[float, float, float, float],
+) -> PresetCfg:
+    """Per-hand Shadow Hand preset (PhysX and Newton MJWarp variants).
 
-    Two overrides versus the single-agent Newton port:
+    Both variants are placed at *prim_path* with the same init pose; per-hand
+    differences (right vs left) come from the caller's *prim_path* / *init_pos* /
+    *init_rot* — the gain tuning is identical on both hands.
+
+    The Newton variant layers two :class:`~isaaclab.actuators.ImplicitActuatorCfg`
+    overrides on top of the single-agent Newton port:
 
     * ``fingers`` actuator: ``stiffness=20.0`` / ``damping=2.0`` (vs PhysX's
       ``5.0`` / ``0.5`` on wrists and ``1.0`` / ``0.1`` on fingers). PhysX layers
@@ -147,14 +154,17 @@ def _newton_shadow_hand_cfg(
       authority. ``20.0`` / ``2.0`` is the smallest tested setting at which
       MAPPO learns the catch (mean reward at iter 200 / 2048 envs goes from
       ~27 at PhysX-mirrored gains to ~777).
-    * ``distal_passive`` actuator on the four ``robot0_(FF|MF|RF|LF)J0`` joints
-      with ``stiffness=10.0`` / ``damping=0.1``. The Newton USD bakes
+    * ``distal_passive`` on the four ``robot0_(FF|MF|RF|LF)J0`` joints with
+      ``stiffness=10.0`` / ``damping=0.1``. The Newton USD bakes
       ``stiffness=286 / damping=57`` on these joints from the MJCF→USD
       translation, which fights the ``MjcTendon`` coupling and bounces the
-      ball. ``stiffness=10`` (1/3 of PhysX ``limit_stiffness=30``) keeps the
-      joints near-passive while the tendon constraint dominates.
+      ball. ``stiffness=10`` (~1/3 of PhysX's ``limit_stiffness=30``) keeps
+      the joints near-passive while the tendon constraint dominates.
     """
-    return _SHADOW_HAND_NEWTON_CFG.replace(
+    physx_cfg = SHADOW_HAND_CFG.replace(prim_path=prim_path).replace(
+        init_state=ArticulationCfg.InitialStateCfg(pos=init_pos, rot=init_rot, joint_pos={".*": 0.0})
+    )
+    newton_cfg = _SHADOW_HAND_NEWTON_CFG.replace(
         prim_path=prim_path,
         init_state=_SHADOW_HAND_NEWTON_CFG.init_state.replace(pos=init_pos, rot=init_rot),
         actuators={
@@ -168,40 +178,7 @@ def _newton_shadow_hand_cfg(
             ),
         },
     )
-
-
-@configclass
-class RightRobotCfg(PresetCfg):
-    physx = SHADOW_HAND_CFG.replace(prim_path="/World/envs/env_.*/RightRobot").replace(
-        init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.0, 0.0, 0.5),
-            rot=(0.0, 0.0, 0.0, 1.0),
-            joint_pos={".*": 0.0},
-        )
-    )
-    newton_mjwarp = _newton_shadow_hand_cfg(
-        prim_path="/World/envs/env_.*/RightRobot",
-        init_pos=(0.0, 0.0, 0.5),
-        init_rot=(0.0, 0.0, 0.0, 1.0),
-    )
-    default = physx
-
-
-@configclass
-class LeftRobotCfg(PresetCfg):
-    physx = SHADOW_HAND_CFG.replace(prim_path="/World/envs/env_.*/LeftRobot").replace(
-        init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.0, -1.0, 0.5),
-            rot=(0.0, 0.0, 1.0, 0.0),
-            joint_pos={".*": 0.0},
-        )
-    )
-    newton_mjwarp = _newton_shadow_hand_cfg(
-        prim_path="/World/envs/env_.*/LeftRobot",
-        init_pos=(0.0, -1.0, 0.5),
-        init_rot=(0.0, 0.0, 1.0, 0.0),
-    )
-    default = physx
+    return preset(default=physx_cfg, physx=physx_cfg, newton_mjwarp=newton_cfg)
 
 
 @configclass
@@ -256,23 +233,6 @@ class ObjectCfg(PresetCfg):
 
 
 @configclass
-class ShadowHandOverSceneCfg(PresetCfg):
-    """Scene preset.
-
-    PhysX supports ``clone_in_fabric=True`` for faster cloning. Newton's
-    cloning path does not, so the Newton variant disables Fabric cloning.
-    """
-
-    physx: InteractiveSceneCfg = InteractiveSceneCfg(
-        num_envs=2048, env_spacing=1.5, replicate_physics=True, clone_in_fabric=True
-    )
-    newton_mjwarp: InteractiveSceneCfg = InteractiveSceneCfg(
-        num_envs=2048, env_spacing=1.5, replicate_physics=True, clone_in_fabric=False
-    )
-    default: InteractiveSceneCfg = physx
-
-
-@configclass
 class PhysicsCfg(PresetCfg):
     """Physics-backend preset (PhysX vs Newton/MJWarp).
 
@@ -296,7 +256,7 @@ class PhysicsCfg(PresetCfg):
             impratio=10.0,
             cone="elliptic",
             update_data_interval=2,
-            iterations=100,
+            ccd_iterations=50,  # bumped from default 35 for multi-finger contact geometry
         ),
         num_substeps=2,
         debug_mode=False,
@@ -325,8 +285,16 @@ class ShadowHandOverEnvCfg(DirectMARLEnvCfg):
         physics=PhysicsCfg(),
     )
     # robot
-    right_robot_cfg: RightRobotCfg = RightRobotCfg()
-    left_robot_cfg: LeftRobotCfg = LeftRobotCfg()
+    right_robot_cfg: PresetCfg = _shadow_hand_cfg(
+        prim_path="/World/envs/env_.*/RightRobot",
+        init_pos=(0.0, 0.0, 0.5),
+        init_rot=(0.0, 0.0, 0.0, 1.0),
+    )
+    left_robot_cfg: PresetCfg = _shadow_hand_cfg(
+        prim_path="/World/envs/env_.*/LeftRobot",
+        init_pos=(0.0, -1.0, 0.5),
+        init_rot=(0.0, 0.0, 1.0, 0.0),
+    )
     actuated_joint_names = [
         "robot0_WRJ1",
         "robot0_WRJ0",
@@ -369,8 +337,8 @@ class ShadowHandOverEnvCfg(DirectMARLEnvCfg):
             ),
         },
     )
-    # scene - use ShadowHandOverSceneCfg so that --preset newton disables clone_in_fabric automatically
-    scene: ShadowHandOverSceneCfg = ShadowHandOverSceneCfg()
+    # scene
+    scene: InteractiveSceneCfg = InteractiveSceneCfg(num_envs=2048, env_spacing=1.5, replicate_physics=True)
 
     # reset
     reset_position_noise = 0.01  # range of position at reset

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/shadow_hand_over_env_cfg.py
@@ -3,10 +3,12 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
 import isaaclab.sim as sim_utils
+from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.envs import DirectMARLEnvCfg
 from isaaclab.managers import EventTermCfg as EventTerm
@@ -17,12 +19,21 @@ from isaaclab.sim import SimulationCfg
 from isaaclab.sim.spawners.materials.physics_materials_cfg import RigidBodyMaterialCfg
 from isaaclab.utils import configclass
 
+from isaaclab_tasks.direct.shadow_hand.shadow_hand_env_cfg import ShadowHandRobotCfg
+from isaaclab_tasks.utils import PresetCfg
+
 from isaaclab_assets.robots.shadow_hand import SHADOW_HAND_CFG
 
 
 @configclass
 class EventCfg:
-    """Configuration for randomization."""
+    """Configuration for randomization (PhysX path).
+
+    Note: this config is currently not wired into ``ShadowHandOverEnvCfg.events`` -
+    it is kept as a reference for future event-randomization work. The event
+    terms here use PhysX-only APIs (rigid-body materials, fixed tendons), so
+    they would need a Newton variant before being enabled in the env.
+    """
 
     # -- robot
     robot_physics_material = EventTerm(
@@ -113,6 +124,186 @@ class EventCfg:
     )
 
 
+# Reuse the single-agent Shadow Hand Newton port (USD path, ``rot`` reapplication
+# workaround, effort limits, joint regex). The multi-agent variant only diverges
+# in actuator gains (stiffness/damping bumped for the catch task) and adds a
+# ``distal_passive`` override for the J0 USD-baked values.
+_SHADOW_HAND_NEWTON_CFG = ShadowHandRobotCfg().newton_mjwarp
+
+
+def _newton_shadow_hand_cfg(
+    prim_path: str, init_pos: tuple[float, float, float], init_rot: tuple[float, float, float, float]
+) -> ArticulationCfg:
+    """Newton Shadow Hand cfg parameterized by per-robot ``prim_path`` and init pose.
+
+    Two overrides versus the single-agent Newton port:
+
+    * ``fingers`` actuator: ``stiffness=20.0`` / ``damping=2.0`` (vs PhysX's
+      ``5.0`` / ``0.5`` on wrists and ``1.0`` / ``0.1`` on fingers). PhysX layers
+      ``fixed_tendons_props(limit_stiffness=30, damping=0.1)`` and runs
+      ``solver_position_iteration_count=8`` per substep — both amplify the
+      effective torque per unit nominal gain. Newton's MJWarp implicit-PD path
+      has neither, so a larger nominal gain is needed for comparable joint
+      authority. ``20.0`` / ``2.0`` is the smallest tested setting at which
+      MAPPO learns the catch (mean reward at iter 200 / 2048 envs goes from
+      ~27 at PhysX-mirrored gains to ~777).
+    * ``distal_passive`` actuator on the four ``robot0_(FF|MF|RF|LF)J0`` joints
+      with ``stiffness=10.0`` / ``damping=0.1``. The Newton USD bakes
+      ``stiffness=286 / damping=57`` on these joints from the MJCF→USD
+      translation, which fights the ``MjcTendon`` coupling and bounces the
+      ball. ``stiffness=10`` (1/3 of PhysX ``limit_stiffness=30``) keeps the
+      joints near-passive while the tendon constraint dominates.
+    """
+    return _SHADOW_HAND_NEWTON_CFG.replace(
+        prim_path=prim_path,
+        init_state=_SHADOW_HAND_NEWTON_CFG.init_state.replace(pos=init_pos, rot=init_rot),
+        actuators={
+            "fingers": _SHADOW_HAND_NEWTON_CFG.actuators["fingers"].replace(stiffness=20.0, damping=2.0),
+            "distal_passive": ImplicitActuatorCfg(
+                joint_names_expr=["robot0_(FF|MF|RF|LF)J0"],
+                stiffness=10.0,
+                damping=0.1,
+                friction=1e-2,
+                armature=2e-3,
+            ),
+        },
+    )
+
+
+@configclass
+class RightRobotCfg(PresetCfg):
+    physx = SHADOW_HAND_CFG.replace(prim_path="/World/envs/env_.*/RightRobot").replace(
+        init_state=ArticulationCfg.InitialStateCfg(
+            pos=(0.0, 0.0, 0.5),
+            rot=(0.0, 0.0, 0.0, 1.0),
+            joint_pos={".*": 0.0},
+        )
+    )
+    newton_mjwarp = _newton_shadow_hand_cfg(
+        prim_path="/World/envs/env_.*/RightRobot",
+        init_pos=(0.0, 0.0, 0.5),
+        init_rot=(0.0, 0.0, 0.0, 1.0),
+    )
+    default = physx
+
+
+@configclass
+class LeftRobotCfg(PresetCfg):
+    physx = SHADOW_HAND_CFG.replace(prim_path="/World/envs/env_.*/LeftRobot").replace(
+        init_state=ArticulationCfg.InitialStateCfg(
+            pos=(0.0, -1.0, 0.5),
+            rot=(0.0, 0.0, 1.0, 0.0),
+            joint_pos={".*": 0.0},
+        )
+    )
+    newton_mjwarp = _newton_shadow_hand_cfg(
+        prim_path="/World/envs/env_.*/LeftRobot",
+        init_pos=(0.0, -1.0, 0.5),
+        init_rot=(0.0, 0.0, 1.0, 0.0),
+    )
+    default = physx
+
+
+@configclass
+class ObjectCfg(PresetCfg):
+    """Hand-over object preset.
+
+    Both backends spawn the same procedural sphere as a free rigid body:
+    Newton's :class:`~isaaclab_newton.assets.RigidObject` resolves the
+    asset via the ``UsdPhysics.RigidBodyAPI`` that
+    :class:`~isaaclab.sim.RigidBodyPropertiesCfg` applies. The Newton
+    variant drops PhysX-only knobs (per-shape solver iterations, sleep
+    thresholds, max depenetration velocity, custom physics material).
+    """
+
+    physx = RigidObjectCfg(
+        prim_path="/World/envs/env_.*/object",
+        spawn=sim_utils.SphereCfg(
+            radius=0.0335,
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.8, 1.0, 0.0)),
+            physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.7),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                kinematic_enabled=False,
+                disable_gravity=False,
+                enable_gyroscopic_forces=True,
+                solver_position_iteration_count=8,
+                solver_velocity_iteration_count=0,
+                sleep_threshold=0.005,
+                stabilization_threshold=0.0025,
+                max_depenetration_velocity=1000.0,
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+            mass_props=sim_utils.MassPropertiesCfg(density=500.0),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.39, 0.54), rot=(0.0, 0.0, 0.0, 1.0)),
+    )
+    newton_mjwarp = RigidObjectCfg(
+        prim_path="/World/envs/env_.*/object",
+        spawn=sim_utils.SphereCfg(
+            radius=0.0335,
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.8, 1.0, 0.0)),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                kinematic_enabled=False,
+                disable_gravity=False,
+                enable_gyroscopic_forces=True,
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+            mass_props=sim_utils.MassPropertiesCfg(density=500.0),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.39, 0.54), rot=(0.0, 0.0, 0.0, 1.0)),
+    )
+    default = physx
+
+
+@configclass
+class ShadowHandOverSceneCfg(PresetCfg):
+    """Scene preset.
+
+    PhysX supports ``clone_in_fabric=True`` for faster cloning. Newton's
+    cloning path does not, so the Newton variant disables Fabric cloning.
+    """
+
+    physx: InteractiveSceneCfg = InteractiveSceneCfg(
+        num_envs=2048, env_spacing=1.5, replicate_physics=True, clone_in_fabric=True
+    )
+    newton_mjwarp: InteractiveSceneCfg = InteractiveSceneCfg(
+        num_envs=2048, env_spacing=1.5, replicate_physics=True, clone_in_fabric=False
+    )
+    default: InteractiveSceneCfg = physx
+
+
+@configclass
+class PhysicsCfg(PresetCfg):
+    """Physics-backend preset (PhysX vs Newton/MJWarp).
+
+    Newton settings mirror the single-agent ShadowHand Newton port: elliptic
+    cone, ``impratio=10`` (favors normal contacts over friction), 100 solver
+    iterations, 2 substeps. Empirically converges on the single-agent ShadowHand
+    tasks; tuning may be needed for handover-specific contact dynamics.
+    """
+
+    physx = PhysxCfg(
+        bounce_threshold_velocity=0.2,
+        gpu_max_rigid_contact_count=2**23,
+        gpu_max_rigid_patch_count=2**23,
+    )
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            solver="newton",
+            integrator="implicitfast",
+            njmax=200,
+            nconmax=70,
+            impratio=10.0,
+            cone="elliptic",
+            update_data_interval=2,
+            iterations=100,
+        ),
+        num_substeps=2,
+        debug_mode=False,
+    )
+    default = physx
+
+
 @configclass
 class ShadowHandOverEnvCfg(DirectMARLEnvCfg):
     # env
@@ -131,25 +322,11 @@ class ShadowHandOverEnvCfg(DirectMARLEnvCfg):
             static_friction=1.0,
             dynamic_friction=1.0,
         ),
-        physics=PhysxCfg(
-            bounce_threshold_velocity=0.2,
-        ),
+        physics=PhysicsCfg(),
     )
     # robot
-    right_robot_cfg: ArticulationCfg = SHADOW_HAND_CFG.replace(prim_path="/World/envs/env_.*/RightRobot").replace(
-        init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.0, 0.0, 0.5),
-            rot=(0.0, 0.0, 0.0, 1.0),
-            joint_pos={".*": 0.0},
-        )
-    )
-    left_robot_cfg: ArticulationCfg = SHADOW_HAND_CFG.replace(prim_path="/World/envs/env_.*/LeftRobot").replace(
-        init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.0, -1.0, 0.5),
-            rot=(0.0, 0.0, 1.0, 0.0),
-            joint_pos={".*": 0.0},
-        )
-    )
+    right_robot_cfg: RightRobotCfg = RightRobotCfg()
+    left_robot_cfg: LeftRobotCfg = LeftRobotCfg()
     actuated_joint_names = [
         "robot0_WRJ1",
         "robot0_WRJ0",
@@ -181,27 +358,7 @@ class ShadowHandOverEnvCfg(DirectMARLEnvCfg):
     ]
 
     # in-hand object
-    object_cfg: RigidObjectCfg = RigidObjectCfg(
-        prim_path="/World/envs/env_.*/object",
-        spawn=sim_utils.SphereCfg(
-            radius=0.0335,
-            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.8, 1.0, 0.0)),
-            physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.7),
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
-                kinematic_enabled=False,
-                disable_gravity=False,
-                enable_gyroscopic_forces=True,
-                solver_position_iteration_count=8,
-                solver_velocity_iteration_count=0,
-                sleep_threshold=0.005,
-                stabilization_threshold=0.0025,
-                max_depenetration_velocity=1000.0,
-            ),
-            collision_props=sim_utils.CollisionPropertiesCfg(),
-            mass_props=sim_utils.MassPropertiesCfg(density=500.0),
-        ),
-        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.39, 0.54), rot=(0.0, 0.0, 0.0, 1.0)),
-    )
+    object_cfg: ObjectCfg = ObjectCfg()
     # goal object
     goal_object_cfg: VisualizationMarkersCfg = VisualizationMarkersCfg(
         prim_path="/Visuals/goal_marker",
@@ -212,8 +369,8 @@ class ShadowHandOverEnvCfg(DirectMARLEnvCfg):
             ),
         },
     )
-    # scene
-    scene: InteractiveSceneCfg = InteractiveSceneCfg(num_envs=2048, env_spacing=1.5, replicate_physics=True)
+    # scene - use ShadowHandOverSceneCfg so that --preset newton disables clone_in_fabric automatically
+    scene: ShadowHandOverSceneCfg = ShadowHandOverSceneCfg()
 
     # reset
     reset_position_noise = 0.01  # range of position at reset


### PR DESCRIPTION
## Summary

Adds Newton backend support for \`Isaac-Shadow-Hand-Over-Direct-v0\` (multi-agent MAPPO/IPPO). Selectable via \`--preset newton\` / Hydra preset resolution; PhysX path unchanged.

The headline calibration finding: Newton needs \`ImplicitActuatorCfg(stiffness=20.0, damping=2.0)\` on the Shadow Hand fingers — vs PhysX's \`1.0/0.1\` on fingers and \`5.0/0.5\` on wrists — because PhysX layers \`fixed_tendons_props(limit_stiffness=30, damping=0.1)\` and runs \`solver_position_iteration_count=8\` per substep. Both amplify the effective torque per unit nominal gain. Newton's MJWarp implicit-PD path has neither, so larger nominal gains are needed for comparable joint authority. With the bump, MAPPO mean reward at iter 200 / 2048 envs goes from ~27 (no catch learned) to ~777, vs the PhysX baseline of ~247.

## Stack

Builds on top of:

- **#5433** [Newton] Rename per-env labels in physics replication — required for Shadow Hand fixed tendons to parse correctly under Newton.

After #5433 merges, this PR's diff vs develop drops to the 3 shadow-hand-specific files.

## What this PR does

### Newton port wiring (\`shadow_hand_over_env_cfg.py\`)

The Newton variant of the Shadow Hand articulation is built as a **delta of the single-agent \`ShadowHandRobotCfg.newton_mjwarp\`** (cross-task import from \`direct/shadow_hand\`), parameterized per-robot \`prim_path\` / \`init_pos\` / \`init_rot\`. Reuses the single-agent's USD path, \`rot\` reapplication workaround, effort limits, and joint regex.

Two \`ImplicitActuatorCfg\` overrides on top of the single-agent cfg:

* **\`fingers\`** (wrist + per-finger joints): \`stiffness=20.0\` / \`damping=2.0\`. The catch-task gain calibration fix.
* **\`distal_passive\`** (the four \`robot0_(FF|MF|RF|LF)J0\` joints): \`stiffness=10.0\` / \`damping=0.1\`. The Newton USD bakes \`stiffness=286 / damping=57\` on these joints from the MJCF→USD translation (which fights the \`MjcTendon\` coupling and bounces the ball). \`stiffness=10\` keeps the joints near-passive while the tendon constraint dominates. PhysX uses tendon coupling on these joints directly and does not need an analogous override.

\`PresetCfg\` subclasses follow the established \`physx\`/\`newton_mjwarp\`/\`default=physx\` pattern — same shape as the single-agent Shadow Hand port already on develop. Newton \`ObjectCfg\` drops PhysX-only \`rigid_props\` knobs (per-shape solver iterations, sleep thresholds, max depenetration velocity, custom physics material). Newton scene cloning sets \`clone_in_fabric=False\`.

### Backend portability fix (\`shadow_hand_over_env.py\`)

One line: \`self.right_hand.root_view.get_dof_limits()\` → \`self.right_hand.data.joint_limits\`. \`root_view\` is PhysX-only; \`data.joint_limits\` is the backend-portable accessor available on both PhysX and Newton articulations.

### Drift alignment with develop

* Newton-preset slot name \`newton_mjwarp\` (matches develop's current convention).
* \`PhysxCfg(bounce_threshold_velocity=0.2, gpu_max_rigid_contact_count=2**23, gpu_max_rigid_patch_count=2**23)\` — matches single-agent Shadow Hand's contact-buffer sizing for 2048-env scale.

## Numbers (200 iter / 2048 envs / seed 42 / MAPPO)

Captured from tfevents in \`~/workspaces/IsaacLab/logs/skrl/shadow_hand_over/\`:

| Setting | Stiffness | Damping | Reward (mean) | Catch learned? |
|---|---:|---:|---:|:---:|
| PhysX baseline | 1.0 (5.0 wrist) | 0.1 (0.5 wrist) + tendon=30/0.1 | **246.7** | yes |
| Newton, develop default | 1.0 | 0.1 | 23.4 | **no** |
| Newton, pinned default | 1.0 | 0.1 | 27.7 | **no** |
| Newton, h1 probe | 50.0 | 5.0 | 617.8 | yes |
| **Newton, this PR** | **20.0** | **2.0** | **777.1** | yes |

20/2 was chosen because it stays closer to the nominal effort-limit budget while still providing enough control authority. Anything in roughly \`[10, 50]\` works.

## Test plan

- [x] PhysX 200-iter baseline at 2048 envs (mean 246.7).
- [x] Newton 200-iter at stiffness 20/2 — mean 777.1, catch learned.
- [x] Newton 200-iter at stiffness 50/5 cross-check — mean 617.8, catch learned.
- [x] \`./isaaclab.sh -f\` clean (pre-commit hooks).
- [x] Changelog fragment under \`source/isaaclab_tasks/changelog.d/jichuanh-shadow-hand-newton-parity.minor.rst\` (CI-driven version bump on merge; no per-PR \`extension.toml\` edit).

## Out of scope (follow-ups)

- **\`EventCfg\` not wired into the env class.** The multi-agent's \`EventCfg\` is defined but never referenced by \`ShadowHandOverEnvCfg.events\` — single-agent's pattern (\`events: ShadowHandEventCfg = ShadowHandEventCfg()\` with PhysX/Newton variants) hasn't been ported. Independent feature add; not a parity blocker.
- **Migrating Shadow Hand Newton USD to the \`mujoco-usd-converter\`-produced asset in \`newton-physics/newton-assets/shadow_hand/usd_structured/\`.** That asset uses \`MjcActuator + MjcTendon\` natively (no baked stiffness=286 problem). Switching would let the \`distal_passive\` override be deleted. Requires Nucleus/S3 asset migration + matching the right-hand asset (newton-assets has only left); separate work.
- **Behavior-level parity** beyond shaped reward (catch rate, drop rate, ball-trajectory smoothness) is left for a follow-up evaluation.