### PR TITLE
[Newton] Bump Newton pin to v1.2.0rc3

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-newton-rc3-bump.minor.rst
+++ b/source/isaaclab/changelog.d/jichuanh-newton-rc3-bump.minor.rst
@@ -1,0 +1,18 @@
+Changed
+^^^^^^^
+
+* Bumped the ``newton[sim]`` pin from ``v1.2.0rc2`` to ``v1.2.0rc3``
+  across :mod:`isaaclab_newton`, :mod:`isaaclab_physx` (``[newton]``
+  extra), :mod:`isaaclab_visualizers` (3×), and
+  ``tools/wheel_builder/res/python_packages.toml``. Restores the
+  pin briefly active on develop between `isaac-sim/IsaacLab#5024
+  <https://github.com/isaac-sim/IsaacLab/pull/5024>`_ and
+  `isaac-sim/IsaacLab#5566
+  <https://github.com/isaac-sim/IsaacLab/pull/5566>`_, this time
+  keeping the canonical ``newton[sim] @ git+...`` form with the
+  ``[sim]`` extra preserved everywhere.
+* No IsaacLab-side ``mujoco`` / ``mujoco-warp`` pin change — the
+  transitive ``mjwarp`` bump flows in through ``newton[sim]`` since
+  `isaac-sim/IsaacLab#5566
+  <https://github.com/isaac-sim/IsaacLab/pull/5566>`_ dropped the
+  explicit pins.

--- a/source/isaaclab_newton/changelog.d/jichuanh-newton-rc3-bump.minor.rst
+++ b/source/isaaclab_newton/changelog.d/jichuanh-newton-rc3-bump.minor.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+* Bumped the ``newton[sim]`` pin from ``v1.2.0rc2`` to ``v1.2.0rc3``.

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -39,7 +39,7 @@ EXTRAS_REQUIRE = {
     "all": [
         "prettytable==3.3.0",
         "PyOpenGL-accelerate==3.1.10",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
     ],
 }
 

--- a/source/isaaclab_physx/changelog.d/jichuanh-newton-rc3-bump.rst
+++ b/source/isaaclab_physx/changelog.d/jichuanh-newton-rc3-bump.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Bumped the optional ``[newton]`` extra to ``v1.2.0rc3`` so the pin
+  matches :mod:`isaaclab_newton`.

--- a/source/isaaclab_physx/setup.py
+++ b/source/isaaclab_physx/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = []
 
 EXTRAS_REQUIRE = {
     "newton": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
     ],
 }
 

--- a/source/isaaclab_visualizers/changelog.d/jichuanh-newton-rc3-bump.rst
+++ b/source/isaaclab_visualizers/changelog.d/jichuanh-newton-rc3-bump.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Bumped the ``newton[sim]`` pin in the ``[newton]``, ``[rerun]``, and
+  ``[viser]`` extras to ``v1.2.0rc3`` so the pin matches
+  :mod:`isaaclab_newton`.

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -24,16 +24,16 @@ EXTRAS_REQUIRE = {
     "kit": [],
     "newton": [
         "warp-lang",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
         "PyOpenGL-accelerate",
         "imgui-bundle>=1.92.5",
     ],
     "rerun": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
         "rerun-sdk>=0.29.0",
     ],
     "viser": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
         "viser>=1.0.16",
     ],
 }

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -87,7 +87,7 @@ pyproject.optional-dependencies.all = [
     # ================================================================================
     { "newton" = [
         "warp-lang==1.13.0",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
         "PyOpenGL-accelerate==3.1.10"
     ] },
     # ================================================================================


### PR DESCRIPTION
## Summary

Bumps the Newton pin to [`v1.2.0rc3`](https://pypi.org/project/newton/1.2.0rc3/), keeping the canonical `newton[sim] @ git+...` form across all five pin sites.

Restores the bump that was briefly active on develop between [isaac-sim/IsaacLab#5024](https://github.com/isaac-sim/IsaacLab/pull/5024) and [isaac-sim/IsaacLab#5566](https://github.com/isaac-sim/IsaacLab/pull/5566) — [isaac-sim/IsaacLab#5024](https://github.com/isaac-sim/IsaacLab/pull/5024) silently moved the pin to `newton==1.2.0rc3` (PyPI form, dropping the `[sim]` extra), and [isaac-sim/IsaacLab#5566](https://github.com/isaac-sim/IsaacLab/pull/5566) reverted it back to `newton[sim] @ git+...@v1.2.0rc2`. This PR brings rc3 back, this time with the proper `[sim]` extra preserved everywhere.

## What's new in Newton v1.2.0rc3 vs v1.2.0rc2

Notable upstream fixes:

- **[newton-physics/newton#2651](https://github.com/newton-physics/newton/pull/2651)** — MPR/GJK no longer assumes convex hulls are centered around the origin (affects rigid-body contact computation for off-center hulls).
- **[newton-physics/newton#2703](https://github.com/newton-physics/newton/pull/2703)** — Kamino FK solver performance improvements.
- **[newton-physics/newton#2721](https://github.com/newton-physics/newton/pull/2721)** — HDR color output for tiled camera sensors.
- SolverMuJoCo fixes: planar meshes, contact-anchor computation, distance conversion.
- Per-mesh color and PBR overrides in `log_mesh` ([newton-physics/newton#2628](https://github.com/newton-physics/newton/pull/2628)) — rerun viewer.

## Required dep bumps

None on the IsaacLab side. Since [isaac-sim/IsaacLab#5566](https://github.com/isaac-sim/IsaacLab/pull/5566) dropped IsaacLab's explicit `mujoco` / `mujoco-warp` pins, the `mjwarp 3.8.0.1 → 3.8.0.2` bump in rc3 flows in transitively through `newton[sim]` with no IsaacLab-side change.

`warp-lang` stays at `1.13.0` (set by [isaac-sim/IsaacLab#5523](https://github.com/isaac-sim/IsaacLab/pull/5523)).

## Pins updated

| File | Change |
|---|---|
| `source/isaaclab_newton/setup.py` | `v1.2.0rc2` → `v1.2.0rc3` |
| `source/isaaclab_physx/setup.py` | `v1.2.0rc2` → `v1.2.0rc3` |
| `source/isaaclab_visualizers/setup.py` | 3× `v1.2.0rc2` → `v1.2.0rc3` |
| `tools/wheel_builder/res/python_packages.toml` | `v1.2.0rc2` → `v1.2.0rc3` |

## Test plan

- [x] Pre-commit clean.
- [ ] CI smoke verifies clean install picks up `newton 1.2.0rc3` and downstream `mjwarp 3.8.0.2`.

## Caveat

This is a version-string-only bump — no IsaacLab-side code adapts were needed. If any rc3 behavioral change (MPR/GJK convex-hull fix, SolverMuJoCo contact-anchor fix) surfaces a regression in scenes with off-center convex meshes or planar collision, those would need follow-up tracking.

**Alternative**: [isaac-sim/IsaacLab#5616](https://github.com/isaac-sim/IsaacLab/pull/5616) bumps directly to v1.2.0rc4 — pick whichever target based on CI signal.