### PR TITLE
[nvbug-6129447] Make isaaclab_physx imports optional in core spawners

### DIFF
--- a/source/isaaclab/changelog.d/my-nvbugs-4.rst
+++ b/source/isaaclab/changelog.d/my-nvbugs-4.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed ``ModuleNotFoundError: No module named 'isaaclab_physx'`` on kit-less /
+  Newton-only installs (e.g. the ``newton,tasks,assets,ov,rl[rsl_rl]`` selector)
+  by making the ``isaaclab_physx`` imports in :mod:`isaaclab.sim.spawners.meshes`
+  and :mod:`isaaclab.sim.spawners.from_files` optional. The ``*_cfg`` modules
+  now fall back to a dummy :class:`DeformableObjectSpawnerCfg` stub (with a
+  warning) when ``isaaclab_physx`` is not installed, and the spawn functions
+  lazily import PhysX-only types inside the deformable-body code path so that
+  rigid-only spawning works without ``isaaclab_physx``.

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -13,10 +13,6 @@ from typing import TYPE_CHECKING
 
 from filelock import FileLock
 
-# deformables only supported on PhysX backend
-from isaaclab_physx.sim import schemas as schemas_physx
-from isaaclab_physx.sim.spawners.materials import SurfaceDeformableBodyMaterialCfg
-
 from pxr import Gf, Sdf, Usd, UsdGeom
 
 from isaaclab.sim import converters, schemas
