### PR TITLE
Pin torch CUDA device before PhysX warmup and PHYSICS_READY dispatch

### DIFF
--- a/source/isaaclab/test/sim/test_simulation_context.py
+++ b/source/isaaclab/test/sim/test_simulation_context.py
@@ -1119,3 +1119,58 @@ def test_exception_in_callback_on_step():
         if handle is not None:
             PhysxManager.deregister_callback(handle)
         SimulationContext.clear_instance()
+
+
+"""
+CUDA device pinning during PHYSICS_READY dispatch.
+"""
+
+
+@pytest.mark.isaacsim_ci
+def test_torch_cuda_device_pinned_during_physics_ready():
+    """``torch.cuda.current_device()`` must match the sim device inside PHYSICS_READY callbacks.
+
+    Regression for an aarch64 / CUDA 13 failure where a PHYSICS_READY callback (e.g.
+    ``ArticulationData.__init__``) hit ``CUDA error: an illegal memory access was
+    encountered`` at ``torch.tensor((gravity[0], gravity[1], gravity[2]),
+    device=self.device)`` alongside ``Failed to create Cuda Context Manager`` from
+    PhysX. PhysX warmup had left the calling thread on a different active CUDA device
+    than ``PhysicsManager._device``, so the first torch CUDA allocation inside the
+    callback tried to switch back and surfaced as the illegal-memory-access error.
+    """
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    sim_device = "cuda:0"
+    cfg = SimulationCfg(device=sim_device, dt=0.01)
+    sim = SimulationContext(cfg)
+
+    cube_cfg = sim_utils.CuboidCfg(size=(0.1, 0.1, 0.1))
+    cube_cfg.func("/World/Cube", cube_cfg)
+
+    observed_device: list[int] = []
+
+    def capture_callback(event):
+        observed_device.append(torch.cuda.current_device())
+
+    handle = PhysxManager.register_callback(capture_callback, event=IsaacEvents.PHYSICS_READY)
+
+    # Perturb the active device prior to reset. On multi-GPU hosts this simulates
+    # the bug; on single-GPU hosts the assertion still pins the contract.
+    other_device = 1 if torch.cuda.device_count() > 1 else 0
+    torch.cuda.set_device(other_device)
+
+    try:
+        sim.reset()
+        assert observed_device, "PHYSICS_READY callback did not fire"
+        expected = int(sim_device.split(":")[1])
+        assert observed_device[0] == expected, (
+            f"torch.cuda.current_device() inside PHYSICS_READY was {observed_device[0]},"
+            f" expected sim device {expected}."
+        )
+    finally:
+        if handle is not None:
+            PhysxManager.deregister_callback(handle)
+        SimulationContext.clear_instance()

--- a/source/isaaclab_physx/changelog.d/proth-fix-physx-cuda-device-before-dispatch.rst
+++ b/source/isaaclab_physx/changelog.d/proth-fix-physx-cuda-device-before-dispatch.rst
@@ -1,0 +1,19 @@
+Fixed
+^^^^^
+
+* Pinned ``torch.cuda.set_device(PhysicsManager._device)`` before PhysX GPU warmup
+  and again before the ``PHYSICS_READY`` dispatch inside
+  :meth:`~isaaclab_physx.physics.PhysxManager.reset` and
+  :meth:`~isaaclab_physx.physics.PhysxManager._warmup_and_create_views`. PhysX
+  (``force_load_physics_from_usd`` / ``start_simulation`` /
+  ``create_simulation_view``) could otherwise bring up its CUDA context on a
+  device that differs from ``PhysicsManager._device``, so the first
+  ``torch.tensor(..., device=self.device)`` allocation in an asset/sensor
+  ``_initialize_impl`` callback (e.g.
+  :class:`~isaaclab_physx.assets.articulation.ArticulationData` initializing
+  ``GRAVITY_VEC_W``) would hit a CudaContextManager that PhysX had failed to
+  rebuild and surface as ``CUDA error: an illegal memory access was encountered``
+  alongside ``Failed to create Cuda Context Manager`` from
+  ``omni.physx.foundation.plugin``. Observed on aarch64 with
+  ``isaacsim==6.0.0rc48`` + ``torch==2.10.0+cu130`` while launching
+  ``Isaac-Navigation-3DObstacles-ARL-Robot-1-v0``.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -289,6 +289,16 @@ class PhysxManager(PhysicsManager):
     @classmethod
     def reset(cls, soft: bool = False) -> None:
         """Reset the physics simulation."""
