### PR TITLE
Adds compatibility note regarding Isaac Sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This branch is a development branch for Isaac Sim 6.0, which is currently only a
 For installation, please refer to the Isaac Sim GitHub repo to build the latest Isaac Sim branch, and follow the binary installation method in the
 Isaac Lab documentation for Isaac Lab installation.
 
+> [!WARNING]
+> A recent breaking change on the Isaac Lab `develop` branch is not compatible with the `develop` branch of Isaac Sim on GitHub.
+> To run Isaac Lab with Isaac Sim's GitHub `develop` branch, use Isaac Lab commit [`f0234a82e432e2a0b0f0a26ca3c5b59e527ddaaa`](https://github.com/isaac-sim/IsaacLab/commit/f0234a82e432e2a0b0f0a26ca3c5b59e527ddaaa) or an earlier commit.
+> Alternatively, use the Isaac Lab [`v3.0.0-beta`](https://github.com/isaac-sim/IsaacLab/tree/v3.0.0-beta) tag.
+
 Note that this branch is currently under active development and may experience breaking changes or error messages.
 Performance issues and regressions may also be observed in some use cases.
 

--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -42,6 +42,13 @@ installation methods.
 
 .. caution::
 
+   **Compatibility warning for Isaac Sim GitHub develop:** A recent breaking change on the Isaac Lab
+   ``develop`` branch is not compatible with the ``develop`` branch of Isaac Sim on GitHub. To run
+   Isaac Lab with Isaac Sim's GitHub ``develop`` branch, use Isaac Lab commit
+   `f0234a82e432e2a0b0f0a26ca3c5b59e527ddaaa <https://github.com/isaac-sim/IsaacLab/commit/f0234a82e432e2a0b0f0a26ca3c5b59e527ddaaa>`__
+   or an earlier commit. Alternatively, use the Isaac Lab
+   `v3.0.0-beta <https://github.com/isaac-sim/IsaacLab/tree/v3.0.0-beta>`__ tag.
+
    We have dropped support for Isaac Sim versions 5.1.0 and below. We recommend using the latest
    Isaac Sim 6.0.0 release to benefit from the latest features and improvements.
 

--- a/docs/source/setup/installation/source_installation.rst
+++ b/docs/source/setup/installation/source_installation.rst
@@ -23,6 +23,15 @@ or want to test Isaac Lab with the nightly version of Isaac Sim.
 The following instructions are adapted from the `Isaac Sim documentation <https://github.com/isaac-sim/IsaacSim?tab=readme-ov-file#quick-start>`_
 for the convenience of users.
 
+.. warning::
+
+   **Compatibility warning for Isaac Sim GitHub develop:** A recent breaking change on the Isaac Lab
+   ``develop`` branch is not compatible with the ``develop`` branch of Isaac Sim on GitHub. To run
+   Isaac Lab with Isaac Sim's GitHub ``develop`` branch, use Isaac Lab commit
+   `f0234a82e432e2a0b0f0a26ca3c5b59e527ddaaa <https://github.com/isaac-sim/IsaacLab/commit/f0234a82e432e2a0b0f0a26ca3c5b59e527ddaaa>`__
+   or an earlier commit. Alternatively, use the Isaac Lab
+   `v3.0.0-beta <https://github.com/isaac-sim/IsaacLab/tree/v3.0.0-beta>`__ tag.
+
 .. attention::
 
    Building Isaac Sim from source requires Ubuntu 22.04 LTS or higher.


### PR DESCRIPTION
# Description

Recent changes in Isaac Lab requires a newer version of Isaac Sim than what is available in the GitHub repo for Isaac Sim. Adds notes in the docs and readme to mention this incompatibility issue and specifies working commits and tags of Isaac Lab that can be used in conjunction with Isaac Sim from GitHub.

## Type of change

- Documentation update


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
