### PR TITLE
Fix crash in kit visualizer

### DIFF
--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -526,6 +526,73 @@ def test_kit_visualizer_default_camera_source_accepts_set_camera_view(monkeypatc
     assert applied_camera_poses == [((1.0, 2.0, 3.0), (0.0, 0.0, 1.0))]
 
 
+def test_kit_visualizer_set_viewport_camera_does_not_require_authored_coi(monkeypatch: pytest.MonkeyPatch):
+    """Regression: ``_set_viewport_camera`` must not feed an unauthored ``omni:kit:centerOfInterest`` into
+    ``ViewportCameraState.set_position_world``.
+
+    A freshly-opened stage's default ``/OmniverseKit_Persp`` camera has no ``omni:kit:centerOfInterest`` attribute
+    authored. ``ViewportCameraState.set_position_world(..., rotate=True)`` reads that attribute as ``None`` and
+    crashes inside ``Matrix4d.Transform`` (the boost binding rejects ``NoneType``). ``_set_viewport_camera`` must
+    therefore use ``rotate=False`` for the eye set; the follow-up ``set_target_world(..., rotate=True)`` performs
+    the look-at rotation and authors the COI as a side effect.
+
+    The fake ``ViewportCameraState`` here mirrors that boost-binding behavior: ``set_position_world(..., rotate=True)``
+    raises ``TypeError``, so the old call path would surface inside ``_set_viewport_camera`` exactly as it did in
+    production.
+    """
+
+    class _FakeViewportApi:
+        def get_active_camera(self):
+            return "/OmniverseKit_Persp"
+
+    state_holder: dict[str, Any] = {}
+
+    class _FakeCameraState:
+        def __init__(self, camera_path: str, viewport_api):
+            self.position_calls: list[tuple[Any, bool]] = []
+            self.target_calls: list[tuple[Any, bool]] = []
+            state_holder["state"] = self
+
+        def set_position_world(self, world_position, rotate):
+            if rotate:
+                raise TypeError(
+                    "Python argument types in Matrix4d.Transform(Matrix4d, NoneType) did not match C++ signature"
+                )
+            self.position_calls.append((world_position, rotate))
+
+        def set_target_world(self, world_target, rotate):
+            self.target_calls.append((world_target, rotate))
+
+    camera_state_module = type(sys)("omni.kit.viewport.utility.camera_state")
+    camera_state_module.ViewportCameraState = _FakeCameraState
+
+    monkeypatch.setitem(sys.modules, "omni", type(sys)("omni"))
+    monkeypatch.setitem(sys.modules, "omni.kit", type(sys)("omni.kit"))
+    monkeypatch.setitem(sys.modules, "omni.kit.viewport", type(sys)("omni.kit.viewport"))
+    monkeypatch.setitem(sys.modules, "omni.kit.viewport.utility", type(sys)("omni.kit.viewport.utility"))
+    monkeypatch.setitem(sys.modules, "omni.kit.viewport.utility.camera_state", camera_state_module)
+
+    cfg = KitVisualizerCfg()
+    visualizer = kit_visualizer.KitVisualizer(cfg)
+    visualizer._viewport_api = _FakeViewportApi()
+
+    eye = (1.0, 2.0, 3.0)
+    target = (4.0, 5.0, 6.0)
+
+    visualizer._set_viewport_camera(eye, target)
+
+    state = state_holder["state"]
+    assert len(state.position_calls) == 1
+    pos_arg, pos_rotate = state.position_calls[0]
+    assert pos_rotate is False
+    assert (float(pos_arg[0]), float(pos_arg[1]), float(pos_arg[2])) == eye
+
+    assert len(state.target_calls) == 1
+    tgt_arg, tgt_rotate = state.target_calls[0]
+    assert tgt_rotate is True
+    assert (float(tgt_arg[0]), float(tgt_arg[1]), float(tgt_arg[2])) == target
+
+
 def test_get_cli_visualizer_types_handles_non_string_setting_without_crashing():
     ctx = object.__new__(SimulationContext)
     ctx.get_setting = lambda name: {"types": "newton,kit"} if name == "/isaaclab/visualizer/types" else None

--- a/source/isaaclab_visualizers/changelog.d/rwiltz-fix-viewport-camera-coi.rst
+++ b/source/isaaclab_visualizers/changelog.d/rwiltz-fix-viewport-camera-coi.rst
@@ -1,0 +1,13 @@
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab_visualizers.kit.KitVisualizer._set_viewport_camera`
+  raising ``Boost.Python.ArgumentError: Matrix4d.Transform(Matrix4d, NoneType)``
+  during ``sim.reset()`` when ``KitVisualizerCfg.eye`` / ``lookat`` were
+  configured. The call was issuing ``ViewportCameraState.set_position_world(...,
+  rotate=True)`` on a freshly-initialized viewport camera, which reads
+  ``omni:kit:centerOfInterest`` from the camera prim and pipes it through
+  ``world_xform.Transform(...)``; on an unauthored COI the attribute getter
+  returns ``None`` and the C++ binding rejects it. The position set now uses
+  ``rotate=False`` -- the subsequent ``set_target_world(..., rotate=True)``
+  authors the COI and rotates the camera to the configured target.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -343,8 +343,14 @@ class KitVisualizer(BaseVisualizer):
         if not camera_path:
             camera_path = "/OmniverseKit_Persp"
 
+        # ``rotate=False`` for the position set: a freshly-opened stage's default
+        # ``/OmniverseKit_Persp`` has no authored ``omni:kit:centerOfInterest``,
+        # which ``set_position_world(..., rotate=True)`` would feed into
+        # ``Matrix4d.Transform`` as ``None`` and crash. The follow-up
+        # ``set_target_world(..., rotate=True)`` performs the look-at rotation
+        # and authors the COI as a side effect, so the final pose is unchanged.
         camera_state = ViewportCameraState(camera_path, self._viewport_api)
-        camera_state.set_position_world(Gf.Vec3d(float(position[0]), float(position[1]), float(position[2])), True)
+        camera_state.set_position_world(Gf.Vec3d(float(position[0]), float(position[1]), float(position[2])), False)
         camera_state.set_target_world(Gf.Vec3d(float(target[0]), float(target[1]), float(target[2])), True)
 
     def _apply_cfg_camera_pose_if_configured(self) -> None:


### PR DESCRIPTION
# Description

Fixes a `Boost.Python.ArgumentError: Matrix4d.Transform(Matrix4d, NoneType)`
crash in `KitVisualizer` that surfaced as a `RuntimeError` from
`SimulationContext.initialize_visualizers()` whenever a `KitVisualizerCfg`
was used with an explicitly configured `eye` / `lookat` and the active
viewport's camera (typically `/OmniverseKit_Persp` on a freshly-opened
stage) had no `omni:kit:centerOfInterest` attribute authored.
`_set_viewport_camera` was issuing
`ViewportCameraState.set_position_world(..., rotate=True)`. With
`rotate=True`, the camera state reads `omni:kit:centerOfInterest` and pipes
it through `Matrix4d.Transform`; on a fresh camera the attribute getter
returns `None` and the boost binding rejects it.
Fix: use `rotate=False` for the position set. The follow-up
`set_target_world(..., rotate=True)` performs the look-at rotation and
authors the COI as a side effect, so the final camera pose is unchanged.
Reproducible from `scripts/environments/teleoperation/teleop_replay_agent.py`
with `--viz kit`. The same bug is reachable from `record_demos.py` on a
clean stage; existing runs avoided it only because something else had
already authored the COI before `_set_viewport_camera` ran.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there