### PR TITLE
Fix docs build: pin warp intersphinx to /latest/

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,8 @@ intersphinx_mapping = {
     "torch": ("https://docs.pytorch.org/docs/2.11/", None),
     "isaacsim": ("https://docs.isaacsim.omniverse.nvidia.com/6.0.0/py/", None),
     "gymnasium": ("https://gymnasium.farama.org/", None),
-    "warp": ("https://nvidia.github.io/warp/", None),
+    # NOTE: pinned to /latest/ because /objects.inv at the root currently 404s
+    "warp": ("https://nvidia.github.io/warp/latest/", None),
     "omniverse": ("https://docs.omniverse.nvidia.com/dev-guide/latest", None),
 }
 

--- a/source/isaaclab/changelog.d/jichuanh-fix-warp-intersphinx.rst
+++ b/source/isaaclab/changelog.d/jichuanh-fix-warp-intersphinx.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Sphinx docs build failing due to ``https://nvidia.github.io/warp/objects.inv`` returning 404.
+  Pinned the ``warp`` intersphinx mapping to ``/latest/``, which is where the inventory now lives.


### PR DESCRIPTION
## Summary

`https://nvidia.github.io/warp/objects.inv` now returns 404 — the Warp docs published `objects.inv` only at versioned subpaths (`/latest/`, `/stable/`, etc.). With Sphinx's `warnings treated as errors`, the broken intersphinx fetch fails the docs build on **every** PR (#5536, #5538, #5540-#5542 all failing on `Build Latest Docs`).

Pinning to `/latest/` matches what other intersphinx targets in this file already do (see the existing PyTorch `/docs/2.11/` pin, also added to work around a /stable/ 404).

## Test plan

- [x] Verified `https://nvidia.github.io/warp/latest/objects.inv` returns 200
- [ ] CI `Build Latest Docs` job passes on this PR (was failing on develop)