### PR TITLE
use RendererCfg as default renderer_cfg in CameraCfg

### DIFF
--- a/source/isaaclab/changelog.d/rschmitt_default_cameracfg_renderer.rst
+++ b/source/isaaclab/changelog.d/rschmitt_default_cameracfg_renderer.rst
@@ -1,0 +1,11 @@
+Added
+^^^^^
+
+* Added :meth:`~isaaclab.utils.backend_utils.get_default_renderer_cfg`. to lazy load the IsaacRtxRendererCfg
+
+Changed
+^^^^^^^
+
+* :class:`~isaaclab.sensors.camera.CameraCfg` now defaults its render_cfg to None.
+  :meth:`~isaaclab.utils.backend_utils.get_default_renderer_cfg` is called during __post_init__ to replace
+  None with a valid config

--- a/source/isaaclab/changelog.d/rschmitt_default_cameracfg_renderer.rst
+++ b/source/isaaclab/changelog.d/rschmitt_default_cameracfg_renderer.rst
@@ -6,6 +6,6 @@ Added
 Changed
 ^^^^^^^
 
-* :class:`~isaaclab.sensors.camera.CameraCfg` now defaults its render_cfg to None.
+* :class:`~isaaclab.sensors.camera.CameraCfg` now defaults its render_cfg to :class:`~isaaclab.renderers.RenderCfg`
   :meth:`~isaaclab.utils.backend_utils.get_default_renderer_cfg` is called during __post_init__ to replace
-  None with a valid config
+  the generic RenderCfg with the default config :class:`~isaaclab_physx.renderers.IsaacRtxRendererCfg`

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -113,7 +113,8 @@ class Camera(SensorBase):
         # IsaacRtxRendererCfg overrides to flip /isaaclab/render/rtx_sensors. The
         # flag must be set pre-sim.reset() because SimulationContext.is_rendering
         # and several env classes read it before the renderer's __init__ runs.
-        if self.cfg.renderer_cfg.renderer_type == "isaac_rtx":
+        renderer_type = getattr(self.cfg.renderer_cfg, "renderer_type", None)
+        if renderer_type == "isaac_rtx":
             get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", True)
 
         # Compute camera orientation (convention conversion) and spawn

--- a/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
@@ -190,7 +190,7 @@ class CameraCfg(SensorBaseCfg):
         on :attr:`renderer_cfg` instead.
     """
 
-    renderer_cfg: RendererCfg | None = field(default=None)
+    renderer_cfg: RendererCfg = field(default_factory=RendererCfg)
     """Renderer configuration for camera sensor.
 
     If ``None``, :meth:`__post_init__` assigns :func:`~isaaclab.utils.backend_utils.get_default_render_cfg`
@@ -204,7 +204,10 @@ class CameraCfg(SensorBaseCfg):
         :class:`DeprecationWarning` and is copied onto ``self.renderer_cfg``
         when that cfg defines the same-named field.
         """
-        if self.renderer_cfg is None:
+        # TODO when Camera.__init__ moves rtx_sensor setting out of camera initialization
+        # the default renderer config instantiation can be moved into the render factory
+        # and get_default_render_cfg method can be removed from backend_utils
+        if self.renderer_cfg.renderer_type == "default":
             self.renderer_cfg = get_default_renderer_cfg()
         # Forwarded by name: any same-named field on ``renderer_cfg`` will receive the value.
         for field_name, default in _DEPRECATED_RENDERER_FIELD_DEFAULTS.items():

--- a/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
@@ -9,11 +9,10 @@ import warnings
 from dataclasses import MISSING, field
 from typing import TYPE_CHECKING, Literal
 
-from isaaclab_physx.renderers import IsaacRtxRendererCfg
-
 from isaaclab.renderers import RendererCfg
 from isaaclab.sim import FisheyeCameraCfg, PinholeCameraCfg
 from isaaclab.utils import configclass
+from isaaclab.utils.backend_utils import get_default_render_cfg
 
 from ..sensor_base_cfg import SensorBaseCfg
 
@@ -191,8 +190,12 @@ class CameraCfg(SensorBaseCfg):
         on :attr:`renderer_cfg` instead.
     """
 
