### PR TITLE
Fix required CI checks for docs-only PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,13 +48,6 @@ name: Docker + Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'source/**'
-      - 'docker/**'
-      - 'tools/**'
-      - 'apps/**'
-      - '.github/workflows/build.yaml'
-      - '.github/actions/**'
     branches:
       - main
       - develop
@@ -77,6 +70,33 @@ env:
   CI_IMAGE_TAG: isaac-lab-ci:${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}-${{ github.sha }}
 
 jobs:
+  changes:
+    name: Detect Docker Test Changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_docker_tests: ${{ steps.detect.outputs.run_docker_tests }}
+    steps:
+    - id: detect
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "run_docker_tests=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        changed_files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+        printf '%s\n' "$changed_files"
+
+        if printf '%s\n' "$changed_files" | grep -qE '^(source/|docker/|tools/|apps/|\.github/workflows/build\.yaml$|\.github/workflows/config\.yaml$|\.github/actions/)'; then
+          echo "run_docker_tests=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "run_docker_tests=false" >> "$GITHUB_OUTPUT"
+        fi
+
   config:
     name: Load Config
     runs-on: ubuntu-latest
@@ -102,7 +122,8 @@ jobs:
   build:
     name: Build Base Docker Image
     runs-on: [self-hosted, gpu]
-    needs: [config]
+    needs: [changes, config]
+    if: needs.changes.outputs.run_docker_tests == 'true'
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6
@@ -122,7 +143,8 @@ jobs:
   build-curobo:
     name: Build cuRobo Docker Image
     runs-on: [self-hosted, gpu]
-    needs: [config]
+    needs: [changes, config]
+    if: needs.changes.outputs.run_docker_tests == 'true'
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6
@@ -506,6 +528,61 @@ jobs:
         include-files: "test_environments_training.py"
         container-name: isaac-lab-environments-training-test
   #endregion
+
+  docker-required-tests-gate:
+    name: Docker Required Tests Gate
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - build
+      - test-isaaclab-core
+      - test-isaaclab-core-2
+      - test-isaaclab-core-3
+      - test-isaaclab-assets
+      - test-isaaclab-contrib
+      - test-isaaclab-newton
+    if: always()
+    steps:
+    - name: Check required Docker test results
+      env:
+        CHANGES_RESULT: ${{ needs.changes.result }}
+        RUN_DOCKER_TESTS: ${{ needs.changes.outputs.run_docker_tests }}
+        BUILD_RESULT: ${{ needs.build.result }}
+        CORE_1_RESULT: ${{ needs.test-isaaclab-core.result }}
+        CORE_2_RESULT: ${{ needs.test-isaaclab-core-2.result }}
+        CORE_3_RESULT: ${{ needs.test-isaaclab-core-3.result }}
+        ASSETS_RESULT: ${{ needs.test-isaaclab-assets.result }}
+        CONTRIB_RESULT: ${{ needs.test-isaaclab-contrib.result }}
+        NEWTON_RESULT: ${{ needs.test-isaaclab-newton.result }}
+      run: |
+        set -euo pipefail
+
+        if [ "$CHANGES_RESULT" != "success" ]; then
+          echo "Change detection failed with result: $CHANGES_RESULT"
+          exit 1
+        fi
+
+        if [ "$RUN_DOCKER_TESTS" != "true" ]; then
+          echo "Docker tests are not required for this change."
+          exit 0
+        fi
+
+        failures=()
+        [ "$BUILD_RESULT" = "success" ] || failures+=("Build Base Docker Image: $BUILD_RESULT")
+        [ "$CORE_1_RESULT" = "success" ] || failures+=("isaaclab (core) [1/3]: $CORE_1_RESULT")
+        [ "$CORE_2_RESULT" = "success" ] || failures+=("isaaclab (core) [2/3]: $CORE_2_RESULT")
+        [ "$CORE_3_RESULT" = "success" ] || failures+=("isaaclab (core) [3/3]: $CORE_3_RESULT")
+        [ "$ASSETS_RESULT" = "success" ] || failures+=("isaaclab_assets: $ASSETS_RESULT")
+        [ "$CONTRIB_RESULT" = "success" ] || failures+=("isaaclab_contrib: $CONTRIB_RESULT")
+        [ "$NEWTON_RESULT" = "success" ] || failures+=("isaaclab_newton: $NEWTON_RESULT")
+
+        if [ "${#failures[@]}" -gt 0 ]; then
+          printf 'Required Docker checks did not pass:\n'
+          printf ' - %s\n' "${failures[@]}"
+          exit 1
+        fi
+
+        echo "Required Docker checks passed."
 
 #region disabled quarantined tests
 # test-quarantined:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -529,31 +529,57 @@ jobs:
         container-name: isaac-lab-environments-training-test
   #endregion
 
