### PR TITLE
Fix broken external links flagged by lychee

### DIFF
--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -403,8 +403,8 @@ configured in the environment's retargeting pipeline. Manus tracking data flows 
 API as headset-based optical hand tracking in Isaac Teleop, so the same retargeters and pipelines
 work with both input sources.
 
-For plugin configuration details, see the `Manus plugin documentation
-<https://github.com/NVIDIA/IsaacTeleop/blob/main/src/plugins/manus/README.md>`_.
+For plugin configuration details, see the
+`Isaac Teleop repository <https://github.com/NVIDIA/IsaacTeleop>`_.
 
 The recommended workflow:
 

--- a/docs/source/setup/ecosystem.rst
+++ b/docs/source/setup/ecosystem.rst
@@ -157,7 +157,7 @@ to Isaac Lab, please reach out to us.
 .. _DoorGym: https://github.com/PSVL/DoorGym/
 .. _ManiSkill: https://github.com/haosulab/ManiSkill
 .. _ThreeDWorld: https://www.threedworld.org/
-.. _RoboSuite: https://robosuite.ai/
+.. _RoboSuite: https://github.com/ARISE-Initiative/robosuite
 .. _MuJoCo: https://mujoco.org/
 .. _MuJoCo Playground: https://playground.mujoco.org/
 .. _MJX: https://mujoco.readthedocs.io/en/stable/mjx.html


### PR DESCRIPTION
## Summary
- ``docs/source/setup/ecosystem.rst``: ``https://robosuite.ai/`` now returns 404. Updated the RoboSuite reference link to the project's GitHub repo (``https://github.com/ARISE-Initiative/robosuite``).
- ``docs/source/how-to/cloudxr_teleoperation.rst``: ``https://github.com/NVIDIA/IsaacTeleop/blob/main/src/plugins/manus/README.md`` is gone (404). The IsaacTeleop repo root still resolves, so the Manus plugin reference now points there until the upstream doc is republished.

These were the two failures from the ``Documentation Links`` CI job; everything else lychee reported was a 301/302 redirect already in the accept list.

## Test plan
- [x] ``pre-commit run --files docs/source/how-to/cloudxr_teleoperation.rst docs/source/setup/ecosystem.rst`` — passes.
- [ ] Re-run ``Documentation Links`` on the PR — expect zero ``[ERROR]`` entries.