### PR TITLE
[PresetCLI] Make physics=/renderer=/presets= work on the unified train/play scripts

### DIFF
--- a/scripts/reinforcement_learning/rl_games/play_rl_games.py
+++ b/scripts/reinforcement_learning/rl_games/play_rl_games.py
@@ -27,7 +27,14 @@ from isaaclab_rl.rl_games import RlGamesGpuEnv, RlGamesVecEnvWrapper
 from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
 import isaaclab_tasks  # noqa: F401
-from isaaclab_tasks.utils import add_launcher_args, get_checkpoint_path, launch_simulation, resolve_task_config
+from isaaclab_tasks.utils import (
+    add_launcher_args,
+    fold_preset_tokens,
+    get_checkpoint_path,
+    launch_simulation,
+    resolve_task_config,
+    setup_preset_cli,
+)
 
 # PLACEHOLDER: Extension template (do not remove this comment)
 with contextlib.suppress(ImportError):
@@ -59,12 +66,12 @@ parser.add_argument(
 )
 parser.add_argument("--real-time", action="store_true", default=False, help="Run in real-time, if possible.")
 add_launcher_args(parser)
-args_cli, hydra_args = parser.parse_known_args()
+args_cli, hydra_args = setup_preset_cli(parser)
 
 if args_cli.video:
     args_cli.enable_cameras = True
 
-sys.argv = [sys.argv[0]] + hydra_args
+sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
 
 
 def main():

--- a/scripts/reinforcement_learning/rl_games/train_rl_games.py
+++ b/scripts/reinforcement_learning/rl_games/train_rl_games.py
@@ -60,10 +60,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         const=True,
         help="if toggled, this experiment will be tracked with Weights and Biases",
     )
+    from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+
     add_isaaclab_launcher_args(parser)
-    args_cli, hydra_args = parser.parse_known_args(argv)
+    # setup_preset_cli registers preset-selection help text + runs parse_known_args;
+    # fold_preset_tokens rewrites typed selectors (physics=, renderer=, presets=) post-argparse.
+    args_cli, hydra_args = setup_preset_cli(parser, argv)
     enable_cameras_for_video(args_cli)
-    set_hydra_args(hydra_args)
+    set_hydra_args(fold_preset_tokens(hydra_args))
     return args_cli
 
 

