### PR TITLE
Runtime backend compatibility check for physx and ovrtx

### DIFF
--- a/source/isaaclab_tasks/changelog.d/pbarejko-error-on-invalid-backend-combinations.rst
+++ b/source/isaaclab_tasks/changelog.d/pbarejko-error-on-invalid-backend-combinations.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added validation in :mod:`isaaclab_tasks.utils.sim_launcher` that raises a descriptive
+  error when an unsupported physics/renderer/visualizer combination is requested
+  (e.g. the kitless OVRTX renderer paired with Isaac Sim PhysX or the Kit visualizer),
+  pointing users at the correct preset instead of failing later with an opaque runtime error.

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
@@ -18,10 +18,11 @@ __all__ = [
     "compute_kit_requirements",
     "setup_preset_cli",
     "fold_preset_tokens",
+    "validate_runtime_compatibility",
 ]
 
 from .hydra import PresetCfg, preset, hydra_task_config, resolve_task_config, resolve_presets
 from .importer import import_packages
 from .parse_cfg import get_checkpoint_path, load_cfg_from_registry, parse_env_cfg
 from .preset_cli import fold_preset_tokens, setup_preset_cli
-from .sim_launcher import add_launcher_args, launch_simulation, compute_kit_requirements
+from .sim_launcher import add_launcher_args, compute_kit_requirements, launch_simulation, validate_runtime_compatibility

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
@@ -71,6 +71,16 @@ def _is_kitless_physics(node) -> bool:
     return isinstance(node, PhysicsCfg) and type(node).__name__ in ("NewtonCfg", "OvPhysxCfg")
 
 
+def _is_kit_physics(node) -> bool:
+    """True when the node is a Kit-required physics config (Isaac Sim PhysX)."""
+    return isinstance(node, PhysicsCfg) and type(node).__name__ == "PhysxCfg"
+
+
+def _is_ovrtx_renderer(node) -> bool:
+    """True when the node is an OVRTX renderer config."""
+    return isinstance(node, RendererCfg) and getattr(node, "renderer_type", None) == "ovrtx"
+
+
 def _get_visualizer_types(launcher_args: argparse.Namespace | dict | None) -> set[str]:
     """Extract requested visualizer type names from launcher args."""
     if isinstance(launcher_args, argparse.Namespace):
