### PR TITLE
[Newton] Bump Newton pin to v1.2.0rc4 (depends on #5614)

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-newton-1.2.0rc3-bump.minor.rst
+++ b/source/isaaclab/changelog.d/jichuanh-newton-1.2.0rc3-bump.minor.rst
@@ -1,0 +1,20 @@
+Changed
+^^^^^^^
+
+* Bumped Newton pin to ``v1.2.0rc3``. Pulls in IsaacLab-relevant fixes
+  from `newton-physics/newton#2651
+  <https://github.com/newton-physics/newton/pull/2651>`_ (MPR/GJK no
+  longer assumes convex hulls are centered around the origin),
+  `newton-physics/newton#2703
+  <https://github.com/newton-physics/newton/pull/2703>`_ (Kamino FK
+  solver performance), `newton-physics/newton#2721
+  <https://github.com/newton-physics/newton/pull/2721>`_ (HDR color
+  output for tiled camera sensors), plus SolverMuJoCo fixes for planar
+  meshes, contact-anchor computation, and distance conversion.
+* The ``newton[sim]`` transitive deps now resolve to ``mjwarp==3.8.0.2``
+  (was ``3.8.0.1``). IsaacLab no longer pins ``mujoco`` / ``mujoco-warp``
+  explicitly (see :pr:`5566`), so these flow in through ``newton[sim]``
+  with no IsaacLab-side pin change.
+* The Newton pin is mirrored across :mod:`isaaclab_newton`,
+  :mod:`isaaclab_visualizers` (3×), :mod:`isaaclab_physx` (``[newton]``
+  extra), and ``tools/wheel_builder/res/python_packages.toml``.

--- a/source/isaaclab/changelog.d/jichuanh-newton-1.2.0rc4-bump.rst
+++ b/source/isaaclab/changelog.d/jichuanh-newton-1.2.0rc4-bump.rst
@@ -1,0 +1,18 @@
+Changed
+^^^^^^^
+
+* Bumped Newton pin to ``v1.2.0rc4``. Pulls in IsaacLab-relevant fixes
+  from `newton-physics/newton#2743
+  <https://github.com/newton-physics/newton/pull/2743>`_ (Collada
+  textures in URDF import), `newton-physics/newton#2823
+  <https://github.com/newton-physics/newton/pull/2823>`_ (device for
+  gravity-data allocation in Kamino — multi-GPU), and
+  `newton-physics/newton#2632
+  <https://github.com/newton-physics/newton/pull/2632>`_
+  (CollisionPipeline small fixes). Also includes a refactor of
+  ``DelassusOperator`` attributes (`newton-physics/newton#2734
+  <https://github.com/newton-physics/newton/pull/2734>`_) and a
+  ViewerGL Plots-window anchor fix (`newton-physics/newton#2818
+  <https://github.com/newton-physics/newton/pull/2818>`_).
+* ``mjwarp`` moves from ``3.8.0.2`` to ``3.8.0.3`` transitively via
+  ``newton[sim]``; no IsaacLab-side pin change required.

--- a/source/isaaclab_newton/changelog.d/jichuanh-newton-1.2.0rc3-bump.minor.rst
+++ b/source/isaaclab_newton/changelog.d/jichuanh-newton-1.2.0rc3-bump.minor.rst
@@ -1,0 +1,17 @@
+Changed
+^^^^^^^
+
+* Bumped Newton pin to ``v1.2.0rc3``. Pulls in IsaacLab-relevant fixes
+  from `newton-physics/newton#2651
+  <https://github.com/newton-physics/newton/pull/2651>`_ (MPR/GJK no
+  longer assumes convex hulls are centered around the origin),
+  `newton-physics/newton#2703
+  <https://github.com/newton-physics/newton/pull/2703>`_ (Kamino FK
+  solver performance), `newton-physics/newton#2721
+  <https://github.com/newton-physics/newton/pull/2721>`_ (HDR color
+  output for tiled camera sensors), plus SolverMuJoCo fixes for planar
+  meshes, contact-anchor computation, and distance conversion.
+* ``mjwarp`` is bumped from ``3.8.0.1`` to ``3.8.0.2`` transitively via
+  ``newton[sim]``; no IsaacLab-side pin change required since
+  :pr:`5566` dropped IsaacLab's explicit ``mujoco`` / ``mujoco-warp``
+  pins.

--- a/source/isaaclab_newton/changelog.d/jichuanh-newton-1.2.0rc4-bump.rst
+++ b/source/isaaclab_newton/changelog.d/jichuanh-newton-1.2.0rc4-bump.rst
@@ -1,0 +1,14 @@
+Changed
+^^^^^^^
+
+* Bumped Newton pin to ``v1.2.0rc4``. Pulls in IsaacLab-relevant fixes
+  from `newton-physics/newton#2743
+  <https://github.com/newton-physics/newton/pull/2743>`_ (Collada
+  textures in URDF import), `newton-physics/newton#2823
+  <https://github.com/newton-physics/newton/pull/2823>`_ (device for
+  gravity-data allocation in Kamino — multi-GPU), and
+  `newton-physics/newton#2632
+  <https://github.com/newton-physics/newton/pull/2632>`_
+  (CollisionPipeline small fixes).
+* ``mjwarp`` moves from ``3.8.0.2`` to ``3.8.0.3`` transitively via
+  ``newton[sim]``.

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -39,7 +39,7 @@ EXTRAS_REQUIRE = {
     "all": [
         "prettytable==3.3.0",
         "PyOpenGL-accelerate==3.1.10",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
     ],
 }
 

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -39,7 +39,7 @@ EXTRAS_REQUIRE = {
     "all": [
         "prettytable==3.3.0",
         "PyOpenGL-accelerate==3.1.10",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc4",
     ],
 }
 

--- a/source/isaaclab_physx/changelog.d/jichuanh-newton-1.2.0rc3-bump.rst
+++ b/source/isaaclab_physx/changelog.d/jichuanh-newton-1.2.0rc3-bump.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Bumped the optional ``[newton]`` extra to ``v1.2.0rc3`` so the Newton
+  pin matches :mod:`isaaclab_newton`. See :mod:`isaaclab_newton` for the
+  list of upstream fixes pulled in.

--- a/source/isaaclab_physx/changelog.d/jichuanh-newton-1.2.0rc4-bump.rst
+++ b/source/isaaclab_physx/changelog.d/jichuanh-newton-1.2.0rc4-bump.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Bumped the optional ``[newton]`` extra to ``v1.2.0rc4`` so the Newton
+  pin matches :mod:`isaaclab_newton`. See :mod:`isaaclab_newton` for the
+  list of upstream fixes pulled in.

--- a/source/isaaclab_physx/setup.py
+++ b/source/isaaclab_physx/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = []
 
 EXTRAS_REQUIRE = {
     "newton": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
     ],
 }
 

