### PR TITLE
[Diag][DO NOT MERGE] Negative arm — revert #5633 torch-defer to validate #5656 numpy!=2.3.5 fix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Dep-manifest diagnostic: prints numpy version + bundled OpenBLAS hash at pytest session start.
+
+Located at the repo root so every subprocess pytest (driven by
+``tools/conftest.py``) discovers and loads it, regardless of which package's
+tests are running. The repo root has no ``isaaclab_*`` subdirectories, so
+``importmode=prepend`` placing the repo root on ``sys.path`` does NOT shadow
+the real pip-installed IsaacLab packages — unlike ``source/conftest.py``,
+where ``source/<pkg>/`` (no ``__init__.py``) would be promoted to a namespace
+package and break ``from isaaclab_teleop import IsaacTeleopCfg`` style imports.
+
+Importing numpy here registers its vendored OpenBLAS ``pthread_atfork``
+handler in the same process that later calls ``fork()`` via
+``SimulationApp()``. The print output identifies which numpy + OpenBLAS bundle
+actually landed in each CI test container.
+"""
+
+import os
+
+import numpy
+
+print(f"\n[dep-manifest] numpy {numpy.__version__}", flush=True)
+_libs_dir = os.path.join(os.path.dirname(numpy.__file__), os.pardir, "numpy.libs")
+if os.path.isdir(_libs_dir):
+    for _f in sorted(os.listdir(_libs_dir)):
+        if "openblas" in _f.lower():
+            print(f"[dep-manifest] bundled openblas: {_f}", flush=True)

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -242,7 +242,6 @@ class AppLauncher:
         # Exposed to train scripts
         self.device_id: int  # device ID for GPU simulation (defaults to 0)
         self.device: str  # resolved device string (e.g. "cuda:0" or "cpu")
-        self._deferred_cuda_device_id: int | None = None
         self.local_rank: int  # local rank of GPUs in the current node
         self.global_rank: int  # global rank for multi-node training
 
@@ -251,7 +250,6 @@ class AppLauncher:
 
         # Create SimulationApp, passing the resolved self._config to it for initialization
         self._create_app()
-        self._set_deferred_cuda_device()
         # Load IsaacSim extensions
         self._load_extensions()
 
@@ -1007,25 +1005,18 @@ class AppLauncher:
         launcher_args["physics_gpu"] = self.device_id
         launcher_args["active_gpu"] = self.device_id
 
-        # Defer importing torch until after SimulationApp starts.  Importing
-        # torch can import NumPy/OpenBLAS, whose at-fork handlers can crash
-        # Kit's platform-info fork during startup.
+        # Set the current CUDA device early so that physics backends (e.g. Newton/Warp)
+        # that allocate on the "current" device during initialization get the correct GPU.
+        # Without this, all ranks may default to cuda:0 for early allocations.
         if "cuda" in device:
-            self._deferred_cuda_device_id = self.device_id
+            import torch
+
+            torch.cuda.set_device(self.device_id)
 
         # Store the resolved device string for downstream consumers (e.g. sim_launcher)
         self.device = device
 
         logger.info("Using device: %s", device)
-
-    def _set_deferred_cuda_device(self) -> None:
-        """Set the current torch CUDA device after Kit startup."""
-        if self._deferred_cuda_device_id is None:
-            return
-
-        import torch
-
-        torch.cuda.set_device(self._deferred_cuda_device_id)
 
     def _resolve_experience_file(self, launcher_args: dict):
         """Resolve experience file related settings."""


### PR DESCRIPTION
## 1. Purpose

Negative arm of the validation for PR #5656 (the ``numpy!=2.3.5`` exclusion).

Develop currently carries **two** independent mitigations for the OpenBLAS atfork SIGSEGV:

1. **PR #5633** (Antoine Richard, merge ``a5eb9add4c3``) which carried PR #5620's content — defers ``import torch`` in ``AppLauncher`` until **after** ``SimulationApp`` starts, so numpy/OpenBLAS isn't loaded in pytest's master process before the Kit fork.
2. **PR #5656** — excludes ``numpy 2.3.5`` from every install path, so even an early numpy import resolves to a non-buggy version.

If either mitigation alone is sufficient, the other is redundant. This PR reverts (1) so we can see whether (2) holds on its own.

## 2. Setup

- Branch base: ``develop`` (latest).
- Commit 1: surgical revert of ``source/isaaclab/isaaclab/app/app_launcher.py`` to its state just before ``a5eb9add4c3`` (#5633). Other files from #5633 left alone — the defer-torch logic in ``AppLauncher.__init__`` is the only piece relevant to the atfork bug.
- Commit 2: ``source/isaaclab/test/conftest.py`` that imports numpy and prints version + bundled OpenBLAS hash at pytest session start.

The conftest is deliberately placed at ``source/isaaclab/test/`` rather than ``source/`` to avoid the namespace-package shadowing that broke PR #5655 — anchoring pytest's rootdir at ``source/`` prepends it to ``sys.path``, making every ``source/<pkg>/`` (no ``__init__.py``) shadow the real pip-installed package and turn ``from isaaclab_teleop import IsaacTeleopCfg`` into an ImportError before any test runs.

## 3. Expected result

- Install resolves to numpy 2.3.4 (highest 2.3.x that satisfies ``!=2.3.5`` under cmeel-boost's cap from #5656).
- ``[dep-manifest]`` log line shows ``numpy 2.3.4`` + ``libscipy_openblas64_-8fb3d286.so``.
- ``import torch`` happens in ``AppLauncher.__init__`` BEFORE ``SimulationApp`` fork, but resolves to non-buggy numpy 2.3.4, so canary jobs (``isaaclab_physx``, ``isaaclab_newton``, ``isaaclab_rl``) pass.

If any canary still SIGSEGVs in ``libomni.platforminfo`` fork, the ``numpy!=2.3.5`` exclusion alone is **not** sufficient and #5633's torch-defer is also necessary — keep both.

If all canaries pass, the ``numpy!=2.3.5`` exclusion alone is sufficient and #5633's torch-defer is redundant — could be reverted in a follow-up cleanup.

## 4. Lifecycle

Diagnostic-only. **Do not merge.** Closes once evidence is captured.

## 5. Related

- PR #5656 — the ``numpy!=2.3.5`` exclusion being validated
- PR #5633 — Antoine's merge of Piotr's #5620 torch-defer mitigation (the one we're temporarily reverting)
- PR #5620 — Piotr's original (closed) version of the same mitigation
- PR #5655 — earlier diagnostic attempt; superseded by this PR (the ``source/conftest.py`` placement there broke test discovery before the bug could surface)
- numpy/numpy#30092
- OpenMathLib/OpenBLAS#5520