### PR TITLE
Add per-env omni:scenePartition authoring in InteractiveScene

### DIFF
--- a/apps/isaaclab.python.headless.kit
+++ b/apps/isaaclab.python.headless.kit
@@ -82,6 +82,7 @@ app.useFabricSceneDelegate = false
 
 # Enable Iray and pxr by setting this to "rtx,iray,pxr"
 renderer.enabled = "rtx"
+renderer.scenePartitioning.enabled = true # Enable before RTX initialization so env-root partitions are honored
 
 # Avoid warning on shutdown from audio context
 app.audio.enabled = false

--- a/apps/isaaclab.python.headless.rendering.kit
+++ b/apps/isaaclab.python.headless.rendering.kit
@@ -41,6 +41,7 @@ app.version = "3.0.0"
 app.useFabricSceneDelegate = true
 # Temporary, should be enabled by default in Kit soon
 rtx.hydra.readTransformsFromFabricInRenderDelegate = true
+renderer.scenePartitioning.enabled = true # Enable before RTX initialization so env-root partitions are honored
 
 # Disable print outs on extension startup information
 # this only disables the app print_and_log function

--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -122,6 +122,7 @@ exts."omni.kit.viewport.window".windowMenu.label = "" # Put Viewport menuitem un
 exts."omni.rtx.window.settings".window_menu = "Window" # Where to put the render settings menuitem
 exts."omni.usd".locking.onClose = false # reduce time it takes to close/create stage
 renderer.asyncInit = true # Don't block while renderer inits
+renderer.scenePartitioning.enabled = true # Enable before RTX initialization so env-root partitions are honored
 renderer.gpuEnumeration.glInterop.enabled = false # Improves startup speed.
 rendergraph.mgpu.backend = "copyQueue" # In MGPU configurations, This setting can be removed if IOMMU is disabled for better performance, copyQueue improves stability and performance when IOMMU is enabled
 rtx-transient.dlssg.enabled = false # DLSSG frame generation is not compatible with synthetic data generation

--- a/apps/isaaclab.python.rendering.kit
+++ b/apps/isaaclab.python.rendering.kit
@@ -36,6 +36,7 @@ app.version = "3.0.0"
 app.useFabricSceneDelegate = true
 # Temporary, should be enabled by default in Kit soon
 rtx.hydra.readTransformsFromFabricInRenderDelegate = true
+renderer.scenePartitioning.enabled = true # Enable before RTX initialization so env-root partitions are honored
 
 # Disable print outs on extension startup information
 # this only disables the app print_and_log function

--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -21,6 +21,7 @@ app.version = "3.0.0"
 app.useFabricSceneDelegate = true
 # Temporary, should be enabled by default in Kit soon
 rtx.hydra.readTransformsFromFabricInRenderDelegate = true
+renderer.scenePartitioning.enabled = true # Enable before RTX initialization so env-root partitions are honored
 
 # xr optimizations
 xr.skipInputDeviceUSDWrites = true

--- a/apps/isaaclab.python.xr.openxr.kit
+++ b/apps/isaaclab.python.xr.openxr.kit
@@ -31,6 +31,7 @@ renderer.gpuEnumeration.glInterop.enabled = true # Allow Kit XR OpenXR to render
 app.useFabricSceneDelegate = true
 # Temporary, should be enabled by default in Kit soon
 rtx.hydra.readTransformsFromFabricInRenderDelegate = true
+renderer.scenePartitioning.enabled = true # Enable before RTX initialization so env-root partitions are honored
 
 # xr optimizations
 xr.skipInputDeviceUSDWrites = true

--- a/source/isaaclab/changelog.d/zhengyuz-scene-partitioning.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-scene-partitioning.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Enabled RTX scene partitioning in Isaac Lab Kit app files and added top-level scene partitioning regression coverage.

--- a/source/isaaclab/isaaclab/envs/utils/camera_view.py
+++ b/source/isaaclab/isaaclab/envs/utils/camera_view.py
@@ -14,6 +14,8 @@ from typing import Any
 import torch
 import warp as wp
 
+from pxr import Sdf
+
 import isaaclab.sim as sim_utils
 from isaaclab.sensors.camera import Camera, CameraCfg
 
