### PR TITLE
Fix document according to bug 6198710

### DIFF
--- a/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
+++ b/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
@@ -13,18 +13,18 @@ The following provides a high-level overview of the complete workflow:
 1. **Create workspace**: Create the ``compass-nurec`` workspace directory
 2. **Install Isaac Sim & Isaac Lab** (Terminal 1): Follow installation steps for Isaac Sim 6.0 and Isaac Lab 3.0
 3. **Install COMPASS Repository** (Terminal 2): Clone and set up the COMPASS repository
-4. **Test setup**: Verify installation using ``play.py``
-5. **Authenticate with Hugging Face**: Generate access token and run ``hf auth login --token <token>``
-6. **Download assets** (can be done in parallel):
+4. **Authenticate with Hugging Face**: Generate access token and run ``hf auth login --token <token>``
+5. **Download assets** (can be done in parallel):
 
    - Download X-Mobility checkpoint: ``hf download nvidia/X-Mobility x_mobility-nav2-semantic_action_path.ckpt``
    - Download COMPASS USD assets: ``hf download nvidia/COMPASS compass_usds.zip``
    - Download NuRec Real2Sim assets: ``hf download nvidia/PhysicalAI-Robotics-NuRec --repo-type dataset``
 
-7. **Prepare assets**:
+6. **Prepare assets**:
 
    - Extract and place ``usd/`` folder into ``compass/rl_env/exts/mobility_es/mobility_es/``
    - Place environment files (e.g., ``nova_carter-galileo/``) in the appropriate location
+7. **Test setup**: Verify installation using ``play.py``
 8. **Train Residual RL Policy**: Run training with ``run.py`` and ``train_config_real2sim.gin``
 9. **Evaluate Trained Policy**: Run evaluation with ``run.py`` and ``eval_config_real2sim.gin``
 10. **Export to ONNX / TensorRT**: Convert the trained model for deployment
@@ -159,17 +159,6 @@ Open a second terminal and follow these steps to install the COMPASS repository.
     ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install -e exts/mobility_es
     cd -
 
-Testing the Setup
-~~~~~~~~~~~~~~~~~
-
-Run the following command from the ``COMPASS`` directory to verify the setup:
-
-.. code-block:: bash
-
-    cd compass/rl_env
-    ${ISAACLAB_PATH}/isaaclab.sh -p scripts/play.py --enable_cameras --visualizer kit
-    cd -
-
 Downloading Assets & Checkpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -288,6 +277,19 @@ For example, for the Galileo environment (nova_carter-galileo):
       * - ``hand_hold-voyager-babyboom-2``
         - Conference room in NVIDIA Voyager building
         - Yes
+
+Testing the Setup
+~~~~~~~~~~~~~~~~~
+
+Once the COMPASS USD assets have been downloaded and placed under
+``compass/rl_env/exts/mobility_es/mobility_es/usd/``, run the following command from the ``COMPASS``
+directory to verify the setup:
+
+.. code-block:: bash
+
+    cd compass/rl_env
+    ${ISAACLAB_PATH}/isaaclab.sh -p scripts/play.py --enable_cameras --visualizer kit
+    cd -
 
 Training the Policy
 -------------------


### PR DESCRIPTION
Issue:
play.py verification step fails with FileNotFoundError for office.usd because the COMPASS USD assets (compass_usds.zip) are not listed as a prerequisite in the documentation, causing the script to always fail when run in documented order.
Running play.py (TC-02 — Verify COMPASS Setup) fails with FileNotFoundError for office.usd. The script is hardcoded to load usd/office/office.usd from the mobility_es extension directory, but this file is part of compass_usds.zip (downloaded from nvidia/COMPASS on Hugging Face). The documentation for PR #5599 and the COMPASS navigation guide do not mention downloading and placing the COMPASS USD assets as a prerequisite for running play.py. As a result, play.py will always fail if run before the asset download step.


Solution:
Add the prerequisite (download compass_usdz.zip) steps before running the play.py verification step in the docs
## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
