### PR TITLE
[Fix] Pin numpy!=2.3.5 to dodge OpenBLAS atfork SIGSEGV at Kit fork()

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-pin-numpy-not-2-3-5.rst
+++ b/source/isaaclab/changelog.d/jichuanh-pin-numpy-not-2-3-5.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Excluded NumPy 2.3.5 from the install constraint (``numpy>=2,!=2.3.5``). The 2.3.5
+  release ships a vendored OpenBLAS (``libscipy_openblas64_-fdde5778.so``) whose
+  ``pthread_atfork`` handler crashes inside Kit's ``libomni.platforminfo`` ``fork()``
+  during ``SimulationApp`` startup, manifesting as non-deterministic SIGSEGV in CI
+  test jobs. See `numpy#30092 <https://github.com/numpy/numpy/issues/30092>`_ and
+  ``OMPE-92261``. With this change pip resolves to NumPy 2.3.4, which ships a
+  different OpenBLAS bundle without the regression.

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -18,7 +18,11 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
-    "numpy>=2",
+    # !=2.3.5 dodges the broken OpenBLAS bundle (libscipy_openblas64_-fdde5778.so)
+    # whose pthread_atfork handler SIGSEGVs inside Kit's libomni.platforminfo fork()
+    # during CI startup. See numpy/numpy#30092 and OMPE-92261. The pin-pink ->
+    # pinocchio -> cmeel-boost transitive constraint already caps numpy <2.4.
+    "numpy>=2,!=2.3.5",
     "torch>=2.10",
     "onnx>=1.18.0",  # 1.16.2 throws access violation on Windows
     "prettytable==3.3.0",

--- a/source/isaaclab_rl/changelog.d/jichuanh-pin-numpy-not-2-3-5.rst
+++ b/source/isaaclab_rl/changelog.d/jichuanh-pin-numpy-not-2-3-5.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Tightened the NumPy install constraint to ``numpy>=2,!=2.3.5`` (was unconstrained)
+  to keep the package consistent with :file:`isaaclab/setup.py` and avoid the
+  OpenBLAS at-fork SIGSEGV.

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -19,7 +19,8 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
-    "numpy",
+    # !=2.3.5 dodges the broken OpenBLAS bundle; see source/isaaclab/setup.py.
+    "numpy>=2,!=2.3.5",
     "torch>=2.10",
     "torchvision>=0.25.0",  # ensure compatibility with torch 2.10.0
     "protobuf>=4.25.8,!=5.26.0",

--- a/source/isaaclab_tasks/changelog.d/jichuanh-pin-numpy-not-2-3-5.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-pin-numpy-not-2-3-5.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Excluded NumPy 2.3.5 from the install constraint (``numpy>=2,!=2.3.5``) to match
+  :file:`isaaclab/setup.py` and avoid the OpenBLAS at-fork SIGSEGV during Kit
+  startup.

--- a/source/isaaclab_tasks/setup.py
+++ b/source/isaaclab_tasks/setup.py
@@ -18,7 +18,8 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
-    "numpy>=2",
+    # !=2.3.5 dodges the broken OpenBLAS bundle; see source/isaaclab/setup.py.
+    "numpy>=2,!=2.3.5",
     "torch>=2.10",
     "torchvision>=0.25.0",  # ensure compatibility with torch 2.10.0
     "protobuf>=4.25.8,!=5.26.0",

--- a/source/isaaclab_visualizers/changelog.d/jichuanh-pin-numpy-not-2-3-5.rst
+++ b/source/isaaclab_visualizers/changelog.d/jichuanh-pin-numpy-not-2-3-5.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Tightened the NumPy install constraint to ``numpy>=2,!=2.3.5`` (was unconstrained)
+  to keep the package consistent with :file:`isaaclab/setup.py` and avoid the
+  OpenBLAS at-fork SIGSEGV.

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -10,7 +10,8 @@ from setuptools import setup
 # Base requirements shared across visualizer backends.
 INSTALL_REQUIRES = [
     "isaaclab",
-    "numpy",
+    # !=2.3.5 dodges the broken OpenBLAS bundle; see source/isaaclab/setup.py.
+    "numpy>=2,!=2.3.5",
 ]
 
 # Every Newton declaration in the repo must use the SAME extra spec (`newton[sim]`).


### PR DESCRIPTION
## TL;DR

NumPy 2.3.5 ships a vendored OpenBLAS (`libscipy_openblas64_-fdde5778.so`) whose `pthread_atfork` handler crashes inside Kit's `libomni.platforminfo` fork() during `SimulationApp` startup. IsaacLab's `setup.py` declares `numpy>=2`, and with the `pin-pink → pinocchio → cmeel-boost` transitive cap of `<2.4`, pip resolves to **2.3.5** — exactly the broken release. This PR adds `!=2.3.5` to that constraint across the four packages that declare a numpy dep. Pip then resolves to **2.3.4**, which ships a different OpenBLAS bundle. Targets the dependency layer of the OpenBLAS-class CI SIGSEGV in IsaacLab's own setup.py.

