### PR TITLE
[STRESS / DO NOT MERGE] Enable FabricFrameView cuda:1 tests in multi-GPU CI

### DIFF
--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -14,19 +14,12 @@
 
 name: FabricFrameView Multi-GPU Tests
 
-# DISABLED: No self-hosted runner with the 'multi-gpu' label is currently
-# registered.  All runs queue indefinitely.  Re-enable once infra provisions
-# a multi-GPU runner (see also .github/workflows/test-multi-gpu.yaml which
-# has the same issue).
-#
-# on:
-#   pull_request:
-#     paths:
-#       - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
-#       - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
-#       - ".github/workflows/test-fabric-multi-gpu.yaml"
-#   workflow_dispatch:
 on:
+  pull_request:
+    paths:
+      - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
+      - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
+      - ".github/workflows/test-fabric-multi-gpu.yaml"
   workflow_dispatch:
 
 concurrency:
@@ -36,14 +29,44 @@ concurrency:
 jobs:
   test-fabric-multi-gpu:
     name: FabricFrameView multi-GPU unit tests
-    runs-on: [self-hosted, linux, x64, gpu, multi-gpu]
-    timeout-minutes: 30
+    runs-on: [self-hosted, linux, x64, multi-gpu]
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install cmake via pip (avoid sudo apt path)
+        # install.py skips its sudo apt-get block when ``cmake`` is already on
+        # PATH (source/isaaclab/isaaclab/cli/commands/install.py:35).  The
+        # pip wheel provides a cmake shim under the setup-python venv's bin/,
+        # which is on PATH, so installing it here bypasses the apt branch.
+        run: pip install cmake
+
       - name: Install Isaac Lab
-        run: ./isaaclab.sh --install
+        # ``--install none`` = core submodules only (no mimic, no teleop, no
+        # auto-extra features).  The FabricFrameView cuda:1 tests only need
+        # isaaclab core + isaaclab_physx + Isaac Sim.  Avoids building
+        # robomimic's egl_probe wheel, which requires libEGL/X11 headers
+        # that the multi-GPU runner image lacks.
+        run: ./isaaclab.sh --install none
+
+      - name: Install Isaac Sim
+        # Isaac Sim is an optional extra in source/isaaclab/setup.py and is
+        # not pulled by ``--install none``.  Without it, AppLauncher's
+        # ``import isaacsim`` is silently caught by
+        # ``contextlib.suppress(ModuleNotFoundError)``, ``EXP_PATH`` stays
+        # unset, and test collection crashes with ``KeyError: 'EXP_PATH'``.
+        #
+        # Pinned to 6.0.0.0 because that is the only release line with a
+        # Python 3.12 wheel.  The 5.x line on PyPI requires Python 3.11
+        # (and source/isaaclab/setup.py's ``isaacsim==5.1.0`` pin is stale
+        # relative to the 3.12 baseline declared in pyproject.toml).
+        run: pip install 'isaacsim[all,extscache]==${{ vars.ISAACSIM_BASE_VERSION || '6.0.0' }}' --extra-index-url https://pypi.nvidia.com
 
       - name: Verify multi-GPU availability
         # Fail loud if the runner regressed to a single GPU.  Without this, the
@@ -62,7 +85,19 @@ jobs:
           fi
 
       - name: Run FabricFrameView multi-GPU unit tests
+        # ``ISAACLAB_TEST_MULTI_GPU=1`` enables the three cuda:1-parameterised
+        # tests in test_views_xform_prim_fabric.py added by PR #5514.  These
+        # tests target FabricFrameView's SelectPrims path on non-zero CUDA
+        # devices and currently hang indefinitely on real multi-GPU hardware
+        # (reproduced locally on 3x RTX 6000 Pro Blackwell and on the
+        # [self-hosted, ..., multi-gpu] runner pool).  The 60-min workflow
+        # timeout will cancel the job and surface the regression in CI for
+        # the FabricFrameView maintainers.  Land this PR once the hang is
+        # fixed in source/isaaclab_physx/.../fabric_frame_view.py.
         env:
+          OMNI_KIT_ACCEPT_EULA: "yes"
+          ACCEPT_EULA: "Y"
+          ISAAC_SIM_HEADLESS: "1"
           ISAACLAB_TEST_MULTI_GPU: "1"
         run: |
           ./isaaclab.sh -p -m pytest \


