### PR TITLE
Fix the default log file path of OVRTX renderer

### DIFF
--- a/source/isaaclab_ov/changelog.d/huidongc-ovrtx-renderer-logging.rst
+++ b/source/isaaclab_ov/changelog.d/huidongc-ovrtx-renderer-logging.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed default OVRTX log file path by using the cross-platform temp directory instead of Linux-specific path ``/tmp``.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
@@ -5,6 +5,9 @@
 
 """Configuration for OVRTX Renderer."""
 
+import os
+import tempfile
+
 from isaaclab.renderers.renderer_cfg import RendererCfg
 from isaaclab.utils.configclass import configclass
 
@@ -40,5 +43,5 @@ class OVRTXRendererCfg(RendererCfg):
     log_level: str = "verbose"
     """OVRTX carb log level: "verbose", "info", "warn", "error"."""
 
-    log_file_path: str = "/tmp/ovrtx_renderer.log"
-    """Path for OVRTX log file."""
+    log_file_path: str = os.path.join(tempfile.gettempdir(), "ovrtx_renderer.log")
+    """Path for OVRTX log file. Defaults to ``<system temp>/ovrtx_renderer.log``."""

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -281,6 +281,50 @@ def _apply_overrides_to_env_cfg(env_cfg: Any, override_args: list[str]) -> Any:
     return env_cfg
 
 
+def _rendering_test_camera_cfgs(env_cfg: Any) -> list[Any]:
+    """Return camera cfgs used by kitless rendering golden-image tests.
+
+    Direct envs (cartpole, shadow hand) expose the tiled camera on ``env_cfg.tiled_camera``.
+    Manager-based dexsuite attaches cameras on the scene preset (``env_cfg.scene.base_camera``,
+    and optionally ``wrist_camera`` for the ``duo_camera`` preset).
+    """
+    cameras: list[Any] = []
+
+    tiled_camera = getattr(env_cfg, "tiled_camera", None)
+    if tiled_camera is not None:
+        cameras.append(tiled_camera)
+
+    scene = getattr(env_cfg, "scene", None)
+    if scene is not None:
+        for camera_name in ("base_camera", "wrist_camera"):
+            camera_cfg = getattr(scene, camera_name, None)
+            if camera_cfg is not None:
+                cameras.append(camera_cfg)
+
+    return cameras
+
+
+def _redirect_ovrtx_renderer_log_to_stdout(env_cfg: Any) -> None:
+    """Point OVRTX renderer logs at process stdout for kitless rendering tests.
+
+    Walks cameras from :func:`_rendering_test_camera_cfgs` (``env_cfg.tiled_camera`` for
+    direct envs, ``env_cfg.scene.base_camera`` / ``wrist_camera`` for manager-based envs)
+    and sets :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.log_file_path` on each camera
+    whose resolved ``renderer_cfg.renderer_type`` is ``"ovrtx"``. Uses ``/dev/stdout`` on
+    Unix and ``CON`` on Windows so pytest captures OVRTX carb output.
+
+    Call after :func:`_apply_overrides_to_env_cfg` when the ``ovrtx_renderer`` preset is
+    active; non-OVRTX cameras are left unchanged.
+    """
+    stdout_sink_path = "CON" if os.name == "nt" else "/dev/stdout"
+
+    camera_cfgs = _rendering_test_camera_cfgs(env_cfg)
+    for camera_cfg in camera_cfgs:
+        renderer_cfg = getattr(camera_cfg, "renderer_cfg", None)
+        if renderer_cfg is not None and getattr(renderer_cfg, "renderer_type", None) == "ovrtx":
+            renderer_cfg.log_file_path = stdout_sink_path
+
+
 def _physics_preset_name(physics_backend: str) -> str:
     """Translate the historical ``"newton"`` backend label (still used by golden-image
     filenames and ``pytest.param`` IDs) to the renamed Hydra preset
@@ -691,6 +735,9 @@ def rendering_test_shadow_hand(
 
     env_cfg.scene.num_envs = 4
 
+    if renderer == "ovrtx_renderer":
+        _redirect_ovrtx_renderer_log_to_stdout(env_cfg)
+
     if data_type == "depth":
         # Disable CNN forward pass as it cannot be meaningfully trained from depth alone and will raise a ValueError.
         env_cfg.feature_extractor.enabled = False
@@ -734,6 +781,9 @@ def rendering_test_cartpole(
 
     env_cfg.scene.num_envs = 4
 
+    if renderer == "ovrtx_renderer":
+        _redirect_ovrtx_renderer_log_to_stdout(env_cfg)
+
     env = None
 
     try:
@@ -774,6 +824,9 @@ def rendering_test_dexsuite_kuka(
     env_cfg = _apply_overrides_to_env_cfg(env_cfg, override_args)
 
     env_cfg.scene.num_envs = 4
+
+    if renderer == "ovrtx_renderer":
+        _redirect_ovrtx_renderer_log_to_stdout(env_cfg)
 
     # Disable the observation point-cloud visualisation markers (/Visuals/ObservationPointCloud).
     # The underlying point sampling uses the global numpy/torch RNG, so marker positions shift

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -281,48 +281,34 @@ def _apply_overrides_to_env_cfg(env_cfg: Any, override_args: list[str]) -> Any:
     return env_cfg
 
 
-def _rendering_test_camera_cfgs(env_cfg: Any) -> list[Any]:
-    """Return camera cfgs used by kitless rendering golden-image tests.
+def _redirect_ovrtx_renderer_log_to_stdout(env_cfg: Any) -> None:
+    """Point OVRTX renderer logs at process stdout for kitless rendering tests.
 
-    Direct envs (cartpole, shadow hand) expose the tiled camera on ``env_cfg.tiled_camera``.
-    Manager-based dexsuite attaches cameras on the scene preset (``env_cfg.scene.base_camera``,
-    and optionally ``wrist_camera`` for the ``duo_camera`` preset).
+    Walks camera cfgs (``env_cfg.tiled_camera`` for direct envs, ``env_cfg.scene.base_camera`` / ``wrist_camera`` for
+    manager-based envs) and sets :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.log_file_path` on each camera whose
+    resolved ``renderer_cfg.renderer_type`` is ``"ovrtx"``. Uses ``/dev/stdout`` on Linux and ``CON`` on Windows so
+    pytest captures OVRTX renderer log.
     """
