### PR TITLE
docs: clarify Windows commands run in Command Prompt, not PowerShell

### DIFF
--- a/docs/source/setup/installation/binaries_installation.rst
+++ b/docs/source/setup/installation/binaries_installation.rst
@@ -36,6 +36,13 @@ please refer to the `Isaac Sim documentation <https://docs.isaacsim.omniverse.nv
 Verifying the Isaac Sim installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+   On Windows, the commands shown in the ``Windows`` tabs throughout this
+   guide use Command Prompt (``cmd.exe``) syntax. Please run them in a
+   Command Prompt window rather than PowerShell, otherwise commands such as
+   ``set`` and ``mklink`` may not behave as expected.
+
 To avoid the overhead of finding and locating the Isaac Sim installation
 directory every time, we recommend exporting the following environment
 variables to your terminal for the remaining of the installation instructions:

--- a/docs/source/setup/installation/source_installation.rst
+++ b/docs/source/setup/installation/source_installation.rst
@@ -65,6 +65,13 @@ for the convenience of users.
 Verifying the Isaac Sim installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+   On Windows, the commands shown in the ``Windows`` tabs throughout this
+   guide use Command Prompt (``cmd.exe``) syntax. Please run them in a
+   Command Prompt window rather than PowerShell, otherwise commands such as
+   ``set`` and ``mklink`` may not behave as expected.
+
 To avoid the overhead of finding and locating the Isaac Sim installation
 directory every time, we recommend exporting the following environment
 variables to your terminal for the remaining of the installation instructions:


### PR DESCRIPTION
# Description

Adds a short note in the Windows tab of both the "Verifying the Isaac Sim installation" sections (pre-built binaries and source installation guides) calling out that the Windows commands shown throughout the guide use Command Prompt (`cmd.exe`) syntax, not PowerShell, so commands like `set` and `mklink` work as documented.

Per @RandomOakForest in #5552:

> Following up, if you have time for a PR, please submit it. The team will review it and will aim to merge it.

Fixes #5552

## Type of change

- Documentation update

## Screenshots

N/A (text-only addition).

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

> Note: this is a docs-only change (two RST files, no code, no extension touched), so the `pre-commit`, tests, changelog and extension version items above are not applicable. Happy to also add a `CONTRIBUTORS.md` entry in a follow-up if maintainers prefer.
