### PR TITLE
[OvPhysX] Adds FrameView for the OVPhysX backend

### DIFF
--- a/source/isaaclab/changelog.d/ovphysx-frameview-dispatch.rst
+++ b/source/isaaclab/changelog.d/ovphysx-frameview-dispatch.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.sim.views.FrameView` dispatch under the OVPhysX
+  backend. ``FrameView(...)`` now routes to
+  :class:`~isaaclab_ovphysx.sim.views.OvPhysxFrameView` instead of silently
+  falling through to ``FabricFrameView``, which returned stale USD spawn
+  poses for sensor frames riding on physics bodies.

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -166,10 +166,14 @@ class InteractiveScene:
             clone_in_fabric=self.cfg.clone_in_fabric,
             device=self.device,
             physics_clone_fn=physics_clone_fn,
-            # For ovphysx: env_1..N are created by physx.clone() in the physics
-            # runtime after add_usd().  USD replication of the asset hierarchy
-            # to env_1..N is skipped — only env_0 needs physics prims in the USD.
-            clone_usd=not self.physics_backend.startswith("ovphysx"),
+            # USD replication runs for every backend.  PhysX/Newton need per-env
+            # USD prims for sensor discovery.  For OVPhysX, the per-env USD
+            # subtrees are layered on TOP of the physics-side ``physx.clone()``
+            # replicas -- PhysX is indifferent to additional USD content and
+            # the two layers don't conflict.  Probing whether this assumption
+            # holds in practice; revert to ``not startswith("ovphysx")`` if
+            # ``physx.clone()`` errors on already-populated targets.
+            clone_usd=True,
         )
 
         # create source prim

--- a/source/isaaclab/isaaclab/sim/views/frame_view.py
+++ b/source/isaaclab/isaaclab/sim/views/frame_view.py
@@ -25,11 +25,17 @@ class FrameView(FactoryBase, BaseFrameView):
 
     - **PhysX / no backend**: :class:`~isaaclab_physx.sim.views.FabricFrameView`
       (Fabric GPU acceleration with USD fallback).
+    - **OVPhysX**: :class:`~isaaclab_ovphysx.sim.views.OvPhysxFrameView`
+      (Warp-native, reads ``body_q`` via the OVPhysX scene data provider).
     - **Newton**: :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView`
-      (GPU-resident site-based transforms).
+      (Warp-native, reads ``body_q`` from the Newton state).
     """
 
-    _backend_class_names = {"physx": "FabricFrameView", "newton": "NewtonSiteFrameView"}
+    _backend_class_names = {
+        "physx": "FabricFrameView",
+        "ovphysx": "OvPhysxFrameView",
+        "newton": "NewtonSiteFrameView",
+    }
 
     @classmethod
     def _get_backend(cls, *args, **kwargs) -> str:
@@ -41,6 +47,8 @@ class FrameView(FactoryBase, BaseFrameView):
         manager_name = ctx.physics_manager.__name__.lower()
         if "newton" in manager_name:
             return "newton"
+        if "ovphysx" in manager_name:
+            return "ovphysx"
         return "physx"
 
     def __new__(cls, *args, **kwargs) -> BaseFrameView:

--- a/source/isaaclab/isaaclab/sim/views/frame_view.py
+++ b/source/isaaclab/isaaclab/sim/views/frame_view.py
@@ -26,7 +26,8 @@ class FrameView(FactoryBase, BaseFrameView):
     - **PhysX / no backend**: :class:`~isaaclab_physx.sim.views.FabricFrameView`
       (Fabric GPU acceleration with USD fallback).
     - **OVPhysX**: :class:`~isaaclab_ovphysx.sim.views.OvPhysxFrameView`
-      (Warp-native, reads ``body_q`` via the OVPhysX scene data provider).
+      (Warp-native, reads body poses via an OVPhysX ``RIGID_BODY_POSE``
+      tensor binding).
     - **Newton**: :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView`
       (Warp-native, reads ``body_q`` from the Newton state).
     """

--- a/source/isaaclab_ovphysx/changelog.d/ovphysx-frameview.minor.rst
+++ b/source/isaaclab_ovphysx/changelog.d/ovphysx-frameview.minor.rst
@@ -1,0 +1,11 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab_ovphysx.sim.views.OvPhysxFrameView`, a
+  Warp-native batched-prim view that reads world poses from the OVPhysX
+  scene data provider's ``body_q`` array. Mirrors
+  :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView` in semantics
+  and API: ``set_world_poses`` / ``set_local_poses`` update the view's
+  internal ``site_local`` buffer and never mutate the physics state.
+  Scales and visibility delegate to a lazy internal
+  :class:`~isaaclab.sim.views.UsdFrameView`.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -405,6 +405,64 @@ class OvPhysxManager(PhysicsManager):
     # Internal helpers
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _export_env0_only_stage(sim_stage: Any, target_file: str) -> None:
+        """Export the simulation stage to ``target_file`` with env_1..N stripped.
+
+        Writes a USD file containing every prim under the live stage **except**
+        ``/World/envs/env_<i>`` for ``i != 0``. Globals (``/physicsScene``,
+        ``/World/ground``, lights, materials, etc.) and ``/World/envs/env_0`` are
+        retained.  ``physx.clone()`` is then expected to repopulate env_1..N at
+        the physics layer with proper clone lineage so that subsequent
+        ``create_tensor_binding`` calls hit the wheel's fast path.
+
+        Implementation: export the full stage to disk, then re-open the result
+        as an :class:`Sdf.Layer` and delete env_1..N prim specs in place.  This
+        avoids mutating the live stage (which other consumers -- sensors,
+        visualizers -- still see in its full N-env form).
+
+        Args:
+            sim_stage: Live USD stage held by ``SimulationContext``.
+            target_file: Output ``.usda`` file path.  Overwritten if it exists.
+        """
+        from pxr import Sdf  # noqa: PLC0415
+
+        # Step 1: full flatten-export of the live stage.  We pass the full file
+        # to ``Sdf.Layer.OpenAsAnonymous`` so the edits below don't write back
+        # to the source layer on disk.
+        sim_stage.Export(target_file)
+
+        # Step 2: open the exported file as an editable Sdf layer and delete
+        # ``/World/envs/env_<digits>`` children for digits != 0.  Walking the
+        # ``/World/envs`` ``PrimSpec``'s ``nameChildren`` keeps us scoped to
+        # the env-namespace and leaves the rest of the stage untouched.
+        layer = Sdf.Layer.FindOrOpen(target_file)
+        if layer is None:
+            raise RuntimeError(
+                f"OvPhysxManager: failed to re-open exported USD layer at {target_file!r} for env-scoping."
+            )
+        envs_spec = layer.GetPrimAtPath("/World/envs")
+        if envs_spec is None or not envs_spec:
+            # No /World/envs in the stage (single-env or non-IsaacLab scene); nothing to scope.
+            logger.debug("OvPhysxManager: no /World/envs prim — exported stage as-is.")
+            return
+
+        env_name_re = re.compile(r"^env_(\d+)$")
+        names_to_remove = [
+            child_name
+            for child_name in list(envs_spec.nameChildren.keys())
+            if (match := env_name_re.match(child_name)) and match.group(1) != "0"
+        ]
+        for child_name in names_to_remove:
+            del envs_spec.nameChildren[child_name]
+
+        if names_to_remove:
+            layer.Export(target_file)
+            logger.info(
+                "OvPhysxManager: stripped %d env_<i!=0> subtrees from exported USD (kept env_0 + globals)",
+                len(names_to_remove),
+            )
+
     @classmethod
     def _warmup_and_load(cls) -> None:
         """Export the USD stage and load it into the ovphysx runtime.
@@ -448,11 +506,27 @@ class OvPhysxManager(PhysicsManager):
             cls._configure_physx_scene_prim(scene_prim, PhysicsManager._cfg, ovphysx_device)
 
         # Export the current USD stage to a temporary file so ovphysx can load it.
+        #
+        # When ``InteractiveScene`` runs with ``clone_usd=True``, the live USD
+        # stage carries env_0..N's full asset subtrees as authored copies.
+        # Handing that stage to ``physx.add_usd`` would make the wheel ingest
+        # all 4096 envs as independent USD-defined bodies, defeating the
+        # ``physx.clone()`` fast path and turning every subsequent
+        # ``create_tensor_binding`` call into an O(N) USD enumeration -- the
+        # hang you'd see at large env counts.
+        #
+        # The workaround: strip ``/World/envs/env_<i>`` for i != 0 from the
+        # exported file before handing it to the wheel.  Sensors that read
+        # USD directly (RayCaster, Camera, ContactSensor discovery) still see
+        # the full N-env stage; only the wheel-side physics ingestion is
+        # scoped to env_0, and ``physx.clone()`` re-populates env_1..N in
+        # the physics runtime with proper clone lineage (which is what the
+        # binding fast path expects).
         cls._tmp_dir = tempfile.TemporaryDirectory(prefix="isaaclab_ovphysx_")
         stage_file = os.path.join(cls._tmp_dir.name, "scene.usda")
-        sim.stage.Export(stage_file)
+        cls._export_env0_only_stage(sim.stage, stage_file)
         cls._stage_path = stage_file
-        logger.info("OvPhysxManager: exported USD stage to %s", stage_file)
+        logger.info("OvPhysxManager: exported env_0-scoped USD stage to %s", stage_file)
 
         if cls._physx is None:
             cls._construct_physx(ovphysx_device, gpu_index)

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -421,6 +421,26 @@ class OvPhysxManager(PhysicsManager):
         avoids mutating the live stage (which other consumers -- sensors,
         visualizers -- still see in its full N-env form).
 
+        Limitations:
+            * **Homogeneous-env assumption.** Every env is treated as an
+              identical copy of env_0 from the physics runtime's point of view.
+              Anything authored *only* under ``/World/envs/env_<i>`` for
+              ``i != 0`` (per-env mass overrides, per-env friction, per-env
+              collision filters, etc.) is dropped from the file handed to
+              ``physx.add_usd`` and therefore not seen by PhysX. Sensors and
+              visualizers still see those overrides in USD (the live stage is
+              unmodified), so a divergence is possible.  Per-env physics state
+              must instead be written via the runtime APIs
+              (``RigidObject.write_root_state_to_sim_index``, etc.).
+            * **Global path convention.** Any physics-relevant prim that lives
+              under ``/World/envs/env_<i!=0>/`` (e.g. an asset-specific
+              ``PhysicsScene``, a per-env material) gets stripped. Globals must
+              live outside ``/World/envs`` (or under ``/World/envs/env_0``) to
+              survive the export.
+            * **Static topology.** Envs added or removed at runtime after
+              warmup are not supported by ``physx.clone()`` lineage and would
+              require a re-warmup with a re-exported stage.
+
         Args:
             sim_stage: Live USD stage held by ``SimulationContext``.
             target_file: Output ``.usda`` file path.  Overwritten if it exists.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/__init__.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""OVPhysX simulation views."""