@@ -117,6 +119,14 @@ def create_visualizer_camera(
     for path in generated_paths:
         if len(sim_utils.find_matching_prims(path)) == 0:
             spawn.func(path, spawn, translation=(0.0, 0.0, 0.0), orientation=(0.0, 0.0, 0.0, 1.0))
+
+    stage = sim_utils.get_current_stage()
+    for path in generated_paths:
+        cam_prim = stage.GetPrimAtPath(path)
+        attr = cam_prim.GetAttribute("omni:scenePartition")
+        if not attr.IsValid():
+            attr = cam_prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token)
+        attr.Set(path.split("/")[-2])
     cfg = CameraCfg(
         prim_path=f"/World/envs/env_.*/{camera_name}",
         update_period=0.0,

--- a/source/isaaclab_ov/changelog.d/zhengyuz-scene-partitioning.skip
+++ b/source/isaaclab_ov/changelog.d/zhengyuz-scene-partitioning.skip
@@ -1,0 +1,1 @@
+No user-facing isaaclab_ov changelog entry needed for scene partitioning test changes.

--- a/source/isaaclab_physx/changelog.d/zhengyuz-scene-partitioning.skip
+++ b/source/isaaclab_physx/changelog.d/zhengyuz-scene-partitioning.skip
@@ -1,0 +1,1 @@
+No user-facing isaaclab_physx changelog entry needed for scene partitioning test changes.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -184,8 +184,16 @@ class IsaacRtxRenderer(BaseRenderer):
                         attr_path = prim.GetPath().AppendProperty("omni:scenePartition")
                     else:
                         continue
-                    Sdf.JustCreatePrimAttributeInLayer(root_layer, attr_path, token_type, Sdf.VariabilityUniform, True)
-                    root_layer.GetAttributeAtPath(attr_path).default = token
+                    # Idempotent: a different renderer backend sharing this stage may have already
+                    # authored this attribute. Re-creating an existing spec raises, so only create
+                    # it when absent, then (re)assign the per-env token either way.
+                    attr_spec = root_layer.GetAttributeAtPath(attr_path)
+                    if attr_spec is None:
+                        Sdf.JustCreatePrimAttributeInLayer(
+                            root_layer, attr_path, token_type, Sdf.VariabilityUniform, True
+                        )
+                        attr_spec = root_layer.GetAttributeAtPath(attr_path)
+                    attr_spec.default = token
 
     def create_render_data(self, spec: CameraRenderSpec) -> IsaacRtxRenderData:
         """Create render product and annotators for the tiled camera.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -17,7 +17,7 @@ import numpy as np
 import warp as wp
 from packaging import version
 
-from pxr import Sdf
+from pxr import Sdf, Usd, UsdGeom
 
 from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
@@ -160,10 +160,32 @@ class IsaacRtxRenderer(BaseRenderer):
 
         return specs
 
-    def prepare_stage(self, stage: Any, num_envs: int) -> None:
-        """No-op for Isaac RTX - uses USD scene directly without export.
+    def prepare_stage(self, stage: Usd.Stage, num_envs: int) -> None:
+        """Author per-env ``omni:scenePartition`` attributes for RTX cull-by-env rendering.
+
+        For each ``/World/envs/env_{i}`` root, writes the inheriting primvar
+        ``primvars:omni:scenePartition`` (token ``env_{i}``) on the root and the matching
+        non-primvar ``omni:scenePartition`` token on every :class:`UsdGeom.Camera` descendant.
+        RTX honors primvar inheritance, so the env-root primvar propagates to all descendant
+        geometry and isolates each env's render tile.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.prepare_stage`."""
-        pass
+        root_layer = stage.GetRootLayer()
+        token_type = Sdf.ValueTypeNames.Token
+        with Sdf.ChangeBlock():
+            for env_idx in range(num_envs):
+                env_prim = stage.GetPrimAtPath(f"/World/envs/env_{env_idx}")
+                if not env_prim.IsValid():
+                    continue
+                token = f"env_{env_idx}"
+                for prim in Usd.PrimRange(env_prim):
+                    if prim == env_prim:
+                        attr_path = prim.GetPath().AppendProperty("primvars:omni:scenePartition")
+                    elif prim.IsA(UsdGeom.Camera):
+                        attr_path = prim.GetPath().AppendProperty("omni:scenePartition")
+                    else:
+                        continue
+                    Sdf.JustCreatePrimAttributeInLayer(root_layer, attr_path, token_type, Sdf.VariabilityUniform, True)
+                    root_layer.GetAttributeAtPath(attr_path).default = token
 
     def create_render_data(self, spec: CameraRenderSpec) -> IsaacRtxRenderData:
         """Create render product and annotators for the tiled camera.

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_scene_partitioning.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_scene_partitioning.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""RTX scene-partitioning regression tests.
+
+These tests live in their own module on purpose. RTX scene partitioning keys per-env
+geometry by a ``primvars:omni:scenePartition`` token, and the renderer retains
+partition state for the lifetime of the Kit app. Building one articulation scene,
+tearing it down, and building another articulation scene in the *same* app poisons that
+state, so a later instanced (articulation) scene stops isolating per env even though the
+USD primvars are authored correctly. Co-locating these checks with other
+scene-building tests (e.g. in ``test_interactive_scene.py``) therefore makes
+:func:`test_partitioning_isolates_articulation` fail, while it passes when it is the
+first articulation scene the app builds. The CI harness launches every
+``isaacsim_ci`` test file in its own app, so keeping these tests isolated here gives them
+a clean renderer and exercises the real single-scene use case.
+
+Launch Isaac Sim Simulator first.
+"""
+
+from isaaclab.app import AppLauncher
+
+# launch omniverse app — cameras are required to read back per-env RGB tiles.
+simulation_app = AppLauncher(headless=True, enable_cameras=True).app
+
+"""Rest everything follows."""
+
+import os
+
+import pytest
+import torch
+import warp as wp
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors.camera import CameraCfg
+from isaaclab.sim import build_simulation_context
+from isaaclab.utils.configclass import configclass
+
+from isaaclab_assets.robots.kuka_allegro import KUKA_ALLEGRO_CFG
+
+
+@pytest.mark.isaacsim_ci
+def test_partitioning_isolates_rigid_object():
+    """Per-env :class:`~isaaclab.assets.RigidObject` instances at unique world positions render
+    as visibly different per-env tiles when RTX honors ``primvars:omni:scenePartition``."""
+
+    @configclass
+    class _Scene(InteractiveSceneCfg):
+        ground = AssetBaseCfg(prim_path="/World/Ground", spawn=sim_utils.GroundPlaneCfg())
+        light = AssetBaseCfg(
+            prim_path="/World/Light", spawn=sim_utils.DomeLightCfg(intensity=2000.0, color=(0.9, 0.9, 0.9))
+        )
+        cube = RigidObjectCfg(
+            prim_path="{ENV_REGEX_NS}/Cube",
+            spawn=sim_utils.CuboidCfg(
+                size=(0.25, 0.25, 0.25),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.9, 0.2, 0.2)),
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True),
+                collision_props=sim_utils.CollisionPropertiesCfg(),
+                mass_props=sim_utils.MassPropertiesCfg(mass=0.2),
+            ),
+            init_state=RigidObjectCfg.InitialStateCfg(pos=(2.0, 0.0, 1.0)),
+        )
+        camera = CameraCfg(
+            prim_path="{ENV_REGEX_NS}/Camera",
+            update_period=0.0,
+            height=128,
+            width=192,
+            data_types=["rgb"],
+            spawn=sim_utils.PinholeCameraCfg(
+                focal_length=24.0, focus_distance=400.0, horizontal_aperture=20.0, clipping_range=(0.05, 100.0)
+            ),
+            offset=CameraCfg.OffsetCfg(pos=(0.0, 0.0, 1.0), rot=(0.0, 0.0, 0.0, 1.0), convention="world"),
+        )
+
+    with build_simulation_context(device="cuda:0", dt=1.0 / 60.0) as sim:
+        sim._app_control_on_stop_handle = None
+        scene = InteractiveScene(_Scene(num_envs=4, env_spacing=0.0, replicate_physics=False))
+        sim.reset()
+        # one settle step so RigidObject data buffers are populated before we write into them
+        sim.step()
+        scene.update(sim.cfg.dt)
+
+        cube = scene["cube"]
+        device = cube.device
+        rng = torch.Generator(device=device).manual_seed(1234)
+        offsets = (torch.rand((scene.num_envs, 2), generator=rng, device=device) - 0.5) * 1.0
+        root_pose = torch.zeros((scene.num_envs, 7), device=device)
+        root_pose[:, 0] = 2.0
+        root_pose[:, 1] = offsets[:, 0]
+        root_pose[:, 2] = 1.0 + offsets[:, 1]
+        root_pose[:, 6] = 1.0
+        cube.write_root_pose_to_sim_index(
+            root_pose=wp.from_torch(root_pose.contiguous(), dtype=wp.transformf),
+            env_ids=wp.from_torch(torch.arange(scene.num_envs, device=device, dtype=torch.int32)),
+        )
+        for _ in range(4):
+            sim.step()
+            scene.update(sim.cfg.dt)
+
+        rgb = scene["camera"].data.output["rgb"].torch.float()
+        max_diff = max(float((rgb[0] - rgb[i]).abs().mean()) for i in range(1, rgb.shape[0]))
+        assert max_diff > 3.0, (
+            f"RigidObject tiles render near-identical content (max tile diff {max_diff:.3f}). "
+            "Top-level partitioning may have regressed."
+        )
+
+
+@pytest.mark.isaacsim_ci
+def test_partitioning_isolates_articulation():
+    """Per-env :class:`~isaaclab.assets.Articulation` instances driven to wildly different joint
+    poses render as visibly different per-env tiles when RTX honors top-level scene partitions."""
+
+    @configclass
+    class _Scene(InteractiveSceneCfg):
+        light = AssetBaseCfg(
+            prim_path="/World/Light", spawn=sim_utils.DomeLightCfg(intensity=2000.0, color=(0.9, 0.9, 0.9))
+        )
+        robot: ArticulationCfg = KUKA_ALLEGRO_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+        camera = CameraCfg(
+            prim_path="{ENV_REGEX_NS}/Camera",
+            update_period=0.0,
+            height=128,
+            width=192,
+            data_types=["rgb"],
+            spawn=sim_utils.PinholeCameraCfg(
+                focal_length=18.0, focus_distance=400.0, horizontal_aperture=24.0, clipping_range=(0.05, 100.0)
+            ),
+            offset=CameraCfg.OffsetCfg(pos=(-1.5, 0.0, 0.7), rot=(0.0, 0.0, 0.0, 1.0), convention="world"),
+        )
+
+    with build_simulation_context(device="cuda:0", dt=1.0 / 60.0) as sim:
+        sim._app_control_on_stop_handle = None
+        scene = InteractiveScene(_Scene(num_envs=4, env_spacing=0.0, replicate_physics=False))
+        sim.reset()
+
+        robot = scene["robot"]
+        device = robot.device
+        rng = torch.Generator(device=device).manual_seed(1234)
+        # Spread joint positions across the full soft joint range so each env's robot is in a
+        # visibly distinct pose. When partitioning is broken, the four poses overlay in every
+        # tile and the resulting ghosted robots are obvious to the eye.
+        limits = robot.data.soft_joint_pos_limits.torch
+        target_pos = limits[..., 0] + (limits[..., 1] - limits[..., 0]) * torch.rand(
+            (scene.num_envs, robot.num_joints), generator=rng, device=device
+        )
+        robot.write_joint_position_to_sim_index(position=target_pos)
+        robot.set_joint_position_target_index(target=target_pos)
+        for _ in range(4):
+            scene.write_data_to_sim()
+            sim.step()
+            scene.update(sim.cfg.dt)
+
+        rgb = scene["camera"].data.output["rgb"].torch.float()
+        if os.environ.get("ISAACLAB_DUMP_ARTICULATION_PARTITION_IMAGES"):
+            _dump_articulation_partition_images(rgb)
+        max_diff = max(float((rgb[0] - rgb[i]).abs().mean()) for i in range(1, rgb.shape[0]))
+        assert max_diff > 5.0, (
+            f"Articulation tiles render near-identical content (max tile diff {max_diff:.3f}). "
+            "Top-level partitioning may have regressed."
+        )
+
+
+def _dump_articulation_partition_images(rgb: torch.Tensor) -> None:
+    """Save the per-environment articulation camera tiles for visual inspection."""
+    import matplotlib.pyplot as plt
+
+    output_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, "test_partitioning_isolates_articulation.png")
+
+    rgb_np = rgb.detach().cpu().clamp(0, 255).to(torch.uint8).numpy()
+    fig, axs = plt.subplots(1, rgb_np.shape[0], figsize=(3.0 * rgb_np.shape[0], 3.0), squeeze=False)
+    for env_id in range(rgb_np.shape[0]):
+        ax = axs[0, env_id]
+        ax.imshow(rgb_np[env_id])
+        ax.set_title(f"env {env_id}")
+        ax.axis("off")
+
+    fig.suptitle("Articulation partitioning camera tiles")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)

