### PR TITLE
docs: fix swapped preserve_order descriptions in resolve_matching_names docstrings

### DIFF
--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -183,11 +183,11 @@ def resolve_matching_names(
     When a list of query regular expressions is provided, the function checks each target string against each
     query regular expression and returns the indices of the matched strings and the matched strings.
 
-    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
+    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
     of the provided list of strings. This means that the ordering is dictated by the order of the target strings
     and not the order of the query regular expressions.
 
-    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
+    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
     of the provided list of query regular expressions.
 
     For example, consider the list of strings is ['a', 'b', 'c', 'd', 'e'] and the regular expressions are ['a|c', 'b'].
@@ -280,11 +280,11 @@ def resolve_matching_names_values(
     """Match a list of regular expressions in a dictionary against a list of strings and return
     the matched indices, names, and values.
 
-    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
+    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
     of the provided list of strings. This means that the ordering is dictated by the order of the target strings
     and not the order of the query regular expressions.
 
-    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
+    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
     of the provided list of query regular expressions.
 
     For example, consider the dictionary is {"a|d|e": 1, "b|c": 2}, the list of strings is ['a', 'b', 'c', 'd', 'e'].


### PR DESCRIPTION
## Description

Fixes #5146

The docstrings for both `resolve_matching_names` and `resolve_matching_names_values` in `source/isaaclab/isaaclab/utils/string.py` had the descriptions for `preserve_order=True` and `preserve_order=False` swapped.

**Current (incorrect) docstring:**
- `preserve_order=True` → "ordering is dictated by the order of the target strings"
- `preserve_order=False` → "ordering is the same as the order of the provided list of query regular expressions"

**Actual code behavior (and examples):**
- `preserve_order=False` → target list order (default, no reordering)
- `preserve_order=True` → query keys order (reordering occurs inside `if preserve_order:`)

The fix swaps the prose descriptions to match the actual code behavior and the provided examples.

## Type of change

- [x] Documentation fix (non-breaking change which fixes a docstring)

## Checklist

- [x] I have checked that there is no similar PR
- [x] The code examples in the docstrings are correct and unchanged