### PR TITLE
Enable OVRTX cloning by default

### DIFF
--- a/source/isaaclab/changelog.d/huidongc-ovrtx-cloning.rst
+++ b/source/isaaclab/changelog.d/huidongc-ovrtx-cloning.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added :func:`~isaaclab.cloner.cloner_utils.is_homogeneous` to detect whether a :class:`~isaaclab.cloner.ClonePlan`
+  assigns every environment from every source (a homogeneous clone mask).

--- a/source/isaaclab/isaaclab/cloner/clone_plan.py
+++ b/source/isaaclab/isaaclab/cloner/clone_plan.py
@@ -29,5 +29,5 @@ class ClonePlan:
 
     clone_mask: torch.Tensor
     """Boolean tensor of shape ``[len(sources), num_envs]``;
-    ``clone_mask[i, j]`` is ``True`` iff env ``j`` was populated from
+    ``clone_mask[i, j]`` is ``True`` if env ``j`` was populated from
     :attr:`sources` ``[i]``."""

--- a/source/isaaclab/isaaclab/cloner/cloner_utils.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_utils.py
@@ -393,3 +393,18 @@ def grid_transforms(N: int, spacing: float = 1.0, up_axis: str = "z", device="cp
     ori = torch.zeros((N, 4), device=device)
     ori[:, 3] = 1.0  # w=1 for identity quaternion
     return pos, ori
+
+
+def is_homogeneous(clone_plan: ClonePlan) -> bool:
+    """Check if a clone plan is homogeneous.
+
+    Homogeneous here means every element of :attr:`~isaaclab.cloner.ClonePlan.clone_mask`
+    is ``True`` (equivalent to ``clone_plan.clone_mask.all()``).
+
+    Args:
+        clone_plan: The clone plan to check.
+
+    Returns:
+        ``True`` if all elements of ``clone_mask`` are ``True``, otherwise ``False``.
+    """
+    return bool(clone_plan.clone_mask.all().item())

--- a/source/isaaclab_ov/changelog.d/huidongc-ovrtx-cloning.rst
+++ b/source/isaaclab_ov/changelog.d/huidongc-ovrtx-cloning.rst
@@ -2,13 +2,15 @@ Fixed
 ^^^^^
 
 * Fixed cloned environments disappearing from tiled camera output if
-  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.use_cloning` is set to ``True``,
+  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.use_ovrtx_cloning` is set to ``True``,
   by correcting scene-partition attribute creation on env roots and cameras.
 
 Changed
 ^^^^^^^
 
-* Changed the default of :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.use_cloning` to ``True``. This will bring
-  notable speedup for the total startup time (Launch to Train), esp. for large-scale env setups. On
-  Isaac-Dexsuite-Kuka-Allegro-Lift-v0 with 1024 env clones, the total startup time (Launch to Train) dropped from
-  ~78s to ~43s.
+* Renamed the ``use_cloning`` field on :class:`~isaaclab_ov.renderers.OVRTXRendererCfg` to ``use_ovrtx_cloning``.
+  Changed its default value to ``True``. This will bring notable speedup for the total startup time (Launch to Train),
+  esp. for large-scale env setups. On Isaac-Dexsuite-Kuka-Allegro-Lift-v0 with 1024 env clones, the total startup time
+  dropped from ~78s to ~43s. Note that if ``use_ovrtx_cloning`` is enabled but the env setup is heterogeneous, the
+  OVRTX renderer will disable the internal cloning path and logs a warning, exporting the full multi-environment stage
+  instead (same effect as setting ``use_ovrtx_cloning`` to ``False`` for that run).

--- a/source/isaaclab_ov/changelog.d/huidongc-ovrtx-cloning.rst
+++ b/source/isaaclab_ov/changelog.d/huidongc-ovrtx-cloning.rst
@@ -8,4 +8,7 @@ Fixed
 Changed
 ^^^^^^^
 
-* Changed the default of :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.use_cloning` to ``True``.
+* Changed the default of :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.use_cloning` to ``True``. This will bring
+  notable speedup for the total startup time (Launch to Train), esp. for large-scale env setups. On
+  Isaac-Dexsuite-Kuka-Allegro-Lift-v0 with 1024 env clones, the total startup time (Launch to Train) dropped from
+  ~78s to ~43s.

--- a/source/isaaclab_ov/changelog.d/huidongc-ovrtx-cloning.rst
+++ b/source/isaaclab_ov/changelog.d/huidongc-ovrtx-cloning.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed cloned environments disappearing from tiled camera output if
+  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.use_cloning` is set to ``True``,
+  by correcting scene-partition attribute creation on env roots and cameras.
+
+Changed
+^^^^^^^
+
+* Changed the default of :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.use_cloning` to ``True``.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -161,7 +161,7 @@ class OVRTXRenderer(BaseRenderer):
         self._camera_rel_path: str | None = None
         self._output_semantic_color_buffer: wp.array | None = None
 
-        self._use_ovrtx_cloning = self.cfg.use_ovrtx_cloning
+        self._use_ovrtx_cloning = self.cfg.use_ovrtx_cloning and _IS_OVRTX_0_3_0_OR_NEWER
 
         if self._use_ovrtx_cloning:
             clone_plan = SimulationContext.instance().get_clone_plan()
@@ -194,7 +194,7 @@ class OVRTXRenderer(BaseRenderer):
             return
 
         logger.info("Preparing stage for export (%d envs, cloning=%s)...", num_envs, self._use_ovrtx_cloning)
-        create_scene_partition_attributes(stage, num_envs, self._use_ovrtx_cloning)
+        create_scene_partition_attributes(stage, num_envs, self._use_ovrtx_cloning, not _IS_OVRTX_0_3_0_OR_NEWER)
 
         export_path = "/tmp/stage_before_ovrtx.usda"
         export_stage_for_ovrtx(stage, export_path, num_envs, self._use_ovrtx_cloning)

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -42,7 +42,9 @@ import ovrtx
 from ovrtx import Device, PrimMode, Renderer, RendererConfig, Semantic
 from packaging.version import Version
 
+from isaaclab.cloner.cloner_utils import is_homogeneous
 from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
+from isaaclab.sim import SimulationContext
 from isaaclab.utils.math import convert_camera_frame_orientation_convention
 
 from .ovrtx_renderer_cfg import OVRTXRendererCfg
@@ -159,6 +161,14 @@ class OVRTXRenderer(BaseRenderer):
         self._camera_rel_path: str | None = None
         self._output_semantic_color_buffer: wp.array | None = None
 
+        self._use_ovrtx_cloning = self.cfg.use_ovrtx_cloning
+
+        if self._use_ovrtx_cloning:
+            clone_plan = SimulationContext.instance().get_clone_plan()
+            if clone_plan and not is_homogeneous(clone_plan):
+                logger.warning("OVRTX cloning disabled because the simulation uses a heterogeneous env setup")
+                self._use_ovrtx_cloning = False
+
         logger.info("Creating OVRTX renderer...")
         OVRTX_CONFIG = RendererConfig(
             log_file_path=self.cfg.log_file_path,
@@ -183,13 +193,11 @@ class OVRTXRenderer(BaseRenderer):
         if stage is None:
             return
 
-        use_cloning = self.cfg.use_cloning
-
-        logger.info("Preparing stage for export (%d envs, cloning=%s)...", num_envs, use_cloning)
-        create_scene_partition_attributes(stage, num_envs, use_cloning)
+        logger.info("Preparing stage for export (%d envs, cloning=%s)...", num_envs, self._use_ovrtx_cloning)
+        create_scene_partition_attributes(stage, num_envs, self._use_ovrtx_cloning)
 
         export_path = "/tmp/stage_before_ovrtx.usda"
-        export_stage_for_ovrtx(stage, export_path, num_envs, use_cloning)
+        export_stage_for_ovrtx(stage, export_path, num_envs, self._use_ovrtx_cloning)
         self._exported_usd_path = export_path
         logger.info("Exported to %s", export_path)
 
@@ -211,7 +219,6 @@ class OVRTXRenderer(BaseRenderer):
         self._camera_rel_path = spec.camera_path_relative_to_env_0
 
         usd_scene_path = self._exported_usd_path
-        use_cloning = self.cfg.use_cloning
 
         if usd_scene_path is not None:
             logger.info("Injecting camera definitions...")
@@ -241,7 +248,7 @@ class OVRTXRenderer(BaseRenderer):
                 logger.exception("Error loading USD: %s", e)
                 raise
 
-            if use_cloning and num_envs > 1:
+            if self._use_ovrtx_cloning and num_envs > 1:
                 logger.info("Using OVRTX internal cloning")
                 self._clone_environments_in_ovrtx(num_envs)
                 self._update_scene_partitions_after_clone(combined_usd_path, num_envs)

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -57,7 +57,7 @@ from .ovrtx_renderer_kernels import (
     sync_newton_transforms_kernel,
 )
 from .ovrtx_usd import (
-    create_cloning_attributes,
+    create_scene_partition_attributes,
     export_stage_for_ovrtx,
     inject_cameras_into_usd,
 )
@@ -186,7 +186,7 @@ class OVRTXRenderer(BaseRenderer):
         use_cloning = self.cfg.use_cloning
 
         logger.info("Preparing stage for export (%d envs, cloning=%s)...", num_envs, use_cloning)
-        create_cloning_attributes(stage, num_envs, use_cloning)
+        create_scene_partition_attributes(stage, num_envs, use_cloning)
 
         export_path = "/tmp/stage_before_ovrtx.usda"
         export_stage_for_ovrtx(stage, export_path, num_envs, use_cloning)

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
@@ -34,7 +34,7 @@ class OVRTXRendererCfg(RendererCfg):
     temp_usd_suffix: str = ".usda"
     """File suffix for temporary combined USD files (e.g. '.usda' or '.usdc')."""
 
-    use_cloning: bool = False
+    use_cloning: bool = True
     """When True, export only env_0 and use OVRTX clone_usd. When False, export full stage."""
 
     log_level: str = "verbose"

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
@@ -34,8 +34,12 @@ class OVRTXRendererCfg(RendererCfg):
     temp_usd_suffix: str = ".usda"
     """File suffix for temporary combined USD files (e.g. '.usda' or '.usdc')."""
 
-    use_cloning: bool = True
-    """When True, export only env_0 and use OVRTX clone_usd. When False, export full stage."""
+    use_ovrtx_cloning: bool = True
+    """When True, export only env_0 and use OVRTX ``clone_usd``. When False, export full multi-environment stage.
+
+    If the simulation uses a heterogeneous env setup, the renderer disables this path and exports the full
+    multi-environment stage instead (same effect as setting this to ``False`` for that run).
+    """
 
     log_level: str = "verbose"
     """OVRTX carb log level: "verbose", "info", "warn", "error"."""

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
@@ -37,6 +37,8 @@ class OVRTXRendererCfg(RendererCfg):
     use_ovrtx_cloning: bool = True
     """When True, export only env_0 and use OVRTX ``clone_usd``. When False, export full multi-environment stage.
 
+    OVRTX cloning is only supported in OVRTX 0.3.0 or newer.
+
     If the simulation uses a heterogeneous env setup, the renderer disables this path and exports the full
     multi-environment stage instead (same effect as setting this to ``False`` for that run).
     """

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -178,21 +178,22 @@ def create_scene_partition_attributes(stage, num_envs: int = 1, use_cloning: boo
         use_cloning: Whether OVRTX cloning is enabled.
     """
     env_indices = [0] if use_cloning else range(num_envs)
-    for env_idx in env_indices:
-        env_path = f"/World/envs/env_{env_idx}"
-        env_prim = stage.GetPrimAtPath(env_path)
-        if not env_prim.IsValid():
-            logger.warning("Failed to get env root prim at '%s'", env_path)
-            continue
+    with Sdf.ChangeBlock():
+        for env_idx in env_indices:
+            env_path = f"/World/envs/env_{env_idx}"
+            env_prim = stage.GetPrimAtPath(env_path)
+            if not env_prim.IsValid():
+                logger.warning("Failed to get env root prim at '%s'", env_path)
+                continue
 
-        scene_partition = f"env_{env_idx}"
-        env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
-        logger.debug("Set scene partition '%s' on env root '%s'", scene_partition, env_prim.GetPath())
+            scene_partition = f"env_{env_idx}"
+            env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
+            logger.debug("Set scene partition '%s' on env root '%s'", scene_partition, env_prim.GetPath())
 
-        for prim in Usd.PrimRange(env_prim):
-            if prim.IsA(UsdGeom.Camera):
-                prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
-                logger.debug("Set scene partition '%s' on camera '%s'", scene_partition, prim.GetPath())
+            for prim in Usd.PrimRange(env_prim):
+                if prim.IsA(UsdGeom.Camera):
+                    prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
+                    logger.debug("Set scene partition '%s' on camera '%s'", scene_partition, prim.GetPath())
 
 
 def export_stage_for_ovrtx(stage, export_path: str, num_envs: int, use_cloning: bool = True) -> str:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -162,10 +162,15 @@ def inject_cameras_into_usd(
     return temp_path, render_product_path
 
 
-def create_scene_partition_attributes(stage, num_envs: int = 1, use_cloning: bool = True) -> None:
+def create_scene_partition_attributes(
+    stage,
+    num_envs: int = 1,
+    use_ovrtx_cloning: bool = True,
+    enable_scene_partition_workaround: bool = False,
+) -> None:
     """Create scene partition attributes for env roots and cameras.
 
-    If use_cloning is True, only env_0 is exported for OVRTX; env_1..env_{n-1} are deactivated before export.
+    If use_ovrtx_cloning is True, only env_0 is exported for OVRTX; env_1..env_{n-1} are deactivated before export.
     OVRTX clones env_0 internally and _update_scene_partitions_after_clone sets partition attributes on the clones.
     So we only need to set attributes on env_0 here.
 
@@ -175,28 +180,34 @@ def create_scene_partition_attributes(stage, num_envs: int = 1, use_cloning: boo
     Args:
         stage: USD stage to modify.
         num_envs: Number of environments.
-        use_cloning: Whether OVRTX cloning is enabled.
+        use_ovrtx_cloning: Whether OVRTX cloning is enabled.
+        enable_scene_partition_workaround: Whether to enable the scene partition workaround for OVRTX 0.2.0 because it
+            doesn't support primvar inheritance.
     """
-    env_indices = [0] if use_cloning else range(num_envs)
-    with Sdf.ChangeBlock():
-        for env_idx in env_indices:
-            env_path = f"/World/envs/env_{env_idx}"
-            env_prim = stage.GetPrimAtPath(env_path)
-            if not env_prim.IsValid():
-                logger.warning("Failed to get env root prim at '%s'", env_path)
+    env_indices = [0] if use_ovrtx_cloning else range(num_envs)
+    for env_idx in env_indices:
+        env_path = f"/World/envs/env_{env_idx}"
+        env_prim = stage.GetPrimAtPath(env_path)
+        if not env_prim.IsValid():
+            logger.warning("Failed to get env root prim at '%s'", env_path)
+            continue
+
+        scene_partition = f"env_{env_idx}"
+        env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
+        logger.debug("Set scene partition '%s' on env root '%s'", scene_partition, env_prim.GetPath())
+
+        for prim in Usd.PrimRange(env_prim):
+            if prim.GetPath() == env_prim.GetPath():
                 continue
-
-            scene_partition = f"env_{env_idx}"
-            env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
-            logger.debug("Set scene partition '%s' on env root '%s'", scene_partition, env_prim.GetPath())
-
-            for prim in Usd.PrimRange(env_prim):
-                if prim.IsA(UsdGeom.Camera):
-                    prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
-                    logger.debug("Set scene partition '%s' on camera '%s'", scene_partition, prim.GetPath())
+            if prim.IsA(UsdGeom.Camera):
+                prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
+                logger.debug("Set scene partition '%s' on camera '%s'", scene_partition, prim.GetPath())
+            elif enable_scene_partition_workaround:
+                prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
+                logger.debug("Set scene partition '%s' on prim '%s'", scene_partition, prim.GetPath())
 
 
-def export_stage_for_ovrtx(stage, export_path: str, num_envs: int, use_cloning: bool = True) -> str:
+def export_stage_for_ovrtx(stage, export_path: str, num_envs: int, use_ovrtx_cloning: bool = True) -> str:
     """Export the stage to a USD file; when num_envs > 1, only env_0 is exported for OVRTX cloning.
 
     When num_envs > 1, deactivates env_1..env_{num_envs-1} before export and reactivates
@@ -211,7 +222,7 @@ def export_stage_for_ovrtx(stage, export_path: str, num_envs: int, use_cloning: 
         export_path (same as input).
     """
     deactivated = []
-    if use_cloning and num_envs > 1:
+    if use_ovrtx_cloning and num_envs > 1:
         logger.info("Deactivating %d cloned environments...", num_envs - 1)
         for env_idx in range(1, num_envs):
             env_path = f"/World/envs/env_{env_idx}"

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -162,43 +162,37 @@ def inject_cameras_into_usd(
     return temp_path, render_product_path
 
 
-def create_cloning_attributes(stage, num_envs: int = 1, use_cloning: bool = True) -> int:
-    """Create OVRTX cloning attributes (scene partition, xform) on env_0 only.
+def create_scene_partition_attributes(stage, num_envs: int = 1, use_cloning: bool = True) -> None:
+    """Create scene partition attributes for env roots and cameras.
 
-    Only env_0 is exported for OVRTX; env_1..env_{n-1} are deactivated before export.
-    OVRTX clones env_0 internally and _update_scene_partitions_after_clone sets
-    partition attributes on the clones. So we only need to set attributes on env_0 here.
+    If use_cloning is True, only env_0 is exported for OVRTX; env_1..env_{n-1} are deactivated before export.
+    OVRTX clones env_0 internally and _update_scene_partitions_after_clone sets partition attributes on the clones.
+    So we only need to set attributes on env_0 here.
 
-    Camera prims are discovered by USD type (``UsdGeom.Camera``) rather than by
-    name, so this works regardless of where the camera is placed in the hierarchy.
+    Camera prims are discovered by USD type (``UsdGeom.Camera``) rather than by name, so this works regardless of
+    where the camera is placed in the hierarchy.
 
     Args:
         stage: USD stage to modify.
         num_envs: Number of environments.
         use_cloning: Whether OVRTX cloning is enabled.
-
-    Returns:
-        Total number of objects (non-camera prims) that received partition attributes.
     """
-    total_objects = 0
     env_indices = [0] if use_cloning else range(num_envs)
     for env_idx in env_indices:
         env_path = f"/World/envs/env_{env_idx}"
         env_prim = stage.GetPrimAtPath(env_path)
         if not env_prim.IsValid():
+            logger.warning("Failed to get env root prim at '%s'", env_path)
             continue
-        partition_name = f"env_{env_idx}"
-        attr = env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token)
-        attr.Set(partition_name)
+
+        scene_partition = f"env_{env_idx}"
+        env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
+        logger.debug("Set scene partition '%s' on env root '%s'", scene_partition, env_prim.GetPath())
+
         for prim in Usd.PrimRange(env_prim):
-            if prim.GetPath() == env_prim.GetPath():
-                continue
             if prim.IsA(UsdGeom.Camera):
-                prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(partition_name)
-            else:
-                prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(partition_name)
-                total_objects += 1
-    return total_objects
+                prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
+                logger.debug("Set scene partition '%s' on camera '%s'", scene_partition, prim.GetPath())
 
 
 def export_stage_for_ovrtx(stage, export_path: str, num_envs: int, use_cloning: bool = True) -> str:

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -47,7 +47,7 @@ PER_TEST_TIMEOUTS = {
     "test_operational_space.py": 1000,
     "test_non_headless_launch.py": 1000,  # This test launches the app in non-headless mode and starts simulation
     "test_rl_games_wrapper.py": 1000,
-    "test_rsl_rl_export_flow.py": 4000,
+    "test_rsl_rl_export_flow.py": 10000,  # This test runs through 54 tasks, each has timeout set to 600s
     "test_rsl_rl_wrapper.py": 1000,
     "test_sb3_wrapper.py": 1000,
     "test_skrl_wrapper.py": 1000,

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -47,7 +47,7 @@ PER_TEST_TIMEOUTS = {
     "test_operational_space.py": 1000,
     "test_non_headless_launch.py": 1000,  # This test launches the app in non-headless mode and starts simulation
     "test_rl_games_wrapper.py": 1000,
-    "test_rsl_rl_export_flow.py": 10000,  # This test runs through 54 tasks, each has timeout set to 600s
+    "test_rsl_rl_export_flow.py": 4000,
     "test_rsl_rl_wrapper.py": 1000,
     "test_sb3_wrapper.py": 1000,
     "test_skrl_wrapper.py": 1000,


### PR DESCRIPTION
# Description

* Added :func:`~isaaclab.cloner.cloner_utils.is_homogeneous` to detect whether a :class:`~isaaclab.cloner.ClonePlan`
  assigns every environment from every source (a homogeneous clone mask).

* Fixed cloned environments disappearing from tiled camera output if
  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.use_ovrtx_cloning` is set to ``True``,
  by correcting scene-partition attribute creation on env roots and cameras.

* Renamed the ``use_cloning`` field on :class:`~isaaclab_ov.renderers.OVRTXRendererCfg` to ``use_ovrtx_cloning``.
  Changed its default value to ``True``. This will bring notable speedup for the total startup time (Launch to Train),
  esp. for large-scale env setups. On Isaac-Dexsuite-Kuka-Allegro-Lift-v0 with 1024 env clones, the total startup time
  dropped from ~78s to ~43s. Note that if ``use_ovrtx_cloning`` is enabled but the env setup is heterogeneous, the
  OVRTX renderer will disable the internal cloning path and logs a warning, exporting the full multi-environment stage
  instead (same effect as setting ``use_ovrtx_cloning`` to ``False`` for that run).


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
