### PR TITLE
[Diag][DO NOT MERGE] Positive arm — numpy 2.3.4 safe with 5656 fix

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -111,7 +111,7 @@ RUN touch /bin/nvidia-smi && \
 # sees nlopt as already satisfied and skips the from-source rebuild that would fail.
 RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
     if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
-        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel numpy && \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel "numpy!=2.3.5" && \
         ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
     fi
 

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -159,7 +159,7 @@ RUN rm -rf ${ISAACSIM_ROOT_PATH}/kit/python/lib/python3.12/site-packages/pip* &&
 # sees nlopt as already satisfied and skips the from-source rebuild that would fail.
 RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
     if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
-        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel numpy && \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel "numpy!=2.3.5" && \
         ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
     fi
 
@@ -171,11 +171,16 @@ RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
 # HACK: Uninstall quadprog as it causes issues with some reinforcement learning frameworks
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog
 
-# Install cuRobo from source (pinned commit); needs CUDA env and Torch
+# Install cuRobo from source (pinned commit); needs CUDA env and Torch.
+# ``numpy!=2.3.5`` is passed so this resolve cannot land on the broken numpy 2.3.5
+# release if any of nvidia-curobo's deps drag numpy back down (cmeel-boost cap).
+# See ``source/isaaclab/setup.py``.
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation \
+    "numpy!=2.3.5" \
     "nvidia-curobo @ git+https://github.com/NVlabs/curobo.git@ebb71702f3f70e767f40fd8e050674af0288abe8"
 
-# Install isaaclab_teleop (needed by Pink IK tests and related env configs)
+# Install isaaclab_teleop (needed by Pink IK tests and related env configs).
+# isaaclab_teleop's setup.py already excludes numpy 2.3.5; no extra argv needed here.
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --editable ${ISAACLAB_PATH}/source/isaaclab_teleop
 
 # aliasing isaaclab.sh and python for convenience