+        # Pin torch to the sim device before callbacks fire. PhysX GPU work in warmup
+        # and the PHYSICS_READY dispatch can leave the calling thread on a different
+        # active CUDA device, so the first torch CUDA allocation inside an asset
+        # ``_initialize_impl`` callback would otherwise hit a CudaContextManager that
+        # PhysX has not rebuilt and surface as ``CUDA error: an illegal memory access
+        # was encountered``.
+        device = PhysicsManager._device
+        if "cuda" in device:
+            torch.cuda.set_device(device)
+
         if not soft:
             # Ensure views are created (warmup only happens once per stage)
             if cls._view is None:
@@ -299,7 +309,6 @@ class PhysxManager(PhysicsManager):
             # Legacy IsaacEvents dispatch for callbacks registered directly on IsaacEvents.
             cls._event_bus.dispatch_event(IsaacEvents.PHYSICS_READY.value, payload={})
 
-        device = PhysicsManager._device
         if "cuda" in device:
             torch.cuda.set_device(device)
 
@@ -735,7 +744,16 @@ class PhysxManager(PhysicsManager):
 
         stage_id = get_current_stage_id()
 
-        is_gpu = "cuda" in PhysicsManager.get_device()
+        device = PhysicsManager.get_device()
+        is_gpu = "cuda" in device
+
+        # Pin torch to the sim device before PhysX brings up its CUDA context. Otherwise
+        # PhysX picks whichever device is currently active on this thread, which may
+        # disagree with ``PhysicsManager._device`` and leave subsequent torch CUDA
+        # allocations targeting a different primary context than PhysX's
+        # CudaContextManager.
+        if is_gpu:
+            torch.cuda.set_device(device)
 
         # Attach stage to PhysX BEFORE loading/starting - only needed for GPU pipeline.
         # For CPU, the old SimulationManager never called attach_stage() explicitly.
@@ -769,6 +787,12 @@ class PhysxManager(PhysicsManager):
         cls._physx.update_simulation(cls.get_physics_dt(), 0.0)
         cls._view_created = True
         cls._scene_data_backend.simulation_view = cls._view
+
+        # PhysX warmup above can leave the calling thread on a different active CUDA
+        # device than ``device``. Restore it before firing PHYSICS_READY so callback
+        # torch allocations hit the same primary context that PhysX is using.
+        if is_gpu:
+            torch.cuda.set_device(device)
 
         cls._event_bus.dispatch_event(IsaacEvents.SIMULATION_VIEW_CREATED.value, payload={})
         cls.dispatch_event(PhysicsEvent.PHYSICS_READY, payload={})


### PR DESCRIPTION
## Summary

PhysX GPU warmup (``force_load_physics_from_usd`` / ``start_simulation`` /
``create_simulation_view``) and the ``PHYSICS_READY`` callback dispatch can leave the
calling thread on a different active CUDA device than ``PhysicsManager._device``.
The first ``torch.tensor(..., device=self.device)`` allocation inside an
asset/sensor ``_initialize_impl`` callback then tries to switch back and, on
platforms with a mismatched CUDA toolkit / driver stack, hits a
``CudaContextManager`` that PhysX failed to rebuild — surfacing as:

```
[Error] [omni.physx.plugin] PhysX error: Failed to unload CUDA module data, returned 700.
[Error] [omni.physx.plugin] PhysX warning: CUDA context validation failed
[Error] [omni.physx.foundation.plugin] Failed to create Cuda Context Manager.
[Error] [omni.physx.plugin] Unable to create PxCudaContextManager!
...
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

with the python traceback pointing at:

```python
File ".../isaaclab_physx/assets/articulation/articulation_data.py", line 88, in __init__
    gravity_dir = torch.tensor((gravity[0], gravity[1], gravity[2]), device=self.device)
