### PR TITLE
Update DexSuite camera mini-batches

### DIFF
--- a/source/isaaclab_tasks/changelog.d/zhengyuz-dexsuite-camera-minibatches.rst
+++ b/source/isaaclab_tasks/changelog.d/zhengyuz-dexsuite-camera-minibatches.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+* Changed DexSuite Kuka-Allegro camera RSL-RL PPO examples to use 8 mini-batches per update.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/config/kuka_allegro/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/config/kuka_allegro/agents/rsl_rl_ppo_cfg.py
@@ -86,7 +86,7 @@ class DexsuiteKukaAllegroPPORunnerCfg(PresetCfg):
         obs_groups={"actor": ["policy", "proprio", "base_image"], "critic": ["policy", "proprio", "perception"]},
         actor=CNN_POLICY_CFG,
         critic=STATE_CRITIC_CFG,
-        algorithm=ALGO_CFG.replace(num_mini_batches=2),
+        algorithm=ALGO_CFG.replace(num_mini_batches=8),
     )
 
     duo_camera = DexsuiteKukaAllegroPPOBaseRunnerCfg().replace(
@@ -97,5 +97,5 @@ class DexsuiteKukaAllegroPPORunnerCfg(PresetCfg):
         },
         actor=CNN_POLICY_CFG,
         critic=STATE_CRITIC_CFG,
-        algorithm=ALGO_CFG.replace(num_mini_batches=2),
+        algorithm=ALGO_CFG.replace(num_mini_batches=8),
     )


### PR DESCRIPTION
## Summary
Since Heterogeneous support #5024  for newton, the base camera training for dexsuite became more difficult to get decent success rate within 2000 iterations, increasing minibatch size from 2 to 8 helps recover the sample efficiency
```
sha               | description                    | SR     | verdict
------------------+--------------------------------+--------+--------
6621d49b          | parent commit                  | 0.7122 | PASS
965136dc          | PR #5024 default               | 0.0051 | FAIL
965136dc_minib8   | PR #5024 + num_mini_batches=8  | 0.6911 | PASS
```
 
- Updated DexSuite Kuka-Allegro single-camera and duo-camera RSL-RL PPO examples to use 8 mini-batches per update.
- Added an isaaclab_tasks changelog fragment for the example config change.
