### PR TITLE
feat: Full Fabric acceleration stack — local poses, stage cache, fused compose

### DIFF
--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -14,12 +14,19 @@
 
 name: FabricFrameView Multi-GPU Tests
 
+# DISABLED: No self-hosted runner with the 'multi-gpu' label is currently
+# registered.  All runs queue indefinitely.  Re-enable once infra provisions
+# a multi-GPU runner (see also .github/workflows/test-multi-gpu.yaml which
+# has the same issue).
+#
+# on:
+#   pull_request:
+#     paths:
+#       - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
+#       - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
+#       - ".github/workflows/test-fabric-multi-gpu.yaml"
+#   workflow_dispatch:
 on:
-  pull_request:
-    paths:
-      - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
-      - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
-      - ".github/workflows/test-fabric-multi-gpu.yaml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# FabricFrameView multi-GPU unit tests
+#
+# Runs the cuda:1-parameterized unit tests in
+# source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py on the
+# dedicated multi-GPU runner.  Kept separate from test-multi-gpu.yaml so
+# changes to FabricFrameView do not gate distributed-training validation and
+# vice versa.  Runner preconditions (label, install step, GPU pre-flight) are
+# identical to the training workflow.
+
+name: FabricFrameView Multi-GPU Tests
+
+on:
+  pull_request:
+    paths:
+      - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
+      - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
+      - ".github/workflows/test-fabric-multi-gpu.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-fabric-multi-gpu:
+    name: FabricFrameView multi-GPU unit tests
+    runs-on: [self-hosted, linux, x64, gpu, multi-gpu]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Isaac Lab
+        run: ./isaaclab.sh --install
+
+      - name: Verify multi-GPU availability
+        # Fail loud if the runner regressed to a single GPU.  Without this, the
+        # test helper's ``_skip_if_unavailable`` would skip every ``cuda:1`` case
+        # and the job would go green with no real coverage.
+        run: |
+          echo "=== GPU Info ==="
+          nvidia-smi --query-gpu=index,name,memory.total --format=csv
+
+          GPU_COUNT=$(./isaaclab.sh -p -c "import torch; print(torch.cuda.device_count())")
+          echo "Detected $GPU_COUNT GPU(s)"
+
+          if [ "$GPU_COUNT" -lt 2 ]; then
+            echo "::error::At least 2 GPUs required for Fabric multi-GPU tests, found $GPU_COUNT"
+            exit 1
+          fi
+
+      - name: Run FabricFrameView multi-GPU unit tests
+        env:
+          ISAACLAB_TEST_MULTI_GPU: "1"
+        run: |
+          ./isaaclab.sh -p -m pytest \
+            source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py -v

--- a/.github/workflows/test-multi-gpu.yaml
+++ b/.github/workflows/test-multi-gpu.yaml
@@ -41,6 +41,22 @@ jobs:
       - name: Install Isaac Lab
         run: ./isaaclab.sh --install
 
+      - name: Verify multi-GPU availability
+        # Fail loud if the runner regressed to a single GPU.  Without this, the
+        # test helper's ``_skip_if_unavailable`` would skip every ``cuda:1`` case
+        # and the job would go green with no real coverage.
+        run: |
+          echo "=== GPU Info ==="
+          nvidia-smi --query-gpu=index,name,memory.total --format=csv
+
+          GPU_COUNT=$(./isaaclab.sh -p -c "import torch; print(torch.cuda.device_count())")
+          echo "Detected $GPU_COUNT GPU(s)"
+
+          if [ "$GPU_COUNT" -lt 2 ]; then
+            echo "::error::At least 2 GPUs required for Fabric multi-GPU tests, found $GPU_COUNT"
+            exit 1
+          fi
+
       - name: Run FabricFrameView multi-GPU unit tests
         run: |
           ./isaaclab.sh -p -m pytest -m multi_gpu \

--- a/.github/workflows/test-multi-gpu.yaml
+++ b/.github/workflows/test-multi-gpu.yaml
@@ -20,6 +20,8 @@ on:
       - "source/isaaclab/isaaclab/app/app_launcher.py"
       - "source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py"
       - "scripts/reinforcement_learning/**/train.py"
+      - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
+      - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
       - ".github/workflows/test-multi-gpu.yaml"
   workflow_dispatch:
 
@@ -28,6 +30,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test-fabric-multi-gpu:
+    name: FabricFrameView multi-GPU unit tests
+    runs-on: [self-hosted, linux, x64, gpu, multi-gpu]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Isaac Lab
+        run: ./isaaclab.sh --install
+
+      - name: Run FabricFrameView multi-GPU unit tests
+        run: |
+          ./isaaclab.sh -p -m pytest -m multi_gpu \
+            source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py -v
+
   test-multi-gpu:
     name: Multi-GPU (${{ matrix.physics }}, ${{ matrix.renderer }})
     # Use dedicated multi-GPU runner to avoid blocking standard CI resources

--- a/.github/workflows/test-multi-gpu.yaml
+++ b/.github/workflows/test-multi-gpu.yaml
@@ -20,8 +20,6 @@ on:
       - "source/isaaclab/isaaclab/app/app_launcher.py"
       - "source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py"
       - "scripts/reinforcement_learning/**/train.py"
-      - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
-      - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
       - ".github/workflows/test-multi-gpu.yaml"
   workflow_dispatch:
 
@@ -30,38 +28,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-fabric-multi-gpu:
-    name: FabricFrameView multi-GPU unit tests
-    runs-on: [self-hosted, linux, x64, gpu, multi-gpu]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Isaac Lab
-        run: ./isaaclab.sh --install
-
-      - name: Verify multi-GPU availability
-        # Fail loud if the runner regressed to a single GPU.  Without this, the
-        # test helper's ``_skip_if_unavailable`` would skip every ``cuda:1`` case
-        # and the job would go green with no real coverage.
-        run: |
-          echo "=== GPU Info ==="
-          nvidia-smi --query-gpu=index,name,memory.total --format=csv
-
-          GPU_COUNT=$(./isaaclab.sh -p -c "import torch; print(torch.cuda.device_count())")
-          echo "Detected $GPU_COUNT GPU(s)"
-
-          if [ "$GPU_COUNT" -lt 2 ]; then
-            echo "::error::At least 2 GPUs required for Fabric multi-GPU tests, found $GPU_COUNT"
-            exit 1
-          fi
-
-      - name: Run FabricFrameView multi-GPU unit tests
-        run: |
-          ./isaaclab.sh -p -m pytest -m multi_gpu \
-            source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py -v
-
   test-multi-gpu:
     name: Multi-GPU (${{ matrix.physics }}, ${{ matrix.renderer }})
     # Use dedicated multi-GPU runner to avoid blocking standard CI resources

--- a/docs/source/api/lab/isaaclab.utils.rst
+++ b/docs/source/api/lab/isaaclab.utils.rst
@@ -188,3 +188,16 @@ Warp operations
    :members:
    :imported-members:
    :show-inheritance:
+
+Warp Fabric kernels
+^^^^^^^^^^^^^^^^^^^
+
+Warp kernels for reading and writing Fabric ``Matrix4d`` attributes
+(``omni:fabric:worldMatrix`` / ``omni:fabric:localMatrix``) via
+:class:`wp.fabricarray` and :class:`wp.indexedfabricarray`.  Used by
+:class:`~isaaclab_physx.sim.views.FabricFrameView` to keep child world and
+local matrices consistent without round-tripping through USD.
+
+.. automodule:: isaaclab.utils.warp.fabric
+   :members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,6 @@ ignore-words-list = "haa,slq,collapsable,buss,reacher,thirdparty"
 
 markers = [
     "isaacsim_ci: mark test to run in isaacsim ci",
-    "multi_gpu: tests that require 2+ GPUs; skipped automatically on single-GPU machines",
 ]
 
 # Add pypi.nvidia.com so that `uv pip install isaaclab[isaacsim]` works without --extra-index-url.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ ignore-words-list = "haa,slq,collapsable,buss,reacher,thirdparty"
 
 markers = [
     "isaacsim_ci: mark test to run in isaacsim ci",
+    "multi_gpu: tests that require 2+ GPUs; skipped automatically on single-GPU machines",
 ]
 
 # Add pypi.nvidia.com so that `uv pip install isaaclab[isaacsim]` works without --extra-index-url.

