### PR TITLE
[Changelog] Parameterize nightly compile over configurable branches

### DIFF
--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -6,16 +6,34 @@
 # Nightly auto-compile: rolls accumulated fragments under
 # ``source/<pkg>/changelog.d/`` into per-package ``CHANGELOG.rst`` entries,
 # bumps each ``extension.toml``, deletes consumed fragments, and pushes the
-# result back to ``develop``. Keeps the develop branch's changelog current
-# without requiring a maintainer to run ``compile`` by hand.
+# result back to each branch in the configured list. Keeps every tracked
+# branch's changelog current without requiring a maintainer to run
+# ``compile`` by hand.
 #
-# The push uses ``CHANGELOG_PAT`` (a personal access token / fine-grained
-# GitHub App token with ``contents:write`` on this repo) when it's
-# available so downstream CI runs on the auto-commit. Falls back to
-# ``GITHUB_TOKEN`` — sufficient for the push itself, but pushes signed
-# with ``GITHUB_TOKEN`` do not trigger workflow runs on the resulting
-# commit, which is by design (avoids infinite loops) but means the
-# Docker / docs rebuild won't re-trigger off the nightly's auto-commit.
+# Scheduled workflow — must live on the default branch (``main``) for the
+# cron to register. See ``.github/workflows/README.md``.
+#
+# This is the single source of truth for the nightly compile. Target
+# branches (``develop``, release branches, ...) need ``tools/changelog/cli.py``
+# checked in — the same copy the PR gate already runs — and the matrix
+# job below checks each branch out, runs that branch's cli.py against its
+# own fragments, and pushes the result back. Using the target's cli.py
+# (rather than main's) keeps the contract between the PR gate
+# (``changelog-check.yml``) and the nightly compile identical: fragments
+# that passed the gate compile under the same rules.
+#
+# Adding a branch to the nightly set is a one-line edit to the ``branches:``
+# input default below.
+#
+# The push uses a short-lived GitHub App installation token minted from
+# ``CHANGELOG_APP_CLIENT_ID`` + ``CHANGELOG_APP_PRIVATE_KEY`` (repo secrets).
+# The App must be installed on this repository with ``contents: write`` and
+# added to the bypass-actor list of each target branch's ruleset so the
+# auto-commit can push directly without satisfying required-checks /
+# required-approval gates.
+# Commits signed by an App token (unlike ``GITHUB_TOKEN``) are treated as
+# external pushes, so they DO trigger downstream workflow runs (Docker
+# rebuild, docs, etc.) without needing a separate PAT.
 
 name: Nightly Changelog Compilation
 
@@ -26,44 +44,106 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
     inputs:
+      branches:
+        description: 'Comma-separated branches to compile'
+        required: false
+        # To extend the nightly set, append more refs to this default
+        # (e.g. ``default: develop,release/3.0.0-beta2``). For one-off
+        # off-cycle compiles, override at dispatch time:
+        #   gh workflow run nightly-changelog.yml \
+        #     -f branches=release/3.0.0-beta2
+        # Each branch must carry ``tools/changelog/cli.py``. Surrounding
+        # whitespace per entry is stripped by the resolver below.
+        default: develop
       dry_run:
         description: 'Preview only — do not commit / push'
         required: false
         type: boolean
         default: false
 
-concurrency:
-  # Only one nightly compile may be in flight at a time. ``cancel-in-progress``
-  # is intentionally false: if a previous run is still finishing its push, we
-  # queue rather than abort it mid-commit.
-  group: nightly-changelog
-  cancel-in-progress: false
-
 permissions:
-  contents: write
+  # Reduced: the App installation token below carries its own write scope.
+  # GITHUB_TOKEN only needs read access for the standard checkout machinery.
+  contents: read
 
 jobs:
-  compile-changelog:
-    name: Compile changelog fragments
+  resolve-branches:
+    # CSV → JSON array bridge. ``workflow_dispatch`` inputs can only be
+    # string / bool / choice, so the branch list arrives as a comma-
+    # separated string; the matrix below needs a JSON list to fan out.
+    # Mirrors the ``setup-versions`` job in ``daily-compatibility.yml``.
+    name: Resolve branch list
     runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      branches: ${{ steps.b.outputs.branches }}
+    steps:
+      - id: b
+        env:
+          # ``inputs.branches`` is empty on schedule events; fall back to
+          # the workflow_dispatch default explicitly so cron uses the
+          # same set as a no-input manual dispatch.
+          BRANCHES: ${{ inputs.branches || 'develop' }}
+        run: |
+          # CSV → JSON array, trimming surrounding whitespace per entry.
+          arr=$(echo "$BRANCHES" | tr ',' '\n' | xargs -n1 | jq -R . | jq -s -c .)
+          echo "branches=$arr" >> "$GITHUB_OUTPUT"
+          echo "Resolved branches: $arr"
+
+  compile-changelog:
+    name: Compile changelog fragments (${{ matrix.branch }})
+    needs: resolve-branches
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      # Independent branches: one failing shouldn't cancel the others.
+      # Mirrors ``daily-compatibility.yml``'s matrix style — each entry
+      # shows up as a separate job tile in the Actions UI, so a failure
+      # on ``release/3.0.0-beta2`` doesn't hide ``develop``'s success
+      # (and ``gh run rerun --failed`` re-runs only the failed entry).
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.resolve-branches.outputs.branches) }}
+    concurrency:
+      # Per-branch group: two runs against the same ref queue, but
+      # different refs (develop and a release branch) compile in parallel.
+      group: nightly-changelog-${{ matrix.branch }}
+      cancel-in-progress: false
 
     steps:
