### PR TITLE
Add perf-smoke comparator scaffolding under tools/

### DIFF
--- a/tools/perf_smoke/README.md
+++ b/tools/perf_smoke/README.md
@@ -1,0 +1,122 @@
+# Perf Smoke Gate (Phase 1)
+
+Tooling for the Isaac Lab PR-time performance regression smoke gate.
+
+## What this directory contains
+
+| File | Purpose |
+|---|---|
+| `check_perf_regression.py` | Comparator. Reads a benchmark JSON + baseline, decides PASS / REGRESSION / HARD_FAILURE. |
+| `baseline.json` | Per-task, per-GPU expected FPS and tolerance. |
+| `test_check_perf_regression.py` | Stdlib `unittest` tests for the comparator. |
+
+The CI workflow that drives this lives in `.github/workflows/build.yaml` (added once the platform decision lands).
+
+## Exit-code contract
+
+| Exit code | Meaning | What the CI workflow does |
+|---|---|---|
+| `0` | PASS — measured FPS within or above the baseline tolerance | Step succeeds. |
+| `1` | REGRESSION — measured FPS dropped beyond `max_regression_pct` | Step exits non-zero; job is `continue-on-error: true` for Phase 1, so the PR check renders neutral. |
+| `2` | HARD_FAILURE — structural problem (missing/malformed result, missing baseline entry, unknown GPU, NaN/zero FPS, etc.) | Step exits non-zero with a distinct annotation; this is the path that catches things like the `tomllib` incident. |
+
+The split between `1` and `2` is intentional. A code-driven slowdown is not the same kind of signal as a broken environment, and the workflow renders them differently.
+
+## Running the comparator
+
+```bash
+./isaaclab.sh -p tools/perf_smoke/check_perf_regression.py \
+    --task Isaac-Cartpole-Direct-v0 \
+    --results-dir ./perf-output \
+    --baseline tools/perf_smoke/baseline.json
+```
+
+Useful flags:
+
+- `--results-glob 'benchmark_non_rl_*.json'` — override the default glob (`benchmark_non_rl_<task>*.json`).
+- `--allow-multiple` — pick the most recent file when multiple match.
+- `--gpu-override 'NVIDIA L40'` — bypass the GPU auto-detection from the result JSON's `hardware_info` phase. Useful for local testing on different hardware.
+
+The comparator prints a single structured line to stdout, e.g.:
+
+```text
+RESULT=PASS task=Isaac-Cartpole-Direct-v0 gpu=NVIDIA L40 baseline_fps=626772 measured_fps=635000 delta_pct=+1.31 threshold_pct=10.00
+```
+
+When `$GITHUB_STEP_SUMMARY` is set, the same line is appended to the job summary in a markdown code block.
+
+## Running the tests
+
+```bash
+./isaaclab.sh -p tools/perf_smoke/test_check_perf_regression.py
+# or
+python3 tools/perf_smoke/test_check_perf_regression.py
+```
+
+Tests use stdlib `unittest` (not `pytest`) because `tools/conftest.py` blocks pytest collection beneath `tools/`. They have no Isaac Lab runtime dependencies and should pass on any Python ≥ 3.10.
+
+## Baseline schema
+
+`baseline.json` is keyed by task, then by GPU name. Substring matching is allowed: a baseline key `"L40"` matches a device named `"NVIDIA L40"`.
+
+```jsonc
+{
+  "Isaac-Cartpole-Direct-v0": {
+    "preset": "default",
+    "num_envs": 4096,
+    "num_frames": 100,
+    "per_gpu": {
+      "NVIDIA L40": {
+        "baseline_fps": 626772,
+        "max_regression_pct": 10.0,
+        "n": 509,
+        "window_days": 77,
+        "source": "OmniPerf historical L40 Ada (EPYC_9124P_1XL40_ADA), P25 of WARM Mean Environment step effective FPS"
+      }
+    }
+  }
+}
+```
+
+`baseline_fps` and `max_regression_pct` are required. Other fields are informational and travel with the entry so reviewers can see how it was derived.
+
+### Choosing `max_regression_pct`
+
+For Phase 1 we use `max(3 × cross-runner CV%, 5%)` rounded up to the nearest whole percent, capped at 15%. The Phase 1 baseline above uses **10%** because:
+
+1. The OmniPerf historical pooled CV on L40 Ada is 2.62% (3× ≈ 8%).
+2. We do not yet have same-runner-vs-cross-runner CV decomposed; pooled may understate cross-runner.
+3. Sporadic ~12-17% drops appear roughly 1-in-30 historical runs and recover on retry — likely contention/thermal, not code. A 10% threshold absorbs typical contention while still catching the 47% PR #5265-style real regression.
+
+We will tighten once we have ≥ 20 of our own PR runs to characterize.
+
+### Choosing `baseline_fps`
+
+We use the **P25** of the WARM `Mean Environment step effective FPS` distribution from a stable post-`num_envs`-drift window, not the median. P25 absorbs more of the historical contention noise and gives natural headroom on a `max(3×CV, 5%)` threshold.
+
+## Adding a new task
+
+1. Pull the OmniPerf historical distribution for the task at the chosen `(num_envs, num_frames, preset)`.
+2. Confirm pooled CV ≤ 4% on the L40 Ada subpool.
+3. Pick `baseline_fps` = P25 of the WARM distribution from a stable window.
+4. Pick `max_regression_pct` per the formula above.
+5. Add the entry to `baseline.json`, including `source` and `notes`.
+6. Add a CI matrix entry (workflow file, once it exists).
+7. Validate against ≥ 20 historical PRs before adding the task to a blocking gate.
+
+## Phase 1 invariants
+
+These constraints exist so the gate can be reasoned about independently of the runner platform decision:
+
+- The comparator is **runtime-free**: no torch, no Kit, no Isaac Sim imports. It runs from a stock Python ≥ 3.10.
+- The result JSON shape is the OmniPerf backend output — see `source/isaaclab/isaaclab/test/benchmark/backends.py::OmniPerfKPIFile`. Other backends (`json`, `osmo`) write a different shape and are not supported.
+- The metric path is fixed: `runtime["Mean Environment step effective FPS"]`. Other phases / metrics are out of scope for Phase 1.
+- The GPU is read from `hardware_info.gpu_devices[hardware_info.gpu_current_device].name`, falling back to the first device in the map. Override via `--gpu-override` for local runs.
+
+## Out of scope for Phase 1
+
+- N-of-M sampling and same-job retries (Phase 1.5).
+- Camera tasks, training tasks (`benchmark_rsl_rl.py`).
+- Per-component (Isaac Sim, Newton, OVRTX, OVPhysX) bisection (Phase 2).
+- PR comments, Slack notifications, dashboards.
+- Writing baselines back to OmniPerf DB.

