### PR TITLE
[Test] Stabilize RTX MDL shader-warmup flake in rendering correctness tests

### DIFF
--- a/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
@@ -1,0 +1,13 @@
+Fixed
+^^^^^
+
+* Stabilized RTX MDL shader-warmup flakes in the rendering-correctness tests
+  by stepping the env 10 frames before reading the camera tensor, instead of
+  a single step. Affected ``test_shadow_hand_vision_presets.py``'s
+  ``test_camera_renders_not_empty`` and the three helper-driven tests in
+  ``rendering_test_utils.py``
+  (``rendering_test_shadow_hand``/``_cartpole``/``_dexsuite_kuka``) — all of
+  which intermittently failed with "Camera output is all zeros or all inf"
+  for ``simple_shading_*_mdl`` and ``simple_shading_constant_diffuse``
+  variants on cold-cache CI runners (the GPU returned a still-zero
+  framebuffer because the MDL material hadn't finished compiling).

--- a/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
@@ -2,11 +2,12 @@ Fixed
 ^^^^^
 
 * Stabilized ``test_camera_renders_not_empty`` in
-  ``test_shadow_hand_vision_presets.py`` by stepping the env 10 frames
-  before reading the camera tensor instead of a single step. The test
-  intermittently failed with "Camera output is all zeros or all inf" for
-  ``simple_shading_*_mdl`` and ``simple_shading_constant_diffuse`` variants
-  on cold-cache CI runners because the GPU returned a still-zero
-  framebuffer before the MDL material finished compiling. The three
-  goldenfile-comparing helpers in ``rendering_test_utils.py`` already use
-  ``flaky(max_runs=3)`` and are left untouched.
+  ``test_shadow_hand_vision_presets.py`` by polling the camera output until
+  all data-type tensors are non-zero, with a 60-step cap, instead of a
+  single ``env.step()``. The test intermittently failed with "Camera output
+  is all zeros or all inf" for ``simple_shading_*_mdl`` and
+  ``simple_shading_constant_diffuse`` variants on cold-cache CI runners
+  because the GPU returned a still-zero framebuffer before the MDL material
+  finished compiling. The three goldenfile-comparing helpers in
+  ``rendering_test_utils.py`` already use ``flaky(max_runs=3)`` and are left
+  untouched.

--- a/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
@@ -1,13 +1,20 @@
 Fixed
 ^^^^^
 
-* Stabilized ``test_camera_renders_not_empty`` in
-  ``test_shadow_hand_vision_presets.py`` by polling the camera output until
-  all data-type tensors are non-zero, with a 60-step cap, instead of a
-  single ``env.step()``. The test intermittently failed with "Camera output
-  is all zeros or all inf" for ``simple_shading_*_mdl`` and
-  ``simple_shading_constant_diffuse`` variants on cold-cache CI runners
-  because the GPU returned a still-zero framebuffer before the MDL material
-  finished compiling. The three goldenfile-comparing helpers in
-  ``rendering_test_utils.py`` already use ``flaky(max_runs=3)`` and are left
-  untouched.
+* Stabilized RTX MDL shader-warmup flakes in the rendering-correctness tests
+  by polling the camera output until every data-type tensor reports a
+  non-zero max before the assertion / golden compare, instead of relying on
+  a single render pass:
+
+  * ``test_camera_renders_not_empty`` in
+    ``test_shadow_hand_vision_presets.py`` polls via ``env.step()`` with a
+    60-step cap.
+  * The three goldenfile helpers in ``rendering_test_utils.py``
+    (``rendering_test_shadow_hand`` / ``_cartpole`` / ``_dexsuite_kuka``)
+    poll via ``sim.render()`` + ``scene.update()`` with a 30-pass cap, so
+    physics state is not advanced and the existing goldens stay valid.
+
+  All variants intermittently failed with "Camera output is all zeros or
+  all inf" for ``simple_shading_*_mdl`` and ``simple_shading_constant_diffuse``
+  on cold-cache CI runners because the GPU returned a still-zero
+  framebuffer before the MDL material finished compiling.

--- a/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
@@ -2,12 +2,17 @@ Fixed
 ^^^^^
 
 * Stabilized RTX MDL shader-warmup flakes in the rendering-correctness tests
-  by stepping the env 10 frames before reading the camera tensor, instead of
-  a single step. Affected ``test_shadow_hand_vision_presets.py``'s
-  ``test_camera_renders_not_empty`` and the three helper-driven tests in
-  ``rendering_test_utils.py``
-  (``rendering_test_shadow_hand``/``_cartpole``/``_dexsuite_kuka``) — all of
-  which intermittently failed with "Camera output is all zeros or all inf"
-  for ``simple_shading_*_mdl`` and ``simple_shading_constant_diffuse``
-  variants on cold-cache CI runners (the GPU returned a still-zero
-  framebuffer because the MDL material hadn't finished compiling).
+  by driving 10 extra ``sim.render()`` + ``scene.update()`` passes between env
+  construction and the camera read in
+  ``rendering_test_utils.py``'s ``rendering_test_shadow_hand``,
+  ``rendering_test_cartpole``, and ``rendering_test_dexsuite_kuka`` helpers.
+  The warmup mirrors the pattern already used by
+  :attr:`~isaaclab.envs.DirectRLEnvCfg.num_rerenders_on_reset` —
+  it does not advance physics, so the existing golden images remain valid.
+  ``test_camera_renders_not_empty`` in
+  ``test_shadow_hand_vision_presets.py`` (which has no golden compare) is
+  stabilized by stepping the env 10 frames before the non-zero pixel check.
+  Both flakes manifested as "Camera output is all zeros or all inf" for
+  ``simple_shading_*_mdl`` and ``simple_shading_constant_diffuse`` variants on
+  cold-cache CI runners — the GPU returned a still-zero framebuffer because
+  the MDL material had not finished compiling.

--- a/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
@@ -3,18 +3,21 @@ Fixed
 
 * Stabilized RTX MDL shader-warmup flakes in the rendering-correctness tests
   by polling the camera output until every data-type tensor reports a
-  non-zero max before the assertion / golden compare, instead of relying on
-  a single render pass:
+  non-zero max before the assertion / golden compare:
 
   * ``test_camera_renders_not_empty`` in
     ``test_shadow_hand_vision_presets.py`` polls via ``env.step()`` with a
     60-step cap.
-  * The three goldenfile helpers in ``rendering_test_utils.py``
-    (``rendering_test_shadow_hand`` / ``_cartpole`` / ``_dexsuite_kuka``)
-    poll via ``sim.render()`` + ``scene.update()`` with a 30-pass cap, so
-    physics state is not advanced and the existing goldens stay valid.
+  * ``rendering_test_utils.warmup_render_until_nonzero`` is invoked from the
+    four rendering helpers in ``rendering_test_utils.py``
+    (``rendering_test_shadow_hand`` / ``_cartpole`` / ``_dexsuite_kuka``) and
+    from ``test_rendering_registered_tasks.py``. It iterates over every
+    sensor in ``env.scene.sensors`` and polls via ``sim.render()`` +
+    ``scene.update()`` with a 30-pass cap. Physics state is not advanced, so
+    the existing golden images stay valid.
 
-  All variants intermittently failed with "Camera output is all zeros or
-  all inf" for ``simple_shading_*_mdl`` and ``simple_shading_constant_diffuse``
-  on cold-cache CI runners because the GPU returned a still-zero
-  framebuffer before the MDL material finished compiling.
+  All affected variants intermittently failed with "Camera output is all
+  zeros or all inf" for ``simple_shading_*_mdl`` and
+  ``simple_shading_constant_diffuse`` on cold-cache CI runners because the
+  GPU returned a still-zero framebuffer before the MDL material finished
+  compiling.

--- a/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-stabilize-rendering-mdl-warmup.rst
@@ -1,18 +1,12 @@
 Fixed
 ^^^^^
 
-* Stabilized RTX MDL shader-warmup flakes in the rendering-correctness tests
-  by driving 10 extra ``sim.render()`` + ``scene.update()`` passes between env
-  construction and the camera read in
-  ``rendering_test_utils.py``'s ``rendering_test_shadow_hand``,
-  ``rendering_test_cartpole``, and ``rendering_test_dexsuite_kuka`` helpers.
-  The warmup mirrors the pattern already used by
-  :attr:`~isaaclab.envs.DirectRLEnvCfg.num_rerenders_on_reset` —
-  it does not advance physics, so the existing golden images remain valid.
-  ``test_camera_renders_not_empty`` in
-  ``test_shadow_hand_vision_presets.py`` (which has no golden compare) is
-  stabilized by stepping the env 10 frames before the non-zero pixel check.
-  Both flakes manifested as "Camera output is all zeros or all inf" for
-  ``simple_shading_*_mdl`` and ``simple_shading_constant_diffuse`` variants on
-  cold-cache CI runners — the GPU returned a still-zero framebuffer because
-  the MDL material had not finished compiling.
+* Stabilized ``test_camera_renders_not_empty`` in
+  ``test_shadow_hand_vision_presets.py`` by stepping the env 10 frames
+  before reading the camera tensor instead of a single step. The test
+  intermittently failed with "Camera output is all zeros or all inf" for
+  ``simple_shading_*_mdl`` and ``simple_shading_constant_diffuse`` variants
+  on cold-cache CI runners because the GPU returned a still-zero
+  framebuffer before the MDL material finished compiling. The three
+  goldenfile-comparing helpers in ``rendering_test_utils.py`` already use
+  ``flaky(max_runs=3)`` and are left untouched.

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -675,32 +675,6 @@ def validate_camera_outputs(
         pytest.fail(reason)
 
 
-def _warmup_render(env, num_passes: int = 10) -> None:
-    """Drive extra render passes to let RTX MDL shaders finish compiling.
-
-    RTX MDL materials compile asynchronously on first use. The single render
-    pass that env construction triggers (via ``scene.update`` in ``__init__``)
-    is not always enough — on cold-cache CI runners the GPU may return a
-    still-zero framebuffer for shader variants that have not finished
-    compiling, which trips :func:`validate_camera_outputs` with "no non-zero
-    pixels" or "all zeros or all inf". ``10`` passes is empirically enough
-    across the MDL presets (``simple_shading_constant_diffuse``,
-    ``simple_shading_diffuse_mdl``, ``simple_shading_full_mdl``) that flake on
-    the CI runners as of 2026-05.
-
-    The warmup calls ``sim.render()`` + ``scene.update()`` rather than
-    ``env.step()``, so it does not advance physics state and the goldens
-    captured at the post-init state remain valid. This mirrors the pattern
-    already used by :attr:`~isaaclab.envs.DirectRLEnvCfg.num_rerenders_on_reset`
-    and :attr:`~isaaclab.envs.DirectRLEnvCfg.wait_for_textures` in the core
-    env classes.
-    """
-    physics_dt = env.physics_dt
-    for _ in range(num_passes):
-        env.sim.render()
-        env.scene.update(dt=physics_dt)
-
-
 def rendering_test_shadow_hand(
     physics_backend: str,
     renderer: str,
@@ -726,7 +700,6 @@ def rendering_test_shadow_hand(
     try:
         env = ShadowHandVisionEnv(env_cfg)
         maybe_save_stage("shadow_hand", physics_backend, renderer, data_type)
-        _warmup_render(env)
 
         validate_camera_outputs(
             "shadow_hand",
@@ -766,7 +739,6 @@ def rendering_test_cartpole(
     try:
         env = CartpoleCameraEnv(env_cfg)
         maybe_save_stage("cartpole", physics_backend, renderer, data_type)
-        _warmup_render(env)
         validate_camera_outputs(
             "cartpole",
             physics_backend,
@@ -823,7 +795,6 @@ def rendering_test_dexsuite_kuka(
     try:
         env = ManagerBasedRLEnv(env_cfg)
         maybe_save_stage("dexsuite_kuka", physics_backend, renderer, data_type)
-        _warmup_render(env)
         validate_camera_outputs(
             "dexsuite_kuka",
             physics_backend,

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -675,7 +675,7 @@ def validate_camera_outputs(
         pytest.fail(reason)
 
 
-def _warmup_render_until_nonzero(env, max_passes: int = 30) -> None:
+def warmup_render_until_nonzero(env, max_passes: int = 30) -> None:
     """Drive extra render passes until every camera output tensor has a non-zero max.
 
     RTX MDL materials compile asynchronously on first use. The single render pass that env
@@ -691,25 +691,33 @@ def _warmup_render_until_nonzero(env, max_passes: int = 30) -> None:
     :attr:`~isaaclab.envs.DirectRLEnvCfg.num_rerenders_on_reset` and
     :attr:`~isaaclab.envs.DirectRLEnvCfg.wait_for_textures` in the core env classes.
     """
-    camera = getattr(env, "_tiled_camera", None)
-    if camera is None:
-        camera = env.scene.sensors.get("base_camera")
-    if camera is None:
+    base = getattr(env, "unwrapped", env)
+    scene = getattr(base, "scene", None)
+    if scene is None or not getattr(scene, "sensors", None):
         return
 
-    physics_dt = env.physics_dt
+    physics_dt = base.physics_dt
     for _ in range(max_passes):
         outputs_ready = True
-        for output in camera.data.output.values():
-            tensor = output if isinstance(output, torch.Tensor) else output.torch
-            finite = torch.where(torch.isinf(tensor), torch.zeros_like(tensor), tensor)
-            if finite.max() <= 0.2:
-                outputs_ready = False
+        for sensor in scene.sensors.values():
+            data = getattr(sensor, "data", None)
+            output = getattr(data, "output", None) if data is not None else None
+            if not isinstance(output, dict):
+                continue
+            for value in output.values():
+                tensor = value if isinstance(value, torch.Tensor) else getattr(value, "torch", None)
+                if tensor is None:
+                    continue
+                finite = torch.where(torch.isinf(tensor), torch.zeros_like(tensor), tensor)
+                if finite.max() <= 0.2:
+                    outputs_ready = False
+                    break
+            if not outputs_ready:
                 break
         if outputs_ready:
             return
-        env.sim.render()
-        env.scene.update(dt=physics_dt)
+        base.sim.render()
+        scene.update(dt=physics_dt)
 
 
 def rendering_test_shadow_hand(
@@ -737,7 +745,7 @@ def rendering_test_shadow_hand(
     try:
         env = ShadowHandVisionEnv(env_cfg)
         maybe_save_stage("shadow_hand", physics_backend, renderer, data_type)
-        _warmup_render_until_nonzero(env)
+        warmup_render_until_nonzero(env)
 
         validate_camera_outputs(
             "shadow_hand",
@@ -777,7 +785,7 @@ def rendering_test_cartpole(
     try:
         env = CartpoleCameraEnv(env_cfg)
         maybe_save_stage("cartpole", physics_backend, renderer, data_type)
-        _warmup_render_until_nonzero(env)
+        warmup_render_until_nonzero(env)
         validate_camera_outputs(
             "cartpole",
             physics_backend,
@@ -834,7 +842,7 @@ def rendering_test_dexsuite_kuka(
     try:
         env = ManagerBasedRLEnv(env_cfg)
         maybe_save_stage("dexsuite_kuka", physics_backend, renderer, data_type)
-        _warmup_render_until_nonzero(env)
+        warmup_render_until_nonzero(env)
         validate_camera_outputs(
             "dexsuite_kuka",
             physics_backend,

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -675,22 +675,30 @@ def validate_camera_outputs(
         pytest.fail(reason)
 
 
-def _warmup_render(env, num_steps: int = 10) -> None:
-    """Step the env ``num_steps`` times to let RTX MDL shaders finish compiling.
+def _warmup_render(env, num_passes: int = 10) -> None:
+    """Drive extra render passes to let RTX MDL shaders finish compiling.
 
-    RTX MDL materials compile asynchronously on first use. A single ``env.step()``
-    is not enough — the GPU may return a still-zero framebuffer for shader
-    variants that have not finished compiling, which trips
-    :func:`validate_camera_outputs` with "no non-zero pixels" or
-    "all zeros or all inf". ``10`` is empirically enough across the MDL
-    presets (``simple_shading_constant_diffuse``, ``simple_shading_diffuse_mdl``,
-    ``simple_shading_full_mdl``) that flake on the CI runners as of 2026-05.
-    Adds ~1-2 s of wall time per parametrize variant; cheap relative to the
-    cost of a CI re-run.
+    RTX MDL materials compile asynchronously on first use. The single render
+    pass that env construction triggers (via ``scene.update`` in ``__init__``)
+    is not always enough — on cold-cache CI runners the GPU may return a
+    still-zero framebuffer for shader variants that have not finished
+    compiling, which trips :func:`validate_camera_outputs` with "no non-zero
+    pixels" or "all zeros or all inf". ``10`` passes is empirically enough
+    across the MDL presets (``simple_shading_constant_diffuse``,
+    ``simple_shading_diffuse_mdl``, ``simple_shading_full_mdl``) that flake on
+    the CI runners as of 2026-05.
+
+    The warmup calls ``sim.render()`` + ``scene.update()`` rather than
+    ``env.step()``, so it does not advance physics state and the goldens
+    captured at the post-init state remain valid. This mirrors the pattern
+    already used by :attr:`~isaaclab.envs.DirectRLEnvCfg.num_rerenders_on_reset`
+    and :attr:`~isaaclab.envs.DirectRLEnvCfg.wait_for_textures` in the core
+    env classes.
     """
-    actions = torch.zeros(env.num_envs, env.action_space.shape[-1], device=env.device)
-    for _ in range(num_steps):
-        env.step(actions)
+    physics_dt = env.physics_dt
+    for _ in range(num_passes):
+        env.sim.render()
+        env.scene.update(dt=physics_dt)
 
 
 def rendering_test_shadow_hand(

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -675,6 +675,43 @@ def validate_camera_outputs(
         pytest.fail(reason)
 
 
+def _warmup_render_until_nonzero(env, max_passes: int = 30) -> None:
+    """Drive extra render passes until every camera output tensor has a non-zero max.
+
+    RTX MDL materials compile asynchronously on first use. The single render pass that env
+    construction triggers (via ``scene.update`` in ``__init__``) is not always enough — on
+    cold-cache CI runners the GPU returns a still-zero framebuffer for shader variants that
+    have not finished compiling, which trips :func:`validate_camera_outputs` with
+    "no non-zero pixels" or "all zeros or all inf".
+
+    Polling exits as soon as every camera output is ready, so the scene state stays at the
+    same "first non-zero frame" the existing goldens were captured at. Renders are driven by
+    ``sim.render()`` + ``scene.update()`` (no ``env.step()``) so physics state is not
+    advanced. This mirrors the pattern used by
+    :attr:`~isaaclab.envs.DirectRLEnvCfg.num_rerenders_on_reset` and
+    :attr:`~isaaclab.envs.DirectRLEnvCfg.wait_for_textures` in the core env classes.
+    """
+    camera = getattr(env, "_tiled_camera", None)
+    if camera is None:
+        camera = env.scene.sensors.get("base_camera")
+    if camera is None:
+        return
+
+    physics_dt = env.physics_dt
+    for _ in range(max_passes):
+        outputs_ready = True
+        for output in camera.data.output.values():
+            tensor = output if isinstance(output, torch.Tensor) else output.torch
+            finite = torch.where(torch.isinf(tensor), torch.zeros_like(tensor), tensor)
+            if finite.max() <= 0.2:
+                outputs_ready = False
+                break
+        if outputs_ready:
+            return
+        env.sim.render()
+        env.scene.update(dt=physics_dt)
+
+
 def rendering_test_shadow_hand(
     physics_backend: str,
     renderer: str,
@@ -700,6 +737,7 @@ def rendering_test_shadow_hand(
     try:
         env = ShadowHandVisionEnv(env_cfg)
         maybe_save_stage("shadow_hand", physics_backend, renderer, data_type)
+        _warmup_render_until_nonzero(env)
 
         validate_camera_outputs(
             "shadow_hand",
@@ -739,6 +777,7 @@ def rendering_test_cartpole(
     try:
         env = CartpoleCameraEnv(env_cfg)
         maybe_save_stage("cartpole", physics_backend, renderer, data_type)
+        _warmup_render_until_nonzero(env)
         validate_camera_outputs(
             "cartpole",
             physics_backend,
@@ -795,6 +834,7 @@ def rendering_test_dexsuite_kuka(
     try:
         env = ManagerBasedRLEnv(env_cfg)
         maybe_save_stage("dexsuite_kuka", physics_backend, renderer, data_type)
+        _warmup_render_until_nonzero(env)
         validate_camera_outputs(
             "dexsuite_kuka",
             physics_backend,

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -675,6 +675,24 @@ def validate_camera_outputs(
         pytest.fail(reason)
 
 
+def _warmup_render(env, num_steps: int = 10) -> None:
+    """Step the env ``num_steps`` times to let RTX MDL shaders finish compiling.
+
+    RTX MDL materials compile asynchronously on first use. A single ``env.step()``
+    is not enough — the GPU may return a still-zero framebuffer for shader
+    variants that have not finished compiling, which trips
+    :func:`validate_camera_outputs` with "no non-zero pixels" or
+    "all zeros or all inf". ``10`` is empirically enough across the MDL
+    presets (``simple_shading_constant_diffuse``, ``simple_shading_diffuse_mdl``,
+    ``simple_shading_full_mdl``) that flake on the CI runners as of 2026-05.
+    Adds ~1-2 s of wall time per parametrize variant; cheap relative to the
+    cost of a CI re-run.
+    """
+    actions = torch.zeros(env.num_envs, env.action_space.shape[-1], device=env.device)
+    for _ in range(num_steps):
+        env.step(actions)
+
+
 def rendering_test_shadow_hand(
     physics_backend: str,
     renderer: str,
@@ -700,6 +718,7 @@ def rendering_test_shadow_hand(
     try:
         env = ShadowHandVisionEnv(env_cfg)
         maybe_save_stage("shadow_hand", physics_backend, renderer, data_type)
+        _warmup_render(env)
 
         validate_camera_outputs(
             "shadow_hand",
@@ -739,6 +758,7 @@ def rendering_test_cartpole(
     try:
         env = CartpoleCameraEnv(env_cfg)
         maybe_save_stage("cartpole", physics_backend, renderer, data_type)
+        _warmup_render(env)
         validate_camera_outputs(
             "cartpole",
             physics_backend,
@@ -795,6 +815,7 @@ def rendering_test_dexsuite_kuka(
     try:
         env = ManagerBasedRLEnv(env_cfg)
         maybe_save_stage("dexsuite_kuka", physics_backend, renderer, data_type)
+        _warmup_render(env)
         validate_camera_outputs(
             "dexsuite_kuka",
             physics_backend,

--- a/source/isaaclab_tasks/test/test_rendering_registered_tasks.py
+++ b/source/isaaclab_tasks/test/test_rendering_registered_tasks.py
@@ -24,6 +24,7 @@ from rendering_test_utils import (  # noqa: E402
     make_generate_html_report_fixture,
     maybe_save_stage,
     validate_camera_outputs,
+    warmup_render_until_nonzero,
 )
 
 pytestmark = pytest.mark.isaacsim_ci
@@ -99,6 +100,7 @@ def test_rendering_registered_tasks(task_id: str, env_name: str):
             sim._app_control_on_stop_handle = None
 
         maybe_save_stage(f"registered_tasks_{task_id}", "default_physics", "default_renderer", "stage")
+        warmup_render_until_nonzero(env)
 
         camera_outputs_nested_dict = _collect_camera_outputs(env)
         num_camera_outputs = len(camera_outputs_nested_dict)

--- a/source/isaaclab_tasks/test/test_shadow_hand_vision_presets.py
+++ b/source/isaaclab_tasks/test/test_shadow_hand_vision_presets.py
@@ -398,7 +398,12 @@ def render_correctness_env(request, shadow_hand_vision_presets):
     env = ShadowHandVisionEnv(cfg)
     env.reset()
     actions = torch.zeros(cfg.scene.num_envs, env.action_space.shape[-1], device=env.device)
-    env.step(actions)
+    # Step enough frames for RTX MDL shader variants to finish compiling. A single step
+    # returns a still-zero framebuffer for ``simple_shading_*_mdl`` presets on cold caches,
+    # which trips the assertion in ``test_camera_renders_not_empty`` below. 10 steps is
+    # empirically enough across the MDL variants that flake in CI as of 2026-05.
+    for _ in range(10):
+        env.step(actions)
     yield renderer_preset, camera_preset, physics, env
     env.close()
 

--- a/source/isaaclab_tasks/test/test_shadow_hand_vision_presets.py
+++ b/source/isaaclab_tasks/test/test_shadow_hand_vision_presets.py
@@ -398,12 +398,21 @@ def render_correctness_env(request, shadow_hand_vision_presets):
     env = ShadowHandVisionEnv(cfg)
     env.reset()
     actions = torch.zeros(cfg.scene.num_envs, env.action_space.shape[-1], device=env.device)
-    # Step enough frames for RTX MDL shader variants to finish compiling. A single step
-    # returns a still-zero framebuffer for ``simple_shading_*_mdl`` presets on cold caches,
-    # which trips the assertion in ``test_camera_renders_not_empty`` below. 10 steps is
-    # empirically enough across the MDL variants that flake in CI as of 2026-05.
-    for _ in range(10):
+    # Step until all camera outputs are non-zero (RTX MDL shaders compile lazily).
+    # ``simple_shading_*_mdl`` presets can take 10–30 frames to produce non-zero pixels
+    # on cold-cache CI runners; poll up to ``_MAX_WARMUP_STEPS`` and exit early once ready.
+    _MAX_WARMUP_STEPS = 60
+    for _ in range(_MAX_WARMUP_STEPS):
         env.step(actions)
+        outputs_ready = True
+        for output in env._tiled_camera.data.output.values():
+            tensor = output.torch
+            finite = torch.where(torch.isinf(tensor), torch.zeros_like(tensor), tensor)
+            if finite.max() <= 0.2:
+                outputs_ready = False
+                break
+        if outputs_ready:
+            break
     yield renderer_preset, camera_preset, physics, env
     env.close()
 


### PR DESCRIPTION
## Description

The rendering-correctness tests intermittently fail on cold-cache CI runners with "Camera output is all zeros or all inf" for `simple_shading_*_mdl` and `simple_shading_constant_diffuse` variants — the GPU returns a still-zero framebuffer because the RTX MDL material has not finished compiling by the time the test reads the camera tensor.

Add a poll-until-non-zero warmup that exits as soon as every camera-output tensor has a non-zero max:

1. **`test_shadow_hand_vision_presets.py::test_camera_renders_not_empty`** — polls via `env.step()` with a 60-step cap. (This test has no `flaky` retry, so a single-step fixture is the actual failure surface.)
2. **`rendering_test_utils.warmup_render_until_nonzero`** — iterates every sensor in `env.scene.sensors` and polls via `sim.render()` + `scene.update()` with a 30-pass cap. Called from the four rendering helpers in `rendering_test_utils.py` (`rendering_test_shadow_hand` / `_cartpole` / `_dexsuite_kuka`) and from `test_rendering_registered_tasks.py`. Mirrors the pattern already in `DirectRLEnvCfg.num_rerenders_on_reset` / `wait_for_textures`; physics state is not advanced, so the existing goldens at the post-init "first non-zero frame" stay valid.

An earlier attempt at a fixed-pass warmup over-rendered in the goldenfile helpers and broke `dexsuite_kuka` goldens at 91% pixel diff — early-exit on first-non-zero avoids that by landing at the same frame the goldens were captured at.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [\`pre-commit\` checks](https://pre-commit.com/) with \`./isaaclab.sh --format\`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's \`config/extension.toml\` file
- [x] I have added my name to the \`CONTRIBUTORS.md\` or my name already exists there