+      # Mint a short-lived (1 h) installation access token for the
+      # ``isaaclab-bot`` GitHub App. The App is on each target branch's
+      # ruleset bypass list, so its push lands without needing the
+      # standard required-checks / required-approval pipeline.
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        id: app-token
+        with:
+          # ``client-id`` (the App's OAuth client ID, ``Iv23...``) supersedes
+          # the deprecated ``app-id`` integer input as of v3.x.
+          client-id: ${{ secrets.CHANGELOG_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+          # Declare the scope the App must have so token mint fails loudly
+          # if the App is misconfigured, instead of failing silently at the
+          # push step.
+          permission-contents: write
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          # Operate on develop, not the repo's default branch. Scheduled
-          # workflows fire from the default branch's workflow file by
-          # default, but we want the *checkout* to be develop so the
-          # compile sees develop's accumulated fragments and the push
-          # writes back to develop.
-          ref: develop
-          # Use a PAT so the auto-commit triggers downstream CI; falls back
-          # to GITHUB_TOKEN which is sufficient for the push itself.
-          token: ${{ secrets.CHANGELOG_PAT || secrets.GITHUB_TOKEN }}
+          # Check out the target branch — the workflow file lives on main,
+          # but the working tree (fragments, extension.toml, CHANGELOG.rst,
+          # and cli.py) is from the branch we're compiling. Using the
+          # branch's own cli.py keeps the compile contract identical to
+          # the PR gate that validated the fragments in the first place.
+          ref: ${{ matrix.branch }}
+          # App token (vs. GITHUB_TOKEN) means the push is signed by
+          # ``isaaclab-bot`` — the bypass identity — and downstream CI
+          # workflows DO trigger on the resulting commit.
+          token: ${{ steps.app-token.outputs.token }}
           # Full history so the compiler can resolve each fragment's merge
           # time via ``git log --diff-filter=A --first-parent``.
           fetch-depth: 0
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
@@ -77,10 +157,12 @@ jobs:
           python3 tools/changelog/cli.py compile $ARGS
 
       - name: Commit and push if fragments were compiled
-        if: inputs.dry_run != 'true'
+        if: ${{ !inputs.dry_run }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Author commits as the App's bot user so the GitHub UI attributes
+          # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
+          git config user.name "isaaclab-bot[bot]"
+          git config user.email "282401363+isaaclab-bot[bot]@users.noreply.github.com"
           git add source/*/changelog.d/ \
                   source/*/docs/CHANGELOG.rst \
                   source/*/config/extension.toml
@@ -113,7 +195,11 @@ jobs:
               done
             } > "$MSG_FILE"
             git commit -F "$MSG_FILE"
-            # Push explicitly to develop so we don't accidentally write
-            # to the source ref of a workflow_dispatch run.
-            git push origin HEAD:develop
+            # Rebase onto the target branch's current tip in case a human
+            # commit landed during this run (~2 min window between
+            # checkout and push). Without this the push fails non-fast-
+            # forward and the batch waits for the next run.
+            git pull --rebase origin "${{ matrix.branch }}"
+            # Push back to the same branch we checked out.
+            git push origin "HEAD:${{ matrix.branch }}"
           fi


### PR DESCRIPTION
## 1. Summary

- Single workflow file, branch-list input, matrix fan-out. Adding a release branch to the nightly is a one-line edit.
- Pattern mirrors `daily-compatibility.yml` (`setup-versions` → `fromJson` matrix), so reviewers see a familiar shape.
- Each matrix entry runs the target branch's own `tools/changelog/cli.py` — same code as the PR gate that validated the fragments. No cli.py duplication or overlay.

## 2. Files

- `.github/workflows/nightly-changelog.yml` — adds `branches` workflow_dispatch input (CSV, default `develop`), `resolve-branches` job, matrix on the compile job. Everything else (App-token mint, rebase-before-push, pinned action SHAs, isaaclab-bot identity, timeout) is verbatim from main.
- `tools/changelog/cli.py` — unchanged from develop. Listed only because the PR was opened against develop and the bundled changelog fragment for this PR lives at the root level.

## 3. Manual usage

```
gh workflow run nightly-changelog.yml \
  -f branches=release/3.0.0-beta2

gh workflow run nightly-changelog.yml \
  -f branches=develop,release/3.0.0-beta2 \
  -f dry_run=true
```

## 4. Extending the nightly set

Edit one line — the `branches:` input default in `nightly-changelog.yml`:

```yaml
inputs:
  branches:
    default: develop,release/3.0.0-beta2
```

Each branch listed must carry `tools/changelog/cli.py` (which it already does if it accepts PRs — the sibling `changelog-check.yml` gate requires it).

## 5. Failure handling

- `fail-fast: false` and per-branch concurrency keys: one branch's compile failing does not block the others.
- The Actions UI shows each branch as a separate job tile (e.g. `Compile changelog fragments (develop)`, `Compile changelog fragments (release/3.0.0-beta2)`), matching the daily-compatibility pattern.
- `gh run rerun --failed <run-id>` re-runs only the failed entries.