### PR TITLE
Disables test timeout retry

### DIFF
--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -48,7 +48,7 @@ legitimate slow launches.
 STARTUP_HANG_RETRIES = 2
 """Number of times to retry a test that hangs during startup before giving up."""
 
-TIMEOUT_RETRIES = 2
+TIMEOUT_RETRIES = 0
 """Number of times to retry a test that reaches its hard timeout before giving up."""
 
 SHUTDOWN_GRACE_PERIOD = 30

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -67,6 +67,7 @@ PER_TEST_TIMEOUTS = {
     "test_rendering_cartpole_kitless.py": 2000,
     "test_rendering_dexsuite_kuka_kitless.py": 2000,
     "test_rendering_shadow_hand_kitless.py": 2000,
+    "test_contact_sensor.py": 2000,
 }
 """A dictionary of tests and their timeouts in seconds.
 


### PR DESCRIPTION
# Description

The timeout retry logic is doing more harm than good as it's causing tests to run extremely long and does not actually resolve any of the timeout issues. Reverting the change to default to 0 retries on timeouts.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
