### PR TITLE
Fix OvPhysX integration patches for kitless mode

### DIFF
--- a/source/isaaclab/changelog.d/fix-ovphysx-integration-patches.rst
+++ b/source/isaaclab/changelog.d/fix-ovphysx-integration-patches.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.sensors.SensorBase` incorrectly registering a
+  PhysX-specific prim deletion callback when using the OvPhysX physics
+  backend, which caused an import failure or incorrect event handling at
+  runtime.

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -296,7 +296,7 @@ class SensorBase(ABC):
         )
         # Optional: prim deletion (only supported by PhysX backend)
         self._prim_deletion_handle = None
-        if "physx" in physics_mgr_cls.__name__.lower():
+        if "physx" in physics_mgr_cls.__name__.lower() and "ovphysx" not in physics_mgr_cls.__name__.lower():
             from isaaclab_physx.physics import IsaacEvents  # noqa: PLC0415
 
             self._prim_deletion_handle = physics_mgr_cls.register_callback(

--- a/source/isaaclab_ovphysx/changelog.d/fix-ovphysx-integration-patches.rst
+++ b/source/isaaclab_ovphysx/changelog.d/fix-ovphysx-integration-patches.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_ovphysx.physics.OvPhysxManager` passing an
+  unsupported ``gpu_index`` parameter to the ``ovphysx.PhysX`` constructor,
+  which caused a ``TypeError`` on GPU device initialization.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -166,11 +166,8 @@ class OvPhysxManager(PhysicsManager):
 
         device_str = PhysicsManager._device
         if "cuda" in device_str:
-            parts = device_str.split(":")
-            gpu_index = int(parts[1]) if len(parts) > 1 else 0
             ovphysx_device = "gpu"
         else:
-            gpu_index = 0
             ovphysx_device = "cpu"
 
         scene_prim = sim.stage.GetPrimAtPath(sim.cfg.physics_prim_path)

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -202,7 +202,7 @@ class OvPhysxManager(PhysicsManager):
 
         import ovphysx
 
-        cls._physx = ovphysx.PhysX(device=ovphysx_device, gpu_index=gpu_index)
+        cls._physx = ovphysx.PhysX(device=ovphysx_device)
 
         # Without worker threads the stepper runs simulate()+fetchResults()
         # synchronously, blocking the calling thread for the full GPU step time.

--- a/source/isaaclab_tasks/changelog.d/fix-ovphysx-integration-patches.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-ovphysx-integration-patches.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added OvPhysX as an available physics backend preset for the Cartpole
+  Camera Direct environment (``presets=ovphysx``).

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_presets_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_presets_env_cfg.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from isaaclab_newton.physics import NewtonCfg
+from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -27,6 +28,7 @@ class PhysicsCfg(PresetCfg):
     default = PhysxCfg()
     physx = PhysxCfg()
     newton_mjwarp = NewtonCfg()
+    ovphysx = OvPhysxCfg()
 
 
 @configclass


### PR DESCRIPTION
# Description

Three small fixes for OvPhysX (kitless) physics backend integration discovered during benchmarking:

1. **SensorBase prim deletion callback guard** — `SensorBase` checked `"physx" in __name__.lower()` to register a PhysX-specific prim deletion callback, but this also matched `OvPhysxManager` (which contains "physx" in its name). Added an explicit exclusion for OvPhysX so the PhysX-only callback is not incorrectly registered.

2. **Remove unsupported `gpu_index` parameter** — `OvPhysxManager._warmup_and_load()` passed `gpu_index` to the `ovphysx.PhysX()` constructor, but the current ovphysx wheel does not accept that parameter, causing a `TypeError` on GPU device initialization.

3. **Add OvPhysX physics backend preset for Cartpole Camera** — The `PhysicsCfg` preset class in the Cartpole Camera Direct environment was missing an `ovphysx = OvPhysxCfg()` entry, so `presets=ovphysx` could not be used for this task.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there