-  docker-required-tests-gate:
-    name: Docker Required Tests Gate
+  docker-tests-gate:
+    name: Docker Tests Gate
     runs-on: ubuntu-latest
     needs:
       - changes
       - build
+      - build-curobo
+      - test-isaaclab-tasks
+      - test-isaaclab-tasks-2
+      - test-isaaclab-tasks-3
       - test-isaaclab-core
       - test-isaaclab-core-2
       - test-isaaclab-core-3
+      - test-isaaclab-rl
+      - test-isaaclab-mimic
       - test-isaaclab-assets
       - test-isaaclab-contrib
+      - test-isaaclab-teleop
+      - test-isaaclab-visualizers
       - test-isaaclab-newton
+      - test-isaaclab-physx
+      - test-isaaclab-ov
+      - test-curobo
+      - test-skillgen
+      - test-environments-training
     if: always()
     steps:
-    - name: Check required Docker test results
+    - name: Check Docker test results
       env:
         CHANGES_RESULT: ${{ needs.changes.result }}
         RUN_DOCKER_TESTS: ${{ needs.changes.outputs.run_docker_tests }}
         BUILD_RESULT: ${{ needs.build.result }}
+        BUILD_CUROBO_RESULT: ${{ needs.build-curobo.result }}
+        TASKS_1_RESULT: ${{ needs.test-isaaclab-tasks.result }}
+        TASKS_2_RESULT: ${{ needs.test-isaaclab-tasks-2.result }}
+        TASKS_3_RESULT: ${{ needs.test-isaaclab-tasks-3.result }}
         CORE_1_RESULT: ${{ needs.test-isaaclab-core.result }}
         CORE_2_RESULT: ${{ needs.test-isaaclab-core-2.result }}
         CORE_3_RESULT: ${{ needs.test-isaaclab-core-3.result }}
+        RL_RESULT: ${{ needs.test-isaaclab-rl.result }}
+        MIMIC_RESULT: ${{ needs.test-isaaclab-mimic.result }}
         ASSETS_RESULT: ${{ needs.test-isaaclab-assets.result }}
         CONTRIB_RESULT: ${{ needs.test-isaaclab-contrib.result }}
+        TELEOP_RESULT: ${{ needs.test-isaaclab-teleop.result }}
+        VISUALIZERS_RESULT: ${{ needs.test-isaaclab-visualizers.result }}
         NEWTON_RESULT: ${{ needs.test-isaaclab-newton.result }}
+        PHYSX_RESULT: ${{ needs.test-isaaclab-physx.result }}
+        OV_RESULT: ${{ needs.test-isaaclab-ov.result }}
+        CUROBO_RESULT: ${{ needs.test-curobo.result }}
+        SKILLGEN_RESULT: ${{ needs.test-skillgen.result }}
+        ENVIRONMENTS_TRAINING_RESULT: ${{ needs.test-environments-training.result }}
       run: |
         set -euo pipefail
 
@@ -569,20 +595,33 @@ jobs:
 
         failures=()
         [ "$BUILD_RESULT" = "success" ] || failures+=("Build Base Docker Image: $BUILD_RESULT")
