### PR TITLE
Fix newton contact sensor crash with scalar sensing_obj_type

### DIFF
--- a/source/isaaclab_newton/changelog.d/fix-newton-contact-sensor-scalar-type.rst
+++ b/source/isaaclab_newton/changelog.d/fix-newton-contact-sensor-scalar-type.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_newton.sensors.ContactSensor` crash when ``sensing_obj_type`` or
+  ``counterpart_type`` is a scalar ``Literal["body", "shape"]`` string (Newton >= 1.2) instead
+  of a per-row enum array. The sensor name resolution now correctly broadcasts the scalar type
+  across all sensing/counterpart indices.

--- a/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor.py
@@ -347,11 +347,12 @@ class ContactSensor(BaseContactSensor):
         shape_labels = self._get_model_labels("shape")
 
         def get_name(idx, kind):
-            kind_name = getattr(kind, "name", None)
-            kind_value = getattr(kind, "value", kind)
-            if kind_name == "BODY" or kind_value == 2:
+            # Handle both legacy enum ObjectType and new scalar Literal["body", "shape"] from Newton >= 1.2
+            kind_str = kind if isinstance(kind, str) else getattr(kind, "name", None)
+            kind_value = getattr(kind, "value", kind) if not isinstance(kind, str) else kind
+            if kind_str in ("body", "BODY") or kind_value == 2:
                 return body_labels[int(idx)].split("/")[-1]
-            if kind_name == "SHAPE" or kind_value == 1:
+            if kind_str in ("shape", "SHAPE") or kind_value == 1:
                 return shape_labels[int(idx)].split("/")[-1]
             return "MATCH_ANY"
 
@@ -367,21 +368,30 @@ class ContactSensor(BaseContactSensor):
                 ]
             return flat_values
 
-        flat_sensing = list(
-            zip(
-                flatten_metadata(self.contact_view.sensing_obj_idx),
-                flatten_metadata(self.contact_view.sensing_obj_type),
-            )
-        )
+        sensing_indices = flatten_metadata(self.contact_view.sensing_obj_idx)
+        sensing_type = self.contact_view.sensing_obj_type
+        # Newton >= 1.2: sensing_obj_type is a scalar Literal["body", "shape"];
+        # broadcast it to match the length of sensing_obj_idx.
+        if isinstance(sensing_type, str):
+            flat_sensing = [(idx, sensing_type) for idx in sensing_indices]
+        else:
+            flat_sensing = list(zip(sensing_indices, flatten_metadata(sensing_type)))
         self._sensor_names = [get_name(idx, kind) for idx, kind in flat_sensing]
         # Assumes the environments are processed in order.
         self._sensor_names = self._sensor_names[: self._num_sensors]
-        flat_counterparts = list(
-            zip(
-                flatten_metadata(self.contact_view.counterpart_indices),
-                flatten_metadata(self.contact_view.counterpart_type),
-            )
-        )
+        counterpart_type = self.contact_view.counterpart_type
+        # Newton >= 1.2: counterpart_type is a scalar Literal["body", "shape"] | None;
+        # broadcast it to match the length of counterpart_indices.
+        # Guard against None before accessing counterpart_indices to avoid
+        # flatten_metadata(None) producing a spurious [None] list.
+        if counterpart_type is None:
+            flat_counterparts = []
+        else:
+            counterpart_indices_flat = flatten_metadata(self.contact_view.counterpart_indices)
+            if isinstance(counterpart_type, str):
+                flat_counterparts = [(idx, counterpart_type) for idx in counterpart_indices_flat]
+            else:
+                flat_counterparts = list(zip(counterpart_indices_flat, flatten_metadata(counterpart_type)))
         self._filter_object_names = [get_name(idx, kind) for idx, kind in flat_counterparts]
 
         force_matrix = self.contact_view.force_matrix


### PR DESCRIPTION
# Description

Fixes a crash in `ContactSensor._create_buffers()` when using Newton >= 1.2, which changed
`SensorContact.sensing_obj_type` and `counterpart_type` from per-row enum arrays to scalar
`Literal["body", "shape"]` strings.

The crash manifests as:
```
ValueError: Not all regular expressions are matched!
    base: []
Available strings: ('MATCH_ANY',)
```

**Root cause (two bugs):**
1. `zip(sensing_obj_idx, sensing_obj_type)` produced only 1 pair when `sensing_obj_type` was a scalar string instead of N pairs
2. `get_name()` only matched legacy enum attributes (`.name == "BODY"`, `.value == 2`), not plain `"body"`/`"shape"` strings

**Fix:**
- Detect scalar string types via `isinstance(kind, str)` and broadcast across all indices
- Update `get_name()` to handle both string and enum type descriptors
- Guard `counterpart_type is None` before accessing `counterpart_indices`
- Legacy enum code path preserved in `else` branches for backward compatibility

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Test Results

Tested with Newton 1.2.0rc2 on an NVIDIA L40 GPU:

| Task | Contact Sensor | Counterpart Filter | Result |
|------|---------------|-------------------|--------|
| `Isaac-Velocity-Flat-Unitree-Go2-v0` (`presets=newton_mjwarp`) | body sensing | No | ✅ Pass (was crashing) |
| `Isaac-Velocity-Flat-G1-v0` (`presets=newton_mjwarp`) | body sensing | No | ✅ Pass (was crashing) |
| `Isaac-Dexsuite-Kuka-Allegro-Lift-v0` (`presets=newton_mjwarp`) | body sensing | Yes (`Object`) | ✅ Pass |
| `Isaac-Cartpole-Camera-Presets-Direct-v0` (`presets=newton_mjwarp,newton_renderer,rgb`) | None | No | ✅ Pass (regression check) |

Additionally verified with 16 unit tests covering string `"body"`/`"shape"`, legacy enum `BODY`/`SHAPE`, `None` counterpart type, and scalar broadcasting logic.