### PR TITLE
Apply PPISP in Camera Wrapper Across Renderers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -138,6 +138,7 @@ Guidelines for modifications:
 * Neel Anand Jawale
 * Nicola Loi
 * Nicholas Blauch
+* Nicolas Moenne-Loccoz
 * Norbert Cygiert
 * Nuoyan Chen (Alvin)
 * Nuralem Abizov

--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -214,6 +214,133 @@ RGB and RGBA
 
 To convert to ``torch.float32``, divide by 255.0.
 
+``rgb_hdr`` returns a 3-channel scene-linear HDR image of type ``torch.float32``, shape ``(B, H, W, 3)``.
+
+Post-render Camera ISP
+~~~~~~~~~~~~~~~~~~~~~~
+
+A camera Image Signal Processing (ISP) pipeline models the chain that maps
+the scene-linear radiance captured by a sensor to the LDR pixel values a
+downstream consumer sees.
+The camera ISP pipeline is usually part of the renderer.
+In Isaac Lab we expose a post-render camera ISP pipeline which is applied on top of the renderer's HDR scene-linear AOV.
+This makes it possible to implement additional post-render processing not currently supported by the renderer backends.
+The pass is configured via :attr:`~sensors.CameraCfg.isp_cfg`
+on every camera and runs once per render tick.
+
+PPISP
+^^^^^
+
+The shipped ISP implementation is **PPISP** (Physically Plausible Image
+Signal Processing), an NVIDIA Spatial Intelligence Lab pipeline designed
+to bring synthetic imagery — most notably 3D Gaussian splat reconstructions
+— closer to real-camera output without re-training the upstream model. See
+the project page: https://research.nvidia.com/labs/sil/projects/ppisp .
+
+PPISP is typically authored alongside a `ParticleField3DGaussianSplat
+<https://openusd.org/release/user_guides/schemas/usdVol/ParticleField3DGaussianSplat.html>`__
+USD asset: it carries a `RenderProduct
+<https://openusd.org/release/user_guides/schemas/usdRender/RenderProduct.html>`__
+whose target camera and PPISP `UsdShade.Shader
+<https://openusd.org/release/api/class_usd_shade_shader.html>`__
+(a shader prim named ``PPISP`` whose inputs follow the PPISP naming
+convention) were calibrated against the real capture rig that produced
+the splats. Configuring the camera with the matching PPISP coefficients
+makes the rendered tile match the calibration target.
+
+The pipeline applies, in order: responsivity → exposure → vignetting →
+color homography → camera response function → uint8 clamp. It runs as a
+single Warp kernel.
+
+Configuration
+^^^^^^^^^^^^^
+
+:attr:`~sensors.CameraCfg.isp_cfg` accepts three forms:
+
+* ``None`` (default) — ISP disabled.
+* :class:`~isaaclab_ppisp.PpispCfg` — explicit PPISP coefficients
+  (:attr:`~isaaclab_ppisp.PpispCfg.inputs`), or
+  :attr:`~isaaclab_ppisp.PpispCfg.shader_prim_path` to import them from a
+  PPISP ``UsdShade.Shader`` already on the stage.
+* :class:`~sensors.CameraISPMode` — auto-discover an ISP shader on the
+  stage (see below).
+
+The cfg applies once per Camera sensor batch. The PPISP Warp kernel takes
+scalar coefficients, so every cloned view in a tiled batch shares the same
+ISP configuration — there is no per-view ISP today.
+
+.. code-block:: python
+
+   from isaaclab.sensors.camera import CameraCfg, CameraISPMode
+   from isaaclab_ppisp import PpispCfg
+
+   # default — ISP disabled
+   cfg = CameraCfg(...)
+
+   # explicit coefficients
+   cfg = CameraCfg(..., isp_cfg=PpispCfg(inputs={"exposureOffset": 1.5}))
+
+   # import coefficients from a USD shader path
+   cfg = CameraCfg(..., isp_cfg=PpispCfg(shader_prim_path="/World/Render/PPISP"))
+
+   # auto-discover from the stage
+   cfg = CameraCfg(..., isp_cfg=CameraISPMode.AUTO_ANY)
+
+Auto-discovery
+^^^^^^^^^^^^^^
+
+Auto-discovery is opt-in via :class:`~sensors.CameraISPMode`. Discovery runs
+once at camera construction using the first matched camera prim in the Camera
+sensor batch:
+
+1. Walk the stage for a USD ``RenderProduct`` whose ``camera`` relationship
+   targets the first matched camera prim **and** that has a child
+   ``UsdShade.Shader`` prim named ``PPISP``. If found, import its inputs as a
+   :class:`~isaaclab_ppisp.PpispCfg`.
+2. ``AUTO_ANY`` only: if step 1 finds nothing, fall back to the first
+   ``UsdShade.Shader`` prim named ``PPISP`` anywhere on the stage.
+3. Otherwise the ISP stays disabled for the whole Camera sensor batch.
+
+In practice this means: if the stage carries a ``ParticleField3DGaussianSplat``
+together with a ``RenderProduct`` that binds a ``PPISP`` shader child to the
+batch's first matched camera prim, the Camera sensor picks up the matching ISP
+automatically and no Python-side coefficient authoring is required.
+
+``AUTO_CAMERA`` runs step 1 only — useful when the stage carries multiple
+PPISP shaders and you want the Camera sensor batch to use exactly the one bound
+to its first matched camera prim.
+
+Renderer support
+^^^^^^^^^^^^^^^^
+
+All three shipped backends advertise the HDR AOV
+(:attr:`~renderers.RenderBufferKind.RGB_HDR`) and compose the ISP pipeline
+internally: the Isaac RTX renderer sources HDR from the Replicator
+``HdrColor`` annotator, the OVRTX renderer from its HDR render var, the
+Newton Warp renderer from its native scene-linear color buffer. Each
+backend allocates its own HDR scratch buffer when the user did not request
+``"rgb_hdr"`` in :attr:`~sensors.CameraCfg.data_types`, and dispatches the
+PPISP kernel into ``rgb`` / ``rgba`` after every render tick.
+
+Known limitations
+^^^^^^^^^^^^^^^^^
+
+* The ISP writes back into the ``rgb`` / ``rgba`` buffers. If neither is
+  requested, configuring ``isp_cfg`` raises at camera init.
+* PPISP inputs are static for the lifetime of the camera. Animated USD
+  shader inputs are collapsed to their first authored time sample.
+* Coefficients are global per camera — no per-pixel or per-region
+  authoring beyond the radial vignetting term.
+* PPISP is the only ISP implementation today. Other ISP families would
+  need a new config type and discoverer entry.
+* On the Isaac RTX and OVRTX backends, enabling ``isp_cfg`` forces RTX-side
+  tonemapping off (``/rtx/rtpt/gaussian/skipTonemapping/enabled=False``)
+  and authors a neutral ``OmniRtxCameraExposureAPI_1`` schema on each
+  camera prim so the post-render ISP is the only path that processes
+  color. Mixing this with RTX-side exposure authoring is not supported.
+* Auto-discovery resolves at camera construction; later authoring of a
+  ``RenderProduct`` or shader on the stage is not picked up.
+
 Depth and Distances
 ~~~~~~~~~~~~~~~~~~~
 
