### PR TITLE
Fix per-substep host syncs in InHandManipulationEnv

### DIFF
--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "1.5.32"
+version = "1.5.33"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,21 @@
 Changelog
 ---------
 
+1.5.33 (2026-04-30)
+~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Stored ``actuated_dof_indices`` and ``finger_bodies`` in
+  :class:`~isaaclab_tasks.direct.inhand_manipulation.InHandManipulationEnv` as
+  pre-allocated GPU :class:`torch.Tensor` objects (plus a parallel
+  :class:`warp.array` of ``int32`` for Newton's ``joint_ids``) instead of
+  Python lists. Eliminates the per-substep host→device sync caused by
+  PyTorch advanced indexing (``tensor[:, py_list]``) constructing and copying
+  a fresh long-tensor on every call.
+
+
 1.5.32 (2026-04-30)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/inhand_manipulation_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/inhand_manipulation/inhand_manipulation_env.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
+import warp as wp
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import Articulation, RigidObject
@@ -37,18 +38,17 @@ class InHandManipulationEnv(DirectRLEnv):
         self.prev_targets = torch.zeros((self.num_envs, self.num_hand_dofs), dtype=torch.float, device=self.device)
         self.cur_targets = torch.zeros((self.num_envs, self.num_hand_dofs), dtype=torch.float, device=self.device)
 
-        # list of actuated joints
-        self.actuated_dof_indices = list()
-        for joint_name in cfg.actuated_joint_names:
-            self.actuated_dof_indices.append(self.hand.joint_names.index(joint_name))
-        self.actuated_dof_indices.sort()
+        # actuated joints — store as a GPU torch.tensor (and a parallel wp.int32
+        # array for Newton's joint_ids) so that ``tensor[:, idx]`` advanced
+        # indexing in ``_apply_action`` does not pay a host→device sync per call.
+        _actuated_idx = sorted(self.hand.joint_names.index(j) for j in cfg.actuated_joint_names)
+        self.actuated_dof_indices = torch.tensor(_actuated_idx, dtype=torch.long, device=self.device)
+        self.actuated_dof_indices_int32 = wp.from_torch(self.actuated_dof_indices.to(torch.int32), dtype=wp.int32)
 
-        # finger bodies
-        self.finger_bodies = list()
-        for body_name in self.cfg.fingertip_body_names:
-            self.finger_bodies.append(self.hand.body_names.index(body_name))
-        self.finger_bodies.sort()
-        self.num_fingertips = len(self.finger_bodies)
+        # fingertip bodies — same reasoning (used in ``_compute_intermediate_values``).
+        _finger_idx = sorted(self.hand.body_names.index(b) for b in self.cfg.fingertip_body_names)
+        self.finger_bodies = torch.tensor(_finger_idx, dtype=torch.long, device=self.device)
+        self.num_fingertips = len(_finger_idx)
 
         # joint limits
         joint_pos_limits = self.hand.data.joint_limits.torch.to(self.device)
@@ -130,7 +130,7 @@ class InHandManipulationEnv(DirectRLEnv):
         self.prev_targets[:, self.actuated_dof_indices] = self.cur_targets[:, self.actuated_dof_indices]
 
         self._set_joint_pos_target(
-            target=self.cur_targets[:, self.actuated_dof_indices], joint_ids=self.actuated_dof_indices
+            target=self.cur_targets[:, self.actuated_dof_indices], joint_ids=self.actuated_dof_indices_int32
         )
 
     def _get_observations(self) -> dict:


### PR DESCRIPTION
# Description

This PR removes a per-substep host stall in `InHandManipulationEnv` that fires on every Shadow Hand / Allegro repose `env.step()`. It yields **−12–25%** per-step latency and **+15–34% FPS** on the non-vision Shadow / Allegro tasks at 1225 envs, and ~9% FPS on the Shadow Hand Vision Benchmark.

**Issue.** `InHandManipulationEnv.__init__` initialized `actuated_dof_indices` and `finger_bodies` as Python `list()`. Each per-substep `tensor[:, py_list]` advanced-indexing call goes through PyTorch's list-to-tensor path, which builds a fresh CPU `int64` tensor and copies it H2D with `non_blocking=False` — forcing a `cudaStreamSynchronize` per call. With decim 2 (Shadow) or 4 (Allegro), that's **14–28 host stalls per `env.step()`**.

**Fix.** Pre-allocate the indices once at init as GPU `torch.Tensor`s, plus a parallel `wp.int32` warp array for Newton's `joint_ids=` parameter. Behavior is bitwise-identical.

### Results

Hardware: NVIDIA RTX 6000 Ada (sm_89), CUDA 12.9, IsaacLab `origin/develop` at `41908c06473`. 1225 envs, 5 trials per config × task.

#### Per-batched-step time (median of 5 trials, min / mean ms)

| config | Shadow non-vision | Allegro non-vision | Shadow Vision Benchmark |
|---|---|---|---|
| **A. baseline** | 12.46 / 23.92 | 23.96 / 41.73 | 74.08 / 81.89 |
| **B. +inhand** | **10.53 / 17.81** | **20.93 / 32.25** | **67.89 / 75.05** |

#### FPS — Shadow / Allegro non-vision (`benchmark_non_rl.py`, 1225 envs)

| config | Shadow min FPS | Shadow mean FPS | Allegro min FPS | Allegro mean FPS |
|---|---|---|---|---|
| A. baseline | 98,315 | 51,212 | 51,127 | 29,355 |
| **B. +inhand** | **116,335** (+18.3%) | **68,782** (+34.3%) | **58,529** (+14.5%) | **37,984** (+29.4%) |

#### FPS — Shadow Hand Vision Benchmark (`benchmark_rlgames.py`, 1225 envs)

| config | mean FPS | Δ vs A |
|---|---|---|
| A. baseline | 14,959 | — |
| **B. +inhand** | **16,322** | **+1,363 (+9.1%)** |

### Dependencies

None. The change is self-contained within Isaac Lab.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

### Shadow Hand Vision Benchmark — InHand fix

`step_146` = 100.9 ms → `step_152` = 90.4 ms. The host-side `cudaStreamSynchronize` rectangle shrinks (fewer per-substep stalls feed into reset and observations) and `_reset_idx` drops 20.6 → 16.3 ms.

| Before (A: baseline) | After (B: +inhand) |
| ------ | ----- |
| <img width="1487" height="687" alt="A_vision" src="https://github.com/user-attachments/assets/e7bf1bb8-5891-4322-8722-27b70ec7bdba" /> | <img width="1487" height="687" alt="B_vision" src="https://github.com/user-attachments/assets/481935d6-fc23-4e92-9e88-4d76b32aaf0c" /> |

### Shadow non-vision — InHand fix only

`step_33` = 29.1 ms → `step_32` = 21.1 ms. On the GPU timeline the gaps between successive physics-kernel launches close up — what was a sequence of sync-gated substeps now runs as packed back-to-back kernel work.

| Before (A: baseline) | After (B: +inhand) |
| ------ | ----- |
| <img width="1487" height="687" alt="A_shadow" src="https://github.com/user-attachments/assets/19a741cf-a8b7-4624-857b-bb75a877d507" /> | <img width="1487" height="687" alt="B_shadow" src="https://github.com/user-attachments/assets/327f583d-e22e-4c61-b4f3-b76e95bd4770" /> |

### Allegro non-vision — InHand fix only (4× substeps make this most visible)

Allegro runs 4 decim substeps, so the baseline GPU timeline has **4 distinct bubbles** between physics-kernel launches (one stall per substep). After the fix those bubbles close up and the four substeps run as a single packed sequence on the GPU. `step_33` = 43.7 ms → `step_36` = 36.5 ms.

| Before (A: baseline) | After (B: +inhand) |
| ------ | ----- |
| <img width="1487" height="687" alt="A_allegro" src="https://github.com/user-attachments/assets/4f17eca2-cd6f-4f07-877c-d7d61c626036" /> | <img width="1487" height="687" alt="B_allegro" src="https://github.com/user-attachments/assets/d77daaed-009d-4fb1-99e4-77c8b0ae13cc" /> |

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
