### PR TITLE
Set seed for string testing

### DIFF
--- a/source/isaaclab/changelog.d/pbarejko-test-string-shuffle-seed.skip
+++ b/source/isaaclab/changelog.d/pbarejko-test-string-shuffle-seed.skip
@@ -1,0 +1,2 @@
+Test-only: seed ``random.shuffle`` in ``test_resolve_matching_names_with_joint_name_strings``
+to remove a ~1/720 flakiness when the shuffle landed back on target order.

--- a/source/isaaclab/test/utils/test_string.py
+++ b/source/isaaclab/test/utils/test_string.py
@@ -121,7 +121,8 @@ def test_resolve_matching_names_with_joint_name_strings():
     assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
     # test matching names with regex but shuffled
     # randomize order of previous query list
-    random.shuffle(query_list)
+    rng = random.Random(0)
+    rng.shuffle(query_list)
     index_list, names_list = string_utils.resolve_matching_names(query_list, robot_joint_names)
     ground_truth_index_list = [0, 1, 4, 5, 8, 9]
     assert names_list != query_list


### PR DESCRIPTION
# Description

Following test can occasionally fail when we get very _unlucky_ when shuffled list will be the same as original.
```
source/isaaclab/test/utils/test_string.py::test_resolve_matching_names_with_joint_name_strings
```

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
