### PR TITLE
[Fix] add_new_robot tutorial wheel-velocity action on GPU device

### DIFF
--- a/scripts/tutorials/01_assets/add_new_robot.py
+++ b/scripts/tutorials/01_assets/add_new_robot.py
@@ -103,6 +103,11 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
     sim_time = 0.0
     count = 0
 
+    # wheel-velocity templates allocated once on the simulation device; the joint
+    # target setters dispatch to GPU Warp kernels and reject CPU tensors.
+    straight_action = torch.tensor([[10.0, 10.0]], device=sim.device)
+    turn_action = torch.tensor([[5.0, -5.0]], device=sim.device)
+
     while simulation_app.is_running():
         # reset
         if count % 500 == 0:
@@ -142,12 +147,12 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
         # drive around
         if count % 100 < 75:
             # Drive straight by setting equal wheel velocities
-            action = torch.Tensor([[10.0, 10.0]])
+            action = straight_action
         else:
             # Turn by applying different velocities
-            action = torch.Tensor([[5.0, -5.0]])
+            action = turn_action
 
-        scene["Jetbot"].set_joint_velocity_target(action)
+        scene["Jetbot"].set_joint_velocity_target_index(target=action)
 
         # wave
         wave_action = scene["Dofbot"].data.default_joint_pos.torch

--- a/source/isaaclab/changelog.d/jichuanh-tutorial-add-new-robot-cpu-device.rst
+++ b/source/isaaclab/changelog.d/jichuanh-tutorial-add-new-robot-cpu-device.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed ``scripts/tutorials/01_assets/add_new_robot.py`` failing at the Jetbot
+  velocity-target setter when the action was a CPU ``torch.Tensor``. The
+  tutorial now allocates the wheel-velocity templates on ``sim.device`` and
+  uses :meth:`~isaaclab.assets.BaseArticulation.set_joint_velocity_target_index`.


### PR DESCRIPTION
## 1. Summary

- ``scripts/tutorials/01_assets/add_new_robot.py`` errored at runtime: the wheel-velocity action was a CPU ``torch.Tensor`` and ``set_joint_velocity_target`` dispatches to a GPU Warp kernel that rejects CPU tensors at type check.
- Allocate the two wheel-velocity templates once on ``sim.device``, reuse across the loop, and call ``set_joint_velocity_target_index`` (also silences the deprecation warning visible in the bug report's first line).
- Scope: tutorial only. 1 file, +12 −3 plus a changelog fragment.

## 2. Why it broke

- The tutorial was added in #289 (2025-03-12) with ``torch.Tensor([[10.0, 10.0]])`` — CPU literal. The asset API at the time accepted CPU torch tensors.
- #4551 (2026-02-13) migrated the assets layer from torch to Warp kernels; CPU torch tensors silently became unsupported because Warp's kernel-argument check requires GPU-accessible data.
- #4911 (2026-03-10) followed up with a sweep that fixed several tutorials. It touched the reset block of this file (added ``wp.to_torch`` and ``_index`` variants for ``write_*_to_sim``), but did not touch the per-step action block — that remained CPU.

The bug has therefore been latent since #4551 and surfaced now that more users are running the tutorial on v3.0.0-beta.

## 3. Why only this tutorial

A grep across ``scripts/tutorials/**.py`` for tensor literals fed into ``set_joint_*_target*`` / ``write_*_to_sim_index`` shows ``add_new_robot.py`` is the only file constructing tensors without a ``device=`` kwarg. Every other tutorial either reads from a ``.torch`` accessor (already on device) or uses ``torch.tensor(..., device=sim.device)``.

## 4. Test plan

- [x] Reproduced the customer's error in isolation: CPU ``torch.Tensor`` → ``wp.launch`` → ``argument 'in_data' expects an array of type array(ndim=2, dtype=float32), but passed value has type Tensor``.
- [x] Same launch with a GPU tensor (``.cuda()``) succeeds.
- [x] Pre-commit clean on changed files.
- [ ] Manual smoke: ``./isaaclab.sh -p scripts/tutorials/01_assets/add_new_robot.py --num_envs 1 --headless`` runs through several reset cycles.

## 5. Out of scope

- The underlying API in ``isaaclab_physx`` silently accepts CPU torch tensors at the Python boundary and only fails inside ``wp.launch``. Auto-moving CPU tensors to ``self.device`` in ``set_joint_*_target_index`` would prevent users from hitting this from other scripts. Not in scope here per the bug-report preference for a tutorial-only fix; flagging for follow-up.

Refs NVBug 6156303