### PR TITLE
Updates wheel versioning

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -46,13 +46,30 @@ jobs:
           python-version: "3.12"
           architecture: x64
 
+      # Compose Docker-image-style metadata for the artifact. The artifact
+      # name is what QA sees in `gh run download`, so we make it scannable:
+      # isaaclab-<VERSION>-build<RUN_NUMBER>-<SHA7>. The wheel inside follows
+      # PEP 440 (VERSION+buildN.SHA7) since pip requires that format.
+      - name: Compute wheel metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          version=$(cat VERSION)
+          sha_slug="${GITHUB_SHA:0:7}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "sha_slug=$sha_slug" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=isaaclab-${version}-build${{ github.run_number }}-${sha_slug}" >> "$GITHUB_OUTPUT"
+
       - name: Build wheel
+        env:
+          WHEEL_BUILD_NUMBER: ${{ github.run_number }}
+          WHEEL_SHA: ${{ github.sha }}
         run: bash tools/wheel_builder/build.sh
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ github.event_name == 'pull_request' && format('isaaclab-wheel-pr-{0}-{1}', github.event.pull_request.number, github.sha) || format('isaaclab-wheel-{0}-{1}', github.ref_name, github.sha) }}
+          name: ${{ steps.meta.outputs.artifact_name }}
           path: tools/wheel_builder/build/dist/isaaclab-*.whl
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -56,8 +56,6 @@ jobs:
           set -euo pipefail
           version=$(cat VERSION)
           sha_slug="${GITHUB_SHA:0:7}"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "sha_slug=$sha_slug" >> "$GITHUB_OUTPUT"
           echo "artifact_name=isaaclab-${version}-build${{ github.run_number }}-${sha_slug}" >> "$GITHUB_OUTPUT"
 
       - name: Build wheel

--- a/tools/wheel_builder/build.sh
+++ b/tools/wheel_builder/build.sh
@@ -8,6 +8,21 @@ VERSION=$(cat VERSION)
 BUILD_DIR=$SELF_DIR/build/stage
 DIST_DIR=$SELF_DIR/build/dist
 
+# Compose a PEP 440 local version when CI metadata is provided so the wheel is
+# traceable to a specific build and commit. With both env vars set the version
+# becomes e.g. "3.0.0+build123.abc1234" (build number is monotonic, sha slug
+# pins the source). If either is missing, fall back to the plain VERSION so
+# local dev builds stay simple.
+WHEEL_BUILD_NUMBER="${WHEEL_BUILD_NUMBER:-}"
+WHEEL_SHA="${WHEEL_SHA:-}"
+if [ -n "$WHEEL_BUILD_NUMBER" ] && [ -n "$WHEEL_SHA" ]; then
+  SHA_SLUG="${WHEEL_SHA:0:7}"
+  WHEEL_VERSION="${VERSION}+build${WHEEL_BUILD_NUMBER}.${SHA_SLUG}"
+else
+  WHEEL_VERSION="${VERSION}"
+fi
+echo "[WHEEL VERSION] $WHEEL_VERSION"
+
 # Platform tags matching the official IsaacLab wheel
 PYTHON_TAG="${PYTHON_TAG:-cp312}"
 ABI_TAG="${ABI_TAG:-cp312}"
@@ -65,7 +80,7 @@ cp "$SELF_DIR/res/__init__.py" "$BUILD_DIR/src/isaaclab/"
 cp "$SELF_DIR/res/__main__.py" "$BUILD_DIR/src/isaaclab/"
 
 # 3. Generate pyproject.toml with dependencies from python_packages.toml
-python3 "$SELF_DIR/gen_pyproject.py" "$SELF_DIR/res/python_packages.toml" "$BUILD_DIR/pyproject.toml" "$VERSION"
+python3 "$SELF_DIR/gen_pyproject.py" "$SELF_DIR/res/python_packages.toml" "$BUILD_DIR/pyproject.toml" "$WHEEL_VERSION"
 
 # 4. Build the wheel
 cd "$BUILD_DIR"


### PR DESCRIPTION
# Description

Adds wheel versioning so QA can identify which build is newer and reproduce any wheel from its commit. The wheel follows PEP 440 local-version `<VERSION>+build<N>.<sha7>`.

Downloading in QA env:

```
# Latest from develop
RUN_ID=$(gh run list --workflow=wheel.yml --branch=develop -L 1 --json databaseId -q '.[0].databaseId')
rm -rf ./out && gh run download "$RUN_ID" --pattern 'isaaclab-*' -D ./out

# Latest from a specific PR branch
RUN_ID=$(gh run list --workflow=wheel.yml --branch=<branch-name> -L 1 --json databaseId -q '.[0].databaseId')
rm -rf ./out && gh run download "$RUN_ID" --pattern 'isaaclab-*' -D ./out

# Specific run
rm -rf ./out && gh run download <run-id> --pattern 'isaaclab-*' -D ./out

# Find newly downloaded wheel file
WHEEL_FILE=$(ls -1t ./out/isaaclab-*/*.whl | head -1)

# Install it
pip install --force-reinstall $WHEEL_FILE
```

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there