### PR TITLE
Fixes joint friction API docs

### DIFF
--- a/source/isaaclab/changelog.d/antoiner-docs-joint-friction.rst
+++ b/source/isaaclab/changelog.d/antoiner-docs-joint-friction.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.assets.Articulation` joint friction API docs to clarify backend-specific semantics.

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -1067,11 +1067,12 @@ class BaseArticulation(AssetBase):
         joint_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
         env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
     ) -> None:
-        r"""Write joint static friction coefficients into the simulation.
+        r"""Write backend-specific joint friction values into the simulation.
 
-        The joint static friction is a unitless quantity. It relates the magnitude of the spatial force transmitted
-        from the parent body to the child body to the maximal static friction force that may be applied by the solver
-        to resist the joint motion.
+        .. warning::
+            The physical meaning and units of joint friction depend on the concrete backend and solver. Do not assume
+            values are comparable across backends; check the backend-specific implementation before interpreting or
+            reusing them.
 
         .. note::
             This method expects partial data.
@@ -1081,7 +1082,7 @@ class BaseArticulation(AssetBase):
             Some backends may provide optimized implementations for masks / indices.
 
         Args:
-            joint_friction_coeff: Joint static friction coefficient. Shape is (len(env_ids), len(joint_ids)).
+            joint_friction_coeff: Backend-specific joint friction values. Shape is (len(env_ids), len(joint_ids)).
             joint_ids: The joint indices to set the joint torque limits for. Defaults to None (all joints).
             env_ids: The environment indices to set the joint torque limits for. Defaults to None (all instances).
         """
@@ -1095,11 +1096,12 @@ class BaseArticulation(AssetBase):
         joint_mask: wp.array | None = None,
         env_mask: wp.array | None = None,
     ) -> None:
-        r"""Write joint static friction coefficients into the simulation.
+        r"""Write backend-specific joint friction values into the simulation.
 
-        The joint static friction is a unitless quantity. It relates the magnitude of the spatial force transmitted
-        from the parent body to the child body to the maximal static friction force that may be applied by the solver
-        to resist the joint motion.
+        .. warning::
+            The physical meaning and units of joint friction depend on the concrete backend and solver. Do not assume
+            values are comparable across backends; check the backend-specific implementation before interpreting or
+            reusing them.
 
         .. note::
             This method expects full data.
@@ -1109,7 +1111,7 @@ class BaseArticulation(AssetBase):
             Some backends may provide optimized implementations for masks / indices.
 
         Args:
-            joint_friction_coeff: Joint static friction coefficient. Shape is (num_instances, num_joints).
+            joint_friction_coeff: Backend-specific joint friction values. Shape is (num_instances, num_joints).
             joint_mask: Joint mask. If None, then all the joints are updated. Shape is (num_joints,).
             env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
         """

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
@@ -248,9 +248,14 @@ class BaseArticulationData(ABC):
     @abstractmethod
     @leapp_tensor_semantics(const=True)
     def joint_friction_coeff(self) -> ProxyArray:
-        """Joint static friction coefficient provided to the simulation.
+        """Backend-specific joint friction values provided to the simulation.
 
         Shape is (num_instances, num_joints), dtype = wp.float32. In torch this resolves to (num_instances, num_joints).
+
+        .. warning::
+            The physical meaning and units of this value depend on the concrete backend and solver. Do not assume
+            values are comparable across backends; check the backend-specific :class:`ArticulationData`
+            implementation before interpreting or reusing them.
         """
         raise NotImplementedError
 

--- a/source/isaaclab_newton/changelog.d/antoiner-docs-joint-friction.rst
+++ b/source/isaaclab_newton/changelog.d/antoiner-docs-joint-friction.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_newton.assets.Articulation` joint friction docs to identify Newton friction as a force or
+  torque value instead of a unitless coefficient.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -1964,7 +1964,19 @@ class Articulation(BaseArticulation):
         joint_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
         env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
     ):
