### PR TITLE
Fixes Kit GUI pause/resume freezing articulation meshes on Isaac Sim 5.1+

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.54.3"
+version = "0.54.4"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -7,12 +7,8 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed Kit GUI pause/resume leaving articulation meshes visually frozen on Isaac Sim 5.1+.
-  Starting with PhysX fabric 107.3.21, the FabricManager skips writing initial articulation
-  poses to fabric on subsequent resumes, so meshes appeared frozen even though physics
-  continued running. :meth:`~isaaclab.sim.SimulationContext.step` now detaches and
-  re-attaches the stage on the fabric interface after the timeline resumes, forcing the
-  FabricManager to reinitialize and write transforms back into fabric.
+* Fixed articulation meshes freezing visually after Kit GUI pause/resume on Isaac Sim 5.1+
+  by re-attaching the stage on the fabric interface in :meth:`~isaaclab.sim.SimulationContext.step`.
 
 
 0.54.3 (2026-02-04)

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Changelog
 ---------
 
+0.54.4 (2026-04-29)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed Kit GUI pause/resume leaving articulation meshes visually frozen on Isaac Sim 5.1+.
+  Starting with PhysX fabric 107.3.21, the FabricManager skips writing initial articulation
+  poses to fabric on subsequent resumes, so meshes appeared frozen even though physics
+  continued running. :meth:`~isaaclab.sim.SimulationContext.step` now detaches and
+  re-attaches the stage on the fabric interface after the timeline resumes, forcing the
+  FabricManager to reinitialize and write transforms back into fabric.
+
+
 0.54.3 (2026-02-04)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -574,14 +574,11 @@ class SimulationContext(_SimulationContext):
                 # skips writing initial articulation poses on subsequent resumes, which causes
                 # articulation meshes to freeze visually while physics continues running.
                 # Detaching and re-attaching the stage forces the FabricManager to fully
-                # re-initialize, including writing transforms to fabric.
+                # re-initialize, including writing transforms to fabric. This also pumps the
+                # app so physics/Hydra pick up the resumed state -- no separate app.update()
+                # is needed.
                 # See: https://github.com/isaac-sim/IsaacLab/issues/4279
                 self._re_sync_fabric()
