### PR TITLE
[CI][Diag] Dump numpy/scipy/openblas state pre-pytest

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -218,6 +218,14 @@ runs:
                 echo \"Installing extra pip packages: \${TEST_EXTRA_PIP_PACKAGES}\"
                 ./isaaclab.sh -p -m pip install \${TEST_EXTRA_PIP_PACKAGES}
               fi
+              # Diagnostic: dump numpy/scipy/openblas state so we can correlate
+              # SIGSEGV crashes with the OpenBLAS atfork regression tracked at
+              # https://github.com/numpy/numpy/issues/30092 and
+              # https://github.com/scipy/scipy/issues/23686.
+              echo '=== Dep manifest (numpy/scipy/openblas) ==='
+              ./isaaclab.sh -p -m pip show numpy scipy 2>/dev/null | grep -E '^(Name|Version|Location):' || true
+              ./isaaclab.sh -p -c \"import numpy, scipy; print('numpy', numpy.__version__); print('scipy', scipy.__version__); import os; [print('bundled openblas:', os.path.join(d, f)) for d in [os.path.dirname(numpy.__file__) + '/../numpy.libs', os.path.dirname(scipy.__file__) + '/../scipy.libs'] if os.path.isdir(d) for f in os.listdir(d) if 'openblas' in f.lower()]\" 2>/dev/null || true
+              echo '=== /Dep manifest ==='
               echo 'Starting pytest with path: $test_path'
               ./isaaclab.sh -p -m pytest --ignore=tools/conftest.py --ignore=source/isaaclab/test/install_ci $test_path $pytest_options -v --junitxml=tests/$result_file
             "


### PR DESCRIPTION
## Description

Pure-diagnostic companion to the CI instability investigation in
[#C06HLQ6CB41](https://nvidia.slack.com/archives/C06HLQ6CB41/p1778683996822719)
and OMPE-92261.

### Why

The hypothesis being explored is that the Isaac Sim base image rotated on 2026-05-12 picked up a NumPy/SciPy wheel whose bundled OpenBLAS triggers the well-documented atfork SIGSEGV (see [numpy#30092](https://github.com/numpy/numpy/issues/30092), [scipy#23686](https://github.com/scipy/scipy/issues/23686)). SciPy 1.16.1 is reported clean, 1.16.2+ has the regression.

But we don't actually know what versions are inside the currently pinned Isaac Sim image (`latest-develop@sha256:0dd49a11…` from PR #5600). Without that, we can't:
- confirm the version cliff,
- decide whether to pin scipy<1.16.2,
- or correlate future SIGSEGVs with specific image rotations.

### What

Adds a 4-line diagnostic print right before pytest runs, emitting:

- `pip show numpy scipy` (Name / Version / Location)
- `numpy.__version__` and `scipy.__version__`
- the actual on-disk filename of the bundled `libscipy_openblas*.so` (the same name that shows up in the crash backtrace)

Output goes to the GitHub Actions log; no artifact upload, no test impact. ~1 second per job.

### Relationship to companion PR

This PR is paired with [the env-var fix-attempt PR](https://github.com/isaac-sim/IsaacLab/pulls?q=is%3Aopen+is%3Apr+author%3Ahujc7) which tests the OpenBLAS thread-pool suppression hypothesis.  Decision tree:

| Env-var PR result | This PR's manifest | Conclusion |
|---|---|---|
| failure rate drops | (any) | Env vars sufficient — land that |
| failure rate stays | scipy ≥ 1.16.2 | Pin scipy<1.16.2 (follow-up) |
| failure rate stays | scipy < 1.16.2 | OpenBLAS hypothesis wrong — pivot |

### Type of change

- Diagnostic / non-functional

### Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [\`pre-commit\` checks](https://pre-commit.com/) with \`./isaaclab.sh --format\`
- [x] CI-only change, no code, no docs, no changelog fragment needed