-        r"""Write joint friction coefficients over selected environment indices into the simulation.
+        r"""Write Newton joint friction force/torque values over selected environment indices into the simulation.
+
+        This writes to Newton's ``Model.joint_friction`` field. Despite the ``coeff`` suffix in the Isaac Lab API
+        name, Newton treats this value as an absolute friction force/torque [N or N·m, depending on joint type], not
+        as a unitless coefficient.
+
+        For example, the MJWarp solver copies this value into MuJoCo Warp's ``dof_frictionloss``. Setting
+        ``joint_friction_coeff`` to 0.2 configures a dry-friction loss limit of 0.2 N·m on a revolute joint DOF,
+        or 0.2 N on a prismatic joint DOF.
+
+        .. note::
+            Solver support is defined by the active Newton solver. Unsupported solvers may ignore
+            ``Model.joint_friction``.
 
         .. note::
             This method expects partial data.
@@ -1974,7 +1986,7 @@ class Articulation(BaseArticulation):
             However, to allow graphed pipelines, the mask method must be used.
 
         Args:
-            joint_friction_coeff: Static friction coefficient :math:`\mu_s`.
+            joint_friction_coeff: Joint friction force/torque [N or N·m, depending on joint type].
                 Shape is (len(env_ids), len(joint_ids)).
             joint_ids: Joint indices. If None, then all joints are used.
             env_ids: Environment indices. If None, then all indices are used.
@@ -2024,7 +2036,19 @@ class Articulation(BaseArticulation):
         joint_mask: wp.array | None = None,
         env_mask: wp.array | None = None,
     ):
-        r"""Write joint friction coefficients over selected environment mask into the simulation.
+        r"""Write Newton joint friction force/torque values over selected environment mask into the simulation.
+
+        This writes to Newton's ``Model.joint_friction`` field. Despite the ``coeff`` suffix in the Isaac Lab API
+        name, Newton treats this value as an absolute friction force/torque [N or N·m, depending on joint type], not
+        as a unitless coefficient.
+
+        For example, the MJWarp solver copies this value into MuJoCo Warp's ``dof_frictionloss``. Setting
+        ``joint_friction_coeff`` to 0.2 configures a dry-friction loss limit of 0.2 N·m on a revolute joint DOF,
+        or 0.2 N on a prismatic joint DOF.
+
+        .. note::
+            Solver support is defined by the active Newton solver. Unsupported solvers may ignore
+            ``Model.joint_friction``.
 
         .. note::
             This method expects full data.
@@ -2034,7 +2058,7 @@ class Articulation(BaseArticulation):
             However, to allow graphed pipelines, the mask method must be used.
 
         Args:
-            joint_friction_coeff: Static friction coefficient :math:`\mu_s`.
+            joint_friction_coeff: Joint friction force/torque [N or N·m, depending on joint type].
                 Shape is (num_instances, num_joints).
             joint_mask: Joint mask. If None, then all joints are used. Shape is (num_joints,).
             env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -342,7 +342,14 @@ class ArticulationData(BaseArticulationData):
 
     @property
     def joint_friction_coeff(self) -> ProxyArray:
-        """Joint static friction coefficient provided to the simulation.
+        """Newton joint friction force/torque provided to the simulation.
+
+        Despite the ``coeff`` suffix in the Isaac Lab API name, Newton stores this as an absolute joint friction
+        force/torque [N or N·m, depending on joint type].
+
+        For example, the MJWarp solver copies this value into MuJoCo Warp's ``dof_frictionloss``. Setting
+        ``joint_friction_coeff`` to 0.2 configures a dry-friction loss limit of 0.2 N·m on a revolute joint DOF,
+        or 0.2 N on a prismatic joint DOF.
 
         Shape is (num_instances, num_joints), dtype = wp.float32. In torch this resolves to (num_instances, num_joints).
         """

--- a/source/isaaclab_physx/changelog.d/antoiner-docs-joint-friction.rst
+++ b/source/isaaclab_physx/changelog.d/antoiner-docs-joint-friction.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_physx.assets.Articulation` joint friction docs to distinguish legacy coefficients from
+  PhysX 5 static and dynamic friction efforts.

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -1684,16 +1684,23 @@ class Articulation(BaseArticulation):
     ):
         r"""Write joint friction coefficients over selected environment indices into the simulation.
 