-            # need to do one step to refresh the app
-            # reason: physics has to parse the scene again and inform other extensions like hydra-delegate.
-            #   without this the app becomes unresponsive.
-            # FIXME: This steps physics as well, which we is not good in general.
-            self.app.update()
 
         # step the simulation
         super().step(render=render)

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -911,11 +911,9 @@ class SimulationContext(_SimulationContext):
         the FabricManager to fully reinitialize -- including writing transforms into fabric so that
         Hydra picks them up via the IFabricHierarchy cached-transform pipeline.
         """
-        if self._fabric_iface is None:
+        if self._fabric_iface is None or self.stage is None:
             return
         stage = self.stage
-        if stage is None:
-            return
         stage_id = UsdUtils.StageCache.Get().GetId(stage).ToLongInt()
         if stage_id <= 0:
             return

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -569,6 +569,14 @@ class SimulationContext(_SimulationContext):
                 # meantime if someone stops, break out of the loop
                 if self.is_stopped():
                     break
+            if not self.is_stopped():
+                # Workaround for PhysX fabric 107.3.21+ (Isaac Sim 5.1+): the fabric extension
+                # skips writing initial articulation poses on subsequent resumes, which causes
+                # articulation meshes to freeze visually while physics continues running.
+                # Detaching and re-attaching the stage forces the FabricManager to fully
+                # re-initialize, including writing transforms to fabric.
+                # See: https://github.com/isaac-sim/IsaacLab/issues/4279
+                self._re_sync_fabric()
             # need to do one step to refresh the app
             # reason: physics has to parse the scene again and inform other extensions like hydra-delegate.
             #   without this the app becomes unresponsive.
@@ -889,6 +897,38 @@ class SimulationContext(_SimulationContext):
             else:
                 # Needed for backward compatibility with older Isaac Sim versions
                 self._update_fabric = self._fabric_iface.update
+
+    def _re_sync_fabric(self):
+        """Force the PhysX fabric extension to re-synchronize after a pause/resume transition.
+
+        Starting with PhysX fabric 107.3.21 (shipped with Isaac Sim 5.1), the FabricManager skips
+        writing initial articulation poses to fabric on subsequent resumes -- only the first play
+        triggers ``FabricManager::resume:rigidBodyInitialization:writeToFabric``. This causes
+        articulation (robot) meshes to freeze visually after pause/resume, even though physics
+        continues to run (see :issue:`4279`).
+
+        The workaround detaches and re-attaches the USD stage on the fabric interface, which forces
+        the FabricManager to fully reinitialize -- including writing transforms into fabric so that
+        Hydra picks them up via the IFabricHierarchy cached-transform pipeline.
+        """
+        if self._fabric_iface is None:
+            return
+        stage = self.stage
+        if stage is None:
+            return
+        stage_id = UsdUtils.StageCache.Get().GetId(stage).ToLongInt()
+        if stage_id <= 0:
+            return
+        try:
+            self._fabric_iface.detach_stage()
+        except Exception:
+            logger.warning("Failed to detach fabric stage during re-sync. Articulation visuals may be stale.")
+            return
+        try:
+            self._fabric_iface.attach_stage(stage_id)
+            self._update_fabric(0.0, 0.0)
+        except Exception:
+            logger.warning("Failed to re-attach fabric stage after pause/resume. Articulation visuals may be stale.")
 
     def _update_anim_recording(self):
         """Tracks anim recording timestamps and triggers finish animation recording if the total time has elapsed."""


### PR DESCRIPTION
# Description

Backports the develop-side fix from #5178 to ``main`` so Isaac Sim 5.1 users on ``main`` benefit from the same Kit GUI pause/resume fix.

Starting with PhysX fabric 107.3.21 (shipped in Isaac Sim 5.1), the FabricManager skips writing initial articulation poses to fabric on subsequent resumes -- only the first play triggers ``FabricManager::resume:rigidBodyInitialization:writeToFabric``. This causes articulation (robot) meshes to freeze visually after pause/resume in the Kit GUI, even though physics continues running underneath.

After the timeline resumes, ``SimulationContext.step()`` now detaches and re-attaches the stage on the fabric interface, forcing the FabricManager to fully reinitialize and write transforms back into fabric so Hydra picks up correct poses on the next render.

The PR description for the develop fix already noted the issue manifests differently on ``main`` (markers pause correctly, but articulations remain frozen) and linked a hotfix gist for ``main``: https://gist.github.com/garylvov/9919d936d0393d548d51d7deaf473402. This PR is that hotfix, packaged with changelog and version bump.

## Mapping from develop to main

The develop-side fix lives across three files because develop introduced a ``PhysicsManager`` / ``PhysxManager`` split that doesn't exist on ``main``. On ``main`` the equivalent logic collapses into a single file:

| | develop (#5178) | main (this PR) |
| --- | --- | --- |
| Wait-for-playing loop | New, in ``PhysxManager.wait_for_playing()`` | Already exists in ``SimulationContext.step()`` |
| Fabric re-sync (``detach_stage`` / ``attach_stage``) | New, in ``PhysxManager._re_sync_fabric()`` | New, added to ``SimulationContext`` |
| ``wait_for_playing()`` no-op base | New, in ``PhysicsManager`` | N/A -- no manager abstraction on main |
| ``UsdUtils`` import | Added | Already imported |
| Files touched | 3 | 1 |

The semantic core (``detach_stage`` then ``attach_stage`` to force PhysX fabric ≥107.3.21 to rewrite articulation poses on resume) is identical to the develop fix.

Fixes #4279

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Verification

Tested on ``main`` with the same task as #5178:

```bash
python scripts/reinforcement_learning/rsl_rl/train.py \
    --task Isaac-Velocity-Flat-Anymal-D-v0 --num_envs 4
```

Press pause in the Kit GUI, wait, then press play again. Articulation meshes resume animating in lockstep with physics.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

Credit to @garylvov for the original develop-side fix and the ``main`` hotfix gist this PR packages.