### PR TITLE
Fixes nvbug-6129447 ("No module named 'isaaclab_physx'")

### DIFF
--- a/source/isaaclab/changelog.d/my-nvbugs-4.rst
+++ b/source/isaaclab/changelog.d/my-nvbugs-4.rst
@@ -1,0 +1,27 @@
+Fixed
+^^^^^
+
+* Fixed ``ModuleNotFoundError: No module named 'isaaclab_physx'`` on kit-less /
+  Newton-only installs (e.g. the ``newton,tasks,assets,ov,rl[rsl_rl]`` selector)
+  by removing the remaining unconditional ``isaaclab_physx`` imports from
+  ``isaaclab`` core:
+
+  * :mod:`isaaclab.sim.spawners.meshes.meshes_cfg` and
+    :mod:`isaaclab.sim.spawners.from_files.from_files_cfg` fall back to a dummy
+    :class:`DeformableObjectSpawnerCfg` stub (with a warning) when
+    ``isaaclab_physx`` is not installed, so ``MeshCfg`` / ``FileCfg`` and their
+    subclasses remain importable.
+  * :mod:`isaaclab.sim.spawners.meshes.meshes` and
+    :mod:`isaaclab.sim.spawners.from_files.from_files` lazily import PhysX-only
+    schemas, materials, and ``RigidBodyMaterialCfg`` inside the deformable-body
+    and compliant-contact code paths, and use the solver-common
+    :class:`~isaaclab.sim.spawners.materials.RigidBodyMaterialBaseCfg` for
+    rigid-material ``isinstance`` checks so rigid-only spawning works without
+    ``isaaclab_physx``.
+  * :attr:`~isaaclab.sim.SimulationCfg.physics_material` now uses a
+    ``default_factory`` that prefers
+    :class:`~isaaclab_physx.sim.spawners.materials.RigidBodyMaterialCfg` when
+    ``isaaclab_physx`` is installed and falls back to
+    :class:`~isaaclab.sim.spawners.materials.RigidBodyMaterialBaseCfg` on
+    kit-less / Newton-only installs, so importing :class:`SimulationCfg` no
+    longer triggers the ``RigidBodyMaterialCfg`` forwarding shim.

--- a/source/isaaclab/isaaclab/sim/simulation_cfg.py
+++ b/source/isaaclab/isaaclab/sim/simulation_cfg.py
@@ -11,12 +11,28 @@ configuring the environment instances, viewer settings, and simulation parameter
 
 from __future__ import annotations
 
+from dataclasses import field
 from typing import Any, Literal  # Literal used by RenderCfg
 
 from isaaclab.physics import PhysicsCfg
-from isaaclab.sim.spawners.materials.physics_materials_cfg import RigidBodyMaterialCfg
+from isaaclab.sim.spawners.materials.physics_materials_cfg import RigidBodyMaterialBaseCfg
 from isaaclab.utils import configclass
 from isaaclab.visualizers import VisualizerCfg
+
+
+def _default_physics_material() -> RigidBodyMaterialBaseCfg:
+    """Construct the default rigid-body physics material for :class:`SimulationCfg`.
+
+    Prefers the PhysX-flavored :class:`~isaaclab_physx.sim.spawners.materials.RigidBodyMaterialCfg`
+    when ``isaaclab_physx`` is installed, falling back to the solver-common
+    :class:`~isaaclab.sim.spawners.materials.RigidBodyMaterialBaseCfg` on kit-less /
+    Newton-only installs that deliberately omit ``isaaclab_physx``.
+    """
+    try:
+        from isaaclab_physx.sim.spawners.materials import RigidBodyMaterialCfg  # noqa: PLC0415
+    except ImportError:
+        return RigidBodyMaterialBaseCfg()
+    return RigidBodyMaterialCfg()
 
 
 @configclass
@@ -193,13 +209,18 @@ class SimulationCfg:
     physics_prim_path: str = "/physicsScene"
     """The prim path where the USD PhysicsScene is created. Default is "/physicsScene"."""
 
