### PR TITLE
Skip cloner perf test and fix ray caster intrinsics camera pose

### DIFF
--- a/source/isaaclab/test/sensors/test_ray_caster_camera.py
+++ b/source/isaaclab/test/sensors/test_ray_caster_camera.py
@@ -898,11 +898,11 @@ def test_output_equal_to_usd_camera_when_intrinsics_set(setup_sim, focal_length_
 
     # set camera position
     camera_warp.set_world_poses_from_view(
-        eyes=torch.tensor([[0.0, 0.0, 5.0]], device=camera_warp.device),
+        eyes=torch.tensor([[0.001, 0.0, 5.0]], device=camera_warp.device),
         targets=torch.tensor([[0.0, 0.0, 0.0]], device=camera_warp.device),
     )
     camera_usd.set_world_poses_from_view(
-        eyes=torch.tensor([[0.0, 0.0, 5.0]], device=camera_usd.device),
+        eyes=torch.tensor([[0.001, 0.0, 5.0]], device=camera_usd.device),
         targets=torch.tensor([[0.0, 0.0, 0.0]], device=camera_usd.device),
     )
 

--- a/source/isaaclab_physx/test/sim/test_cloner.py
+++ b/source/isaaclab_physx/test/sim/test_cloner.py
@@ -552,10 +552,17 @@ def test_disabled_fabric_change_notifies_toggles_ifabricusd_flag(sim):
     assert bindings.is_enabled(fabric_id), "outer exit should restore the flag"
 
 
+@pytest.mark.skip(
+    reason=(
+        "Local-only perf regression; correctness is covered by"
+        " test_disabled_fabric_change_notifies_toggles_ifabricusd_flag."
+        " Re-enable manually when touching listener suspension."
+    )
+)
 def test_disabled_fabric_change_notifies_speedup_regression():
     """Local-only perf regression: listener suspension speeds up clone+reset by >= 1.2x.
 
-    Skipped under ``CI=true`` — the suspension mechanism's correctness is covered by
+    Skipped unconditionally — the suspension mechanism's correctness is covered by
     :func:`test_disabled_fabric_change_notifies_toggles_ifabricusd_flag`; the wall-clock
     win is platform-sensitive (deferred Fabric resync in ``sim.reset`` can offset the
     scene-time savings on some hardware). Re-verify locally when touching the suspension.
@@ -564,7 +571,6 @@ def test_disabled_fabric_change_notifies_speedup_regression():
     ``replicate_physics=True`` is required (drops to ~1.19x without), and 16 bodies x
     4096 envs ≈ 64K firings keeps listener cost above noise. See PR #5432.
     """
-    import os
     import time
 
     import isaaclab.cloner._fabric_notices as fabric_notices_mod
@@ -573,8 +579,6 @@ def test_disabled_fabric_change_notifies_speedup_regression():
     from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
     from isaaclab.utils import configclass
 
-    if os.getenv("CI", "").lower() in ("true", "1"):
-        pytest.skip("CI: covered by toggle test; perf is platform-sensitive — re-verify locally")
     if fabric_notices_mod.get_bindings() is None:
         pytest.skip("omni::fabric::IFabricUsd unavailable")
 


### PR DESCRIPTION
# Description

Two unrelated CI flakes in the same test infrastructure area, bundled because both are minimal targeted fixes.

### 1. `test_disabled_fabric_change_notifies_speedup_regression` (`source/isaaclab_physx/test/sim/test_cloner.py`)

This is a wall-clock perf regression test that's intended to run **locally only** — it asserts a >= 1.2× speedup of clone+reset with listener suspension. The result is platform-sensitive (deferred Fabric resync in `sim.reset` can offset the scene-time savings on some hardware), so it was meant to be skipped in CI.

The original guard was `if os.getenv(\"CI\", \"\").lower() in (\"true\", \"1\"): pytest.skip(...)` inside the test body. However, this project's CI doesn't set the `CI` env var — it selects tests via the `isaacsim_ci` pytest marker registered in `pyproject.toml` and applied module-wide via `pytestmark` at the top of `test_cloner.py`. Result: the env-var skip never fires, and the test runs (and occasionally flakes) on CI.

Fix: replace the dead env-var branch with a top-level `@pytest.mark.skip(...)` decorator so the test is collected and skipped unconditionally regardless of how CI selects tests. The correctness of the suspension mechanism is still covered by `test_disabled_fabric_change_notifies_toggles_ifabricusd_flag`, which is unaffected. Re-enable the perf test manually when touching listener suspension.

### 2. `test_output_equal_to_usd_camera_when_intrinsics_set` (`source/isaaclab/test/sensors/test_ray_caster_camera.py`)

Intermittent CI failure where the ray caster camera output mismatched the USD camera reference with inf-valued differences across all 518400 elements:

```
E   Mismatched elements: 518400 / 518400 (100.0%)
E   Greatest absolute difference: inf at index (0, 0, 0, 0) (up to 0.0001 allowed)
E   Greatest relative difference: inf at index (0, 0, 0, 0) (up to 0.005 allowed)
```

Root cause: the test placed the camera at `eye=(0, 0, 5)` looking at `target=(0, 0, 0)`, which is colinear with the default up vector and produces a degenerate view transform. Fix: nudge `eye` to `(0.001, 0, 5)` for both the ray caster and USD camera, keeping them at identical poses while breaking the singularity. The underlying degeneracy is tracked in a separate internal ticket; this is the test-side mitigation.

Fixes # (n/a)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A — test infrastructure changes.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there