+
+from isaaclab.utils.module import lazy_export
+
+lazy_export()

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/__init__.pyi
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/__init__.pyi
@@ -1,0 +1,6 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+__all__: list[str] = []

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/__init__.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""OVPhysX simulation views."""
+
+from isaaclab.utils.module import lazy_export
+
+lazy_export()

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/__init__.pyi
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/__init__.pyi
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+__all__ = [
+    "OvPhysxFrameView",
+]
+
+from .ovphysx_frame_view import OvPhysxFrameView

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 from typing import Any
 
 import warp as wp
@@ -22,6 +23,19 @@ from isaaclab.sim.views.usd_frame_view import UsdFrameView
 from isaaclab.utils.warp import ProxyArray
 
 from isaaclab_ovphysx.physics import OvPhysxManager
+
+# Attributes that ``SensorBase.__init__`` sizes from ``len(_parent_prims)`` and
+# that must be re-allocated when an :class:`OvPhysxFrameView` discovers a larger
+# binding count under ``clone_usd=False``. Used by :meth:`_patch_caller_sensor`.
+_SENSOR_BASE_ENV_SIZED_ATTRS = (
+    "_num_envs",
+    "_ALL_ENV_MASK",
+    "_reset_mask",
+    "_reset_mask_torch",
+    "_is_outdated",
+    "_timestamp",
+    "_timestamp_last_update",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -318,6 +332,12 @@ class OvPhysxFrameView(BaseFrameView):
         # Lazy USD view for scales / visibility.
         self._usd_view: UsdFrameView | None = None
 
+        # HACK: Capture the caller sensor (if any) so we can patch its env-sized
+        # buffers once the binding count is known. Required because
+        # ``SensorBase.__init__`` sizes ``_num_envs`` from ``find_matching_prims``
+        # which returns only env_0 under OVPhysX's ``clone_usd=False`` scenes.
+        self._caller_sensor = self._find_caller_sensor()
+
         # Try synchronous init; defer to PHYSICS_READY if the PhysX instance is not yet alive.
         physx = self._try_get_physx()
         if physx is not None:
@@ -333,6 +353,55 @@ class OvPhysxFrameView(BaseFrameView):
     def _try_get_physx() -> Any | None:
         """Return the active OVPhysX ``PhysX`` instance, or ``None`` if not yet created."""
         return OvPhysxManager.get_physx_instance()
+
+    @staticmethod
+    def _find_caller_sensor() -> Any | None:
+        """Walk the call stack to find a ``SensorBase``-like instance that owns this view.
+
+        Duck-typed: any object on the stack that exposes the full set of
+        env-sized attributes that ``SensorBase.__init__`` allocates is treated
+        as a sensor. Returns ``None`` when the view is constructed outside a
+        sensor (e.g. directly by user code or via scene ``extras``).
+        """
+        frame = sys._getframe(1)
+        while frame is not None:
+            candidate = frame.f_locals.get("self")
+            if candidate is not None and all(hasattr(candidate, attr) for attr in _SENSOR_BASE_ENV_SIZED_ATTRS):
+                return candidate
+            frame = frame.f_back
+        return None
+
+    def _patch_caller_sensor_env_count(self) -> None:
+        """Re-allocate the caller sensor's env-sized buffers to match the binding count.
+
+        HACK: Works around ``SensorBase.__init__`` deriving ``_num_envs`` from
+        ``len(_parent_prims)`` -- under OVPhysX's ``clone_usd=False`` scenes only
+        env_0 exists in USD, so the sensor sees ``_num_envs = 1`` while the
+        underlying RIGID_BODY_POSE binding correctly exposes all envs. Without
+        this patch, any sensor that calls ``reset(env_ids=[0..N-1])`` indexes
+        past its 1-element ``_reset_mask_torch`` and triggers a CUDA assert.
+
+        Mirrors the local fix the OVPhysX ``ContactSensor`` applies to itself at
+        ``contact_sensor.py:240-248``.
+        """
+        sensor = self._caller_sensor
+        if sensor is None or sensor._num_envs == self.count:
+            return
+        new_count = self.count
+        device = sensor._device
+        sensor._num_envs = new_count
+        sensor._ALL_ENV_MASK = wp.ones((new_count,), dtype=wp.bool, device=device)
+        sensor._reset_mask = wp.zeros((new_count,), dtype=wp.bool, device=device)
+        sensor._reset_mask_torch = wp.to_torch(sensor._reset_mask)
+        sensor._is_outdated = wp.ones(new_count, dtype=wp.bool, device=device)
+        sensor._timestamp = wp.zeros(new_count, dtype=wp.float32, device=device)
+        sensor._timestamp_last_update = wp.zeros_like(sensor._timestamp)
+        logger.info(
+            "OvPhysxFrameView: resized %s._num_envs from prior value to %d to match "
+            "OVPhysX binding count (clone_usd=False scene).",
+            type(sensor).__name__,
+            new_count,
+        )
 
     def _on_physics_ready(self, _event) -> None:
         """Callback invoked when the OVPhysX ``PhysX`` instance becomes available."""
@@ -472,6 +541,11 @@ class OvPhysxFrameView(BaseFrameView):
         self._quat_ta = ProxyArray(self._quat_buf)
         self._local_pos_ta = ProxyArray(self._local_pos_buf)
         self._local_quat_ta = ProxyArray(self._local_quat_buf)
+
+        # 8. HACK: patch the caller sensor's env-sized buffers if it derived
+        #    its env count from the (under-counting) USD prim list. See
+        #    :meth:`_patch_caller_sensor_env_count` for context.
+        self._patch_caller_sensor_env_count()
 
     def _resolve_rigid_body_ancestor(
         self,

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 import re
-import sys
 from typing import Any
 
 import warp as wp
@@ -23,19 +22,6 @@ from isaaclab.sim.views.usd_frame_view import UsdFrameView
 from isaaclab.utils.warp import ProxyArray
 
 from isaaclab_ovphysx.physics import OvPhysxManager
-
-# Attributes that ``SensorBase.__init__`` sizes from ``len(_parent_prims)`` and
-# that must be re-allocated when an :class:`OvPhysxFrameView` discovers a larger
-# binding count under ``clone_usd=False``. Used by :meth:`_patch_caller_sensor`.
-_SENSOR_BASE_ENV_SIZED_ATTRS = (
-    "_num_envs",
-    "_ALL_ENV_MASK",
-    "_reset_mask",
-    "_reset_mask_torch",
-    "_is_outdated",
-    "_timestamp",
-    "_timestamp_last_update",
-)
 
 logger = logging.getLogger(__name__)
 
@@ -332,12 +318,6 @@ class OvPhysxFrameView(BaseFrameView):
         # Lazy USD view for scales / visibility.
         self._usd_view: UsdFrameView | None = None
 
-        # HACK: Capture the caller sensor (if any) so we can patch its env-sized
-        # buffers once the binding count is known. Required because
-        # ``SensorBase.__init__`` sizes ``_num_envs`` from ``find_matching_prims``
-        # which returns only env_0 under OVPhysX's ``clone_usd=False`` scenes.
-        self._caller_sensor = self._find_caller_sensor()
-
         # Try synchronous init; defer to PHYSICS_READY if the PhysX instance is not yet alive.
         physx = self._try_get_physx()
         if physx is not None:
@@ -353,55 +333,6 @@ class OvPhysxFrameView(BaseFrameView):
     def _try_get_physx() -> Any | None:
         """Return the active OVPhysX ``PhysX`` instance, or ``None`` if not yet created."""
         return OvPhysxManager.get_physx_instance()
-
-    @staticmethod
-    def _find_caller_sensor() -> Any | None:
-        """Walk the call stack to find a ``SensorBase``-like instance that owns this view.
-
-        Duck-typed: any object on the stack that exposes the full set of
-        env-sized attributes that ``SensorBase.__init__`` allocates is treated
-        as a sensor. Returns ``None`` when the view is constructed outside a
-        sensor (e.g. directly by user code or via scene ``extras``).
-        """
-        frame = sys._getframe(1)
-        while frame is not None:
-            candidate = frame.f_locals.get("self")
-            if candidate is not None and all(hasattr(candidate, attr) for attr in _SENSOR_BASE_ENV_SIZED_ATTRS):
-                return candidate
-            frame = frame.f_back
-        return None
-
-    def _patch_caller_sensor_env_count(self) -> None:
-        """Re-allocate the caller sensor's env-sized buffers to match the binding count.
-
-        HACK: Works around ``SensorBase.__init__`` deriving ``_num_envs`` from
-        ``len(_parent_prims)`` -- under OVPhysX's ``clone_usd=False`` scenes only
-        env_0 exists in USD, so the sensor sees ``_num_envs = 1`` while the
-        underlying RIGID_BODY_POSE binding correctly exposes all envs. Without
-        this patch, any sensor that calls ``reset(env_ids=[0..N-1])`` indexes
-        past its 1-element ``_reset_mask_torch`` and triggers a CUDA assert.
-
-        Mirrors the local fix the OVPhysX ``ContactSensor`` applies to itself at
-        ``contact_sensor.py:240-248``.
-        """
-        sensor = self._caller_sensor
-        if sensor is None or sensor._num_envs == self.count:
-            return
-        new_count = self.count
-        device = sensor._device
-        sensor._num_envs = new_count
-        sensor._ALL_ENV_MASK = wp.ones((new_count,), dtype=wp.bool, device=device)
-        sensor._reset_mask = wp.zeros((new_count,), dtype=wp.bool, device=device)
-        sensor._reset_mask_torch = wp.to_torch(sensor._reset_mask)
-        sensor._is_outdated = wp.ones(new_count, dtype=wp.bool, device=device)
-        sensor._timestamp = wp.zeros(new_count, dtype=wp.float32, device=device)
-        sensor._timestamp_last_update = wp.zeros_like(sensor._timestamp)
-        logger.info(
-            "OvPhysxFrameView: resized %s._num_envs from prior value to %d to match "
-            "OVPhysX binding count (clone_usd=False scene).",
-            type(sensor).__name__,
-            new_count,
-        )
 
     def _on_physics_ready(self, _event) -> None:
         """Callback invoked when the OVPhysX ``PhysX`` instance becomes available."""
@@ -429,6 +360,19 @@ class OvPhysxFrameView(BaseFrameView):
 
         xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
         identity_xform7 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+
+        # 0. Reject prim_paths that resolve to a rigid body itself: a FrameView
+        #    should track a non-physics child of a body (a sensor frame), not
+        #    the body. Mirrors the Newton guard at
+        #    ``newton_site_frame_view.py:572-584``.
+        for prim in self._prims:
+            if self._prim_or_template_has_rigid_body_api(prim):
+                raise ValueError(
+                    f"OvPhysxFrameView prim '{prim.GetPath().pathString}' resolves to a rigid body. "
+                    "FrameView should only be used for non-physics prims (cameras, sensor mounts, "
+                    "Xform markers). Use OvPhysX's RigidObject or Articulation APIs to control "
+                    "physics bodies directly, or point prim_path at a non-physics child of the body."
+                )
 
         # 1. Resolve each (template) prim's ancestor body + the prim->ancestor offset.
         per_prim_ancestor: list[str | None] = []
@@ -541,11 +485,6 @@ class OvPhysxFrameView(BaseFrameView):
         self._quat_ta = ProxyArray(self._quat_buf)
         self._local_pos_ta = ProxyArray(self._local_pos_buf)
         self._local_quat_ta = ProxyArray(self._local_quat_buf)
-
-        # 8. HACK: patch the caller sensor's env-sized buffers if it derived
-        #    its env count from the (under-counting) USD prim list. See
-        #    :meth:`_patch_caller_sensor_env_count` for context.
-        self._patch_caller_sensor_env_count()
 
     def _resolve_rigid_body_ancestor(
         self,
@@ -896,11 +835,37 @@ class OvPhysxFrameView(BaseFrameView):
         return self._usd_view
 
     def get_scales(self, indices: wp.array | None = None) -> wp.array:
-        """Get scales for prims in the view (USD-backed)."""
+        """Get prim scales from the USD stage's ``xformOp:scale`` attribute.
+
+        .. note::
+            This reads the *static* USD authored value, not a live physics-state
+            value. OVPhysX does not maintain a per-shape ``shape_scale`` array
+            equivalent to Newton's ``model.shape_scale``, so sim-driven scale
+            updates are not reflected here. For sites under ``clone_usd=False``
+            envs without authored USD prims, the read returns the env_0
+            template's scale via the lazy internal :class:`UsdFrameView`.
+
+        Args:
+            indices: Subset of sites to query. ``None`` means all sites.
+
+        Returns:
+            ``wp.array`` of shape ``(M, 3)``.
+        """
         return self._ensure_usd_view().get_scales(indices)
 
     def set_scales(self, scales: wp.array, indices: wp.array | None = None) -> None:
-        """Set scales for prims in the view (USD-backed)."""
+        """Set prim scales by writing the USD ``xformOp:scale`` attribute.
+
+        .. note::
+            The write lands in the USD stage but does *not* propagate to any
+            OVPhysX-side collision-shape scale. PhysX is unaffected; this is a
+            stage-only annotation. Use :class:`~isaaclab_ovphysx.assets.RigidObject`
+            APIs if you need to change physics-effective shape sizes.
+
+        Args:
+            scales: Scales ``(M, 3)`` as ``wp.array``.
+            indices: Subset of sites to update. ``None`` means all sites.
+        """
         self._ensure_usd_view().set_scales(scales, indices)
 
     def get_visibility(self, indices: wp.array | None = None):

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
@@ -1,0 +1,736 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""OVPhysX-backed FrameView -- Warp-native, GPU-resident pose queries."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import warp as wp
+
+from pxr import Gf, Usd, UsdGeom
+
+import isaaclab.sim as sim_utils
+from isaaclab.physics import PhysicsEvent
+from isaaclab.sim.views.base_frame_view import BaseFrameView
+from isaaclab.sim.views.usd_frame_view import UsdFrameView
+from isaaclab.utils.warp import ProxyArray
+
+from isaaclab_ovphysx.physics import OvPhysxManager
+
+logger = logging.getLogger(__name__)
+
+WORLD_BODY_INDEX = -1
+
+
+@wp.kernel
+def _compute_site_world_transforms(
+    body_q: wp.array(dtype=wp.transformf),
+    site_body: wp.array(dtype=wp.int32),
+    site_local: wp.array(dtype=wp.transformf),
+    out_pos: wp.array(dtype=wp.vec3f),
+    out_quat: wp.array(dtype=wp.vec4f),
+):
+    """Compute world-space transforms for every site in the view.
+
+    For each site *i*, computes ``world = body_q[site_body[i]] * site_local[i]``
+    and splits the result into position and quaternion outputs.  When
+    ``site_body[i] == -1`` the site is world-attached and ``site_local[i]`` is
+    returned directly.
+
+    Args:
+        body_q: Rigid-body world transforms from the OVPhysX-backed Newton state,
+            shape ``[num_bodies]``.
+        site_body: Per-site body index (flat model-level), shape ``[num_sites]``.
+            ``-1`` indicates a world-attached site.
+        site_local: Per-site local offset relative to its parent body, shape ``[num_sites]``.
+        out_pos: Output world positions [m], shape ``[num_sites]``.
+        out_quat: Output world orientations as ``(qx, qy, qz, qw)``, shape ``[num_sites]``.
+    """
+    i = wp.tid()
+    bid = site_body[i]
+    if bid == -1:
+        world = site_local[i]
+    else:
+        world = wp.transform_multiply(body_q[bid], site_local[i])
+    out_pos[i] = wp.transform_get_translation(world)
+    q = wp.transform_get_rotation(world)
+    out_quat[i] = wp.vec4f(q[0], q[1], q[2], q[3])
+
+
+@wp.kernel
+def _compute_site_world_transforms_indexed(
+    body_q: wp.array(dtype=wp.transformf),
+    site_body: wp.array(dtype=wp.int32),
+    site_local: wp.array(dtype=wp.transformf),
+    indices: wp.array(dtype=wp.int32),
+    out_pos: wp.array(dtype=wp.vec3f),
+    out_quat: wp.array(dtype=wp.vec4f),
+):
+    """Indexed variant of :func:`_compute_site_world_transforms`."""
+    i = wp.tid()
+    si = indices[i]
+    bid = site_body[si]
+    if bid == -1:
+        world = site_local[si]
+    else:
+        world = wp.transform_multiply(body_q[bid], site_local[si])
+    out_pos[i] = wp.transform_get_translation(world)
+    q = wp.transform_get_rotation(world)
+    out_quat[i] = wp.vec4f(q[0], q[1], q[2], q[3])
+
+
+@wp.kernel
+def _write_site_local_from_world_poses(
+    body_q: wp.array(dtype=wp.transformf),
+    site_body: wp.array(dtype=wp.int32),
+    world_pos: wp.array(dtype=wp.vec3f),
+    world_quat: wp.array(dtype=wp.vec4f),
+    site_local: wp.array(dtype=wp.transformf),
+):
+    """Update site local offsets so that sites reach desired world poses.
+
+    For each site *i*, sets ``site_local[i] = inv(body_q[bid]) * desired_world``
+    so that subsequent reads produce the requested world pose.  Does **not**
+    modify ``body_q``.  World-attached sites (``site_body[i] == -1``) receive
+    the desired world transform directly.
+
+    Args:
+        body_q: Rigid-body world transforms, shape ``[num_bodies]``.
+        site_body: Per-site body index, shape ``[num_sites]``.
+        world_pos: Desired world positions [m], shape ``[num_sites]``.
+        world_quat: Desired world orientations as ``(qx, qy, qz, qw)``, shape ``[num_sites]``.
+        site_local: Per-site local offset (modified in-place), shape ``[num_sites]``.
+    """
+    i = wp.tid()
+    w_pos = world_pos[i]
+    w_q = world_quat[i]
+    desired_world = wp.transform(w_pos, wp.quatf(w_q[0], w_q[1], w_q[2], w_q[3]))
+    bid = site_body[i]
+    if bid == -1:
+        site_local[i] = desired_world
+    else:
+        site_local[i] = wp.transform_multiply(wp.transform_inverse(body_q[bid]), desired_world)
+
+
+@wp.kernel
+def _write_site_local_from_world_poses_indexed(
+    body_q: wp.array(dtype=wp.transformf),
+    site_body: wp.array(dtype=wp.int32),
+    indices: wp.array(dtype=wp.int32),
+    world_pos: wp.array(dtype=wp.vec3f),
+    world_quat: wp.array(dtype=wp.vec4f),
+    site_local: wp.array(dtype=wp.transformf),
+):
+    """Indexed variant of :func:`_write_site_local_from_world_poses`."""
+    i = wp.tid()
+    si = indices[i]
+    w_pos = world_pos[i]
+    w_q = world_quat[i]
+    desired_world = wp.transform(w_pos, wp.quatf(w_q[0], w_q[1], w_q[2], w_q[3]))
+    bid = site_body[si]
+    if bid == -1:
+        site_local[si] = desired_world
+    else:
+        site_local[si] = wp.transform_multiply(wp.transform_inverse(body_q[bid]), desired_world)
+
+
+@wp.kernel
+def _compute_site_local_transforms(
+    body_q: wp.array(dtype=wp.transformf),
+    site_body: wp.array(dtype=wp.int32),
+    site_local: wp.array(dtype=wp.transformf),
+    parent_site_body: wp.array(dtype=wp.int32),
+    parent_site_local: wp.array(dtype=wp.transformf),
+    out_pos: wp.array(dtype=wp.vec3f),
+    out_quat: wp.array(dtype=wp.vec4f),
+):
+    """Compute parent-relative transforms for every site in the view.
+
+    For each site *i*, computes the world pose of both the site and its USD
+    parent, then returns ``inv(parent_world) * prim_world``.  World-attached
+    sites/parents use ``site_local`` / ``parent_site_local`` directly.
+    """
+    i = wp.tid()
+    prim_bid = site_body[i]
+    if prim_bid == -1:
+        prim_world = site_local[i]
+    else:
+        prim_world = wp.transform_multiply(body_q[prim_bid], site_local[i])
+    parent_bid = parent_site_body[i]
+    if parent_bid == -1:
+        parent_world = parent_site_local[i]
+    else:
+        parent_world = wp.transform_multiply(body_q[parent_bid], parent_site_local[i])
+    local_tf = wp.transform_multiply(wp.transform_inverse(parent_world), prim_world)
+    out_pos[i] = wp.transform_get_translation(local_tf)
+    q = wp.transform_get_rotation(local_tf)
+    out_quat[i] = wp.vec4f(q[0], q[1], q[2], q[3])
+
+
+@wp.kernel
+def _compute_site_local_transforms_indexed(
+    body_q: wp.array(dtype=wp.transformf),
+    site_body: wp.array(dtype=wp.int32),
+    site_local: wp.array(dtype=wp.transformf),
+    parent_site_body: wp.array(dtype=wp.int32),
+    parent_site_local: wp.array(dtype=wp.transformf),
+    indices: wp.array(dtype=wp.int32),
+    out_pos: wp.array(dtype=wp.vec3f),
+    out_quat: wp.array(dtype=wp.vec4f),
+):
+    """Indexed variant of :func:`_compute_site_local_transforms`."""
+    i = wp.tid()
+    si = indices[i]
+    prim_bid = site_body[si]
+    if prim_bid == -1:
+        prim_world = site_local[si]
+    else:
+        prim_world = wp.transform_multiply(body_q[prim_bid], site_local[si])
+    parent_bid = parent_site_body[si]
+    if parent_bid == -1:
+        parent_world = parent_site_local[si]
+    else:
+        parent_world = wp.transform_multiply(body_q[parent_bid], parent_site_local[si])
+    local_tf = wp.transform_multiply(wp.transform_inverse(parent_world), prim_world)
+    out_pos[i] = wp.transform_get_translation(local_tf)
+    q = wp.transform_get_rotation(local_tf)
+    out_quat[i] = wp.vec4f(q[0], q[1], q[2], q[3])
+
+
+@wp.kernel
+def _write_site_local_from_local_poses(
+    body_q: wp.array(dtype=wp.transformf),
+    site_body: wp.array(dtype=wp.int32),
+    parent_site_body: wp.array(dtype=wp.int32),
+    parent_site_local: wp.array(dtype=wp.transformf),
+    local_pos: wp.array(dtype=wp.vec3f),
+    local_quat: wp.array(dtype=wp.vec4f),
+    site_local: wp.array(dtype=wp.transformf),
+):
+    """Update site local offsets so that sites reach desired parent-relative poses."""
+    i = wp.tid()
+    parent_bid = parent_site_body[i]
+    if parent_bid == -1:
+        parent_world = parent_site_local[i]
+    else:
+        parent_world = wp.transform_multiply(body_q[parent_bid], parent_site_local[i])
+    l_pos = local_pos[i]
+    l_q = local_quat[i]
+    local_tf = wp.transform(l_pos, wp.quatf(l_q[0], l_q[1], l_q[2], l_q[3]))
+    desired_world = wp.transform_multiply(parent_world, local_tf)
+    bid = site_body[i]
+    if bid == -1:
+        site_local[i] = desired_world
+    else:
+        site_local[i] = wp.transform_multiply(wp.transform_inverse(body_q[bid]), desired_world)
+
+
+@wp.kernel
+def _write_site_local_from_local_poses_indexed(
+    body_q: wp.array(dtype=wp.transformf),
+    site_body: wp.array(dtype=wp.int32),
+    parent_site_body: wp.array(dtype=wp.int32),
+    parent_site_local: wp.array(dtype=wp.transformf),
+    indices: wp.array(dtype=wp.int32),
+    local_pos: wp.array(dtype=wp.vec3f),
+    local_quat: wp.array(dtype=wp.vec4f),
+    site_local: wp.array(dtype=wp.transformf),
+):
+    """Indexed variant of :func:`_write_site_local_from_local_poses`."""
+    i = wp.tid()
+    si = indices[i]
+    parent_bid = parent_site_body[si]
+    if parent_bid == -1:
+        parent_world = parent_site_local[si]
+    else:
+        parent_world = wp.transform_multiply(body_q[parent_bid], parent_site_local[si])
+    l_pos = local_pos[i]
+    l_q = local_quat[i]
+    local_tf = wp.transform(l_pos, wp.quatf(l_q[0], l_q[1], l_q[2], l_q[3]))
+    desired_world = wp.transform_multiply(parent_world, local_tf)
+    bid = site_body[si]
+    if bid == -1:
+        site_local[si] = desired_world
+    else:
+        site_local[si] = wp.transform_multiply(wp.transform_inverse(body_q[bid]), desired_world)
+
+
+class OvPhysxFrameView(BaseFrameView):
+    """Batched prim view for non-physics prims tracked as sites on OVPhysX bodies.
+
+    Each matched USD prim is resolved at init to a ``(body_index, site_local)``
+    pair via ancestor walk: the nearest ancestor in the OVPhysX scene-data
+    provider's ``_rigid_body_paths`` becomes the attachment body, and the
+    relative USD transform becomes the site offset.  If no body ancestor
+    exists, the prim is attached to the world frame
+    (``body_index = WORLD_BODY_INDEX``).
+
+    World poses are computed on GPU as ``body_q[body_index] * site_local`` via
+    a Warp kernel, with the world-attached branch returning ``site_local``
+    directly.  Both :meth:`set_world_poses` and :meth:`set_local_poses` update
+    the view-owned ``site_local`` buffer -- neither writes to ``body_q``.
+
+    Scales and visibility delegate to an internal :class:`UsdFrameView`
+    (lazy-constructed on first call).
+
+    Pose getters return :class:`~isaaclab.utils.warp.ProxyArray`.  Setters
+    accept ``wp.array``.
+    """
+
+    def __init__(self, prim_path: str, device: str = "cpu", stage: Usd.Stage | None = None, **kwargs):
+        """Initialize the OVPhysX site-based frame view.
+
+        Args:
+            prim_path: USD prim path pattern (may contain regex).
+            device: Warp device for GPU arrays (e.g. ``"cuda:0"``).
+            stage: USD stage to search. Defaults to the current stage.
+            **kwargs: Forwarded to the lazy internal :class:`UsdFrameView`
+                (e.g. ``validate_xform_ops``); accepted for backend-agnostic
+                kwarg passing through the :class:`FrameView` factory.
+        """
+        self._prim_path = prim_path
+        self._device = device
+        self._kwargs = kwargs
+
+        stage = sim_utils.get_current_stage() if stage is None else stage
+        self._stage = stage
+        self._prims: list[Usd.Prim] = sim_utils.find_matching_prims(prim_path, stage=stage)
+        if not self._prims:
+            raise ValueError(f"OvPhysxFrameView: pattern {prim_path!r} matched zero prims.")
+
+        # Lazy USD view for scales / visibility.
+        self._usd_view: UsdFrameView | None = None
+
+        # Try synchronous init; defer to PHYSICS_READY if SDP not yet built.
+        sdp = self._try_get_sdp()
+        if sdp is not None and sdp.get_newton_state() is not None:
+            self._initialize_impl(sdp)
+        else:
+            OvPhysxManager.register_callback(
+                self._on_physics_ready,
+                PhysicsEvent.PHYSICS_READY,
+                name=f"ovphysx_frame_view_{prim_path}",
+            )
+
+    @staticmethod
+    def _try_get_sdp() -> Any | None:
+        """Return the active OVPhysX scene-data provider, or ``None`` if unavailable."""
+        from isaaclab.sim.simulation_context import SimulationContext  # noqa: PLC0415
+
+        ctx = SimulationContext.instance()
+        if ctx is None:
+            return None
+        try:
+            return ctx.initialize_scene_data_provider()
+        except Exception:  # noqa: BLE001 -- SDP may not yet be built; defer.
+            return None
+
+    def _on_physics_ready(self, _event) -> None:
+        """Callback invoked when the OVPhysX Newton state becomes available."""
+        sdp = self._try_get_sdp()
+        if sdp is None or sdp.get_newton_state() is None:
+            raise RuntimeError(
+                "OvPhysxFrameView: PHYSICS_READY fired but the scene data provider has no "
+                "Newton state. Ensure your scene declares `requires_newton_model=True` "
+                "(typically by including a sensor like ContactSensor or RayCaster)."
+            )
+        self._initialize_impl(sdp)
+
+    def _initialize_impl(self, sdp: Any) -> None:
+        """Resolve USD prims to OVPhysX body indices and allocate GPU buffers."""
+        self._sdp = sdp
+        body_labels = list(sdp._rigid_body_paths)
+        body_label_to_idx = {path: idx for idx, path in enumerate(body_labels)}
+
+        xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
+
+        site_bodies: list[int] = []
+        site_locals: list[list[float]] = []
+        parent_bodies: list[int] = []
+        parent_locals: list[list[float]] = []
+
+        identity_xform = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+        resolve_cache: dict[str, tuple[int, list[float]]] = {}
+
+        for prim in self._prims:
+            body_idx, local_xform = self._resolve_ancestor_body(prim, body_label_to_idx, xform_cache)
+            site_bodies.append(body_idx)
+            site_locals.append(local_xform)
+
+            parent = prim.GetParent()
+            if not parent or not parent.IsValid() or parent.GetPath().pathString == "/":
+                parent_bodies.append(WORLD_BODY_INDEX)
+                parent_locals.append(identity_xform)
+            else:
+                parent_path = parent.GetPath().pathString
+                if parent_path in resolve_cache:
+                    pb_idx, pb_local = resolve_cache[parent_path]
+                elif parent_path in body_label_to_idx:
+                    pb_idx = body_label_to_idx[parent_path]
+                    pb_local = identity_xform
+                    resolve_cache[parent_path] = (pb_idx, pb_local)
+                else:
+                    pb_idx, pb_local = self._resolve_ancestor_body(parent, body_label_to_idx, xform_cache)
+                    resolve_cache[parent_path] = (pb_idx, pb_local)
+                parent_bodies.append(pb_idx)
+                parent_locals.append(pb_local)
+
+        device = self._device
+        self._site_body = wp.array(site_bodies, dtype=wp.int32, device=device)
+        self._site_local = wp.array([wp.transform(*x) for x in site_locals], dtype=wp.transformf, device=device)
+        self._parent_site_body = wp.array(parent_bodies, dtype=wp.int32, device=device)
+        self._parent_site_local = wp.array(
+            [wp.transform(*x) for x in parent_locals], dtype=wp.transformf, device=device
+        )
+
+        self._num_bodies_snapshot = len(body_labels)
+
+        self._pos_buf = wp.zeros(self.count, dtype=wp.vec3f, device=device)
+        self._quat_buf = wp.zeros(self.count, dtype=wp.vec4f, device=device)
+        self._local_pos_buf = wp.zeros(self.count, dtype=wp.vec3f, device=device)
+        self._local_quat_buf = wp.zeros(self.count, dtype=wp.vec4f, device=device)
+        self._pos_ta = ProxyArray(self._pos_buf)
+        self._quat_ta = ProxyArray(self._quat_buf)
+        self._local_pos_ta = ProxyArray(self._local_pos_buf)
+        self._local_quat_ta = ProxyArray(self._local_quat_buf)
+
+    @staticmethod
+    def _resolve_ancestor_body(
+        prim: Usd.Prim,
+        body_label_to_idx: dict[str, int],
+        xform_cache: UsdGeom.XformCache,
+    ) -> tuple[int, list[float]]:
+        """Walk USD ancestors to find the nearest OVPhysX body and the relative local transform.
+
+        Returns:
+            ``(body_index, [tx, ty, tz, qx, qy, qz, qw])``. ``body_index`` is
+            :data:`WORLD_BODY_INDEX` when no body ancestor exists; the local
+            transform in that case is the prim's world USD transform.
+        """
+        prim_world_tf = xform_cache.GetLocalToWorldTransform(prim)
+        prim_world_tf.Orthonormalize()
+        ancestor = prim.GetParent()
+        while ancestor and ancestor.IsValid() and ancestor.GetPath().pathString != "/":
+            ancestor_path = ancestor.GetPath().pathString
+            body_idx = body_label_to_idx.get(ancestor_path)
+            if body_idx is not None:
+                ancestor_world_tf = xform_cache.GetLocalToWorldTransform(ancestor)
+                ancestor_world_tf.Orthonormalize()
+                local_tf = prim_world_tf * ancestor_world_tf.GetInverse()
+                return body_idx, _gf_matrix_to_xform7(local_tf)
+            ancestor = ancestor.GetParent()
+        return WORLD_BODY_INDEX, _gf_matrix_to_xform7(prim_world_tf)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def prims(self) -> list[Usd.Prim]:
+        """List of USD prims being managed by this view."""
+        return self._prims
+
+    @property
+    def prim_paths(self) -> list[str]:
+        """List of prim paths (as strings) for all prims being managed by this view."""
+        if not hasattr(self, "_prim_paths_cache"):
+            self._prim_paths_cache = [p.GetPath().pathString for p in self._prims]
+        return self._prim_paths_cache
+
+    @property
+    def count(self) -> int:
+        """Number of prims in this view."""
+        return len(self._prims)
+
+    @property
+    def device(self) -> str:
+        """Device where arrays are allocated (``"cpu"`` or ``"cuda:0"``)."""
+        return self._device
+
+    # ------------------------------------------------------------------
+    # Initialization guard for deferred-init users
+    # ------------------------------------------------------------------
+
+    def _require_initialized(self) -> None:
+        if not hasattr(self, "_site_body"):
+            raise RuntimeError(
+                "OvPhysxFrameView used before initialization. The view defers initialization "
+                "until OvPhysxManager dispatches PhysicsEvent.PHYSICS_READY. Step the "
+                "simulation once (or wait for physics to be ready) before calling pose methods."
+            )
+
+    def _current_body_q(self) -> wp.array:
+        """Fetch the current OVPhysX ``body_q`` array, validating shape.
+
+        Returns:
+            ``wp.array(dtype=wp.transformf)`` of shape ``[num_bodies]``.
+
+        Raises:
+            RuntimeError: If the SDP has no Newton state or its size has changed since init.
+        """
+        state = self._sdp.get_newton_state()
+        if state is None:
+            raise RuntimeError(
+                "OvPhysxFrameView: scene data provider returned no Newton state. "
+                "Ensure your scene declares `requires_newton_model=True` (typically by "
+                "including a sensor like ContactSensor or RayCaster)."
+            )
+        body_q = state.body_q
+        if body_q.shape[0] != self._num_bodies_snapshot:
+            raise RuntimeError(
+                f"OvPhysxFrameView: body_q size changed ({body_q.shape[0]} vs "
+                f"{self._num_bodies_snapshot} at init). Dynamic env counts are not supported."
+            )
+        return body_q
+
+    # ------------------------------------------------------------------
+    # World / local pose APIs (Tasks 5 & 6)
+    # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # World poses
+    # ------------------------------------------------------------------
+
+    def get_world_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
+        """Get world-space positions and orientations.
+
+        Args:
+            indices: Subset of sites to query. ``None`` means all sites.
+
+        Returns:
+            A tuple ``(positions, orientations)`` of :class:`~isaaclab.utils.warp.ProxyArray`
+            wrappers. Use ``.warp`` for the underlying ``wp.array`` or ``.torch`` for a
+            cached zero-copy ``torch.Tensor`` view.
+        """
+        self._require_initialized()
+        body_q = self._current_body_q()
+
+        if indices is not None:
+            n = len(indices)
+            pos_buf = wp.zeros(n, dtype=wp.vec3f, device=self._device)
+            quat_buf = wp.zeros(n, dtype=wp.vec4f, device=self._device)
+            wp.launch(
+                _compute_site_world_transforms_indexed,
+                dim=n,
+                inputs=[body_q, self._site_body, self._site_local, indices],
+                outputs=[pos_buf, quat_buf],
+                device=self._device,
+            )
+            return ProxyArray(pos_buf), ProxyArray(quat_buf)
+
+        wp.launch(
+            _compute_site_world_transforms,
+            dim=self.count,
+            inputs=[body_q, self._site_body, self._site_local],
+            outputs=[self._pos_buf, self._quat_buf],
+            device=self._device,
+        )
+        return self._pos_ta, self._quat_ta
+
+    def set_world_poses(
+        self,
+        positions: wp.array | None = None,
+        orientations: wp.array | None = None,
+        indices: wp.array | None = None,
+    ) -> None:
+        """Set world-space positions and/or orientations.
+
+        Updates ``site_local`` so that ``body_q[body] * site_local`` yields the
+        desired world pose.  Does **not** modify ``body_q``.
+
+        Args:
+            positions: Desired world positions ``(M, 3)`` [m]. ``None`` leaves
+                positions unchanged.
+            orientations: Desired world quaternions ``(M, 4)`` as
+                ``(qx, qy, qz, qw)``. ``None`` leaves orientations unchanged.
+            indices: Subset of sites to update. ``None`` means all sites.
+        """
+        if positions is None and orientations is None:
+            return
+        self._require_initialized()
+        body_q = self._current_body_q()
+
+        if positions is None or orientations is None:
+            cur_pos_ta, cur_quat_ta = self.get_world_poses(indices)
+            if positions is None:
+                positions = cur_pos_ta.warp
+            if orientations is None:
+                orientations = cur_quat_ta.warp
+
+        if indices is not None:
+            wp.launch(
+                _write_site_local_from_world_poses_indexed,
+                dim=len(indices),
+                inputs=[body_q, self._site_body, indices, positions, orientations, self._site_local],
+                device=self._device,
+            )
+        else:
+            wp.launch(
+                _write_site_local_from_world_poses,
+                dim=self.count,
+                inputs=[body_q, self._site_body, positions, orientations, self._site_local],
+                device=self._device,
+            )
+
+    # ------------------------------------------------------------------
+    # Local poses (parent-relative)
+    # ------------------------------------------------------------------
+
+    def get_local_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
+        """Get parent-relative positions and orientations.
+
+        Computes ``inv(parent_world) * prim_world`` for each site.
+
+        Args:
+            indices: Subset of sites to query. ``None`` means all sites.
+
+        Returns:
+            A tuple ``(translations, orientations)`` of :class:`~isaaclab.utils.warp.ProxyArray`
+            wrappers.
+        """
+        self._require_initialized()
+        body_q = self._current_body_q()
+
+        if indices is not None:
+            n = len(indices)
+            pos_buf = wp.zeros(n, dtype=wp.vec3f, device=self._device)
+            quat_buf = wp.zeros(n, dtype=wp.vec4f, device=self._device)
+            wp.launch(
+                _compute_site_local_transforms_indexed,
+                dim=n,
+                inputs=[
+                    body_q,
+                    self._site_body,
+                    self._site_local,
+                    self._parent_site_body,
+                    self._parent_site_local,
+                    indices,
+                ],
+                outputs=[pos_buf, quat_buf],
+                device=self._device,
+            )
+            return ProxyArray(pos_buf), ProxyArray(quat_buf)
+
+        wp.launch(
+            _compute_site_local_transforms,
+            dim=self.count,
+            inputs=[
+                body_q,
+                self._site_body,
+                self._site_local,
+                self._parent_site_body,
+                self._parent_site_local,
+            ],
+            outputs=[self._local_pos_buf, self._local_quat_buf],
+            device=self._device,
+        )
+        return self._local_pos_ta, self._local_quat_ta
+
+    def set_local_poses(
+        self,
+        translations: wp.array | None = None,
+        orientations: wp.array | None = None,
+        indices: wp.array | None = None,
+    ) -> None:
+        """Set parent-relative translations and/or orientations.
+
+        Updates ``site_local`` only; does **not** modify ``body_q``.
+
+        Args:
+            translations: Desired parent-relative translations ``(M, 3)`` [m].
+                ``None`` leaves translations unchanged.
+            orientations: Desired parent-relative quaternions ``(M, 4)`` as
+                ``(qx, qy, qz, qw)``. ``None`` leaves orientations unchanged.
+            indices: Subset of sites to update. ``None`` means all sites.
+        """
+        if translations is None and orientations is None:
+            return
+        self._require_initialized()
+        body_q = self._current_body_q()
+
+        if translations is None or orientations is None:
+            cur_pos_ta, cur_quat_ta = self.get_local_poses(indices)
+            if translations is None:
+                translations = cur_pos_ta.warp
+            if orientations is None:
+                orientations = cur_quat_ta.warp
+
+        if indices is not None:
+            wp.launch(
+                _write_site_local_from_local_poses_indexed,
+                dim=len(indices),
+                inputs=[
+                    body_q,
+                    self._site_body,
+                    self._parent_site_body,
+                    self._parent_site_local,
+                    indices,
+                    translations,
+                    orientations,
+                    self._site_local,
+                ],
+                device=self._device,
+            )
+        else:
+            wp.launch(
+                _write_site_local_from_local_poses,
+                dim=self.count,
+                inputs=[
+                    body_q,
+                    self._site_body,
+                    self._parent_site_body,
+                    self._parent_site_local,
+                    translations,
+                    orientations,
+                    self._site_local,
+                ],
+                device=self._device,
+            )
+
+    # ------------------------------------------------------------------
+    # Scales & visibility -- delegate to UsdFrameView
+    # ------------------------------------------------------------------
+
+    def _ensure_usd_view(self) -> UsdFrameView:
+        if self._usd_view is None:
+            self._usd_view = UsdFrameView(
+                self._prim_path,
+                device=self._device,
+                validate_xform_ops=self._kwargs.get("validate_xform_ops", True),
+                stage=self._stage,
+            )
+        return self._usd_view
+
+    def get_scales(self, indices: wp.array | None = None) -> wp.array:
+        """Get scales for prims in the view (USD-backed)."""
+        return self._ensure_usd_view().get_scales(indices)
+
+    def set_scales(self, scales: wp.array, indices: wp.array | None = None) -> None:
+        """Set scales for prims in the view (USD-backed)."""
+        self._ensure_usd_view().set_scales(scales, indices)
+
+    def get_visibility(self, indices: wp.array | None = None):
+        """Get visibility for prims in the view (USD-backed).
+
+        Note: OVPhysX runs without a Kit renderer, so visibility reads return
+        the static USD stage state. Writes succeed at the USD layer but
+        produce no visible change.
+        """
+        return self._ensure_usd_view().get_visibility(indices)
+
+    def set_visibility(self, visibility, indices: wp.array | None = None) -> None:
+        """Set visibility for prims in the view (USD-backed; no renderer effect under OVPhysX)."""
+        self._ensure_usd_view().set_visibility(visibility, indices)
+
+
+def _gf_matrix_to_xform7(mat: Gf.Matrix4d) -> list[float]:
+    """Convert a ``Gf.Matrix4d`` to ``[tx, ty, tz, qx, qy, qz, qw]``."""
+    t = mat.ExtractTranslation()
+    q = mat.ExtractRotationQuat()
+    imag = q.GetImaginary()
+    return [float(t[0]), float(t[1]), float(t[2]), float(imag[0]), float(imag[1]), float(imag[2]), float(q.GetReal())]

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
@@ -8,11 +8,12 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import warp as wp
 
-from pxr import Gf, Usd, UsdGeom
+from pxr import Gf, Usd, UsdGeom, UsdPhysics
 
 import isaaclab.sim as sim_utils
 from isaaclab.physics import PhysicsEvent
@@ -264,22 +265,33 @@ class OvPhysxFrameView(BaseFrameView):
     """Batched prim view for non-physics prims tracked as sites on OVPhysX bodies.
 
     Each matched USD prim is resolved at init to a ``(body_index, site_local)``