--- a/tools/perf_smoke/baseline.json
+++ b/tools/perf_smoke/baseline.json
@@ -1,0 +1,27 @@
+{
+    "_schema_version": 1,
+    "_notes": [
+        "Phase 1 perf smoke gate baselines.",
+        "Source: OmniPerf historical data, 90-day window analysis (~5,000 runs).",
+        "Per-GPU keys are matched against the 'name' field of hardware_info.gpu_devices.",
+        "Substring matching is allowed: a baseline key 'L40' matches a device named 'NVIDIA L40'.",
+        "max_regression_pct is the symmetric tolerance below baseline_fps before REGRESSION fires.",
+        "Initial threshold is intentionally loose (10%) for warning-only Phase 1; tighten once we",
+        "characterize cross-runner variance from our own jobs."
+    ],
+    "Isaac-Cartpole-Direct-v0": {
+        "preset": "default",
+        "num_envs": 4096,
+        "num_frames": 100,
+        "per_gpu": {
+            "NVIDIA L40": {
+                "baseline_fps": 626772,
+                "max_regression_pct": 10.0,
+                "n": 509,
+                "window_days": 77,
+                "source": "OmniPerf L40 Ada (EPYC_9124P_1XL40_ADA), P25 of WARM Mean Environment step effective FPS",
+                "notes": "Pooled CV 2.62%; conservative P25 baseline picked over median to absorb sporadic 12-17% contention drops observed roughly 1-in-30 runs."
+            }
+        }
+    }
+}

