### PR TITLE
Fix FrameView staleness for sensors parented under physics bodies

### DIFF
--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -1163,8 +1163,14 @@ class AppLauncher:
         # set setting to indicate no RTX sensors are used (set to True when RTX sensor is created)
         settings.set_bool("/isaaclab/render/rtx_sensors", False)
 
-        # set fabric update flag to disable updating transforms when rendering is disabled
-        settings.set_bool("/physics/fabricUpdateTransformations", self._rendering_enabled())
+        # Enable PhysX -> Fabric rigid-body / articulation-link transform writes when
+        # rendering is enabled. Don't stomp the setting back to False if it was already
+        # turned on by a kit experience or by ``sim_launcher`` after detecting a
+        # FrameView-based sensor (RayCaster / Camera) in the env config — those readers
+        # depend on Fabric being fresh in headless training too. ``settings.get`` may
+        # return ``1``/``0`` from kit_args overrides, so cast through ``bool``.
+        existing = bool(settings.get("/physics/fabricUpdateTransformations"))
+        settings.set_bool("/physics/fabricUpdateTransformations", self._rendering_enabled() or existing)
 
         # use fixed time stepping disabled; custom loop runner from Isaac Sim is used instead
         settings.set_bool("/app/player/useFixedTimeStepping", False)

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -175,6 +175,11 @@ class PhysxManager(PhysicsManager):
     _subscriptions: ClassVar[dict[str, Any]] = {}
     _fabric: ClassVar[Any] = None
     _update_fabric: ClassVar[Callable[[float, float], None] | None] = None
+    # Accumulated sim time fed to ``_update_fabric``. ``omni.physx.fabric``'s body-write
+    # path gates on a strictly increasing simulation timestamp; passing ``(0.0, 0.0)``
+    # is a no-op for rigid-body / articulation-link transforms (the legacy ``forward()``
+    # call site predates the FrameView read path that depends on these writes).
+    _fabric_sim_time: ClassVar[float] = 0.0
     _anim_recorder: ClassVar[AnimationRecorder | None] = None
     _callback_exception: ClassVar[Exception | None] = None
 
@@ -263,6 +268,16 @@ class PhysxManager(PhysicsManager):
         cls._physx_sim.simulate(sim.cfg.dt, 0.0)
         cls._physx_sim.fetch_results()
 
+        # Push PhysX rigid-body / articulation-link world transforms into Fabric so any
+        # FrameView reader (RayCaster, Camera) sees the post-step pose. The body-write
+        # path is gated by ``/physics/fabricUpdateTransformations``; when off this call
+        # is internally a no-op for transforms (still cheap for the once-per-step
+        # invocation). ``currentTime`` must monotonically advance — passing ``0.0``
+        # would be skipped by ``DirectGpuHelper::update``.
+        if cls._update_fabric is not None:
+            cls._fabric_sim_time += sim.cfg.dt
+            cls._update_fabric(sim.cfg.dt, cls._fabric_sim_time)
+
         device = PhysicsManager._device
         if "cuda" in device:
             torch.cuda.set_device(device)
@@ -333,6 +348,7 @@ class PhysxManager(PhysicsManager):
 
         cls._fabric = None
         cls._update_fabric = None
+        cls._fabric_sim_time = 0.0
         cls._anim_recorder = None
         cls._warmup_needed = True
         cls._view_created = False

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -17,7 +17,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "isaaclab" / "test"
 
 from isaaclab.app import AppLauncher
 
-simulation_app = AppLauncher(headless=True).app
+# Mirror what ``sim_launcher.launch_simulation`` injects when it auto-detects a
+# FrameView-based sensor in the env config. These two settings are required for
+# PhysX to write rigid-body / articulation-link world transforms into Fabric
+# every step (the data path that FabricFrameView reads).
+simulation_app = AppLauncher(
+    headless=True,
+    kit_args="--/app/useFabricSceneDelegate=1 --/physics/fabricUpdateTransformations=1",
+).app
 
 import pytest  # noqa: E402
 import torch  # noqa: E402
