### PR TITLE
[Changelog]Use isaaclab-bot GitHub App token for nightly changelog push

### DIFF
--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -65,6 +65,10 @@ jobs:
         with:
           app-id: ${{ secrets.CHANGELOG_APP_ID }}
           private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+          # Declare the scope the App must have so token mint fails loudly
+          # if the App is misconfigured, instead of failing silently at the
+          # push step.
+          permission-contents: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
@@ -96,7 +100,7 @@ jobs:
           python3 tools/changelog/cli.py compile $ARGS
 
       - name: Commit and push if fragments were compiled
-        if: inputs.dry_run != 'true'
+        if: ${{ !inputs.dry_run }}
         run: |
           # Author commits as the App's bot user so the GitHub UI attributes
           # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
@@ -134,6 +138,11 @@ jobs:
               done
             } > "$MSG_FILE"
             git commit -F "$MSG_FILE"
+            # Rebase onto develop's current tip in case a human commit
+            # landed during this run (~2 min window between checkout and
+            # push). Without this the push fails non-fast-forward and the
+            # batch waits for the next run.
+            git pull --rebase origin develop
             # Push explicitly to develop so we don't accidentally write
             # to the source ref of a workflow_dispatch run.
             git push origin HEAD:develop

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -12,13 +12,15 @@
 # Scheduled workflow — must live on the default branch (``main``) for the
 # cron to register. See ``.github/workflows/README.md``.
 #
-# The push uses ``CHANGELOG_PAT`` (a personal access token / fine-grained
-# GitHub App token with ``contents:write`` on this repo) when it's
-# available so downstream CI runs on the auto-commit. Falls back to
-# ``GITHUB_TOKEN`` — sufficient for the push itself, but pushes signed
-# with ``GITHUB_TOKEN`` do not trigger workflow runs on the resulting
-# commit, which is by design (avoids infinite loops) but means the
-# Docker / docs rebuild won't re-trigger off the nightly's auto-commit.
+# The push uses a short-lived GitHub App installation token minted from
+# ``CHANGELOG_APP_ID`` + ``CHANGELOG_APP_PRIVATE_KEY`` (repo secrets). The
+# App must be installed on this repository with ``contents: write`` and
+# added to the bypass-actor list of ``develop``'s branch ruleset so the
+# auto-commit can push directly without satisfying required-checks /
+# required-approval gates.
+# Commits signed by an App token (unlike ``GITHUB_TOKEN``) are treated as
+# external pushes, so they DO trigger downstream workflow runs (Docker
+# rebuild, docs, etc.) without needing a separate PAT.
 
 name: Nightly Changelog Compilation
 
@@ -43,7 +45,9 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  # Reduced: the App installation token below carries its own write scope.
+  # GITHUB_TOKEN only needs read access for the standard checkout machinery.
+  contents: read
 
 jobs:
   compile-changelog:
@@ -52,6 +56,16 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # Mint a short-lived (1 h) installation access token for the
+      # ``isaaclab-bot`` GitHub App. The App is on develop's branch-ruleset
+      # bypass list, so its push lands without needing the standard
+      # required-checks / required-approval pipeline.
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.CHANGELOG_APP_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           # Operate on develop, not the repo's default branch. Scheduled
@@ -60,9 +74,10 @@ jobs:
           # compile sees develop's accumulated fragments and the push
           # writes back to develop.
           ref: develop
-          # Use a PAT so the auto-commit triggers downstream CI; falls back
-          # to GITHUB_TOKEN which is sufficient for the push itself.
-          token: ${{ secrets.CHANGELOG_PAT || secrets.GITHUB_TOKEN }}
+          # App token (vs. GITHUB_TOKEN) means the push is signed by
+          # ``isaaclab-bot`` — the bypass identity — and downstream CI
+          # workflows DO trigger on the resulting commit.
+          token: ${{ steps.app-token.outputs.token }}
           # Full history so the compiler can resolve each fragment's merge
           # time via ``git log --diff-filter=A --first-parent``.
           fetch-depth: 0
@@ -83,8 +98,10 @@ jobs:
       - name: Commit and push if fragments were compiled
         if: inputs.dry_run != 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Author commits as the App's bot user so the GitHub UI attributes
+          # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
+          git config user.name "isaaclab-bot[bot]"
+          git config user.email "282401363+isaaclab-bot[bot]@users.noreply.github.com"
           git add source/*/changelog.d/ \
                   source/*/docs/CHANGELOG.rst \
                   source/*/config/extension.toml


### PR DESCRIPTION
## Why

Develop's branch ruleset requires 18 status checks **and** 1 approval before any push. The nightly compile workflow (https://github.com/isaac-sim/IsaacLab/pull/5482) was authenticated with `GITHUB_TOKEN` (identity `github-actions[bot]`), which has neither the bypass entitlement nor a way to satisfy approvals. Result: the cron pushed cleanly until it hit develop, then failed with `protected branch hook declined` — fragments accumulate, no auto-bump happens.

Confirmed failure: https://github.com/isaac-sim/IsaacLab/actions/runs/25419200769

## What this PR does

Switches the workflow's checkout/push token to a short-lived installation access token minted from the `isaaclab-bot` GitHub App (created by @kellyguo11 and added to develop's ruleset bypass list).

| Change | Effect |
|---|---|
| Add `actions/create-github-app-token@v3.1.1` step (SHA-pinned) | Mints a 1-hour installation token from `CHANGELOG_APP_ID` + `CHANGELOG_APP_PRIVATE_KEY` repo secrets. |
| `actions/checkout` token: `app-token` instead of `GITHUB_TOKEN` | Push is signed by `isaaclab-bot[bot]` — the bypass identity. Lands without satisfying required-checks / required-approval. |
| `git config user.{name,email}` updated to `isaaclab-bot[bot]` | Auto-commits attribute to the bot user in the GitHub UI. |
| Workflow `permissions: contents: write` → `contents: read` | The App token carries write access; `GITHUB_TOKEN` only needs read. Tightens least-privilege. |
| Header comment rewritten | Documents the App-token model + bypass requirement. |

## Side benefit: triggers downstream workflows

`GITHUB_TOKEN`-signed pushes don't trigger downstream workflows by design (loop guard). App-token-signed pushes are treated as external pushes and DO trigger downstream CI — so docs / Docker rebuild jobs fire on the auto-commit naturally, no separate PAT required.

## Setup status

Already done by maintainers:
- [x] `isaaclab-bot` GitHub App created with `contents: write` permission
- [x] App installed on `isaac-sim/IsaacLab`
- [x] App added to develop's ruleset bypass actor list
- [x] Repo secrets `CHANGELOG_APP_ID` and `CHANGELOG_APP_PRIVATE_KEY` set

## Test plan

- [x] PR diff is YAML-only, no code changes.
- [ ] After merge: manually trigger via `gh workflow run "Nightly Changelog Compilation" --repo isaac-sim/IsaacLab` and verify the push lands and the bot user shows as the commit author on https://github.com/isaac-sim/IsaacLab/commits/develop.
- [ ] Confirm the next 5 AM UTC cron sweeps the accumulated fragment backlog (~22 fragments at last count).

cc @kellyguo11