--- a/tools/perf_smoke/check_perf_regression.py
+++ b/tools/perf_smoke/check_perf_regression.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Compare an OmniPerf benchmark JSON against a per-GPU baseline.
+
+Used by the Phase 1 perf-smoke CI gate. Runs the comparison logic and exits
+with one of three codes that the workflow translates into a PR signal:
+
+* ``0`` PASS              -- measured FPS within or above the baseline threshold.
+* ``1`` REGRESSION        -- measured FPS dropped beyond ``max_regression_pct``.
+* ``2`` HARD_FAILURE      -- structural problem (missing/malformed result, missing
+  baseline entry, NaN/zero FPS, GPU model not in baseline, etc.).
+
+The split between regression and hard failure is intentional: it lets us
+distinguish "your code got slower" from "the environment is broken" without
+relying on log-grep heuristics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+EXIT_PASS = 0
+EXIT_REGRESSION = 1
+EXIT_HARD_FAILURE = 2
+
+METRIC_PHASE = "runtime"
+METRIC_NAME = "Mean Environment step effective FPS"
+
+DEFAULT_GLOB_TEMPLATE = "benchmark_non_rl_{task}*.json"
+
+
+class CompareError(Exception):
+    """Raised for any structural problem that should map to ``HARD_FAILURE``."""
+
+
+def _emit(result: str, **fields: object) -> None:
+    """Print a structured single-line summary, optionally to ``$GITHUB_STEP_SUMMARY``.
+
+    Args:
+        result: One of ``PASS``, ``REGRESSION``, ``HARD_FAILURE``.
+        **fields: Additional ``key=value`` pairs to include on the line.
+    """
+    parts = [f"RESULT={result}"] + [f"{k}={v}" for k, v in fields.items()]
+    line = " ".join(parts)
+    print(line)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as f:
+                f.write(f"### Perf Smoke: {result}\n\n```\n{line}\n```\n")
+        except OSError:
+            # Summary is best-effort; never let it mask the real exit code.
+            pass
+
+
+def _resolve_results(results_dir: str, glob_pattern: str, allow_multiple: bool) -> Path:
+    """Resolve the result JSON path within ``results_dir``.
+
+    Args:
+        results_dir: Directory the benchmark wrote into.
+        glob_pattern: Glob pattern relative to ``results_dir``.
+        allow_multiple: When ``True`` and multiple files match, return the most
+            recent by filename sort. When ``False``, multiple matches is a hard
+            failure.
+
+    Returns:
+        Path to the chosen result JSON.
+
+    Raises:
+        CompareError: When no files match, or multiple files match without
+            ``allow_multiple``.
+    """
+    matches = sorted(glob.glob(os.path.join(results_dir, glob_pattern)))
+    if not matches:
+        raise CompareError(f"no_results_found dir={results_dir!r} glob={glob_pattern!r}")
+    if len(matches) > 1 and not allow_multiple:
+        raise CompareError(f"multiple_results n={len(matches)}")
+    return Path(matches[-1])
+
+
+def _load_json(path: Path) -> dict:
+    """Load a JSON file as a dict.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        Parsed top-level dict.
+
+    Raises:
+        CompareError: When the file is missing, unreadable, malformed, or the
+            top-level value is not an object.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        raise CompareError(f"file_not_found path={path}")
+    except json.JSONDecodeError as e:
+        raise CompareError(f"malformed_json path={path} line={e.lineno} col={e.colno}")
+    if not isinstance(data, dict):
+        raise CompareError(f"json_not_object path={path}")
+    return data
+
+
+def _extract_fps(result: dict) -> float:
+    """Pull the effective-FPS metric out of the OmniPerf result document.
+
+    Args:
+        result: Top-level dict loaded from the OmniPerf JSON.
+
+    Returns:
+        Mean environment-step effective FPS, as a positive float.
+
+    Raises:
+        CompareError: When the runtime phase is missing, the metric is absent,
+            or the value is not a finite positive number.
+    """
+    phase_data = result.get(METRIC_PHASE)
+    if not isinstance(phase_data, dict):
+        raise CompareError(f"missing_phase phase={METRIC_PHASE}")
+    if METRIC_NAME not in phase_data:
+        raise CompareError(f"missing_metric phase={METRIC_PHASE} metric={METRIC_NAME!r}")
+    value = phase_data[METRIC_NAME]
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise CompareError(f"invalid_metric_type metric={METRIC_NAME!r} value={value!r}")
+    if value != value:  # NaN
+        raise CompareError(f"nan_metric metric={METRIC_NAME!r}")
+    if value <= 0:
+        raise CompareError(f"non_positive_metric metric={METRIC_NAME!r} value={value}")
+    return float(value)
+
+
+def _extract_gpu_name(result: dict) -> str | None:
+    """Read the runner's GPU model name from the result JSON's hardware metadata.
+
+    Args:
+        result: Top-level dict loaded from the OmniPerf JSON.
+
+    Returns:
+        The current device's reported name (e.g. ``"NVIDIA L40"``), or ``None``
+        when hardware metadata is absent or malformed.
+    """
+    hw = result.get("hardware_info")
+    if not isinstance(hw, dict):
+        return None
+    devices = hw.get("gpu_devices")
+    if not isinstance(devices, dict) or not devices:
+        return None
+    current = str(hw.get("gpu_current_device", "0"))
+    device = devices.get(current) or next(iter(devices.values()), None)
+    if isinstance(device, dict):
+        name = device.get("name")
+        return name if isinstance(name, str) and name else None
+    return None
+
+
+def _match_gpu(per_gpu: dict, gpu_key: str) -> tuple[str, dict]:
+    """Find the baseline entry whose key is a (sub)string match for ``gpu_key``.
+
+    The baseline can use either the exact ``torch`` device name (e.g.
+    ``"NVIDIA L40"``) or a coarser tag (e.g. ``"L40"``). Substring matching in
+    either direction lets a single baseline cover minor naming variations.
+
+    Args:
+        per_gpu: Mapping from baseline key to baseline entry.
+        gpu_key: GPU identifier read from the result (or override).
+
+    Returns:
+        Tuple of ``(matched_key, entry)``.
+
+    Raises:
+        CompareError: When no key in ``per_gpu`` matches ``gpu_key``.
+    """
+    for key, entry in per_gpu.items():
+        if key == gpu_key or key in gpu_key or gpu_key in key:
+            if not isinstance(entry, dict):
+                raise CompareError(f"malformed_baseline_entry gpu={key!r}")
+            return key, entry
+    raise CompareError(f"baseline_gpu_mismatch gpu={gpu_key!r} known={sorted(per_gpu)}")
+
+
+def _resolve_baseline(baseline: dict, task: str, gpu_name: str | None, gpu_override: str | None) -> tuple[str, dict]:
+    """Look up the baseline entry for the given task and GPU.
+
+    Args:
+        baseline: Top-level baseline document.
+        task: Task name (e.g. ``"Isaac-Cartpole-Direct-v0"``).
+        gpu_name: GPU name read from the result JSON (may be ``None``).
+        gpu_override: Explicit GPU key supplied on the CLI; takes precedence
+            over ``gpu_name`` when set.
+
+    Returns:
+        Tuple of ``(matched_gpu_key, entry)``.
+
+    Raises:
+        CompareError: When the task is missing, the per-GPU map is absent, no
+            GPU identifier is available, no baseline entry matches the GPU, or
+            a required entry field is missing.
+    """
+    task_entry = baseline.get(task)
+    if not isinstance(task_entry, dict):
+        raise CompareError(f"missing_baseline_task task={task!r}")
+    per_gpu = task_entry.get("per_gpu")
+    if not isinstance(per_gpu, dict) or not per_gpu:
+        raise CompareError(f"missing_per_gpu task={task!r}")
+    gpu_key = gpu_override or gpu_name
+    if not gpu_key:
+        raise CompareError(f"unknown_gpu task={task!r}")
+    matched_key, entry = _match_gpu(per_gpu, gpu_key)
+    for field in ("baseline_fps", "max_regression_pct"):
+        if field not in entry:
+            raise CompareError(f"missing_baseline_field task={task!r} gpu={matched_key!r} field={field}")
+    return matched_key, entry
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns the process exit code."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
+    parser.add_argument("--task", required=True, help="Task name, e.g. Isaac-Cartpole-Direct-v0.")
+    parser.add_argument("--results-dir", required=True, help="Directory containing the benchmark JSON.")
+    parser.add_argument("--baseline", required=True, help="Path to baseline.json.")
+    parser.add_argument(
+        "--results-glob",
+        default=None,
+        help=f"Glob for the result file (defaults to {DEFAULT_GLOB_TEMPLATE!r}).",
+    )
+    parser.add_argument(
+        "--gpu-override",
+        default=None,
+        help="Override the GPU name read from the result JSON's hardware_info phase.",
+    )
+    parser.add_argument(
+        "--allow-multiple",
+        action="store_true",
+        help="Permit multiple result files; pick the most recent by sort order.",
+    )
+    args = parser.parse_args(argv)
+
+    glob_pattern = args.results_glob or DEFAULT_GLOB_TEMPLATE.format(task=args.task)
+
+    try:
+        result_path = _resolve_results(args.results_dir, glob_pattern, args.allow_multiple)
+        result = _load_json(result_path)
+        baseline = _load_json(Path(args.baseline))
+        measured_fps = _extract_fps(result)
+        gpu_name = _extract_gpu_name(result)
+        gpu_key, entry = _resolve_baseline(baseline, args.task, gpu_name, args.gpu_override)
+    except CompareError as e:
+        _emit("HARD_FAILURE", reason=str(e), task=args.task)
+        return EXIT_HARD_FAILURE
+
+    baseline_fps = float(entry["baseline_fps"])
+    threshold_pct = float(entry["max_regression_pct"])
+    delta_pct = (measured_fps - baseline_fps) / baseline_fps * 100.0
+
+    common: dict[str, object] = {
+        "task": args.task,
+        "gpu": gpu_key,
+        "baseline_fps": f"{baseline_fps:.0f}",
+        "measured_fps": f"{measured_fps:.0f}",
+        "delta_pct": f"{delta_pct:+.2f}",
+        "threshold_pct": f"{threshold_pct:.2f}",
+    }
+    if delta_pct < -threshold_pct:
+        _emit("REGRESSION", **common)
+        return EXIT_REGRESSION
+    _emit("PASS", **common)
+    return EXIT_PASS
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf_smoke/test_check_perf_regression.py
+++ b/tools/perf_smoke/test_check_perf_regression.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for ``check_perf_regression.py``.
+
+Stdlib ``unittest`` (not pytest) because ``tools/conftest.py`` blocks pytest
+collection under ``tools/``. Run directly:
+
+.. code-block:: bash
+
+    ./isaaclab.sh -p tools/perf_smoke/test_check_perf_regression.py
+    # or
+    python3 tools/perf_smoke/test_check_perf_regression.py
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import math
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import check_perf_regression as cpr  # noqa: E402
+
+TASK = "Isaac-Cartpole-Direct-v0"
+GPU = "NVIDIA L40"
+BASELINE_FPS = 626772
+THRESHOLD_PCT = 10.0
+
+
+def _result_doc(fps: float | int | str | None, gpu: str | None = GPU) -> dict:
+    """Build a minimal OmniPerf-shaped result document for tests."""
+    doc: dict = {
+        "runtime": {cpr.METRIC_NAME: fps},
+    }
+    if gpu is not None:
+        doc["hardware_info"] = {
+            "gpu_current_device": 0,
+            "gpu_devices": {"0": {"name": gpu, "total_memory_gb": 44.5}},
+        }
+    return doc
+
+
+def _baseline_doc(fps: int = BASELINE_FPS, threshold: float = THRESHOLD_PCT, gpu_key: str = GPU) -> dict:
+    """Build a minimal baseline document for tests."""
+    return {
+        TASK: {
+            "per_gpu": {
+                gpu_key: {
+                    "baseline_fps": fps,
+                    "max_regression_pct": threshold,
+                },
+            },
+        },
+    }
+
+
+class CheckPerfRegressionTests(unittest.TestCase):
+    """End-to-end CLI behavior for the comparator."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.results_dir = self.tmp / "perf-output"
+        self.results_dir.mkdir()
+        self.baseline_path = self.tmp / "baseline.json"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _write_result(self, doc: dict | str, name: str | None = None) -> Path:
+        """Write a result file. ``doc`` may be a dict or a raw string for malformed-JSON tests."""
+        path = self.results_dir / (name or f"benchmark_non_rl_{TASK}_2026-05-22.json")
+        if isinstance(doc, str):
+            path.write_text(doc, encoding="utf-8")
+        else:
+            path.write_text(json.dumps(doc), encoding="utf-8")
+        return path
+
+    def _write_baseline(self, doc: dict) -> None:
+        self.baseline_path.write_text(json.dumps(doc), encoding="utf-8")
+
+    def _run(self, *extra: str) -> tuple[int, str]:
+        """Invoke ``main`` with the standard arg set plus ``extra`` overrides."""
+        argv = [
+            "--task",
+            TASK,
+            "--results-dir",
+            str(self.results_dir),
+            "--baseline",
+            str(self.baseline_path),
+            *extra,
+        ]
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = cpr.main(argv)
+        return code, buf.getvalue().strip()
+
+    # ----- pass / regression / improvement -----
+
+    def test_pass_within_threshold(self) -> None:
+        # 5% drop on a 10% threshold -> PASS
+        self._write_result(_result_doc(int(BASELINE_FPS * 0.95)))
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_PASS)
+        self.assertIn("RESULT=PASS", out)
+        self.assertIn("delta_pct=-5.00", out)
+
+    def test_pass_improvement(self) -> None:
+        self._write_result(_result_doc(int(BASELINE_FPS * 1.08)))
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_PASS)
+        self.assertIn("delta_pct=+8.00", out)
+
+    def test_pass_at_exact_threshold(self) -> None:
+        # Exactly -10% on a 10% threshold -> PASS (boundary is inclusive of pass).
+        # Use the float-valued FPS rather than int-truncating; truncation lands
+        # us a fraction of a percent past -10% and would flip the result.
+        self._write_result(_result_doc(BASELINE_FPS * 0.90))
+        self._write_baseline(_baseline_doc())
+        code, _ = self._run()
+        self.assertEqual(code, cpr.EXIT_PASS)
+
+    def test_regression_below_threshold(self) -> None:
+        self._write_result(_result_doc(int(BASELINE_FPS * 0.85)))
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_REGRESSION)
+        self.assertIn("RESULT=REGRESSION", out)
+        self.assertIn("delta_pct=-15.00", out)
+
+    # ----- structural failures -> HARD_FAILURE -----
+
+    def test_no_results_file(self) -> None:
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("reason=no_results_found", out)
+
+    def test_multiple_results_strict(self) -> None:
+        self._write_result(_result_doc(BASELINE_FPS), name=f"benchmark_non_rl_{TASK}_a.json")
+        self._write_result(_result_doc(BASELINE_FPS), name=f"benchmark_non_rl_{TASK}_b.json")
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("multiple_results", out)
+
+    def test_multiple_results_allow(self) -> None:
+        self._write_result(_result_doc(BASELINE_FPS), name=f"benchmark_non_rl_{TASK}_a.json")
+        self._write_result(_result_doc(BASELINE_FPS), name=f"benchmark_non_rl_{TASK}_b.json")
+        self._write_baseline(_baseline_doc())
+        code, _ = self._run("--allow-multiple")
+        self.assertEqual(code, cpr.EXIT_PASS)
+
+    def test_malformed_json(self) -> None:
+        self._write_result("{not valid json")
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("malformed_json", out)
+
+    def test_missing_metric_phase(self) -> None:
+        self._write_result({"hardware_info": {"gpu_devices": {"0": {"name": GPU}}}})
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("missing_phase", out)
+
+    def test_missing_metric_name(self) -> None:
+        doc = _result_doc(BASELINE_FPS)
+        doc["runtime"] = {"some other metric": 1.0}
+        self._write_result(doc)
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("missing_metric", out)
+
+    def test_nan_metric(self) -> None:
+        doc = _result_doc(BASELINE_FPS)
+        doc["runtime"][cpr.METRIC_NAME] = float("nan")
+        # JSON doesn't natively support NaN; write via the allow_nan default and confirm
+        # the loader rejects it cleanly. We sidestep the dump by writing manually.
+        path = self.results_dir / f"benchmark_non_rl_{TASK}.json"
+        path.write_text(
+            '{"runtime": {"' + cpr.METRIC_NAME + '": NaN}, '
+            '"hardware_info": {"gpu_current_device": 0, "gpu_devices": {"0": {"name": "' + GPU + '"}}}}',
+            encoding="utf-8",
+        )
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        # Python's json loader accepts NaN by default and yields float('nan'); the
+        # comparator must catch it explicitly.
+        self.assertTrue("nan_metric" in out or "malformed_json" in out)
+
+    def test_zero_metric(self) -> None:
+        self._write_result(_result_doc(0))
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("non_positive_metric", out)
+
+    def test_string_metric(self) -> None:
+        self._write_result(_result_doc("not a number"))
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("invalid_metric_type", out)
+
+    def test_missing_baseline_task(self) -> None:
+        self._write_result(_result_doc(BASELINE_FPS))
+        self._write_baseline({"some-other-task": _baseline_doc()[TASK]})
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("missing_baseline_task", out)
+
+    def test_missing_baseline_field(self) -> None:
+        self._write_result(_result_doc(BASELINE_FPS))
+        broken = _baseline_doc()
+        del broken[TASK]["per_gpu"][GPU]["max_regression_pct"]
+        self._write_baseline(broken)
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("missing_baseline_field", out)
+
+    def test_baseline_gpu_mismatch(self) -> None:
+        # Result reports an unknown GPU.
+        self._write_result(_result_doc(BASELINE_FPS, gpu="NVIDIA Some Other GPU"))
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("baseline_gpu_mismatch", out)
+
+    def test_no_gpu_in_result_without_override(self) -> None:
+        self._write_result(_result_doc(BASELINE_FPS, gpu=None))
+        self._write_baseline(_baseline_doc())
+        code, out = self._run()
+        self.assertEqual(code, cpr.EXIT_HARD_FAILURE)
+        self.assertIn("unknown_gpu", out)
+
+    def test_gpu_override(self) -> None:
+        self._write_result(_result_doc(BASELINE_FPS, gpu=None))
+        self._write_baseline(_baseline_doc())
+        code, _ = self._run("--gpu-override", GPU)
+        self.assertEqual(code, cpr.EXIT_PASS)
+
+    def test_gpu_substring_match(self) -> None:
+        # Baseline keyed by a coarse tag matches a device whose name contains it.
+        self._write_result(_result_doc(BASELINE_FPS, gpu="NVIDIA L40"))
+        self._write_baseline(_baseline_doc(gpu_key="L40"))
+        code, _ = self._run()
+        self.assertEqual(code, cpr.EXIT_PASS)
+
+
+class HelperFunctionTests(unittest.TestCase):
+    """Direct unit tests for helper functions where edge cases are easier to express."""
+
+    def test_extract_fps_rejects_bool(self) -> None:
+        with self.assertRaises(cpr.CompareError):
+            cpr._extract_fps({"runtime": {cpr.METRIC_NAME: True}})
+
+    def test_extract_fps_accepts_int(self) -> None:
+        self.assertEqual(cpr._extract_fps({"runtime": {cpr.METRIC_NAME: 1234}}), 1234.0)
+
+    def test_extract_gpu_name_missing_phase(self) -> None:
+        self.assertIsNone(cpr._extract_gpu_name({}))
+
+    def test_extract_gpu_name_picks_current_device(self) -> None:
+        doc = {
+            "hardware_info": {
+                "gpu_current_device": 1,
+                "gpu_devices": {
+                    "0": {"name": "GPU A"},
+                    "1": {"name": "GPU B"},
+                },
+            },
+        }
+        self.assertEqual(cpr._extract_gpu_name(doc), "GPU B")
+
+    def test_match_gpu_substring_either_direction(self) -> None:
+        per_gpu = {"L40": {"baseline_fps": 1.0, "max_regression_pct": 1.0}}
+        key, _ = cpr._match_gpu(per_gpu, "NVIDIA L40")
+        self.assertEqual(key, "L40")
+
+    def test_threshold_boundary_is_inclusive_pass(self) -> None:
+        # Mirrors test_pass_at_exact_threshold but exercised via a math invariant.
+        baseline = 1000.0
+        threshold = 10.0
+        measured = baseline * (1 - threshold / 100)
+        delta = (measured - baseline) / baseline * 100
+        self.assertTrue(math.isclose(delta, -threshold))
+        # Comparator uses strict ``<`` so exactly -threshold passes.
+        self.assertFalse(delta < -threshold)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
# Description

