### PR TITLE
Pytorch View bug in wrench_composer.py

### DIFF
--- a/source/isaaclab/isaaclab/utils/wrench_composer.py
+++ b/source/isaaclab/isaaclab/utils/wrench_composer.py
@@ -334,14 +334,17 @@ class WrenchComposer:
         else:
             if isinstance(env_ids, list):
                 env_ids = torch.tensor(env_ids, dtype=torch.int64, device=self.device)
+            elif isinstance(env_ids, wp.array):
+                env_ids = wp.to_torch(env_ids)
             elif isinstance(env_ids, slice):
                 if env_ids == slice(None):
                     self._composed_force_b.zero_()
                     self._composed_torque_b.zero_()
+                    self._active = False  # slice(None) resets all envs, equivalent to env_ids=None
                     self._link_poses_updated = False
                     return
 
-            wp.to_torch(self._composed_force_b)[env_ids] = 0.0
-            wp.to_torch(self._composed_torque_b)[env_ids] = 0.0
+            self._composed_force_b_torch[env_ids] = 0.0
+            self._composed_torque_b_torch[env_ids] = 0.0
 
         self._link_poses_updated = False

--- a/source/isaaclab/isaaclab/utils/wrench_composer.py
+++ b/source/isaaclab/isaaclab/utils/wrench_composer.py
@@ -332,18 +332,16 @@ class WrenchComposer:
             self._composed_torque_b.zero_()
             self._active = False
         else:
-            indices = env_ids
-            if isinstance(env_ids, torch.Tensor):
-                indices = wp.from_torch(env_ids.to(torch.int32), dtype=wp.int32)
-            elif isinstance(env_ids, list):
-                indices = wp.array(env_ids, dtype=wp.int32, device=self.device)
+            if isinstance(env_ids, list):
+                env_ids = torch.tensor(env_ids, dtype=torch.int64, device=self.device)
             elif isinstance(env_ids, slice):
                 if env_ids == slice(None):
-                    indices = self._ALL_ENV_INDICES_WP
-                else:
-                    indices = env_ids
+                    self._composed_force_b.zero_()
+                    self._composed_torque_b.zero_()
+                    self._link_poses_updated = False
+                    return
 
-            self._composed_force_b[indices].zero_()
-            self._composed_torque_b[indices].zero_()
+            wp.to_torch(self._composed_force_b)[env_ids] = 0.0
+            wp.to_torch(self._composed_torque_b)[env_ids] = 0.0
 
         self._link_poses_updated = False


### PR DESCRIPTION
# Description

Fixes a silent training freeze caused by Warp fancy indexing in WrenchComposer.reset().
 
  After hundreds of environment resets (typically 500–1000+ training iterations with large numbers of environments), calling warp_array[warp_index_array].zero_() enters an infinite SIGSEGV loop. The temporary indexed view created by Warp's __getitem__ → __init__ → **_init_from_ptr** path loses its CUDA pointer validity over time under sustained GPU compute load. The process appears frozen with no Python exception. The SIGSEGV is caught internally by the CUDA signal handler, which immediately re-faults on the same address.

**Cause:** _composed_force_b[indices].zero_() and _composed_torque_b[indices].zero_() use Warp fancy indexing to create a temporary sub-array view. This view holds a derived CUDA pointer that becomes stale after many iterations.

**Fix:** Replace the Warp fancy indexing with wp.to_torch(), which returns a stable PyTorch tensor sharing the same underlying GPU memory. PyTorch indexed
  assignment (tensor[env_ids] = 0.0) is then used to zero the relevant rows. This avoids the _init_from_ptr path entirely while producing identical
  results.

The slice(None) case already had a working full-array .zero_() path and is preserved. The list input case is converted to a torch.Tensor to be compatible with the PyTorch indexing path.

--------
**To reproduce:** Run any DirectRLEnv-based task with 1000+ environments and --headless for several hundred iterations. Attach py-spy to the training process when it freezes. The main thread will be stuck at warp/types.py _init_from_ptr, called from wrench_composer.py:347.
