### PR TITLE
[Fix] Register Warp task variants in benchmark and environment scripts

### DIFF
--- a/scripts/benchmarks/benchmark_non_rl.py
+++ b/scripts/benchmarks/benchmark_non_rl.py
@@ -8,6 +8,7 @@
 """Launch Isaac Sim Simulator first."""
 
 import argparse
+import contextlib
 import os
 import sys
 import time
@@ -84,6 +85,10 @@ from isaaclab.envs import DirectMARLEnvCfg, DirectRLEnvCfg, ManagerBasedRLEnvCfg
 from isaaclab.utils.dict import print_dict
 
 import isaaclab_tasks  # noqa: F401
+
+# PLACEHOLDER: Extension template (do not remove this comment)
+with contextlib.suppress(ImportError):
+    import isaaclab_tasks_experimental  # noqa: F401
 from isaaclab_tasks.utils import launch_simulation, resolve_task_config
 
 imports_time_end = time.perf_counter_ns()

--- a/scripts/benchmarks/benchmark_rlgames.py
+++ b/scripts/benchmarks/benchmark_rlgames.py
@@ -8,6 +8,7 @@
 """Launch Isaac Sim Simulator first."""
 
 import argparse
+import contextlib
 import os
 import sys
 import time
@@ -90,6 +91,10 @@ from isaaclab.utils.io import dump_yaml
 from isaaclab_rl.rl_games import RlGamesGpuEnv, RlGamesVecEnvWrapper
 
 import isaaclab_tasks  # noqa: F401
+
+# PLACEHOLDER: Extension template (do not remove this comment)
+with contextlib.suppress(ImportError):
+    import isaaclab_tasks_experimental  # noqa: F401
 from isaaclab_tasks.utils import launch_simulation, resolve_task_config
 
 imports_time_end = time.perf_counter_ns()

--- a/scripts/benchmarks/benchmark_rsl_rl.py
+++ b/scripts/benchmarks/benchmark_rsl_rl.py
@@ -8,6 +8,7 @@
 """Launch Isaac Sim Simulator first."""
 
 import argparse
+import contextlib
 import os
 import sys
 import time
@@ -93,6 +94,10 @@ from isaaclab.utils.io import dump_yaml
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper, handle_deprecated_rsl_rl_cfg
 
 import isaaclab_tasks  # noqa: F401
+
+# PLACEHOLDER: Extension template (do not remove this comment)
+with contextlib.suppress(ImportError):
+    import isaaclab_tasks_experimental  # noqa: F401
 from isaaclab_tasks.utils import get_checkpoint_path, launch_simulation, resolve_task_config
 
 imports_time_end = time.perf_counter_ns()

--- a/scripts/environments/export_IODescriptors.py
+++ b/scripts/environments/export_IODescriptors.py
@@ -8,6 +8,7 @@
 """Launch Isaac Sim Simulator first."""
 
 import argparse
+import contextlib
 import os
 
 from isaaclab.app import AppLauncher
@@ -32,6 +33,9 @@ import gymnasium as gym
 import torch
 
 import isaaclab_tasks  # noqa: F401
+
+with contextlib.suppress(ImportError):
+    import isaaclab_tasks_experimental  # noqa: F401
 from isaaclab_tasks.utils import parse_env_cfg
 
 # PLACEHOLDER: Extension template (do not remove this comment)

--- a/scripts/environments/list_envs.py
+++ b/scripts/environments/list_envs.py
@@ -16,6 +16,7 @@ with `Isaac` in their name.
 """Launch Isaac Sim Simulator first."""
 
 import argparse
+import contextlib
 
 from isaaclab.app import AppLauncher
 
@@ -46,6 +47,10 @@ import gymnasium as gym
 from prettytable import PrettyTable
 
 import isaaclab_tasks  # noqa: F401
+
+# PLACEHOLDER: Extension template (do not remove this comment)
+with contextlib.suppress(ImportError):
+    import isaaclab_tasks_experimental  # noqa: F401
 
 
 def _format_presets(preset_map: dict | None) -> str:

--- a/scripts/environments/random_agent.py
+++ b/scripts/environments/random_agent.py
@@ -6,12 +6,16 @@
 """Script to an environment with random action agent."""
 
 import argparse
