### PR TITLE
Gate isaacteleop dependency on Linux to fix Windows install

### DIFF
--- a/source/isaaclab_teleop/config/extension.toml
+++ b/source/isaaclab_teleop/config/extension.toml
@@ -1,6 +1,6 @@
 [package]
 # Semantic Versioning is used: https://semver.org/
-version = "0.3.8"
+version = "0.3.9"
 
 # Description
 title =  "Isaac Lab Teleop"

--- a/source/isaaclab_teleop/docs/CHANGELOG.rst
+++ b/source/isaaclab_teleop/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.3.9 (2026-04-29)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed installation failure on Windows by adding ``platform_system == 'Linux'``
+  marker to the ``isaacteleop`` dependency, which is only available on Linux.
+
+
 0.3.8 (2026-04-24)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_teleop/setup.py
+++ b/source/isaaclab_teleop/setup.py
@@ -19,7 +19,8 @@ SUPPORTED_ARCHS = "platform_machine in 'x86_64,AMD64'"
 
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
-    "isaacteleop[retargeters,ui,cloudxr]~=1.2.0",
+    # IsaacTeleop is only available on Linux x86_64
+    f"isaacteleop[retargeters,ui,cloudxr]~=1.2.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
     # required by isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1_t2_dex_retargeting_utils
     f"dex-retargeting==0.5.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
 ]


### PR DESCRIPTION
# Description

Added platform_system == 'Linux' marker to the isaacteleop dependency in isaaclab_teleop/setup.py so pip no longer fails to resolve it on Windows.
The isaaclab_teleop package itself remains in the teleop and all extras unconditionally — only the native isaacteleop library is skipped on non-Linux platforms.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
