### PR TITLE
[Fix] add_new_robot tutorial wheel-velocity action on GPU device (#5776)

### DIFF
--- a/scripts/tutorials/01_assets/add_new_robot.py
+++ b/scripts/tutorials/01_assets/add_new_robot.py
@@ -103,6 +103,11 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
     sim_time = 0.0
     count = 0
 
+    # wheel-velocity templates allocated once on the simulation device; the joint
+    # target setters dispatch to GPU Warp kernels and reject CPU tensors.
+    straight_action = torch.tensor([[10.0, 10.0]], device=sim.device)
+    turn_action = torch.tensor([[5.0, -5.0]], device=sim.device)
+
     while simulation_app.is_running():
         # reset
         if count % 500 == 0:
@@ -142,12 +147,12 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
         # drive around
         if count % 100 < 75:
             # Drive straight by setting equal wheel velocities
-            action = torch.Tensor([[10.0, 10.0]])
+            action = straight_action
         else:
             # Turn by applying different velocities
-            action = torch.Tensor([[5.0, -5.0]])
+            action = turn_action
 
-        scene["Jetbot"].set_joint_velocity_target(action)
+        scene["Jetbot"].set_joint_velocity_target_index(target=action)
 
         # wave
         wave_action = scene["Dofbot"].data.default_joint_pos.torch

--- a/source/isaaclab/changelog.d/jichuanh-tutorial-add-new-robot-cpu-device.rst
+++ b/source/isaaclab/changelog.d/jichuanh-tutorial-add-new-robot-cpu-device.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed ``scripts/tutorials/01_assets/add_new_robot.py`` failing at the Jetbot
+  velocity-target setter when the action was a CPU ``torch.Tensor``. The
+  tutorial now allocates the wheel-velocity templates on ``sim.device`` and
+  uses :meth:`~isaaclab.assets.BaseArticulation.set_joint_velocity_target_index`.


### PR DESCRIPTION
Cherry-pick of #5776 onto ``release/3.0.0-beta2``.

Customer-reported tutorial bug filed against the v3.0.0-beta2 release. Original fix landed on develop in #5776 (commit ddc055de66f).

## 1. Summary

- ``scripts/tutorials/01_assets/add_new_robot.py`` errored at runtime: the wheel-velocity action was a CPU ``torch.Tensor`` and ``set_joint_velocity_target`` dispatches to a GPU Warp kernel that rejects CPU tensors at type check.
- Allocate the two wheel-velocity templates once on ``sim.device``, reuse across the loop, and call ``set_joint_velocity_target_index`` (also silences the deprecation warning visible in the bug report's first line).
- Cherry-pick applies cleanly with no conflicts.

## 2. Test plan

- [x] Cherry-pick applied cleanly off the release branch (no conflicts).
- [x] Pre-commit clean on the changed files.
- [x] End-to-end smoke verified on develop in #5776: 25 reset cycles, no error, no deprecation warning.

Refs NVBug 6156303