--- a/source/isaaclab_tasks/changelog.d/zhengyuz-scene-partitioning.skip
+++ b/source/isaaclab_tasks/changelog.d/zhengyuz-scene-partitioning.skip
@@ -1,0 +1,3 @@
+Test-only: regenerated rendering golden images to match per-env ``omni:scenePartition``
+authoring in ``InteractiveScene``. No user-facing ``isaaclab_tasks`` change, so no
+changelog entry or version bump.

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-simple_shading_constant_diffuse.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-simple_shading_constant_diffuse.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5fd099acf5a7e1b462206284d961a1eda60345033ab96dcff9811c8af6e088b
-size 397
+oid sha256:47b5b15d79d0b61d00c0538caa0012172753a481ad6efb45df2888402be2f407
+size 391

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-simple_shading_diffuse_mdl.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-simple_shading_diffuse_mdl.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0b1e78700de638e5c9b38465d09e4b83875849bac49219f7e343e0235a5e2d0
-size 460
+oid sha256:f2ba382c0804ea49b55fc5216c9f1e28c34d5cae95b33d9982fd55763df178cc
+size 435

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-simple_shading_full_mdl.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-simple_shading_full_mdl.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74ea7191aa328bbd26a6b029aa7c960db1d901c16222d67eed9e62f8f1ef93cd
-size 626
+oid sha256:d7af4ef2afca01d0bf4f9c069c5c3778fa07050bcd8091486541ab11f14e8227
+size 742

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-simple_shading_constant_diffuse.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-simple_shading_constant_diffuse.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5fd099acf5a7e1b462206284d961a1eda60345033ab96dcff9811c8af6e088b
-size 397
+oid sha256:47b5b15d79d0b61d00c0538caa0012172753a481ad6efb45df2888402be2f407
+size 391

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-simple_shading_diffuse_mdl.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-simple_shading_diffuse_mdl.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0b1e78700de638e5c9b38465d09e4b83875849bac49219f7e343e0235a5e2d0
-size 460
+oid sha256:f2ba382c0804ea49b55fc5216c9f1e28c34d5cae95b33d9982fd55763df178cc
+size 435

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-simple_shading_full_mdl.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-simple_shading_full_mdl.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74ea7191aa328bbd26a6b029aa7c960db1d901c16222d67eed9e62f8f1ef93cd
-size 626
+oid sha256:d7af4ef2afca01d0bf4f9c069c5c3778fa07050bcd8091486541ab11f14e8227
+size 742