+        [ "$BUILD_CUROBO_RESULT" = "success" ] || failures+=("Build cuRobo Docker Image: $BUILD_CUROBO_RESULT")
+        [ "$TASKS_1_RESULT" = "success" ] || failures+=("isaaclab_tasks [1/3]: $TASKS_1_RESULT")
+        [ "$TASKS_2_RESULT" = "success" ] || failures+=("isaaclab_tasks [2/3]: $TASKS_2_RESULT")
+        [ "$TASKS_3_RESULT" = "success" ] || failures+=("isaaclab_tasks [3/3]: $TASKS_3_RESULT")
         [ "$CORE_1_RESULT" = "success" ] || failures+=("isaaclab (core) [1/3]: $CORE_1_RESULT")
         [ "$CORE_2_RESULT" = "success" ] || failures+=("isaaclab (core) [2/3]: $CORE_2_RESULT")
         [ "$CORE_3_RESULT" = "success" ] || failures+=("isaaclab (core) [3/3]: $CORE_3_RESULT")
+        [ "$RL_RESULT" = "success" ] || failures+=("isaaclab_rl: $RL_RESULT")
+        [ "$MIMIC_RESULT" = "success" ] || failures+=("isaaclab_mimic: $MIMIC_RESULT")
         [ "$ASSETS_RESULT" = "success" ] || failures+=("isaaclab_assets: $ASSETS_RESULT")
         [ "$CONTRIB_RESULT" = "success" ] || failures+=("isaaclab_contrib: $CONTRIB_RESULT")
+        [ "$TELEOP_RESULT" = "success" ] || failures+=("isaaclab_teleop: $TELEOP_RESULT")
+        [ "$VISUALIZERS_RESULT" = "success" ] || failures+=("isaaclab_visualizers: $VISUALIZERS_RESULT")
         [ "$NEWTON_RESULT" = "success" ] || failures+=("isaaclab_newton: $NEWTON_RESULT")
+        [ "$PHYSX_RESULT" = "success" ] || failures+=("isaaclab_physx: $PHYSX_RESULT")
+        [ "$OV_RESULT" = "success" ] || failures+=("isaaclab_ov: $OV_RESULT")
+        [ "$CUROBO_RESULT" = "success" ] || failures+=("test-curobo: $CUROBO_RESULT")
+        [ "$SKILLGEN_RESULT" = "success" ] || failures+=("test-skillgen: $SKILLGEN_RESULT")
+        [ "$ENVIRONMENTS_TRAINING_RESULT" = "success" ] || failures+=("environments_training: $ENVIRONMENTS_TRAINING_RESULT")
 
         if [ "${#failures[@]}" -gt 0 ]; then
-          printf 'Required Docker checks did not pass:\n'
+          printf 'Docker checks did not pass:\n'
           printf ' - %s\n' "${failures[@]}"
           exit 1
         fi
 
-        echo "Required Docker checks passed."
+        echo "Docker checks passed."
 
 #region disabled quarantined tests
 # test-quarantined:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,6 +91,7 @@ jobs:
         changed_files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
         printf '%s\n' "$changed_files"
 
+        # config.yaml controls the base image names and tags consumed by the Docker build jobs.
         if printf '%s\n' "$changed_files" | grep -qE '^(source/|docker/|tools/|apps/|\.github/workflows/build\.yaml$|\.github/workflows/config\.yaml$|\.github/actions/)'; then
           echo "run_docker_tests=true" >> "$GITHUB_OUTPUT"
         else

--- a/.github/workflows/install-ci.yml
+++ b/.github/workflows/install-ci.yml
@@ -7,15 +7,6 @@ name: Installation Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'apps/**'
-      - 'VERSION'
-      - 'tools/**'
-      - 'source/**'
-      - '**/pyproject.toml'
-      - '**/environment.yaml'
-      - '.github/actions/run-package-tests/**'
-      - '.github/workflows/install-ci.yml'
   push:
     branches:
       - main
@@ -33,9 +24,39 @@ on:
         default: ''
 permissions:
   contents: read
+  pull-requests: read
 jobs:
+  changes:
+    name: Detect Installation Test Changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_install_tests: ${{ steps.detect.outputs.run_install_tests }}
+    steps:
+      - id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run_install_tests=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+          printf '%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -qE '^(apps/|tools/|source/|\.github/actions/run-package-tests/|\.github/workflows/install-ci\.yml$|VERSION$)|(^|/)pyproject\.toml$|(^|/)environment\.ya?ml$'; then
+            echo "run_install_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_install_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+
   install-tests:
     name: Installation Tests