@@ -104,3 +111,71 @@ def view_factory():
         )
 
     return factory
+
+
+# ------------------------------------------------------------------
+# Backend-specific contract: world poses must follow physics integration
+# ------------------------------------------------------------------
+#
+# The shared contract uses static USD writes to move the parent. Real callers
+# (RayCaster, Camera, IMU spawned under articulation/rigid bodies) rely on
+# PhysX → Fabric per-step writes propagating through ``IFabricHierarchy`` to
+# child Xforms. None of the existing static tests exercise that path, which
+# allowed a fabric-write regression to ship undetected: ``RayCaster`` parented
+# under an articulation body returned its spawn-time pose forever even as the
+# body moved meters under gravity.
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+def test_world_pose_tracks_physics_body_parent(device):
+    """Child Xform world pose must follow a RigidBody parent through physics integration.
+
+    Spawns a child Xform under a ``RigidBody`` + ``ArticulationRoot`` parent
+    elevated at z=5, lets gravity drop it for 1 s, then asserts the
+    :class:`FabricFrameView` returns a fresh world pose. With the working
+    PhysX → Fabric write path, the child should drop several meters; with a
+    broken write path, ``get_world_poses`` returns the spawn pose forever.
+    """
+    _skip_if_unavailable(device)
+
+    from pxr import UsdPhysics
+
+    initial_z = 5.0
+    parent_path = "/World/PhysicsParent"
+    child_path = f"{parent_path}/Child"
+
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim(parent_path, "Xform", translation=(0.0, 0.0, initial_z), stage=stage)
+    parent_prim = stage.GetPrimAtPath(parent_path)
+    UsdPhysics.RigidBodyAPI.Apply(parent_prim)
+    UsdPhysics.ArticulationRootAPI.Apply(parent_prim)
+    UsdPhysics.MassAPI.Apply(parent_prim).CreateMassAttr().Set(1.0)
+    cube_path = f"{parent_path}/CollisionCube"
+    cube = UsdGeom.Cube.Define(stage, cube_path)
+    cube.CreateSizeAttr().Set(0.1)
+    UsdPhysics.CollisionAPI.Apply(stage.GetPrimAtPath(cube_path))
+    sim_utils.create_prim(child_path, "Camera", translation=CHILD_OFFSET, stage=stage)
+    sim_utils.update_stage()
+
+    sim = sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01, device=device, use_fabric=True))
+    view = FrameView(child_path, device=device, sync_usd_on_fabric_write=True)
+    sim.reset()
+
+    pos_before = view.get_world_poses()[0].torch[0].clone()
+
+    # ~1 s of free fall: child should drop several meters in z.
+    for _ in range(100):
+        sim.step(render=False)
+
+    pos_after = view.get_world_poses()[0].torch[0]
+    drift_z = (pos_before[2] - pos_after[2]).item()
+
+    # Free-fall over 1 s under g≈9.81 should drop the body well past any
+    # spawn-time noise. A drift below 0.5 m means the FrameView is reading
+    # a stale fabric matrix that PhysX never updated.
+    assert drift_z > 0.5, (
+        f"FabricFrameView returned stale pose after physics integration. "
+        f"z before={pos_before[2].item():.4f} z after={pos_after[2].item():.4f} "
+        f"drift={drift_z:.4f}m. PhysX → Fabric write path is broken or the "
+        f"hierarchy isn't propagating parent body movement to the child Xform."
+    )

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
@@ -113,6 +113,22 @@ def _set_visualizer_intent_on_launcher_args(
         launcher_args["visualizer_intent"] = visualizer_intent
 
 
+def _needs_fabric_reads(node) -> bool:
+    """True for sensor configs whose pose is read through :class:`FrameView` (Fabric).
+
+    These sensors depend on PhysX writing rigid-body / articulation-link world
+    transforms into Fabric every step. The omni.physx.fabric extension only does
+    those writes when the Fabric Scene Delegate is active *and*
+    ``/physics/fabricUpdateTransformations`` is True. In headless training (no
+    rendering) those are off by default, which silently freezes the sensor pose
+    at spawn time. Detecting these configs lets ``launch_simulation`` flip the
+    settings on at kit boot so the FrameView contract holds.
+    """
+    from isaaclab.sensors.ray_caster import RayCasterCfg
+
+    return isinstance(node, (CameraCfg, RayCasterCfg))
+
+
 def _is_kit_camera(node) -> bool:
     """True for a CameraCfg whose renderer requires Kit (not Newton)."""
     if not isinstance(node, CameraCfg):
@@ -137,7 +153,7 @@ def _is_kit_camera(node) -> bool:
 def compute_kit_requirements(
     env_cfg,
     launcher_args: argparse.Namespace | dict | None = None,
-) -> tuple[bool, bool, set[str]]:
+) -> tuple[bool, bool, set[str], bool]:
     """Compute whether Kit is needed and related flags.
 
     Uses the same logic as :func:`launch_simulation` to decide whether Isaac Sim
@@ -148,14 +164,16 @@ def compute_kit_requirements(
         launcher_args: Optional CLI args; if ``--visualizer`` includes ``kit``, needs_kit is True.
 
     Returns:
-        (needs_kit, has_kit_cameras, visualizer_types)
+        (needs_kit, has_kit_cameras, visualizer_types, needs_fabric_reads)
     """
