### PR TITLE
[H6 fix attempt] Make Newton ViewerGL context current before get_frame

### DIFF
--- a/source/isaaclab_visualizers/test/conftest.py
+++ b/source/isaaclab_visualizers/test/conftest.py
@@ -5,16 +5,16 @@
 
 """H6 fix attempt: make Newton ViewerGL's GL context current before get_frame().
 
-Newton's ViewerGL.get_frame issues GL calls (glBindFramebuffer, glReadPixels,
-RegisteredGLBuffer.map) without first calling self._make_current(). If Kit's
-GLFW window context is current at the moment get_frame() runs, those GL calls
-operate on Kit's context where Newton's FBO/PBO ids are invalid. The result
-silently reads from Kit's framebuffer (empty for the visualizer test) or
-returns zeros from glReadPixels.
+Newton's ViewerGL.get_frame issues GL calls without first calling
+self._make_current(). If Kit's GLFW context is current at the moment
+get_frame() runs, those GL calls operate on Kit's context where Newton's
+FBO/PBO ids are invalid - the readback returns zeros, the test fails as
+"fully black".
 
-This patch wraps ViewerGL.get_frame to call self.renderer._make_current()
-at the start. If the visualizer test passes with this in place, the fix is
-to push self._make_current() into Newton upstream's get_frame.
+The patch is applied via pytest_collection_modifyitems so Newton is imported
+only AFTER the test file has run AppLauncher (which sets up Kit's pxr
+bindings). Importing Newton at conftest top-level pulls pxr in too early
+and causes a TypeError on Kit 110+ ('No to_python converter for GfVec3f').
 """
 
 from __future__ import annotations
@@ -43,4 +43,6 @@ def _patch_viewergl_make_current_before_get_frame():
     print("[H6] ViewerGL.get_frame wrapped with _make_current()", flush=True)
 
 
-_patch_viewergl_make_current_before_get_frame()
+def pytest_collection_modifyitems(config, items):  # noqa: ARG001
+    """Hook fires after test files are collected (i.e., after AppLauncher in test files runs)."""
+    _patch_viewergl_make_current_before_get_frame()

--- a/source/isaaclab_visualizers/test/conftest.py
+++ b/source/isaaclab_visualizers/test/conftest.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""H6 fix attempt: make Newton ViewerGL's GL context current before get_frame().
+
+Newton's ViewerGL.get_frame issues GL calls (glBindFramebuffer, glReadPixels,
+RegisteredGLBuffer.map) without first calling self._make_current(). If Kit's
+GLFW window context is current at the moment get_frame() runs, those GL calls
+operate on Kit's context where Newton's FBO/PBO ids are invalid. The result
+silently reads from Kit's framebuffer (empty for the visualizer test) or
+returns zeros from glReadPixels.
+
+This patch wraps ViewerGL.get_frame to call self.renderer._make_current()
+at the start. If the visualizer test passes with this in place, the fix is
+to push self._make_current() into Newton upstream's get_frame.
+"""
+
+from __future__ import annotations
+
+
+def _patch_viewergl_make_current_before_get_frame():
+    try:
+        from newton._src.viewer.viewer_gl import ViewerGL
+    except ImportError:
+        return
+
+    if getattr(ViewerGL, "_h6_patched", False):
+        return
+
+    original_get_frame = ViewerGL.get_frame
+
+    def patched_get_frame(self, target_image=None, render_ui=False):
+        try:
+            self.renderer._make_current()
+        except Exception as exc:  # noqa: BLE001
+            print(f"[H6] _make_current failed: {exc}", flush=True)
+        return original_get_frame(self, target_image=target_image, render_ui=render_ui)
+
+    ViewerGL.get_frame = patched_get_frame
+    ViewerGL._h6_patched = True
+    print("[H6] ViewerGL.get_frame wrapped with _make_current()", flush=True)
+
+
+_patch_viewergl_make_current_before_get_frame()


### PR DESCRIPTION
Fix-attempt PR for the viewergl-fully-black regression on develop.

Hypothesis: Newton's `ViewerGL.get_frame` does not call `self._make_current()`. If Kit's GLFW context is current when `get_frame()` runs (after `env.step()` ticks Kit), Newton's GL calls (`glBindFramebuffer`, `glReadPixels`, `RegisteredGLBuffer.map`) operate on Kit's context — Newton's FBO/PBO IDs are invalid there, so the readback returns zeros. The bug presents as 'Viewer frame appears fully black'.

This patch wraps `get_frame` via a test conftest to call `_make_current()` first.

If `test_cartpole_newton_visualizer_viewergl_rgb_motion` passes with this in place, the proper fix is upstream in Newton (`newton/_src/viewer/viewer_gl.py:get_frame` should call `self._make_current()` at the start).

Related diagnostic in https://github.com/isaac-sim/IsaacLab/pull/5540. PR https://github.com/isaac-sim/IsaacLab/pull/5521 hypothesis already disproven by https://github.com/isaac-sim/IsaacLab/pull/5539.

DO NOT MERGE — testing only.