### PR TITLE
Fixes benchmark scripts when tensorboard logs are missing

### DIFF
--- a/scripts/benchmarks/benchmark_rlgames.py
+++ b/scripts/benchmarks/benchmark_rlgames.py
@@ -288,20 +288,33 @@ def main(
         log_simulation_start_time(benchmark, Timer.get_timer_info("simulation_start") * 1000)
         log_total_start_time(benchmark, (task_startup_time_end - app_start_time_begin) / 1e6)
         log_runtime_step_times(benchmark, rl_training_times, compute_stats=True)
-        log_rl_policy_rewards(benchmark, log_data["rewards/iter"])
-        log_rl_policy_episode_lengths(benchmark, log_data["episode_lengths/iter"])
+
+        rewards = log_data.get("rewards/iter")
+        episode_lengths = log_data.get("episode_lengths/iter")
+        if rewards:
+            log_rl_policy_rewards(benchmark, rewards)
+        else:
+            print("[WARNING] TensorBoard log is missing 'rewards/iter'; skipping reward benchmark metrics.")
+        if episode_lengths:
+            log_rl_policy_episode_lengths(benchmark, episode_lengths)
+        else:
+            print("[WARNING] TensorBoard log is missing 'episode_lengths/iter'; skipping episode-length metrics.")
+
         success_rates = get_success_rate_log(log_data)
         if success_rates is not None:
             log_rl_policy_success_rates(benchmark, success_rates)
-        log_convergence(
-            benchmark,
-            log_data["rewards/iter"],
-            args_cli.task,
-            workflow="rl_games",
-            should_check_convergence=args_cli.check_convergence,
-            reward_threshold=args_cli.reward_threshold,
-            convergence_config=args_cli.convergence_config,
-        )
+        if rewards:
+            log_convergence(
+                benchmark,
+                rewards,
+                args_cli.task,
+                workflow="rl_games",
+                should_check_convergence=args_cli.check_convergence,
+                reward_threshold=args_cli.reward_threshold,
+                convergence_config=args_cli.convergence_config,
+            )
+        elif args_cli.check_convergence:
+            print("[WARNING] Cannot check convergence because 'rewards/iter' was not logged.")
 
         tracker = get_success_tracker(args_cli, observer.tracker, log_data)
         log_success(benchmark, tracker, framework_iteration_count=observer.framework_iteration_count)

--- a/scripts/benchmarks/benchmark_rlgames.py
+++ b/scripts/benchmarks/benchmark_rlgames.py
@@ -103,13 +103,9 @@ from isaaclab.utils.timer import Timer
 from scripts.benchmarks.utils import (
     get_backend_type,
     get_preset_string,
-    get_success_rate_log,
     log_app_start_time,
-    log_convergence,
     log_python_imports_time,
-    log_rl_policy_episode_lengths,
-    log_rl_policy_rewards,
-    log_rl_policy_success_rates,
+    log_rl_training_metrics,
     log_runtime_step_times,
     log_scene_creation_time,
     log_simulation_start_time,
@@ -288,33 +284,17 @@ def main(
         log_simulation_start_time(benchmark, Timer.get_timer_info("simulation_start") * 1000)
         log_total_start_time(benchmark, (task_startup_time_end - app_start_time_begin) / 1e6)
         log_runtime_step_times(benchmark, rl_training_times, compute_stats=True)
-
-        rewards = log_data.get("rewards/iter")
-        episode_lengths = log_data.get("episode_lengths/iter")
-        if rewards:
-            log_rl_policy_rewards(benchmark, rewards)
-        else:
-            print("[WARNING] TensorBoard log is missing 'rewards/iter'; skipping reward benchmark metrics.")
-        if episode_lengths:
-            log_rl_policy_episode_lengths(benchmark, episode_lengths)
-        else:
-            print("[WARNING] TensorBoard log is missing 'episode_lengths/iter'; skipping episode-length metrics.")
-
-        success_rates = get_success_rate_log(log_data)
-        if success_rates is not None:
-            log_rl_policy_success_rates(benchmark, success_rates)
-        if rewards:
-            log_convergence(
-                benchmark,
-                rewards,
-                args_cli.task,
-                workflow="rl_games",
-                should_check_convergence=args_cli.check_convergence,
-                reward_threshold=args_cli.reward_threshold,
-                convergence_config=args_cli.convergence_config,
-            )
-        elif args_cli.check_convergence:
-            print("[WARNING] Cannot check convergence because 'rewards/iter' was not logged.")
+        log_rl_training_metrics(
+            benchmark,
+            log_data,
+            reward_tag="rewards/iter",
+            episode_length_tag="episode_lengths/iter",
+            task=args_cli.task,
+            workflow="rl_games",
+            should_check_convergence=args_cli.check_convergence,
+            reward_threshold=args_cli.reward_threshold,
+            convergence_config=args_cli.convergence_config,
+        )
 
         tracker = get_success_tracker(args_cli, observer.tracker, log_data)
         log_success(benchmark, tracker, framework_iteration_count=observer.framework_iteration_count)

--- a/scripts/benchmarks/benchmark_rsl_rl.py
+++ b/scripts/benchmarks/benchmark_rsl_rl.py
@@ -105,13 +105,9 @@ from isaaclab.utils.timer import Timer
 from scripts.benchmarks.utils import (
     get_backend_type,
     get_preset_string,
-    get_success_rate_log,
     log_app_start_time,
-    log_convergence,
     log_python_imports_time,
-    log_rl_policy_episode_lengths,
-    log_rl_policy_rewards,
-    log_rl_policy_success_rates,
+    log_rl_training_metrics,
     log_runtime_step_times,
     log_scene_creation_time,
     log_simulation_start_time,
@@ -287,34 +283,17 @@ def main(
         log_simulation_start_time(benchmark, Timer.get_timer_info("simulation_start") * 1000)
         log_total_start_time(benchmark, (task_startup_time_end - app_start_time_begin) / 1e6)
         log_runtime_step_times(benchmark, rl_training_times, compute_stats=True)
-
-        rewards = log_data.get("Train/mean_reward")
-        episode_lengths = log_data.get("Train/mean_episode_length")
-        if rewards:
-            log_rl_policy_rewards(benchmark, rewards)
-        else:
-            print("[WARNING] TensorBoard log is missing 'Train/mean_reward'; skipping reward benchmark metrics.")
-        if episode_lengths:
-            log_rl_policy_episode_lengths(benchmark, episode_lengths)
-        else:
-            print("[WARNING] TensorBoard log is missing 'Train/mean_episode_length'; skipping episode-length metrics.")
-
-        success_rates = get_success_rate_log(log_data)
-        if success_rates is not None:
-            log_rl_policy_success_rates(benchmark, success_rates)
-
-        if rewards:
-            log_convergence(
-                benchmark,
-                rewards,
-                args_cli.task,
-                workflow="rsl_rl",
-                should_check_convergence=args_cli.check_convergence,
-                reward_threshold=args_cli.reward_threshold,
-                convergence_config=args_cli.convergence_config,
-            )
-        elif args_cli.check_convergence:
-            print("[WARNING] Cannot check convergence because 'Train/mean_reward' was not logged.")
+        log_rl_training_metrics(
+            benchmark,
+            log_data,
+            reward_tag="Train/mean_reward",
+            episode_length_tag="Train/mean_episode_length",
+            task=args_cli.task,
+            workflow="rsl_rl",
+            should_check_convergence=args_cli.check_convergence,
+            reward_threshold=args_cli.reward_threshold,
+            convergence_config=args_cli.convergence_config,
+        )
 
         tracker = get_success_tracker(args_cli, early_stop_ctx.tracker, log_data)
         log_success(benchmark, tracker, framework_iteration_count=early_stop_ctx.framework_iteration_count)

--- a/scripts/benchmarks/benchmark_rsl_rl.py
+++ b/scripts/benchmarks/benchmark_rsl_rl.py
@@ -287,21 +287,34 @@ def main(
         log_simulation_start_time(benchmark, Timer.get_timer_info("simulation_start") * 1000)
         log_total_start_time(benchmark, (task_startup_time_end - app_start_time_begin) / 1e6)
         log_runtime_step_times(benchmark, rl_training_times, compute_stats=True)
-        log_rl_policy_rewards(benchmark, log_data["Train/mean_reward"])
-        log_rl_policy_episode_lengths(benchmark, log_data["Train/mean_episode_length"])
+
+        rewards = log_data.get("Train/mean_reward")
+        episode_lengths = log_data.get("Train/mean_episode_length")
+        if rewards:
+            log_rl_policy_rewards(benchmark, rewards)
+        else:
+            print("[WARNING] TensorBoard log is missing 'Train/mean_reward'; skipping reward benchmark metrics.")
+        if episode_lengths:
+            log_rl_policy_episode_lengths(benchmark, episode_lengths)
+        else:
+            print("[WARNING] TensorBoard log is missing 'Train/mean_episode_length'; skipping episode-length metrics.")
+
         success_rates = get_success_rate_log(log_data)
         if success_rates is not None:
             log_rl_policy_success_rates(benchmark, success_rates)
 
-        log_convergence(
-            benchmark,
-            log_data["Train/mean_reward"],
-            args_cli.task,
-            workflow="rsl_rl",
-            should_check_convergence=args_cli.check_convergence,
-            reward_threshold=args_cli.reward_threshold,
-            convergence_config=args_cli.convergence_config,
-        )
+        if rewards:
+            log_convergence(
+                benchmark,
+                rewards,
+                args_cli.task,
+                workflow="rsl_rl",
+                should_check_convergence=args_cli.check_convergence,
+                reward_threshold=args_cli.reward_threshold,
+                convergence_config=args_cli.convergence_config,
+            )
+        elif args_cli.check_convergence:
+            print("[WARNING] Cannot check convergence because 'Train/mean_reward' was not logged.")
 
         tracker = get_success_tracker(args_cli, early_stop_ctx.tracker, log_data)
         log_success(benchmark, tracker, framework_iteration_count=early_stop_ctx.framework_iteration_count)

--- a/scripts/benchmarks/test/test_training_metrics.py
+++ b/scripts/benchmarks/test/test_training_metrics.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for benchmark training-metric logging helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.benchmarks.utils import SUCCESS_RATE_LOG_TAGS, log_rl_training_metrics
+
+
+class _FakeBenchmark:
+    """Collect benchmark measurements without initializing benchmark backends."""
+
+    def __init__(self):
+        self.measurements: list[tuple[str, str, object, str]] = []
+
+    def add_measurement(self, phase, measurement):
+        self.measurements.append((phase, measurement.name, measurement.value, getattr(measurement, "unit", "")))
+
+    def measurement_by_name(self, name: str):
+        return next(m for m in self.measurements if m[1] == name)
+
+
+@pytest.mark.parametrize(
+    "workflow,reward_tag,episode_length_tag",
+    [
+        ("rl_games", "rewards/iter", "episode_lengths/iter"),
+        ("rsl_rl", "Train/mean_reward", "Train/mean_episode_length"),
+    ],
+)
+def test_log_rl_training_metrics_skips_missing_short_run_scalars(
+    workflow: str, reward_tag: str, episode_length_tag: str, capsys: pytest.CaptureFixture[str]
+):
+    """Short benchmark runs may finish before reward and episode-length scalars are emitted."""
+    benchmark = _FakeBenchmark()
+
+    log_rl_training_metrics(
+        benchmark,
+        log_data={},
+        reward_tag=reward_tag,
+        episode_length_tag=episode_length_tag,
+        task="Isaac-Ant-v0",
+        workflow=workflow,
+        should_check_convergence=True,
+    )
+
+    assert benchmark.measurements == []
+    output = capsys.readouterr().out
+    assert f"TensorBoard log is missing '{reward_tag}'" in output
+    assert f"TensorBoard log is missing '{episode_length_tag}'" in output
+    assert f"Cannot check convergence because '{reward_tag}' was not logged" in output
+
+
+@pytest.mark.parametrize(
+    "workflow,reward_tag,episode_length_tag",
+    [
+        ("rl_games", "rewards/iter", "episode_lengths/iter"),
+        ("rsl_rl", "Train/mean_reward", "Train/mean_episode_length"),
+    ],
+)
+def test_log_rl_training_metrics_logs_present_normal_run_scalars(
+    workflow: str, reward_tag: str, episode_length_tag: str, capsys: pytest.CaptureFixture[str]
+):
+    """Normal runs with reward and episode-length scalars should log train metrics."""
+    benchmark = _FakeBenchmark()
+
+    log_rl_training_metrics(
+        benchmark,
+        log_data={
+            reward_tag: [1.0, 2.0, 3.0],
+            episode_length_tag: [10.0, 11.0],
+            SUCCESS_RATE_LOG_TAGS[0]: [0.25, 0.5],
+        },
+        reward_tag=reward_tag,
+        episode_length_tag=episode_length_tag,
+        task="Isaac-Ant-v0",
+        workflow=workflow,
+    )
+
+    assert benchmark.measurement_by_name("Rewards")[2] == [1.0, 2.0, 3.0]
+    assert benchmark.measurement_by_name("Max Rewards")[2] == 3.0
+    assert benchmark.measurement_by_name("Episode Lengths")[2] == [10.0, 11.0]
+    assert benchmark.measurement_by_name("Max Episode Lengths")[2] == 11.0
+    assert benchmark.measurement_by_name("Success Rates")[2] == [0.25, 0.5]
+    assert benchmark.measurement_by_name("success_rate")[2] == 0.5
+    assert "TensorBoard log is missing" not in capsys.readouterr().out

--- a/scripts/benchmarks/utils.py
+++ b/scripts/benchmarks/utils.py
@@ -295,6 +295,52 @@ def log_success(benchmark, tracker, framework_iteration_count: int | None = None
         )
 
 
+def log_rl_training_metrics(
+    benchmark: BaseIsaacLabBenchmark,
+    log_data: dict[str, list[float]],
+    reward_tag: str,
+    episode_length_tag: str,
+    task: str,
+    workflow: str,
+    should_check_convergence: bool = False,
+    reward_threshold: float | None = None,
+    convergence_config: str = "full",
+) -> None:
+    """Log optional RL training metrics from TensorBoard data.
+
+    Short smoke-test runs can finish before the RL framework emits reward or
+    episode-length scalars. Missing tags should skip those measurements instead
+    of failing the whole benchmark.
+    """
+    rewards = log_data.get(reward_tag)
+    episode_lengths = log_data.get(episode_length_tag)
+    if rewards:
+        log_rl_policy_rewards(benchmark, rewards)
+    else:
+        print(f"[WARNING] TensorBoard log is missing '{reward_tag}'; skipping reward benchmark metrics.")
+    if episode_lengths:
+        log_rl_policy_episode_lengths(benchmark, episode_lengths)
+    else:
+        print(f"[WARNING] TensorBoard log is missing '{episode_length_tag}'; skipping episode-length metrics.")
+
+    success_rates = get_success_rate_log(log_data)
+    if success_rates is not None:
+        log_rl_policy_success_rates(benchmark, success_rates)
+
+    if rewards:
+        log_convergence(
+            benchmark,
+            rewards,
+            task,
+            workflow=workflow,
+            should_check_convergence=should_check_convergence,
+            reward_threshold=reward_threshold,
+            convergence_config=convergence_config,
+        )
+    elif should_check_convergence:
+        print(f"[WARNING] Cannot check convergence because '{reward_tag}' was not logged.")
+
+
 def parse_cprofile_stats(
     profile: cProfile.Profile,
     isaaclab_prefixes: list[str],


### PR DESCRIPTION
# Description

When benchmarking scripts are executed with num_iterations set to below the threshold for reward logging, the run can produce missing reward data. However, the scripts are hardcoded to always parse rewards from tensorboard, which may not exist in these cases. This change patches the RL benchmarking scripts to only process rewards logging if they were written to tensorboard.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
