### PR TITLE
[CI unblock] Fix two bugs causing isaaclab (core) per-test timeouts

### DIFF
--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -18,7 +18,9 @@ keywords = ["experience", "app", "usd"]
 "isaacsim.core.deprecation_manager" = { order = -100 }
 "isaacsim.core.experimental.materials" = {}
 "isaacsim.core.experimental.objects" = {}
-"isaacsim.core.experimental.primdata" = {}
+# Optional: not yet present in publicly-released isaacsim 6.0.x; Kit's resolver
+# otherwise stalls on remote registry sync. Hard-load once it ships publicly.
+"isaacsim.core.experimental.primdata" = { optional = true }
 "isaacsim.core.experimental.prims" = {}
 "isaacsim.core.experimental.utils" = {}
 "isaacsim.core.nodes" = {}
@@ -31,9 +33,12 @@ keywords = ["experience", "app", "usd"]
 "isaacsim.robot.policy.examples" = {}
 "isaacsim.robot.schema" = {}
 "isaacsim.robot.experimental.wheeled_robots" = {}
-"isaacsim.robot.wheeled_robots.nodes" = {}
+# Optional: not yet present in publicly-released isaacsim 6.0.x; Kit's resolver
+# otherwise stalls on remote registry sync. Hard-load once it ships publicly.
+"isaacsim.robot.wheeled_robots.nodes" = { optional = true }
 "isaacsim.sensors.experimental.physics" = {}
-"isaacsim.sensors.experimental.rtx" = {}
+# Optional: see comment above.
+"isaacsim.sensors.experimental.rtx" = { optional = true }
 "isaacsim.simulation_app" = {}
 "isaacsim.storage.native" = {}
 "isaacsim.util.debug_draw" = {}

--- a/source/isaaclab/changelog.d/jichuanh-ci-unblock-kit-optional-experimental-exts.rst
+++ b/source/isaaclab/changelog.d/jichuanh-ci-unblock-kit-optional-experimental-exts.rst
@@ -1,0 +1,27 @@
+Fixed
+^^^^^
+
+* Fixed ``apps/isaaclab.python.kit`` referencing three Isaac Sim extensions
+  that don't exist in publicly-released ``isaacsim 6.0.x``:
+  ``isaacsim.core.experimental.primdata``,
+  ``isaacsim.robot.wheeled_robots.nodes``, and
+  ``isaacsim.sensors.experimental.rtx``. The references were added in #5293
+  as part of the deprecated-extension migration, but the renamed targets
+  only exist in unreleased Isaac Sim builds. Kit's resolver falls back to
+  remote registry sync for every missing dependency, which silently burns
+  ~55s locally and 1000s+ in CI (the registry endpoints are slow /
+  unreachable from runners), triggering recent "isaaclab (core)" per-test
+  timeouts on ``test_non_headless_launch.py``, ``test_outdated_sensor.py``,
+  and ``test_color_randomization.py``. Marking the three as
+  ``{ optional = true }`` makes Kit's resolver tolerate their absence while
+  still picking them up automatically once they ship in a future Isaac Sim
+  release.
+* Fixed :func:`~isaaclab.envs.mdp.events.randomize_visual_color` and three
+  sibling event terms crashing with
+  ``AttributeError: 'NoneType' object has no attribute 'split'`` when
+  ``omni.replicator.core`` is loaded as a namespace package by Kit's
+  extension manager (which leaves ``rep.__file__ = None``). Replaced the
+  fragile ``rep.__file__.split("/")[-5][21:]`` version extraction with a
+  dedicated helper ``_get_replicator_version`` that falls back to
+  ``rep.__path__[0]`` -- always populated -- and uses ``re.search`` rather
+  than positional slicing, so it survives both packaging modes.

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -28,6 +28,25 @@ from isaaclab.actuators import ImplicitActuator
 from isaaclab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
 from isaaclab.utils.version import compare_versions
 
