### PR TITLE
Fix init bug

### DIFF
--- a/source/isaaclab/changelog.d/mh-init_patch_configclass.rst
+++ b/source/isaaclab/changelog.d/mh-init_patch_configclass.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed ``configclass`` resolution from :mod:`isaaclab.utils` so importing the
+  ``configclass`` submodule first no longer causes decorator imports to resolve
+  to the module instead of the callable decorator.

--- a/source/isaaclab/isaaclab/utils/__init__.py
+++ b/source/isaaclab/isaaclab/utils/__init__.py
@@ -8,3 +8,5 @@
 import lazy_loader as lazy
 
 __getattr__, __dir__, __all__ = lazy.attach_stub(__name__, __file__)
+
+from .configclass import checked_apply, configclass, resolve_cfg_presets


### PR DESCRIPTION
# Description

Fixed an issue with `uv run` due to the import order of configclass.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
