### PR TITLE
Force interval events by default

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-force-interval-events-default.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-force-interval-events-default.skip
@@ -1,0 +1,4 @@
+Test-only change.
+
+* Flipped the default of ``force_interval_events`` from ``False`` to ``True`` in
+  ``_run_environments`` and ``_check_random_actions`` (``env_test_utils.py``).

--- a/source/isaaclab_tasks/test/env_test_utils.py
+++ b/source/isaaclab_tasks/test/env_test_utils.py
@@ -259,7 +259,7 @@ def _run_environments(
     create_stage_in_memory=False,
     disable_clone_in_fabric=False,
     physics_preset_name: str | None = None,
-    force_interval_events: bool = False,
+    force_interval_events: bool = True,
 ):
     """Run all environments and check environments return valid signals.
 
@@ -351,7 +351,7 @@ def _check_random_actions(
     create_stage_in_memory: bool = False,
     disable_clone_in_fabric: bool = False,
     physics_preset_name: str | None = None,
-    force_interval_events: bool = False,
+    force_interval_events: bool = True,
 ):
     """Run random actions and check environments return valid signals.
 

--- a/source/isaaclab_tasks/test/test_environments.py
+++ b/source/isaaclab_tasks/test/test_environments.py
@@ -37,10 +37,4 @@ from env_test_utils import _run_environments, setup_environment  # isort: skip
 @pytest.mark.isaacsim_ci
 def test_environments(task_name, num_envs, device):
     # run environments without stage in memory
-    _run_environments(
-        task_name,
-        device,
-        num_envs,
-        force_interval_events=True,
-        create_stage_in_memory=False,
-    )
+    _run_environments(task_name, device, num_envs, create_stage_in_memory=False)


### PR DESCRIPTION
# Description

- Follow up PR to https://github.com/isaac-sim/IsaacLab/pull/5713
- Update `force_interval_events` to be default on all test helpers
- If there is no `interval` mode, this function is a no-op. For all others, this helps test the `interval` critical path at each `step()` call.
- Currently the following files will benefit from this change: `test_environments.py`, `test_environments_with_stage_in_memory.py`, `test_environments_newton.py`, and `test_factory_environments.py`.
- 9 of the 12 newly-affected files are no-ops

## Fixes:
- Forge `dead_zone_thresholds` fired ~3×/env pre-#5713, dropped to 0×/env after #5713's 100→20 step cut, restored to 20×/env by this PR.
- `push_robot` terms never fired even in the legacy 100-step budget. This PR is the first time they're exercised in CI.

## Type of change

- Test behavior change

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there