### PR TITLE
Fix Compass training doc

### DIFF
--- a/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
+++ b/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
@@ -206,18 +206,13 @@ Download the pre-packaged COMPASS USD assets using the Hugging Face CLI:
 Alternatively, you can download it manually from:
 https://huggingface.co/nvidia/COMPASS/blob/main/compass_usds.zip
 
-Extract the downloaded ``compass_usds.zip`` file. Then move/copy the ``usd`` folder from the extracted location:
+Extract the downloaded ``compass_usds.zip`` file and move the ``usd`` folder into the COMPASS extension directory:
 
 .. code-block:: bash
 
-    <download_path>/compass_usds/groot_mobility_rl_es_usds/usd
-
-into the COMPASS extension directory:
-
-.. code-block:: bash
-
-    # Ensure that you are in COMPASS root directory
-    compass/rl_env/exts/mobility_es/mobility_es/
+    cd <compass-nurec>/COMPASS
+    unzip compass_usds.zip
+    mv groot_mobility_rl_es_usds/usd compass/rl_env/exts/mobility_es/mobility_es/
 
 **3. NuRec Real2Sim Assets**
 

--- a/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
+++ b/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
@@ -222,6 +222,39 @@ Download the NuRec Real2Sim assets from the `PhysicalAI-Robotics-NuRec dataset`_
 
     hf download nvidia/PhysicalAI-Robotics-NuRec --repo-type dataset --local-dir <compass-nurec>/PhysicalAI-Robotics-NuRec
 
+.. tip::
+
+   The full dataset is large. To download only the environment(s) you need, use the ``--include`` and
+   ``--exclude`` glob filters supported by ``hf download``. Quote the patterns so your shell does not
+   expand them, and the original folder structure is preserved under ``--local-dir``.
+
+   .. code-block:: bash
+
+       # Download a single environment
+       hf download nvidia/PhysicalAI-Robotics-NuRec --repo-type dataset \
+           --local-dir <compass-nurec>/PhysicalAI-Robotics-NuRec \
+           --include "nova_carter-galileo/*"
+
+       # Download multiple environments at once
+       hf download nvidia/PhysicalAI-Robotics-NuRec --repo-type dataset \
+           --local-dir <compass-nurec>/PhysicalAI-Robotics-NuRec \
+           --include "nova_carter-galileo/*" "nova_carter-cafe/*"
+
+       # Recursively include sub-folders
+       hf download nvidia/PhysicalAI-Robotics-NuRec --repo-type dataset \
+           --local-dir <compass-nurec>/PhysicalAI-Robotics-NuRec \
+           --include "nova_carter-galileo/**"
+
+       # Pull only specific files within an environment
+       hf download nvidia/PhysicalAI-Robotics-NuRec --repo-type dataset \
+           --local-dir <compass-nurec>/PhysicalAI-Robotics-NuRec \
+           --include "nova_carter-galileo/stage.usdz" "nova_carter-galileo/3dgrt/**"
+
+       # Download everything except the large mesh files
+       hf download nvidia/PhysicalAI-Robotics-NuRec --repo-type dataset \
+           --local-dir <compass-nurec>/PhysicalAI-Robotics-NuRec \
+           --exclude "**/*.usdz"
+
 Alternatively, you can download them manually from the `PhysicalAI-Robotics-NuRec dataset`_ on Hugging Face:
 
 .. note::
@@ -236,7 +269,16 @@ The dataset provides several environments. For COMPASS, download the environment
     # Ensure that you are in COMPASS root directory
     compass/rl_env/exts/mobility_es/mobility_es/usd/<environment_name>/
 
-For example, for the Galileo environment (nova_carter-galileo):
+For example, for the Galileo environment (nova_carter-galileo), move the downloaded folder into
+the COMPASS extension directory:
+
+.. code-block:: bash
+
+    # Run from the COMPASS root directory
+    mv <compass-nurec>/PhysicalAI-Robotics-NuRec/nova_carter-galileo \
+       compass/rl_env/exts/mobility_es/mobility_es/usd/
+
+The resulting layout should look like:
 
 .. code-block:: bash
 

--- a/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
+++ b/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
@@ -213,7 +213,6 @@ Extract the downloaded ``compass_usds.zip`` file and move the ``usd`` folder int
     cd <compass-nurec>/COMPASS
     unzip compass_usds.zip
     mv groot_mobility_rl_es_usds/usd compass/rl_env/exts/mobility_es/mobility_es/
-    cd -
 
 **3. NuRec Real2Sim Assets**
 

--- a/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
+++ b/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
@@ -213,6 +213,7 @@ Extract the downloaded ``compass_usds.zip`` file and move the ``usd`` folder int
     cd <compass-nurec>/COMPASS
     unzip compass_usds.zip
     mv groot_mobility_rl_es_usds/usd compass/rl_env/exts/mobility_es/mobility_es/
+    cd -
 
 **3. NuRec Real2Sim Assets**
 


### PR DESCRIPTION
# Description
Issue with the folder structure when unzipping and copying compass_usdz.zip:

cp: cannot stat '.../compass_usds/groot_mobility_rl_es_usds/usd': No such file or directory

Actual extracted structure:
COMPASS_assets/
└── groot_mobility_rl_es_usds/
    └── usd/
        ├── office/
        └── ...

Solution:
Doc should show the correct path:
groot_mobility_rl_es_usds/usd
And should include the actual shell commands (unzip + mv/cp) rather than just describing what to do.

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