-        For Isaac Sim versions below 5.0, only the static friction coefficient is set.
-        This limits the resisting force or torque up to a maximum proportional to the transmitted
-        spatial force: :math:`\|F_{resist}\| \leq \mu_s \, \|F_{spatial}\|`.
+        For Isaac Sim versions below 5.0, only the legacy unitless joint friction coefficient is set.
+        This limits the resisting force or torque up to a maximum proportional to the transmitted spatial force:
+        :math:`\|F_{resist}\| \leq \mu_s \, \|F_{spatial}\|`.
 
-        For Isaac Sim versions 5.0 and above, the static, dynamic, and viscous friction coefficients
-        are set. The model combines Coulomb (static & dynamic) friction with a viscous term:
+        For Isaac Sim versions 5.0 and above, the PhysX joint friction parameter model is used. It combines
+        Coulomb (static and dynamic) friction with a viscous term:
 
-        - Static friction :math:`\mu_s` defines the maximum effort that prevents motion at rest.
-        - Dynamic friction :math:`\mu_d` applies once motion begins and remains constant during motion.
-        - Viscous friction :math:`c_v` is a velocity-proportional resistive term.
+        - Static friction effort defines the maximum effort that prevents motion at rest [N or N·m, depending on
+          joint type].
+        - Dynamic friction effort applies once motion begins and remains constant during motion [N or N·m,
+          depending on joint type].
+        - Viscous friction coefficient is a velocity-proportional resistive term [N·s/m or N·m·s/rad, depending
+          on joint type].
+
+        .. warning::
+            For Isaac Sim versions 5.0 and above, the static friction effort must be greater than or equal to the
+            dynamic friction effort.
 
         .. note::
             This method expects partial data or full data.
@@ -1703,11 +1710,12 @@ class Articulation(BaseArticulation):
             is only supporting indexing, hence masks need to be converted to indices.
 
         Args:
-            joint_friction_coeff: Static friction coefficient :math:`\mu_s`.
-                Shape is (len(env_ids), len(joint_ids)) or (num_instances, num_joints).
-            joint_dynamic_friction_coeff: Dynamic (Coulomb) friction coefficient :math:`\mu_d`.
+            joint_friction_coeff: Legacy unitless coefficient for Isaac Sim versions below 5.0, or static friction
+                effort [N or N·m, depending on joint type] for Isaac Sim versions 5.0 and above. Shape is
+                (len(env_ids), len(joint_ids)) or (num_instances, num_joints).
+            joint_dynamic_friction_coeff: Dynamic friction effort [N or N·m, depending on joint type].
                 Same shape as above. If None, the dynamic coefficient is not updated.
-            joint_viscous_friction_coeff: Viscous friction coefficient :math:`c_v`.
+            joint_viscous_friction_coeff: Viscous friction coefficient [N·s/m or N·m·s/rad, depending on joint type].
                 Same shape as above. If None, the viscous coefficient is not updated.
             joint_ids: Joint indices. If None, then all joints are used.
             env_ids: Environment indices. If None, then all indices are used.