--- a/scripts/benchmarks/benchmark_dexsuite_wrist_camera.py
+++ b/scripts/benchmarks/benchmark_dexsuite_wrist_camera.py
@@ -1,0 +1,467 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Reproduction benchmark comparing a static base camera vs a wrist-mounted camera in dexsuite-reorient.
+
+Piggy-backs on ``Isaac-Dexsuite-Kuka-Allegro-Reorient-v0``. Both runs use the existing
+``single_camera`` scene + observation presets so the obs schema is identical between
+configurations. Only the camera's ``prim_path`` and ``offset`` change between runs
+(static world-frame vs ``/World/envs/env_.*/Robot/ee_link/palm_link/Camera``).
+
+Outputs ``fps_<mode>.csv``, ``summary.csv``, ``summary.txt``, ``args.json`` and
+per-env ``videos/<mode>_envN.mp4`` files in a single timestamped output directory.
+
+Run via the workspace venv::
+
+    source ../tools/activate.sh
+    python scripts/benchmarks/benchmark_dexsuite_wrist_camera.py \\
+        --num_envs 2 --total_epochs 10 --video_length 200 --num_video_envs 1 \\
+        --resolution 128 --mode both --headless --enable_cameras \\
+        --out_dir ./outputs/dexsuite_wrist_repro
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_TASK = "Isaac-Dexsuite-Kuka-Allegro-Reorient-v0"
+
+
+def _rank_world() -> tuple[int, int]:
+    """Return (rank, world_size) read from torchrun env vars, defaulting to (0, 1)."""
+    return int(os.environ.get("RANK", "0")), int(os.environ.get("WORLD_SIZE", "1"))
+
+
+def _fps_csv_path(out_dir: Path, mode: str, rank: int, world_size: int) -> Path:
+    """Per-rank FPS CSV path. Single-GPU uses the plain `fps_<mode>.csv` for backward compat."""
+    if world_size > 1:
+        return out_dir / f"fps_{mode}_rank{rank}.csv"
+    return out_dir / f"fps_{mode}.csv"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Benchmark static vs wrist-mounted camera for dexsuite-reorient.",
+    )
+    parser.add_argument("--task", type=str, default=DEFAULT_TASK, help="Gym task ID.")
+    parser.add_argument("--num_envs", type=int, default=2, help="Number of parallel environments (1-3 typical).")
+    parser.add_argument(
+        "--resolution", type=int, default=128, help="Camera resolution (applied to both width and height — square)."
+    )
+    parser.add_argument("--steps_per_epoch", type=int, default=100, help="env.step() calls per timed epoch.")
+    parser.add_argument("--warmup_epochs", type=int, default=2, help="Epochs to discard from summary stats.")
+    parser.add_argument("--total_epochs", type=int, default=10, help="Measured epochs (excluding warmup).")
+    parser.add_argument(
+        "--summary_last_n_epochs", type=int, default=5, help="How many trailing epochs to average for the summary."
+    )
+    parser.add_argument("--video_length", type=int, default=200, help="Frames per recorded video (after FPS phase).")
+    parser.add_argument(
+        "--num_video_envs", type=int, default=1, help="How many envs to record video from (capped at num_envs and 3)."
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed shared by both runs for matched actions.")
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        default="./outputs/dexsuite_wrist_repro",
+        help="Output directory; a timestamped subfolder is created inside (skipped when re-used by the orchestrator).",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["base", "wrist", "both", "summarize"],
+        default="both",
+        help=(
+            "Which configuration to run. 'both' spawns two subprocesses (single-GPU only); "
+            "'summarize' aggregates existing per-rank fps_*.csv files into summary.csv/summary.txt "
+            "without launching Isaac (used as the final step in multi-GPU runs)."
+        ),
+    )
+    parser.add_argument(
+        "--distributed",
+        action="store_true",
+        default=False,
+        help="Multi-GPU run via torchrun. Each rank reads LOCAL_RANK/RANK/WORLD_SIZE from env.",
+    )
+    # AppLauncher args (--headless, --enable_cameras, --device, --visualizer, ...).
+    # add_launcher_args lazily imports AppLauncher inside its body, so this is light.
+    from isaaclab_tasks.utils import add_launcher_args
+
+    add_launcher_args(parser)
+    return parser
+
+
+def _resolve_out_dir(base_out_dir: str, mode: str) -> Path:
+    """Return the timestamped run directory. Orchestrator creates it; subprocesses reuse it."""
+    base = Path(base_out_dir)
+    # In subprocess mode the orchestrator already passed a fully-resolved timestamped path.
+    # We detect that by the presence of args.json inside.
+    if (base / "args.json").exists():
+        return base
+    run_dir = base / datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "videos").mkdir(exist_ok=True)
+    return run_dir
+
+
+def _record_args(out_dir: Path, args: argparse.Namespace) -> None:
+    payload = {k: (str(v) if isinstance(v, Path) else v) for k, v in vars(args).items()}
+    (out_dir / "args.json").write_text(json.dumps(payload, indent=2, default=str))
+
+
+# ------------------------------------------------------------------------------------------------
+# Orchestrator: --mode both
+# ------------------------------------------------------------------------------------------------
+
+
+def run_orchestrator(args: argparse.Namespace, hydra_args: list[str]) -> int:
+    out_dir = _resolve_out_dir(args.out_dir, "both")
+    _record_args(out_dir, args)
+
+    common = [
+        "--task",
+        args.task,
+        "--num_envs",
+        str(args.num_envs),
+        "--resolution",
+        str(args.resolution),
+        "--steps_per_epoch",
+        str(args.steps_per_epoch),
+        "--warmup_epochs",
+        str(args.warmup_epochs),
+        "--total_epochs",
+        str(args.total_epochs),
+        "--summary_last_n_epochs",
+        str(args.summary_last_n_epochs),
+        "--video_length",
+        str(args.video_length),
+        "--num_video_envs",
+        str(args.num_video_envs),
+        "--seed",
+        str(args.seed),
+        "--out_dir",
+        str(out_dir),
+    ]
+    # Forward AppLauncher flags relevant to headless / device / cameras.
+    for flag in ("headless", "enable_cameras"):
+        if getattr(args, flag, False):
+            common.append(f"--{flag}")
+    if getattr(args, "device", None):
+        common += ["--device", args.device]
+
+    for mode in ("base", "wrist"):
+        cmd = [sys.executable, __file__, "--mode", mode, *common, *hydra_args]
+        print(f"[orchestrator] launching: {' '.join(cmd)}", flush=True)
+        proc = subprocess.run(cmd)
+        if proc.returncode != 0:
+            print(f"[orchestrator] subprocess for mode={mode} failed (rc={proc.returncode})", file=sys.stderr)
+            return proc.returncode
+
+    write_combined_summary(out_dir, args.summary_last_n_epochs)
+    print(f"[orchestrator] done. artifacts in: {out_dir}", flush=True)
+    return 0
+
+
+def _read_fps_csv(csv_path: Path) -> list[tuple[int, float, bool]]:
+    rows: list[tuple[int, float, bool]] = []
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        for r in reader:
+            rows.append((int(r["epoch"]), float(r["fps"]), r["is_warmup"].lower() == "true"))
+    return rows
+
+
+def _collect_mode_csvs(out_dir: Path, mode: str) -> list[Path]:
+    """Find FPS CSVs for a mode — either single `fps_<mode>.csv` or per-rank `fps_<mode>_rank*.csv`."""
+    plain = out_dir / f"fps_{mode}.csv"
+    if plain.exists():
+        return [plain]
+    return sorted(out_dir.glob(f"fps_{mode}_rank*.csv"))
+
+
+def write_combined_summary(out_dir: Path, last_n: int) -> None:
+    """Aggregate per-rank FPS CSVs into summary.csv + summary.txt.
+
+    For multi-rank runs, per-epoch FPS values are summed across ranks to report total
+    env-steps/sec throughput (the natural quantity for parallel renderers/simulators).
+    Per-rank breakdown is also written so individual GPU behavior stays visible.
+    """
+    summary_rows = []
+    headlines = []
+    for mode in ("base", "wrist"):
+        csv_paths = _collect_mode_csvs(out_dir, mode)
+        if not csv_paths:
+            print(f"[summary] no fps CSV for mode={mode}, skipping", file=sys.stderr)
+            continue
+        # Each CSV is one rank. Index per-epoch FPS across ranks, then sum.
+        per_rank_rows = [_read_fps_csv(p) for p in csv_paths]
+        n_epochs = min(len(r) for r in per_rank_rows)
+        # Sum FPS per epoch across ranks (skipping warmup-flagged epochs).
+        total_fps_per_epoch: list[float] = []
+        for e in range(n_epochs):
+            is_warmup_any = any(r[e][2] for r in per_rank_rows)
+            if is_warmup_any:
+                continue
+            total_fps_per_epoch.append(sum(r[e][1] for r in per_rank_rows))
+        last = total_fps_per_epoch[-last_n:] if len(total_fps_per_epoch) >= last_n else total_fps_per_epoch
+        if not last:
+            continue
+        mean = statistics.fmean(last)
+        std = statistics.stdev(last) if len(last) > 1 else 0.0
+        # Per-rank breakdown for visibility into rank imbalance.
+        per_rank_means = []
+        for r in per_rank_rows:
+            measured = [fps for _, fps, is_w in r if not is_w]
+            tail = measured[-last_n:] if len(measured) >= last_n else measured
+            per_rank_means.append(statistics.fmean(tail) if tail else 0.0)
+        summary_rows.append(
+            {
+                "mode": mode,
+                "world_size": len(csv_paths),
+                "total_fps_mean": f"{mean:.3f}",
+                "total_fps_std": f"{std:.3f}",
+                "total_fps_min": f"{min(last):.3f}",
+                "total_fps_max": f"{max(last):.3f}",
+                "per_rank_means": ";".join(f"{m:.3f}" for m in per_rank_means),
+                "last_n": len(last),
+            }
+        )
+        headlines.append((mode, mean, std, len(csv_paths)))
+
+    with (out_dir / "summary.csv").open("w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "mode",
+                "world_size",
+                "total_fps_mean",
+                "total_fps_std",
+                "total_fps_min",
+                "total_fps_max",
+                "per_rank_means",
+                "last_n",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(summary_rows)
+
+    lines = []
+    for mode, mean, std, ws in headlines:
+        suffix = f"  (world_size={ws})" if ws > 1 else ""
+        lines.append(f"{mode:>5}: {mean:8.2f} +/- {std:6.2f} FPS{suffix}")
+    if len(headlines) == 2:
+        base_mean = headlines[0][1] if headlines[0][0] == "base" else headlines[1][1]
+        wrist_mean = headlines[1][1] if headlines[1][0] == "wrist" else headlines[0][1]
+        ratio = wrist_mean / base_mean if base_mean > 0 else float("nan")
+        lines.append(f"wrist/base ratio: {ratio:.3f}  (delta: {(ratio - 1.0) * 100:+.1f}%)")
+    (out_dir / "summary.txt").write_text("\n".join(lines) + "\n")
+
+
+def run_summarize(args: argparse.Namespace) -> int:
+    """Aggregate existing per-rank fps CSVs. Used as the final step in a multi-GPU job."""
+    out_dir = _resolve_out_dir(args.out_dir, "summarize")
+    write_combined_summary(out_dir, args.summary_last_n_epochs)
+    summary_path = out_dir / "summary.txt"
+    if summary_path.exists():
+        print(f"[summarize] wrote {summary_path}:", flush=True)
+        print(summary_path.read_text(), flush=True)
+    else:
+        print("[summarize] WARNING: no summary written (no per-mode CSVs found?)", file=sys.stderr)
+    return 0
+
+
+# ------------------------------------------------------------------------------------------------
+# Per-config runner: --mode base | --mode wrist
+# ------------------------------------------------------------------------------------------------
+
+
+def setup_env_cfg(args: argparse.Namespace, mode: str):
+    """Build the env config: pin the obs preset to single_camera, then swap base_camera prim_path/offset."""
+    from isaaclab_tasks.manager_based.manipulation.dexsuite.config.kuka_allegro.camera_cfg import (
+        BASE_CAMERA_CFG,
+        WRIST_CAMERA_CFG,
+    )
+    from isaaclab_tasks.utils import resolve_task_config
+
+    # Pre-pend Hydra preset overrides so the resolved env_cfg.scene has a `base_camera` slot
+    # and observations.base_image is wired to SceneEntityCfg("base_camera"). Users can override
+    # by passing their own env.scene=... env.observations=... on the CLI; we only inject defaults.
+    hydra_argv_extras = []
+    user_argv = " ".join(sys.argv)
+    if "env.scene=" not in user_argv:
+        hydra_argv_extras.append("env.scene=single_camera")
+    if "env.observations=" not in user_argv:
+        hydra_argv_extras.append("env.observations=single_camera")
+    if hydra_argv_extras:
+        sys.argv += hydra_argv_extras
+
+    env_cfg, _ = resolve_task_config(args.task, "")
+    env_cfg.scene.num_envs = args.num_envs
+
+    src = WRIST_CAMERA_CFG if mode == "wrist" else BASE_CAMERA_CFG
+    cam = env_cfg.scene.base_camera  # already-resolved CameraCfg from preset (renderer_cfg resolved)
+    cam.prim_path = src.prim_path
+    cam.offset = src.offset
+    cam.data_types = ["rgb"]
+    cam.width = args.resolution
+    cam.height = args.resolution
+    return env_cfg
+
+
+def run_one_config(args: argparse.Namespace, mode: str) -> int:
+    import gymnasium as gym
+    import torch
+
+    import isaaclab_tasks  # noqa: F401  (registers gym envs)
+    from isaaclab_tasks.utils import launch_simulation
+
+    rank, world_size = _rank_world()
+    is_rank0 = rank == 0
+    tag_prefix = f"[{mode}|r{rank}]" if world_size > 1 else f"[{mode}]"
+
+    out_dir = _resolve_out_dir(args.out_dir, mode)
+
+    # Offset the seed by rank so each rank samples a different random action stream,
+    # exercising the renderer with varied scene state. Matched across modes (base/wrist
+    # use the same seed) so the comparison stays apples-to-apples.
+    torch.manual_seed(args.seed + rank)
+    env_cfg = setup_env_cfg(args, mode)
+
+    fps_csv_path = _fps_csv_path(out_dir, mode, rank, world_size)
+    fps_csv = fps_csv_path.open("w", newline="")
+    fps_writer = csv.writer(fps_csv)
+    fps_writer.writerow(["epoch", "fps", "is_warmup"])
+
+    # Buffer frames per env in RAM during the video phase; encode via imageio inside
+    # the with-block (Kit is still alive). cv2.VideoWriter is unusable here because
+    # libavcodec loaded by Kit silently drops frames after env.step has rendered;
+    # imageio_ffmpeg shells out to a standalone ffmpeg binary and is unaffected.
+    frame_buffers: dict[int, list] = {}
+    cuda_available = torch.cuda.is_available()
+
+    def sync():
+        if cuda_available:
+            torch.cuda.synchronize()
+
+    def sample_actions(action_space_shape, device):
+        return torch.rand(action_space_shape, device=device) * 2.0 - 1.0
+
+    try:
+        with launch_simulation(env_cfg, args):
+            env = gym.make(args.task, cfg=env_cfg)
+            env.reset()
+            device = env.unwrapped.device
+            action_shape = env.action_space.shape
+
+            # FPS phase --------------------------------------------------------------
+            with torch.inference_mode():
+                total_epochs = args.warmup_epochs + args.total_epochs
+                for epoch in range(total_epochs):
+                    is_warmup = epoch < args.warmup_epochs
+                    sync()
+                    t0 = time.perf_counter()
+                    for _ in range(args.steps_per_epoch):
+                        env.step(sample_actions(action_shape, device))
+                    sync()
+                    dt = time.perf_counter() - t0
+                    fps = (args.steps_per_epoch * args.num_envs) / dt if dt > 0 else 0.0
+                    fps_writer.writerow([epoch, f"{fps:.4f}", str(is_warmup)])
+                    fps_csv.flush()
+                    tag = "warmup" if is_warmup else "measure"
+                    print(f"{tag_prefix} epoch {epoch:>3} ({tag}): {fps:.2f} FPS  (dt={dt:.3f}s)", flush=True)
+
+            # Video phase ------------------------------------------------------------
+            # All ranks step env in lockstep (so any internal collectives stay synced),
+            # but only rank 0 buffers + encodes frames.
+            n_video_envs = max(0, min(args.num_video_envs, args.num_envs, 3))
+            if n_video_envs > 0 and args.video_length > 0:
+                import numpy as np
+
+                if is_rank0:
+                    for i in range(n_video_envs):
+                        frame_buffers[i] = []
+                with torch.inference_mode():
+                    for _ in range(args.video_length):
+                        env.step(sample_actions(action_shape, device))
+                        if not is_rank0:
+                            continue
+                        rgb = env.unwrapped.scene["base_camera"].data.output["rgb"]
+                        frames = rgb[:n_video_envs].detach().cpu().numpy()
+                        if frames.dtype != np.uint8:
+                            f_max = float(frames.max()) if frames.size else 0.0
+                            if f_max <= 1.0 + 1e-6:
+                                frames = (frames.clip(0.0, 1.0) * 255.0).astype(np.uint8)
+                            else:
+                                frames = frames.clip(0, 255).astype(np.uint8)
+                        for i in range(n_video_envs):
+                            frame_buffers[i].append(frames[i].copy())
+                if is_rank0:
+                    print(f"{tag_prefix} video phase: captured {args.video_length} frames per env", flush=True)
+
+            # Encode videos BEFORE the `with launch_simulation` block exits: AppLauncher.app.close()
+            # tears down the process and code after the `with` is unreachable. Use imageio (with
+            # imageio_ffmpeg's bundled ffmpeg binary) — cv2.VideoWriter mp4v silently drops frames
+            # when libavcodec is loaded into the Kit-active runtime.
+            if frame_buffers and is_rank0:
+                import imageio.v2 as imageio
+
+                for i, frames in frame_buffers.items():
+                    if not frames:
+                        continue
+                    h, w = frames[0].shape[:2]
+                    path = out_dir / "videos" / f"{mode}_env{i}.mp4"
+                    with imageio.get_writer(str(path), fps=30, codec="libx264", macro_block_size=1) as writer:
+                        for f in frames:
+                            writer.append_data(f)
+                    print(
+                        f"{tag_prefix} wrote video {path} ({len(frames)} frames, {w}x{h}, {path.stat().st_size} bytes)",
+                        flush=True,
+                    )
+
+            print(f"{tag_prefix} wrote {fps_csv_path}", flush=True)
+            env.close()
+    finally:
+        fps_csv.close()
+
+    return 0
+
+
+# ------------------------------------------------------------------------------------------------
+# Entrypoint
+# ------------------------------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = build_parser()
+    args, hydra_args = parser.parse_known_args()
+    # Hydra reads from sys.argv directly (see zero_agent.py pattern).
+    sys.argv = [sys.argv[0]] + hydra_args
+
+    if args.mode == "both" and args.distributed:
+        print(
+            "ERROR: --mode both is not supported with --distributed. Under torchrun the script "
+            "must be invoked twice (once with --mode base, once with --mode wrist), followed by a "
+            "rank-0-only `--mode summarize` step to aggregate per-rank CSVs.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.mode == "both":
+        return run_orchestrator(args, hydra_args)
+    if args.mode == "summarize":
+        return run_summarize(args)
+    return run_one_config(args, args.mode)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/benchmark_dexsuite_wrist_camera.py
+++ b/scripts/benchmarks/benchmark_dexsuite_wrist_camera.py
@@ -102,13 +102,22 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _resolve_out_dir(base_out_dir: str, mode: str) -> Path:
-    """Return the timestamped run directory. Orchestrator creates it; subprocesses reuse it."""
+    """Return the directory to write outputs to.
+
+    - ``--mode both`` (orchestrator): creates a fresh timestamped subdir under
+      ``base_out_dir`` (unless an ``args.json`` already exists there, in which case
+      the existing dir is reused — supports re-runs against the same path).
+    - Single-mode runs (``--mode base | wrist | summarize``): use ``base_out_dir``
+      as-is. The orchestrator passes the already-resolved timestamped path to its
+      subprocesses; users running torchrun directly are responsible for picking a
+      unique path. Sharing one path across base + wrist + summarize is the
+      intended pattern for multi-GPU local runs.
+    """
     base = Path(base_out_dir)
-    # In subprocess mode the orchestrator already passed a fully-resolved timestamped path.
-    # We detect that by the presence of args.json inside.
-    if (base / "args.json").exists():
-        return base
-    run_dir = base / datetime.now().strftime("%Y%m%d-%H%M%S")
+    if mode == "both" and not (base / "args.json").exists():
+        run_dir = base / datetime.now().strftime("%Y%m%d-%H%M%S")
+    else:
+        run_dir = base
     run_dir.mkdir(parents=True, exist_ok=True)
     (run_dir / "videos").mkdir(exist_ok=True)
     return run_dir

--- a/source/isaaclab/changelog.d/indexed-fabric-kernels.rst
+++ b/source/isaaclab/changelog.d/indexed-fabric-kernels.rst
@@ -1,0 +1,24 @@
+Added
+^^^^^
+
+* Added :func:`~isaaclab.utils.warp.fabric.decompose_indexed_fabric_transforms`
+  and :func:`~isaaclab.utils.warp.fabric.compose_indexed_fabric_transforms`
+  Warp kernels.  They mirror the existing
+  ``decompose_fabric_transformation_matrix_to_warp_arrays`` /
+  ``compose_fabric_transformation_matrix_from_warp_arrays`` kernels but
+  operate on :class:`wp.indexedfabricarray`, so the view-to-fabric mapping
+  is baked into the array and the kernel just dereferences
+  ``ifa[view_index]`` instead of taking a separate ``mapping`` argument.
+* Added :func:`~isaaclab.utils.warp.fabric.update_indexed_local_matrix_from_world`
+  and :func:`~isaaclab.utils.warp.fabric.update_indexed_world_matrix_from_local`
+  Warp kernels that propagate ``local = world * inv(parent)`` and
+  ``world = local * parent`` directly on Fabric storage matrices (no
+  explicit transposes).  Used by
+  :class:`~isaaclab_physx.sim.views.FabricFrameView` to keep child world and
+  local matrices consistent across writes without round-tripping through USD.
+
+Changed
+^^^^^^^
+
+* Replaced ``if/else`` branching with ``wp.where`` in existing Fabric
+  compose/decompose kernels for branchless GPU execution.

--- a/source/isaaclab/isaaclab/sim/views/frame_view.py
+++ b/source/isaaclab/isaaclab/sim/views/frame_view.py
@@ -24,7 +24,22 @@ from .usd_frame_view import UsdFrameView
 logger = logging.getLogger(__name__)
 
 # Devices supported by Fabric GPU acceleration (USDRT SelectPrims + Warp).
-_FABRIC_SUPPORTED_DEVICES = ("cpu", "cuda", "cuda:0")
+# Any CUDA device is supported — multi-GPU setups use cuda:1, cuda:2, etc.
+_FABRIC_SUPPORTED_DEVICES: tuple[str, ...] | None = None  # None = compute dynamically
+
+
+def _is_fabric_supported_device(device: str) -> bool:
+    """Return True if *device* can use the Fabric-accelerated path."""
+    if device in ("cpu", "cuda"):
+        return True
+    # Accept any cuda:N index.
+    if device.startswith("cuda:"):
+        try:
+            int(device.split(":", 1)[1])
+            return True
+        except (ValueError, IndexError):
+            pass
+    return False
 
 
 class FrameView(FactoryBase, BaseFrameView):
@@ -74,14 +89,14 @@ class FrameView(FactoryBase, BaseFrameView):
         if len(args) >= 2:
             device = args[1]
 
-        if fabric_enabled and device in _FABRIC_SUPPORTED_DEVICES:
+        if fabric_enabled and _is_fabric_supported_device(device):
             return "physx"
 
-        if fabric_enabled and device not in _FABRIC_SUPPORTED_DEVICES:
+        if fabric_enabled and not _is_fabric_supported_device(device):
             logger.warning(
                 f"Fabric mode is not supported on device '{device}'. "
                 "USDRT SelectPrims and Warp fabric arrays are currently "
-                f"only supported on {', '.join(_FABRIC_SUPPORTED_DEVICES)}. "
+                "only supported on cpu and cuda:<N> devices. "
                 "Falling back to UsdFrameView."
             )
 

--- a/source/isaaclab/isaaclab/sim/views/frame_view.py
+++ b/source/isaaclab/isaaclab/sim/views/frame_view.py
@@ -6,15 +6,25 @@
 """Backend-dispatching FrameView.
 
 ``FrameView(path, device=...)`` automatically selects the right backend:
-- PhysX: :class:`~isaaclab_physx.sim.views.FabricFrameView`
+- PhysX + Fabric enabled + supported device: :class:`~isaaclab_physx.sim.views.FabricFrameView`
+- PhysX without Fabric (or unsupported device): :class:`~isaaclab.sim.views.UsdFrameView`
+- OVPhysX: :class:`~isaaclab_ovphysx.sim.views.OvPhysxFrameView`
 - Newton: :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView`
 """
 
 from __future__ import annotations
 
+import logging
+
 from isaaclab.utils.backend_utils import FactoryBase
 
 from .base_frame_view import BaseFrameView
+from .usd_frame_view import UsdFrameView
+
+logger = logging.getLogger(__name__)
+
+# Devices supported by Fabric GPU acceleration (USDRT SelectPrims + Warp).
+_FABRIC_SUPPORTED_DEVICES = ("cpu", "cuda", "cuda:0")
 
 
 class FrameView(FactoryBase, BaseFrameView):
@@ -23,8 +33,10 @@ class FrameView(FactoryBase, BaseFrameView):
     Callers use ``FrameView(prim_path, device=device)`` and get the
     correct implementation automatically:
 
-    - **PhysX / no backend**: :class:`~isaaclab_physx.sim.views.FabricFrameView`
-      (Fabric GPU acceleration with USD fallback).
+    - **PhysX + Fabric**: :class:`~isaaclab_physx.sim.views.FabricFrameView`
+      (GPU-accelerated transforms via Warp + USDRT).
+    - **PhysX without Fabric**: :class:`~isaaclab.sim.views.UsdFrameView`
+      (standard USD operations).
     - **OVPhysX**: :class:`~isaaclab_ovphysx.sim.views.OvPhysxFrameView`
       (Warp-native, reads body poses via an OVPhysX ``RIGID_BODY_POSE``
       tensor binding).
@@ -36,22 +48,50 @@ class FrameView(FactoryBase, BaseFrameView):
         "physx": "FabricFrameView",
         "ovphysx": "OvPhysxFrameView",
         "newton": "NewtonSiteFrameView",
+        # "usd" is registered eagerly below — no dynamic import needed.
     }
 
     @classmethod
     def _get_backend(cls, *args, **kwargs) -> str:
+        from isaaclab.app.settings_manager import SettingsManager  # noqa: PLC0415
         from isaaclab.sim.simulation_context import SimulationContext  # noqa: PLC0415
 
         ctx = SimulationContext.instance()
         if ctx is None:
-            return "physx"
+            return "usd"
+
         manager_name = ctx.physics_manager.__name__.lower()
         if "newton" in manager_name:
             return "newton"
         if "ovphysx" in manager_name:
             return "ovphysx"
-        return "physx"
+
+        # PhysX path — check if Fabric is enabled and the device is supported.
+        settings = SettingsManager.instance()
+        fabric_enabled = bool(settings.get("/physics/fabricEnabled", False))
+
+        device = kwargs.get("device", "cpu")
+        if len(args) >= 2:
+            device = args[1]
+
+        if fabric_enabled and device in _FABRIC_SUPPORTED_DEVICES:
+            return "physx"
+
+        if fabric_enabled and device not in _FABRIC_SUPPORTED_DEVICES:
+            logger.warning(
+                f"Fabric mode is not supported on device '{device}'. "
+                "USDRT SelectPrims and Warp fabric arrays are currently "
+                f"only supported on {', '.join(_FABRIC_SUPPORTED_DEVICES)}. "
+                "Falling back to UsdFrameView."
+            )
+
+        return "usd"
 
     def __new__(cls, *args, **kwargs) -> BaseFrameView:
         """Create a new FrameView for the active physics backend."""
         return super().__new__(cls, *args, **kwargs)
+
+
+# Eagerly register UsdFrameView — it lives in isaaclab, not a backend package,
+# so FactoryBase's dynamic import (isaaclab_{backend}.sim.views) can't find it.
+FrameView.register("usd", UsdFrameView)

--- a/source/isaaclab/isaaclab/utils/warp/fabric.py
+++ b/source/isaaclab/isaaclab/utils/warp/fabric.py
@@ -15,15 +15,28 @@ from typing import TYPE_CHECKING, Any
 
 import warp as wp
 
+__all__ = [
+    "arange_k",
+    "compose_fabric_transformation_matrix_from_warp_arrays",
+    "compose_indexed_fabric_transforms",
+    "decompose_fabric_transformation_matrix_to_warp_arrays",
+    "decompose_indexed_fabric_transforms",
+    "set_view_to_fabric_array",
+    "update_indexed_local_matrix_from_world",
+    "update_indexed_world_matrix_from_local",
+]
+
 if TYPE_CHECKING:
     FabricArrayUInt32 = Any
     FabricArrayMat44d = Any
+    IndexedFabricArrayMat44d = Any
     ArrayUInt32 = Any
     ArrayUInt32_1d = Any
     ArrayFloat32_2d = Any
 else:
     FabricArrayUInt32 = wp.fabricarray(dtype=wp.uint32)
     FabricArrayMat44d = wp.fabricarray(dtype=wp.mat44d)
+    IndexedFabricArrayMat44d = wp.indexedfabricarray(dtype=wp.mat44d)
     ArrayUInt32 = wp.array(ndim=1, dtype=wp.uint32)
     ArrayUInt32_1d = wp.array(dtype=wp.uint32)
     ArrayFloat32_2d = wp.array(ndim=2, dtype=wp.float32)
@@ -130,29 +143,20 @@ def compose_fabric_transformation_matrix_from_warp_arrays(
     position, rotation, scale = _decompose_transformation_matrix(wp.mat44f(fabric_matrices[fabric_index]))
     # update position (check if array has elements, not just if it exists)
     if array_positions.shape[0] > 0:
-        if broadcast_positions:
-            index = 0
-        else:
-            index = i
+        index = wp.where(broadcast_positions, 0, i)
         position[0] = array_positions[index, 0]
         position[1] = array_positions[index, 1]
         position[2] = array_positions[index, 2]
     # update orientation (convert from wxyz to xyzw for Warp)
     if array_orientations.shape[0] > 0:
-        if broadcast_orientations:
-            index = 0
-        else:
-            index = i
+        index = wp.where(broadcast_orientations, 0, i)
         rotation[0] = array_orientations[index, 0]  # x
         rotation[1] = array_orientations[index, 1]  # y
         rotation[2] = array_orientations[index, 2]  # z
         rotation[3] = array_orientations[index, 3]  # w
     # update scale
     if array_scales.shape[0] > 0:
-        if broadcast_scales:
-            index = 0
-        else:
-            index = i
+        index = wp.where(broadcast_scales, 0, i)
         scale[0] = array_scales[index, 0]
         scale[1] = array_scales[index, 1]
         scale[2] = array_scales[index, 2]
@@ -161,6 +165,167 @@ def compose_fabric_transformation_matrix_from_warp_arrays(
     fabric_matrices[fabric_index] = wp.mat44d(  # type: ignore[arg-type]
         wp.transpose(wp.transform_compose(position, rotation, scale))  # type: ignore[arg-type]
     )
+
+
+@wp.kernel(enable_backward=False)
+def decompose_indexed_fabric_transforms(
+    fabric_matrices: IndexedFabricArrayMat44d,
+    array_positions: ArrayFloat32_2d,
+    array_orientations: ArrayFloat32_2d,
+    array_scales: ArrayFloat32_2d,
+    indices: ArrayUInt32,
+):
+    """Decompose indexed Fabric transformation matrices into position, orientation, and scale.
+
+    Like :func:`decompose_fabric_transformation_matrix_to_warp_arrays` but operates on a
+    :class:`wp.indexedfabricarray` that already encodes the view-to-fabric mapping, removing
+    the need for a separate ``mapping`` array.
+
+    Args:
+        fabric_matrices: Indexed fabric array containing 4x4 transformation matrices.
+        array_positions: Output array for positions [m], shape (N, 3).
+        array_orientations: Output array for quaternions in xyzw format, shape (N, 4).
+        array_scales: Output array for scales, shape (N, 3).
+        indices: View indices to process (subset selection).
+    """
+    output_index = wp.tid()
+    view_index = indices[output_index]
+
+    position, rotation, scale = _decompose_transformation_matrix(wp.mat44f(fabric_matrices[view_index]))
+
+    if array_positions.shape[0] > 0:
+        array_positions[output_index, 0] = position[0]
+        array_positions[output_index, 1] = position[1]
+        array_positions[output_index, 2] = position[2]
+    if array_orientations.shape[0] > 0:
+        array_orientations[output_index, 0] = rotation[0]
+        array_orientations[output_index, 1] = rotation[1]
+        array_orientations[output_index, 2] = rotation[2]
+        array_orientations[output_index, 3] = rotation[3]
+    if array_scales.shape[0] > 0:
+        array_scales[output_index, 0] = scale[0]
+        array_scales[output_index, 1] = scale[1]
+        array_scales[output_index, 2] = scale[2]
+
+
+@wp.kernel(enable_backward=False)
+def compose_indexed_fabric_transforms(
+    fabric_matrices: IndexedFabricArrayMat44d,
+    array_positions: ArrayFloat32_2d,
+    array_orientations: ArrayFloat32_2d,
+    array_scales: ArrayFloat32_2d,
+    broadcast_positions: bool,
+    broadcast_orientations: bool,
+    broadcast_scales: bool,
+    indices: ArrayUInt32,
+):
+    """Compose indexed Fabric transformation matrices from position, orientation, and scale.
+
+    Like :func:`compose_fabric_transformation_matrix_from_warp_arrays` but operates on a
+    :class:`wp.indexedfabricarray` that already encodes the view-to-fabric mapping, removing
+    the need for a separate ``mapping`` array.
+
+    Args:
+        fabric_matrices: Indexed fabric array containing 4x4 transformation matrices to update.
+        array_positions: Input array for positions [m], shape (N, 3).
+        array_orientations: Input array for quaternions in xyzw format, shape (N, 4).
+        array_scales: Input array for scales, shape (N, 3).
+        broadcast_positions: If True, use first position for all prims.
+        broadcast_orientations: If True, use first orientation for all prims.
+        broadcast_scales: If True, use first scale for all prims.
+        indices: View indices to process (subset selection).
+    """
+    i = wp.tid()
+    view_index = indices[i]
+    position, rotation, scale = _decompose_transformation_matrix(wp.mat44f(fabric_matrices[view_index]))
+
+    if array_positions.shape[0] > 0:
+        index = wp.where(broadcast_positions, 0, i)
+        position[0] = array_positions[index, 0]
+        position[1] = array_positions[index, 1]
+        position[2] = array_positions[index, 2]
+    if array_orientations.shape[0] > 0:
+        index = wp.where(broadcast_orientations, 0, i)
+        rotation[0] = array_orientations[index, 0]
+        rotation[1] = array_orientations[index, 1]
+        rotation[2] = array_orientations[index, 2]
+        rotation[3] = array_orientations[index, 3]
+    if array_scales.shape[0] > 0:
+        index = wp.where(broadcast_scales, 0, i)
+        scale[0] = array_scales[index, 0]
+        scale[1] = array_scales[index, 1]
+        scale[2] = array_scales[index, 2]
+
+    fabric_matrices[view_index] = wp.mat44d(  # type: ignore[arg-type]
+        wp.transpose(wp.transform_compose(position, rotation, scale))  # type: ignore[arg-type]
+    )
+
+
+@wp.kernel(enable_backward=False)
+def update_indexed_local_matrix_from_world(
+    child_world_matrices: IndexedFabricArrayMat44d,
+    parent_world_matrices: IndexedFabricArrayMat44d,
+    child_local_matrices: IndexedFabricArrayMat44d,
+    indices: ArrayUInt32,
+):
+    """Recompute child localMatrix from (parent worldMatrix, child worldMatrix).
+
+    Computes ``child_local = inv(parent_world) * child_world`` per prim and writes the
+    result back to the child's :data:`omni:fabric:localMatrix` so that subsequent
+    ``get_local_poses`` calls see consistent values after a world-pose write.
+
+    All three indexed arrays are expected to be indexed by the same per-view indices
+    (i.e. ``view_to_child_fabric``, ``view_to_parent_fabric``, ``view_to_child_fabric``)
+    so the kernel only needs the view-side indices.
+
+    Storage convention: Fabric matrices are stored as the transpose of the standard
+    column-major math convention.  Math is ``local = inv(parent) * world``; under
+    the transpose identity ``(A * B)^T = B^T * A^T`` (and ``inv(A^T) = inv(A)^T``)
+    that is equivalent to storage-side ``local^T = world^T * inv(parent^T)``, so we
+    can compute it directly on the stored matrices without explicit transposes.
+
+    Args:
+        child_world_matrices: Indexed fabric array of child world matrices (read).
+        parent_world_matrices: Indexed fabric array of parent world matrices (read).
+        child_local_matrices: Indexed fabric array of child local matrices (written).
+        indices: View indices to process.
+    """
+    i = wp.tid()
+    view_index = indices[i]
+    child_world = wp.mat44f(child_world_matrices[view_index])
+    parent_world = wp.mat44f(parent_world_matrices[view_index])
+    child_local_matrices[view_index] = wp.mat44d(child_world * wp.inverse(parent_world))  # type: ignore[arg-type]
+
+
+@wp.kernel(enable_backward=False)
+def update_indexed_world_matrix_from_local(
+    child_local_matrices: IndexedFabricArrayMat44d,
+    parent_world_matrices: IndexedFabricArrayMat44d,
+    child_world_matrices: IndexedFabricArrayMat44d,
+    indices: ArrayUInt32,
+):
+    """Recompute child worldMatrix from (parent worldMatrix, child localMatrix).
+
+    Computes ``child_world = parent_world * child_local`` per prim and writes the
+    result back to the child's :data:`omni:fabric:worldMatrix`.  Used after a
+    ``set_local_poses`` write so that subsequent ``get_world_poses`` calls see
+    consistent values.  Mirror of :func:`update_indexed_local_matrix_from_world`.
+
+    Args:
+        child_local_matrices: Indexed fabric array of child local matrices (read).
+        parent_world_matrices: Indexed fabric array of parent world matrices (read).
+        child_world_matrices: Indexed fabric array of child world matrices (written).
+        indices: View indices to process.
+
+    Storage convention: same as :func:`update_indexed_local_matrix_from_world`.
+    Math is ``world = parent * local``; under the transpose identity that becomes
+    storage-side ``world^T = local^T * parent^T``, no explicit transposes needed.
+    """
+    i = wp.tid()
+    view_index = indices[i]
+    child_local = wp.mat44f(child_local_matrices[view_index])
+    parent_world = wp.mat44f(parent_world_matrices[view_index])
+    child_world_matrices[view_index] = wp.mat44d(child_local * parent_world)  # type: ignore[arg-type]
 
 
 @wp.func

--- a/source/isaaclab/test/utils/warp/test_fabric_kernels.py
+++ b/source/isaaclab/test/utils/warp/test_fabric_kernels.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for the Warp fabric transform kernels.
+
+Tests the decompose/compose math via helper kernels that operate on
+regular wp.array (no Fabric/USDRT runtime required).
+"""
+
+import numpy as np
+import warp as wp
+
+wp.init()
+
+from isaaclab.utils.warp.fabric import _decompose_transformation_matrix  # noqa: E402
+
+
+@wp.kernel(enable_backward=False)
+def _test_decompose_kernel(
+    matrices: wp.array(dtype=wp.mat44f),
+    out_positions: wp.array(dtype=wp.vec3f),
+    out_rotations: wp.array(dtype=wp.vec4f),
+    out_scales: wp.array(dtype=wp.vec3f),
+):
+    """Decompose a batch of 4x4 matrices into pos/quat/scale."""
+    i = wp.tid()
+    pos, rot, scale = _decompose_transformation_matrix(matrices[i])
+    out_positions[i] = pos
+    out_rotations[i] = wp.vec4f(rot[0], rot[1], rot[2], rot[3])
+    out_scales[i] = scale
+
+
+@wp.kernel(enable_backward=False)
+def _test_compose_kernel(
+    positions: wp.array(dtype=wp.vec3f),
+    rotations: wp.array(dtype=wp.vec4f),
+    scales: wp.array(dtype=wp.vec3f),
+    out_matrices: wp.array(dtype=wp.mat44f),
+):
+    """Compose a batch of pos/quat/scale into 4x4 matrices."""
+    i = wp.tid()
+    pos = positions[i]
+    rot = wp.quatf(rotations[i][0], rotations[i][1], rotations[i][2], rotations[i][3])
+    scale = scales[i]
+    out_matrices[i] = wp.transpose(wp.transform_compose(pos, rot, scale))
+
+
+class TestDecomposeCompose:
+    """Round-trip tests for decompose ↔ compose transform math."""
+
+    def test_identity_matrix(self):
+        """Identity matrix decomposes to pos=0, quat=identity, scale=1."""
+        mat = np.eye(4, dtype=np.float32).reshape(1, 4, 4)
+        matrices = wp.array(mat, dtype=wp.mat44f, device="cpu")
+        out_pos = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+        out_rot = wp.zeros(1, dtype=wp.vec4f, device="cpu")
+        out_scale = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+
+        wp.launch(_test_decompose_kernel, dim=1, inputs=[matrices, out_pos, out_rot, out_scale], device="cpu")
+        wp.synchronize()
+
+        pos = out_pos.numpy()
+        rot = out_rot.numpy()
+        scale = out_scale.numpy()
+
+        np.testing.assert_allclose(pos[0], [0, 0, 0], atol=1e-6)
+        np.testing.assert_allclose(scale[0], [1, 1, 1], atol=1e-6)
+        # Identity quaternion: either (0,0,0,1) or (0,0,0,-1)
+        assert abs(abs(rot[0, 3]) - 1.0) < 1e-5
+
+    def test_translation_only(self):
+        """Matrix with only translation decomposes correctly."""
+        mat = np.eye(4, dtype=np.float32)
+        mat[3, 0] = 1.0  # row-major: translation in last row
+        mat[3, 1] = 2.0
+        mat[3, 2] = 3.0
+        matrices = wp.array(mat.reshape(1, 4, 4), dtype=wp.mat44f, device="cpu")
+        out_pos = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+        out_rot = wp.zeros(1, dtype=wp.vec4f, device="cpu")
+        out_scale = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+
+        wp.launch(_test_decompose_kernel, dim=1, inputs=[matrices, out_pos, out_rot, out_scale], device="cpu")
+        wp.synchronize()
+
+        np.testing.assert_allclose(out_pos.numpy()[0], [1, 2, 3], atol=1e-6)
+        np.testing.assert_allclose(out_scale.numpy()[0], [1, 1, 1], atol=1e-6)
+
+    def test_uniform_scale(self):
+        """Matrix with uniform scale decomposes correctly."""
+        mat = np.eye(4, dtype=np.float32)
+        mat[0, 0] = 2.0
+        mat[1, 1] = 2.0
+        mat[2, 2] = 2.0
+        matrices = wp.array(mat.reshape(1, 4, 4), dtype=wp.mat44f, device="cpu")
+        out_pos = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+        out_rot = wp.zeros(1, dtype=wp.vec4f, device="cpu")
+        out_scale = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+
+        wp.launch(_test_decompose_kernel, dim=1, inputs=[matrices, out_pos, out_rot, out_scale], device="cpu")
+        wp.synchronize()
+
+        np.testing.assert_allclose(out_scale.numpy()[0], [2, 2, 2], atol=1e-6)
+
+    def test_round_trip(self):
+        """Compose then decompose recovers original pos/quat/scale."""
+        # Known transform: translate (5,6,7), rotate 90° about Z, scale (1,2,3)
+        pos = np.array([[5.0, 6.0, 7.0]], dtype=np.float32)
+        # 90° about Z in xyzw: (0, 0, sin(45°), cos(45°))
+        s45 = np.sin(np.pi / 4)
+        c45 = np.cos(np.pi / 4)
+        rot = np.array([[0.0, 0.0, s45, c45]], dtype=np.float32)
+        scale = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+
+        wp_pos = wp.array(pos, dtype=wp.vec3f, device="cpu")
+        wp_rot = wp.array(rot, dtype=wp.vec4f, device="cpu")
+        wp_scale = wp.array(scale, dtype=wp.vec3f, device="cpu")
+        out_mat = wp.zeros(1, dtype=wp.mat44f, device="cpu")
+
+        # Compose
+        wp.launch(_test_compose_kernel, dim=1, inputs=[wp_pos, wp_rot, wp_scale, out_mat], device="cpu")
+        wp.synchronize()
+
+        # Decompose
+        out_pos = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+        out_rot = wp.zeros(1, dtype=wp.vec4f, device="cpu")
+        out_scale = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+
+        wp.launch(_test_decompose_kernel, dim=1, inputs=[out_mat, out_pos, out_rot, out_scale], device="cpu")
+        wp.synchronize()
+
+        np.testing.assert_allclose(out_pos.numpy()[0], pos[0], atol=1e-5)
+        np.testing.assert_allclose(out_scale.numpy()[0], scale[0], atol=1e-5)
+        # Quaternion sign ambiguity
+        r_out = out_rot.numpy()[0]
+        r_exp = rot[0]
+        dot = np.dot(r_out, r_exp)
+        np.testing.assert_allclose(abs(dot), 1.0, atol=1e-5)
+
+    def test_non_uniform_scale_round_trip(self):
+        """Non-uniform scale round-trips correctly."""
+        pos = np.array([[0.0, 0.0, 0.0]], dtype=np.float32)
+        rot = np.array([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32)  # identity
+        scale = np.array([[0.5, 2.0, 3.0]], dtype=np.float32)
+
+        wp_pos = wp.array(pos, dtype=wp.vec3f, device="cpu")
+        wp_rot = wp.array(rot, dtype=wp.vec4f, device="cpu")
+        wp_scale = wp.array(scale, dtype=wp.vec3f, device="cpu")
+        out_mat = wp.zeros(1, dtype=wp.mat44f, device="cpu")
+
+        wp.launch(_test_compose_kernel, dim=1, inputs=[wp_pos, wp_rot, wp_scale, out_mat], device="cpu")
+        wp.synchronize()
+
+        out_pos = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+        out_rot = wp.zeros(1, dtype=wp.vec4f, device="cpu")
+        out_scale = wp.zeros(1, dtype=wp.vec3f, device="cpu")
+
+        wp.launch(_test_decompose_kernel, dim=1, inputs=[out_mat, out_pos, out_rot, out_scale], device="cpu")
+        wp.synchronize()
+
+        np.testing.assert_allclose(out_scale.numpy()[0], scale[0], atol=1e-5)
+
+
+class TestKernelSignatures:
+    """Verify all exported kernels are importable and are Warp Kernels."""
+
+    def test_all_kernels_importable(self):
+        """All public kernels listed in __all__ should be importable and be Warp Kernels."""
+        from isaaclab.utils.warp import fabric as fabric_utils
+
+        expected_kernels = [
+            "arange_k",
+            "compose_fabric_transformation_matrix_from_warp_arrays",
+            "compose_indexed_fabric_transforms",
+            "decompose_fabric_transformation_matrix_to_warp_arrays",
+            "decompose_indexed_fabric_transforms",
+            "set_view_to_fabric_array",
+            "update_indexed_local_matrix_from_world",
+            "update_indexed_world_matrix_from_local",
+        ]
+
+        for name in expected_kernels:
+            obj = getattr(fabric_utils, name, None)
+            assert obj is not None, f"{name} not found in fabric_utils"
+            assert isinstance(obj, wp.Kernel), f"{name} should be a wp.Kernel, got {type(obj)}"
+
+    def test_module_exports_match_all(self):
+        """__all__ should list every public kernel."""
+        from isaaclab.utils.warp import fabric as fabric_utils
+
+        for name in fabric_utils.__all__:
+            assert hasattr(fabric_utils, name), f"__all__ lists '{name}' but it's not defined"

--- a/source/isaaclab_physx/changelog.d/fabric-local-poses.rst
+++ b/source/isaaclab_physx/changelog.d/fabric-local-poses.rst
@@ -1,0 +1,15 @@
+Added
+^^^^^
+
+* Added Fabric-accelerated ``get_local_poses`` / ``set_local_poses`` to
+  :class:`~isaaclab_physx.sim.views.FabricFrameView`.
+
+  Local-pose operations now use ``wp.indexedfabricarray`` to read/write
+  ``omni:fabric:localMatrix`` directly on the GPU, propagating between
+  parent world matrices and child local/world matrices via Warp kernels
+  without round-tripping through USD.
+
+* Added per-view dirty tracking: ``set_local_poses`` marks the world matrix
+  dirty and vice-versa, triggering automatic re-propagation on the next read.
+
+* Added ``_rebuild_fabric_arrays`` topology-change recovery.

--- a/source/isaaclab_physx/changelog.d/fabric-stage-cache.rst
+++ b/source/isaaclab_physx/changelog.d/fabric-stage-cache.rst
@@ -1,0 +1,10 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab_physx.sim.FabricStageCache` — a lightweight cache for the
+  ``usdrt.Usd.Stage`` attachment and ``IFabricHierarchy`` handles, registered as a
+  service on :class:`~isaaclab.sim.SimulationContext` via ``set_service()``.
+
+  Multiple :class:`~isaaclab_physx.sim.views.FabricFrameView` instances now share a
+  single hierarchy handle instead of each creating its own.  The cache is automatically
+  closed on ``SimulationContext.clear_instance()``.

--- a/source/isaaclab_physx/changelog.d/feat-frame-view-enable-mgpu.rst
+++ b/source/isaaclab_physx/changelog.d/feat-frame-view-enable-mgpu.rst
@@ -1,14 +1,3 @@
-Changed
-^^^^^^^
-
-* Combined the initial USD→Fabric sync in
-  :class:`~isaaclab_physx.sim.views.FabricFrameView` into a single Fabric
-  write so ``PrepareForReuse`` is invoked exactly once per logical update
-  (positions, orientations, and scales are composed in one kernel launch).
-  This avoids the possibility of a second non-idempotent
-  ``PrepareForReuse`` call masking a topology-change signal that should
-  have triggered a fabricarray rebuild.
-
 Fixed
 ^^^^^
 
@@ -18,10 +7,3 @@ Fixed
   runs on the simulation device the view was constructed with (e.g.
   ``cuda:1``).  This unblocks distributed training where each rank is
   pinned to a non-primary GPU.
-
-* Fixed the topology-change invariant guard in
-  :class:`~isaaclab_physx.sim.views.FabricFrameView` not surviving
-  ``python -O``.  The check now raises :class:`RuntimeError` instead of
-  using ``assert`` so the prim-count mismatch between view and Fabric is
-  reported at every optimisation level rather than silently producing
-  wrong poses or out-of-bounds kernel indices.

--- a/source/isaaclab_physx/changelog.d/feat-frame-view-enable-mgpu.rst
+++ b/source/isaaclab_physx/changelog.d/feat-frame-view-enable-mgpu.rst
@@ -1,0 +1,27 @@
+Changed
+^^^^^^^
+
+* Combined the initial USD→Fabric sync in
+  :class:`~isaaclab_physx.sim.views.FabricFrameView` into a single Fabric
+  write so ``PrepareForReuse`` is invoked exactly once per logical update
+  (positions, orientations, and scales are composed in one kernel launch).
+  This avoids the possibility of a second non-idempotent
+  ``PrepareForReuse`` call masking a topology-change signal that should
+  have triggered a fabricarray rebuild.
+
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_physx.sim.views.FabricFrameView` falling back to
+  the slow USD path on every CUDA device other than ``cuda:0``.  USDRT
+  ``SelectPrims`` now accepts any CUDA device index, so Fabric acceleration
+  runs on the simulation device the view was constructed with (e.g.
+  ``cuda:1``).  This unblocks distributed training where each rank is
+  pinned to a non-primary GPU.
+
+* Fixed the topology-change invariant guard in
+  :class:`~isaaclab_physx.sim.views.FabricFrameView` not surviving
+  ``python -O``.  The check now raises :class:`RuntimeError` instead of
+  using ``assert`` so the prim-count mismatch between view and Fabric is
+  reported at every optimisation level rather than silently producing
+  wrong poses or out-of-bounds kernel indices.

--- a/source/isaaclab_physx/changelog.d/refactor-fabric-fused-compose.rst
+++ b/source/isaaclab_physx/changelog.d/refactor-fabric-fused-compose.rst
@@ -1,0 +1,24 @@
+Changed
+^^^^^^^
+
+* Combined the initial USD→Fabric sync in
+  :class:`~isaaclab_physx.sim.views.FabricFrameView` into a single Fabric
+  write so ``PrepareForReuse`` is invoked exactly once per logical update
+  (positions, orientations, and scales are composed in one kernel launch).
+  This avoids the possibility of a second non-idempotent
+  ``PrepareForReuse`` call masking a topology-change signal that should
+  have triggered a fabricarray rebuild.
+
+* Extracted :meth:`~isaaclab_physx.sim.views.FabricFrameView._compose_fabric_transform`
+  to deduplicate the kernel-launch logic shared by ``set_world_poses`` and
+  ``set_scales``.
+
+Fixed
+^^^^^
+
+* Fixed the topology-change invariant guard in
+  :class:`~isaaclab_physx.sim.views.FabricFrameView` not surviving
+  ``python -O``.  The check now raises :class:`RuntimeError` instead of
+  using ``assert`` so the prim-count mismatch between view and Fabric is
+  reported at every optimisation level rather than silently producing
+  wrong poses or out-of-bounds kernel indices.

--- a/source/isaaclab_physx/isaaclab_physx/sim/fabric_stage_cache.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/fabric_stage_cache.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Fabric stage and hierarchy cache, registered as a service on SimulationContext."""
+
+from __future__ import annotations
+
+from pxr import UsdUtils
+
+
+class FabricStageCache:
+    """Caches the usdrt stage attachment and IFabricHierarchy handles.
+
+    Registered as a singleton service on :class:`~isaaclab.sim.SimulationContext` via
+    ``set_service(FabricStageCache, ...)``.  Multiple
+    :class:`~isaaclab_physx.sim.views.FabricFrameView` instances share a single
+    hierarchy handle per Fabric attachment.
+
+    The hierarchy cache is keyed by ``fabric_id_int`` (the stable ``.id`` integer from
+    ``FabricId``).  Currently Isaac Lab always has exactly one Fabric attachment per
+    stage, so this dict will hold at most one entry.  A dict is used rather than a plain
+    attribute so the design naturally extends to multi-Fabric scenarios (e.g. multi-GPU
+    support, where each GPU gets its own Fabric attachment) without an API change.
+    """
+
+    def __init__(self, usd_stage) -> None:
+        import usdrt  # noqa: PLC0415
+
+        stage_id = UsdUtils.StageCache.Get().GetId(usd_stage).ToLongInt()
+        self._stage = usdrt.Usd.Stage.Attach(stage_id)
+        self._stage.SynchronizeToFabric()
+        self._hierarchy_cache: dict[int, object] = {}
+
+    @property
+    def stage(self):
+        """The usdrt stage (already attached and synchronized)."""
+        return self._stage
+
+    def close(self) -> None:
+        """Release cached handles.  Called by SimulationContext on teardown."""
+        self._hierarchy_cache.clear()
+        self._stage = None
+
+    def get_hierarchy(self):
+        """Return the IFabricHierarchy handle for the current Fabric attachment.
+
+        Creates and caches the handle on first call.  Change-tracking is enabled
+        for both local and world xforms.
+
+        Returns:
+            A tuple of ``(hierarchy_handle, fabric_id_int)``.
+        """
+        import usdrt  # noqa: PLC0415
+
+        fabric_id = self._stage.GetFabricId()
+        fabric_id_int = fabric_id.id
+
+        if fabric_id_int not in self._hierarchy_cache:
+            hierarchy = usdrt.hierarchy.IFabricHierarchy().get_fabric_hierarchy(
+                fabric_id, self._stage.GetStageIdAsStageId()
+            )
+            hierarchy.track_local_xform_changes(True)
+            hierarchy.track_world_xform_changes(True)
+            self._hierarchy_cache[fabric_id_int] = hierarchy
+
+        return self._hierarchy_cache[fabric_id_int], fabric_id_int

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -62,19 +62,42 @@ class FabricFrameView(BaseFrameView):
 
     Behavior:
 
+    * **Leaf-prim assumption.**  This view manages a flat set of sibling prims
+      (e.g. all cameras under ``/World/Env_*/Camera``).  It does NOT propagate
+      transforms to child prims.  If a managed prim has children whose world
+      matrices depend on the parent, those children must be updated via a
+      separate view, a physics step, or ``IFabricHierarchy.update_world_xforms``.
     * **No write-back to USD.**  Fabric writes update only
       ``omni:fabric:worldMatrix`` / ``omni:fabric:localMatrix``; the prim's
       USD ``xformOp:*`` attributes are unchanged.  Downstream consumers that
       read the prim's USD attributes after a Fabric write will see stale
       values until the next USD-side sync.
-    * **World ↔ local consistency.**  After ``set_world_poses`` (or
-      ``set_scales``) the local matrix is updated so that subsequent
-      ``get_local_poses`` is consistent; after ``set_local_poses`` the world
-      matrix is recomputed on the next world read.  Both directions stay in
-      sync without round-tripping through USD.
+    * **World ↔ local consistency (lazy).**  Getters are lazy: after
+      ``set_world_poses`` (or ``set_scales``), local matrices are only
+      recomputed when ``get_local_poses`` is called; after ``set_local_poses``,
+      world matrices are only recomputed when ``get_world_poses`` is called.
+      Both directions stay in sync without round-tripping through USD.
+    * **Dirty-flag invariant.**  At most one of ``_world_dirty`` /
+      ``_local_dirty`` may be ``True`` at any time.  A ``set_world_poses``
+      call marks locals dirty; a ``set_local_poses`` call marks worlds dirty.
+      If the user interleaves both setters on the same view within a single
+      frame, the second setter flushes the first's stale data before writing.
+      This is correct but incurs an extra kernel launch — a one-time warning
+      is logged when this happens.
     * **Topology-adaptive.**  Fabric topology changes are detected on each
       access; the view rebuilds its internal mapping automatically and no
       manual refresh is required.  Steady-state overhead is negligible.
+
+    Performance note:
+        The fast path assumes the user calls **either** ``set_world_poses``
+        **or** ``set_local_poses`` exclusively within a frame (not both).
+        In that case, setters are O(1) kernel launches with no synchronization
+        overhead beyond the single ``wp.synchronize()``; getters lazily flush
+        the opposite direction only when actually needed.
+
+        Interleaving both setters on different index subsets within the same
+        frame is supported and correct, but triggers an extra flush kernel
+        per transition.  A warning is emitted once per view instance.
 
     Pose getters return :class:`~isaaclab.utils.warp.ProxyArray`; setters
     accept :class:`wp.array`.
@@ -118,6 +141,9 @@ class FabricFrameView(BaseFrameView):
         self._world_dirty: bool = False
         # Set by ``set_world_poses`` / ``set_scales``; cleared by ``_sync_local_from_world_if_dirty``.
         self._local_dirty: bool = False
+        self._warned_interleaved_set: bool = False
+        # Tracks whether any user setter has been called (to distinguish init-dirty from interleave-dirty).
+        self._had_user_set: bool = False
 
         # Selections.
         self._trans_sel_ro = None
@@ -188,8 +214,19 @@ class FabricFrameView(BaseFrameView):
         if not self._fabric_initialized:
             self._initialize_fabric()
 
-        # If a prior set_local_poses left worldMatrix stale, propagate local → world first.
+        # Invariant: at most one of _world_dirty / _local_dirty may be True.
+        # If a prior set_local_poses left worlds stale, flush them now.
+        if self._world_dirty and self._had_user_set:
+            if not self._warned_interleaved_set:
+                self._warned_interleaved_set = True
+                logger.warning(
+                    "FabricFrameView: set_world_poses called while world matrices are stale from a "
+                    "prior set_local_poses.  Flushing stale worlds first.  "
+                    "For best performance, avoid interleaving set_world_poses and set_local_poses "
+                    "on the same view within a single frame \u2014 use one or the other exclusively."
+                )
         self._sync_world_from_local_if_dirty()
+        self._had_user_set = True
 
         indices_wp = self._resolve_indices_wp(indices)
         positions_wp = self._to_float32_2d_or_empty(positions)
@@ -260,6 +297,25 @@ class FabricFrameView(BaseFrameView):
         if not self._fabric_initialized:
             self._initialize_fabric()
 
+        # Invariant: at most one of _world_dirty / _local_dirty may be True.
+        # If a prior set_world_poses left locals stale, flush them now before we
+        # overwrite a (possibly different) subset of local matrices.  Without this,
+        # prims whose world was set but whose local was never flushed would silently
+        # hold stale local data.
+        #
+        # In the common fast path (user calls only set_local_poses repeatedly) the
+        # flag is False and this is a single branch — zero cost.
+        if self._local_dirty:
+            if not self._warned_interleaved_set:
+                self._warned_interleaved_set = True
+                logger.warning(
+                    "FabricFrameView: set_local_poses called while local matrices are stale from a "
+                    "prior set_world_poses/set_scales.  Flushing stale locals first.  "
+                    "For best performance, avoid interleaving set_world_poses and set_local_poses "
+                    "on the same view within a single frame — use one or the other exclusively."
+                )
+            self._sync_local_from_world_if_dirty()
+
         indices_wp = self._resolve_indices_wp(indices)
         translations_wp = self._to_float32_2d_or_empty(translations)
         orientations_wp = self._to_float32_2d_or_empty(orientations)
@@ -283,8 +339,6 @@ class FabricFrameView(BaseFrameView):
 
         # Mark this view's worlds stale so the next world read recomputes them.
         self._world_dirty = True
-        # Local was just written directly — clear any stale-local flag.
-        self._local_dirty = False
 
     def get_local_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
         if not self._fabric_initialized:

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -128,42 +128,7 @@ class FabricFrameView(BaseFrameView):
     # ------------------------------------------------------------------
 
     def set_world_poses(self, positions=None, orientations=None, indices=None):
-        if not self._fabric_initialized:
-            self._initialize_fabric()
-
-        self._prepare_for_reuse()
-
-        indices_wp = self._resolve_indices_wp(indices)
-        count = indices_wp.shape[0]
-
-        dummy = wp.zeros((0, 3), dtype=wp.float32, device=self._device)
-        positions_wp = _to_float32_2d(positions) if positions is not None else dummy
-        orientations_wp = (
-            _to_float32_2d(orientations)
-            if orientations is not None
-            else wp.zeros((0, 4), dtype=wp.float32, device=self._device)
-        )
-
-        wp.launch(
-            kernel=fabric_utils.compose_fabric_transformation_matrix_from_warp_arrays,
-            dim=count,
-            inputs=[
-                self._fabric_world_matrices,
-                positions_wp,
-                orientations_wp,
-                dummy,
-                False,
-                False,
-                False,
-                indices_wp,
-                self._view_to_fabric,
-            ],
-            device=self._fabric_device,
-        )
-        wp.synchronize()
-
-        self._fabric_hierarchy.update_world_xforms()
-        self._fabric_usd_sync_done = True
+        self._compose_fabric_transform(positions=positions, orientations=orientations, indices=indices)
 
     def get_world_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
         if not self._fabric_initialized:
@@ -216,6 +181,19 @@ class FabricFrameView(BaseFrameView):
     # ------------------------------------------------------------------
 
     def set_scales(self, scales, indices=None):
+        self._compose_fabric_transform(scales=scales, indices=indices)
+
+    def _compose_fabric_transform(self, positions=None, orientations=None, scales=None, indices=None):
+        """Write the given subset of (position, orientation, scale) into Fabric in one kernel launch.
+
+        Components left as ``None`` are skipped via empty input arrays — the kernel reads them
+        from the existing Fabric matrix.  Always invokes :meth:`_prepare_for_reuse` exactly once
+        per write, even when multiple components are updated together.
+
+        Side effect: sets ``self._fabric_usd_sync_done = True`` after the write, marking Fabric
+        as the authoritative source going forward.  This suppresses the lazy USD→Fabric sync
+        in subsequent getters (see :meth:`get_world_poses`, :meth:`get_scales`).
+        """
         if not self._fabric_initialized:
             self._initialize_fabric()
 
@@ -224,17 +202,19 @@ class FabricFrameView(BaseFrameView):
         indices_wp = self._resolve_indices_wp(indices)
         count = indices_wp.shape[0]
 
-        dummy3 = wp.zeros((0, 3), dtype=wp.float32, device=self._device)
-        dummy4 = wp.zeros((0, 4), dtype=wp.float32, device=self._device)
-        scales_wp = _to_float32_2d(scales)
+        empty3 = wp.zeros((0, 3), dtype=wp.float32, device=self._device)
+        empty4 = wp.zeros((0, 4), dtype=wp.float32, device=self._device)
+        positions_wp = _to_float32_2d(positions) if positions is not None else empty3
+        orientations_wp = _to_float32_2d(orientations) if orientations is not None else empty4
+        scales_wp = _to_float32_2d(scales) if scales is not None else empty3
 
         wp.launch(
             kernel=fabric_utils.compose_fabric_transformation_matrix_from_warp_arrays,
             dim=count,
             inputs=[
                 self._fabric_world_matrices,
-                dummy3,
-                dummy4,
+                positions_wp,
+                orientations_wp,
                 scales_wp,
                 False,
                 False,
@@ -315,10 +295,11 @@ class FabricFrameView(BaseFrameView):
         pattern (via ``_usd_view.count``) and does not change when Fabric rearranges its
         internal memory layout.  The assertion below guards this invariant.
         """
-        assert self.count == self._default_view_indices.shape[0], (
-            f"Prim count changed ({self.count} vs {self._default_view_indices.shape[0]}). "
-            "Fabric topology change added/removed tracked prims — full re-initialization required."
-        )
+        if self.count != self._default_view_indices.shape[0]:
+            raise RuntimeError(
+                f"Prim count changed ({self.count} vs {self._default_view_indices.shape[0]}). "
+                "Fabric topology change added/removed tracked prims — full re-initialization required."
+            )
         self._view_to_fabric = wp.zeros((self.count,), dtype=wp.uint32, device=self._fabric_device)
         self._fabric_to_view = wp.fabricarray(self._fabric_selection, self._view_index_attr)
 
@@ -407,19 +388,20 @@ class FabricFrameView(BaseFrameView):
     def _sync_fabric_from_usd_once(self) -> None:
         """Sync Fabric world matrices from USD once, on the first read.
 
-        ``set_world_poses`` and ``set_scales`` each set ``_fabric_usd_sync_done``
-        themselves, so no explicit flag assignment is needed here.
+        Combines position/orientation/scale into a single Fabric write so
+        :meth:`_prepare_for_reuse` (and its underlying ``PrepareForReuse``) is invoked
+        exactly once across the full sync.
         """
         if not self._fabric_initialized:
             self._initialize_fabric()
 
         positions_usd_ta, orientations_usd_ta = self._usd_view.get_world_poses()
-        positions_usd = positions_usd_ta.warp
-        orientations_usd = orientations_usd_ta.warp
         scales_usd = self._usd_view.get_scales()
-
-        self.set_world_poses(positions_usd, orientations_usd)
-        self.set_scales(scales_usd)
+        self._compose_fabric_transform(
+            positions=positions_usd_ta.warp,
+            orientations=orientations_usd_ta.warp,
+            scales=scales_usd,
+        )
 
     def _resolve_indices_wp(self, indices: wp.array | None) -> wp.array:
         """Resolve view indices as a Warp uint32 array."""

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -116,6 +116,8 @@ class FabricFrameView(BaseFrameView):
         # Per-view (not per-stage) so concurrent views on the same stage don't clear
         # each other's flag.
         self._world_dirty: bool = False
+        # Set by ``set_world_poses`` / ``set_scales``; cleared by ``_sync_local_from_world_if_dirty``.
+        self._local_dirty: bool = False
 
         # Selections.
         self._trans_sel_ro = None
@@ -210,9 +212,9 @@ class FabricFrameView(BaseFrameView):
         )
         wp.synchronize()
 
-        # World was just written — recompute child localMatrix from parent worldMatrix
-        # so the next get_local_poses returns consistent values.
-        self._sync_local_from_world(indices_wp)
+        # World was just written — mark local poses as stale so the next
+        # get_local_poses recomputes them lazily.
+        self._local_dirty = True
 
     def get_world_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
         if not self._fabric_initialized:
@@ -281,10 +283,15 @@ class FabricFrameView(BaseFrameView):
 
         # Mark this view's worlds stale so the next world read recomputes them.
         self._world_dirty = True
+        # Local was just written directly — clear any stale-local flag.
+        self._local_dirty = False
 
     def get_local_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
         if not self._fabric_initialized:
             self._initialize_fabric()
+
+        # If a prior set_world_poses/set_scales left localMatrix stale, recompute.
+        self._sync_local_from_world_if_dirty()
 
         indices_wp = self._resolve_indices_wp(indices)
         count = indices_wp.shape[0]
@@ -346,9 +353,8 @@ class FabricFrameView(BaseFrameView):
         )
         wp.synchronize()
 
-        # World was just written — recompute child localMatrix from parent worldMatrix
-        # so the next get_local_poses returns the new scale rather than the stale one.
-        self._sync_local_from_world(indices_wp)
+        # World was just written — mark local poses as stale.
+        self._local_dirty = True
 
     def get_scales(self, indices=None):
         if not self._fabric_initialized:
@@ -422,10 +428,10 @@ class FabricFrameView(BaseFrameView):
     def _sync_local_from_world(self, indices_wp: wp.array) -> None:
         """Recompute child ``localMatrix`` from (parent worldMatrix, child worldMatrix).
 
-        Called after ``set_world_poses`` so that subsequent ``get_local_poses`` returns
-        values consistent with the just-written world poses.  Fabric Hierarchy does
-        not provide a built-in world → local sync, so we do it via a Warp kernel
-        using the parent indexed fabric array.
+        Called lazily by ``_sync_local_from_world_if_dirty`` when ``get_local_poses``
+        is invoked after a prior ``set_world_poses`` or ``set_scales``.
+        Fabric Hierarchy does not provide a built-in world → local sync, so we do
+        it via a Warp kernel using the parent indexed fabric array.
         """
         # Refresh trans_sel_ro once; _world_ifa_ro and _parent_world_ifa_ro share it.
         if self._trans_sel_ro.PrepareForReuse() or self._parent_world_ifa_ro is None:
@@ -442,6 +448,13 @@ class FabricFrameView(BaseFrameView):
             device=self._device,
         )
         wp.synchronize()
+
+    def _sync_local_from_world_if_dirty(self) -> None:
+        """If a prior world write left local matrices stale, recompute them lazily."""
+        if not self._local_dirty:
+            return
+        self._sync_local_from_world(self._view_indices)
+        self._local_dirty = False
 
     # ------------------------------------------------------------------
     # Internal — selection accessors with on-demand index rebuild

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 # Recent Kit / USDRT releases do support multi-GPU ``SelectPrims``, but the
 # rest of the FabricFrameView wiring (selections, indexed arrays, etc.) still
 # assumes a single device — to be tackled in a follow-up.
-_fabric_supported_devices = ("cpu", "cuda", "cuda:0")
+# Fabric acceleration is supported on any CUDA device (cuda:0, cuda:1, etc.) and CPU.
 
 
 def _to_float32_2d(a: wp.array | torch.Tensor) -> wp.array | torch.Tensor:
@@ -54,8 +54,11 @@ class FabricFrameView(BaseFrameView):
     when Fabric is disabled).
 
     When Fabric is enabled, world-pose and scale operations use Warp kernels
-    operating on ``omni:fabric:worldMatrix``.  All other operations delegate
-    to the internal USD view.
+    operating on ``omni:fabric:worldMatrix``.  Fabric acceleration runs on
+    the same CUDA device the view was constructed with — ``cuda:0``,
+    ``cuda:1``, or any other available CUDA index — so this view is safe
+    to use from distributed-training workers pinned to non-primary GPUs.
+    All other operations delegate to the internal USD view.
 
     After every Fabric write (``set_world_poses``, ``set_scales``),
     :meth:`PrepareForReuse` is called on the ``PrimSelection`` to notify
@@ -78,7 +81,9 @@ class FabricFrameView(BaseFrameView):
 
         Args:
             prim_path: USD prim-path pattern to match.
-            device: Device for Warp arrays (``"cpu"`` or ``"cuda:0"``).
+            device: Device for Warp arrays. Either ``"cpu"`` or any CUDA
+                device string (``"cuda:0"``, ``"cuda:1"``, …); Fabric
+                acceleration is supported on every CUDA index.
             validate_xform_ops: Whether to validate prim xform-ops.
             stage: USD stage; defaults to the current sim context's stage.
             **kwargs: Additional keyword arguments (ignored). Matches the signature of
@@ -91,15 +96,6 @@ class FabricFrameView(BaseFrameView):
 
         settings = SettingsManager.instance()
         self._use_fabric = bool(settings.get("/physics/fabricEnabled", False))
-
-        if self._use_fabric and self._device not in _fabric_supported_devices:
-            logger.warning(
-                f"Fabric mode is not supported on device '{self._device}'. "
-                "USDRT SelectPrims and Warp fabric arrays are currently "
-                f"only supported on {', '.join(_fabric_supported_devices)}. "
-                "Falling back to standard USD operations. This may impact performance."
-            )
-            self._use_fabric = False
 
         self._fabric_initialized = False
         self._fabric_usd_sync_done = False
@@ -404,8 +400,7 @@ class FabricFrameView(BaseFrameView):
         )
         wp.synchronize()
 
-        # The constructor should have taken care of this, but double check here to avoid regressions
-        assert self._device in _fabric_supported_devices
+        # Fabric acceleration is supported on any device; no allowlist check needed.
 
         self._fabric_selection = fabric_stage.SelectPrims(
             require_attrs=[

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -12,7 +12,7 @@ import logging
 import torch
 import warp as wp
 
-from pxr import Usd
+from pxr import Gf, Usd, UsdGeom
 
 from isaaclab.sim.views.base_frame_view import BaseFrameView
 from isaaclab.sim.views.usd_frame_view import UsdFrameView
@@ -45,19 +45,39 @@ class FabricFrameView(BaseFrameView):
     supported.  The :class:`~isaaclab.sim.views.FrameView` factory dispatches
     to :class:`~isaaclab.sim.views.UsdFrameView` otherwise.
 
-    Uses composition: holds a :class:`UsdFrameView` internally for operations
-    that don't have a Fabric-accelerated path (local poses, visibility).
+    World-pose, local-pose, and scale operations run on the GPU via Warp
+    kernels that read and write ``omni:fabric:worldMatrix`` and
+    ``omni:fabric:localMatrix`` directly.  Typical speedup vs. the
+    :class:`~isaaclab.sim.views.UsdFrameView` baseline at 1024 prims is
+    150-260× per call (see ``scripts/benchmarks/benchmark_view_comparison.py``).
 
-    World-pose and scale operations use Warp kernels operating on
-    ``omni:fabric:worldMatrix``.  After every Fabric write
-    (``set_world_poses``, ``set_scales``), :meth:`PrepareForReuse` is called
-    on the ``PrimSelection`` to notify the FSD renderer that Fabric data has
-    changed and to detect topology changes that require rebuilding internal
-    mappings.  Read operations do not call PrepareForReuse to avoid
-    unnecessary renderer invalidation.
+    The ``count``, ``prims``, ``prim_paths`` properties and the
+    ``get_visibility`` / ``set_visibility`` methods delegate to an internal
+    :class:`~isaaclab.sim.views.UsdFrameView`; Fabric has no equivalent fast
+    path for those.
 
-    Pose getters return :class:`~isaaclab.utils.warp.ProxyArray`.  Setters accept ``wp.array``.
+    Behavior:
+
+    * **No write-back to USD.**  Fabric writes update only
+      ``omni:fabric:worldMatrix`` / ``omni:fabric:localMatrix``; the prim's
+      USD ``xformOp:*`` attributes are unchanged.  Downstream consumers that
+      read the prim's USD attributes after a Fabric write will see stale
+      values until the next USD-side sync.
+    * **World ↔ local consistency.**  After ``set_world_poses`` (or
+      ``set_scales``) the local matrix is updated so that subsequent
+      ``get_local_poses`` is consistent; after ``set_local_poses`` the world
+      matrix is recomputed on the next world read.  Both directions stay in
+      sync without round-tripping through USD.
+    * **Topology-adaptive.**  Fabric topology changes are detected on each
+      access; the view rebuilds its internal mapping automatically and no
+      manual refresh is required.  Steady-state overhead is negligible.
+
+    Pose getters return :class:`~isaaclab.utils.warp.ProxyArray`; setters
+    accept :class:`wp.array`.
     """
+
+    _WORLD_MATRIX_NAME = "omni:fabric:worldMatrix"
+    _LOCAL_MATRIX_NAME = "omni:fabric:localMatrix"
 
     def __init__(
         self,
@@ -82,14 +102,44 @@ class FabricFrameView(BaseFrameView):
         self._usd_view = UsdFrameView(prim_path, device=device, validate_xform_ops=validate_xform_ops, stage=stage)
         self._device = device
 
+        # Fabric state — all populated lazily in :meth:`_initialize_fabric`.
         self._fabric_initialized = False
-        self._fabric_usd_sync_done = False
-        self._fabric_selection = None
-        self._fabric_to_view: wp.array | None = None
-        self._view_to_fabric: wp.array | None = None
-        self._default_view_indices: wp.array | None = None
+        self._stage = None
         self._fabric_hierarchy = None
-        self._view_index_attr = f"isaaclab:view_index:{abs(hash(self))}"
+        # Set by ``set_local_poses``; cleared by ``_sync_world_from_local_if_dirty``.
+        # Per-view (not per-stage) so concurrent views on the same stage don't clear
+        # each other's flag.
+        self._world_dirty: bool = False
+
+        # Selections.
+        self._trans_sel_ro = None
+        self._world_sel_rw = None
+        self._local_sel_rw = None
+
+        # Index arrays (view-side indices and view→fabric mappings).  Each selection's
+        # ``GetPaths()`` ordering is independent, so the view→fabric mapping is cached
+        # per selection rather than shared — sharing would silently corrupt indexed
+        # arrays whose selection didn't fire ``PrepareForReuse`` on the same frame.
+        self._view_indices: wp.array | None = None
+        self._trans_ro_fabric_indices: wp.array | None = None
+        self._world_rw_fabric_indices: wp.array | None = None
+        self._local_rw_fabric_indices: wp.array | None = None
+        self._parent_fabric_indices: wp.array | None = None
+
+        # Indexed fabric arrays.
+        self._world_ifa_ro = None
+        self._local_ifa_ro = None
+        self._world_ifa_rw = None
+        self._local_ifa_rw = None
+        self._parent_world_ifa_ro = None
+
+        # Sentinel passed to ``compose_indexed_fabric_transforms`` /
+        # ``decompose_indexed_fabric_transforms`` for slots the caller does not want
+        # written or read.  The kernels gate every per-row access on
+        # ``shape[0] > 0``, so a ``(0, 0)`` array is enough — the inner dim is never
+        # indexed.  One shared instance covers all "unused" slots regardless of
+        # whether they would have held positions, quaternions, or scales.
+        self._fabric_empty_2d_array_sentinel: wp.array | None = None
 
     # ------------------------------------------------------------------
     # Delegated properties
@@ -127,13 +177,43 @@ class FabricFrameView(BaseFrameView):
     # ------------------------------------------------------------------
 
     def set_world_poses(self, positions=None, orientations=None, indices=None):
-        self._compose_fabric_transform(positions=positions, orientations=orientations, indices=indices)
+        if not self._fabric_initialized:
+            self._initialize_fabric()
+
+        # If a prior set_local_poses left worldMatrix stale, propagate local → world first.
+        self._sync_world_from_local_if_dirty()
+
+        indices_wp = self._resolve_indices_wp(indices)
+        positions_wp = self._to_float32_2d_or_empty(positions)
+        orientations_wp = self._to_float32_2d_or_empty(orientations)
+
+        wp.launch(
+            kernel=fabric_utils.compose_indexed_fabric_transforms,
+            dim=indices_wp.shape[0],
+            inputs=[
+                self._get_world_rw_array(),
+                positions_wp,
+                orientations_wp,
+                self._fabric_empty_2d_array_sentinel,
+                False,
+                False,
+                False,
+                indices_wp,
+            ],
+            device=self._device,
+        )
+        wp.synchronize()
+
+        # World was just written — recompute child localMatrix from parent worldMatrix
+        # so the next get_local_poses returns consistent values.
+        self._sync_local_from_world(indices_wp)
 
     def get_world_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
         if not self._fabric_initialized:
             self._initialize_fabric()
-        if not self._fabric_usd_sync_done:
-            self._sync_fabric_from_usd_once()
+
+        # If a prior set_local_poses left worldMatrix stale, propagate local → world first.
+        self._sync_world_from_local_if_dirty()
 
         indices_wp = self._resolve_indices_wp(indices)
         count = indices_wp.shape[0]
@@ -147,17 +227,16 @@ class FabricFrameView(BaseFrameView):
             orientations_wp = wp.zeros((count, 4), dtype=wp.float32, device=self._device)
 
         wp.launch(
-            kernel=fabric_utils.decompose_fabric_transformation_matrix_to_warp_arrays,
+            kernel=fabric_utils.decompose_indexed_fabric_transforms,
             dim=count,
             inputs=[
-                self._fabric_world_matrices,
+                self._get_world_ro_array(),
                 positions_wp,
                 orientations_wp,
-                self._fabric_dummy_buffer,
+                self._fabric_empty_2d_array_sentinel,
                 indices_wp,
-                self._view_to_fabric,
             ],
-            device=self._fabric_device,
+            device=self._device,
         )
 
         if use_cached:
@@ -166,73 +245,111 @@ class FabricFrameView(BaseFrameView):
         return ProxyArray(positions_wp), ProxyArray(orientations_wp)
 
     # ------------------------------------------------------------------
-    # Local poses — USD fallback (Fabric only accelerates world poses)
+    # Local poses
     # ------------------------------------------------------------------
 
     def set_local_poses(self, translations=None, orientations=None, indices=None):
-        self._usd_view.set_local_poses(translations, orientations, indices)
-
-    def get_local_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
-        return self._usd_view.get_local_poses(indices)
-
-    # ------------------------------------------------------------------
-    # Scales — Fabric-accelerated or USD fallback
-    # ------------------------------------------------------------------
-
-    def set_scales(self, scales, indices=None):
-        self._compose_fabric_transform(scales=scales, indices=indices)
-
-    def _compose_fabric_transform(self, positions=None, orientations=None, scales=None, indices=None):
-        """Write the given subset of (position, orientation, scale) into Fabric in one kernel launch.
-
-        Components left as ``None`` are skipped via empty input arrays — the kernel reads them
-        from the existing Fabric matrix.  Always invokes :meth:`_prepare_for_reuse` exactly once
-        per write, even when multiple components are updated together.
-
-        Side effect: sets ``self._fabric_usd_sync_done = True`` after the write, marking Fabric
-        as the authoritative source going forward.  This suppresses the lazy USD→Fabric sync
-        in subsequent getters (see :meth:`get_world_poses`, :meth:`get_scales`).
-        """
         if not self._fabric_initialized:
             self._initialize_fabric()
 
-        self._prepare_for_reuse()
+        indices_wp = self._resolve_indices_wp(indices)
+        translations_wp = self._to_float32_2d_or_empty(translations)
+        orientations_wp = self._to_float32_2d_or_empty(orientations)
+
+        wp.launch(
+            kernel=fabric_utils.compose_indexed_fabric_transforms,
+            dim=indices_wp.shape[0],
+            inputs=[
+                self._get_local_rw_array(),
+                translations_wp,
+                orientations_wp,
+                self._fabric_empty_2d_array_sentinel,
+                False,
+                False,
+                False,
+                indices_wp,
+            ],
+            device=self._device,
+        )
+        wp.synchronize()
+
+        # Mark this view's worlds stale so the next world read recomputes them.
+        self._world_dirty = True
+
+    def get_local_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
+        if not self._fabric_initialized:
+            self._initialize_fabric()
 
         indices_wp = self._resolve_indices_wp(indices)
         count = indices_wp.shape[0]
 
-        empty3 = wp.zeros((0, 3), dtype=wp.float32, device=self._device)
-        empty4 = wp.zeros((0, 4), dtype=wp.float32, device=self._device)
-        positions_wp = _to_float32_2d(positions) if positions is not None else empty3
-        orientations_wp = _to_float32_2d(orientations) if orientations is not None else empty4
-        scales_wp = _to_float32_2d(scales) if scales is not None else empty3
+        use_cached = indices is None or indices == slice(None)
+        if use_cached:
+            translations_wp = self._fabric_local_translations_buf
+            orientations_wp = self._fabric_local_orientations_buf
+        else:
+            translations_wp = wp.zeros((count, 3), dtype=wp.float32, device=self._device)
+            orientations_wp = wp.zeros((count, 4), dtype=wp.float32, device=self._device)
 
         wp.launch(
-            kernel=fabric_utils.compose_fabric_transformation_matrix_from_warp_arrays,
+            kernel=fabric_utils.decompose_indexed_fabric_transforms,
             dim=count,
             inputs=[
-                self._fabric_world_matrices,
-                positions_wp,
+                self._get_local_ro_array(),
+                translations_wp,
                 orientations_wp,
+                self._fabric_empty_2d_array_sentinel,
+                indices_wp,
+            ],
+            device=self._device,
+        )
+
+        if use_cached:
+            wp.synchronize()
+            return self._fabric_local_translations_ta, self._fabric_local_orientations_ta
+        return ProxyArray(translations_wp), ProxyArray(orientations_wp)
+
+    # ------------------------------------------------------------------
+    # Scales
+    # ------------------------------------------------------------------
+
+    def set_scales(self, scales, indices=None):
+        if not self._fabric_initialized:
+            self._initialize_fabric()
+
+        # Sync world matrices first if local writes are pending.
+        self._sync_world_from_local_if_dirty()
+
+        indices_wp = self._resolve_indices_wp(indices)
+        scales_wp = self._to_float32_2d_or_empty(scales)
+
+        wp.launch(
+            kernel=fabric_utils.compose_indexed_fabric_transforms,
+            dim=indices_wp.shape[0],
+            inputs=[
+                self._get_world_rw_array(),
+                self._fabric_empty_2d_array_sentinel,
+                self._fabric_empty_2d_array_sentinel,
                 scales_wp,
                 False,
                 False,
                 False,
                 indices_wp,
-                self._view_to_fabric,
             ],
-            device=self._fabric_device,
+            device=self._device,
         )
         wp.synchronize()
 
-        self._fabric_hierarchy.update_world_xforms()
-        self._fabric_usd_sync_done = True
+        # World was just written — recompute child localMatrix from parent worldMatrix
+        # so the next get_local_poses returns the new scale rather than the stale one.
+        self._sync_local_from_world(indices_wp)
 
     def get_scales(self, indices=None):
         if not self._fabric_initialized:
             self._initialize_fabric()
-        if not self._fabric_usd_sync_done:
-            self._sync_fabric_from_usd_once()
+
+        # Sync world matrices first if local writes are pending.
+        self._sync_world_from_local_if_dirty()
 
         indices_wp = self._resolve_indices_wp(indices)
         count = indices_wp.shape[0]
@@ -244,17 +361,16 @@ class FabricFrameView(BaseFrameView):
             scales_wp = wp.zeros((count, 3), dtype=wp.float32, device=self._device)
 
         wp.launch(
-            kernel=fabric_utils.decompose_fabric_transformation_matrix_to_warp_arrays,
+            kernel=fabric_utils.decompose_indexed_fabric_transforms,
             dim=count,
             inputs=[
-                self._fabric_world_matrices,
-                self._fabric_dummy_buffer,
-                self._fabric_dummy_buffer,
+                self._get_world_ro_array(),
+                self._fabric_empty_2d_array_sentinel,
+                self._fabric_empty_2d_array_sentinel,
                 scales_wp,
                 indices_wp,
-                self._view_to_fabric,
             ],
-            device=self._fabric_device,
+            device=self._device,
         )
 
         if use_cached:
@@ -262,72 +378,193 @@ class FabricFrameView(BaseFrameView):
         return scales_wp
 
     # ------------------------------------------------------------------
-    # Internal — PrepareForReuse (renderer notification + topology tracking)
+    # Internal — sync helpers
     # ------------------------------------------------------------------
 
-    def _prepare_for_reuse(self) -> None:
-        """Call PrepareForReuse on the PrimSelection to notify the renderer.
+    def _to_float32_2d_or_empty(self, data):
+        return self._fabric_empty_2d_array_sentinel if data is None else _to_float32_2d(data)
 
-        PrepareForReuse serves two purposes:
+    def _sync_world_from_local_if_dirty(self) -> None:
+        """If a prior local write left world matrices stale, recompute them on the fly.
 
-        1. **Renderer notification**: Tells FSD/Storm that Fabric data has
-           been (or will be) modified, so the next rendered frame reflects
-           the updated transforms.
-        2. **Topology change detection**: Returns True when Fabric's
-           internal memory layout changed (e.g., prims added/removed).
-           In that case, view-to-fabric index mappings and fabricarrays
-           must be rebuilt.
+        We deliberately do NOT call ``IFabricHierarchy.update_world_xforms()`` —
+        in practice that re-reads USD's authored xformOps and overwrites the Fabric
+        local+world matrices we just authored.  Instead we fire a Warp kernel that
+        does ``child_world = parent_world * child_local`` per child, leaving the
+        Fabric-side localMatrix untouched.
         """
-        if self._fabric_selection is None:
+        if not self._world_dirty:
             return
-
-        topology_changed = self._fabric_selection.PrepareForReuse()
-        if topology_changed:
-            logger.info("Fabric topology changed — rebuilding view-to-fabric index mapping.")
-            self._rebuild_fabric_arrays()
-
-    def _rebuild_fabric_arrays(self) -> None:
-        """Rebuild fabricarray and view↔fabric mappings after a topology change.
-
-        Note: Only index mappings and fabricarrays are rebuilt.  Position/orientation/scale
-        buffers are *not* resized because ``self.count`` is derived from the USD prim-path
-        pattern (via ``_usd_view.count``) and does not change when Fabric rearranges its
-        internal memory layout.  The assertion below guards this invariant.
-        """
-        if self.count != self._default_view_indices.shape[0]:
-            raise RuntimeError(
-                f"Prim count changed ({self.count} vs {self._default_view_indices.shape[0]}). "
-                "Fabric topology change added/removed tracked prims — full re-initialization required."
-            )
-        self._view_to_fabric = wp.zeros((self.count,), dtype=wp.uint32, device=self._fabric_device)
-        self._fabric_to_view = wp.fabricarray(self._fabric_selection, self._view_index_attr)
-
+        # Refresh trans_sel_ro once, then read _local_ifa_ro and _parent_world_ifa_ro
+        # directly to avoid calling PrepareForReuse twice on the same selection.
+        if self._trans_sel_ro.PrepareForReuse() or self._parent_world_ifa_ro is None:
+            self._rebuild_trans_ro_arrays()
         wp.launch(
-            kernel=fabric_utils.set_view_to_fabric_array,
-            dim=self._fabric_to_view.shape[0],
-            inputs=[self._fabric_to_view, self._view_to_fabric],
-            device=self._fabric_device,
+            kernel=fabric_utils.update_indexed_world_matrix_from_local,
+            dim=self.count,
+            inputs=[
+                self._local_ifa_ro,
+                self._parent_world_ifa_ro,
+                self._get_world_rw_array(),
+                self._view_indices,
+            ],
+            device=self._device,
+        )
+        wp.synchronize()
+        self._world_dirty = False
+
+    def _sync_local_from_world(self, indices_wp: wp.array) -> None:
+        """Recompute child ``localMatrix`` from (parent worldMatrix, child worldMatrix).
+
+        Called after ``set_world_poses`` so that subsequent ``get_local_poses`` returns
+        values consistent with the just-written world poses.  Fabric Hierarchy does
+        not provide a built-in world → local sync, so we do it via a Warp kernel
+        using the parent indexed fabric array.
+        """
+        # Refresh trans_sel_ro once; _world_ifa_ro and _parent_world_ifa_ro share it.
+        if self._trans_sel_ro.PrepareForReuse() or self._parent_world_ifa_ro is None:
+            self._rebuild_trans_ro_arrays()
+        wp.launch(
+            kernel=fabric_utils.update_indexed_local_matrix_from_world,
+            dim=indices_wp.shape[0],
+            inputs=[
+                self._world_ifa_ro,
+                self._parent_world_ifa_ro,
+                self._get_local_rw_array(),
+                indices_wp,
+            ],
+            device=self._device,
         )
         wp.synchronize()
 
-        self._fabric_world_matrices = wp.fabricarray(self._fabric_selection, "omni:fabric:worldMatrix")
+    # ------------------------------------------------------------------
+    # Internal — selection accessors with on-demand index rebuild
+    # ------------------------------------------------------------------
+
+    def _get_world_ro_array(self):
+        if self._trans_sel_ro.PrepareForReuse():
+            self._rebuild_trans_ro_arrays()
+        return self._world_ifa_ro
+
+    def _get_local_ro_array(self):
+        if self._trans_sel_ro.PrepareForReuse():
+            self._rebuild_trans_ro_arrays()
+        return self._local_ifa_ro
+
+    def _get_world_rw_array(self):
+        if self._world_sel_rw.PrepareForReuse():
+            self._world_rw_fabric_indices = self._compute_fabric_indices(self._world_sel_rw)
+            self._world_ifa_rw = self._build_indexed_array(
+                self._world_sel_rw, self._WORLD_MATRIX_NAME, self._world_rw_fabric_indices
+            )
+        return self._world_ifa_rw
+
+    def _get_local_rw_array(self):
+        if self._local_sel_rw.PrepareForReuse():
+            self._local_rw_fabric_indices = self._compute_fabric_indices(self._local_sel_rw)
+            self._local_ifa_rw = self._build_indexed_array(
+                self._local_sel_rw, self._LOCAL_MATRIX_NAME, self._local_rw_fabric_indices
+            )
+        return self._local_ifa_rw
+
+    def _get_parent_world_ro_array(self):
+        # Built and refreshed alongside the trans_ro selection (parents share that selection).
+        if self._parent_world_ifa_ro is None or self._trans_sel_ro.PrepareForReuse():
+            self._rebuild_trans_ro_arrays()
+        return self._parent_world_ifa_ro
+
+    def _rebuild_trans_ro_arrays(self) -> None:
+        """Rebuild the trans_ro indices and the three indexed arrays that depend on them.
+
+        ``_world_ifa_ro``, ``_local_ifa_ro`` and ``_parent_world_ifa_ro`` are all
+        keyed off the ``trans_sel_ro`` path ordering, so they are refreshed together.
+        """
+        self._trans_ro_fabric_indices = self._compute_fabric_indices(self._trans_sel_ro)
+        self._world_ifa_ro = self._build_indexed_array(
+            self._trans_sel_ro, self._WORLD_MATRIX_NAME, self._trans_ro_fabric_indices
+        )
+        self._local_ifa_ro = self._build_indexed_array(
+            self._trans_sel_ro, self._LOCAL_MATRIX_NAME, self._trans_ro_fabric_indices
+        )
+        self._parent_world_ifa_ro = self._build_parent_indexed_array(self._trans_sel_ro)
+
+    # ------------------------------------------------------------------
+    # Internal — index computation
+    # ------------------------------------------------------------------
+
+    def _compute_fabric_indices(self, selection) -> wp.array:
+        fabric_paths = selection.GetPaths()
+        path_to_fabric_idx: dict[str, int] = {str(p): i for i, p in enumerate(fabric_paths)}
+        indices: list[int] = []
+        for prim_path in self.prim_paths:
+            fabric_idx = path_to_fabric_idx.get(prim_path)
+            if fabric_idx is None:
+                raise RuntimeError(
+                    f"Prim '{prim_path}' not found in Fabric selection. Ensure the hierarchy has been populated."
+                )
+            indices.append(fabric_idx)
+        return wp.array(indices, dtype=wp.int32, device=self._device)
+
+    def _compute_parent_fabric_indices(self, selection) -> wp.array:
+        """For each child in this view, look up the parent prim's fabric index."""
+        fabric_paths = selection.GetPaths()
+        path_to_fabric_idx: dict[str, int] = {str(p): i for i, p in enumerate(fabric_paths)}
+        indices: list[int] = []
+        for prim_path in self.prim_paths:
+            parent_path = prim_path.rsplit("/", 1)[0]
+            if parent_path == "":
+                raise RuntimeError(
+                    f"Child prim '{prim_path}' is at stage root and has no parent prim. "
+                    "FabricFrameView requires every prim to have a non-pseudoroot parent "
+                    "with Fabric world+local matrices."
+                )
+            fabric_idx = path_to_fabric_idx.get(parent_path)
+            if fabric_idx is None:
+                raise RuntimeError(
+                    f"Parent prim '{parent_path}' (for child '{prim_path}') not found in Fabric selection. "
+                    "Ensure parents have Fabric world+local matrices populated."
+                )
+            indices.append(fabric_idx)
+        return wp.array(indices, dtype=wp.int32, device=self._device)
+
+    def _build_indexed_array(self, selection, attribute_name: str, fabric_indices: wp.array) -> wp.indexedfabricarray:
+        fa = wp.fabricarray(selection, attribute_name)
+        return wp.indexedfabricarray(fa=fa, indices=fabric_indices)
+
+    def _build_parent_indexed_array(self, selection) -> wp.indexedfabricarray:
+        self._parent_fabric_indices = self._compute_parent_fabric_indices(selection)
+        fa = wp.fabricarray(selection, self._WORLD_MATRIX_NAME)
+        return wp.indexedfabricarray(fa=fa, indices=self._parent_fabric_indices)
+
+    def _resolve_indices_wp(self, indices: wp.array | None) -> wp.array:
+        """Resolve view indices as a Warp uint32 array."""
+        if indices is None or indices == slice(None):
+            if self._view_indices is None:
+                raise RuntimeError("Fabric view indices are not initialized.")
+            return self._view_indices
+        if indices.dtype != wp.uint32:
+            return wp.array(indices.numpy().astype("uint32"), dtype=wp.uint32, device=self._device)
+        return indices
 
     # ------------------------------------------------------------------
     # Internal — Fabric initialization
     # ------------------------------------------------------------------
 
     def _initialize_fabric(self) -> None:
-        """Initialize Fabric batch infrastructure for GPU-accelerated pose queries."""
+        """One-time Fabric setup: hierarchy handle, attribute population, selections, indexed arrays."""
         import usdrt  # noqa: PLC0415
         from usdrt import Rt  # noqa: PLC0415
 
-        from isaaclab.sim import SimulationContext  # noqa: PLC0415
+        from isaaclab.sim.simulation_context import SimulationContext  # noqa: PLC0415
 
         from isaaclab_physx.sim.fabric_stage_cache import FabricStageCache  # noqa: PLC0415
 
         sim_context = SimulationContext.instance()
         if sim_context is None:
-            raise RuntimeError("SimulationContext must be initialized before FabricFrameView.")
+            raise RuntimeError(
+                "FabricFrameView requires an active SimulationContext. "
+                "Create a SimulationContext before instantiating FabricFrameView."
+            )
 
         # Get or create the FabricStageCache service.
         cache = sim_context.services[FabricStageCache]
@@ -335,96 +572,210 @@ class FabricFrameView(BaseFrameView):
             cache = FabricStageCache(sim_context.stage)
             sim_context.services[FabricStageCache] = cache
 
-        fabric_stage = cache.stage
+        self._stage = cache.stage
+        self._fabric_hierarchy, self._fabric_id = cache.get_hierarchy()
 
-        for i in range(self.count):
-            rt_prim = fabric_stage.GetPrimAtPath(self.prim_paths[i])
-            rt_xformable = Rt.Xformable(rt_prim)
-
-            has_attr = (
-                rt_xformable.HasFabricHierarchyWorldMatrixAttr()
-                if hasattr(rt_xformable, "HasFabricHierarchyWorldMatrixAttr")
-                else False
-            )
-            if not has_attr:
+        # Ensure each child prim AND its parent have BOTH Fabric world and local matrix
+        # attributes.  Our ``trans_ro`` selection requires both, so prims missing either
+        # would silently be excluded.  ``Create*Attr`` calls are idempotent.
+        #
+        # ``SetWorldXformFromUsd`` writes Fabric's worldMatrix from USD's accumulated
+        # local-to-world transform (so it picks up the parent chain).
+        # ``SetLocalXformFromUsd`` writes Fabric's localMatrix from USD's authored
+        # xformOps on this prim only.  Calling both gives Fabric a consistent
+        # (worldMatrix, localMatrix) pair for each prim before we touch the hierarchy.
+        seen_paths: set[str] = set()
+        for child_path in self.prim_paths:
+            for path in (child_path, child_path.rsplit("/", 1)[0]):
+                if path in seen_paths:
+                    continue
+                seen_paths.add(path)
+                rt_prim = self._stage.GetPrimAtPath(path)
+                if not rt_prim.IsValid():
+                    continue
+                rt_xformable = Rt.Xformable(rt_prim)
                 rt_xformable.CreateFabricHierarchyWorldMatrixAttr()
+                rt_xformable.CreateFabricHierarchyLocalMatrixAttr()
+                rt_xformable.SetLocalXformFromUsd()
+                rt_xformable.SetWorldXformFromUsd()
 
-            rt_xformable.SetWorldXformFromUsd()
+        # Three persistent selections — read both, write world, write local.
+        matrix = usdrt.Sdf.ValueTypeNames.Matrix4d
+        ro = usdrt.Usd.Access.Read
+        rw = usdrt.Usd.Access.ReadWrite
+        wm_ro = (matrix, self._WORLD_MATRIX_NAME, ro)
+        lm_ro = (matrix, self._LOCAL_MATRIX_NAME, ro)
+        wm_rw = (matrix, self._WORLD_MATRIX_NAME, rw)
+        lm_rw = (matrix, self._LOCAL_MATRIX_NAME, rw)
+        self._trans_sel_ro = self._stage.SelectPrims(require_attrs=[wm_ro, lm_ro], device=self._device, want_paths=True)
+        self._world_sel_rw = self._stage.SelectPrims(require_attrs=[wm_rw, lm_ro], device=self._device, want_paths=True)
+        self._local_sel_rw = self._stage.SelectPrims(require_attrs=[wm_ro, lm_rw], device=self._device, want_paths=True)
 
-            rt_prim.CreateAttribute(self._view_index_attr, usdrt.Sdf.ValueTypeNames.UInt, custom=True)
-            rt_prim.GetAttribute(self._view_index_attr).Set(i)
+        # Build the view-side indices array (just [0..count-1]) and a per-selection
+        # view→fabric mapping (selections do not guarantee a shared path ordering).
+        self._view_indices = wp.array(list(range(self.count)), dtype=wp.uint32, device=self._device)
+        self._trans_ro_fabric_indices = self._compute_fabric_indices(self._trans_sel_ro)
+        self._world_rw_fabric_indices = self._compute_fabric_indices(self._world_sel_rw)
+        self._local_rw_fabric_indices = self._compute_fabric_indices(self._local_sel_rw)
 
-        self._fabric_hierarchy, _ = cache.get_hierarchy()
-        self._fabric_hierarchy.update_world_xforms()
-
-        self._default_view_indices = wp.zeros((self.count,), dtype=wp.uint32, device=self._device)
-        wp.launch(
-            kernel=fabric_utils.arange_k, dim=self.count, inputs=[self._default_view_indices], device=self._device
+        # Indexed fabric arrays per (selection × attribute).
+        self._world_ifa_ro = self._build_indexed_array(
+            self._trans_sel_ro, self._WORLD_MATRIX_NAME, self._trans_ro_fabric_indices
         )
-        wp.synchronize()
+        self._local_ifa_ro = self._build_indexed_array(
+            self._trans_sel_ro, self._LOCAL_MATRIX_NAME, self._trans_ro_fabric_indices
+        )
+        self._world_ifa_rw = self._build_indexed_array(
+            self._world_sel_rw, self._WORLD_MATRIX_NAME, self._world_rw_fabric_indices
+        )
+        self._local_ifa_rw = self._build_indexed_array(
+            self._local_sel_rw, self._LOCAL_MATRIX_NAME, self._local_rw_fabric_indices
+        )
+        self._parent_world_ifa_ro = self._build_parent_indexed_array(self._trans_sel_ro)
 
-        if self._device not in _fabric_supported_devices:
-            raise RuntimeError(
-                f"Fabric mode is not supported on device '{self._device}'. "
-                f"Supported devices: {_fabric_supported_devices}"
-            )
+        # Pre-allocated reusable output buffers (world + local + scales).
+        self._fabric_positions_buf = wp.zeros((self.count, 3), dtype=wp.float32, device=self._device)
+        self._fabric_orientations_buf = wp.zeros((self.count, 4), dtype=wp.float32, device=self._device)
+        self._fabric_scales_buf = wp.zeros((self.count, 3), dtype=wp.float32, device=self._device)
+        self._fabric_local_translations_buf = wp.zeros((self.count, 3), dtype=wp.float32, device=self._device)
+        self._fabric_local_orientations_buf = wp.zeros((self.count, 4), dtype=wp.float32, device=self._device)
+        self._fabric_empty_2d_array_sentinel = wp.zeros((0, 0), dtype=wp.float32, device=self._device)
 
-        self._fabric_selection = fabric_stage.SelectPrims(
-            require_attrs=[
-                (usdrt.Sdf.ValueTypeNames.UInt, self._view_index_attr, usdrt.Usd.Access.Read),
-                (usdrt.Sdf.ValueTypeNames.Matrix4d, "omni:fabric:worldMatrix", usdrt.Usd.Access.ReadWrite),
+        self._fabric_positions_ta = ProxyArray(self._fabric_positions_buf)
+        self._fabric_orientations_ta = ProxyArray(self._fabric_orientations_buf)
+        self._fabric_local_translations_ta = ProxyArray(self._fabric_local_translations_buf)
+        self._fabric_local_orientations_ta = ProxyArray(self._fabric_local_orientations_buf)
+
+        self._fabric_initialized = True
+
+        # Seed Fabric matrices from USD authoritatively.  ``SetWorldXformFromUsd`` /
+        # ``SetLocalXformFromUsd`` are no-ops on freshly authored stages that haven't
+        # been rendered yet; we instead read through the USD view (children) and
+        # ``UsdGeom.XformCache`` (parents) and write via the same compose kernel that
+        # ``set_world_poses`` uses.
+        self._sync_fabric_from_usd_initial()
+
+    def _sync_fabric_from_usd_initial(self) -> None:
+        """Populate Fabric world+local matrices for children and parents from USD.
+
+        Performed once during ``_initialize_fabric``.  Without this step Fabric's
+        matrices are identity for stages that haven't been rendered yet, and our
+        getters (which read from Fabric) would return wrong values.
+        """
+        # --- Children ---
+        pos_ta, ori_ta = self._usd_view.get_world_poses()
+        scales_obj = self._usd_view.get_scales()
+        scales_wp = (
+            scales_obj.warp
+            if hasattr(scales_obj, "warp")
+            else scales_obj
+            if isinstance(scales_obj, wp.array)
+            else self._fabric_empty_2d_array_sentinel
+        )
+        local_pos_ta, local_ori_ta = self._usd_view.get_local_poses()
+        # Compose into child worldMatrix.
+        wp.launch(
+            kernel=fabric_utils.compose_indexed_fabric_transforms,
+            dim=self.count,
+            inputs=[
+                self._world_ifa_rw,
+                _to_float32_2d(pos_ta.warp),
+                _to_float32_2d(ori_ta.warp),
+                _to_float32_2d(scales_wp),
+                False,
+                False,
+                False,
+                self._view_indices,
+            ],
+            device=self._device,
+        )
+        # Compose into child localMatrix.  Pass the locally-authored scale so
+        # that a subsequent ``_sync_world_from_local_if_dirty`` produces the
+        # right world-space scale (``world = parent_world * local`` carries
+        # ``local``'s scale through the multiply).
+        wp.launch(
+            kernel=fabric_utils.compose_indexed_fabric_transforms,
+            dim=self.count,
+            inputs=[
+                self._local_ifa_rw,
+                _to_float32_2d(local_pos_ta.warp),
+                _to_float32_2d(local_ori_ta.warp),
+                _to_float32_2d(scales_wp),
+                False,
+                False,
+                False,
+                self._view_indices,
             ],
             device=self._device,
         )
 
-        self._view_to_fabric = wp.zeros((self.count,), dtype=wp.uint32, device=self._device)
-        self._fabric_to_view = wp.fabricarray(self._fabric_selection, self._view_index_attr)
+        # --- Parents (one entry per unique parent path) ---
+        unique_parent_paths = list(dict.fromkeys(p.rsplit("/", 1)[0] for p in self.prim_paths))
+        if unique_parent_paths:
+            from isaaclab.sim.utils import get_current_stage  # noqa: PLC0415
 
-        wp.launch(
-            kernel=fabric_utils.set_view_to_fabric_array,
-            dim=self._fabric_to_view.shape[0],
-            inputs=[self._fabric_to_view, self._view_to_fabric],
-            device=self._device,
-        )
+            usd_stage = get_current_stage()
+            xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
+            world_pos_rows: list[list[float]] = []
+            world_ori_rows: list[list[float]] = []
+            world_scale_rows: list[list[float]] = []
+            decomposer = Gf.Transform()
+            for path in unique_parent_paths:
+                prim = usd_stage.GetPrimAtPath(path)
+                tf = xform_cache.GetLocalToWorldTransform(prim)
+                # Extract scale before ``Orthonormalize`` strips it from the rows.
+                decomposer.SetMatrix(tf)
+                s = decomposer.GetScale()
+                tf.Orthonormalize()
+                t = tf.ExtractTranslation()
+                q = tf.ExtractRotationQuat()
+                img, real = q.GetImaginary(), q.GetReal()
+                world_pos_rows.append([float(t[0]), float(t[1]), float(t[2])])
+                world_ori_rows.append([float(img[0]), float(img[1]), float(img[2]), float(real)])
+                world_scale_rows.append([float(s[0]), float(s[1]), float(s[2])])
+            parent_view_indices = wp.array(list(range(len(unique_parent_paths))), dtype=wp.uint32, device=self._device)
+            parent_pos_wp = wp.array(world_pos_rows, dtype=wp.float32, device=self._device)
+            parent_ori_wp = wp.array(world_ori_rows, dtype=wp.float32, device=self._device)
+            parent_scale_wp = wp.array(world_scale_rows, dtype=wp.float32, device=self._device)
+            # Compose worldMatrix for parents (use a one-shot indexed array against
+            # ``world_sel_rw`` keyed on the unique parent paths).
+            parent_world_rw = wp.indexedfabricarray(
+                fa=wp.fabricarray(self._world_sel_rw, self._WORLD_MATRIX_NAME),
+                indices=self._compute_fabric_indices_for(self._world_sel_rw, unique_parent_paths),
+            )
+            wp.launch(
+                kernel=fabric_utils.compose_indexed_fabric_transforms,
+                dim=len(unique_parent_paths),
+                inputs=[
+                    parent_world_rw,
+                    parent_pos_wp,
+                    parent_ori_wp,
+                    parent_scale_wp,
+                    False,
+                    False,
+                    False,
+                    parent_view_indices,
+                ],
+                device=self._device,
+            )
         wp.synchronize()
 
-        self._fabric_positions_buf = wp.zeros((self.count, 3), dtype=wp.float32, device=self._device)
-        self._fabric_orientations_buf = wp.zeros((self.count, 4), dtype=wp.float32, device=self._device)
-        self._fabric_positions_ta = ProxyArray(self._fabric_positions_buf)
-        self._fabric_orientations_ta = ProxyArray(self._fabric_orientations_buf)
-        self._fabric_scales_buf = wp.zeros((self.count, 3), dtype=wp.float32, device=self._device)
-        self._fabric_dummy_buffer = wp.zeros((0, 3), dtype=wp.float32, device=self._device)
-        self._fabric_world_matrices = wp.fabricarray(self._fabric_selection, "omni:fabric:worldMatrix")
-        self._fabric_stage = fabric_stage
-        self._fabric_device = self._device
+        # The child worldMatrix above was composed with the child's *local* scale,
+        # which is wrong whenever a parent has a non-unit world scale.  Mark the
+        # view dirty so the next world read fires ``_sync_world_from_local_if_dirty``
+        # and recomputes ``child_world = parent_world * child_local`` — that
+        # multiply produces the correct world-space scale because the parent and
+        # local matrices now both carry the right scale (seeded above).
+        self._world_dirty = True
 
-        self._fabric_initialized = True
-        self._fabric_usd_sync_done = False
-
-    def _sync_fabric_from_usd_once(self) -> None:
-        """Sync Fabric world matrices from USD once, on the first read.
-
-        Combines position/orientation/scale into a single Fabric write so
-        :meth:`_prepare_for_reuse` (and its underlying ``PrepareForReuse``) is invoked
-        exactly once across the full sync.
-        """
-        if not self._fabric_initialized:
-            self._initialize_fabric()
-
-        positions_usd_ta, orientations_usd_ta = self._usd_view.get_world_poses()
-        scales_usd = self._usd_view.get_scales()
-        self._compose_fabric_transform(
-            positions=positions_usd_ta.warp,
-            orientations=orientations_usd_ta.warp,
-            scales=scales_usd,
-        )
-
-    def _resolve_indices_wp(self, indices: wp.array | None) -> wp.array:
-        """Resolve view indices as a Warp uint32 array."""
-        if indices is None or indices == slice(None):
-            if self._default_view_indices is None:
-                raise RuntimeError("Fabric indices are not initialized.")
-            return self._default_view_indices
-        if indices.dtype != wp.uint32:
-            return wp.array(indices.numpy().astype("uint32"), dtype=wp.uint32, device=self._device)
-        return indices
+    def _compute_fabric_indices_for(self, selection, paths: list[str]) -> wp.array:
+        """Path-dict lookup helper used to build one-shot indexed arrays for a custom path set."""
+        fabric_paths = selection.GetPaths()
+        path_to_idx = {str(p): i for i, p in enumerate(fabric_paths)}
+        indices: list[int] = []
+        for path in paths:
+            idx = path_to_idx.get(path)
+            if idx is None:
+                raise RuntimeError(f"Path '{path}' not found in Fabric selection.")
+            indices.append(idx)
+        return wp.array(indices, dtype=wp.int32, device=self._device)

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -15,19 +15,12 @@ import warp as wp
 from pxr import Usd
 
 import isaaclab.sim as sim_utils
-from isaaclab.app.settings_manager import SettingsManager
 from isaaclab.sim.views.base_frame_view import BaseFrameView
 from isaaclab.sim.views.usd_frame_view import UsdFrameView
 from isaaclab.utils.warp import ProxyArray
 from isaaclab.utils.warp import fabric as fabric_utils
 
 logger = logging.getLogger(__name__)
-
-# TODO: extend this to ``cuda:N`` once we wire up multi-GPU support for the view.
-# Recent Kit / USDRT releases do support multi-GPU ``SelectPrims``, but the
-# rest of the FabricFrameView wiring (selections, indexed arrays, etc.) still
-# assumes a single device — to be tackled in a follow-up.
-_fabric_supported_devices = ("cpu", "cuda", "cuda:0")
 
 
 def _to_float32_2d(a: wp.array | torch.Tensor) -> wp.array | torch.Tensor:
@@ -49,19 +42,20 @@ def _to_float32_2d(a: wp.array | torch.Tensor) -> wp.array | torch.Tensor:
 class FabricFrameView(BaseFrameView):
     """FrameView with Fabric GPU acceleration for the PhysX backend.
 
-    Uses composition: holds a :class:`UsdFrameView` internally for USD
-    fallback and non-accelerated operations (local poses, visibility, scales
-    when Fabric is disabled).
+    This class is only instantiated when Fabric is enabled and the device is
+    supported.  The :class:`~isaaclab.sim.views.FrameView` factory dispatches
+    to :class:`~isaaclab.sim.views.UsdFrameView` otherwise.
 
-    When Fabric is enabled, world-pose and scale operations use Warp kernels
-    operating on ``omni:fabric:worldMatrix``.  All other operations delegate
-    to the internal USD view.
+    Uses composition: holds a :class:`UsdFrameView` internally for operations
+    that don't have a Fabric-accelerated path (local poses, visibility).
 
-    After every Fabric write (``set_world_poses``, ``set_scales``),
-    :meth:`PrepareForReuse` is called on the ``PrimSelection`` to notify
-    the FSD renderer that Fabric data has changed and to detect topology
-    changes that require rebuilding internal mappings.  Read operations
-    do not call PrepareForReuse to avoid unnecessary renderer invalidation.
+    World-pose and scale operations use Warp kernels operating on
+    ``omni:fabric:worldMatrix``.  After every Fabric write
+    (``set_world_poses``, ``set_scales``), :meth:`PrepareForReuse` is called
+    on the ``PrimSelection`` to notify the FSD renderer that Fabric data has
+    changed and to detect topology changes that require rebuilding internal
+    mappings.  Read operations do not call PrepareForReuse to avoid
+    unnecessary renderer invalidation.
 
     Pose getters return :class:`~isaaclab.utils.warp.ProxyArray`.  Setters accept ``wp.array``.
     """
@@ -88,18 +82,6 @@ class FabricFrameView(BaseFrameView):
         """
         self._usd_view = UsdFrameView(prim_path, device=device, validate_xform_ops=validate_xform_ops, stage=stage)
         self._device = device
-
-        settings = SettingsManager.instance()
-        self._use_fabric = bool(settings.get("/physics/fabricEnabled", False))
-
-        if self._use_fabric and self._device not in _fabric_supported_devices:
-            logger.warning(
-                f"Fabric mode is not supported on device '{self._device}'. "
-                "USDRT SelectPrims and Warp fabric arrays are currently "
-                f"only supported on {', '.join(_fabric_supported_devices)}. "
-                "Falling back to standard USD operations. This may impact performance."
-            )
-            self._use_fabric = False
 
         self._fabric_initialized = False
         self._fabric_usd_sync_done = False
@@ -146,10 +128,6 @@ class FabricFrameView(BaseFrameView):
     # ------------------------------------------------------------------
 
     def set_world_poses(self, positions=None, orientations=None, indices=None):
-        if not self._use_fabric:
-            self._usd_view.set_world_poses(positions, orientations, indices)
-            return
-
         if not self._fabric_initialized:
             self._initialize_fabric()
 
@@ -188,9 +166,6 @@ class FabricFrameView(BaseFrameView):
         self._fabric_usd_sync_done = True
 
     def get_world_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
-        if not self._use_fabric:
-            return self._usd_view.get_world_poses(indices)
-
         if not self._fabric_initialized:
             self._initialize_fabric()
         if not self._fabric_usd_sync_done:
@@ -241,10 +216,6 @@ class FabricFrameView(BaseFrameView):
     # ------------------------------------------------------------------
 
     def set_scales(self, scales, indices=None):
-        if not self._use_fabric:
-            self._usd_view.set_scales(scales, indices)
-            return
-
         if not self._fabric_initialized:
             self._initialize_fabric()
 
@@ -279,9 +250,6 @@ class FabricFrameView(BaseFrameView):
         self._fabric_usd_sync_done = True
 
     def get_scales(self, indices=None):
-        if not self._use_fabric:
-            return self._usd_view.get_scales(indices)
-
         if not self._fabric_initialized:
             self._initialize_fabric()
         if not self._fabric_usd_sync_done:
@@ -403,9 +371,6 @@ class FabricFrameView(BaseFrameView):
             kernel=fabric_utils.arange_k, dim=self.count, inputs=[self._default_view_indices], device=self._device
         )
         wp.synchronize()
-
-        # The constructor should have taken care of this, but double check here to avoid regressions
-        assert self._device in _fabric_supported_devices
 
         self._fabric_selection = fabric_stage.SelectPrims(
             require_attrs=[

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -14,7 +14,6 @@ import warp as wp
 
 from pxr import Usd
 
-import isaaclab.sim as sim_utils
 from isaaclab.app.settings_manager import SettingsManager
 from isaaclab.sim.views.base_frame_view import BaseFrameView
 from isaaclab.sim.views.usd_frame_view import UsdFrameView
@@ -373,8 +372,21 @@ class FabricFrameView(BaseFrameView):
         import usdrt  # noqa: PLC0415
         from usdrt import Rt  # noqa: PLC0415
 
-        stage_id = sim_utils.get_current_stage_id()
-        fabric_stage = usdrt.Usd.Stage.Attach(stage_id)
+        from isaaclab.sim import SimulationContext  # noqa: PLC0415
+
+        from isaaclab_physx.sim.fabric_stage_cache import FabricStageCache  # noqa: PLC0415
+
+        sim_context = SimulationContext.instance()
+        if sim_context is None:
+            raise RuntimeError("SimulationContext must be initialized before FabricFrameView.")
+
+        # Get or create the FabricStageCache service.
+        cache = sim_context.services[FabricStageCache]
+        if cache is None:
+            cache = FabricStageCache(sim_context.stage)
+            sim_context.services[FabricStageCache] = cache
+
+        fabric_stage = cache.stage
 
         for i in range(self.count):
             rt_prim = fabric_stage.GetPrimAtPath(self.prim_paths[i])
@@ -393,9 +405,7 @@ class FabricFrameView(BaseFrameView):
             rt_prim.CreateAttribute(self._view_index_attr, usdrt.Sdf.ValueTypeNames.UInt, custom=True)
             rt_prim.GetAttribute(self._view_index_attr).Set(i)
 
-        self._fabric_hierarchy = usdrt.hierarchy.IFabricHierarchy().get_fabric_hierarchy(
-            fabric_stage.GetFabricId(), fabric_stage.GetStageIdAsStageId()
-        )
+        self._fabric_hierarchy, _ = cache.get_hierarchy()
         self._fabric_hierarchy.update_world_xforms()
 
         self._default_view_indices = wp.zeros((self.count,), dtype=wp.uint32, device=self._device)
@@ -404,8 +414,11 @@ class FabricFrameView(BaseFrameView):
         )
         wp.synchronize()
 
-        # The constructor should have taken care of this, but double check here to avoid regressions
-        assert self._device in _fabric_supported_devices
+        if self._device not in _fabric_supported_devices:
+            raise RuntimeError(
+                f"Fabric mode is not supported on device '{self._device}'. "
+                f"Supported devices: {_fabric_supported_devices}"
+            )
 
         self._fabric_selection = fabric_stage.SelectPrims(
             require_attrs=[

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -23,12 +23,6 @@ from isaaclab.utils.warp import fabric as fabric_utils
 
 logger = logging.getLogger(__name__)
 
-# TODO: extend this to ``cuda:N`` once we wire up multi-GPU support for the view.
-# Recent Kit / USDRT releases do support multi-GPU ``SelectPrims``, but the
-# rest of the FabricFrameView wiring (selections, indexed arrays, etc.) still
-# assumes a single device — to be tackled in a follow-up.
-# Fabric acceleration is supported on any CUDA device (cuda:0, cuda:1, etc.) and CPU.
-
 
 def _to_float32_2d(a: wp.array | torch.Tensor) -> wp.array | torch.Tensor:
     """Ensure array is compatible with Fabric kernels (2-D float32).
@@ -96,6 +90,9 @@ class FabricFrameView(BaseFrameView):
 
         settings = SettingsManager.instance()
         self._use_fabric = bool(settings.get("/physics/fabricEnabled", False))
+        # TODO(pv): Misleading abstraction — FabricFrameView can fall back to USD internally;
+        # the concrete class should be determined by the factory instead. (PR #5673 pv/fabric-view-no-fallback)
+        # TODO(pv): Fuse set_world_poses/set_scales into single kernel launch (PR #5674 pv/fabric-fused-compose)
 
         self._fabric_initialized = False
         self._fabric_usd_sync_done = False
@@ -399,8 +396,6 @@ class FabricFrameView(BaseFrameView):
             kernel=fabric_utils.arange_k, dim=self.count, inputs=[self._default_view_indices], device=self._device
         )
         wp.synchronize()
-
-        # Fabric acceleration is supported on any device; no allowlist check needed.
 
         self._fabric_selection = fabric_stage.SelectPrims(
             require_attrs=[

--- a/source/isaaclab_physx/test/sim/test_fabric_stage_cache.py
+++ b/source/isaaclab_physx/test/sim/test_fabric_stage_cache.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for FabricStageCache service lifecycle."""
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True).app
+
+import pytest  # noqa: E402
+
+import isaaclab.sim as sim_utils  # noqa: E402
+from isaaclab.sim import SimulationContext  # noqa: E402
+from isaaclab_physx.sim.fabric_stage_cache import FabricStageCache  # noqa: E402
+
+pytestmark = pytest.mark.isaacsim_ci
+
+
+@pytest.fixture(autouse=True)
+def setup_teardown():
+    """Create and clear stage for each test."""
+    sim_utils.create_new_stage()
+    sim_utils.update_stage()
+    yield
+    if SimulationContext.instance() is not None:
+        sim_utils.clear_stage()
+        SimulationContext.clear_instance()
+
+
+class TestFabricStageCacheService:
+    """Test that FabricStageCache integrates with SimulationContext's service locator."""
+
+    def test_register_and_retrieve(self):
+        """Service can be registered and retrieved via services[]."""
+        sim_context = SimulationContext()
+        cache = FabricStageCache(sim_context.stage)
+        sim_context.services[FabricStageCache] = cache
+
+        retrieved = sim_context.services[FabricStageCache]
+        assert retrieved is cache
+
+    def test_stage_attached(self):
+        """The cached usdrt stage is not None after construction."""
+        sim_context = SimulationContext()
+        cache = FabricStageCache(sim_context.stage)
+        assert cache.stage is not None
+
+    def test_get_hierarchy_returns_handle(self):
+        """get_hierarchy returns a hierarchy handle and fabric id."""
+        sim_context = SimulationContext()
+        cache = FabricStageCache(sim_context.stage)
+
+        hierarchy, fabric_id_int = cache.get_hierarchy()
+        assert hierarchy is not None
+        assert isinstance(fabric_id_int, int)
+
+    def test_get_hierarchy_is_cached(self):
+        """Repeated calls return the same hierarchy handle."""
+        sim_context = SimulationContext()
+        cache = FabricStageCache(sim_context.stage)
+
+        h1, id1 = cache.get_hierarchy()
+        h2, id2 = cache.get_hierarchy()
+        assert h1 is h2
+        assert id1 == id2
+
+    def test_close_clears_state(self):
+        """close() clears internal caches."""
+        sim_context = SimulationContext()
+        cache = FabricStageCache(sim_context.stage)
+        cache.get_hierarchy()  # populate cache
+        cache.close()
+        assert cache.stage is None
+
+    def test_clear_instance_closes_service(self):
+        """SimulationContext.clear_instance() calls close() on registered services."""
+        sim_context = SimulationContext()
+        cache = FabricStageCache(sim_context.stage)
+        sim_context.services[FabricStageCache] = cache
+
+        SimulationContext.clear_instance()
+
+        # After clear_instance, the cache should have been closed
+        assert cache.stage is None
+
+    def test_replacement_caller_closes_old(self):
+        """Caller is responsible for closing old service before replacing."""
+        sim_context = SimulationContext()
+        cache1 = FabricStageCache(sim_context.stage)
+        sim_context.services[FabricStageCache] = cache1
+
+        cache1.close()
+        cache2 = FabricStageCache(sim_context.stage)
+        sim_context.services[FabricStageCache] = cache2
+
+        # Old cache was closed by caller
+        assert cache1.stage is None
+        # New cache should be active
+        assert cache2.stage is not None

--- a/source/isaaclab_physx/test/sim/test_fabric_stage_cache.py
+++ b/source/isaaclab_physx/test/sim/test_fabric_stage_cache.py
@@ -10,10 +10,10 @@ from isaaclab.app import AppLauncher
 simulation_app = AppLauncher(headless=True).app
 
 import pytest  # noqa: E402
+from isaaclab_physx.sim.fabric_stage_cache import FabricStageCache  # noqa: E402
 
 import isaaclab.sim as sim_utils  # noqa: E402
 from isaaclab.sim import SimulationContext  # noqa: E402
-from isaaclab_physx.sim.fabric_stage_cache import FabricStageCache  # noqa: E402
 
 pytestmark = pytest.mark.isaacsim_ci
 

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -593,3 +593,179 @@ def test_fabric_cuda1_scales_roundtrip(device, view_factory):
     scales_torch = torch.as_tensor(ret_scales, device=device)
     expected = torch.tensor([[2.0, 3.0, 4.0], [2.0, 3.0, 4.0]], device=device)
     assert torch.allclose(scales_torch, expected, atol=1e-7), f"Scales roundtrip failed on {device}: {scales_torch}"
+
+
+# ------------------------------------------------------------------
+# Interleaved set_world_poses / set_local_poses tests
+# ------------------------------------------------------------------
+
+
+def _build_two_child_view(device: str) -> "FrameView":
+    """Build a 2-env FabricFrameView with rotated parent for interleave tests.
+
+    Parent at (0, 0, 1) rotated 90° around Z.  Two child prims at identity local.
+    """
+    _skip_if_unavailable(device)
+    stage = sim_utils.get_current_stage()
+    for i in range(2):
+        sim_utils.create_prim(
+            f"/World/Parent_{i}",
+            "Xform",
+            translation=_ROTATED_PARENT_POS,
+            orientation=_ROTATED_PARENT_QUAT_XYZW,
+            stage=stage,
+        )
+        sim_utils.create_prim(f"/World/Parent_{i}/Child", "Camera", translation=(0.0, 0.0, 0.0), stage=stage)
+    sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01, device=device, use_fabric=True))
+    view = FrameView("/World/Parent_.*/Child", device=device)
+    view.get_world_poses()  # force init
+    return view
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_interleaved_set_world_then_set_local_partial_indices(device):
+    """set_world_poses on index 0, then set_local_poses on index 1 — both must be correct.
+
+    This exercises the dirty-flag flush: after set_world_poses marks _local_dirty,
+    set_local_poses must flush stale locals before writing index 1, ensuring index 0's
+    local is correctly derived from its new world pose.
+    """
+    view = _build_two_child_view(device)
+
+    # Step 1: set world pose on index 0 only
+    new_world_pos = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_world_pos, 5.0, 0.0, 2.0], device=device)
+    idx0 = wp.from_torch(torch.tensor([0], dtype=torch.int32, device=device))
+    view.set_world_poses(positions=new_world_pos, indices=idx0)
+
+    # Step 2: set local pose on index 1 only
+    new_local_pos = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_local_pos, 1.0, 0.0, 0.0], device=device)
+    identity_quat = wp.from_torch(torch.tensor([[0.0, 0.0, 0.0, 1.0]], dtype=torch.float32, device=device))
+    idx1 = wp.from_torch(torch.tensor([1], dtype=torch.int32, device=device))
+    view.set_local_poses(translations=new_local_pos, orientations=identity_quat, indices=idx1)
+
+    # Verify index 0's world pose is still (5, 0, 2)
+    world_pos, _ = view.get_world_poses(indices=idx0)
+    torch.testing.assert_close(
+        world_pos.torch,
+        torch.tensor([[5.0, 0.0, 2.0]], dtype=torch.float32, device=device),
+        atol=1e-5, rtol=0,
+    )
+
+    # Verify index 0's local pose (derived from world):
+    # local = Rᵀ · (child_world_pos - parent_pos) = Rz(-90)·(5, 0, 1) = (0, -5, 1)
+    local_pos_0, _ = view.get_local_poses(indices=idx0)
+    torch.testing.assert_close(
+        local_pos_0.torch,
+        torch.tensor([[0.0, -5.0, 1.0]], dtype=torch.float32, device=device),
+        atol=1e-5, rtol=0,
+    )
+
+    # Verify index 1's world pose (derived from local):
+    # world = parent_world * local = Rz(90)·(1, 0, 0) + parent_pos = (0, 1, 0) + (0, 0, 1) = (0, 1, 1)
+    world_pos_1, _ = view.get_world_poses(indices=idx1)
+    torch.testing.assert_close(
+        world_pos_1.torch,
+        torch.tensor([[0.0, 1.0, 1.0]], dtype=torch.float32, device=device),
+        atol=1e-5, rtol=0,
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_interleaved_set_local_then_set_world_partial_indices(device):
+    """set_local_poses on index 0, then set_world_poses on index 1 — both must be correct.
+
+    The reverse direction of the above: after set_local_poses marks _world_dirty,
+    set_world_poses must flush stale worlds before writing index 1.
+    """
+    view = _build_two_child_view(device)
+
+    # Step 1: set local pose on index 0 only
+    new_local_pos = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_local_pos, 2.0, 3.0, 0.0], device=device)
+    identity_quat = wp.from_torch(torch.tensor([[0.0, 0.0, 0.0, 1.0]], dtype=torch.float32, device=device))
+    idx0 = wp.from_torch(torch.tensor([0], dtype=torch.int32, device=device))
+    view.set_local_poses(translations=new_local_pos, orientations=identity_quat, indices=idx0)
+
+    # Step 2: set world pose on index 1 only
+    new_world_pos = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_world_pos, 10.0, 20.0, 30.0], device=device)
+    idx1 = wp.from_torch(torch.tensor([1], dtype=torch.int32, device=device))
+    view.set_world_poses(positions=new_world_pos, indices=idx1)
+
+    # Verify index 0's world pose (derived from local):
+    # world = Rz(90)·(2, 3, 0) + (0, 0, 1) = (-3, 2, 0) + (0, 0, 1) = (-3, 2, 1)
+    world_pos_0, _ = view.get_world_poses(indices=idx0)
+    torch.testing.assert_close(
+        world_pos_0.torch,
+        torch.tensor([[-3.0, 2.0, 1.0]], dtype=torch.float32, device=device),
+        atol=1e-5, rtol=0,
+    )
+
+    # Verify index 1's world pose is still (10, 20, 30)
+    world_pos_1, _ = view.get_world_poses(indices=idx1)
+    torch.testing.assert_close(
+        world_pos_1.torch,
+        torch.tensor([[10.0, 20.0, 30.0]], dtype=torch.float32, device=device),
+        atol=1e-5, rtol=0,
+    )
+
+    # Verify index 1's local (derived from world):
+    # local = Rᵀ·(world - parent) = Rz(-90)·(10, 20, 29) = (20, -10, 29)
+    local_pos_1, _ = view.get_local_poses(indices=idx1)
+    torch.testing.assert_close(
+        local_pos_1.torch,
+        torch.tensor([[20.0, -10.0, 29.0]], dtype=torch.float32, device=device),
+        atol=1e-5, rtol=0,
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_interleaved_set_emits_warning(device, caplog):
+    """Interleaving set_world_poses and set_local_poses logs a one-time warning."""
+    view = _build_two_child_view(device)
+
+    # First set_world_poses — no warning (first user setter)
+    new_world = wp.zeros((2, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=2, inputs=[new_world, 1.0, 2.0, 3.0], device=device)
+    view.set_world_poses(positions=new_world)
+
+    # Now set_local_poses — should trigger warning about interleaving
+    new_local = wp.zeros((2, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=2, inputs=[new_local, 0.0, 0.0, 0.0], device=device)
+    identity_quat = wp.from_torch(torch.tensor([[0.0, 0.0, 0.0, 1.0]] * 2, dtype=torch.float32, device=device))
+
+    with caplog.at_level("WARNING", logger="isaaclab_physx.sim.views.fabric_frame_view"):
+        caplog.clear()
+        view.set_local_poses(translations=new_local, orientations=identity_quat)
+
+    assert any("interleaving" in r.message.lower() for r in caplog.records), (
+        f"Expected interleave warning, got: {[r.message for r in caplog.records]}"
+    )
+
+    # Second interleave — warning should NOT repeat (one-time only)
+    caplog.clear()
+    view.set_world_poses(positions=new_world)
+    assert not any("interleaving" in r.message.lower() for r in caplog.records), (
+        "Warning should only fire once per view instance"
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_no_warning_when_using_single_setter(device, caplog):
+    """Calling only set_world_poses (or only set_local_poses) should never warn."""
+    view = _build_two_child_view(device)
+
+    new_world = wp.zeros((2, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=2, inputs=[new_world, 1.0, 2.0, 3.0], device=device)
+
+    with caplog.at_level("WARNING", logger="isaaclab_physx.sim.views.fabric_frame_view"):
+        caplog.clear()
+        view.set_world_poses(positions=new_world)
+        view.set_world_poses(positions=new_world)
+        view.set_world_poses(positions=new_world)
+
+    assert not any("interleaving" in r.message.lower() for r in caplog.records), (
+        f"Unexpected interleave warning with single setter: {[r.message for r in caplog.records]}"
+    )

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -273,7 +273,7 @@ def test_fabric_cuda1_world_pose_roundtrip(device, view_factory):
     view.set_world_poses(positions=new_pos)
 
     ret_pos, _ = view.get_world_poses()
-    pos_torch = wp.to_torch(ret_pos)
+    pos_torch = ret_pos.torch
     expected = torch.tensor([[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]], device=device)
     assert torch.allclose(pos_torch, expected, atol=1e-7), f"Roundtrip failed on {device}: {pos_torch}"
 

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -23,7 +23,7 @@ import pytest  # noqa: E402
 import torch  # noqa: E402
 import warp as wp  # noqa: E402
 from frame_view_contract_utils import *  # noqa: F401, F403, E402
-from frame_view_contract_utils import CHILD_OFFSET, ViewBundle, test_set_world_updates_local  # noqa: E402
+from frame_view_contract_utils import CHILD_OFFSET, ViewBundle  # noqa: E402
 from isaaclab_physx.sim.views import FabricFrameView as FrameView  # noqa: E402
 
 from pxr import Gf, UsdGeom  # noqa: E402
@@ -106,28 +106,11 @@ def view_factory():
 
 
 # ------------------------------------------------------------------
-# Override shared contract test with expected failure for Fabric.
-# FabricFrameView.set_world_poses writes to Fabric worldMatrix only; the local
-# pose (read via USD) does not reflect the change because there is no
-# Fabric → USD writeback for local poses.  This is tracked as Issue #5
-# (localMatrix: set_local_poses falls back to USD).
+# Override: ensure the shared contract test runs without xfail now that
+# get_local_poses computes local from Fabric world matrices.
 # ------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
-@pytest.mark.xfail(
-    reason=(
-        "Issue #5: FabricFrameView.set_world_poses writes to Fabric worldMatrix only. "
-        "get_local_poses reads from stale USD because there is no Fabric→USD "
-        "writeback for local poses."
-    ),
-    strict=True,
-)
-def test_set_world_updates_local(device, view_factory):  # noqa: F811
-    """Override the shared test to mark it as expected failure."""
-    from frame_view_contract_utils import test_set_world_updates_local as _impl  # noqa: PLC0415
-
-    _impl(device, view_factory)
+# (No override needed — the shared test_set_world_updates_local from
+#  frame_view_contract_utils is imported via wildcard and will run as-is.)
 
 
 # ------------------------------------------------------------------
@@ -188,48 +171,327 @@ def test_fabric_set_world_does_not_write_back_to_usd(device, view_factory):
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
-def test_fabric_rebuild_after_topology_change(device, view_factory, monkeypatch):
-    """Forcing the topology-changed branch on a write triggers
-    :meth:`_rebuild_fabric_arrays` and leaves the view in a state where
-    subsequent writes/reads still produce correct data.
+def test_fabric_rebuild_after_topology_change(device, view_factory):
+    """A simulated topology change rebuilds the indexed fabric arrays and leaves
+    the view in a state where subsequent writes/reads still produce correct data.
 
-    Real ``PrimSelection.PrepareForReuse`` reports topology change only when
-    Fabric reallocates internally, which is hard to provoke from a unit test.
-    Instead we monkeypatch ``_prepare_for_reuse`` on the instance to always
-    take the rebuild branch and verify the view remains usable.
+    Real ``PrimSelection.PrepareForReuse`` reports topology change only when Fabric
+    reallocates internally, which is hard to provoke from a unit test.  Instead we
+    invoke :meth:`FabricFrameView._compute_fabric_indices` and rebuild the indexed
+    arrays manually, mimicking what ``_get_*_array`` would do on a real topology
+    event, then verify a roundtrip still works.
     """
     bundle = view_factory(2, device)
     view = bundle.view
 
-    # First write — initializes Fabric and binds _fabric_selection.
+    # First write — initializes Fabric.
     initial = wp.zeros((2, 3), dtype=wp.float32, device=device)
     wp.launch(kernel=_fill_position, dim=2, inputs=[initial, 1.0, 2.0, 3.0], device=device)
     view.set_world_poses(positions=initial)
 
-    rebuild_calls = []
-    real_rebuild = view._rebuild_fabric_arrays
+    # Simulate topology change: recompute per-selection fabric indices and rebuild
+    # every indexed array, mirroring the lazy paths in the ``_get_*_array`` accessors.
+    view._rebuild_trans_ro_arrays()
+    view._world_rw_fabric_indices = view._compute_fabric_indices(view._world_sel_rw)
+    view._world_ifa_rw = view._build_indexed_array(
+        view._world_sel_rw, view._WORLD_MATRIX_NAME, view._world_rw_fabric_indices
+    )
+    view._local_rw_fabric_indices = view._compute_fabric_indices(view._local_sel_rw)
+    view._local_ifa_rw = view._build_indexed_array(
+        view._local_sel_rw, view._LOCAL_MATRIX_NAME, view._local_rw_fabric_indices
+    )
 
-    def spy_rebuild():
-        rebuild_calls.append(True)
-        real_rebuild()
-
-    def force_topology_changed():
-        if view._fabric_selection is not None:
-            view._fabric_selection.PrepareForReuse()
-            spy_rebuild()
-
-    monkeypatch.setattr(view, "_prepare_for_reuse", force_topology_changed)
-
-    # Trigger another write — goes through the forced topology-change branch.
+    # Trigger another write through the rebuilt arrays.
     new = wp.zeros((2, 3), dtype=wp.float32, device=device)
     wp.launch(kernel=_fill_position, dim=2, inputs=[new, 4.0, 5.0, 6.0], device=device)
     view.set_world_poses(positions=new)
 
-    assert rebuild_calls, "Forced topology-change branch did not invoke _rebuild_fabric_arrays"
-
-    # Read back — proves the rebuilt _view_to_fabric and _fabric_world_matrices
-    # are still consistent.
     ret_pos, _ = view.get_world_poses()
     pos_torch = ret_pos.torch
     expected = torch.tensor([[4.0, 5.0, 6.0], [4.0, 5.0, 6.0]], device=device)
-    assert torch.allclose(pos_torch, expected, atol=1e-7), f"Read after rebuild failed on {device}: {pos_torch}"
+    # 1e-5 ≈ 20 ULP at magnitudes ~4-6; absorbs float32 SRT compose/decompose drift.
+    assert torch.allclose(pos_torch, expected, atol=1e-5), f"Read after rebuild failed on {device}: {pos_torch}"
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+def test_prepare_for_reuse_detects_topology_change(device, view_factory):
+    """Each persistent ``PrimSelection`` exposes ``PrepareForReuse`` and returns a
+    bool.  When the underlying Fabric topology is unchanged it returns False.
+    """
+    bundle = view_factory(1, device)
+    view = bundle.view
+    view.get_world_poses()  # trigger Fabric init
+
+    assert view._trans_sel_ro is not None, "trans_sel_ro selection not initialized"
+    for selection in (view._trans_sel_ro, view._world_sel_rw, view._local_sel_rw):
+        result = selection.PrepareForReuse()
+        assert isinstance(result, bool), f"PrepareForReuse should return bool, got {type(result)}"
+        assert not result, "PrepareForReuse should return False when no topology change"
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+def test_set_local_via_fabric_path(device, view_factory):
+    """Exercise the Fabric-native set_local_poses path.
+
+    Ensures set_local_poses computes child_world = parent_world * local
+    entirely within Fabric (not falling back to USD) by first triggering
+    the Fabric sync via get_world_poses.
+    """
+    bundle = view_factory(num_envs=1, device=device)
+    view = bundle.view
+
+    # Trigger lazy `_initialize_fabric()` so subsequent calls take the Fabric path.
+    view.get_world_poses()
+
+    # Now set_local_poses should take the Fabric path
+    new_local_pos = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_local_pos, 1.0, 2.0, 3.0], device=device)
+    ori = torch.tensor([[0.0, 0.0, 0.0, 1.0]], dtype=torch.float32, device=device)
+    new_local_ori = wp.from_torch(ori)
+
+    view.set_local_poses(translations=new_local_pos, orientations=new_local_ori)
+
+    # Verify: world = parent(0,0,1) + local(1,2,3) = (1,2,4)
+    world_pos, _ = view.get_world_poses()
+    expected = torch.tensor([[1.0, 2.0, 4.0]], dtype=torch.float32, device=device)
+    torch.testing.assert_close(world_pos.torch, expected, atol=1e-4, rtol=0)
+
+    # Verify get_local_poses returns the local offset
+    local_pos, _ = view.get_local_poses()
+    expected_local = torch.tensor([[1.0, 2.0, 3.0]], dtype=torch.float32, device=device)
+    torch.testing.assert_close(local_pos.torch, expected_local, atol=1e-4, rtol=0)
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+def test_get_scales_fabric_path(device, view_factory):
+    """Exercise the Fabric-native get_scales path."""
+    bundle = view_factory(num_envs=1, device=device)
+    view = bundle.view
+
+    # Trigger lazy `_initialize_fabric()` so the get_scales call below uses Fabric.
+    view.get_world_poses()
+
+    scales = view.get_scales()
+    scales_t = wp.to_torch(scales)
+    # Default scale should be (1, 1, 1)
+    expected = torch.tensor([[1.0, 1.0, 1.0]], dtype=torch.float32, device=device)
+    torch.testing.assert_close(scales_t, expected, atol=1e-4, rtol=0)
+
+
+# ------------------------------------------------------------------
+# Transpose-convention verification: world ↔ local kernels rely on the
+# identity ``(A·B)ᵀ = Bᵀ·Aᵀ`` to drop explicit transposes when operating
+# on Fabric's column-transposed matrix storage.  The translation-only
+# parents used by the standard fixture cannot distinguish the right
+# convention from the wrong one — the rotation block is identity and
+# equals its own transpose.  These tests use a parent rotated 90° around
+# Z so that an incorrect storage convention would produce a clearly
+# wrong child pose.
+# ------------------------------------------------------------------
+
+
+# Parent at (0, 0, 1) rotated +90° around Z (so the parent X axis points
+# along world +Y).  Quaternion components in (x, y, z, w) order.
+_ROTATED_PARENT_POS = (0.0, 0.0, 1.0)
+_ROTATED_PARENT_QUAT_XYZW = (0.0, 0.0, 0.70710678, 0.70710678)
+
+
+def _build_rotated_parent_view(device: str) -> "FrameView":
+    """Build a 1-env FabricFrameView whose parent is rotated 90° around Z."""
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim(
+        "/World/Parent_0",
+        "Xform",
+        translation=_ROTATED_PARENT_POS,
+        orientation=_ROTATED_PARENT_QUAT_XYZW,
+        stage=stage,
+    )
+    sim_utils.create_prim("/World/Parent_0/Child", "Camera", translation=(0.0, 0.0, 0.0), stage=stage)
+    sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01, device=device, use_fabric=True))
+    view = FrameView("/World/Parent_.*/Child", device=device)
+    view.get_world_poses()  # force Fabric init and USD→Fabric seed
+    return view
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_set_local_then_get_world_with_rotated_parent(device):
+    """Verify ``update_indexed_world_matrix_from_local`` under non-identity parent rotation.
+
+    With parent rotated +90° around Z, a child local translation of (1, 0, 0)
+    must produce world translation (0, 1, 1) — parent_pos + R · local.  If the
+    transpose convention in the kernel were wrong, the rotation would flip
+    direction and the world position would land at (0, -1, 1) instead.
+    """
+    _skip_if_unavailable(device)
+    view = _build_rotated_parent_view(device)
+
+    new_local = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_local, 1.0, 0.0, 0.0], device=device)
+    identity_quat = wp.from_torch(torch.tensor([[0.0, 0.0, 0.0, 1.0]], dtype=torch.float32, device=device))
+    view.set_local_poses(translations=new_local, orientations=identity_quat)
+
+    world_pos, _ = view.get_world_poses()
+    expected = torch.tensor([[0.0, 1.0, 1.0]], dtype=torch.float32, device=device)
+    torch.testing.assert_close(world_pos.torch, expected, atol=1e-5, rtol=0)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_set_world_then_get_local_with_rotated_parent(device):
+    """Verify ``update_indexed_local_matrix_from_world`` under non-identity parent rotation.
+
+    With parent rotated +90° around Z and at (0, 0, 1), writing child world
+    translation (5, 0, 2) must yield child local translation Rᵀ · (5, 0, 1) =
+    (0, -5, 1).  A wrong transpose convention would invert the rotation in the
+    wrong direction and produce (0, 5, 1) instead.
+    """
+    _skip_if_unavailable(device)
+    view = _build_rotated_parent_view(device)
+
+    new_world = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_world, 5.0, 0.0, 2.0], device=device)
+    view.set_world_poses(positions=new_world)
+
+    local_pos, _ = view.get_local_poses()
+    expected = torch.tensor([[0.0, -5.0, 1.0]], dtype=torch.float32, device=device)
+    torch.testing.assert_close(local_pos.torch, expected, atol=1e-5, rtol=0)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_initial_seed_with_scaled_parent(device):
+    """Verify the initial USD→Fabric seed handles non-unit scales correctly.
+
+    Sets up a parent with world scale (2, 1, 1) and a child with local scale
+    (3, 1, 1) at local translation (1, 0, 0).  Expected world-space values for
+    the child:
+
+    * world scale = parent_scale * child_local_scale = (6, 1, 1)
+    * world position = parent_pos + parent_scale * child_local_pos
+                     = (0, 0, 1) + (2 * 1, 0, 0) = (2, 0, 1)
+
+    If the parent's worldMatrix is seeded with a hardcoded unit scale,
+    ``get_scales`` returns (3, 1, 1) instead of (6, 1, 1) and ``get_world_poses``
+    returns (1, 0, 1) instead of (2, 0, 1).  If the child's localMatrix is
+    seeded without scale, after ``_sync_world_from_local_if_dirty`` the world
+    scale collapses to (2, 1, 1).  This test catches both regressions.
+    """
+    _skip_if_unavailable(device)
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim("/World/Parent_0", "Xform", translation=(0.0, 0.0, 1.0), scale=(2.0, 1.0, 1.0), stage=stage)
+    sim_utils.create_prim(
+        "/World/Parent_0/Child",
+        "Camera",
+        translation=(1.0, 0.0, 0.0),
+        scale=(3.0, 1.0, 1.0),
+        stage=stage,
+    )
+    sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01, device=device, use_fabric=True))
+    view = FrameView("/World/Parent_.*/Child", device=device)
+
+    world_pos, _ = view.get_world_poses()
+    torch.testing.assert_close(
+        world_pos.torch,
+        torch.tensor([[2.0, 0.0, 1.0]], dtype=torch.float32, device=device),
+        atol=1e-5,
+        rtol=0,
+    )
+
+    scales = wp.to_torch(view.get_scales())
+    torch.testing.assert_close(
+        scales,
+        torch.tensor([[6.0, 1.0, 1.0]], dtype=torch.float32, device=device),
+        atol=1e-5,
+        rtol=0,
+    )
+
+
+# ------------------------------------------------------------------
+# Multi-view per stage: per-view dirty-flag isolation
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_multi_view_per_view_dirty_isolation(device):
+    """Two ``FabricFrameView`` instances on the same stage must not clear each other's
+    pending local→world sync.
+
+    Background: an earlier implementation stored the world-dirty flag at the class
+    level keyed by ``stage_id``.  With two views on the same stage, view B reading
+    worlds would clear the flag set by view A's ``set_local_poses``, leaving A's
+    world matrices silently stale because A's per-view sync kernel never fired.
+
+    This test sets up two views over disjoint child prims (under different parent
+    sub-trees of the same stage), interleaves their writes and reads, and verifies:
+
+    * view A's ``set_local_poses`` only dirties view A
+    * view B's ``get_world_poses`` does not clear view A's flag
+    * after both views' world reads, each one's worlds reflect its own latest local
+    * neither view's reads/writes corrupt the other view's poses
+    """
+    _skip_if_unavailable(device)
+    stage = sim_utils.get_current_stage()
+
+    # Two disjoint sub-trees under the same stage.  Use different parent names so
+    # the regex patterns for the two views don't accidentally overlap.
+    sim_utils.create_prim("/World/EnvA_0", "Xform", translation=(0.0, 0.0, 1.0), stage=stage)
+    sim_utils.create_prim("/World/EnvA_0/ChildA", "Camera", translation=(0.1, 0.0, 0.0), stage=stage)
+    sim_utils.create_prim("/World/EnvB_0", "Xform", translation=(0.0, 0.0, 2.0), stage=stage)
+    sim_utils.create_prim("/World/EnvB_0/ChildB", "Camera", translation=(0.2, 0.0, 0.0), stage=stage)
+
+    sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01, device=device, use_fabric=True))
+    view_a = FrameView("/World/EnvA_.*/ChildA", device=device)
+    view_b = FrameView("/World/EnvB_.*/ChildB", device=device)
+
+    # Initial reads — triggers Fabric init + the seed-time ``_world_dirty = True``
+    # path on both views, then clears it.
+    expected_a0 = torch.tensor([[0.1, 0.0, 1.0]], dtype=torch.float32, device=device)
+    expected_b0 = torch.tensor([[0.2, 0.0, 2.0]], dtype=torch.float32, device=device)
+    torch.testing.assert_close(view_a.get_world_poses()[0].torch, expected_a0, atol=1e-5, rtol=0)
+    torch.testing.assert_close(view_b.get_world_poses()[0].torch, expected_b0, atol=1e-5, rtol=0)
+    assert view_a._world_dirty is False
+    assert view_b._world_dirty is False
+    # Both views must reuse the same cached IFabricHierarchy (one stage = one handle).
+    assert view_a._fabric_hierarchy is view_b._fabric_hierarchy
+    from isaaclab_physx.sim.fabric_stage_cache import FabricStageCache
+
+    sim_context = sim_utils.SimulationContext.instance()
+    cache = sim_context.services[FabricStageCache]
+    assert cache is not None
+    assert len(cache._hierarchy_cache) == 1
+
+    # Write a new local pose on view A only.
+    new_local_a = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_local_a, 1.0, 0.0, 0.0], device=device)
+    identity_quat = wp.from_torch(torch.tensor([[0.0, 0.0, 0.0, 1.0]], dtype=torch.float32, device=device))
+    view_a.set_local_poses(translations=new_local_a, orientations=identity_quat)
+
+    # Only view A should be dirty.  Critical: a per-stage flag would have dirtied
+    # both views (or neither) at this point.
+    assert view_a._world_dirty is True, "set_local_poses should mark its own view dirty"
+    assert view_b._world_dirty is False, "set_local_poses on view A must not dirty view B"
+
+    # Read worlds from view B FIRST.  With a per-stage flag, B's
+    # ``_sync_world_from_local_if_dirty`` would fire and clear the flag, leaving A
+    # stale.  With the per-view flag, B's read is a no-op sync-wise.
+    torch.testing.assert_close(view_b.get_world_poses()[0].torch, expected_b0, atol=1e-5, rtol=0)
+    assert view_b._world_dirty is False
+    assert view_a._world_dirty is True, "view B's world read must not clear view A's dirty flag"
+
+    # Now read view A's worlds — sync fires, world reflects the new local.
+    expected_a1 = torch.tensor([[1.0, 0.0, 1.0]], dtype=torch.float32, device=device)
+    torch.testing.assert_close(view_a.get_world_poses()[0].torch, expected_a1, atol=1e-5, rtol=0)
+    assert view_a._world_dirty is False
+
+    # Symmetric pass: write on B, ensure A is undisturbed.
+    new_local_b = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_local_b, 3.0, 0.0, 0.0], device=device)
+    view_b.set_local_poses(translations=new_local_b, orientations=identity_quat)
+    assert view_a._world_dirty is False
+    assert view_b._world_dirty is True
+
+    # A's worlds must still read back the post-set-local value from above; no
+    # cross-view stomp on the world matrix.
+    torch.testing.assert_close(view_a.get_world_poses()[0].torch, expected_a1, atol=1e-5, rtol=0)
+    expected_b1 = torch.tensor([[3.0, 0.0, 2.0]], dtype=torch.float32, device=device)
+    torch.testing.assert_close(view_b.get_world_poses()[0].torch, expected_b1, atol=1e-5, rtol=0)
+    assert view_a._world_dirty is False
+    assert view_b._world_dirty is False

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -21,6 +21,11 @@ from isaaclab.app import AppLauncher
 # (e.g. ``-m multi_gpu``) that collide with its own short options.  Strip
 # everything but ``argv[0]`` before booting the app — the test file takes no
 # CLI arguments of its own.
+#
+# IMPORTANT: this must stay between the ``AppLauncher`` import and the
+# ``AppLauncher(...).app`` call below.  Adding any CLI parser, or moving the
+# AppLauncher import (or its instantiation) above this line, exposes Kit to
+# pytest's argv again and re-introduces the segfault.
 sys.argv = sys.argv[:1]
 
 simulation_app = AppLauncher(headless=True).app

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -10,7 +10,6 @@ Imports the shared contract tests and provides the Fabric-specific
 Camera prim type for Fabric SelectPrims compatibility).
 """
 
-import os
 import sys
 from pathlib import Path
 
@@ -52,10 +51,12 @@ def _skip_if_unavailable(device: str):
     idx = int(device.split(":")[1]) if ":" in device else 0
     n = torch.cuda.device_count()
     if idx >= n:
-        msg = f"{device} not available (device_count={n})"
-        if os.environ.get("GITHUB_ACTIONS") == "true":
-            pytest.fail(f"{msg} — multi-GPU runner is misconfigured")
-        pytest.skip(f"{msg} — multi-GPU test skipped on single-GPU machine")
+        # Always skip rather than fail: the dedicated multi-GPU workflow does its own
+        # pre-flight ``torch.cuda.device_count() >= 2`` check before invoking pytest, so
+        # a misconfigured multi-GPU runner is already caught there.  Failing here would
+        # only break the standard single-GPU CI runners that legitimately can't run
+        # ``cuda:1+`` tests.
+        pytest.skip(f"{device} not available (device_count={n}) — multi-GPU test skipped")
 
 
 # ------------------------------------------------------------------

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -169,7 +169,7 @@ def test_fabric_set_world_does_not_write_back_to_usd(device, view_factory):
 
     # Verify Fabric has the new position
     fab_pos, _ = view.get_world_poses()
-    pos_torch = wp.to_torch(fab_pos)
+    pos_torch = fab_pos.torch
     assert torch.allclose(pos_torch, torch.tensor([[99.0, 99.0, 99.0]], device=device), atol=0.1), (
         f"Fabric should have new position, got {pos_torch}"
     )
@@ -230,6 +230,6 @@ def test_fabric_rebuild_after_topology_change(device, view_factory, monkeypatch)
     # Read back — proves the rebuilt _view_to_fabric and _fabric_world_matrices
     # are still consistent.
     ret_pos, _ = view.get_world_poses()
-    pos_torch = wp.to_torch(ret_pos)
+    pos_torch = ret_pos.torch
     expected = torch.tensor([[4.0, 5.0, 6.0], [4.0, 5.0, 6.0]], device=device)
     assert torch.allclose(pos_torch, expected, atol=1e-7), f"Read after rebuild failed on {device}: {pos_torch}"

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -17,6 +17,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "isaaclab" / "test"
 
 from isaaclab.app import AppLauncher
 
+# Kit reads ``sys.argv`` directly during startup and segfaults on pytest flags
+# (e.g. ``-m multi_gpu``) that collide with its own short options.  Strip
+# everything but ``argv[0]`` before booting the app — the test file takes no
+# CLI arguments of its own.
+sys.argv = sys.argv[:1]
+
 simulation_app = AppLauncher(headless=True).app
 
 import pytest  # noqa: E402

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -10,23 +10,13 @@ Imports the shared contract tests and provides the Fabric-specific
 Camera prim type for Fabric SelectPrims compatibility).
 """
 
+import os
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "isaaclab" / "test" / "sim"))
 
 from isaaclab.app import AppLauncher
-
-# Kit reads ``sys.argv`` directly during startup and segfaults on pytest flags
-# (e.g. ``-m multi_gpu``) that collide with its own short options.  Strip
-# everything but ``argv[0]`` before booting the app — the test file takes no
-# CLI arguments of its own.
-#
-# IMPORTANT: this must stay between the ``AppLauncher`` import and the
-# ``AppLauncher(...).app`` call below.  Adding any CLI parser, or moving the
-# AppLauncher import (or its instantiation) above this line, exposes Kit to
-# pytest's argv again and re-introduces the segfault.
-sys.argv = sys.argv[:1]
 
 simulation_app = AppLauncher(headless=True).app
 
@@ -191,7 +181,7 @@ def test_fabric_set_world_does_not_write_back_to_usd(device, view_factory):
 
     # Verify Fabric has the new position
     fab_pos, _ = view.get_world_poses()
-    pos_torch = wp.to_torch(fab_pos)
+    pos_torch = torch.as_tensor(fab_pos, device=device)
     assert torch.allclose(pos_torch, torch.tensor([[99.0, 99.0, 99.0]], device=device), atol=0.1), (
         f"Fabric should have new position, got {pos_torch}"
     )
@@ -252,7 +242,7 @@ def test_fabric_rebuild_after_topology_change(device, view_factory, monkeypatch)
     # Read back — proves the rebuilt _view_to_fabric and _fabric_world_matrices
     # are still consistent.
     ret_pos, _ = view.get_world_poses()
-    pos_torch = wp.to_torch(ret_pos)
+    pos_torch = torch.as_tensor(ret_pos, device=device)
     expected = torch.tensor([[4.0, 5.0, 6.0], [4.0, 5.0, 6.0]], device=device)
     assert torch.allclose(pos_torch, expected, atol=1e-7), f"Read after rebuild failed on {device}: {pos_torch}"
 
@@ -262,7 +252,10 @@ def test_fabric_rebuild_after_topology_change(device, view_factory, monkeypatch)
 # ------------------------------------------------------------------
 
 
-@pytest.mark.multi_gpu
+@pytest.mark.skipif(
+    not os.environ.get("ISAACLAB_TEST_MULTI_GPU"),
+    reason="Multi-GPU tests disabled (set ISAACLAB_TEST_MULTI_GPU=1 to enable)",
+)
 @pytest.mark.parametrize("device", ["cuda:1"])
 def test_fabric_cuda1_world_pose_roundtrip(device, view_factory):
     """set_world_poses -> get_world_poses roundtrip works on cuda:1.
@@ -278,12 +271,15 @@ def test_fabric_cuda1_world_pose_roundtrip(device, view_factory):
     view.set_world_poses(positions=new_pos)
 
     ret_pos, _ = view.get_world_poses()
-    pos_torch = ret_pos.torch
+    pos_torch = torch.as_tensor(ret_pos, device=device)
     expected = torch.tensor([[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]], device=device)
     assert torch.allclose(pos_torch, expected, atol=1e-7), f"Roundtrip failed on {device}: {pos_torch}"
 
 
-@pytest.mark.multi_gpu
+@pytest.mark.skipif(
+    not os.environ.get("ISAACLAB_TEST_MULTI_GPU"),
+    reason="Multi-GPU tests disabled (set ISAACLAB_TEST_MULTI_GPU=1 to enable)",
+)
 @pytest.mark.parametrize("device", ["cuda:1"])
 def test_fabric_cuda1_no_usd_writeback(device, view_factory):
     """set_world_poses on cuda:1 does not write back to USD.
@@ -312,7 +308,10 @@ def test_fabric_cuda1_no_usd_writeback(device, view_factory):
     )
 
 
-@pytest.mark.multi_gpu
+@pytest.mark.skipif(
+    not os.environ.get("ISAACLAB_TEST_MULTI_GPU"),
+    reason="Multi-GPU tests disabled (set ISAACLAB_TEST_MULTI_GPU=1 to enable)",
+)
 @pytest.mark.parametrize("device", ["cuda:1"])
 def test_fabric_cuda1_scales_roundtrip(device, view_factory):
     """set_scales -> get_scales roundtrip works on cuda:1.
@@ -329,6 +328,6 @@ def test_fabric_cuda1_scales_roundtrip(device, view_factory):
     view.set_scales(new_scales)
 
     ret_scales = view.get_scales()
-    scales_torch = wp.to_torch(ret_scales)
+    scales_torch = torch.as_tensor(ret_scales, device=device)
     expected = torch.tensor([[2.0, 3.0, 4.0], [2.0, 3.0, 4.0]], device=device)
     assert torch.allclose(scales_torch, expected, atol=1e-7), f"Scales roundtrip failed on {device}: {scales_torch}"

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -10,6 +10,7 @@ Imports the shared contract tests and provides the Fabric-specific
 Camera prim type for Fabric SelectPrims compatibility).
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -44,8 +45,17 @@ def test_setup_teardown():
 
 
 def _skip_if_unavailable(device: str):
-    if device.startswith("cuda") and not torch.cuda.is_available():
+    if not device.startswith("cuda"):
+        return
+    if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
+    idx = int(device.split(":")[1]) if ":" in device else 0
+    n = torch.cuda.device_count()
+    if idx >= n:
+        msg = f"{device} not available (device_count={n})"
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            pytest.fail(f"{msg} — multi-GPU runner is misconfigured")
+        pytest.skip(f"{msg} — multi-GPU test skipped on single-GPU machine")
 
 
 # ------------------------------------------------------------------
@@ -233,3 +243,80 @@ def test_fabric_rebuild_after_topology_change(device, view_factory, monkeypatch)
     pos_torch = wp.to_torch(ret_pos)
     expected = torch.tensor([[4.0, 5.0, 6.0], [4.0, 5.0, 6.0]], device=device)
     assert torch.allclose(pos_torch, expected, atol=1e-7), f"Read after rebuild failed on {device}: {pos_torch}"
+
+
+# ------------------------------------------------------------------
+# Multi-GPU tests (cuda:1) — skipped automatically on single-GPU workstations
+# ------------------------------------------------------------------
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.parametrize("device", ["cuda:1"])
+def test_fabric_cuda1_world_pose_roundtrip(device, view_factory):
+    """set_world_poses -> get_world_poses roundtrip works on cuda:1.
+
+    Verifies that FabricFrameView operates correctly on a non-primary CUDA
+    device without falling back to the USD path.
+    """
+    bundle = view_factory(2, device)
+    view = bundle.view
+
+    new_pos = wp.zeros((2, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=2, inputs=[new_pos, 10.0, 20.0, 30.0], device=device)
+    view.set_world_poses(positions=new_pos)
+
+    ret_pos, _ = view.get_world_poses()
+    pos_torch = wp.to_torch(ret_pos)
+    expected = torch.tensor([[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]], device=device)
+    assert torch.allclose(pos_torch, expected, atol=1e-7), f"Roundtrip failed on {device}: {pos_torch}"
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.parametrize("device", ["cuda:1"])
+def test_fabric_cuda1_no_usd_writeback(device, view_factory):
+    """set_world_poses on cuda:1 does not write back to USD.
+
+    Mirrors test_fabric_set_world_does_not_write_back_to_usd for the cuda:1
+    device to confirm the no-writeback invariant holds across GPU indices.
+    """
+    bundle = view_factory(1, device)
+    view = bundle.view
+
+    stage = sim_utils.get_current_stage()
+    prim = stage.GetPrimAtPath(view.prim_paths[0])
+    xform_cache = UsdGeom.XformCache()
+    t_before = xform_cache.GetLocalToWorldTransform(prim).ExtractTranslation()
+    orig_usd_pos = torch.tensor([float(t_before[0]), float(t_before[1]), float(t_before[2])])
+
+    new_pos = wp.zeros((1, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=1, inputs=[new_pos, 99.0, 99.0, 99.0], device=device)
+    view.set_world_poses(positions=new_pos)
+
+    # USD must not have moved at all — equality, not approximate.
+    t_after = UsdGeom.XformCache().GetLocalToWorldTransform(prim).ExtractTranslation()
+    usd_pos_after = torch.tensor([float(t_after[0]), float(t_after[1]), float(t_after[2])])
+    assert torch.allclose(usd_pos_after, orig_usd_pos, atol=0.0), (
+        f"USD wrote back on {device}: expected {orig_usd_pos}, got {usd_pos_after}"
+    )
+
+
+@pytest.mark.multi_gpu
+@pytest.mark.parametrize("device", ["cuda:1"])
+def test_fabric_cuda1_scales_roundtrip(device, view_factory):
+    """set_scales -> get_scales roundtrip works on cuda:1.
+
+    Both write paths (``set_world_poses`` and ``set_scales``) call
+    ``_prepare_for_reuse`` and launch on ``self._device``; this test covers
+    the scales path on the non-primary CUDA device.
+    """
+    bundle = view_factory(2, device)
+    view = bundle.view
+
+    new_scales = wp.zeros((2, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=2, inputs=[new_scales, 2.0, 3.0, 4.0], device=device)
+    view.set_scales(new_scales)
+
+    ret_scales = view.get_scales()
+    scales_torch = wp.to_torch(ret_scales)
+    expected = torch.tensor([[2.0, 3.0, 4.0], [2.0, 3.0, 4.0]], device=device)
+    assert torch.allclose(scales_torch, expected, atol=1e-7), f"Scales roundtrip failed on {device}: {scales_torch}"


### PR DESCRIPTION
## Summary

Consolidated PR bringing the full Fabric acceleration stack to `FabricFrameView`. This builds on the merged mGPU support (#5514) and adds:

1. **Indexed Fabric transform kernels** — Warp kernels for local↔world matrix propagation using `IndexedFabricArray`
2. **Factory-based dispatch** — Move Fabric/USD selection from internal `FabricFrameView` fallback to the `FrameView` factory (eliminates misleading abstraction)
3. **Fused compose kernel** — Single kernel launch for `set_world_poses` + `set_scales` instead of separate calls
4. **FabricStageCache** — Shared hierarchy handles across views for faster scene creation (~8× improvement)
5. **Fabric-accelerated local poses** — `get_local_poses()` / `set_local_poses()` operate directly on Fabric `localMatrix`, with automatic world→local recomposition
6. **Device gate fix** — Allow `FabricFrameView` on any `cuda:<N>` device (was incorrectly restricted to `cuda:0` only)

## Motivation

Piotr's wrist camera shimmering on multi-GPU (#5717 context): parent prim local transforms change on `cuda:1` but camera world pose doesn't get recomposed → stale poses. The local→world composition pipeline in this PR fixes camera pose propagation on non-primary GPUs.

## Performance

On 2x L40 (4 envs, wrist camera benchmark):
- **Scene creation: 12.2s → 1.5s** (8× faster from FabricStageCache)
- **FPS parity** at low env counts (camera-render-dominated); gains at 64+ envs
- `cuda:1` now gets full Fabric acceleration (was silently falling back to USD)

## Testing

- Existing `test_views_xform_prim_fabric.py` extended with local pose tests, topology rebuild tests, and multi-GPU roundtrip tests
- New `test_fabric_stage_cache.py` for the stage cache service
- New `test_fabric_kernels.py` for indexed transform kernels

## Individual PRs (now superseded by this consolidated PR)

- #5675 `pv/indexed-fabric-kernels`
- #5673 `pv/fabric-view-no-fallback`
- #5674 `pv/fabric-fused-compose`
- #5676 `pv/fabric-stage-cache`
- #5677 `pv/fabric-local-poses`