-    cameras: list[Any] = []
+    camera_cfgs: list[Any] = []
 
+    # direct envs
     tiled_camera = getattr(env_cfg, "tiled_camera", None)
     if tiled_camera is not None:
-        cameras.append(tiled_camera)
+        camera_cfgs.append(tiled_camera)
 
+    # manager-based envs
     scene = getattr(env_cfg, "scene", None)
     if scene is not None:
         for camera_name in ("base_camera", "wrist_camera"):
             camera_cfg = getattr(scene, camera_name, None)
             if camera_cfg is not None:
-                cameras.append(camera_cfg)
+                camera_cfgs.append(camera_cfg)
 
-    return cameras
-
-
-def _redirect_ovrtx_renderer_log_to_stdout(env_cfg: Any) -> None:
-    """Point OVRTX renderer logs at process stdout for kitless rendering tests.
-
-    Walks cameras from :func:`_rendering_test_camera_cfgs` (``env_cfg.tiled_camera`` for
-    direct envs, ``env_cfg.scene.base_camera`` / ``wrist_camera`` for manager-based envs)
-    and sets :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.log_file_path` on each camera
-    whose resolved ``renderer_cfg.renderer_type`` is ``"ovrtx"``. Uses ``/dev/stdout`` on
-    Unix and ``CON`` on Windows so pytest captures OVRTX carb output.
-
-    Call after :func:`_apply_overrides_to_env_cfg` when the ``ovrtx_renderer`` preset is
-    active; non-OVRTX cameras are left unchanged.
-    """
-    stdout_sink_path = "CON" if os.name == "nt" else "/dev/stdout"
-
-    camera_cfgs = _rendering_test_camera_cfgs(env_cfg)
+    # redirect OVRTX renderer log to stdout
     for camera_cfg in camera_cfgs:
         renderer_cfg = getattr(camera_cfg, "renderer_cfg", None)
         if renderer_cfg is not None and getattr(renderer_cfg, "renderer_type", None) == "ovrtx":
-            renderer_cfg.log_file_path = stdout_sink_path
+            renderer_cfg.log_file_path = "CON" if os.name == "nt" else "/dev/stdout"
 
 
 def _physics_preset_name(physics_backend: str) -> str:


### PR DESCRIPTION
# Description

- The default log file path of OVRTX renderer uses `/tmp/ovrtx_renderer.log` which is Linux specific. We need to use a cross-platform temp directory instead.
- Redirect OVRTX renderer log to stdout for rendering tests so that we can view what is going on with CI, e.g. time for shader compilation will be visible in the CI logs, see `rendering-correctness` test job (https://github.com/isaac-sim/IsaacLab/actions/runs/26287973633/job/77380393480?pr=5749):
```log
2026-05-22T12:41:09Z [376,470ms] [Info] [omni.rtx] Waiting for compilation of ray tracing shaders for RTX renderer main raytracing pipeline by GPU driver: 30 seconds so far
2026-05-22T12:41:39Z [406,471ms] [Info] [omni.rtx] Waiting for compilation of ray tracing shaders for RTX renderer main raytracing pipeline by GPU driver: 60 seconds so far
2026-05-22T12:42:09Z [436,471ms] [Info] [omni.rtx] Waiting for compilation of ray tracing shaders for RTX renderer main raytracing pipeline by GPU driver: 90 seconds so far
2026-05-22T12:42:39Z [466,471ms] [Info] [omni.rtx] Waiting for compilation of ray tracing shaders for RTX renderer main raytracing pipeline by GPU driver: 120 seconds so far
2026-05-22T12:43:09Z [496,471ms] [Info] [omni.rtx] Waiting for compilation of ray tracing shaders for RTX renderer main raytracing pipeline by GPU driver: 150 seconds so far
2026-05-22T12:43:39Z [526,471ms] [Info] [omni.rtx] Waiting for compilation of ray tracing shaders for RTX renderer main raytracing pipeline by GPU driver: 180 seconds so far
2026-05-22T12:44:09Z [556,471ms] [Info] [omni.rtx] Waiting for compilation of ray tracing shaders for RTX renderer main raytracing pipeline by GPU driver: 210 seconds so far
2026-05-22T12:44:16Z [563,300ms] [Info] [omni.rtx] Ray tracing shader compilation for RTX renderer main raytracing pipeline finished after 216 seconds
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
