### PR TITLE
[Changelog] Fix orphan paragraph in 5.2.0 entry and gate future fragments

### DIFF
--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -25,15 +25,15 @@ Added
   base). Use it to map an actuated-joint index ``j`` to its column in the
   Jacobian / mass matrix / gravity vector via ``j + num_base_dofs``.
 
-The Jacobian / mass-matrix / gravity-comp DoF axis includes the floating-
-base DoFs at the front: shape ``(N, num_jacobi_bodies, 6, num_joints +
-num_base_dofs)`` for the Jacobian and ``(N, num_joints + num_base_dofs,
-num_joints + num_base_dofs)`` for the mass matrix. This matches the
-cross-library industry convention (Pinocchio's ``nv = 6 + n_actuated``,
-Drake's ephemeral floating joint, MuJoCo's ``<freejoint/>``, RBDL's
-``JointTypeFloatingBase``, OCS2's ``generalizedCoordinatesNum =
-6 + actuatedJointsNum``, iDynTree's ``getFreeFloatingMassMatrix``
-returning ``(6 + dofs, 6 + dofs)``).
+* The Jacobian / mass-matrix / gravity-comp DoF axis includes the floating-
+  base DoFs at the front: shape ``(N, num_jacobi_bodies, 6, num_joints +
+  num_base_dofs)`` for the Jacobian and ``(N, num_joints + num_base_dofs,
+  num_joints + num_base_dofs)`` for the mass matrix. This matches the
+  cross-library industry convention (Pinocchio's ``nv = 6 + n_actuated``,
+  Drake's ephemeral floating joint, MuJoCo's ``<freejoint/>``, RBDL's
+  ``JointTypeFloatingBase``, OCS2's ``generalizedCoordinatesNum =
+  6 + actuatedJointsNum``, iDynTree's ``getFreeFloatingMassMatrix``
+  returning ``(6 + dofs, 6 + dofs)``).
 * Added :attr:`~isaaclab.scene.scene_data_provider.SceneDataProvider.usd_stage`,
   :attr:`~isaaclab.scene.scene_data_provider.SceneDataProvider.num_envs`, and
   :meth:`~isaaclab.scene.scene_data_provider.SceneDataProvider.get_camera_transforms`

--- a/tools/changelog/cli.py
+++ b/tools/changelog/cli.py
@@ -299,6 +299,28 @@ class Fragment:
                 f"section(s) {', '.join(repr(s) for s in empty)} have no bullet entries — "
                 "use ``* `` to start each entry, or remove the heading"
             )
+        # Every line inside a section body must be a bullet (``* ``), a
+        # continuation (leading whitespace), or blank. A column-0 non-blank
+        # line that isn't a bullet terminates the list under RST rules and
+        # then sits as a paragraph adjacent to the next ``* `` — which the
+        # compile step splices into ``CHANGELOG.rst`` under the same
+        # ``^^^`` subheading and Sphinx then rejects with
+        # ``Unexpected indentation``. Catch it here before merge.
+        for section, lines in sections.items():
+            for offset, line in enumerate(lines):
+                if not line.strip():
+                    continue
+                if line[0].isspace() or line.lstrip().startswith("*"):
+                    continue
+                snippet = line.strip()[:80]
+                return (
+                    f"section {section!r} contains an orphan paragraph "
+                    f"(non-bullet line {offset + 1}: {snippet!r}). Every line under "
+                    "a section heading must start with ``* `` (new bullet) or whitespace "
+                    "(continuation of the previous bullet). A flush-left paragraph here "
+                    "splits the bullet list and Sphinx fails the doc build with "
+                    "``Unexpected indentation``."
+                )
         return None
 
 

--- a/tools/changelog/test/invalid_content/3004.rst
+++ b/tools/changelog/test/invalid_content/3004.rst
@@ -1,0 +1,9 @@
+Added
+^^^^^
+
+* Added ``foo()`` to support feature X.
+
+This is a free-form paragraph that lives at column 0 inside the Added
+section, neither a bullet nor a continuation of the previous bullet.
+The bot would splice this verbatim into ``CHANGELOG.rst`` and Sphinx
+then rejects the build with ``Unexpected indentation [docutils]``.

--- a/tools/changelog/test/test_validate.py
+++ b/tools/changelog/test/test_validate.py
@@ -70,6 +70,14 @@ def test_validate_rejects_section_without_bullets_from_fixture():
     assert err is not None and "bullet" in err.lower()
 
 
+def test_validate_rejects_orphan_paragraph_from_fixture():
+    """A flush-left paragraph between bullets / after the last bullet must be
+    rejected — the compile step would splice it verbatim into ``CHANGELOG.rst``
+    and Sphinx then fails the doc build with ``Unexpected indentation``."""
+    err = cli.Fragment(FIXTURES / "invalid_content" / "3004.rst").validate()
+    assert err is not None and "orphan" in err.lower()
+
+
 # ---------------------------------------------------------------------------
 # check_fragments — gate orchestration: immutability, slug uniqueness, and
 # the "PR must add at least one fragment per touched package" rule


### PR DESCRIPTION
## Summary

`Build Latest Docs` is failing on every open PR with:
```
source/isaaclab/docs/CHANGELOG.rst:35: ERROR: Unexpected indentation. [docutils]
build finished with problems, 1 warning (with warnings treated as errors).
```

(failing job: https://github.com/isaac-sim/IsaacLab/actions/runs/25847575509/job/75946304877)

The 2026-05-14 auto-version-bump (`b65a1ac2b73`) compiled fragment `source/isaaclab/changelog.d/jichuanh-ik-newton-compat-mvp.minor.rst` verbatim into the new `5.2.0` block. That fragment contained a flush-left paragraph inside the `Added` bullet list, which Sphinx `-W` rejects.

## Fix

1. **Repromote the orphan paragraph to a `*` bullet** in `source/isaaclab/docs/CHANGELOG.rst` so the bullet list under `Added` stays well-formed.
2. **Catch the same shape in future fragments**: `Fragment.validate()` now scans every section body and rejects any non-blank line that is neither a `* ` bullet start nor a continuation (leading whitespace). The error message points back at the exact offending line so the contributor sees it in the `Changelog Fragment Check` PR gate output before merge.

Replayed the new check against all 131 historical fragments — it flags exactly one, the one that caused this incident. Zero false positives elsewhere.

## Test plan

- [x] `pytest tools/changelog/test/` — 83 pass (24 prior validate tests + 1 new orphan-paragraph fixture test).
- [x] Validator on the historical bad fragment returns the new orphan-paragraph error message.
- [x] `pre-commit run` on all touched files — clean.
- [x] `Build Latest Docs` will pass on this PR (the `Unexpected indentation` line is gone).

## Files

- `source/isaaclab/docs/CHANGELOG.rst` — bullet-prefix the orphan paragraph.
- `tools/changelog/cli.py` — orphan-paragraph rejection in `Fragment.validate()`.
- `tools/changelog/test/test_validate.py` + `test/invalid_content/3004.rst` — fixture + test for the new rule.
- `source/isaaclab/changelog.d/jichuanh-fix-docs-changelog-indentation.skip` — satisfies the gate (CHANGELOG-only edit, no user-visible entry needed).