### PR TITLE
Added windows instructions to leapp docs

### DIFF
--- a/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
+++ b/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
@@ -72,19 +72,49 @@ Exporting a Policy
 
 Use the RSL-RL export script to export a trained checkpoint:
 
-.. code-block:: bash
+.. tab-set::
+   :sync-group: os
 
-   ./isaaclab.sh -p scripts/reinforcement_learning/leapp/rsl_rl/export.py \
-       --task <TASK_NAME> \
-       --checkpoint <PATH_TO_CHECKPOINT>
+   .. tab-item:: :icon:`fa-brands fa-linux` Linux
+      :sync: linux
+
+      .. code-block:: bash
+
+         ./isaaclab.sh -p scripts/reinforcement_learning/leapp/rsl_rl/export.py \
+             --task <TASK_NAME> \
+             --checkpoint <PATH_TO_CHECKPOINT>
+
+   .. tab-item:: :icon:`fa-brands fa-windows` Windows
+      :sync: windows
+
+      .. code-block:: batch
+
+         isaaclab.bat -p scripts\reinforcement_learning\leapp\rsl_rl\export.py ^
+             --task <TASK_NAME> ^
+             --checkpoint <PATH_TO_CHECKPOINT>
 
 For example, to export a UR10 reach policy:
 
-.. code-block:: bash
+.. tab-set::
+   :sync-group: os
 
-   ./isaaclab.sh -p scripts/reinforcement_learning/leapp/rsl_rl/export.py \
-       --task Isaac-Reach-UR10-v0 \
-       --checkpoint logs/rsl_rl/ur10_reach/< date timestamp >/model_4999.pt
+   .. tab-item:: :icon:`fa-brands fa-linux` Linux
+      :sync: linux
+
+      .. code-block:: bash
+
+         ./isaaclab.sh -p scripts/reinforcement_learning/leapp/rsl_rl/export.py \
+             --task Isaac-Reach-UR10-v0 \
+             --checkpoint logs/rsl_rl/ur10_reach/< date timestamp >/model_4999.pt
+
+   .. tab-item:: :icon:`fa-brands fa-windows` Windows
+      :sync: windows
+
+      .. code-block:: batch
+
+         isaaclab.bat -p scripts\reinforcement_learning\leapp\rsl_rl\export.py ^
+             --task Isaac-Reach-UR10-v0 ^
+             --checkpoint logs\rsl_rl\ur10_reach\<date timestamp>\model_4999.pt
 
 By default, the export artifacts are saved in the same directory as the checkpoint. The
 exported graph is named after the task.

--- a/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
+++ b/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
@@ -46,20 +46,50 @@ If you want to run the exported example with the existing
 ``Isaac-Velocity-Rough-Anymal-C-Direct-v0`` task registration, copy the annotated
 tutorial environment into the task package:
 
-.. code-block:: bash
+.. tab-set::
+   :sync-group: os
 
-   cp scripts/tutorials/06_deploy/anymal_c_env.py \
-      source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/anymal_c_env.py
+   .. tab-item:: :icon:`fa-brands fa-linux` Linux
+      :sync: linux
+
+      .. code-block:: bash
+
+         cp scripts/tutorials/06_deploy/anymal_c_env.py \
+            source/isaaclab_tasks/isaaclab_tasks/direct/anymal_c/anymal_c_env.py
+
+   .. tab-item:: :icon:`fa-brands fa-windows` Windows
+      :sync: windows
+
+      .. code-block:: batch
+
+         copy scripts\tutorials\06_deploy\anymal_c_env.py ^
+            source\isaaclab_tasks\isaaclab_tasks\direct\anymal_c\anymal_c_env.py
 
 After your environment includes the required LEAPP input, output, and state
 annotations, export a trained policy with:
 
-.. code-block:: bash
+.. tab-set::
+   :sync-group: os
 
-   ./isaaclab.sh -p scripts/reinforcement_learning/leapp/rsl_rl/export.py \
-       --task <TASK_NAME> \
-       --checkpoint <PATH_TO_CHECKPOINT> \
-       --export_save_path <EXPORT_PATH>
+   .. tab-item:: :icon:`fa-brands fa-linux` Linux
+      :sync: linux
+
+      .. code-block:: bash
+
+         ./isaaclab.sh -p scripts/reinforcement_learning/leapp/rsl_rl/export.py \
+             --task <TASK_NAME> \
+             --checkpoint <PATH_TO_CHECKPOINT> \
+             --export_save_path <EXPORT_PATH>
+
+   .. tab-item:: :icon:`fa-brands fa-windows` Windows
+      :sync: windows
+
+      .. code-block:: batch
+
+         isaaclab.bat -p scripts\reinforcement_learning\leapp\rsl_rl\export.py ^
+             --task <TASK_NAME> ^
+             --checkpoint <PATH_TO_CHECKPOINT> ^
+             --export_save_path <EXPORT_PATH>
 
 The ``--task`` argument is the registered task name, such as
 ``Isaac-Velocity-Rough-Anymal-C-Direct-v0``. The ``--checkpoint`` argument


### PR DESCRIPTION
Fixes # (issue)
Adds windows documentation for leapp export. builds on top of https://github.com/isaac-sim/IsaacLab/pull/5726 where some changes were forgotten

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