--- a/source/isaaclab_physx/setup.py
+++ b/source/isaaclab_physx/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = []
 
 EXTRAS_REQUIRE = {
     "newton": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc4",
     ],
 }
 

--- a/source/isaaclab_visualizers/changelog.d/jichuanh-newton-1.2.0rc3-bump.rst
+++ b/source/isaaclab_visualizers/changelog.d/jichuanh-newton-1.2.0rc3-bump.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Bumped the ``newton[sim]`` pin in the ``[newton]``, ``[rerun]``, and
+  ``[viser]`` extras to ``v1.2.0rc3`` so all Newton declarations across
+  the repo stay on the same release. See :mod:`isaaclab_newton` for the
+  list of upstream fixes pulled in.

--- a/source/isaaclab_visualizers/changelog.d/jichuanh-newton-1.2.0rc4-bump.rst
+++ b/source/isaaclab_visualizers/changelog.d/jichuanh-newton-1.2.0rc4-bump.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Bumped the ``newton[sim]`` pin in the ``[newton]``, ``[rerun]``, and
+  ``[viser]`` extras to ``v1.2.0rc4``. See :mod:`isaaclab_newton` for
+  the list of upstream fixes pulled in.

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -24,16 +24,16 @@ EXTRAS_REQUIRE = {
     "kit": [],
     "newton": [
         "warp-lang",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc4",
         "PyOpenGL-accelerate",
         "imgui-bundle>=1.92.5",
     ],
     "rerun": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc4",
         "rerun-sdk>=0.29.0",
     ],
     "viser": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc4",
         "viser>=1.0.16",
     ],
 }

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -24,16 +24,16 @@ EXTRAS_REQUIRE = {
     "kit": [],
     "newton": [
         "warp-lang",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
         "PyOpenGL-accelerate",
         "imgui-bundle>=1.92.5",
     ],
     "rerun": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
         "rerun-sdk>=0.29.0",
     ],
     "viser": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
         "viser>=1.0.16",
     ],
 }

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -87,7 +87,7 @@ pyproject.optional-dependencies.all = [
     # ================================================================================
     { "newton" = [
         "warp-lang==1.13.0",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
         "PyOpenGL-accelerate==3.1.10"
     ] },
     # ================================================================================

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -87,7 +87,7 @@ pyproject.optional-dependencies.all = [
     # ================================================================================
     { "newton" = [
         "warp-lang==1.13.0",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc3",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc4",
         "PyOpenGL-accelerate==3.1.10"
     ] },
     # ================================================================================


### PR DESCRIPTION
## Summary

Bumps the Newton pin to [`v1.2.0rc4`](https://pypi.org/project/newton/1.2.0rc4/) across all five pin sites. Stacked on top of [#5614](https://github.com/isaac-sim/IsaacLab/pull/5614) (rc3) so the diff shows only the rc3 → rc4 delta; the final branch state is identical to landing rc4 directly on develop.

Purpose: get CI signal on whether rc4 can be accepted as the IsaacLab pin. If CI passes here and on #5614, we can merge whichever target is preferred; if rc3 lands first, rebasing this branch onto develop reduces it to a clean rc3 → rc4 delta.

## What's new in Newton v1.2.0rc4 vs v1.2.0rc3

Notable upstream changes:

- **[newton-physics/newton#2743](https://github.com/newton-physics/newton/pull/2743)** — Fix Collada textures in URDF import.
- **[newton-physics/newton#2823](https://github.com/newton-physics/newton/pull/2823)** — Fix device for gravity-data allocation in Kamino (multi-GPU).
- **[newton-physics/newton#2632](https://github.com/newton-physics/newton/pull/2632)** — CollisionPipeline small fixes.
- **[newton-physics/newton#2734](https://github.com/newton-physics/newton/pull/2734)** — Refactor `DelassusOperator` attributes. Not used in IsaacLab source today (verified by grep), so no IsaacLab-side adapt needed.
- **[newton-physics/newton#2818](https://github.com/newton-physics/newton/pull/2818)** — Anchor ViewerGL Plots window to bottom-right.
- Misc doc / example cleanups (Mermaid rendering, actuators API sidebar, anymal_c walk visual terrain, Kamino README examples).

## Required dep bumps

None on the IsaacLab side. The `mjwarp 3.8.0.2 → 3.8.0.3` bump in rc4 flows in transitively through `newton[sim]`.

`warp-lang` stays at `1.13.0`.

## Pins updated (delta vs #5614)

| File | Change |
|---|---|
| `source/isaaclab_newton/setup.py` | `v1.2.0rc3` → `v1.2.0rc4` |
| `source/isaaclab_physx/setup.py` | `v1.2.0rc3` → `v1.2.0rc4` |
| `source/isaaclab_visualizers/setup.py` | 3× `v1.2.0rc3` → `v1.2.0rc4` |
| `tools/wheel_builder/res/python_packages.toml` | `v1.2.0rc3` → `v1.2.0rc4` |

## Test plan

- [x] Pre-commit clean.
- [ ] CI smoke verifies clean install picks up `newton 1.2.0rc4` and downstream `mjwarp 3.8.0.3`.