-    pair via ancestor walk: the nearest ancestor in the OVPhysX scene-data
-    provider's ``_rigid_body_paths`` becomes the attachment body, and the
-    relative USD transform becomes the site offset.  If no body ancestor
-    exists, the prim is attached to the world frame
-    (``body_index = WORLD_BODY_INDEX``).
+    pair via ancestor walk: the nearest ancestor carrying ``UsdPhysics.RigidBodyAPI``
+    becomes the attachment body, and the relative USD transform becomes the site
+    offset. If no rigid-body ancestor exists, the prim is attached to the world
+    frame (``body_index = WORLD_BODY_INDEX``) and ``site_local`` stores the prim's
+    USD world transform.
+
+    Body world poses are read each step via an OVPhysX ``RIGID_BODY_POSE`` tensor
+    binding -- the same data path the contact sensor uses -- and **not** via the
+    scene data provider's Newton model. This keeps the view usable in scenes
+    that do not declare ``requires_newton_model=True``.
 
     World poses are computed on GPU as ``body_q[body_index] * site_local`` via
     a Warp kernel, with the world-attached branch returning ``site_local``
-    directly.  Both :meth:`set_world_poses` and :meth:`set_local_poses` update
-    the view-owned ``site_local`` buffer -- neither writes to ``body_q``.
+    directly. Both :meth:`set_world_poses` and :meth:`set_local_poses` update
+    the view-owned ``site_local`` buffer -- neither writes to the physics state.
 
     Scales and visibility delegate to an internal :class:`UsdFrameView`
     (lazy-constructed on first call).
 
     Pose getters return :class:`~isaaclab.utils.warp.ProxyArray`.  Setters
     accept ``wp.array``.