+
+def _get_replicator_version(rep) -> str:
+    """Return the X.Y.Z version of ``omni.replicator.core``.
+
+    ``rep.__file__`` can be ``None`` when ``omni.replicator.core`` is loaded as a
+    namespace package by Kit's extension manager (e.g. on the Kit 110.x stack),
+    so we fall back to ``rep.__path__[0]``, which always points to the extscache
+    directory whose name embeds the version (e.g.
+    ``"omni.replicator.core-1.13.4+110.0.0.lx64.r.cp312"``).
+    """
+    rep_path = rep.__file__ or (rep.__path__[0] if getattr(rep, "__path__", None) else None)
+    if rep_path is None:
+        raise RuntimeError("omni.replicator.core has no resolvable __file__ or __path__")
+    match = re.search(r"omni\.replicator\.core-(\d+\.\d+\.\d+)", rep_path)
+    if match is None:
+        raise RuntimeError(f"Could not parse omni-replicator-core version from {rep_path!r}")
+    return match.group(1)
+
+
 if TYPE_CHECKING:
     from isaaclab_physx.assets import DeformableObject
 
@@ -2087,7 +2106,7 @@ class randomize_visual_texture_material(ManagerTermBase):
             )
 
         # extract the replicator version
-        version = re.match(r"^(\d+\.\d+\.\d+)", rep.__file__.split("/")[-5][21:]).group(1)
+        version = _get_replicator_version(rep)
 
         # use different path for different version of replicator
         if compare_versions(version, "1.12.4") < 0:
@@ -2157,7 +2176,7 @@ class randomize_visual_texture_material(ManagerTermBase):
         import omni.replicator.core as rep
 
         # extract the replicator version
-        version = re.match(r"^(\d+\.\d+\.\d+)", rep.__file__.split("/")[-5][21:]).group(1)
+        version = _get_replicator_version(rep)
 
         # use different path for different version of replicator
         if compare_versions(version, "1.12.4") < 0:
@@ -2246,7 +2265,7 @@ class randomize_visual_color(ManagerTermBase):
         # TODO: Need to make it work for multiple meshes.
 
         # extract the replicator version
-        version = re.match(r"^(\d+\.\d+\.\d+)", rep.__file__.split("/")[-5][21:]).group(1)
+        version = _get_replicator_version(rep)
 
         # use different path for different version of replicator
         if compare_versions(version, "1.12.4") < 0:
@@ -2315,7 +2334,7 @@ class randomize_visual_color(ManagerTermBase):
         # we import the module here since we may not always need the replicator
         import omni.replicator.core as rep
 
-        version = re.match(r"^(\d+\.\d+\.\d+)", rep.__file__.split("/")[-5][21:]).group(1)
+        version = _get_replicator_version(rep)
 
         # use different path for different version of replicator
         if compare_versions(version, "1.12.4") < 0:


### PR DESCRIPTION
## Summary

Two independent bugs that both show up in the `isaaclab (core) [1/3]` CI matrix as per-test timeouts on:

- `source/isaaclab/test/app/test_non_headless_launch.py`
- `source/isaaclab/test/sensors/test_outdated_sensor.py`
- `source/isaaclab/test/envs/test_color_randomization.py`

CI evidence:
- https://github.com/isaac-sim/IsaacLab/actions/runs/25736858658/job/75581695189
- https://github.com/isaac-sim/IsaacLab/actions/runs/25735656567

## Fix 1 — Missing isaacsim experimental extensions in `apps/isaaclab.python.kit`

The experience declares three Isaac Sim extensions as **hard** deps that don't exist in publicly-released `isaacsim 6.0.x`:

- `isaacsim.core.experimental.primdata`
- `isaacsim.robot.wheeled_robots.nodes`
- `isaacsim.sensors.experimental.rtx`

They were introduced in #5293 as part of the deprecated-extension migration ahead of an upstream Isaac Sim release, but the renamed targets only ship in unreleased Isaac Sim builds.

When Kit's resolver can't satisfy a hard dep locally, it falls back to a remote registry sync that walks 10k+ packages across 4 registries (`kit/default`, `kit/sdk`, `kit/prod/default`, `kit/prod/sdk`). On a fast network this still burns ~55s before failing; on the CI self-hosted runners the registry endpoints appear slow / rate-limited, which is what's pushing per-test wall-time to **1000s / 1700s**. CI then retries each test 3×.

