### PR TITLE
Remove colors of deformable cube tutorial docs

### DIFF
--- a/docs/source/tutorials/01_assets/run_deformable_object.rst
+++ b/docs/source/tutorials/01_assets/run_deformable_object.rst
@@ -163,7 +163,7 @@ Now that we have gone through the code, let's run the script and see the result:
    ./isaaclab.sh -p scripts/tutorials/01_assets/run_deformable_object.py --visualizer kit
 
 
-This should open a stage with a ground plane, lights, and several green cubes. Two of the four cubes must be dropping
+This should open a stage with a ground plane, lights, and several cubes. Two of the four cubes must be dropping
 from a height and settling on to the ground. Meanwhile the other two cubes must be moving along the z-axis. You
 should see a marker showing the kinematic target position for the nodes at the bottom-left corner of the cubes.
 To stop the simulation, you can either close the window, or press ``Ctrl+C`` in the terminal


### PR DESCRIPTION
# Description

Clear up docs on tutorials for deformable asset. No need to mention color of cubes (in case this changes in the future). 

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
