### PR TITLE
Fix Newton viewer black screen from camera type mismatch

### DIFF
--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import warp as wp
 from newton.viewer import ViewerGL
+from pyglet.math import Vec3
 
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
 
@@ -454,9 +455,9 @@ class NewtonVisualizer(BaseVisualizer):
         if self._viewer is None:
             return
         cam_pos, cam_target = pose
-        self._viewer.camera.pos = wp.vec3(*cam_pos)
-        cam_pos_np = np.array(cam_pos, dtype=np.float32)
-        cam_target_np = np.array(cam_target, dtype=np.float32)
+        cam_pos_np = np.asarray(cam_pos, dtype=np.float32)
+        cam_target_np = np.asarray(cam_target, dtype=np.float32)
+        self._viewer.camera.pos = Vec3(*cam_pos_np.tolist())
         direction = cam_target_np - cam_pos_np
         yaw = np.degrees(np.arctan2(direction[1], direction[0]))
         horizontal_dist = np.sqrt(direction[0] ** 2 + direction[1] ** 2)


### PR DESCRIPTION
# Description

`NewtonVisualizer._apply_camera_pose` assigns `self._viewer.camera.pos = wp.vec3(...)`, but `newton.viewer.camera.Camera` initializes and operates on `pos` as a `pyglet.math.Vec3`. With recent Newton (>= newton-physics/newton@8449b01c, *"Blender-Style Viewer Camera Controls"*), the per-frame camera integration goes through the new `Camera.translate(delta)`, which forces `delta` through `_as_vec3` -> `PyVec3` and then computes `self.pos += delta`. That becomes `wp.vec3 + PyVec3`, which Warp rejects with:

> TypeError: Built-in functions cannot be called with non-Warp array types, such as lists, tuples, and NumPy arrays.

`SimulationContext.update_visualizers` then removes the failing visualizer from the active list, the user sees a window that opens and stays completely black with no UI.

This is only the case for newer Newton versions; the `isaaclab_newton` package pins Newton at `newton-physics/newton@a27277ed` (`source/isaaclab_newton/setup.py`), where the per-frame update reads:

```python
dv = type(self.camera.pos)(*self._cam_vel)
self.camera.pos += dv * dt
```

The `type(self.camera.pos)(*...)` trick adapts to whatever type external code assigns to `pos`, so `wp`.
So `vec3 += wp.vec3` happens to work incidentally. 

## Fix

The fix is to use `pyglet.math.Vec3` (Newton's actual `Camera.pos` type) in `_apply_camera_pose` instead of `wp.vec3`. This is what Newton expected in both the pinned and current versions, so the change is strictly more correct and backward-compatible.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there