### PR TITLE
Fix skrl drone-ARL configs using STATES instead of OBSERVATIONS

### DIFF
--- a/source/isaaclab_tasks/changelog.d/proth-fix-skrl-drone-arl-states-input.rst
+++ b/source/isaaclab_tasks/changelog.d/proth-fix-skrl-drone-arl-states-input.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed ``AttributeError: 'NoneType' object has no attribute 'shape'`` raised
+  when instantiating skrl PPO models for the ``Isaac-TrackPositionNoObstacles-ARL-Robot-1-*``
+  and ``Isaac-Navigation-3DObstacles-ARL-Robot-1-*`` tasks. The drone-ARL skrl
+  configs used ``input: STATES`` for both policy and value networks, which
+  skrl 2.0 resolves against ``state_space`` (``None`` for single-agent
+  environments). Updated the configs to use ``input: OBSERVATIONS`` to match
+  the rest of the single-agent skrl configs in IsaacLab.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/navigation/config/arl_robot_1/agents/skrl_rough_ppo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/navigation/config/arl_robot_1/agents/skrl_rough_ppo_cfg.yaml
@@ -19,7 +19,7 @@ models:
     initial_log_std: 0.0
     network:
       - name: mlp
-        input: STATES
+        input: OBSERVATIONS
         layers: [256, 128, 64]
         activations: elu
       - name: gru
@@ -33,7 +33,7 @@ models:
     clip_actions: False
     network:
       - name: mlp
-        input: STATES
+        input: OBSERVATIONS
         layers: [256, 128, 64]
         activations: elu
       - name: gru

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/track_position_state_based/config/arl_robot_1/agents/skrl_ppo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/track_position_state_based/config/arl_robot_1/agents/skrl_ppo_cfg.yaml
@@ -19,7 +19,7 @@ models:
     initial_log_std: 0.0
     network:
       - name: mlp
-        input: STATES
+        input: OBSERVATIONS
         layers: [256, 128, 64]
         activations: elu
       - name: gru
@@ -33,7 +33,7 @@ models:
     clip_actions: False
     network:
       - name: mlp
-        input: STATES
+        input: OBSERVATIONS
         layers: [256, 128, 64]
         activations: elu
       - name: gru


### PR DESCRIPTION
## Summary

- Training/playing the drone-ARL skrl tasks (`Isaac-TrackPositionNoObstacles-ARL-Robot-1-*`, `Isaac-Navigation-3DObstacles-ARL-Robot-1-*`) crashed at `Runner(env, agent_cfg)` with `AttributeError: 'NoneType' object has no attribute 'shape'` in `LazyLinear.initialize_parameters`.
- Root cause: the two drone-ARL skrl YAMLs declare `input: STATES` for the policy and value networks. In skrl 2.0 the model instantiator now resolves `STATES` against `state_space`, which is `None` for single-agent envs, so the generated `compute()` calls `self.mlp_container(None)` and the first `LazyLinear` raises on `input.shape[-1]`.
- Switched both configs to `input: OBSERVATIONS`, matching every other single-agent skrl config in IsaacLab. The two multi-agent MAPPO configs that legitimately use `STATES` (`direct/shadow_hand_over`, `direct/cart_double_pendulum`) are unaffected.

## Files changed

- `source/isaaclab_tasks/.../drone_arl/track_position_state_based/config/arl_robot_1/agents/skrl_ppo_cfg.yaml`
- `source/isaaclab_tasks/.../drone_arl/navigation/config/arl_robot_1/agents/skrl_rough_ppo_cfg.yaml`
- `source/isaaclab_tasks/changelog.d/proth-fix-skrl-drone-arl-states-input.rst` (patch fragment)

## Test plan

- [x] Reproduced the exact stack trace (`<string>` line 48 → `container.py:253` → `lazy.py:263` → `linear.py:323`) with `input: STATES` using a standalone skrl `shared_model` instantiation against a single-agent obs/action space.
- [x] After the YAML change, the same standalone instantiation loads both edited YAMLs from disk and successfully runs `init_state_dict(role='policy')` and `init_state_dict(role='value')` on a `SharedModel`.
- [x] `./isaaclab.sh -f` (pre-commit) passes locally.
- [ ] Full end-to-end `train.py`/`play.py` smoke test against:
  - `Isaac-TrackPositionNoObstacles-ARL-Robot-1-v0`
  - `Isaac-TrackPositionNoObstacles-ARL-Robot-1-Play-v0 --use_pretrained_checkpoint`
  - `Isaac-Navigation-3DObstacles-ARL-Robot-1-v0`