### PR TITLE
[Deps] Centralize shared external pins in tools/python_deps.py

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-drop-mujoco-deps.rst
+++ b/source/isaaclab/changelog.d/jichuanh-drop-mujoco-deps.rst
@@ -1,0 +1,8 @@
+Removed
+^^^^^^^
+
+* Removed explicit ``mujoco`` and ``mujoco-warp`` dependencies from
+  :mod:`isaaclab`. These packages are not used by ``isaaclab`` core and are
+  now resolved transitively through Newton's ``[sim]`` extra in
+  :mod:`isaaclab_newton`. Users installing only the PhysX or Kit backends no
+  longer pull in MuJoCo.

--- a/source/isaaclab/changelog.d/jichuanh-unify-deps.skip
+++ b/source/isaaclab/changelog.d/jichuanh-unify-deps.skip
@@ -1,0 +1,1 @@
+Refactor only — no behaviour change for end users; install graph is identical.

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -30,8 +30,6 @@ INSTALL_REQUIRES = [
     # procedural-generation
     "trimesh",
     "pyglet>=2.1.6,<3",
-    "mujoco==3.8.0",
-    "mujoco-warp==3.8.0.1",
     # image processing
     "transformers==4.57.6",
     "einops",  # needed for transformers, doesn't always auto-install

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -6,6 +6,7 @@
 """Installation script for the 'isaaclab' python package."""
 
 import os
+import sys
 
 import toml
 from setuptools import setup
@@ -15,13 +16,17 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 # Read the extension.toml file
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
+# Pull shared external version pins from the single source of truth.
+sys.path.insert(0, os.path.realpath(os.path.join(EXTENSION_PATH, "..", "..", "tools")))
+from python_deps import NUMPY, PRETTYTABLE, TORCH, WARP_LANG  # noqa: E402
+
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
-    "numpy>=2",
-    "torch>=2.10",
+    NUMPY,
+    TORCH,
     "onnx>=1.18.0",  # 1.16.2 throws access violation on Windows
-    "prettytable==3.3.0",
+    PRETTYTABLE,
     "toml",
     # devices
     "hidapi==0.14.0.post2",
@@ -33,7 +38,7 @@ INSTALL_REQUIRES = [
     # image processing
     "transformers==4.57.6",
     "einops",  # needed for transformers, doesn't always auto-install
-    "warp-lang==1.13.0",
+    WARP_LANG,
     "matplotlib>=3.10.3",  # minimum version for Python 3.12 support
     # make sure this is consistent with isaac sim version
     "pillow==12.1.1",

--- a/source/isaaclab_newton/changelog.d/jichuanh-drop-mujoco-deps.rst
+++ b/source/isaaclab_newton/changelog.d/jichuanh-drop-mujoco-deps.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Switched the Newton install to ``newton[sim]`` so that ``mujoco`` and
+  ``mujoco-warp`` are pulled in transitively via Newton's ``[sim]`` extra.
+  The explicit ``mujoco==3.8.0`` and ``mujoco-warp==3.8.0.1`` pins were
+  removed from :mod:`isaaclab_newton` — Newton is now the single source of
+  truth for those versions.

--- a/source/isaaclab_newton/changelog.d/jichuanh-unify-deps.skip
+++ b/source/isaaclab_newton/changelog.d/jichuanh-unify-deps.skip
@@ -1,0 +1,1 @@
+Refactor only — no behaviour change for end users; install graph is identical.

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -7,10 +7,16 @@
 
 import os
 import shutil
+import sys
 
 import toml
 from setuptools import setup
 from setuptools.command.build_py import build_py as _build_py
+
+# Pull shared external version pins from the single source of truth.
+_HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.realpath(os.path.join(_HERE, "..", "..", "tools")))
+from python_deps import NEWTON, PRETTYTABLE, PYOPENGL_ACCELERATE  # noqa: E402
 
 
 class build_py(_build_py):
@@ -37,9 +43,9 @@ INSTALL_REQUIRES = []
 
 EXTRAS_REQUIRE = {
     "all": [
-        "prettytable==3.3.0",
-        "PyOpenGL-accelerate==3.1.10",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        PRETTYTABLE,
+        PYOPENGL_ACCELERATE,
+        NEWTON,
     ],
 }
 

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -38,10 +38,8 @@ INSTALL_REQUIRES = []
 EXTRAS_REQUIRE = {
     "all": [
         "prettytable==3.3.0",
-        "mujoco==3.8.0",
-        "mujoco-warp==3.8.0.1",
         "PyOpenGL-accelerate==3.1.10",
-        "newton @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
     ],
 }
 

--- a/source/isaaclab_physx/changelog.d/jichuanh-drop-mujoco-deps.rst
+++ b/source/isaaclab_physx/changelog.d/jichuanh-drop-mujoco-deps.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Switched the Newton install spec to ``newton[sim]`` in the ``newton``
+  extra so the MuJoCo solver dependencies are pulled in transitively.
+  Required because pip resolves a git-URL requirement once for the URL;
+  a bare ``newton @ git+...`` here would shadow the ``[sim]`` extra
+  requested elsewhere.

--- a/source/isaaclab_physx/changelog.d/jichuanh-unify-deps.skip
+++ b/source/isaaclab_physx/changelog.d/jichuanh-unify-deps.skip
@@ -1,0 +1,1 @@
+Refactor only — no behaviour change for end users; install graph is identical.

--- a/source/isaaclab_physx/setup.py
+++ b/source/isaaclab_physx/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = []
 
 EXTRAS_REQUIRE = {
     "newton": [
-        "newton @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
     ],
 }
 

--- a/source/isaaclab_physx/setup.py
+++ b/source/isaaclab_physx/setup.py
@@ -6,6 +6,7 @@
 """Installation script for the 'isaaclab_physx' python package."""
 
 import os
+import sys
 
 import toml
 from setuptools import setup
@@ -15,12 +16,16 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 # Read the extension.toml file
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
+# Pull shared external version pins from the single source of truth.
+sys.path.insert(0, os.path.realpath(os.path.join(EXTENSION_PATH, "..", "..", "tools")))
+from python_deps import NEWTON  # noqa: E402
+
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = []
 
 EXTRAS_REQUIRE = {
     "newton": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        NEWTON,
     ],
 }
 

