### PR TITLE
Fix NewtonManager scene data provider backend detection when _sim is unset

### DIFF
--- a/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
+++ b/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
@@ -26,8 +26,8 @@ def _reset_newton_manager_state():
     NewtonManager._model = None
     NewtonManager._state_0 = None
     NewtonManager._num_envs = None
-    NewtonManager._visualization_scene_data = None
-    NewtonManager._visualization_mapping = None
+    NewtonManager._scene_data = None
+    NewtonManager._scene_data_mapping = None
 
 
 def test_ensure_visualization_model_noop_when_backend_is_newton(monkeypatch):
@@ -153,6 +153,7 @@ def test_update_visualization_state_noop_when_backend_is_newton(monkeypatch):
 
     _reset_newton_manager_state()
     monkeypatch.setattr(NewtonManager, "_backend_is_newton", classmethod(lambda cls, scene_data_provider=None: True))
+    monkeypatch.setattr(NewtonManager, "get_scene_data_provider", classmethod(lambda cls: SimpleNamespace()))
 
     # Pre-set sentinel values to ensure update doesn't touch them.
     NewtonManager._model = "live-model"

--- a/source/isaaclab_newton/changelog.d/dev-newton-manager-fix.rst
+++ b/source/isaaclab_newton/changelog.d/dev-newton-manager-fix.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab_newton.physics.NewtonManager._backend_is_newton`
+  returning ``False`` when ``PhysicsManager._sim`` was unset but a
+  :class:`~isaaclab.sim.SimulationContext` instance existed. The scene-data
+  provider lookup now consistently falls back to
+  :meth:`~isaaclab.sim.SimulationContext.instance`, via a new
+  :meth:`~isaaclab_newton.physics.NewtonManager.get_scene_data_provider`
+  helper shared with :meth:`~isaaclab_newton.physics.NewtonManager.update_visualization_state`.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1795,15 +1795,15 @@ class NewtonManager(PhysicsManager):
         coordinate the sync explicitly.
         """
 
+        if scene_data_provider is None:
+            scene_data_provider = cls.get_scene_data_provider()
+        if scene_data_provider is None:
+            return
+
         if cls._backend_is_newton(scene_data_provider):
             return
         cls._ensure_visualization_model()
         if cls._state_0 is None or cls._model is None or cls._state_0.body_q is None:
-            return
-
-        if scene_data_provider is None:
-            scene_data_provider = cls.get_scene_data_provider()
-        if scene_data_provider is None:
             return
 
         if cls._scene_data is None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1763,6 +1763,11 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def get_scene_data_provider(cls) -> SceneDataProvider | None:
+        """Return the active scene data provider, or None if unavailable.
+
+        Prefers ``PhysicsManager._sim`` when set; otherwise falls back to
+        ``SimulationContext.instance()``.
+        """
         sim = PhysicsManager._sim
         if sim is None:
             from isaaclab.sim import SimulationContext

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -34,8 +34,7 @@ from newton.sensors import SensorIMU as NewtonSensorIMU
 from newton.solvers import SolverBase, SolverKamino, SolverNotifyFlags
 
 from isaaclab.physics import CallbackHandle, PhysicsEvent, PhysicsManager
-from isaaclab.scene_data import SceneDataBackend, SceneDataFormat
-from isaaclab.sim import SimulationContext
+from isaaclab.scene_data import SceneDataBackend, SceneDataFormat, SceneDataProvider
 from isaaclab.sim.utils.newton_model_utils import replace_newton_shape_colors
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.utils import checked_apply
@@ -1557,10 +1556,11 @@ class NewtonManager(PhysicsManager):
         """Return ``True`` when the active sim backend is Newton."""
         if scene_data_provider is not None:
             return isinstance(scene_data_provider.backend, NewtonSceneDataBackend)
-        sim = PhysicsManager._sim
-        if sim is None:
+
+        scene_data_provider = cls.get_scene_data_provider()
+        if scene_data_provider is None:
             return False
-        return isinstance(sim.get_scene_data_provider().backend, NewtonSceneDataBackend)
+        return isinstance(scene_data_provider.backend, NewtonSceneDataBackend)
 
     @classmethod
     def _ensure_visualization_model(cls) -> None:
@@ -1762,6 +1762,18 @@ class NewtonManager(PhysicsManager):
         return builder
 
     @classmethod
+    def get_scene_data_provider(cls) -> SceneDataProvider | None:
+        sim = PhysicsManager._sim
+        if sim is None:
+            from isaaclab.sim import SimulationContext
+
+            sim = SimulationContext.instance()
+
+        if sim is not None:
+            return sim.get_scene_data_provider()
+        return None
+
+    @classmethod
     def update_visualization_state(cls, scene_data_provider=None) -> None:
         """Refresh visualization state for the active sim backend.
 
@@ -1777,27 +1789,26 @@ class NewtonManager(PhysicsManager):
         Invoked lazily from :meth:`get_state` so consumers do not need to
         coordinate the sync explicitly.
         """
+
         if cls._backend_is_newton(scene_data_provider):
             return
         cls._ensure_visualization_model()
         if cls._state_0 is None or cls._model is None or cls._state_0.body_q is None:
             return
-        sdp = scene_data_provider
-        if sdp is None:
-            sim = SimulationContext.instance()
-            if sim is not None:
-                sdp = sim.get_scene_data_provider()
-        if sdp is None:
+
+        if scene_data_provider is None:
+            scene_data_provider = cls.get_scene_data_provider()
+        if scene_data_provider is None:
             return
 
         if cls._scene_data is None:
             cls._scene_data = SceneDataFormat.Transform()
         if cls._scene_data_mapping is None:
             body_paths = list(getattr(cls._model, "body_label", None) or [])
-            cls._scene_data_mapping = sdp.create_mapping(body_paths)
+            cls._scene_data_mapping = scene_data_provider.create_mapping(body_paths)
 
         cls._scene_data.transforms = cls._state_0.body_q
-        sdp.get_transforms(cls._scene_data, mapping=cls._scene_data_mapping)
+        scene_data_provider.get_transforms(cls._scene_data, mapping=cls._scene_data_mapping)
 
     @classmethod
     def get_state_1(cls) -> State:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1533,7 +1533,7 @@ class NewtonManager(PhysicsManager):
         return cls._state_0
 
     @classmethod
-    def get_state(cls, scene_data_provider=None) -> State:
+    def get_state(cls, scene_data_provider: SceneDataProvider | None = None) -> State:
         """Get the current Newton state for visualization.
 
         Use this method from visualizers/renderers/video recorders that need a
@@ -1552,15 +1552,11 @@ class NewtonManager(PhysicsManager):
         return cls._num_envs
 
     @classmethod
-    def _backend_is_newton(cls, scene_data_provider=None) -> bool:
+    def _backend_is_newton(cls, scene_data_provider: SceneDataProvider | None = None) -> bool:
         """Return ``True`` when the active sim backend is Newton."""
         if scene_data_provider is not None:
             return isinstance(scene_data_provider.backend, NewtonSceneDataBackend)
-
-        scene_data_provider = cls.get_scene_data_provider()
-        if scene_data_provider is None:
-            return False
-        return isinstance(scene_data_provider.backend, NewtonSceneDataBackend)
+        return isinstance(cls.get_scene_data_provider().backend, NewtonSceneDataBackend)
 
     @classmethod
     def _ensure_visualization_model(cls) -> None:
@@ -1762,7 +1758,7 @@ class NewtonManager(PhysicsManager):
         return builder
 
     @classmethod
-    def get_scene_data_provider(cls) -> SceneDataProvider | None:
+    def get_scene_data_provider(cls) -> SceneDataProvider:
         """Return the active scene data provider, or None if unavailable.
 
         Prefers ``PhysicsManager._sim`` when set; otherwise falls back to
@@ -1774,12 +1770,11 @@ class NewtonManager(PhysicsManager):
 
             sim = SimulationContext.instance()
 
-        if sim is not None:
-            return sim.get_scene_data_provider()
-        return None
+        assert sim is not None
+        return sim.get_scene_data_provider()
 
     @classmethod
-    def update_visualization_state(cls, scene_data_provider=None) -> None:
+    def update_visualization_state(cls, scene_data_provider: SceneDataProvider | None = None) -> None:
         """Refresh visualization state for the active sim backend.
 
         Newton sim backend: no-op — ``_state_0`` is the live, authoritative state
@@ -1797,8 +1792,8 @@ class NewtonManager(PhysicsManager):
 
         if scene_data_provider is None:
             scene_data_provider = cls.get_scene_data_provider()
-        if scene_data_provider is None:
-            return
+
+        assert scene_data_provider is not None
 
         if cls._backend_is_newton(scene_data_provider):
             return


### PR DESCRIPTION
## Summary

- `NewtonManager._backend_is_newton` returned `False` when
  `PhysicsManager._sim` was `None`, even if a `SimulationContext`
  instance existed — leaving backend detection inconsistent with
  `update_visualization_state`, which already fell back to
  `SimulationContext.instance()`.
- Introduce a shared `NewtonManager.get_scene_data_provider` classmethod
  that prefers `PhysicsManager._sim` and falls back to
  `SimulationContext.instance()`.
- Route both `_backend_is_newton` and `update_visualization_state`
  through the new helper so they agree on the active scene-data
  provider.

## Test plan

- [ ] Run the relevant `isaaclab_newton` physics tests:
      `./isaaclab.sh -p -m pytest source/isaaclab_newton/test`
- [ ] Exercise a PhysX-backed scene where `PhysicsManager._sim` is unset
      at the moment `get_state` is called and confirm visualization
      transforms are populated.
- [ ] Confirm Newton-backed runs still short-circuit
      `update_visualization_state` (no shadow model built).
- [ ] `./isaaclab.sh -f`
