### PR TITLE
Fix OvPhysX 0.4 compatibility

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -121,6 +121,7 @@ Guidelines for modifications:
 * Louis Le Lay
 * Lukas Fröhlich
 * Manuel Schweiger
+* Marco Alesiani
 * Masoud Moghani
 * Mateo Guaman Castro
 * Maurice Rahme

--- a/source/isaaclab/changelog.d/malesiani-ovphysx-04-fixes.rst
+++ b/source/isaaclab/changelog.d/malesiani-ovphysx-04-fixes.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the sensor prim-deletion callback guard so the OvPhysX backend is not
+  treated as the Kit PhysX backend.

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -296,7 +296,7 @@ class SensorBase(ABC):
         )
         # Optional: prim deletion (only supported by PhysX backend)
         self._prim_deletion_handle = None
-        if "physx" in physics_mgr_cls.__name__.lower():
+        if physics_mgr_cls.__name__ == "PhysxManager":
             from isaaclab_physx.physics import IsaacEvents  # noqa: PLC0415
 
             self._prim_deletion_handle = physics_mgr_cls.register_callback(

--- a/source/isaaclab_ovphysx/changelog.d/malesiani-ovphysx-04-fixes.rst
+++ b/source/isaaclab_ovphysx/changelog.d/malesiani-ovphysx-04-fixes.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed OvPhysX articulation tensor reads and writes for ``ovphysx`` 0.4
+  compatibility.
+* Restored DirectGPU startup settings for OvPhysX GPU simulations.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
@@ -1759,7 +1759,7 @@ class Articulation(BaseArticulation):
         # (keyed on object identity) handles the fast path automatically.
         self._effort_binding = self._get_binding(TT.DOF_ACTUATION_FORCE)
         if self._effort_binding is not None:
-            torque = self._data.applied_torque
+            torque = self._data._applied_torque
             shape = self._effort_binding.shape
             self._effort_write_view = wp.array(
                 ptr=torque.ptr,
@@ -1780,10 +1780,10 @@ class Articulation(BaseArticulation):
             return b, v
 
         self._pos_target_binding, self._pos_target_write_view = _make_write_view(
-            TT.DOF_POSITION_TARGET, self._data.joint_pos_target
+            TT.DOF_POSITION_TARGET, self._data._joint_pos_target
         )
         self._vel_target_binding, self._vel_target_write_view = _make_write_view(
-            TT.DOF_VELOCITY_TARGET, self._data.joint_vel_target
+            TT.DOF_VELOCITY_TARGET, self._data._joint_vel_target
         )
 
         # Let the articulation data know that it is fully instantiated and ready to use.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation_data.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation_data.py
@@ -1684,10 +1684,24 @@ class ArticulationData(BaseArticulationData):
 
         Reads directly into the target array -- no scratch buffer, no extra copy.
         """
+        self._read_binding_into_view(tensor_type, wp_array)
+
+    def _read_binding_into_view(self, tensor_type: int, view: wp.array) -> None:
+        """Read an ovphysx binding into a float32 warp view."""
         binding = self._get_binding(tensor_type)
         if binding is None:
             return
-        binding.read(wp_array)
+
+        from isaaclab_ovphysx.tensor_types import _CPU_ONLY_TYPES
+
+        if tensor_type in _CPU_ONLY_TYPES and str(view.device) != "cpu":
+            scratch = self._get_read_scratch(tensor_type)
+            if scratch is None:
+                return
+            binding.read(scratch)
+            wp.copy(view, scratch)
+        else:
+            binding.read(view)
 
     def _read_binding_into_buf(self, tensor_type: int, buf: TimestampedBuffer) -> None:
         """Read from an ovphysx binding into a TimestampedBuffer, skipping if fresh."""
@@ -1696,7 +1710,7 @@ class ArticulationData(BaseArticulationData):
         view = self._get_read_view(tensor_type, buf.data)
         if view is None:
             return
-        self._get_binding(tensor_type).read(view)
+        self._read_binding_into_view(tensor_type, view)
         buf.timestamp = self._sim_timestamp
 
     def _read_transform_binding(self, tensor_type: int, buf: TimestampedBuffer) -> None:
@@ -1706,7 +1720,7 @@ class ArticulationData(BaseArticulationData):
         view = self._get_read_view(tensor_type, buf.data, 7)
         if view is None:
             return
-        self._get_binding(tensor_type).read(view)
+        self._read_binding_into_view(tensor_type, view)
         buf.timestamp = self._sim_timestamp
 
     def _read_spatial_vector_binding(self, tensor_type: int, buf: TimestampedBuffer) -> None:
@@ -1716,7 +1730,7 @@ class ArticulationData(BaseArticulationData):
         view = self._get_read_view(tensor_type, buf.data, 6)
         if view is None:
             return
-        self._get_binding(tensor_type).read(view)
+        self._read_binding_into_view(tensor_type, view)
         buf.timestamp = self._sim_timestamp
 
     """

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -13,6 +13,7 @@ using the ovphysx C/Python API.
 from __future__ import annotations
 
 import atexit
+import inspect
 import logging
 import os
 import tempfile
@@ -202,7 +203,23 @@ class OvPhysxManager(PhysicsManager):
 
         import ovphysx
 
-        cls._physx = ovphysx.PhysX(device=ovphysx_device, gpu_index=gpu_index)
+        physx_kwargs = {"device": ovphysx_device}
+        physx_signature = inspect.signature(ovphysx.PhysX)
+        physx_parameters = physx_signature.parameters
+        if "active_cuda_gpus" in physx_parameters:
+            if ovphysx_device == "gpu":
+                # ovphysx 0.4 accepts a comma-separated CUDA ordinal string; IsaacLab selects one GPU.
+                physx_kwargs["active_cuda_gpus"] = str(gpu_index)
+                physx_kwargs["config"] = ovphysx.PhysXConfig(
+                    carbonite_overrides={
+                        "/physics/suppressReadback": True,
+                        "/physics/suppressFabricUpdate": True,
+                    }
+                )
+        elif "gpu_index" in physx_parameters:
+            physx_kwargs["gpu_index"] = gpu_index
+
+        cls._physx = ovphysx.PhysX(**physx_kwargs)
 
         # Without worker threads the stepper runs simulate()+fetchResults()
         # synchronously, blocking the calling thread for the full GPU step time.

--- a/source/isaaclab_ovphysx/test/assets/test_articulation_data.py
+++ b/source/isaaclab_ovphysx/test/assets/test_articulation_data.py
@@ -40,3 +40,19 @@ class TestArticulationData:
             atol=1e-6,
             err_msg="Joint acceleration should be computed as delta_velocity / dt.",
         )
+
+    def test_cpu_only_binding_read_stages_to_gpu_view(self):
+        """CPU-only bindings should be staged before copying into GPU-backed data buffers."""
+        if not wp.is_cuda_available():
+            pytest.skip("CUDA is required to test CPU-to-GPU staging.")
+
+        mock_bindings = MockOvPhysxBindingSet(num_instances=1, num_joints=2, num_bodies=1)
+        data = ArticulationData(mock_bindings.bindings, device="cuda")
+        data._create_buffers()
+
+        expected = np.array([[[1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0]]], dtype=np.float32)
+        mock_bindings.bindings[TT.BODY_COM_POSE]._data[...] = expected
+
+        data._read_transform_binding(TT.BODY_COM_POSE, data._body_com_pose_b)
+
+        np.testing.assert_allclose(data._body_com_pose_b.data.numpy(), expected, atol=1e-6)

--- a/source/isaaclab_tasks/changelog.d/malesiani-ovphysx-camera-cartpole.rst
+++ b/source/isaaclab_tasks/changelog.d/malesiani-ovphysx-camera-cartpole.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added the ``ovphysx`` physics preset to the cartpole camera presets task.

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_presets_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cartpole/cartpole_camera_presets_env_cfg.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from isaaclab_newton.physics import NewtonCfg
+from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -27,6 +28,7 @@ class PhysicsCfg(PresetCfg):
     default = PhysxCfg()
     physx = PhysxCfg()
     newton_mjwarp = NewtonCfg()
+    ovphysx = OvPhysxCfg()
 
 
 @configclass


### PR DESCRIPTION
Summary

- Fixes OvPhysX backend compatibility with the upcoming ovphysx 0.4 API by using `active_cuda_gpus` and explicit DirectGPU Carbonite settings when supported, while preserving the older `gpu_index` constructor path.
- Fixes CPU-only OvPhysX tensor binding reads into GPU-backed articulation buffers.
- Uses raw Warp buffers for OvPhysX articulation write views instead of `ProxyArray` wrappers.
- Adds the `ovphysx` physics preset to the cartpole camera presets task.

Validation

- `./isaaclab.sh -f`
- `./isaaclab.sh -p -m pytest source/isaaclab_ovphysx/test/assets/test_articulation_data.py source/isaaclab_ovphysx/test/assets/test_articulation.py`
- `./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-Direct-v0 --num_envs 64 --max_iterations 2 --headless presets=ovphysx`
- `./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Ant-Direct-v0 --num_envs 64 --max_iterations 2 --headless presets=ovphysx`
- `./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Humanoid-Direct-v0 --num_envs 64 --max_iterations 2 --headless presets=ovphysx`
- `./isaaclab.sh -p scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole-Camera-Presets-Direct-v0 --num_envs=32 --max_iterations=2 --headless --enable_cameras presets=ovphysx,ovrtx_renderer,rgb`

# Description

This PR fixes several small IsaacLab-side issues needed for the OvPhysX backend to run the supported direct cartpole, ant, and humanoid tasks with the upcoming ovphysx 0.4 wheel. It also enables the cartpole camera presets task to select the `ovphysx` physics preset.

The OvPhysX manager now detects the new constructor surface and passes explicit DirectGPU settings for GPU simulations. Older public wheels that still use `gpu_index` keep the previous constructor path.

Fixes # (not applicable)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there