### PR TITLE
Refactor visualizer cloning around per-group ClonePlan

### DIFF
--- a/source/isaaclab/changelog.d/clone-plan-visualizer-cleanup.minor.rst
+++ b/source/isaaclab/changelog.d/clone-plan-visualizer-cleanup.minor.rst
@@ -1,0 +1,43 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab.cloner.ClonePlan` frozen dataclass capturing per-group
+  prototype-to-environment mappings (``dest_template``, ``prototype_paths``,
+  ``clone_mask``). Lets downstream consumers (scene data providers, mesh samplers)
+  read prototype geometry once and scatter to environments via the per-group mask
+  instead of walking per-env USD paths.
+* Added :meth:`~isaaclab.sim.SimulationContext.get_clone_plans` and
+  :meth:`~isaaclab.sim.SimulationContext.set_clone_plans` for publishing and
+  consuming the cloner's per-group plan map.
+* Added :attr:`~isaaclab.scene.InteractiveScene.clone_plans` property (forwards to
+  :meth:`~isaaclab.sim.SimulationContext.get_clone_plans`) so consumers holding a
+  scene reference can read the published plans without going through the sim
+  context.
+
+Changed
+^^^^^^^
+
+* **Breaking:** :func:`~isaaclab.cloner.clone_from_template` now returns
+  ``dict[str, ClonePlan]`` instead of ``None``. Bind the result and publish it
+  through :meth:`~isaaclab.sim.SimulationContext.set_clone_plans` if downstream
+  consumers (e.g. the PhysX scene data provider's Newton-visualizer build path)
+  need to read the plan.
+
+Removed
+^^^^^^^
+
+* **Breaking:** Removed
+  :attr:`~isaaclab.cloner.TemplateCloneCfg.visualizer_clone_fn`,
+  :func:`~isaaclab.cloner.resolve_visualizer_clone_fn`, and
+  :class:`~isaaclab.physics.scene_data_requirements.VisualizerPrebuiltArtifacts`.
+  Scene data providers now build backend models from the
+  :class:`~isaaclab.cloner.ClonePlan` map via
+  :meth:`~isaaclab.sim.SimulationContext.get_clone_plans` instead of receiving a
+  prebuilt artifact through a clone-time callback.
+* **Breaking:** Removed
+  :meth:`~isaaclab.sim.SimulationContext.get_scene_data_visualizer_prebuilt_artifact`,
+  :meth:`~isaaclab.sim.SimulationContext.set_scene_data_visualizer_prebuilt_artifact`,
+  and
+  :meth:`~isaaclab.sim.SimulationContext.clear_scene_data_visualizer_prebuilt_artifact`.
+  Use :meth:`~isaaclab.sim.SimulationContext.get_clone_plans` /
+  :meth:`~isaaclab.sim.SimulationContext.set_clone_plans` instead.

--- a/source/isaaclab/isaaclab/cloner/__init__.pyi
+++ b/source/isaaclab/isaaclab/cloner/__init__.pyi
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 __all__ = [
+    "ClonePlan",
     "TemplateCloneCfg",
     "random",
     "sequential",
@@ -12,10 +13,10 @@ __all__ = [
     "filter_collisions",
     "grid_transforms",
     "make_clone_plan",
-    "resolve_visualizer_clone_fn",
     "usd_replicate",
 ]
 
+from .clone_plan import ClonePlan
 from .cloner_cfg import TemplateCloneCfg
 from .cloner_strategies import random, sequential
 from .cloner_utils import (
@@ -24,6 +25,5 @@ from .cloner_utils import (
     filter_collisions,
     grid_transforms,
     make_clone_plan,
-    resolve_visualizer_clone_fn,
     usd_replicate,
 )

--- a/source/isaaclab/isaaclab/cloner/clone_plan.py
+++ b/source/isaaclab/isaaclab/cloner/clone_plan.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import torch
+
+
+@dataclass(frozen=True)
+class ClonePlan:
+    """Per-group mapping from prototype prims to per-environment clones.
+
+    Produced by :func:`~isaaclab.cloner.clone_from_template` for each prototype group it
+    discovers under the template root. Lets downstream consumers (e.g. mesh samplers,
+    ray-cast sensors) read prototype geometry once and scatter to environments via
+    :attr:`clone_mask` instead of walking per-env USD paths.
+
+    Attributes are population-time invariants and the dataclass is frozen. Hash and
+    equality operate on :attr:`dest_template` only (the natural identity — it is the key
+    in :attr:`SimulationContext.get_clone_plans`); the mutable list/tensor fields are
+    excluded since ``torch.Tensor`` is not hashable and structural equality is rarely the
+    semantics consumers want.
+    """
+
+    dest_template: str
+    """Destination path template for this group, e.g. ``"/World/envs/env_{}/Object"``."""
+
+    prototype_paths: list[str] = field(hash=False, compare=False)
+    """Prototype prim paths in this group, e.g.
+    ``["/World/template/Object/proto_asset_0", "/World/template/Object/proto_asset_1"]``."""
+
+    clone_mask: torch.Tensor = field(hash=False, compare=False)
+    """Boolean tensor of shape ``[num_prototypes_in_group, num_envs]``;
+    ``clone_mask[i, j]`` is ``True`` iff env ``j`` was populated from
+    :attr:`prototype_paths` ``[i]``. Each column sums to exactly one."""

--- a/source/isaaclab/isaaclab/cloner/cloner_cfg.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_cfg.py
@@ -73,9 +73,6 @@ class TemplateCloneCfg:
     physics_clone_fn: callable | None = None
     """Function used to perform physics replication."""
 
-    visualizer_clone_fn: callable | None = None
-    """Optional function used to build precomputed visualizer artifacts from the clone plan."""
-
     clone_strategy: callable = random
     """Function used to build prototype-to-environment mapping. Default is :func:`random`."""
 

--- a/source/isaaclab/isaaclab/cloner/cloner_utils.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_utils.py
@@ -9,7 +9,7 @@ import contextlib
 import itertools
 import logging
 import math
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import torch
@@ -17,12 +17,13 @@ import torch
 from pxr import Gf, Sdf, Usd, UsdGeom, UsdUtils, Vt
 
 import isaaclab.sim as sim_utils
-from isaaclab.physics.scene_data_requirements import SceneDataRequirement, VisualizerPrebuiltArtifacts
 
 from . import _fabric_notices
 
 if TYPE_CHECKING:
     from .cloner_cfg import TemplateCloneCfg
+
+from .clone_plan import ClonePlan
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,9 @@ def disabled_fabric_change_notifies(stage: Usd.Stage, *, restore: bool = True) -
             bindings.set_enable(fabric_id, True)
 
 
-def clone_from_template(stage: Usd.Stage, num_clones: int, template_clone_cfg: TemplateCloneCfg) -> None:
+def clone_from_template(
+    stage: Usd.Stage, num_clones: int, template_clone_cfg: TemplateCloneCfg
+) -> dict[str, ClonePlan]:
     """Clone assets from a template root into per-environment destinations.
 
     This utility discovers prototype prims under ``cfg.template_root`` whose names start with
@@ -118,6 +121,10 @@ def clone_from_template(stage: Usd.Stage, num_clones: int, template_clone_cfg: T
         template_clone_cfg: Configuration describing template location, destination pattern,
             and replication/mapping behavior.
 
+    Returns:
+        Mapping from each group's destination template (e.g. ``"/World/envs/env_{}/Object"``)
+        to its :class:`ClonePlan`. Empty when no prototype groups are discovered.
+
     Note:
         This function suspends the Fabric USD notice listener for the duration of the call
         and **leaves it disabled on return**. It is intended to be invoked from a scene-init
@@ -128,6 +135,7 @@ def clone_from_template(stage: Usd.Stage, num_clones: int, template_clone_cfg: T
         :func:`disabled_fabric_change_notifies` with ``restore=True``.
     """
     cfg: TemplateCloneCfg = template_clone_cfg
+    plans: dict[str, ClonePlan] = {}
     # Suspend Fabric's USD notice listener for the duration of bulk authoring. ``restore=False``
     # because clone_from_template is only called at scene-init time, which is followed by
     # ``SimulationContext.reset`` — that reset path does the Fabric resync naturally, and
@@ -161,6 +169,15 @@ def clone_from_template(stage: Usd.Stage, num_clones: int, template_clone_cfg: T
                 src, dest, num_clones, cfg.clone_strategy, cfg.device
             )
 
+            # Per-group plans: slice ``clone_masking`` along the prototype axis using cumulative
+            # group sizes — each group's mask rows are contiguous in the ``[total_protos, num_envs]``
+            # tensor that ``make_clone_plan`` produced.
+            offsets = [0, *itertools.accumulate(len(g) for g in src)]
+            plans = {
+                d: ClonePlan(dest_template=d, prototype_paths=list(ps), clone_mask=clone_masking[lo:hi])
+                for ps, d, lo, hi in zip(src, dest, offsets, offsets[1:])
+            }
+
             # Spawn the first instance of clones from prototypes, then deactivate the prototypes, those first
             # instances will be served as sources for usd and physics replication.
             proto_idx = clone_masking.to(torch.int32).argmax(dim=1)
@@ -170,27 +187,27 @@ def clone_from_template(stage: Usd.Stage, num_clones: int, template_clone_cfg: T
             stage.GetPrimAtPath(cfg.template_root).SetActive(False)
             get_pos = lambda path: stage.GetPrimAtPath(path).GetAttribute("xformOp:translate").Get()  # noqa: E731
             positions = torch.tensor([get_pos(clone_path_fmt.format(i)) for i in world_indices])
-            # If all prototypes map to env_0, clone whole env_0 to all envs; else clone per-object
+            # Heterogeneous default: emit per-prototype (sources, destinations, mask) and trust
+            # env_0..N's existing xforms (proto-spawn above already placed them, so don't
+            # re-author). When every env happens to pick prototype 0, collapse below to a
+            # single env_0 → all-envs copy and re-author positions (the destination subtree
+            # replaces env_1..N's prior xform).
+            sources = [tpl.format(int(idx)) for tpl, idx in zip(dest_paths, proto_idx.tolist())]
+            usd_positions: torch.Tensor | None = None
             if torch.all(proto_idx == 0):
-                mapping = clone_masking.new_ones(1, num_clones)
-                replicate_args = [clone_path_fmt.format(0)], [clone_path_fmt], world_indices, mapping
-                if cfg.clone_physics and cfg.physics_clone_fn is not None:
-                    cfg.physics_clone_fn(stage, *replicate_args, positions=positions, device=cfg.device)
-                if cfg.visualizer_clone_fn is not None:
-                    cfg.visualizer_clone_fn(stage, *replicate_args, positions=positions, device=cfg.device)
-                if cfg.clone_usd:
-                    # parse env_origins directly from clone_path
-                    usd_replicate(stage, *replicate_args, positions=positions)
+                sources = [clone_path_fmt.format(0)]
+                dest_paths = [clone_path_fmt]
+                clone_masking = clone_masking.new_ones(1, num_clones)
+                usd_positions = positions
 
-            else:
-                selected_src = [tpl.format(int(idx)) for tpl, idx in zip(dest_paths, proto_idx.tolist())]
-                replicate_args = selected_src, dest_paths, world_indices, clone_masking
-                if cfg.clone_physics and cfg.physics_clone_fn is not None:
-                    cfg.physics_clone_fn(stage, *replicate_args, positions=positions, device=cfg.device)
-                if cfg.visualizer_clone_fn is not None:
-                    cfg.visualizer_clone_fn(stage, *replicate_args, positions=positions, device=cfg.device)
-                if cfg.clone_usd:
-                    usd_replicate(stage, *replicate_args)
+            if cfg.clone_physics and cfg.physics_clone_fn is not None:
+                cfg.physics_clone_fn(
+                    stage, sources, dest_paths, world_indices, clone_masking, positions=positions, device=cfg.device
+                )
+            if cfg.clone_usd:
+                usd_replicate(stage, sources, dest_paths, world_indices, clone_masking, positions=usd_positions)
+
+    return plans
 
 
 def make_clone_plan(
@@ -482,37 +499,3 @@ def grid_transforms(N: int, spacing: float = 1.0, up_axis: str = "z", device="cp
     ori = torch.zeros((N, 4), device=device)
     ori[:, 3] = 1.0  # w=1 for identity quaternion
     return pos, ori
-
-
-def resolve_visualizer_clone_fn(
-    physics_backend: str,
-    requirements: SceneDataRequirement,
-    stage,
-    set_visualizer_artifact: Callable[[VisualizerPrebuiltArtifacts | None], None],
-):
-    """Return an optional visualizer prebuild hook for clone workflows.
-
-    Args:
-        physics_backend: Active physics backend name.
-        requirements: Aggregated scene-data requirements.
-        stage: USD stage used by the clone callback.
-        set_visualizer_artifact: Callback for storing prebuilt visualizer artifacts.
-
-    Returns:
-        Clone callback when the prebuild path is supported; otherwise ``None``.
-    """
-    if "physx" not in physics_backend or not requirements.requires_newton_model:
-        return None
-    try:
-        from isaaclab_newton.cloner.newton_replicate import (
-            create_newton_visualizer_prebuild_clone_fn,
-        )
-    except (ImportError, ModuleNotFoundError) as exc:
-        logger.warning("Visualizer prebuild hook unavailable: failed to import backend helper.")
-        logger.debug("Visualizer prebuild import failure details: %s", exc)
-        return None
-
-    return create_newton_visualizer_prebuild_clone_fn(
-        stage=stage,
-        set_visualizer_artifact=set_visualizer_artifact,
-    )

--- a/source/isaaclab/isaaclab/physics/scene_data_requirements.py
+++ b/source/isaaclab/isaaclab/physics/scene_data_requirements.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any
 
 
 @dataclass(frozen=True)
@@ -22,21 +21,6 @@ class SceneDataRequirement:
 
     requires_newton_model: bool = False
     requires_usd_stage: bool = False
-
-
-@dataclass(frozen=True)
-class VisualizerPrebuiltArtifacts:
-    """Prebuilt model/state payload shared from scene setup to providers.
-
-    This gets produced during clone-time visualizer prebuild and then read by
-    scene data providers as a fast path (instead of rebuilding from USD).
-    """
-
-    model: Any
-    state: Any
-    rigid_body_paths: list[str]
-    articulation_paths: list[str]
-    num_envs: int
 
 
 _VISUALIZER_REQUIREMENTS: dict[str, SceneDataRequirement] = {

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -138,7 +138,6 @@ class InteractiveScene:
         self.sim = SimulationContext.instance()
         self.stage = get_current_stage()
         self.stage_id = get_current_stage_id()
-        self.sim.clear_scene_data_visualizer_prebuilt_artifact()
         self.physics_backend = self.sim.physics_manager.__name__.lower()
         requested_viz_types = set(self.sim.resolve_visualizer_types())
         if self.physics_backend.startswith("ovphysx"):
@@ -165,7 +164,6 @@ class InteractiveScene:
             clone_in_fabric=self.cfg.clone_in_fabric,
             device=self.device,
             physics_clone_fn=physics_clone_fn,
-            visualizer_clone_fn=None,
             # For ovphysx: env_1..N are created by physx.clone() in the physics
             # runtime after add_usd().  USD replication of the asset hierarchy
             # to env_1..N is skipped — only env_0 needs physics prims in the USD.
@@ -199,7 +197,10 @@ class InteractiveScene:
         if has_scene_cfg_entities:
             self._add_entities_from_cfg()
 
-        self._refresh_visualizer_clone_fn_from_requirements(requested_viz_types)
+        # Aggregate scene-data requirements from declared visualizers and constructed sensors,
+        # then publish to ``SimulationContext`` so downstream providers (constructed later by
+        # :meth:`SimulationContext.initialize_visualizers`) see the full picture in one read.
+        self._aggregate_scene_data_requirements(requested_viz_types)
 
         if has_scene_cfg_entities:
             self.clone_environments(copy_from_source=(not self.cfg.replicate_physics))
@@ -216,8 +217,6 @@ class InteractiveScene:
             If True, clones are independent copies of the source prim and won't reflect its changes (start-up time
             may increase). Defaults to False.
         """
-        self._refresh_visualizer_clone_fn_from_requirements()
-
         # PhysX-only: set env id bit count for replicated physics. Newton handles env separation in its own API.
         # Intentionally matches both physx and ovphysx (both are PhysX-based)
         if self.cfg.replicate_physics and "physx" in self.physics_backend:
@@ -231,7 +230,9 @@ class InteractiveScene:
         with cloner.disabled_fabric_change_notifies(self.stage, restore=False):
             if self._is_scene_setup_from_cfg():
                 self.cloner_cfg.clone_physics = not copy_from_source
-                cloner.clone_from_template(self.stage, num_clones=self.num_envs, template_clone_cfg=self.cloner_cfg)
+                plans = cloner.clone_from_template(
+                    self.stage, num_clones=self.num_envs, template_clone_cfg=self.cloner_cfg
+                )
             else:
                 mapping = torch.ones((1, self.num_envs), device=self.device, dtype=torch.bool)
                 replicate_args = (
@@ -239,18 +240,37 @@ class InteractiveScene:
                     [self.env_fmt],
                     self._ALL_INDICES,
                     mapping,
-                    self._default_env_origins,
                 )
 
                 if not copy_from_source and self.cloner_cfg.physics_clone_fn is not None:
-                    self.cloner_cfg.physics_clone_fn(self.stage, *replicate_args, device=self.cloner_cfg.device)
-                if self.cloner_cfg.visualizer_clone_fn is not None:
-                    self.cloner_cfg.visualizer_clone_fn(self.stage, *replicate_args, device=self.cloner_cfg.device)
+                    self.cloner_cfg.physics_clone_fn(
+                        self.stage, *replicate_args, positions=self._default_env_origins, device=self.cloner_cfg.device
+                    )
                 if self.cloner_cfg.clone_usd:
-                    cloner.usd_replicate(self.stage, *replicate_args)
+                    cloner.usd_replicate(self.stage, *replicate_args, positions=self._default_env_origins)
+                # Synthesize a single trivial ClonePlan so consumers (scene data providers,
+                # pointcloud samplers, etc.) get a uniform interface regardless of whether
+                # the scene was authored via prototypes or by hand under env_0.
+                plans = {
+                    self.env_fmt: cloner.ClonePlan(
+                        dest_template=self.env_fmt,
+                        prototype_paths=[self.env_fmt.format(0)],
+                        clone_mask=mapping,
+                    )
+                }
 
-    def _refresh_visualizer_clone_fn_from_requirements(self, visualizer_types=()) -> None:
-        """Refresh clone-time visualizer prebuild hook from current scene-data requirements."""
+        # Publish to ``SimulationContext`` (the canonical owner). The :attr:`clone_plans`
+        # property below forwards reads back through ``sim.get_clone_plans()`` so consumers
+        # holding a scene reference still see the published plans without a duplicate cache.
+        self.sim.set_clone_plans(plans)
+
+    def _aggregate_scene_data_requirements(self, visualizer_types=()) -> None:
+        """Aggregate scene-data requirements from visualizers and sensor renderers.
+
+        Runs once after :meth:`_add_entities_from_cfg` so all sensors are constructed and
+        their renderer types are visible. Pushes the merged :class:`SceneDataRequirement` to
+        :class:`SimulationContext` for later consumption by the scene data provider.
+        """
         discovered_req = resolve_scene_data_requirements(
             visualizer_types=visualizer_types,
             renderer_types=self._sensor_renderer_types(),
@@ -260,33 +280,13 @@ class InteractiveScene:
         if requirements != current_req:
             self.sim.update_scene_data_requirements(requirements)
 
-        visualizer_clone_fn = cloner.resolve_visualizer_clone_fn(
-            physics_backend=self.physics_backend,
-            requirements=requirements,
-            stage=self.stage,
-            set_visualizer_artifact=self.sim.set_scene_data_visualizer_prebuilt_artifact,
-        )
-        if visualizer_clone_fn is not None:
-            logger.debug(
-                "Enabling visualizer artifact prebuild for clone path "
-                "(backend=%s, requires_newton_model=%s, requires_usd_stage=%s).",
-                self.physics_backend,
-                requirements.requires_newton_model,
-                requirements.requires_usd_stage,
-            )
-            self.cloner_cfg.visualizer_clone_fn = visualizer_clone_fn
-
     def _sensor_renderer_types(self) -> list[str]:
-        """Return renderer type names used by scene sensors."""
-        renderer_types: list[str] = []
-        for sensor in self._sensors.values():
-            sensor_cfg = getattr(sensor, "cfg", None)
-            renderer_cfg = getattr(sensor_cfg, "renderer_cfg", None)
-            if renderer_cfg is None:
-                continue
-            renderer_type = getattr(renderer_cfg, "renderer_type", "default")
-            renderer_types.append(renderer_type)
-        return renderer_types
+        """Return renderer type names used by scene sensors (skipping any without a renderer cfg)."""
+        return [
+            getattr(rcfg, "renderer_type", "default")
+            for s in self._sensors.values()
+            if (rcfg := getattr(getattr(s, "cfg", None), "renderer_cfg", None)) is not None
+        ]
 
     def filter_collisions(self, global_prim_paths: list[str] | None = None):
         """Filter environments collisions.
@@ -425,6 +425,18 @@ class InteractiveScene:
     def surface_grippers(self) -> dict[str, SurfaceGripper]:
         """A dictionary of the surface grippers in the scene."""
         return self._surface_grippers
+
+    @property
+    def clone_plans(self) -> dict[str, cloner.ClonePlan]:
+        """Per-group clone plans produced by :meth:`clone_environments`.
+
+        Forwards to :meth:`SimulationContext.get_clone_plans`, which is the canonical owner.
+        Keyed by each group's destination path template
+        (e.g. ``"/World/envs/env_{}/Object"``); the value records the prototype prim paths
+        and the per-env prototype assignment mask. Empty until :meth:`clone_environments`
+        runs, and (for the cfg path) empty when the scene cfg has no template prototypes.
+        """
+        return self.sim.get_clone_plans()
 
     @property
     def extras(self) -> dict[str, FrameView]:

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -108,7 +108,6 @@ class Camera(SensorBase):
         self._check_supported_data_types(cfg)
         # initialize base class
         super().__init__(cfg)
-        self._register_renderer_scene_data_requirements()
 
         # TODO(follow-up PR): move this flag flip out of Camera. The cleanest path is
         # an apply_pre_reset_settings() hook on RendererCfg (default no-op) that
@@ -135,30 +134,6 @@ class Camera(SensorBase):
         # Renderer and render data — assigned in _initialize_impl.
         self._renderer: BaseRenderer | None = None
         self._render_data = None
-
-    def _register_renderer_scene_data_requirements(self) -> None:
-        """Register renderer requirements early enough for clone-time prebuilds."""
-        renderer_type = getattr(getattr(self.cfg, "renderer_cfg", None), "renderer_type", None)
-        if renderer_type is None:
-            return
-
-        from isaaclab.physics.scene_data_requirements import aggregate_requirements, requirement_for_renderer_type
-        from isaaclab.sim import SimulationContext
-
-        sim = SimulationContext.instance()
-        if sim is None:
-            logger.debug("SimulationContext not available; deferring renderer requirements registration.")
-            return
-
-        try:
-            renderer_req = requirement_for_renderer_type(renderer_type)
-        except ValueError:
-            return
-
-        current_req = sim.get_scene_data_requirements()
-        merged_req = aggregate_requirements((current_req, renderer_req))
-        if merged_req != current_req:
-            sim.update_scene_data_requirements(merged_req)
 
     def __del__(self):
         """Unsubscribes from callbacks and cleans up renderer resources."""

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -11,7 +11,7 @@ import os
 import traceback
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import toml
 import torch
@@ -25,7 +25,6 @@ from isaaclab.envs.utils.recording_hooks import run_recording_hooks_after_visual
 from isaaclab.physics import BaseSceneDataProvider, PhysicsManager, SceneDataProvider
 from isaaclab.physics.scene_data_requirements import (
     SceneDataRequirement,
-    VisualizerPrebuiltArtifacts,
     resolve_scene_data_requirements,
 )
 from isaaclab.renderers.render_context import RenderContext
@@ -33,6 +32,9 @@ from isaaclab.sim.utils import create_new_stage
 from isaaclab.utils.string import clear_resolve_matching_names_cache
 from isaaclab.utils.version import has_kit
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
+
+if TYPE_CHECKING:
+    from isaaclab.cloner.clone_plan import ClonePlan
 
 from .simulation_cfg import SimulationCfg
 from .spawners import DomeLightCfg, GroundPlaneCfg
@@ -173,7 +175,11 @@ class SimulationContext:
         self._scene_data_provider: BaseSceneDataProvider | None = None
         self._visualizers: list[BaseVisualizer] = []
         self._scene_data_requirements = SceneDataRequirement()
-        self._visualizer_prebuilt_artifact: VisualizerPrebuiltArtifacts | None = None
+        # Per-group clone plans published by InteractiveScene after cloning. Providers (e.g.
+        # the Newton visualizer model rebuilder on a PhysX backend) consume these to derive
+        # their own backend args. Empty dict until :meth:`InteractiveScene.clone_environments`
+        # runs.
+        self._clone_plans: dict[str, ClonePlan] = {}
         self._visualizer_step_counter = 0
         # Default visualization dt used before/without visualizer initialization.
         physics_dt = getattr(self.cfg.physics, "dt", None)
@@ -627,21 +633,18 @@ class SimulationContext:
         """Update scene-data requirements."""
         self._scene_data_requirements = requirements
 
-    def get_scene_data_visualizer_prebuilt_artifact(self) -> VisualizerPrebuiltArtifacts | None:
-        """Return optional prebuilt visualizer artifact."""
-        return self._visualizer_prebuilt_artifact
+    def get_clone_plans(self) -> dict[str, ClonePlan]:
+        """Return per-group clone plans published by the scene, keyed by destination template.
 
-    def set_scene_data_visualizer_prebuilt_artifact(self, artifact: VisualizerPrebuiltArtifacts | None) -> None:
-        """Set or clear the optional visualizer prebuilt artifact.
-
-        The scene (clone flow) writes this once, and providers can read it
-        during initialization as a fast path.
+        Set by :meth:`InteractiveScene.clone_environments` after replication. Consumed by
+        scene data providers that build backend models (e.g. Newton visualizer model on a
+        PhysX backend) from the same plan the cloner used. Empty dict until the scene clones.
         """
-        self._visualizer_prebuilt_artifact = artifact
+        return self._clone_plans
 
-    def clear_scene_data_visualizer_prebuilt_artifact(self) -> None:
-        """Clear optional prebuilt artifact in provider context."""
-        self.set_scene_data_visualizer_prebuilt_artifact(None)
+    def set_clone_plans(self, plans: dict[str, ClonePlan]) -> None:
+        """Set the cloner's per-group clone-plan map."""
+        self._clone_plans = plans
 
     @property
     def visualizers(self) -> list[BaseVisualizer]:

--- a/source/isaaclab/test/scene/test_interactive_scene.py
+++ b/source/isaaclab/test/scene/test_interactive_scene.py
@@ -130,17 +130,34 @@ def test_reset_to_env_ids_input_types(device, setup_scene):
     assert_state_equal(prev_state, scene.get_state())
 
 
-def test_clone_environments_non_cfg_invokes_visualizer_clone_fn(monkeypatch: pytest.MonkeyPatch):
-    """Non-cfg clone path should execute visualizer clone callback with replicate args."""
+def test_clone_environments_non_cfg_publishes_clone_plans(monkeypatch: pytest.MonkeyPatch):
+    """Non-cfg clone path must dispatch physics + USD replicate and publish a ``ClonePlan``.
+
+    Replaces the old test that asserted a per-call visualizer clone callback was invoked. The
+    visualizer-fn callback was removed in favor of providers reading
+    :meth:`SimulationContext.get_clone_plans`; this test asserts the new contract: even
+    without prototype templates, the scene synthesizes a single trivial ClonePlan.
+    """
+    from isaaclab.cloner import ClonePlan
+
     scene = object.__new__(InteractiveScene)
     scene.cfg = SimpleNamespace(replicate_physics=False, num_envs=3)
     scene.stage = object()
     scene.physics_backend = "physx"
     scene._sensors = {}
+
+    set_plans_calls: list = []
+    sim_state: dict = {"plans": {}}
+
+    def _set_clone_plans(plans):
+        sim_state["plans"] = plans
+        set_plans_calls.append(plans)
+
     scene.sim = SimpleNamespace(
         get_scene_data_requirements=lambda: SceneDataRequirement(),
         update_scene_data_requirements=lambda requirements: None,
-        set_scene_data_visualizer_prebuilt_artifact=lambda artifact: None,
+        set_clone_plans=_set_clone_plans,
+        get_clone_plans=lambda: sim_state["plans"],
     )
     scene.env_fmt = "/World/envs/env_{}"
     scene._ALL_INDICES = torch.arange(3, dtype=torch.long)
@@ -160,14 +177,10 @@ def test_clone_environments_non_cfg_invokes_visualizer_clone_fn(monkeypatch: pyt
     monkeypatch.setattr("isaaclab.scene.interactive_scene.cloner.disabled_fabric_change_notifies", _noop_fabric_notices)
 
     physics_calls = []
-    visualizer_calls = []
     usd_calls = []
 
     def _physics_clone_fn(stage, *args, **kwargs):
         physics_calls.append((stage, args, kwargs))
-
-    def _visualizer_clone_fn(stage, *args, **kwargs):
-        visualizer_calls.append((stage, args, kwargs))
 
     def _usd_replicate(stage, *args, **kwargs):
         usd_calls.append((stage, args, kwargs))
@@ -175,58 +188,61 @@ def test_clone_environments_non_cfg_invokes_visualizer_clone_fn(monkeypatch: pyt
     scene.cloner_cfg = SimpleNamespace(
         device="cpu",
         physics_clone_fn=_physics_clone_fn,
-        visualizer_clone_fn=_visualizer_clone_fn,
         clone_usd=True,
     )
     monkeypatch.setattr("isaaclab.scene.interactive_scene.cloner.usd_replicate", _usd_replicate)
 
     scene.clone_environments(copy_from_source=False)
     assert len(physics_calls) == 1
-    assert len(visualizer_calls) == 1
     assert len(usd_calls) == 1
     mapping = physics_calls[0][1][3]
     assert mapping.dtype == torch.bool
     assert mapping.shape == (1, scene.num_envs)
+    # Plans are published once per clone, regardless of physics/usd flag combinations.
+    assert len(set_plans_calls) == 1
+    plans = set_plans_calls[-1]
+    assert set(plans.keys()) == {scene.env_fmt}
+    plan = plans[scene.env_fmt]
+    assert isinstance(plan, ClonePlan)
+    assert plan.dest_template == scene.env_fmt
+    assert plan.prototype_paths == [scene.env_fmt.format(0)]
+    assert plan.clone_mask.shape == (1, scene.num_envs)
+    assert scene.clone_plans is plans
 
     physics_calls.clear()
-    visualizer_calls.clear()
     usd_calls.clear()
+    set_plans_calls.clear()
     scene.clone_environments(copy_from_source=True)
     assert len(physics_calls) == 0
-    assert len(visualizer_calls) == 1
     assert len(usd_calls) == 1
+    assert len(set_plans_calls) == 1
 
 
-def test_refresh_visualizer_clone_fn_uses_registered_requirements(monkeypatch: pytest.MonkeyPatch):
-    """Clone-time prebuild hook should be installed from requirements registered after scene init."""
+def test_aggregate_scene_data_requirements_merges_visualizers_and_renderers(monkeypatch: pytest.MonkeyPatch):
+    """Scene aggregation must OR visualizer and sensor-renderer requirements onto sim context.
+
+    Replaces the old test that asserted a clone-time visualizer hook was installed from
+    requirements. The hook is gone; the only remaining behavior is publishing the merged
+    :class:`SceneDataRequirement` to the simulation context.
+    """
     scene = object.__new__(InteractiveScene)
     scene.physics_backend = "physx"
     scene.stage = object()
-    scene._sensors = {}
-    scene.cloner_cfg = SimpleNamespace(visualizer_clone_fn=None)
+    scene._sensors = {
+        "cam": SimpleNamespace(cfg=SimpleNamespace(renderer_cfg=SimpleNamespace(renderer_type="newton_warp")))
+    }
 
-    requirements = SceneDataRequirement(requires_newton_model=True)
+    posted: list = []
     scene.sim = SimpleNamespace(
-        get_scene_data_requirements=lambda: requirements,
-        update_scene_data_requirements=lambda requirements: None,
-        set_scene_data_visualizer_prebuilt_artifact=lambda artifact: None,
+        get_scene_data_requirements=lambda: SceneDataRequirement(),
+        update_scene_data_requirements=posted.append,
     )
 
-    captured = {}
+    scene._aggregate_scene_data_requirements({"rerun"})
 
-    def _resolve_visualizer_clone_fn(**kwargs):
-        captured.update(kwargs)
-        return "visualizer-clone-fn"
-
-    monkeypatch.setattr(
-        "isaaclab.scene.interactive_scene.cloner.resolve_visualizer_clone_fn",
-        _resolve_visualizer_clone_fn,
-    )
-
-    scene._refresh_visualizer_clone_fn_from_requirements()
-
-    assert captured["requirements"].requires_newton_model
-    assert scene.cloner_cfg.visualizer_clone_fn == "visualizer-clone-fn"
+    assert len(posted) == 1
+    merged = posted[0]
+    assert merged.requires_newton_model
 
 
 def assert_state_equal(s1: dict, s2: dict, path=""):

--- a/source/isaaclab/test/sensors/test_camera.py
+++ b/source/isaaclab/test/sensors/test_camera.py
@@ -17,7 +17,6 @@ simulation_app = AppLauncher(headless=True, enable_cameras=True).app
 
 import copy
 import random
-from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -28,9 +27,7 @@ import omni.replicator.core as rep
 from pxr import Gf, Usd, UsdGeom
 
 import isaaclab.sim as sim_utils
-from isaaclab.physics.scene_data_requirements import SceneDataRequirement
 from isaaclab.sensors.camera import Camera, CameraCfg
-from isaaclab.sim import SimulationContext
 
 pytestmark = pytest.mark.isaacsim_ci
 
@@ -46,23 +43,6 @@ QUAT_WORLD = (-0.27984815, -0.1159169, 0.88047623, -0.3647052)
 # resolutions
 HEIGHT = 240
 WIDTH = 320
-
-
-def test_camera_registers_renderer_scene_data_requirements(monkeypatch: pytest.MonkeyPatch):
-    """Camera creation path should register renderer-driven scene-data requirements."""
-    camera = object.__new__(Camera)
-    camera.cfg = SimpleNamespace(renderer_cfg=SimpleNamespace(renderer_type="newton_warp"))
-    updates = []
-    sim = SimpleNamespace(
-        get_scene_data_requirements=lambda: SceneDataRequirement(),
-        update_scene_data_requirements=updates.append,
-    )
-
-    monkeypatch.setattr(SimulationContext, "instance", staticmethod(lambda: sim))
-
-    camera._register_renderer_scene_data_requirements()
-
-    assert updates == [SceneDataRequirement(requires_newton_model=True)]
 
 
 def setup() -> tuple[sim_utils.SimulationContext, CameraCfg, float]:

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -20,9 +20,7 @@ import torch
 from pxr import UsdGeom
 
 import isaaclab.sim as sim_utils
-from isaaclab.cloner import usd_replicate
-from isaaclab.cloner.cloner_utils import resolve_visualizer_clone_fn
-from isaaclab.physics.scene_data_requirements import SceneDataRequirement, VisualizerPrebuiltArtifacts
+from isaaclab.cloner import ClonePlan, TemplateCloneCfg, clone_from_template, sequential, usd_replicate
 from isaaclab.sim import build_simulation_context
 
 pytestmark = pytest.mark.isaacsim_ci
@@ -223,79 +221,56 @@ def test_clone_decorator_wildcard_patterns(
     )
 
 
-def test_resolve_visualizer_clone_fn_returns_none_when_not_physx_backend():
-    """Resolver should ignore non-PhysX backends."""
-    hook = resolve_visualizer_clone_fn(
-        physics_backend="newton",
-        requirements=SceneDataRequirement(requires_newton_model=True),
-        stage=object(),
-        set_visualizer_artifact=lambda artifact: artifact,
-    )
-    assert hook is None
+def test_clone_from_template_returns_clone_plan(sim):
+    """clone_from_template exposes per-group ClonePlan dicts with prototype-to-env masks.
+
+    Builds two USD prototypes under one group, clones across four envs with the deterministic
+    sequential strategy, and asserts the returned dict has one entry keyed by the group's
+    destination template, with a ``[2, 4]`` boolean mask whose columns sum to one.
+    """
+    num_clones = 4
+    cfg = TemplateCloneCfg(device=sim.cfg.device, clone_strategy=sequential, clone_physics=False)
+
+    sim_utils.create_prim(cfg.template_root, "Xform")
+    sim_utils.create_prim(f"{cfg.template_root}/Object", "Xform")
+    sim_utils.create_prim(f"{cfg.template_root}/Object/proto_asset_0", "Xform")
+    sim_utils.create_prim(f"{cfg.template_root}/Object/proto_asset_1", "Xform")
+    sim_utils.create_prim("/World/envs", "Xform")
+    for i in range(num_clones):
+        sim_utils.create_prim(f"/World/envs/env_{i}", "Xform", translation=(0, 0, 0))
+
+    stage = sim_utils.get_current_stage()
+    plans = clone_from_template(stage, num_clones=num_clones, template_clone_cfg=cfg)
+
+    assert isinstance(plans, dict)
+    assert list(plans.keys()) == ["/World/envs/env_{}/Object"]
+    plan = plans["/World/envs/env_{}/Object"]
+    assert isinstance(plan, ClonePlan)
+    assert plan.dest_template == "/World/envs/env_{}/Object"
+    assert sorted(plan.prototype_paths) == [
+        "/World/template/Object/proto_asset_0",
+        "/World/template/Object/proto_asset_1",
+    ]
+    assert plan.clone_mask.shape == (2, num_clones)
+    assert plan.clone_mask.dtype == torch.bool
+    # Each env gets exactly one prototype (column-sum invariant)
+    assert torch.all(plan.clone_mask.sum(dim=0) == 1)
+    # Sequential strategy assigns env i → prototype (i % num_protos)
+    actual_proto_idx = plan.clone_mask.to(torch.int).argmax(dim=0).cpu()
+    assert torch.equal(actual_proto_idx, torch.tensor([0, 1, 0, 1]))
 
 
-def test_resolve_visualizer_clone_fn_returns_none_when_newton_model_not_required():
-    """Resolver should not load optional hook when requirement is not requested."""
-    hook = resolve_visualizer_clone_fn(
-        physics_backend="physx",
-        requirements=SceneDataRequirement(requires_newton_model=False),
-        stage=object(),
-        set_visualizer_artifact=lambda artifact: artifact,
-    )
-    assert hook is None
+def test_clone_from_template_returns_empty_dict_when_no_prototypes(sim):
+    """clone_from_template returns an empty dict when no prototypes match the identifier."""
+    num_clones = 2
+    cfg = TemplateCloneCfg(device=sim.cfg.device, clone_strategy=sequential, clone_physics=False)
 
+    sim_utils.create_prim(cfg.template_root, "Xform")
+    sim_utils.create_prim("/World/envs", "Xform")
+    for i in range(num_clones):
+        sim_utils.create_prim(f"/World/envs/env_{i}", "Xform", translation=(0, 0, 0))
 
-def test_resolve_visualizer_clone_fn_returns_callable_when_available(sim):
-    """Resolver should return a callable hook when backend helper is available."""
-    pytest.importorskip("isaaclab_newton.cloner.newton_replicate")
-    hook = resolve_visualizer_clone_fn(
-        physics_backend="physx",
-        requirements=SceneDataRequirement(requires_newton_model=True),
-        stage=sim_utils.get_current_stage(),
-        set_visualizer_artifact=lambda artifact: artifact,
-    )
-    assert callable(hook)
+    stage = sim_utils.get_current_stage()
+    plans = clone_from_template(stage, num_clones=num_clones, template_clone_cfg=cfg)
 
-
-def test_physx_newton_requirement_hook_populates_prebuilt_artifact(sim, monkeypatch: pytest.MonkeyPatch):
-    """PhysX + Newton requirement path should populate prebuilt visualizer artifact."""
-    newton_replicate = pytest.importorskip("isaaclab_newton.cloner.newton_replicate")
-
-    class _FakeModel:
-        body_label = ["/World/envs/env_0/A", "/World/envs/env_1/A"]
-        articulation_label = ["/World/envs/env_0/Robot", "/World/envs/env_1/Robot"]
-
-    fake_model = _FakeModel()
-    fake_state = object()
-
-    def _fake_prebuild(*args, **kwargs):
-        return fake_model, fake_state
-
-    monkeypatch.setattr(newton_replicate, "newton_visualizer_prebuild", _fake_prebuild)
-
-    captured: list[VisualizerPrebuiltArtifacts] = []
-    hook = resolve_visualizer_clone_fn(
-        physics_backend="physx",
-        requirements=SceneDataRequirement(requires_newton_model=True),
-        stage=sim_utils.get_current_stage(),
-        set_visualizer_artifact=lambda artifact: captured.append(artifact),
-    )
-
-    assert callable(hook)
-    hook(
-        stage=sim_utils.get_current_stage(),
-        sources=["/World/template/A"],
-        destinations=["/World/envs/env_{}/A"],
-        env_ids=torch.tensor([0, 1], dtype=torch.long),
-        mapping=torch.ones((1, 2), dtype=torch.bool),
-        device="cpu",
-    )
-
-    assert len(captured) == 1
-    artifact = captured[0]
-    assert isinstance(artifact, VisualizerPrebuiltArtifacts)
-    assert artifact.model is fake_model
-    assert artifact.state is fake_state
-    assert artifact.rigid_body_paths == fake_model.body_label
-    assert artifact.articulation_paths == fake_model.articulation_label
-    assert artifact.num_envs == 2
+    assert plans == {}

--- a/source/isaaclab/test/sim/test_physx_scene_data_provider_visualizer_contract.py
+++ b/source/isaaclab/test/sim/test_physx_scene_data_provider_visualizer_contract.py
@@ -7,71 +7,215 @@
 
 from __future__ import annotations
 
+import sys
 from types import SimpleNamespace
-from unittest.mock import patch
 
+import pytest
+import torch
 from isaaclab_physx.scene_data_providers import PhysxSceneDataProvider
 
-from isaaclab.physics.scene_data_requirements import VisualizerPrebuiltArtifacts
+from isaaclab.cloner import ClonePlan
+
+PROVIDER_MOD = "isaaclab_physx.scene_data_providers.physx_scene_data_provider"
 
 
-def _make_provider():
-    return object.__new__(PhysxSceneDataProvider)
+def _silent_stage() -> SimpleNamespace:
+    """Stage stub whose ``GetPrimAtPath`` returns an invalid prim — env xforms read as zero."""
+    return SimpleNamespace(GetPrimAtPath=lambda path: SimpleNamespace(IsValid=lambda: False))
 
 
-def test_get_newton_model_returns_model_when_sync_enabled():
-    """Callers receive the full Newton model from :meth:`get_newton_model`."""
-    provider = _make_provider()
-    provider._needs_newton_sync = True
-    provider._newton_model = "full-model"
+@pytest.fixture
+def stub_provider():
+    """Bare :class:`PhysxSceneDataProvider` with all buffer attrs initialized to defaults.
 
-    assert provider.get_newton_model() == "full-model"
+    Tests assign ``_simulation_context`` and ``_stage`` themselves; everything else is the
+    pre-build state the build path expects.
+    """
+    p = object.__new__(PhysxSceneDataProvider)
+    p._device = "cpu"
+    p._xform_views = {}
+    p._view_body_index_map = {}
+    p._view_order_tensors = {}
+    p._pose_buf_num_bodies = 0
+    p._positions_buf = None
+    p._orientations_buf = None
+    p._covered_buf = None
+    p._xform_mask_buf = None
+    return p
 
 
-@patch("isaaclab_physx.scene_data_providers.physx_scene_data_provider.replace_newton_shape_colors", lambda m, s: None)
-def test_load_prebuilt_artifact_populates_provider_state():
-    """Loading the prebuilt artifact sets model, state, and rigid-body paths."""
-    provider = _make_provider()
-    artifact = VisualizerPrebuiltArtifacts(
-        model="prebuilt-model",
-        state="prebuilt-state",
-        rigid_body_paths=["/World/envs/env_0/A"],
-        articulation_paths=["/World/envs/env_0/Robot"],
-        num_envs=4,
+@pytest.fixture
+def newton_stub(monkeypatch):
+    """Stub the ``isaaclab_newton`` newton-prebuild module and the side-effect helpers.
+
+    Returned :class:`SimpleNamespace` exposes:
+
+    * ``calls`` — list of kwargs from each prebuild invocation,
+    * ``model`` / ``state_obj`` — what prebuild returns; tests can override before invoking.
+    """
+    state = SimpleNamespace(
+        calls=[],
+        model=SimpleNamespace(body_label=[], articulation_label=[]),
+        state_obj=object(),
     )
-    provider._simulation_context = SimpleNamespace(get_scene_data_visualizer_prebuilt_artifact=lambda: artifact)
-    provider._stage = None
 
-    provider._xform_views = {"old": object()}
-    provider._view_body_index_map = {"old": [1]}
-    provider._view_order_tensors = {"old": object()}
-    provider._pose_buf_num_bodies = 7
-    provider._positions_buf = object()
-    provider._orientations_buf = object()
-    provider._covered_buf = object()
-    provider._xform_mask_buf = object()
-    provider._load_newton_model_from_prebuilt_artifact()
-    assert provider._newton_model == "prebuilt-model"
-    assert provider._newton_state == "prebuilt-state"
-    assert provider._rigid_body_paths == ["/World/envs/env_0/A"]
-    assert provider._rigid_body_view_paths == ["/World/envs/env_0/A", "/World/envs/env_0/Robot"]
-    assert provider._num_envs_at_last_newton_build == 4
-    assert provider._last_newton_model_build_source == "prebuilt"
-    assert provider._xform_views == {}
-    assert provider._view_body_index_map == {}
-    assert provider._view_order_tensors == {}
-    assert provider._pose_buf_num_bodies == 0
-    assert provider._positions_buf is None
-    assert provider._orientations_buf is None
-    assert provider._covered_buf is None
-    assert provider._xform_mask_buf is None
+    def _prebuild(**kwargs):
+        state.calls.append(dict(kwargs))
+        return state.model, state.state_obj
+
+    monkeypatch.setitem(
+        sys.modules, "isaaclab_newton.cloner.newton_replicate", SimpleNamespace(newton_visualizer_prebuild=_prebuild)
+    )
+    monkeypatch.setattr(f"{PROVIDER_MOD}.UsdGeom.GetStageUpAxis", lambda stage: "Z")
+    monkeypatch.setattr(f"{PROVIDER_MOD}.replace_newton_shape_colors", lambda m, s: None)
+    return state
 
 
-def test_load_prebuilt_artifact_missing_sets_error_state():
-    """When no artifact is registered, model/state stay unset."""
-    provider = _make_provider()
-    provider._simulation_context = SimpleNamespace(get_scene_data_visualizer_prebuilt_artifact=lambda: None)
-    provider._load_newton_model_from_prebuilt_artifact()
-    assert provider._last_newton_model_build_source == "missing"
-    assert provider._newton_model is None
-    assert provider._newton_state is None
+def test_get_newton_model_returns_model_when_sync_enabled(stub_provider):
+    """Callers receive the full Newton model from :meth:`get_newton_model`."""
+    stub_provider._needs_newton_sync = True
+    stub_provider._newton_model = "full-model"
+    assert stub_provider.get_newton_model() == "full-model"
+
+
+def test_build_from_clone_plans_populates_provider_state(stub_provider, newton_stub):
+    """Building from per-group clone plans sets model, state, and rigid-body paths.
+
+    Asserts the provider derives its own (sources, destinations, mask) from the plans
+    without consulting any auxiliary spec object: representative source paths are recovered
+    from ``dest_template.format(<first env using each prototype>)``, masks are concatenated
+    along the prototype axis, and per-env positions are read from stage xforms.
+    """
+    newton_stub.model = SimpleNamespace(
+        body_label=["/World/envs/env_0/Object/A"],
+        articulation_label=["/World/envs/env_0/Robot"],
+    )
+    plans = {
+        "/World/envs/env_{}/Object": ClonePlan(
+            dest_template="/World/envs/env_{}/Object",
+            prototype_paths=["/World/template/Object/proto_0", "/World/template/Object/proto_1"],
+            # proto 0 → env 0, 2 ; proto 1 → env 1, 3
+            clone_mask=torch.tensor([[True, False, True, False], [False, True, False, True]], dtype=torch.bool),
+        ),
+        "/World/envs/env_{}/Robot": ClonePlan(
+            dest_template="/World/envs/env_{}/Robot",
+            prototype_paths=["/World/template/Robot/proto_0"],
+            clone_mask=torch.ones((1, 4), dtype=torch.bool),
+        ),
+    }
+    stub_provider._simulation_context = SimpleNamespace(get_clone_plans=lambda: plans)
+    stub_provider._stage = _silent_stage()
+
+    stub_provider._build_newton_model_from_clone_plans()
+
+    assert stub_provider._newton_model is newton_stub.model
+    assert stub_provider._newton_state is newton_stub.state_obj
+    assert stub_provider._rigid_body_paths == newton_stub.model.body_label
+    assert stub_provider._rigid_body_view_paths == newton_stub.model.body_label + newton_stub.model.articulation_label
+    assert stub_provider._num_envs_at_last_newton_build == 4
+    assert stub_provider._last_newton_model_build_source == "built"
+
+    kw = newton_stub.calls[-1]
+    # Source recovery picks the first-env user per prototype.
+    assert kw["sources"] == [
+        "/World/envs/env_0/Object",
+        "/World/envs/env_1/Object",
+        "/World/envs/env_0/Robot",
+    ]
+    assert kw["destinations"] == ["/World/envs/env_{}/Object", "/World/envs/env_{}/Object", "/World/envs/env_{}/Robot"]
+    assert kw["mapping"].shape == (3, 4)
+    assert kw["positions"].shape == (4, 3)
+
+
+def test_build_from_clone_plans_missing_sets_error_state(stub_provider):
+    """When no clone plans are published, model/state stay unset."""
+    stub_provider._simulation_context = SimpleNamespace(get_clone_plans=lambda: {})
+    stub_provider._stage = object()
+
+    stub_provider._build_newton_model_from_clone_plans()
+
+    assert stub_provider._last_newton_model_build_source == "missing"
+    assert stub_provider._newton_model is None
+    assert stub_provider._newton_state is None
+
+
+def test_build_from_clone_plans_skips_unused_prototype_rows(stub_provider, newton_stub):
+    """A prototype row with no assigned env (all-False mask row) is dropped, not raised on.
+
+    When ``num_prototypes > num_envs`` under a sequential strategy (or any strategy that
+    leaves some prototypes unused), ``clone_mask[row].nonzero()[0]`` would otherwise raise
+    ``IndexError``. The provider must filter unused rows out of sources/destinations/mask.
+    """
+    # 3 prototypes, 2 envs, sequential: env 0 → proto 0, env 1 → proto 1, proto 2 unused.
+    plans = {
+        "/World/envs/env_{}/Object": ClonePlan(
+            dest_template="/World/envs/env_{}/Object",
+            prototype_paths=[
+                "/World/template/Object/proto_0",
+                "/World/template/Object/proto_1",
+                "/World/template/Object/proto_2",
+            ],
+            clone_mask=torch.tensor([[True, False], [False, True], [False, False]], dtype=torch.bool),
+        )
+    }
+    stub_provider._simulation_context = SimpleNamespace(get_clone_plans=lambda: plans)
+    stub_provider._stage = _silent_stage()
+
+    stub_provider._build_newton_model_from_clone_plans()
+
+    assert stub_provider._last_newton_model_build_source == "built"
+    kw = newton_stub.calls[-1]
+    # Unused proto_2 row dropped; only the two assigned prototypes survive.
+    assert kw["sources"] == ["/World/envs/env_0/Object", "/World/envs/env_1/Object"]
+    assert kw["mapping"].shape == (2, 2)
+
+
+def test_build_from_clone_plans_uses_dest_template_for_env_lookup(stub_provider, newton_stub):
+    """Env-origin lookup uses the per-plan ``dest_template`` prefix, not a hardcoded path.
+
+    A scene with a non-default env path (``/Stage/scenes/env_<i>``) should still have its
+    xform translates read correctly. Replaces the prior hardcoded ``/World/envs/env_<i>``.
+    """
+    visited: list[str] = []
+
+    def _get_prim(path):
+        visited.append(path)
+        return SimpleNamespace(IsValid=lambda: False)
+
+    plans = {
+        "/Stage/scenes/env_{}/Object": ClonePlan(
+            dest_template="/Stage/scenes/env_{}/Object",
+            prototype_paths=["/Stage/template/Object/proto_0"],
+            clone_mask=torch.ones((1, 3), dtype=torch.bool),
+        )
+    }
+    stub_provider._simulation_context = SimpleNamespace(get_clone_plans=lambda: plans)
+    stub_provider._stage = SimpleNamespace(GetPrimAtPath=_get_prim)
+
+    stub_provider._build_newton_model_from_clone_plans()
+
+    assert {f"/Stage/scenes/env_{i}" for i in range(3)} <= set(visited)
+    assert not any(p.startswith("/World/envs/") for p in visited)
+
+
+def test_clone_plan_is_hashable_with_unhashable_fields():
+    """``ClonePlan`` must hash despite carrying a tensor and a list.
+
+    With ``field(hash=False)`` on the unhashable members, hashing operates on
+    ``dest_template`` only — the natural identity (it is the dict key in
+    :meth:`SimulationContext.get_clone_plans`).
+    """
+    plan_a = ClonePlan(
+        dest_template="/World/envs/env_{}/Object",
+        prototype_paths=["/World/template/Object/proto_0"],
+        clone_mask=torch.ones((1, 4), dtype=torch.bool),
+    )
+    plan_b = ClonePlan(
+        dest_template="/World/envs/env_{}/Object",
+        prototype_paths=["/World/template/Object/proto_99"],
+        clone_mask=torch.zeros((1, 4), dtype=torch.bool),
+    )
+    assert isinstance(hash(plan_a), int)
+    # Equality folds in only dest_template, so two plans with the same destination compare
+    # equal regardless of prototype/mask differences.
+    assert plan_a == plan_b

--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -449,7 +449,7 @@ def _make_context_with_settings(
     ctx._visualizers = []
     ctx._scene_data_provider = _FakeProvider()
     ctx._scene_data_requirements = None
-    ctx._visualizer_prebuilt_artifact = None
+    ctx._clone_plans = {}
     ctx._visualizer_step_counter = 0
     ctx._viz_dt = 0.01
     ctx.get_setting = lambda name: settings.get(name)

--- a/source/isaaclab_newton/changelog.d/clone-plan-visualizer-cleanup.minor.rst
+++ b/source/isaaclab_newton/changelog.d/clone-plan-visualizer-cleanup.minor.rst
@@ -1,0 +1,9 @@
+Removed
+^^^^^^^
+
+* **Breaking:** Removed
+  ``isaaclab_newton.cloner.newton_replicate.create_newton_visualizer_prebuild_clone_fn``.
+  Callers that need a Newton model for visualization should call
+  :func:`~isaaclab_newton.cloner.newton_replicate.newton_visualizer_prebuild`
+  directly with the ``(sources, destinations, env_ids, mask, positions)`` bundle
+  derived from :meth:`~isaaclab.sim.SimulationContext.get_clone_plans`.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
@@ -5,16 +5,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
 import torch
 import warp as wp
 from newton import ModelBuilder, solvers
 from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 
-from pxr import Usd, UsdGeom
-
-from isaaclab.physics.scene_data_requirements import VisualizerPrebuiltArtifacts
+from pxr import Usd
 
 from isaaclab_newton.physics import NewtonManager
 
@@ -243,55 +239,3 @@ def newton_visualizer_prebuild(
     model = builder.finalize(device=device)
     state = model.state()
     return model, state
-
-
-def create_newton_visualizer_prebuild_clone_fn(
-    stage,
-    set_visualizer_artifact: Callable[[VisualizerPrebuiltArtifacts | None], None],
-):
-    """Create a cloner callback that prebuilds Newton visualizer artifacts.
-
-    Args:
-        stage: USD stage used by the clone callback.
-        set_visualizer_artifact: Callback used to store the produced prebuilt artifact.
-
-    Returns:
-        Clone callback that builds and stores visualizer prebuilt artifacts.
-    """
-    up_axis = UsdGeom.GetStageUpAxis(stage)
-
-    def _visualizer_clone_fn(
-        stage,
-        sources,
-        destinations,
-        env_ids,
-        mapping,
-        positions=None,
-        quaternions=None,
-        device="cpu",
-    ):
-        """Prebuild Newton model/state and store visualizer artifacts for clone consumers."""
-        model, state = newton_visualizer_prebuild(
-            stage=stage,
-            sources=sources,
-            destinations=destinations,
-            env_ids=env_ids,
-            mapping=mapping,
-            positions=positions,
-            quaternions=quaternions,
-            device=device,
-            up_axis=up_axis,
-        )
-        set_visualizer_artifact(
-            VisualizerPrebuiltArtifacts(
-                model=model,
-                state=state,
-                rigid_body_paths=list(getattr(model, "body_label", None) or getattr(model, "body_key", [])),
-                articulation_paths=list(
-                    getattr(model, "articulation_label", None) or getattr(model, "articulation_key", [])
-                ),
-                num_envs=int(mapping.size(1)),
-            )
-        )
-
-    return _visualizer_clone_fn

--- a/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
+++ b/source/isaaclab_physx/isaaclab_physx/scene_data_providers/physx_scene_data_provider.py
@@ -13,6 +13,7 @@ import time
 from collections import deque
 from typing import Any
 
+import torch
 import warp as wp
 
 from pxr import UsdGeom, UsdPhysics
@@ -41,7 +42,8 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
     - body poses via PhysX tensor views, with FrameView fallback
     - camera poses & intrinsics
     - USD stage handles
-    - Newton model/state (from the simulation context prebuilt payload when required)
+    - Newton model/state (built locally from the scene's per-group :class:`ClonePlan` map
+      when required)
     """
 
     # ---- Environment discovery / metadata -------------------------------------------------
@@ -122,12 +124,12 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
         self._xform_mask_buf = None
         # View index order as device tensors for vectorized scatter in _apply_view_poses.
         self._view_order_tensors: dict[str, Any] = {}
-        # Last load outcome (tests / debug): "prebuilt" | "missing" | "error".
+        # Last load outcome (tests / debug): "built" | "missing" | "error".
         self._last_newton_model_build_source: str | None = None
         self._last_newton_model_build_elapsed_ms: float | None = None
 
         if self._needs_newton_sync:
-            self._load_newton_model_from_prebuilt_artifact()
+            self._build_newton_model_from_clone_plans()
             self._setup_rigid_body_view()
 
     # ---- Newton model + PhysX view setup --------------------------------------------------
@@ -148,87 +150,104 @@ class PhysxSceneDataProvider(BaseSceneDataProvider):
         needs_rebuild = self._newton_model is None or self._newton_state is None
         needs_rebuild = needs_rebuild or (self._num_envs_at_last_newton_build != num_envs)
         if needs_rebuild:
-            self._load_newton_model_from_prebuilt_artifact()
+            self._build_newton_model_from_clone_plans()
             self._setup_rigid_body_view()
 
-    def _model_body_paths(self, model) -> list[str]:
-        """Return body paths/keys from a Newton model.
+    def _build_newton_model_from_clone_plans(self) -> None:
+        """Build Newton model and state from the scene's per-group :class:`ClonePlan` map.
 
-        Args:
-            model: Newton model object.
-
-        Returns:
-            Body paths/keys from the model, or an empty list when unavailable.
+        Reads plans :meth:`InteractiveScene.clone_environments` publishes on
+        :class:`SimulationContext`, derives the flat ``(sources, destinations, mask)`` shape
+        :func:`isaaclab_newton.cloner.newton_visualizer_prebuild` expects, and caches the
+        resulting model/state. Per-prototype source paths recover as
+        ``dest_template.format(<first env using this prototype>)``; per-env positions are
+        read off ``xformOp:translate`` on the env-level prims derived from the same template.
+        Pre-condition violations raise :class:`RuntimeError` (logged as ``"missing"``);
+        ``isaaclab_newton`` being absent (optional dep) maps to ``"missing"`` via the
+        import's own exception types; unexpected failures fall through to ``"error"``.
         """
-        if model is None:
-            return []
-        return list(getattr(model, "body_label", None) or getattr(model, "body_key", []))
-
-    def _load_newton_model_from_prebuilt_artifact(self) -> None:
-        """Load Newton model and state from the simulation context prebuilt artifact."""
         start_t = time.perf_counter()
+        source = "missing"
         try:
-            artifact = self._simulation_context.get_scene_data_visualizer_prebuilt_artifact()
-            if not artifact:
-                self._last_newton_model_build_source = "missing"
-                logger.error(
-                    "[PhysxSceneDataProvider] No visualizer prebuilt artifact on the simulation context "
-                    "(expected VisualizerPrebuiltArtifacts from scene setup)."
-                )
-                self._clear_newton_model_state()
-                return
+            plans = self._simulation_context.get_clone_plans()
+            if not plans:
+                raise RuntimeError("No clone plans on simulation context.")
+            from isaaclab_newton.cloner.newton_replicate import newton_visualizer_prebuild
 
-            model = artifact.model
-            state = artifact.state
+            # Flatten per-group plans into one (sources, destinations, mask) bundle. Source
+            # paths recover via ``dest_template.format(<first env using this prototype>)``;
+            # all-False rows are dropped (possible when ``num_prototypes > num_envs``).
+            plan_list = list(plans.values())
+            num_envs = plan_list[0].clone_mask.size(1)
+            if any(p.clone_mask.size(1) != num_envs for p in plan_list):
+                raise RuntimeError(f"Clone plans disagree on num_envs: {[p.clone_mask.size(1) for p in plan_list]}")
+            sources, destinations, mask_rows = [], [], []
+            for p in plan_list:
+                for i in range(p.clone_mask.size(0)):
+                    nz = p.clone_mask[i].nonzero(as_tuple=False)
+                    if nz.numel() == 0:
+                        continue
+                    sources.append(p.dest_template.format(int(nz[0].item())))
+                    destinations.append(p.dest_template)
+                    mask_rows.append(p.clone_mask[i : i + 1])
+            if not sources:
+                raise RuntimeError("All clone-plan prototype rows are empty.")
+            mask = torch.cat(mask_rows, dim=0)
+
+            # Env-level path template = dest_template up to the first ``{}``. Per-env world
+            # positions: xformOp:translate read off each env prim; missing prims fall through.
+            env_path_template = plan_list[0].dest_template.split("{}")[0] + "{}"
+            positions = torch.zeros((num_envs, 3), dtype=torch.float32, device=self._device)
+            for i in range(num_envs):
+                prim = self._stage.GetPrimAtPath(env_path_template.format(i))
+                if prim.IsValid() and (v := prim.GetAttribute("xformOp:translate").Get()) is not None:
+                    positions[i] = torch.tensor([v[0], v[1], v[2]], device=self._device)
+
+            model, state = newton_visualizer_prebuild(
+                stage=self._stage,
+                sources=sources,
+                destinations=destinations,
+                env_ids=torch.arange(num_envs, dtype=torch.long, device=mask.device),
+                mapping=mask,
+                positions=positions,
+                device=self._device,
+                up_axis=UsdGeom.GetStageUpAxis(self._stage),
+            )
             if model is None or state is None:
-                self._last_newton_model_build_source = "missing"
-                logger.error(
-                    "[PhysxSceneDataProvider] Prebuilt artifact is missing model or state; cannot sync PhysX to Newton."
-                )
-                self._clear_newton_model_state()
-                return
+                raise RuntimeError("newton_visualizer_prebuild returned None.")
 
-            self._newton_model = model
-            self._newton_state = state
-
+            self._newton_model, self._newton_state = model, state
             replace_newton_shape_colors(self._newton_model, self._stage)
-
-            body_paths = list(artifact.rigid_body_paths) or self._model_body_paths(model)
-            self._rigid_body_paths = body_paths
-            view_paths = list(body_paths)
-            if artifact.articulation_paths:
-                seen = set(view_paths)
-                for path in artifact.articulation_paths:
-                    if path not in seen:
-                        view_paths.append(path)
-                        seen.add(path)
-            self._rigid_body_view_paths = view_paths
+            # Newton renamed ``*_key`` → ``*_label`` mid-development; fall back so we work either way.
+            # ``dict.fromkeys`` preserves order while deduping — articulation roots can overlap rigid bodies.
+            label_or_key = lambda kind: list(getattr(model, f"{kind}_label", None) or getattr(model, f"{kind}_key", []))  # noqa: E731
+            self._rigid_body_paths = label_or_key("body")
+            self._rigid_body_view_paths = list(dict.fromkeys(self._rigid_body_paths + label_or_key("articulation")))
+            # Reset cached views/buffers; rebuilt lazily by ``_setup_rigid_body_view``.
             self._xform_views.clear()
-            self._view_body_index_map = {}
             self._view_order_tensors.clear()
+            self._view_body_index_map = {}
             self._pose_buf_num_bodies = 0
-            self._positions_buf = None
-            self._orientations_buf = None
-            self._covered_buf = None
-            self._xform_mask_buf = None
-            self._num_envs_at_last_newton_build = int(artifact.num_envs)
-            self._last_newton_model_build_source = "prebuilt"
+            self._positions_buf = self._orientations_buf = self._covered_buf = self._xform_mask_buf = None
+            self._num_envs_at_last_newton_build = num_envs
+            source = "built"
+        except (ImportError, ModuleNotFoundError) as exc:
+            logger.warning("[PhysxSceneDataProvider] isaaclab_newton not available: %s", exc)
+            self._clear_newton_model_state()
+        except RuntimeError as exc:
+            logger.error("[PhysxSceneDataProvider] %s", exc)
+            self._clear_newton_model_state()
         except Exception as exc:
-            self._last_newton_model_build_source = "error"
-            logger.error("[PhysxSceneDataProvider] Failed to load Newton model from prebuilt artifact: %s", exc)
+            source = "error"
+            logger.error("[PhysxSceneDataProvider] Failed to build Newton model from clone plans: %s", exc)
             self._clear_newton_model_state()
         finally:
-            elapsed_ms = (time.perf_counter() - start_t) * 1000.0
-            self._last_newton_model_build_elapsed_ms = elapsed_ms
-            try:
-                num_envs = self.get_num_envs()
-            except Exception:
-                num_envs = -1
+            self._last_newton_model_build_elapsed_ms = (time.perf_counter() - start_t) * 1000.0
+            self._last_newton_model_build_source = source
             logger.debug(
-                "[PhysxSceneDataProvider] Newton model load source=%s num_envs=%d elapsed_ms=%.2f",
-                self._last_newton_model_build_source,
-                num_envs,
-                elapsed_ms,
+                "[PhysxSceneDataProvider] Newton model build source=%s elapsed_ms=%.2f",
+                source,
+                self._last_newton_model_build_elapsed_ms,
             )
 
     def _clear_newton_model_state(self) -> None:


### PR DESCRIPTION
# Description

Routes the visualizer-side cloning data through a per-group `ClonePlan` map and has the PhysX scene data provider pull a Newton model from those plans directly — replacing the clone-time `visualizer_clone_fn` callback and the `VisualizerPrebuiltArtifacts` payload introduced in #5398.

## Pipeline

```
InteractiveScene.clone_environments
    plans = clone_from_template(...)        # dict[str, ClonePlan]
    sim.set_clone_plans(plans)              # canonical owner
            ↓