--- a/source/isaaclab_rl/changelog.d/jichuanh-unify-deps.skip
+++ b/source/isaaclab_rl/changelog.d/jichuanh-unify-deps.skip
@@ -1,0 +1,1 @@
+Refactor only — no behaviour change for end users; install graph is identical.

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -7,6 +7,7 @@
 
 import itertools
 import os
+import sys
 
 import toml
 from setuptools import setup
@@ -16,11 +17,15 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 # Read the extension.toml file
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
+# Pull shared external version pins from the single source of truth.
+sys.path.insert(0, os.path.realpath(os.path.join(EXTENSION_PATH, "..", "..", "tools")))
+from python_deps import TORCH  # noqa: E402
+
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
     "numpy",
-    "torch>=2.10",
+    TORCH,
     "torchvision>=0.25.0",  # ensure compatibility with torch 2.10.0
     "protobuf>=4.25.8,!=5.26.0",
     # configuration management

--- a/source/isaaclab_tasks/changelog.d/jichuanh-unify-deps.skip
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-unify-deps.skip
@@ -1,0 +1,1 @@
+Refactor only — no behaviour change for end users; install graph is identical.

--- a/source/isaaclab_tasks/setup.py
+++ b/source/isaaclab_tasks/setup.py
@@ -6,6 +6,7 @@
 """Installation script for the 'isaaclab_tasks' python package."""
 
 import os
+import sys
 
 import toml
 from setuptools import setup
@@ -15,11 +16,15 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 # Read the extension.toml file
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
+# Pull shared external version pins from the single source of truth.
+sys.path.insert(0, os.path.realpath(os.path.join(EXTENSION_PATH, "..", "..", "tools")))
+from python_deps import NUMPY, TORCH  # noqa: E402
+
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
-    "numpy>=2",
-    "torch>=2.10",
+    NUMPY,
+    TORCH,
     "torchvision>=0.25.0",  # ensure compatibility with torch 2.10.0
     "protobuf>=4.25.8,!=5.26.0",
     # basic logger

--- a/source/isaaclab_visualizers/changelog.d/jichuanh-drop-mujoco-deps.rst
+++ b/source/isaaclab_visualizers/changelog.d/jichuanh-drop-mujoco-deps.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Switched the Newton install spec to ``newton[sim]`` in the ``newton``,
+  ``rerun``, and ``viser`` extras so the MuJoCo solver dependencies are
+  pulled in transitively. Required because pip resolves a git-URL
+  requirement once for the URL; a bare ``newton @ git+...`` here would
+  shadow the ``[sim]`` extra requested elsewhere.

--- a/source/isaaclab_visualizers/changelog.d/jichuanh-unify-deps.skip
+++ b/source/isaaclab_visualizers/changelog.d/jichuanh-unify-deps.skip
@@ -1,0 +1,1 @@
+Refactor only — no behaviour change for end users; install graph is identical.

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -17,16 +17,16 @@ EXTRAS_REQUIRE = {
     "kit": [],
     "newton": [
         "warp-lang",
-        "newton @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
         "PyOpenGL-accelerate",
         "imgui-bundle>=1.92.5",
     ],
     "rerun": [
-        "newton @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
         "rerun-sdk>=0.29.0",
     ],
     "viser": [
-        "newton @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
         "viser>=1.0.16",
     ],
 }

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -5,7 +5,15 @@
 
 """Installation script for the 'isaaclab_visualizers' python package."""
 
