### PR TITLE
Restore rendering correctness tests in IsaacSim CI

### DIFF
--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -31,6 +31,13 @@ inputs:
     description: 'Pattern to filter test files (e.g., isaaclab_tasks)'
     default: ''
     required: false
+  exclude-pattern:
+    description: >-
+      Comma-separated substrings; test files whose path contains any entry are
+      skipped. Combines with filter-pattern (include + exclude). Also supports
+      the legacy pd filter-pattern: "not <pattern>" form for exclude-only jobs.
+    default: ''
+    required: false
   shard-index:
     description: 'Zero-based shard index'
     default: ''
@@ -132,6 +139,7 @@ runs:
         image-tag: ${{ inputs.image-tag }}
         pytest-options: ${{ inputs.pytest-options }}
         filter-pattern: ${{ inputs.filter-pattern }}
+        exclude-pattern: ${{ inputs.exclude-pattern }}
         shard-index: ${{ inputs.shard-index }}
         shard-count: ${{ inputs.shard-count }}
         curobo-only: ${{ inputs.curobo-only }}

--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -28,14 +28,17 @@ inputs:
     default: 'cache-base'
     required: false
   filter-pattern:
-    description: 'Pattern to filter test files (e.g., isaaclab_tasks)'
+    description: >-
+      Pattern to filter test files (e.g., isaaclab_tasks); test files whose path
+      contains this pattern are included. Only one pattern can be used at a time,
+      no comma-separated substrings allowed. Also supports the legacy "not <pattern>"
+      form for exclude-only jobs.
     default: ''
     required: false
   exclude-pattern:
     description: >-
       Comma-separated substrings; test files whose path contains any entry are
-      skipped. Combines with filter-pattern (include + exclude). Also supports
-      the legacy pd filter-pattern: "not <pattern>" form for exclude-only jobs.
+      skipped. Combines with filter-pattern (include + exclude).
     default: ''
     required: false
   shard-index:

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -31,6 +31,12 @@ inputs:
     description: 'Pattern to filter test files (e.g., isaaclab_tasks)'
     default: ''
     required: false
+  exclude-pattern:
+    description: >-
+      Comma-separated substrings passed as TEST_EXCLUDE_PATTERN; test files
+      whose path contains any entry are skipped. Combines with filter-pattern.
+    default: ''
+    required: false
   curobo-only:
     description: 'Run only cuRobo and SkillGen tests (requires the cuRobo Docker image)'
     default: 'false'
@@ -75,13 +81,14 @@ runs:
           local reports_dir="$5"
           local pytest_options="$6"
           local filter_pattern="$7"
-          local curobo_only="$8"
-          local include_files="$9"
-          local quarantined_only="${10}"
-          local shard_index="${11}"
-          local shard_count="${12}"
-          local volume_mount_source="${13}"
-          local extra_pip_packages="${14}"
+          local exclude_pattern="$8"
+          local curobo_only="$9"
+          local include_files="${10}"
+          local quarantined_only="${11}"
+          local shard_index="${12}"
+          local shard_count="${13}"
+          local volume_mount_source="${14}"
+          local extra_pip_packages="${15}"
           local logs_pid=""
           local wait_pid=""
           local docker_wait_file="/tmp/.docker_exit_${container_name}"
@@ -109,6 +116,9 @@ runs:
           fi
           if [ -n "$filter_pattern" ]; then
             echo "With filter pattern: $filter_pattern"
+          fi
+          if [ -n "$exclude_pattern" ]; then
+            echo "With exclude pattern: $exclude_pattern"
           fi
           if [ "$curobo_only" = "true" ]; then
             echo "cuRobo-only mode enabled: running only cuRobo and SkillGen tests"
@@ -165,9 +175,12 @@ runs:
             if [[ "$filter_pattern" == "not "* ]]; then
               # Handle "not <pattern>" case - note the trailing space to avoid
               # matching words that happen to start with "not".
-              exclude_pattern="${filter_pattern#not }"
-              docker_env_vars="$docker_env_vars -e TEST_EXCLUDE_PATTERN=$exclude_pattern"
-              echo "Setting exclude pattern: $exclude_pattern"
+              filter_exclude_pattern="${filter_pattern#not }"
+              if [ -n "$exclude_pattern" ]; then
+                exclude_pattern="${exclude_pattern},${filter_exclude_pattern}"
+              else
+                exclude_pattern="$filter_exclude_pattern"
+              fi
             else
               # Handle positive pattern case
               docker_env_vars="$docker_env_vars -e TEST_FILTER_PATTERN=$filter_pattern"