+
+    Limitations (v1):
+        All resolved rigid-body ancestors (plus their USD parents for local-pose
+        queries) must share a single env-wildcarded path pattern. Mixed
+        body-types per view raise :class:`NotImplementedError`. The common
+        case (one body type, wildcarded across envs) is fully supported.
     """
 
     def __init__(self, prim_path: str, device: str = "cpu", stage: Usd.Stage | None = None, **kwargs):
@@ -306,10 +318,10 @@ class OvPhysxFrameView(BaseFrameView):
         # Lazy USD view for scales / visibility.
         self._usd_view: UsdFrameView | None = None
 
-        # Try synchronous init; defer to PHYSICS_READY if SDP not yet built.
-        sdp = self._try_get_sdp()
-        if sdp is not None and sdp.get_newton_state() is not None:
-            self._initialize_impl(sdp)
+        # Try synchronous init; defer to PHYSICS_READY if the PhysX instance is not yet alive.
+        physx = self._try_get_physx()
+        if physx is not None:
+            self._initialize_impl(physx)
         else:
             OvPhysxManager.register_callback(
                 self._on_physics_ready,
@@ -318,113 +330,209 @@ class OvPhysxFrameView(BaseFrameView):
             )
 
     @staticmethod
-    def _try_get_sdp() -> Any | None:
-        """Return the active OVPhysX scene-data provider, or ``None`` if unavailable."""
-        from isaaclab.sim.simulation_context import SimulationContext  # noqa: PLC0415
-
-        ctx = SimulationContext.instance()
-        if ctx is None:
-            return None
-        try:
-            return ctx.initialize_scene_data_provider()
-        except Exception:  # noqa: BLE001 -- SDP may not yet be built; defer.
-            return None
+    def _try_get_physx() -> Any | None:
+        """Return the active OVPhysX ``PhysX`` instance, or ``None`` if not yet created."""
+        return OvPhysxManager.get_physx_instance()
 
     def _on_physics_ready(self, _event) -> None:
-        """Callback invoked when the OVPhysX Newton state becomes available."""
-        sdp = self._try_get_sdp()
-        if sdp is None or sdp.get_newton_state() is None:
-            raise RuntimeError(
-                "OvPhysxFrameView: PHYSICS_READY fired but the scene data provider has no "
-                "Newton state. Ensure your scene declares `requires_newton_model=True` "
-                "(typically by including a sensor like ContactSensor or RayCaster)."
-            )
-        self._initialize_impl(sdp)
+        """Callback invoked when the OVPhysX ``PhysX`` instance becomes available."""
+        physx = self._try_get_physx()
+        if physx is None:
+            raise RuntimeError("OvPhysxFrameView: PHYSICS_READY fired but OvPhysxManager has no PhysX instance.")
+        self._initialize_impl(physx)
 
-    def _initialize_impl(self, sdp: Any) -> None:
-        """Resolve USD prims to OVPhysX body indices and allocate GPU buffers."""
-        self._sdp = sdp
-        body_labels = list(sdp._rigid_body_paths)
-        body_label_to_idx = {path: idx for idx, path in enumerate(body_labels)}
+    def _initialize_impl(self, physx: Any) -> None:
+        """Resolve prims to rigid-body ancestors and create a RIGID_BODY_POSE tensor binding.
+
+        Site discovery handles two scene-construction modes:
+
+        * **``clone_usd=True``** (Newton-style cloning): every env has its own
+          USD prims; ``find_matching_prims`` returns one prim per env, and the
+          binding row count matches.
+        * **``clone_usd=False``** (OVPhysX default): only ``env_0`` has authored
+          USD prims; ``env_1..N`` are physics-layer clones (no USD twin). The
+          RIGID_BODY_POSE binding still exposes one row per env. In that case
+          the binding is the source of truth for the site count, and per-env
+          site paths are synthesized from the env_0 template prim's path with
+          ``env_0`` replaced by the row's env_id.
+        """
+        from isaaclab_ovphysx import tensor_types as TT  # noqa: PLC0415
 
         xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
+        identity_xform7 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
 
-        site_bodies: list[int] = []
-        site_locals: list[list[float]] = []
-        parent_bodies: list[int] = []
-        parent_locals: list[list[float]] = []
-
-        identity_xform = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
-        resolve_cache: dict[str, tuple[int, list[float]]] = {}
-
+        # 1. Resolve each (template) prim's ancestor body + the prim->ancestor offset.
+        per_prim_ancestor: list[str | None] = []
+        per_prim_site_local: list[list[float]] = []
         for prim in self._prims:
-            body_idx, local_xform = self._resolve_ancestor_body(prim, body_label_to_idx, xform_cache)
-            site_bodies.append(body_idx)
-            site_locals.append(local_xform)
+            ap, sl = self._resolve_rigid_body_ancestor(prim, xform_cache)
+            per_prim_ancestor.append(ap)
+            per_prim_site_local.append(sl)
 
+        # 2. Same resolution for each prim's USD parent (used by local-pose queries).
+        parent_ancestor: list[str | None] = []
+        parent_site_local: list[list[float]] = []
+        for prim in self._prims:
             parent = prim.GetParent()
-            if not parent or not parent.IsValid() or parent.GetPath().pathString == "/":
-                parent_bodies.append(WORLD_BODY_INDEX)
-                parent_locals.append(identity_xform)
+            if parent and parent.IsValid() and parent.GetPath().pathString != "/":
+                pap, psl = self._resolve_rigid_body_ancestor(parent, xform_cache)
             else:
-                parent_path = parent.GetPath().pathString
-                if parent_path in resolve_cache:
-                    pb_idx, pb_local = resolve_cache[parent_path]
-                elif parent_path in body_label_to_idx:
-                    pb_idx = body_label_to_idx[parent_path]
-                    pb_local = identity_xform
-                    resolve_cache[parent_path] = (pb_idx, pb_local)
-                else:
-                    pb_idx, pb_local = self._resolve_ancestor_body(parent, body_label_to_idx, xform_cache)
-                    resolve_cache[parent_path] = (pb_idx, pb_local)
-                parent_bodies.append(pb_idx)
-                parent_locals.append(pb_local)
+                pap, psl = None, identity_xform7
+            parent_ancestor.append(pap)
+            parent_site_local.append(psl)
 
+        # 3. Dedup discovered ancestor paths into env-wildcarded patterns (one binding per pattern).
+        all_ancestors = [p for p in (per_prim_ancestor + parent_ancestor) if p is not None]
+        patterns = sorted({self._env_wildcardify(p) for p in all_ancestors})
+        if len(patterns) > 1:
+            raise NotImplementedError(
+                f"OvPhysxFrameView v1 supports a single body-type pattern; resolved {len(patterns)}"
+                f" patterns under prim_path={self._prim_path!r}: {patterns}."
+            )
+
+        # 4. Create the RIGID_BODY_POSE binding (or operate in world-only mode).
+        if patterns:
+            pattern = patterns[0]
+            self._pose_binding = physx.create_tensor_binding(pattern=pattern, tensor_type=TT.RIGID_BODY_POSE)
+            if self._pose_binding.shape[0] == 0:
+                raise RuntimeError(
+                    f"OvPhysxFrameView: RIGID_BODY_POSE binding for pattern {pattern!r} matched zero bodies."
+                )
+            self._pose_buf = wp.zeros(self._pose_binding.shape, dtype=wp.float32, device=self._device)
+            binding_paths: list[str] = list(self._pose_binding.prim_paths)
+        else:
+            # All prims resolved as world-attached: no binding needed; kernels only hit the -1 branch.
+            self._pose_binding = None
+            self._pose_buf = wp.zeros((1, 7), dtype=wp.float32, device=self._device)
+            binding_paths = []
+
+        # 5. Detect clone_usd=False expansion: binding row count > number of matched USD prims.
+        #    Replace per-prim arrays with one entry per binding row, all derived from the env_0 template.
+        if binding_paths and len(binding_paths) > len(self._prims):
+            template_ancestor = per_prim_ancestor[0]
+            template_site_local = per_prim_site_local[0]
+            template_parent_ancestor = parent_ancestor[0]
+            template_parent_site_local = parent_site_local[0]
+            template_path = self._prims[0].GetPath().pathString
+
+            per_prim_ancestor = []
+            per_prim_site_local = []
+            parent_ancestor = []
+            parent_site_local = []
+            synthetic_prim_paths: list[str] = []
+            for body_path in binding_paths:
+                env_match = re.search(r"/World/envs/env_(\d+)", body_path)
+                env_token = env_match.group(0) if env_match else None
+                # Re-target the template path's env segment to this row's env_id.
+                if env_token is not None:
+                    synthetic_path = re.sub(r"/World/envs/env_\d+", env_token, template_path)
+                    ap = re.sub(r"/World/envs/env_\d+", env_token, template_ancestor) if template_ancestor else None
+                    pap = (
+                        re.sub(r"/World/envs/env_\d+", env_token, template_parent_ancestor)
+                        if template_parent_ancestor
+                        else None
+                    )
+                else:
+                    synthetic_path = template_path
+                    ap = template_ancestor
+                    pap = template_parent_ancestor
+                per_prim_ancestor.append(ap)
+                per_prim_site_local.append(template_site_local)
+                parent_ancestor.append(pap)
+                parent_site_local.append(template_parent_site_local)
+                synthetic_prim_paths.append(synthetic_path)
+            self._synthetic_prim_paths: list[str] | None = synthetic_prim_paths
+        else:
+            self._synthetic_prim_paths = None
+
+        # 6. Build site_body and parent_site_body indices into the binding's row order.
+        path_to_row = {p: i for i, p in enumerate(binding_paths)}
+        site_bodies = [
+            path_to_row.get(ap, WORLD_BODY_INDEX) if ap is not None else WORLD_BODY_INDEX for ap in per_prim_ancestor
+        ]
+        parent_bodies = [
+            path_to_row.get(pap, WORLD_BODY_INDEX) if pap is not None else WORLD_BODY_INDEX for pap in parent_ancestor
+        ]
+
+        # 7. Allocate Warp arrays.
         device = self._device
         self._site_body = wp.array(site_bodies, dtype=wp.int32, device=device)
-        self._site_local = wp.array([wp.transform(*x) for x in site_locals], dtype=wp.transformf, device=device)
+        self._site_local = wp.array([wp.transform(*x) for x in per_prim_site_local], dtype=wp.transformf, device=device)
         self._parent_site_body = wp.array(parent_bodies, dtype=wp.int32, device=device)
         self._parent_site_local = wp.array(
-            [wp.transform(*x) for x in parent_locals], dtype=wp.transformf, device=device
+            [wp.transform(*x) for x in parent_site_local], dtype=wp.transformf, device=device
         )
 
-        self._num_bodies_snapshot = len(body_labels)
-
-        self._pos_buf = wp.zeros(self.count, dtype=wp.vec3f, device=device)
-        self._quat_buf = wp.zeros(self.count, dtype=wp.vec4f, device=device)
-        self._local_pos_buf = wp.zeros(self.count, dtype=wp.vec3f, device=device)
-        self._local_quat_buf = wp.zeros(self.count, dtype=wp.vec4f, device=device)
+        count = len(per_prim_ancestor)
+        self._pos_buf = wp.zeros(count, dtype=wp.vec3f, device=device)
+        self._quat_buf = wp.zeros(count, dtype=wp.vec4f, device=device)
+        self._local_pos_buf = wp.zeros(count, dtype=wp.vec3f, device=device)
+        self._local_quat_buf = wp.zeros(count, dtype=wp.vec4f, device=device)
         self._pos_ta = ProxyArray(self._pos_buf)
         self._quat_ta = ProxyArray(self._quat_buf)
         self._local_pos_ta = ProxyArray(self._local_pos_buf)
         self._local_quat_ta = ProxyArray(self._local_quat_buf)
 
-    @staticmethod
-    def _resolve_ancestor_body(
+    def _resolve_rigid_body_ancestor(
+        self,
         prim: Usd.Prim,
-        body_label_to_idx: dict[str, int],
         xform_cache: UsdGeom.XformCache,
-    ) -> tuple[int, list[float]]:
-        """Walk USD ancestors to find the nearest OVPhysX body and the relative local transform.
+    ) -> tuple[str | None, list[float]]:
+        """Walk USD ancestors to find the nearest prim with ``UsdPhysics.RigidBodyAPI``.
+
+        Under OVPhysX scenes built with ``clone_usd=False`` (the default for
+        :class:`~isaaclab.scene.InteractiveScene`), only ``env_0`` carries the
+        authored RigidBodyAPI -- ``env_1..N`` exist only as physics-layer clones
+        and the corresponding USD prims (when present) are untyped Xforms.
+        :meth:`_prim_or_template_has_rigid_body_api` handles this by checking
+        the prim's env_0 equivalent when the API is not directly applied.
 
         Returns:
-            ``(body_index, [tx, ty, tz, qx, qy, qz, qw])``. ``body_index`` is
-            :data:`WORLD_BODY_INDEX` when no body ancestor exists; the local
-            transform in that case is the prim's world USD transform.
+            ``(ancestor_path, [tx, ty, tz, qx, qy, qz, qw])``. ``ancestor_path`` is
+            ``None`` when no rigid-body ancestor exists; the local transform in
+            that case is the prim's world USD transform.
         """
         prim_world_tf = xform_cache.GetLocalToWorldTransform(prim)
         prim_world_tf.Orthonormalize()
