### PR TITLE
Locks qpsolvers version to be last known compatible version with PINK IK

### DIFF
--- a/source/isaaclab/changelog.d/peterd-lock-qpsolvers-version.rst
+++ b/source/isaaclab/changelog.d/peterd-lock-qpsolvers-version.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Pinned ``qpsolvers==4.11.0`` to keep Pink IK working. ``qpsolvers`` 4.12.0
+  dropped the ``primal_start`` kwarg, causing ``pin-pink==3.1.0`` to raise
+  ``TypeError`` inside ``solve_ik``;
+  :class:`~isaaclab.controllers.pink_ik.PinkIKController` then silently
+  fell back to returning the current joints, making IK a no-op.

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -70,6 +70,7 @@ INSTALL_REQUIRES += [
     f"pin ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
     f"pin-pink==3.1.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
     f"daqp==0.7.2 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
+    f"qpsolvers==4.11.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
 ]
 # Adds OpenUSD dependencies based on architecture for Kit less mode.
 INSTALL_REQUIRES += [


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Locks the version of qpsolvers to 4.11.0 which is last known version that works with pin_pink. 
This fixes Pink IK tests.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
