### PR TITLE
Replaces fcntl with filelock to avoid windows import issues

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,6 +205,7 @@ autodoc_mock_imports = [
     "pinocchio",
     "nvidia.srl",
     "flatdict",
+    "filelock",
     "IPython",
     "cv2",
     "imageio",

--- a/source/isaaclab/changelog.d/antoiner-fix-from-files-windows-filelock.rst
+++ b/source/isaaclab/changelog.d/antoiner-fix-from-files-windows-filelock.rst
@@ -1,0 +1,12 @@
+Fixed
+^^^^^
+
+* Fixed :mod:`isaaclab.sim.spawners.from_files` failing to import on Windows
+  due to an unconditional ``import fcntl`` (Unix-only). The distributed-rank
+  USD spawn lock now uses :class:`filelock.FileLock`, which works on both
+  Windows and POSIX.
+
+Changed
+^^^^^^^
+
+* Added :mod:`filelock` to ``isaaclab`` install requirements.

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -5,11 +5,13 @@
 
 from __future__ import annotations
 
-import fcntl
 import logging
 import os
 import tempfile
+from contextlib import nullcontext
 from typing import TYPE_CHECKING
+
+from filelock import FileLock
 
 # deformables only supported on PhysX backend
 from isaaclab_physx.sim import schemas as schemas_physx
@@ -316,10 +318,10 @@ def _spawn_from_usd_file(
         raise FileNotFoundError(f"USD file not found at path: '{usd_path}'.")
 
     if _world_size > 1:
-        lock_path = os.path.join(tempfile.gettempdir(), "isaaclab_usd_spawn.lock")
-        lock_fd = open(lock_path, "w")  # noqa: SIM115
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
-    try:
+        lock = FileLock(os.path.join(tempfile.gettempdir(), "isaaclab_usd_spawn.lock"))
+    else:
+        lock = nullcontext()
+    with lock:
         if file_status == 2:
             usd_path = retrieve_file_path(usd_path, force_download=False)
         stage = get_current_stage()
@@ -334,10 +336,6 @@ def _spawn_from_usd_file(
             )
         else:
             logger.warning(f"A prim already exists at prim path: '{prim_path}'.")
-    finally:
-        if _world_size > 1:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            lock_fd.close()
 
     # modify variants
     if hasattr(cfg, "variants") and cfg.variants is not None:

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -54,6 +54,8 @@ INSTALL_REQUIRES = [
     "flaky",
     "packaging",
     "psutil",
+    # cross-platform file locking (used to serialize USD spawn across distributed ranks)
+    "filelock",
     # Required by pydantic-core/imgui_bundle on Python 3.12 (Sentinel symbol).
     "typing_extensions>=4.14.0",
     "lazy_loader>=0.4",


### PR DESCRIPTION
# Description

The `isaaclab.sim.spawners.from_files` module imports `fcntl` unconditionally at module load. `fcntl` is Unix-only, so on Windows the import fails with:

```
ModuleNotFoundError: No module named 'fcntl'
```

This breaks **any** Windows usage of the spawner — including single-GPU runs that never take the lock path. Reproducer reported by a user (IsaacLab `develop` @ `b258e87`, IsaacSim `6.0.0rc41`):

```
python scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole-v0 --headless --video --video_length 100 --video_interval 500 --max_iterations 5
```

`fcntl` was introduced in #5032 to serialize USD download/stage composition across distributed ranks (preventing segfaults in `Sdf_CrateFile::_MmapStream::Read` on shared cached USD files). The intent is correct — only the implementation is Unix-only.

## Change

- Replace `fcntl.flock` with [`filelock.FileLock`](https://pypi.org/project/filelock/), which uses `fcntl` on POSIX and `msvcrt` on Windows.
- Use `contextlib.nullcontext` for the single-rank path so the lock file is only created when actually needed (i.e., `LOCAL_WORLD_SIZE > 1`).
- Drop the manual `try/finally` and the `# noqa: SIM115` on the bare `open(...)` — the `with FileLock(...)` form is exception-safe.
- Declare `filelock` in `source/isaaclab/setup.py::INSTALL_REQUIRES`. It was previously only transitively available via `transformers` → `huggingface_hub`; making it a direct dep so we don't depend on a transitive chain that could change.

The lock semantics are unchanged: an exclusive advisory lock on `<tempdir>/isaaclab_usd_spawn.lock`, held only while `LOCAL_WORLD_SIZE > 1`.

Original lock implementation: @ooctipus (#5032) — tagging for review since this changes the locking primitive.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A — import-time failure on Windows; no UI surface.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation (N/A — internal change)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — the failure is `import fcntl` at module load on Windows; a regression test would require a Windows CI runner, which IsaacLab does not currently exercise. Locally verified the module imports and `FileLock` resolves to `filelock._unix.UnixFileLock` on Linux (and would resolve to `WindowsFileLock` on Windows).
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there