### PR TITLE
Fixes ARM64 docker build issue + re-enables JUnit artifacts (for sidecar service)

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -405,6 +405,15 @@ runs:
         if-no-files-found: ignore
         retention-days: 7
 
+    - name: Upload JUnit XML report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: junit-${{ inputs.container-name }}
+        path: ${{ inputs.reports-dir }}/${{ inputs.result-file }}
+        if-no-files-found: ignore
+        retention-days: 7
+
     - name: Clean up Docker container
       if: always() && !cancelled()
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,7 +101,7 @@ jobs:
           $'^\\.github/workflows/config\\.yaml$\tBase image config'
           $'^\\.github/actions/\tCI actions'
         )
-        triggered_jobs="Docker build + non-root verify jobs + all test-* matrix jobs"
+        triggered_jobs="Docker build jobs + all test-* matrix jobs (non-root verify is folded into test-isaaclab-ov and test-curobo)"
 
         render_table() {
           local files="$1" entry regex desc count sample
@@ -215,51 +215,6 @@ jobs:
         dockerfile-path: docker/Dockerfile.base
         cache-tag: cache-base
 
-  verify-base-non-root:
-    name: verify-base-non-root
-    runs-on: [self-hosted, gpu]
-    timeout-minutes: 30
-    needs: [build, config]
-    if: needs.build.result == 'success'
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 1
-        lfs: true
-
-    - name: Pull Base Docker image
-      uses: ./.github/actions/ecr-build-push-pull
-      with:
-        image-tag: ${{ env.CI_IMAGE_TAG }}
-        isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
-        isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
-        dockerfile-path: docker/Dockerfile.base
-        cache-tag: cache-base
-
-    - name: Run Dockerfile non-root regression test
-      shell: bash
-      run: |
-        set -euo pipefail
-        docker run --rm \
-          -v "$PWD":/workspace/isaaclab \
-          --entrypoint bash \
-          "${{ env.CI_IMAGE_TAG }}" \
-          -lc 'cd /workspace/isaaclab && /isaac-sim/python.sh -m pytest docker/test/test_dockerfile_nonroot.py -q'
-
-    - name: Verify Base runtime user is non-root
-      shell: bash
-      run: |
-        set -euo pipefail
-        runtime_identity="$(docker run --rm --entrypoint bash "${{ env.CI_IMAGE_TAG }}" \
-          -lc 'printf "%s %s %s\n" "$(id -u)" "$(id -g)" "$(id -un 2>/dev/null || true)"')"
-        read -r runtime_uid runtime_gid runtime_user <<< "${runtime_identity}"
-        echo "Base runtime identity: uid=${runtime_uid} gid=${runtime_gid} user=${runtime_user}"
-        if [ "${runtime_uid}" = "0" ]; then
-          echo "::error::Base Docker image must not run as root by default."
-          exit 1
-        fi
-
   build-curobo:
     name: Build cuRobo Docker Image
     runs-on: [self-hosted, gpu]
@@ -281,50 +236,6 @@ jobs:
         dockerfile-path: docker/Dockerfile.curobo
         cache-tag: cache-curobo
 
-  verify-curobo-non-root:
-    name: verify-curobo-non-root
-    runs-on: [self-hosted, gpu]
-    timeout-minutes: 30
-    needs: [build-curobo, config]
-    if: needs.build-curobo.result == 'success'
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 1
-        lfs: true
-
-    - name: Pull cuRobo Docker image
-      uses: ./.github/actions/ecr-build-push-pull
-      with:
-        image-tag: ${{ env.CI_IMAGE_TAG }}-curobo
-        isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
-        isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
-        dockerfile-path: docker/Dockerfile.curobo
-        cache-tag: cache-curobo
-
-    - name: Run Dockerfile non-root regression test
-      shell: bash
-      run: |
-        set -euo pipefail
-        docker run --rm \
-          -v "$PWD":/workspace/isaaclab \
-          --entrypoint bash \
-          "${{ env.CI_IMAGE_TAG }}-curobo" \
-          -lc 'cd /workspace/isaaclab && /isaac-sim/python.sh -m pytest docker/test/test_dockerfile_nonroot.py -q'
-
-    - name: Verify cuRobo runtime user is non-root
-      shell: bash
-      run: |
-        set -euo pipefail
-        runtime_identity="$(docker run --rm --entrypoint bash "${{ env.CI_IMAGE_TAG }}-curobo" \
-          -lc 'printf "%s %s %s\n" "$(id -u)" "$(id -g)" "$(id -un 2>/dev/null || true)"')"
-        read -r runtime_uid runtime_gid runtime_user <<< "${runtime_identity}"
-        echo "cuRobo runtime identity: uid=${runtime_uid} gid=${runtime_gid} user=${runtime_user}"
-        if [ "${runtime_uid}" = "0" ]; then
-          echo "::error::cuRobo Docker image must not run as root by default."
-          exit 1
-        fi
   #endregion
 
   #region test jobs
@@ -629,6 +540,32 @@ jobs:
         filter-pattern: "isaaclab_ov"
         container-name: isaac-lab-ov-test
 
+    # Folded from the former standalone verify-base-non-root job: reuses the
+    # base image already pulled by run-package-tests to keep the regression
+    # check without burning a separate runner.
+    - name: Run Dockerfile non-root regression test
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker run --rm \
+          -v "$PWD":/workspace/isaaclab \
+          --entrypoint bash \
+          "${{ env.CI_IMAGE_TAG }}" \
+          -lc 'cd /workspace/isaaclab && /isaac-sim/python.sh -m pytest docker/test/test_dockerfile_nonroot.py -q'
+
+    - name: Verify Base runtime user is non-root
+      shell: bash
+      run: |
+        set -euo pipefail
+        runtime_identity="$(docker run --rm --entrypoint bash "${{ env.CI_IMAGE_TAG }}" \
+          -lc 'printf "%s %s %s\n" "$(id -u)" "$(id -g)" "$(id -un 2>/dev/null || true)"')"
+        read -r runtime_uid runtime_gid runtime_user <<< "${runtime_identity}"
+        echo "Base runtime identity: uid=${runtime_uid} gid=${runtime_gid} user=${runtime_user}"
+        if [ "${runtime_uid}" = "0" ]; then
+          echo "::error::Base Docker image must not run as root by default."
+          exit 1
+        fi
+
   test-curobo:
     name: test-curobo
     runs-on: [self-hosted, gpu]
@@ -650,6 +587,32 @@ jobs:
         cache-tag: cache-curobo
         include-files: "test_curobo_planner_franka.py,test_curobo_planner_cube_stack.py,test_pink_ik.py"
         container-name: isaac-lab-curobo-test
+
+    # Folded from the former standalone verify-curobo-non-root job: reuses
+    # the curobo image already pulled by run-package-tests to keep the
+    # regression check without burning a separate runner.
+    - name: Run Dockerfile non-root regression test
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker run --rm \
+          -v "$PWD":/workspace/isaaclab \
+          --entrypoint bash \
+          "${{ env.CI_IMAGE_TAG }}-curobo" \
+          -lc 'cd /workspace/isaaclab && /isaac-sim/python.sh -m pytest docker/test/test_dockerfile_nonroot.py -q'
+
+    - name: Verify cuRobo runtime user is non-root
+      shell: bash
+      run: |
+        set -euo pipefail
+        runtime_identity="$(docker run --rm --entrypoint bash "${{ env.CI_IMAGE_TAG }}-curobo" \
+          -lc 'printf "%s %s %s\n" "$(id -u)" "$(id -g)" "$(id -un 2>/dev/null || true)"')"
+        read -r runtime_uid runtime_gid runtime_user <<< "${runtime_identity}"
+        echo "cuRobo runtime identity: uid=${runtime_uid} gid=${runtime_gid} user=${runtime_user}"
+        if [ "${runtime_uid}" = "0" ]; then
+          echo "::error::cuRobo Docker image must not run as root by default."
+          exit 1
+        fi
 
   test-skillgen:
     name: test-skillgen

--- a/.github/workflows/install-ci.yml
+++ b/.github/workflows/install-ci.yml
@@ -157,6 +157,15 @@ jobs:
 
           tools/run_install_ci.py docker $RUNNER_ARGS -- --tb=short "${PYTEST_EXTRA_ARGS[@]}"
 
+      - name: Upload JUnit XML report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-install-tests-uv
+          path: ${{ github.workspace }}/results/results.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
   install-tests-conda:
     name: Installation Tests (conda)
     needs: [changes]
@@ -183,3 +192,12 @@ jobs:
           fi
 
           tools/run_install_ci.py docker $RUNNER_ARGS -- --tb=short "${PYTEST_EXTRA_ARGS[@]}"
+
+      - name: Upload JUnit XML report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-install-tests-conda
+          path: ${{ github.workspace }}/results-conda/results.xml
+          if-no-files-found: ignore
+          retention-days: 7

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -52,11 +52,13 @@ RUN apt-get update && \
 # arm64-only build deps:
 # - imgui-bundle has no prebuilt arm64 wheel; needs GL/X11 dev headers.
 # - swig is required for the nlopt source build (see arm64 nlopt step below).
+# - libgmp-dev is required by pytetwild's fTetWild source build (no aarch64 wheel for 0.2.3).
 RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
         apt-get update && \
         apt-get install -y --no-install-recommends \
         libgl1-mesa-dev libopengl-dev libglx-dev \
         libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev \
+        libgmp-dev \
         swig; \
     fi
 


### PR DESCRIPTION
# Description

- arm64 docker build: add `libgmp-dev` to the arm64-only apt deps so `pytetwild==0.2.3` (added by #5443) can compile its fTetWild backend from source; there is no aarch64 wheel for that version.
- JUnit XML uploads: `run-tests` action and both `install-ci.yml` jobs now upload their `results.xml` as workflow artifacts so downstream tooling and reviewers can pull the JUnit report without re-running the job.
- Folded the standalone `verify-base-non-root` and `verify-curobo-non-root` jobs into `test-isaaclab-ov` and `test-curobo` so the regression check piggybacks on the image those jobs already pulled, dropping two extra self-hosted GPU runner allocations per PR.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there