### PR DESCRIPTION
## 1. Summary

- Single squashed commit on top of `develop`: workflow that runs the FabricFrameView contract tests on the multi-GPU runner with `ISAACLAB_TEST_MULTI_GPU=1`.
- Activates the three cuda:1-parameterised tests in `source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py` added by #5514.
- Surfaces the FabricFrameView SelectPrims hang on non-zero CUDA device indices as a CI signal so maintainers can iterate on a fix.

## 2. Status

This PR is **expected to fail** with the 60-minute workflow timeout. It exists as an in-CI reproduction of the FabricFrameView cuda:1 hang, not as landable work.

Reproductions:
- Local: 3× RTX 6000 Pro Blackwell on Horde DGXC, 90s SIGTERM
- CI: `[self-hosted, linux, x64, multi-gpu]` runner, 60-min workflow timeout cancellation

The first cuda:1 test (`test_fabric_cuda1_world_pose_roundtrip[cuda:1]`) deadlocks before completing. Tests 2 and 3 never run. pytest with ``-v`` only prints a test ID on completion, so the visible log signature is: cpu+cuda:0 tests pass through ``test_fabric_rebuild_after_topology_change[cuda:0] PASSED [92%]``, then silence until the workflow timeout fires.

## 3. Local reproduction

Conda env: `env_isaaclab` (Python 3.12, isaacsim 6.0.0.0). Hardware: any host with `torch.cuda.device_count() >= 2`.

Targets the three cuda:1-specific tests explicitly (the only tests in the repo parametrized over `["cuda:1"]`), so the test selection is unambiguous:

```bash
cd <IsaacLab worktree>   # must be on a checkout that has PR #5514 merged (latest develop)
conda activate env_isaaclab

timeout 90 env \
  ISAACLAB_TEST_MULTI_GPU=1 \
  OMNI_KIT_ACCEPT_EULA=yes \
  ACCEPT_EULA=Y \
  ISAAC_SIM_HEADLESS=1 \
  ./isaaclab.sh -p -m pytest \
    "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_world_pose_roundtrip" \
    "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_no_usd_writeback" \
    "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_scales_roundtrip" \
    -v --tb=short
```

Expected behavior:
- 3 tests collected, 3 selected.
- ``test_fabric_cuda1_world_pose_roundtrip[cuda:1]`` starts.
- No further pytest output for the remainder of the timeout (the first test never completes; tests 2 and 3 never start).
- Outer ``timeout 90`` sends SIGTERM (exit 143).

Pre-flight sanity (optional) — confirms cuda:1 is usable from torch + warp on the host, so the hang is isolated to the Fabric path:

```bash
./isaaclab.sh -p -c "
import torch, warp as wp
print(f'cuda count: {torch.cuda.device_count()}')
for i in range(torch.cuda.device_count()):
    torch.cuda.set_device(i)
    assert torch.zeros(10, device=f'cuda:{i}').device.index == i
wp.init()
for i in range(torch.cuda.device_count()):
    with wp.ScopedDevice(f'cuda:{i}'):
        assert str(wp.zeros(10, dtype=wp.float32).device) == f'cuda:{i}'
print('cuda:N alloc OK for torch and warp')
"
```

## 4. Bug surface

- File: `source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py`
- Code path: USDRT `SelectPrims` invocation when the device index is not 0
- Origin: #5514 removed the `_fabric_supported_devices = ("cpu", "cuda", "cuda:0")` allowlist with the rationale "USDRT SelectPrims now accepts any CUDA device index", but the call still deadlocks in practice.

## 5. Resolution path

Land #5738 first (multi-GPU CI infrastructure with cuda:1 gated off → green). When the underlying FabricFrameView hang is fixed in a separate PR, this PR's CI goes green and the env-var flip can land — restoring multi-GPU regression gating for FabricFrameView.

## 6. Dependencies

- Related to #5738 (multi-GPU CI infrastructure). This PR uses the same workflow file but with `ISAACLAB_TEST_MULTI_GPU=1` set to actually run the cuda:1 tests.

## 7. Test plan

- [ ] Workflow appears in checks on this draft PR.
- [ ] cpu + cuda:0 tests pass (~30s in pytest).
- [ ] First cuda:1 test enters deadlock; job cancelled at 60-min timeout.
- [x] Local reproduction recipe in §3 confirms the same hang outside CI (verified on Horde, 90s SIGTERM).