-    physics_material: RigidBodyMaterialCfg = RigidBodyMaterialCfg()
-    """Default physics material settings for rigid bodies. Default is RigidBodyMaterialCfg.
+    physics_material: RigidBodyMaterialBaseCfg = field(default_factory=_default_physics_material)
+    """Default physics material settings for rigid bodies.
 
     The physics engine defaults to this physics material for all the rigid body prims that do not have any
     physics material specified on them.
 
     The material is created at the path: ``{physics_prim_path}/defaultMaterial``.
+
+    Defaults to :class:`~isaaclab_physx.sim.spawners.materials.RigidBodyMaterialCfg` when
+    ``isaaclab_physx`` is installed, and to the solver-common
+    :class:`~isaaclab.sim.spawners.materials.RigidBodyMaterialBaseCfg` on kit-less /
+    Newton-only installs.
     """
 
     use_fabric: bool = True

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -13,14 +13,9 @@ from typing import TYPE_CHECKING
 
 from filelock import FileLock
 
-# deformables only supported on PhysX backend
-from isaaclab_physx.sim import schemas as schemas_physx
-from isaaclab_physx.sim.spawners.materials import SurfaceDeformableBodyMaterialCfg
-
 from pxr import Gf, Sdf, Usd, UsdGeom
 
 from isaaclab.sim import converters, schemas
-from isaaclab.sim.spawners.materials import RigidBodyMaterialCfg
 from isaaclab.sim.utils import (
     add_labels,
     bind_physics_material,
@@ -386,6 +381,11 @@ def _spawn_from_usd_file(
 
     # define deformable body properties, or modify if deformable body API is present (PhysX only)
     if cfg.deformable_props is not None:
+        # Lazily import PhysX-specific types only when deformable bodies are used.
+        # ``isaaclab_physx`` is optional under kit-less / Newton-only installs.
+        from isaaclab_physx.sim import schemas as schemas_physx  # noqa: PLC0415
+        from isaaclab_physx.sim.spawners.materials import SurfaceDeformableBodyMaterialCfg  # noqa: PLC0415
+
         prim = stage.GetPrimAtPath(prim_path)
         deformable_type = "surface" if isinstance(cfg.physics_material, SurfaceDeformableBodyMaterialCfg) else "volume"
         if "OmniPhysicsDeformableBodyAPI" in prim.GetAppliedSchemas():
@@ -471,6 +471,10 @@ def spawn_from_usd_with_compliant_contact_material(
         prim_paths = cfg.physics_material_prim_path
 
     if stiff is not None or damp is not None:
+        # Compliant-contact stiffness / damping are PhysX-specific; the PhysX-flavored
+        # ``RigidBodyMaterialCfg`` lives in ``isaaclab_physx`` and is only imported here.
+        from isaaclab_physx.sim.spawners.materials import RigidBodyMaterialCfg  # noqa: PLC0415
+
         material_kwargs = {}
         if stiff is not None:
             material_kwargs["compliant_contact_stiffness"] = stiff

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
@@ -5,11 +5,27 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from dataclasses import MISSING
 
-# deformables only supported on PhysX backend
-from isaaclab_physx.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+# deformables only supported on the PhysX backend; ``isaaclab_physx`` is optional under
+# kit-less / Newton-only installs. Fall back to a dummy stub so this module still imports
+# when ``isaaclab_physx`` is not available.
+try:
+    from isaaclab_physx.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+except ImportError as e:
+    warnings.warn(
+        f"""Could not import DeformableObjectSpawnerCfg, is isaaclab_physx installed?
+        Safe to ignore if using newton only. Complete exception: {e}"""
+    )
+    # import dummy class to avoid errors in type hints
+    from isaaclab.utils import configclass
+
+    @configclass
+    class DeformableObjectSpawnerCfg:
+        deformable_props = None
+
 
 from isaaclab.sim import converters, schemas
 from isaaclab.sim.spawners import materials

--- a/source/isaaclab/isaaclab/sim/spawners/meshes/meshes.py
+++ b/source/isaaclab/isaaclab/sim/spawners/meshes/meshes.py
@@ -11,16 +11,12 @@ import numpy as np
 import trimesh
 import trimesh.transformations
 
-# deformables only supported on PhysX backend
-from isaaclab_physx.sim import schemas as schemas_physx
-from isaaclab_physx.sim.spawners.materials import DeformableBodyMaterialCfg, SurfaceDeformableBodyMaterialCfg
-
 from pxr import Usd, UsdPhysics
 
 from isaaclab.sim import schemas
 from isaaclab.sim.utils import bind_physics_material, bind_visual_material, clone, create_prim, get_current_stage
 
-from ..materials import RigidBodyMaterialCfg
+from ..materials import RigidBodyMaterialBaseCfg
 
 if TYPE_CHECKING:
     from . import meshes_cfg
@@ -352,6 +348,16 @@ def _spawn_mesh_geom_from_mesh(
 
     .. _USDGeomMesh: https://openusd.org/dev/api/class_usd_geom_mesh.html
     """
