### PR TITLE
Remove the `is_homogeneous` helper from isaaclab core

### DIFF
--- a/source/isaaclab/changelog.d/huidongc-remove-homogeneous-helper.rst
+++ b/source/isaaclab/changelog.d/huidongc-remove-homogeneous-helper.rst
@@ -1,0 +1,4 @@
+Removed
+^^^^^^^
+
+* Removed :func:`~isaaclab.cloner.cloner_utils.is_homogeneous` because it is an implementation detail.

--- a/source/isaaclab/isaaclab/cloner/cloner_utils.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_utils.py
@@ -393,18 +393,3 @@ def grid_transforms(N: int, spacing: float = 1.0, up_axis: str = "z", device="cp
     ori = torch.zeros((N, 4), device=device)
     ori[:, 3] = 1.0  # w=1 for identity quaternion
     return pos, ori
-
-
-def is_homogeneous(clone_plan: ClonePlan) -> bool:
-    """Check if a clone plan is homogeneous.
-
-    Homogeneous here means every element of :attr:`~isaaclab.cloner.ClonePlan.clone_mask`
-    is ``True`` (equivalent to ``clone_plan.clone_mask.all()``).
-
-    Args:
-        clone_plan: The clone plan to check.
-
-    Returns:
-        ``True`` if all elements of ``clone_mask`` are ``True``, otherwise ``False``.
-    """
-    return bool(clone_plan.clone_mask.all().item())

--- a/source/isaaclab_ov/changelog.d/huidongc-remove-homogeneous-helper.skip
+++ b/source/isaaclab_ov/changelog.d/huidongc-remove-homogeneous-helper.skip
@@ -1,0 +1,3 @@
+
+Internal refactor: inlined the homogeneous clone-plan check in
+:class:`~isaaclab_ov.renderers.OVRTXRenderer`; no user-facing API change.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -44,7 +44,6 @@ import ovrtx
 from ovrtx import Device, PrimMode, Renderer, RendererConfig, Semantic
 from packaging.version import Version
 
-from isaaclab.cloner.cloner_utils import is_homogeneous
 from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.warp.warp_math import convert_camera_frame_orientation_convention_wp
@@ -174,7 +173,7 @@ class OVRTXRenderer(BaseRenderer):
 
         if self._use_ovrtx_cloning:
             clone_plan = SimulationContext.instance().get_clone_plan()
-            if clone_plan and not is_homogeneous(clone_plan):
+            if clone_plan and not clone_plan.clone_mask.all().item():
                 logger.warning("OVRTX cloning disabled because the simulation uses a heterogeneous env setup")
                 self._use_ovrtx_cloning = False
 


### PR DESCRIPTION
# Description

Removed `is_homogeneous()` helper for clone plan from the IsaacLab core.

## Type of change

- Internal refactoring (non-user-visible behavior change)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