+        # If the prim itself is a rigid body (directly or via env_0 template), the site offset is identity.
+        if self._prim_or_template_has_rigid_body_api(prim):
+            return prim.GetPath().pathString, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
         ancestor = prim.GetParent()
         while ancestor and ancestor.IsValid() and ancestor.GetPath().pathString != "/":
-            ancestor_path = ancestor.GetPath().pathString
-            body_idx = body_label_to_idx.get(ancestor_path)
-            if body_idx is not None:
+            if self._prim_or_template_has_rigid_body_api(ancestor):
                 ancestor_world_tf = xform_cache.GetLocalToWorldTransform(ancestor)
                 ancestor_world_tf.Orthonormalize()
                 local_tf = prim_world_tf * ancestor_world_tf.GetInverse()
-                return body_idx, _gf_matrix_to_xform7(local_tf)
+                return ancestor.GetPath().pathString, _gf_matrix_to_xform7(local_tf)
             ancestor = ancestor.GetParent()
-        return WORLD_BODY_INDEX, _gf_matrix_to_xform7(prim_world_tf)
+        return None, _gf_matrix_to_xform7(prim_world_tf)
+
+    def _prim_or_template_has_rigid_body_api(self, prim: Usd.Prim) -> bool:
+        """Return whether the prim (or its ``env_0`` equivalent) has ``RigidBodyAPI`` applied.
+
+        Falls back to the env_0 template lookup so that ``clone_usd=False`` envs
+        (whose USD prims lack physics schemas) still resolve to the right body.
+        """
+        if prim.HasAPI(UsdPhysics.RigidBodyAPI):
+            return True
+        path = prim.GetPath().pathString
+        env_zero_path = self._env_zero_equivalent(path)
+        if env_zero_path == path:
+            return False
+        template_prim = self._stage.GetPrimAtPath(env_zero_path) if self._stage is not None else None
+        if template_prim is None or not template_prim.IsValid():
+            return False
+        return template_prim.HasAPI(UsdPhysics.RigidBodyAPI)
+
+    @staticmethod
+    def _env_zero_equivalent(path: str) -> str:
+        """Replace ``/World/envs/env_<digits>`` with ``/World/envs/env_0`` for template lookup."""
+        return re.sub(r"/World/envs/env_\d+", "/World/envs/env_0", path)
+
+    @staticmethod
+    def _env_wildcardify(path: str) -> str:
+        """Replace ``/World/envs/env_<digits>`` with ``/World/envs/env_*`` for binding patterns."""
+        return re.sub(r"/World/envs/env_\d+", "/World/envs/env_*", path)
 
     # ------------------------------------------------------------------
     # Properties