-    renderer_cfg: RendererCfg = field(default_factory=IsaacRtxRendererCfg)
-    """Renderer configuration for camera sensor."""
+    renderer_cfg: RendererCfg | None = field(default=None)
+    """Renderer configuration for camera sensor.
+
+    If ``None``, :meth:`__post_init__` assigns :func:`~isaaclab.utils.backend_utils.get_default_render_cfg`
+    (lazy import of ``isaaclab_physx.renderers``; requires ``isaaclab_physx``).
+    """
 
     def __post_init__(self):
         """Forward deprecated RTX-flavored fields onto :attr:`renderer_cfg`.
@@ -201,6 +204,8 @@ class CameraCfg(SensorBaseCfg):
         :class:`DeprecationWarning` and is copied onto ``self.renderer_cfg``
         when that cfg defines the same-named field.
         """
+        if self.renderer_cfg is None:
+            self.renderer_cfg = get_default_render_cfg()
         # Forwarded by name: any same-named field on ``renderer_cfg`` will receive the value.
         for field_name, default in _DEPRECATED_RENDERER_FIELD_DEFAULTS.items():
             value = getattr(self, field_name)

--- a/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
@@ -202,7 +202,8 @@ class CameraCfg(SensorBaseCfg):
         # TODO when Camera.__init__ moves rtx_sensor setting out of camera initialization
         # the default renderer config instantiation can be moved into the render factory
         # and get_default_render_cfg method can be removed from backend_utils
-        if self.renderer_cfg.renderer_type == "default":
+        renderer_type = getattr(self.renderer_cfg, "renderer_type", None)
+        if renderer_type == "default":
             from isaaclab.utils.backend_utils import get_default_renderer_cfg
 
             self.renderer_cfg = get_default_renderer_cfg()

--- a/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Literal
 from isaaclab.renderers import RendererCfg
 from isaaclab.sim import FisheyeCameraCfg, PinholeCameraCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.backend_utils import get_default_renderer_cfg
 
 from ..sensor_base_cfg import SensorBaseCfg
 
@@ -191,11 +190,7 @@ class CameraCfg(SensorBaseCfg):
     """
 
     renderer_cfg: RendererCfg = field(default_factory=RendererCfg)
-    """Renderer configuration for camera sensor.
-
-    If ``None``, :meth:`__post_init__` assigns :func:`~isaaclab.utils.backend_utils.get_default_render_cfg`
-    (lazy import of ``isaaclab_physx.renderers``; requires ``isaaclab_physx``).
-    """
+    """Renderer configuration for camera sensor."""
 
     def __post_init__(self):
         """Forward deprecated RTX-flavored fields onto :attr:`renderer_cfg`.
@@ -208,6 +203,8 @@ class CameraCfg(SensorBaseCfg):
         # the default renderer config instantiation can be moved into the render factory
         # and get_default_render_cfg method can be removed from backend_utils
         if self.renderer_cfg.renderer_type == "default":
+            from isaaclab.utils.backend_utils import get_default_renderer_cfg
+
             self.renderer_cfg = get_default_renderer_cfg()
         # Forwarded by name: any same-named field on ``renderer_cfg`` will receive the value.
         for field_name, default in _DEPRECATED_RENDERER_FIELD_DEFAULTS.items():

--- a/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Literal
 from isaaclab.renderers import RendererCfg
 from isaaclab.sim import FisheyeCameraCfg, PinholeCameraCfg
 from isaaclab.utils import configclass
-from isaaclab.utils.backend_utils import get_default_render_cfg
+from isaaclab.utils.backend_utils import get_default_renderer_cfg
 
 from ..sensor_base_cfg import SensorBaseCfg
 