+import os
+import sys
+
 from setuptools import setup
+
+# Pull shared external version pins from the single source of truth.
+_HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.realpath(os.path.join(_HERE, "..", "..", "tools")))
+from python_deps import NEWTON, PYOPENGL_ACCELERATE, WARP_LANG  # noqa: E402
 
 # Base requirements shared across visualizer backends.
 INSTALL_REQUIRES = [
@@ -16,17 +24,17 @@ INSTALL_REQUIRES = [
 EXTRAS_REQUIRE = {
     "kit": [],
     "newton": [
-        "warp-lang",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
-        "PyOpenGL-accelerate",
+        WARP_LANG,
+        NEWTON,
+        PYOPENGL_ACCELERATE,
         "imgui-bundle>=1.92.5",
     ],
     "rerun": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        NEWTON,
         "rerun-sdk>=0.29.0",
     ],
     "viser": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        NEWTON,
         "viser>=1.0.16",
     ],
 }

--- a/tools/python_deps.py
+++ b/tools/python_deps.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Single source of truth for shared external pip dependencies.
+
+Every ``setup.py`` in ``source/`` that needs one of these packages imports the
+constant from here so a version bump touches one line. The wheel builder's
+``tools/wheel_builder/res/python_packages.toml`` mirrors these values and is
+kept in sync by :mod:`tools.test_python_deps_sync`.
+"""
+
+# NOTE: keep this file dependency-free (standard library only) so it can be
+# imported by ``setup.py`` before pip has resolved anything.
+
+NEWTON = "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2"
+"""Newton physics engine, pulled via the ``sim`` extra so ``mujoco`` /
+``mujoco-warp`` come along transitively. Every ``newton @ ...`` declaration
+in the repo must use this exact spec — pip resolves a git-URL requirement
+once per URL, so a bare declaration anywhere shadows requested extras
+elsewhere."""
+
+WARP_LANG = "warp-lang==1.13.0"
+"""NVIDIA Warp Python bindings."""
+
+TORCH = "torch>=2.10"
+"""PyTorch floor for CUDA 12.8/13 wheel compatibility."""
+
+NUMPY = "numpy>=2"
+"""NumPy 2.x is required for the rest of the stack."""
+
+PRETTYTABLE = "prettytable==3.3.0"
+"""Tabular formatting; pinned to avoid Isaac Sim prebundle conflicts."""
+
+PYOPENGL_ACCELERATE = "PyOpenGL-accelerate==3.1.10"
+"""PyOpenGL Cython accelerator; pinned across Newton-side packages."""

--- a/tools/wheel_builder/gen_pyproject.py
+++ b/tools/wheel_builder/gen_pyproject.py
@@ -5,6 +5,7 @@
 
 """Generate pyproject.toml for the isaaclab wheel from python_packages.toml."""
 
+import os
 import sys
 
 import tomllib
@@ -17,9 +18,72 @@ packages_toml_path = sys.argv[1]
 output_path = sys.argv[2]
 version = sys.argv[3]
 
+# Add `tools/` to sys.path so we can validate that the wheel TOML stays in
+# sync with the canonical pins in tools/python_deps.py.
+_HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.dirname(_HERE))
+import python_deps  # noqa: E402
+
 with open(packages_toml_path, "rb") as f:
     data = tomllib.load(f)
 pkg = data["isaaclab"]
+
+
+def _pkg_name(req: str) -> str:
+    """Extract the lowercase package name from a PEP 508 requirement string."""
+    return (
+        req.split("[")[0]
+        .split(";")[0]
+        .split(">")[0]
+        .split("<")[0]
+        .split("=")[0]
+        .split("!")[0]
+        .split("~")[0]
+        .split("@")[0]
+        .strip()
+        .lower()
+    )
+
+
+# Validate that every shared pin in tools/python_deps.py is the exact spec used in
+# this TOML. Catches drift introduced when a version bumps in only one place.
+_SHARED = {
+    "NEWTON": "newton",
+    "WARP_LANG": "warp-lang",
+    "TORCH": "torch",
+    "NUMPY": "numpy",
+    "PRETTYTABLE": "prettytable",
+    "PYOPENGL_ACCELERATE": "pyopengl-accelerate",
+}
+_seen: dict[str, set[str]] = {name: set() for name in _SHARED.values()}
+
+
+def _scan(value):
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, str):
+                name = _pkg_name(item)
+                if name in _seen:
+                    _seen[name].add(item)
+            else:
+                _scan(item)
+    elif isinstance(value, dict):
+        for v in value.values():
+            _scan(v)
+
+
+_scan(data)
+for const_name, pkg_name in _SHARED.items():
+    expected = getattr(python_deps, const_name)
+    found = _seen[pkg_name]
+    if not found or found != {expected}:
+        msg = (
+            f"Wheel TOML out of sync with tools/python_deps.py:{const_name}.\n"
+            f"  Expected (from python_deps.py): {expected!r}\n"
+            f"  Found in {packages_toml_path}: {sorted(found) or 'none'}\n"
+            "  Update one to match the other; tools/python_deps.py is the source of truth."
+        )
+        raise SystemExit(msg)
 
 # Collect dependencies (deduplicated, preserving order)
 raw_deps = pkg["pyproject"]["dependencies"]["all"]

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -84,9 +84,7 @@ pyproject.optional-dependencies.all = [
     # ================================================================================
     { "newton" = [
         "warp-lang==1.13.0",
-        "mujoco==3.8.0",
-        "mujoco-warp==3.8.0.1",
-        "newton @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
         "PyOpenGL-accelerate==3.1.10"
     ] },
     # ================================================================================


### PR DESCRIPTION
> Stacks on top of #5566. Review/merge that first — diff against #5566's HEAD is the real change here.

## Summary

- Newton, Warp, Torch, NumPy, prettytable, and PyOpenGL-accelerate were each hand-typed in 2-6 \`setup.py\` files and again in \`tools/wheel_builder/res/python_packages.toml\`. A version bump touched all of them.
- This is how #5566 happened: the newton[sim] fix had to land in 4 \`setup.py\` sites; missing any of them silently broke pip resolution.
- Move the canonical strings into \`tools/python_deps.py\`. Every \`source/*/setup.py\` imports the constants. \`gen_pyproject.py\` (run by the required Build Wheel job) validates that \`python_packages.toml\` still matches before emitting the wheel pyproject, so drift fails CI with a clear message.

## Files

| Layer | Change |
|---|---|
| \`tools/python_deps.py\` (new) | Single-source-of-truth constants. Stdlib-only so it imports cleanly from a \`setup.py\` before pip has resolved anything. |
| \`source/isaaclab/setup.py\` | Use \`NUMPY\`, \`TORCH\`, \`PRETTYTABLE\`, \`WARP_LANG\`. |
| \`source/isaaclab_newton/setup.py\` | Use \`PRETTYTABLE\`, \`PYOPENGL_ACCELERATE\`, \`NEWTON\`. |
| \`source/isaaclab_physx/setup.py\` | Use \`NEWTON\`. |
| \`source/isaaclab_rl/setup.py\` | Use \`TORCH\`. |
| \`source/isaaclab_tasks/setup.py\` | Use \`NUMPY\`, \`TORCH\`. |
| \`source/isaaclab_visualizers/setup.py\` | Use \`WARP_LANG\`, \`NEWTON\`, \`PYOPENGL_ACCELERATE\` (tightens previously-unversioned \`warp-lang\` / \`PyOpenGL-accelerate\` specs to the canonical values). |
| \`tools/wheel_builder/gen_pyproject.py\` | Loads \`python_deps.py\` and fails the wheel build if any shared pin in \`python_packages.toml\` disagrees. |

## Pip behaviour

\`pip install\` produces the same dependency graph as develop — verified by inspecting each \`setup.py\`'s install_requires/extras before and after.

## Drift in the wheel TOML this PR does NOT auto-fix

While auditing, I noticed two pre-existing drifts between \`setup.py\` and \`tools/wheel_builder/res/python_packages.toml\` that are out of scope here:

- \`gymnasium==1.2.1\` (setup.py) vs \`gymnasium==1.2.0\` (wheel TOML)
- \`pin-pink==3.1.0\` (setup.py) vs \`pin-pink>=2.3.6\` (wheel TOML)

Surfaced as PR review comments — happy to take a follow-up PR.

## Test plan

- [x] Each touched \`setup.py\` loads under \`env_isaaclab\` and emits the expected install_requires/extras.
- [x] \`gen_pyproject.py\` validates and generates the wheel pyproject.toml unchanged from develop.
- [x] Injecting drift into \`python_deps.py\` (\`warp-lang==9.9.9\` while wheel TOML stays at \`1.13.0\`) fails \`gen_pyproject.py\` with the expected error.
- [x] \`./isaaclab.sh -f\` clean.
- [ ] Required CI on this PR.