### PR TITLE
Updates PhysX GPU buffer dimensions for ARL navigation environment

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-arl-navigation-physx-gpu-pairs.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-arl-navigation-physx-gpu-pairs.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed PhysX GPU buffer capacities for the ARL Robot 1 navigation task.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/navigation/config/arl_robot_1/navigation_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/navigation/config/arl_robot_1/navigation_env_cfg.py
@@ -337,7 +337,11 @@ class NavigationVelocityFloatingObstacleEnvCfg(ManagerBasedRLEnvCfg):
             static_friction=1.0,
             dynamic_friction=1.0,
         )
-        self.sim.physics = PhysxCfg(gpu_max_rigid_patch_count=2**21)
+        self.sim.physics = PhysxCfg(
+            gpu_max_rigid_contact_count=2**25,
+            gpu_max_rigid_patch_count=2**23,
+            gpu_found_lost_pairs_capacity=2**23,
+        )
         # update sensor update periods
         # we tick all the sensors based on the smallest update period (physics update period)
         if self.scene.contact_forces is not None:


### PR DESCRIPTION
# Description

Updates PhysX GPU buffer dimensions for ARL navigation environment to resolve GPU buffer overflow errors from PhysX.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
