### PR TITLE
Document Kamino solver presets

### DIFF
--- a/docs/source/experimental-features/newton-physics-integration/solver-transitioning.rst
+++ b/docs/source/experimental-features/newton-physics-integration/solver-transitioning.rst
@@ -2,7 +2,16 @@ Solver Transitioning
 ====================
 
 Transitioning to the Newton physics engine introduces new physics solvers that handle simulation using different numerical approaches.
-While Newton supports several different solvers, our initial focus for Isaac Lab is on using the MuJoCo-Warp solver from Google DeepMind.
+While Newton supports several different solvers, our initial focus for Isaac Lab is on using the
+MuJoCo-Warp solver from Google DeepMind. Isaac Lab also includes beta support for the Kamino
+solver on selected classic tasks. Kamino is selected through a physics preset rather than as a
+separate backend; see :ref:`hydra-backend-solver-presets`.
+
+.. note::
+
+    Kamino support is experimental and currently depends on assets being structured
+    in a way that Kamino can consume. Assets that work with MuJoCo-Warp or PhysX
+    may still require model-structure updates before they work with Kamino.
 
 The way the physics scene itself is defined does not change - we continue to use USD as the primary way to set basic parameters of objects and robots in the scene,
 and for current environments, the exact same USD files used for the PhysX-based Isaac Lab are used.
@@ -12,15 +21,18 @@ What does require change is the way that some solver-specific settings are confi
 Tuning these parameters can have a significant impact on both simulation performance and behaviour.
 
 For now, we will show an example of setting these parameters to help provide a feel for these changes.
-Note that the :class:`~isaaclab.sim.NewtonCfg` replaces the :class:`~isaaclab.sim.PhysxCfg` and is used to set everything related to the physical simulation parameters except for the ``dt``:
+Note that the :class:`~isaaclab_newton.physics.NewtonCfg` replaces
+:class:`~isaaclab_physx.physics.PhysxCfg` and is used to set everything related to the physical
+simulation parameters except for the ``dt``:
 
 .. code-block:: python
 
-    from isaaclab.sim._impl.newton_manager_cfg import NewtonCfg
-    from isaaclab.sim._impl.solvers_cfg import MJWarpSolverCfg
+    from isaaclab.sim import SimulationCfg
+    from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 
     solver_cfg = MJWarpSolverCfg(
-        nefc_per_env=35,
+        njmax=35,
+        nconmax=20,
         ls_iterations=10,
         cone="pyramidal",
         ls_parallel=True,
@@ -31,14 +43,17 @@ Note that the :class:`~isaaclab.sim.NewtonCfg` replaces the :class:`~isaaclab.si
         num_substeps=1,
         debug_mode=False,
     )
-    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, newton_cfg=newton_cfg)
+    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=newton_cfg)
 
 
 Here is a very brief explanation of some of the key parameters above:
 
-* ``nefc_per_env``: This is the size of the buffer constraints we want MuJoCo warp to
-  pre-allocate for a given environment. A large value will slow down the simulation,
-  while a too small value may lead to some contacts being missed.
+* ``njmax``: This is the number of constraint rows MuJoCo-Warp pre-allocates for a
+  given environment. A large value will slow down the simulation, while a too small
+  value may lead to missing constraints.
+
+* ``nconmax``: This is the maximum number of contact points MuJoCo-Warp pre-allocates
+  for a given environment. Set it high enough for the expected contact count.
 
 * ``ls_iterations``: The number of line searches performed by the MuJoCo Warp solver.
   Line searches are used to find an optimal step size, and for each solver step,

--- a/docs/source/features/hydra.rst
+++ b/docs/source/features/hydra.rst
@@ -242,6 +242,74 @@ disabled unless explicitly selected:
     python train.py --task=Isaac-Reach-Franka-v0 env.scene.camera=large
 
 
+.. _hydra-backend-solver-presets:
+
+Backend and Solver Presets
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Physics backend selection uses the same preset system. A task can define a
+``PresetCfg`` whose entries replace the complete physics config:
+
+.. code-block:: python
+
+    from isaaclab.utils import configclass
+    from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+    from isaaclab_physx.physics import PhysxCfg
+    from isaaclab_tasks.utils import PresetCfg
+
+    @configclass
+    class CartpolePhysicsCfg(PresetCfg):
+        default: PhysxCfg = PhysxCfg()
+        physx: PhysxCfg = PhysxCfg()
+        newton: NewtonCfg = NewtonCfg(
+            solver_cfg=MJWarpSolverCfg(njmax=5, nconmax=3),
+            num_substeps=1,
+        )
+        kamino: NewtonCfg = NewtonCfg(
+            solver_cfg=KaminoSolverCfg(
+                integrator="moreau",
+                use_collision_detector=True,
+                sparse_jacobian=True,
+                padmm_max_iterations=100,
+            ),
+            num_substeps=1,
+            debug_mode=False,
+            use_cuda_graph=True,
+        )
+
+The ``newton`` and ``kamino`` entries both select the Newton physics backend because
+both entries are :class:`~isaaclab_newton.physics.NewtonCfg` objects. The difference
+is the solver configuration: ``newton`` uses
+:class:`~isaaclab_newton.physics.MJWarpSolverCfg`, while ``kamino`` uses
+:class:`~isaaclab_newton.physics.KaminoSolverCfg`.
+
+Kamino is therefore a solver preset, not a separate Isaac Lab backend. The same
+Newton assets, sensors, renderers, and visualizers are used after the preset is
+resolved. It is a Proximal Alternating Direction Method of Multipliers (P-ADMM)
+based solver for constrained rigid multi-body dynamics, and its Isaac Lab support
+is currently beta.
+
+.. note::
+
+    Kamino support is experimental and currently depends on the asset being
+    structured in a way that Kamino can consume. Assets that work with the
+    MuJoCo-Warp or PhysX presets may still require model-structure updates before
+    they work with ``presets=kamino``.
+
+.. code-block:: bash
+
+    # Select the Kamino solver preset everywhere it is defined
+    python train.py --task=Isaac-Cartpole-v0 presets=kamino
+
+    # Select the Kamino solver preset for a specific physics config path
+    python train.py --task=Isaac-Cartpole-v0 env.sim.physics=kamino
+
+The ``kamino`` preset is currently defined for ``Isaac-Cartpole-Direct-v0``,
+``Isaac-Ant-Direct-v0``, ``Isaac-Cartpole-v0``, and ``Isaac-Ant-v0``. Passing
+``presets=kamino`` to a task without a ``kamino`` preset does not enable Kamino;
+add and validate a task-specific preset first.
+
+
 Inline Presets with preset()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
# Description

Document Kamino solver selection through the existing Hydra preset system.

- Adds a "Backend and Solver Presets" section that explains how `newton` and `kamino` presets both use `NewtonCfg` but choose different solver configs.
- Notes that Kamino is experimental and depends on assets being structured for Kamino.
- Adds a brief mention from the Newton solver-transitioning page and updates the MuJoCo-Warp example to current public config APIs.

Fixes: N/A

## Type of change

- Documentation update

## Screenshots

N/A. Documentation-only change.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension config file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there