### PR TITLE
Removed OVRTX 0.2.x compatibility code paths

### DIFF
--- a/source/isaaclab_ov/changelog.d/remove-legacy-ovrtx-code-path.rst
+++ b/source/isaaclab_ov/changelog.d/remove-legacy-ovrtx-code-path.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+* Removed OVRTX 0.2.x compatibility code paths from :class:`~isaaclab_ov.renderers.OVRTXRenderer`.

--- a/source/isaaclab_ov/changelog.d/remove-legacy-ovrtx-code-path.rst
+++ b/source/isaaclab_ov/changelog.d/remove-legacy-ovrtx-code-path.rst
@@ -1,4 +1,4 @@
 Changed
 ^^^^^^^
 
-* Removed OVRTX 0.2.x compatibility code paths from :class:`~isaaclab_ov.renderers.OVRTXRenderer`.
+* Removed legacy OVRTX 0.2.x code paths from :class:`~isaaclab_ov.renderers.OVRTXRenderer`.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import logging
 import math
 import os
-import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -40,9 +39,7 @@ import isaaclab.utils.warp  # noqa: F401  # initializes Warp runtime
 # By setting OVRTX_SKIP_USD_CHECK, we prevent the C library from loading the pxr Python package.
 os.environ["OVRTX_SKIP_USD_CHECK"] = "1"
 
-import ovrtx
 from ovrtx import Device, PrimMode, Renderer, RendererConfig, Semantic
-from packaging.version import Version
 
 from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
 from isaaclab.sim import SimulationContext