@@ -175,6 +188,11 @@ runs:
             fi
           else
             echo "No filter pattern provided"
+          fi
+
+          if [ -n "$exclude_pattern" ]; then
+            docker_env_vars="$docker_env_vars -e TEST_EXCLUDE_PATTERN=$exclude_pattern"
+            echo "Setting exclude pattern: $exclude_pattern"
           fi
 
           if [ -n "$extra_pip_packages" ]; then
@@ -369,7 +387,7 @@ runs:
         }
 
         # Call the function with provided parameters
-        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "${{ inputs.pytest-options }}" "${{ inputs.filter-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}"
+        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "${{ inputs.pytest-options }}" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}"
 
     - name: Kill container on cancellation
       if: cancelled()

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -28,13 +28,17 @@ inputs:
     default: ''
     required: false
   filter-pattern:
-    description: 'Pattern to filter test files (e.g., isaaclab_tasks)'
+    description: >-
+      Pattern to filter test files (e.g., isaaclab_tasks); test files whose path
+      contains this pattern are included. Only one pattern can be used at a time,
+      no comma-separated substrings allowed. Also supports the legacy "not <pattern>"
+      form for exclude-only jobs.
     default: ''
     required: false
   exclude-pattern:
     description: >-
-      Comma-separated substrings passed as TEST_EXCLUDE_PATTERN; test files
-      whose path contains any entry are skipped. Combines with filter-pattern.
+      Comma-separated substrings; test files whose path contains any entry are
+      excluded. Combines with filter-pattern (include + exclude).
     default: ''
     required: false
   curobo-only:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -346,6 +346,7 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_tasks"
+        exclude-pattern: "test_rendering_"
         shard-index: "0"
         shard-count: "3"
         container-name: isaac-lab-tasks-1-test
@@ -368,6 +369,7 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_tasks"
+        exclude-pattern: "test_rendering_"
         shard-index: "1"
         shard-count: "3"
         container-name: isaac-lab-tasks-2-test
@@ -390,6 +392,7 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_tasks"
+        exclude-pattern: "test_rendering_"
         shard-index: "2"
         shard-count: "3"
         container-name: isaac-lab-tasks-3-test

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -117,29 +117,6 @@ merges. The job is currently disabled. Add test filenames here to
 quarantine them from regular CI.
 """
 
-RENDERING_CORRECTNESS_TESTS = [
-    "test_rendering_cartpole.py",
-    "test_rendering_dexsuite_kuka.py",
-    "test_rendering_registered_tasks.py",
-    "test_rendering_shadow_hand.py",
-]
-"""Rendering-correctness tests that run in-kit (non-kitless variants).
-
-These tests are skipped in the generic ``isaaclab_tasks [N/3]`` CI jobs
-and run in the dedicated ``test-rendering-correctness`` CI job.
-"""
-
-RENDERING_CORRECTNESS_KITLESS_TESTS = [
-    "test_rendering_cartpole_kitless.py",
-    "test_rendering_dexsuite_kuka_kitless.py",
-    "test_rendering_shadow_hand_kitless.py",
-]
-"""Kitless rendering-correctness tests (OVRTX golden-image comparisons).
-
-These tests are skipped in the generic ``isaaclab_tasks [N/3]`` CI jobs
-and run in the dedicated ``test-rendering-correctness-kitless`` CI job.
-"""
-
 TESTS_TO_SKIP = [
     # lab
     "test_argparser_launch.py",  # app.close issue
@@ -155,10 +132,6 @@ TESTS_TO_SKIP = [
     # quarantined tests - run in dedicated CI job that does not block PR merges
     *QUARANTINED_TESTS,
     "test_environments_training.py",  # Long-running RL training test; runs in dedicated CI job
-    # rendering-correctness tests - run in dedicated test-rendering-correctness CI job
-    *RENDERING_CORRECTNESS_TESTS,
-    # kitless rendering-correctness tests - run in dedicated test-rendering-correctness-kitless CI job
-    *RENDERING_CORRECTNESS_KITLESS_TESTS,
 ]
 """A list of tests to skip in CI (see conftest.py)."""
 


### PR DESCRIPTION
# Description

The skip list is a global list that will impact all CI jobs. We only want to skip render correctness tests in the isaaclab_tasks (1/2/3) test jobs. We still want to include rendering correctness tests for IsaacSim nightly integration CI jobs:

```sh
./isaaclab.sh -p -m pytest tools -m isaacsim_ci
```


## Type of change

- Testing-only change

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
