### PR TITLE
[Newton] Bump Newton pin to v1.2.0 (stable)

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-newton-v120-stable-bump.minor.rst
+++ b/source/isaaclab/changelog.d/jichuanh-newton-v120-stable-bump.minor.rst
@@ -1,0 +1,14 @@
+Changed
+^^^^^^^
+
+* Bumped the ``newton[sim]`` pin from ``v1.2.0rc2`` to ``v1.2.0``
+  (stable) across :mod:`isaaclab_newton`, :mod:`isaaclab_physx`
+  (``[newton]`` extra), :mod:`isaaclab_visualizers` (3×), and
+  ``tools/wheel_builder/res/python_packages.toml``. Upstream release
+  notes: `newton-physics/newton v1.2.0
+  <https://github.com/newton-physics/newton/releases/tag/v1.2.0>`_.
+* No IsaacLab-side ``mujoco`` / ``mujoco-warp`` pin change — the
+  transitive ``mjwarp`` bump flows in through ``newton[sim]`` since
+  `isaac-sim/IsaacLab#5566
+  <https://github.com/isaac-sim/IsaacLab/pull/5566>`_ dropped the
+  explicit pins.

--- a/source/isaaclab_newton/changelog.d/jichuanh-newton-v120-stable-bump.minor.rst
+++ b/source/isaaclab_newton/changelog.d/jichuanh-newton-v120-stable-bump.minor.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Bumped the ``newton[sim]`` pin from ``v1.2.0rc2`` to ``v1.2.0``
+  (stable). Upstream release notes: `newton-physics/newton v1.2.0
+  <https://github.com/newton-physics/newton/releases/tag/v1.2.0>`_.

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -39,7 +39,7 @@ EXTRAS_REQUIRE = {
     "all": [
         "prettytable==3.3.0",
         "PyOpenGL-accelerate==3.1.10",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0",
     ],
 }
 

--- a/source/isaaclab_physx/changelog.d/jichuanh-newton-v120-stable-bump.rst
+++ b/source/isaaclab_physx/changelog.d/jichuanh-newton-v120-stable-bump.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Bumped the optional ``[newton]`` extra to ``v1.2.0`` (stable) so the
+  pin matches :mod:`isaaclab_newton`.

--- a/source/isaaclab_physx/setup.py
+++ b/source/isaaclab_physx/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = []
 
 EXTRAS_REQUIRE = {
     "newton": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0",
     ],
 }
 

--- a/source/isaaclab_visualizers/changelog.d/jichuanh-newton-v120-stable-bump.rst
+++ b/source/isaaclab_visualizers/changelog.d/jichuanh-newton-v120-stable-bump.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Bumped the ``newton[sim]`` pin in the ``[newton]``, ``[rerun]``, and
+  ``[viser]`` extras to ``v1.2.0`` (stable) so the pin matches
+  :mod:`isaaclab_newton`.

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -24,16 +24,16 @@ EXTRAS_REQUIRE = {
     "kit": [],
     "newton": [
         "warp-lang",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0",
         "PyOpenGL-accelerate",
         "imgui-bundle>=1.92.5",
     ],
     "rerun": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0",
         "rerun-sdk>=0.29.0",
     ],
     "viser": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0",
         "viser>=1.0.16",
     ],
 }

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -87,7 +87,7 @@ pyproject.optional-dependencies.all = [
     # ================================================================================
     { "newton" = [
         "warp-lang==1.13.0",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0rc2",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.0",
         "PyOpenGL-accelerate==3.1.10"
     ] },
     # ================================================================================


### PR DESCRIPTION
## Summary

Bumps the Newton pin from `v1.2.0rc2` (current develop) directly to the [`v1.2.0` stable release](https://github.com/newton-physics/newton/releases/tag/v1.2.0) across all five pin sites, keeping the canonical `newton[sim] @ git+...` form everywhere.

Per Kelly Guo's suggestion: skip the rc bump and go straight to stable. Upstream published `v1.2.0` on 2026-05-12.

**Alternative**: [isaac-sim/IsaacLab#5614](https://github.com/isaac-sim/IsaacLab/pull/5614) (rc3 bump) — pick whichever target based on CI signal. This one is the most forward target.

> Branch is still named `jichuanh/newton-1.2.0rc4-bump` from when this PR was originally proposing rc4 — the branch name doesn't match the current target but the diff is correct. Force-pushing the rename would close/reopen the PR, which adds noise without changing the artifact.

## What's new in Newton v1.2.0 vs v1.2.0rc2

Full release notes: [newton-physics/newton release v1.2.0](https://github.com/newton-physics/newton/releases/tag/v1.2.0). Notable IsaacLab-relevant fixes:

- [newton-physics/newton#2651](https://github.com/newton-physics/newton/pull/2651) — MPR/GJK no longer assumes convex hulls are centered around the origin.
- [newton-physics/newton#2703](https://github.com/newton-physics/newton/pull/2703) — Kamino FK solver performance.
- [newton-physics/newton#2721](https://github.com/newton-physics/newton/pull/2721) — HDR color output for tiled camera sensors.
- [newton-physics/newton#2743](https://github.com/newton-physics/newton/pull/2743) — Collada textures in URDF import.
- [newton-physics/newton#2823](https://github.com/newton-physics/newton/pull/2823) — Gravity-data device allocation in Kamino (multi-GPU).
- [newton-physics/newton#2632](https://github.com/newton-physics/newton/pull/2632) — CollisionPipeline small fixes.
- [newton-physics/newton#2734](https://github.com/newton-physics/newton/pull/2734) — `DelassusOperator` attribute refactor. Not used in IsaacLab source today (verified by grep), no adapt needed.
- SolverMuJoCo fixes: planar meshes, contact-anchor computation, distance conversion.

## Required dep bumps

None on the IsaacLab side. The `mjwarp 3.8.0.1 → 3.8.0.3` bump flows in transitively through `newton[sim]`, since [isaac-sim/IsaacLab#5566](https://github.com/isaac-sim/IsaacLab/pull/5566) dropped IsaacLab's explicit `mujoco` / `mujoco-warp` pins.

`warp-lang` stays at `1.13.0` (set by [isaac-sim/IsaacLab#5523](https://github.com/isaac-sim/IsaacLab/pull/5523)).

## Pins updated

| File | Change |
|---|---|
| `source/isaaclab_newton/setup.py` | `v1.2.0rc2` → `v1.2.0` |
| `source/isaaclab_physx/setup.py` | `v1.2.0rc2` → `v1.2.0` |
| `source/isaaclab_visualizers/setup.py` | 3× `v1.2.0rc2` → `v1.2.0` |
| `tools/wheel_builder/res/python_packages.toml` | `v1.2.0rc2` → `v1.2.0` |

## Test plan

- [x] Pre-commit clean.
- [ ] CI smoke verifies clean install picks up `newton 1.2.0` and downstream `mjwarp 3.8.0.3`.