@@ -52,12 +49,10 @@ from .ovrtx_renderer_cfg import OVRTXRendererCfg
 from .ovrtx_renderer_kernels import (
     create_camera_transforms_kernel,
     extract_all_depth_tiles_kernel,
-    extract_all_depth_tiles_kernel_legacy,
     extract_all_rgb_float_tiles_kernel,
     extract_all_rgb_half_tiles_kernel,
     extract_all_rgba_tiles_kernel,
     generate_random_colors_from_ids_kernel,
-    generate_random_colors_from_ids_kernel_legacy,
     sync_newton_transforms_kernel,
 )
 from .ovrtx_usd import (
@@ -73,10 +68,6 @@ if TYPE_CHECKING:
     from isaaclab.utils.warp import ProxyArray
 
 from isaaclab.renderers.camera_render_spec import CameraRenderSpec
-
-# Shared integration floor for this module; reuse for ovrtx features that share one support floor.
-_OVRTX_VERSION = Version(ovrtx.__version__)
-_IS_OVRTX_0_3_0_OR_NEWER = Version("0.3.0") <= _OVRTX_VERSION
 
 # The resolved integer value is assigned to the ``omni:rtx:minimal:mode`` attribute of the render product.
 _RTX_MINIMAL_MODES = {
@@ -171,7 +162,6 @@ class OVRTXRenderer(BaseRenderer):
     def __init__(self, cfg: OVRTXRendererCfg):
         self.cfg = cfg
         self._device = "cuda:0"  # default; overridden by create_render_data(spec)
-        self._usd_handles = []
         self._render_product_paths = []
         self._camera_binding = None
         self._object_binding = None
@@ -181,7 +171,7 @@ class OVRTXRenderer(BaseRenderer):
         self._camera_rel_path: str | None = None
         self._output_semantic_color_buffer: wp.array | None = None
 
-        self._use_ovrtx_cloning = self.cfg.use_ovrtx_cloning and _IS_OVRTX_0_3_0_OR_NEWER
+        self._use_ovrtx_cloning = self.cfg.use_ovrtx_cloning
 
         if self._use_ovrtx_cloning:
             clone_plan = SimulationContext.instance().get_clone_plan()
@@ -193,7 +183,7 @@ class OVRTXRenderer(BaseRenderer):
         OVRTX_CONFIG = RendererConfig(
             log_file_path=self.cfg.log_file_path,
             log_level=self.cfg.log_level,
-            read_gpu_transforms=_IS_OVRTX_0_3_0_OR_NEWER,
+            read_gpu_transforms=True,
             keep_system_alive=True,
         )
         self._renderer = Renderer(OVRTX_CONFIG)
@@ -233,7 +223,7 @@ class OVRTXRenderer(BaseRenderer):
             return
 
         logger.info("Preparing stage for export (%d envs, cloning=%s)...", num_envs, self._use_ovrtx_cloning)
-        create_scene_partition_attributes(stage, num_envs, self._use_ovrtx_cloning, not _IS_OVRTX_0_3_0_OR_NEWER)
+        create_scene_partition_attributes(stage, num_envs, self._use_ovrtx_cloning)
 
         self._exported_usd_string = export_stage_to_string(stage, num_envs, self._use_ovrtx_cloning)
 
@@ -272,33 +262,19 @@ class OVRTXRenderer(BaseRenderer):
             combined_usd_string = self._exported_usd_string + "\n\n" + render_product_string
             self._exported_usd_string = None  # Free memory
 
+            # If temp_usd_dir is set, write the combined USD stage to a temporary file.
             if self.cfg.temp_usd_dir is not None:
                 temp_usd_dir = Path(self.cfg.temp_usd_dir)
-            elif not _IS_OVRTX_0_3_0_OR_NEWER:
-                # OVRTX 0.2.0 is not able to load USD from a string, so we need to write to a temporary file.
-                temp_usd_dir = Path(tempfile.gettempdir()) / "ovrtx"
-            else:
-                temp_usd_dir = None
-
-            if temp_usd_dir is not None:
                 temp_usd_dir.mkdir(parents=True, exist_ok=True)
                 temp_usd_path = temp_usd_dir / "ovrtx_renderer_stage.usda"
                 with open(temp_usd_path, "w", encoding="utf-8") as f:
                     f.write(combined_usd_string)
                     logger.info("Wrote combined USD stage to %s", temp_usd_path)
-            else:
-                temp_usd_path = None
 
             logger.info("Loading USD into OvRTX...")
             try:
-                if _IS_OVRTX_0_3_0_OR_NEWER:
-                    self._renderer.open_usd_from_string(combined_usd_string)
-                    logger.info("OVRTX loaded USD from string successfully")
-                else:
-                    assert temp_usd_path is not None  # OVRTX < 0.3.0 always materializes combined USD on disk.
-                    handle = self._renderer.add_usd(str(temp_usd_path), path_prefix=None)
-                    self._usd_handles.append(handle)
-                    logger.info("OVRTX loaded USD from file successfully (path: %s, handle: %s)", temp_usd_path, handle)
+                self._renderer.open_usd_from_string(combined_usd_string)
+                logger.info("OVRTX loaded USD from string successfully")
             except Exception as e:
                 logger.exception("Error loading USD: %s", e)
                 raise
@@ -545,11 +521,7 @@ class OVRTXRenderer(BaseRenderer):
         output_colors = self._output_semantic_color_buffer
 
         wp.launch(
-            kernel=(
-                generate_random_colors_from_ids_kernel
-                if _IS_OVRTX_0_3_0_OR_NEWER
-                else generate_random_colors_from_ids_kernel_legacy
-            ),
+            kernel=generate_random_colors_from_ids_kernel,
             dim=input_ids.shape,
             inputs=[input_ids, output_colors],
             device=self._device,
@@ -589,12 +561,10 @@ class OVRTXRenderer(BaseRenderer):
         self, render_data: OVRTXRenderData, tiled_depth_data: wp.array, output_buffers: dict
     ) -> None:
         """Extract per-env depth tiles into output_buffers (single kernel launch)."""
-        kernel = extract_all_depth_tiles_kernel if _IS_OVRTX_0_3_0_OR_NEWER else extract_all_depth_tiles_kernel_legacy
-
         for depth_type in ["depth", "distance_to_image_plane", "distance_to_camera"]:
             if depth_type in output_buffers:
                 wp.launch(
-                    kernel=kernel,
+                    kernel=extract_all_depth_tiles_kernel,
                     dim=(render_data.num_envs, render_data.height, render_data.width),
                     inputs=[
                         tiled_depth_data,
@@ -763,13 +733,7 @@ class OVRTXRenderer(BaseRenderer):
         self._object_binding = None
 
         if self._renderer:
-            if self._usd_handles:
-                for handle in self._usd_handles:
-                    try:
-                        self._renderer.remove_usd(handle)
-                    except Exception as e:
-                        logger.warning("Error removing USD: %s", e)
-                self._usd_handles.clear()
+            self._renderer.reset_stage()
             self._renderer = None
 
         self._render_product_paths.clear()

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -733,7 +733,11 @@ class OVRTXRenderer(BaseRenderer):
         self._object_binding = None
 
         if self._renderer:
-            self._renderer.reset_stage()
+            try:
+                self._renderer.reset_stage()
+            except Exception as e:
+                logger.warning("Error resetting stage: %s", e)
+
             self._renderer = None
 
         self._render_product_paths.clear()

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
@@ -146,33 +146,6 @@ def extract_all_rgb_half_tiles_kernel(
 
 
 @wp.kernel
-def extract_all_depth_tiles_kernel_legacy(
-    tiled_buffer: wp.array(dtype=wp.float32, ndim=2),  # type: ignore
-    output_buffer: wp.array(dtype=wp.float32, ndim=4),  # type: ignore
-    num_cols: int,
-    tile_width: int,
-    tile_height: int,
-):
-    """Extract all depth tiles from a tiled buffer in a single kernel launch.
-
-    Used with ovrtx older than 0.3.0.
-
-    Args:
-        tiled_buffer: 2D float32 array of shape (H, W) for depth.
-        output_buffer: 4D float32 array of shape (num_envs, H, W, 1) for depth.
-        num_cols: number of columns in the tiled buffer.
-        tile_width: width of each tile.
-        tile_height: height of each tile.
-    """
-    env_idx, y, x = wp.tid()
-    tile_x = env_idx % num_cols
-    tile_y = env_idx // num_cols
-    src_x = tile_x * tile_width + x
-    src_y = tile_y * tile_height + y
-    output_buffer[env_idx, y, x, 0] = tiled_buffer[src_y, src_x]
-
-
-@wp.kernel
 def extract_all_depth_tiles_kernel(
     tiled_buffer: wp.array(dtype=wp.float32, ndim=3),  # type: ignore
     output_buffer: wp.array(dtype=wp.float32, ndim=4),  # type: ignore
@@ -319,23 +292,6 @@ def random_color_from_id(input_id: wp.uint32) -> wp.uint32:
         | (wp.uint32(ai) << wp.uint32(24))
     )
     return color
-
-
-@wp.kernel
-def generate_random_colors_from_ids_kernel_legacy(
-    input_ids: wp.array(dtype=wp.uint32, ndim=2),  # type: ignore
-    output_colors: wp.array(dtype=wp.uint32, ndim=2),  # type: ignore
-):
-    """Generate random colors given IDs (e.g. semantic IDs).
-
-    Used with ovrtx older than 0.3.0.
-
-    Args:
-        input_ids: 2D uint32 array of shape (H, W) for semantic IDs per pixel.
-        output_data: 2D uint32 array; each word is `r | (g<<8) | (b<<16) | (a<<24)`
-    """
-    i, j = wp.tid()
-    output_colors[i, j] = random_color_from_id(input_ids[i, j])
 
 
 @wp.kernel

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -179,7 +179,6 @@ def create_scene_partition_attributes(
     stage,
     num_envs: int = 1,
     use_ovrtx_cloning: bool = True,
-    enable_scene_partition_workaround: bool = False,
 ) -> None:
     """Create scene partition attributes for env roots and cameras.
 
@@ -194,8 +193,6 @@ def create_scene_partition_attributes(
         stage: USD stage to modify.
         num_envs: Number of environments.
         use_ovrtx_cloning: Whether OVRTX cloning is enabled.
-        enable_scene_partition_workaround: Whether to enable the scene partition workaround for OVRTX 0.2.0 because it
-            doesn't support primvar inheritance.
     """
     env_indices = [0] if use_ovrtx_cloning else range(num_envs)
     for env_idx in env_indices:
@@ -212,12 +209,12 @@ def create_scene_partition_attributes(
         for prim in Usd.PrimRange(env_prim):
             if prim.GetPath() == env_prim.GetPath():
                 continue
-            if prim.IsA(UsdGeom.Camera):
-                prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
-                logger.debug("Set scene partition '%s' on camera '%s'", scene_partition, prim.GetPath())
-            elif enable_scene_partition_workaround:
-                prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
-                logger.debug("Set scene partition '%s' on prim '%s'", scene_partition, prim.GetPath())
+
+            if not prim.IsA(UsdGeom.Camera):
+                continue
+
+            prim.CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set(scene_partition)
+            logger.debug("Set scene partition '%s' on camera '%s'", scene_partition, prim.GetPath())
 
 
 def export_stage_to_string(stage, num_envs: int, use_ovrtx_cloning: bool = True) -> str:

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
@@ -12,12 +12,10 @@ import pytest
 import warp as wp
 from isaaclab_ov.renderers.ovrtx_renderer_kernels import (
     extract_all_depth_tiles_kernel,
-    extract_all_depth_tiles_kernel_legacy,
     extract_all_rgb_float_tiles_kernel,
     extract_all_rgb_half_tiles_kernel,
     extract_all_rgba_tiles_kernel,
     generate_random_colors_from_ids_kernel,
-    generate_random_colors_from_ids_kernel_legacy,
 )
 
 DEVICE = "cuda:0"
@@ -75,26 +73,6 @@ def _reference_color(input_id: int) -> int:
     return r | (g << 8) | (b << 16) | (a << 24)
 
 
-def _reference_extract_all_depth_tiles_legacy(
-    tiled_2d: np.ndarray,
-    num_envs: int,
-    num_cols: int,
-    tile_width: int,
-    tile_height: int,
-) -> np.ndarray:
-    """NumPy reference for ``extract_all_depth_tiles_kernel_legacy`` (2D tiled buffer)."""
-    out = np.zeros((num_envs, tile_height, tile_width, 1), dtype=np.float32)
-    for env_idx in range(num_envs):
-        tile_x = env_idx % num_cols
-        tile_y = env_idx // num_cols
-        for y in range(tile_height):
-            for x in range(tile_width):
-                src_y = tile_y * tile_height + y
-                src_x = tile_x * tile_width + x
-                out[env_idx, y, x, 0] = tiled_2d[src_y, src_x]
-    return out
-
-
 def _reference_extract_all_depth_tiles(
     tiled_np: np.ndarray,
     num_envs: int,
@@ -103,7 +81,16 @@ def _reference_extract_all_depth_tiles(
     tile_height: int,
 ) -> np.ndarray:
     """NumPy reference for ``extract_all_depth_tiles_kernel``."""
-    return _reference_extract_all_depth_tiles_legacy(tiled_np[..., 0], num_envs, num_cols, tile_width, tile_height)
+    out = np.zeros((num_envs, tile_height, tile_width, 1), dtype=np.float32)
+    for env_idx in range(num_envs):
+        tile_x = env_idx % num_cols
+        tile_y = env_idx // num_cols
+        for y in range(tile_height):
+            for x in range(tile_width):
+                src_y = tile_y * tile_height + y
+                src_x = tile_x * tile_width + x
+                out[env_idx, y, x, 0] = tiled_np[src_y, src_x, 0]
+    return out
 
 
 def _reference_extract_all_rgba_tiles(
@@ -231,86 +218,6 @@ class TestExtractAllDepthTilesKernel:
         wp.synchronize()
 
         expected = _reference_extract_all_depth_tiles(tiled_np, num_envs, num_cols, tile_width, tile_height)
-        np.testing.assert_allclose(output_wp.numpy(), expected, rtol=1e-6, atol=1e-6)
-
-
-class TestExtractAllDepthTilesKernelLegacy:
-    """Tests for ``extract_all_depth_tiles_kernel_legacy`` (ovrtx < 0.3.0, 2D tiled buffer)."""
-
-    def test_two_by_two_tile_grid(self):
-        num_cols = 2
-        num_envs = 4
-        tile_width = 2
-        tile_height = 3
-        tiled_h = (num_envs // num_cols) * tile_height
-        tiled_w = num_cols * tile_width
-        tiled_np = np.zeros((tiled_h, tiled_w), dtype=np.float32)
-        for h in range(tiled_h):
-            for w in range(tiled_w):
-                tiled_np[h, w] = float(h * 1000 + w)
-
-        tiled_wp = wp.array(tiled_np, dtype=wp.float32, ndim=2, device=DEVICE)
-        output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 1), dtype=wp.float32, device=DEVICE)
-
-        wp.launch(
-            kernel=extract_all_depth_tiles_kernel_legacy,
-            dim=(num_envs, tile_height, tile_width),
-            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
-            device=DEVICE,
-        )
-        wp.synchronize()
-
-        expected = _reference_extract_all_depth_tiles_legacy(tiled_np, num_envs, num_cols, tile_width, tile_height)
-        np.testing.assert_allclose(output_wp.numpy(), expected, rtol=0, atol=0)
-
-    def test_single_tile(self):
-        num_cols = 1
-        num_envs = 1
-        tile_width = 4
-        tile_height = 4
-        tiled_np = np.arange(tile_height * tile_width, dtype=np.float32).reshape(tile_height, tile_width)
-
-        tiled_wp = wp.array(tiled_np, dtype=wp.float32, ndim=2, device=DEVICE)
-        output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 1), dtype=wp.float32, device=DEVICE)
-
-        wp.launch(
-            kernel=extract_all_depth_tiles_kernel_legacy,
-            dim=(num_envs, tile_height, tile_width),
-            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
-            device=DEVICE,
-        )
-        wp.synchronize()
-
-        expected = _reference_extract_all_depth_tiles_legacy(tiled_np, num_envs, num_cols, tile_width, tile_height)
-        np.testing.assert_array_equal(output_wp.numpy(), expected)
-
-    @pytest.mark.parametrize(
-        ("num_cols", "num_envs", "tile_width", "tile_height"),
-        [
-            (3, 6, 2, 2),
-            (1, 3, 5, 1),
-            (4, 8, 1, 1),
-        ],
-    )
-    def test_various_layouts(self, num_cols, num_envs, tile_width, tile_height):
-        num_rows = (num_envs + num_cols - 1) // num_cols
-        tiled_h = num_rows * tile_height
-        tiled_w = num_cols * tile_width
-        rng = np.random.default_rng(12345)
-        tiled_np = rng.random((tiled_h, tiled_w), dtype=np.float32).astype(np.float32)
-
-        tiled_wp = wp.array(tiled_np, dtype=wp.float32, ndim=2, device=DEVICE)
-        output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 1), dtype=wp.float32, device=DEVICE)
-
-        wp.launch(
-            kernel=extract_all_depth_tiles_kernel_legacy,
-            dim=(num_envs, tile_height, tile_width),
-            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
-            device=DEVICE,
-        )
-        wp.synchronize()
-
-        expected = _reference_extract_all_depth_tiles_legacy(tiled_np, num_envs, num_cols, tile_width, tile_height)
         np.testing.assert_allclose(output_wp.numpy(), expected, rtol=1e-6, atol=1e-6)
 
 
@@ -578,88 +485,6 @@ class TestRandomColorsFromIdsKernel:
 
         ref_color = _reference_color(int(np.uint32(input_value)))
         out_color = int(output_colors.numpy()[0, 0, 0])
-        assert out_color == ref_color, (
-            f"id=0x{int(np.uint32(input_value)):08x}: expected 0x{ref_color:08x}, got 0x{out_color:08x}"
-        )
-
-
-class TestRandomColorsFromIdsKernelLegacy:
-    """Tests for ``generate_random_colors_from_ids_kernel_legacy`` (ovrtx < 0.3.0, 2D buffers)."""
-
-    def test_random_colors(self):
-        inputs_np = np.array([[0, 1], [2, 3]], dtype=np.uint32)
-        input_ids = wp.array(inputs_np, dtype=wp.uint32, ndim=2, device=DEVICE)
-        output_colors = wp.zeros(shape=inputs_np.shape, dtype=wp.uint32, device=DEVICE)
-
-        wp.launch(
-            kernel=generate_random_colors_from_ids_kernel_legacy,
-            dim=inputs_np.shape,
-            inputs=[input_ids, output_colors],
-            device=DEVICE,
-        )
-        wp.synchronize()
-
-        out_np = output_colors.numpy()
-        for (i, j), input_id in np.ndenumerate(inputs_np):
-            input_id = int(np.uint32(input_id))
-            ref_color = _reference_color(input_id)
-            out_color = int(out_np[i, j])
-            assert out_color == ref_color, (
-                f"At ({i},{j}) id={input_id}: expected 0x{ref_color:08x}, got 0x{out_color:08x}"
-            )
-
-    def test_deterministic_across_launches(self):
-        shape = (4, 4)
-        rng = np.random.default_rng(42)
-        inputs_np = rng.integers(0, 2**31, size=shape, dtype=np.uint32)
-        input_ids = wp.array(inputs_np, dtype=wp.uint32, ndim=2, device=DEVICE)
-        output_colors = wp.zeros(shape=shape, dtype=wp.uint32, device=DEVICE)
-
-        wp.launch(
-            kernel=generate_random_colors_from_ids_kernel_legacy,
-            dim=shape,
-            inputs=[input_ids, output_colors],
-            device=DEVICE,
-        )
-        wp.synchronize()
-        first_run = output_colors.numpy().copy()
-
-        wp.launch(
-            kernel=generate_random_colors_from_ids_kernel_legacy,
-            dim=shape,
-            inputs=[input_ids, output_colors],
-            device=DEVICE,
-        )
-        wp.synchronize()
-        second_run = output_colors.numpy()
-
-        np.testing.assert_array_equal(first_run, second_run)
-
-    @pytest.mark.parametrize(
-        "input_value",
-        [
-            0,
-            1,
-            2,
-            3,
-            100,
-        ],
-    )
-    def test_single_value(self, input_value):
-        inputs_np = np.array([[input_value]], dtype=np.uint32)
-        input_ids = wp.array(inputs_np, dtype=wp.uint32, ndim=2, device=DEVICE)
-        output_colors = wp.zeros(shape=(1, 1), dtype=wp.uint32, device=DEVICE)
-
-        wp.launch(
-            kernel=generate_random_colors_from_ids_kernel_legacy,
-            dim=(1, 1),
-            inputs=[input_ids, output_colors],
-            device=DEVICE,
-        )
-        wp.synchronize()
-
-        ref_color = _reference_color(int(np.uint32(input_value)))
-        out_color = int(output_colors.numpy()[0, 0])
         assert out_color == ref_color, (
             f"id=0x{int(np.uint32(input_value)):08x}: expected 0x{ref_color:08x}, got 0x{out_color:08x}"
         )


### PR DESCRIPTION
# Description

Removed OVRTX 0.2.x compatibility code paths from :class:`~isaaclab_ov.renderers.OVRTXRenderer`.

## Type of change

- Code cleanup

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there