### PR TITLE
Switch assets.py omni.client calls to async

### DIFF
--- a/apps/isaaclab.python.headless.kit
+++ b/apps/isaaclab.python.headless.kit
@@ -28,6 +28,7 @@ log.outputStreamLevel = "Warn"
 "omni.physx.fabric" = {}
 "usdrt.scenegraph" = {}
 "omni.kit.telemetry" = {}
+"omni.kit.async_engine" = {}
 "omni.kit.loop" = {}
 # this is needed to create physics material through CreatePreviewSurfaceMaterialPrim
 "omni.kit.usd.mdl" = {}

--- a/apps/isaaclab.python.headless.rendering.kit
+++ b/apps/isaaclab.python.headless.rendering.kit
@@ -15,6 +15,7 @@ version = "3.0.0"
 keywords = ["experience", "app", "isaaclab", "python", "camera", "minimal"]
 
 [dependencies]
+"omni.kit.async_engine" = {}
 # Isaac Lab minimal app
 "isaaclab.python.headless" = {}
 "isaacsim.core.rendering_manager" = {}

--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -59,6 +59,7 @@ keywords = ["experience", "app", "usd"]
 "omni.hydra.engine.stats" = {}
 "omni.hydra.rtx" = {}
 "omni.kit.mainwindow" = {}
+"omni.kit.async_engine" = {}
 "omni.kit.manipulator.camera" = {}
 "omni.kit.manipulator.prim" = {}
 "omni.kit.manipulator.selection" = {}

--- a/apps/isaaclab.python.rendering.kit
+++ b/apps/isaaclab.python.rendering.kit
@@ -15,6 +15,7 @@ version = "3.0.0"
 keywords = ["experience", "app", "isaaclab", "python", "camera", "minimal"]
 
 [dependencies]
+"omni.kit.async_engine" = {}
 # Isaac Lab minimal app
 "isaaclab.python" = {}
 

--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -31,6 +31,7 @@ xr.skipInputDeviceUSDWrites = true
 cameras_enabled = true
 
 [dependencies]
+"omni.kit.async_engine" = {}
 "isaaclab.python.xr.openxr" = {}
 
 # NOTE: xr.profile.ar.enabled is intentionally NOT set here.

--- a/apps/isaaclab.python.xr.openxr.kit
+++ b/apps/isaaclab.python.xr.openxr.kit
@@ -37,6 +37,7 @@ xr.skipInputDeviceUSDWrites = true
 'rtx-transient'.resourcemanager.enableTextureStreaming = false
 
 [dependencies]
+"omni.kit.async_engine" = {}
 "isaaclab.python" = {}
 
 # Required for XR instruction widget (CopyFabricPrim)

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -74,12 +74,11 @@ def _drive_kit_async(coro):
     app = _kit_app()
     if app is None:
         return asyncio.run(coro)
-    try:
-        import omni.kit.async_engine  # noqa: PLC0415
+    # omni.kit.async_engine's observer pumps asyncio on each Kit frame -- scheduling on any
+    # other loop would deadlock the spin below. Fail loudly if a custom kit config drops it.
+    import omni.kit.async_engine  # noqa: PLC0415
 
-        task = omni.kit.async_engine.run_coroutine(coro)
-    except Exception:
-        task = asyncio.ensure_future(coro)
+    task = omni.kit.async_engine.run_coroutine(coro)
     while not task.done():
         app.update()
         time.sleep(0)

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -52,6 +52,40 @@ ISAACLAB_NUCLEUS_DIR: str = f"{ISAAC_NUCLEUS_DIR}/IsaacLab"
 """Path to the ``Isaac/IsaacLab`` directory on the NVIDIA Nucleus Server."""
 
 
+def _kit_app():
+    """Return the running Kit app or ``None`` if Kit is not running."""
+    try:
+        import omni.kit.app  # noqa: PLC0415
+
+        return omni.kit.app.get_app()
+    except Exception:
+        return None
+
+
+def _drive_kit_async(coro):
+    """Run an ``omni.client`` ``_async`` coroutine without blocking Kit's main thread.
+
+    Schedules the coroutine on Kit's asyncio loop and ticks ``app.update()`` until
+    it resolves; falls back to a private event loop when Kit isn't running.
+    """
+    import asyncio  # noqa: PLC0415
+    import time  # noqa: PLC0415
+
+    app = _kit_app()
+    if app is None:
+        return asyncio.run(coro)
+    try:
+        import omni.kit.async_engine  # noqa: PLC0415
+
+        task = omni.kit.async_engine.run_coroutine(coro)
+    except Exception:
+        task = asyncio.ensure_future(coro)
+    while not task.done():
+        app.update()
+        time.sleep(0)
+    return task.result()
+
+
 def check_file_path(path: str) -> Literal[0, 1, 2]:
     """Checks if a file exists on the Nucleus Server or locally.
 
@@ -70,7 +104,7 @@ def check_file_path(path: str) -> Literal[0, 1, 2]:
 
     import omni.client  # noqa: PLC0415
 
-    if omni.client.stat(path.replace(os.sep, "/"))[0] == omni.client.Result.OK:
+    if _drive_kit_async(omni.client.stat_async(path.replace(os.sep, "/")))[0] == omni.client.Result.OK:
         return 2
     else:
         return 0
@@ -131,7 +165,10 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
             if _UDIM_RE.search(cur_url):
                 for tile in range(1001, 1101):
                     tile_url = _UDIM_RE.sub(str(tile), cur_url)
-                    if omni.client.stat(tile_url.replace(os.sep, "/"))[0] == omni.client.Result.OK:
+                    if (
+                        _drive_kit_async(omni.client.stat_async(tile_url.replace(os.sep, "/")))[0]
+                        == omni.client.Result.OK
+                    ):
                         if tile_url not in visited:
                             to_visit.append(tile_url)
                     else:
@@ -143,7 +180,9 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
             os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
             if not os.path.isfile(target_path) or force_download:
-                result = omni.client.copy(cur_url, target_path, omni.client.CopyBehavior.OVERWRITE)
+                result = _drive_kit_async(
+                    omni.client.copy_async(cur_url, target_path, omni.client.CopyBehavior.OVERWRITE)
+                )
                 if result != omni.client.Result.OK and force_download:
                     raise RuntimeError(f"Unable to copy file: '{cur_url}'. Is the Nucleus Server running?")
 
@@ -183,7 +222,7 @@ def read_file(path: str) -> io.BytesIO:
     elif file_status == 2:
         import omni.client  # noqa: PLC0415
 
-        file_content = omni.client.read_file(path.replace(os.sep, "/"))[2]
+        file_content = _drive_kit_async(omni.client.read_file_async(path.replace(os.sep, "/")))[2]
         return io.BytesIO(memoryview(file_content).tobytes())
     else:
         raise FileNotFoundError(f"Unable to find the file: {path}")


### PR DESCRIPTION
The four sync calls (stat, copy, read_file) in check_file_path, retrieve_file_path, and read_file parked Kit's main thread on every Nucleus round-trip and triggered Kit's "Detected a blocking function" warning during env init.
    
They now run through a new _drive_kit_async helper, which schedules the *_async coroutine on Kit's asyncio loop and ticks app.update() until it resolves -- same wall time, but Kit keeps rendering during the wait.


Fixes # (issue)


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