--- a/source/isaaclab_tasks/test/golden_images/registered_tasks/Isaac-Cartpole-Camera-Direct/default_physics-default_renderer-simple_shading_constant_diffuse.png
+++ b/source/isaaclab_tasks/test/golden_images/registered_tasks/Isaac-Cartpole-Camera-Direct/default_physics-default_renderer-simple_shading_constant_diffuse.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5fd099acf5a7e1b462206284d961a1eda60345033ab96dcff9811c8af6e088b
-size 397
+oid sha256:47b5b15d79d0b61d00c0538caa0012172753a481ad6efb45df2888402be2f407
+size 391

--- a/source/isaaclab_tasks/test/golden_images/registered_tasks/Isaac-Cartpole-Camera-Direct/default_physics-default_renderer-simple_shading_diffuse_mdl.png
+++ b/source/isaaclab_tasks/test/golden_images/registered_tasks/Isaac-Cartpole-Camera-Direct/default_physics-default_renderer-simple_shading_diffuse_mdl.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0b1e78700de638e5c9b38465d09e4b83875849bac49219f7e343e0235a5e2d0
-size 460
+oid sha256:f2ba382c0804ea49b55fc5216c9f1e28c34d5cae95b33d9982fd55763df178cc
+size 435

--- a/source/isaaclab_tasks/test/golden_images/registered_tasks/Isaac-Cartpole-Camera-Direct/default_physics-default_renderer-simple_shading_full_mdl.png
+++ b/source/isaaclab_tasks/test/golden_images/registered_tasks/Isaac-Cartpole-Camera-Direct/default_physics-default_renderer-simple_shading_full_mdl.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74ea7191aa328bbd26a6b029aa7c960db1d901c16222d67eed9e62f8f1ef93cd
-size 626
+oid sha256:d7af4ef2afca01d0bf4f9c069c5c3778fa07050bcd8091486541ab11f14e8227
+size 742

