### PR TITLE
Fix LeappDeploymentEnv missing extras attribute

### DIFF
--- a/source/isaaclab/changelog.d/klakhi-fix-leapp-deployment-env-extras.rst
+++ b/source/isaaclab/changelog.d/klakhi-fix-leapp-deployment-env-extras.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~envs.LeappDeploymentEnv` crashing on ``reset()`` with
+  ``AttributeError: 'LeappDeploymentEnv' object has no attribute 'extras'``
+  by initializing ``self.extras`` in ``__init__``.

--- a/source/isaaclab/isaaclab/envs/leapp_deployment_env.py
+++ b/source/isaaclab/isaaclab/envs/leapp_deployment_env.py
@@ -175,6 +175,7 @@ class LeappDeploymentEnv:
         self._leapp_yaml_path = leapp_yaml_path
         self._step_count = 0
         self._sim_step_counter = 0
+        self.extras: dict = {}
 
         # ── Simulation + scene ────────────────────────────────────
         self.sim = SimulationContext(cfg.sim)


### PR DESCRIPTION
CommandManager terms call self._env.extras during reset(). LeappDeploymentEnv bypasses the standard ManagerBasedRLEnv init path and never initializes this dict, causing an AttributeError on the first reset() call.

Add self.extras: dict = {} to __init__ to fix the crash.

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
