### PR TITLE
Fixes uv run path and aligns closer to ./isaaclab.sh -i approach

### DIFF
--- a/.github/workflows/license-exceptions.json
+++ b/.github/workflows/license-exceptions.json
@@ -497,5 +497,10 @@
     "package": "ovphysx",
     "license": "LicenseRef-NVIDIA-Omniverse",
     "comment": "NVIDIA"
+  },
+  {
+    "package": "decorator",
+    "license": "UNKNOWN",
+    "comment": "BSD-2"
   }
 ]

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload wheel artifact
         if: steps.changes.outputs.run_build == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: tools/wheel_builder/build/dist/isaaclab-*.whl
@@ -162,7 +162,7 @@ jobs:
 
       - name: Download wheel artifact for install test
         if: steps.changes.outputs.run_build == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        uses: actions/download-artifact@v7
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: /tmp/isaaclab-wheel-artifact

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -26,7 +26,7 @@ jobs:
   build-wheel:
     name: Build Wheel
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
 
     steps:
       - name: Detect wheel-relevant changes
@@ -119,14 +119,14 @@ jobs:
 
       - name: Checkout code
         if: steps.changes.outputs.run_build == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 1
           lfs: true
 
       - name: Setup Python
         if: steps.changes.outputs.run_build == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
           architecture: x64
@@ -153,9 +153,42 @@ jobs:
 
       - name: Upload wheel artifact
         if: steps.changes.outputs.run_build == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
           path: tools/wheel_builder/build/dist/isaaclab-*.whl
           if-no-files-found: error
           retention-days: 30
+
+      - name: Download wheel artifact for install test
+        if: steps.changes.outputs.run_build == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: ${{ steps.meta.outputs.artifact_name }}
+          path: /tmp/isaaclab-wheel-artifact
+
+      - name: Test wheel extras resolution
+        if: steps.changes.outputs.run_build == 'true'
+        run: |
+          set -euo pipefail
+
+          python -m pip install --user uv
+          export PATH="$HOME/.local/bin:$PATH"
+          cd /tmp
+
+          uv venv --python 3.12 /tmp/isaaclab-wheel-install
+          source /tmp/isaaclab-wheel-install/bin/activate
+          uv pip install --upgrade pip
+
+          wheel="$(find /tmp/isaaclab-wheel-artifact -name 'isaaclab-*.whl' -print -quit)"
+          if [ -z "$wheel" ]; then
+            echo "No isaaclab wheel found in downloaded artifact" >&2
+            exit 1
+          fi
+
+          uv pip install \
+            --dry-run \
+            --extra-index-url https://pypi.nvidia.com \
+            --index-strategy unsafe-best-match \
+            --prerelease=allow \
+            "${wheel}[isaacsim,all]"

