### PR TITLE
[OVPHYSX] RigidObjectCollection asset

### DIFF
--- a/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
@@ -14,16 +14,42 @@ collection interfaces need to comply with the same interface contract.
 The setup is a bit convoluted so that we can run these tests without requiring Isaac Sim or GPU simulation.
 """
 
-"""Launch Isaac Sim Simulator first."""
+"""Launch Isaac Sim Simulator first (when available)."""
 
-from isaaclab.app import AppLauncher
-
-HEADLESS = True
-
-# launch omniverse app
-simulation_app = AppLauncher(headless=True).app
-
+import os
+import sys
 from unittest.mock import MagicMock
+
+# When running kitless (e.g., ovphysx backend via run_ovphysx.sh), AppLauncher
+# will try to boot Kit and hang. Skip it entirely: run_ovphysx.sh sets
+# LD_PRELOAD to the ovphysx libcarb.so, which is the signature of a kitless
+# ovphysx run. Also guard the case where neither LD_PRELOAD nor EXP_PATH is
+# set (bare Python, no Kit at all).
+_kitless = "ovphysx" in os.environ.get("LD_PRELOAD", "") or (
+    os.environ.get("LD_PRELOAD", "") == "" and "EXP_PATH" not in os.environ
+)
+
+if not _kitless:
+    from isaaclab.app import AppLauncher
+
+    simulation_app = AppLauncher(headless=True).app
+else:
+    simulation_app = None
+    # Stub out the Kit/Omniverse modules that are not present under
+    # run_ovphysx.sh (pxr, carb, omni, omni.kit[.app] are real on PYTHONPATH).
+    # ``omni`` is a real namespace package, so missing submodules also need
+    # to be installed as attributes on it -- ``sys.modules`` alone is not
+    # enough because attribute access on the real ``omni`` won't fall
+    # through to ``sys.modules``.
+    import omni as _omni
+
+    for _mod in ("physics", "physics.tensors", "physx", "timeline", "usd"):
+        _stub = MagicMock()
+        sys.modules[f"omni.{_mod}"] = _stub
+        # Bind the leaf attribute so that ``omni.<leaf>`` resolves.
+        setattr(_omni, _mod.split(".", 1)[0], _stub)
+    for _mod in ("isaacsim.core", "isaacsim.core.simulation_manager"):
+        sys.modules.setdefault(_mod, MagicMock())
 
 import numpy as np
 import pytest
@@ -73,6 +99,23 @@ try:
 
     BACKENDS.append("newton")
 except ImportError:
+    pass
+
+try:
+    from isaaclab_ovphysx.assets.rigid_object_collection.rigid_object_collection import (
+        RigidObjectCollection as OvPhysxRigidObjectCollection,
+    )
+    from isaaclab_ovphysx.assets.rigid_object_collection.rigid_object_collection_data import (
+        RigidObjectCollectionData as OvPhysxRigidObjectCollectionData,
+    )
+    from isaaclab_ovphysx.test.mock_interfaces.views import MockOvPhysxBindingSet
+
+    # Guard against stub implementations (not yet functional).
+    if not hasattr(OvPhysxRigidObjectCollection, "_create_buffers"):
+        raise AttributeError("OvPhysxRigidObjectCollection is a stub; skipping ovphysx backend")
+
+    BACKENDS.append("ovphysx")
+except (ImportError, AttributeError):
     pass
 
 
@@ -209,6 +252,61 @@ def create_newton_rigid_object_collection(
     return collection, mock_view
 
 
+def create_ovphysx_rigid_object_collection(
+    num_instances: int = 2,
+    num_bodies: int = 3,
+    device: str = "cuda:0",
+):
+    """Create a test OVPhysX RigidObjectCollection instance with mocked tensor bindings."""
+    body_names = [f"object_{i}" for i in range(num_bodies)]
+
+    collection = object.__new__(OvPhysxRigidObjectCollection)
+
+    rigid_objects = {f"object_{i}": RigidObjectCfg(prim_path=f"/World/Object_{i}") for i in range(num_bodies)}
+    collection.cfg = RigidObjectCollectionCfg(rigid_objects=rigid_objects)
+
+    # Use articulation-mode bindings with num_joints=0 to get (N, B, ...) shaped tensors.
+    mock_bindings = MockOvPhysxBindingSet(
+        num_instances=num_instances,
+        num_joints=0,
+        num_bodies=num_bodies,
+        body_names=body_names,
+        asset_kind="articulation",
+    )
+    mock_bindings.set_random_data()
+
+    object.__setattr__(collection, "_device", device)
+    object.__setattr__(collection, "_ovphysx", MagicMock())
+    object.__setattr__(collection, "_bindings", mock_bindings.bindings)
+    object.__setattr__(collection, "_num_instances", num_instances)
+    object.__setattr__(collection, "_num_bodies", num_bodies)
+    object.__setattr__(collection, "_body_names_list", body_names)
+
+    # Create RigidObjectCollectionData
+    data = OvPhysxRigidObjectCollectionData(mock_bindings.bindings, num_bodies, device)
+    data.num_instances = num_instances
+    data.num_bodies = num_bodies
+    data._is_primed = True
+    object.__setattr__(collection, "_data", data)
+
+    # Allocate the buffers that RigidObjectCollection normally allocates in _initialize_impl.
+    collection._create_buffers()
+
+    # Replace the real wrench composers with mocks for iface coverage.
+    mock_inst_wrench = MockWrenchComposer(collection)
+    mock_perm_wrench = MockWrenchComposer(collection)
+    object.__setattr__(collection, "_instantaneous_wrench_composer", mock_inst_wrench)
+    object.__setattr__(collection, "_permanent_wrench_composer", mock_perm_wrench)
+
+    # Prevent __del__ / _clear_callbacks from raising
+    object.__setattr__(collection, "_initialize_handle", None)
+    object.__setattr__(collection, "_invalidate_initialize_handle", None)
+    object.__setattr__(collection, "_prim_deletion_handle", None)
+    object.__setattr__(collection, "_debug_vis_handle", None)
+
+    return collection, mock_bindings
+
+
 def create_mock_rigid_object_collection(
     num_instances: int = 2,
     num_bodies: int = 3,
@@ -232,6 +330,8 @@ def get_rigid_object_collection(
 ):
     if backend == "physx":
         return create_physx_rigid_object_collection(num_instances, num_bodies, device)
+    elif backend == "ovphysx":
+        return create_ovphysx_rigid_object_collection(num_instances, num_bodies, device)
     elif backend == "newton":
         return create_newton_rigid_object_collection(num_instances, num_bodies, device)
     elif backend.lower() == "mock":

--- a/source/isaaclab_ovphysx/changelog.d/antoiner-feat-ovphysx_rigidobjectcollection.major.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-feat-ovphysx_rigidobjectcollection.major.rst
@@ -1,0 +1,13 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab_ovphysx.assets.RigidObjectCollection` and
+  :class:`~isaaclab_ovphysx.assets.RigidObjectCollectionData` for the
+  OVPhysX backend, completing the rigid-body asset surface alongside
+  :class:`~isaaclab_ovphysx.assets.RigidObject` and
+  :class:`~isaaclab_ovphysx.assets.Articulation`. Supports
+  ``(env, body)`` dual indexing and per-body property setters. Uses the
+  ovphysx 0.4.3+ native fused multi-prim binding API
+  (``create_tensor_binding(prim_paths=[...])``) so one binding spans all
+  ``num_instances * num_bodies`` prims per tensor type, mirroring the
+  strided-view reshape pattern used by the PhysX collection.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/__init__.pyi
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/__init__.pyi
@@ -7,8 +7,11 @@ __all__ = [
     "Articulation",
     "ArticulationData",
     "RigidObject",
+    "RigidObjectCollection",
+    "RigidObjectCollectionData",
     "RigidObjectData",
 ]
 
 from .articulation import Articulation, ArticulationData
 from .rigid_object import RigidObject, RigidObjectData
+from .rigid_object_collection import RigidObjectCollection, RigidObjectCollectionData

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/kernels.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/kernels.py
@@ -1349,6 +1349,31 @@ def write_joint_friction_to_buffer_index(
 
 
 @wp.kernel
+def resolve_view_ids(
+    env_ids: wp.array(dtype=wp.int32),
+    body_ids: wp.array(dtype=wp.int32),
+    num_query_envs: wp.int32,
+    num_total_envs: wp.int32,
+    view_ids: wp.array(dtype=wp.int32),
+) -> None:
+    """Resolve flat view indices from environment and body index pairs.
+
+    Computes flat view indices from (env_id, body_id) pairs using body-major ordering:
+    ``view_id = body_id * num_total_envs + env_id``. The output array is laid out in
+    column-major order over the (env, body) grid.
+
+    Args:
+        env_ids: Input environment indices. Shape is (num_query_envs,).
+        body_ids: Input body indices. Shape is (num_query_bodies,).
+        num_query_envs: Total number of queried environments.
+        num_total_envs: Total number of environments in the simulation.
+        view_ids: Output flat view indices. Shape is (num_query_bodies * num_query_envs,).
+    """
+    i, j = wp.tid()
+    view_ids[j * num_query_envs + i] = body_ids[j] * num_total_envs + env_ids[i]
+
+
+@wp.kernel
 def write_joint_friction_to_buffer_mask(
     in_data: wp.array2d(dtype=wp.float32),
     env_mask: wp.array(dtype=wp.bool),

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/__init__.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sub-module for ovphysx-backed rigid object collection assets."""
+
+from isaaclab.utils.module import lazy_export
+
+lazy_export()

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/__init__.pyi
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/__init__.pyi
@@ -1,0 +1,12 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+__all__ = [
+    "RigidObjectCollection",
+    "RigidObjectCollectionData",
+]
+
+from .rigid_object_collection import RigidObjectCollection
+from .rigid_object_collection_data import RigidObjectCollectionData

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
@@ -1,0 +1,1525 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import re
+import warnings
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+import warp as wp
+
+from pxr import UsdPhysics
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets.rigid_object_collection.base_rigid_object_collection import BaseRigidObjectCollection
+from isaaclab.utils.string import resolve_matching_names
+from isaaclab.utils.wrench_composer import WrenchComposer
+
+from isaaclab_ovphysx import tensor_types as TT
+from isaaclab_ovphysx.assets import kernels as shared_kernels
+from isaaclab_ovphysx.assets.kernels import _body_wrench_to_world, resolve_view_ids
+from isaaclab_ovphysx.physics import OvPhysxManager
+
+from .rigid_object_collection_data import RigidObjectCollectionData
+
+if TYPE_CHECKING:
+    from isaaclab.assets.rigid_object_collection.rigid_object_collection_cfg import RigidObjectCollectionCfg
+
+
+class RigidObjectCollection(BaseRigidObjectCollection):
+    """A rigid object collection class.
+
+    This class represents a collection of rigid objects in the simulation, where the state of the
+    rigid objects can be accessed and modified using a batched ``(env_ids, object_ids)`` API.
+
+    For each rigid body in the collection, the root prim of the asset must have the `USD RigidBodyAPI`_
+    applied to it. This API is used to define the simulation properties of the rigid bodies. On playing the
+    simulation, the physics engine will automatically register the rigid bodies and create a corresponding
+    rigid body handle. This handle can be accessed using the :attr:`root_view` attribute.
+
+    Rigid objects in the collection are uniquely identified via the key of the dictionary
+    :attr:`~isaaclab.assets.RigidObjectCollectionCfg.rigid_objects` in the
+    :class:`~isaaclab.assets.RigidObjectCollectionCfg` configuration class.
+    This differs from the :class:`~isaaclab.assets.RigidObject` class, where a rigid object is identified by
+    the name of the Xform where the `USD RigidBodyAPI`_ is applied. This would not be possible for the rigid
+    object collection since the :attr:`~isaaclab.assets.RigidObjectCollectionCfg.rigid_objects` dictionary
+    could contain the same rigid object multiple times, leading to ambiguity.
+
+    .. _`USD RigidBodyAPI`: https://openusd.org/dev/api/class_usd_physics_rigid_body_a_p_i.html
+    """
+
+    cfg: RigidObjectCollectionCfg
+    """Configuration instance for the rigid object."""
+
+    __backend_name__: str = "ovphysx"
+    """The name of the backend for the rigid object."""
+
+    def __init__(self, cfg: RigidObjectCollectionCfg):
+        """Initialize the rigid object.
+
+        Args:
+            cfg: A configuration instance.
+        """
+        # Note: We never call the parent constructor as it tries to call its own spawning which we don't want.
+        # check that the config is valid
+        cfg.validate()
+        # store inputs
+        self.cfg = cfg.copy()
+        # flag for whether the asset is initialized
+        self._is_initialized = False
+        # spawn the rigid objects
+        for rigid_body_cfg in self.cfg.rigid_objects.values():
+            # spawn the asset
+            if rigid_body_cfg.spawn is not None:
+                rigid_body_cfg.spawn.func(
+                    rigid_body_cfg.prim_path,
+                    rigid_body_cfg.spawn,
+                    translation=rigid_body_cfg.init_state.pos,
+                    orientation=rigid_body_cfg.init_state.rot,
+                )
+            # check that spawn was successful
+            matching_prims = sim_utils.find_matching_prims(rigid_body_cfg.prim_path)
+            if len(matching_prims) == 0:
+                raise RuntimeError(f"Could not find prim with path {rigid_body_cfg.prim_path}.")
+        # stores object names
+        self._body_names_list: list[str] = []
+        # one fused TensorBinding per tensor type, populated in _initialize_impl
+        self._bindings: dict[int, Any] = {}
+
+        # register various callback functions
+        self._register_callbacks()
+        self._debug_vis_handle = None
+
+    """
+    Properties
+    """
+
+    @property
+    def data(self) -> RigidObjectCollectionData:
+        return self._data
+
+    @property
+    def num_instances(self) -> int:
+        return self._num_instances
+
+    @property
+    def num_bodies(self) -> int:
+        """Number of bodies in the rigid object collection."""
+        return self._num_bodies
+
+    @property
+    def body_names(self) -> list[str]:
+        """Ordered names of bodies in the rigid object collection."""
+        return list(self._body_names_list)
+
+    @property
+    def root_view(self):
+        """Root view for the rigid object collection.
+
+        Dictionary keyed by TensorType constant, each value a single fused
+        :class:`~isaaclab_ovphysx.TensorBinding` spanning all bodies in the collection.
+
+        .. note::
+            Use this view with caution. It requires handling of tensors in a specific way.
+        """
+        return self._bindings
+
+    @property
+    def instantaneous_wrench_composer(self) -> WrenchComposer:
+        """Instantaneous wrench composer.
+
+        Returns a :class:`~isaaclab.utils.wrench_composer.WrenchComposer` instance. Wrenches added or set to this wrench
+        composer are only valid for the current simulation step. At the end of the simulation step, the wrenches set
+        to this object are discarded. This is useful to apply forces that change all the time, things like drag forces
+        for instance.
+        """
+        return self._instantaneous_wrench_composer
+
+    @property
+    def permanent_wrench_composer(self) -> WrenchComposer:
+        """Permanent wrench composer.
+
+        Returns a :class:`~isaaclab.utils.wrench_composer.WrenchComposer` instance. Wrenches added or set to this wrench
+        composer are persistent and are applied to the simulation at every step. This is useful to apply forces that
+        are constant over a period of time, things like the thrust of a motor for instance.
+        """
+        return self._permanent_wrench_composer
+
+    """
+    Operations.
+    """
+
+    def reset(
+        self,
+        env_ids: Sequence[int] | wp.array | None = None,
+        object_ids: slice | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Resets all internal buffers of selected environments and objects.
+
+        Args:
+            env_ids: Environment indices. If None, then all indices are used.
+            object_ids: Object indices. If None, then all indices are used.
+            env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
+        """
+        # resolve all indices
+        if (env_ids is None) or (env_ids == slice(None)):
+            env_ids = slice(None)
+        # reset external wrench
+        self._instantaneous_wrench_composer.reset(env_ids, env_mask)
+        self._permanent_wrench_composer.reset(env_ids, env_mask)
+
+    def write_data_to_sim(self) -> None:
+        """Write external wrench to the simulation.
+
+        .. note::
+            We write external wrench to the simulation here since this function is called before the simulation step.
+            This ensures that the external wrench is applied at every simulation step.
+        """
+        inst = self._instantaneous_wrench_composer
+        perm = self._permanent_wrench_composer
+        if not inst.active and not perm.active:
+            return
+        if inst.active:
+            if perm.active:
+                inst.add_raw_buffers_from(perm)
+            force_b = inst.out_force_b.warp
+            torque_b = inst.out_torque_b.warp
+        else:
+            force_b = perm.out_force_b.warp
+            torque_b = perm.out_torque_b.warp
+
+        poses = self._data.body_link_pose_w.warp  # (N, B) wp.transformf
+        wp.launch(
+            _body_wrench_to_world,
+            dim=(self._num_instances, self._num_bodies),
+            inputs=[force_b, torque_b, poses],
+            outputs=[self._wrench_buf],
+            device=self._device,
+        )
+        binding = self._get_binding(TT.LINK_WRENCH)
+        if binding is not None:
+            # The articulation-mode mock used by iface tests exposes an instance-major
+            # ``(N, B, 9)`` view directly; the native fused binding lays elements body-
+            # major flat as ``(N * B, 9)``. Dispatch via the binding's exposed shape.
+            if len(binding.shape) >= 2 and binding.shape[1] == self._num_bodies:
+                binding.write(self._wrench_buf)
+            else:
+                view = self.reshape_data_to_view_3d(self._wrench_buf, 9, device=self._device)
+                binding.write(view)
+        inst.reset()
+
+    def update(self, dt: float) -> None:
+        """Updates the simulation data.
+
+        Args:
+            dt: The time step size in seconds.
+        """
+        self._data.update(dt)
+
+    """
+    Operations - Finders.
+    """
+
+    def find_bodies(
+        self, name_keys: str | Sequence[str], preserve_order: bool = False
+    ) -> tuple[torch.Tensor, list[str]]:
+        """Find bodies in the rigid body collection based on the name keys.
+
+        Please check the :meth:`isaaclab.utils.string_utils.resolve_matching_names` function for more
+        information on the name matching.
+
+        Args:
+            name_keys: A regular expression or a list of regular expressions to match the body names.
+            preserve_order: Whether to preserve the order of the name keys in the output. Defaults to False.
+
+        Returns:
+            A tuple of lists containing the body indices and names.
+        """
+        obj_ids, obj_names = resolve_matching_names(name_keys, self.body_names, preserve_order)
+        return torch.tensor(obj_ids, device=self._device, dtype=torch.int32), obj_names
+
+    """
+    Operations - Write to simulation.
+    """
+
+    def write_body_pose_to_sim_index(
+        self,
+        *,
+        body_poses: wp.array,
+        body_ids: Sequence[int] | wp.array | None = None,
+        env_ids: Sequence[int] | wp.array | None = None,
+    ) -> None:
+        """Set the body pose over selected environment and body indices into the simulation.
+
+        The body pose comprises of the cartesian position and quaternion orientation in (x, y, z, w).
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            body_poses: Body poses in simulation frame [m, rad]. Shape is (len(env_ids), len(body_ids), 7)
+                or (len(env_ids), len(body_ids)) with dtype wp.transformf.
+            body_ids: Body indices. If None, then all indices are used.
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        self.write_body_link_pose_to_sim_index(body_poses=body_poses, body_ids=body_ids, env_ids=env_ids)
+
+    def write_body_pose_to_sim_mask(
+        self,
+        *,
+        body_poses: wp.array,
+        body_mask: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Set the body pose over selected environment and body masks into the simulation.
+
+        The body pose comprises of the cartesian position and quaternion orientation in (x, y, z, w).
+
+        .. note::
+            This method expects full data.
+
+        Args:
+            body_poses: Body poses in simulation frame [m, rad]. Shape is (num_instances, num_bodies, 7)
+                or (num_instances, num_bodies) with dtype wp.transformf.
+            body_mask: Body mask. If None, then all bodies are updated. Shape is (num_bodies,).
+            env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
+        """
+        self.write_body_link_pose_to_sim_mask(body_poses=body_poses, body_mask=body_mask, env_mask=env_mask)
+
+    def write_body_velocity_to_sim_index(
+        self,
+        *,
+        body_velocities: wp.array,
+        body_ids: Sequence[int] | wp.array | None = None,
+        env_ids: Sequence[int] | wp.array | None = None,
+    ) -> None:
+        """Set the body velocity over selected environment and body indices into the simulation.
+
+        The velocity comprises linear velocity (x, y, z) and angular velocity (x, y, z) in that order.
+
+        .. note::
+            This sets the velocity of the body's center of mass rather than the body's frame.
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            body_velocities: Body velocities in simulation world frame [m/s, rad/s].
+                Shape is (len(env_ids), len(body_ids)) with dtype wp.spatial_vectorf.
+            body_ids: Body indices. If None, then all indices are used.
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        self.write_body_com_velocity_to_sim_index(body_velocities=body_velocities, body_ids=body_ids, env_ids=env_ids)
+
+    def write_body_velocity_to_sim_mask(
+        self,
+        *,
+        body_velocities: wp.array,
+        body_mask: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Set the body velocity over selected environment and body masks into the simulation.
+
+        The velocity comprises linear velocity (x, y, z) and angular velocity (x, y, z) in that order.
+
+        .. note::
+            This sets the velocity of the body's center of mass rather than the body's frame.
+
+        .. note::
+            This method expects full data.
+
+        Args:
+            body_velocities: Body velocities in simulation world frame [m/s, rad/s].
+                Shape is (num_instances, num_bodies) with dtype wp.spatial_vectorf.
+            body_mask: Body mask. If None, then all bodies are updated. Shape is (num_bodies,).
+            env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
+        """
+        self.write_body_com_velocity_to_sim_mask(
+            body_velocities=body_velocities, body_mask=body_mask, env_mask=env_mask
+        )
+
+    def write_body_link_pose_to_sim_index(
+        self,
+        *,
+        body_poses: wp.array,
+        body_ids: Sequence[int] | wp.array | None = None,
+        env_ids: Sequence[int] | wp.array | None = None,
+    ) -> None:
+        """Set the body link pose over selected environment and body indices into the simulation.
+
+        The body link pose comprises of the cartesian position and quaternion orientation in (x, y, z, w).
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            body_poses: Body link poses in simulation frame [m, rad]. Shape is (len(env_ids), len(body_ids), 7)
+                or (len(env_ids), len(body_ids)) with dtype wp.transformf.
+            body_ids: Body indices. If None, then all indices are used.
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        env_ids = self._resolve_env_ids(env_ids)
+        body_ids = self._resolve_body_ids(body_ids)
+        self.assert_shape_and_dtype(body_poses, (env_ids.shape[0], body_ids.shape[0]), wp.transformf, "body_poses")
+        wp.launch(
+            shared_kernels.set_body_link_pose_to_sim,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[body_poses, env_ids, body_ids, False],
+            outputs=[
+                self.data._body_link_pose_w.data,
+                self.data._body_link_state_w.data,
+                self.data._body_state_w.data,
+            ],
+            device=self._device,
+        )
+        # Mark the link pose fresh so reads within the same step return the
+        # kernel-written value rather than re-fetching the pre-step OVPhysX state.
+        self.data._body_link_pose_w.timestamp = self.data._sim_timestamp
+        self.data._body_com_pose_w.timestamp = -1.0
+        self.data._body_com_state_w.timestamp = -1.0
+        self.data._body_link_state_w.timestamp = -1.0
+        self.data._body_state_w.timestamp = -1.0
+        # set into simulation
+        self._binding_write(TT.LINK_POSE, self.data._body_link_pose_w.data, env_ids=env_ids)
+
+    def write_body_link_pose_to_sim_mask(
+        self,
+        *,
+        body_poses: wp.array,
+        body_mask: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Set the body link pose over selected environment and body masks into the simulation.
+
+        The body link pose comprises of the cartesian position and quaternion orientation in (x, y, z, w).
+
+        .. note::
+            This method expects full data.
+
+        Args:
+            body_poses: Body link poses in simulation frame [m, rad]. Shape is (num_instances, num_bodies, 7)
+                or (num_instances, num_bodies) with dtype wp.transformf.
+            body_mask: Body mask. If None, then all bodies are updated. Shape is (num_bodies,).
+            env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
+        """
+        if env_mask is not None:
+            env_mask_t = wp.to_torch(env_mask) if isinstance(env_mask, wp.array) else env_mask
+            env_ids = self._resolve_env_ids(torch.nonzero(env_mask_t)[:, 0].to(torch.int32))
+        else:
+            env_ids = self._ALL_ENV_INDICES
+        if body_mask is not None:
+            body_mask_t = wp.to_torch(body_mask) if isinstance(body_mask, wp.array) else body_mask
+            body_ids = self._resolve_body_ids(torch.nonzero(body_mask_t)[:, 0].to(torch.int32))
+        else:
+            body_ids = self._ALL_BODY_INDICES
+        self.assert_shape_and_dtype(body_poses, (self._num_instances, self._num_bodies), wp.transformf, "body_poses")
+        wp.launch(
+            shared_kernels.set_body_link_pose_to_sim,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[body_poses, env_ids, body_ids, True],
+            outputs=[
+                self.data._body_link_pose_w.data,
+                self.data._body_link_state_w.data,
+                self.data._body_state_w.data,
+            ],
+            device=self._device,
+        )
+        # Invalidate dependent timestamps
+        self.data._body_com_pose_w.timestamp = -1.0
+        self.data._body_com_state_w.timestamp = -1.0
+        self.data._body_link_state_w.timestamp = -1.0
+        self.data._body_state_w.timestamp = -1.0
+        # set into simulation
+        self._binding_write(TT.LINK_POSE, self.data._body_link_pose_w.data, env_ids=env_ids)
+
+    def write_body_com_pose_to_sim_index(
+        self,
+        *,
+        body_poses: wp.array,
+        body_ids: Sequence[int] | wp.array | None = None,
+        env_ids: Sequence[int] | wp.array | None = None,
+    ) -> None:
+        """Set the body center of mass pose over selected environment and body indices into the simulation.
+
+        The body center of mass pose comprises of the cartesian position and quaternion orientation in (x, y, z, w).
+        The orientation is the orientation of the principal axes of inertia.
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            body_poses: Body center of mass poses in simulation frame [m, rad].
+                Shape is (len(env_ids), len(body_ids), 7) or (len(env_ids), len(body_ids)) with dtype wp.transformf.
+            body_ids: Body indices. If None, then all indices are used.
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        env_ids = self._resolve_env_ids(env_ids)
+        body_ids = self._resolve_body_ids(body_ids)
+        self.assert_shape_and_dtype(body_poses, (env_ids.shape[0], body_ids.shape[0]), wp.transformf, "body_poses")
+        wp.launch(
+            shared_kernels.set_body_com_pose_to_sim,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[body_poses, self.data.body_com_pose_b, env_ids, body_ids, False],
+            outputs=[
+                self.data._body_com_pose_w.data,
+                self.data._body_link_pose_w.data,
+                self.data._body_com_state_w.data,
+                self.data._body_link_state_w.data,
+                self.data._body_state_w.data,
+            ],
+            device=self._device,
+        )
+        # Invalidate dependent timestamps
+        self.data._body_link_state_w.timestamp = -1.0
+        self.data._body_state_w.timestamp = -1.0
+        self.data._body_com_state_w.timestamp = -1.0
+        # set into simulation (OVPhysX only exposes the link frame)
+        self._binding_write(TT.LINK_POSE, self.data._body_link_pose_w.data, env_ids=env_ids)
+
+    def write_body_com_pose_to_sim_mask(
+        self,
+        *,
+        body_poses: wp.array,
+        body_mask: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Set the body center of mass pose over selected environment and body masks into the simulation.
+
+        The body center of mass pose comprises of the cartesian position and quaternion orientation in (x, y, z, w).
+        The orientation is the orientation of the principal axes of inertia.
+
+        .. note::
+            This method expects full data.
+
+        Args:
+            body_poses: Body center of mass poses in simulation frame [m, rad].
+                Shape is (num_instances, num_bodies, 7) or (num_instances, num_bodies) with dtype wp.transformf.
+            body_mask: Body mask. If None, then all bodies are updated. Shape is (num_bodies,).
+            env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
+        """
+        if env_mask is not None:
+            env_mask_t = wp.to_torch(env_mask) if isinstance(env_mask, wp.array) else env_mask
+            env_ids = self._resolve_env_ids(torch.nonzero(env_mask_t)[:, 0].to(torch.int32))
+        else:
+            env_ids = self._ALL_ENV_INDICES
+        if body_mask is not None:
+            body_mask_t = wp.to_torch(body_mask) if isinstance(body_mask, wp.array) else body_mask
+            body_ids = self._resolve_body_ids(torch.nonzero(body_mask_t)[:, 0].to(torch.int32))
+        else:
+            body_ids = self._ALL_BODY_INDICES
+        self.assert_shape_and_dtype(body_poses, (self._num_instances, self._num_bodies), wp.transformf, "body_poses")
+        wp.launch(
+            shared_kernels.set_body_com_pose_to_sim,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[body_poses, self.data.body_com_pose_b, env_ids, body_ids, True],
+            outputs=[
+                self.data._body_com_pose_w.data,
+                self.data._body_link_pose_w.data,
+                self.data._body_com_state_w.data,
+                self.data._body_link_state_w.data,
+                self.data._body_state_w.data,
+            ],
+            device=self._device,
+        )
+        # Invalidate dependent timestamps
+        self.data._body_link_state_w.timestamp = -1.0
+        self.data._body_state_w.timestamp = -1.0
+        self.data._body_com_state_w.timestamp = -1.0
+        # set into simulation (OVPhysX only exposes the link frame)
+        self._binding_write(TT.LINK_POSE, self.data._body_link_pose_w.data, env_ids=env_ids)
+
+    def write_body_com_velocity_to_sim_index(
+        self,
+        *,
+        body_velocities: wp.array,
+        body_ids: Sequence[int] | wp.array | None = None,
+        env_ids: Sequence[int] | wp.array | None = None,
+    ) -> None:
+        """Set the body center of mass velocity over selected environment and body indices into the simulation.
+
+        The velocity comprises linear velocity (x, y, z) and angular velocity (x, y, z) in that order.
+
+        .. note::
+            This sets the velocity of the body's center of mass rather than the body's frame.
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            body_velocities: Body center of mass velocities in simulation world frame [m/s, rad/s].
+                Shape is (len(env_ids), len(body_ids)) with dtype wp.spatial_vectorf.
+            body_ids: Body indices. If None, then all indices are used.
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        env_ids = self._resolve_env_ids(env_ids)
+        body_ids = self._resolve_body_ids(body_ids)
+        self.assert_shape_and_dtype(
+            body_velocities, (env_ids.shape[0], body_ids.shape[0]), wp.spatial_vectorf, "body_velocities"
+        )
+        wp.launch(
+            shared_kernels.set_body_com_velocity_to_sim,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[body_velocities, env_ids, body_ids, False],
+            outputs=[
+                self.data._body_com_vel_w.data,
+                self.data._body_com_acc_w.data,
+                self.data._body_state_w.data,
+                self.data._body_com_state_w.data,
+            ],
+            device=self._device,
+        )
+        # Mark the COM velocity fresh so reads within the same step return the
+        # kernel-written value rather than re-fetching the pre-step OVPhysX state.
+        self.data._body_com_vel_w.timestamp = self.data._sim_timestamp
+        self.data._body_link_vel_w.timestamp = -1.0
+        self.data._body_state_w.timestamp = -1.0
+        self.data._body_com_state_w.timestamp = -1.0
+        self.data._body_link_state_w.timestamp = -1.0
+        # set into simulation
+        self._binding_write(TT.LINK_VELOCITY, self.data._body_com_vel_w.data, env_ids=env_ids)
+
+    def write_body_com_velocity_to_sim_mask(
+        self,
+        *,
+        body_velocities: wp.array,
+        body_mask: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Set the body center of mass velocity over selected environment and body masks into the simulation.
+
+        The velocity comprises linear velocity (x, y, z) and angular velocity (x, y, z) in that order.
+
+        .. note::
+            This sets the velocity of the body's center of mass rather than the body's frame.
+
+        .. note::
+            This method expects full data.
+
+        Args:
+            body_velocities: Body center of mass velocities in simulation world frame [m/s, rad/s].
+                Shape is (num_instances, num_bodies) with dtype wp.spatial_vectorf.
+            body_mask: Body mask. If None, then all bodies are updated. Shape is (num_bodies,).
+            env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
+        """
+        if env_mask is not None:
+            env_mask_t = wp.to_torch(env_mask) if isinstance(env_mask, wp.array) else env_mask
+            env_ids = self._resolve_env_ids(torch.nonzero(env_mask_t)[:, 0].to(torch.int32))
+        else:
+            env_ids = self._ALL_ENV_INDICES
+        if body_mask is not None:
+            body_mask_t = wp.to_torch(body_mask) if isinstance(body_mask, wp.array) else body_mask
+            body_ids = self._resolve_body_ids(torch.nonzero(body_mask_t)[:, 0].to(torch.int32))
+        else:
+            body_ids = self._ALL_BODY_INDICES
+        self.assert_shape_and_dtype(
+            body_velocities, (self._num_instances, self._num_bodies), wp.spatial_vectorf, "body_velocities"
+        )
+        wp.launch(
+            shared_kernels.set_body_com_velocity_to_sim,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[body_velocities, env_ids, body_ids, True],
+            outputs=[
+                self.data._body_com_vel_w.data,
+                self.data._body_com_acc_w.data,
+                self.data._body_state_w.data,
+                self.data._body_com_state_w.data,
+            ],
+            device=self._device,
+        )
+        # Invalidate dependent timestamps
+        self.data._body_link_vel_w.timestamp = -1.0
+        self.data._body_state_w.timestamp = -1.0
+        self.data._body_com_state_w.timestamp = -1.0
+        self.data._body_link_state_w.timestamp = -1.0
+        # set into simulation
+        self._binding_write(TT.LINK_VELOCITY, self.data._body_com_vel_w.data, env_ids=env_ids)
+
+    def write_body_link_velocity_to_sim_index(
+        self,
+        *,
+        body_velocities: wp.array,
+        body_ids: Sequence[int] | wp.array | None = None,
+        env_ids: Sequence[int] | wp.array | None = None,
+    ) -> None:
+        """Set the body link velocity over selected environment and body indices into the simulation.
+
+        The velocity comprises linear velocity (x, y, z) and angular velocity (x, y, z) in that order.
+
+        .. note::
+            This sets the velocity of the body's frame rather than the body's center of mass.
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            body_velocities: Body link velocities in simulation world frame [m/s, rad/s].
+                Shape is (len(env_ids), len(body_ids)) with dtype wp.spatial_vectorf.
+            body_ids: Body indices. If None, then all indices are used.
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        env_ids = self._resolve_env_ids(env_ids)
+        body_ids = self._resolve_body_ids(body_ids)
+        self.assert_shape_and_dtype(
+            body_velocities, (env_ids.shape[0], body_ids.shape[0]), wp.spatial_vectorf, "body_velocities"
+        )
+        wp.launch(
+            shared_kernels.set_body_link_velocity_to_sim,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[
+                body_velocities,
+                self.data.body_com_pose_b,
+                self.data.body_link_pose_w,
+                env_ids,
+                body_ids,
+                False,
+            ],
+            outputs=[
+                self.data._body_link_vel_w.data,
+                self.data._body_com_vel_w.data,
+                self.data._body_com_acc_w.data,
+                self.data._body_link_state_w.data,
+                self.data._body_state_w.data,
+                self.data._body_com_state_w.data,
+            ],
+            device=self._device,
+        )
+        # Invalidate dependent timestamps
+        self.data._body_link_state_w.timestamp = -1.0
+        self.data._body_state_w.timestamp = -1.0
+        self.data._body_com_state_w.timestamp = -1.0
+        # set into simulation
+        self._binding_write(TT.LINK_VELOCITY, self.data._body_com_vel_w.data, env_ids=env_ids)
+
+    def write_body_link_velocity_to_sim_mask(
+        self,
+        *,
+        body_velocities: wp.array,
+        body_mask: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Set the body link velocity over selected environment and body masks into the simulation.
+
+        The velocity comprises linear velocity (x, y, z) and angular velocity (x, y, z) in that order.
+
+        .. note::
+            This sets the velocity of the body's frame rather than the body's center of mass.
+
+        .. note::
+            This method expects full data.
+
+        Args:
+            body_velocities: Body link velocities in simulation world frame [m/s, rad/s].
+                Shape is (num_instances, num_bodies) with dtype wp.spatial_vectorf.
+            body_mask: Body mask. If None, then all bodies are updated. Shape is (num_bodies,).
+            env_mask: Environment mask. If None, then all the instances are updated. Shape is (num_instances,).
+        """
+        if env_mask is not None:
+            env_mask_t = wp.to_torch(env_mask) if isinstance(env_mask, wp.array) else env_mask
+            env_ids = self._resolve_env_ids(torch.nonzero(env_mask_t)[:, 0].to(torch.int32))
+        else:
+            env_ids = self._ALL_ENV_INDICES
+        if body_mask is not None:
+            body_mask_t = wp.to_torch(body_mask) if isinstance(body_mask, wp.array) else body_mask
+            body_ids = self._resolve_body_ids(torch.nonzero(body_mask_t)[:, 0].to(torch.int32))
+        else:
+            body_ids = self._ALL_BODY_INDICES
+        self.assert_shape_and_dtype(
+            body_velocities, (self._num_instances, self._num_bodies), wp.spatial_vectorf, "body_velocities"
+        )
+        wp.launch(
+            shared_kernels.set_body_link_velocity_to_sim,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[
+                body_velocities,
+                self.data.body_com_pose_b,
+                self.data.body_link_pose_w,
+                env_ids,
+                body_ids,
+                True,
+            ],
+            outputs=[
+                self.data._body_link_vel_w.data,
+                self.data._body_com_vel_w.data,
+                self.data._body_com_acc_w.data,
+                self.data._body_link_state_w.data,
+                self.data._body_state_w.data,
+                self.data._body_com_state_w.data,
+            ],
+            device=self._device,
+        )
+        # Invalidate dependent timestamps
+        self.data._body_link_state_w.timestamp = -1.0
+        self.data._body_state_w.timestamp = -1.0
+        self.data._body_com_state_w.timestamp = -1.0
+        # set into simulation
+        self._binding_write(TT.LINK_VELOCITY, self.data._body_com_vel_w.data, env_ids=env_ids)
+
+    """
+    Operations - Setters.
+    """
+
+    def set_masses_index(
+        self,
+        *,
+        masses: wp.array,
+        body_ids: Sequence[int] | wp.array | None = None,
+        env_ids: Sequence[int] | wp.array | None = None,
+    ) -> None:
+        """Set body masses over selected env / body indices into the simulation.
+
+        This is a CPU-only write routed through pinned-host staging because
+        ``BODY_MASS`` is a CPU-only OVPhysX binding.
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            masses: Body masses [kg]. Shape is (len(env_ids), len(body_ids))
+                with dtype wp.float32.
+            body_ids: Body indices. If None, then all indices are used.
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        env_ids = self._resolve_env_ids(env_ids)
+        body_ids = self._resolve_body_ids(body_ids)
+        self.assert_shape_and_dtype(masses, (env_ids.shape[0], body_ids.shape[0]), wp.float32, "masses")
+        wp.launch(
+            shared_kernels.write_2d_data_to_buffer_with_indices,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[masses, env_ids, body_ids],
+            outputs=[self.data._body_mass.data],
+            device=self._device,
+        )
+        wp.copy(self.data._cpu_body_mass, self.data._body_mass.data)
+        self._binding_write(
+            TT.BODY_MASS, self.data._cpu_body_mass, env_ids=self._get_cpu_env_ids(env_ids), device="cpu"
+        )
+
+    def set_masses_mask(
+        self,
+        *,
+        masses: wp.array,
+        body_mask: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Set body masses over selected env / body masks into the simulation.
+
+        This is a CPU-only write routed through pinned-host staging because
+        ``BODY_MASS`` is a CPU-only OVPhysX binding.
+
+        .. note::
+            This method expects full data.
+
+        Args:
+            masses: Body masses [kg]. Shape is (num_instances, num_bodies)
+                with dtype wp.float32.
+            body_mask: Body mask. If None, all bodies are updated.
+                Shape is (num_bodies,).
+            env_mask: Environment mask. If None, all instances are updated.
+                Shape is (num_instances,).
+        """
+        if env_mask is not None:
+            env_mask_t = wp.to_torch(env_mask) if isinstance(env_mask, wp.array) else env_mask
+            env_ids = self._resolve_env_ids(torch.nonzero(env_mask_t)[:, 0].to(torch.int32))
+        else:
+            env_ids = self._ALL_ENV_INDICES
+        self.assert_shape_and_dtype(masses, (self._num_instances, self._num_bodies), wp.float32, "masses")
+        wp.launch(
+            shared_kernels.write_2d_data_to_buffer_with_mask,
+            dim=(self._num_instances, self._num_bodies),
+            inputs=[masses, self._resolve_env_mask(env_mask), self._resolve_body_mask(body_mask)],
+            outputs=[self.data._body_mass.data],
+            device=self._device,
+        )
+        wp.copy(self.data._cpu_body_mass, self.data._body_mass.data)
+        self._binding_write(
+            TT.BODY_MASS, self.data._cpu_body_mass, env_ids=self._get_cpu_env_ids(env_ids), device="cpu"
+        )
+
+    def set_coms_index(
+        self,
+        *,
+        coms: wp.array,
+        body_ids: Sequence[int] | wp.array | None = None,
+        env_ids: Sequence[int] | wp.array | None = None,
+    ) -> None:
+        """Set body center-of-mass poses over selected env / body indices into the simulation.
+
+        This is a CPU-only write routed through pinned-host staging because
+        ``BODY_COM_POSE`` is a CPU-only OVPhysX binding.
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            coms: Body center-of-mass poses [m, quaternion (w, x, y, z)].
+                Shape is (len(env_ids), len(body_ids)) with dtype wp.transformf.
+            body_ids: Body indices. If None, then all indices are used.
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        env_ids = self._resolve_env_ids(env_ids)
+        body_ids = self._resolve_body_ids(body_ids)
+        self.assert_shape_and_dtype(coms, (env_ids.shape[0], body_ids.shape[0]), wp.transformf, "coms")
+        wp.launch(
+            shared_kernels.write_body_com_pose_to_buffer_index,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[coms, env_ids, body_ids],
+            outputs=[self.data._body_com_pose_b.data],
+            device=self._device,
+        )
+        # Invalidate derived buffers that depend on body_com_pose_b.
+        self.data._body_com_pose_w.timestamp = -1.0
+        wp.copy(self.data._cpu_body_coms, self.data._body_com_pose_b.data)
+        self._binding_write(
+            TT.BODY_COM_POSE,
+            self.data._cpu_body_coms,
+            env_ids=self._get_cpu_env_ids(env_ids),
+            device="cpu",
+            data_dim=7,
+        )
+
+    def set_coms_mask(
+        self,
+        *,
+        coms: wp.array,
+        body_mask: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Set body center-of-mass poses over selected env / body masks into the simulation.
+
+        This is a CPU-only write routed through pinned-host staging because
+        ``BODY_COM_POSE`` is a CPU-only OVPhysX binding.
+
+        .. note::
+            This method expects full data.
+
+        Args:
+            coms: Body center-of-mass poses [m, quaternion (w, x, y, z)].
+                Shape is (num_instances, num_bodies) with dtype wp.transformf.
+            body_mask: Body mask. If None, all bodies are updated.
+                Shape is (num_bodies,).
+            env_mask: Environment mask. If None, all instances are updated.
+                Shape is (num_instances,).
+        """
+        if env_mask is not None:
+            env_mask_t = wp.to_torch(env_mask) if isinstance(env_mask, wp.array) else env_mask
+            env_ids = self._resolve_env_ids(torch.nonzero(env_mask_t)[:, 0].to(torch.int32))
+        else:
+            env_ids = self._ALL_ENV_INDICES
+        self.assert_shape_and_dtype(coms, (self._num_instances, self._num_bodies), wp.transformf, "coms")
+        wp.launch(
+            shared_kernels.write_body_com_pose_to_buffer_mask,
+            dim=(self._num_instances, self._num_bodies),
+            inputs=[coms, self._resolve_env_mask(env_mask), self._resolve_body_mask(body_mask)],
+            outputs=[self.data._body_com_pose_b.data],
+            device=self._device,
+        )
+        # Invalidate derived buffers that depend on body_com_pose_b.
+        self.data._body_com_pose_w.timestamp = -1.0
+        wp.copy(self.data._cpu_body_coms, self.data._body_com_pose_b.data)
+        self._binding_write(
+            TT.BODY_COM_POSE,
+            self.data._cpu_body_coms,
+            env_ids=self._get_cpu_env_ids(env_ids),
+            device="cpu",
+            data_dim=7,
+        )
+
+    def set_inertias_index(
+        self,
+        *,
+        inertias: wp.array,
+        body_ids: Sequence[int] | wp.array | None = None,
+        env_ids: Sequence[int] | wp.array | None = None,
+    ) -> None:
+        """Set body inertia tensors over selected env / body indices into the simulation.
+
+        This is a CPU-only write routed through pinned-host staging because
+        ``BODY_INERTIA`` is a CPU-only OVPhysX binding.
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            inertias: Body inertia tensors [kg·m²]. Shape is
+                (len(env_ids), len(body_ids), 9) with dtype wp.float32.
+                The 9 components are the row-major flatten of the 3×3 inertia
+                matrix (Ixx, Ixy, Ixz, Iyx, Iyy, Iyz, Izx, Izy, Izz).
+            body_ids: Body indices. If None, then all indices are used.
+            env_ids: Environment indices. If None, then all indices are used.
+        """
+        env_ids = self._resolve_env_ids(env_ids)
+        body_ids = self._resolve_body_ids(body_ids)
+        self.assert_shape_and_dtype(inertias, (env_ids.shape[0], body_ids.shape[0], 9), wp.float32, "inertias")
+        wp.launch(
+            shared_kernels.write_body_inertia_to_buffer_index,
+            dim=(env_ids.shape[0], body_ids.shape[0]),
+            inputs=[inertias, env_ids, body_ids],
+            outputs=[self.data._body_inertia.data],
+            device=self._device,
+        )
+        wp.copy(self.data._cpu_body_inertia, self.data._body_inertia.data)
+        self._binding_write(
+            TT.BODY_INERTIA,
+            self.data._cpu_body_inertia,
+            env_ids=self._get_cpu_env_ids(env_ids),
+            device="cpu",
+            data_dim=9,
+        )
+
+    def set_inertias_mask(
+        self,
+        *,
+        inertias: wp.array,
+        body_mask: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Set body inertia tensors over selected env / body masks into the simulation.
+
+        This is a CPU-only write routed through pinned-host staging because
+        ``BODY_INERTIA`` is a CPU-only OVPhysX binding.
+
+        .. note::
+            This method expects full data.
+
+        Args:
+            inertias: Body inertia tensors [kg·m²]. Shape is
+                (num_instances, num_bodies, 9) with dtype wp.float32.
+                The 9 components are the row-major flatten of the 3×3 inertia
+                matrix (Ixx, Ixy, Ixz, Iyx, Iyy, Iyz, Izx, Izy, Izz).
+            body_mask: Body mask. If None, all bodies are updated.
+                Shape is (num_bodies,).
+            env_mask: Environment mask. If None, all instances are updated.
+                Shape is (num_instances,).
+        """
+        if env_mask is not None:
+            env_mask_t = wp.to_torch(env_mask) if isinstance(env_mask, wp.array) else env_mask
+            env_ids = self._resolve_env_ids(torch.nonzero(env_mask_t)[:, 0].to(torch.int32))
+        else:
+            env_ids = self._ALL_ENV_INDICES
+        self.assert_shape_and_dtype(inertias, (self._num_instances, self._num_bodies, 9), wp.float32, "inertias")
+        wp.launch(
+            shared_kernels.write_body_inertia_to_buffer_mask,
+            dim=(self._num_instances, self._num_bodies),
+            inputs=[inertias, self._resolve_env_mask(env_mask), self._resolve_body_mask(body_mask)],
+            outputs=[self.data._body_inertia.data],
+            device=self._device,
+        )
+        wp.copy(self.data._cpu_body_inertia, self.data._body_inertia.data)
+        self._binding_write(
+            TT.BODY_INERTIA,
+            self.data._cpu_body_inertia,
+            env_ids=self._get_cpu_env_ids(env_ids),
+            device="cpu",
+            data_dim=9,
+        )
+
+    def _initialize_impl(self) -> None:
+        """Initialize the rigid object collection from the OVPhysX simulation backend.
+
+        For each body in :attr:`cfg.rigid_objects`, validates the prim tree,
+        converts the IsaacLab prim path to an fnmatch glob, and eagerly creates
+        a single fused :class:`TensorBinding` per tensor type using the new
+        ``prim_paths=[...]`` API introduced in ovphysx 0.4.3.
+
+        Then creates the :class:`RigidObjectCollectionData` container and primes
+        the asset-side buffers.
+        """
+        physx_instance = OvPhysxManager.get_physx_instance()
+        if physx_instance is None:
+            raise RuntimeError("OvPhysxManager has not been initialized yet.")
+        self._ovphysx = physx_instance
+        self._device = OvPhysxManager.get_device()
+
+        self._prim_paths: list[str] = []
+        self._body_names_list: list[str] = []
+
+        for name, obj_cfg in self.cfg.rigid_objects.items():
+            # Convert IsaacLab prim-path notation to the fnmatch-style glob that
+            # OVPhysX create_tensor_binding expects.  Two conventions are in use:
+            #   /World/envs/env_.*/object   -- regex dot-star for any env index
+            #   /World/envs/{ENV_REGEX_NS}/object -- explicit placeholder
+            pattern = re.sub(r"\{ENV_REGEX_NS\}", "*", obj_cfg.prim_path)
+            pattern = re.sub(r"\.\*", "*", pattern)
+
+            # Validate the prim tree before creating tensor bindings.
+            # OVPhysX silently returns a zero-count binding when the pattern
+            # matches nothing; fail fast here with a clear message instead.
+            template_prim = sim_utils.find_first_matching_prim(obj_cfg.prim_path)
+            if template_prim is None:
+                raise RuntimeError(f"Failed to find prim for expression: '{obj_cfg.prim_path}' (body '{name}').")
+            template_prim_path = template_prim.GetPath().pathString
+
+            root_prims = sim_utils.get_all_matching_child_prims(
+                template_prim_path,
+                predicate=lambda prim: prim.HasAPI(UsdPhysics.RigidBodyAPI),
+                traverse_instance_prims=False,
+            )
+            if len(root_prims) == 0:
+                raise RuntimeError(
+                    f"Failed to find a rigid body when resolving '{obj_cfg.prim_path}' (body '{name}')."
+                    " Please ensure that the prim has 'USD RigidBodyAPI' applied."
+                )
+            if len(root_prims) > 1:
+                raise RuntimeError(
+                    f"Failed to find a single rigid body when resolving '{obj_cfg.prim_path}' (body '{name}')."
+                    f" Found multiple '{root_prims}' under '{template_prim_path}'."
+                    " Please ensure that there is only one rigid body in the prim path tree."
+                )
+
+            articulation_prims = sim_utils.get_all_matching_child_prims(
+                template_prim_path,
+                predicate=lambda prim: prim.HasAPI(UsdPhysics.ArticulationRootAPI),
+                traverse_instance_prims=False,
+            )
+            if len(articulation_prims) != 0:
+                if articulation_prims[0].GetAttribute("physxArticulation:articulationEnabled").Get():
+                    raise RuntimeError(
+                        f"Found an articulation root when resolving '{obj_cfg.prim_path}' (body '{name}') in the"
+                        f" rigid object collection. These are located at: '{articulation_prims}' under"
+                        f" '{template_prim_path}'. Please disable the articulation root in the USD or from code by"
+                        " setting the parameter 'ArticulationRootPropertiesCfg.articulation_enabled' to False in the"
+                        " spawn configuration."
+                    )
+
+            # resolve root prim back into the regex expression
+            root_prim_path = root_prims[0].GetPath().pathString
+            suffix = root_prim_path[len(template_prim_path) :]
+            if suffix:
+                pattern = pattern + suffix
+
+            self._prim_paths.append(pattern)
+            self._body_names_list.append(name)
+
+        self._num_bodies = len(self._prim_paths)
+
+        # ovphysx 0.4.3+ accepts ``prim_paths=[g0, ..., g_{B-1}]`` and returns a single
+        # binding spanning N*B prims with shape ``(N*B, D)`` in body-major order
+        # ``(body0_env0, body0_env1, ..., body1_env0, ...)``. Bindings are stored under
+        # the ``LINK_*``/``BODY_*`` data-class keys so the same key works with the
+        # articulation-mode mock used by iface tests.
+        _TT_MAP = (
+            (TT.LINK_POSE, TT.RIGID_BODY_POSE),
+            (TT.LINK_VELOCITY, TT.RIGID_BODY_VELOCITY),
+            (TT.LINK_WRENCH, TT.RIGID_BODY_WRENCH),
+            (TT.BODY_MASS, TT.RIGID_BODY_MASS),
+            (TT.BODY_COM_POSE, TT.RIGID_BODY_COM_POSE),
+            (TT.BODY_INERTIA, TT.RIGID_BODY_INERTIA),
+        )
+        for store_key, rb_tt in _TT_MAP:
+            try:
+                self._bindings[store_key] = self._ovphysx.create_tensor_binding(
+                    prim_paths=self._prim_paths, tensor_type=rb_tt
+                )
+            except Exception as e:
+                raise RuntimeError(
+                    f"OVPhysX could not create fused RIGID_BODY binding {rb_tt!r} for"
+                    f" prim_paths={self._prim_paths!r}."
+                    f" Check that each prim path matches at least one"
+                    f" UsdPhysics.RigidBodyAPI prim."
+                ) from e
+
+        # Native fused binding has ``count == N * num_bodies`` (body-major flat).
+        pose_count = self._bindings[TT.LINK_POSE].count
+        if pose_count % self._num_bodies != 0:
+            raise RuntimeError(
+                f"Fused LINK_POSE binding count {pose_count} is not divisible by"
+                f" num_bodies {self._num_bodies}. prim_paths={self._prim_paths!r}."
+            )
+        self._num_instances = pose_count // self._num_bodies
+
+        self._data = RigidObjectCollectionData(
+            root_view=self._bindings,
+            num_bodies=self._num_bodies,
+            device=self._device,
+        )
+
+        self._create_buffers()
+        self._process_cfg()
+        self.update(0.0)
+        self._data.is_primed = True
+
+    def _create_buffers(self) -> None:
+        """Pre-allocate asset-side index arrays and CPU staging buffers."""
+        N = self._num_instances
+        B = self._num_bodies
+
+        self._ALL_ENV_INDICES = wp.array(np.arange(N), dtype=wp.int32, device=self._device)
+        self._ALL_BODY_INDICES = wp.array(np.arange(B), dtype=wp.int32, device=self._device)
+
+        # CPU copy of all-env indices used when calling CPU-only binding.write().
+        self._cpu_all_env_ids = wp.zeros(N, dtype=wp.int32, device="cpu", pinned=True)
+        wp.copy(self._cpu_all_env_ids, self._ALL_ENV_INDICES)
+
+        # All-true boolean masks used as defaults in mask-based kernel calls.
+        self._ALL_TRUE_ENV_MASK = wp.array(np.ones(N, dtype=bool), dtype=wp.bool, device=self._device)
+        self._ALL_TRUE_BODY_MASK = wp.array(np.ones(B, dtype=bool), dtype=wp.bool, device=self._device)
+
+        # External wrench buffer: direct (N, B, 9) contiguous allocation.
+        # The fused LINK_WRENCH binding writes from a single (N, B, 9) buffer.
+        self._wrench_buf = wp.zeros((N, B, 9), dtype=wp.float32, device=self._device)
+
+        self._instantaneous_wrench_composer = WrenchComposer(self)
+        self._permanent_wrench_composer = WrenchComposer(self)
+
+        # set information about rigid body into data
+        self._data.body_names = self._body_names_list
+
+    def _process_cfg(self) -> None:
+        """Post-processing of configuration parameters.
+
+        Reads the per-body initial state from :attr:`cfg.rigid_objects` and
+        broadcasts it across all environment instances to produce
+        ``(num_instances, num_bodies, data_size)`` default-state arrays.
+        """
+        default_body_poses = []
+        default_body_vels = []
+
+        for obj_cfg in self.cfg.rigid_objects.values():
+            default_body_pose = tuple(obj_cfg.init_state.pos) + tuple(obj_cfg.init_state.rot)
+            default_body_vel = tuple(obj_cfg.init_state.lin_vel) + tuple(obj_cfg.init_state.ang_vel)
+            # Broadcast across num_instances: (data_size,) -> (num_instances, data_size)
+            default_body_pose = np.tile(np.array(default_body_pose, dtype=np.float32), (self._num_instances, 1))
+            default_body_vel = np.tile(np.array(default_body_vel, dtype=np.float32), (self._num_instances, 1))
+            default_body_poses.append(default_body_pose)
+            default_body_vels.append(default_body_vel)
+
+        # Stack per-body arrays: each (num_instances, data_size) -> (num_instances, num_bodies, data_size)
+        default_body_poses = np.stack(default_body_poses, axis=1)
+        default_body_vels = np.stack(default_body_vels, axis=1)
+        self._data.default_body_pose = wp.array(default_body_poses, dtype=wp.transformf, device=self._device)
+        self._data.default_body_vel = wp.array(default_body_vels, dtype=wp.spatial_vectorf, device=self._device)
+
+    """
+    Internal simulation callbacks.
+    """
+
+    def _invalidate_initialize_callback(self, event) -> None:
+        """Invalidates the scene elements."""
+        # call parent
+        super()._invalidate_initialize_callback(event)
+
+    """
+    Helper functions.
+    """
+
+    def _get_binding(self, tensor_type: int):
+        """Return the cached fused :class:`TensorBinding` for *tensor_type*.
+
+        All bindings are eagerly created in :meth:`_initialize_impl` and stored
+        under the ``TT.LINK_*`` / ``TT.BODY_*`` keys that
+        :class:`RigidObjectCollectionData` uses.
+
+        Args:
+            tensor_type: The TensorType constant identifying which simulation
+                buffer to bind (e.g. :attr:`~isaaclab_ovphysx.tensor_types.LINK_POSE`).
+
+        Returns:
+            The cached :class:`TensorBinding`, or ``None`` if not found.
+        """
+        return self._bindings.get(tensor_type)
+
+    def reshape_data_to_view_2d(self, data: wp.array, device: str | None = None) -> wp.array:
+        """Reshape instance-major ``(num_instances, num_bodies)`` data to body-major view order.
+
+        The native fused multi-prim binding lays data out as
+        ``(body0_env0, body0_env1, ..., body1_env0, body1_env1, ...)`` with shape
+        ``(num_bodies * num_instances,)``.  This helper builds a strided view of the
+        instance-major buffer with the transposed layout and clones it into a
+        contiguous body-major flat array.
+
+        Args:
+            data: Source buffer with shape ``(num_instances, num_bodies)`` (any single-element dtype).
+            device: Optional target device for the cloned output.  Defaults to ``data.device``.
+
+        Returns:
+            Contiguous body-major flat buffer with shape ``(num_bodies * num_instances,)``.
+        """
+        if device is None:
+            device = str(data.device)
+        element_size = wp.types.type_size_in_bytes(data.dtype)
+        strided_view = wp.array(
+            ptr=data.ptr,
+            shape=(self.num_bodies, self.num_instances),
+            dtype=data.dtype,
+            strides=(element_size, self.num_bodies * element_size),
+            device=str(data.device),
+        )
+        return wp.clone(strided_view, device=device).reshape((self.num_bodies * self.num_instances,))
+
+    def reshape_data_to_view_3d(self, data: wp.array, data_dim: int, device: str | None = None) -> wp.array:
+        """Reshape instance-major ``(num_instances, num_bodies, data_dim)`` data to body-major view order.
+
+        Companion of :meth:`reshape_data_to_view_2d` for 3D buffers (e.g. inertia
+        tensors).  Output shape is ``(num_bodies * num_instances, data_dim)``.
+
+        Args:
+            data: Source buffer with shape ``(num_instances, num_bodies, data_dim)``.
+            data_dim: Trailing per-element dimension size.
+            device: Optional target device for the cloned output.  Defaults to ``data.device``.
+
+        Returns:
+            Contiguous body-major buffer with shape ``(num_bodies * num_instances, data_dim)``.
+        """
+        if device is None:
+            device = str(data.device)
+        element_size = wp.types.type_size_in_bytes(data.dtype)
+        row_size = element_size * data_dim
+        strided_view = wp.array(
+            ptr=data.ptr,
+            shape=(self.num_bodies, self.num_instances, data_dim),
+            dtype=data.dtype,
+            strides=(row_size, self.num_bodies * row_size, element_size),
+            device=str(data.device),
+        )
+        return wp.clone(strided_view, device=device).reshape((self.num_bodies * self.num_instances, data_dim))
+
+    def _binding_write(
+        self,
+        tensor_type: int,
+        instance_major_data: wp.array,
+        env_ids: wp.array,
+        device: str | None = None,
+        data_dim: int | None = None,
+    ) -> None:
+        """Write an instance-major buffer through a fused binding.
+
+        Dispatches to one of two paths depending on the binding's layout:
+
+        * **Native fused binding** (``count == num_instances * num_bodies``,
+          body-major flat layout): the instance-major buffer is reshaped via
+          :meth:`reshape_data_to_view_2d` / :meth:`reshape_data_to_view_3d` to a
+          contiguous body-major view, then written with body-major view indices
+          ``view_id = body_id * num_instances + env_id``.
+        * **Articulation-mode mock** (``count == num_instances``, instance-major
+          ``(N, B[, D])`` shape): the buffer is written directly with the
+          environment indices, matching the existing mock contract.
+
+        Args:
+            tensor_type: TensorType key identifying the cached binding.
+            instance_major_data: Instance-major buffer of shape ``(N, B)`` or
+                ``(N, B, data_dim)``.  May use ``wp.float32`` or a structured dtype.
+            env_ids: Environment indices (1D ``wp.int32`` on ``self._device`` or
+                ``"cpu"`` for CPU-only bindings).
+            device: Destination device for the body-major clone (only used on the
+                fused-binding path).  Defaults to ``self._device``.
+            data_dim: When provided, treat the buffer as 3D and use
+                :meth:`reshape_data_to_view_3d`.  When ``None`` (default), use
+                :meth:`reshape_data_to_view_2d`.
+        """
+        binding = self._get_binding(tensor_type)
+        if binding is None:
+            return
+        if device is None:
+            device = self._device
+        # Disambiguate via the binding's exposed shape: the articulation-mode
+        # mock returns a directly instance-major view ``(N, B[, D])`` while the
+        # native fused multi-prim binding lays elements body-major-flat with
+        # ``shape == (N * B[, D])``.
+        is_mock_layout = len(binding.shape) >= 2 and binding.shape[1] == self._num_bodies
+        if is_mock_layout:
+            float32_data = (
+                instance_major_data if instance_major_data.dtype == wp.float32 else instance_major_data.view(wp.float32)
+            )
+            binding.write(float32_data, indices=env_ids)
+            return
+        # Native fused path: body-major flat (N*B[, D]); reshape and use view_ids.
+        if data_dim is None:
+            view = self.reshape_data_to_view_2d(instance_major_data, device=device).view(wp.float32)
+        else:
+            view = self.reshape_data_to_view_3d(instance_major_data, data_dim, device=device)
+        view_ids = self._env_body_ids_to_view_ids(env_ids, self._ALL_BODY_INDICES, device=device)
+        binding.write(view, indices=view_ids)
+
+    """
+    Internal helper.
+    """
+
+    def _resolve_env_ids(self, env_ids) -> wp.array:
+        """Resolve environment indices to a warp int32 array on ``self._device``.
+
+        Tests sometimes hand us indices on CPU even when the sim runs on GPU; we move the
+        resolved array onto ``self._device`` so kernel launches don't fail on a device
+        mismatch.
+        """
+        if env_ids is None or env_ids == slice(None):
+            return self._ALL_ENV_INDICES
+        if isinstance(env_ids, list):
+            return wp.array(env_ids, dtype=wp.int32, device=self._device)
+        if isinstance(env_ids, torch.Tensor):
+            return wp.from_torch(env_ids.to(torch.int32), dtype=wp.int32)
+        if isinstance(env_ids, wp.array) and str(env_ids.device) != self._device:
+            env_ids = wp.clone(env_ids, device=self._device)
+        return env_ids
+
+    def _resolve_body_ids(self, body_ids) -> wp.array:
+        """Resolve body indices to a warp int32 array on ``self._device``."""
+        if body_ids is None or body_ids == slice(None):
+            return self._ALL_BODY_INDICES
+        if isinstance(body_ids, list):
+            return wp.array(body_ids, dtype=wp.int32, device=self._device)
+        return body_ids
+
+    def _env_body_ids_to_view_ids(
+        self, env_ids: torch.Tensor | wp.array, body_ids: torch.Tensor | wp.array, device: str = "cuda:0"
+    ) -> wp.array:
+        """Convert environment and body indices to flat view indices (body-major ordering).
+
+        Computes ``view_id = body_id * num_instances + env_id`` for each
+        (env_id, body_id) pair.  The output array is laid out column-major over
+        the (env, body) grid, matching the PhysX ``root_view`` ordering.
+
+        Args:
+            env_ids: Environment indices.
+            body_ids: Body indices.
+            device: Target device for the returned array.
+
+        Returns:
+            A :class:`wp.array` of shape ``(len(env_ids) * len(body_ids),)`` with
+            flat view indices on *device*.
+        """
+        if isinstance(env_ids, torch.Tensor):
+            env_ids = wp.from_torch(env_ids.to(torch.int32), dtype=wp.int32)
+        if isinstance(body_ids, torch.Tensor):
+            body_ids = wp.from_torch(body_ids.to(torch.int32), dtype=wp.int32)
+        if str(env_ids.device) != device:
+            env_ids = wp.clone(env_ids, device=device)
+        if str(body_ids.device) != device:
+            body_ids = wp.clone(body_ids, device=device)
+        num_query_envs = env_ids.shape[0]
+        view_ids = wp.zeros(num_query_envs * body_ids.shape[0], dtype=wp.int32, device=device)
+        wp.launch(
+            resolve_view_ids,
+            dim=(num_query_envs, body_ids.shape[0]),
+            inputs=[env_ids, body_ids, num_query_envs, self.num_instances],
+            outputs=[view_ids],
+            device=device,
+        )
+        return view_ids
+
+    def _resolve_env_mask(self, env_mask: wp.array | None) -> wp.array:
+        """Resolve an environment mask to a ``wp.bool`` array on ``self._device``.
+
+        ``None`` returns the pre-allocated all-true mask.
+
+        Args:
+            env_mask: Boolean environment mask or None. Shape is (num_instances,).
+
+        Returns:
+            A ``wp.bool`` array of shape (num_instances,) on ``self._device``.
+        """
+        if env_mask is None:
+            return self._ALL_TRUE_ENV_MASK
+        if isinstance(env_mask, torch.Tensor):
+            return wp.from_torch(env_mask.to(torch.bool), dtype=wp.bool)
+        if isinstance(env_mask, wp.array) and str(env_mask.device) != self._device:
+            env_mask = wp.clone(env_mask, device=self._device)
+        return env_mask
+
+    def _resolve_body_mask(self, body_mask: wp.array | None) -> wp.array:
+        """Resolve a body mask to a ``wp.bool`` array on ``self._device``.
+
+        ``None`` returns the pre-allocated all-true mask.
+
+        Args:
+            body_mask: Boolean body mask or None. Shape is (num_bodies,).
+
+        Returns:
+            A ``wp.bool`` array of shape (num_bodies,) on ``self._device``.
+        """
+        if body_mask is None:
+            return self._ALL_TRUE_BODY_MASK
+        if isinstance(body_mask, torch.Tensor):
+            return wp.from_torch(body_mask.to(torch.bool), dtype=wp.bool)
+        if isinstance(body_mask, wp.array) and str(body_mask.device) != self._device:
+            body_mask = wp.clone(body_mask, device=self._device)
+        return body_mask
+
+    def _get_cpu_env_ids(self, env_ids: wp.array) -> wp.array:
+        """Return CPU int32 env indices for CPU-only binding writes.
+
+        Uses the pre-allocated pinned ``_cpu_all_env_ids`` fast path when
+        *env_ids* covers all instances, otherwise clones to CPU.
+
+        Args:
+            env_ids: A warp int32 array of environment indices on any device.
+
+        Returns:
+            A warp int32 array guaranteed to live on ``"cpu"``.
+        """
+        if env_ids.ptr == self._ALL_ENV_INDICES.ptr:
+            return self._cpu_all_env_ids
+        return wp.clone(env_ids, device="cpu")
+
+    """
+    Deprecated properties and methods.
+    """
+
+    def write_body_state_to_sim(
+        self,
+        body_states: torch.Tensor | wp.array,
+        env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
+        body_ids: slice | torch.Tensor | None = None,
+    ) -> None:
+        """Deprecated, same as :meth:`write_body_link_pose_to_sim_index` and
+        :meth:`write_body_com_velocity_to_sim_index`."""
+        warnings.warn(
+            "The function 'write_body_state_to_sim' will be deprecated in a future release. Please"
+            " use 'write_body_link_pose_to_sim_index' and 'write_body_com_velocity_to_sim_index' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if isinstance(body_states, wp.array):
+            body_states = wp.to_torch(body_states)
+        self.write_body_link_pose_to_sim_index(body_poses=body_states[:, :, :7], env_ids=env_ids, body_ids=body_ids)
+        self.write_body_com_velocity_to_sim_index(
+            body_velocities=body_states[:, :, 7:], env_ids=env_ids, body_ids=body_ids
+        )
+
+    def write_body_com_state_to_sim(
+        self,
+        body_states: torch.Tensor | wp.array,
+        env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
+        body_ids: slice | torch.Tensor | None = None,
+    ) -> None:
+        """Deprecated, same as :meth:`write_body_com_pose_to_sim_index` and
+        :meth:`write_body_com_velocity_to_sim_index`."""
+        warnings.warn(
+            "The function 'write_body_com_state_to_sim' will be deprecated in a future release. Please"
+            " use 'write_body_com_pose_to_sim_index' and 'write_body_com_velocity_to_sim_index' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if isinstance(body_states, wp.array):
+            body_states = wp.to_torch(body_states)
+        self.write_body_com_pose_to_sim_index(body_poses=body_states[:, :, :7], env_ids=env_ids, body_ids=body_ids)
+        self.write_body_com_velocity_to_sim_index(
+            body_velocities=body_states[:, :, 7:], env_ids=env_ids, body_ids=body_ids
+        )
+
+    def write_body_link_state_to_sim(
+        self,
+        body_states: torch.Tensor | wp.array,
+        env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
+        body_ids: slice | torch.Tensor | None = None,
+    ) -> None:
+        """Deprecated, same as :meth:`write_body_link_pose_to_sim_index` and
+        :meth:`write_body_link_velocity_to_sim_index`."""
+        warnings.warn(
+            "The function 'write_body_link_state_to_sim' will be deprecated in a future release. Please"
+            " use 'write_body_link_pose_to_sim_index' and 'write_body_link_velocity_to_sim_index' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if isinstance(body_states, wp.array):
+            body_states = wp.to_torch(body_states)
+        self.write_body_link_pose_to_sim_index(body_poses=body_states[:, :, :7], env_ids=env_ids, body_ids=body_ids)
+        self.write_body_link_velocity_to_sim_index(
+            body_velocities=body_states[:, :, 7:], env_ids=env_ids, body_ids=body_ids
+        )

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -1,0 +1,1132 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import numpy as np
+import torch
+import warp as wp
+
+from isaaclab.assets.rigid_object_collection.base_rigid_object_collection_data import BaseRigidObjectCollectionData
+from isaaclab.utils.buffers import TimestampedBufferWarp as TimestampedBuffer
+from isaaclab.utils.math import normalize
+from isaaclab.utils.warp import ProxyArray
+
+from isaaclab_ovphysx import tensor_types as TT
+from isaaclab_ovphysx.assets import kernels as shared_kernels
+from isaaclab_ovphysx.physics import OvPhysxManager as SimulationManager
+
+
+class RigidObjectCollectionData(BaseRigidObjectCollectionData):
+    """Data container for a rigid object collection.
+
+    This class contains the data for a rigid object collection in the simulation. The data includes the state of
+    all the bodies in the collection. The data is stored in the simulation world frame unless otherwise specified.
+    The data is in the order ``(num_instances, num_objects, data_size)``, where data_size is the size of the data.
+
+    For a rigid body, there are two frames of reference that are used:
+
+    - Actor frame: The frame of reference of the rigid body prim. This typically corresponds to the Xform prim
+      with the rigid body schema.
+    - Center of mass frame: The frame of reference of the center of mass of the rigid body.
+
+    Depending on the settings of the simulation, the actor frame and the center of mass frame may be the same.
+    This needs to be taken into account when interpreting the data.
+
+    The data is lazily updated, meaning that the data is only updated when it is accessed. This is useful
+    when the data is expensive to compute or retrieve. The data is updated when the timestamp of the buffer
+    is older than the current simulation timestamp. The timestamp is updated whenever the data is updated.
+
+    .. note::
+        **Pull-to-refresh model.** Properties pull fresh data from the OVPhysX tensor API on first access
+        per timestamp and cache the result. This differs from Newton, where buffers are refreshed
+        automatically by the simulation.
+
+    .. note::
+        **ProxyArray pointer stability.** Each :class:`ProxyArray` wrapper is created once and reused
+        because the OVPhysX tensor API returns views into stable, pre-allocated GPU buffers whose device
+        pointer does not change across simulation steps.
+    """
+
+    __backend_name__: str = "ovphysx"
+    """The name of the backend for the rigid object collection data."""
+
+    def __init__(
+        self,
+        root_view: dict[int, Any],
+        num_bodies: int,
+        device: str,
+    ):
+        """Initializes the rigid object data.
+
+        Args:
+            root_view: Fused TensorBinding dict, keyed by TensorType constant. Each value is a single
+                :class:`TensorBinding` spanning all bodies in the collection.
+            num_bodies: The number of bodies in the collection.
+            device: The device used for processing.
+        """
+        super().__init__(root_view, num_bodies, device)
+        # Store the bindings dict (the equivalent of the root view in PhysX).
+        self._bindings = root_view
+        self._binding_getter = None  # may be set externally after construction
+        self.num_bodies = num_bodies
+        self._num_bodies = num_bodies
+        # Set initial time stamp
+        self._sim_timestamp = 0.0
+        self._is_primed = False
+        # Body-major read scratch buffers (keyed by tensor_type). Allocated on the binding's own
+        # device — pinned host for CPU-only bindings, GPU for the rest — so ``binding.read(scratch)``
+        # never crosses devices.
+        self._cpu_staging_buffers: dict[int, wp.array] = {}
+
+        # Read num_instances from the LINK_POSE binding. The native fused multi-prim binding lays
+        # elements out body-major-flat with ``shape == (N * B, 7)`` and ``count == N * B``. The
+        # articulation-mode mock used by iface tests exposes an instance-major view directly with
+        # ``shape == (N, B, 7)`` and ``count == N``. Dispatch via the binding's exposed shape.
+        pose_binding = self._bindings[TT.LINK_POSE]
+        if len(pose_binding.shape) >= 2 and pose_binding.shape[1] == num_bodies:
+            self.num_instances = pose_binding.count
+        else:
+            self.num_instances = pose_binding.count // num_bodies
+        self._num_instances = self.num_instances
+
+        if SimulationManager._sim is not None and hasattr(SimulationManager._sim, "cfg"):
+            gravity = SimulationManager._sim.cfg.gravity
+        else:
+            gravity = (0.0, 0.0, -9.81)
+
+        gravity_dir = torch.tensor((gravity[0], gravity[1], gravity[2]), device=self.device)
+        if torch.linalg.norm(gravity_dir) > 0.0:
+            gravity_dir = normalize(gravity_dir.unsqueeze(0)).squeeze(0)
+        gravity_dir = gravity_dir.repeat(self.num_instances, self.num_bodies, 1)
+        forward_vec = torch.tensor((1.0, 0.0, 0.0), device=self.device).repeat(self.num_instances, self.num_bodies, 1)
+
+        # Initialize constants
+        self.GRAVITY_VEC_W = ProxyArray(wp.from_torch(gravity_dir, dtype=wp.vec3f))
+        self.FORWARD_VEC_B = ProxyArray(wp.from_torch(forward_vec, dtype=wp.vec3f))
+
+        self._create_buffers()
+
+    @property
+    def is_primed(self) -> bool:
+        """Whether the rigid object collection data is fully instantiated and ready to use."""
+        return self._is_primed
+
+    @is_primed.setter
+    def is_primed(self, value: bool) -> None:
+        """Set whether the rigid object collection data is fully instantiated and ready to use.
+
+        .. note::
+            Once this quantity is set to True, it cannot be changed.
+
+        Args:
+            value: The primed state.
+
+        Raises:
+            ValueError: If the rigid object collection data is already primed.
+        """
+        if self._is_primed:
+            raise ValueError("The rigid object collection data is already primed.")
+        self._is_primed = value
+
+    def update(self, dt: float) -> None:
+        """Updates the data for the rigid object collection.
+
+        Args:
+            dt: The time step for the update [s]. This must be a positive value.
+        """
+        # update the simulation timestamp
+        self._sim_timestamp += dt
+        # Prime the FD-dependent COM acceleration so the first read returns a sensible (zero) value.
+        _ = self.body_com_acc_w
+
+    """
+    Names.
+    """
+
+    body_names: list[str] = None
+    """Body names in the order parsed by the simulation view."""
+
+    """
+    Defaults.
+    """
+
+    @property
+    def default_body_pose(self) -> ProxyArray:
+        """Default body pose ``[pos, quat]`` in local environment frame.
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.transformf``.
+        In torch this resolves to (num_instances, num_bodies, 7).
+        Set by :meth:`~RigidObjectCollection._process_cfg` during initialization.
+        """
+        if self._default_body_pose_ta is None:
+            self._default_body_pose_ta = ProxyArray(self._default_body_pose)
+        return self._default_body_pose_ta
+
+    @default_body_pose.setter
+    def default_body_pose(self, value: wp.array) -> None:
+        self._default_body_pose.assign(value)
+
+    @property
+    def default_body_vel(self) -> ProxyArray:
+        """Default body velocity ``[lin_vel, ang_vel]`` in local environment frame.
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.spatial_vectorf``.
+        In torch this resolves to (num_instances, num_bodies, 6).
+        Set by :meth:`~RigidObjectCollection._process_cfg` during initialization.
+        """
+        if self._default_body_vel_ta is None:
+            self._default_body_vel_ta = ProxyArray(self._default_body_vel)
+        return self._default_body_vel_ta
+
+    @default_body_vel.setter
+    def default_body_vel(self, value: wp.array) -> None:
+        self._default_body_vel.assign(value)
+
+    @property
+    def default_body_state(self) -> ProxyArray:
+        """Default root state ``[pos, quat, lin_vel, ang_vel]`` in local environment frame.
+
+        Deprecated. Use :attr:`default_body_pose` and :attr:`default_body_vel` instead.
+
+        Shape is (num_instances, num_bodies), dtype = ``vec13f``.
+        In torch this resolves to (num_instances, num_bodies, 13).
+        """
+        warnings.warn(
+            "Reading the body state directly is deprecated since IsaacLab 3.0 and will be removed in a future version. "
+            "Please use the default_body_pose and default_body_vel properties instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self._default_body_state is None:
+            self._default_body_state = wp.zeros(
+                (self.num_instances, self.num_bodies), dtype=shared_kernels.vec13f, device=self.device
+            )
+            self._default_body_state_ta = ProxyArray(self._default_body_state)
+        wp.launch(
+            shared_kernels.concat_body_pose_and_vel_to_state,
+            dim=(self.num_instances, self.num_bodies),
+            inputs=[
+                self._default_body_pose,
+                self._default_body_vel,
+            ],
+            outputs=[
+                self._default_body_state,
+            ],
+            device=self.device,
+        )
+        return self._default_body_state_ta
+
+    """
+    Body state properties.
+    """
+
+    @property
+    def body_link_pose_w(self) -> ProxyArray:
+        """Body link pose ``[pos, quat]`` in simulation world frame [m, -].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.transformf``.
+        In torch this resolves to (num_instances, num_bodies, 7).
+        This quantity is the pose of the actor frame of the rigid body relative to
+        the world. The orientation is provided in (x, y, z, w) format.
+        """
+        if self._body_link_pose_w.timestamp < self._sim_timestamp:
+            self._read_transform_binding(TT.LINK_POSE, self._body_link_pose_w)
+            # Invalidate sliced sub-component proxies so they are rebuilt from the
+            # updated buffer on next access.
+            self._body_link_pos_w_ta = None
+            self._body_link_quat_w_ta = None
+        if self._body_link_pose_w_ta is None:
+            self._body_link_pose_w_ta = ProxyArray(self._body_link_pose_w.data)
+        return self._body_link_pose_w_ta
+
+    @property
+    def body_link_vel_w(self) -> ProxyArray:
+        """Body link velocity ``[lin_vel, ang_vel]`` in simulation world frame [m/s, rad/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.spatial_vectorf``.
+        In torch this resolves to (num_instances, num_bodies, 6).
+        This quantity contains the linear and angular velocities of the actor frame
+        of the rigid body relative to the world.
+        """
+        if self._body_link_vel_w.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.get_body_link_vel_from_body_com_vel,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[
+                    self.body_com_vel_w,
+                    self.body_link_pose_w,
+                    self.body_com_pose_b,
+                ],
+                outputs=[self._body_link_vel_w.data],
+                device=self.device,
+            )
+            self._body_link_vel_w.timestamp = self._sim_timestamp
+            self._body_link_lin_vel_w_ta = None
+            self._body_link_ang_vel_w_ta = None
+        if self._body_link_vel_w_ta is None:
+            self._body_link_vel_w_ta = ProxyArray(self._body_link_vel_w.data)
+        return self._body_link_vel_w_ta
+
+    @property
+    def body_com_pose_w(self) -> ProxyArray:
+        """Body center of mass pose ``[pos, quat]`` in simulation world frame [m, -].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.transformf``.
+        In torch this resolves to (num_instances, num_bodies, 7).
+        This quantity is the pose of the center of mass frame of the rigid body
+        relative to the world. The orientation is provided in (x, y, z, w) format.
+        """
+        if self._body_com_pose_w.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.get_body_com_pose_from_body_link_pose,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[
+                    self.body_link_pose_w,
+                    self.body_com_pose_b,
+                ],
+                outputs=[self._body_com_pose_w.data],
+                device=self.device,
+            )
+            self._body_com_pose_w.timestamp = self._sim_timestamp
+            self._body_com_pos_w_ta = None
+            self._body_com_quat_w_ta = None
+        if self._body_com_pose_w_ta is None:
+            self._body_com_pose_w_ta = ProxyArray(self._body_com_pose_w.data)
+        return self._body_com_pose_w_ta
+
+    @property
+    def body_com_vel_w(self) -> ProxyArray:
+        """Body center of mass velocity ``[lin_vel, ang_vel]`` in simulation world frame [m/s, rad/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.spatial_vectorf``.
+        In torch this resolves to (num_instances, num_bodies, 6).
+        This quantity contains the linear and angular velocities of the rigid body's
+        center of mass frame relative to the world.
+        """
+        if self._body_com_vel_w.timestamp < self._sim_timestamp:
+            self._read_spatial_vector_binding(TT.LINK_VELOCITY, self._body_com_vel_w)
+            self._body_com_lin_vel_w_ta = None
+            self._body_com_ang_vel_w_ta = None
+        if self._body_com_vel_w_ta is None:
+            self._body_com_vel_w_ta = ProxyArray(self._body_com_vel_w.data)
+        return self._body_com_vel_w_ta
+
+    @property
+    def body_com_acc_w(self) -> ProxyArray:
+        """Acceleration of all bodies ``[lin_acc, ang_acc]`` in the simulation world frame [m/s², rad/s²].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.spatial_vectorf``.
+        In torch this resolves to (num_instances, num_bodies, 6).
+        This quantity is the acceleration of the rigid bodies' center of mass frame relative
+        to the world, derived by finite differencing consecutive COM velocities.
+        """
+        if self._body_com_acc_w.timestamp < self._sim_timestamp:
+            if self._previous_body_com_vel is None:
+                self._previous_body_com_vel = wp.clone(self.body_com_vel_w.warp)
+            wp.launch(
+                shared_kernels.derive_body_acceleration_from_body_com_velocities,
+                dim=(self.num_instances, self.num_bodies),
+                device=self.device,
+                inputs=[
+                    self.body_com_vel_w.warp,
+                    SimulationManager.get_physics_dt(),
+                    self._previous_body_com_vel,
+                ],
+                outputs=[
+                    self._body_com_acc_w.data,
+                ],
+            )
+            self._body_com_acc_w.timestamp = self._sim_timestamp
+            self._body_com_lin_acc_w_ta = None
+            self._body_com_ang_acc_w_ta = None
+        if self._body_com_acc_w_ta is None:
+            self._body_com_acc_w_ta = ProxyArray(self._body_com_acc_w.data)
+        return self._body_com_acc_w_ta
+
+    @property
+    def body_com_pose_b(self) -> ProxyArray:
+        """Center of mass pose ``[pos, quat]`` of all bodies in their respective body link frames [m, -].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.transformf``.
+        In torch this resolves to (num_instances, num_bodies, 7).
+        This quantity is the pose of the center of mass frame of the rigid body
+        relative to the body's link frame. The orientation is provided in
+        (x, y, z, w) format.
+        """
+        if self._body_com_pose_b.timestamp < self._sim_timestamp:
+            self._read_transform_binding(TT.BODY_COM_POSE, self._body_com_pose_b)
+            self._body_com_pos_b_ta = None
+            self._body_com_quat_b_ta = None
+        if self._body_com_pose_b_ta is None:
+            self._body_com_pose_b_ta = ProxyArray(self._body_com_pose_b.data)
+        return self._body_com_pose_b_ta
+
+    @property
+    def body_mass(self) -> ProxyArray:
+        """Mass of all bodies [kg].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.float32``.
+        In torch this resolves to (num_instances, num_bodies).
+        """
+        if self._body_mass_ta is None:
+            self._body_mass_ta = ProxyArray(self._body_mass.data)
+        return self._body_mass_ta
+
+    @property
+    def body_inertia(self) -> ProxyArray:
+        """Inertia tensor of all bodies, expressed at the center of mass [kg·m²].
+
+        Shape is (num_instances, num_bodies, 9), dtype = ``wp.float32``.
+        The 9 components are the row-major flatten of the 3×3 inertia matrix
+        ``(Ixx, Ixy, Ixz, Iyx, Iyy, Iyz, Izx, Izy, Izz)``.
+        In torch this resolves to (num_instances, num_bodies, 9).
+        """
+        if self._body_inertia_ta is None:
+            self._body_inertia_ta = ProxyArray(self._body_inertia.data)
+        return self._body_inertia_ta
+
+    """
+    Deprecated state-concat properties.
+    """
+
+    @property
+    def body_state_w(self) -> ProxyArray:
+        """Deprecated, same as :attr:`body_link_pose_w` and :attr:`body_com_vel_w`."""
+        warnings.warn(
+            "The `body_state_w` property will be deprecated in IsaacLab 4.0. Please use `body_link_pose_w` and "
+            "`body_com_vel_w` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self._body_state_w.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.concat_body_pose_and_vel_to_state,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[self.body_link_pose_w, self.body_com_vel_w],
+                outputs=[self._body_state_w.data],
+                device=self.device,
+            )
+            self._body_state_w.timestamp = self._sim_timestamp
+        if self._body_state_w_ta is None:
+            self._body_state_w_ta = ProxyArray(self._body_state_w.data)
+        return self._body_state_w_ta
+
+    @property
+    def body_link_state_w(self) -> ProxyArray:
+        """Deprecated, same as :attr:`body_link_pose_w` and :attr:`body_link_vel_w`."""
+        warnings.warn(
+            "The `body_link_state_w` property will be deprecated in IsaacLab 4.0. Please use `body_link_pose_w` and "
+            "`body_link_vel_w` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self._body_link_state_w.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.concat_body_pose_and_vel_to_state,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[self.body_link_pose_w, self.body_link_vel_w],
+                outputs=[self._body_link_state_w.data],
+                device=self.device,
+            )
+            self._body_link_state_w.timestamp = self._sim_timestamp
+        if self._body_link_state_w_ta is None:
+            self._body_link_state_w_ta = ProxyArray(self._body_link_state_w.data)
+        return self._body_link_state_w_ta
+
+    @property
+    def body_com_state_w(self) -> ProxyArray:
+        """Deprecated, same as :attr:`body_com_pose_w` and :attr:`body_com_vel_w`."""
+        warnings.warn(
+            "The `body_com_state_w` property will be deprecated in IsaacLab 4.0. Please use `body_com_pose_w` and "
+            "`body_com_vel_w` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self._body_com_state_w.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.concat_body_pose_and_vel_to_state,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[self.body_com_pose_w, self.body_com_vel_w],
+                outputs=[self._body_com_state_w.data],
+                device=self.device,
+            )
+            self._body_com_state_w.timestamp = self._sim_timestamp
+        if self._body_com_state_w_ta is None:
+            self._body_com_state_w_ta = ProxyArray(self._body_com_state_w.data)
+        return self._body_com_state_w_ta
+
+    """
+    Sliced properties.
+    """
+
+    @property
+    def body_link_pos_w(self) -> ProxyArray:
+        """Positions of all bodies in simulation world frame [m].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        This quantity is the position of the rigid bodies' actor frame relative to
+        the world.
+        """
+        parent = self.body_link_pose_w
+        if self._body_link_pos_w_ta is None:
+            self._body_link_pos_w_ta = ProxyArray(self._get_pos_from_transform(parent.warp))
+        return self._body_link_pos_w_ta
+
+    @property
+    def body_link_quat_w(self) -> ProxyArray:
+        """Orientation (x, y, z, w) of all bodies in simulation world frame.
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.quatf``.
+        In torch this resolves to (num_instances, num_bodies, 4).
+        This quantity is the orientation of the rigid bodies' actor frame relative
+        to the world.
+        """
+        parent = self.body_link_pose_w
+        if self._body_link_quat_w_ta is None:
+            self._body_link_quat_w_ta = ProxyArray(self._get_quat_from_transform(parent.warp))
+        return self._body_link_quat_w_ta
+
+    @property
+    def body_link_lin_vel_w(self) -> ProxyArray:
+        """Linear velocity of all bodies in simulation world frame [m/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        This quantity is the linear velocity of the rigid bodies' actor frame
+        relative to the world.
+        """
+        parent = self.body_link_vel_w
+        if self._body_link_lin_vel_w_ta is None:
+            self._body_link_lin_vel_w_ta = ProxyArray(self._get_lin_vel_from_spatial_vector(parent.warp))
+        return self._body_link_lin_vel_w_ta
+
+    @property
+    def body_link_ang_vel_w(self) -> ProxyArray:
+        """Angular velocity of all bodies in simulation world frame [rad/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        This quantity is the angular velocity of the rigid bodies' actor frame
+        relative to the world.
+        """
+        parent = self.body_link_vel_w
+        if self._body_link_ang_vel_w_ta is None:
+            self._body_link_ang_vel_w_ta = ProxyArray(self._get_ang_vel_from_spatial_vector(parent.warp))
+        return self._body_link_ang_vel_w_ta
+
+    @property
+    def body_link_lin_vel_b(self) -> ProxyArray:
+        """Linear velocity of all bodies in their respective body (actor) frames [m/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        if self._body_link_lin_vel_b.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.quat_apply_inverse_2D_kernel,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[self.body_link_lin_vel_w, self.body_link_quat_w],
+                outputs=[self._body_link_lin_vel_b.data],
+                device=self.device,
+            )
+            self._body_link_lin_vel_b.timestamp = self._sim_timestamp
+        if self._body_link_lin_vel_b_ta is None:
+            self._body_link_lin_vel_b_ta = ProxyArray(self._body_link_lin_vel_b.data)
+        return self._body_link_lin_vel_b_ta
+
+    @property
+    def body_link_ang_vel_b(self) -> ProxyArray:
+        """Angular velocity of all bodies in their respective body (actor) frames [rad/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        if self._body_link_ang_vel_b.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.quat_apply_inverse_2D_kernel,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[self.body_link_ang_vel_w, self.body_link_quat_w],
+                outputs=[self._body_link_ang_vel_b.data],
+                device=self.device,
+            )
+            self._body_link_ang_vel_b.timestamp = self._sim_timestamp
+        if self._body_link_ang_vel_b_ta is None:
+            self._body_link_ang_vel_b_ta = ProxyArray(self._body_link_ang_vel_b.data)
+        return self._body_link_ang_vel_b_ta
+
+    @property
+    def body_com_pos_w(self) -> ProxyArray:
+        """Positions of all bodies' center of mass in simulation world frame [m].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        parent = self.body_com_pose_w
+        if self._body_com_pos_w_ta is None:
+            self._body_com_pos_w_ta = ProxyArray(self._get_pos_from_transform(parent.warp))
+        return self._body_com_pos_w_ta
+
+    @property
+    def body_com_quat_w(self) -> ProxyArray:
+        """Orientation (x, y, z, w) of the principal axes of inertia of all bodies in simulation world frame.
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.quatf``.
+        In torch this resolves to (num_instances, num_bodies, 4).
+        """
+        parent = self.body_com_pose_w
+        if self._body_com_quat_w_ta is None:
+            self._body_com_quat_w_ta = ProxyArray(self._get_quat_from_transform(parent.warp))
+        return self._body_com_quat_w_ta
+
+    @property
+    def body_com_lin_vel_w(self) -> ProxyArray:
+        """Linear velocity of all bodies' center of mass in simulation world frame [m/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        parent = self.body_com_vel_w
+        if self._body_com_lin_vel_w_ta is None:
+            self._body_com_lin_vel_w_ta = ProxyArray(self._get_lin_vel_from_spatial_vector(parent.warp))
+        return self._body_com_lin_vel_w_ta
+
+    @property
+    def body_com_ang_vel_w(self) -> ProxyArray:
+        """Angular velocity of all bodies' center of mass in simulation world frame [rad/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        parent = self.body_com_vel_w
+        if self._body_com_ang_vel_w_ta is None:
+            self._body_com_ang_vel_w_ta = ProxyArray(self._get_ang_vel_from_spatial_vector(parent.warp))
+        return self._body_com_ang_vel_w_ta
+
+    @property
+    def body_com_lin_vel_b(self) -> ProxyArray:
+        """Linear velocity of all bodies' center of mass in their respective body (actor) frames [m/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        if self._body_com_lin_vel_b.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.quat_apply_inverse_2D_kernel,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[self.body_com_lin_vel_w, self.body_link_quat_w],
+                outputs=[self._body_com_lin_vel_b.data],
+                device=self.device,
+            )
+            self._body_com_lin_vel_b.timestamp = self._sim_timestamp
+        if self._body_com_lin_vel_b_ta is None:
+            self._body_com_lin_vel_b_ta = ProxyArray(self._body_com_lin_vel_b.data)
+        return self._body_com_lin_vel_b_ta
+
+    @property
+    def body_com_ang_vel_b(self) -> ProxyArray:
+        """Angular velocity of all bodies' center of mass in their respective body (actor) frames [rad/s].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        if self._body_com_ang_vel_b.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.quat_apply_inverse_2D_kernel,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[self.body_com_ang_vel_w, self.body_link_quat_w],
+                outputs=[self._body_com_ang_vel_b.data],
+                device=self.device,
+            )
+            self._body_com_ang_vel_b.timestamp = self._sim_timestamp
+        if self._body_com_ang_vel_b_ta is None:
+            self._body_com_ang_vel_b_ta = ProxyArray(self._body_com_ang_vel_b.data)
+        return self._body_com_ang_vel_b_ta
+
+    @property
+    def body_com_lin_acc_w(self) -> ProxyArray:
+        """Linear acceleration of all bodies' center of mass in simulation world frame [m/s²].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        parent = self.body_com_acc_w
+        if self._body_com_lin_acc_w_ta is None:
+            self._body_com_lin_acc_w_ta = ProxyArray(self._get_lin_vel_from_spatial_vector(parent.warp))
+        return self._body_com_lin_acc_w_ta
+
+    @property
+    def body_com_ang_acc_w(self) -> ProxyArray:
+        """Angular acceleration of all bodies' center of mass in simulation world frame [rad/s²].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        parent = self.body_com_acc_w
+        if self._body_com_ang_acc_w_ta is None:
+            self._body_com_ang_acc_w_ta = ProxyArray(self._get_ang_vel_from_spatial_vector(parent.warp))
+        return self._body_com_ang_acc_w_ta
+
+    @property
+    def body_com_pos_b(self) -> ProxyArray:
+        """Center of mass position of all of the bodies in their respective link frames [m].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        parent = self.body_com_pose_b
+        if self._body_com_pos_b_ta is None:
+            self._body_com_pos_b_ta = ProxyArray(self._get_pos_from_transform(parent.warp))
+        return self._body_com_pos_b_ta
+
+    @property
+    def body_com_quat_b(self) -> ProxyArray:
+        """Orientation (x, y, z, w) of the principal axes of inertia of all of the bodies
+        in their respective link frames.
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.quatf``.
+        In torch this resolves to (num_instances, num_bodies, 4).
+        """
+        parent = self.body_com_pose_b
+        if self._body_com_quat_b_ta is None:
+            self._body_com_quat_b_ta = ProxyArray(self._get_quat_from_transform(parent.warp))
+        return self._body_com_quat_b_ta
+
+    """
+    Derived Properties.
+    """
+
+    @property
+    def projected_gravity_b(self) -> ProxyArray:
+        """Projection of the gravity direction onto each body frame [-].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.vec3f``.
+        In torch this resolves to (num_instances, num_bodies, 3).
+        """
+        if self._projected_gravity_b.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.quat_apply_inverse_2D_kernel,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[self.GRAVITY_VEC_W, self.body_link_quat_w],
+                outputs=[self._projected_gravity_b.data],
+                device=self.device,
+            )
+            self._projected_gravity_b.timestamp = self._sim_timestamp
+        if self._projected_gravity_b_ta is None:
+            self._projected_gravity_b_ta = ProxyArray(self._projected_gravity_b.data)
+        return self._projected_gravity_b_ta
+
+    @property
+    def heading_w(self) -> ProxyArray:
+        """Yaw heading of each body frame [rad].
+
+        Shape is (num_instances, num_bodies), dtype = ``wp.float32``.
+        In torch this resolves to (num_instances, num_bodies).
+
+        .. note::
+            This quantity is computed by assuming that the forward-direction of each
+            body frame is along the x-direction, i.e. :math:`(1, 0, 0)`.
+        """
+        if self._heading_w.timestamp < self._sim_timestamp:
+            wp.launch(
+                shared_kernels.body_heading_w,
+                dim=(self.num_instances, self.num_bodies),
+                inputs=[self.FORWARD_VEC_B, self.body_link_quat_w],
+                outputs=[self._heading_w.data],
+                device=self.device,
+            )
+            self._heading_w.timestamp = self._sim_timestamp
+        if self._heading_w_ta is None:
+            self._heading_w_ta = ProxyArray(self._heading_w.data)
+        return self._heading_w_ta
+
+    def _create_buffers(self) -> None:
+        """Eagerly allocate every per-body TimestampedBuffer and the slots for
+        cached :class:`ProxyArray` wrappers.
+
+        Buffers use direct ``(num_instances, num_bodies, D)`` shapes, matching
+        the fused binding output.  No flat+strided tricks are needed because the
+        fused binding returns a contiguous ``(N, B, D)`` array directly.
+        """
+        super()._create_buffers()
+
+        N = self.num_instances
+        B = self.num_bodies
+
+        # -- link frame w.r.t. world frame
+        self._body_link_pose_w = TimestampedBuffer((N, B), self.device, wp.transformf)
+        self._body_link_vel_w = TimestampedBuffer((N, B), self.device, wp.spatial_vectorf)
+        # -- com frame w.r.t. link frame
+        self._body_com_pose_b = TimestampedBuffer((N, B), self.device, wp.transformf)
+        # -- com frame w.r.t. world frame
+        self._body_com_pose_w = TimestampedBuffer((N, B), self.device, wp.transformf)
+        self._body_com_vel_w = TimestampedBuffer((N, B), self.device, wp.spatial_vectorf)
+        # -- combined state (cached, used by deprecated concat properties)
+        self._body_state_w = TimestampedBuffer((N, B), self.device, shared_kernels.vec13f)
+        self._body_link_state_w = TimestampedBuffer((N, B), self.device, shared_kernels.vec13f)
+        self._body_com_state_w = TimestampedBuffer((N, B), self.device, shared_kernels.vec13f)
+        # -- derived properties (in-body-frame velocities)
+        self._body_link_lin_vel_b = TimestampedBuffer((N, B), self.device, wp.vec3f)
+        self._body_link_ang_vel_b = TimestampedBuffer((N, B), self.device, wp.vec3f)
+        self._body_com_lin_vel_b = TimestampedBuffer((N, B), self.device, wp.vec3f)
+        self._body_com_ang_vel_b = TimestampedBuffer((N, B), self.device, wp.vec3f)
+        # -- derived properties (acceleration via finite differencing)
+        self._body_com_acc_w = TimestampedBuffer((N, B), self.device, wp.spatial_vectorf)
+        # Holds the previous-step COM velocity for FD; initialised lazily on first access.
+        self._previous_body_com_vel: wp.array | None = None
+        # -- derived properties (projected gravity and heading)
+        self._projected_gravity_b = TimestampedBuffer((N, B), self.device, wp.vec3f)
+        self._heading_w = TimestampedBuffer((N, B), self.device, wp.float32)
+
+        # -- Body properties: mass (N, B) and inertia (N, B, 9).
+        # Initialised eagerly from the CPU-only bindings.
+        self._body_mass = TimestampedBuffer((N, B), self.device, wp.float32)
+        self._body_inertia = TimestampedBuffer((N, B, 9), self.device, wp.float32)
+
+        # Pinned CPU staging buffers used by mass/com/inertia setters.
+        pinned = self.device != "cpu"
+        self._cpu_body_mass = wp.zeros((N, B), dtype=wp.float32, device="cpu", pinned=pinned)
+        self._cpu_body_coms = wp.zeros((N, B, 7), dtype=wp.float32, device="cpu", pinned=pinned)
+        self._cpu_body_inertia = wp.zeros((N, B, 9), dtype=wp.float32, device="cpu", pinned=pinned)
+
+        # Eagerly read mass and inertia (CPU-only bindings) at construction time.
+        # The native fused binding returns body-major flat data ``(N*B[, D])``;
+        # the articulation-mode mock returns instance-major ``(N, B[, D])``.
+        # In either case we reshape on the CPU into instance-major numpy arrays.
+        def _read_cpu(tensor_type, trailing_dim=None):
+            binding = self._get_binding(tensor_type)
+            if binding is None:
+                return None
+            np_buf = np.zeros(binding.shape, dtype=np.float32)
+            binding.read(np_buf)
+            if binding.count == N:
+                # Mock fast-path: already (N, B[, D]).
+                return np_buf
+            # Native fused path: body-major flat -> instance-major via reshape+transpose.
+            if trailing_dim is None:
+                return np_buf.reshape(B, N).T.copy()
+            return np_buf.reshape(B, N, trailing_dim).transpose(1, 0, 2).copy()
+
+        np_mass = _read_cpu(TT.BODY_MASS)
+        if np_mass is not None:
+            wp.copy(self._body_mass.data, wp.from_numpy(np_mass, dtype=wp.float32, device=self.device))
+            self._body_mass.timestamp = self._sim_timestamp
+
+        np_inertia = _read_cpu(TT.BODY_INERTIA, trailing_dim=9)
+        if np_inertia is not None:
+            wp.copy(
+                self._body_inertia.data,
+                wp.from_numpy(np_inertia, dtype=wp.float32, device=self.device),
+            )
+            self._body_inertia.timestamp = self._sim_timestamp
+
+        # -- Defaults (allocated here, filled by _process_cfg after __init__).
+        # Zero-initialized buffers; populated by RigidObjectCollection._process_cfg.
+        self._default_body_pose = wp.zeros((N, B), dtype=wp.transformf, device=self.device)
+        self._default_body_vel = wp.zeros((N, B), dtype=wp.spatial_vectorf, device=self.device)
+
+        # Initialize ProxyArray wrappers.
+        self._pin_proxy_arrays()
+
+    def _pin_proxy_arrays(self) -> None:
+        """Create pinned :class:`ProxyArray` wrappers for all data buffers.
+
+        This is called once from :meth:`_create_buffers` during initialization.
+        OVPhysX tensor API buffers have stable GPU pointers across simulation steps,
+        so no rebinding is needed (unlike Newton).
+        """
+        # Defaults
+        self._default_body_pose_ta: ProxyArray | None = None
+        self._default_body_vel_ta: ProxyArray | None = None
+        # Body state (timestamped)
+        self._body_link_pose_w_ta: ProxyArray | None = None
+        self._body_link_vel_w_ta: ProxyArray | None = None
+        self._body_com_pose_w_ta: ProxyArray | None = None
+        self._body_com_vel_w_ta: ProxyArray | None = None
+        self._body_com_pose_b_ta: ProxyArray | None = None
+        # Body properties
+        self._body_mass_ta: ProxyArray | None = None
+        self._body_inertia_ta: ProxyArray | None = None
+        # Derived properties (in-body-frame velocities)
+        self._body_link_lin_vel_b_ta: ProxyArray | None = None
+        self._body_link_ang_vel_b_ta: ProxyArray | None = None
+        self._body_com_lin_vel_b_ta: ProxyArray | None = None
+        self._body_com_ang_vel_b_ta: ProxyArray | None = None
+        # Derived properties (FD acceleration)
+        self._body_com_acc_w_ta: ProxyArray | None = None
+        self._body_com_lin_acc_w_ta: ProxyArray | None = None
+        self._body_com_ang_acc_w_ta: ProxyArray | None = None
+        # Derived properties (projected gravity and heading)
+        self._projected_gravity_b_ta: ProxyArray | None = None
+        self._heading_w_ta: ProxyArray | None = None
+        # Sliced properties (body link)
+        self._body_link_pos_w_ta: ProxyArray | None = None
+        self._body_link_quat_w_ta: ProxyArray | None = None
+        self._body_link_lin_vel_w_ta: ProxyArray | None = None
+        self._body_link_ang_vel_w_ta: ProxyArray | None = None
+        # Sliced properties (body com)
+        self._body_com_pos_w_ta: ProxyArray | None = None
+        self._body_com_quat_w_ta: ProxyArray | None = None
+        self._body_com_lin_vel_w_ta: ProxyArray | None = None
+        self._body_com_ang_vel_w_ta: ProxyArray | None = None
+        # Sliced properties (body com in body frame)
+        self._body_com_pos_b_ta: ProxyArray | None = None
+        self._body_com_quat_b_ta: ProxyArray | None = None
+        # Deprecated state-concat properties
+        self._default_body_state: wp.array | None = None
+        self._default_body_state_ta: ProxyArray | None = None
+        self._body_state_w_ta: ProxyArray | None = None
+        self._body_link_state_w_ta: ProxyArray | None = None
+        self._body_com_state_w_ta: ProxyArray | None = None
+
+    """
+    Helpers.
+    """
+
+    def _get_binding(self, tensor_type: int):
+        """Return the binding for the given tensor type, or None.
+
+        Args:
+            tensor_type: The TensorType constant identifying which simulation buffer.
+
+        Returns:
+            The cached :class:`TensorBinding`, or ``None`` if not available.
+        """
+        b = self._bindings.get(tensor_type)
+        if b is not None:
+            return b
+        if self._binding_getter is not None:
+            b = self._binding_getter(tensor_type)
+            if b is not None:
+                self._bindings[tensor_type] = b
+            return b
+        return None
+
+    def _read_view_scratch(self, tensor_type: int, binding) -> wp.array:
+        """Return a cached body-major scratch float32 buffer matching ``binding.shape``.
+
+        Allocated on the binding's own device (GPU bindings → GPU, CPU-only
+        bindings → pinned host) so that ``binding.read(scratch)`` never crosses
+        devices.  The scratch buffer is body-major flat
+        ``(num_bodies * num_instances[, D])`` and is reshaped into instance-major
+        ``(N, B[, D])`` by :meth:`_reshape_view_to_data_2d` /
+        :meth:`_reshape_view_to_data_3d` before being copied into the user-facing
+        timestamped buffer.
+
+        Args:
+            tensor_type: TensorType key (used as cache key).
+            binding: The fused :class:`TensorBinding` whose shape the scratch
+                must match.
+
+        Returns:
+            Cached body-major scratch buffer for reads.
+        """
+        scratch = self._cpu_staging_buffers.get(tensor_type)
+        if scratch is not None:
+            return scratch
+        binding_device = "cpu" if tensor_type in TT._CPU_ONLY_TYPES else self.device
+        pinned = binding_device == "cpu" and self.device != "cpu"
+        if pinned:
+            scratch = wp.zeros(binding.shape, dtype=wp.float32, device="cpu", pinned=True)
+        else:
+            scratch = wp.zeros(binding.shape, dtype=wp.float32, device=binding_device)
+        self._cpu_staging_buffers[tensor_type] = scratch
+        return scratch
+
+    def _read_binding_into_instance_major(self, tensor_type: int, buf: TimestampedBuffer, floats_per_elem: int) -> None:
+        """Read a fused binding into the instance-major ``buf.data``.
+
+        The native fused multi-prim binding returns data in body-major flat order
+        ``(body0_env0, body0_env1, ..., body1_env0, ...)`` with
+        ``binding.count == num_instances * num_bodies``.  The articulation-mode
+        mock used by iface tests instead exposes a directly instance-major view
+        with ``binding.count == num_instances`` and shape ``(N, B[, D])``.
+
+        This method dispatches to the right path:
+
+        * **Mock fast-path** (``binding.count == num_instances``): a float32 view
+          of the destination buffer is filled directly via ``binding.read()``.
+        * **Native fused path** (``binding.count == num_instances * num_bodies``):
+          ``binding.read()`` fills a body-major scratch, which is then reshaped
+          into instance-major order via :meth:`_reshape_view_to_data_2d` (for
+          single-element-per-body fields like mass) or
+          :meth:`_reshape_view_to_data_3d` (for fields with a trailing
+          ``floats_per_elem`` dimension), and the result is copied into the
+          destination buffer.
+
+        Args:
+            tensor_type: TensorType key identifying the binding.
+            buf: Timestamped buffer to refresh.  ``buf.data`` is
+                ``(num_instances, num_bodies)`` for single-element-per-body
+                fields (e.g. mass), or ``(num_instances, num_bodies, ...)`` for
+                multi-component fields.
+            floats_per_elem: Number of trailing ``float32`` elements per body
+                (e.g. 7 for transformf, 6 for spatial_vectorf, 9 for inertia).
+                Pass 1 for plain scalar fields like mass.
+        """
+        if buf.timestamp >= self._sim_timestamp:
+            return
+        binding = self._get_binding(tensor_type)
+        if binding is None:
+            return
+
+        B = self.num_bodies
+
+        # Disambiguate via the binding's exposed shape: the articulation-mode
+        # mock returns a directly instance-major view ``(N, B[, D])`` while the
+        # native fused multi-prim binding lays elements body-major-flat with
+        # ``shape == (N * B[, D])``.
+        is_mock_layout = len(binding.shape) >= 2 and binding.shape[1] == B
+
+        if is_mock_layout:
+            if buf.data.dtype == wp.float32:
+                view = buf.data
+            else:
+                view = wp.array(
+                    ptr=buf.data.ptr,
+                    shape=binding.shape,
+                    dtype=wp.float32,
+                    device=str(buf.data.device),
+                    copy=False,
+                )
+            binding.read(view)
+            buf.timestamp = self._sim_timestamp
+            return
+
+        # Native fused path: read body-major scratch then strided-view reshape.
+        scratch = self._read_view_scratch(tensor_type, binding)
+        binding.read(scratch)
+        if floats_per_elem <= 1:
+            reshaped = self._reshape_view_to_data_2d(scratch)
+        else:
+            reshaped = self._reshape_view_to_data_3d(scratch, floats_per_elem)
+        # Copy into buf.data, reinterpreting structured-dtype buffers as float32.
+        if buf.data.dtype == wp.float32:
+            dst_view = buf.data
+        else:
+            dst_view = wp.array(
+                ptr=buf.data.ptr,
+                shape=reshaped.shape,
+                dtype=wp.float32,
+                device=str(buf.data.device),
+                copy=False,
+            )
+        wp.copy(dst_view, reshaped)
+        buf.timestamp = self._sim_timestamp
+
+    def _read_transform_binding(self, tensor_type: int, buf: TimestampedBuffer) -> None:
+        """Read a pose binding (``wp.transformf`` buffer), skipping if fresh.
+
+        Args:
+            tensor_type: TensorType key.
+            buf: Timestamped :class:`wp.transformf` buffer to refresh.
+        """
+        self._read_binding_into_instance_major(tensor_type, buf, floats_per_elem=7)
+
+    def _read_spatial_vector_binding(self, tensor_type: int, buf: TimestampedBuffer) -> None:
+        """Read a velocity binding (``wp.spatial_vectorf`` buffer), skipping if fresh.
+
+        Args:
+            tensor_type: TensorType key.
+            buf: Timestamped :class:`wp.spatial_vectorf` buffer to refresh.
+        """
+        self._read_binding_into_instance_major(tensor_type, buf, floats_per_elem=6)
+
+    def _reshape_view_to_data_2d(self, data: wp.array) -> wp.array:
+        """Reshape body-major flat data into instance-major ``(num_instances, num_bodies)``.
+
+        The native fused binding lays elements out body-major:
+        ``(body0_env0, body0_env1, ..., body1_env0, body1_env1, ...)``.  This helper
+        constructs a strided view that traverses the data in instance-major order
+        ``(env0_body0, env0_body1, ..., env1_body0, ...)``, then clones it onto
+        :attr:`device` for contiguity and (when needed) cross-device transfer.
+
+        Args:
+            data: Body-major flat buffer.  Shape is ``(num_bodies * num_instances,)``
+                with any single-element dtype.
+
+        Returns:
+            Contiguous instance-major buffer with shape ``(num_instances, num_bodies)``
+            on :attr:`device`.
+        """
+        element_size = wp.types.type_size_in_bytes(data.dtype)
+        strided_view = wp.array(
+            ptr=data.ptr,
+            shape=(self.num_instances, self.num_bodies),
+            dtype=data.dtype,
+            strides=(element_size, self.num_instances * element_size),
+            device=str(data.device),
+        )
+        return wp.clone(strided_view, self.device)
+
+    def _reshape_view_to_data_3d(self, data: wp.array, data_dim: int) -> wp.array:
+        """Reshape body-major flat data into instance-major ``(num_instances, num_bodies, data_dim)``.
+
+        Companion of :meth:`_reshape_view_to_data_2d` for fields with a trailing
+        per-body dimension (e.g. pose has 7, spatial velocity has 6, inertia has 9).
+
+        Args:
+            data: Body-major flat buffer with shape ``(num_bodies * num_instances, data_dim)``
+                or ``(num_bodies * num_instances,)`` reinterpreted as ``data_dim``-wide rows.
+            data_dim: Trailing per-body dimension size.
+
+        Returns:
+            Contiguous instance-major buffer with shape
+            ``(num_instances, num_bodies, data_dim)`` on :attr:`device`.
+        """
+        element_size = wp.types.type_size_in_bytes(wp.float32)
+        row_size = element_size * data_dim
+        strided_view = wp.array(
+            ptr=data.ptr,
+            shape=(self.num_instances, self.num_bodies, data_dim),
+            dtype=wp.float32,
+            strides=(row_size, self.num_instances * row_size, element_size),
+            device=str(data.device),
+        )
+        return wp.clone(strided_view, self.device)
+
+    def _get_pos_from_transform(self, transform: wp.array) -> wp.array:
+        """Generates a position array from a transform array."""
+        return wp.array(
+            ptr=transform.ptr,
+            shape=transform.shape,
+            dtype=wp.vec3f,
+            strides=transform.strides,
+            device=self.device,
+        )
+
+    def _get_quat_from_transform(self, transform: wp.array) -> wp.array:
+        """Generates a quaternion array from a transform array."""
+        return wp.array(
+            ptr=transform.ptr + 3 * 4,
+            shape=transform.shape,
+            dtype=wp.quatf,
+            strides=transform.strides,
+            device=self.device,
+        )
+
+    def _get_lin_vel_from_spatial_vector(self, sv: wp.array) -> wp.array:
+        """Generates a linear velocity array from a spatial vector array."""
+        return wp.array(
+            ptr=sv.ptr,
+            shape=sv.shape,
+            dtype=wp.vec3f,
+            strides=sv.strides,
+            device=self.device,
+        )
+
+    def _get_ang_vel_from_spatial_vector(self, sv: wp.array) -> wp.array:
+        """Generates an angular velocity array from a spatial vector array."""
+        return wp.array(
+            ptr=sv.ptr + 3 * 4,
+            shape=sv.shape,
+            dtype=wp.vec3f,
+            strides=sv.strides,
+            device=self.device,
+        )

--- a/source/isaaclab_ovphysx/setup.py
+++ b/source/isaaclab_ovphysx/setup.py
@@ -37,6 +37,7 @@ setup(
         "isaaclab_ovphysx",
         "isaaclab_ovphysx.assets",
         "isaaclab_ovphysx.assets.articulation",
+        "isaaclab_ovphysx.assets.rigid_object_collection",
         "isaaclab_ovphysx.cloner",
         "isaaclab_ovphysx.physics",
         "isaaclab_ovphysx.test",

--- a/source/isaaclab_ovphysx/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/test/assets/test_rigid_object_collection.py
@@ -1,0 +1,963 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ignore private usage of variables warning
+# pyright: reportPrivateUsage=none
+
+
+"""Real-backend tests for the OVPhysX RigidObjectCollection.
+
+Run via ``./scripts/run_ovphysx.sh -m pytest`` (kitless, no ``AppLauncher``).
+
+``ovphysx<=0.3.7`` binds device mode (CPU vs GPU) at the C++ layer on the
+first ``ovphysx.PhysX(device=...)`` construction and cannot swap it without a
+process restart.  Full coverage therefore requires two separate pytest
+invocations -- once with ``-k 'cpu'`` and once with ``-k 'cuda:0'``.  The
+``_ovphysx_skip_other_device`` autouse fixture below preempts the manager's
+:exc:`RuntimeError` by ``pytest.skip``-ing on the unlocked device so
+single-device runs finish cleanly.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+import torch
+import warp as wp
+
+# The CI isaaclab_ov* pattern unintentionally collects isaaclab_ovphysx tests,
+# but the ovphysx wheel is not installed in that environment. Skip gracefully
+# so the isaaclab_ov CI pipeline is not blocked by an unrelated dependency.
+pytest.importorskip("ovphysx.types", reason="ovphysx wheel not installed")
+
+from isaaclab_ovphysx.assets import RigidObjectCollection  # noqa: E402
+from isaaclab_ovphysx.physics import OvPhysxCfg  # noqa: E402
+
+import isaaclab.sim as sim_utils  # noqa: E402
+from isaaclab.assets import RigidObjectCfg, RigidObjectCollectionCfg  # noqa: E402
+from isaaclab.sim import SimulationCfg, build_simulation_context  # noqa: E402
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR  # noqa: E402
+from isaaclab.utils.math import (  # noqa: E402
+    combine_frame_transforms,
+    default_orientation,
+    quat_apply_inverse,
+    quat_inv,
+    quat_mul,
+    quat_rotate,
+    random_orientation,
+    subtract_frame_transforms,
+)
+
+wp.init()
+
+
+_LOCKED_DEVICE: list[str | None] = [None]
+"""Device the session pins to on the first parametrized test that runs."""
+
+
+@pytest.fixture(autouse=True)
+def _ovphysx_skip_other_device(request):
+    """Skip parametrized tests on the device the session is not pinned to.
+
+    See the module docstring for the wheel's process-global device-mode lock.
+    """
+    callspec = getattr(request.node, "callspec", None)
+    device = callspec.params.get("device") if callspec is not None else None
+    if device is None:
+        # Test does not parametrize on device.
+        return
+    locked = _LOCKED_DEVICE[0]
+    if locked is None:
+        _LOCKED_DEVICE[0] = device
+        return
+    if device != locked:
+        pytest.skip(
+            f"ovphysx process-global device lock is held by '{locked}'; cannot run '{device}' "
+            "tests in the same session.  Run pytest twice (once per device) for full coverage."
+        )
+
+
+def _ovphysx_sim_context(device: str, **kwargs):
+    """Wrapper around :func:`build_simulation_context` that injects OVPhysX cfg.
+
+    PhysX tests pass ``device=device`` directly and let
+    :func:`build_simulation_context` build a default :class:`SimulationCfg`.
+    OVPhysX needs ``physics=OvPhysxCfg()`` set on the cfg so the manager
+    dispatches to OVPhysX rather than PhysX, so we build the cfg here and
+    pass it through.  ``gravity_enabled`` is consumed locally (it is ignored
+    by ``build_simulation_context`` once a ``sim_cfg`` is provided).
+    ``add_ground_plane``, ``auto_add_lighting``, and other kwargs continue
+    to flow through ``build_simulation_context`` as before.
+    """
+    dt = kwargs.pop("dt", 1.0 / 60.0)
+    gravity_enabled = kwargs.pop("gravity_enabled", True)
+    gravity = (0.0, 0.0, -9.81) if gravity_enabled else (0.0, 0.0, 0.0)
+    sim_cfg = SimulationCfg(physics=OvPhysxCfg(), device=device, dt=dt, gravity=gravity)
+    return build_simulation_context(device=device, sim_cfg=sim_cfg, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Material-property gap (xfail reason shared by the test below)
+# ---------------------------------------------------------------------------
+
+_MATERIAL_GAP_REASON = (
+    "Requires RIGID_BODY_MATERIAL TensorType (or a view-helper) on the ovphysx "
+    "wheel side.  RigidObjectCollection.root_view is a per-tensor-type bindings dict on "
+    "OVPhysX, so root_view.get_material_properties() / set_material_properties() "
+    "are not available.  See "
+    "docs/superpowers/specs/2026-04-28-ovphysx-wheel-gaps-for-marco.md."
+)
+
+
+def generate_cubes_scene(
+    num_envs: int = 1,
+    num_cubes: int = 1,
+    height=1.0,
+    has_api: bool = True,
+    kinematic_enabled: bool = False,
+    device: str = "cuda:0",
+) -> tuple[RigidObjectCollection, torch.Tensor]:
+    """Generate a scene with the provided number of cubes.
+
+    Args:
+        num_envs: Number of envs to generate.
+        num_cubes: Number of cubes to generate.
+        height: Height of the cubes.
+        has_api: Whether the cubes have a rigid body API on them.
+        kinematic_enabled: Whether the cubes are kinematic.
+        device: Device to use for the simulation.
+
+    Returns:
+        A tuple containing the rigid object representing the cubes and the origins of the cubes.
+
+    """
+    origins = torch.tensor([(i * 3.0, 0, height) for i in range(num_envs)]).to(device)
+    # Create Top-level Xforms, one for each cube
+    for i, origin in enumerate(origins):
+        sim_utils.create_prim(f"/World/Table_{i}", "Xform", translation=origin)
+
+    # Resolve spawn configuration
+    if has_api:
+        spawn_cfg = sim_utils.UsdFileCfg(
+            usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/DexCube/dex_cube_instanceable.usd",
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=kinematic_enabled),
+        )
+    else:
+        # since no rigid body properties defined, this is just a static collider
+        spawn_cfg = sim_utils.CuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+        )
+
+    # create the rigid object configs.  OVPhysX matches prim paths via fnmatch globs (not regex),
+    # so use ``Table_*`` rather than the PhysX ``Table_.*`` form.
+    cube_config_dict = {}
+    for i in range(num_cubes):
+        cube_object_cfg = RigidObjectCfg(
+            prim_path=f"/World/Table_*/Object_{i}",
+            spawn=spawn_cfg,
+            init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 3 * i, height)),
+        )
+        cube_config_dict[f"cube_{i}"] = cube_object_cfg
+    # create the rigid object collection
+    cube_object_collection_cfg = RigidObjectCollectionCfg(rigid_objects=cube_config_dict)
+    cube_object_colection = RigidObjectCollection(cfg=cube_object_collection_cfg)
+
+    return cube_object_colection, origins
+
+
+@pytest.mark.parametrize("num_envs", [1, 2])
+@pytest.mark.parametrize("num_cubes", [1, 3])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.isaacsim_ci
+def test_initialization(num_envs, num_cubes, device):
+    """Test initialization for prim with rigid body API at the provided prim path."""
+    with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
+        object_collection, _ = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
+
+        # Check that the framework doesn't hold excessive strong references.
+        assert sys.getrefcount(object_collection) < 10
+
+        # Play sim
+        sim.reset()
+
+        # Check if object is initialized
+        assert object_collection.is_initialized
+        assert len(object_collection.body_names) == num_cubes
+
+        # Check buffers that exist and have correct shapes
+        assert object_collection.data.body_link_pos_w.torch.shape == (num_envs, num_cubes, 3)
+        assert object_collection.data.body_link_quat_w.torch.shape == (num_envs, num_cubes, 4)
+        assert object_collection.data.body_mass.torch.shape == (num_envs, num_cubes)
+        assert object_collection.data.body_inertia.torch.shape == (num_envs, num_cubes, 9)
+
+        # Simulate physics
+        for _ in range(2):
+            sim.step()
+            object_collection.update(sim.cfg.dt)
+
+
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.isaacsim_ci
+def test_id_conversion(device):
+    """Test environment and object index conversion to physics view indices."""
+    with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
+        object_collection, _ = generate_cubes_scene(num_envs=2, num_cubes=3, device=device)
+
+        # Play sim
+        sim.reset()
+
+        expected = [
+            torch.tensor([4, 5], device=device, dtype=torch.int32),
+            torch.tensor([4], device=device, dtype=torch.int32),
+            torch.tensor([0, 2, 4], device=device, dtype=torch.int32),
+            torch.tensor([1, 3, 5], device=device, dtype=torch.int32),
+        ]
+
+        torch_all_env_indices = wp.to_torch(object_collection._ALL_ENV_INDICES)
+        torch_all_body_indices = wp.to_torch(object_collection._ALL_BODY_INDICES)
+
+        view_ids = object_collection._env_body_ids_to_view_ids(
+            torch_all_env_indices, torch_all_body_indices[None, 2], device=device
+        )
+        assert (wp.to_torch(view_ids) == expected[0]).all()
+        view_ids = object_collection._env_body_ids_to_view_ids(
+            torch_all_env_indices[None, 0], torch_all_body_indices[None, 2], device=device
+        )
+        assert (wp.to_torch(view_ids) == expected[1]).all()
+        view_ids = object_collection._env_body_ids_to_view_ids(
+            torch_all_env_indices[None, 0], torch_all_body_indices, device=device
+        )
+        assert (wp.to_torch(view_ids) == expected[2]).all()
+        view_ids = object_collection._env_body_ids_to_view_ids(
+            torch_all_env_indices[None, 1], torch_all_body_indices, device=device
+        )
+        assert (wp.to_torch(view_ids) == expected[3]).all()
+
+
+@pytest.mark.parametrize("num_envs", [1, 2])
+@pytest.mark.parametrize("num_cubes", [1, 3])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.isaacsim_ci
+def test_initialization_with_kinematic_enabled(num_envs, num_cubes, device):
+    """Test that initialization for prim with kinematic flag enabled."""
+    with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
+        object_collection, origins = generate_cubes_scene(
+            num_envs=num_envs, num_cubes=num_cubes, kinematic_enabled=True, device=device
+        )
+
+        # Check that the framework doesn't hold excessive strong references.
+        assert sys.getrefcount(object_collection) < 10
+
+        # Play sim
+        sim.reset()
+
+        # Check if object is initialized
+        assert object_collection.is_initialized
+        assert len(object_collection.body_names) == num_cubes
+
+        # Check buffers that exist and have correct shapes
+        assert object_collection.data.body_link_pos_w.torch.shape == (num_envs, num_cubes, 3)
+        assert object_collection.data.body_link_quat_w.torch.shape == (num_envs, num_cubes, 4)
+
+        # Simulate physics
+        for _ in range(2):
+            sim.step()
+            object_collection.update(sim.cfg.dt)
+            # check that the object is kinematic
+            default_body_pose = object_collection.data.default_body_pose.torch.clone()
+            default_body_vel = object_collection.data.default_body_vel.torch.clone()
+            default_body_pose[..., :3] += origins.unsqueeze(1)
+            torch.testing.assert_close(object_collection.data.body_link_pose_w.torch, default_body_pose)
+            torch.testing.assert_close(object_collection.data.body_link_vel_w.torch, default_body_vel)
+
+
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.isaacsim_ci
+def test_initialization_with_no_rigid_body(num_cubes, device):
+    """Test that initialization fails when no rigid body is found at the provided prim path."""
+    with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
+        object_collection, _ = generate_cubes_scene(num_cubes=num_cubes, has_api=False, device=device)
+
+        # Check that the framework doesn't hold excessive strong references.
+        assert sys.getrefcount(object_collection) < 10
+
+        # Play sim
+        with pytest.raises(RuntimeError):
+            sim.reset()
+
+
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.isaacsim_ci
+def test_external_force_buffer(device):
+    """Test if external force buffer correctly updates in the force value is zero case."""
+    num_envs = 2
+    num_cubes = 1
+    with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
+        object_collection, origins = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
+        sim.reset()
+
+        # find objects to apply the force
+        object_ids, object_names = object_collection.find_bodies(".*")
+        # reset object
+        object_collection.reset()
+
+        # perform simulation
+        for step in range(5):
+            # initiate force tensor
+            external_wrench_b = torch.zeros(object_collection.num_instances, len(object_ids), 6, device=sim.device)
+
+            # decide if zero or non-zero force
+            if step == 0 or step == 3:
+                force = 1.0
+            else:
+                force = 0.0
+
+            # apply force to the object
+            external_wrench_b[:, :, 0] = force
+            external_wrench_b[:, :, 3] = force
+
+            object_collection.permanent_wrench_composer.set_forces_and_torques_index(
+                forces=external_wrench_b[..., :3],
+                torques=external_wrench_b[..., 3:],
+                body_ids=object_ids,
+                env_ids=None,
+            )
+
+            # check if the object collection's force and torque buffers are correctly updated
+            for i in range(num_envs):
+                assert object_collection._permanent_wrench_composer.composed_force.torch[i, 0, 0].item() == force
+                assert object_collection._permanent_wrench_composer.composed_torque.torch[i, 0, 0].item() == force
+
+            object_collection.instantaneous_wrench_composer.add_forces_and_torques_index(
+                body_ids=object_ids,
+                forces=external_wrench_b[..., :3],
+                torques=external_wrench_b[..., 3:],
+            )
+
+            # apply action to the object collection
+            object_collection.write_data_to_sim()
+            sim.step()
+            object_collection.update(sim.cfg.dt)
+
+
+@pytest.mark.parametrize("num_envs", [1, 2])
+@pytest.mark.parametrize("num_cubes", [1, 4])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.isaacsim_ci
+def test_external_force_on_single_body(num_envs, num_cubes, device):
+    """Test application of external force on the base of the object."""
+    with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
+        object_collection, origins = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
+        sim.reset()
+
+        # find objects to apply the force
+        object_ids, object_names = object_collection.find_bodies(".*")
+
+        # Sample a force equal to the weight of the object
+        external_wrench_b = torch.zeros(object_collection.num_instances, len(object_ids), 6, device=sim.device)
+        # Every 2nd cube should have a force applied to it
+        external_wrench_b[:, 0::2, 2] = 9.81 * object_collection.data.body_mass.torch[:, 0::2]
+
+        for i in range(5):
+            # reset object state
+            body_pose = object_collection.data.default_body_pose.torch.clone()
+            body_vel = object_collection.data.default_body_vel.torch.clone()
+            # need to shift the position of the cubes otherwise they will be on top of each other
+            body_pose[..., :2] += origins.unsqueeze(1)[..., :2]
+            object_collection.write_body_link_pose_to_sim_index(body_poses=body_pose)
+            object_collection.write_body_com_velocity_to_sim_index(body_velocities=body_vel)
+            # reset object
+            object_collection.reset()
+
+            is_global = False
+            if i % 2 == 0:
+                positions = object_collection.data.body_link_pos_w.torch[:, object_ids, :3]
+                is_global = True
+            else:
+                positions = None
+
+            # apply force
+            object_collection.permanent_wrench_composer.set_forces_and_torques_index(
+                forces=external_wrench_b[..., :3],
+                torques=external_wrench_b[..., 3:],
+                positions=positions,
+                body_ids=object_ids,
+                env_ids=None,
+                is_global=is_global,
+            )
+            for _ in range(10):
+                # write data to sim
+                object_collection.write_data_to_sim()
+                # step sim
+                sim.step()
+                # update object collection
+                object_collection.update(sim.cfg.dt)
+
+            # First object should still be at the same Z position (1.0)
+            torch.testing.assert_close(
+                object_collection.data.body_link_pos_w.torch[:, 0::2, 2],
+                torch.ones_like(object_collection.data.body_link_pos_w.torch[:, 0::2, 2]),
+            )
+            # Second object should have fallen, so it's Z height should be less than initial height of 1.0
+            assert torch.all(object_collection.data.body_link_pos_w.torch[:, 1::2, 2] < 1.0)
+
+
+@pytest.mark.parametrize("num_envs", [1, 2])
+@pytest.mark.parametrize("num_cubes", [1, 4])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.isaacsim_ci
+def test_external_force_on_single_body_at_position(num_envs, num_cubes, device):
+    """Test application of external force on the base of the object at a specific position.
+
+    In this test, we apply a force equal to the weight of an object on the base of
+    one of the objects at 1m in the Y direction, we check that the object rotates around it's X axis.
+    For the other object, we do not apply any force and check that it falls down.
+    """
+    with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
+        object_collection, origins = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
+        sim.reset()
+
+        # find objects to apply the force
+        object_ids, object_names = object_collection.find_bodies(".*")
+
+        # Sample a force equal to the weight of the object
+        external_wrench_b = torch.zeros(object_collection.num_instances, len(object_ids), 6, device=sim.device)
+        external_wrench_positions_b = torch.zeros(
+            object_collection.num_instances, len(object_ids), 3, device=sim.device
+        )
+        # Every 2nd cube should have a force applied to it
+        external_wrench_b[:, 0::2, 2] = 500.0
+        external_wrench_positions_b[:, 0::2, 1] = 1.0
+
+        # Desired force and torque
+        for i in range(5):
+            # reset object state
+            body_pose = object_collection.data.default_body_pose.torch.clone()
+            body_vel = object_collection.data.default_body_vel.torch.clone()
+            # need to shift the position of the cubes otherwise they will be on top of each other
+            body_pose[..., :2] += origins.unsqueeze(1)[..., :2]
+            object_collection.write_body_link_pose_to_sim_index(body_poses=body_pose)
+            object_collection.write_body_com_velocity_to_sim_index(body_velocities=body_vel)
+            # reset object
+            object_collection.reset()
+
+            is_global = False
+            if i % 2 == 0:
+                body_com_pos_w = object_collection.data.body_link_pos_w.torch[:, object_ids, :3]
+                external_wrench_positions_b[..., 0] = 0.0
+                external_wrench_positions_b[..., 1] = 1.0
+                external_wrench_positions_b[..., 2] = 0.0
+                external_wrench_positions_b += body_com_pos_w
+                is_global = True
+            else:
+                external_wrench_positions_b[..., 0] = 0.0
+                external_wrench_positions_b[..., 1] = 1.0
+                external_wrench_positions_b[..., 2] = 0.0
+
+            # apply force
+            object_collection.permanent_wrench_composer.set_forces_and_torques_index(
+                forces=external_wrench_b[..., :3],
+                torques=external_wrench_b[..., 3:],
+                positions=external_wrench_positions_b,
+                body_ids=object_ids,
+                env_ids=None,
+                is_global=is_global,
+            )
+            object_collection.permanent_wrench_composer.add_forces_and_torques_index(
+                forces=external_wrench_b[..., :3],
+                torques=external_wrench_b[..., 3:],
+                positions=external_wrench_positions_b,
+                body_ids=object_ids,
+                is_global=is_global,
+            )
+
+            for _ in range(10):
+                # write data to sim
+                object_collection.write_data_to_sim()
+                # step sim
+                sim.step()
+                # update object collection
+                object_collection.update(sim.cfg.dt)
+
+            # First object should be rotating around it's X axis
+            assert torch.all(object_collection.data.body_com_ang_vel_b.torch[:, 0::2, 0] > 0.1)
+            # Second object should have fallen, so it's Z height should be less than initial height of 1.0
+            assert torch.all(object_collection.data.body_link_pos_w.torch[:, 1::2, 2] < 1.0)
+
+
+@pytest.mark.parametrize("num_envs", [1, 3])
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("gravity_enabled", [False])
+@pytest.mark.isaacsim_ci
+def test_set_object_state(num_envs, num_cubes, device, gravity_enabled):
+    """Test setting the state of the object.
+
+    .. note::
+        Turn off gravity for this test as we don't want any external forces acting on the object
+        to ensure state remains static
+    """
+    with _ovphysx_sim_context(device=device, gravity_enabled=gravity_enabled, auto_add_lighting=True) as sim:
+        object_collection, origins = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
+        sim.reset()
+
+        state_types = ["body_link_pos_w", "body_link_quat_w", "body_com_lin_vel_w", "body_com_ang_vel_w"]
+
+        # Set each state type individually as they are dependent on each other
+        for state_type_to_randomize in state_types:
+            state_dict = {
+                "body_link_pos_w": torch.zeros_like(object_collection.data.body_link_pos_w.torch, device=sim.device),
+                "body_link_quat_w": default_orientation(num=num_cubes * num_envs, device=sim.device).view(
+                    num_envs, num_cubes, 4
+                ),
+                "body_com_lin_vel_w": torch.zeros_like(
+                    object_collection.data.body_com_lin_vel_w.torch, device=sim.device
+                ),
+                "body_com_ang_vel_w": torch.zeros_like(
+                    object_collection.data.body_com_ang_vel_w.torch, device=sim.device
+                ),
+            }
+
+            for _ in range(5):
+                # reset object
+                object_collection.reset()
+
+                # Set random state
+                if state_type_to_randomize == "body_link_quat_w":
+                    state_dict[state_type_to_randomize] = random_orientation(
+                        num=num_cubes * num_envs, device=sim.device
+                    ).view(num_envs, num_cubes, 4)
+                else:
+                    state_dict[state_type_to_randomize] = torch.randn(num_envs, num_cubes, 3, device=sim.device)
+                    # make sure objects do not overlap
+                    if state_type_to_randomize == "body_link_pos_w":
+                        state_dict[state_type_to_randomize][..., :2] += origins.unsqueeze(1)[..., :2]
+
+                # perform simulation
+                for _ in range(5):
+                    body_pose = torch.cat(
+                        [state_dict["body_link_pos_w"], state_dict["body_link_quat_w"]],
+                        dim=-1,
+                    )
+                    body_vel = torch.cat(
+                        [state_dict["body_com_lin_vel_w"], state_dict["body_com_ang_vel_w"]],
+                        dim=-1,
+                    )
+                    # reset object state
+                    object_collection.write_body_link_pose_to_sim_index(body_poses=body_pose)
+                    object_collection.write_body_com_velocity_to_sim_index(body_velocities=body_vel)
+                    sim.step()
+
+                    # assert that set object quantities are equal to the ones set in the state_dict
+                    for key, expected_value in state_dict.items():
+                        value = getattr(object_collection.data, key).torch
+                        torch.testing.assert_close(value, expected_value, rtol=1e-5, atol=1e-5)
+
+                    object_collection.update(sim.cfg.dt)
+
+
+@pytest.mark.parametrize("num_envs", [1, 4])
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("with_offset", [True, False])
+@pytest.mark.parametrize("gravity_enabled", [False])
+@pytest.mark.isaacsim_ci
+def test_object_state_properties(num_envs, num_cubes, device, with_offset, gravity_enabled):
+    """Test the object_com_state_w and object_link_state_w properties."""
+    with _ovphysx_sim_context(device=device, gravity_enabled=gravity_enabled, auto_add_lighting=True) as sim:
+        cube_object, env_pos = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, height=0.0, device=device)
+        env_ids = torch.tensor([x for x in range(num_envs)], dtype=torch.int32)
+
+        sim.reset()
+
+        # check if cube_object is initialized
+        assert cube_object.is_initialized
+
+        # change center of mass offset from link frame
+        offset = (
+            torch.tensor([0.1, 0.0, 0.0], device=device).repeat(num_envs, num_cubes, 1)
+            if with_offset
+            else torch.tensor([0.0, 0.0, 0.0], device=device).repeat(num_envs, num_cubes, 1)
+        )
+
+        # Read current COMs, mutate the translation, write back via the OVPhysX
+        # ``set_coms_index`` setter (PhysX uses ``root_view.set_coms`` + reshape helpers
+        # for the same operation; OVPhysX wraps the wheel RIGID_BODY_COM_POSE write in
+        # :meth:`set_coms_index`).
+        com = cube_object.data.body_com_pose_b.torch.clone()  # shape (num_envs, num_cubes, 7)
+        com[..., :3] = offset.to(com.device)
+        cube_object.set_coms_index(
+            coms=wp.from_torch(com.contiguous(), dtype=wp.transformf),
+            env_ids=wp.from_torch(env_ids, dtype=wp.int32),
+        )
+
+        # check center of mass has been set
+        torch.testing.assert_close(cube_object.data.body_com_pose_b.torch, com)
+
+        # random z spin velocity
+        spin_twist = torch.zeros(6, device=device)
+        spin_twist[5] = torch.randn(1, device=device)
+
+        # initial spawn point
+        init_com = cube_object.data.body_com_pose_w.torch[..., :3]
+
+        for i in range(10):
+            # spin the object around Z axis (com)
+            cube_object.write_body_com_velocity_to_sim_index(body_velocities=spin_twist.repeat(num_envs, num_cubes, 1))
+            sim.step()
+            cube_object.update(sim.cfg.dt)
+
+            # get state properties
+            object_link_pose_w = cube_object.data.body_link_pose_w.torch
+            object_link_vel_w = cube_object.data.body_link_vel_w.torch
+            object_com_pose_w = cube_object.data.body_com_pose_w.torch
+            object_com_vel_w = cube_object.data.body_com_vel_w.torch
+
+            # if offset is [0,0,0] all object_state_%_w will match and all body_%_w will match
+            if not with_offset:
+                torch.testing.assert_close(object_link_pose_w, object_com_pose_w)
+                torch.testing.assert_close(object_com_vel_w, object_link_vel_w)
+            else:
+                # cubes are spinning around center of mass
+                # position will not match
+                # center of mass position will be constant (i.e. spinning around com)
+                torch.testing.assert_close(init_com, object_com_pose_w[..., :3])
+
+                # link position will be moving but should stay constant away from center of mass
+                object_link_state_pos_rel_com = quat_apply_inverse(
+                    object_link_pose_w[..., 3:],
+                    object_link_pose_w[..., :3] - object_com_pose_w[..., :3],
+                )
+
+                torch.testing.assert_close(-offset, object_link_state_pos_rel_com)
+
+                # orientation of com will be a constant rotation from link orientation
+                com_quat_b = cube_object.data.body_com_quat_b.torch
+                com_quat_w = quat_mul(object_link_pose_w[..., 3:], com_quat_b)
+                torch.testing.assert_close(com_quat_w, object_com_pose_w[..., 3:])
+
+                # orientation of link will match object state will always match
+                torch.testing.assert_close(object_link_pose_w[..., 3:], object_link_pose_w[..., 3:])
+
+                # lin_vel will not match
+                # center of mass vel will be constant (i.e. spinning around com)
+                torch.testing.assert_close(
+                    torch.zeros_like(object_com_vel_w[..., :3]),
+                    object_com_vel_w[..., :3],
+                )
+
+                # link frame will be moving, and should be equal to input angular velocity cross offset
+                lin_vel_rel_object_gt = quat_apply_inverse(object_link_pose_w[..., 3:], object_link_vel_w[..., :3])
+                lin_vel_rel_gt = torch.linalg.cross(spin_twist.repeat(num_envs, num_cubes, 1)[..., 3:], -offset)
+                torch.testing.assert_close(lin_vel_rel_gt, lin_vel_rel_object_gt, atol=1e-4, rtol=1e-3)
+
+                # ang_vel will always match
+                torch.testing.assert_close(object_com_vel_w[..., 3:], object_com_vel_w[..., 3:])
+                torch.testing.assert_close(object_com_vel_w[..., 3:], object_link_vel_w[..., 3:])
+
+
+@pytest.mark.parametrize("num_envs", [1, 3])
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("with_offset", [True, False])
+@pytest.mark.parametrize("state_location", ["com", "link"])
+@pytest.mark.parametrize("gravity_enabled", [False])
+@pytest.mark.isaacsim_ci
+def test_write_object_state(num_envs, num_cubes, device, with_offset, state_location, gravity_enabled):
+    """Test the setters for object_state using both the link frame and center of mass as reference frame."""
+    with _ovphysx_sim_context(device=device, gravity_enabled=gravity_enabled, auto_add_lighting=True) as sim:
+        # Create a scene with random cubes
+        cube_object, env_pos = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, height=0.0, device=device)
+        env_ids = torch.tensor([x for x in range(num_envs)], dtype=torch.int32)
+        object_ids = torch.tensor([x for x in range(num_cubes)], dtype=torch.int32)
+
+        sim.reset()
+
+        # Check if cube_object is initialized
+        assert cube_object.is_initialized
+
+        # change center of mass offset from link frame
+        offset = (
+            torch.tensor([0.1, 0.0, 0.0], device=device).repeat(num_envs, num_cubes, 1)
+            if with_offset
+            else torch.tensor([0.0, 0.0, 0.0], device=device).repeat(num_envs, num_cubes, 1)
+        )
+
+        com = cube_object.data.body_com_pose_b.torch.clone()  # shape (num_envs, num_cubes, 7)
+        com[..., :3] = offset.to(com.device)
+        cube_object.set_coms_index(
+            coms=wp.from_torch(com.contiguous(), dtype=wp.transformf),
+            env_ids=wp.from_torch(env_ids, dtype=wp.int32),
+        )
+        # check center of mass has been set
+        torch.testing.assert_close(cube_object.data.body_com_pose_b.torch, com)
+
+        rand_state = torch.zeros(num_envs, num_cubes, 13, device=device)
+        rand_state[..., :7] = cube_object.data.default_body_pose.torch
+        rand_state[..., :3] += cube_object.data.body_link_pos_w.torch
+        # make quaternion a unit vector
+        rand_state[..., 3:7] = torch.nn.functional.normalize(rand_state[..., 3:7], dim=-1)
+
+        env_ids = env_ids.to(device)
+        object_ids = object_ids.to(device)
+        for i in range(10):
+            sim.step()
+            cube_object.update(sim.cfg.dt)
+
+            if state_location == "com":
+                if i % 2 == 0:
+                    cube_object.write_body_com_pose_to_sim_index(body_poses=rand_state[..., :7])
+                    cube_object.write_body_com_velocity_to_sim_index(body_velocities=rand_state[..., 7:])
+                else:
+                    cube_object.write_body_com_pose_to_sim_index(
+                        body_poses=rand_state[..., :7], env_ids=env_ids, body_ids=object_ids
+                    )
+                    cube_object.write_body_com_velocity_to_sim_index(
+                        body_velocities=rand_state[..., 7:], env_ids=env_ids, body_ids=object_ids
+                    )
+            elif state_location == "link":
+                if i % 2 == 0:
+                    cube_object.write_body_link_pose_to_sim_index(body_poses=rand_state[..., :7])
+                    cube_object.write_body_link_velocity_to_sim_index(body_velocities=rand_state[..., 7:])
+                else:
+                    cube_object.write_body_link_pose_to_sim_index(
+                        body_poses=rand_state[..., :7], env_ids=env_ids, body_ids=object_ids
+                    )
+                    cube_object.write_body_link_velocity_to_sim_index(
+                        body_velocities=rand_state[..., 7:], env_ids=env_ids, body_ids=object_ids
+                    )
+
+            if state_location == "com":
+                torch.testing.assert_close(rand_state[..., :7], cube_object.data.body_com_pose_w.torch)
+                torch.testing.assert_close(rand_state[..., 7:], cube_object.data.body_com_vel_w.torch)
+            elif state_location == "link":
+                torch.testing.assert_close(rand_state[..., :7], cube_object.data.body_link_pose_w.torch)
+                torch.testing.assert_close(rand_state[..., 7:], cube_object.data.body_link_vel_w.torch)
+
+
+@pytest.mark.parametrize("num_envs", [1, 3])
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.isaacsim_ci
+def test_reset_object_collection(num_envs, num_cubes, device):
+    """Test resetting the state of the rigid object."""
+    with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
+        object_collection, _ = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
+        sim.reset()
+
+        for i in range(5):
+            sim.step()
+            object_collection.update(sim.cfg.dt)
+
+            # Move the object to a random position
+            body_pose = object_collection.data.default_body_pose.torch.clone()
+            body_pose[..., :3] = torch.randn(num_envs, num_cubes, 3, device=sim.device)
+            # Random orientation
+            body_pose[..., 3:7] = random_orientation(num=num_cubes, device=sim.device)
+            object_collection.write_body_link_pose_to_sim_index(body_poses=body_pose)
+            body_vel = object_collection.data.default_body_vel.torch.clone()
+            object_collection.write_body_com_velocity_to_sim_index(body_velocities=body_vel)
+
+            if i % 2 == 0:
+                object_collection.reset()
+
+                # Reset should zero external forces and torques
+                assert not object_collection._instantaneous_wrench_composer.active
+                assert not object_collection._permanent_wrench_composer.active
+                assert torch.count_nonzero(object_collection._instantaneous_wrench_composer.composed_force.torch) == 0
+                assert torch.count_nonzero(object_collection._instantaneous_wrench_composer.composed_torque.torch) == 0
+                assert torch.count_nonzero(object_collection._permanent_wrench_composer.composed_force.torch) == 0
+                assert torch.count_nonzero(object_collection._permanent_wrench_composer.composed_torque.torch) == 0
+
+
+@pytest.mark.xfail(reason=_MATERIAL_GAP_REASON, strict=False)
+@pytest.mark.parametrize("num_envs", [1, 3])
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.isaacsim_ci
+def test_set_material_properties(num_envs, num_cubes, device):
+    """Test getting and setting material properties of rigid object."""
+    raise NotImplementedError(_MATERIAL_GAP_REASON)
+
+
+@pytest.mark.parametrize("num_envs", [1, 3])
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("gravity_enabled", [True, False])
+@pytest.mark.isaacsim_ci
+def test_gravity_vec_w(num_envs, num_cubes, device, gravity_enabled):
+    """Test that gravity vector direction is set correctly for the rigid object."""
+    with _ovphysx_sim_context(device=device, gravity_enabled=gravity_enabled, auto_add_lighting=True) as sim:
+        object_collection, _ = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
+
+        # Obtain gravity direction
+        gravity_dir = (0.0, 0.0, -1.0) if gravity_enabled else (0.0, 0.0, 0.0)
+
+        sim.reset()
+
+        # Check if gravity vector is set correctly
+        gravity_vec = object_collection.data.GRAVITY_VEC_W.torch
+        assert gravity_vec[0, 0, 0] == gravity_dir[0]
+        assert gravity_vec[0, 0, 1] == gravity_dir[1]
+        assert gravity_vec[0, 0, 2] == gravity_dir[2]
+
+        # Perform simulation
+        for _ in range(2):
+            sim.step()
+            object_collection.update(sim.cfg.dt)
+
+            # Expected gravity value is the acceleration of the body
+            gravity = torch.zeros(num_envs, num_cubes, 6, device=device)
+            if gravity_enabled:
+                gravity[..., 2] = -9.81
+
+            # Check the body accelerations are correct
+            torch.testing.assert_close(object_collection.data.body_com_acc_w.torch, gravity)
+
+
+@pytest.mark.parametrize("num_envs", [1, 3])
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("with_offset", [True])
+@pytest.mark.parametrize("state_location", ["com", "link", "root"])
+@pytest.mark.parametrize("gravity_enabled", [False])
+@pytest.mark.isaacsim_ci
+def test_write_object_state_functions_data_consistency(
+    num_envs, num_cubes, device, with_offset, state_location, gravity_enabled
+):
+    """Test the setters for object_state using both the link frame and center of mass as reference frame."""
+    with _ovphysx_sim_context(device=device, gravity_enabled=gravity_enabled, auto_add_lighting=True) as sim:
+        # Create a scene with random cubes
+        cube_object, env_pos = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, height=0.0, device=device)
+        env_ids = torch.tensor([x for x in range(num_envs)], dtype=torch.int32)
+        object_ids = torch.tensor([x for x in range(num_cubes)], dtype=torch.int32)
+
+        sim.reset()
+
+        # Check if cube_object is initialized
+        assert cube_object.is_initialized
+
+        # change center of mass offset from link frame
+        offset = (
+            torch.tensor([0.1, 0.0, 0.0], device=device).repeat(num_envs, num_cubes, 1)
+            if with_offset
+            else torch.tensor([0.0, 0.0, 0.0], device=device).repeat(num_envs, num_cubes, 1)
+        )
+
+        com = cube_object.data.body_com_pose_b.torch.clone()  # shape (num_envs, num_cubes, 7)
+        com[..., :3] = offset.to(com.device)
+        cube_object.set_coms_index(
+            coms=wp.from_torch(com.contiguous(), dtype=wp.transformf),
+            env_ids=wp.from_torch(env_ids, dtype=wp.int32),
+        )
+
+        # check center of mass has been set
+        torch.testing.assert_close(cube_object.data.body_com_pose_b.torch, com)
+
+        rand_state = torch.rand(num_envs, num_cubes, 13, device=device)
+        rand_state[..., :3] += cube_object.data.body_link_pos_w.torch
+        # make quaternion a unit vector
+        rand_state[..., 3:7] = torch.nn.functional.normalize(rand_state[..., 3:7], dim=-1)
+
+        env_ids = env_ids.to(device)
+        object_ids = object_ids.to(device)
+        sim.step()
+        cube_object.update(sim.cfg.dt)
+
+        body_link_pose_w = cube_object.data.body_link_pose_w.torch
+        body_com_pose_w = cube_object.data.body_com_pose_w.torch
+        object_link_to_com_pos, object_link_to_com_quat = subtract_frame_transforms(
+            body_link_pose_w[..., :3].view(-1, 3),
+            body_link_pose_w[..., 3:7].view(-1, 4),
+            body_com_pose_w[..., :3].view(-1, 3),
+            body_com_pose_w[..., 3:7].view(-1, 4),
+        )
+
+        if state_location == "com":
+            cube_object.write_body_com_pose_to_sim_index(
+                body_poses=rand_state[..., :7], env_ids=env_ids, body_ids=object_ids
+            )
+            cube_object.write_body_com_velocity_to_sim_index(
+                body_velocities=rand_state[..., 7:], env_ids=env_ids, body_ids=object_ids
+            )
+        elif state_location == "link":
+            cube_object.write_body_link_pose_to_sim_index(
+                body_poses=rand_state[..., :7], env_ids=env_ids, body_ids=object_ids
+            )
+            cube_object.write_body_link_velocity_to_sim_index(
+                body_velocities=rand_state[..., 7:], env_ids=env_ids, body_ids=object_ids
+            )
+        elif state_location == "root":
+            cube_object.write_body_link_pose_to_sim_index(
+                body_poses=rand_state[..., :7], env_ids=env_ids, body_ids=object_ids
+            )
+            cube_object.write_body_com_velocity_to_sim_index(
+                body_velocities=rand_state[..., 7:], env_ids=env_ids, body_ids=object_ids
+            )
+
+        if state_location == "com":
+            com_pose_w = cube_object.data.body_com_pose_w.torch
+            com_vel_w = cube_object.data.body_com_vel_w.torch
+            expected_root_link_pos, expected_root_link_quat = combine_frame_transforms(
+                com_pose_w[..., :3].view(-1, 3),
+                com_pose_w[..., 3:].view(-1, 4),
+                quat_rotate(quat_inv(object_link_to_com_quat), -object_link_to_com_pos),
+                quat_inv(object_link_to_com_quat),
+            )
+            expected_object_link_pose = torch.cat((expected_root_link_pos, expected_root_link_quat), dim=1).view(
+                num_envs, -1, 7
+            )
+            link_pose_w = cube_object.data.body_link_pose_w.torch
+            link_vel_w = cube_object.data.body_link_vel_w.torch
+            # test both root_pose and root_link successfully updated when root_com updates
+            torch.testing.assert_close(expected_object_link_pose, link_pose_w)
+            # skip lin_vel because it differs from link frame, this should be fine because we are only checking
+            # if velocity update is triggered, which can be determined by comparing angular velocity
+            torch.testing.assert_close(com_vel_w[..., 3:], link_vel_w[..., 3:])
+            torch.testing.assert_close(expected_object_link_pose, link_pose_w)
+            torch.testing.assert_close(com_vel_w[..., 3:], cube_object.data.body_com_vel_w.torch[..., 3:])
+        elif state_location == "link":
+            link_pose_w = cube_object.data.body_link_pose_w.torch
+            link_vel_w = cube_object.data.body_link_vel_w.torch
+            expected_com_pos, expected_com_quat = combine_frame_transforms(
+                link_pose_w[..., :3].view(-1, 3),
+                link_pose_w[..., 3:].view(-1, 4),
+                object_link_to_com_pos,
+                object_link_to_com_quat,
+            )
+            expected_object_com_pose = torch.cat((expected_com_pos, expected_com_quat), dim=1).view(num_envs, -1, 7)
+            com_pose_w = cube_object.data.body_com_pose_w.torch
+            com_vel_w = cube_object.data.body_com_vel_w.torch
+            # test both root_pose and root_com successfully updated when root_link updates
+            torch.testing.assert_close(expected_object_com_pose, com_pose_w)
+            # skip lin_vel because it differs from link frame, this should be fine because we are only checking
+            # if velocity update is triggered, which can be determined by comparing angular velocity
+            torch.testing.assert_close(link_vel_w[..., 3:], com_vel_w[..., 3:])
+            torch.testing.assert_close(link_pose_w, cube_object.data.body_link_pose_w.torch)
+            torch.testing.assert_close(link_vel_w[..., 3:], cube_object.data.body_com_vel_w.torch[..., 3:])
+        elif state_location == "root":
+            body_link_pose_w = cube_object.data.body_link_pose_w.torch
+            body_com_vel_w = cube_object.data.body_com_vel_w.torch
+            expected_object_com_pos, expected_object_com_quat = combine_frame_transforms(
+                body_link_pose_w[..., :3].view(-1, 3),
+                body_link_pose_w[..., 3:].view(-1, 4),
+                object_link_to_com_pos,
+                object_link_to_com_quat,
+            )
+            expected_object_com_pose = torch.cat((expected_object_com_pos, expected_object_com_quat), dim=1).view(
+                num_envs, -1, 7
+            )
+            com_pose_w = cube_object.data.body_com_pose_w.torch
+            com_vel_w = cube_object.data.body_com_vel_w.torch
+            link_pose_w = cube_object.data.body_link_pose_w.torch
+            link_vel_w = cube_object.data.body_link_vel_w.torch
+            # test both root_com and root_link successfully updated when root_pose updates
+            torch.testing.assert_close(expected_object_com_pose, com_pose_w)
+            torch.testing.assert_close(body_com_vel_w, com_vel_w)
+            torch.testing.assert_close(body_link_pose_w, link_pose_w)
+            torch.testing.assert_close(body_com_vel_w[..., 3:], link_vel_w[..., 3:])


### PR DESCRIPTION
# Description

Implements `RigidObjectCollection` and `RigidObjectCollectionData` for the OVPhysX backend, completing the rigid-body asset surface alongside `RigidObject` (#5426) and `Articulation` (#5459). The collection manages N distinct rigid bodies per environment with `(env, body)` dual indexing.

The asset creates **one native fused TensorBinding per tensor type** via the ovphysx 0.4.3 `create_tensor_binding(prim_paths=[glob_0, …, glob_{B-1}])` API, mirroring how PhysX's `RigidBodyView` aggregates multiple body prims into a single flat view. Each binding spans `num_instances * num_bodies` prims and returns body-major flat data `(body_0_env_0, body_0_env_1, …, body_1_env_0, …)`. The data class and asset writers use strided-view reshape helpers (`_reshape_view_to_data_2d/_3d` and `reshape_data_to_view_2d/_3d`, ported from the PhysX collection) to convert between body-major view layout and the instance-major `(N, B, D)` layout exposed to users — no Warp kernels added, no per-body Python fan-out at runtime.

Fixes #5317

**Stacked on:**
- #5459 — OVPhysX `Articulation`
- #5426 — OVPhysX `RigidObject`

**Carries a one-commit cherry-pick of #5545's `ovphysx_manager.py` portion** (required for ovphysx 0.4 `active_cuda_gpus` API). Drop the cherry-pick once #5545 lands.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

N/A — backend infrastructure, no visible behaviour change.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [pre-commit checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog (fragment file under `source/isaaclab_ovphysx/changelog.d/`)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Test plan

Tested in a Docker container built from `docker/Dockerfile.base` (IsaacSim `6.0.0-dev2`) with the ovphysx 0.4.3 wheel installed:

- `./scripts/run_ovphysx.sh -m pytest source/isaaclab/test/assets/test_rigid_object_collection_iface.py -k ovphysx` → **636 passed**
- `./scripts/run_ovphysx.sh -m pytest source/isaaclab_ovphysx/test/assets/test_rigid_object_collection.py` → **72 passed, 76 skipped (device-mode lock — a second invocation with `-k 'cpu'` covers CPU), 4 xfailed** (material-properties gap shared with `RigidObject` until the wheel exposes `RIGID_BODY_MATERIAL`)
- `./isaaclab.sh -f` → clean
