### PR TITLE
chore: update ruff target-version to py312

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ all = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py312"
 
 # Exclude directories
 extend-exclude = [
@@ -98,6 +98,8 @@ ignore = [
     "SIM118", # Use {key} in {dict} instead of {key} in {dict}.keys()
     "UP006",  # Use 'dict' instead of 'Dict' type annotation
     "UP018",  # Unnecessary `float` call (rewrite as a literal)
+    "UP040",  # TypeAlias annotation → `type` keyword (PEP 695, migrate later)
+    "UP047",  # Generic function → type parameters (PEP 695, migrate later)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/reinforcement_learning/rl_games/train.py
+++ b/scripts/reinforcement_learning/rl_games/train.py
@@ -24,7 +24,6 @@ import random
 import sys
 import time
 from datetime import datetime
-from distutils.util import strtobool
 
 import gymnasium as gym
 from rl_games.common import env_configurations, vecenv
@@ -36,6 +35,7 @@ from isaaclab.utils.assets import retrieve_file_path
 from isaaclab.utils.dict import print_dict
 from isaaclab.utils.io import dump_yaml
 from isaaclab.utils.seed import configure_seed
+from isaaclab.utils.string import strtobool
 
 from isaaclab_rl.rl_games import MultiObserver, PbtAlgoObserver, RlGamesGpuEnv, RlGamesVecEnvWrapper
 

--- a/scripts/reinforcement_learning/rl_games/train_rl_games.py
+++ b/scripts/reinforcement_learning/rl_games/train_rl_games.py
@@ -15,7 +15,6 @@ import os
 import random
 import time
 from datetime import datetime
-from distutils.util import strtobool
 
 from common import (
     add_common_train_args,
@@ -29,6 +28,8 @@ from common import (
     validate_distributed_device,
     wrap_record_video,
 )
+
+from isaaclab.utils.string import strtobool
 
 import isaaclab_tasks  # noqa: F401
 

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -7,9 +7,8 @@ import os
 import re
 import shutil
 import sys
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 from ..utils import (
     ISAACLAB_ROOT,

--- a/source/isaaclab/isaaclab/devices/haply/se3_haply.py
+++ b/source/isaaclab/isaaclab/devices/haply/se3_haply.py
@@ -344,7 +344,7 @@ class HaplyDevice(DeviceBase):
 
                             await asyncio.sleep(1.0 / self.data_rate)
 
-                        except asyncio.TimeoutError:
+                        except TimeoutError:
                             self.consecutive_timeouts += 1
 
                             # Check if timeout

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -546,3 +546,27 @@ def list_intersection(list1: list[Any], list2: list[Any] | None) -> list[Any]:
         return list1
     set2 = set(list2)
     return [x for x in list1 if x in set2]
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to True/False.
+
+    True values are ``y``, ``yes``, ``t``, ``true``, ``on``, and ``1``.
+    False values are ``n``, ``no``, ``f``, ``false``, ``off``, and ``0``.
+
+    Args:
+        val: The string to convert.
+
+    Returns:
+        The boolean interpretation of *val*.
+
+    Raises:
+        ValueError: If *val* is not a recognised truth string.
+    """
+    v = val.lower()
+    if v in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif v in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val!r}")

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -8,9 +8,8 @@
 from __future__ import annotations
 
 import re
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 
 def _repo_root() -> Path:

--- a/source/isaaclab/test/cli/test_wheel_builder_metadata.py
+++ b/source/isaaclab/test/cli/test_wheel_builder_metadata.py
@@ -8,9 +8,8 @@
 from __future__ import annotations
 
 import ast
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 
 def _repo_root() -> Path:

--- a/tools/wheel_builder/gen_pyproject.py
+++ b/tools/wheel_builder/gen_pyproject.py
@@ -6,7 +6,6 @@
 """Generate pyproject.toml for the isaaclab wheel from python_packages.toml."""
 
 import sys
-
 import tomllib
 
 if len(sys.argv) != 4:


### PR DESCRIPTION
The project requires `python >= 3.12` but ruff was configured with `target-version = "py310"`. This causes false positives (e.g. `ExceptionGroup` flagged as undefined) and prevents correct stdlib import sorting for modules like `tomllib`.

This PR updates `target-version` to `"py312"` and applies the resulting auto-fixes.