@@ -1793,16 +1801,23 @@ class Articulation(BaseArticulation):
     ):
         r"""Write joint friction coefficients over selected environment mask into the simulation.
 
-        For Isaac Sim versions below 5.0, only the static friction coefficient is set.
-        This limits the resisting force or torque up to a maximum proportional to the transmitted
-        spatial force: :math:`\|F_{resist}\| \leq \mu_s \, \|F_{spatial}\|`.
+        For Isaac Sim versions below 5.0, only the legacy unitless joint friction coefficient is set.
+        This limits the resisting force or torque up to a maximum proportional to the transmitted spatial force:
+        :math:`\|F_{resist}\| \leq \mu_s \, \|F_{spatial}\|`.
 
-        For Isaac Sim versions 5.0 and above, the static, dynamic, and viscous friction coefficients
-        are set. The model combines Coulomb (static & dynamic) friction with a viscous term:
+        For Isaac Sim versions 5.0 and above, the PhysX joint friction parameter model is used. It combines
+        Coulomb (static and dynamic) friction with a viscous term:
 
-        - Static friction :math:`\mu_s` defines the maximum effort that prevents motion at rest.
-        - Dynamic friction :math:`\mu_d` applies once motion begins and remains constant during motion.
-        - Viscous friction :math:`c_v` is a velocity-proportional resistive term.
+        - Static friction effort defines the maximum effort that prevents motion at rest [N or N·m, depending on
+          joint type].
+        - Dynamic friction effort applies once motion begins and remains constant during motion [N or N·m,
+          depending on joint type].
+        - Viscous friction coefficient is a velocity-proportional resistive term [N·s/m or N·m·s/rad, depending
+          on joint type].
+
+        .. warning::
+            For Isaac Sim versions 5.0 and above, the static friction effort must be greater than or equal to the
+            dynamic friction effort.
 
         .. note::
             This method expects full data.
@@ -1812,11 +1827,12 @@ class Articulation(BaseArticulation):
             is only supporting indexing, hence masks need to be converted to indices.
 
         Args:
-            joint_friction_coeff: Static friction coefficient :math:`\mu_s`.
-                Shape is (num_instances, num_joints).
-            joint_dynamic_friction_coeff: Dynamic (Coulomb) friction coefficient :math:`\mu_d`.
+            joint_friction_coeff: Legacy unitless coefficient for Isaac Sim versions below 5.0, or static friction
+                effort [N or N·m, depending on joint type] for Isaac Sim versions 5.0 and above. Shape is
+                (num_instances, num_joints).
+            joint_dynamic_friction_coeff: Dynamic friction effort [N or N·m, depending on joint type].
                 Same shape as above. If None, the dynamic coefficient is not updated.
-            joint_viscous_friction_coeff: Viscous friction coefficient :math:`c_v`.
+            joint_viscous_friction_coeff: Viscous friction coefficient [N·s/m or N·m·s/rad, depending on joint type].
                 Same shape as above. If None, the viscous coefficient is not updated.
             joint_mask: Joint mask. If None, then all joints are used.
             env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
@@ -1842,7 +1858,9 @@ class Articulation(BaseArticulation):
         env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
         full_data: bool = False,
     ) -> None:
-        """Write joint dynamic friction coefficient over selected environment indices into the simulation.
+        """Write joint dynamic friction effort over selected environment indices into the simulation.
+
+        The dynamic friction effort is [N or N·m, depending on joint type].
 
         .. note::
             This method expects partial data or full data.
@@ -1852,8 +1870,8 @@ class Articulation(BaseArticulation):
             is only supporting indexing, hence masks need to be converted to indices.
 
         Args:
-            joint_dynamic_friction_coeff: Joint dynamic friction coefficient. Shape is (len(env_ids), len(joint_ids))
-                or (num_instances, num_joints) if full_data.
+            joint_dynamic_friction_coeff: Dynamic friction effort [N or N·m, depending on joint type]. Shape is
+                (len(env_ids), len(joint_ids)) or (num_instances, num_joints) if full_data.
             joint_ids: Joint indices. If None, then all joints are used.
             env_ids: Environment indices. If None, then all indices are used.
             full_data: Whether to expect full data. Defaults to False.
@@ -1907,7 +1925,9 @@ class Articulation(BaseArticulation):
         joint_mask: wp.array | None = None,
         env_mask: wp.array | None = None,
     ) -> None:
-        """Write joint dynamic friction coefficient over selected environment mask into the simulation.
+        """Write joint dynamic friction effort over selected environment mask into the simulation.
+
+        The dynamic friction effort is [N or N·m, depending on joint type].
 
         .. note::
             This method expects full data.
@@ -1917,7 +1937,8 @@ class Articulation(BaseArticulation):
             is only supporting indexing, hence masks need to be converted to indices.
 
         Args:
-            joint_dynamic_friction_coeff: Joint dynamic friction coefficient. Shape is (num_instances, num_joints).
+            joint_dynamic_friction_coeff: Dynamic friction effort [N or N·m, depending on joint type]. Shape is
+                (num_instances, num_joints).
             joint_mask: Joint mask. If None, then all joints are used.
             env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
         """
