### PR TITLE
Fix total_reward calculation in technical_env_design

### DIFF
--- a/docs/source/setup/walkthrough/technical_env_design.rst
+++ b/docs/source/setup/walkthrough/technical_env_design.rst
@@ -146,7 +146,7 @@ and ``_get_rewards`` with the following.
         return observations
 
     def _get_rewards(self) -> torch.Tensor:
-        total_reward = torch.linalg.norm(self.velocity, dim=-1, keepdim=True)
+        total_reward = torch.linalg.norm(self.velocity, dim=-1)
         return total_reward
 
 The robot exists as an Articulation object within the Isaac Lab API. That object carries a data class, the ``ArticulationData``, which contains all the data for **specific** robots on the stage.


### PR DESCRIPTION
Removed 'keepdim=True' from total_reward calculation.

Reason:

The training crashes immediately with:                                                                                                                                                           
                                                                                                                                                                                                                                                        
  RuntimeError: output with shape [100, 1] doesn't match the broadcast shape [100, 100]
                                                                                                                                                                                                                                                        
  Location: rsl_rl/algorithms/ppo.py, inside process_env_step at the line:                                                                                                                                                                              
  self.transition.rewards += self.gamma * torch.squeeze(...)                                                                                                                                                                                            
                                                                                                                                                                                                                                                        
  Root Cause                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                        
  _get_rewards() returns a tensor of shape [num_envs, 1] due to keepdim=True:                                                                                                                                                                           
                                                                                                                                                                                                                                                        
  def _get_rewards(self) -> torch.Tensor:                                                                                                                                                                                                               
      total_reward = torch.linalg.norm(self.velocity, dim=-1, keepdim=True)  # shape: [N, 1]                                                                                                                                                            
      return total_reward                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                        
  rsl_rl expects rewards of shape [num_envs] (1-D). The extra dimension causes a broadcast failure when the runner tries to accumulate rewards.                                                                                                         
                                                                                                                                                                                                                                                        
  Fix                                                                                                                                                                                                                                                   
                  
  Remove keepdim=True:                                                                                                                                                                                                                                  
   
  total_reward = torch.linalg.norm(self.velocity, dim=-1)  # shape: [N]                                                                                                                                                                                 
                                                                                                                                                                                                                                                        
  Environment                                                                                                                                                                                                                                           
  - Isaacsim 5.1.0 + IsaacLab 2.3.2+ rsl_rl                                                                                                                                                                                                                                   
  - num_envs = 100

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
