### PR TITLE
Updating docs, explicitly call out physicx support and handtracking r…

### DIFF
--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -120,6 +120,14 @@ terminal or ``source`` step is needed. Launch a teleoperation script directly:
        --visualizer kit \
        --xr
 
+.. tip::
+
+   The ``Isaac-PickPlace-GR1T2-WaistEnabled-Abs-v0`` task above uses **hand tracking** as its
+   input mode. Make sure your XR device has hand tracking enabled (optical hand tracking on
+   Quest 3, or the built-in hand tracking on Apple Vision Pro). Different tasks require
+   different input modes (motion controllers vs hand tracking) -- see the
+   :ref:`isaac-teleop-control-schemes` table for the full list.
+
 To switch the CloudXR device profile at launch time (e.g. from Quest to Apple Vision Pro),
 use the ``--cloudxr_env`` flag:
 

--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -148,17 +148,17 @@ for the lift-cube environment:
     |                         |                              |                                                                             | ``segmentation``,            |
     |                         |                              |                                                                             | ``simple_shading_*``         |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+------------------------------+
-    | |gr1_pick_place|        | |gr1_pick_place-link|        | Pick up and place an object in a basket with a GR-1 humanoid robot          |                              |
+    | |gr1_pick_place|        | |gr1_pick_place-link|        | Pick up and place an object in a basket with a GR-1 humanoid robot          | ``physx``                    |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+------------------------------+
-    | |gr1_pp_waist|          | |gr1_pp_waist-link|          | Pick up and place an object in a basket with a GR-1 humanoid robot          |                              |
+    | |gr1_pp_waist|          | |gr1_pp_waist-link|          | Pick up and place an object in a basket with a GR-1 humanoid robot          | ``physx``                    |
     |                         |                              | with waist degrees-of-freedom enables that provides a wider reach space.    |                              |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+------------------------------+
-    | |g1_pick_place|         | |g1_pick_place-link|         | Pick up and place an object in a basket with a Unitree G1 humanoid robot    |                              |
+    | |g1_pick_place|         | |g1_pick_place-link|         | Pick up and place an object in a basket with a Unitree G1 humanoid robot    | ``physx``                    |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+------------------------------+
-    | |g1_pick_place_fixed|   | |g1_pick_place_fixed-link|   | Pick up and place an object in a basket with a Unitree G1 humanoid robot    |                              |
+    | |g1_pick_place_fixed|   | |g1_pick_place_fixed-link|   | Pick up and place an object in a basket with a Unitree G1 humanoid robot    | ``physx``                    |
     |                         |                              | with three-fingered hands. Robot is set up with the base fixed in place.    |                              |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+------------------------------+
-    | |g1_pick_place_lm|      | |g1_pick_place_lm-link|      | Pick up and place an object in a basket with a Unitree G1 humanoid robot    |                              |
+    | |g1_pick_place_lm|      | |g1_pick_place_lm-link|      | Pick up and place an object in a basket with a Unitree G1 humanoid robot    | ``physx``                    |
     |                         |                              | with three-fingered hands and in-place locomanipulation capabilities        |                              |
     |                         |                              | enabled (i.e. Robot lower body balances in-place while upper body is        |                              |
     |                         |                              | controlled via Inverse Kinematics).                                         |                              |
@@ -189,7 +189,7 @@ for the lift-cube environment:
     |                         |                              |                                                                             | ``simple_shading_*``         |
     |                         |                              |                                                                             | ``{64,128,256}``             |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+------------------------------+
-    | |galbot_stack|          | |galbot_stack-link|          | Stack three cubes (bottom to top: blue, red, green) with the left arm of    |                              |
+    | |galbot_stack|          | |galbot_stack-link|          | Stack three cubes (bottom to top: blue, red, green) with the left arm of    | ``physx``                    |
     |                         |                              | a Galbot humanoid robot                                                     |                              |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+------------------------------+
     | |agibot_place_mug|      | |agibot_place_mug-link|      | Pick up and place a mug upright with a Agibot A2D humanoid robot            |                              |
@@ -1108,6 +1108,11 @@ inferencing, including reading from an already trained checkpoint and disabling 
       - Manager Based
       -
       -
+    * - Isaac-Stack-Cube-Franka-IK-Abs-v0
+      -
+      - Manager Based
+      -
+      - ``physx``
     * - Isaac-Dexsuite-Kuka-Allegro-Lift-v0
 
         Camera variants (requires ``--enable_cameras``):
@@ -1156,7 +1161,37 @@ inferencing, including reading from an already trained checkpoint and disabling 
       -
       - Manager Based
       -
+      - ``physx``
+    * - Isaac-PickPlace-GR1T2-Abs-v0
       -
+      - Manager Based
+      -
+      - ``physx``
+    * - Isaac-PickPlace-GR1T2-WaistEnabled-Abs-v0
+      -
+      - Manager Based
+      -
+      - ``physx``
+    * - Isaac-NutPour-GR1T2-Pink-IK-Abs-v0
+      -
+      - Manager Based
+      -
+      - ``physx``
+    * - Isaac-ExhaustPipe-GR1T2-Pink-IK-Abs-v0
+      -
+      - Manager Based
+      -
+      - ``physx``
+    * - Isaac-PickPlace-Locomanipulation-G1-Abs-v0
+      -
+      - Manager Based
+      -
+      - ``physx``
+    * - Isaac-PickPlace-FixedBaseUpperBodyIK-G1-Abs-v0
+      -
+      - Manager Based
+      -
+      - ``physx``
     * - Isaac-Stack-Cube-UR10-Long-Suction-IK-Rel-v0
       -
       - Manager Based
@@ -1171,42 +1206,17 @@ inferencing, including reading from an already trained checkpoint and disabling 
       -
       - Manager Based
       -
-      -
+      - ``physx``
     * - Isaac-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow-v0
       -
       - Manager Based
       -
-      -
+      - ``physx``
     * - Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-Visuomotor-v0
       - Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-Visuomotor-Play-v0
       - Manager Based
       -
-      -
-    * - Isaac-Place-Mug-Agibot-Left-Arm-RmpFlow-v0
-      -
-      - Manager Based
-      -
-      -
-    * - Isaac-Place-Toy2Box-Agibot-Right-Arm-RmpFlow-v0
-      -
-      - Manager Based
-      -
-      -
-    * - Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-RmpFlow-v0
-      -
-      - Manager Based
-      -
-      -
-    * - Isaac-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow-v0
-      -
-      - Manager Based
-      -
-      -
-    * - Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-Visuomotor-v0
-      - Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-Visuomotor-Play-v0
-      - Manager Based
-      -
-      -
+      - ``physx``
     * - Isaac-Place-Mug-Agibot-Left-Arm-RmpFlow-v0
       -
       - Manager Based


### PR DESCRIPTION
# Description

Newton is not supported for real-time teleoperation in this release. Update the environments documentation to list the physx preset for all teleop environments so users know which physics backend to use.

Add physx preset to GR1, G1, Galbot, and Franka IK-Abs teleop entries in the visual environment table
Add missing teleop environments to the comprehensive list (PickPlace GR1T2, NutPour, ExhaustPipe, Locomanipulation G1, FixedBase G1, Stack-Cube-Franka-IK-Abs)
Add physx preset to existing Galbot stack entries in the comprehensive list
Remove duplicate Galbot/Agibot rows in the comprehensive list
Add a tip about hand tracking input mode to the CloudXR teleoperation guide
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there