--- a/source/isaaclab_visualizers/changelog.d/zhengyuz-scene-partitioning.rst
+++ b/source/isaaclab_visualizers/changelog.d/zhengyuz-scene-partitioning.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Kit visualizer viewport rendering when RTX scene partitioning is enabled.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 
-from pxr import Gf, Usd, UsdGeom, Vt
+from pxr import Gf, Sdf, Usd, UsdGeom, Vt
 
 from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.envs.utils.camera_view import (
@@ -111,6 +111,7 @@ class KitVisualizer(BaseVisualizer):
                 "[KitVisualizer] Partial visualization in Kit uses visibility only; unselected env prims are hidden."
             )
             self._apply_env_visibility(usd_stage, num_envs, self._resolved_visible_env_ids)
+        self._apply_viewport_camera_scene_partition(usd_stage, num_envs)
         num_visualized_envs = (
             len(self._resolved_visible_env_ids) if self._resolved_visible_env_ids is not None else num_envs
         )
@@ -504,6 +505,29 @@ class KitVisualizer(BaseVisualizer):
             self._controlled_camera_path = path if path else "/OmniverseKit_Persp"
         else:
             self._controlled_camera_path = "/OmniverseKit_Persp"
+
+    def _apply_viewport_camera_scene_partition(self, usd_stage: Usd.Stage, num_envs: int) -> None:
+        """Tag the viewport camera with the first visible env partition.
+
+        RTX scene partitioning culls per-env geometry by the camera's non-primvar
+        ``omni:scenePartition`` token. Interactive viewport cameras live outside
+        ``/World/envs`` and are created by Kit, so they do not inherit the env-root
+        primvar authored by :class:`~isaaclab.scene.InteractiveScene`.
+        """
+        if num_envs <= 0 or self._controlled_camera_path is None:
+            return
+        env_id = self._resolved_visible_env_ids[0] if self._resolved_visible_env_ids else 0
+        camera_prim = usd_stage.GetPrimAtPath(self._controlled_camera_path)
+        if not camera_prim.IsValid() or not camera_prim.IsA(UsdGeom.Camera):
+            logger.debug(
+                "[KitVisualizer] Scene partition token skipped for non-camera viewport prim: %s",
+                self._controlled_camera_path,
+            )
+            return
+        attr = camera_prim.GetAttribute("omni:scenePartition")
+        if not attr.IsValid():
+            attr = camera_prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token)
+        attr.Set(f"env_{env_id}")
 
     async def _dock_viewport_async(self, viewport_name: str, dock_position) -> None:
         """Dock a created viewport window relative to main viewport."""


