### PR TITLE
[OVPHYSX] SceneDataProvider

### DIFF
--- a/source/isaaclab_ovphysx/changelog.d/antoiner-feat-ovphysx-scene-data-backend.minor.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-feat-ovphysx-scene-data-backend.minor.rst
@@ -1,0 +1,16 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab_ovphysx.physics.OvPhysxSceneDataBackend` and
+  :meth:`~isaaclab_ovphysx.physics.OvPhysxManager.get_scene_data_backend`
+  so the central
+  :class:`~isaaclab.scene.scene_data_provider.SceneDataProvider`
+  (introduced in #5128) can expose OVPhysX rigid-body transforms to
+  Rerun, Viser, and the native Newton viewport. The backend creates one
+  ovphysx ``TT.RIGID_BODY_POSE`` binding per distinct env-wildcard
+  rigid-body prim path (cartpole produces 2 bindings, Allegro hand ~17,
+  each covering all envs), reads each binding into a pre-allocated
+  ``wp.float32`` staging buffer via ``TensorBinding.read(dst)``, and
+  concatenates the per-binding reads into a single ``wp.transformf``
+  merged buffer that the central provider consumes as
+  :class:`~isaaclab.physics.scene_data_backend.SceneDataFormat.Transform`.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -258,6 +258,14 @@ class OvPhysxManager(PhysicsManager):
         cls._usd_handle = None
         cls._stage_path = None
         cls._pending_clones = []
+        # Construct the SceneDataBackend eagerly so :class:`SimulationContext`
+        # captures a real instance (not ``None``) when it builds the central
+        # :class:`~isaaclab.scene.scene_data_provider.SceneDataProvider` in
+        # its own ``__init__``. Bindings stay empty until :meth:`_warmup_and_load`
+        # calls :meth:`OvPhysxSceneDataBackend.setup`, at which point the wheel
+        # and the USD stage are live. Matches PhysX's pattern of constructing
+        # the backend during ``initialize()``.
+        cls._scene_data_backend = OvPhysxSceneDataBackend()
 
     @classmethod
     def reset(cls, soft: bool = False) -> None:
@@ -299,6 +307,11 @@ class OvPhysxManager(PhysicsManager):
         cls._usd_handle = None
         cls._stage_path = None
         cls._warmup_done = False
+        # Drop the SceneDataBackend singleton: its cached ``TensorBinding`` handles
+        # point into the wheel's prior scene which we just ``physx.reset()``-ed.
+        # The next :class:`SimulationContext` re-creates the backend in
+        # :meth:`initialize`. Matches Newton's lifecycle.
+        cls._scene_data_backend = None
 
         if cls._tmp_dir is not None:
             cls._tmp_dir.cleanup()
@@ -339,10 +352,13 @@ class OvPhysxManager(PhysicsManager):
     def get_scene_data_backend(cls) -> SceneDataBackend:
         """Return the SceneDataBackend for the central SceneDataProvider.
 
-        Returns ``None`` before :meth:`_warmup_and_load` has run; afterwards
-        returns the singleton :class:`OvPhysxSceneDataBackend` initialized
-        against the ovphysx wheel's ``PhysX`` instance and the exported USD
-        stage.
+        Constructed eagerly in :meth:`initialize` so :class:`SimulationContext`
+        captures a real instance (not ``None``) when wiring up the central
+        :class:`~isaaclab.scene.scene_data_provider.SceneDataProvider`. Bindings
+        are empty until :meth:`_warmup_and_load` calls
+        :meth:`OvPhysxSceneDataBackend.setup` against the live ovphysx ``PhysX``
+        and USD stage; reads against an unsetup backend return empty data
+        rather than raising.
         """
         return cls._scene_data_backend
 

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -16,19 +16,168 @@ import atexit
 import inspect
 import logging
 import os
+import re
 import tempfile
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from isaaclab.physics import PhysicsEvent, PhysicsManager
+import warp as wp
+
+from pxr import UsdPhysics
+
+from isaaclab.physics import PhysicsEvent, PhysicsManager, SceneDataBackend, SceneDataFormat
 
 if TYPE_CHECKING:
     from isaaclab.sim.simulation_context import SimulationContext
 
     from .ovphysx_manager_cfg import OvPhysxCfg
 
-__all__ = ["OvPhysxManager"]
+__all__ = ["OvPhysxManager", "OvPhysxSceneDataBackend"]
 
 logger = logging.getLogger(__name__)
+
+
+class OvPhysxSceneDataBackend(SceneDataBackend):
+    """Scene-data backend for the OVPhysX physics manager.
+
+    Mirrors :class:`~isaaclab_physx.physics.PhysxSceneDataBackend`'s contract
+    but adapts to the ovphysx wheel's one-pattern-per-binding API: each
+    distinct env-wildcard rigid-body prim path produces its own
+    ``TT.RIGID_BODY_POSE`` binding. ``transforms`` reads each binding into
+    its pre-allocated float32 staging buffer and concatenates them into a
+    single ``wp.transformf`` array.
+
+    The merged-buffer + staging-buffer separation is required because the
+    wheel's ``TensorBinding.read(dst)`` writes into ``dst`` only when
+    ``dst.shape == binding.shape``, so we cannot read directly into a slice
+    of the merged buffer.
+    """
+
+    def __init__(self):
+        self._physx = None
+        self._rigid_bindings: list[dict[str, object]] = []
+        self._merged_transforms: wp.array | None = None
+        self._scene_data = SceneDataFormat.Transform()
+        self._device: str = "cpu"
+
+    @property
+    def transform_count(self) -> int:
+        """Sum of per-binding row counts."""
+        return sum(int(entry["row_count"]) for entry in self._rigid_bindings)
+
+    @property
+    def transform_paths(self) -> list[str]:
+        """Concatenated ``prim_paths`` across all bindings, in registration order."""
+        paths: list[str] = []
+        for entry in self._rigid_bindings:
+            paths.extend(list(entry["pose"].prim_paths))
+        return paths
+
+    def setup(self, physx, stage) -> None:
+        """Discover RigidBodyAPI prims, dedup by env-wildcard form, create one binding per pattern.
+
+        Args:
+            physx: Live ``ovphysx.PhysX`` instance (the wheel handle).
+            stage: USD stage to traverse for RigidBodyAPI prims.
+        """
+        from isaaclab_ovphysx import tensor_types as TT  # local: keep heavy ovphysx out of module load
+
+        self._physx = physx
+        self._rigid_bindings = []
+        self._merged_transforms = None
+
+        if stage is None:
+            return
+
+        # Discover RigidBodyAPI prims, dedup by env-wildcard form.
+        patterns: set[str] = set()
+        for prim in stage.Traverse():
+            if prim.HasAPI(UsdPhysics.RigidBodyAPI):
+                patterns.add(re.sub(r"/World/envs/env_\d+", "/World/envs/env_*", prim.GetPath().pathString))
+
+        if not patterns:
+            return
+
+        # One pose binding per distinct pattern.
+        total_count = 0
+        for pattern in sorted(patterns):
+            try:
+                pose_binding = physx.create_tensor_binding(pattern=pattern, tensor_type=TT.RIGID_BODY_POSE)
+            except Exception as exc:
+                logger.warning(
+                    "[OvPhysxSceneDataBackend] Failed to create RIGID_BODY_POSE binding for %s: %s",
+                    pattern,
+                    exc,
+                )
+                continue
+            row_count = int(pose_binding.shape[0])
+            if row_count == 0:
+                logger.debug(
+                    "[OvPhysxSceneDataBackend] Pattern %s matched 0 rigid bodies; skipping.",
+                    pattern,
+                )
+                continue
+            self._rigid_bindings.append(
+                {
+                    "pattern": pattern,
+                    "pose": pose_binding,
+                    "pose_buf": wp.zeros(pose_binding.shape, dtype=wp.float32, device=self._device),
+                    "row_offset": total_count,
+                    "row_count": row_count,
+                }
+            )
+            total_count += row_count
+
+        if total_count > 0:
+            self._merged_transforms = wp.zeros((total_count,), dtype=wp.transformf, device=self._device)
+
+    @property
+    def transforms(self) -> SceneDataFormat.Transform:
+        """Read all bindings into the merged buffer; return as ``SceneDataFormat.Transform``.
+
+        Each binding's float32 ``(N, 7)`` read buffer is reinterpreted as ``(N,)`` of
+        ``wp.transformf`` (zero-copy via ``wp.array(ptr=..., dtype=wp.transformf)``)
+        and copied into the merged buffer at the binding's ``row_offset``.
+
+        Returns:
+            ``SceneDataFormat.Transform`` with ``transforms`` set to the merged
+            ``wp.array(dtype=wp.transformf)``. ``transforms`` is ``None`` when no
+            bindings are wired.
+        """
+        if self._merged_transforms is None or not self._rigid_bindings:
+            self._scene_data.transforms = self._merged_transforms
+            return self._scene_data
+
+        for entry in self._rigid_bindings:
+            buf: wp.array = entry["pose_buf"]
+            try:
+                entry["pose"].read(buf)
+            except Exception as exc:
+                logger.warning(
+                    "[OvPhysxSceneDataBackend] RIGID_BODY_POSE read failed for %s: %s",
+                    entry["pattern"],
+                    exc,
+                )
+                continue
+            # Reinterpret the (N, 7) float32 buffer as (N,) wp.transformf without a copy.
+            n = int(entry["row_count"])
+            transformf_view = wp.array(
+                ptr=buf.ptr,
+                shape=(n,),
+                dtype=wp.transformf,
+                device=str(buf.device),
+                copy=False,
+            )
+            offset = int(entry["row_offset"])
+            wp.copy(
+                self._merged_transforms,
+                transformf_view,
+                dest_offset=offset,
+                src_offset=0,
+                count=n,
+            )
+
+        self._scene_data.transforms = self._merged_transforms
+        return self._scene_data
 
 
 class OvPhysxManager(PhysicsManager):
@@ -59,6 +208,7 @@ class OvPhysxManager(PhysicsManager):
     # parent_positions is a list of (x, y, z) tuples — one per target.
     _pending_clones: ClassVar[list[tuple[str, list[str], list[tuple[float, float, float]]]]] = []
     _atexit_registered: ClassVar[bool] = False
+    _scene_data_backend: ClassVar[OvPhysxSceneDataBackend | None] = None
 
     @classmethod
     def get_dt(cls) -> float:
@@ -185,6 +335,17 @@ class OvPhysxManager(PhysicsManager):
         """Return the underlying ovphysx.PhysX instance (or None if not yet created)."""
         return cls._physx
 
+    @classmethod
+    def get_scene_data_backend(cls) -> SceneDataBackend:
+        """Return the SceneDataBackend for the central SceneDataProvider.
+
+        Returns ``None`` before :meth:`_warmup_and_load` has run; afterwards
+        returns the singleton :class:`OvPhysxSceneDataBackend` initialized
+        against the ovphysx wheel's ``PhysX`` instance and the exported USD
+        stage.
+        """
+        return cls._scene_data_backend
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -285,6 +446,15 @@ class OvPhysxManager(PhysicsManager):
         # instance carries its old buffer layout from the previous stage.
         if ovphysx_device == "gpu":
             cls._physx.warmup_gpu()
+
+        # Initialize the SceneDataBackend now that the wheel's PhysX is live and
+        # the USD is loaded. The central
+        # ``isaaclab.scene.scene_data_provider.SceneDataProvider`` consumes this
+        # via :meth:`get_scene_data_backend`.
+        if cls._scene_data_backend is None:
+            cls._scene_data_backend = OvPhysxSceneDataBackend()
+        cls._scene_data_backend._device = PhysicsManager._device
+        cls._scene_data_backend.setup(cls._physx, sim.stage)
 
         cls.dispatch_event(PhysicsEvent.MODEL_INIT, payload={})
         cls._warmup_done = True

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -54,7 +54,14 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
 
     def __init__(self):
         self._physx = None
-        self._rigid_bindings: list[dict[str, object]] = []
+        # Each entry: ``{"pattern": str, "pose": TensorBinding,
+        # "pose_buf": wp.array (float32, (N, 7)),
+        # "pose_buf_transformf": wp.array (transformf, (N,)),
+        # "row_offset": int, "row_count": int}``.
+        # The ``pose_buf_transformf`` view aliases ``pose_buf`` via zero-copy
+        # ``wp.array(ptr=...)``; cached at setup time so per-step reads in
+        # :attr:`transforms` don't churn Python allocations.
+        self._rigid_bindings: list[dict[str, Any]] = []
         self._merged_transforms: wp.array | None = None
         self._scene_data = SceneDataFormat.Transform()
         self._device: str = "cpu"
@@ -116,11 +123,23 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
                     pattern,
                 )
                 continue
+            pose_buf = wp.zeros(pose_binding.shape, dtype=wp.float32, device=self._device)
+            # Zero-copy reinterpret of the (N, 7) float32 staging buffer as (N,) wp.transformf.
+            # Same pointer + layout; transformf is 7 float32s (pos.xyz + quat.xyzw). Cached
+            # so per-step ``transforms`` reads don't reallocate the view object.
+            pose_buf_transformf = wp.array(
+                ptr=pose_buf.ptr,
+                shape=(row_count,),
+                dtype=wp.transformf,
+                device=str(pose_buf.device),
+                copy=False,
+            )
             self._rigid_bindings.append(
                 {
                     "pattern": pattern,
                     "pose": pose_binding,
-                    "pose_buf": wp.zeros(pose_binding.shape, dtype=wp.float32, device=self._device),
+                    "pose_buf": pose_buf,
+                    "pose_buf_transformf": pose_buf_transformf,
                     "row_offset": total_count,
                     "row_count": row_count,
                 }
@@ -135,12 +154,15 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
         """Read all bindings into the merged buffer; return as ``SceneDataFormat.Transform``.
 
         Each binding's float32 ``(N, 7)`` read buffer is reinterpreted as ``(N,)`` of
-        ``wp.transformf`` (zero-copy via ``wp.array(ptr=..., dtype=wp.transformf)``)
-        and copied into the merged buffer at the binding's ``row_offset``.
+        ``wp.transformf`` (zero-copy via ``wp.array(ptr=..., dtype=wp.transformf)``,
+        cached on the entry at setup time) and copied into the merged buffer at the
+        binding's ``row_offset``.
 
         Returns:
-            ``SceneDataFormat.Transform`` with ``transforms`` set to the merged
-            ``wp.array(dtype=wp.transformf)``. ``transforms`` is ``None`` when no
+            ``SceneDataFormat.Transform`` whose ``transforms`` field is a
+            ``wp.array(dtype=wp.transformf)`` of length :attr:`transform_count`.
+            Each ``wp.transformf`` row carries position [m] followed by
+            quaternion (xyzw, unit). ``transforms`` is ``None`` when no
             bindings are wired.
         """
         if self._merged_transforms is None or not self._rigid_bindings:
@@ -148,9 +170,8 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
             return self._scene_data
 
         for entry in self._rigid_bindings:
-            buf: wp.array = entry["pose_buf"]
             try:
-                entry["pose"].read(buf)
+                entry["pose"].read(entry["pose_buf"])
             except Exception as exc:
                 logger.warning(
                     "[OvPhysxSceneDataBackend] RIGID_BODY_POSE read failed for %s: %s",
@@ -158,22 +179,12 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
                     exc,
                 )
                 continue
-            # Reinterpret the (N, 7) float32 buffer as (N,) wp.transformf without a copy.
-            n = int(entry["row_count"])
-            transformf_view = wp.array(
-                ptr=buf.ptr,
-                shape=(n,),
-                dtype=wp.transformf,
-                device=str(buf.device),
-                copy=False,
-            )
-            offset = int(entry["row_offset"])
             wp.copy(
                 self._merged_transforms,
-                transformf_view,
-                dest_offset=offset,
+                entry["pose_buf_transformf"],
+                dest_offset=int(entry["row_offset"]),
                 src_offset=0,
-                count=n,
+                count=int(entry["row_count"]),
             )
 
         self._scene_data.transforms = self._merged_transforms

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -39,17 +39,25 @@ logger = logging.getLogger(__name__)
 class OvPhysxSceneDataBackend(SceneDataBackend):
     """Scene-data backend for the OVPhysX physics manager.
 
-    Mirrors :class:`~isaaclab_physx.physics.PhysxSceneDataBackend`'s contract
-    but adapts to the ovphysx wheel's one-pattern-per-binding API: each
-    distinct env-wildcard rigid-body prim path produces its own
-    ``TT.RIGID_BODY_POSE`` binding. ``transforms`` reads each binding into
-    its pre-allocated float32 staging buffer and concatenates them into a
-    single ``wp.transformf`` array.
+    Mirrors the contract of ``PhysxSceneDataBackend`` but adapts to the
+    ovphysx wheel's one-pattern-per-binding API: each distinct env-wildcard
+    rigid-body prim path produces its own ``TT.RIGID_BODY_POSE`` binding.
+    :attr:`transforms` reads each binding into its pre-allocated float32
+    staging buffer and concatenates them into a single ``wp.transformf``
+    array.
 
     The merged-buffer + staging-buffer separation is required because the
     wheel's ``TensorBinding.read(dst)`` writes into ``dst`` only when
     ``dst.shape == binding.shape``, so we cannot read directly into a slice
     of the merged buffer.
+
+    Unlike PhysX -- which receives a live :class:`omni.physics.tensors.SimulationView`
+    via a ``simulation_view`` property setter and discovers prims lazily --
+    OVPhysX wires bindings through an explicit :meth:`setup` call that
+    takes the live ``ovphysx.PhysX`` handle and the USD stage. The wheel
+    exposes a ``physx + stage`` pair rather than a single ``SimulationView``,
+    so a property setter would have to either bundle the two or fire on the
+    second assignment; the explicit call keeps the lifecycle obvious.
     """
 
     def __init__(self):
@@ -64,7 +72,6 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
         self._rigid_bindings: list[dict[str, Any]] = []
         self._merged_transforms: wp.array | None = None
         self._scene_data = SceneDataFormat.Transform()
-        self._device: str = "cpu"
 
     @property
     def transform_count(self) -> int:
@@ -79,12 +86,13 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
             paths.extend(list(entry["pose"].prim_paths))
         return paths
 
-    def setup(self, physx, stage) -> None:
+    def setup(self, physx, stage, device: str) -> None:
         """Discover RigidBodyAPI prims, dedup by env-wildcard form, create one binding per pattern.
 
         Args:
             physx: Live ``ovphysx.PhysX`` instance (the wheel handle).
             stage: USD stage to traverse for RigidBodyAPI prims.
+            device: Warp device string used to allocate the staging and merged buffers.
         """
         from isaaclab_ovphysx import tensor_types as TT  # local: keep heavy ovphysx out of module load
 
@@ -110,20 +118,13 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
             try:
                 pose_binding = physx.create_tensor_binding(pattern=pattern, tensor_type=TT.RIGID_BODY_POSE)
             except Exception as exc:
-                logger.warning(
-                    "[OvPhysxSceneDataBackend] Failed to create RIGID_BODY_POSE binding for %s: %s",
-                    pattern,
-                    exc,
-                )
+                logger.warning("Failed to create RIGID_BODY_POSE binding for %s: %s", pattern, exc)
                 continue
             row_count = int(pose_binding.shape[0])
             if row_count == 0:
-                logger.debug(
-                    "[OvPhysxSceneDataBackend] Pattern %s matched 0 rigid bodies; skipping.",
-                    pattern,
-                )
+                logger.debug("Pattern %s matched 0 rigid bodies; skipping.", pattern)
                 continue
-            pose_buf = wp.zeros(pose_binding.shape, dtype=wp.float32, device=self._device)
+            pose_buf = wp.zeros(pose_binding.shape, dtype=wp.float32, device=device)
             # Zero-copy reinterpret of the (N, 7) float32 staging buffer as (N,) wp.transformf.
             # Same pointer + layout; transformf is 7 float32s (pos.xyz + quat.xyzw). Cached
             # so per-step ``transforms`` reads don't reallocate the view object.
@@ -147,7 +148,7 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
             total_count += row_count
 
         if total_count > 0:
-            self._merged_transforms = wp.zeros((total_count,), dtype=wp.transformf, device=self._device)
+            self._merged_transforms = wp.zeros((total_count,), dtype=wp.transformf, device=device)
 
     @property
     def transforms(self) -> SceneDataFormat.Transform:
@@ -173,11 +174,7 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
             try:
                 entry["pose"].read(entry["pose_buf"])
             except Exception as exc:
-                logger.warning(
-                    "[OvPhysxSceneDataBackend] RIGID_BODY_POSE read failed for %s: %s",
-                    entry["pattern"],
-                    exc,
-                )
+                logger.warning("RIGID_BODY_POSE read failed for %s: %s", entry["pattern"], exc)
                 continue
             wp.copy(
                 self._merged_transforms,
@@ -480,8 +477,7 @@ class OvPhysxManager(PhysicsManager):
         # via :meth:`get_scene_data_backend`.
         if cls._scene_data_backend is None:
             cls._scene_data_backend = OvPhysxSceneDataBackend()
-        cls._scene_data_backend._device = PhysicsManager._device
-        cls._scene_data_backend.setup(cls._physx, sim.stage)
+        cls._scene_data_backend.setup(cls._physx, sim.stage, PhysicsManager._device)
 
         cls.dispatch_event(PhysicsEvent.MODEL_INIT, payload={})
         cls._warmup_done = True

--- a/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
@@ -9,6 +9,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
+# The CI isaaclab_ov* pattern unintentionally collects isaaclab_ovphysx tests,
+# but the ovphysx wheel is not installed in that environment. Skip gracefully
+# so the isaaclab_ov CI pipeline is not blocked by an unrelated dependency.
+pytest.importorskip("ovphysx.types", reason="ovphysx wheel not installed")
+
 
 def _make_stub_binding(prim_paths: list[str]) -> SimpleNamespace:
     """Stub an ovphysx ``TensorBinding`` exposing ``shape``, ``count``, ``prim_paths``, and ``read(dst)``."""

--- a/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
@@ -174,16 +174,24 @@ def test_transforms_reads_each_binding_and_returns_transform_format():
         host = np.array([[3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]], dtype=np.float32)
         _wp.copy(dst, _wp.from_numpy(host, dtype=_wp.float32, device="cpu").reshape((1, 7)))
 
+    # ``pose_buf_transformf`` is the zero-copy transformf view over the float32 staging
+    # buffer; production code caches it at setup time. Tests mirror that shape here.
+    buf_a_tf = _wp.array(ptr=buf_a.ptr, shape=(2,), dtype=_wp.transformf, device="cpu", copy=False)
+    buf_b_tf = _wp.array(ptr=buf_b.ptr, shape=(1,), dtype=_wp.transformf, device="cpu", copy=False)
     b._rigid_bindings = [
         {
+            "pattern": "/World/envs/env_*/Cube",
             "pose": SimpleNamespace(read=fake_read_a, prim_paths=["/Cube0", "/Cube1"]),
             "pose_buf": buf_a,
+            "pose_buf_transformf": buf_a_tf,
             "row_offset": 0,
             "row_count": 2,
         },
         {
+            "pattern": "/World/envs/env_*/Pole",
             "pose": SimpleNamespace(read=fake_read_b, prim_paths=["/Pole"]),
             "pose_buf": buf_b,
+            "pose_buf_transformf": buf_b_tf,
             "row_offset": 2,
             "row_count": 1,
         },
@@ -236,3 +244,106 @@ def test_manager_returns_none_when_backend_uninitialized():
         assert OvPhysxManager.get_scene_data_backend() is None
     finally:
         OvPhysxManager._scene_data_backend = saved
+
+
+def test_setup_continues_when_create_tensor_binding_raises(monkeypatch, caplog):
+    """A single failed binding-creation logs a warning and skips that pattern; others proceed."""
+    import logging
+
+    from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
+
+    b = OvPhysxSceneDataBackend()
+    b._device = "cpu"
+
+    paths = [
+        "/World/envs/env_0/Robot/cart",
+        "/World/envs/env_0/Robot/pole",
+    ]
+
+    def fake_traverse():
+        for p in paths:
+            yield SimpleNamespace(
+                HasAPI=lambda api: True,
+                GetPath=lambda p=p: SimpleNamespace(pathString=p),
+            )
+
+    stage = SimpleNamespace(Traverse=fake_traverse)
+
+    class FlakyPhysX:
+        def create_tensor_binding(self, pattern, tensor_type):
+            if pattern.endswith("/cart"):
+                raise RuntimeError("simulated wheel-side failure")
+            return SimpleNamespace(
+                pattern=pattern, tensor_type=tensor_type, shape=(1, 7), count=1, prim_paths=[], read=lambda dst: None
+            )
+
+    import isaaclab_ovphysx.physics.ovphysx_manager as om_mod
+
+    monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object()))
+
+    with caplog.at_level(logging.WARNING, logger=om_mod.logger.name):
+        b.setup(FlakyPhysX(), stage)
+
+    # The pole pattern survived; the cart pattern was logged and skipped.
+    assert len(b._rigid_bindings) == 1
+    assert b._rigid_bindings[0]["pattern"].endswith("/pole")
+    assert any("simulated wheel-side failure" in record.message for record in caplog.records)
+
+
+def test_transforms_logs_warning_when_a_binding_read_fails(caplog):
+    """A failed ``binding.read(dst)`` logs and skips that binding; other bindings still merge."""
+    import logging
+
+    import warp as _wp
+
+    _wp.init()
+
+    from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
+
+    b = OvPhysxSceneDataBackend()
+    b._device = "cpu"
+    b._merged_transforms = _wp.zeros((2,), dtype=_wp.transformf, device="cpu")
+
+    buf_good = _wp.zeros((1, 7), dtype=_wp.float32, device="cpu")
+    buf_bad = _wp.zeros((1, 7), dtype=_wp.float32, device="cpu")
+    buf_good_tf = _wp.array(ptr=buf_good.ptr, shape=(1,), dtype=_wp.transformf, device="cpu", copy=False)
+    buf_bad_tf = _wp.array(ptr=buf_bad.ptr, shape=(1,), dtype=_wp.transformf, device="cpu", copy=False)
+
+    def good_read(dst):
+        import numpy as np
+
+        host = np.array([[7.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]], dtype=np.float32)
+        _wp.copy(dst, _wp.from_numpy(host, dtype=_wp.float32, device="cpu").reshape((1, 7)))
+
+    def bad_read(dst):
+        raise RuntimeError("simulated read failure")
+
+    b._rigid_bindings = [
+        {
+            "pattern": "/World/envs/env_*/Good",
+            "pose": SimpleNamespace(read=good_read, prim_paths=["/Good"]),
+            "pose_buf": buf_good,
+            "pose_buf_transformf": buf_good_tf,
+            "row_offset": 0,
+            "row_count": 1,
+        },
+        {
+            "pattern": "/World/envs/env_*/Bad",
+            "pose": SimpleNamespace(read=bad_read, prim_paths=["/Bad"]),
+            "pose_buf": buf_bad,
+            "pose_buf_transformf": buf_bad_tf,
+            "row_offset": 1,
+            "row_count": 1,
+        },
+    ]
+
+    import isaaclab_ovphysx.physics.ovphysx_manager as om_mod
+
+    with caplog.at_level(logging.WARNING, logger=om_mod.logger.name):
+        out = b.transforms
+
+    assert out is b._scene_data
+    assert any("simulated read failure" in record.message for record in caplog.records)
+    # Good row was still written; bad row is left at the merged buffer's prior contents (zeros).
+    flat = out.transforms.numpy().view("<f4").reshape((2, 7))
+    assert flat[0, 0] == 7.0

--- a/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
@@ -88,7 +88,7 @@ def test_transform_paths_empty_when_no_bindings():
 
 
 def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
-    """``setup(physx, stage)`` buckets RigidBodyAPI prims by env-wildcard form.
+    """``setup(physx, stage, device)`` buckets RigidBodyAPI prims by env-wildcard form.
 
     For cartpole-shaped scenes (``cart``, ``pole``), expect 2 bindings — one
     per distinct env-relative prim path.
@@ -96,7 +96,6 @@ def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
     from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
 
     b = OvPhysxSceneDataBackend()
-    b._device = "cpu"
 
     # Stage stub: traversal yields four RigidBodyAPI prims (cart/pole across two envs).
     paths = [
@@ -136,7 +135,7 @@ def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
 
     monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object()))
 
-    b.setup(FakePhysX(), stage)
+    b.setup(FakePhysX(), stage, "cpu")
 
     # Cartpole = 2 distinct env-wildcard patterns -> 2 bindings.
     assert len(created) == 2
@@ -161,7 +160,6 @@ def test_transforms_reads_each_binding_and_returns_transform_format():
     from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
 
     b = OvPhysxSceneDataBackend()
-    b._device = "cpu"
     b._merged_transforms = _wp.zeros((3,), dtype=_wp.transformf, device="cpu")
 
     # Two bindings: first with 2 rows, second with 1 row.
@@ -260,7 +258,6 @@ def test_setup_continues_when_create_tensor_binding_raises(monkeypatch, caplog):
     from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
 
     b = OvPhysxSceneDataBackend()
-    b._device = "cpu"
 
     paths = [
         "/World/envs/env_0/Robot/cart",
@@ -289,7 +286,7 @@ def test_setup_continues_when_create_tensor_binding_raises(monkeypatch, caplog):
     monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object()))
 
     with caplog.at_level(logging.WARNING, logger=om_mod.logger.name):
-        b.setup(FlakyPhysX(), stage)
+        b.setup(FlakyPhysX(), stage, "cpu")
 
     # The pole pattern survived; the cart pattern was logged and skipped.
     assert len(b._rigid_bindings) == 1
@@ -308,7 +305,6 @@ def test_transforms_logs_warning_when_a_binding_read_fails(caplog):
     from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
 
     b = OvPhysxSceneDataBackend()
-    b._device = "cpu"
     b._merged_transforms = _wp.zeros((2,), dtype=_wp.transformf, device="cpu")
 
     buf_good = _wp.zeros((1, 7), dtype=_wp.float32, device="cpu")

--- a/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
@@ -36,7 +36,12 @@ def test_transform_count_sums_across_bindings():
     """``transform_count`` returns the sum of each binding's row count."""
     b = _bare_backend()
     b._rigid_bindings = [
-        {"pose": _make_stub_binding(["/World/envs/env_0/Cube", "/World/envs/env_1/Cube"]), "pose_buf": None, "row_offset": 0, "row_count": 2},
+        {
+            "pose": _make_stub_binding(["/World/envs/env_0/Cube", "/World/envs/env_1/Cube"]),
+            "pose_buf": None,
+            "row_offset": 0,
+            "row_count": 2,
+        },
         {"pose": _make_stub_binding(["/World/envs/env_0/Pole"]), "pose_buf": None, "row_offset": 2, "row_count": 1},
     ]
     assert b.transform_count == 3
@@ -46,7 +51,12 @@ def test_transform_paths_concatenates_prim_paths():
     """``transform_paths`` concatenates each binding's ``prim_paths`` in registration order."""
     b = _bare_backend()
     b._rigid_bindings = [
-        {"pose": _make_stub_binding(["/World/envs/env_0/Cube", "/World/envs/env_1/Cube"]), "pose_buf": None, "row_offset": 0, "row_count": 2},
+        {
+            "pose": _make_stub_binding(["/World/envs/env_0/Cube", "/World/envs/env_1/Cube"]),
+            "pose_buf": None,
+            "row_offset": 0,
+            "row_count": 2,
+        },
         {"pose": _make_stub_binding(["/World/envs/env_0/Pole"]), "pose_buf": None, "row_offset": 2, "row_count": 1},
     ]
     assert b.transform_paths == [
@@ -104,7 +114,11 @@ def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
         def create_tensor_binding(self, pattern, tensor_type):
             shape = (2, 7)  # 2 envs match each pattern
             b = SimpleNamespace(
-                pattern=pattern, tensor_type=tensor_type, shape=shape, count=2, prim_paths=[],
+                pattern=pattern,
+                tensor_type=tensor_type,
+                shape=shape,
+                count=2,
+                prim_paths=[],
                 read=lambda dst: None,
             )
             created.append(b)
@@ -112,6 +126,7 @@ def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
 
     # Patch UsdPhysics so HasAPI in the test doesn't depend on the real PXR module.
     import isaaclab_ovphysx.physics.ovphysx_manager as om_mod
+
     monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object()))
 
     b.setup(FakePhysX(), stage)
@@ -149,20 +164,29 @@ def test_transforms_reads_each_binding_and_returns_transform_format():
     def fake_read_a(dst):
         # Fill with row-distinct sentinel transforms (pos.x = row index, quat = identity).
         import numpy as np
-        host = np.array([[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
-                         [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]], dtype=np.float32)
+
+        host = np.array([[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0], [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]], dtype=np.float32)
         _wp.copy(dst, _wp.from_numpy(host, dtype=_wp.float32, device="cpu").reshape((2, 7)))
 
     def fake_read_b(dst):
         import numpy as np
+
         host = np.array([[3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]], dtype=np.float32)
         _wp.copy(dst, _wp.from_numpy(host, dtype=_wp.float32, device="cpu").reshape((1, 7)))
 
     b._rigid_bindings = [
-        {"pose": SimpleNamespace(read=fake_read_a, prim_paths=["/Cube0", "/Cube1"]),
-         "pose_buf": buf_a, "row_offset": 0, "row_count": 2},
-        {"pose": SimpleNamespace(read=fake_read_b, prim_paths=["/Pole"]),
-         "pose_buf": buf_b, "row_offset": 2, "row_count": 1},
+        {
+            "pose": SimpleNamespace(read=fake_read_a, prim_paths=["/Cube0", "/Cube1"]),
+            "pose_buf": buf_a,
+            "row_offset": 0,
+            "row_count": 2,
+        },
+        {
+            "pose": SimpleNamespace(read=fake_read_b, prim_paths=["/Pole"]),
+            "pose_buf": buf_b,
+            "row_offset": 2,
+            "row_count": 1,
+        },
     ]
 
     out = b.transforms

--- a/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for OvPhysxSceneDataBackend (new SceneDataBackend interface, post-#5128)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _make_stub_binding(prim_paths: list[str]) -> SimpleNamespace:
+    """Stub an ovphysx ``TensorBinding`` exposing ``shape``, ``count``, ``prim_paths``, and ``read(dst)``."""
+    n = len(prim_paths)
+    return SimpleNamespace(
+        shape=(n, 7),
+        count=n,
+        prim_paths=list(prim_paths),
+        read=lambda dst: None,  # no-op write; transform_count/paths don't trigger reads.
+    )
+
+
+def _bare_backend():
+    """Construct an ``OvPhysxSceneDataBackend`` instance bypassing the live-wheel ``__init__``.
+
+    Tests seed ``_rigid_bindings`` and the merged buffer directly, mirroring the
+    bypass-init pattern used in ``test_newton_manager_visualization_state.py``.
+    """
+    from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
+
+    return object.__new__(OvPhysxSceneDataBackend)
+
+
+def test_transform_count_sums_across_bindings():
+    """``transform_count`` returns the sum of each binding's row count."""
+    b = _bare_backend()
+    b._rigid_bindings = [
+        {"pose": _make_stub_binding(["/World/envs/env_0/Cube", "/World/envs/env_1/Cube"]), "pose_buf": None, "row_offset": 0, "row_count": 2},
+        {"pose": _make_stub_binding(["/World/envs/env_0/Pole"]), "pose_buf": None, "row_offset": 2, "row_count": 1},
+    ]
+    assert b.transform_count == 3
+
+
+def test_transform_paths_concatenates_prim_paths():
+    """``transform_paths`` concatenates each binding's ``prim_paths`` in registration order."""
+    b = _bare_backend()
+    b._rigid_bindings = [
+        {"pose": _make_stub_binding(["/World/envs/env_0/Cube", "/World/envs/env_1/Cube"]), "pose_buf": None, "row_offset": 0, "row_count": 2},
+        {"pose": _make_stub_binding(["/World/envs/env_0/Pole"]), "pose_buf": None, "row_offset": 2, "row_count": 1},
+    ]
+    assert b.transform_paths == [
+        "/World/envs/env_0/Cube",
+        "/World/envs/env_1/Cube",
+        "/World/envs/env_0/Pole",
+    ]
+
+
+def test_transform_count_zero_when_no_bindings():
+    """``transform_count`` returns 0 when the bindings list is empty."""
+    b = _bare_backend()
+    b._rigid_bindings = []
+    assert b.transform_count == 0
+
+
+def test_transform_paths_empty_when_no_bindings():
+    """``transform_paths`` returns an empty list when the bindings list is empty."""
+    b = _bare_backend()
+    b._rigid_bindings = []
+    assert b.transform_paths == []
+
+
+def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
+    """``setup(physx, stage)`` buckets RigidBodyAPI prims by env-wildcard form.
+
+    For cartpole-shaped scenes (``cart``, ``pole``), expect 2 bindings — one
+    per distinct env-relative prim path.
+    """
+    from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
+
+    b = OvPhysxSceneDataBackend()
+    b._device = "cpu"
+
+    # Stage stub: traversal yields four RigidBodyAPI prims (cart/pole across two envs).
+    paths = [
+        "/World/envs/env_0/Robot/cart",
+        "/World/envs/env_0/Robot/pole",
+        "/World/envs/env_1/Robot/cart",
+        "/World/envs/env_1/Robot/pole",
+    ]
+
+    def fake_traverse():
+        for p in paths:
+            yield SimpleNamespace(
+                HasAPI=lambda api: True,
+                GetPath=lambda p=p: SimpleNamespace(pathString=p),
+            )
+
+    stage = SimpleNamespace(Traverse=fake_traverse)
+
+    created: list[SimpleNamespace] = []
+
+    class FakePhysX:
+        def create_tensor_binding(self, pattern, tensor_type):
+            shape = (2, 7)  # 2 envs match each pattern
+            b = SimpleNamespace(
+                pattern=pattern, tensor_type=tensor_type, shape=shape, count=2, prim_paths=[],
+                read=lambda dst: None,
+            )
+            created.append(b)
+            return b
+
+    # Patch UsdPhysics so HasAPI in the test doesn't depend on the real PXR module.
+    import isaaclab_ovphysx.physics.ovphysx_manager as om_mod
+    monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object()))
+
+    b.setup(FakePhysX(), stage)
+
+    # Cartpole = 2 distinct env-wildcard patterns -> 2 bindings.
+    assert len(created) == 2
+    assert {c.pattern for c in created} == {
+        "/World/envs/env_*/Robot/cart",
+        "/World/envs/env_*/Robot/pole",
+    }
+    # Per-binding row counts sum to 4.
+    assert b.transform_count == 4
+
+
+def test_transforms_reads_each_binding_and_returns_transform_format():
+    """``transforms`` writes each binding's poses into the merged buffer at its offset.
+
+    The returned struct is ``SceneDataFormat.Transform`` with ``transforms`` set to
+    the merged ``wp.transformf`` array.
+    """
+    import warp as _wp
+
+    _wp.init()
+
+    from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
+
+    b = OvPhysxSceneDataBackend()
+    b._device = "cpu"
+    b._merged_transforms = _wp.zeros((3,), dtype=_wp.transformf, device="cpu")
+
+    # Two bindings: first with 2 rows, second with 1 row.
+    buf_a = _wp.zeros((2, 7), dtype=_wp.float32, device="cpu")
+    buf_b = _wp.zeros((1, 7), dtype=_wp.float32, device="cpu")
+
+    def fake_read_a(dst):
+        # Fill with row-distinct sentinel transforms (pos.x = row index, quat = identity).
+        import numpy as np
+        host = np.array([[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+                         [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]], dtype=np.float32)
+        _wp.copy(dst, _wp.from_numpy(host, dtype=_wp.float32, device="cpu").reshape((2, 7)))
+
+    def fake_read_b(dst):
+        import numpy as np
+        host = np.array([[3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]], dtype=np.float32)
+        _wp.copy(dst, _wp.from_numpy(host, dtype=_wp.float32, device="cpu").reshape((1, 7)))
+
+    b._rigid_bindings = [
+        {"pose": SimpleNamespace(read=fake_read_a, prim_paths=["/Cube0", "/Cube1"]),
+         "pose_buf": buf_a, "row_offset": 0, "row_count": 2},
+        {"pose": SimpleNamespace(read=fake_read_b, prim_paths=["/Pole"]),
+         "pose_buf": buf_b, "row_offset": 2, "row_count": 1},
+    ]
+
+    out = b.transforms
+    assert out is b._scene_data
+    assert out.transforms is b._merged_transforms
+
+    merged_host = out.transforms.numpy()  # (3,) of transformf -> view as float32 (3, 7) for assertion
+    # Each transformf is 7 floats (pos.xyz + quat.xyzw). Verify row 0 / 1 / 2 contents.
+    flat = merged_host.view("<f4").reshape((3, 7))
+    assert flat[0, 0] == 1.0
+    assert flat[1, 0] == 2.0
+    assert flat[2, 0] == 3.0
+
+
+def test_transforms_returns_empty_struct_when_no_bindings():
+    """``transforms`` returns the cached struct (transforms None) when nothing is wired."""
+    from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
+
+    b = OvPhysxSceneDataBackend()
+    out = b.transforms
+    assert out is b._scene_data
+    assert out.transforms is None
+
+
+def test_manager_returns_scene_data_backend_instance():
+    """``OvPhysxManager.get_scene_data_backend()`` returns the cached singleton."""
+    from isaaclab_ovphysx.physics import OvPhysxManager
+    from isaaclab_ovphysx.physics.ovphysx_manager import OvPhysxSceneDataBackend
+
+    # Reset class state and inject a fresh backend instance.
+    OvPhysxManager._scene_data_backend = OvPhysxSceneDataBackend()
+    try:
+        out = OvPhysxManager.get_scene_data_backend()
+        assert isinstance(out, OvPhysxSceneDataBackend)
+        assert out is OvPhysxManager._scene_data_backend
+    finally:
+        OvPhysxManager._scene_data_backend = None
+
+
+def test_manager_returns_none_when_backend_uninitialized():
+    """Before warmup, ``get_scene_data_backend`` returns the uninitialized ``None``."""
+    from isaaclab_ovphysx.physics import OvPhysxManager
+
+    saved = OvPhysxManager._scene_data_backend
+    OvPhysxManager._scene_data_backend = None
+    try:
+        assert OvPhysxManager.get_scene_data_backend() is None
+    finally:
+        OvPhysxManager._scene_data_backend = saved


### PR DESCRIPTION
# Description

Adds `OvPhysxSceneDataProvider`, the OVPhysX-backend implementation of `BaseSceneDataProvider`. Enables Newton-based visualizers (Rerun, Viser, native Newton viewport) to render OVPhysX simulations. Also fixes the `SceneDataProvider` factory dispatch (and adds a regression test) so the substring check `"physx" in "ovphysxmanager"` no longer routes ovphysx to PhysX.

Fixes #5327

> [!IMPORTANT]
> **Stacked on #5459** (`[OVPHYSX] Articulation rewrite`). The base of this PR is `develop`, so the diff includes every commit from #5459 — review only the 16 SDP-specific commits on top (`git log antoiner/feat/ovphysx_articulation..antoiner/feat/ovphysx_scene_data_provider`). Once #5459 merges, this PR will rebase cleanly.

## Architectural notes

Mirrors `PhysxSceneDataProvider` end-to-end: build a Newton model from the scene's `ClonePlan` at init (gated on `SceneDataRequirement.requires_newton_model`), then on every `update()` read body poses through ovphysx `TensorBinding`s and write them into the Newton state's `body_q` via a single Warp kernel.

The interesting OVPhysX-specific surface:

- **One-pattern-per-binding**: the ovphysx wheel's `PhysX.create_tensor_binding` accepts a single glob-style pattern per binding (not a list, unlike PhysX's `RigidBodyView`). We bucket Newton body paths by their env-wildcard form (`/World/envs/env_*/Robot/cart`, `/World/envs/env_*/Robot/pole`, ...), one pose+velocity binding per distinct relative path. Cartpole produces 2 bindings; Allegro hand ~17 — each covering all envs.
- **`RIGID_BODY_POSE` covers everything**: confirmed via standalone probe + wheel docs that the matcher accepts any prim with `UsdPhysics.RigidBodyAPI`, including articulation links. No separate `LINK_POSE` plumbing is needed. Paths flow through a `RigidBodyAPI` filter (mirroring `PhysxSceneDataProvider._setup_rigid_body_view` line ~281) so joints and articulation-root xforms are excluded from binding patterns.
- **Wheel-0.4 `binding.read(dst)` API**: pre-allocated warp destination buffers, so per-step reads are allocation-free.
- **View-order reorder**: each binding's `prim_paths` is matched against the Newton `body_label` ordering to build a per-binding reorder tensor with `-1` sentinels for rows owned by other bindings. The pose merge respects partial coverage across bindings, with `FrameView` fallback for anything that lacks `RigidBodyAPI` (cameras, decorative xforms).
- **Factory fix**: `SceneDataProvider._get_backend` now checks `"ovphysx"` explicitly before `"physx"` so the substring overlap doesn't route the wrong backend.

## Files changed (16 commits since `antoiner/feat/ovphysx_articulation`)

- `source/isaaclab/isaaclab/physics/scene_data_provider.py` — factory dispatch fix (+9/-1).
- `source/isaaclab/test/sim/test_scene_data_provider_factory.py` — new parametrized regression test (44 lines).
- `source/isaaclab_ovphysx/isaaclab_ovphysx/scene_data_providers/__init__.py`, `__init__.pyi` — package scaffolding.
- `source/isaaclab_ovphysx/isaaclab_ovphysx/scene_data_providers/ovphysx_scene_data_provider.py` — the provider (~760 lines).
- `source/isaaclab_ovphysx/test/scene_data_providers/test_ovphysx_scene_data_provider.py` — 18 stub-based unit tests covering factory dispatch, metadata, env discovery, Newton-model build, binding setup, pose-merge orchestration, transform/velocity getters, view-order reorder, camera-transform stage walk.
- `docs/source/api/index.rst` + `docs/source/api/lab_ovphysx/isaaclab_ovphysx.scene_data_providers.rst` — first `isaaclab_ovphysx` section in the API reference.
- `source/isaaclab/changelog.d/antoiner-feat-ovphysx-scene-data-provider.rst` — patch fragment for the factory fix.
- `source/isaaclab_ovphysx/changelog.d/antoiner-feat-ovphysx-scene-data-provider.minor.rst` — minor fragment for the new provider.

## Type of change

- New feature (non-breaking change which adds functionality).
- Bug fix (factory dispatch).

## Validation

1. **Unit tests** — `./isaaclab.sh -p -m pytest source/isaaclab/test/sim/test_scene_data_provider_factory.py source/isaaclab_ovphysx/test/scene_data_providers/` → 23 passed.
2. **End-to-end** — `./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Cartpole-Direct-v0 --visualizer newton --num_envs 4096 presets=ovphysx` reaches the simulation loop; visualizer renders the cartpole scene.
3. **Pre-commit** — `./isaaclab.sh -f` clean.
4. **Pattern probe** — standalone reproduction at `/tmp/probe_rigid_body_pose_on_articulation.py` confirmed `RIGID_BODY_POSE` accepts articulation-link patterns. Reproducible against the wheel's bundled minimal articulation USD.

## Known follow-ups (not in this PR)

- Extract `_build_newton_model_from_clone_plan` into a shared helper used by both PhysX and OVPhysX providers (currently a verbatim copy).
- `FrameView` factory could grow an explicit `"ovphysx"` registration entry (today's dispatch falls through to the `"physx"` branch, which works because `FabricFrameView` reads from the shared USD stage).
- Pattern length cap: if a scene's distinct-body-path count exceeds the wheel's per-pattern matcher limit (unknown), chunk into multiple bindings indexed by buffer-row offset. Hasn't bitten yet.
- A future `test_ovphysx_scene_data_provider_visualizer_contract.py` mirroring `test_physx_scene_data_provider_visualizer_contract.py`.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there