### PR TITLE
Pin PyTorch intersphinx to /docs/2.11/ to fix broken /stable/ alias

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,7 +136,8 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "trimesh": ("https://trimesh.org/", None),
-    "torch": ("https://docs.pytorch.org/docs/stable/", None),
+    # NOTE: PyTorch intersphinx entry temporarily removed; pytorch.org no longer
+    # serves objects.inv (404), which breaks `make current-docs` (uses -W).
     "isaacsim": ("https://docs.isaacsim.omniverse.nvidia.com/6.0.0/py/", None),
     "gymnasium": ("https://gymnasium.farama.org/", None),
     "warp": ("https://nvidia.github.io/warp/", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,8 +136,8 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "trimesh": ("https://trimesh.org/", None),
-    # NOTE: PyTorch intersphinx entry temporarily removed; pytorch.org no longer
-    # serves objects.inv (404), which breaks `make current-docs` (uses -W).
+    # NOTE: pinned to /docs/2.11/ because /docs/stable/objects.inv currently 404s
+    "torch": ("https://docs.pytorch.org/docs/2.11/", None),
     "isaacsim": ("https://docs.isaacsim.omniverse.nvidia.com/6.0.0/py/", None),
     "gymnasium": ("https://gymnasium.farama.org/", None),
     "warp": ("https://nvidia.github.io/warp/", None),


### PR DESCRIPTION
# Description

PyTorch's /docs/stable/ is broken (no objects.inv), so Sphinx 404s; pin to a real versioned path.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there