### PR TITLE
Fix .dockerignore so the _isaac_sim host symlink is not copied into the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,7 +23,7 @@ recordings/
 **/__pycache__/
 **/*.egg-info/
 # ignore isaac sim symlink
-_isaac_sim?
+_isaac_sim
 # Docker history
 docker/.isaac-lab-docker-history
 # ignore uv environment


### PR DESCRIPTION
# Description

> ⚠️ **High priority** — this silently breaks the docker image for anyone who has a local `_isaac_sim` symlink at the repo root (the standard developer setup pointing to a local Isaac Sim build).

`.dockerignore` has long carried the entry:

```
# ignore isaac sim symlink
_isaac_sim?
```

The `?` in dockerignore glob syntax means *exactly one character*, so the pattern only matches names like `_isaac_simX` and **does not match the bare `_isaac_sim` symlink** that contributors create at the repo root.

This was harmless until `docker/Dockerfile.base` switched to a wholesale `COPY --chown=isaaclab:isaaclab ../ ${ISAACLAB_PATH}/` near the end of the image build. That broad copy now sweeps the host `_isaac_sim` symlink into the image, **overwriting the in-image symlink** that the earlier `RUN ln -sf ${ISAACSIM_ROOT_PATH} ${ISAACLAB_PATH}/_isaac_sim` step creates. Inside the container, `_isaac_sim` ends up pointing at the host path (e.g. `../IsaacSim/_build/linux-x86_64/release`), which doesn't exist there — so every `isaaclab.sh` command that follows the symlink fails.

This PR fixes the pattern to match the actual symlink name.

Fixes # (no tracking issue — discovered while debugging a broken local docker image)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A — one-character `.dockerignore` change.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (N/A — no user-facing docs)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — `.dockerignore` glob; verified manually)
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file (N/A — no `source/<package>/` touched)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there