### PR TITLE
Regression test: FrameView staleness under physics integration

### DIFF
--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -104,3 +104,71 @@ def view_factory():
         )
 
     return factory
+
+
+# ------------------------------------------------------------------
+# Backend-specific contract: world poses must follow physics integration
+# ------------------------------------------------------------------
+#
+# The shared contract uses static USD writes to move the parent. Real callers
+# (RayCaster, Camera, IMU spawned under articulation/rigid bodies) rely on
+# PhysX → Fabric per-step writes propagating through ``IFabricHierarchy`` to
+# child Xforms. None of the existing static tests exercise that path, which
+# allowed a fabric-write regression to ship undetected: ``RayCaster`` parented
+# under an articulation body returns its spawn-time pose forever even as the
+# body moves meters under gravity.
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+def test_world_pose_tracks_physics_body_parent(device):
+    """Child Xform world pose must follow a RigidBody parent through physics integration.
+
+    Spawns a child Xform under a ``RigidBody`` + ``ArticulationRoot`` parent
+    elevated at z=5, lets gravity drop it for 1 s, then asserts the
+    :class:`FabricFrameView` returns a fresh world pose. With the working
+    PhysX → Fabric write path, the child should drop several meters; with a
+    broken write path, ``get_world_poses`` returns the spawn pose forever.
+    """
+    _skip_if_unavailable(device)
+
+    from pxr import UsdPhysics
+
+    initial_z = 5.0
+    parent_path = "/World/PhysicsParent"
+    child_path = f"{parent_path}/Child"
+
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim(parent_path, "Xform", translation=(0.0, 0.0, initial_z), stage=stage)
+    parent_prim = stage.GetPrimAtPath(parent_path)
+    UsdPhysics.RigidBodyAPI.Apply(parent_prim)
+    UsdPhysics.ArticulationRootAPI.Apply(parent_prim)
+    UsdPhysics.MassAPI.Apply(parent_prim).CreateMassAttr().Set(1.0)
+    cube_path = f"{parent_path}/CollisionCube"
+    cube = UsdGeom.Cube.Define(stage, cube_path)
+    cube.CreateSizeAttr().Set(0.1)
+    UsdPhysics.CollisionAPI.Apply(stage.GetPrimAtPath(cube_path))
+    sim_utils.create_prim(child_path, "Camera", translation=CHILD_OFFSET, stage=stage)
+    sim_utils.update_stage()
+
+    sim = sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01, device=device, use_fabric=True))
+    view = FrameView(child_path, device=device, sync_usd_on_fabric_write=True)
+    sim.reset()
+
+    pos_before = view.get_world_poses()[0].torch[0].clone()
+
+    # ~1 s of free fall: child should drop several meters in z.
+    for _ in range(100):
+        sim.step(render=False)
+
+    pos_after = view.get_world_poses()[0].torch[0]
+    drift_z = (pos_before[2] - pos_after[2]).item()
+
+    # Free-fall over 1 s under g≈9.81 should drop the body well past any
+    # spawn-time noise. A drift below 0.5 m means the FrameView is reading
+    # a stale fabric matrix that PhysX never updated.
+    assert drift_z > 0.5, (
+        f"FabricFrameView returned stale pose after physics integration. "
+        f"z before={pos_before[2].item():.4f} z after={pos_after[2].item():.4f} "
+        f"drift={drift_z:.4f}m. PhysX → Fabric write path is broken or the "
+        f"hierarchy isn't propagating parent body movement to the child Xform."
+    )


### PR DESCRIPTION
## Summary

- Adds a contract test in `test_views_xform_prim_fabric.py` that drops a `RigidBody`/`ArticulationRoot` parent under gravity and asserts the child Xform's `FabricFrameView.get_world_poses()` follows it.
- **Expected to FAIL on develop today.** Drift = 0.0000 m: the sensor pose stays byte-identical to the spawn pose for the entire 1 s of free fall.
- The fix lives in a follow-up branch.

## Why

Every other FrameView contract test asserts pose at init time (before any `sim.step`). That's why a fabric-write regression introduced in #5179 has been shipping silently — RayCaster / Camera / IMU sensors parented under articulation or rigid bodies return their spawn-time pose forever in headless training. Height-scan obs in rough-terrain locomotion was a frozen patch from spawn; agents have been training on a constant input.

Without this test, no CI signal would have caught the bug. Adding it here so the fix PR has a concrete green/red marker.

## Test plan

- [ ] CI for `test_world_pose_tracks_physics_body_parent[cuda:0]` shows FAIL with the assertion message documenting drift = 0.0000 m.
- [ ] After the companion fix lands, this test goes green.