@@ -281,7 +408,7 @@ An ``info`` dictionary is available via ``tiled_camera.data.info['instance_id_se
   The ``idToLabels`` dict maps instance ID to USD prim path.
 
 Instance Segmentation
-"""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~
 
 .. figure:: ../../../_static/overview/sensors/camera_instance.jpg
     :align: center

--- a/source/isaaclab/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
+++ b/source/isaaclab/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab.sensors.camera.CameraISPMode` (values ``AUTO_CAMERA`` and ``AUTO_ANY``) and the :attr:`~isaaclab.sensors.camera.CameraCfg.isp_cfg` field to author or auto-discover an ISP cfg (:class:`~isaaclab_ppisp.PpispCfg`) from a USD ``RenderProduct`` bound to the camera (or anywhere on the stage as a fallback).
+* Added :attr:`~isaaclab.renderers.RenderBufferKind.RGB_HDR` to the renderer output contract so backends can advertise a 3-channel float HDR AOV.
+* Added :meth:`~isaaclab.renderers.BaseRenderer.prepare_cameras` hook so backends can author per-camera USD overrides.
+* Added :class:`~isaaclab.renderers.CameraRenderSpec`, an immutable description of a tiled camera passed to render backends so they no longer hold a reference to the camera sensor instance.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -432,9 +432,12 @@ def _install_isaacsim() -> None:
 
 
 # Source directories installed on every ./isaaclab.sh -i invocation (even "none").
-# Order matters: isaaclab must be first so dependents resolve against the local copy.
+# Order matters: isaaclab must be first so dependents resolve against the local copy,
+# and isaaclab_ppisp must precede the renderer backends (newton/ov/physx) that
+# declare it as an INSTALL_REQUIRES bare-name dep.
 CORE_ISAACLAB_SUBMODULES: list[str] = [
     "isaaclab",
+    "isaaclab_ppisp",
     "isaaclab_assets",
     "isaaclab_contrib",
     "isaaclab_experimental",

--- a/source/isaaclab/isaaclab/renderers/base_renderer.py
+++ b/source/isaaclab/isaaclab/renderers/base_renderer.py
@@ -25,6 +25,21 @@ class BaseRenderer(ABC):
         """Post-physics one-time initialization hook. Called only once."""
         return
 
+    def prepare_cameras(self, stage: Any, spec: CameraRenderSpec) -> None:
+        """Pre-render per-camera setup the backend needs.
+
+        The default implementation is a no-op. Renderer subclasses override
+        to perform whatever per-camera initialization their backend requires
+        — e.g. authoring stage attributes on the resolved camera prims,
+        configuring per-tile GPU buffers, or any other state setup.
+
+        Args:
+            stage: Scene stage the camera prims live on, or ``None``
+                when no stage context applies. Stage-less backends ignore it.
+            spec: Immutable description of the tiled camera bundle.
+        """
+        return
+
     @abstractmethod
     def supported_output_types(self) -> dict[RenderBufferKind, RenderBufferSpec]:
         """Per-output layout (channels + dtype) this renderer can produce.

--- a/source/isaaclab/isaaclab/renderers/output_contract.py
+++ b/source/isaaclab/isaaclab/renderers/output_contract.py
@@ -25,6 +25,7 @@ class RenderBufferKind(StrEnum):
 
     RGB = "rgb"
     RGBA = "rgba"
+    RGB_HDR = "rgb_hdr"
     ALBEDO = "albedo"
     DEPTH = "depth"
     DISTANCE_TO_IMAGE_PLANE = "distance_to_image_plane"

--- a/source/isaaclab/isaaclab/sensors/camera/__init__.pyi
+++ b/source/isaaclab/isaaclab/sensors/camera/__init__.pyi
@@ -7,6 +7,7 @@ __all__ = [
     "Camera",
     "CameraCfg",
     "CameraData",
+    "CameraISPMode",
     "RenderBufferKind",
     "RenderBufferSpec",
     "TiledCamera",
@@ -20,6 +21,7 @@ __all__ = [
 from .camera import Camera
 from .camera_cfg import CameraCfg
 from .camera_data import CameraData, RenderBufferKind, RenderBufferSpec
+from .camera_isp import CameraISPMode
 from .tiled_camera import TiledCamera
 from .tiled_camera_cfg import TiledCameraCfg
 from .utils import (

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -17,7 +17,6 @@ from pxr import UsdGeom
 
 import isaaclab.sim as sim_utils
 import isaaclab.utils.sensors as sensor_utils
-from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.renderers import BaseRenderer, CameraRenderSpec
 from isaaclab.sim.views import FrameView
 from isaaclab.utils import to_camel_case
@@ -148,16 +147,7 @@ class Camera(SensorBase):
         # initialize base class
         super().__init__(cfg)
 
-        # TODO(follow-up PR): move this flag flip out of Camera. The cleanest path is
-        # an apply_pre_reset_settings() hook on RendererCfg (default no-op) that
-        # IsaacRtxRendererCfg overrides to flip /isaaclab/render/rtx_sensors. The
-        # flag must be set pre-sim.reset() because SimulationContext.is_rendering
-        # and several env classes read it before the renderer's __init__ runs.
-        renderer_type = getattr(self.cfg.renderer_cfg, "renderer_type", None)
-        if renderer_type == "isaac_rtx":
-            get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", True)
-
-        # Compute camera orientation (convention conversion) and spawn
+        # Compute camera orientation (convention conversion) and spawn.
         rot = torch.tensor(self.cfg.offset.rot, dtype=torch.float32, device="cpu").unsqueeze(0)
         rot_offset = convert_camera_frame_orientation_convention(
             rot, origin=self.cfg.offset.convention, target="opengl"
@@ -166,6 +156,34 @@ class Camera(SensorBase):
         if self.cfg.spawn is not None and self.cfg.spawn.vertical_aperture is None:
             self.cfg.spawn.vertical_aperture = self.cfg.spawn.horizontal_aperture * self.cfg.height / self.cfg.width
         self._resolve_and_spawn("camera", translation=self.cfg.offset.pos, orientation=rot_offset)
+
+        # An ISP (any ``isp_cfg`` other than ``None``) requires the HDR AOV;
+        # an explicit ``"rgb_hdr"`` in ``data_types`` also requires the
+        # HDR-routing flag flipped on the RTX-bearing backends.
+        require_hdr_output = "rgb_hdr" in self.cfg.data_types or self.cfg.isp_cfg is not None
+
+        # TODO(follow-up PR): move this flag flip out of Camera. The cleanest path is
+        # an apply_pre_reset_settings() hook on RendererCfg (default no-op) that
+        # IsaacRtxRendererCfg overrides to flip /isaaclab/render/rtx_sensors. The
+        # flag must be set pre-sim.reset() because SimulationContext.is_rendering
+        # and several env classes read it before the renderer's __init__ runs.
+        renderer_type = getattr(self.cfg.renderer_cfg, "renderer_type", None)
+        if renderer_type == "isaac_rtx":
+            from isaaclab.app.settings_manager import get_settings_manager
+
+            settings = get_settings_manager()
+            settings.set_bool("/isaaclab/render/rtx_sensors", True)
+            if require_hdr_output:
+                settings.set_bool("/rtx/rtpt/gaussian/skipTonemapping/enabled", False)
+        elif renderer_type == "ovrtx" and require_hdr_output:
+            from isaaclab.app.settings_manager import get_settings_manager
+
+            get_settings_manager().set_bool("/rtx/rtpt/gaussian/skipTonemapping/enabled", False)
+            # FIXME: settings set_bool is a no-op for ovrtx
+            # warning only since it affects only ParticleField3DGaussianSplat scene
+            logger.warning(
+                "OVRTX backend with PPISP/HDR requires /rtx/rtpt/gaussian/skipTonemapping/enabled to be false."
+            )
 
         # UsdGeom Camera prim for the sensor
         self._sensor_prims: list[UsdGeom.Camera] = list()
@@ -453,6 +471,30 @@ class Camera(SensorBase):
         self._renderer = sim_ctx.render_context.get_renderer(self.cfg.renderer_cfg)
         logger.info("Using renderer: %s", type(self._renderer).__name__)
 
+        # Build the render spec early — both the wrapper ISP (which delegates
+        # any renderer-side per-camera setup) and ``create_render_data`` consume
+        # it, and the prims are already authored at this point.
+        cam_paths = tuple(str(p.GetPath()) for p in sim_utils.find_matching_prims(self.cfg.prim_path, self.stage))
+        env_0_prefix = "/World/envs/env_0/"
+        rel_under_env0 = (
+            cam_paths[0].removeprefix(env_0_prefix) if cam_paths and cam_paths[0].startswith(env_0_prefix) else ""
+        )
+        device_str = self._device if isinstance(self._device, str) else str(self._device)
+        render_spec = CameraRenderSpec(
+            cfg=self.cfg,
+            device=device_str,
+            num_instances=len(cam_paths),
+            camera_prim_paths=cam_paths,
+            view_count=len(cam_paths),
+            camera_path_relative_to_env_0=rel_under_env0,
+        )
+
+        # Delegate per-camera USD setup to the renderer — must run **before**
+        # ``ensure_prepare_stage`` so renderers that snapshot the stage
+        # (ovrtx's ``stage.Export``) capture the resulting overrides in their
+        # exported USD.
+        self._renderer.prepare_cameras(self.stage, render_spec)
+
         # Stage preprocessing must happen before creating the view because the view keeps
         # references to prims located in the stage.
         sim_ctx.render_context.ensure_prepare_stage(self.stage, self._num_envs)
@@ -480,21 +522,6 @@ class Camera(SensorBase):
             # Add to list
             self._sensor_prims.append(UsdGeom.Camera(cam_prim))
 
-        # View needs to exist before creating render data
-        cam_paths = tuple(cam_prim.GetPath().pathString for cam_prim in self._view.prims)
-        env_0_prefix = "/World/envs/env_0/"
-        rel_under_env0 = (
-            cam_paths[0].removeprefix(env_0_prefix) if cam_paths and cam_paths[0].startswith(env_0_prefix) else ""
-        )
-        device_str = self._device if isinstance(self._device, str) else str(self._device)
-        render_spec = CameraRenderSpec(
-            cfg=self.cfg,
-            device=device_str,
-            num_instances=self.num_instances,
-            camera_prim_paths=cam_paths,
-            view_count=self._view.count,
-            camera_path_relative_to_env_0=rel_under_env0,
-        )
         self._render_data = self._renderer.create_render_data(render_spec)
 
         # Create internal buffers (includes intrinsic matrix and pose init)

--- a/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import MISSING, field
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from isaaclab.renderers import RendererCfg
 from isaaclab.sim import FisheyeCameraCfg, PinholeCameraCfg
 from isaaclab.utils.configclass import configclass
 
 from ..sensor_base_cfg import SensorBaseCfg
+from .camera_isp import CameraISPMode
 
 if TYPE_CHECKING:
     from .camera import Camera
@@ -191,6 +192,29 @@ class CameraCfg(SensorBaseCfg):
 
     renderer_cfg: RendererCfg = field(default_factory=RendererCfg)
     """Renderer configuration for camera sensor."""
+
+    isp_cfg: Any | CameraISPMode | None = None
+    """Post-render ISP cfg applied by the renderer backend after it produces HDR output.
+
+    Defaults to ``None`` (ISP disabled). Auto-discovery is opt-in via a
+    :class:`CameraISPMode` sentinel — see below.
+
+    Accepted values:
+
+    * ``None`` — ISP disabled. No HDR AOV is requested and no RTX-side
+      tonemapping flags are flipped.
+    * A :class:`CameraISPMode` sentinel — the renderer backend walks the USD stage to
+      discover an ISP shader (e.g. via the :mod:`isaaclab_ppisp` package).
+    * A concrete ISP cfg dataclass (e.g. :class:`isaaclab_ppisp.PpispCfg`) — used directly.
+
+    The cfg applies once per Camera sensor batch. The PPISP Warp kernel takes
+    scalar coefficients, so every cloned view in a tiled batch shares the same
+    ISP configuration — there is no per-view ISP today.
+
+    :mod:`isaaclab.sensors.camera` does not depend on any ISP implementation; the
+    annotation is intentionally loose (``Any``) so the sensor layer can carry the
+    cfg through to a renderer that knows what to do with it.
+    """
 
     def __post_init__(self):
         """Forward deprecated RTX-flavored fields onto :attr:`renderer_cfg`.

--- a/source/isaaclab/isaaclab/sensors/camera/camera_isp.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_isp.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sentinel enum for :attr:`~isaaclab.sensors.camera.CameraCfg.isp_cfg`.
+
+The renderer backend (which depends on the appropriate ISP implementation
+package) is responsible for resolving these sentinels to a concrete cfg and
+applying the ISP pipeline. :mod:`isaaclab.sensors.camera` carries the sentinel
+through to the renderer without knowing about any specific ISP implementation.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class CameraISPMode(StrEnum):
+    """Sentinel modes for :attr:`~isaaclab.sensors.camera.CameraCfg.isp_cfg`.
+
+    Selects how the renderer backend discovers the ISP configuration from the
+    USD stage at camera initialization time. Discovery resolves one cfg for
+    the whole Camera sensor batch, using the first matched camera prim as the
+    camera-bound lookup target. ``isp_cfg=None`` disables ISP entirely; this
+    enum carries only the *active* discovery strategies.
+    """
+
+    AUTO_CAMERA = "auto_camera"
+    """Discover an ISP cfg bound to the batch's first matched camera prim.
+
+    The renderer walks the stage for a ``RenderProduct`` whose ``camera``
+    relationship targets the first matched camera prim in the sensor batch. If
+    found and it has an ISP shader child, parses the shader. Resolves to
+    ``None`` (no ISP) if no match.
+    """
+
+    AUTO_ANY = "auto_any"
+    """Same as :attr:`AUTO_CAMERA`, then fall back to the first ISP shader anywhere on the stage.
+
+    Used to honour a stage-wide ISP authoring even when no ``RenderProduct``
+    binds the shader explicitly to the batch's first matched camera prim.
+    Resolves to ``None`` only when the stage contains no ISP shader at all.
+    """

--- a/source/isaaclab/test/install_ci/test_install_command_parsing.py
+++ b/source/isaaclab/test/install_ci/test_install_command_parsing.py
@@ -111,6 +111,7 @@ class TestInstallConstants:
     def test_core_submodules_contains_expected_packages(self):
         expected = {
             "isaaclab",
+            "isaaclab_ppisp",
             "isaaclab_assets",
             "isaaclab_contrib",
             "isaaclab_experimental",

--- a/source/isaaclab/test/install_ci/test_isaaclabx_i_none.py
+++ b/source/isaaclab/test/install_ci/test_isaaclabx_i_none.py
@@ -22,6 +22,7 @@ from utils import UV_Mixin, find_isaaclab_root
 # Core packages that must be importable after ``-i none``.
 _CORE_PACKAGES = [
     "isaaclab",
+    "isaaclab_ppisp",
     "isaaclab_assets",
     "isaaclab_contrib",
     "isaaclab_experimental",

--- a/source/isaaclab/test/renderers/test_camera_output_contract.py
+++ b/source/isaaclab/test/renderers/test_camera_output_contract.py
@@ -6,6 +6,7 @@
 """Tests for the renderer→camera output contract."""
 
 import warnings
+from types import SimpleNamespace
 
 import pytest
 import warp as wp
@@ -127,11 +128,32 @@ def test_newton_warp_supported_output_types_key_set():
     assert set(specs.keys()) == {
         RenderBufferKind.RGB,
         RenderBufferKind.RGBA,
+        RenderBufferKind.RGB_HDR,
         RenderBufferKind.ALBEDO,
         RenderBufferKind.DEPTH,
         RenderBufferKind.NORMALS,
         RenderBufferKind.INSTANCE_SEGMENTATION_FAST,
     }
+    assert specs[RenderBufferKind.RGB_HDR] == RenderBufferSpec(3, wp.float32)
+
+
+def test_newton_warp_wraps_requested_rgb_hdr_output():
+    """NewtonWarpRenderer wires requested RGB_HDR proxies to the Newton HDR output slot."""
+    pytest.importorskip("isaaclab_newton")
+    pytest.importorskip("newton")
+    wp.init()
+    from isaaclab_newton.renderers.newton_warp_renderer import RenderData
+
+    from isaaclab.utils.warp.proxy_array import ProxyArray
+
+    fake_sensor = SimpleNamespace(model=SimpleNamespace(world_count=2, device="cpu"))
+    render_data = RenderData(fake_sensor, SimpleNamespace(cfg=SimpleNamespace(width=4, height=3, isp_cfg=None)))
+    hdr_proxy = ProxyArray(wp.zeros((2, 3, 4, 3), dtype=wp.float32, device="cpu"))
+
+    render_data.set_outputs({str(RenderBufferKind.RGB_HDR): hdr_proxy})
+
+    assert render_data.outputs.hdr_color_image is not None
+    assert render_data.get_output(RenderBufferKind.RGB_HDR) is render_data.outputs.hdr_color_image
 
 
 def _make_camera_cfg(data_types: list[str]) -> CameraCfg:

--- a/source/isaaclab/test/sensors/generate_synthetic_gaussian_asset.py
+++ b/source/isaaclab/test/sensors/generate_synthetic_gaussian_asset.py
@@ -1,0 +1,565 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Generate a tiny synthetic Gaussian-Splat USD asset for camera PPISP tests.
+
+Avoids dependencies on heavyweight Nucleus assets by authoring a few large
+opaque gaussians of known colors, bound to ``ParticleFieldEmissive.mdl`` with
+``apply_inverse_tonemap=0`` and ``apply_srgb_linear=0`` so the wrapper PPISP is
+the sole ISP authority. Tests assert *semantic invariants* of the PPISP
+behavior (vignetting darkens corners, exposure offset increases mean, the CRF
+compresses highlights, etc.) instead of doing a fidelity-against-baked
+comparison — which sidesteps cross-renderer HDR-magnitude calibration drift
+entirely.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import math
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import torch
+from isaaclab_ppisp import PpispCfg, normalize_ppisp_cfg
+
+from pxr import Gf, Sdf, Usd, UsdGeom
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import AssetBaseCfg, RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors.camera import Camera, CameraCfg
+from isaaclab.terrains import TerrainImporterCfg
+from isaaclab.utils.configclass import configclass
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from isaaclab.renderers.renderer_cfg import RendererCfg
+    from isaaclab.sim import SimulationCfg, SimulationContext
+
+
+# SH degree-0 evaluation constant ``Y_0 = 1 / (2 * sqrt(pi))``. The standard
+# 3DGS convention encodes a particle's base color as
+# ``color = 0.5 + Y_0 * dc`` so inverting gives ``dc = (color - 0.5) / Y_0``.
+_SH_Y0 = 1.0 / (2.0 * math.sqrt(math.pi))
+
+
+@dataclass
+class SyntheticGaussian:
+    """One opaque gaussian in the synthetic scene."""
+
+    position: tuple[float, float, float]
+    """World-space position (x, y, z) in metres."""
+
+    color: tuple[float, float, float]
+    """Target final color in [0, 1] linear scene-referred space. Encoded into SH so
+    the rendered (pre-PPISP) HDR pixels at the gaussian center approximate this color."""
+
+    scale: float = 0.3
+    """Isotropic scale (radius) of the gaussian ellipsoid in metres."""
+
+    opacity: float = 1.0
+    """Opacity in [0, 1]. Use 1.0 for fully opaque coverage."""
+
+
+@dataclass
+class SyntheticGaussianScene:
+    """Scene description consumed by :func:`make_synthetic_gaussian_usd`.
+
+    Defaults arrange four large fully-opaque gaussians (R, G, B, W) in a 2x2
+    grid in the X-Y plane at Z=0, with a camera placed on +Z looking at the
+    grid origin.
+    """
+
+    gaussians: list[SyntheticGaussian] = field(
+        default_factory=lambda: [
+            SyntheticGaussian(position=(-0.6, +0.6, 0.0), color=(0.9, 0.1, 0.1)),  # red
+            SyntheticGaussian(position=(+0.6, +0.6, 0.0), color=(0.1, 0.9, 0.1)),  # green
+            SyntheticGaussian(position=(-0.6, -0.6, 0.0), color=(0.1, 0.1, 0.9)),  # blue
+            SyntheticGaussian(position=(+0.6, -0.6, 0.0), color=(0.9, 0.9, 0.9)),  # white
+        ]
+    )
+    """Gaussians in the scene. Default forms a 2x2 RGBW grid."""
+
+    camera_position: tuple[float, float, float] = (0.0, 0.0, 3.0)
+    """Camera position. Default looks at the grid origin from +Z."""
+
+    focal_length: float = 24.0
+    """Pinhole camera focal length in mm."""
+
+    horizontal_aperture: float = 20.955
+    """Camera horizontal aperture in mm."""
+
+
+def make_synthetic_gaussian_usd(path: str, scene: SyntheticGaussianScene | None = None) -> str:
+    """Author a tiny gaussian-splat USD at ``path`` and return that path.
+
+    The asset references ``ParticleFieldEmissive.mdl`` with ``apply_inverse_tonemap=0``
+    and ``apply_srgb_linear=0`` so the wrapper PPISP is the sole ISP authority.
+    The default prim is ``World``; cameras live at ``/World/Cameras/test_cam``
+    and the gaussians at ``/World/Scene/gaussians/Gaussians/gaussians``.
+    """
+    if scene is None:
+        scene = SyntheticGaussianScene()
+
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    stage = Usd.Stage.CreateNew(path)
+    stage.SetMetadata("metersPerUnit", 1.0)
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+
+    # Default prim ``/World`` so this asset can be referenced under any parent.
+    world = UsdGeom.Xform.Define(stage, "/World")
+    stage.SetDefaultPrim(world.GetPrim())
+
+    # Camera under ``/World/Cameras/test_cam``. Authored without time samples so
+    # ``UsdGeom.XformCache`` resolves the world transform at the default time.
+    UsdGeom.Xform.Define(stage, "/World/Cameras")
+    cam = UsdGeom.Camera.Define(stage, "/World/Cameras/test_cam")
+    cam.GetFocalLengthAttr().Set(scene.focal_length)
+    cam.GetHorizontalApertureAttr().Set(scene.horizontal_aperture)
+    cam.GetClippingRangeAttr().Set(Gf.Vec2f(0.01, 1000.0))
+    cam.GetFStopAttr().Set(1.0)
+    # Look from camera_position toward origin (-Z view direction).
+    cx, cy, cz = scene.camera_position
+    cam.AddTranslateOp().Set(Gf.Vec3d(cx, cy, cz))
+
+    # Gaussian particle field. Use a deeply nested path matching the typical
+    # 3DGS export layout so user-side scene wiring matches real assets.
+    UsdGeom.Xform.Define(stage, "/World/Scene")
+    UsdGeom.Xform.Define(stage, "/World/Scene/gaussians")
+    UsdGeom.Xform.Define(stage, "/World/Scene/gaussians/Gaussians")
+    gauss_prim_path = "/World/Scene/gaussians/Gaussians/gaussians"
+    gauss_prim = stage.DefinePrim(gauss_prim_path, "ParticleField3DGaussianSplat")
+
+    def _attr(name: str, type_name: Sdf.ValueTypeName, value):
+        attr = gauss_prim.CreateAttribute(name, type_name)
+        attr.Set(value)
+        return attr
+
+    _attr("positions", Sdf.ValueTypeNames.Point3fArray, [Gf.Vec3f(*g.position) for g in scene.gaussians])
+    _attr(
+        "orientations",
+        Sdf.ValueTypeNames.QuatfArray,
+        # Identity quaternion (w, x, y, z) - Gf.Quatf takes (real, imaginary).
+        [Gf.Quatf(1.0, 0.0, 0.0, 0.0) for _ in scene.gaussians],
+    )
+    _attr(
+        "scales",
+        Sdf.ValueTypeNames.Float3Array,
+        [Gf.Vec3f(g.scale, g.scale, g.scale) for g in scene.gaussians],
+    )
+    _attr("opacities", Sdf.ValueTypeNames.FloatArray, [float(g.opacity) for g in scene.gaussians])
+
+    # Encode the desired final color in SH degree-0 coefficients. With
+    # apply_inverse_tonemap=0 and apply_srgb_linear=0, the MDL evaluates the
+    # gaussian color as ``0.5 + Y_0 * dc * emission_intensity``. Solving for dc
+    # gives the inverse encoding used here.
+    sh_coeffs = [
+        Gf.Vec3f(
+            (g.color[0] - 0.5) / _SH_Y0,
+            (g.color[1] - 0.5) / _SH_Y0,
+            (g.color[2] - 0.5) / _SH_Y0,
+        )
+        for g in scene.gaussians
+    ]
+    _attr("radiance:sphericalHarmonicsCoefficients", Sdf.ValueTypeNames.Float3Array, sh_coeffs)
+    sh_degree_attr = gauss_prim.CreateAttribute(
+        "radiance:sphericalHarmonicsDegree", Sdf.ValueTypeNames.Int, custom=False
+    )
+    sh_degree_attr.Set(0)
+
+    # Conservative extent — bounding box of all gaussian centers expanded by
+    # their largest scale.
+    if scene.gaussians:
+        max_scale = max(g.scale for g in scene.gaussians)
+        positions = [g.position for g in scene.gaussians]
+        lo = (
+            min(p[0] for p in positions) - max_scale,
+            min(p[1] for p in positions) - max_scale,
+            min(p[2] for p in positions) - max_scale,
+        )
+        hi = (
+            max(p[0] for p in positions) + max_scale,
+            max(p[1] for p in positions) + max_scale,
+            max(p[2] for p in positions) + max_scale,
+        )
+        gauss_prim.CreateAttribute("extent", Sdf.ValueTypeNames.Float3Array).Set([Gf.Vec3f(*lo), Gf.Vec3f(*hi)])
+
+    # Material binding: ``ParticleFieldEmissive.mdl`` with the two boolean
+    # ``apply_*`` inputs set to false so the wrapper PPISP is the sole ISP
+    # authority and the gaussian color comes out of the renderer as linear
+    # scene-referred radiance.
+    UsdGeom.Xform.Define(stage, "/World/Scene/gaussians/Looks")
+    material = stage.DefinePrim("/World/Scene/gaussians/Looks/ParticleFieldEmissive", "Material")
+    shader = stage.DefinePrim("/World/Scene/gaussians/Looks/ParticleFieldEmissive/Shader", "Shader")
+    shader.CreateAttribute("info:implementationSource", Sdf.ValueTypeNames.Token).Set("sourceAsset")
+    shader.CreateAttribute("info:mdl:sourceAsset", Sdf.ValueTypeNames.Asset).Set("ParticleFieldEmissive.mdl")
+    shader.CreateAttribute("info:mdl:sourceAsset:subIdentifier", Sdf.ValueTypeNames.Token).Set("ParticleFieldEmissive")
+    shader.CreateAttribute("inputs:apply_inverse_tonemap", Sdf.ValueTypeNames.Bool, custom=True).Set(False)
+    shader.CreateAttribute("inputs:apply_srgb_linear", Sdf.ValueTypeNames.Bool, custom=True).Set(False)
+    shader.CreateAttribute("outputs:out", Sdf.ValueTypeNames.Token, custom=True)
+    for output in ("mdl:displacement", "mdl:surface", "mdl:volume"):
+        material.CreateAttribute(f"outputs:{output}", Sdf.ValueTypeNames.Token).AddConnection(
+            shader.GetPath().AppendProperty("outputs:out")
+        )
+    gauss_prim.CreateRelationship("material:binding").SetTargets([material.GetPath()])
+
+    stage.GetRootLayer().Save()
+    return path
+
+
+# PPISP cfg helpers ----------------------------------------------------------
+
+
+# Strong negative radial coefficient — the warp kernel uses
+# ``factor = clamp(1 + alpha1 * r^2 + alpha2 * r^4 + alpha3 * r^6, 0, 1)`` where
+# ``r`` is normalised by ``max(W, H)``. With this value the corner of a square
+# frame (``r^2 = 0.5``) attenuates by ``factor = 1 + (-1.5)(0.5) = 0.25``, i.e.
+# corners drop to ~25% of center intensity. Visible but not fully black.
+_AGGRESSIVE_VIGNETTING_ALPHA1 = -1.8
+
+# Negative exposure offset (input × 2^-5 = ÷32) tuned so the aggressive cfg
+# safely brings the RTX-bearing backends' gaussian HDR magnitudes (~10
+# single-tile, ~17 multi-tile observed on OVRTX) below the CRF's [0,1] clamp
+# before tonemapping. Newton's much lower native HDR scale is normalised
+# separately via :func:`make_aggressive_ppisp_cfg`'s ``responsivity`` kwarg.
+_AGGRESSIVE_EXPOSURE_OFFSET = -5.0
+
+
+def make_aggressive_ppisp_cfg(*, responsivity: float = 1.0) -> PpispCfg:
+    """Return a :class:`~isaaclab_ppisp.PpispCfg` with every PPISP feature engaged enough
+    to be assertable in a downstream test.
+
+    Each input is dialed past the "subtle correction" defaults so an integration
+    test can check semantic invariants of the wrapper PPISP pipeline:
+
+    * **Exposure**: ``exposureOffset = -5`` (input × 2^-5 = ÷32) — tuned so that
+      a near-typical RTX-style gaussian HDR magnitude (≈10–17) lands below the
+      CRF's [0,1] clamp before tonemapping, then CRF compresses to upper LDR.
+    * **Vignetting**: per-channel ``alpha1 = -1.8`` — corners drop to ~0% of
+      center intensity for a square frame. Slight per-channel imbalance
+      (R < G < B in alpha2) produces a non-uniform corner colour cast.
+    * **Color homography**: ``red_latent`` pulls the red anchor outward and
+      ``green_latent`` pulls the green anchor down — input white pixels acquire
+      a visible warm hue shift.
+    * **CRF**: per-channel toe/shoulder/gamma/center values that meaningfully
+      compress highlights (no overflow above 1.0 ⇒ max LDR uint8 stays at 255
+      only when the wrapper actually clamps; under-engaged CRF would let the
+      explicit ``clamp(.., 0, 1)`` in the kernel do all the work).
+
+    Args:
+        responsivity: PPISP achromatic ``responsivity`` factor applied **before**
+            exposure. Defaults to ``1.0`` (calibrated for RTX-bearing backends'
+            HDR magnitude). The Newton backend produces a much lower-magnitude
+            HDR for the same scene and tests pass a value > 1 to bring its
+            effective signal in line with the RTX backends.
+    """
+    inputs: dict[str, float | tuple[float, float]] = {
+        "responsivity": responsivity,
+        "exposureOffset": _AGGRESSIVE_EXPOSURE_OFFSET,
+        # Vignetting: identical optical center for all channels (image center),
+        # with a slight per-channel falloff offset so a vignetted region has
+        # a faint chromatic gradient — verifies the per-channel paths are wired.
+        "vignettingCenterR": (0.0, 0.0),
+        "vignettingAlpha1R": _AGGRESSIVE_VIGNETTING_ALPHA1,
+        "vignettingAlpha2R": -0.4,
+        "vignettingAlpha3R": 0.0,
+        "vignettingCenterG": (0.0, 0.0),
+        "vignettingAlpha1G": _AGGRESSIVE_VIGNETTING_ALPHA1,
+        "vignettingAlpha2G": -0.2,
+        "vignettingAlpha3G": 0.0,
+        "vignettingCenterB": (0.0, 0.0),
+        "vignettingAlpha1B": _AGGRESSIVE_VIGNETTING_ALPHA1,
+        "vignettingAlpha2B": 0.0,
+        "vignettingAlpha3B": 0.0,
+        # Color homography: shift the red and green anchors so the output picks
+        # up a clear hue rotation. Blue and neutral remain near identity.
+        "colorLatentRed": (0.4, 0.0),
+        "colorLatentGreen": (0.0, -0.4),
+        "colorLatentBlue": (0.0, 0.0),
+        "colorLatentNeutral": (0.0, 0.0),
+        # CRF: stronger shoulder than the default highlight knee so a saturated
+        # input is compressed rather than clipped. Per-channel gammas are split
+        # to produce a subtle warm cast.
+        "crfToeR": 0.05,
+        "crfShoulderR": 0.20,
+        "crfGammaR": 0.50,
+        "crfCenterR": 0.0,
+        "crfToeG": 0.05,
+        "crfShoulderG": 0.20,
+        "crfGammaG": 0.45,
+        "crfCenterG": 0.0,
+        "crfToeB": 0.05,
+        "crfShoulderB": 0.20,
+        "crfGammaB": 0.40,
+        "crfCenterB": 0.0,
+    }
+    return normalize_ppisp_cfg(PpispCfg(inputs=inputs))
+
+
+def assert_ppisp_invariants(
+    rgb_tile: torch.Tensor,
+    *,
+    patch: int = 16,
+    vignetting_corner_ratio_max: float = 0.5,
+    label: str = "",
+) -> None:
+    """Assert the four PPISP signatures expected from :func:`make_aggressive_ppisp_cfg`
+    on a single ``[H, W, C>=3]`` rgb tile (uint8-range floats).
+
+    1. Non-degenerate frame: ``5 < mean < 250``.
+    2. Vignetting: each of the 4 corner patches is below
+       ``vignetting_corner_ratio_max`` times the center patch (``alpha1=-1.8``
+       drives the pre-CRF corner factor to ~0; after CRF compression the
+       per-renderer corner/center ratio sits well below 0.5).
+    3. Exposure: center patch mean > 50 (the aggressive cfg's
+       ``responsivity * 2^exposureOffset`` is tuned so the per-renderer HDR
+       magnitude lands solidly into mid-to-upper LDR after CRF).
+    4. CRF clamping: output stays in ``[0, 255]`` (also catches NaNs implicitly).
+
+    ``label`` is included in every assertion message so the caller can identify
+    which renderer / tile failed.
+    """
+    prefix = f"[{label}] " if label else ""
+    h, w = rgb_tile.shape[:2]
+
+    mean = rgb_tile.mean().item()
+    assert 5.0 < mean < 250.0, f"{prefix}render is degenerate (mean={mean:.1f})"
+
+    cy, cx = h // 2 - patch // 2, w // 2 - patch // 2
+    center_mean = rgb_tile[cy : cy + patch, cx : cx + patch, :3].mean().item()
+    assert center_mean > 1.0, f"{prefix}center patch is degenerate (mean={center_mean:.1f})"
+
+    for corner_name, y0, x0 in (
+        ("top-left", 0, 0),
+        ("top-right", 0, w - patch),
+        ("bottom-left", h - patch, 0),
+        ("bottom-right", h - patch, w - patch),
+    ):
+        corner_mean = rgb_tile[y0 : y0 + patch, x0 : x0 + patch, :3].mean().item()
+        ratio = corner_mean / center_mean
+        assert ratio < vignetting_corner_ratio_max, (
+            f"{prefix}vignetting too weak at {corner_name}: corner/center = {ratio:.3f} "
+            f"(expected < {vignetting_corner_ratio_max}). "
+            f"corner_mean={corner_mean:.1f}, center_mean={center_mean:.1f}"
+        )
+
+    assert center_mean > 50.0, (
+        f"{prefix}aggressive PPISP cfg should land the center patch above 50 (mid-LDR); "
+        f"got {center_mean:.1f}. Check responsivity/exposureOffset and that the renderer is producing HDR > 0."
+    )
+
+    assert rgb_tile.max().item() <= 255.0, f"{prefix}output overflow: max={rgb_tile.max().item():.1f}"
+    assert rgb_tile.min().item() >= 0.0, f"{prefix}output underflow: min={rgb_tile.min().item():.1f}"
+
+
+def assert_ppisp_lifts_exposure(
+    hdr_tile: torch.Tensor,
+    rgb_tile: torch.Tensor,
+    *,
+    patch: int = 16,
+    hdr_center_min: float = 1.0e-2,
+    ldr_center_norm_range: tuple[float, float] = (0.1, 0.95),
+    label: str = "",
+) -> None:
+    """Assert PPISP normalises the renderer's HDR into a useful LDR range.
+
+    Different renderer backends produce wildly different HDR magnitudes for the
+    same synthetic gaussian scene (Newton's emissive scale is ~10× lower than
+    the RTX backends'). The aggressive cfg's ``responsivity`` knob is tuned per
+    backend to bring the effective signal in line; this assertion then only
+    enforces that:
+
+    * the renderer is producing an HDR AOV (lower bound on the HDR center)
+    * PPISP delivers a non-degenerate LDR center (not black, not fully
+      saturated)
+
+    Localises failures:
+
+    * **Renderer not producing HDR** — caught by the HDR lower bound.
+    * **PPISP saturated or black** — caught by the LDR range bound; suggests
+      either ``responsivity``/``exposureOffset`` mis-tuned or the pipeline
+      not running.
+
+    Args:
+        hdr_tile: ``[H, W, 3]`` float HDR tile (from ``output["rgb_hdr"]``).
+        rgb_tile: ``[H, W, C>=3]`` uint8-range float LDR tile (from ``output["rgb"]``).
+        patch: Center-patch window size in pixels.
+        hdr_center_min: Lower bound on the raw HDR center mean.
+        ldr_center_norm_range: ``(min, max)`` for the LDR center mean / 255.
+        label: Included in every assertion message so the caller can identify
+            which renderer / tile failed.
+    """
+    prefix = f"[{label}] " if label else ""
+    h, w = rgb_tile.shape[:2]
+    cy, cx = h // 2 - patch // 2, w // 2 - patch // 2
+
+    hdr_center = hdr_tile[cy : cy + patch, cx : cx + patch, :3].float().mean().item()
+    ldr_center_norm = rgb_tile[cy : cy + patch, cx : cx + patch, :3].float().mean().item() / 255.0
+
+    assert hdr_center > hdr_center_min, (
+        f"{prefix}HDR center too dark (mean={hdr_center:.4f}) — renderer not producing the HDR AOV?"
+    )
+    ldr_lo, ldr_hi = ldr_center_norm_range
+    assert ldr_lo < ldr_center_norm < ldr_hi, (
+        f"{prefix}PPISP LDR center out of range: ldr_norm={ldr_center_norm:.4f} "
+        f"(expected {ldr_lo} < x < {ldr_hi}; hdr_center={hdr_center:.4f}). "
+        f"Likely saturated or black — check responsivity/exposureOffset tuning."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# InteractiveScene helpers shared by the Isaac RTX-, Newton-, and OVRTX-backed
+# gaussian tests.
+# ──────────────────────────────────────────────────────────────────────────────
+
+SYNTHETIC_GAUSSIAN_SCENE_REL_PATH = "Scene"
+"""Asset prim path under each environment in :class:`SyntheticGaussianSceneCfg`."""
+
+SYNTHETIC_GAUSSIAN_CAMERA_NAME = "test_cam"
+"""Camera prim name authored inside the synthesised asset USD."""
+
+SYNTHETIC_GAUSSIAN_CAMERA_REGEX = (
+    f"/World/envs/env_.*/{SYNTHETIC_GAUSSIAN_SCENE_REL_PATH}/Cameras/{SYNTHETIC_GAUSSIAN_CAMERA_NAME}"
+)
+"""Regex camera prim path that resolves to one camera per env (single or tiled)."""
+
+
+@configclass
+class SyntheticGaussianSceneCfg(InteractiveSceneCfg):
+    """Minimal :class:`~isaaclab.scene.InteractiveScene` cfg wrapping the synthesised gaussian asset.
+
+    The :attr:`anchor` rigid body exists solely to give Newton-backed physics
+    a non-empty body table — it is invisible at the camera viewpoint and far
+    enough below the scene to never appear in the render.
+
+    The ``gaussian`` asset URL is filled in at runtime by
+    :func:`fresh_synthetic_gaussian_interactive_scene`.
+    """
+
+    env_spacing: float = 2.0
+
+    terrain = TerrainImporterCfg(prim_path="/World/ground", terrain_type="plane")
+
+    gaussian = AssetBaseCfg(
+        prim_path=f"{{ENV_REGEX_NS}}/{SYNTHETIC_GAUSSIAN_SCENE_REL_PATH}",
+        spawn=sim_utils.UsdFileCfg(usd_path=""),  # filled in at runtime
+    )
+
+    anchor = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Anchor",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.01, 0.01, 0.01),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(),
+            mass_props=sim_utils.MassPropertiesCfg(mass=0.001),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+            physics_material=sim_utils.RigidBodyMaterialCfg(),
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 0.0)),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, -100.0)),
+    )
+
+
+@contextlib.contextmanager
+def fresh_synthetic_gaussian_interactive_scene(
+    usd_path: str,
+    sim_cfg: SimulationCfg,
+    *,
+    num_envs: int = 1,
+) -> Iterator[SimulationContext]:
+    """Yield a fresh :class:`~isaaclab.sim.SimulationContext` with the synthesised
+    gaussian asset referenced under each env via :class:`SyntheticGaussianSceneCfg`.
+
+    The InteractiveScene is held alive for the lifetime of the context — its
+    callbacks register *weak* refs to the parent's bound methods; if the scene
+    is dropped, the next ``dispatch_event`` raises ``ReferenceError`` from a
+    dead weakref.
+
+    Args:
+        usd_path: Path to the synthesised gaussian USD asset (typically produced
+            by :func:`make_synthetic_gaussian_usd`).
+        sim_cfg: The simulation cfg (caller-provided, since the physics backend
+            and timestep are renderer-specific).
+        num_envs: Number of tiled envs to spawn.
+
+    Yields:
+        The constructed :class:`SimulationContext`.
+    """
+    sim_utils.create_new_stage()
+    sim = sim_utils.SimulationContext(sim_cfg)
+    scene_cfg = SyntheticGaussianSceneCfg(num_envs=num_envs)
+    scene_cfg.gaussian.spawn = sim_utils.UsdFileCfg(usd_path=usd_path)
+    scene = InteractiveScene(scene_cfg)  # noqa: F841 — kept alive intentionally
+    try:
+        yield sim
+    finally:
+        with contextlib.suppress(Exception):
+            sim.stop()
+        with contextlib.suppress(Exception):
+            sim.clear_instance()
+
+
+def render_synthetic_gaussian_scene(
+    usd_path: str,
+    *,
+    sim_cfg: SimulationCfg,
+    renderer_cfg: RendererCfg,
+    data_types: list[str],
+    num_envs: int = 1,
+    height: int = 128,
+    width: int = 128,
+    sim_dt: float = 1.0 / 60.0,
+    stabilisation_steps: int = 5,
+    responsivity: float = 1.0,
+) -> dict[str, torch.Tensor]:
+    """Render the synthesised gaussian asset with the aggressive wrapper ISP.
+
+    Builds an :class:`~isaaclab.scene.InteractiveScene` via
+    :func:`fresh_synthetic_gaussian_interactive_scene`, instantiates a
+    :class:`~isaaclab.sensors.camera.Camera` whose prim path is
+    :data:`SYNTHETIC_GAUSSIAN_CAMERA_REGEX` (one camera per env), drives the
+    sim for ``stabilisation_steps`` ticks, and returns every requested output.
+
+    Args:
+        usd_path: Path to the synthesised gaussian USD asset.
+        sim_cfg: Caller-provided simulation cfg (carries the physics backend).
+        renderer_cfg: Renderer cfg (typically ``IsaacRtxRendererCfg``,
+            ``NewtonWarpRendererCfg``, or ``OVRTXRendererCfg``).
+        data_types: List passed through to :attr:`~isaaclab.sensors.camera.CameraCfg.data_types`.
+            Include ``"rgb_hdr"`` here when callers need access to the renderer's HDR AOV
+            (e.g. for :func:`assert_ppisp_lifts_exposure`).
+        num_envs: Number of tiled envs.
+        height: Render height [pixels].
+        width: Render width [pixels].
+        sim_dt: Simulation timestep [s] used for ``camera.update``.
+        stabilisation_steps: Sim steps to run before reading the final frame.
+
+    Returns:
+        A dict mapping every key present in ``camera.data.output`` to a
+        ``[num_envs, height, width, channels]`` float32 CPU tensor (uint8 LDR
+        buffers are cast to float for downstream arithmetic).
+    """
+    isp_cfg = make_aggressive_ppisp_cfg(responsivity=responsivity)
+    with fresh_synthetic_gaussian_interactive_scene(usd_path, sim_cfg, num_envs=num_envs) as sim:
+        cfg = CameraCfg(
+            prim_path=SYNTHETIC_GAUSSIAN_CAMERA_REGEX,
+            update_period=0.0,
+            height=height,
+            width=width,
+            data_types=data_types,
+            spawn=None,
+            isp_cfg=isp_cfg,
+            renderer_cfg=renderer_cfg,
+        )
+        camera = Camera(cfg)
+        sim.reset()
+        for _ in range(stabilisation_steps):
+            sim.step()
+        camera.update(sim_dt)
+        outputs = {name: tensor.clone().detach().cpu().to(torch.float32) for name, tensor in camera.data.output.items()}
+        del camera
+        return outputs

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Validate the camera PPISP wrapper applied to a 3D Gaussian (NuRec /
+ParticleField) scene through the ``isaac_rtx`` renderer.
+
+The scene is synthesised at test time by :mod:`generate_synthetic_gaussian_asset` — a few
+large fully-opaque Gaussians of known colors arranged in front of the camera,
+bound to ``ParticleFieldEmissive.mdl`` with ``apply_inverse_tonemap=0`` and
+``apply_srgb_linear=0`` so the wrapper PPISP is the only ISP authority.
+
+The wrapper PPISP cfg
+(:func:`generate_synthetic_gaussian_asset.make_aggressive_ppisp_cfg`) engages every PPISP
+feature past its subtle-correction defaults so the integration test can check
+*semantic invariants* of the PPISP pipeline (vignetting darkens corners,
+exposure increases mean, no overflow above 255, output stays in [0, 255])
+instead of doing a fidelity-against-baked comparison — which would have to
+absorb renderer-internal HDR-magnitude calibration drift between renderers.
+
+Renderer parametrization:
+  * ``isaac_rtx`` is the only renderer exercised by this test.
+  * ``ovrtx`` coverage lives in ``test_camera_ppisp_gaussian_ovrtx.py``, which
+    uses the same ``InteractiveScene`` setup.
+  * ``newton_warp`` coverage lives in ``test_camera_ppisp_gaussian_newton.py``,
+    which builds an ``InteractiveScene`` with a Newton-backed
+    ``SimulationCfg`` to give Newton the model it needs.
+"""
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True, enable_cameras=True).app
+
+"""Rest everything follows."""
+
+import tempfile
+
+import pytest
+from generate_synthetic_gaussian_asset import (
+    SYNTHETIC_GAUSSIAN_CAMERA_REGEX,
+    assert_ppisp_invariants,
+    assert_ppisp_lifts_exposure,
+    make_synthetic_gaussian_usd,
+    render_synthetic_gaussian_scene,
+)
+
+from isaaclab.sim import SimulationCfg
+
+
+def _collect_renderer_cfg_params() -> list:
+    """Return pytest.param entries for installed RTX-backed renderer packages.
+
+    Each renderer lives in its own optional package; a missing package is silently
+    excluded so tests run on partial installs. ``ovrtx`` and ``newton_warp`` are
+    not listed here — their dedicated tests
+    (``test_camera_ppisp_gaussian_ovrtx.py`` / ``test_camera_ppisp_gaussian_newton.py``)
+    use ``InteractiveScene`` so cameras land under ``/World/envs/env_0/``.
+    """
+    params: list = []
+    try:
+        from isaaclab_physx.renderers import IsaacRtxRendererCfg
+
+        params.append(pytest.param(IsaacRtxRendererCfg, id="isaac_rtx"))
+    except ImportError:
+        pass
+    return params
+
+
+_RENDERER_CFG_PARAMS = _collect_renderer_cfg_params()
+
+SIM_DT = 0.01
+MULTI_TILE_COUNT = 4
+ISAAC_RTX_RESPONSIVITY = 1.2
+
+
+def _isaac_rtx_sim_cfg(device: str) -> SimulationCfg:
+    return SimulationCfg(dt=SIM_DT, device=device)
+
+
+if not _RENDERER_CFG_PARAMS:
+    pytest.skip(
+        "No renderer packages installed (isaaclab_physx).",
+        allow_module_level=True,
+    )
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.parametrize("renderer_cfg_cls", _RENDERER_CFG_PARAMS)
+@pytest.mark.isaacsim_ci
+def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians(renderer_cfg_cls, device):
+    """Wrapper PPISP via ``isaac_rtx`` must show every PPISP-feature signature.
+
+    Renders a synthetic RGBW gaussian grid through ``isaac_rtx`` + the aggressive
+    wrapper PPISP cfg and asserts (via :func:`assert_ppisp_invariants`):
+
+    1. **Non-degenerate frame** — content is rendered (not pure black / pure white).
+    2. **Vignetting** — each corner patch mean is meaningfully below the center mean.
+    3. **Exposure** — center patch is bright (the +2 stop boost lifts the gaussian
+       colors well into the upper half of the 0-255 range).
+    4. **CRF clamping** — output stays in [0, 255] with no overflow.
+    """
+    with tempfile.TemporaryDirectory(prefix="isaaclab-synth-gauss-") as tmpdir:
+        asset_path = make_synthetic_gaussian_usd(f"{tmpdir}/synthetic_gaussians.usda")
+        output = render_synthetic_gaussian_scene(
+            asset_path,
+            sim_cfg=_isaac_rtx_sim_cfg(device),
+            renderer_cfg=renderer_cfg_cls(),
+            data_types=["rgb", "rgb_hdr"],
+            sim_dt=SIM_DT,
+            responsivity=ISAAC_RTX_RESPONSIVITY,
+        )
+    assert_ppisp_lifts_exposure(output["rgb_hdr"][0], output["rgb"][0], label="isaac_rtx")
+    assert_ppisp_invariants(output["rgb"][0], label="isaac_rtx")
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.parametrize("renderer_cfg_cls", _RENDERER_CFG_PARAMS)
+@pytest.mark.isaacsim_ci
+def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_multitile(renderer_cfg_cls, device):
+    """Multi-tile wrapper PPISP via ``isaac_rtx`` must hold the same invariants
+    independently for every tile.
+
+    Builds an :class:`InteractiveScene` with :data:`MULTI_TILE_COUNT` envs so
+    the camera regex resolves to one camera per env;
+    :attr:`Camera.data.output["rgb"]` then carries one frame per matched camera
+    and each tile is asserted independently.
+    """
+    with tempfile.TemporaryDirectory(prefix="isaaclab-synth-gauss-") as tmpdir:
+        asset_path = make_synthetic_gaussian_usd(f"{tmpdir}/synthetic_gaussians.usda")
+        output = render_synthetic_gaussian_scene(
+            asset_path,
+            sim_cfg=_isaac_rtx_sim_cfg(device),
+            renderer_cfg=renderer_cfg_cls(),
+            data_types=["rgb", "rgb_hdr"],
+            num_envs=MULTI_TILE_COUNT,
+            sim_dt=SIM_DT,
+            responsivity=ISAAC_RTX_RESPONSIVITY,
+        )
+
+    rgb = output["rgb"]
+    rgb_hdr = output["rgb_hdr"]
+    assert rgb.shape[0] == MULTI_TILE_COUNT, (
+        f"Expected {MULTI_TILE_COUNT} tiles, got shape={tuple(rgb.shape)}. "
+        f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
+    )
+    for i in range(MULTI_TILE_COUNT):
+        assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"isaac_rtx tile {i}")
+        assert_ppisp_invariants(rgb[i], label=f"isaac_rtx tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_newton.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_newton.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Validate the camera ISP wrapper applied to a 3D Gaussian (NuRec /
+ParticleField) scene through the Newton (warp) renderer.
+
+The scene is synthesised at test time by :mod:`generate_synthetic_gaussian_asset`
+and rendered via :func:`generate_synthetic_gaussian_asset.render_synthetic_gaussian_scene`.
+The aggressive wrapper ISP cfg
+(:func:`generate_synthetic_gaussian_asset.make_aggressive_ppisp_cfg`) engages every
+ISP feature past its subtle-correction defaults so the integration test can
+check semantic invariants — vignetting darkens corners, exposure increases
+mean, CRF clamps output to [0, 255] — without needing to do a fidelity
+comparison against a baked-SH reference.
+
+Newton's Warp ray tracer is not physically based, so absolute brightness for
+the same scene differs from RTX-backed renderers, but the ISP-side signatures
+(vignetting falloff ratio, no overflow, etc.) are renderer-agnostic and the
+same thresholds apply.
+
+Notes:
+  * Uses ``InteractiveScene`` because ``newton_warp`` requires
+    ``/World/envs/env_0/...`` and a Newton model owned by ``NewtonManager``;
+    bare ``create_prim`` won't populate either.
+  * The shared helper adds an invisible rigid-body anchor under env_0 because
+    Newton fails to build a model when the scene has no rigid bodies (just
+    ParticleField).
+"""
+
+import importlib.util
+
+import pytest
+
+_REQUIRED_MODULES = ("isaaclab_newton", "newton")
+_MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
+_SKIP_MISSING_NEWTON = pytest.mark.skipif(
+    bool(_MISSING_MODULES),
+    reason=f"requires optional modules: {', '.join(_MISSING_MODULES)}",
+)
+
+if not _MISSING_MODULES:
+    # Launch Isaac Sim before importing modules that depend on an active app.
+
+    from isaaclab.app import AppLauncher  # noqa: E402
+
+    simulation_app = AppLauncher(headless=True, enable_cameras=True).app
+
+    import tempfile  # noqa: E402
+
+    from generate_synthetic_gaussian_asset import (  # noqa: E402
+        SYNTHETIC_GAUSSIAN_CAMERA_REGEX,
+        assert_ppisp_invariants,
+        assert_ppisp_lifts_exposure,
+        make_synthetic_gaussian_usd,
+        render_synthetic_gaussian_scene,
+    )
+    from isaaclab_newton.physics.mjwarp_manager_cfg import MJWarpSolverCfg  # noqa: E402
+    from isaaclab_newton.physics.newton_manager_cfg import NewtonCfg  # noqa: E402
+    from isaaclab_newton.renderers import NewtonWarpRendererCfg  # noqa: E402
+
+    from isaaclab.sim import SimulationCfg  # noqa: E402
+else:
+    tempfile = None
+    SYNTHETIC_GAUSSIAN_CAMERA_REGEX = None
+    assert_ppisp_invariants = None
+    assert_ppisp_lifts_exposure = None
+    make_synthetic_gaussian_usd = None
+    render_synthetic_gaussian_scene = None
+    SimulationCfg = None
+    MJWarpSolverCfg = None
+    NewtonCfg = None
+    NewtonWarpRendererCfg = None
+
+SIM_DT = 1.0 / 60.0
+MULTI_TILE_COUNT = 4
+
+
+def _newton_sim_cfg(device: str) -> SimulationCfg:
+    return SimulationCfg(
+        dt=SIM_DT,
+        physics=NewtonCfg(solver_cfg=MJWarpSolverCfg(), num_substeps=1),
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.isaacsim_ci
+@_SKIP_MISSING_NEWTON
+def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_newton(device):
+    """Wrapper ISP via ``newton_warp`` must show every ISP-feature signature.
+
+    Renders a synthetic RGBW gaussian grid through Newton's Warp ray tracer
+    plus the aggressive wrapper ISP cfg and asserts the same semantic
+    invariants (via :func:`assert_ppisp_invariants`) as the ovrtx counterpart:
+    vignetting falloff, exposure-boosted center, output bounded in [0, 255].
+    """
+    with tempfile.TemporaryDirectory(prefix="isaaclab-synth-gauss-") as tmpdir:
+        asset_path = make_synthetic_gaussian_usd(f"{tmpdir}/synthetic_gaussians.usda")
+        output = render_synthetic_gaussian_scene(
+            asset_path,
+            sim_cfg=_newton_sim_cfg(device),
+            renderer_cfg=NewtonWarpRendererCfg(),
+            data_types=["rgb", "rgb_hdr"],
+            sim_dt=SIM_DT,
+            # Newton's emissive HDR is ~50x lower than the RTX backends' for
+            # the same scene; lift the effective signal so the aggressive cfg
+            # (tuned for the RTX scale) lands in the same LDR range.
+            responsivity=50.0,
+        )
+    assert_ppisp_lifts_exposure(output["rgb_hdr"][0], output["rgb"][0], label="newton_warp")
+    assert_ppisp_invariants(output["rgb"][0], label="newton_warp")
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.isaacsim_ci
+@_SKIP_MISSING_NEWTON
+def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_newton_multitile(device):
+    """Multi-tile wrapper ISP via ``newton_warp`` must hold the same invariants
+    independently for every tile.
+
+    Builds an :class:`InteractiveScene` with :data:`MULTI_TILE_COUNT` envs so
+    the camera regex resolves to one camera per env;
+    :attr:`Camera.data.output["rgb"]` then carries one frame per matched
+    camera and each is asserted independently.
+    """
+    with tempfile.TemporaryDirectory(prefix="isaaclab-synth-gauss-") as tmpdir:
+        asset_path = make_synthetic_gaussian_usd(f"{tmpdir}/synthetic_gaussians.usda")
+        output = render_synthetic_gaussian_scene(
+            asset_path,
+            sim_cfg=_newton_sim_cfg(device),
+            renderer_cfg=NewtonWarpRendererCfg(),
+            data_types=["rgb", "rgb_hdr"],
+            num_envs=MULTI_TILE_COUNT,
+            sim_dt=SIM_DT,
+            responsivity=50.0,
+        )
+
+    rgb = output["rgb"]
+    rgb_hdr = output["rgb_hdr"]
+    assert rgb.shape[0] == MULTI_TILE_COUNT, (
+        f"Expected {MULTI_TILE_COUNT} tiles, got shape={tuple(rgb.shape)}. "
+        f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
+    )
+    for i in range(MULTI_TILE_COUNT):
+        assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"newton_warp tile {i}")
+        assert_ppisp_invariants(rgb[i], label=f"newton_warp tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Validate the camera ISP wrapper applied to a 3D Gaussian (NuRec /
+ParticleField) scene through the ``ovrtx`` renderer.
+
+The asset is synthesised at test time by :mod:`generate_synthetic_gaussian_asset`
+and rendered via :func:`generate_synthetic_gaussian_asset.render_synthetic_gaussian_scene`.
+The aggressive wrapper ISP cfg
+(:func:`generate_synthetic_gaussian_asset.make_aggressive_ppisp_cfg`) intentionally
+engages every feature past its subtle-correction defaults so each can be
+asserted independently:
+
+* **Exposure** offset of +2 stops (input ×4).
+* **Vignetting** with ``alpha1 = -1.5`` per channel — corners attenuate to
+  ~25-40% of center.
+* **Color homography** that shifts red and green chromaticity anchors.
+* **CRF** with stronger shoulder than default — saturated input compresses
+  rather than clips.
+
+The integration test checks *semantic invariants* of the ISP pipeline
+(vignetting darkens corners, exposure increases mean, no overflow above 255)
+instead of a fidelity-against-baked comparison, which would have to absorb
+renderer-internal HDR-magnitude calibration drift between renderers.
+
+Notes:
+  * Runs **kit-less**: this test does not call
+    :class:`~isaaclab.app.AppLauncher`. ``ovrtx`` and Isaac Sim Kit ship the
+    same RTX hydra libraries (``librtx.hydra.so``, ``liblegacy.hydra.so``)
+    under conflicting USD namespaces; loading both into the same process
+    causes a dynamic-linker crash. See
+    :func:`isaaclab_tasks.utils.sim_launcher.launch_simulation` for the
+    documented incompatibility.
+  * Uses Newton physics because ``ovrtx`` is incompatible with Kit/Isaac Sim
+    and the PhysX backend requires Kit (``carb``) to bootstrap.
+  * Requests ``"rgb_hdr"`` in ``data_types`` because
+    ``isaaclab_ov.get_render_var_configs`` only authors ``HdrColor`` when
+    ``"rgb_hdr"`` is in ``data_types``; in kit-less mode there is no
+    Replicator AnnotatorRegistry to auto-add it.
+"""
+
+import importlib.util
+import tempfile
+
+import pytest
+from generate_synthetic_gaussian_asset import (
+    SYNTHETIC_GAUSSIAN_CAMERA_REGEX,
+    assert_ppisp_invariants,
+    assert_ppisp_lifts_exposure,
+    make_synthetic_gaussian_usd,
+    render_synthetic_gaussian_scene,
+)
+
+from isaaclab.sim import SimulationCfg
+
+# OVRTX renderer + Newton physics are required (kit-less + non-PhysX). Use a
+# collection-time skip marker instead of module-level ``importorskip`` so CI's
+# per-file runner does not see pytest's "no tests collected" exit code.
+_REQUIRED_MODULES = ("isaaclab_ov", "ovrtx", "isaaclab_newton")
+_MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
+_SKIP_MISSING_OVRTX = pytest.mark.skipif(
+    bool(_MISSING_MODULES),
+    reason=f"requires optional modules: {', '.join(_MISSING_MODULES)}",
+)
+
+if not _MISSING_MODULES:
+    from isaaclab_newton.physics.mjwarp_manager_cfg import MJWarpSolverCfg  # noqa: E402
+    from isaaclab_newton.physics.newton_manager_cfg import NewtonCfg  # noqa: E402
+    from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
+else:
+    MJWarpSolverCfg = None
+    NewtonCfg = None
+    OVRTXRendererCfg = None
+
+SIM_DT = 1.0 / 60.0
+MULTI_TILE_COUNT = 4
+
+# Mark the gaussian-on-OVRTX tests xfail by default: the wrapper-side
+# ``carb.settings.set_bool`` call that disables RTX-side tonemapping is a
+# no-op for the kit-less ovrtx backend, and the equivalent must be applied
+# externally before launching pytest.
+_XFAIL_OVRTX_GAUSSIAN_PPISP = pytest.mark.xfail(
+    reason=(
+        "kit-less ovrtx cannot toggle RTX-side tonemapping at runtime; the equivalent must be "
+        "applied externally before launching pytest"
+    ),
+    strict=False,
+)
+
+
+def _ovrtx_sim_cfg(device: str) -> SimulationCfg:
+    return SimulationCfg(
+        dt=SIM_DT,
+        physics=NewtonCfg(solver_cfg=MJWarpSolverCfg(), num_substeps=1),
+        device=device,
+    )
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.isaacsim_ci
+@_SKIP_MISSING_OVRTX
+@_XFAIL_OVRTX_GAUSSIAN_PPISP
+def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_ovrtx(device):
+    """Wrapper ISP via ``ovrtx`` must show every ISP-feature signature.
+
+    Renders a synthetic RGBW gaussian grid through ``ovrtx`` plus the
+    aggressive wrapper ISP cfg and asserts (via :func:`assert_ppisp_invariants`):
+
+    1. **Non-degenerate frame** — content is rendered (not pure black / pure white).
+    2. **Vignetting** — each corner patch mean is meaningfully below the center patch mean.
+    3. **Exposure** — center patch is bright (the +2 stop boost lifts the
+       gaussian colors well into the upper half of the 0-255 range).
+    4. **CRF clamping** — no value exceeds 255 (kernel ``wp.clamp`` plus CRF
+       compression keeps the output bounded).
+    """
+    with tempfile.TemporaryDirectory(prefix="isaaclab-synth-gauss-") as tmpdir:
+        asset_path = make_synthetic_gaussian_usd(f"{tmpdir}/synthetic_gaussians.usda")
+        output = render_synthetic_gaussian_scene(
+            asset_path,
+            sim_cfg=_ovrtx_sim_cfg(device),
+            renderer_cfg=OVRTXRendererCfg(),
+            data_types=["rgb", "rgb_hdr"],
+            sim_dt=SIM_DT,
+        )
+    assert_ppisp_lifts_exposure(output["rgb_hdr"][0], output["rgb"][0], label="ovrtx")
+    assert_ppisp_invariants(output["rgb"][0], label="ovrtx")
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.isaacsim_ci
+@_SKIP_MISSING_OVRTX
+@_XFAIL_OVRTX_GAUSSIAN_PPISP
+def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_ovrtx_multitile(device):
+    """Multi-tile wrapper ISP via ``ovrtx`` must hold the same invariants
+    independently for every tile.
+
+    Builds an :class:`InteractiveScene` with :data:`MULTI_TILE_COUNT` envs so
+    the camera regex resolves to one camera per env;
+    :attr:`Camera.data.output["rgb"]` then carries one frame per matched
+    camera and each is asserted independently.
+    """
+    with tempfile.TemporaryDirectory(prefix="isaaclab-synth-gauss-") as tmpdir:
+        asset_path = make_synthetic_gaussian_usd(f"{tmpdir}/synthetic_gaussians.usda")
+        output = render_synthetic_gaussian_scene(
+            asset_path,
+            sim_cfg=_ovrtx_sim_cfg(device),
+            renderer_cfg=OVRTXRendererCfg(),
+            data_types=["rgb", "rgb_hdr"],
+            num_envs=MULTI_TILE_COUNT,
+            sim_dt=SIM_DT,
+        )
+
+    rgb = output["rgb"]
+    rgb_hdr = output["rgb_hdr"]
+    assert rgb.shape[0] == MULTI_TILE_COUNT, (
+        f"Expected {MULTI_TILE_COUNT} tiles, got shape={tuple(rgb.shape)}. "
+        f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
+    )
+    for i in range(MULTI_TILE_COUNT):
+        assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"ovrtx tile {i}")
+        assert_ppisp_invariants(rgb[i], label=f"ovrtx tile {i}")

--- a/source/isaaclab_newton/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
+++ b/source/isaaclab_newton/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added an HDR output (:attr:`~isaaclab.renderers.RenderBufferKind.RGB_HDR`) to :class:`~isaaclab_newton.renderers.NewtonWarpRenderer`, sourced from its native scene-linear color buffer.
+* Added internal :class:`~isaaclab.renderers.PpispPipeline` composition in :class:`~isaaclab_newton.renderers.NewtonWarpRenderer`: when :attr:`~isaaclab.sensors.camera.CameraCfg.isp_cfg` is set the renderer allocates its own HDR scratch tensor and dispatches the PPISP kernel into the camera's ``rgb`` / ``rgba`` output after each render.

--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -13,6 +13,7 @@ keywords = ["robotics", "simulation", "newton"]
 
 [dependencies]
 "isaaclab" = {}
+"isaaclab_ppisp" = {}
 
 [core]
 reloadable = false

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -24,6 +24,8 @@ from ..physics.newton_manager import NewtonManager
 from .newton_warp_renderer_cfg import NewtonWarpRendererCfg
 
 if TYPE_CHECKING:
+    from isaaclab_ppisp import PpispPipeline
+
     from isaaclab.sensors.camera.camera_data import CameraData
     from isaaclab.utils.warp import ProxyArray
 
@@ -39,6 +41,7 @@ class RenderData:
     # but the Newton sensor API consumes it as (world_count,1,H,W) uint32 (same bytes, packed view).
     _OUTPUT_MAP: dict[str, tuple[str, type]] = {
         str(RenderBufferKind.RGBA): ("color_image", wp.uint32),
+        str(RenderBufferKind.RGB_HDR): ("hdr_color_image", wp.vec3f),
         str(RenderBufferKind.ALBEDO): ("albedo_image", wp.uint32),
         str(RenderBufferKind.DEPTH): ("depth_image", wp.float32),
         str(RenderBufferKind.NORMALS): ("normals_image", wp.vec3f),
@@ -48,6 +51,7 @@ class RenderData:
     @dataclass
     class CameraOutputs:
         color_image: wp.array(dtype=wp.uint32, ndim=4) = None
+        hdr_color_image: wp.array(dtype=wp.vec3f, ndim=4) = None
         albedo_image: wp.array(dtype=wp.uint32, ndim=4) = None
         depth_image: wp.array(dtype=wp.float32, ndim=4) = None
         normals_image: wp.array(dtype=wp.vec3f, ndim=4) = None
@@ -63,6 +67,24 @@ class RenderData:
         self.outputs = RenderData.CameraOutputs()
         self.width = getattr(spec.cfg, "width", 100)
         self.height = getattr(spec.cfg, "height", 100)
+        # Post-render PPISP pipeline composed when ``spec.cfg.isp_cfg`` is set.
+        # ``isp_cfg`` is already fully normalised by Camera by the time it reaches here.
+        self.ppisp_pipeline: PpispPipeline | None = None
+        if spec.cfg.isp_cfg is not None:
+            from isaaclab_ppisp import PpispPipeline
+
+            self.ppisp_pipeline = PpispPipeline(spec.cfg.isp_cfg)
+        self._hdr_scratch_wp: wp.array | None = None
+        """Internal HDR scratch buffer allocated when PPISP is composed but the
+        user did not request ``"rgb_hdr"`` in ``data_types``. Also exposed to
+        the Newton sensor through :attr:`CameraOutputs.hdr_color_image` as a
+        vec3f reinterpretation of this same backing storage."""
+        self._ppisp_hdr_source: wp.array | None = None
+        """PPISP HDR source bound once in :meth:`set_outputs` from the caller's
+        ``rgb_hdr`` output or :attr:`_hdr_scratch_wp`."""
+        self._ppisp_rgba_dest: wp.array | None = None
+        """PPISP LDR destination bound once in :meth:`set_outputs` from the
+        caller's ``rgba`` output."""
 
     def set_outputs(self, output_data: dict[str, ProxyArray]):
         shape = (self.newton_sensor.model.world_count, self.num_cameras, self.height, self.width)
@@ -79,10 +101,41 @@ class RenderData:
                 field_name,
                 wp.array(ptr=wp_arr.ptr, dtype=dtype, shape=shape, device=wp_arr.device, copy=False),
             )
+        # When PPISP is composed but the user did not request the raw HDR AOV,
+        # allocate an internal HDR scratch buffer and route a vec3f-shaped view
+        # of it as the Newton sensor's ``hdr_color_image`` so the renderer
+        # fills it directly.
+        if self.ppisp_pipeline is not None and self.outputs.hdr_color_image is None:
+            ref_proxy = next(iter(output_data.values()))
+            self._hdr_scratch_wp = wp.zeros(
+                (self.newton_sensor.model.world_count, self.height, self.width, 3),
+                dtype=wp.float32,
+                device=ref_proxy.device,
+            )
+            self.outputs.hdr_color_image = wp.array(
+                ptr=self._hdr_scratch_wp.ptr,
+                dtype=wp.vec3f,
+                shape=shape,
+                device=self._hdr_scratch_wp.device,
+                copy=False,
+            )
+        # Bind the two warp arrays the per-frame PPISP dispatch needs.
+        if self.ppisp_pipeline is not None:
+            if str(RenderBufferKind.RGBA) not in output_data:
+                raise ValueError(
+                    "Newton renderer ISP requires 'rgba' (or 'rgb', which aliases into rgba) as the"
+                    " LDR output destination, but neither was provided. Add 'rgb' or 'rgba' to"
+                    " Camera.cfg.data_types when isp_cfg is set."
+                )
+            hdr_proxy = output_data.get(str(RenderBufferKind.RGB_HDR))
+            self._ppisp_hdr_source = hdr_proxy.warp if hdr_proxy is not None else self._hdr_scratch_wp
+            self._ppisp_rgba_dest = output_data[str(RenderBufferKind.RGBA)].warp
 
     def get_output(self, output_name: str) -> wp.array:
         if output_name == RenderBufferKind.RGBA:
             return self.outputs.color_image
+        elif output_name == RenderBufferKind.RGB_HDR:
+            return self.outputs.hdr_color_image
         elif output_name == RenderBufferKind.ALBEDO:
             return self.outputs.albedo_image
         elif output_name == RenderBufferKind.DEPTH:
@@ -195,11 +248,25 @@ class NewtonWarpRenderer(BaseRenderer):
         return {
             RenderBufferKind.RGBA: RenderBufferSpec(4, wp.uint8),
             RenderBufferKind.RGB: RenderBufferSpec(3, wp.uint8),
+            RenderBufferKind.RGB_HDR: RenderBufferSpec(3, wp.float32),
             RenderBufferKind.ALBEDO: RenderBufferSpec(4, wp.uint8),
             RenderBufferKind.DEPTH: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.NORMALS: RenderBufferSpec(3, wp.float32),
             RenderBufferKind.INSTANCE_SEGMENTATION_FAST: seg_spec,
         }
+
+    def prepare_cameras(self, stage: Any, spec: CameraRenderSpec) -> None:
+        """Resolve the camera's PPISP cfg before rendering.
+
+        :mod:`isaaclab.sensors.camera` does not depend on PPISP; the renderer
+        owns the sentinel-resolution + cfg-normalization step. Newton has no
+        USD-side overrides to author beyond this.
+        """
+        if not spec.camera_prim_paths:
+            return
+        from isaaclab_ppisp import resolve_and_normalize
+
+        spec.cfg.isp_cfg = resolve_and_normalize(spec.cfg.isp_cfg, stage, spec.camera_prim_paths[0])
 
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """No-op for Newton Warp - uses Newton scene directly without stage export.
@@ -248,6 +315,7 @@ class NewtonWarpRenderer(BaseRenderer):
             render_data.camera_transforms,
             render_data.camera_rays,
             color_image=render_data.outputs.color_image,
+            hdr_color_image=render_data.outputs.hdr_color_image,
             albedo_image=render_data.outputs.albedo_image,
             depth_image=render_data.outputs.depth_image,
             normal_image=render_data.outputs.normals_image,
@@ -255,6 +323,14 @@ class NewtonWarpRenderer(BaseRenderer):
             # ARGB 93% gray to improve visibility of dark objects and align with RTX renderer background
             clear_data=newton.sensors.SensorTiledCamera.ClearData(clear_color=0xFFEEEEEE),
         )
+
+        # Post-render PPISP: HDR scene-linear → LDR RGBA. Source/destination
+        # tensors were bound once in ``set_outputs``.
+        if render_data.ppisp_pipeline is not None:
+            render_data.ppisp_pipeline.apply(
+                render_data._ppisp_hdr_source,
+                render_data._ppisp_rgba_dest,
+            )
 
     def read_output(self, render_data: RenderData, camera_data: CameraData) -> None:
         """Copy rendered outputs to the camera data buffers.

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -33,7 +33,7 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 # Read the extension.toml file
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
-INSTALL_REQUIRES = []
+INSTALL_REQUIRES = ["isaaclab_ppisp"]
 
 EXTRAS_REQUIRE = {
     "all": [

--- a/source/isaaclab_ov/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
+++ b/source/isaaclab_ov/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added an HDR output (:attr:`~isaaclab.renderers.RenderBufferKind.RGB_HDR`) to :class:`~isaaclab_ov.renderers.OVRTXRenderer`, sourced from the OVRTX HDR render var.
+* Added internal :class:`~isaaclab.renderers.PpispPipeline` composition in :class:`~isaaclab_ov.renderers.OVRTXRenderer`: when :attr:`~isaaclab.sensors.camera.CameraCfg.isp_cfg` is set the renderer allocates its own HDR scratch tensor and dispatches the PPISP kernel into the camera's ``rgb`` / ``rgba`` output after each render.
+* Added a :meth:`~isaaclab.renderers.BaseRenderer.prepare_cameras` override on :class:`~isaaclab_ov.renderers.OVRTXRenderer` that authors a neutral ``OmniRtxCameraExposureAPI_1`` schema on each camera prim so RTX-side tonemapping does not double-process the ISP output.

--- a/source/isaaclab_ov/config/extension.toml
+++ b/source/isaaclab_ov/config/extension.toml
@@ -9,3 +9,4 @@ keywords = ["robotics", "simulation", "rendering", "ovrtx", "omniverse"]
 
 [dependencies]
 "isaaclab" = {}
+"isaaclab_ppisp" = {}

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -53,6 +53,8 @@ from .ovrtx_renderer_kernels import (
     create_camera_transforms_kernel,
     extract_all_depth_tiles_kernel,
     extract_all_depth_tiles_kernel_legacy,
+    extract_all_rgb_float_tiles_kernel,
+    extract_all_rgb_half_tiles_kernel,
     extract_all_rgba_tiles_kernel,
     generate_random_colors_from_ids_kernel,
     generate_random_colors_from_ids_kernel_legacy,
@@ -65,6 +67,8 @@ from .ovrtx_usd import (
 )
 
 if TYPE_CHECKING:
+    from isaaclab_ppisp import PpispPipeline
+
     from isaaclab.sensors.camera.camera_data import CameraData
     from isaaclab.utils.warp import ProxyArray
 
@@ -123,6 +127,13 @@ class OVRTXRenderData:
         self.num_cols = math.ceil(math.sqrt(self.num_envs))
         self.num_rows = math.ceil(self.num_envs / self.num_cols)
         self.warp_buffers: dict[str, wp.array] = {}
+        # Post-render PPISP pipeline composed when ``spec.cfg.isp_cfg`` is set.
+        # ``isp_cfg`` is already fully normalised by the time it reaches here (Camera does it).
+        self.ppisp_pipeline: PpispPipeline | None = None
+        if spec.cfg.isp_cfg is not None:
+            from isaaclab_ppisp import PpispPipeline
+
+            self.ppisp_pipeline = PpispPipeline(spec.cfg.isp_cfg)
 
 
 class OVRTXRenderer(BaseRenderer):
@@ -140,6 +151,7 @@ class OVRTXRenderer(BaseRenderer):
         return {
             RenderBufferKind.RGBA: RenderBufferSpec(4, wp.uint8),
             RenderBufferKind.RGB: RenderBufferSpec(3, wp.uint8),
+            RenderBufferKind.RGB_HDR: RenderBufferSpec(3, wp.float32),
             RenderBufferKind.ALBEDO: RenderBufferSpec(4, wp.uint8),
             RenderBufferKind.SIMPLE_SHADING_CONSTANT_DIFFUSE: RenderBufferSpec(3, wp.uint8),
             RenderBufferKind.SIMPLE_SHADING_DIFFUSE_MDL: RenderBufferSpec(3, wp.uint8),
@@ -192,6 +204,25 @@ class OVRTXRenderer(BaseRenderer):
             )
         logger.info("OVRTX renderer created successfully")
 
+    def prepare_cameras(self, stage: Any, spec: CameraRenderSpec) -> None:
+        """Resolve the camera's PPISP cfg and apply OVRTX-specific USD overrides.
+
+        First resolves ``spec.cfg.isp_cfg`` (sentinel discovery + normalization)
+        via :func:`isaaclab_ppisp.resolve_and_normalize` so :mod:`isaaclab` does
+        not need to know about PPISP. Then, when an ISP is configured, pins
+        ``exposure:*`` to neutral and applies ``OmniRtxCameraExposureAPI_1`` so
+        the RTX exposure model OVRTX embeds does not compound on top of the
+        ISP. Without an ISP, the camera prim's authored exposure is left alone.
+        """
+        if not spec.camera_prim_paths:
+            return
+        from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+
+        spec.cfg.isp_cfg = resolve_and_normalize(spec.cfg.isp_cfg, stage, spec.camera_prim_paths[0])
+        if spec.cfg.isp_cfg is None:
+            return
+        apply_rtx_exposure_overrides(stage, list(spec.camera_prim_paths))
+
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """Prepare the USD stage for OVRTX before :meth:`create_render_data`.
 
@@ -216,6 +247,8 @@ class OVRTXRenderer(BaseRenderer):
         height = spec.cfg.height
         num_envs = spec.num_instances
         data_types = spec.cfg.data_types if spec.cfg.data_types else ["rgb"]
+        if spec.cfg.isp_cfg is not None and "rgb_hdr" not in data_types:
+            data_types = [*data_types, "rgb_hdr"]
 
         env_0_prefix = "/World/envs/env_0/"
         first_cam_path = spec.camera_prim_paths[0]
@@ -416,6 +449,23 @@ class OVRTXRenderer(BaseRenderer):
         render_data.warp_buffers = {
             name: proxy.warp for name, proxy in output_data.items() if name != str(RenderBufferKind.RGB)
         }
+        # When PPISP is composed but the user did not request the raw HDR AOV,
+        # allocate an internal HDR scratch buffer under "rgb_hdr" so both the
+        # HdrColor extractor and PPISP dispatch can use the same buffer map.
+        if render_data.ppisp_pipeline is not None and str(RenderBufferKind.RGB_HDR) not in render_data.warp_buffers:
+            ref_proxy = next(iter(output_data.values()))
+            render_data.warp_buffers[str(RenderBufferKind.RGB_HDR)] = wp.zeros(
+                (render_data.num_envs, render_data.height, render_data.width, 3),
+                dtype=wp.float32,
+                device=ref_proxy.device,
+            )
+        if render_data.ppisp_pipeline is not None:
+            if str(RenderBufferKind.RGBA) not in render_data.warp_buffers:
+                raise ValueError(
+                    "OVRTX renderer ISP requires 'rgba' (or 'rgb', which aliases into rgba) as the"
+                    " LDR output destination, but neither was provided. Add 'rgb' or 'rgba' to"
+                    " Camera.cfg.data_types when isp_cfg is set."
+                )
 
     def update_transforms(self) -> None:
         """Sync physics objects to OVRTX."""
@@ -556,12 +606,54 @@ class OVRTXRenderer(BaseRenderer):
                     device=self._device,
                 )
 
+    def _extract_hdr_color_tiles(
+        self, render_data: OVRTXRenderData, tiled_data: wp.array, output_buffers: dict
+    ) -> None:
+        """Extract per-env HdrColor tiles into output_buffers."""
+        if "rgb_hdr" not in output_buffers:
+            return
+        if tiled_data.dtype == wp.float16:
+            kernel = extract_all_rgb_half_tiles_kernel
+        elif tiled_data.dtype == wp.float32:
+            kernel = extract_all_rgb_float_tiles_kernel
+        else:
+            raise TypeError(f"Unsupported OVRTX HdrColor dtype: {tiled_data.dtype}.")
+        wp.launch(
+            kernel=kernel,
+            dim=(render_data.num_envs, render_data.height, render_data.width),
+            inputs=[
+                tiled_data,
+                output_buffers["rgb_hdr"],
+                render_data.num_cols,
+                render_data.width,
+                render_data.height,
+            ],
+            device=self._device,
+        )
+
+    def _prepare_ppisp_hdr_source(
+        self, render_data: OVRTXRenderData, tiled_data: wp.array, output_buffers: dict
+    ) -> wp.array:
+        """Return the PPISP HdrColor source on the output buffer device."""
+        if render_data.ppisp_pipeline is None:
+            return tiled_data
+
+        output_device = str(output_buffers[str(RenderBufferKind.RGB_HDR)].device)
+        if str(tiled_data.device) == output_device:
+            return tiled_data
+
+        # FIXME: OVRTX render var mapping can select a different CUDA device
+        # than the camera/output buffers on MGPU systems. Keep this PPISP-only
+        # bridge until render var mapping can be constrained like transform
+        # bindings, which use ``device_id=self._device_id``.
+        return wp.clone(tiled_data, device=output_device)
+
     def _process_render_frame(self, render_data: OVRTXRenderData, frame, output_buffers: dict) -> None:
         """Extract RGB, depth, albedo, and semantic from a single render frame into output_buffers."""
         if "LdrColor" in frame.render_vars:
             buffer_key = None
 
-            if "rgba" in output_buffers:
+            if render_data.ppisp_pipeline is None and "rgba" in output_buffers:
                 buffer_key = "rgba"
             else:
                 # The output buffers must contain only one simple shading data type at most after resolution of the data
@@ -592,6 +684,12 @@ class OVRTXRenderer(BaseRenderer):
             with frame.render_vars["DiffuseAlbedoSD"].map(device=Device.CUDA) as mapping:
                 tiled_albedo_data = wp.from_dlpack(mapping.tensor)
                 self._extract_rgba_tiles(render_data, tiled_albedo_data, output_buffers, "albedo", suffix="albedo")
+
+        if "HdrColor" in frame.render_vars and "rgb_hdr" in output_buffers:
+            with frame.render_vars["HdrColor"].map(device=Device.CUDA) as mapping:
+                tiled_hdr_data = wp.from_dlpack(mapping.tensor)
+                tiled_hdr_data = self._prepare_ppisp_hdr_source(render_data, tiled_hdr_data, output_buffers)
+                self._extract_hdr_color_tiles(render_data, tiled_hdr_data, output_buffers)
 
         if "SemanticSegmentation" in frame.render_vars and "semantic_segmentation" in output_buffers:
             with frame.render_vars["SemanticSegmentation"].map(device=Device.CUDA) as mapping:
@@ -634,6 +732,14 @@ class OVRTXRenderer(BaseRenderer):
                     render_data,
                     products[product_path].frames[0],
                     render_data.warp_buffers,
+                )
+
+            # Post-render PPISP: HDR scene-linear → LDR RGBA. Source/destination
+            # buffers are the same warp buffer map used by extraction.
+            if render_data.ppisp_pipeline is not None:
+                render_data.ppisp_pipeline.apply(
+                    render_data.warp_buffers[str(RenderBufferKind.RGB_HDR)],
+                    render_data.warp_buffers[str(RenderBufferKind.RGBA)],
                 )
         except Exception as e:
             logger.warning("OVRTX rendering failed: %s", e, exc_info=True)

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
@@ -108,6 +108,44 @@ def extract_all_rgba_tiles_kernel(
 
 
 @wp.kernel
+def extract_all_rgb_float_tiles_kernel(
+    tiled_buffer: wp.array(dtype=wp.float32, ndim=3),  # type: ignore
+    output_buffer: wp.array(dtype=wp.float32, ndim=4),  # type: ignore  (num_envs, H, W, 3)
+    num_cols: int,
+    tile_width: int,
+    tile_height: int,
+):
+    """Extract ALL RGB float tiles from a tiled buffer in a single kernel launch."""
+    env_idx, y, x = wp.tid()
+    tile_x = env_idx % num_cols
+    tile_y = env_idx // num_cols
+    src_x = tile_x * tile_width + x
+    src_y = tile_y * tile_height + y
+    output_buffer[env_idx, y, x, 0] = tiled_buffer[src_y, src_x, 0]
+    output_buffer[env_idx, y, x, 1] = tiled_buffer[src_y, src_x, 1]
+    output_buffer[env_idx, y, x, 2] = tiled_buffer[src_y, src_x, 2]
+
+
+@wp.kernel
+def extract_all_rgb_half_tiles_kernel(
+    tiled_buffer: wp.array(dtype=wp.float16, ndim=3),  # type: ignore
+    output_buffer: wp.array(dtype=wp.float32, ndim=4),  # type: ignore  (num_envs, H, W, 3)
+    num_cols: int,
+    tile_width: int,
+    tile_height: int,
+):
+    """Extract ALL RGB half tiles into float32 output in a single kernel launch."""
+    env_idx, y, x = wp.tid()
+    tile_x = env_idx % num_cols
+    tile_y = env_idx // num_cols
+    src_x = tile_x * tile_width + x
+    src_y = tile_y * tile_height + y
+    output_buffer[env_idx, y, x, 0] = wp.float32(tiled_buffer[src_y, src_x, 0])
+    output_buffer[env_idx, y, x, 1] = wp.float32(tiled_buffer[src_y, src_x, 1])
+    output_buffer[env_idx, y, x, 2] = wp.float32(tiled_buffer[src_y, src_x, 2])
+
+
+@wp.kernel
 def extract_all_depth_tiles_kernel_legacy(
     tiled_buffer: wp.array(dtype=wp.float32, ndim=2),  # type: ignore
     output_buffer: wp.array(dtype=wp.float32, ndim=4),  # type: ignore

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -19,6 +19,7 @@ def get_render_var_config(data_types: list[str]) -> tuple[str, str, str]:
     use_albedo = "albedo" in data_types
     use_semantic = "semantic_segmentation" in data_types
     use_rgb = any(dt in ["rgb", "rgba"] for dt in data_types)
+    use_hdr = "rgb_hdr" in data_types
 
     if use_depth and not (use_rgb or use_albedo or use_semantic):
         return "/Render/Vars/depth", "depth", "DistanceToImagePlaneSD"
@@ -26,7 +27,26 @@ def get_render_var_config(data_types: list[str]) -> tuple[str, str, str]:
         return "/Render/Vars/albedo", "albedo", "DiffuseAlbedoSD"
     if use_semantic and not (use_rgb or use_albedo):
         return "/Render/Vars/semantic", "semantic", "SemanticSegmentation"
+    if use_hdr and not use_rgb:
+        return "/Render/Vars/HdrColor", "HdrColor", "HdrColor"
     return "/Render/Vars/LdrColor", "LdrColor", "LdrColor"
+
+
+def get_render_var_configs(data_types: list[str]) -> list[tuple[str, str, str]]:
+    """Return render var configs needed for the requested data types.
+
+    Returns the single render var resolved by :func:`get_render_var_config`,
+    plus ``HdrColor`` when both ``"rgb"`` (or ``"rgba"``) and ``"rgb_hdr"`` are
+    in ``data_types`` so PPISP can consume the HDR AOV alongside the LDR
+    destination on the same render product. Other multi-AOV combinations are
+    not supported.
+    """
+    data_types = data_types if data_types else ["rgb"]
+    render_vars: list[tuple[str, str, str]] = [get_render_var_config(data_types)]
+    use_rgb = any(dt in ["rgb", "rgba"] for dt in data_types)
+    if use_rgb and "rgb_hdr" in data_types:
+        render_vars.append(("/Render/Vars/HdrColor", "HdrColor", "HdrColor"))
+    return render_vars
 
 
 def build_render_scope_usd(
@@ -38,6 +58,7 @@ def build_render_scope_usd(
     tiled_width: int,
     tiled_height: int,
     minimal_mode: int | None = None,
+    render_var_configs: list[tuple[str, str, str]] | None = None,
 ) -> str:
     """Build the Render scope USD string (def Scope Render, RenderProduct, Vars).
 
@@ -50,6 +71,7 @@ def build_render_scope_usd(
         tiled_width: Width of the tiled image.
         tiled_height: Height of the tiled image.
         minimal_mode: RTX minimal mode. None if not requested. Valid values are 1, 2, 3.
+        render_var_configs: Render variables to author. Uses the single render var arguments if not provided.
 
     Returns:
         The USD string for the render scope.
@@ -65,6 +87,16 @@ def build_render_scope_usd(
         ]
 
     render_mode_block = "\n        ".join(render_mode_lines)
+    if render_var_configs is None:
+        render_var_configs = [(render_var_path, render_var_name, source_name)]
+    ordered_vars = ", ".join(f"<{path}>" for path, _, _ in render_var_configs)
+    render_var_defs = "\n".join(
+        f'''        def RenderVar "{name}"
+        {{
+            uniform string sourceName = "{source}"
+        }}'''
+        for _, name, source in render_var_configs
+    )
 
     return f'''
 def Scope "Render"
@@ -77,16 +109,13 @@ def Scope "Render"
         float omni:rtx:rt:ambientLight:intensity = 1.0
         {render_mode_block}
         token[] omni:rtx:waitForEvents = ["AllLoadingFinished", "OnlyOnFirstRequest"]
-        rel orderedVars = <{render_var_path}>
+        rel orderedVars = [{ordered_vars}]
         uniform int2 resolution = ({tiled_width}, {tiled_height})
     }}
 
     def "Vars"
     {{
-        def RenderVar "{render_var_name}"
-        {{
-            uniform string sourceName = "{source_name}"
-        }}
+{render_var_defs}
     }}
 }}
 '''
@@ -129,7 +158,8 @@ def build_render_product_as_string(
     render_product_name = "RenderProduct"
     render_product_path = f"/Render/{render_product_name}"
 
-    render_var_path, render_var_name, source_name = get_render_var_config(data_types)
+    render_var_configs = get_render_var_configs(data_types)
+    render_var_path, render_var_name, source_name = render_var_configs[0]
 
     camera_content = build_render_scope_usd(
         camera_paths,
@@ -140,6 +170,7 @@ def build_render_product_as_string(
         tiled_width,
         tiled_height,
         minimal_mode,
+        render_var_configs,
     )
     return camera_content, render_product_path
 

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -5,21 +5,34 @@
 
 """Tests for the OVRTX renderer output contract."""
 
+import importlib.util
+
 import pytest
 import torch
 import warp as wp
-
-pytest.importorskip("isaaclab_ov")
-pytest.importorskip("ovrtx")
-
-from isaaclab_ov.renderers import OVRTXRendererCfg
-from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderData, OVRTXRenderer
 
 from isaaclab.sensors.camera import CameraCfg
 from isaaclab.sensors.camera.camera_data import CameraData, RenderBufferKind, RenderBufferSpec
 from isaaclab.sim import PinholeCameraCfg
 
-pytestmark = pytest.mark.isaacsim_ci
+_REQUIRED_MODULES = ("isaaclab_ov", "ovrtx")
+_MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
+
+pytestmark = [
+    pytest.mark.isaacsim_ci,
+    pytest.mark.skipif(
+        bool(_MISSING_MODULES),
+        reason=f"requires optional modules: {', '.join(_MISSING_MODULES)}",
+    ),
+]
+
+if not _MISSING_MODULES:
+    from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
+    from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderData, OVRTXRenderer  # noqa: E402
+else:
+    OVRTXRenderData = None
+    OVRTXRenderer = None
+    OVRTXRendererCfg = None
 
 _SPAWN = PinholeCameraCfg(
     focal_length=24.0,
@@ -41,31 +54,46 @@ def _make_camera_cfg(data_types: list[str]) -> CameraCfg:
 
 def _make_ovrtx_render_data() -> OVRTXRenderData:
     rd = OVRTXRenderData.__new__(OVRTXRenderData)
+    rd.width = 16
+    rd.height = 8
+    rd.num_envs = 2
     rd.warp_buffers = {}
+    rd.ppisp_pipeline = None
     return rd
+
+
+def _make_ovrtx_renderer_without_backend() -> OVRTXRenderer:
+    renderer = OVRTXRenderer.__new__(OVRTXRenderer)
+    renderer.cfg = OVRTXRendererCfg()
+    return renderer
 
 
 def test_ovrtx_supported_output_types_key_set():
     """OVRTX publishes the documented key set and per-output spec."""
-    renderer = OVRTXRenderer(OVRTXRendererCfg())
+    renderer = _make_ovrtx_renderer_without_backend()
     specs = renderer.supported_output_types()
 
     assert set(specs.keys()) == {
         RenderBufferKind.RGB,
         RenderBufferKind.RGBA,
+        RenderBufferKind.RGB_HDR,
         RenderBufferKind.ALBEDO,
+        RenderBufferKind.SIMPLE_SHADING_CONSTANT_DIFFUSE,
+        RenderBufferKind.SIMPLE_SHADING_DIFFUSE_MDL,
+        RenderBufferKind.SIMPLE_SHADING_FULL_MDL,
         RenderBufferKind.SEMANTIC_SEGMENTATION,
         RenderBufferKind.DEPTH,
         RenderBufferKind.DISTANCE_TO_IMAGE_PLANE,
         RenderBufferKind.DISTANCE_TO_CAMERA,
     }
     assert specs[RenderBufferKind.RGBA] == RenderBufferSpec(4, wp.uint8)
+    assert specs[RenderBufferKind.RGB_HDR] == RenderBufferSpec(3, wp.float32)
     assert specs[RenderBufferKind.DEPTH] == RenderBufferSpec(1, wp.float32)
 
 
 def test_ovrtx_set_outputs_wraps_caller_torch_zero_copy():
     """OVRTXRenderer.set_outputs publishes warp views over the caller's warp storage."""
-    renderer = OVRTXRenderer(OVRTXRendererCfg())
+    renderer = _make_ovrtx_renderer_without_backend()
 
     if not torch.cuda.is_available():
         pytest.skip("OVRTX zero-copy wrapping requires a CUDA device")
@@ -89,13 +117,103 @@ def test_ovrtx_set_outputs_wraps_caller_torch_zero_copy():
     assert "rgb" not in render_data.warp_buffers
 
 
+def test_ovrtx_set_outputs_wraps_requested_rgb_hdr_output():
+    """OVRTXRenderer.set_outputs publishes a zero-copy view for requested RGB_HDR."""
+    renderer = _make_ovrtx_renderer_without_backend()
+
+    if not torch.cuda.is_available():
+        pytest.skip("OVRTX zero-copy wrapping requires a CUDA device")
+    device = "cuda"
+
+    cfg = _make_camera_cfg(["rgb_hdr"])
+    data = CameraData.allocate(
+        data_types=cfg.data_types,
+        height=8,
+        width=16,
+        num_views=2,
+        device=device,
+        supported_specs=renderer.supported_output_types(),
+    )
+    render_data = _make_ovrtx_render_data()
+    renderer.set_outputs(render_data, data.output)
+
+    assert render_data.warp_buffers["rgb_hdr"].ptr == data.output["rgb_hdr"].warp.ptr
+
+
+def test_ovrtx_set_outputs_routes_ppisp_buffers_through_warp_buffers():
+    """OVRTXRenderer.set_outputs stores PPISP source/destination in warp_buffers."""
+    renderer = _make_ovrtx_renderer_without_backend()
+
+    cfg = _make_camera_cfg(["rgb"])
+    data = CameraData.allocate(
+        data_types=cfg.data_types,
+        height=8,
+        width=16,
+        num_views=2,
+        device="cpu",
+        supported_specs=renderer.supported_output_types(),
+    )
+    render_data = _make_ovrtx_render_data()
+    render_data.ppisp_pipeline = object()
+    renderer.set_outputs(render_data, data.output)
+
+    assert render_data.warp_buffers["rgba"].ptr == data.output["rgba"].warp.ptr
+    assert "rgb_hdr" in render_data.warp_buffers
+    assert render_data.warp_buffers["rgb_hdr"].shape == (2, 8, 16, 3)
+    assert render_data.warp_buffers["rgb_hdr"].dtype is wp.float32
+
+
+def test_ovrtx_process_frame_skips_ldr_rgba_when_ppisp_is_active():
+    """PPISP owns RGBA output, so OVRTX LdrColor should not pre-fill it."""
+
+    class FailingRenderVar:
+        def map(self, *args, **kwargs):
+            raise AssertionError("PPISP RGBA output must not read OVRTX LdrColor")
+
+    class Frame:
+        render_vars = {"LdrColor": FailingRenderVar()}
+
+    renderer = _make_ovrtx_renderer_without_backend()
+    render_data = _make_ovrtx_render_data()
+    render_data.ppisp_pipeline = object()
+
+    renderer._process_render_frame(render_data, Frame(), {"rgba": object()})
+
+
+def test_ovrtx_ppisp_hdr_source_is_cloned_to_output_device(monkeypatch):
+    """PPISP HdrColor source is moved to the HDR output buffer device."""
+
+    class FakeArray:
+        device = "cuda:1"
+
+    class OutputArray:
+        device = "cuda:0"
+
+    cloned = object()
+    clone_calls = []
+
+    def fake_clone(src, *, device):
+        clone_calls.append((src, device))
+        return cloned
+
+    monkeypatch.setattr(wp, "clone", fake_clone)
+
+    renderer = _make_ovrtx_renderer_without_backend()
+    render_data = _make_ovrtx_render_data()
+    render_data.ppisp_pipeline = object()
+    source = FakeArray()
+
+    assert renderer._prepare_ppisp_hdr_source(render_data, source, {"rgb_hdr": OutputArray()}) is cloned
+    assert clone_calls == [(source, "cuda:0")]
+
+
 def test_ovrtx_read_output_is_a_no_op_after_consolidation():
     """OVRTXRenderer.read_output is a no-op once set_outputs wires up zero-copy."""
-    renderer = OVRTXRenderer(OVRTXRendererCfg())
+    renderer = _make_ovrtx_renderer_without_backend()
     render_data = _make_ovrtx_render_data()
     camera_data = CameraData()
     camera_data.info = {}
-    camera_data.output = {}
+    camera_data._output = {}
 
     result = renderer.read_output(render_data, camera_data)
     assert result is None

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
@@ -13,6 +13,8 @@ import warp as wp
 from isaaclab_ov.renderers.ovrtx_renderer_kernels import (
     extract_all_depth_tiles_kernel,
     extract_all_depth_tiles_kernel_legacy,
+    extract_all_rgb_float_tiles_kernel,
+    extract_all_rgb_half_tiles_kernel,
     extract_all_rgba_tiles_kernel,
     generate_random_colors_from_ids_kernel,
     generate_random_colors_from_ids_kernel_legacy,
@@ -127,6 +129,28 @@ def _reference_extract_all_rgba_tiles(
                 out[env_idx, y, x, 2] = tiled_np[src_y, src_x, 2]
                 if num_channels == 4:
                     out[env_idx, y, x, 3] = tiled_np[src_y, src_x, 3]
+    return out
+
+
+def _reference_extract_all_rgb_float_tiles(
+    tiled_np: np.ndarray,
+    num_envs: int,
+    num_cols: int,
+    tile_width: int,
+    tile_height: int,
+) -> np.ndarray:
+    """NumPy reference for ``extract_all_rgb_float_tiles_kernel``."""
+    out = np.zeros((num_envs, tile_height, tile_width, 3), dtype=np.float32)
+    for env_idx in range(num_envs):
+        tile_x = env_idx % num_cols
+        tile_y = env_idx // num_cols
+        for y in range(tile_height):
+            for x in range(tile_width):
+                src_y = tile_y * tile_height + y
+                src_x = tile_x * tile_width + x
+                out[env_idx, y, x, 0] = tiled_np[src_y, src_x, 0]
+                out[env_idx, y, x, 1] = tiled_np[src_y, src_x, 1]
+                out[env_idx, y, x, 2] = tiled_np[src_y, src_x, 2]
     return out
 
 
@@ -413,6 +437,68 @@ class TestExtractAllRgbaTilesKernel:
             tiled_np, num_envs, num_cols, tile_width, tile_height, num_channels
         )
         np.testing.assert_array_equal(output_wp.numpy(), expected)
+
+
+class TestExtractAllRgbFloatTilesKernel:
+    """Tests for ``extract_all_rgb_float_tiles_kernel`` used by OVRTX HdrColor."""
+
+    def test_two_by_two_tile_grid(self):
+        num_cols = 2
+        num_envs = 4
+        tile_width = 2
+        tile_height = 3
+        tiled_h = (num_envs // num_cols) * tile_height
+        tiled_w = num_cols * tile_width
+        tiled_np = np.zeros((tiled_h, tiled_w, 3), dtype=np.float32)
+        for h in range(tiled_h):
+            for w in range(tiled_w):
+                tiled_np[h, w, 0] = float(h * 1000 + w)
+                tiled_np[h, w, 1] = float(h * 1000 + w + 100)
+                tiled_np[h, w, 2] = float(h * 1000 + w + 200)
+
+        tiled_wp = wp.array(tiled_np, dtype=wp.float32, ndim=3, device=DEVICE)
+        output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 3), dtype=wp.float32, device=DEVICE)
+
+        wp.launch(
+            kernel=extract_all_rgb_float_tiles_kernel,
+            dim=(num_envs, tile_height, tile_width),
+            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
+            device=DEVICE,
+        )
+        wp.synchronize()
+
+        expected = _reference_extract_all_rgb_float_tiles(tiled_np, num_envs, num_cols, tile_width, tile_height)
+        np.testing.assert_allclose(output_wp.numpy(), expected, rtol=0, atol=0)
+
+    def test_half_input_writes_float_output(self):
+        num_cols = 2
+        num_envs = 4
+        tile_width = 2
+        tile_height = 3
+        tiled_h = (num_envs // num_cols) * tile_height
+        tiled_w = num_cols * tile_width
+        tiled_np = np.zeros((tiled_h, tiled_w, 3), dtype=np.float16)
+        for h in range(tiled_h):
+            for w in range(tiled_w):
+                tiled_np[h, w, 0] = np.float16(h * 10 + w)
+                tiled_np[h, w, 1] = np.float16(h * 10 + w + 0.25)
+                tiled_np[h, w, 2] = np.float16(h * 10 + w + 0.5)
+
+        tiled_wp = wp.array(tiled_np, dtype=wp.float16, ndim=3, device=DEVICE)
+        output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 3), dtype=wp.float32, device=DEVICE)
+
+        wp.launch(
+            kernel=extract_all_rgb_half_tiles_kernel,
+            dim=(num_envs, tile_height, tile_width),
+            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
+            device=DEVICE,
+        )
+        wp.synchronize()
+
+        expected = _reference_extract_all_rgb_float_tiles(
+            tiled_np.astype(np.float32), num_envs, num_cols, tile_width, tile_height
+        )
+        np.testing.assert_allclose(output_wp.numpy(), expected, rtol=0, atol=0)
 
 
 class TestRandomColorsFromIdsKernel:

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for OVRTX USD render product authoring."""
+
+import importlib.util
+
+import pytest
+
+_REQUIRED_MODULES = ("isaaclab_ov", "pxr")
+_MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
+
+pytestmark = [
+    pytest.mark.isaacsim_ci,
+    pytest.mark.skipif(
+        bool(_MISSING_MODULES),
+        reason=f"requires optional modules: {', '.join(_MISSING_MODULES)}",
+    ),
+]
+
+if not _MISSING_MODULES:
+    from isaaclab_ov.renderers.ovrtx_usd import (  # noqa: E402
+        build_render_scope_usd,
+        get_render_var_config,
+        get_render_var_configs,
+    )
+else:
+    build_render_scope_usd = None
+    get_render_var_config = None
+    get_render_var_configs = None
+
+
+def test_ovrtx_rgb_hdr_uses_hdr_color_render_var():
+    """Requesting RGB_HDR from OVRTX selects the HdrColor render variable."""
+    assert get_render_var_config(["rgb_hdr"]) == ("/Render/Vars/HdrColor", "HdrColor", "HdrColor")
+
+
+def test_ovrtx_rgb_and_rgb_hdr_author_both_render_vars():
+    """Requesting LDR RGB and RGB_HDR keeps both OVRTX render variables."""
+    render_var_configs = get_render_var_configs(["rgb", "rgb_hdr"])
+
+    assert render_var_configs == [
+        ("/Render/Vars/LdrColor", "LdrColor", "LdrColor"),
+        ("/Render/Vars/HdrColor", "HdrColor", "HdrColor"),
+    ]
+
+    render_scope = build_render_scope_usd(
+        camera_paths=["/World/envs/env_0/Camera"],
+        render_product_name="RenderProduct",
+        render_var_path=render_var_configs[0][0],
+        render_var_name=render_var_configs[0][1],
+        source_name=render_var_configs[0][2],
+        tiled_width=16,
+        tiled_height=8,
+        render_var_configs=render_var_configs,
+    )
+
+    assert "rel orderedVars = [</Render/Vars/LdrColor>, </Render/Vars/HdrColor>]" in render_scope
+    assert 'def RenderVar "LdrColor"' in render_scope
+    assert 'def RenderVar "HdrColor"' in render_scope

--- a/source/isaaclab_physx/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
+++ b/source/isaaclab_physx/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added an HDR output (:attr:`~isaaclab.renderers.RenderBufferKind.RGB_HDR`) to :class:`~isaaclab_physx.renderers.IsaacRtxRenderer`, sourced from the Replicator ``HdrColor`` annotator.
+* Added internal :class:`~isaaclab.renderers.PpispPipeline` composition in :class:`~isaaclab_physx.renderers.IsaacRtxRenderer`: when :attr:`~isaaclab.sensors.camera.CameraCfg.isp_cfg` is set the renderer allocates its own HDR scratch buffer and dispatches the PPISP kernel into the camera's ``rgb`` / ``rgba`` output after each render.
+* Added a :meth:`~isaaclab.renderers.BaseRenderer.prepare_cameras` override on :class:`~isaaclab_physx.renderers.IsaacRtxRenderer` that authors a neutral ``OmniRtxCameraExposureAPI_1`` schema on each camera prim so RTX-side tonemapping does not double-process the ISP output.

--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -13,6 +13,7 @@ keywords = ["robotics", "simulation", "physx"]
 
 [dependencies]
 "isaaclab" = {}
+"isaaclab_ppisp" = {}
 
 [core]
 reloadable = false

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -31,6 +31,8 @@ from .isaac_rtx_renderer_utils import ensure_isaac_rtx_render_update, ensure_rtx
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from isaaclab_ppisp import PpispPipeline
+
     from isaaclab.sensors.camera.camera_data import CameraData
     from isaaclab.utils.warp import ProxyArray
 
@@ -76,6 +78,12 @@ class IsaacRtxRenderData:
     output_data: dict[str, ProxyArray] | None = None
     spec: CameraRenderSpec | None = None
     renderer_info: dict[str, Any] = field(default_factory=dict)
+    ppisp_pipeline: PpispPipeline | None = None
+    """Post-render PPISP pipeline composed when ``spec.cfg.isp_cfg`` is set."""
+    _hdr_scratch_wp: wp.array | None = None
+    """Internal HDR scratch buffer allocated when the user did not request
+    ``"rgb_hdr"`` in ``data_types`` but the PPISP pipeline still needs
+    somewhere to receive the HDR AOV before LDR conversion."""
 
 
 class IsaacRtxRenderer(BaseRenderer):
@@ -95,6 +103,25 @@ class IsaacRtxRenderer(BaseRenderer):
         ensure_rtx_hydra_engine_attached()
         # ``/isaaclab/render/rtx_sensors`` is owned by ``Camera.__init__`` (must be set pre-``sim.reset()``).
 
+    def prepare_cameras(self, stage: Any, spec: CameraRenderSpec) -> None:
+        """Resolve the camera's PPISP cfg and apply RTX-specific USD overrides.
+
+        First resolves ``spec.cfg.isp_cfg`` (sentinel discovery + normalization)
+        via :func:`isaaclab_ppisp.resolve_and_normalize` so :mod:`isaaclab` does
+        not need to know about PPISP. Then, when an ISP is configured, pins
+        ``exposure:*`` to neutral and applies ``OmniRtxCameraExposureAPI_1`` so
+        RTX's physical-camera exposure model does not compound on top of the
+        ISP. Without an ISP, the camera prim's authored exposure is left alone.
+        """
+        if not spec.camera_prim_paths:
+            return
+        from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+
+        spec.cfg.isp_cfg = resolve_and_normalize(spec.cfg.isp_cfg, stage, spec.camera_prim_paths[0])
+        if spec.cfg.isp_cfg is None:
+            return
+        apply_rtx_exposure_overrides(stage, list(spec.camera_prim_paths))
+
     def supported_output_types(self) -> dict[RenderBufferKind, RenderBufferSpec]:
         """Publish the per-output Replicator layout this RTX backend writes.
 
@@ -110,6 +137,7 @@ class IsaacRtxRenderer(BaseRenderer):
             # ``Camera`` aliases ``rgb`` as a view into ``rgba`` storage.
             RenderBufferKind.RGBA: RenderBufferSpec(4, wp.uint8),
             RenderBufferKind.RGB: RenderBufferSpec(3, wp.uint8),
+            RenderBufferKind.RGB_HDR: RenderBufferSpec(3, wp.float32),
             RenderBufferKind.DEPTH: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_IMAGE_PLANE: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_CAMERA: RenderBufferSpec(1, wp.float32),
@@ -150,7 +178,9 @@ class IsaacRtxRenderer(BaseRenderer):
         isaac_sim_version = get_isaac_sim_version()
 
         if isaac_sim_version.major >= 6:
-            needs_color_render = "rgb" in spec.cfg.data_types or "rgba" in spec.cfg.data_types
+            needs_color_render = any(
+                data_type in spec.cfg.data_types for data_type in ("rgb", "rgba", str(RenderBufferKind.RGB_HDR))
+            )
             if not needs_color_render:
                 settings.set_bool("/rtx/sdg/force/disableColorRender", True)
             if settings.get("/isaaclab/has_gui"):
@@ -208,12 +238,31 @@ class IsaacRtxRenderer(BaseRenderer):
             if simple_shading_mode is not None:
                 get_settings_manager().set_int(SIMPLE_SHADING_MODE_SETTING, simple_shading_mode)
 
+        needs_hdr_color = str(RenderBufferKind.RGB_HDR) in spec.cfg.data_types or (
+            spec.cfg.isp_cfg is not None and any(data_type in ("rgb", "rgba") for data_type in spec.cfg.data_types)
+        )
+        if needs_hdr_color:
+            rep.AnnotatorRegistry.register_annotator_from_aov(
+                aov="HdrColor", output_data_type=np.float32, output_channels=4
+            )
+
         # Define annotators based on requested data types
         annotators = {}
         for annotator_type in spec.cfg.data_types:
             if annotator_type == "rgba" or annotator_type == "rgb":
-                annotator = rep.AnnotatorRegistry.get_annotator("rgb", device=spec.device, do_array_copy=False)
-                annotators["rgba"] = annotator
+                if spec.cfg.isp_cfg is not None:
+                    if str(RenderBufferKind.RGB_HDR) not in annotators:
+                        annotator = rep.AnnotatorRegistry.get_annotator(
+                            "HdrColor", device=spec.device, do_array_copy=False
+                        )
+                        annotators[str(RenderBufferKind.RGB_HDR)] = annotator
+                else:
+                    annotator = rep.AnnotatorRegistry.get_annotator("rgb", device=spec.device, do_array_copy=False)
+                    annotators["rgba"] = annotator
+            elif annotator_type == str(RenderBufferKind.RGB_HDR):
+                if str(RenderBufferKind.RGB_HDR) not in annotators:
+                    annotator = rep.AnnotatorRegistry.get_annotator("HdrColor", device=spec.device, do_array_copy=False)
+                    annotators[str(RenderBufferKind.RGB_HDR)] = annotator
             elif annotator_type == "albedo":
                 # TODO: this is a temporary solution because replicator has not exposed the annotator yet
                 # once it's exposed, we can remove this
@@ -259,10 +308,17 @@ class IsaacRtxRenderer(BaseRenderer):
         for annotator in annotators.values():
             annotator.attach(render_product_paths)
 
+        ppisp_pipeline = None
+        if spec.cfg.isp_cfg is not None:
+            from isaaclab_ppisp import PpispPipeline
+
+            ppisp_pipeline = PpispPipeline(spec.cfg.isp_cfg, stage=stage)
+
         return IsaacRtxRenderData(
             annotators=annotators,
             render_product_paths=render_product_paths,
             spec=spec,
+            ppisp_pipeline=ppisp_pipeline,
         )
 
     def _resolve_simple_shading_mode(self, spec: CameraRenderSpec) -> int | None:
@@ -281,7 +337,27 @@ class IsaacRtxRenderer(BaseRenderer):
     def set_outputs(self, render_data: IsaacRtxRenderData, output_data: dict[str, ProxyArray]):
         """Store reference to output buffers for writing during render.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.set_outputs`."""
+        if render_data.ppisp_pipeline is not None and str(RenderBufferKind.RGBA) not in output_data:
+            raise ValueError(
+                "Isaac RTX renderer ISP requires 'rgba' (or 'rgb', which aliases into rgba) as the"
+                " LDR output destination, but neither was provided. Add 'rgb' or 'rgba' to"
+                " Camera.cfg.data_types when isp_cfg is set."
+            )
         render_data.output_data = output_data
+        # Allocate an internal HDR scratch buffer when PPISP is composed but
+        # the user did not request the raw HDR AOV in ``data_types`` — the
+        # PPISP kernel still needs somewhere to receive the HDR annotator
+        # output before LDR conversion.
+        if render_data.ppisp_pipeline is not None and str(RenderBufferKind.RGB_HDR) not in output_data:
+            spec = render_data.spec
+            assert spec is not None
+            hdr_spec = self.supported_output_types()[RenderBufferKind.RGB_HDR]
+            assert hdr_spec.dtype is wp.float32
+            render_data._hdr_scratch_wp = wp.zeros(
+                (spec.num_instances, spec.cfg.height, spec.cfg.width, hdr_spec.channels),
+                dtype=wp.float32,
+                device=spec.device,
+            )
 
     def update_transforms(self) -> None:
         """No-op for Isaac RTX - uses USD scene directly.
@@ -364,9 +440,17 @@ class IsaacRtxRenderer(BaseRenderer):
                 tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
             if data_type in SIMPLE_SHADING_MODES:
                 tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
+            if data_type == str(RenderBufferKind.RGB_HDR):
+                tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
 
-            # Get the warp array since the kernel is overloaded for specific types
-            buf_wp = output_data[data_type].warp
+            # The HDR annotator's destination is the user-visible ``output_data["rgb_hdr"]``
+            # when they requested it explicitly; otherwise the renderer's internal
+            # scratch buffer that the PPISP pipeline reads.
+            if data_type == str(RenderBufferKind.RGB_HDR) and data_type not in output_data:
+                assert render_data._hdr_scratch_wp is not None
+                buf_wp = render_data._hdr_scratch_wp
+            else:
+                buf_wp = output_data[data_type].warp
             wp.launch(
                 kernel=reshape_tiled_image,
                 dim=(view_count, cfg.height, cfg.width),
@@ -396,6 +480,14 @@ class IsaacRtxRenderer(BaseRenderer):
             ):
                 replacement = 0.0 if self.cfg.depth_clipping_behavior == "zero" else cfg.spawn.clipping_range[1]
                 replace_inf_depth_wp(buf_wp, replacement, device=device)
+
+        # Post-render PPISP: HDR scene-linear → LDR RGBA. The camera enforces
+        # that ``rgba`` (or ``rgb`` aliasing into it) is present when an ISP is
+        # configured, so writing to ``output_data["rgba"]`` is safe.
+        if render_data.ppisp_pipeline is not None:
+            hdr_proxy = output_data.get(str(RenderBufferKind.RGB_HDR))
+            hdr_source = hdr_proxy.warp if hdr_proxy is not None else render_data._hdr_scratch_wp
+            render_data.ppisp_pipeline.apply(hdr_source, output_data[str(RenderBufferKind.RGBA)].warp)
 
     def read_output(self, render_data: IsaacRtxRenderData, camera_data: CameraData) -> None:
         """Populate per-output metadata collected during render(). Pixel data already written in render().

--- a/source/isaaclab_physx/setup.py
+++ b/source/isaaclab_physx/setup.py
@@ -16,7 +16,7 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
 # Minimum dependencies required prior to installation
-INSTALL_REQUIRES = []
+INSTALL_REQUIRES = ["isaaclab_ppisp"]
 
 EXTRAS_REQUIRE = {
     "newton": [

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the Isaac RTX renderer output contract."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+import warp as wp
+from packaging import version
+
+from isaaclab.renderers import RenderBufferKind, RenderBufferSpec
+
+pytestmark = pytest.mark.isaacsim_ci
+
+
+def _install_omni_stubs(monkeypatch):
+    omni_module = sys.modules.get("omni", types.ModuleType("omni"))
+    replicator_module = types.ModuleType("omni.replicator")
+    replicator_core_module = types.ModuleType("omni.replicator.core")
+    syntheticdata_module = types.ModuleType("omni.syntheticdata")
+    usd_module = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "omni", omni_module)
+    monkeypatch.setitem(sys.modules, "omni.replicator", replicator_module)
+    monkeypatch.setitem(sys.modules, "omni.replicator.core", replicator_core_module)
+    monkeypatch.setitem(sys.modules, "omni.syntheticdata", syntheticdata_module)
+    monkeypatch.setitem(sys.modules, "omni.usd", usd_module)
+    monkeypatch.setattr(omni_module, "replicator", replicator_module, raising=False)
+    monkeypatch.setattr(omni_module, "syntheticdata", syntheticdata_module, raising=False)
+    monkeypatch.setattr(omni_module, "usd", usd_module, raising=False)
+    monkeypatch.setattr(replicator_module, "core", replicator_core_module, raising=False)
+
+    return replicator_core_module, syntheticdata_module
+
+
+def test_isaac_rtx_supported_output_types_include_rgb_hdr(monkeypatch):
+    """Isaac RTX advertises RGB_HDR as a 3-channel float renderer output."""
+    _install_omni_stubs(monkeypatch)
+    from isaaclab_physx.renderers.isaac_rtx_renderer import IsaacRtxRenderer
+    from isaaclab_physx.renderers.isaac_rtx_renderer_cfg import IsaacRtxRendererCfg
+
+    renderer = IsaacRtxRenderer.__new__(IsaacRtxRenderer)
+    renderer.cfg = IsaacRtxRendererCfg()
+    with patch("isaaclab_physx.renderers.isaac_rtx_renderer.get_isaac_sim_version", return_value=version.parse("6.0")):
+        specs = renderer.supported_output_types()
+
+    assert specs[RenderBufferKind.RGB_HDR] == RenderBufferSpec(3, wp.float32)

--- a/source/isaaclab_ppisp/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
+++ b/source/isaaclab_ppisp/changelog.d/nicolasm-ppisp-renderer-simple-integration.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added the :mod:`isaaclab_ppisp` package: a renderer-backend-agnostic post-render PPISP (Physically Plausible Image Signal Processing) pipeline that converts HDR scene-linear color to LDR RGBA at the end of a render tick.
+* Added :class:`~isaaclab_ppisp.PpispPipeline`, :class:`~isaaclab_ppisp.PpispCfg`, the PPISP Warp kernel (:func:`~isaaclab_ppisp.apply_ppisp_to_rgba`), and the USD shader discovery helpers (:func:`~isaaclab_ppisp.auto_camera_ppisp_cfg`, :func:`~isaaclab_ppisp.auto_any_ppisp_cfg`).
+* Backend renderers (:class:`~isaaclab_physx.renderers.IsaacRtxRenderer`, :class:`~isaaclab_ov.renderers.OVRTXRenderer`, :class:`~isaaclab_newton.renderers.NewtonWarpRenderer`) compose :class:`~isaaclab_ppisp.PpispPipeline` internally when :attr:`~isaaclab.sensors.camera.CameraCfg.isp_cfg` is set.

--- a/source/isaaclab_ppisp/config/extension.toml
+++ b/source/isaaclab_ppisp/config/extension.toml
@@ -1,0 +1,21 @@
+[package]
+
+# Note: Semantic Versioning is used: https://semver.org/
+version = "0.1.0"
+
+# Description
+title = "Post-render PPISP (Physically Plausible Image Signal Processing) for IsaacLab"
+description="Extension providing a renderer-backend-agnostic PPISP pipeline that converts HDR scene-linear color to LDR RGBA at the end of a render tick."
+readme  = "docs/README.md"
+repository = "https://github.com/isaac-sim/IsaacLab"
+category = "robotics"
+keywords = ["robotics", "simulation", "rendering", "isp", "ppisp"]
+
+[dependencies]
+"isaaclab" = {}
+
+[core]
+reloadable = false
+
+[[python.module]]
+name = "isaaclab_ppisp"

--- a/source/isaaclab_ppisp/isaaclab_ppisp/__init__.py
+++ b/source/isaaclab_ppisp/isaaclab_ppisp/__init__.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Post-render PPISP (Physically Plausible Image Signal Processing) for IsaacLab.
+
+Provides the renderer-backend-agnostic ISP pipeline that converts the renderer's
+HDR scene-linear AOV to LDR RGBA at the end of a render tick. Renderer backends
+(:class:`~isaaclab_physx.renderers.IsaacRtxRenderer`,
+:class:`~isaaclab_ov.renderers.OVRTXRenderer`,
+:class:`~isaaclab_newton.renderers.NewtonWarpRenderer`) compose
+:class:`PpispPipeline` internally when the camera's
+:attr:`~isaaclab.sensors.camera.CameraCfg.isp_cfg` is set.
+"""
+
+import os
+
+import toml
+
+from isaaclab.utils.module import lazy_export
+
+ISAACLAB_PPISP_EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
+"""Path to the extension source directory."""
+
+_pkg_dir = os.path.dirname(os.path.abspath(__file__))
+_toml_path = os.path.join(_pkg_dir, "config", "extension.toml")
+if not os.path.isfile(_toml_path):
+    _toml_path = os.path.join(ISAACLAB_PPISP_EXT_DIR, "config", "extension.toml")
+
+ISAACLAB_PPISP_METADATA = toml.load(_toml_path)
+"""Extension metadata dictionary parsed from the extension.toml file."""
+
+__version__ = ISAACLAB_PPISP_METADATA["package"]["version"]
+
+lazy_export()

--- a/source/isaaclab_ppisp/isaaclab_ppisp/__init__.pyi
+++ b/source/isaaclab_ppisp/isaaclab_ppisp/__init__.pyi
@@ -1,0 +1,36 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+__all__ = [
+    "PPISP_DEFAULT_INPUTS",
+    "PPISP_SHADER_NAME",
+    "PpispCfg",
+    "PpispPipeline",
+    "apply_ppisp_to_rgba",
+    "apply_rtx_exposure_overrides",
+    "auto_any_ppisp_cfg",
+    "auto_camera_ppisp_cfg",
+    "default_ppisp_inputs",
+    "normalize_ppisp_cfg",
+    "ppisp_cfg_from_usd_shader",
+    "ppisp_cfg_from_usd_stage",
+    "resolve_and_normalize",
+]
+
+from .cfg import (
+    PPISP_DEFAULT_INPUTS,
+    PPISP_SHADER_NAME,
+    PpispCfg,
+    auto_any_ppisp_cfg,
+    auto_camera_ppisp_cfg,
+    default_ppisp_inputs,
+    normalize_ppisp_cfg,
+    ppisp_cfg_from_usd_shader,
+    ppisp_cfg_from_usd_stage,
+    resolve_and_normalize,
+)
+from .kernels import apply_ppisp_to_rgba
+from .pipeline import PpispPipeline
+from .rtx_camera_overrides import apply_rtx_exposure_overrides

--- a/source/isaaclab_ppisp/isaaclab_ppisp/cfg.py
+++ b/source/isaaclab_ppisp/isaaclab_ppisp/cfg.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""PPISP configuration and USD/shader parsing helpers.
+
+The implementation follows the physically plausible ISP model described in
+https://arxiv.org/abs/2601.18336.
+"""
+
+from __future__ import annotations
+
+from dataclasses import field
+from typing import Any
+
+from isaaclab.utils.configclass import configclass
+
+PPISP_SHADER_NAME = "PPISP"
+"""Conventional prim name for a PPISP shader child under a ``RenderProduct``."""
+
+PPISP_FLOAT2_INPUTS = {
+    "vignettingCenterR",
+    "vignettingCenterG",
+    "vignettingCenterB",
+    "colorLatentBlue",
+    "colorLatentRed",
+    "colorLatentGreen",
+    "colorLatentNeutral",
+}
+
+PPISP_DEFAULT_INPUTS: dict[str, float | tuple[float, float]] = {
+    "responsivity": 1.0,
+    "exposureOffset": 0.0,
+    "vignettingCenterR": (0.0, 0.0),
+    "vignettingAlpha1R": 0.0,
+    "vignettingAlpha2R": 0.0,
+    "vignettingAlpha3R": 0.0,
+    "vignettingCenterG": (0.0, 0.0),
+    "vignettingAlpha1G": 0.0,
+    "vignettingAlpha2G": 0.0,
+    "vignettingAlpha3G": 0.0,
+    "vignettingCenterB": (0.0, 0.0),
+    "vignettingAlpha1B": 0.0,
+    "vignettingAlpha2B": 0.0,
+    "vignettingAlpha3B": 0.0,
+    "colorLatentBlue": (0.0, 0.0),
+    "colorLatentRed": (0.0, 0.0),
+    "colorLatentGreen": (0.0, 0.0),
+    "colorLatentNeutral": (0.0, 0.0),
+    "crfToeR": 0.013659,
+    "crfShoulderR": 0.013659,
+    "crfGammaR": 0.378165,
+    "crfCenterR": 0.0,
+    "crfToeG": 0.013659,
+    "crfShoulderG": 0.013659,
+    "crfGammaG": 0.378165,
+    "crfCenterG": 0.0,
+    "crfToeB": 0.013659,
+    "crfShoulderB": 0.013659,
+    "crfGammaB": 0.378165,
+    "crfCenterB": 0.0,
+}
+
+
+def default_ppisp_inputs() -> dict[str, float | tuple[float, float]]:
+    """Return a copy of the PPISP identity/default input dictionary."""
+    return dict(PPISP_DEFAULT_INPUTS)
+
+
+@configclass
+class PpispCfg:
+    """Configuration for PPISP post-processing.
+
+    PPISP inputs are static in IsaacLab. If imported from animated USD shader inputs,
+    the first authored time sample is used and later samples are ignored.
+    """
+
+    shader_prim_path: str | None = None
+    """Optional source USD shader prim path used to populate :attr:`inputs`."""
+
+    inputs: dict[str, float | tuple[float, float]] = field(default_factory=default_ppisp_inputs)
+    """Flat PPISP shader input values keyed by USD input name.
+
+    Coordinate conventions for spatial inputs:
+
+    * ``vignettingCenter{R,G,B}`` is a 2D offset in UV space normalised by
+      ``max(width, height)`` with the image center at ``(0.0, 0.0)``. The
+      :data:`PPISP_DEFAULT_INPUTS` defaults place every channel's
+      optical center at the image center.
+    * Radial vignetting coefficients ``vignettingAlpha{1,2,3}{R,G,B}`` are
+      polynomial coefficients in the same normalised radius, applied as
+      ``factor = clamp(1 + a1*r^2 + a2*r^4 + a3*r^6, 0, 1)``; with a square
+      frame the image corners sit at ``r^2 = 0.5``.
+    """
+
+
+def normalize_ppisp_cfg(
+    ppisp_cfg: PpispCfg | None,
+    stage: Any | None = None,
+) -> PpispCfg | None:
+    """Normalise a :class:`PpispCfg` for downstream consumption.
+
+    * If ``ppisp_cfg`` is ``None``, returns ``None``.
+    * If ``ppisp_cfg.shader_prim_path`` is set and ``stage`` is supplied,
+      merges the shader-authored values with the cfg's explicit overrides
+      (see :func:`_merge_shader_inputs_with_cfg`).
+    * Otherwise validates ``ppisp_cfg.inputs`` and fills in defaults.
+    """
+    if ppisp_cfg is None:
+        return None
+    if not isinstance(ppisp_cfg, PpispCfg):
+        raise TypeError(f"Unsupported PPISP configuration type: {type(ppisp_cfg)!r}")
+    input_overrides = dict(ppisp_cfg.inputs)
+    if ppisp_cfg.shader_prim_path and stage is not None:
+        return _merge_shader_inputs_with_cfg(ppisp_cfg, stage, input_overrides)
+    ppisp_cfg.inputs = _normalized_inputs(input_overrides)
+    return ppisp_cfg
+
+
+def ppisp_cfg_from_usd_shader(shader: Any) -> PpispCfg:
+    """Create :class:`PpispCfg` from a ``UsdShade.Shader`` prim.
+
+    Animated inputs are collapsed to their first authored time sample.
+    """
+    cfg = PpispCfg(shader_prim_path=str(shader.GetPath()))
+    values = default_ppisp_inputs()
+    for input_name in values:
+        shader_input = shader.GetInput(input_name)
+        if not shader_input:
+            continue
+        attr = shader_input.GetAttr()
+        value = _read_first_authored_value(attr)
+        if value is not None:
+            values[input_name] = _normalize_input_value(input_name, value)
+    cfg.inputs = values
+    return cfg
+
+
+def ppisp_cfg_from_usd_stage(stage: Any, shader_prim_path: str) -> PpispCfg:
+    """Create :class:`PpispCfg` from a shader prim path in a USD stage."""
+    from pxr import UsdShade
+
+    shader = UsdShade.Shader(stage.GetPrimAtPath(shader_prim_path))
+    if not shader:
+        raise ValueError(f"PPISP shader prim not found at path: {shader_prim_path}")
+    return ppisp_cfg_from_usd_shader(shader)
+
+
+def _normalized_inputs(inputs: dict[str, Any]) -> dict[str, float | tuple[float, float]]:
+    values = default_ppisp_inputs()
+    for input_name, value in inputs.items():
+        if input_name not in values:
+            raise ValueError(f"Unknown PPISP input: {input_name}")
+        values[input_name] = _normalize_input_value(input_name, value)
+    return values
+
+
+def _merge_shader_inputs_with_cfg(
+    ppisp_cfg: PpispCfg,
+    stage: Any,
+    input_overrides: dict[str, Any],
+) -> PpispCfg:
+    parsed_cfg = ppisp_cfg_from_usd_stage(stage, ppisp_cfg.shader_prim_path)
+    if input_overrides != PPISP_DEFAULT_INPUTS:
+        parsed_cfg.inputs.update(_normalized_input_overrides(input_overrides))
+    return parsed_cfg
+
+
+def _normalized_input_overrides(inputs: dict[str, Any]) -> dict[str, float | tuple[float, float]]:
+    values = {}
+    for input_name, value in inputs.items():
+        if input_name not in PPISP_DEFAULT_INPUTS:
+            raise ValueError(f"Unknown PPISP input: {input_name}")
+        values[input_name] = _normalize_input_value(input_name, value)
+    return values
+
+
+def _normalize_input_value(input_name: str, value: Any) -> float | tuple[float, float]:
+    if input_name in PPISP_FLOAT2_INPUTS:
+        if len(value) != 2:
+            raise ValueError(f"PPISP input '{input_name}' expects two values.")
+        return (float(value[0]), float(value[1]))
+    return float(value)
+
+
+def _read_first_authored_value(attr: Any) -> Any:
+    time_samples = attr.GetTimeSamples()
+    if time_samples:
+        return attr.Get(time_samples[0])
+    return attr.Get()
+
+
+def resolve_and_normalize(isp_cfg: Any, stage: Any, camera_prim_path: str) -> PpispCfg | None:
+    """Resolve a Camera sensor batch's ``isp_cfg`` to a normalised cfg or ``None``.
+
+    Handles all three legal forms of :attr:`~isaaclab.sensors.camera.CameraCfg.isp_cfg`:
+
+    * ``None`` → returns ``None``.
+    * :class:`~isaaclab.sensors.camera.CameraISPMode` sentinel — walks the stage
+      via :func:`auto_camera_ppisp_cfg` (and :func:`auto_any_ppisp_cfg` for
+      ``AUTO_ANY``) to discover a PPISP shader. Returns the parsed +
+      normalised :class:`PpispCfg`, or ``None`` if no shader matched.
+    * Concrete :class:`PpispCfg` — normalises in place (validates input keys,
+      fills defaults, and merges shader-authored values when ``shader_prim_path``
+      is set).
+
+    This is the single entry point renderer backends call inside their
+    ``prepare_cameras`` hook so :mod:`isaaclab.sensors.camera` does not need
+    to know about PPISP types at all. The returned cfg applies to the whole
+    Camera sensor batch; callers pass the first matched camera prim path for
+    the camera-bound discovery phase.
+
+    Args:
+        isp_cfg: The Camera sensor's :attr:`isp_cfg` value (``None``, ``CameraISPMode``, or :class:`PpispCfg`).
+        stage: USD stage used for sentinel discovery and shader-path resolution.
+        camera_prim_path: Absolute path of the first matched camera prim in the
+            Camera sensor batch (target of the ``camera`` relationship for the
+            camera-bound discovery phase).
+
+    Returns:
+        A fully-normalised :class:`PpispCfg`, or ``None`` if the batch has no ISP.
+    """
+    # Local import avoids a top-of-module dep on isaaclab.sensors.
+    from isaaclab.sensors.camera.camera_isp import CameraISPMode
+
+    if isp_cfg is None:
+        return None
+    if isinstance(isp_cfg, CameraISPMode):
+        resolved = auto_camera_ppisp_cfg(stage, camera_prim_path)
+        if resolved is None and isp_cfg == CameraISPMode.AUTO_ANY:
+            resolved = auto_any_ppisp_cfg(stage)
+        if resolved is None:
+            return None
+        return normalize_ppisp_cfg(resolved, stage=stage)
+    return normalize_ppisp_cfg(isp_cfg, stage=stage)
+
+
+def auto_camera_ppisp_cfg(stage: Any, camera_prim_path: str) -> PpispCfg | None:
+    """Find the first PPISP shader on ``stage`` bound to ``camera_prim_path``.
+
+    Walks ``stage`` looking for the first ``RenderProduct`` whose ``camera``
+    relationship targets ``camera_prim_path``. If that ``RenderProduct`` has a
+    child shader at ``<render_product>/<PPISP_SHADER_NAME>``, parses
+    and returns the corresponding :class:`PpispCfg`. Returns ``None`` if
+    no matching ``RenderProduct`` is found, or if it has no PPISP shader child.
+
+    Args:
+        stage: USD stage to search.
+        camera_prim_path: Absolute camera prim path the ``RenderProduct``'s
+            ``camera`` relationship must target.
+
+    Returns:
+        Parsed :class:`PpispCfg` if a matching shader was found, else ``None``.
+    """
+    from pxr import Sdf, UsdShade
+
+    target_path = Sdf.Path(camera_prim_path)
+    for prim in stage.Traverse():
+        if prim.GetTypeName() != "RenderProduct":
+            continue
+        camera_rel = prim.GetRelationship("camera")
+        if not camera_rel:
+            continue
+        if target_path not in camera_rel.GetTargets():
+            continue
+        shader_path = prim.GetPath().AppendChild(PPISP_SHADER_NAME)
+        shader_prim = stage.GetPrimAtPath(shader_path)
+        if shader_prim and shader_prim.IsValid():
+            return ppisp_cfg_from_usd_shader(UsdShade.Shader(shader_prim))
+        return None
+    return None
+
+
+def auto_any_ppisp_cfg(stage: Any) -> PpispCfg | None:
+    """Find the first PPISP shader anywhere on ``stage``, regardless of binding.
+
+    Walks ``stage`` looking for the first prim named
+    :data:`PPISP_SHADER_NAME` that resolves to a valid ``UsdShade.Shader``.
+    Returns ``None`` if no such shader exists.
+
+    Used as a fallback when no ``RenderProduct`` binds a PPISP shader to a
+    given camera but the scene still contains a PPISP configuration that
+    should apply.
+
+    Args:
+        stage: USD stage to search.
+
+    Returns:
+        Parsed :class:`PpispCfg` for the first matching shader, else ``None``.
+    """
+    from pxr import UsdShade
+
+    for prim in stage.Traverse():
+        if prim.GetName() != PPISP_SHADER_NAME:
+            continue
+        shader = UsdShade.Shader(prim)
+        if shader:
+            return ppisp_cfg_from_usd_shader(shader)
+    return None

--- a/source/isaaclab_ppisp/isaaclab_ppisp/kernels.py
+++ b/source/isaaclab_ppisp/isaaclab_ppisp/kernels.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Warp kernels for PPISP post-processing."""
+
+from __future__ import annotations
+
+import warp as wp
+
+from .cfg import PpispCfg
+
+wp.init()
+
+
+@wp.func
+def _bounded_softplus(raw: wp.float32, min_value: wp.float32):
+    """Map an unconstrained parameter to a positive value with a lower bound.
+
+    The PPISP CRF stores toe/shoulder/gamma as raw optimization parameters. This
+    helper applies ``min + log(1 + exp(raw))`` so the resulting shape parameters
+    stay positive and numerically away from degenerate zero values.
+    """
+    return min_value + wp.log(1.0 + wp.exp(raw))
+
+
+@wp.func
+def _sigmoid(raw: wp.float32):
+    return 1.0 / (1.0 + wp.exp(0.0 - raw))
+
+
+@wp.func
+def _apply_vignetting(
+    value: wp.float32,
+    uv: wp.vec2f,
+    optical_center: wp.vec2f,
+    alpha1: wp.float32,
+    alpha2: wp.float32,
+    alpha3: wp.float32,
+):
+    """Apply per-channel radial vignetting in local normalized image coordinates.
+
+    The pixel coordinate ``uv`` is centered on the current de-tiled camera image
+    and normalized by ``max(width, height)``. The falloff is the clamped radial
+    polynomial ``1 + a1 r^2 + a2 r^4 + a3 r^6``, where
+    ``r^2 = dot(uv - optical_center, uv - optical_center)``.
+    """
+    delta = uv - optical_center
+    radius_squared = wp.dot(delta, delta)
+    radius_power = radius_squared
+    falloff = wp.float32(1.0) + alpha1 * radius_power
+    radius_power = radius_power * radius_squared
+    falloff = falloff + alpha2 * radius_power
+    radius_power = radius_power * radius_squared
+    falloff = falloff + alpha3 * radius_power
+    return value * wp.clamp(falloff, 0.0, 1.0)
+
+
+@wp.func
+def _apply_crf(
+    value: wp.float32,
+    toe_raw: wp.float32,
+    shoulder_raw: wp.float32,
+    gamma_raw: wp.float32,
+    center_raw: wp.float32,
+):
+    """Apply one channel of the PPISP camera response function.
+
+    The CRF is a piecewise power curve split around ``center = sigmoid(raw)``.
+    Toe, shoulder, and gamma are bounded-softplus parameters. Values below the
+    center use the toe exponent; values above it use the shoulder exponent; the
+    result is then raised to ``gamma``. The center is clamped away from 0 and 1
+    because it appears in the denominator of both curve segments.
+    """
+    x = wp.clamp(value, 0.0, 1.0)
+    toe = _bounded_softplus(toe_raw, 0.3)
+    shoulder = _bounded_softplus(shoulder_raw, 0.3)
+    gamma = _bounded_softplus(gamma_raw, 0.1)
+    center = wp.clamp(_sigmoid(center_raw), 1.0e-6, 1.0 - 1.0e-6)
+
+    lerp_value = (shoulder - toe) * center + toe
+    a = (shoulder * center) / lerp_value
+    b = 1.0 - a
+
+    y = wp.float32(0.0)
+    if x <= center:
+        y = a * wp.pow(x / center, toe)
+    else:
+        y = 1.0 - b * wp.pow((1.0 - x) / (1.0 - center), shoulder)
+
+    return wp.pow(wp.max(0.0, y), gamma)
+
+
+@wp.func
+def _compute_homography_mul(
+    rgb: wp.vec3f,
+    blue_latent: wp.vec2f,
+    red_latent: wp.vec2f,
+    green_latent: wp.vec2f,
+    neutral_latent: wp.vec2f,
+):
+    """Apply the PPISP color correction homography.
+
+    The four 2D latent controls perturb the blue, red, green, and neutral
+    chromaticity anchors. A projective transform is solved from those anchors
+    and applied in ``r,g,intensity`` space, preserving the input pixel intensity
+    after the chromaticity remap.
+    """
+    blue_delta = wp.vec2f(
+        0.0480542 * blue_latent[0] - 0.0043631 * blue_latent[1],
+        -0.0043631 * blue_latent[0] + 0.0481283 * blue_latent[1],
+    )
+    red_delta = wp.vec2f(
+        0.0580570 * red_latent[0] - 0.0179872 * red_latent[1],
+        -0.0179872 * red_latent[0] + 0.0431061 * red_latent[1],
+    )
+    green_delta = wp.vec2f(
+        0.0433336 * green_latent[0] - 0.0180537 * green_latent[1],
+        -0.0180537 * green_latent[0] + 0.0580500 * green_latent[1],
+    )
+    neutral_delta = wp.vec2f(
+        0.0128369 * neutral_latent[0] - 0.0034654 * neutral_latent[1],
+        -0.0034654 * neutral_latent[0] + 0.0128158 * neutral_latent[1],
+    )
+
+    target_blue = wp.vec3f(blue_delta[0], blue_delta[1], 1.0)
+    target_red = wp.vec3f(1.0 + red_delta[0], red_delta[1], 1.0)
+    target_green = wp.vec3f(green_delta[0], 1.0 + green_delta[1], 1.0)
+    target_gray = wp.vec3f(1.0 / 3.0 + neutral_delta[0], 1.0 / 3.0 + neutral_delta[1], 1.0)
+
+    row0 = wp.vec3f(target_gray[1] - target_blue[1], target_gray[1] - target_red[1], target_gray[1] - target_green[1])
+    row1 = wp.vec3f(target_blue[0] - target_gray[0], target_red[0] - target_gray[0], target_green[0] - target_gray[0])
+    row2 = wp.vec3f(
+        -target_gray[1] * target_blue[0] + target_gray[0] * target_blue[1],
+        -target_gray[1] * target_red[0] + target_gray[0] * target_red[1],
+        -target_gray[1] * target_green[0] + target_gray[0] * target_green[1],
+    )
+
+    lam = wp.cross(row0, row1)
+    if wp.dot(lam, lam) < 1.0e-20:
+        lam = wp.cross(row0, row2)
+        if wp.dot(lam, lam) < 1.0e-20:
+            lam = wp.cross(row1, row2)
+
+    col0 = -target_blue * lam[0] + target_red * lam[1]
+    col1 = -target_blue * lam[0] + target_green * lam[2]
+    col2 = target_blue * lam[0]
+
+    h22 = col0[2] + col1[2] + col2[2]
+    if wp.abs(h22) > 1.0e-20:
+        inv_h22 = 1.0 / h22
+        col0 = col0 * inv_h22
+        col1 = col1 * inv_h22
+        col2 = col2 * inv_h22
+
+    intensity = rgb[0] + rgb[1] + rgb[2]
+    rgi = col0 * rgb[0] + col1 * rgb[1] + col2 * intensity
+    rgi = rgi * (intensity / (rgi[2] + 1.0e-5))
+    return wp.vec3f(rgi[0], rgi[1], rgi[2] - rgi[0] - rgi[1])
+
+
+@wp.kernel(enable_backward=False)
+def _apply_ppisp_kernel(
+    hdr_color: wp.array4d(dtype=wp.float32),
+    out_rgba: wp.array4d(dtype=wp.uint8),
+    image_width: wp.int32,
+    image_height: wp.int32,
+    responsivity: wp.float32,
+    exposure_offset: wp.float32,
+    vignetting_center_r: wp.vec2f,
+    vignetting_alpha1_r: wp.float32,
+    vignetting_alpha2_r: wp.float32,
+    vignetting_alpha3_r: wp.float32,
+    vignetting_center_g: wp.vec2f,
+    vignetting_alpha1_g: wp.float32,
+    vignetting_alpha2_g: wp.float32,
+    vignetting_alpha3_g: wp.float32,
+    vignetting_center_b: wp.vec2f,
+    vignetting_alpha1_b: wp.float32,
+    vignetting_alpha2_b: wp.float32,
+    vignetting_alpha3_b: wp.float32,
+    color_latent_blue: wp.vec2f,
+    color_latent_red: wp.vec2f,
+    color_latent_green: wp.vec2f,
+    color_latent_neutral: wp.vec2f,
+    crf_toe_r: wp.float32,
+    crf_shoulder_r: wp.float32,
+    crf_gamma_r: wp.float32,
+    crf_center_r: wp.float32,
+    crf_toe_g: wp.float32,
+    crf_shoulder_g: wp.float32,
+    crf_gamma_g: wp.float32,
+    crf_center_g: wp.float32,
+    crf_toe_b: wp.float32,
+    crf_shoulder_b: wp.float32,
+    crf_gamma_b: wp.float32,
+    crf_center_b: wp.float32,
+):
+    """Apply the camera PPISP pipeline to one de-tiled HDR color tensor.
+
+    For each pixel, the model applies HDR responsivity scaling, exposure
+    scaling, per-channel vignetting, color homography correction, CRF tone
+    mapping, and uint8 RGBA packing. The first tensor dimension is the
+    camera/environment index, so image-space effects use local ``height_id``
+    and ``width_id`` coordinates per camera.
+    """
+    camera_id, height_id, width_id = wp.tid()
+    rgb = wp.vec3f(
+        hdr_color[camera_id, height_id, width_id, 0],
+        hdr_color[camera_id, height_id, width_id, 1],
+        hdr_color[camera_id, height_id, width_id, 2],
+    )
+    max_resolution = wp.float32(image_width)
+    if image_height > image_width:
+        max_resolution = wp.float32(image_height)
+    uv = wp.vec2f(
+        (wp.float32(width_id) + 0.5 - wp.float32(image_width) * 0.5) / max_resolution,
+        (wp.float32(height_id) + 0.5 - wp.float32(image_height) * 0.5) / max_resolution,
+    )
+
+    # 0. HDR responsivity (achromatic, applied pre-PPISP) — orthogonal to the
+    # asset-baked radiance scaling on Gaussian SH coefficients. Default 1.0 = no-op.
+    out_rgb = rgb * responsivity
+    # 1. Exposure
+    out_rgb = out_rgb * wp.pow(2.0, exposure_offset)
+    out_rgb[0] = _apply_vignetting(
+        out_rgb[0], uv, vignetting_center_r, vignetting_alpha1_r, vignetting_alpha2_r, vignetting_alpha3_r
+    )
+    out_rgb[1] = _apply_vignetting(
+        out_rgb[1], uv, vignetting_center_g, vignetting_alpha1_g, vignetting_alpha2_g, vignetting_alpha3_g
+    )
+    out_rgb[2] = _apply_vignetting(
+        out_rgb[2], uv, vignetting_center_b, vignetting_alpha1_b, vignetting_alpha2_b, vignetting_alpha3_b
+    )
+    out_rgb = _compute_homography_mul(
+        out_rgb, color_latent_blue, color_latent_red, color_latent_green, color_latent_neutral
+    )
+    out_rgb[0] = _apply_crf(out_rgb[0], crf_toe_r, crf_shoulder_r, crf_gamma_r, crf_center_r)
+    out_rgb[1] = _apply_crf(out_rgb[1], crf_toe_g, crf_shoulder_g, crf_gamma_g, crf_center_g)
+    out_rgb[2] = _apply_crf(out_rgb[2], crf_toe_b, crf_shoulder_b, crf_gamma_b, crf_center_b)
+
+    out_rgba[camera_id, height_id, width_id, 0] = wp.uint8(wp.clamp(out_rgb[0], 0.0, 1.0) * 255.0)
+    out_rgba[camera_id, height_id, width_id, 1] = wp.uint8(wp.clamp(out_rgb[1], 0.0, 1.0) * 255.0)
+    out_rgba[camera_id, height_id, width_id, 2] = wp.uint8(wp.clamp(out_rgb[2], 0.0, 1.0) * 255.0)
+    out_rgba[camera_id, height_id, width_id, 3] = wp.uint8(255)
+
+
+def apply_ppisp_to_rgba(hdr_color: wp.array, out_rgba: wp.array, cfg: PpispCfg) -> None:
+    """Apply PPISP to ``hdr_color`` and write LDR RGBA into ``out_rgba``.
+
+    Args:
+        hdr_color: HDR scene-linear input. ``wp.array4d(dtype=wp.float32)`` of
+            shape ``(N, H, W, 3)``.
+        out_rgba: LDR RGBA output. ``wp.array4d(dtype=wp.uint8)`` of shape
+            ``(N, H, W, 4)``. Written in place.
+        cfg: PPISP configuration.
+    """
+    if hdr_color.dtype is not wp.float32:
+        raise ValueError(f"Camera PPISP HDR input must be wp.float32, got {hdr_color.dtype}.")
+    if out_rgba.dtype is not wp.uint8:
+        raise ValueError(f"Camera PPISP RGBA output must be wp.uint8, got {out_rgba.dtype}.")
+
+    inputs = cfg.inputs
+    wp.launch(
+        _apply_ppisp_kernel,
+        dim=out_rgba.shape[:3],
+        inputs=[
+            hdr_color,
+            out_rgba,
+            int(out_rgba.shape[2]),
+            int(out_rgba.shape[1]),
+            float(inputs.get("responsivity", 1.0)),
+            float(inputs["exposureOffset"]),
+            wp.vec2f(*inputs["vignettingCenterR"]),
+            float(inputs["vignettingAlpha1R"]),
+            float(inputs["vignettingAlpha2R"]),
+            float(inputs["vignettingAlpha3R"]),
+            wp.vec2f(*inputs["vignettingCenterG"]),
+            float(inputs["vignettingAlpha1G"]),
+            float(inputs["vignettingAlpha2G"]),
+            float(inputs["vignettingAlpha3G"]),
+            wp.vec2f(*inputs["vignettingCenterB"]),
+            float(inputs["vignettingAlpha1B"]),
+            float(inputs["vignettingAlpha2B"]),
+            float(inputs["vignettingAlpha3B"]),
+            wp.vec2f(*inputs["colorLatentBlue"]),
+            wp.vec2f(*inputs["colorLatentRed"]),
+            wp.vec2f(*inputs["colorLatentGreen"]),
+            wp.vec2f(*inputs["colorLatentNeutral"]),
+            float(inputs["crfToeR"]),
+            float(inputs["crfShoulderR"]),
+            float(inputs["crfGammaR"]),
+            float(inputs["crfCenterR"]),
+            float(inputs["crfToeG"]),
+            float(inputs["crfShoulderG"]),
+            float(inputs["crfGammaG"]),
+            float(inputs["crfCenterG"]),
+            float(inputs["crfToeB"]),
+            float(inputs["crfShoulderB"]),
+            float(inputs["crfGammaB"]),
+            float(inputs["crfCenterB"]),
+        ],
+        device=str(out_rgba.device),
+    )

--- a/source/isaaclab_ppisp/isaaclab_ppisp/pipeline.py
+++ b/source/isaaclab_ppisp/isaaclab_ppisp/pipeline.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Post-render PPISP pipeline composed into renderer backends.
+
+:class:`PpispPipeline` runs *after* a renderer fills its HDR scene-linear AOV,
+converting HDR → LDR via a single Warp kernel. Renderer backends instantiate
+this class when their cfg/spec carries a :class:`PpispCfg` and dispatch
+:meth:`apply` once per render tick. The HDR scratch buffer is owned by the
+renderer backend, not by this class.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import warp as wp
+
+from .cfg import PpispCfg, normalize_ppisp_cfg
+from .kernels import apply_ppisp_to_rgba
+
+
+class PpispPipeline:
+    """Post-render PPISP kernel applier.
+
+    Constructed by renderer backends when ``spec.cfg.isp_cfg`` is set. Owns the
+    normalised :class:`PpispCfg` and dispatches the PPISP Warp kernel once per
+    render tick via :meth:`apply`.
+
+    One pipeline instance applies to the whole Camera sensor batch. The PPISP
+    Warp kernel takes scalar coefficients, so every cloned view in a tiled
+    batch shares the same ISP configuration — there is no per-view ISP today.
+    Per-view support would require packing the cfg into GPU arrays and indexing
+    by ``camera_id`` inside the kernel.
+
+    Today only :class:`PpispCfg` is accepted; future ISP implementations can
+    either subclass or be selected by cfg type without changes to the backend
+    renderers.
+    """
+
+    def __init__(self, cfg: PpispCfg, stage: Any = None):
+        """Initialize the PPISP pipeline.
+
+        Normalises ``cfg`` on construction (validates input keys, fills
+        defaults, and — when ``cfg.shader_prim_path`` is set and ``stage`` is
+        non-``None`` — merges shader-authored values with user overrides).
+        :class:`~isaaclab.sensors.camera.Camera` already normalises ``isp_cfg``
+        before passing the :class:`~isaaclab.renderers.CameraRenderSpec` to
+        the backend, so renderer backends typically pass ``stage=None`` here.
+
+        Args:
+            cfg: The PPISP configuration.
+            stage: Optional USD stage used to resolve ``cfg.shader_prim_path``.
+        """
+        self.cfg = normalize_ppisp_cfg(cfg, stage=stage)
+
+    def apply(self, hdr: wp.array, rgba: wp.array) -> None:
+        """Run the PPISP kernel: HDR scene-linear → LDR RGBA, in place on ``rgba``."""
+        apply_ppisp_to_rgba(hdr, rgba, self.cfg)

--- a/source/isaaclab_ppisp/isaaclab_ppisp/rtx_camera_overrides.py
+++ b/source/isaaclab_ppisp/isaaclab_ppisp/rtx_camera_overrides.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""RTX-specific per-camera-prim USD overrides authored when PPISP is active.
+
+Kept in a Kit-free module (no ``omni.*`` imports) so it can be unit-tested
+without booting Isaac Sim. Both Kit-driven Isaac RTX and Kit-less OVRTX embed
+the same RTX core and author the same exposure schema, so the helper lives
+here in :mod:`isaaclab_ppisp` and is called from both backends'
+``prepare_cameras`` hook.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Neutral RTX-side values authored on the camera prim when PPISP is the ISP
+# authority. RTX otherwise compounds its own physical-camera exposure model
+# on top of PPISP, leaving the HDR AOV under- or over-exposed. PPISP supplies
+# its own ``responsivity`` / ``exposureOffset``; pinning these stage-side
+# values (``iso=0`` plus ``autoExposure:enabled=False``) keeps RTX's exposure
+# stage a no-op.
+#
+# Each entry is ``(attribute_name, sdf_type_name, value)`` where
+# ``sdf_type_name`` is the suffix of ``Sdf.ValueTypeNames``; values are
+# coerced inside :func:`apply_rtx_exposure_overrides`.
+_NEUTRAL_CAMERA_EXPOSURE: tuple[tuple[str, str, Any], ...] = (
+    ("exposure", "Float", 0.0),
+    ("exposure:fStop", "Float", 1.0),
+    ("exposure:iso", "Float", 0.0),
+    ("exposure:responsivity", "Float", 1.0),
+    ("exposure:time", "Float", 1.0),
+    ("omni:rtx:autoExposure:enabled", "Bool", False),
+)
+
+# API schemas applied (prepended) on each camera prim so Kit's USD watcher
+# routes the camera's ``exposure:*`` and ``omni:rtx:autoExposure:*``
+# attributes into the per-camera carb settings RTX consumes.
+_PPISP_CAMERA_API_SCHEMAS: tuple[str, ...] = (
+    "OmniRtxCameraAutoExposureAPI_1",
+    "OmniRtxCameraExposureAPI_1",
+)
+
+
+def apply_rtx_exposure_overrides(stage: Any, prim_paths: list[str]) -> None:
+    """Pin RTX-side exposure to neutral and apply the API schemas on each camera prim.
+
+    On every prim in ``prim_paths``:
+
+    1. Author the neutral values from :data:`_NEUTRAL_CAMERA_EXPOSURE` —
+       ``exposure:*`` knobs disabling RTX's physical-camera exposure stage
+       plus ``omni:rtx:autoExposure:enabled=False``.
+    2. Apply the :data:`_PPISP_CAMERA_API_SCHEMAS` API schemas via
+       ``SetMetadata("apiSchemas", ...)``. In Kit, ``omni.kit``'s USD
+       watcher pumps the authored attributes into the per-camera carb
+       settings RTX consumes. ``Sdf.TokenListOp`` metadata is used rather
+       than ``Usd.Prim.ApplyAPI`` so this does not require the USD
+       ``PlugRegistry`` to have discovered the RTX-settings schema plugin
+       yet.
+
+    Existing API schemas on the prim are preserved — the RTX schemas are
+    prepended, not replaced.
+
+    Args:
+        stage: USD stage containing the camera prim(s).
+        prim_paths: Resolved camera prim paths (typically one per env).
+    """
+    from pxr import Sdf
+
+    sdf_value_types = {
+        "Bool": Sdf.ValueTypeNames.Bool,
+        "Float": Sdf.ValueTypeNames.Float,
+    }
+
+    def coerce(value: Any, sdf_type_name: str) -> Any:
+        if sdf_type_name == "Float":
+            return float(value)
+        return value
+
+    for prim_path in prim_paths:
+        prim = stage.GetPrimAtPath(prim_path)
+        if not prim or not prim.IsValid():
+            continue
+        current = prim.GetMetadata("apiSchemas") or Sdf.TokenListOp()
+        existing = list(current.prependedItems) + list(current.explicitItems) + list(current.appendedItems)
+        missing = [s for s in _PPISP_CAMERA_API_SCHEMAS if s not in existing]
+        if missing:
+            merged = Sdf.TokenListOp.Create(prependedItems=[*missing, *existing])
+            prim.SetMetadata("apiSchemas", merged)
+        for attr_name, sdf_type_name, value in _NEUTRAL_CAMERA_EXPOSURE:
+            attr = prim.GetAttribute(attr_name)
+            if not attr:
+                attr = prim.CreateAttribute(attr_name, sdf_value_types[sdf_type_name], custom=False)
+            attr.Set(coerce(value, sdf_type_name))

--- a/source/isaaclab_ppisp/pyproject.toml
+++ b/source/isaaclab_ppisp/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools<82.0.0", "wheel", "toml"]
+build-backend = "setuptools.build_meta"

--- a/source/isaaclab_ppisp/setup.py
+++ b/source/isaaclab_ppisp/setup.py
@@ -3,29 +3,34 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Installation script for the 'isaaclab_ov' python package."""
+"""Installation script for the 'isaaclab_ppisp' python package."""
 
 import os
+import shutil
 
 import toml
 from setuptools import setup
+from setuptools.command.build_py import build_py as _build_py
 
-# Obtain the extension data from the extension.toml file
+
+class build_py(_build_py):
+    """Custom build command that bundles config/extension.toml into the package."""
+
+    def run(self):
+        super().run()
+        src = os.path.join(EXTENSION_PATH, "config", "extension.toml")
+        dst_dir = os.path.join(self.build_lib, "isaaclab_ppisp", "config")
+        os.makedirs(dst_dir, exist_ok=True)
+        shutil.copy(src, os.path.join(dst_dir, "extension.toml"))
+
+
 EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
-# Read the extension.toml file
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
-EXTRAS_REQUIRE = {
-    "ovrtx": [
-        "ovrtx>=0.3.0,<0.4.0",
-    ],
-}
-
-# add "[all]" for convenience
-EXTRAS_REQUIRE["all"] = sorted(set(dep for deps in EXTRAS_REQUIRE.values() for dep in deps))
+INSTALL_REQUIRES = []
 
 setup(
-    name="isaaclab_ov",
+    name="isaaclab_ppisp",
     author="Isaac Lab Project Developers",
     maintainer="Isaac Lab Project Developers",
     url=EXTENSION_TOML_DATA["package"]["repository"],
@@ -34,13 +39,16 @@ setup(
     keywords=EXTENSION_TOML_DATA["package"]["keywords"],
     license="BSD-3-Clause",
     include_package_data=True,
+    package_data={"": ["*.pyi"]},
     python_requires=">=3.12",
-    install_requires=["isaaclab_ppisp"],
-    extras_require=EXTRAS_REQUIRE,
-    packages=["isaaclab_ov"],
+    install_requires=INSTALL_REQUIRES,
+    packages=[
+        "isaaclab_ppisp",
+    ],
     classifiers=[
         "Natural Language :: English",
         "Programming Language :: Python :: 3.12",
     ],
     zip_safe=False,
+    cmdclass={"build_py": build_py},
 )

--- a/source/isaaclab_ppisp/test/test_ppisp.py
+++ b/source/isaaclab_ppisp/test/test_ppisp.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for PPISP USD parsing helpers."""
+
+import pytest
+from isaaclab_ppisp import PpispCfg, normalize_ppisp_cfg, ppisp_cfg_from_usd_shader
+
+from pxr import Gf, Sdf, Usd, UsdShade
+
+
+def test_ppisp_shader_import_uses_first_time_sample():
+    stage = Usd.Stage.CreateInMemory()
+    shader = UsdShade.Shader.Define(stage, "/Render/RenderProduct/PPISP")
+
+    exposure = shader.CreateInput("exposureOffset", Sdf.ValueTypeNames.Float).GetAttr()
+    exposure.Set(1.0)
+    exposure.Set(2.0, 10.0)
+    exposure.Set(3.0, 20.0)
+
+    color = shader.CreateInput("colorLatentBlue", Sdf.ValueTypeNames.Float2).GetAttr()
+    color.Set(Gf.Vec2f(0.0, 0.0))
+    color.Set(Gf.Vec2f(0.1, 0.2), 5.0)
+
+    cfg = ppisp_cfg_from_usd_shader(shader)
+
+    assert cfg.inputs["exposureOffset"] == 2.0
+    assert cfg.inputs["colorLatentBlue"] == pytest.approx((0.1, 0.2))
+
+
+def test_normalize_ppisp_cfg_imports_shader_prim_path_from_stage():
+    stage = Usd.Stage.CreateInMemory()
+    shader = UsdShade.Shader.Define(stage, "/Render/RenderProduct/PPISP")
+    shader.CreateInput("exposureOffset", Sdf.ValueTypeNames.Float).Set(1.5)
+    shader.CreateInput("colorLatentRed", Sdf.ValueTypeNames.Float2).Set(Gf.Vec2f(0.25, -0.5))
+
+    cfg = normalize_ppisp_cfg(PpispCfg(shader_prim_path="/Render/RenderProduct/PPISP"), stage=stage)
+
+    assert cfg.shader_prim_path == "/Render/RenderProduct/PPISP"
+    assert cfg.inputs["exposureOffset"] == 1.5
+    assert cfg.inputs["colorLatentRed"] == pytest.approx((0.25, -0.5))
+
+
+def test_normalize_ppisp_cfg_applies_explicit_overrides_after_shader_import():
+    stage = Usd.Stage.CreateInMemory()
+    shader = UsdShade.Shader.Define(stage, "/Render/RenderProduct/PPISP")
+    shader.CreateInput("exposureOffset", Sdf.ValueTypeNames.Float).Set(1.5)
+    shader.CreateInput("colorLatentRed", Sdf.ValueTypeNames.Float2).Set(Gf.Vec2f(0.25, -0.5))
+
+    cfg = normalize_ppisp_cfg(
+        PpispCfg(
+            shader_prim_path="/Render/RenderProduct/PPISP",
+            inputs={"exposureOffset": 2.0},
+        ),
+        stage=stage,
+    )
+
+    assert cfg.inputs["exposureOffset"] == 2.0
+    assert cfg.inputs["colorLatentRed"] == pytest.approx((0.25, -0.5))

--- a/source/isaaclab_ppisp/test/test_ppisp_kernels.py
+++ b/source/isaaclab_ppisp/test/test_ppisp_kernels.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import warp as wp
+from isaaclab_ppisp import PpispCfg, apply_ppisp_to_rgba, normalize_ppisp_cfg
+
+from isaaclab.sensors.camera.tiled_camera_cfg import TiledCameraCfg
+
+wp.init()
+
+
+def _hdr(fill: float, shape: tuple[int, ...]) -> wp.array:
+    return wp.full(shape=shape, value=wp.float32(fill), dtype=wp.float32)
+
+
+def _rgba(shape: tuple[int, ...]) -> wp.array:
+    return wp.zeros(shape=shape, dtype=wp.uint8)
+
+
+def test_ppisp_warp_exposure_increases_ldr_output():
+    hdr_color = _hdr(0.25, (1, 4, 4, 3))
+    baseline = _rgba((1, 4, 4, 4))
+    exposed = _rgba((1, 4, 4, 4))
+
+    apply_ppisp_to_rgba(hdr_color, baseline, normalize_ppisp_cfg(PpispCfg(inputs={"exposureOffset": 0.0})))
+    apply_ppisp_to_rgba(hdr_color, exposed, normalize_ppisp_cfg(PpispCfg(inputs={"exposureOffset": 1.0})))
+
+    baseline_np = baseline.numpy()
+    exposed_np = exposed.numpy()
+    assert (baseline_np[..., 3] == 255).all()
+    assert (exposed_np[..., 3] == 255).all()
+    assert exposed_np[..., :3].astype(float).mean() > baseline_np[..., :3].astype(float).mean()
+
+
+def test_ppisp_warp_responsivity_lifts_dim_input():
+    """Responsivity is applied pre-PPISP and recovers near-zero linear inputs."""
+    hdr_color = _hdr(1.0e-3, (1, 4, 4, 3))
+    baseline = _rgba((1, 4, 4, 4))
+    boosted = _rgba((1, 4, 4, 4))
+
+    apply_ppisp_to_rgba(hdr_color, baseline, normalize_ppisp_cfg(PpispCfg(inputs={"responsivity": 1.0})))
+    apply_ppisp_to_rgba(hdr_color, boosted, normalize_ppisp_cfg(PpispCfg(inputs={"responsivity": 1000.0})))
+
+    baseline_np = baseline.numpy()
+    boosted_np = boosted.numpy()
+    assert (baseline_np[..., 3] == 255).all()
+    assert (boosted_np[..., 3] == 255).all()
+    assert boosted_np[..., :3].astype(float).mean() > baseline_np[..., :3].astype(float).mean()
+
+
+def test_ppisp_warp_vignetting_uses_detiled_camera_coordinates():
+    hdr_color = _hdr(0.5, (2, 5, 5, 3))
+    rgba = _rgba((2, 5, 5, 4))
+
+    apply_ppisp_to_rgba(
+        hdr_color,
+        rgba,
+        normalize_ppisp_cfg(
+            PpispCfg(
+                inputs={
+                    "vignettingAlpha1R": -1.0,
+                    "vignettingAlpha1G": -1.0,
+                    "vignettingAlpha1B": -1.0,
+                }
+            )
+        ),
+    )
+
+    rgba_np = rgba.numpy()
+    assert (rgba_np[:, 2, 2, :3] > rgba_np[:, 0, 0, :3]).all()
+    assert (rgba_np[0] == rgba_np[1]).all()
+
+
+def test_ppisp_warp_crf_extreme_centers_stay_finite():
+    import numpy as np
+
+    hdr_data = np.array(
+        [
+            [
+                [[0.0, 0.25, 0.5], [0.75, 1.0, 0.5]],
+                [[0.0, 0.25, 0.5], [0.75, 1.0, 0.5]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+    hdr_color = wp.from_numpy(hdr_data, dtype=wp.float32)
+    rgba = _rgba((1, 2, 2, 4))
+
+    apply_ppisp_to_rgba(
+        hdr_color,
+        rgba,
+        normalize_ppisp_cfg(
+            PpispCfg(
+                inputs={
+                    "crfCenterR": -100.0,
+                    "crfCenterG": 100.0,
+                    "crfCenterB": -100.0,
+                }
+            )
+        ),
+    )
+
+    rgba_np = rgba.numpy()
+    assert (rgba_np[..., 3] == 255).all()
+    assert np.isfinite(rgba_np.astype(float)).all()
+
+
+def test_tiled_camera_cfg_accepts_ppisp_cfg():
+    ppisp_cfg = PpispCfg(inputs={"exposureOffset": 1.0})
+
+    cfg = TiledCameraCfg(
+        prim_path="/World/Camera",
+        width=4,
+        height=4,
+        data_types=["rgb"],
+        isp_cfg=ppisp_cfg,
+    )
+
+    assert cfg.isp_cfg == ppisp_cfg

--- a/source/isaaclab_ppisp/test/test_rtx_camera_overrides.py
+++ b/source/isaaclab_ppisp/test/test_rtx_camera_overrides.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the RTX-side camera-exposure overrides applied when PPISP is active."""
+
+from isaaclab_ppisp import apply_rtx_exposure_overrides
+
+from pxr import Sdf, Usd, UsdGeom
+
+
+def test_apply_rtx_exposure_overrides_resets_authored_exposure_values():
+    """When PPISP is the ISP authority, the camera prim's RTX-side exposure must be neutral."""
+    stage = Usd.Stage.CreateInMemory()
+    cam = UsdGeom.Camera.Define(stage, "/World/Camera")
+    prim = cam.GetPrim()
+    # Author non-neutral values to confirm the helper overrides them.
+    prim.CreateAttribute("exposure", Sdf.ValueTypeNames.Float).Set(2.0)
+    prim.CreateAttribute("exposure:fStop", Sdf.ValueTypeNames.Float).Set(2.8)
+    prim.CreateAttribute("exposure:iso", Sdf.ValueTypeNames.Float).Set(800.0)
+    prim.CreateAttribute("exposure:responsivity", Sdf.ValueTypeNames.Float).Set(0.5)
+    prim.CreateAttribute("exposure:time", Sdf.ValueTypeNames.Float).Set(1.0 / 60.0)
+    prim.CreateAttribute("omni:rtx:autoExposure:enabled", Sdf.ValueTypeNames.Bool).Set(True)
+
+    apply_rtx_exposure_overrides(stage, ["/World/Camera"])
+
+    assert prim.GetAttribute("exposure").Get() == 0.0
+    assert prim.GetAttribute("exposure:fStop").Get() == 1.0
+    assert prim.GetAttribute("exposure:iso").Get() == 0.0
+    assert prim.GetAttribute("exposure:responsivity").Get() == 1.0
+    assert prim.GetAttribute("exposure:time").Get() == 1.0
+    assert prim.GetAttribute("omni:rtx:autoExposure:enabled").Get() is False
+    # The PPISP API schemas must also be applied — that is what makes Kit's
+    # USD watcher route the camera prim's ``exposure:*`` and
+    # ``omni:rtx:autoExposure:*`` attributes into the per-camera carb
+    # settings RTX consumes.
+    api_schemas = prim.GetMetadata("apiSchemas")
+    assert api_schemas is not None
+    applied = list(api_schemas.prependedItems) + list(api_schemas.explicitItems) + list(api_schemas.appendedItems)
+    assert "OmniRtxCameraAutoExposureAPI_1" in applied
+    assert "OmniRtxCameraExposureAPI_1" in applied


### PR DESCRIPTION
 ## Description
  
  Introduces a wrapper-side Physically Plausible Image Signal Processing (PPISP) pipeline on the Camera sensor that converts  the renderer's HDR AOV to LDR RGBA on every render tick. The pipeline applies responsivity → exposure → vignetting →  color homography → camera response function → uint8 clamp in a single Warp kernel, called once per tick from the camera.
The kernel runs after the renderer fills the HDR buffer and writes back into the user-requested rgb/rgba output, so the rest of the pipeline stays untouched.

The integration is renderer-agnostic. New public surface in isaaclab.sensors.camera:

  - CameraPPISPCfg — explicit ISP coefficients (or a USD shader prim path).
  - CameraISPMode — AUTO_CAMERA (find an ISP shader bound to this camera via a RenderProduct), AUTO_ANY (fall back to the  first PPISP shader anywhere on stage).
  - CameraISP — owns HDR-buffer allocation and per-tick kernel dispatch.
  - CameraCfg.isp_cfg — accepts CameraPPISPCfg | CameraISPMode | None; defaults to CameraISPMode.AUTO_ANY.

Renderer contract extensions (in isaaclab.renderers):

  - RenderBufferKind.RGB_HDR (3-channel float, scene-linear).
  - RendererCfg.apply_pre_reset_settings(*, require_hdr_output) — backend hook to author global carb settings before sim.reset().
  - BaseRenderer.prepare_cameras(stage, spec) — backend hook for per-camera USD setup.
  - CameraRenderSpec — immutable snapshot of a tiled camera bundle so backends don't hold a reference to the sensor.

  Backend changes:

  - IsaacRtxRenderer (isaaclab_physx): advertises RGB_HDR via the Replicator HdrColor annotator; prepare_cameras authors a  neutral OmniRtxCameraExposureAPI_1 schema on each camera prim so RTX-side tonemapping does not double-process the ISP output; apply_pre_reset_settings sets /isaaclab/render/rtx_sensors=True and flips /rtx/rtpt/gaussian/skipTonemapping/enabled=False when HDR is requested (required to keep 3DGS splats in HDR).
  - OVRTXRenderer (isaaclab_ov): mirrors the IsaacRtx changes (HDR render var, neutral exposure schema, skipTonemapping).
  The exposure-override helper is intentionally duplicated rather than imported across sibling packages during the release window.
  - NewtonWarpRenderer (isaaclab_newton): advertises RGB_HDR (its scene-linear color is already what we need).

## Dependencies

No new runtime dependencies. Uses existing IsaacLab dependencies: Warp, Torch, USD, and renderer-specific backends.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Screenshots
Not applicable.

## Checklist
- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there