## Why this fix lives here, not in Isaac Sim's base image

Verified by `docker run` on both candidate Isaac Sim images (the current pin `sha256:0dd49a11…` and the rolling `sha256:06197a67…`) — both prebundle **numpy 2.3.1** with the safe OpenBLAS hash `-56d6093b`. The broken numpy 2.3.5 enters the running container at **IsaacLab's** `docker/Dockerfile.base:117-118`, when `isaaclab.sh --install` runs and pip resolves IsaacLab's `numpy>=2` constraint to 2.3.5 — installing into `_isaac_sim/kit/python/lib/python3.12/site-packages/` and shadowing the base image's prebundle.

So the dependency-resolution layer is in IsaacLab's `setup.py`.

## NumPy 2.3.x → bundled OpenBLAS hash bisection (verified)

| numpy | bundled OpenBLAS | Status |
|---|---|---|
| 2.3.0 | `libscipy_openblas64_-56d6093b.so` | ✅ same hash as Isaac Sim base prebundle; no-crash repro |
| 2.3.1 | `libscipy_openblas64_-56d6093b.so` | ✅ same hash |
| 2.3.2 | `libscipy_openblas64_-8fb3d286.so` | ❓ different hash; was resolved version for IsaacLab CI Jul–Nov 2025 without these crashes (note: pre-driver-595.58.03) |
| 2.3.3 | `libscipy_openblas64_-8fb3d286.so` | ❓ same as 2.3.2 |
| 2.3.4 | `libscipy_openblas64_-8fb3d286.so` | ❓ same as 2.3.2 |
| **2.3.5** | **`libscipy_openblas64_-fdde5778.so`** | ❌ **broken — exact hash in the crash backtrace** |

With this PR's `numpy>=2,!=2.3.5`, pip resolves to **2.3.4** (highest non-broken). The `-8fb3d286` bundle was IsaacLab CI's resolved version for ~4 months before 2.3.5 was released, but it wasn't tested against the new CUDA 13.2 driver / runner environment that started showing the SIGSEGV pattern on 2026-05-12. If a reviewer prefers maximally-conservative, the constraint can be tightened to `numpy>=2,<2.3.2` which forces the bit-identical-to-base-image 2.3.1.

## Why not bump to numpy ≥ 2.4.1 (which has the upstream OpenBLAS fix)?

`pin-pink` (Pink IK library) depends on `pin` (Pinocchio) → `libpinocchio 3.9.0` → `cmeel-boost ~=1.89.0`. The latest `cmeel-boost 1.89.0` declares:

```
Requires-Dist: numpy >=2.3, <2.4 ; python_version >= '3.11.0'
```

Forcing `numpy>=2.4 + pin>=2.6.3` produces `ResolutionImpossible`. Until `cmeel-boost` upstream lifts its cap (or IsaacLab moves Pinocchio to a non-PyPI install path), the highest numpy IsaacLab can resolve to is **2.3.x**. Excluding 2.3.5 is therefore the short-term fix at the dependency-resolution layer.

## Related in-flight work

- **#5620** (pbarejko) — code-side fix: defers numpy/torch imports until after `AppLauncher` runs Kit, and adjusts a couple of tests that don't need `AppLauncher`. Operates at the import-order layer.
- **#5621** (nvsekkin) — adds `PYTHONFAULTHANDLER=1` + `-vv` to surface crash backtraces in CI. Diagnostic instrumentation.
- **#5625** (jichuanh) — CI-side env vars (`OMP_/OPENBLAS_/MKL_NUM_THREADS=1`). Operates at the OpenBLAS runtime layer.

This PR operates at the dependency-resolution layer. The four approaches address different layers of the same problem; reviewers can choose which set to land.

## Files touched

```
source/isaaclab/setup.py:21              "numpy>=2"          → "numpy>=2,!=2.3.5"
source/isaaclab_tasks/setup.py:21        "numpy>=2"          → "numpy>=2,!=2.3.5"
source/isaaclab_rl/setup.py:22           "numpy"             → "numpy>=2,!=2.3.5"
source/isaaclab_visualizers/setup.py:13  "numpy"             → "numpy>=2,!=2.3.5"
+ one changelog fragment per package
```

All four sites must agree per IsaacLab convention (pip first-declaration-wins on transitive resolution).

## References

- [numpy/numpy#30092 — Binary Builds Deadlock due to OpenBLAS threading issue with fork](https://github.com/numpy/numpy/issues/30092)
- [scipy/scipy#23686 — Hang in scipy 1.16.2 on macOS x86_64 in scipy.sparse.linalg.eigsh after fork](https://github.com/scipy/scipy/issues/23686)
- [OpenMathLib/OpenBLAS#5520 — atfork deadlock fix](https://github.com/OpenMathLib/OpenBLAS/pull/5520)
- JIRA: OMPE-92261

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] Changelog fragments added for each touched package