Phase 1 groundwork for the PR-time performance regression smoke gate.

Adds a runtime-free comparator (`tools/perf_smoke/check_perf_regression.py`) that reads an OmniPerf benchmark JSON, looks up the per-task per-GPU baseline, and exits with one of three codes that the eventual CI workflow will translate into a PR signal:

| Exit | Meaning |
|---|---|
| `0` PASS | Measured FPS within or above the tolerance. |
| `1` REGRESSION | Measured FPS dropped beyond `max_regression_pct`. |
| `2` HARD_FAILURE | Structural problem — missing/malformed result, missing baseline entry, NaN/zero FPS, GPU model not in baseline, etc. Kept distinct from `REGRESSION` so environment-breakage incidents (e.g. the `tomllib` import failure on the wrong Python) surface as a different signal than a real perf regression. |

The comparator has no IsaacLab / torch / Kit dependencies, runs from a stock Python ≥ 3.10, and writes a structured single-line summary to stdout plus an optional `$GITHUB_STEP_SUMMARY` block.

**Phase 1 baseline:** `Isaac-Cartpole-Direct-v0` on `NVIDIA L40` (`num_envs=4096`, `num_frames=100`, default preset). The baseline FPS is the P25 of the OmniPerf historical WARM distribution over a 77-day stable window (n=509, pooled CV 2.62%). The 10% tolerance is intentionally loose for the warning-only Phase 1 and absorbs the sporadic 12–17% contention drops observed roughly 1-in-30 historical runs.