-    is_kitless, has_kit_cameras = _scan_config(env_cfg, [_is_kitless_physics, _is_kit_camera])
+    is_kitless, has_kit_cameras, needs_fabric_reads = _scan_config(
+        env_cfg, [_is_kitless_physics, _is_kit_camera, _needs_fabric_reads]
+    )
     needs_kit = has_kit_cameras or not is_kitless
     visualizer_types = _get_visualizer_types(launcher_args)
     if "kit" in visualizer_types:
         needs_kit = True
-    return needs_kit, has_kit_cameras, visualizer_types
+    return needs_kit, has_kit_cameras, visualizer_types, needs_fabric_reads
 
 
 def _resolve_distributed_device(
@@ -236,7 +254,7 @@ def launch_simulation(
         with launch_simulation(env_cfg, args_cli):
             main()
     """
-    needs_kit, has_kit_cameras, visualizer_types = compute_kit_requirements(env_cfg, launcher_args)
+    needs_kit, has_kit_cameras, visualizer_types, needs_fabric_reads = compute_kit_requirements(env_cfg, launcher_args)
     visualizer_intent = _compute_visualizer_intent(env_cfg)
     _set_visualizer_intent_on_launcher_args(launcher_args, visualizer_intent)
 
@@ -249,6 +267,24 @@ def launch_simulation(
             if not launcher_args.get("enable_cameras", False):
                 logger.info("Auto-enabling cameras: scene contains camera sensors with a Kit renderer.")
                 launcher_args["enable_cameras"] = True
+
+    # Auto-enable Fabric Scene Delegate + PhysX -> Fabric transform writes when the env
+    # config contains FrameView-based sensors. FSD has to be set at kit boot (carb
+    # setting changes after SimulationContext is created don't take effect — PhysX
+    # registers bodies during warmup), so inject it via kit_args before AppLauncher.
+    if needs_kit and needs_fabric_reads and not has_kit_cameras:
+        fabric_kit_args = "--/app/useFabricSceneDelegate=1 --/physics/fabricUpdateTransformations=1"
+        logger.info(
+            "Auto-enabling Fabric Scene Delegate: scene contains FrameView-based sensors "
+            "(RayCaster / Camera). PhysX rigid-body world transforms will be pushed into "
+            "Fabric every step so the sensor reads stay fresh."
+        )
+        if isinstance(launcher_args, argparse.Namespace):
+            existing = getattr(launcher_args, "kit_args", "") or ""
+            launcher_args.kit_args = (existing + " " + fabric_kit_args).strip()
+        elif isinstance(launcher_args, dict):
+            existing = launcher_args.get("kit_args", "") or ""
+            launcher_args["kit_args"] = (existing + " " + fabric_kit_args).strip()
 
     close_fn: Any = None
 

--- a/source/isaaclab_tasks/test/test_distributed_device_resolution.py
+++ b/source/isaaclab_tasks/test/test_distributed_device_resolution.py
@@ -433,7 +433,7 @@ class TestLaunchSimulationDevicePropagation:
         monkeypatch.setattr(
             sim_launcher,
             "compute_kit_requirements",
-            lambda env_cfg, launcher_args: (True, False, set()),
+            lambda env_cfg, launcher_args: (True, False, set(), False),
         )
         # Mock _resolve_distributed_device to avoid torch.cuda calls
         monkeypatch.setattr(
@@ -461,7 +461,7 @@ class TestLaunchSimulationDevicePropagation:
         monkeypatch.setattr(
             sim_launcher,
             "compute_kit_requirements",
-            lambda env_cfg, launcher_args: (False, False, set()),
+            lambda env_cfg, launcher_args: (False, False, set(), False),
         )
         monkeypatch.setattr(
             sim_launcher,

--- a/source/isaaclab_tasks/test/test_preset_kit_decision.py
+++ b/source/isaaclab_tasks/test/test_preset_kit_decision.py
@@ -32,33 +32,33 @@ def _resolve_with_presets(presets: str):
 def test_preset_newton_ovrtx_does_not_need_kit():
     """Newton + OVRTX renderer is kitless — no AppLauncher required."""
     env_cfg = _resolve_with_presets("newton,ovrtx_renderer")
-    needs_kit, _, _ = compute_kit_requirements(env_cfg)
+    needs_kit, _, _, _ = compute_kit_requirements(env_cfg)
     assert needs_kit is False
 
 
 def test_preset_newton_newton_renderer_does_not_need_kit():
     """Newton + Newton Warp renderer is kitless."""
     env_cfg = _resolve_with_presets("newton,newton_renderer")
-    needs_kit, _, _ = compute_kit_requirements(env_cfg)
+    needs_kit, _, _, _ = compute_kit_requirements(env_cfg)
     assert needs_kit is False
 
 
 def test_preset_physx_needs_kit():
     """PhysX physics requires Kit."""
     env_cfg = _resolve_with_presets("physx")
-    needs_kit, _, _ = compute_kit_requirements(env_cfg)
+    needs_kit, _, _, _ = compute_kit_requirements(env_cfg)
     assert needs_kit is True
 
 
 def test_preset_default_needs_kit():
     """Default (PhysX + Isaac RTX) requires Kit."""
     env_cfg = _resolve_with_presets("default")
-    needs_kit, _, _ = compute_kit_requirements(env_cfg)
+    needs_kit, _, _, _ = compute_kit_requirements(env_cfg)
     assert needs_kit is True
 
 
 def test_preset_newton_isaac_rtx_needs_kit():
     """Newton + Isaac RTX renderer requires Kit (RTX runs in Kit)."""
     env_cfg = _resolve_with_presets("newton,isaacsim_rtx_renderer")
-    needs_kit, _, _ = compute_kit_requirements(env_cfg)
+    needs_kit, _, _, _ = compute_kit_requirements(env_cfg)
     assert needs_kit is True

--- a/source/isaaclab_tasks/test/test_sim_launcher_visualizer_intent.py
+++ b/source/isaaclab_tasks/test/test_sim_launcher_visualizer_intent.py
@@ -73,7 +73,7 @@ def test_launch_simulation_kitless_viz_none_sets_disable_all(monkeypatch):
                 captured["disable_all"] = value
 
     monkeypatch.setattr(
-        sim_launcher, "compute_kit_requirements", lambda env_cfg, launcher_args: (False, False, {"none"})
+        sim_launcher, "compute_kit_requirements", lambda env_cfg, launcher_args: (False, False, {"none"}, False)
     )
     # `app_launcher` imports both names from settings_manager; provide a full stub module
     # so `from isaaclab.app import AppLauncher` succeeds in kitless mode.


### PR DESCRIPTION
## Summary

- Fixes the bug demonstrated by #5476: FrameView-based sensors (RayCaster, Camera, IMU under articulation / rigid bodies) silently returned their spawn-time pose forever in headless training. Height-scan obs in rough-terrain locomotion was a frozen patch from spawn.
- Root cause: #5179 switched RayCaster from PhysX tensor views to FrameView (Fabric). The PhysX → Fabric write path is gated by three independent flags, all off in headless: `/app/useFabricSceneDelegate`, `/physics/fabricUpdateTransformations`, and a per-step `_update_fabric(dt, time)` call.
- Companion regression test in #5476 goes green with this PR.

## Changes

| file | what |
|---|---|
| `source/isaaclab_physx/.../physx_manager.py` | `PhysicsManager.step` calls `_update_fabric(dt, sim_time)` after each `simulate/fetch_results` with monotonic `_fabric_sim_time`. Body-write block is gated by the carb setting — call is free when nothing's registered. |
| `source/isaaclab/isaaclab/app/app_launcher.py` | Stop unconditionally setting `/physics/fabricUpdateTransformations` to `_rendering_enabled()`. Respect the value if a kit file / kit_args / `sim_launcher` already set it True. |
| `source/isaaclab_tasks/.../sim_launcher.py` | New `_needs_fabric_reads` predicate scanning `env_cfg` for `RayCasterCfg` / `CameraCfg`. When detected, `launch_simulation` injects `--/app/useFabricSceneDelegate=1 --/physics/fabricUpdateTransformations=1` into `kit_args` before `AppLauncher` (FSD must be set at kit boot). Mirrors the existing `_is_kit_camera` auto-detect. |
| `compute_kit_requirements` signature | Now returns 4-tuple including `needs_fabric_reads`. Three internal test files updated. |
| `test_views_xform_prim_fabric.py` | Module-level `AppLauncher` passes the kit_args `sim_launcher` would inject. Regression test `test_world_pose_tracks_physics_body_parent` (also added in #5476) goes green. |

## Performance

`anymal_c` rough terrain, 1024 envs, 500 steps after 100 warmup, RTX 5090:

| variant | per-step | env-steps/s | vs baseline |
|---|---:|---:|---:|
| fix off (today's broken state) | 4.481 ms | 228k | baseline |
| **fix on** | **5.073 ms** | **201k** | **+13.2%** |
| no FrameView env | 4.456 ms | 230k | noise |

~13% physics-step cost when a heightmap / camera sensor is in the env (cost of pushing all anymal articulation transforms into Fabric every step). **Zero overhead for envs without FrameView sensors.** This is the cost of correct observations vs the silent training corruption we had.

## Why not just enable `--enable_cameras`?

That works but loads RTX shaders, hydra texture, replicator, and viewport extensions — adds seconds to startup and significant GPU memory for users who don't need rendering. The `_needs_fabric_reads` auto-detect uses only the FSD scene-delegate flag (free routing setting; no shaders, no extensions) plus the PhysX → Fabric writer toggle.

## What about Newton?

Newton has its own implementation in `newton_manager.sync_transforms_to_usd` that doesn't depend on `omni.physx.fabric`, so this PR does not affect the Newton backend. (Aside: Newton's sync is gated on `pre_render`, which suggests a similar bug for pure-headless Newton training — worth a separate investigation.)

## Test plan

- [ ] CI for `test_world_pose_tracks_physics_body_parent[cuda:0]` goes green.
- [ ] Existing `test_views_xform_prim_fabric.py` contract tests still pass (18 passed locally).
- [ ] `test_ray_caster_integration.py` still passes (6 passed locally).
- [ ] `Isaac-Velocity-Rough-Anymal-C-v0` height_scan obs now varies as the robot walks (verified by re-recording the heightmap video from before/after).

Linked: #5476