+    needs: [changes]
+    if: needs.changes.outputs.run_install_tests == 'true'
     runs-on: [self-hosted, gpu]
     timeout-minutes: 90
     steps:
@@ -56,3 +77,34 @@ jobs:
           fi
 
           tools/run_install_ci.py docker $RUNNER_ARGS -- --tb=short "${PYTEST_EXTRA_ARGS[@]}"
+
+  installation-tests-gate:
+    name: Installation Tests Gate
+    needs: [changes, install-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check installation test result
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          RUN_INSTALL_TESTS: ${{ needs.changes.outputs.run_install_tests }}
+          INSTALL_TESTS_RESULT: ${{ needs.install-tests.result }}
+        run: |
+          set -euo pipefail
+
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "Change detection failed with result: $CHANGES_RESULT"
+            exit 1
+          fi
+
+          if [ "$RUN_INSTALL_TESTS" != "true" ]; then
+            echo "Installation tests are not required for this change."
+            exit 0
+          fi
+
+          if [ "$INSTALL_TESTS_RESULT" != "success" ]; then
+            echo "Installation Tests did not pass: $INSTALL_TESTS_RESULT"
+            exit 1
+          fi
+
+          echo "Installation Tests passed."

--- a/.github/workflows/test_required_ci_gates.py
+++ b/.github/workflows/test_required_ci_gates.py
@@ -31,6 +31,10 @@ def _as_list(value: str | list[str]) -> list[str]:
     return [value]
 
 
+def _assert_job_if_is_exactly(job: dict[str, Any], expected: str) -> None:
+    assert job["if"] == expected
+
+
 def test_required_docker_test_workflow_reports_for_docs_only_prs():
     workflow = _load_workflow("build.yaml")
 
@@ -43,19 +47,34 @@ def test_required_docker_test_workflow_reports_for_docs_only_prs():
     for job_name in ("build", "build-curobo"):
         job = jobs[job_name]
         assert "changes" in _as_list(job["needs"])
-        assert "needs.changes.outputs.run_docker_tests == 'true'" in job["if"]
+        _assert_job_if_is_exactly(job, "needs.changes.outputs.run_docker_tests == 'true'")
 
-    gate = jobs["docker-required-tests-gate"]
-    assert gate["name"] == "Docker Required Tests Gate"
+    gate = jobs["docker-tests-gate"]
+    assert gate["name"] == "Docker Tests Gate"
     assert gate["if"] == "always()"
-    assert "changes" in gate["needs"]
-    assert "build" in gate["needs"]
-    assert "test-isaaclab-core" in gate["needs"]
-    assert "test-isaaclab-core-2" in gate["needs"]
-    assert "test-isaaclab-core-3" in gate["needs"]
-    assert "test-isaaclab-assets" in gate["needs"]
-    assert "test-isaaclab-contrib" in gate["needs"]
-    assert "test-isaaclab-newton" in gate["needs"]
+    assert gate["needs"] == [
+        "changes",
+        "build",
+        "build-curobo",
+        "test-isaaclab-tasks",
+        "test-isaaclab-tasks-2",
+        "test-isaaclab-tasks-3",
+        "test-isaaclab-core",
+        "test-isaaclab-core-2",
+        "test-isaaclab-core-3",
+        "test-isaaclab-rl",
+        "test-isaaclab-mimic",
+        "test-isaaclab-assets",
+        "test-isaaclab-contrib",
+        "test-isaaclab-teleop",
+        "test-isaaclab-visualizers",
+        "test-isaaclab-newton",
+        "test-isaaclab-physx",
+        "test-isaaclab-ov",
+        "test-curobo",
+        "test-skillgen",
+        "test-environments-training",
+    ]
 
 
 def test_required_installation_workflow_reports_for_docs_only_prs():
@@ -69,7 +88,7 @@ def test_required_installation_workflow_reports_for_docs_only_prs():
 
     install_tests = jobs["install-tests"]
     assert "changes" in _as_list(install_tests["needs"])
-    assert "needs.changes.outputs.run_install_tests == 'true'" in install_tests["if"]
+    _assert_job_if_is_exactly(install_tests, "needs.changes.outputs.run_install_tests == 'true'")
 
     gate = jobs["installation-tests-gate"]
     assert gate["name"] == "Installation Tests Gate"

--- a/.github/workflows/test_required_ci_gates.py
+++ b/.github/workflows/test_required_ci_gates.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression tests for required CI checks that must always report."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_WORKFLOW_DIR = Path(__file__).resolve().parent
+
+
+def _load_workflow(name: str) -> dict[str, Any]:
+    with (_WORKFLOW_DIR / name).open(encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _on_config(workflow: dict[str, Any]) -> dict[str, Any]:
+    # PyYAML follows YAML 1.1, where the key "on" is parsed as True.
+    return workflow.get("on", workflow.get(True, {}))
+
+
+def _as_list(value: str | list[str]) -> list[str]:
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def test_required_docker_test_workflow_reports_for_docs_only_prs():
+    workflow = _load_workflow("build.yaml")
+
+    pull_request = _on_config(workflow)["pull_request"]
+    assert "paths" not in pull_request
+
+    jobs = workflow["jobs"]
+    assert jobs["changes"]["outputs"]["run_docker_tests"] == "${{ steps.detect.outputs.run_docker_tests }}"
+
+    for job_name in ("build", "build-curobo"):
+        job = jobs[job_name]
+        assert "changes" in _as_list(job["needs"])
+        assert "needs.changes.outputs.run_docker_tests == 'true'" in job["if"]
+
+    gate = jobs["docker-required-tests-gate"]
+    assert gate["name"] == "Docker Required Tests Gate"
+    assert gate["if"] == "always()"
+    assert "changes" in gate["needs"]
+    assert "build" in gate["needs"]
+    assert "test-isaaclab-core" in gate["needs"]
+    assert "test-isaaclab-core-2" in gate["needs"]
+    assert "test-isaaclab-core-3" in gate["needs"]
+    assert "test-isaaclab-assets" in gate["needs"]
+    assert "test-isaaclab-contrib" in gate["needs"]
+    assert "test-isaaclab-newton" in gate["needs"]
+
+
+def test_required_installation_workflow_reports_for_docs_only_prs():
+    workflow = _load_workflow("install-ci.yml")
+
+    pull_request = _on_config(workflow)["pull_request"]
+    assert "paths" not in pull_request
+
+    jobs = workflow["jobs"]
+    assert jobs["changes"]["outputs"]["run_install_tests"] == "${{ steps.detect.outputs.run_install_tests }}"
+
+    install_tests = jobs["install-tests"]
+    assert "changes" in _as_list(install_tests["needs"])
+    assert "needs.changes.outputs.run_install_tests == 'true'" in install_tests["if"]
+
+    gate = jobs["installation-tests-gate"]
+    assert gate["name"] == "Installation Tests Gate"
+    assert gate["if"] == "always()"
+    assert gate["needs"] == ["changes", "install-tests"]


### PR DESCRIPTION
## Summary
- Remove PR-level path filters from required Docker and installation workflows so checks are always reported.
- Add change-detection jobs that skip expensive self-hosted tests for docs-only PRs.
- Add gate checks for branch protection: `Docker Tests Gate` and `Installation Tests Gate`.
- Add a regression test that verifies required workflows do not use path filters and expose gate jobs.

## Testing
- `./isaaclab.sh -p -m pytest .github/workflows/test_required_ci_gates.py -q`
- `./isaaclab.sh -f`

## Follow-up for branch protection
After this merges, update the required checks to require the gate checks instead of the individual Docker shards and installation job:
- require `Docker Tests Gate`
- require `Installation Tests Gate`
- remove required checks for `Installation Tests`, `isaaclab (core) [1/3]`, `isaaclab (core) [2/3]`, `isaaclab (core) [3/3]`, `isaaclab_assets`, `isaaclab_contrib`, and `isaaclab_newton`