+import contextlib
 import sys
 
 import gymnasium as gym
 import torch
 
 import isaaclab_tasks  # noqa: F401
+
+with contextlib.suppress(ImportError):
+    import isaaclab_tasks_experimental  # noqa: F401
 from isaaclab_tasks.utils import (
     add_launcher_args,
     fold_preset_tokens,

--- a/scripts/environments/zero_agent.py
+++ b/scripts/environments/zero_agent.py
@@ -6,12 +6,16 @@
 """Script to run an environment with zero action agent."""
 
 import argparse
+import contextlib
 import sys
 
 import gymnasium as gym
 import torch
 
 import isaaclab_tasks  # noqa: F401
+
+with contextlib.suppress(ImportError):
+    import isaaclab_tasks_experimental  # noqa: F401
 from isaaclab_tasks.utils import (
     add_launcher_args,
     fold_preset_tokens,

--- a/source/isaaclab_tasks/changelog.d/jichuanh-benchmark-warp-tasks-import.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-benchmark-warp-tasks-import.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed benchmark and environment scripts (``scripts/benchmarks/benchmark_{rsl_rl,rlgames,non_rl}.py``,
+  ``scripts/environments/{list_envs,random_agent,zero_agent,export_IODescriptors}.py``) failing with
+  ``gymnasium.error.NameNotFound`` for ``-Warp-v0`` task variants. Added the conditional
+  ``isaaclab_tasks_experimental`` import that the RL training scripts already use.


### PR DESCRIPTION
## 1. Summary

- Benchmark scripts and standalone environment helpers failed with ``gymnasium.error.NameNotFound: Environment 'Isaac-Cartpole-Direct-Warp' doesn't exist`` when invoked with any ``-Warp-v0`` task. Docs at ``source/overview/core-concepts/physical-backends/newton/warp-environments.rst`` advertise the very command that fails.
- Root cause: the affected scripts import ``isaaclab_tasks`` only; the ``-Warp-v0`` variants are registered in the optional ``isaaclab_tasks_experimental`` extension. The RL training/play scripts already conditionally import it; these did not.
- Fix: add the same ``with contextlib.suppress(ImportError): import isaaclab_tasks_experimental`` block after the existing ``import isaaclab_tasks``. Seven scripts, 39 insertions total.

## 2. Scripts changed

| File | Before | After |
|---|---|---|
| ``scripts/benchmarks/benchmark_rsl_rl.py`` | imports ``isaaclab_tasks`` only | + conditional ``isaaclab_tasks_experimental`` |
| ``scripts/benchmarks/benchmark_non_rl.py`` | imports ``isaaclab_tasks`` only | + conditional ``isaaclab_tasks_experimental`` |
| ``scripts/benchmarks/benchmark_rlgames.py`` | imports ``isaaclab_tasks`` only | + conditional ``isaaclab_tasks_experimental`` |
| ``scripts/environments/list_envs.py`` | imports ``isaaclab_tasks`` only | + conditional ``isaaclab_tasks_experimental`` |
| ``scripts/environments/random_agent.py`` | imports ``isaaclab_tasks`` only | + conditional ``isaaclab_tasks_experimental`` |
| ``scripts/environments/zero_agent.py`` | imports ``isaaclab_tasks`` only | + conditional ``isaaclab_tasks_experimental`` |
| ``scripts/environments/export_IODescriptors.py`` | imports ``isaaclab_tasks`` only | + conditional ``isaaclab_tasks_experimental`` |

All eight ``scripts/reinforcement_learning/{rl_games,rsl_rl,sb3,skrl}/{train,play}.py`` scripts already follow this pattern; the affected scripts are the remaining gap.

## 3. Verification

- Pre-commit clean on all 8 changed files (ruff, ruff-format, codespell, RST hooks).
- Pattern mirrors ``scripts/reinforcement_learning/rsl_rl/train.py:56-58``, which is the canonical placement.
- ``contextlib.suppress(ImportError)`` keeps the scripts working when the experimental extension isn't installed (e.g. minimal IsaacLab installs).

## 4. Cherry-pick target

The customer-visible bug is on ``release/3.0.0-beta2`` per the NVBug. After this lands on ``develop``, cherry-pick onto that release branch so QA can verify on the same build.

Refs NVBug 6224916