### PR TITLE
Fix invalid inline comment in Windows batch code block

### DIFF
--- a/docs/source/setup/installation/kitless_installation.rst
+++ b/docs/source/setup/installation/kitless_installation.rst
@@ -44,7 +44,8 @@ with MJWarp physics and the Newton visualizer:
       .. code-block:: batch
 
          :: Install Isaac Lab (Newton backend, no Isaac Sim required)
-         isaaclab.bat --install   :: or isaaclab.bat -i
+         :: or: isaaclab.bat -i
+         isaaclab.bat --install
 
          :: Kickoff training with MJWarp physics and Newton visualizer
          isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py ^


### PR DESCRIPTION
## Summary

* Fixed an invalid inline `::` comment in the Windows batch code block on the kit-less installation page. In Windows batch, `::` only works as a comment at the start of a line — when placed inline after a command, the tokens are passed as arguments, causing a runtime error. Moved the shorthand hint (`or: isaaclab.bat -i`) to its own comment line.

## Test plan

- [ ] Verify the rendered docs page shows the corrected batch snippet.
- [ ] Confirm the `isaaclab.bat --install` command runs without unexpected extra arguments on Windows.