--- a/source/conftest.py
+++ b/source/conftest.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Dep-manifest diagnostic: prints numpy version + bundled OpenBLAS hash at pytest session start.
+
+Loaded by pytest when collecting tests under ``source/``. Importing numpy here registers
+its vendored OpenBLAS ``pthread_atfork`` handler in pytest's process, which is the same
+process that later calls ``fork()`` via ``SimulationApp()``. The output identifies which
+numpy + OpenBLAS bundle actually landed in each CI test container.
+"""
+
+import os
+
+import numpy
+
+print(f"\n[dep-manifest] numpy {numpy.__version__}", flush=True)
+_libs_dir = os.path.join(os.path.dirname(numpy.__file__), os.pardir, "numpy.libs")
+if os.path.isdir(_libs_dir):
+    for _f in sorted(os.listdir(_libs_dir)):
+        if "openblas" in _f.lower():
+            print(f"[dep-manifest] bundled openblas: {_f}", flush=True)

--- a/source/isaaclab/changelog.d/jichuanh-force-numpy-install.rst
+++ b/source/isaaclab/changelog.d/jichuanh-force-numpy-install.rst
@@ -1,0 +1,20 @@
+Fixed
+^^^^^
+
+* Excluded the broken ``numpy 2.3.5`` release from every install path that pulls
+  numpy. ``numpy 2.3.5``'s vendored OpenBLAS
+  (``libscipy_openblas64_-fdde5778.so``) registers a buggy ``pthread_atfork``
+  handler that crashes Kit's ``libomni.platforminfo`` ``fork()`` during
+  ``SimulationApp`` startup. The exclusion is declared at every site:
+
+  * Each ``source/<pkg>/setup.py`` that depends on numpy directly or
+    transitively (``isaaclab``, ``isaaclab_tasks``, ``isaaclab_rl``,
+    ``isaaclab_visualizers``, ``isaaclab_teleop``, ``isaaclab_mimic``).
+  * The ``pin-pink`` force-reinstall in
+    :meth:`isaaclab.cli.commands.install._ensure_pink_ik_dependencies_installed`.
+  * The ARM ``setuptools wheel numpy`` pre-install in
+    :meth:`isaaclab.cli.commands.install._maybe_preinstall_arm_nlopt`.
+  * The ARM nlopt prep step in ``docker/Dockerfile.base``.
+  * The ``nvidia-curobo`` install in ``docker/Dockerfile.curobo``.
+
+  See numpy/numpy#30092 and OMPE-92261.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -135,7 +135,7 @@ def _maybe_preinstall_arm_nlopt(pip_cmd: list[str]) -> None:
         return
     print_info("Pre-installing nlopt==2.6.2 on ARM (no-build-isolation)...")
     print_info("  step 1/2: ensure setuptools/wheel/numpy are importable for the no-build-isolation backend")
-    run_command(pip_cmd + ["install", "setuptools", "wheel", "numpy"])
+    run_command(pip_cmd + ["install", "setuptools", "wheel", "numpy!=2.3.5"])
     print_info("  step 2/2: install nlopt==2.6.2 with --no-build-isolation")
     run_command(pip_cmd + ["install", "--no-build-isolation", "nlopt==2.6.2"])
 
@@ -213,8 +213,12 @@ def _ensure_pink_ik_dependencies_installed(python_exe: str, pip_cmd: list[str], 
         return
 
     print_info("Pink IK dependency probe failed. Force-installing the cmeel pinocchio and DAQP stack.")
+    # Pass ``numpy!=2.3.5`` so this fresh resolve (which sees only pin-pink's deps
+    # plus cmeel-boost's ``numpy<2.4`` cap) cannot land on the broken numpy 2.3.5
+    # release. See numpy/numpy#30092 and the rationale in
+    # :file:`source/isaaclab/setup.py`.
     install_result = run_command(
-        pip_cmd + ["install", "--upgrade", "--force-reinstall", *_PINK_IK_STACK],
+        pip_cmd + ["install", "--upgrade", "--force-reinstall", "numpy!=2.3.5", *_PINK_IK_STACK],
         check=False,
     )
     if install_result.returncode != 0:

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -18,7 +18,13 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
-    "numpy>=2",
+    # numpy 2.3.5 ships a vendored OpenBLAS whose ``pthread_atfork`` handler crashes
+    # Kit's ``libomni.platforminfo`` ``fork()`` during ``SimulationApp`` startup.
+    # The exclusion is declared at every install site that pulls numpy (this
+    # setup.py, the other source/* setup.py files, the pin-pink force-reinstall in
+    # ``isaaclab.cli.commands.install``, and the standalone ``pip install`` lines in
+    # docker/Dockerfile.*). See numpy/numpy#30092 and OMPE-92261.
+    "numpy>=2,!=2.3.5",
     "torch>=2.10",
     "onnx>=1.18.0",  # 1.16.2 throws access violation on Windows
     "prettytable==3.3.0",

--- a/source/isaaclab_mimic/changelog.d/jichuanh-force-numpy-install.rst
+++ b/source/isaaclab_mimic/changelog.d/jichuanh-force-numpy-install.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Excluded the broken ``numpy 2.3.5`` release from the package's install
+  requirements. ``isaaclab_mimic`` pulls numpy transitively via ``h5py``; an
+  explicit exclusion keeps the broken 2.3.5 out of resolves that depend on
+  this package. See ``source/isaaclab/setup.py`` for the full rationale.

--- a/source/isaaclab_mimic/setup.py
+++ b/source/isaaclab_mimic/setup.py
@@ -23,6 +23,9 @@ INSTALL_REQUIRES = [
     "ipywidgets==8.1.5",
     # data collection
     "h5py==3.15.1",
+    # h5py pulls numpy; without the exclusion the resolve can land on the broken
+    # 2.3.5. See ``source/isaaclab/setup.py``.
+    "numpy!=2.3.5",
 ]
 
 # nvidia-srl-usd-to-urdf depends on usd-core which has no aarch64 wheels

--- a/source/isaaclab_rl/changelog.d/jichuanh-force-numpy-install.rst
+++ b/source/isaaclab_rl/changelog.d/jichuanh-force-numpy-install.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Excluded the broken ``numpy 2.3.5`` release from the package's install requirements.
+  ``numpy 2.3.5``'s vendored OpenBLAS registers a ``pthread_atfork`` handler that
+  crashes Kit's ``libomni.platforminfo`` ``fork()`` during ``SimulationApp`` startup.
+  See ``source/isaaclab/setup.py`` and ``isaaclab.cli.commands.install`` for the
+  authoritative install-time defense.

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -19,7 +19,8 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
-    "numpy",
+    # See ``source/isaaclab/setup.py`` for the rationale on ``!=2.3.5``.
+    "numpy!=2.3.5",
     "torch>=2.10",
     "torchvision>=0.25.0",  # ensure compatibility with torch 2.10.0
     "protobuf>=4.25.8,!=5.26.0",

--- a/source/isaaclab_tasks/changelog.d/jichuanh-force-numpy-install.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-force-numpy-install.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Excluded the broken ``numpy 2.3.5`` release from the package's install requirements.
+  ``numpy 2.3.5``'s vendored OpenBLAS registers a ``pthread_atfork`` handler that
+  crashes Kit's ``libomni.platforminfo`` ``fork()`` during ``SimulationApp`` startup.
+  See ``source/isaaclab/setup.py`` and ``isaaclab.cli.commands.install`` for the
+  authoritative install-time defense.

--- a/source/isaaclab_tasks/setup.py
+++ b/source/isaaclab_tasks/setup.py
@@ -18,7 +18,8 @@ EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extensio
 # Minimum dependencies required prior to installation
 INSTALL_REQUIRES = [
     # generic
-    "numpy>=2",
+    # See ``source/isaaclab/setup.py`` for the rationale on ``!=2.3.5``.
+    "numpy>=2,!=2.3.5",
     "torch>=2.10",
     "torchvision>=0.25.0",  # ensure compatibility with torch 2.10.0
     "protobuf>=4.25.8,!=5.26.0",

--- a/source/isaaclab_teleop/changelog.d/jichuanh-force-numpy-install.rst
+++ b/source/isaaclab_teleop/changelog.d/jichuanh-force-numpy-install.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Excluded the broken ``numpy 2.3.5`` release from the package's install
+  requirements. ``isaaclab_teleop`` pulls numpy transitively via
+  ``dex-retargeting`` -> ``pin`` -> ``cmeel-boost`` (which caps ``numpy<2.4``),
+  so without an explicit exclusion pip lands on the broken 2.3.5. See
+  ``source/isaaclab/setup.py`` for the full rationale.

--- a/source/isaaclab_teleop/setup.py
+++ b/source/isaaclab_teleop/setup.py
@@ -23,6 +23,9 @@ INSTALL_REQUIRES = [
     f"isaacteleop[retargeters,ui,cloudxr]~=1.3.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
     # required by isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1_t2_dex_retargeting_utils
     f"dex-retargeting==0.5.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
+    # dex-retargeting pulls ``pin`` (cmeel pinocchio) -> cmeel-boost (``numpy<2.4``);
+    # without an exclusion here pip lands on numpy 2.3.5. See ``source/isaaclab/setup.py``.
+    "numpy!=2.3.5",
 ]
 
 # Installation operation

--- a/source/isaaclab_visualizers/changelog.d/jichuanh-force-numpy-install.rst
+++ b/source/isaaclab_visualizers/changelog.d/jichuanh-force-numpy-install.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Excluded the broken ``numpy 2.3.5`` release from the package's install requirements.
+  ``numpy 2.3.5``'s vendored OpenBLAS registers a ``pthread_atfork`` handler that
+  crashes Kit's ``libomni.platforminfo`` ``fork()`` during ``SimulationApp`` startup.
+  See ``source/isaaclab/setup.py`` and ``isaaclab.cli.commands.install`` for the
+  authoritative install-time defense.

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -10,7 +10,8 @@ from setuptools import setup
 # Base requirements shared across visualizer backends.
 INSTALL_REQUIRES = [
     "isaaclab",
-    "numpy",
+    # See ``source/isaaclab/setup.py`` for the rationale on ``!=2.3.5``.
+    "numpy!=2.3.5",
 ]
 
 # Every Newton declaration in the repo must use the SAME extra spec (`newton[sim]`).


### PR DESCRIPTION
## Purpose

Positive arm of the single-variable A/B that validates https://github.com/isaac-sim/IsaacLab/pull/5656.

Companion negative arm: https://github.com/isaac-sim/IsaacLab/pull/5655.

## Setup

- Branch base: develop (`a9b62101ca6`).
- Cherry-pick of 5656's fix commit (`eae5a01c` — the 10-site `numpy!=2.3.5` exclusion).
- One commit on top: `source/conftest.py` that prints the resolved numpy version and bundled OpenBLAS .so filename at pytest session start. **Same patch contents as the negative arm's conftest commit.**
- No `isaaclab.sh --install` overrides, no force-reinstall, no action.yml edits.

`git diff jichuanh/validate-numpy-pin-5642..jichuanh/validate-numpy-2-3-4-worstcase` between the negative arm and this branch equals exactly 5656's 10-site exclusion — nothing else.

## Expected result

- Install resolves to numpy 2.3.4 (highest 2.3.x that satisfies `!=2.3.5` under cmeel-boost's cap).
- `[dep-manifest]` log line shows `numpy 2.3.4` + `libscipy_openblas64_-8fb3d286.so`.
- Canary jobs pass:
  - `isaaclab_physx`
  - `isaaclab_newton`
  - `isaaclab_rl`

If any canary fails with the atfork-in-libomni.platforminfo backtrace, 2.3.4's OpenBLAS bundle is also broken and 5656 needs to be tightened (e.g. exclude 2.3.x entirely and force >=2.4 via the path documented in 5656 §8.1).

## Lifecycle

Diagnostic-only. **Do not merge.** Closes once evidence is captured.

## Related

- https://github.com/isaac-sim/IsaacLab/pull/5656 — the fix being validated
- https://github.com/isaac-sim/IsaacLab/pull/5655 — negative arm
- https://github.com/numpy/numpy/issues/30092
- https://github.com/OpenMathLib/OpenBLAS/pull/5520