### PR TITLE
Fixes doc build errors in mimic datagen

### DIFF
--- a/source/isaaclab_mimic/changelog.d/fix-mimic-datagen-import.rst
+++ b/source/isaaclab_mimic/changelog.d/fix-mimic-datagen-import.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :mod:`isaaclab_mimic.datagen` imports in packaged installs and avoided
+  importing task configuration modules until data generation config setup.

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/generation.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/generation.py
@@ -19,8 +19,6 @@ from isaaclab.managers.recorder_manager import RecorderManagerBaseCfg
 from isaaclab_mimic.datagen.data_generator import DataGenerator
 from isaaclab_mimic.datagen.datagen_info_pool import DataGenInfoPool
 
-from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
-
 # global variable to keep track of the data generation statistics
 num_success = 0
 num_failures = 0
@@ -180,6 +178,8 @@ def setup_env_config(
     Raises:
         NotImplementedError: If no success termination term found
     """
+    from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
+
     env_cfg = parse_env_cfg(env_name, device=device, num_envs=num_envs)
 
     if generation_num_trials is not None:

--- a/source/isaaclab_mimic/setup.py
+++ b/source/isaaclab_mimic/setup.py
@@ -10,7 +10,7 @@ import os
 import platform
 
 import toml
-from setuptools import setup
+from setuptools import find_namespace_packages, setup
 
 # Obtain the extension data from the extension.toml file
 EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -45,7 +45,7 @@ EXTRAS_REQUIRE["all"] = list(set(EXTRAS_REQUIRE["all"]))
 # Installation operation
 setup(
     name="isaaclab_mimic",
-    packages=["isaaclab_mimic"],
+    packages=find_namespace_packages(include=["isaaclab_mimic", "isaaclab_mimic.*"]),
     author=EXTENSION_TOML_DATA["package"]["author"],
     maintainer=EXTENSION_TOML_DATA["package"]["maintainer"],
     url=EXTENSION_TOML_DATA["package"]["repository"],


### PR DESCRIPTION
# Description

Fix errors in documentation build job, where imports were causing compilation issues

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- Documentation update


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
