### PR TITLE
Fix Kit Python info logging

### DIFF
--- a/source/isaaclab/changelog.d/fix-kit-python-info-logging.rst
+++ b/source/isaaclab/changelog.d/fix-kit-python-info-logging.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Kit launches hiding Isaac Lab Python ``INFO`` logs, including joint
+  wrench sensor initialization messages.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -182,6 +182,44 @@ class AppLauncher:
             )
         return has_any, has_kit
 
+    @staticmethod
+    def _resolve_python_logging_level(launcher_args: dict) -> int:
+        """Resolve the Python logging level that should survive Kit startup."""
+        if launcher_args.get("verbose", False) or "--verbose" in sys.argv:
+            return logging.DEBUG
+        if launcher_args.get("info", False) or "--info" in sys.argv:
+            return logging.INFO
+
+        level = logging.getLogger().getEffectiveLevel()
+        return logging.WARNING if level == logging.NOTSET else level
+
+    @staticmethod
+    def _apply_python_logging_level(level: int) -> None:
+        """Apply a Python logging level to the root logger and its handlers."""
+        root_logger = logging.getLogger()
+        root_logger.setLevel(level)
+        for handler in root_logger.handlers:
+            handler.setLevel(level)
+
+    @staticmethod
+    def _ensure_isaaclab_info_stream_handler() -> None:
+        """Add a stream handler for Isaac Lab INFO records hidden by Kit logging."""
+        handler_name = "isaaclab_info_stream"
+        root_logger = logging.getLogger()
+        if any(getattr(handler, "name", None) == handler_name for handler in root_logger.handlers):
+            return
+
+        class _IsaacLabInfoFilter(logging.Filter):
+            def filter(self, record: logging.LogRecord) -> bool:
+                return record.levelno == logging.INFO and record.name.startswith("isaaclab")
+
+        handler = logging.StreamHandler(sys.stdout)
+        handler.name = handler_name
+        handler.setLevel(logging.INFO)
+        handler.addFilter(_IsaacLabInfoFilter())
+        handler.setFormatter(logging.Formatter("[INFO]: %(message)s"))
+        root_logger.addHandler(handler)
+
     def __init__(self, launcher_args: argparse.Namespace | dict | None = None, **kwargs):
         """Create a `SimulationApp`_ instance based on the input settings.
 
@@ -231,6 +269,9 @@ class AppLauncher:
                     " discern priority between them."
                 )
             launcher_args.update(kwargs)
+
+        # Preserve the Python logging intent before Kit installs its own logging bridge.
+        self._python_logging_level = AppLauncher._resolve_python_logging_level(launcher_args)
 
         # Define config members that are read from env-vars or keyword args
         self._headless: bool  # 0: GUI, 1: Headless
@@ -1178,8 +1219,16 @@ class AppLauncher:
             logger.info("Applied RTX settings for deterministic rendering (--deterministic).")
 
         # After SimulationApp starts, Kit installs its Python log bridge at DEBUG level.
-        # Re-apply root logger level to WARNING to suppress third-party and verbose debug/info noise.
-        logging.getLogger().setLevel(logging.WARNING)
+        # Re-apply the intended Python logging level, then add a scoped stream handler for
+        # Isaac Lab INFO records that Kit's bridge does not mirror to the console.
+        AppLauncher._apply_python_logging_level(self._python_logging_level)
+        if self._python_logging_level <= logging.INFO:
+            AppLauncher._ensure_isaaclab_info_stream_handler()
+        elif self._python_logging_level == logging.WARNING:
+            AppLauncher._ensure_isaaclab_info_stream_handler()
+            # Let Isaac Lab INFO records reach the scoped handler while the other root
+            # handlers remain at WARNING.
+            logging.getLogger().setLevel(logging.INFO)
         settings = get_settings_manager()
 
         # set setting to indicate Isaac Lab's offscreen_render pipeline should be enabled


### PR DESCRIPTION
# Description

Fixes the Kit-backed Python logging path so Isaac Lab `INFO` records remain visible after `SimulationApp` installs Kit's logging bridge. This restores the PhysX joint wrench sensor initialization log for `Isaac-Ant-v0` with `presets=physx` while keeping the sensor implementations on standard Python logging.

Fixes the reported joint wrench sensor logging issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Test Plan

- `./isaaclab.sh -f`
- `git diff --check`
- `timeout 120s ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Ant-v0 --num_envs 1 --viz newton presets=physx`
  - Verified output includes `[INFO]: Joint wrench sensor initialized: 1 envs, 9 bodies`
- `./isaaclab.sh -p -m pytest source/isaaclab_physx/test/sensors/test_joint_wrench_sensor.py::test_initialization_and_shapes`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation (not applicable; no documentation page change required)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not added per request; verified with existing test and repro command)
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
