### PR TITLE
[Scene] Deprecate InteractiveSceneCfg.clone_in_fabric

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-deprecate-clone-in-fabric.rst
+++ b/source/isaaclab/changelog.d/jichuanh-deprecate-clone-in-fabric.rst
@@ -1,0 +1,9 @@
+Deprecated
+^^^^^^^^^^
+
+* Deprecated :attr:`~isaaclab.scene.InteractiveSceneCfg.clone_in_fabric`.
+  The field is currently a no-op — no physics backend (PhysX, Newton,
+  OmniPhysX) reads its value, so setting it to ``True`` has no effect.
+  Setting the field to ``True`` now raises a :class:`DeprecationWarning`.
+  Remove the kwarg from your :class:`~isaaclab.scene.InteractiveSceneCfg`
+  constructor; the field will be removed in a future release.

--- a/source/isaaclab/isaaclab/scene/interactive_scene_cfg.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
 from dataclasses import MISSING
 
 from isaaclab.utils.configclass import configclass
@@ -114,13 +115,21 @@ class InteractiveSceneCfg:
     clone_in_fabric: bool = False
     """Enable/disable cloning in fabric. Default is False.
 
-    Omniverse Fabric is a more optimized method for performing cloning in scene creation. This reduces the time
-    taken to create the scene. However, it limits flexibility in accessing the stage through USD APIs and instead,
-    the stage must be accessed through USDRT.
-
-    .. note::
-        Cloning in fabric can only be enabled if :attr:`replicated_physics` is also enabled.
-        If :attr:`replicated_physics` is ``False``, cloning in Fabric will automatically
-        default to ``False``.
-
+    .. deprecated:: 4.6.23
+        This field is a no-op: no physics backend (PhysX, Newton, OmniPhysX) reads it.
+        Remove the kwarg from your :class:`InteractiveSceneCfg` constructor.
+        The field will be removed in a future release.
     """
+
+    def __post_init__(self):
+        """Warn when the deprecated :attr:`clone_in_fabric` is set to a non-default value."""
+        # Only warn on explicit non-default (True) — silent False matches the default.
+        if self.clone_in_fabric:
+            warnings.warn(
+                "InteractiveSceneCfg.clone_in_fabric is deprecated and will be removed in a future release."
+                " The field is a no-op (no physics backend reads it); remove the kwarg.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # Reset so callers that copy this cfg (e.g. via configclass.replace) don't re-warn.
+            self.clone_in_fabric = False


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/isaac-sim/IsaacLab/pull/5437 addressing @ooctipus's comment: https://github.com/isaac-sim/IsaacLab/pull/5437#discussion_r3222181657

`InteractiveSceneCfg.clone_in_fabric` is dead. The field is declared on `InteractiveSceneCfg`, passed through to `TemplateCloneCfg` at scene init, and **never read by any physics backend** — verified by grepping every `*_physx`, `*_newton`, `*_ovphysx`, `*_ov` package: zero hits. Setting `clone_in_fabric=True` today has no effect on cloning.

This PR deprecates the field per `AGENTS.md`'s breaking-change rule (deprecate first, remove in a later release).

## Behavior

- Field type, default, and existing callers are unchanged.
- Setting `clone_in_fabric=True` now emits a `DeprecationWarning` from `__post_init__` and the field is reset to `False` before scene init proceeds (so re-runs via `configclass.replace` don't double-warn).
- Setting `clone_in_fabric=False` (the default) is silent — matches the previous behavior.

## Out of scope (for later cleanup)

- Removal of the field itself (deprecation period must elapse).
- Cleanup of the ~14 `isaaclab_tasks` env-cfg sites that currently set `clone_in_fabric=True` (they're no-ops today; will trigger the new warning until the field is removed).
- `TemplateCloneCfg.clone_in_fabric` (internal-only; downstream of `InteractiveSceneCfg`).

## Test plan

- [ ] Existing `test_simulation_stage_in_memory.py` / `test_environments_with_stage_in_memory.py` continue to pass.
- [ ] Manual smoke: construct an env with `clone_in_fabric=True` and confirm the DeprecationWarning fires.