```

Reported on aarch64 with ``isaacsim==6.0.0rc48`` + ``torch==2.10.0+cu130`` launching
``Isaac-Navigation-3DObstacles-ARL-Robot-1-v0``.

## Fix

- ``PhysxManager.reset``: call ``torch.cuda.set_device(PhysicsManager._device)``
  *before* the warmup / ``PHYSICS_READY`` dispatch, and again afterwards before
  ``initialize_kinematic_bodies``.
- ``PhysxManager._warmup_and_create_views``: call
  ``torch.cuda.set_device(device)`` before PhysX brings up its CUDA context and
  again after view creation but before dispatching ``PHYSICS_READY``.

This keeps torch and PhysX on the same primary context throughout asset/sensor
initialization, so allocations like ``GRAVITY_VEC_W`` in
:class:`ArticulationData` / :class:`RigidObjectData` /
:class:`RigidObjectCollectionData` no longer trip on a half-torn-down
``CudaContextManager``.

## Test plan / verification status

### Verified

- [x] ``./isaaclab.sh -f`` on the touched files (ruff / ruff-format / codespell /
  license-header / RST hooks all pass).
- [x] New regression
  ``test_torch_cuda_device_pinned_during_physics_ready`` in
  ``source/isaaclab/test/sim/test_simulation_context.py`` perturbs the active
  CUDA device, calls ``sim.reset()``, and asserts a ``PHYSICS_READY`` callback
  observes ``torch.cuda.current_device() == sim_device``. Passes against the
  ``isaac-lab-base`` container locally. On a single-GPU host the bug never
  manifests, so the test asserts the invariant that this PR guarantees rather
  than reproducing the original failure.
- [x] Full ``test_simulation_context.py`` suite passes (44/44) with the fix
  applied.
- [x] End-to-end ``Isaac-Navigation-3DObstacles-ARL-Robot-1-v0``
  (``--headless --max_iterations 1 --num_envs 4``) ran cleanly across two
  ``IsaacLab`` docker rebuilds on x86_64 RTX 5090:
   - ``isaacsim==6.0.0.0`` (GA, ``pypi.nvidia.com``) +
     ``torch==2.10.0+cu128`` (uv venv inside ``isaac-lab-base``)
   - ``nvcr.io/nvidian/isaac-sim:latest-develop`` (Isaac Sim
     **6.0.0-alpha.226**, newer than the reporter's rc48) +
     ``torch==2.10.0+cu128`` (fresh ``docker compose build`` of
     ``isaac-lab-base`` against that base)

  With ``LD_PRELOAD=libgomp.so.1`` + ``OPENBLAS_NUM_THREADS=1`` (numpy/openblas
  atfork workaround, unrelated to this PR). Both stacks completed 24 PPO
  steps and wrote a final checkpoint **with the fix applied** — i.e. the fix
  does not regress the task.

### Honest negative result: A/B did not reproduce the bug

- [x] On both stacks above I re-ran the same task with ``physx_manager.py``
  reverted to its pre-fix state. Both runs also completed cleanly — 24 PPO
  steps, final checkpoint, **0 errors**, no ``PxCudaContextManager`` /
  ``illegal memory access`` failures. So the publicly-reproducible stacks
  available to me — including the latest develop Isaac Sim (alpha.226) — do
  not exhibit the reporter's failure regardless of whether this PR is
  applied. I cannot empirically demonstrate that this PR fixes the original
  bug; only that it doesn't regress the task on adjacent stacks.

- [ ] The reporter's exact stack — aarch64 + ``isaacsim==6.0.0rc48``
  (pre-release, only on NVIDIA internal artifactory) + ``torch 2.10.0+cu130``
  (CUDA 13) — was not available. Now that the publicly-newer
  ``alpha.226`` build also runs clean here, the failure is most likely
  isolated to **aarch64** (Jetson) or **CUDA 13 toolkit** specifically (or
  the combination), rather than to anything in IsaacLab develop.
  **Please ask the reporter to re-run the exact repro on top of this branch
  to confirm the fix lands.** If it does not, treat this PR as defensive
  hardening rather than a root-cause fix and close it in favour of further
  investigation on Jetson / CUDA 13.

### Adjacent env-skew finding (not addressed here)

- [ ] On ``isaacsim==6.0.0.0`` and on the current
  ``nvcr.io/nvidia/isaac-sim:6.0.0-dev2`` image,
  ``omni.physics.tensors-110.0.7`` still ships ``api.py`` under ``impl/`` — so
  ``import omni.physics.tensors.api as physx`` (introduced in #5358) fails at
  module load and the failing task never reaches the CUDA path covered by
  this PR. Resolved by upgrading to
  ``nvcr.io/nvidian/isaac-sim:latest-develop`` (ships
  ``omni.physics.tensors-110.1.11`` with the new top-level ``api.py``), but
  worth tracking separately if the develop branch should remain runnable on
  the public NGC image.