@@ -386,6 +382,11 @@ def _spawn_from_usd_file(
 
     # define deformable body properties, or modify if deformable body API is present (PhysX only)
     if cfg.deformable_props is not None:
+        # Lazily import PhysX-specific types only when deformable bodies are used.
+        # ``isaaclab_physx`` is optional under kit-less / Newton-only installs.
+        from isaaclab_physx.sim import schemas as schemas_physx  # noqa: PLC0415
+        from isaaclab_physx.sim.spawners.materials import SurfaceDeformableBodyMaterialCfg  # noqa: PLC0415
+
         prim = stage.GetPrimAtPath(prim_path)
         deformable_type = "surface" if isinstance(cfg.physics_material, SurfaceDeformableBodyMaterialCfg) else "volume"
         if "OmniPhysicsDeformableBodyAPI" in prim.GetAppliedSchemas():

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
@@ -5,11 +5,27 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from dataclasses import MISSING
 
-# deformables only supported on PhysX backend
-from isaaclab_physx.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+# deformables only supported on the PhysX backend; ``isaaclab_physx`` is optional under
+# kit-less / Newton-only installs. Fall back to a dummy stub so this module still imports
+# when ``isaaclab_physx`` is not available.
+try:
+    from isaaclab_physx.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+except ImportError as e:
+    warnings.warn(
+        f"""Could not import DeformableObjectSpawnerCfg, is isaaclab_physx installed?
+        Safe to ignore if using newton only. Complete exception: {e}"""
+    )
+    # import dummy class to avoid errors in type hints
+    from isaaclab.utils import configclass
+
+    @configclass
+    class DeformableObjectSpawnerCfg:
+        deformable_props = None
+
 
 from isaaclab.sim import converters, schemas
 from isaaclab.sim.spawners import materials

--- a/source/isaaclab/isaaclab/sim/spawners/meshes/meshes.py
+++ b/source/isaaclab/isaaclab/sim/spawners/meshes/meshes.py
@@ -11,10 +11,6 @@ import numpy as np
 import trimesh
 import trimesh.transformations
 
-# deformables only supported on PhysX backend
-from isaaclab_physx.sim import schemas as schemas_physx
-from isaaclab_physx.sim.spawners.materials import DeformableBodyMaterialCfg, SurfaceDeformableBodyMaterialCfg
-
 from pxr import Usd, UsdPhysics
 
 from isaaclab.sim import schemas
@@ -352,6 +348,16 @@ def _spawn_mesh_geom_from_mesh(
 
     .. _USDGeomMesh: https://openusd.org/dev/api/class_usd_geom_mesh.html
     """
+    # Lazily import PhysX-specific types only when deformable bodies are used. Deformable
+    # bodies are only supported on the PhysX backend and ``isaaclab_physx`` is optional
+    # under kit-less / Newton-only installs.
+    if cfg.deformable_props is not None:
+        from isaaclab_physx.sim import schemas as schemas_physx  # noqa: PLC0415
+        from isaaclab_physx.sim.spawners.materials import (  # noqa: PLC0415
+            DeformableBodyMaterialCfg,
+            SurfaceDeformableBodyMaterialCfg,
+        )
+
     # obtain stage handle
     stage = stage if stage is not None else get_current_stage()
 

--- a/source/isaaclab/isaaclab/sim/spawners/meshes/meshes_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/meshes/meshes_cfg.py
@@ -5,12 +5,28 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from dataclasses import MISSING
 from typing import Literal
 
-# deformables only supported on PhysX backend
-from isaaclab_physx.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+# deformables only supported on the PhysX backend; ``isaaclab_physx`` is optional under
+# kit-less / Newton-only installs. Fall back to a dummy stub so this module still imports
+# when ``isaaclab_physx`` is not available.
+try:
+    from isaaclab_physx.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+except ImportError as e:
+    warnings.warn(
+        f"""Could not import DeformableObjectSpawnerCfg, is isaaclab_physx installed?
+        Safe to ignore if using newton only. Complete exception: {e}"""
+    )
+    # import dummy class to avoid errors in type hints
+    from isaaclab.utils import configclass
+
+    @configclass
+    class DeformableObjectSpawnerCfg:
+        deformable_props = None
+
 
 from isaaclab.sim.spawners import materials
 from isaaclab.sim.spawners.spawner_cfg import RigidObjectSpawnerCfg


### PR DESCRIPTION
## Summary

Fixes NVBug 6129447 — `ModuleNotFoundError: No module named 'isaaclab_physx'` on the kit-less / Minimal Newton install selector (e.g. `newton,tasks,assets,ov,rl[rsl_rl]`). That selector deliberately omits `isaaclab_physx`, but `isaaclab.sim.spawners.meshes` and `isaaclab.sim.spawners.from_files` imported it unconditionally at module load time, so any code path that touches `MeshCfg` / `FileCfg` (the standard `isaaclab_tasks.utils.sim_launcher` chain does) failed at import time.

This PR defers the four top-level `from isaaclab_physx ...` imports in `isaaclab` core:

- `source/isaaclab/isaaclab/sim/spawners/meshes/meshes_cfg.py`
- `source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py`
- `source/isaaclab/isaaclab/sim/spawners/meshes/meshes.py`
- `source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py`

### Approach

Two patterns are applied based on how the import is used:

**`*_cfg.py`** — `DeformableObjectSpawnerCfg` is used as a base class for `MeshCfg` / `FileCfg`, so it must resolve at class-definition time. Wrap the import in a `try / except ImportError` block that falls back to a dummy stub. This mirrors the existing pattern in `source/isaaclab/isaaclab/sim/spawners/wrappers/wrappers_cfg.py`. When `isaaclab_physx` is installed the public class hierarchy is unchanged.

**`meshes.py` / `from_files.py`** — `schemas_physx`, `DeformableBodyMaterialCfg`, and `SurfaceDeformableBodyMaterialCfg` are only used inside the deformable-body code path. Move the imports inside the spawn function bodies, gated on `cfg.deformable_props is not None`. Rigid-only spawns no longer trigger any `isaaclab_physx` import.

### Context

This work was originally bundled with PR #5530 but was pulled out per @KellyG-NV's review request ("this should have been fixed in a separate PR"). The original `camera_cfg.py` patch from that attempt is no longer needed — `develop` already lazily resolves the default renderer through `isaaclab.utils.backend_utils.get_default_renderer_cfg`, so `camera_cfg.py` does not need to change.

## Test plan

- [x] `./isaaclab.sh -f` (pre-commit) passes on the changed files.
- [x] `python3 -m py_compile` on the four touched files.
- [x] AST check confirms `try/except + fallback stub` in the cfg modules and no top-level `isaaclab_physx` import in the runtime modules.
- [ ] Verify on a kit-less Newton install (`newton,tasks,assets,ov,rl[rsl_rl]`) that `import isaaclab.sim.spawners.meshes.meshes_cfg` and `import isaaclab.sim.spawners.from_files.from_files_cfg` succeed (was the failing path in the bug repro).
- [ ] Verify rigid-only `MeshCuboidCfg` / `UsdFileCfg` spawns work end-to-end on a kit-less install with no `isaaclab_physx`.
- [ ] Verify deformable spawns still work on a PhysX install (the lazy import inside `_spawn_mesh_geom_from_mesh` / `_spawn_from_usd_file` resolves correctly).