### PR TITLE
docs: fix Windows batch inline comment syntax and add shorthand command

### DIFF
--- a/docs/source/setup/installation/include/src_build_isaaclab.rst
+++ b/docs/source/setup/installation/include/src_build_isaaclab.rst
@@ -34,7 +34,8 @@ Installation
 
          .. code:: batch
 
-            isaaclab.bat --install :: or "isaaclab.bat -i"
+            isaaclab.bat --install
+            isaaclab.bat -i
 
 
    All core submodules are **always** installed regardless of what is passed to ``-i``.


### PR DESCRIPTION
The Windows batch command in the installation docs had an inline 
comment using :: which breaks the command when
copy-pasted:

isaaclab.bat --install :: or "isaaclab.bat -i"

In Windows batch, :: only works at the start of a line and not inline.

Fix: removed the inline comment and listed the shorthand as a separate line instead:

isaaclab.bat --install
isaaclab.bat -i

This is an updated version of #5104, following @kellyguo11's feedback to list the shorthand command separately rather than removing it entirely.

Fixes #5086