--- a/docker/test/test_run_install_ci.py
+++ b/docker/test/test_run_install_ci.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_PATH = REPO_ROOT / "tools" / "run_install_ci.py"
+CONTAINER_RESULTS_XML = "/tmp/isaaclab-installci-results.xml"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("run_install_ci", RUNNER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    runner = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(runner)
+    return runner
+
+
+def _docker_args(**overrides):
+    args = {
+        "base_image": "ubuntu:24.04",
+        "conda": False,
+        "gpu": False,
+        "no_cache": False,
+        "no_pip_cache": True,
+        "no_uv_cache": True,
+        "pytest_args": ["--tb=short", "-sv", "-m", "uv"],
+        "results_dir": None,
+        "shell": False,
+        "wheel": None,
+    }
+    args.update(overrides)
+    return argparse.Namespace(**args)
+
+
+def test_docker_results_dir_copies_junit_after_container_exit(tmp_path, monkeypatch):
+    runner = _load_runner()
+    docker_runs = []
+    docker_side_effects = []
+
+    def fake_build_image(*_args, **_kwargs):
+        return 0
+
+    def fake_call(cmd, timeout):
+        docker_runs.append((cmd, timeout))
+        return 0
+
+    def fake_run_cmd(cmd, **kwargs):
+        docker_side_effects.append((cmd, kwargs))
+        if cmd[:2] == ["docker", "cp"]:
+            Path(cmd[3]).write_text("<testsuite />\n", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(runner, "_build_image", fake_build_image)
+    monkeypatch.setattr(runner, "_find_repo_root", lambda: REPO_ROOT)
+    monkeypatch.setattr(runner, "run_cmd", fake_run_cmd)
+    monkeypatch.setattr(runner.subprocess, "call", fake_call)
+
+    rc = runner._cmd_docker(_docker_args(results_dir=str(tmp_path)))
+
+    assert rc == 0
+    assert len(docker_runs) == 1
+
+    docker_run_cmd, timeout = docker_runs[0]
+    assert timeout == 5400
+    assert "--rm" not in docker_run_cmd
+    assert "--name" in docker_run_cmd
+    assert f"{tmp_path.resolve()}:/tmp/results" not in docker_run_cmd
+    assert f"--junitxml={CONTAINER_RESULTS_XML}" in docker_run_cmd
+
+    container_name = docker_run_cmd[docker_run_cmd.index("--name") + 1]
+    host_results_xml = tmp_path / "results.xml"
+    assert host_results_xml.read_text(encoding="utf-8") == "<testsuite />\n"
+
+    side_effect_cmds = [cmd for cmd, _kwargs in docker_side_effects]
+    assert [
+        "docker",
+        "cp",
+        f"{container_name}:{CONTAINER_RESULTS_XML}",
+        str(host_results_xml.resolve()),
+    ] in side_effect_cmds
+    assert ["docker", "rm", "-f", container_name] in side_effect_cmds
+
+
+def test_docker_without_results_dir_uses_rm_and_no_junit_copy(monkeypatch):
+    runner = _load_runner()
+    docker_runs = []
+    docker_side_effects = []
+
+    monkeypatch.setattr(runner, "_build_image", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(runner, "_find_repo_root", lambda: REPO_ROOT)
+    monkeypatch.setattr(runner, "run_cmd", lambda cmd, **kwargs: docker_side_effects.append((cmd, kwargs)))
+    monkeypatch.setattr(runner.subprocess, "call", lambda cmd, timeout: docker_runs.append((cmd, timeout)) or 0)
+
+    rc = runner._cmd_docker(_docker_args())
+
+    assert rc == 0
+    assert len(docker_runs) == 1
+
+    docker_run_cmd, _timeout = docker_runs[0]
+    assert "--rm" in docker_run_cmd
+    assert "--name" not in docker_run_cmd
+    assert all(not arg.startswith("--junitxml=") for arg in docker_run_cmd)
+    assert docker_side_effects == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ dependencies = [
     "isaaclab-assets",
     "isaaclab-contrib",
     "isaaclab-experimental",
-    "isaaclab-newton",
+    "isaaclab-newton[all]",
     "isaaclab-ov",
     "isaaclab-ovphysx",
-    "isaaclab-physx",
-    "isaaclab-rl",
+    "isaaclab-physx[newton]",
+    "isaaclab-rl[rsl-rl]",
     "isaaclab-tasks",
     "isaaclab-tasks-experimental",
     "isaaclab-visualizers",
@@ -27,16 +27,34 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-isaacsim = [
-    "isaacsim[all,extscache]==5.1.0",
+contrib = [
+    "isaaclab-contrib",
+]
+mimic = [
+    "isaaclab-mimic",
+]
+newton = [
+    "isaaclab-newton[all]",
+    "isaaclab-physx[newton]",
+    "isaaclab-visualizers[newton]",
+]
+ov = [
+    "isaaclab-ovphysx[ovphysx]",
+]
+rl = [
+    "isaaclab-rl[rsl-rl]",
+]
+rl-all = [
+    "isaaclab-rl[all]",
+]
+rtx = [
+    "isaaclab-ov[ovrtx]",
 ]
 all = [
-    "isaacsim[all,extscache]==5.1.0",
     "isaaclab-mimic",
     "isaaclab-newton[all]",
     "isaaclab-physx[newton]",
     "isaaclab-rl[all]",
-    "isaaclab-teleop",
     "isaaclab-visualizers[all]",
 ]
 
@@ -201,6 +219,7 @@ explicit = true
 index-strategy = "unsafe-best-match"
 prerelease = "allow"
 override-dependencies = ["numpy>=2"]
+python-preference = "only-managed"
 package = false
 
 [tool.uv.sources]

--- a/source/isaaclab/changelog.d/fix-rsl-rl-wheel-pin.rst
+++ b/source/isaaclab/changelog.d/fix-rsl-rl-wheel-pin.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed the ``isaaclab`` wheel's ``rsl-rl`` optional dependency to install
+  ``rsl-rl-lib==5.0.1``, matching the version required by the RSL-RL training
+  scripts.

--- a/source/isaaclab/changelog.d/fix-uv-run-pyproject.rst
+++ b/source/isaaclab/changelog.d/fix-uv-run-pyproject.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed the root ``uv run`` workflow by restoring the documented
+  ``pyproject.toml`` extras, the IsaacLab-only ``all`` extra, and removing the
+  Isaac Sim extra from the development project.
+* Fixed ``uv run`` creating ``.venv`` from an active conda Python by requiring
+  uv-managed Python for the development project.

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the root pyproject metadata used by the ``uv run`` workflow."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import tomllib
+
+
+def _repo_root() -> Path:
+    """Find the Isaac Lab repository root from this test file."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").is_file() and (parent / "source").is_dir():
+            return parent
+    raise RuntimeError("Could not find Isaac Lab repository root.")
+
+
+def _root_pyproject() -> dict:
+    """Load the root development ``pyproject.toml``."""
+    with (_repo_root() / "pyproject.toml").open("rb") as f:
+        return tomllib.load(f)
+
+
+def test_uv_run_extra_names_match_documented_workflow():
+    """Docs must only reference ``uv run --extra`` names that pyproject defines."""
+    repo_root = _repo_root()
+    docs = (repo_root / "docs/source/setup/installation/uv_run.rst").read_text(encoding="utf-8")
+    documented_extras = set(re.findall(r"--extra\s+([A-Za-z0-9_-]+)", docs))
+    optional_dependencies = _root_pyproject()["project"]["optional-dependencies"]
+
+    assert documented_extras
+    assert documented_extras <= set(optional_dependencies)
+
+
+def test_uv_run_keeps_modular_extras_without_isaacsim():
+    """The root dev project keeps local module extras but leaves Isaac Sim opt-in out."""
+    optional_dependencies = _root_pyproject()["project"]["optional-dependencies"]
+
+    expected_extras = {
+        "contrib": ["isaaclab-contrib"],
+        "mimic": ["isaaclab-mimic"],
+        "newton": ["isaaclab-newton[all]", "isaaclab-physx[newton]", "isaaclab-visualizers[newton]"],
+        "ov": ["isaaclab-ovphysx[ovphysx]"],
+        "rl": ["isaaclab-rl[rsl-rl]"],
+        "rl-all": ["isaaclab-rl[all]"],
+        "rtx": ["isaaclab-ov[ovrtx]"],
+        "all": [
+            "isaaclab-mimic",
+            "isaaclab-newton[all]",
+            "isaaclab-physx[newton]",
+            "isaaclab-rl[all]",
+            "isaaclab-visualizers[all]",
+        ],
+    }
+
+    assert optional_dependencies == expected_extras
+    assert "isaacsim" not in optional_dependencies
+
+
+def test_uv_run_base_dependencies_cover_newton_rsl_rl_training():
+    """The documented bare ``uv run train`` command needs Newton and RSL-RL extras."""
+    dependencies = _root_pyproject()["project"]["dependencies"]
+
+    assert "isaaclab-newton[all]" in dependencies
+    assert "isaaclab-physx[newton]" in dependencies
+    assert "isaaclab-rl[rsl-rl]" in dependencies
+
+
+def test_uv_run_uses_managed_python():
+    """Avoid building the project venv from conda Python and its older C++ runtime."""
+    tool_uv = _root_pyproject()["tool"]["uv"]
+
+    assert tool_uv["python-preference"] == "only-managed"

--- a/source/isaaclab/test/cli/test_wheel_builder_metadata.py
+++ b/source/isaaclab/test/cli/test_wheel_builder_metadata.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for wheel-builder package metadata."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import tomllib
+
+
+def _repo_root() -> Path:
+    """Find the Isaac Lab repository root from this test file."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").is_file() and (parent / "source").is_dir():
+            return parent
+    raise RuntimeError("Could not find Isaac Lab repository root.")
+
+
+def _rsl_rl_pin_from_setup() -> str:
+    """Return the ``rsl-rl-lib`` pin declared by ``source/isaaclab_rl/setup.py``."""
+    setup_path = _repo_root() / "source/isaaclab_rl/setup.py"
+    module = ast.parse(setup_path.read_text(encoding="utf-8"))
+
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "EXTRAS_REQUIRE" for target in node.targets):
+            continue
+        extras_require = ast.literal_eval(node.value)
+        for dependency in extras_require["rsl-rl"]:
+            if dependency.startswith("rsl-rl-lib=="):
+                return dependency
+
+    raise AssertionError("Could not find rsl-rl-lib pin in source/isaaclab_rl/setup.py")
+
+
+def test_wheel_builder_rsl_rl_pin_matches_source_package():
+    """The bundled wheel metadata must install the RSL-RL version required by training scripts."""
+    expected_pin = _rsl_rl_pin_from_setup()
+    packages_path = _repo_root() / "tools/wheel_builder/res/python_packages.toml"
+    with packages_path.open("rb") as f:
+        packages = tomllib.load(f)
+
+    optional_dependencies = packages["isaaclab"]["pyproject"]["optional-dependencies"]["all"]
+    dependencies_by_extra = {name: deps for entry in optional_dependencies for name, deps in entry.items()}
+
+    for extra_name in ("rsl-rl", "rsl_rl", "all"):
+        rsl_rl_pins = [dep for dep in dependencies_by_extra[extra_name] if dep.startswith("rsl-rl-lib==")]
+        assert rsl_rl_pins == [expected_pin]

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -98,8 +98,8 @@ pyproject.optional-dependencies.all = [
     { "skrl" = ["skrl>=1.4.3"] },
     # { "rl-games" = ["rl-games==1.6.1"] },  # TODO: re-enable when rl-games Python package supports Python 3.11
     # { "rl_games" = ["rl-games==1.6.1"] },  # TODO: re-enable when rl-games Python package supports Python 3.11
-    { "rsl-rl" = ["rsl-rl-lib==3.1.2", "onnxscript>=0.5"] },
-    { "rsl_rl" = ["rsl-rl-lib==3.1.2", "onnxscript>=0.5"] },
+    { "rsl-rl" = ["rsl-rl-lib==5.0.1", "onnxscript>=0.5"] },
+    { "rsl_rl" = ["rsl-rl-lib==5.0.1", "onnxscript>=0.5"] },
     # ================================================================================
     # https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab_visualizers/setup.py
     # ================================================================================
@@ -113,7 +113,7 @@ pyproject.optional-dependencies.all = [
         "rich",
         "skrl>=1.4.3",
         # "rl-games==1.6.1",  # TODO: re-enable when rl-games Python package supports Python 3.11
-        "rsl-rl-lib==3.1.2",
+        "rsl-rl-lib==5.0.1",
         "onnxscript>=0.5",
     ] },
 ]


### PR DESCRIPTION
# Description

Fixes the uv run path that got broken by #5650. Updates the available options to align closer with the new logic for ./isaaclab.sh -i modular installation.

Also adds more unit tests for uv run and pip package.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