--- a/scripts/reinforcement_learning/rsl_rl/play_rsl_rl.py
+++ b/scripts/reinforcement_learning/rsl_rl/play_rsl_rl.py
@@ -32,7 +32,13 @@ from isaaclab_rl.rsl_rl import (
 from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
 import isaaclab_tasks  # noqa: F401
-from isaaclab_tasks.utils import add_launcher_args, get_checkpoint_path, launch_simulation
+from isaaclab_tasks.utils import (
+    add_launcher_args,
+    fold_preset_tokens,
+    get_checkpoint_path,
+    launch_simulation,
+    setup_preset_cli,
+)
 from isaaclab_tasks.utils.hydra import hydra_task_config
 
 # local imports
@@ -64,7 +70,7 @@ parser.add_argument("--real-time", action="store_true", default=False, help="Run
 parser.add_argument("--external_callback", default=None, help="Fully qualified path to an externally defined callback.")
 cli_args.add_rsl_rl_args(parser)
 add_launcher_args(parser)
-args_cli, remaining_args = parser.parse_known_args()
+args_cli, remaining_args = setup_preset_cli(parser)
 
 if args_cli.video:
     args_cli.enable_cameras = True
@@ -81,7 +87,7 @@ if args_cli.external_callback:
 # The remaining arguments are the arguments that were not consumed by both this scripts
 # argparser and (optionally) the external callback function.
 remaining_args = list_intersection(remaining_args, remaining_args_env_registration)
-sys.argv = [sys.argv[0]] + remaining_args
+sys.argv = [sys.argv[0]] + fold_preset_tokens(remaining_args)
 
 # Check for installed RSL-RL version
 installed_version = metadata.version("rsl-rl-lib")

--- a/scripts/reinforcement_learning/rsl_rl/train_rsl_rl.py
+++ b/scripts/reinforcement_learning/rsl_rl/train_rsl_rl.py
@@ -66,6 +66,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse RSL-RL training arguments."""
     from isaaclab.utils.string import list_intersection, string_to_callable
 
+    from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+
     parser = argparse.ArgumentParser(description="Train an RL agent with RSL-RL.")
     add_common_train_args(
         parser,
@@ -79,7 +81,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     CLI_ARGS.add_rsl_rl_args(parser)
     add_isaaclab_launcher_args(parser)
-    args_cli, remaining_args = parser.parse_known_args(argv)
+    # setup_preset_cli registers preset-selection help text + runs parse_known_args
+    args_cli, remaining_args = setup_preset_cli(parser, argv)
     enable_cameras_for_video(args_cli)
 
     remaining_args_env_registration = None
@@ -87,7 +90,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         external_callback_function = string_to_callable(args_cli.external_callback, separator=".")
         remaining_args_env_registration = external_callback_function()
 
-    set_hydra_args(list_intersection(remaining_args, remaining_args_env_registration))
+    # fold_preset_tokens rewrites typed selectors (physics=, renderer=, presets=) post-argparse
+    set_hydra_args(fold_preset_tokens(list_intersection(remaining_args, remaining_args_env_registration)))
     return args_cli
 
 

--- a/scripts/reinforcement_learning/sb3/play_sb3.py
+++ b/scripts/reinforcement_learning/sb3/play_sb3.py
@@ -25,7 +25,14 @@ from isaaclab_rl.sb3 import Sb3VecEnvWrapper, process_sb3_cfg
 from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
 import isaaclab_tasks  # noqa: F401
-from isaaclab_tasks.utils import add_launcher_args, get_checkpoint_path, launch_simulation, resolve_task_config
+from isaaclab_tasks.utils import (
+    add_launcher_args,
+    fold_preset_tokens,
+    get_checkpoint_path,
+    launch_simulation,
+    resolve_task_config,
+    setup_preset_cli,
+)
 
 # PLACEHOLDER: Extension template (do not remove this comment)
 with contextlib.suppress(ImportError):
@@ -63,12 +70,12 @@ parser.add_argument(
     help="Use a slower SB3 wrapper but keep all the extra training info.",
 )
 add_launcher_args(parser)
-args_cli, hydra_args = parser.parse_known_args()
+args_cli, hydra_args = setup_preset_cli(parser)
 
 if args_cli.video:
     args_cli.enable_cameras = True
 
-sys.argv = [sys.argv[0]] + hydra_args
+sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
 
 
 def main():

--- a/scripts/reinforcement_learning/sb3/train_sb3.py
+++ b/scripts/reinforcement_learning/sb3/train_sb3.py
@@ -67,10 +67,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=False,
         help="Use a slower SB3 wrapper but keep all the extra training info.",
     )
+    from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+
     add_isaaclab_launcher_args(parser)
-    args_cli, hydra_args = parser.parse_known_args(argv)
+    # setup_preset_cli registers preset-selection help text + runs parse_known_args;
+    # fold_preset_tokens rewrites typed selectors (physics=, renderer=, presets=) post-argparse.
+    args_cli, hydra_args = setup_preset_cli(parser, argv)
     enable_cameras_for_video(args_cli)
-    set_hydra_args(hydra_args)
+    set_hydra_args(fold_preset_tokens(hydra_args))
     return args_cli
 
 

--- a/scripts/reinforcement_learning/skrl/play_skrl.py
+++ b/scripts/reinforcement_learning/skrl/play_skrl.py
@@ -28,7 +28,14 @@ from isaaclab.utils.dict import print_dict
 from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
 import isaaclab_tasks  # noqa: F401
-from isaaclab_tasks.utils import add_launcher_args, get_checkpoint_path, launch_simulation, resolve_task_config
+from isaaclab_tasks.utils import (
+    add_launcher_args,
+    fold_preset_tokens,
+    get_checkpoint_path,
+    launch_simulation,
+    resolve_task_config,
+    setup_preset_cli,
+)
 
 # PLACEHOLDER: Extension template (do not remove this comment)
 with contextlib.suppress(ImportError):
@@ -77,12 +84,12 @@ parser.add_argument(
 )
 parser.add_argument("--real-time", action="store_true", default=False, help="Run in real-time, if possible.")
 add_launcher_args(parser)
-args_cli, hydra_args = parser.parse_known_args()
+args_cli, hydra_args = setup_preset_cli(parser)
 
 if args_cli.video:
     args_cli.enable_cameras = True
 
-sys.argv = [sys.argv[0]] + hydra_args
+sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
 
 # -- check skrl version ------------------------------------------------------
 if version.parse(skrl.__version__) < version.parse(SKRL_VERSION):

--- a/scripts/reinforcement_learning/skrl/train_skrl.py
+++ b/scripts/reinforcement_learning/skrl/train_skrl.py
@@ -66,10 +66,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         choices=["AMP", "PPO", "IPPO", "MAPPO"],
         help="The RL algorithm used for training the skrl agent.",
     )
+    from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+
     add_isaaclab_launcher_args(parser)
-    args_cli, hydra_args = parser.parse_known_args(argv)
+    # setup_preset_cli registers preset-selection help text + runs parse_known_args;
+    # fold_preset_tokens rewrites typed selectors (physics=, renderer=, presets=) post-argparse.
+    args_cli, hydra_args = setup_preset_cli(parser, argv)
     enable_cameras_for_video(args_cli)
-    set_hydra_args(hydra_args)
+    set_hydra_args(fold_preset_tokens(hydra_args))
     return args_cli
 
 

--- a/scripts/reinforcement_learning/test/test_typed_preset_cli_train_play.py
+++ b/scripts/reinforcement_learning/test/test_typed_preset_cli_train_play.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""End-to-end test that typed preset selectors reach the resolver from each
+unified train/play entrypoint.
+
+The four supported RL libraries (rl_games, rsl_rl, sb3, skrl) each have a
+``train_<library>.py`` / ``play_<library>.py`` script that the unified
+``scripts/reinforcement_learning/{train,play}.py`` dispatchers route to via
+``--rl_library``. Each entrypoint must wire the typed preset CLI
+(``setup_preset_cli`` + ``fold_preset_tokens`` from
+:mod:`isaaclab_tasks.utils.preset_cli`) so that user-typed ``physics=NAME``
+/ ``renderer=NAME`` / ``presets=NAME`` tokens are folded into the canonical
+form Hydra consumes. Without the fold, those tokens hit Hydra as a struct
+override against a non-existent top-level key and raise
+``Key 'physics' is not in struct`` -- the original symptom of the #5715
+regression.
+
+This test invokes each entrypoint via the unified dispatcher with
+``physics=does_not_exist`` and asserts:
+
+* the Hydra struct error is **absent** (would indicate the fold did not
+  run), and
+* the resolver's own ``Unknown preset(s)`` error is **present** (the
+  fold ran and the resolver received the canonical token).
+
+Resolve fails before any Kit/sim launch, so each subprocess exits in a
+few seconds without needing GPU.
+
+``rlinf`` is intentionally excluded: those scripts manage their own
+``GlobalHydra`` instance and have never been integrated with the typed
+preset CLI.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Each (action, library) pair runs through the unified dispatcher at
+# ``scripts/reinforcement_learning/{action}.py``. Dispatching matches how
+# ``./isaaclab.sh train`` / ``./isaaclab.sh play`` invoke these in practice.
+_ENTRYPOINT_CASES = [
+    (action, library) for action in ("train", "play") for library in ("rl_games", "rsl_rl", "sb3", "skrl")
+]
+
+
+@pytest.mark.parametrize("action,library", _ENTRYPOINT_CASES)
+def test_typed_preset_reaches_resolver(action: str, library: str) -> None:
+    """``physics=<unknown>`` must reach the resolver, not crash Hydra's struct check.
+
+    Confirms that the dispatched entrypoint wired ``setup_preset_cli`` +
+    ``fold_preset_tokens`` correctly: the typed selector got rewritten into
+    the canonical ``presets=<csv>`` form before Hydra received it, and the
+    resolver then surfaced its own ``Unknown preset(s)`` error against the
+    deliberately invalid name.
+    """
+    dispatcher = REPO_ROOT / "scripts" / "reinforcement_learning" / f"{action}.py"
+    assert dispatcher.exists(), f"missing dispatcher: {dispatcher}"
+
+    cmd = [
+        sys.executable,
+        str(dispatcher),
+        "--rl_library",
+        library,
+        "--task=Isaac-Ant-v0",
+        "physics=does_not_exist",
+        "--headless",
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        env=os.environ.copy(),
+    )
+
+    combined = result.stdout + result.stderr
+    label = f"{action}.py --rl_library {library}"
+    assert "is not in struct" not in combined, (
+        f"{label}: Hydra's struct-override error reached the user, meaning the typed preset "
+        f"selector was NOT folded before Hydra processed it. The entrypoint must call "
+        f"setup_preset_cli + fold_preset_tokens before set_hydra_args / sys.argv assignment.\n"
+        f"--- stderr tail ---\n{result.stderr[-2000:]}\n"
+        f"--- stdout tail ---\n{result.stdout[-2000:]}\n"
+    )
+    assert "Unknown preset(s): does_not_exist" in combined, (
+        f"{label}: resolver's 'Unknown preset(s)' error did not appear. Either the fold did not "
+        f"reach the resolver, or the script exited earlier with a different error.\n"
+        f"--- stderr tail ---\n{result.stderr[-2000:]}\n"
+        f"--- stdout tail ---\n{result.stdout[-2000:]}\n"
+    )


### PR DESCRIPTION
## 1. Summary

- Typed preset selectors (`physics=NAME`, `renderer=NAME`, `presets=NAME`) from #5587 silently fail on the unified `scripts/reinforcement_learning/train.py` dispatcher with `Key 'physics' is not in struct`.
- Root cause is merge-ordering between #5587 (preset CLI) and #5623 (unified train/play refactor): the new `train_<library>.py` / `play_<library>.py` files were authored without the `setup_preset_cli` + `fold_preset_tokens` integration that #5587 had applied to the older scripts.
- Wire the integration into the 4 unified train scripts and the 4 unified play scripts. 8 files, +71 / −20 LOC.

## 2. Repro

Before the fix (on develop):

```
$ python scripts/reinforcement_learning/train.py --rl_library rsl_rl \
      --task=Isaac-Ant-v0 physics=newton_mjwarp --headless

[INFO]: Parsing configuration from: isaaclab_tasks.manager_based.classic.ant.ant_env_cfg:AntEnvCfg
[INFO]: Parsing configuration from: isaaclab_tasks.manager_based.classic.ant.agents.rsl_rl_ppo_cfg:AntPPORunnerCfg
Could not override 'physics'.
To append to your config use +physics=newton_mjwarp
Key 'physics' is not in struct
    full_key: physics
    object_type=dict
```

After the fix: training launches normally with the Newton MuJoCo-Warp backend.

For an invalid value (`physics=does_not_exist`) the resolver emits a helpful error listing available variants and their cfg paths:

```
ValueError: Unknown preset(s): does_not_exist

Available presets (grouped by affected paths):

  newton_kamino
    -> env.sim.physics

  newton_mjwarp, physx
    -> env.observations
    -> env.sim.physics
```

## 3. Fix

Apply the canonical pattern from `isaaclab_tasks.utils.preset_cli`:

For train scripts:
```python
args_cli, hydra_args = setup_preset_cli(parser, argv)  # was: parser.parse_known_args(argv)
# ...
set_hydra_args(fold_preset_tokens(hydra_args))         # was: set_hydra_args(hydra_args)
```

For play scripts (which set `sys.argv` directly):
```python
args_cli, hydra_args = setup_preset_cli(parser)        # was: parser.parse_known_args()
sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
```

`rsl_rl/train_rsl_rl.py` has an extra `--external_callback` intersection step; the fold runs after the intersection, matching the documented pattern.

## 4. Out of scope

- `train_rlinf.py` / `play_rlinf.py` — these use their own `GlobalHydra` instance and were never integrated with the typed-preset CLI. Adding support is a separate feature, not a regression.

## 5. Test plan

- [x] Repro confirmed on develop before the fix.
- [x] All 4 train scripts smoke-tested with `physics=newton_mjwarp` on Isaac-Ant-v0 — each reaches Newton sim init (no Hydra struct error). Verified via the unified dispatcher AND via direct library-script invocation.
- [x] All 4 play scripts smoke-tested with `physics=newton_mjwarp` + a fake `--checkpoint` — each resolves env_cfg + agent_cfg successfully and fails downstream at checkpoint loading (expected; proves the typed selector was accepted). Both invocation paths verified.
- [x] `--help` output includes `physics=NAME` / `renderer=NAME` / `presets=NAME[,NAME,...]` syntax with available variants per task. Verified via both invocation paths.
- [x] Invalid value (`physics=does_not_exist`) produces a clear error listing available presets.
- [x] Added `scripts/reinforcement_learning/test/test_typed_preset_cli_train_play.py` — parametrized subprocess test that drives `physics=does_not_exist` through the unified dispatcher for all 8 train/play entrypoints. Asserts the Hydra struct error is absent and the resolver's "Unknown preset(s)" error is present. ~20 s, no GPU. Verified to fail when any of the 8 scripts is reverted to develop's broken state.
- [x] Pre-commit clean.
- [ ] CI green on `Docker + Tests`.
