### PR TITLE
Fix uv run due to missing ppisp ref

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "isaaclab-ov",
     "isaaclab-ovphysx",
     "isaaclab-physx[newton]",
+    "isaaclab-ppisp",
     "isaaclab-rl[rsl-rl]",
     "isaaclab-tasks",
     "isaaclab-tasks-experimental",
@@ -232,6 +233,7 @@ isaaclab = { path = "source/isaaclab", editable = true }
 "isaaclab-ov" = { path = "source/isaaclab_ov", editable = true }
 "isaaclab-ovphysx" = { path = "source/isaaclab_ovphysx", editable = true }
 "isaaclab-physx" = { path = "source/isaaclab_physx", editable = true }
+"isaaclab-ppisp" = { path = "source/isaaclab_ppisp", editable = true }
 "isaaclab-rl" = { path = "source/isaaclab_rl", editable = true }
 "isaaclab-tasks" = { path = "source/isaaclab_tasks", editable = true }
 "isaaclab-tasks-experimental" = { path = "source/isaaclab_tasks_experimental", editable = true }


### PR DESCRIPTION
# Description

Fix missing uv source for ppisp submodule

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
