### PR TITLE
fix: support GR00T N1.6 SO-101 RLinf converters

### DIFF
--- a/source/isaaclab_contrib/isaaclab_contrib/rl/rlinf/extension.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/rl/rlinf/extension.py
@@ -261,17 +261,31 @@ def _register_gr00t_converters(cfg: dict) -> None:
     Args:
         cfg: The IsaacLab-specific configuration dictionary (``env.train.isaaclab``).
     """
-    from rlinf.models.embodiment.gr00t import simulation_io
-
     obs_converter_type = cfg.get("obs_converter_type", "dex3")
 
-    if obs_converter_type not in simulation_io.OBS_CONVERSION:
-        simulation_io.OBS_CONVERSION[obs_converter_type] = _convert_isaaclab_obs_to_gr00t
-        logger.info(f"Registered obs converter: {obs_converter_type}")
+    simulation_modules = []
+    try:
+        from rlinf.models.embodiment.gr00t import simulation_io as gr00t_simulation_io
 
-    if obs_converter_type not in simulation_io.ACTION_CONVERSION:
-        simulation_io.ACTION_CONVERSION[obs_converter_type] = _convert_gr00t_to_isaaclab_action
-        logger.info(f"Registered action converter: {obs_converter_type}")
+        simulation_modules.append(("gr00t", gr00t_simulation_io))
+    except Exception as exc:
+        logger.debug(f"Could not import GR00T N1.5 simulation_io: {exc}")
+
+    try:
+        from rlinf.models.embodiment.gr00t_n1d6 import simulation_io as gr00t_n1d6_simulation_io
+
+        simulation_modules.append(("gr00t_n1d6", gr00t_n1d6_simulation_io))
+    except Exception as exc:
+        logger.debug(f"Could not import GR00T N1.6 simulation_io: {exc}")
+
+    for module_name, simulation_io in simulation_modules:
+        if obs_converter_type not in simulation_io.OBS_CONVERSION:
+            simulation_io.OBS_CONVERSION[obs_converter_type] = _convert_isaaclab_obs_to_gr00t
+            logger.info(f"Registered {module_name} obs converter: {obs_converter_type}")
+
+        if obs_converter_type not in simulation_io.ACTION_CONVERSION:
+            simulation_io.ACTION_CONVERSION[obs_converter_type] = _convert_gr00t_to_isaaclab_action
+            logger.info(f"Registered {module_name} action converter: {obs_converter_type}")
 
 
 def _convert_isaaclab_obs_to_gr00t(env_obs: dict) -> dict:
@@ -323,10 +337,18 @@ def _convert_isaaclab_obs_to_gr00t(env_obs: dict) -> dict:
                 gr00t_key = spec.get("gr00t_key")
                 slice_range = spec.get("slice", [0, states_np.shape[-1]])
                 if gr00t_key:
-                    groot_obs[gr00t_key] = states_np[:, :, slice_range[0] : slice_range[1]]
+                    state_part = states_np[:, :, slice_range[0] : slice_range[1]]
+                    if "scale" in spec:
+                        state_part = state_part * np.asarray(spec["scale"], dtype=state_part.dtype)
+                    if "offset" in spec:
+                        state_part = state_part + np.asarray(spec["offset"], dtype=state_part.dtype)
+                    groot_obs[gr00t_key] = state_part
 
-    # Pass through task descriptions
-    groot_obs["annotation.human.action.task_description"] = env_obs.get("task_descriptions", [])
+    # Pass through task descriptions.  SO-101 N1.6 checkpoints use
+    # annotation.human.task_description, while older LIBERO-style configs use
+    # annotation.human.action.task_description.
+    language_key = gr00t_mapping.get("language_key", "annotation.human.action.task_description")
+    groot_obs[language_key] = env_obs.get("task_descriptions", [])
 
     return groot_obs
 
@@ -352,8 +374,18 @@ def _convert_gr00t_to_isaaclab_action(action_chunk: dict, chunk_size: int = 1) -
     prefix_pad = action_mapping.get("prefix_pad", 0)
     suffix_pad = action_mapping.get("suffix_pad", 0)
 
-    # Concatenate all action parts
-    action_parts = [v[:, :chunk_size, :] for v in action_chunk.values()]
+    # Concatenate action parts in the configured order when provided.
+    action_keys = action_mapping.get("gr00t_action_keys") or list(action_chunk.keys())
+    action_parts = []
+    for key in action_keys:
+        if key in action_chunk:
+            action_parts.append(action_chunk[key][:, :chunk_size, :])
+            continue
+        short_key = key.split(".", 1)[1] if key.startswith("action.") else f"action.{key}"
+        if short_key in action_chunk:
+            action_parts.append(action_chunk[short_key][:, :chunk_size, :])
+    if not action_parts:
+        raise KeyError(f"No configured GR00T action keys found in action chunk: keys={list(action_chunk)}")
     action_concat = np.concatenate(action_parts, axis=-1)
 
     # Apply padding
@@ -364,6 +396,10 @@ def _convert_gr00t_to_isaaclab_action(action_chunk: dict, chunk_size: int = 1) -
             mode="constant",
             constant_values=0,
         )
+    if "scale" in action_mapping:
+        action_concat = action_concat * np.asarray(action_mapping["scale"], dtype=action_concat.dtype)
+    if "offset" in action_mapping:
+        action_concat = action_concat + np.asarray(action_mapping["offset"], dtype=action_concat.dtype)
     return action_concat
 
 
@@ -473,6 +509,9 @@ def _create_generic_env_wrapper(task_id: str) -> type:
                 from isaaclab.app import AppLauncher
 
                 sim_app = AppLauncher(headless=True, enable_cameras=True).app
+                # Import workshop tasks after AppLauncher starts so gymnasium sees
+                # the custom SO-101 task IDs inside RLinf's subprocess.
+                import sim_to_real_so101.tasks  # noqa: F401
                 import gymnasium as gym
 
                 from isaaclab_tasks.utils import load_cfg_from_registry


### PR DESCRIPTION
## Summary
- Registers IsaacLab/RLinf converters for both existing GR00T and GR00T N1.6 simulation modules.
- Adds configurable language key, ordered action keys, and affine scale/offset mapping for state/action bridges.
- Imports custom task packages after `AppLauncher` startup inside RLinf subprocess env construction so externally registered Gym task IDs are visible.

## Context
This was validated as part of an SO-101 vials-to-rack GR00T N1.6 RLinf smoke using RLinf PR #1079 and Isaac-GR00T `n1.6-release`.

## Tested
- `python3 -m py_compile source/isaaclab_contrib/isaaclab_contrib/rl/rlinf/extension.py`
- Downstream bounded Isaac Sim/RLinf smoke: 1 env, 1 epoch, rollout completed, actor/critic metrics printed, checkpoint saved.