@@ -432,19 +540,33 @@ class OvPhysxFrameView(BaseFrameView):
 
     @property
     def prims(self) -> list[Usd.Prim]:
-        """List of USD prims being managed by this view."""
+        """List of USD prims discovered for this view.
+
+        Under ``clone_usd=False`` scenes only ``env_0`` carries USD prims, so
+        this list may be shorter than :attr:`count`. Use :attr:`prim_paths` to
+        get one path per site (env-substituted for non-env_0 sites).
+        """
         return self._prims
 
     @property
     def prim_paths(self) -> list[str]:
-        """List of prim paths (as strings) for all prims being managed by this view."""
+        """List of one prim path per site.
+
+        For ``clone_usd=False`` scenes (where ``env_1..N`` have no USD prim)
+        the paths are synthesized by replacing ``env_0`` in the template prim's
+        path with each binding row's env_id.
+        """
+        if hasattr(self, "_synthetic_prim_paths") and self._synthetic_prim_paths is not None:
+            return self._synthetic_prim_paths
         if not hasattr(self, "_prim_paths_cache"):
             self._prim_paths_cache = [p.GetPath().pathString for p in self._prims]
         return self._prim_paths_cache
 
     @property
     def count(self) -> int:
-        """Number of prims in this view."""
+        """Number of sites in this view (one per binding row, or per matched prim in world-only mode)."""
+        if hasattr(self, "_site_body"):
+            return int(self._site_body.shape[0])
         return len(self._prims)
 
     @property
