### PR TITLE
[DO NOT MERGE] Test revert of PR #5521 to isolate viewergl failure

### DIFF
--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -113,8 +113,7 @@ class Camera(SensorBase):
         # IsaacRtxRendererCfg overrides to flip /isaaclab/render/rtx_sensors. The
         # flag must be set pre-sim.reset() because SimulationContext.is_rendering
         # and several env classes read it before the renderer's __init__ runs.
-        renderer_type = getattr(self.cfg.renderer_cfg, "renderer_type", None)
-        if renderer_type == "isaac_rtx":
+        if self.cfg.renderer_cfg.renderer_type == "isaac_rtx":
             get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", True)
 
         # Compute camera orientation (convention conversion) and spawn

--- a/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera_cfg.py
@@ -9,6 +9,8 @@ import warnings
 from dataclasses import MISSING, field
 from typing import TYPE_CHECKING, Literal
 
+from isaaclab_physx.renderers import IsaacRtxRendererCfg
+
 from isaaclab.renderers import RendererCfg
 from isaaclab.sim import FisheyeCameraCfg, PinholeCameraCfg
 from isaaclab.utils import configclass
@@ -189,7 +191,7 @@ class CameraCfg(SensorBaseCfg):
         on :attr:`renderer_cfg` instead.
     """
 
-    renderer_cfg: RendererCfg = field(default_factory=RendererCfg)
+    renderer_cfg: RendererCfg = field(default_factory=IsaacRtxRendererCfg)
     """Renderer configuration for camera sensor."""
 
     def __post_init__(self):
@@ -199,14 +201,6 @@ class CameraCfg(SensorBaseCfg):
         :class:`DeprecationWarning` and is copied onto ``self.renderer_cfg``
         when that cfg defines the same-named field.
         """
-        # TODO when Camera.__init__ moves rtx_sensor setting out of camera initialization
-        # the default renderer config instantiation can be moved into the render factory
-        # and get_default_render_cfg method can be removed from backend_utils
-        renderer_type = getattr(self.renderer_cfg, "renderer_type", None)
-        if renderer_type == "default":
-            from isaaclab.utils.backend_utils import get_default_renderer_cfg
-
-            self.renderer_cfg = get_default_renderer_cfg()
         # Forwarded by name: any same-named field on ``renderer_cfg`` will receive the value.
         for field_name, default in _DEPRECATED_RENDERER_FIELD_DEFAULTS.items():
             value = getattr(self, field_name)

--- a/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/camera/tiled_camera_cfg.py
@@ -27,14 +27,6 @@ class TiledCameraCfg(CameraCfg):
     class_type: type["TiledCamera"] | str = "{DIR}.tiled_camera:TiledCamera"
 
     def __post_init__(self):
-        # TODO when Camera.__init__ moves rtx_sensor setting out of camera initialization
-        # the default renderer config instantiation can be moved into the render factory
-        # and get_default_render_cfg method can be removed from backend_utils
-        renderer_type = getattr(self.renderer_cfg, "renderer_type", None)
-        if renderer_type == "default":
-            from isaaclab.utils.backend_utils import get_default_renderer_cfg
-
-            self.renderer_cfg = get_default_renderer_cfg()
         warnings.warn(
             "TiledCameraCfg is deprecated. Use CameraCfg directly — "
             "Camera now includes TiledCamera's vectorized rendering optimizations.",

--- a/source/isaaclab/isaaclab/utils/backend_utils.py
+++ b/source/isaaclab/isaaclab/utils/backend_utils.py
@@ -3,46 +3,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from __future__ import annotations
-
 import importlib
 import logging
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from isaaclab.renderers.renderer_cfg import RendererCfg
 
 logger = logging.getLogger(__name__)
-
-
-def get_default_renderer_cfg() -> RendererCfg:
-    """Return the default :class:`~isaaclab.renderers.renderer_cfg.RendererCfg` for cameras.
-
-    Lazily imports :mod:`isaaclab_physx.renderers` and returns a new
-    :class:`~isaaclab_physx.renderers.IsaacRtxRendererCfg` instance.
-
-    Returns:
-        A new default Isaac RTX renderer configuration.
-
-    Raises:
-        ImportError: If :mod:`isaaclab_physx.renderers` cannot be imported or does not
-            expose ``IsaacRtxRendererCfg``.
-    """
-    try:
-        renderers_mod = importlib.import_module("isaaclab_physx.renderers")
-    except ImportError as e:
-        raise ImportError(
-            "The default camera renderer configuration requires the optional 'isaaclab_physx' "
-            "package (import 'isaaclab_physx.renderers'). Install isaaclab_physx or set "
-            "CameraCfg.renderer_cfg explicitly."
-        ) from e
-    try:
-        default_cls = renderers_mod.IsaacRtxRendererCfg
-    except AttributeError as e:
-        raise ImportError(
-            "Module 'isaaclab_physx.renderers' is available but does not define 'IsaacRtxRendererCfg'."
-        ) from e
-    return default_cls()
 
 
 class FactoryBase:


### PR DESCRIPTION
## Purpose

Hypothesis test only — do not merge. Validates whether https://github.com/isaac-sim/IsaacLab/pull/5521 introduced the \`test_cartpole_newton_visualizer_viewergl_rgb_motion\` deterministic failure observed across https://github.com/isaac-sim/IsaacLab/pull/5523, https://github.com/isaac-sim/IsaacLab/pull/5534, https://github.com/isaac-sim/IsaacLab/pull/5024, https://github.com/isaac-sim/IsaacLab/pull/5495, https://github.com/isaac-sim/IsaacLab/pull/5492 (skip in https://github.com/isaac-sim/IsaacLab/pull/5538).

If the visualizer test **passes** here → https://github.com/isaac-sim/IsaacLab/pull/5521's camera-cfg lazy-import change is the trigger and the fix lives in adjusting that init order.

If it **fails** here → https://github.com/isaac-sim/IsaacLab/pull/5521 isn't the cause and the regression is elsewhere (likely the daily Isaac Sim image).

## Diff

Single revert of \`7b44452e9fa\` (https://github.com/isaac-sim/IsaacLab/pull/5521 merge commit) on top of develop tip.