@@ -156,6 +166,60 @@ def compute_kit_requirements(
     if "kit" in visualizer_types:
         needs_kit = True
     return needs_kit, has_kit_cameras, visualizer_types
+
+
+def validate_runtime_compatibility(
+    env_cfg,
+    launcher_args: argparse.Namespace | dict | None = None,
+) -> None:
+    """Validate that the resolved physics, renderer, and visualizer combination is supported.
+
+    The OVRTX renderer (``OVRTXRendererCfg``, ``renderer_type="ovrtx"``) is a kitless
+    renderer that runs without Isaac Sim / Omniverse Kit. Combining it with Kit-based
+    runtimes — Isaac Sim PhysX physics (``PhysxCfg``) or the Kit visualizer
+    (``--visualizer kit`` / a ``visualizer_cfgs`` entry with ``visualizer_type="kit"``) —
+    is unsupported. When such a combination is detected this function raises with a
+    message that points the user at the correct ``isaacsim_rtx_renderer`` preset.
+
+    Args:
+        env_cfg: Resolved environment config (e.g. from :func:`resolve_task_config`).
+        launcher_args: Optional CLI args. Inspected for ``--visualizer kit``.
+
+    Raises:
+        ValueError: If the OVRTX renderer is combined with Kit-based physics or the
+            Kit visualizer.
+    """
+    has_kit_physics, has_ovrtx_renderer = _scan_config(env_cfg, [_is_kit_physics, _is_ovrtx_renderer])
+    if not has_ovrtx_renderer:
+        return
+
+    visualizer_intent = _compute_visualizer_intent(env_cfg)
+    visualizer_types = _get_visualizer_types(launcher_args)
+    has_kit_visualizer = "kit" in visualizer_types or visualizer_intent.get("has_kit_visualizer", False)
+
+    if not has_kit_physics and not has_kit_visualizer:
+        return
+
+    sources = []
+    if has_kit_physics:
+        sources.append("Isaac Sim PhysX physics (`PhysxCfg`)")
+    if has_kit_visualizer:
+        sources.append('the Kit visualizer (`--visualizer kit` / `visualizer_type="kit"`)')
+    sources_text = " and ".join(sources)
+
+    raise ValueError(
+        "Invalid backend combination: the OVRTX renderer (`OVRTXRendererCfg`,"
+        ' `renderer_type="ovrtx"`) is a kitless renderer and cannot be used together'
+        f" with Isaac Sim / Kit ({sources_text}).\n"
+        "\n"
+        "To fix this, pick one of the following supported combinations:\n"
+        "  * Keep Isaac Sim / Kit and switch the renderer:\n"
+        "      presets=isaacsim_rtx_renderer\n"
+        "    (uses `IsaacRtxRendererCfg`, the Kit-compatible renderer.)\n"
+        "  * Keep the OVRTX renderer and switch to a kitless physics backend\n"
+        "    (and avoid `--visualizer kit`):\n"
+        "      presets=newton,ovrtx_renderer\n"
+    )
 
 
 def _resolve_distributed_device(
@@ -254,6 +318,7 @@ def launch_simulation(
                 "Use '--visualizer newton' instead, which is fully compatible with ovrtx presets."
             )
 
+    validate_runtime_compatibility(env_cfg, launcher_args)
     needs_kit, has_kit_cameras, visualizer_types = compute_kit_requirements(env_cfg, launcher_args)
     visualizer_intent = _compute_visualizer_intent(env_cfg)
     _set_visualizer_intent_on_launcher_args(launcher_args, visualizer_intent)

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
@@ -218,7 +218,7 @@ def validate_runtime_compatibility(
         "    (uses `IsaacRtxRendererCfg`, the Kit-compatible renderer.)\n"
         "  * Keep the OVRTX renderer and switch to a kitless physics backend\n"
         "    (and avoid `--visualizer kit`):\n"
-        "      presets=newton,ovrtx_renderer\n"
+        "      presets=newton_mjwarp,ovrtx_renderer\n"
     )
 
 

--- a/source/isaaclab_tasks/test/test_runtime_compatibility.py
+++ b/source/isaaclab_tasks/test/test_runtime_compatibility.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for :func:`isaaclab_tasks.utils.sim_launcher.validate_runtime_compatibility`.
+
+The OVRTX renderer is kitless and cannot run together with Isaac Sim / Kit
+runtimes (``PhysxCfg`` physics or the Kit visualizer). These tests verify that
+invalid combinations selected via ``presets=...`` (or ``--visualizer kit``) raise
+a clear error pointing the user at the correct ``isaacsim_rtx_renderer`` preset.
+No Kit/GPU required — safe for CI and beginners.
+"""
+
+import argparse
+import sys
+
+import pytest
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils import resolve_task_config, validate_runtime_compatibility
+
+_CAMERA_PRESETS_TASK = "Isaac-Cartpole-Camera-Presets-Direct-v0"
+
+
+def _resolve_with_presets(presets: str):
+    """Resolve env_cfg with given presets. Modifies sys.argv temporarily."""
+    old_argv = sys.argv.copy()
+    try:
+        sys.argv = [sys.argv[0], f"presets={presets}"]
+        env_cfg, _ = resolve_task_config(_CAMERA_PRESETS_TASK, "rl_games_cfg_entry_point")
+        return env_cfg
+    finally:
+        sys.argv = old_argv
+
+
+# ---------------------------------------------------------------------------
+# Invalid: OVRTX renderer + Isaac Sim / Kit
+# ---------------------------------------------------------------------------
+
+
+def test_default_physx_plus_ovrtx_raises():
+    """Default physics is PhysxCfg; pairing it with the OVRTX renderer must raise."""
+    env_cfg = _resolve_with_presets("ovrtx_renderer")
+    with pytest.raises(ValueError, match=r"OVRTX renderer.*Isaac Sim / Kit"):
+        validate_runtime_compatibility(env_cfg)
+
+
+def test_explicit_physx_plus_ovrtx_raises():
+    """Explicit physx preset + ovrtx_renderer is the canonical invalid combination."""
+    env_cfg = _resolve_with_presets("physx,ovrtx_renderer")
+    with pytest.raises(ValueError) as excinfo:
+        validate_runtime_compatibility(env_cfg)
+    msg = str(excinfo.value)
+    assert "PhysxCfg" in msg
+    assert "isaacsim_rtx_renderer" in msg
+
+
+def test_kit_visualizer_plus_ovrtx_raises():
+    """``--visualizer kit`` combined with OVRTX renderer must raise.
+
+    Use Newton physics so the only Kit-side runtime is the visualizer; this
+    isolates the visualizer-vs-renderer check from the physics-vs-renderer one.
+    """
+    env_cfg = _resolve_with_presets("newton,ovrtx_renderer")
+    launcher_args = argparse.Namespace(visualizer="kit")
+    with pytest.raises(ValueError) as excinfo:
+        validate_runtime_compatibility(env_cfg, launcher_args)
+    msg = str(excinfo.value)
+    assert "Kit visualizer" in msg
+    assert "isaacsim_rtx_renderer" in msg
+
+
+def test_kit_visualizer_dict_args_plus_ovrtx_raises():
+    """The dict form of launcher args (used by Hydra) must also be inspected."""
+    env_cfg = _resolve_with_presets("newton,ovrtx_renderer")
+    with pytest.raises(ValueError, match=r"Kit visualizer"):
+        validate_runtime_compatibility(env_cfg, {"visualizer": "kit,newton"})
+
+
+# ---------------------------------------------------------------------------
+# Valid combinations: must NOT raise
+# ---------------------------------------------------------------------------
+
+
+def test_newton_plus_ovrtx_is_valid():
+    """Newton physics + OVRTX renderer is the supported kitless combination."""
+    env_cfg = _resolve_with_presets("newton,ovrtx_renderer")
+    validate_runtime_compatibility(env_cfg)
+
+
+def test_physx_plus_isaacsim_rtx_is_valid():
+    """PhysX physics + Isaac RTX renderer is the supported Kit combination."""
+    env_cfg = _resolve_with_presets("physx,isaacsim_rtx_renderer")
+    validate_runtime_compatibility(env_cfg)
+
+
+def test_default_preset_is_valid():
+    """The default preset (PhysX + Isaac RTX) is supported."""
+    env_cfg = _resolve_with_presets("default")
+    validate_runtime_compatibility(env_cfg)
+
+
+def test_newton_plus_isaacsim_rtx_is_valid():
+    """Newton + Isaac RTX renderer is supported (RTX runs in Kit, Newton syncs to USD)."""
+    env_cfg = _resolve_with_presets("newton,isaacsim_rtx_renderer")
+    validate_runtime_compatibility(env_cfg)
+
+
+def test_kit_visualizer_with_isaacsim_rtx_is_valid():
+    """``--visualizer kit`` is fine as long as no OVRTX renderer is configured."""
+    env_cfg = _resolve_with_presets("newton,isaacsim_rtx_renderer")
+    validate_runtime_compatibility(env_cfg, argparse.Namespace(visualizer="kit"))


### PR DESCRIPTION
# Description

`physx` and `ovrtx` preset is not supported

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