@@ -1942,6 +1963,8 @@ class Articulation(BaseArticulation):
     ) -> None:
         """Write joint viscous friction coefficient over selected environment indices into the simulation.
 
+        The coefficient is [N·s/m or N·m·s/rad, depending on joint type].
+
         .. note::
             This method expects partial data or full data.
 
@@ -1950,8 +1973,8 @@ class Articulation(BaseArticulation):
             is only supporting indexing, hence masks need to be converted to indices.
 
         Args:
-            joint_viscous_friction_coeff: Joint viscous friction coefficient. Shape is (len(env_ids), len(joint_ids))
-                or (num_instances, num_joints) if full_data.
+            joint_viscous_friction_coeff: Viscous friction coefficient [N·s/m or N·m·s/rad, depending on joint type].
+                Shape is (len(env_ids), len(joint_ids)) or (num_instances, num_joints) if full_data.
             joint_ids: Joint indices. If None, then all joints are used.
             env_ids: Environment indices. If None, then all indices are used.
             full_data: Whether to expect full data. Defaults to False.
@@ -2010,6 +2033,8 @@ class Articulation(BaseArticulation):
     ) -> None:
         """Write joint viscous friction coefficient over selected environment mask into the simulation.
 
+        The coefficient is [N·s/m or N·m·s/rad, depending on joint type].
+
         .. note::
             This method expects full data.
 
@@ -2018,7 +2043,8 @@ class Articulation(BaseArticulation):
             is only supporting indexing, hence masks need to be converted to indices.
 
         Args:
-            joint_viscous_friction_coeff: Joint viscous friction coefficient. Shape is (num_instances, num_joints).
+            joint_viscous_friction_coeff: Viscous friction coefficient [N·s/m or N·m·s/rad, depending on joint type].
+                Shape is (num_instances, num_joints).
             joint_mask: Joint mask. If None, then all joints are used.
             env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
         """

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation_data.py
@@ -369,7 +369,10 @@ class ArticulationData(BaseArticulationData):
 
     @property
     def joint_friction_coeff(self) -> ProxyArray:
-        """Joint static friction coefficient provided to the simulation.
+        """PhysX joint static friction value provided to the simulation.
+
+        For Isaac Sim 5.0 and later, this is the static friction effort [N or N·m, depending on joint type].
+        For earlier Isaac Sim versions, this is the legacy unitless joint friction coefficient.
 
         Shape is (num_instances, num_joints), dtype = wp.float32. In torch this resolves to (num_instances, num_joints).
         """
@@ -379,7 +382,9 @@ class ArticulationData(BaseArticulationData):
 
     @property
     def joint_dynamic_friction_coeff(self) -> ProxyArray:
-        """Joint dynamic friction coefficient provided to the simulation.
+        """PhysX joint dynamic friction effort provided to the simulation.
+
+        The effort is [N or N·m, depending on joint type].
 
         Shape is (num_instances, num_joints), dtype = wp.float32. In torch this resolves to (num_instances, num_joints).
         """
@@ -390,6 +395,8 @@ class ArticulationData(BaseArticulationData):
     @property
     def joint_viscous_friction_coeff(self) -> ProxyArray:
         """Joint viscous friction coefficient provided to the simulation.
+
+        The coefficient is [N·s/m or N·m·s/rad, depending on joint type].
 
         Shape is (num_instances, num_joints), dtype = wp.float32. In torch this resolves to (num_instances, num_joints).
         """


### PR DESCRIPTION
# Description

Clarifies the articulation joint friction API docs across the base, PhysX, and Newton implementations.

The base API now warns that joint friction semantics are backend-specific. The PhysX docs distinguish legacy
unitless coefficients from PhysX 5 static/dynamic friction efforts and viscous coefficients. The Newton docs now
identify joint friction as an absolute force/torque value and include an MJWarp example mapping the value to
MuJoCo Warp's `dof_frictionloss`.

Fixes isaac-sim/IsaacLab-Internal#875

## Type of change

- Documentation update

## Screenshots

Not applicable.

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable: docs-only change)
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