+    # Lazily import PhysX-specific types only when deformable bodies are used. Deformable
+    # bodies are only supported on the PhysX backend and ``isaaclab_physx`` is optional
+    # under kit-less / Newton-only installs.
+    if cfg.deformable_props is not None:
+        from isaaclab_physx.sim import schemas as schemas_physx  # noqa: PLC0415
+        from isaaclab_physx.sim.spawners.materials import (  # noqa: PLC0415
+            DeformableBodyMaterialCfg,
+            SurfaceDeformableBodyMaterialCfg,
+        )
+
     # obtain stage handle
     stage = stage if stage is not None else get_current_stage()
 
@@ -370,7 +376,7 @@ def _spawn_mesh_geom_from_mesh(
         if not isinstance(cfg.physics_material, DeformableBodyMaterialCfg):
             raise ValueError("Deformable properties require a deformable physics material.")
     if cfg.rigid_props is not None and cfg.physics_material is not None:
-        if not isinstance(cfg.physics_material, RigidBodyMaterialCfg):
+        if not isinstance(cfg.physics_material, RigidBodyMaterialBaseCfg):
             raise ValueError("Rigid properties require a rigid physics material.")
 
     # create all the paths we need for clarity

--- a/source/isaaclab/isaaclab/sim/spawners/meshes/meshes_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/meshes/meshes_cfg.py
@@ -5,12 +5,28 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from dataclasses import MISSING
 from typing import Literal
 
-# deformables only supported on PhysX backend
-from isaaclab_physx.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+# deformables only supported on the PhysX backend; ``isaaclab_physx`` is optional under
+# kit-less / Newton-only installs. Fall back to a dummy stub so this module still imports
+# when ``isaaclab_physx`` is not available.
+try:
+    from isaaclab_physx.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+except ImportError as e:
+    warnings.warn(
+        f"""Could not import DeformableObjectSpawnerCfg, is isaaclab_physx installed?
+        Safe to ignore if using newton only. Complete exception: {e}"""
+    )
+    # import dummy class to avoid errors in type hints
+    from isaaclab.utils import configclass
+
+    @configclass
+    class DeformableObjectSpawnerCfg:
+        deformable_props = None
+
 
 from isaaclab.sim.spawners import materials
 from isaaclab.sim.spawners.spawner_cfg import RigidObjectSpawnerCfg


### PR DESCRIPTION
# Description

Fixes NVBug 6129447 — `ModuleNotFoundError: No module named 'isaaclab_physx'` on kit-less / Minimal Newton installs (e.g. `newton,tasks,assets,ov,rl[rsl_rl]`).

Defers the remaining unconditional `isaaclab_physx` imports in `isaaclab` core:

- `spawners/meshes/meshes_cfg.py`, `spawners/from_files/from_files_cfg.py` — fall back to a dummy `DeformableObjectSpawnerCfg` stub (mirrors `wrappers/wrappers_cfg.py`).
- `spawners/meshes/meshes.py`, `spawners/from_files/from_files.py` — move PhysX-only imports inside the deformable / compliant-contact code paths and validate rigid materials against `RigidBodyMaterialBaseCfg`.
- `sim/simulation_cfg.py` — lazy `default_factory` for `physics_material`, preferring `RigidBodyMaterialCfg` when `isaaclab_physx` is installed, falling back to `RigidBodyMaterialBaseCfg` on kit-less. Root cause of the re-opened traceback.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there