### PR TITLE
[IK] Stop DiffIK action term from accumulating body-offset on aliased Jacobian buffer

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-diffik-jacobian-aliasing-fix.rst
+++ b/source/isaaclab/changelog.d/jichuanh-diffik-jacobian-aliasing-fix.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed translational Jacobian drift in
+  :meth:`~isaaclab.envs.mdp.actions.DifferentialInverseKinematicsAction._compute_frame_jacobian`
+  when called multiple times per step with non-``None`` ``body_offset``.

--- a/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/task_space_actions.py
@@ -95,6 +95,9 @@ class DifferentialInverseKinematicsAction(ActionTerm):
         self._raw_actions = torch.zeros(self.num_envs, self.action_dim, device=self.device)
         self._processed_actions = torch.zeros_like(self.raw_actions)
 
+        # owned buffer; _compute_frame_jacobian mutates this, not the data-layer view.
+        self._jacobian_b = torch.zeros(self.num_envs, 6, len(self._jacobi_joint_ids), device=self.device)
+
         # save the scale as tensors
         self._scale = torch.zeros((self.num_envs, self.action_dim), device=self.device)
         self._scale[:] = torch.tensor(self.cfg.scale, device=self.device)
@@ -241,8 +244,7 @@ class DifferentialInverseKinematicsAction(ActionTerm):
         This function accounts for the target frame offset and applies the necessary transformations to obtain
         the right Jacobian from the parent body Jacobian.
         """
-        # read the parent jacobian
-        jacobian = self.jacobian_b
+        self._jacobian_b[:] = self.jacobian_b
         # account for the offset
         if self.cfg.body_offset is not None:
             # Modify the jacobian to account for the offset
@@ -250,12 +252,16 @@ class DifferentialInverseKinematicsAction(ActionTerm):
             # v_link = v_ee + w_ee x r_link_ee = v_J_ee * q + w_J_ee * q x r_link_ee
             #        = (v_J_ee + w_J_ee x r_link_ee ) * q
             #        = (v_J_ee - r_link_ee_[x] @ w_J_ee) * q
-            jacobian[:, 0:3, :] += torch.bmm(-math_utils.skew_symmetric_matrix(self._offset_pos), jacobian[:, 3:, :])
+            self._jacobian_b[:, 0:3, :] += torch.bmm(
+                -math_utils.skew_symmetric_matrix(self._offset_pos), self._jacobian_b[:, 3:, :]
+            )
             # -- rotational part
             # w_link = R_link_ee @ w_ee
-            jacobian[:, 3:, :] = torch.bmm(math_utils.matrix_from_quat(self._offset_rot), jacobian[:, 3:, :])
+            self._jacobian_b[:, 3:, :] = torch.bmm(
+                math_utils.matrix_from_quat(self._offset_rot), self._jacobian_b[:, 3:, :]
+            )
 
-        return jacobian
+        return self._jacobian_b
 
 
 class OperationalSpaceControllerAction(ActionTerm):

--- a/source/isaaclab/test/envs/test_diffik_jacobian_aliasing.py
+++ b/source/isaaclab/test/envs/test_diffik_jacobian_aliasing.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression tests for DiffIK Jacobian aliasing (NVBug 6043099).
+
+``DifferentialInverseKinematicsAction._compute_frame_jacobian`` historically
+aliased the parent Jacobian and applied the body-offset correction in place.
+When the parent Jacobian was a view onto the engine's mutable buffer, repeated
+calls within a single simulation step accumulated the correction. The fix
+copies the Jacobian into an owned buffer before mutating, making the method
+idempotent regardless of whether ``jacobian_b`` returns a view or a copy.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from isaaclab.envs.mdp.actions.task_space_actions import DifferentialInverseKinematicsAction
+from isaaclab.utils import math as math_utils
+
+
+class _Stub:
+    """Minimal stand-in for ``DifferentialInverseKinematicsAction`` that exposes only
+    what ``_compute_frame_jacobian`` reads. ``jacobian_b`` returns the backing buffer
+    **without copying**, mirroring the worst case where the data layer hands out a view
+    onto engine memory. The owned ``_jacobian_b`` buffer is what the fixed method must
+    write into.
+    """
+
+    def __init__(self, num_envs: int, num_joints: int, body_offset_pos, body_offset_rot, backing_buffer):
+        self.cfg = SimpleNamespace(body_offset=SimpleNamespace(pos=body_offset_pos, rot=body_offset_rot))
+        self._offset_pos = torch.tensor(body_offset_pos, dtype=torch.float32).repeat(num_envs, 1)
+        self._offset_rot = torch.tensor(body_offset_rot, dtype=torch.float32).repeat(num_envs, 1)
+        self._jacobian_b = torch.zeros(num_envs, 6, num_joints)
+        self._backing_buffer = backing_buffer
+
+    @property
+    def jacobian_b(self):
+        return self._backing_buffer
+
+
+def _make_stub(num_envs: int, num_joints: int, body_offset_pos, body_offset_rot, backing_buffer: torch.Tensor):
+    return _Stub(num_envs, num_joints, body_offset_pos, body_offset_rot, backing_buffer)
+
+
+def test_compute_frame_jacobian_is_idempotent_within_step():
+    """Two consecutive calls under the same state must return identical Jacobians.
+
+    Regression for NVBug 6043099. With the buggy alias-and-mutate pattern, the
+    second call returned the first-call result with the body-offset correction
+    applied a second time.
+    """
+    num_envs, num_joints = 4, 7
+    backing = torch.randn(num_envs, 6, num_joints)
+    backing_snapshot = backing.clone()
+
+    stub = _make_stub(
+        num_envs,
+        num_joints,
+        body_offset_pos=[0.0, 0.0, 0.05],
+        body_offset_rot=[1.0, 0.0, 0.0, 0.0],
+        backing_buffer=backing,
+    )
+
+    compute = DifferentialInverseKinematicsAction._compute_frame_jacobian
+
+    j1 = compute(stub).clone()
+    j2 = compute(stub).clone()
+    j3 = compute(stub).clone()
+
+    torch.testing.assert_close(j1, j2)
+    torch.testing.assert_close(j1, j3)
+    # The backing buffer must be untouched: the fix may not corrupt the source.
+    torch.testing.assert_close(backing, backing_snapshot)
+
+
+def test_compute_frame_jacobian_applies_offset_once():
+    """The body-offset correction is applied exactly once.
+
+    Compares the method output against an out-of-place reference computation.
+    """
+    num_envs, num_joints = 2, 5
+    backing = torch.randn(num_envs, 6, num_joints)
+    offset_pos = [0.1, -0.02, 0.03]
+    offset_rot = [0.7071, 0.0, 0.7071, 0.0]
+
+    stub = _make_stub(num_envs, num_joints, offset_pos, offset_rot, backing)
+
+    # Reference: out-of-place computation, no aliasing.
+    skew = math_utils.skew_symmetric_matrix(stub._offset_pos)
+    rot = math_utils.matrix_from_quat(stub._offset_rot)
+    ref_trans = backing[:, 0:3, :] + torch.bmm(-skew, backing[:, 3:, :])
+    ref_rot = torch.bmm(rot, backing[:, 3:, :])
+    reference = torch.cat([ref_trans, ref_rot], dim=1)
+
+    actual = DifferentialInverseKinematicsAction._compute_frame_jacobian(stub)
+    torch.testing.assert_close(actual, reference)
+
+
+def test_compute_frame_jacobian_returns_owned_buffer():
+    """The returned tensor must be the owned buffer, not the data-layer source.
+
+    Guards against future regressions where ``return self.jacobian_b`` slips back in.
+    """
+    num_envs, num_joints = 1, 3
+    backing = torch.randn(num_envs, 6, num_joints)
+    stub = _make_stub(num_envs, num_joints, [0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], backing)
+
+    out = DifferentialInverseKinematicsAction._compute_frame_jacobian(stub)
+    assert out.data_ptr() == stub._jacobian_b.data_ptr()
+    assert out.data_ptr() != backing.data_ptr()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 1. Summary

- `DifferentialInverseKinematicsAction._compute_frame_jacobian` aliased `self.jacobian_b` and applied the body-offset correction in place. If the underlying data source returns a view onto the engine's mutable Jacobian buffer, repeated calls within a single step drifted the translational Jacobian linearly per call.
- Fix: allocate an owned `self._jacobian_b` buffer in `__init__`, copy into it before mutating. Mirrors the pattern already used by `OperationalSpaceControllerAction._compute_ee_jacobian`.
- Adds a stub-based regression test that fails against the previous behavior (2/3 assertions) and passes after the fix.
- One file changed in product code (+16 −5); no behavior change for callers because the returned tensor has identical values.

## 2. Why the previous code happened to work today

- `self.jacobian_b` calls `self.jacobian_w`, which advanced-indexes the source buffer as `[:, int_body_idx, :, list_joint_ids]`. PyTorch mixed advanced indexing returns a fresh copy per call, so the in-place `+=` mutated a copy in practice.
- The safety depended entirely on `_jacobi_body_idx` being a single int and `_jacobi_joint_ids` being a list. A refactor to slices would re-expose the bug.
- The new owned-buffer pattern makes the copy explicit at the action term boundary and is insensitive to upstream indexing semantics.

## 3. Test plan

- [x] `test_compute_frame_jacobian_is_idempotent_within_step` — three consecutive calls under non-`None` body offset return identical tensors. Fails against `develop`, passes against the fix.
- [x] `test_compute_frame_jacobian_applies_offset_once` — output matches an out-of-place reference computation.
- [x] `test_compute_frame_jacobian_returns_owned_buffer` — return tensor is the owned buffer, not the data-layer source.
- [x] Pre-commit (`./isaaclab.sh -f`) clean on changed files.

## 4. Out of scope

- The `jacobian_b` property itself does the same alias-then-mutate trick when rotating into base frame (`jacobian[:, :3, :] = torch.bmm(...)`). Currently safe by the same advanced-indexing copy. Left alone in this PR to keep scope minimal; flagging for a possible follow-up.
- `OperationalSpaceControllerAction.jacobian_b` has the same property-level pattern but its consumer copies into an owned buffer before mutating, so it's safe-by-consumer.

Refs NVBug 6043099