### PR TITLE
Added rendering test for ovphysx

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -699,7 +699,7 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_tasks"
-        extra-pip-packages: "ovrtx"
+        extra-pip-packages: "ovrtx ovphysx"
         include-files: "test_rendering_cartpole_kitless.py,test_rendering_dexsuite_kuka_kitless.py,test_rendering_shadow_hand_kitless.py"
         container-name: isaac-lab-rendering-correctness-kitless-test
   #endregion

--- a/.github/workflows/daily-compatibility.yml
+++ b/.github/workflows/daily-compatibility.yml
@@ -111,7 +111,7 @@ jobs:
         image-tag: ${{ env.DOCKER_IMAGE_TAG }}
         pytest-options: ""
         filter-pattern: "isaaclab_tasks"
-        extra-pip-packages: "ovrtx"
+        extra-pip-packages: "ovrtx ovphysx"
 
     - name: Copy All Test Results from IsaacLab Tasks Container
       run: |

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
@@ -272,6 +273,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
+    ovphysx = OvPhysxCfg()
     default = physx
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
-from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
@@ -273,7 +272,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    ovphysx = OvPhysxCfg()
     default = physx
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/dexsuite_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/dexsuite_env_cfg.py
@@ -6,6 +6,7 @@
 from dataclasses import MISSING
 
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
+from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -448,6 +449,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
+    ovphysx = OvPhysxCfg()
     physx = default
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/dexsuite_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/dexsuite/dexsuite_env_cfg.py
@@ -6,7 +6,6 @@
 from dataclasses import MISSING
 
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
-from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -449,7 +448,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    ovphysx = OvPhysxCfg()
     physx = default
 
 

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-depth.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-depth.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8929af0b155ac73e4dd74dd70dbc502fb78bd962248e5c46f88972a0a7e3e80e
+size 538

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-rgb.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-rgb.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43e4e5e1b33b0f33b80cd03c267deb4a6097676aa70f21f7abebeae073909fc4
+size 801

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-rgba.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-rgba.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe5c40ef94b011927a506d244aa42fc85e65b1da2b3789ec9dd569c157afe154
+size 864

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-albedo.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-albedo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88da57e08497b308d47c3e606d40142291adde3c0fe2df46ab0a924d39b6847b
+size 435

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-depth.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-depth.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea4e6ba2251666e4df0c937fbd123489f2a06939bda9e674d5f84eb5c8831f7d
+size 422

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-rgb.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-rgb.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f6602790e76c3448bbfae2dc2df961e2122ab90aa3e5a7e94fb143aa7f27525
+size 2576

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-rgba.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-rgba.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0f30114683915380110cbf4ed63023d38555358f09aa5c0a8810b83cdcc3a15
+size 2871

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fbe8833cefa8b037cb80538ff73ec9c503253cfe410282f3b9acdea12e7a017
+size 427

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-simple_shading_constant_diffuse.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-simple_shading_constant_diffuse.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47b5b15d79d0b61d00c0538caa0012172753a481ad6efb45df2888402be2f407
+size 391

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-simple_shading_diffuse_mdl.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-simple_shading_diffuse_mdl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2ba382c0804ea49b55fc5216c9f1e28c34d5cae95b33d9982fd55763df178cc
+size 435

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-simple_shading_full_mdl.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-simple_shading_full_mdl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7af4ef2afca01d0bf4f9c069c5c3778fa07050bcd8091486541ab11f14e8227
+size 742

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -289,6 +289,19 @@ KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS = [
         id="newton-ovrtx-semantic_segmentation",
         marks=_FLAKY_MARK,
     ),
