### PR TITLE
OMPE-94619: Fix non-deterministic test_noise failures.

### DIFF
--- a/source/isaaclab/changelog.d/jmart-test-noise.skip
+++ b/source/isaaclab/changelog.d/jmart-test-noise.skip
@@ -1,0 +1,3 @@
+Test-only: use ``torch.ones`` instead of ``torch.rand`` for ``op="scale"`` in
+``test_noise.py`` to avoid 0/0=NaN when ``torch.rand`` on CUDA returns exact 0
+(per its documented ``[0, 1)`` contract). Fixes OMPE-94619.

--- a/source/isaaclab/test/utils/test_noise.py
+++ b/source/isaaclab/test/utils/test_noise.py
@@ -15,8 +15,12 @@ import isaaclab.utils.noise as noise
 def test_gaussian_noise(device, noise_device, op):
     """Test guassian_noise function."""
 
-    # create random data set
-    data = torch.rand(10000, 3, device=device)
+    # Use ones for 'scale' so noisy_data is the noise term directly;
+    # random data can be exactly 0 (torch.rand's [0, 1) contract), and 0/0 = NaN (OMPE-94619).
+    if op == "scale":
+        data = torch.ones(10000, 3, device=device)
+    else:
+        data = torch.rand(10000, 3, device=device)
     # define standard deviation and mean
     std = torch.tensor([0.1, 0.2, 0.3], device=noise_device)
     mean = torch.tensor([0.4, 0.5, 0.6], device=noise_device)
@@ -29,9 +33,7 @@ def test_gaussian_noise(device, noise_device, op):
         # calculate resulting noise compared to original data set
         if op == "add":
             std_result, mean_result = torch.std_mean(noisy_data - data, dim=0)
-        elif op == "scale":
-            std_result, mean_result = torch.std_mean(noisy_data / data, dim=0)
-        elif op == "abs":
+        elif op == "scale" or op == "abs":
             std_result, mean_result = torch.std_mean(noisy_data, dim=0)
 
         assert str(noise_cfg.mean.device) == device
@@ -45,8 +47,12 @@ def test_gaussian_noise(device, noise_device, op):
 @pytest.mark.parametrize("op", ["add", "scale", "abs"])
 def test_uniform_noise(device, noise_device, op):
     """Test uniform_noise function."""
-    # create random data set
-    data = torch.rand(10000, 3, device=device)
+    # Use ones for 'scale' so noisy_data is the noise term directly;
+    # random data can be exactly 0 (torch.rand's [0, 1) contract), and 0/0 = NaN (OMPE-94619).
+    if op == "scale":
+        data = torch.ones(10000, 3, device=device)
+    else:
+        data = torch.rand(10000, 3, device=device)
     # define uniform minimum and maximum
     n_min = torch.tensor([0.1, 0.2, 0.3], device=noise_device)
     n_max = torch.tensor([0.4, 0.5, 0.6], device=noise_device)
@@ -60,10 +66,7 @@ def test_uniform_noise(device, noise_device, op):
         if op == "add":
             min_result, _ = torch.min(noisy_data - data, dim=0)
             max_result, _ = torch.max(noisy_data - data, dim=0)
-        elif op == "scale":
-            min_result, _ = torch.min(torch.div(noisy_data, data), dim=0)
-            max_result, _ = torch.max(torch.div(noisy_data, data), dim=0)
-        elif op == "abs":
+        elif op == "scale" or op == "abs":
             min_result, _ = torch.min(noisy_data, dim=0)
             max_result, _ = torch.max(noisy_data, dim=0)
 
@@ -79,8 +82,12 @@ def test_uniform_noise(device, noise_device, op):
 @pytest.mark.parametrize("op", ["add", "scale", "abs"])
 def test_constant_noise(device, noise_device, op):
     """Test constant_noise"""
-    # create random data set
-    data = torch.rand(10000, 3, device=device)
+    # Use ones for 'scale' so noisy_data is the bias term directly;
+    # random data can be exactly 0 (torch.rand's [0, 1) contract), and 0/0 = NaN (OMPE-94619).
+    if op == "scale":
+        data = torch.ones(10000, 3, device=device)
+    else:
+        data = torch.rand(10000, 3, device=device)
     # define a bias
     bias = torch.tensor([0.1, 0.2, 0.3], device=noise_device)
     # create noise config
@@ -92,9 +99,7 @@ def test_constant_noise(device, noise_device, op):
         # calculate resulting noise compared to original data set
         if op == "add":
             bias_result = noisy_data - data
-        elif op == "scale":
-            bias_result = noisy_data / data
-        elif op == "abs":
+        elif op == "scale" or op == "abs":
             bias_result = noisy_data
 
         assert str(noise_cfg.bias.device) == device


### PR DESCRIPTION
# Description

`torch.rand` can return exact 0 per its [0, 1) contract (~1 in 2^25 on CUDA). The scale-branch of test_noise recovers the scale factor and noise contribution by dividing `noisy_data / data`. Since `data` was generated via `torch.rand`, this produces NaN about ~1 in 1000 test runs (0.1% of the time.) This can be deterministically reproduced by feeding it a seed of 1981.

This change fixes the test by switching `data` to `torch.ones` for the scale branch in all three noise tests so `noisy_data` is the noise term directly. There is no need to recover the scale factor and noise contribution separately. The internal `rand_like` call inside `noise_cfg.func` is still exercised and measured, which is the goal of the test.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation *(N/A - test change only)*
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there