### PR TITLE
Pbarejko/ovrtx remove deprecated

### DIFF
--- a/source/isaaclab_ov/changelog.d/pbarejko-ovrtx-replace-old-mapping-style.rst
+++ b/source/isaaclab_ov/changelog.d/pbarejko-ovrtx-replace-old-mapping-style.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Remove old mapping style in OVRTX renderer.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -558,50 +558,47 @@ class OVRTXRenderer(BaseRenderer):
                         break
 
             if buffer_key is not None:
-                with frame.render_vars["LdrColor"].map(device=Device.CUDA) as mapping:
-                    tiled_data = wp.from_dlpack(mapping.tensor)
-                    self._extract_rgba_tiles(render_data, tiled_data, output_buffers, buffer_key)
+                mapping = frame.render_vars["LdrColor"].map(device=Device.CUDA)
+                tiled_data = wp.from_dlpack(mapping.tensor)
+                self._extract_rgba_tiles(render_data, tiled_data, output_buffers, buffer_key)
 
         for depth_var in ["DistanceToImagePlaneSD", "DepthSD"]:
             if depth_var not in frame.render_vars:
                 continue
-            with frame.render_vars[depth_var].map(device=Device.CUDA) as mapping:
-                tiled_depth_data = wp.from_dlpack(mapping.tensor)
-                if tiled_depth_data.dtype == wp.uint32:
-                    tiled_depth_data = wp.from_torch(
-                        wp.to_torch(tiled_depth_data).view(torch.float32), dtype=wp.float32
-                    )
-                self._extract_depth_tiles(render_data, tiled_depth_data, output_buffers)
-            break
+            mapping = frame.render_vars[depth_var].map(device=Device.CUDA)
+            tiled_depth_data = wp.from_dlpack(mapping.tensor)
+            if tiled_depth_data.dtype == wp.uint32:
+                tiled_depth_data = wp.from_torch(wp.to_torch(tiled_depth_data).view(torch.float32), dtype=wp.float32)
+            self._extract_depth_tiles(render_data, tiled_depth_data, output_buffers)
 
         if "DiffuseAlbedoSD" in frame.render_vars and "albedo" in output_buffers:
-            with frame.render_vars["DiffuseAlbedoSD"].map(device=Device.CUDA) as mapping:
-                tiled_albedo_data = wp.from_dlpack(mapping.tensor)
-                self._extract_rgba_tiles(render_data, tiled_albedo_data, output_buffers, "albedo", suffix="albedo")
+            mapping = frame.render_vars["DiffuseAlbedoSD"].map(device=Device.CUDA)
+            tiled_albedo_data = wp.from_dlpack(mapping.tensor)
+            self._extract_rgba_tiles(render_data, tiled_albedo_data, output_buffers, "albedo", suffix="albedo")
 
         if "SemanticSegmentation" in frame.render_vars and "semantic_segmentation" in output_buffers:
-            with frame.render_vars["SemanticSegmentation"].map(device=Device.CUDA) as mapping:
-                tiled_semantic_data = wp.from_dlpack(mapping.tensor)
+            mapping = frame.render_vars["SemanticSegmentation"].map(device=Device.CUDA)
+            tiled_semantic_data = wp.from_dlpack(mapping.tensor)
 
-                if tiled_semantic_data.dtype == wp.uint32:
-                    semantic_colors = self._generate_random_colors_from_ids(tiled_semantic_data)
+            if tiled_semantic_data.dtype == wp.uint32:
+                semantic_colors = self._generate_random_colors_from_ids(tiled_semantic_data)
 
-                    semantic_torch = wp.to_torch(semantic_colors)
-                    semantic_uint8 = semantic_torch.view(torch.uint8)
+                semantic_torch = wp.to_torch(semantic_colors)
+                semantic_uint8 = semantic_torch.view(torch.uint8)
 
-                    if semantic_torch.dim() == 2:
-                        h, w = semantic_torch.shape
-                        semantic_uint8 = semantic_uint8.reshape(h, w, 4)
+                if semantic_torch.dim() == 2:
+                    h, w = semantic_torch.shape
+                    semantic_uint8 = semantic_uint8.reshape(h, w, 4)
 
-                    tiled_semantic_data = wp.from_torch(semantic_uint8, dtype=wp.uint8)
+                tiled_semantic_data = wp.from_torch(semantic_uint8, dtype=wp.uint8)
 
-                self._extract_rgba_tiles(
-                    render_data,
-                    tiled_semantic_data,
-                    output_buffers,
-                    "semantic_segmentation",
-                    suffix="semantic",
-                )
+            self._extract_rgba_tiles(
+                render_data,
+                tiled_semantic_data,
+                output_buffers,
+                "semantic_segmentation",
+                suffix="semantic",
+            )
 
     def render(self, render_data: OVRTXRenderData) -> None:
         """Render the scene into the provided RenderData."""


### PR DESCRIPTION
# Description

Remove deprecated mapping style:

```
/home/pbarejko/git/IsaacLab/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py:561: DeprecationWarning: Context manager usage of _MappedRenderVar is deprecated and will be removed in a later release. Use the mapping directly: ``mapping = render_var.map()``. The C render resource is held alive by DLPack consumers of ``mapping.tensor`` (zero-copy views via numpy/Warp), so release those views (or take a ``.copy()``) as soon as you are done to free the resource.
  with frame.render_vars["LdrColor"].map(device=Device.CUDA) as mapping:
```

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