+    # ovphysx + newton_renderer (warp)
+    pytest.param(
+        "ovphysx",
+        "newton_renderer",
+        "rgb",
+        id="ovphysx-newton_warp-rgb",
+    ),
+    pytest.param(
+        "ovphysx",
+        "newton_renderer",
+        "depth",
+        id="ovphysx-newton_warp-depth",
+    ),
     # newton + newton_renderer (warp)
     pytest.param(
         "newton",

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -761,6 +761,10 @@ def rendering_test_shadow_hand(
     data_type: str,
     comparison_scores: list[dict],
 ) -> None:
+    if physics_backend == "ovphysx":
+        pytest.skip("ovphysx is not supported yet.")
+        return
+
     from isaaclab_tasks.direct.shadow_hand.shadow_hand_vision_env import ShadowHandVisionEnv
     from isaaclab_tasks.direct.shadow_hand.shadow_hand_vision_env_cfg import ShadowHandVisionEnvCfg
 
@@ -848,6 +852,10 @@ def rendering_test_dexsuite_kuka(
     data_type: str,
     comparison_scores: list[dict],
 ) -> None:
+    if physics_backend == "ovphysx":
+        pytest.skip("ovphysx is not supported yet.")
+        return
+
     from isaaclab.envs import ManagerBasedRLEnv
 
     from isaaclab_tasks.manager_based.manipulation.dexsuite.config.kuka_allegro.dexsuite_kuka_allegro_env_cfg import (

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -566,35 +566,44 @@ def make_attach_comparison_properties_fixture(comparison_scores: list[dict]):
     return _attach_comparison_properties
 
 
-def make_require_ovrtx_install_fixture():
-    """Create an autouse fixture that fails fast when OVRTX is required but not installed.
+def make_require_ovlibs_install_fixture():
+    """Create an autouse fixture that fails fast when OV libraries are required but not installed.
 
-    Only parametrized cases with ``renderer == "ovrtx_renderer"`` are checked (Newton
-    Warp kitless cases do not need ``ov[ovrtx]``). Install with
-    ``./isaaclab.sh -i 'ov[ovrtx]'`` (or the equivalent in your environment).
+    Only parametrized cases with ``renderer == "ovrtx_renderer"`` or ``physics_backend == "ovphysx"`` are checked.
+    Install with ``./isaaclab.sh -i 'ov[all]'`` (or the equivalent in your environment).
     """
 
     @pytest.fixture(autouse=True)
-    def _require_ovrtx_install(request):
+    def _require_ovlibs_install(request):
         callspec = getattr(request.node, "callspec", None)
         if callspec is None:
             return
 
-        if callspec.params.get("renderer") != "ovrtx_renderer":
-            return
+        if callspec.params.get("renderer") == "ovrtx_renderer":
+            try:
+                import ovrtx
 
-        try:
-            import ovrtx
+                print(f"ovrtx version: {ovrtx.__version__}")
+            except ImportError as exc:
+                pytest.fail(
+                    "Kitless OVRTX rendering tests require the optional dependency ov[ovrtx]. "
+                    "Install with: ./isaaclab.sh -i 'ov[ovrtx]'\n"
+                    f"ImportError: {exc}"
+                )
 
-            print(f"ovrtx version: {ovrtx.__version__}")
-        except ImportError as exc:
-            pytest.fail(
-                "Kitless OVRTX rendering tests require the optional dependency ov[ovrtx]. "
-                "Install with: ./isaaclab.sh -i 'ov[ovrtx]'\n"
-                f"ImportError: {exc}"
-            )
+        if callspec.params.get("physics_backend") == "ovphysx":
+            try:
+                import ovphysx
 
-    return _require_ovrtx_install
+                print(f"ovphysx version: {ovphysx.__version__}")
+            except ImportError as exc:
+                pytest.fail(
+                    "Kitless OVPhysX rendering tests require the optional dependency ov[ovphysx]. "
+                    "Install with: ./isaaclab.sh -i 'ov[ovphysx]'\n"
+                    f"ImportError: {exc}"
+                )
+
+    return _require_ovlibs_install
 
 
 def _make_grid(images: torch.Tensor) -> torch.Tensor:
@@ -776,7 +785,6 @@ def rendering_test_shadow_hand(
 ) -> None:
     if physics_backend == "ovphysx":
         pytest.skip("ovphysx is not supported yet.")
-        return
 
     from isaaclab_tasks.direct.shadow_hand.shadow_hand_vision_env import ShadowHandVisionEnv
     from isaaclab_tasks.direct.shadow_hand.shadow_hand_vision_env_cfg import ShadowHandVisionEnvCfg
@@ -867,7 +875,6 @@ def rendering_test_dexsuite_kuka(
 ) -> None:
     if physics_backend == "ovphysx":
         pytest.skip("ovphysx is not supported yet.")
-        return
 
     from isaaclab.envs import ManagerBasedRLEnv
 

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -189,6 +189,56 @@ PHYSICS_RENDERER_AOV_COMBINATIONS = [
 ]
 
 KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS = [
+    # ovphysx + ovrtx_renderer
+    pytest.param(
+        "ovphysx",
+        "ovrtx_renderer",
+        "rgb",
+        id="ovphysx-ovrtx-rgb",
+        marks=_FLAKY_MARK,
+    ),
+    pytest.param(
+        "ovphysx",
+        "ovrtx_renderer",
+        "albedo",
+        id="ovphysx-ovrtx-albedo",
+        marks=_FLAKY_MARK,
+    ),
+    pytest.param(
+        "ovphysx",
+        "ovrtx_renderer",
+        "depth",
+        id="ovphysx-ovrtx-depth",
+        marks=_FLAKY_MARK,
+    ),
+    pytest.param(
+        "ovphysx",
+        "ovrtx_renderer",
+        "simple_shading_constant_diffuse",
+        id="ovphysx-ovrtx-simple_shading_constant_diffuse",
+        marks=_FLAKY_MARK,
+    ),
+    pytest.param(
+        "ovphysx",
+        "ovrtx_renderer",
+        "simple_shading_diffuse_mdl",
+        id="ovphysx-ovrtx-simple_shading_diffuse_mdl",
+        marks=_FLAKY_MARK,
+    ),
+    pytest.param(
+        "ovphysx",
+        "ovrtx_renderer",
+        "simple_shading_full_mdl",
+        id="ovphysx-ovrtx-simple_shading_full_mdl",
+        marks=_FLAKY_MARK,
+    ),
+    pytest.param(
+        "ovphysx",
+        "ovrtx_renderer",
+        "semantic_segmentation",
+        id="ovphysx-ovrtx-semantic_segmentation",
+        marks=_FLAKY_MARK,
+    ),
     # newton + ovrtx_renderer
     pytest.param(
         "newton",

--- a/source/isaaclab_tasks/test/test_rendering_cartpole_kitless.py
+++ b/source/isaaclab_tasks/test/test_rendering_cartpole_kitless.py
@@ -13,7 +13,7 @@ from rendering_test_utils import (
     make_attach_comparison_properties_fixture,
     make_determinism_fixture,
     make_generate_html_report_fixture,
-    make_require_ovrtx_install_fixture,
+    make_require_ovlibs_install_fixture,
     rendering_test_cartpole,
 )
 
@@ -24,7 +24,7 @@ _COMPARISON_SCORES: list[dict] = []
 _determinism_fixture = make_determinism_fixture()
 _generate_html_report_fixture = make_generate_html_report_fixture(_COMPARISON_SCORES, Path(__file__).stem + ".html")
 _attach_comparison_properties_fixture = make_attach_comparison_properties_fixture(_COMPARISON_SCORES)
-_require_ovrtx_install_fixture = make_require_ovrtx_install_fixture()
+_require_ovlibs_install_fixture = make_require_ovlibs_install_fixture()
 
 
 @pytest.mark.parametrize("physics_backend,renderer,data_type", KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS)

--- a/source/isaaclab_tasks/test/test_rendering_dexsuite_kuka_kitless.py
+++ b/source/isaaclab_tasks/test/test_rendering_dexsuite_kuka_kitless.py
@@ -13,7 +13,7 @@ from rendering_test_utils import (
     make_attach_comparison_properties_fixture,
     make_determinism_fixture,
     make_generate_html_report_fixture,
-    make_require_ovrtx_install_fixture,
+    make_require_ovlibs_install_fixture,
     rendering_test_dexsuite_kuka,
 )
 
@@ -24,7 +24,7 @@ _COMPARISON_SCORES: list[dict] = []
 _determinism_fixture = make_determinism_fixture()
 _generate_html_report_fixture = make_generate_html_report_fixture(_COMPARISON_SCORES, Path(__file__).stem + ".html")
 _attach_comparison_properties_fixture = make_attach_comparison_properties_fixture(_COMPARISON_SCORES)
-_require_ovrtx_install_fixture = make_require_ovrtx_install_fixture()
+_require_ovlibs_install_fixture = make_require_ovlibs_install_fixture()
 
 
 @pytest.mark.parametrize("physics_backend,renderer,data_type", KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS)

--- a/source/isaaclab_tasks/test/test_rendering_shadow_hand_kitless.py
+++ b/source/isaaclab_tasks/test/test_rendering_shadow_hand_kitless.py
@@ -13,7 +13,7 @@ from rendering_test_utils import (
     make_attach_comparison_properties_fixture,
     make_determinism_fixture,
     make_generate_html_report_fixture,
-    make_require_ovrtx_install_fixture,
+    make_require_ovlibs_install_fixture,
     rendering_test_shadow_hand,
 )
 
@@ -24,7 +24,7 @@ _COMPARISON_SCORES: list[dict] = []
 _determinism_fixture = make_determinism_fixture()
 _generate_html_report_fixture = make_generate_html_report_fixture(_COMPARISON_SCORES, Path(__file__).stem + ".html")
 _attach_comparison_properties_fixture = make_attach_comparison_properties_fixture(_COMPARISON_SCORES)
-_require_ovrtx_install_fixture = make_require_ovrtx_install_fixture()
+_require_ovlibs_install_fixture = make_require_ovlibs_install_fixture()
 
 
 @pytest.mark.parametrize("physics_backend,renderer,data_type", KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS)


### PR DESCRIPTION
# Description

Added rendering test for ovphysx.

Only the cartpole env is supported, so we skip testing for the other two envs.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