Marks the three as `{ optional = true }`. Kit will skip them when absent (the convention used by isaacsim's own extensions, e.g. `omni.kit.notification_manager = { optional = true }` in `isaacsim.app.compatibility_check`). When upstream Isaac Sim ships these extensions publicly, they auto-load — no further IL change.

## Fix 2 — `randomize_visual_color` (and three siblings) crash on `rep.__file__ = None`

`source/isaaclab/isaaclab/envs/mdp/events.py` had four sites doing:

```python
version = re.match(r"^(\d+\.\d+\.\d+)", rep.__file__.split("/")[-5][21:]).group(1)
```

This assumes `omni.replicator.core` always exposes a string `__file__`. But Kit's extension manager loads `omni.replicator.core` as a **namespace package**, leaving `rep.__file__ = None`. Calling `.split("/")` on `None` raises `AttributeError: 'NoneType' object has no attribute 'split'`, killing the event term before `compare_versions` runs. Locally reproduced — `test_color_randomization` fails with exactly that traceback at `events.py:2249`.

Replaces the four occurrences with a small helper:

```python
def _get_replicator_version(rep) -> str:
    rep_path = rep.__file__ or (rep.__path__[0] if getattr(rep, "__path__", None) else None)
    if rep_path is None:
        raise RuntimeError("omni.replicator.core has no resolvable __file__ or __path__")
    match = re.search(r"omni\.replicator\.core-(\d+\.\d+\.\d+)", rep_path)
    if match is None:
        raise RuntimeError(f"Could not parse omni-replicator-core version from {rep_path!r}")
    return match.group(1)
```

`rep.__path__[0]` is always populated for namespace packages and embeds the extscache directory name (e.g. `omni.replicator.core-1.13.4+110.0.0.lx64.r.cp312`), so the version is recoverable.

## Are all three tests fixed by these?

| Test | Local repro of CI symptom? | Verified fix locally? |
|---|---|---|
| `test_non_headless_launch` | yes — Kit dep error in 9-57s vs CI's 1000s+ | ✅ **passes (14s)** after the kit-file fix |
| `test_outdated_sensor` | no — passes locally regardless of the kit fix (its kit experience, `isaaclab.python.headless.rendering.kit`, has all deps locally) | (cannot verify locally; needs CI) |
| `test_color_randomization` | yes — `rep.__file__ is None` crash | events.py fix removes the `__file__` crash; locally the test still hits a separate `rep.functional` issue caused by my local Kit 110.0.0 having a stale `omni.replicator.core` that fails on `wp.context.Kernel` import. CI uses Kit 110.1.1 with a different `omni.replicator.core` that doesn't have that issue, so CI should pass after both fixes here |

**Honest caveat**: I cannot reproduce tests 2 & 3's CI hangs locally — locally they fail in different ways (or pass). The `kit/default` registry-sync path is the most plausible shared mechanism, since:

1. All three tests share the `AppLauncher` boot path.
2. CI's runner network behavior + Kit's registry-resolver retry logic could plausibly cascade the failure cost across the suite, even for camera-enabled tests that use a different kit experience.
3. Both fixes here are real bug fixes, narrowly scoped, and tested for non-regression on test 1.

If the camera tests still time out on this PR's CI, the residual cause is likely separate and worth a follow-up bisect against the suspect commits (#5523 Newton 1.2.0rc2, #5492 OVRTX, #5473 Newton viz markers, etc.).

## Test plan

- [x] **Local: `isaacsim==6.0.0.0` (PyPI) + Kit 110.0.0 + L40, no MIG**
  - `test_non_headless_launch`: **57s exit-1 → 14s PASSED**
  - `test_outdated_sensor`: 18s PASSED before fix, 17s PASSED after (kit fix doesn't change behavior locally)
  - `test_color_randomization`: separate `rep.functional` issue from local Kit version skew; events.py fix removes the `rep.__file__` crash that would otherwise hit in CI too
- [ ] CI `isaaclab (core)` matrix turns green
- [ ] No new failures elsewhere

## Related

- #5293 — original migration that introduced the speculative kit-file refs.
- Kelly's commit message on #5293 mentioned a `kellyg/fix-installation` branch as a follow-up for "installation, prebundle, and extension-exclusion fixes"; that branch is no longer on the remote, so this PR fills part of that gap. cc @kellyguo11