**Tests** use stdlib `unittest` (not `pytest`) because `tools/conftest.py` blocks pytest collection beneath `tools/`. 25 cases cover pass / regression / improvement / threshold boundary plus 15+ structural failure modes. See `tools/perf_smoke/README.md` for the full contract.

**CI integration is intentionally deferred** — its shape depends on the runner-platform decision (GH self-hosted vs OSMO vs Colossus). This PR deliberately builds only the platform-independent piece so the workflow wiring can be added in a follow-up without churn.

Draft because the workflow wiring lands in a separate commit on this branch after the runner-platform decision.

## Type of change

- New feature (non-breaking change which adds functionality)

## Test plan

- [x] `python tools/perf_smoke/test_check_perf_regression.py` (Windows, Python 3.14) — 25/25 passed
- [x] `python3 tools/perf_smoke/test_check_perf_regression.py` (Linux, Python 3.10) — 25/25 passed
- [x] `./isaaclab.sh -p tools/perf_smoke/test_check_perf_regression.py` (Linux, IsaacLab venv on Python 3.11) — 25/25 passed
- [x] `./isaaclab.sh -f` (Linux) — all pre-commit hooks passed, no files modified

## Screenshots

N/A — pure tooling change, no UI.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (`tools/perf_smoke/README.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (25 stdlib `unittest` cases)
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file — N/A: `tools/` is not a versioned package, so no changelog fragment applies (per `AGENTS.md`)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there