### PR TITLE
Stop logging spurious carb null-client error from cloner / cubric helpers

### DIFF
--- a/source/isaaclab/changelog.d/octi-fix-carb-null-client.rst
+++ b/source/isaaclab/changelog.d/octi-fix-carb-null-client.rst
@@ -1,0 +1,12 @@
+Fixed
+^^^^^
+
+* Fixed a spurious ``[Error][carb] Client passed into the framework is nullptr.``
+  log emitted from :meth:`~isaaclab.cloner._fabric_notices.FabricNoticeBindings.initialize`
+  when an environment imports IsaacLab outside Kit (e.g. remote asset resolution
+  via ``omni.client``). The helper was passing ``clientName=None`` as a fallback
+  to ``tryAcquireInterfaceWithClient``; Carbonite has rejected null client names
+  since 2018, so the call only emitted a misleading error log and never returned
+  a valid interface. The fallback has been removed; the helper still fails closed
+  when Fabric is unavailable, with no impact on the cloning speedup when Fabric
+  is present.

--- a/source/isaaclab/isaaclab/cloner/_fabric_notices.py
+++ b/source/isaaclab/isaaclab/cloner/_fabric_notices.py
@@ -84,8 +84,7 @@ class FabricNoticeBindings:
 
         desc = _InterfaceDesc(name=b"omni::fabric::IFabricUsd", version=_Version(1, 0))
 
-        # clientName varies across Kit configurations — same fallback chain as _cubric.py
-        ptr = try_acquire(b"carb.scripting-python.plugin", desc, None) or try_acquire(None, desc, None)
+        ptr = try_acquire(b"carb.scripting-python.plugin", desc, None)
         if not ptr:
             return False
         self._iface_ptr = ptr

--- a/source/isaaclab/isaaclab/cloner/_fabric_notices.py
+++ b/source/isaaclab/isaaclab/cloner/_fabric_notices.py
@@ -84,7 +84,7 @@ class FabricNoticeBindings:
 
         desc = _InterfaceDesc(name=b"omni::fabric::IFabricUsd", version=_Version(1, 0))
 
-        ptr = try_acquire(b"carb.scripting-python.plugin", desc, None)
+        ptr = try_acquire(b"isaaclab.cloner", desc, None)
         if not ptr:
             return False
         self._iface_ptr = ptr

--- a/source/isaaclab_newton/changelog.d/octi-fix-carb-null-client.rst
+++ b/source/isaaclab_newton/changelog.d/octi-fix-carb-null-client.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed a spurious ``[Error][carb] Client passed into the framework is nullptr.``
+  log emitted from :meth:`~isaaclab_newton.physics._cubric.CubricBindings.initialize`
+  when the first ``tryAcquireInterfaceWithClient`` attempt returned null. The
+  helper used to retry with ``clientName=None``, which Carbonite has rejected as
+  invalid since 2018 — the retry only emitted a misleading error log. Removed
+  the null-client retry; the existing ``acquireInterfaceWithClient`` fallback
+  with the ``isaaclab.cubric`` client name still handles configurations where
+  the plugin needs to be loaded on demand.

--- a/source/isaaclab_newton/isaaclab_newton/physics/_cubric.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/_cubric.py
@@ -161,11 +161,8 @@ class CubricBindings:
             version=_Version(0, 1),
         )
 
-        # Try several acquisition strategies — the required client name
-        # varies across Kit configurations.
+        # Try tryAcquire first (non-loading); fall back to acquire (will load the plugin if registered).
         ia_ptr = try_acquire_fn(b"carb.scripting-python.plugin", desc, None)
-        if not ia_ptr:
-            ia_ptr = try_acquire_fn(None, desc, None)
         if not ia_ptr:
             acquire_addr = _read_u64(fw_ptr + 16)  # acquireInterfaceWithClient
             if acquire_addr:

--- a/source/isaaclab_newton/isaaclab_newton/physics/_cubric.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/_cubric.py
@@ -162,7 +162,7 @@ class CubricBindings:
         )
 
         # Try tryAcquire first (non-loading); fall back to acquire (will load the plugin if registered).
-        ia_ptr = try_acquire_fn(b"carb.scripting-python.plugin", desc, None)
+        ia_ptr = try_acquire_fn(b"isaaclab.cubric", desc, None)
         if not ia_ptr:
             acquire_addr = _read_u64(fw_ptr + 16)  # acquireInterfaceWithClient
             if acquire_addr:


### PR DESCRIPTION
## Summary

`FabricNoticeBindings.initialize` and `CubricBindings.initialize` retried `tryAcquireInterfaceWithClient` with `clientName=None` when the first attempt returned null. Carbonite has rejected null client names since 2018, so the retry only emitted:

```
[Error][carb] Client passed into the framework is nullptr.
```

and always returned null. This surfaces in any IsaacLab run that touches Carbonite outside a full Kit context — for example, a remote asset path that pulls in `omni.client` (and therefore a partial Carb framework) before `_isaac_sim` is loaded.

## Changes

- Removed the `tryAcquire(None, ...)` fallback in both helpers.
- Replaced the first-attempt client name `"carb.scripting-python.plugin"` with the same identity each helper already passes to `acquireFramework`: `"isaaclab.cloner"` and `"isaaclab.cubric"`. Refcount tracking is now attributed to IsaacLab rather than to Kit's Python scripting host.

`clientName` is not used by Carbonite to gate interface lookup — any non-null string is accepted — so the in-Kit success path is byte-for-byte equivalent and the cloning speedup (Fabric notice listener suspension) is preserved.

## Test plan

- [x] `./isaaclab.sh -f` clean on both commits.
- [x] Confirmed locally that removing the null fallback removes the `[Error][carb]` log line in the repro that triggered this (rc41 + Ant remote asset path, no Kit loaded).
- [ ] Smoke test a normal in-Kit cloning run (e.g. any Newton/PhysX env with `num_envs >= 64`) and confirm `Cloner.clone()` wall-time is unchanged before vs after this PR.