### PR TITLE
Fix Isaac Sim app path routing

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "5.0.0"
+version = "5.0.1"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+5.0.1 (2026-05-11)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed AppLauncher experience and render preset path resolution to use the
+  tracked ``apps`` directory after the legacy ``apps/isaacsim_5`` files were
+  removed.
+
+
 5.0.0 (2026-05-11)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -1007,10 +1007,6 @@ class AppLauncher:
         # If nothing is provided resolve the experience file based on the headless flag
         kit_app_exp_path = os.environ["EXP_PATH"]
         isaaclab_app_exp_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), *[".."] * 4, "apps")
-        # For Isaac Sim 4.5 compatibility, we use the 4.5 app files in a different folder
-        # if launcher_args.get("use_isaacsim_45", False):
-        if self.is_isaac_sim_version_5():
-            isaaclab_app_exp_path = os.path.join(isaaclab_app_exp_path, "isaacsim_5")
 
         if self._sim_experience_file == "":
             # check if the headless flag is set
@@ -1237,30 +1233,6 @@ class AppLauncher:
         self._app.close()
         # raise the error for keyboard interrupt
         raise KeyboardInterrupt
-
-    def is_isaac_sim_version_5(self) -> bool:
-        if not hasattr(self, "_is_sim_ver_5"):
-            # 1) Try to read the VERSION file (for manual / binary installs)
-            version_path = os.path.abspath(os.path.join(os.path.dirname(isaacsim.__file__), "../../VERSION"))
-            if os.path.isfile(version_path):
-                with open(version_path) as f:
-                    ver = f.readline().strip()
-                    if ver.startswith("5"):
-                        self._is_sim_ver_5 = True
-                        return True
-
-            # 2) Fall back to metadata (for pip installs)
-            from importlib.metadata import version as pkg_version
-
-            try:
-                ver = pkg_version("isaacsim")
-                if ver.startswith("5"):
-                    self._is_sim_ver_5 = True
-                else:
-                    self._is_sim_ver_5 = False
-            except Exception:
-                self._is_sim_ver_5 = False
-        return self._is_sim_ver_5
 
     def _hide_play_button(self, flag):
         """Hide/Unhide the play button in the toolbar.

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -232,11 +232,6 @@ class SimulationContext:
                 )
 
             isaaclab_app_exp_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), *[".."] * 4, "apps")
-            from isaaclab.utils.version import get_isaac_sim_version
-
-            if get_isaac_sim_version().major < 6:
-                isaaclab_app_exp_path = os.path.join(isaaclab_app_exp_path, "isaacsim_5")
-
             preset_filename = os.path.join(isaaclab_app_exp_path, f"rendering_modes/{rendering_mode}.kit")
             if os.path.exists(preset_filename):
                 with open(preset_filename) as file:

--- a/source/isaaclab/test/sim/test_simulation_render_config.py
+++ b/source/isaaclab/test/sim/test_simulation_render_config.py
@@ -23,7 +23,6 @@ import toml
 from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.sim.simulation_cfg import RenderCfg, SimulationCfg
 from isaaclab.sim.simulation_context import SimulationContext
-from isaaclab.utils.version import get_isaac_sim_version
 
 
 @pytest.mark.skip(reason="Timeline not stopped")
@@ -105,9 +104,6 @@ def test_render_cfg_presets():
 
         # grab isaac lab apps path
         isaaclab_app_exp_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), *[".."] * 4, "apps")
-        # for Isaac Sim 5 compatibility, we use the 5 rendering mode app files in a different folder
-        if get_isaac_sim_version().major < 6:
-            isaaclab_app_exp_path = os.path.join(isaaclab_app_exp_path, "isaacsim_5")
 
         # grab preset settings
         preset_filename = os.path.join(isaaclab_app_exp_path, f"rendering_modes/{rendering_mode}.kit")


### PR DESCRIPTION
## Summary

- route AppLauncher experience file lookup through the tracked root `apps/` directory
- route render preset loading and its test through `apps/rendering_modes`
- remove the legacy Isaac Sim 5 `apps/isaacsim_5` branch after that tree was removed
- add a `5.0.1` changelog entry and bump the isaaclab extension version

## Rationale

Current `develop` no longer contains `apps/isaacsim_5`, but AppLauncher,
SimulationContext render presets, and the render preset test still branch to
that directory for Isaac Sim versions below 6. That makes the fallback path point
to files that are not present in the repository.

## Validation

- `git ls-tree origin/develop:apps` shows only `rendering_modes`
- `VIRTUAL_ENV=/home/rlrk/env_isaaclab6 ./isaaclab.sh -f`
- `./isaaclab.sh -p -m py_compile source/isaaclab/isaaclab/app/app_launcher.py source/isaaclab/isaaclab/sim/simulation_context.py source/isaaclab/test/sim/test_simulation_render_config.py`
- `git diff --cached --check`