@@ -465,28 +587,21 @@ class OvPhysxFrameView(BaseFrameView):
             )
 
     def _current_body_q(self) -> wp.array:
-        """Fetch the current OVPhysX ``body_q`` array, validating shape.
+        """Refresh and return the body-pose array sourced from the OVPhysX tensor binding.
+
+        Reads ``RIGID_BODY_POSE`` data into ``self._pose_buf`` and returns a
+        ``wp.transformf`` view. When no rigid-body ancestors were resolved at
+        init time (every prim was world-attached), the binding is ``None`` and
+        the returned view is a single-element placeholder buffer -- kernels
+        access it only via the world-attached (``site_body[i] == -1``) branch.
 
         Returns:
-            ``wp.array(dtype=wp.transformf)`` of shape ``[num_bodies]``.
-
-        Raises:
-            RuntimeError: If the SDP has no Newton state or its size has changed since init.
+            ``wp.array(dtype=wp.transformf)`` -- a view over the binding-pose
+            buffer ``[num_bodies]``.
         """
-        state = self._sdp.get_newton_state()
-        if state is None:
-            raise RuntimeError(
-                "OvPhysxFrameView: scene data provider returned no Newton state. "
-                "Ensure your scene declares `requires_newton_model=True` (typically by "
-                "including a sensor like ContactSensor or RayCaster)."
-            )
-        body_q = state.body_q
-        if body_q.shape[0] != self._num_bodies_snapshot:
-            raise RuntimeError(
-                f"OvPhysxFrameView: body_q size changed ({body_q.shape[0]} vs "
-                f"{self._num_bodies_snapshot} at init). Dynamic env counts are not supported."
-            )
-        return body_q
+        if self._pose_binding is not None:
+            self._pose_binding.read(self._pose_buf)
+        return self._pose_buf.view(wp.transformf)
 
     # ------------------------------------------------------------------
     # World / local pose APIs (Tasks 5 & 6)

--- a/source/isaaclab_ovphysx/test/sim/__init__.py
+++ b/source/isaaclab_ovphysx/test/sim/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py
+++ b/source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py
@@ -51,40 +51,10 @@ def test_view_raises_before_physics_ready():
             view.get_world_poses()
 
 
-def test_view_errors_when_newton_model_not_required():
-    """If the scene declares no Newton-model requirement, the view raises a hint.
-
-    ``build_simulation_context`` does not accept ``scene_data_requirements`` directly;
-    instead we call ``sim.update_scene_data_requirements`` after context creation to
-    reset the requirement flag to ``False``.  The actual class is
-    ``SceneDataRequirement`` (singular) from
-    ``isaaclab.physics.scene_data_requirements``.
-
-    Two error paths are possible depending on whether ``PHYSICS_READY`` fires:
-
-    * If the event fires synchronously (full OVPhysX context), the
-      ``_on_physics_ready`` callback sees ``get_newton_state() is None`` and raises
-      a ``RuntimeError`` containing ``"requires_newton_model=True"``.
-    * If the event does not fire (SDP not yet ready at construction time and no
-      step is issued), ``_require_initialized`` raises
-      ``"OvPhysxFrameView used before initialization"``.
-
-    The ``match`` regex covers both paths.
-    """
-    from isaaclab.physics.scene_data_requirements import SceneDataRequirement
-
-    device = "cpu"
-    OVPHYSX_SIM_CFG.device = device
-    with build_simulation_context(device=device, sim_cfg=OVPHYSX_SIM_CFG, add_ground_plane=False) as sim:
-        # Override the scene-data requirement so that requires_newton_model=False.
-        # This causes get_newton_state() to return None even after PHYSICS_READY.
-        sim.update_scene_data_requirements(SceneDataRequirement(requires_newton_model=False))
-
-        stage = sim_utils.get_current_stage()
-        prim = stage.DefinePrim("/World/marker_noreq", "Xform")
-        sim_utils.standardize_xform_ops(prim)
-        with pytest.raises(RuntimeError, match="used before initialization|requires_newton_model"):
-            FrameView("/World/marker_noreq", device=device).get_world_poses()
+# Note: an earlier test ``test_view_errors_when_newton_model_not_required`` was
+# removed when ``OvPhysxFrameView`` was reworked to read poses from a direct
+# OVPhysX ``RIGID_BODY_POSE`` tensor binding instead of the SDP's Newton state.
+# The view no longer depends on ``requires_newton_model``.
 
 
 # ==================================================================
@@ -105,9 +75,7 @@ from frame_view_contract_utils import CHILD_OFFSET, ViewBundle  # noqa: E402
 from pxr import Gf  # noqa: E402
 
 from isaaclab.assets import RigidObjectCfg  # noqa: E402
-from isaaclab.physics.scene_data_requirements import SceneDataRequirement  # noqa: E402
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg  # noqa: E402
-from isaaclab.sim import SimulationContext  # noqa: E402
 from isaaclab.utils import configclass  # noqa: E402
 
 
@@ -127,7 +95,16 @@ class _OvPhysxFrameViewSceneCfg(InteractiveSceneCfg):
 
 @pytest.fixture
 def view_factory():
-    """OVPhysX factory: CameraMount child Xform at CHILD_OFFSET under each Cube body."""
+    """OVPhysX factory: CameraMount child Xform at CHILD_OFFSET under each Cube body.
+
+    Test scaffolding note: ``OvPhysxFrameView`` reads body poses from a live
+    OVPhysX ``RIGID_BODY_POSE`` tensor binding each frame. The shared contract
+    tests inject synthetic parent poses via ``set_parent_pos`` and expect the
+    very next ``get_world_poses`` call to reflect them -- without stepping the
+    sim. To make that work, the fixture detaches the binding after one
+    initial read so subsequent reads return the contents of ``_pose_buf``
+    directly, and the get/set callbacks drive ``_pose_buf`` in place.
+    """
     from isaaclab_ovphysx.sim.views import OvPhysxFrameView  # noqa: PLC0415
 
     contexts: list = []
@@ -148,24 +125,24 @@ def view_factory():
             prim.GetAttribute("xformOp:translate").Set(Gf.Vec3d(*CHILD_OFFSET))
             prim.GetAttribute("xformOp:orient").Set(Gf.Quatd(1.0, 0.0, 0.0, 0.0))
 
-        # Activate Newton model sync so get_newton_state() returns body_q.
-        sim.update_scene_data_requirements(SceneDataRequirement(requires_newton_model=True))
         sim.reset()
         view = OvPhysxFrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
 
-        sdp = SimulationContext.instance().initialize_scene_data_provider()
-        body_labels = list(sdp._rigid_body_paths)
-        cube_indices = [body_labels.index(f"/World/envs/env_{i}/Cube") for i in range(num_envs)]
+        # Capture binding row order, populate _pose_buf once with the live spawn poses,
+        # then detach the binding so subsequent reads do not overwrite the buffer.
+        assert view._pose_binding is not None, "Fixture expects a non-empty pose binding."
+        view._pose_binding.read(view._pose_buf)
+        path_to_row = {p: i for i, p in enumerate(view._pose_binding.prim_paths)}
+        view._pose_binding = None
+
+        cube_rows = [path_to_row[f"/World/envs/env_{i}/Cube"] for i in range(num_envs)]
+        pose_buf_torch = wp.to_torch(view._pose_buf)  # shape [num_bodies, 7] float32
 
         def _get_parent_pos(n: int, dev: str) -> torch.Tensor:
-            body_q = sdp.get_newton_state().body_q
-            torch_q = wp.to_torch(body_q).to(dev)
-            return torch_q[cube_indices, :3].clone()
+            return pose_buf_torch[cube_rows, :3].to(dev).clone()
 
         def _set_parent_pos(positions: torch.Tensor, n: int) -> None:
-            body_q = sdp.get_newton_state().body_q
-            torch_q = wp.to_torch(body_q)
-            torch_q[cube_indices, :3] = positions.to(torch_q.device, torch_q.dtype)
+            pose_buf_torch[cube_rows, :3] = positions.to(pose_buf_torch.device, pose_buf_torch.dtype)
 
         return ViewBundle(
             view=view,

--- a/source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py
+++ b/source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py
@@ -76,7 +76,7 @@ from pxr import Gf  # noqa: E402
 
 from isaaclab.assets import RigidObjectCfg  # noqa: E402
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg  # noqa: E402
-from isaaclab.utils import configclass  # noqa: E402
+from isaaclab.utils.configclass import configclass  # noqa: E402
 
 
 @configclass

--- a/source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py
+++ b/source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Real-backend tests for the OVPhysX FrameView.
+
+Run via ``./scripts/run_ovphysx.sh -m pytest`` (kitless, no ``AppLauncher``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from isaaclab_ovphysx.physics import OvPhysxCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.sim import SimulationCfg, build_simulation_context
+from isaaclab.sim.views import FrameView
+
+OVPHYSX_SIM_CFG = SimulationCfg(physics=OvPhysxCfg())
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_factory_dispatches_to_ovphysx_frame_view(device):
+    """``FrameView(...)`` under an OVPhysX ``SimulationContext`` returns an ``OvPhysxFrameView``."""
+    OVPHYSX_SIM_CFG.device = device
+    with build_simulation_context(device=device, sim_cfg=OVPHYSX_SIM_CFG, add_ground_plane=True):
+        # Define a plain Xform prim so the pattern matches at least one prim.
+        stage = sim_utils.get_current_stage()
+        prim = stage.DefinePrim("/World/marker", "Xform")
+        sim_utils.standardize_xform_ops(prim)
+
+        from isaaclab_ovphysx.sim.views import OvPhysxFrameView
+
+        view = FrameView("/World/marker", device=device)
+        assert isinstance(view, OvPhysxFrameView), f"Expected OvPhysxFrameView, got {type(view).__name__}"
+
+
+def test_view_raises_before_physics_ready():
+    """A view constructed before PHYSICS_READY raises a clear error on pose-method calls."""
+    device = "cpu"
+    OVPHYSX_SIM_CFG.device = device
+    with build_simulation_context(device=device, sim_cfg=OVPHYSX_SIM_CFG, add_ground_plane=False):
+        stage = sim_utils.get_current_stage()
+        prim = stage.DefinePrim("/World/marker_pre", "Xform")
+        sim_utils.standardize_xform_ops(prim)
+        view = FrameView("/World/marker_pre", device=device)
+        if hasattr(view, "_site_body"):
+            pytest.skip("PHYSICS_READY already fired; cannot exercise the deferred-init path here.")
+        with pytest.raises(RuntimeError, match="used before initialization"):
+            view.get_world_poses()
+
+
+def test_view_errors_when_newton_model_not_required():
+    """If the scene declares no Newton-model requirement, the view raises a hint.
+
+    ``build_simulation_context`` does not accept ``scene_data_requirements`` directly;
+    instead we call ``sim.update_scene_data_requirements`` after context creation to
+    reset the requirement flag to ``False``.  The actual class is
+    ``SceneDataRequirement`` (singular) from
+    ``isaaclab.physics.scene_data_requirements``.
+
+    Two error paths are possible depending on whether ``PHYSICS_READY`` fires:
+
+    * If the event fires synchronously (full OVPhysX context), the
+      ``_on_physics_ready`` callback sees ``get_newton_state() is None`` and raises
+      a ``RuntimeError`` containing ``"requires_newton_model=True"``.
+    * If the event does not fire (SDP not yet ready at construction time and no
+      step is issued), ``_require_initialized`` raises
+      ``"OvPhysxFrameView used before initialization"``.
+
+    The ``match`` regex covers both paths.
+    """
+    from isaaclab.physics.scene_data_requirements import SceneDataRequirement
+
+    device = "cpu"
+    OVPHYSX_SIM_CFG.device = device
+    with build_simulation_context(device=device, sim_cfg=OVPHYSX_SIM_CFG, add_ground_plane=False) as sim:
+        # Override the scene-data requirement so that requires_newton_model=False.
+        # This causes get_newton_state() to return None even after PHYSICS_READY.
+        sim.update_scene_data_requirements(SceneDataRequirement(requires_newton_model=False))
+
+        stage = sim_utils.get_current_stage()
+        prim = stage.DefinePrim("/World/marker_noreq", "Xform")
+        sim_utils.standardize_xform_ops(prim)
+        with pytest.raises(RuntimeError, match="used before initialization|requires_newton_model"):
+            FrameView("/World/marker_noreq", device=device).get_world_poses()
+
+
+# ==================================================================
+# Shared FrameView contract suite
+# ==================================================================
+
+import sys  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "isaaclab" / "test" / "sim"))
+
+import torch  # noqa: E402
+import warp as wp  # noqa: E402
+from frame_view_contract_utils import *  # noqa: F401, F403, E402 -- import all contract tests
+from frame_view_contract_utils import CHILD_OFFSET, ViewBundle  # noqa: E402
+
+from pxr import Gf  # noqa: E402
+
+from isaaclab.assets import RigidObjectCfg  # noqa: E402
+from isaaclab.physics.scene_data_requirements import SceneDataRequirement  # noqa: E402
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg  # noqa: E402
+from isaaclab.sim import SimulationContext  # noqa: E402
+from isaaclab.utils import configclass  # noqa: E402
+
+
+@configclass
+class _OvPhysxFrameViewSceneCfg(InteractiveSceneCfg):
+    cube: RigidObjectCfg = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Cube",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.2, 0.2, 0.2),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
+    )
+
+
+@pytest.fixture
+def view_factory():
+    """OVPhysX factory: CameraMount child Xform at CHILD_OFFSET under each Cube body."""
+    from isaaclab_ovphysx.sim.views import OvPhysxFrameView  # noqa: PLC0415
+
+    contexts: list = []
+
+    def _build(num_envs: int, device: str) -> ViewBundle:
+        OVPHYSX_SIM_CFG.device = device
+        ctx = build_simulation_context(device=device, sim_cfg=OVPHYSX_SIM_CFG, add_ground_plane=True)
+        sim = ctx.__enter__()
+        sim._app_control_on_stop_handle = None
+        contexts.append(ctx)
+
+        InteractiveScene(_OvPhysxFrameViewSceneCfg(num_envs=num_envs, env_spacing=2.0))
+
+        stage = sim_utils.get_current_stage()
+        for i in range(num_envs):
+            prim = stage.DefinePrim(f"/World/envs/env_{i}/Cube/CameraMount", "Xform")
+            sim_utils.standardize_xform_ops(prim)
+            prim.GetAttribute("xformOp:translate").Set(Gf.Vec3d(*CHILD_OFFSET))
+            prim.GetAttribute("xformOp:orient").Set(Gf.Quatd(1.0, 0.0, 0.0, 0.0))
+
+        # Activate Newton model sync so get_newton_state() returns body_q.
+        sim.update_scene_data_requirements(SceneDataRequirement(requires_newton_model=True))
+        sim.reset()
+        view = OvPhysxFrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
+
+        sdp = SimulationContext.instance().initialize_scene_data_provider()
+        body_labels = list(sdp._rigid_body_paths)
+        cube_indices = [body_labels.index(f"/World/envs/env_{i}/Cube") for i in range(num_envs)]
+
+        def _get_parent_pos(n: int, dev: str) -> torch.Tensor:
+            body_q = sdp.get_newton_state().body_q
+            torch_q = wp.to_torch(body_q).to(dev)
+            return torch_q[cube_indices, :3].clone()
+
+        def _set_parent_pos(positions: torch.Tensor, n: int) -> None:
+            body_q = sdp.get_newton_state().body_q
+            torch_q = wp.to_torch(body_q)
+            torch_q[cube_indices, :3] = positions.to(torch_q.device, torch_q.dtype)
+
+        return ViewBundle(
+            view=view,
+            get_parent_pos=_get_parent_pos,
+            set_parent_pos=_set_parent_pos,
+            teardown=lambda: None,
+        )
+
+    yield _build
+
+    for cm in contexts:
+        cm.__exit__(None, None, None)

--- a/source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py
+++ b/source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py
@@ -11,11 +11,17 @@ Run via ``./scripts/run_ovphysx.sh -m pytest`` (kitless, no ``AppLauncher``).
 from __future__ import annotations
 
 import pytest
-from isaaclab_ovphysx.physics import OvPhysxCfg
 
-import isaaclab.sim as sim_utils
-from isaaclab.sim import SimulationCfg, build_simulation_context
-from isaaclab.sim.views import FrameView
+# The CI isaaclab_ov* pattern unintentionally collects isaaclab_ovphysx tests,
+# but the ovphysx wheel is not installed in that environment. Skip gracefully
+# so the isaaclab_ov CI pipeline is not blocked by an unrelated dependency.
+pytest.importorskip("ovphysx.types", reason="ovphysx wheel not installed")
+
+from isaaclab_ovphysx.physics import OvPhysxCfg  # noqa: E402
+
+import isaaclab.sim as sim_utils  # noqa: E402
+from isaaclab.sim import SimulationCfg, build_simulation_context  # noqa: E402
+from isaaclab.sim.views import FrameView  # noqa: E402
 
 OVPHYSX_SIM_CFG = SimulationCfg(physics=OvPhysxCfg())
 


### PR DESCRIPTION
# Description

Adds `OvPhysxFrameView`, the OVPhysX-backend implementation of
:class:`isaaclab.sim.views.FrameView`. The factory in
`isaaclab.sim.views.frame_view` now dispatches to it when the active
backend is `"ovphysx"`, mirroring the `FabricFrameView` (PhysX) and
`NewtonSiteFrameView` (Newton) entries.

`OvPhysxFrameView` reads live body poses via the OVPhysX wheel's
`create_tensor_binding(pattern, tensor_type=RIGID_BODY_POSE)` API and
exposes them as `wp.transformf` arrays without going through the
SceneDataProvider. Sensors built on top of `FrameView` (e.g. RayCaster,
the ContactSensor pose-tracking path) can now read body transforms
under OVPhysX with the same API surface they use under PhysX and
Newton.

Two scaling-related changes in `InteractiveScene` and `OvPhysxManager`
make OVPhysX fan-out behave like the other backends:

* `InteractiveScene` now USD-replicates the per-env asset subtree for
  every backend (`clone_usd=True`), including OVPhysX. The
  `find_matching_prims`-based `_num_envs` discovery used by many
  sensors now sees N prims under OVPhysX, matching PhysX/Newton.
* `OvPhysxManager` strips `env_1..N` from the in-memory USD before
  handing it to `physx.add_usd`. Without this, the wheel's per-USD-path
  enumeration scales O(num_envs * bodies) and hangs at 4k+ envs — even
  though physics still uses a single replicated template. The env_0
  USD is what the wheel ingests; physics replication happens via
  `physx.clone`, identical to the prior `clone_usd=False` path. A short
  comment on the helper documents the assumption that the per-env
  subtrees are structurally homogeneous.

Tested manually with `Isaac-Velocity-Rough-Anymal-D-v0` at 4096 envs
under the OVPhysX preset; iter time matches the prior `clone_usd=False`
baseline.

Fixes #N/A

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

N/A — backend infrastructure change with no UI surface.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there