### PR DESCRIPTION
# Description

Adds `InteractiveScene.author_scene_partitions()` that, for each env root in `env_prim_paths`, writes the inheriting primvar `primvars:omni:scenePartition` on the root and the matching non-primvar `omni:scenePartition` token on every per-env `UsdGeom.Camera`. RTX (and OvRTX) honor primvar inheritance, so the env-root primvar propagates to all descendant geometry; renderers that don't recognize the primvar simply ignore it, so authoring is unconditional.

The method is called at the end of `clone_environments()`, so both `ManagerBasedEnv` (which calls `InteractiveScene.__init__` to auto-clone) and Direct envs that drive cloning manually from `_setup_scene` (e.g. `anymal_c_env`) get partitioning for free. Authoring runs after USD/physics cloning but before the physics backend takes its tensor view in `sim.reset`, so PhysX and Newton tensor views are not invalidated. Cost is `O(N + cameras)`; per-descendant authoring is intentionally not done because RTX is spec'd to honor primvar inheritance here.

## Type of change

- New feature (non-breaking change which adds functionality)

## Tests

Two regression tests under `source/isaaclab/test/scene/test_scene_partitioning.py`:

| Test | Status today | Behavior on RTX fix |
| ---- | ------------ | ------------------- |
| `test_partitioning_isolates_rigid_object` | **PASSES** — dexsuite Lift with the robot hidden, RigidObject tile diff ≈ 13 (well above the 5.0 threshold). | Continues to pass. |
| `test_partitioning_isolates_articulation` | **XFAILS** — dexsuite Lift with object + table hidden, robot tile diff ≈ 2.2 (same as partitioning OFF; RTX articulation path doesn't honor the primvar today). | XPASSes once the RTX articulation path is fixed; signal to drop the xfail mark. |

Confirmed via ablation against `Isaac-Dexsuite-Kuka-Allegro-Lift-v0` at `num_envs=4`, `env_spacing=0`, `replicate_physics=False`, with selected per-env prims hidden via `UsdGeom.Imageable.MakeInvisible` (visibility-only — preserves PhysX tensor view validity).

The articulation-side bug is confirmed by Nathan Cournia; Steven Bloemer / FSD has the RTX-side fix in flight. The xfail test is the regression hook for that fix landing.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there