PhysxSceneDataProvider.__init__
    plans = sim.get_clone_plans()
    sources, destinations, mask = aggregate(plans)
    positions = read_env_xforms(stage)
    model, state = newton_visualizer_prebuild(...)
```

Single source of truth, single direction. No clone-time callback, no requirements push from sensors, no late-resolve refresh loop.

## Notable changes

- **Add** `ClonePlan` (`dest_template`, `prototype_paths`, `clone_mask`); `SimulationContext.{get,set}_clone_plans`; `InteractiveScene.clone_plans` forwarder.
- **Remove** `TemplateCloneCfg.visualizer_clone_fn`, `cloner.resolve_visualizer_clone_fn`, `VisualizerPrebuiltArtifacts`, `SimulationContext.{get,set,clear}_scene_data_visualizer_prebuilt_artifact`, `Camera._register_renderer_scene_data_requirements`, `create_newton_visualizer_prebuild_clone_fn`.
- **Collapse** three calls to `_refresh_visualizer_clone_fn_from_requirements` into one `_aggregate_scene_data_requirements` after entities are constructed.
- **Provider** derives flat `(sources, destinations, mask)` from per-group plans, recovering each source path as `dest_template.format(<first env using this prototype>)` and reading per-env positions off the env-template's `xformOp:translate`.

## Type of change

- Bug fix
- Breaking change *(removes the public symbols listed above. They were introduced in #5398 four days ago; the changelog fragments are filed as `.minor.rst` since the surface had no time to acquire dependents.)*

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added changelog fragments under `source/isaaclab/changelog.d/`, `source/isaaclab_newton/changelog.d/` (both `.minor.rst`), and `source/isaaclab_physx/changelog.d/` (`.skip` — private/internal changes only)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

