### PR TITLE
Fix Kit segfault when pytest passes unrecognized flags via sys.argv

### DIFF
--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -17,6 +17,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "isaaclab" / "test"
 
 from isaaclab.app import AppLauncher
 
+# Workaround: Kit reads sys.argv directly during startup and segfaults on
+# unrecognized flags (e.g. pytest's ``-m``, ``-k``, ``--co``).  Strip
+# everything but argv[0] before booting.  See GDAT ticket for upstream fix.
+sys.argv = sys.argv[:1]
+
 simulation_app = AppLauncher(headless=True).app
 
 import pytest  # noqa: E402


### PR DESCRIPTION
# Description

Kit reads `sys.argv` directly during startup and segfaults when it encounters unrecognized pytest flags (e.g. `-m`, `-k`, `--co`). This makes it impossible to use standard pytest CLI features (markers, keyword filters, collect-only) with any test that boots Kit via `AppLauncher`.

**Workaround:** Strip `sys.argv` down to `argv[0]` before calling `AppLauncher(...)` in affected test files.

**Root cause:** Kit's internal argument parser crashes (SIGSEGV) instead of ignoring unknown arguments.

**Upstream fix needed:** Kit should either:
1. Not read `sys.argv` globally during startup, or
2. Ignore/skip arguments it does not recognize

## Repro

```bash
# Any Kit-based test with a pytest flag triggers the crash:
./isaaclab.sh -p -m pytest -m some_marker source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
# → SIGSEGV before any test runs
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