@@ -205,7 +205,7 @@ class CameraCfg(SensorBaseCfg):
         when that cfg defines the same-named field.
         """
         if self.renderer_cfg is None:
-            self.renderer_cfg = get_default_render_cfg()
+            self.renderer_cfg = get_default_renderer_cfg()
         # Forwarded by name: any same-named field on ``renderer_cfg`` will receive the value.
         for field_name, default in _DEPRECATED_RENDERER_FIELD_DEFAULTS.items():
             value = getattr(self, field_name)

--- a/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
@@ -27,7 +27,6 @@ class TiledCameraCfg(CameraCfg):
     class_type: type["TiledCamera"] | str = "{DIR}.tiled_camera:TiledCamera"
 
     def __post_init__(self):
-        # Leaf ``__post_init__`` only: call parent so ``renderer_cfg`` is filled.
         super().__post_init__()
         warnings.warn(
             "TiledCameraCfg is deprecated. Use CameraCfg directly — "

--- a/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
@@ -27,7 +27,13 @@ class TiledCameraCfg(CameraCfg):
     class_type: type["TiledCamera"] | str = "{DIR}.tiled_camera:TiledCamera"
 
     def __post_init__(self):
-        super().__post_init__()
+        # TODO when Camera.__init__ moves rtx_sensor setting out of camera initialization
+        # the default renderer config instantiation can be moved into the render factory
+        # and get_default_render_cfg method can be removed from backend_utils
+        if self.renderer_cfg.renderer_type == "default":
+            from isaaclab.utils.backend_utils import get_default_renderer_cfg
+
+            self.renderer_cfg = get_default_renderer_cfg()
         warnings.warn(
             "TiledCameraCfg is deprecated. Use CameraCfg directly — "
             "Camera now includes TiledCamera's vectorized rendering optimizations.",

--- a/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
@@ -30,7 +30,8 @@ class TiledCameraCfg(CameraCfg):
         # TODO when Camera.__init__ moves rtx_sensor setting out of camera initialization
         # the default renderer config instantiation can be moved into the render factory
         # and get_default_render_cfg method can be removed from backend_utils
-        if self.renderer_cfg.renderer_type == "default":
+        renderer_type = getattr(self.renderer_cfg, "renderer_type", None)
+        if renderer_type == "default":
             from isaaclab.utils.backend_utils import get_default_renderer_cfg
 
             self.renderer_cfg = get_default_renderer_cfg()

--- a/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
@@ -27,6 +27,8 @@ class TiledCameraCfg(CameraCfg):
     class_type: type["TiledCamera"] | str = "{DIR}.tiled_camera:TiledCamera"
 
     def __post_init__(self):
+        # Leaf ``__post_init__`` only: call parent so ``renderer_cfg`` is filled.
+        super().__post_init__()
         warnings.warn(
             "TiledCameraCfg is deprecated. Use CameraCfg directly — "
             "Camera now includes TiledCamera's vectorized rendering optimizations.",

--- a/source/isaaclab/isaaclab/utils/backend_utils.py
+++ b/source/isaaclab/isaaclab/utils/backend_utils.py
@@ -3,10 +3,46 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import importlib
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from isaaclab.renderers.renderer_cfg import RendererCfg
 
 logger = logging.getLogger(__name__)
+
+
+def get_default_render_cfg() -> RendererCfg:
+    """Return the default :class:`~isaaclab.renderers.renderer_cfg.RendererCfg` for cameras.
+
+    Lazily imports :mod:`isaaclab_physx.renderers` and returns a new
+    :class:`~isaaclab_physx.renderers.IsaacRtxRendererCfg` instance.
+
+    Returns:
+        A new default Isaac RTX renderer configuration.
+
+    Raises:
+        ImportError: If :mod:`isaaclab_physx.renderers` cannot be imported or does not
+            expose ``IsaacRtxRendererCfg``.
+    """
+    try:
+        renderers_mod = importlib.import_module("isaaclab_physx.renderers")
+    except ImportError as e:
+        raise ImportError(
+            "The default camera renderer configuration requires the optional 'isaaclab_physx' "
+            "package (import 'isaaclab_physx.renderers'). Install isaaclab_physx or set "
+            "CameraCfg.renderer_cfg explicitly."
+        ) from e
+    try:
+        default_cls = renderers_mod.IsaacRtxRendererCfg
+    except AttributeError as e:
+        raise ImportError(
+            "Module 'isaaclab_physx.renderers' is available but does not define 'IsaacRtxRendererCfg'."
+        ) from e
+    return default_cls()
 
 
 class FactoryBase:

--- a/source/isaaclab/isaaclab/utils/backend_utils.py
+++ b/source/isaaclab/isaaclab/utils/backend_utils.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_default_render_cfg() -> RendererCfg:
+def get_default_renderer_cfg() -> RendererCfg:
     """Return the default :class:`~isaaclab.renderers.renderer_cfg.RendererCfg` for cameras.
 
     Lazily imports :mod:`isaaclab_physx.renderers` and returns a new


### PR DESCRIPTION
# Description

the camera config was importing `isaaclab_physx.renderers` because the default render_cfg was set to that config.  this PR sets that to RendererConfig to remove the import, but provides a get_default_render_config method to the backend_utils to lazily import the config if needed.  this is called __post_init__ on the camera config to replace the generic config as soon as possible to avoid downstream issues referencing the renderer config.  this action can be moved to the factory if downstream references are cleaned up.

## Type of change

- Refactor to remove imports in cfg class

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

