### PR TITLE
Fix PhysX scene data rigid body view

### DIFF
--- a/source/isaaclab_physx/changelog.d/scene-data-rigid-body-view.rst
+++ b/source/isaaclab_physx/changelog.d/scene-data-rigid-body-view.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed PhysX scene-data rigid-body view creation to use exact rigid-body prim
+  paths, avoiding spurious warnings for assets whose joint prims share body names.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -173,9 +173,8 @@ class PhysxSceneDataBackend(SceneDataBackend):
     def get_rigid_body_view(self) -> omni.physics.tensors.RigidBodyView | None:
         """Lazily create a rigid body view covering all rigid bodies in the scene.
 
-        Discovers rigid body prims by traversing the USD stage and converts
-        per-environment paths (``/World/envs/env_N/...``) into wildcard
-        patterns so a single PhysX view covers every environment instance.
+        Discovers rigid body prims by traversing the USD stage and creates the
+        PhysX view from their exact prim paths.
         """
         if self._rigid_body_view is not None:
             return self._rigid_body_view
@@ -187,15 +186,15 @@ class PhysxSceneDataBackend(SceneDataBackend):
         if stage is None:
             return None
 
-        patterns: set[str] = set()
+        paths: list[str] = []
         for prim in stage.Traverse():
             if prim.HasAPI(UsdPhysics.RigidBodyAPI):
-                patterns.add(re.sub(r"/World/envs/env_\d+", "/World/envs/env_*", prim.GetPath().pathString))
+                paths.append(prim.GetPath().pathString)
 
-        if not patterns:
+        if not paths:
             return None
 
-        self._rigid_body_view = self._simulation_view.create_rigid_body_view(list(patterns))
+        self._rigid_body_view = self._simulation_view.create_rigid_body_view(paths)
         return self._rigid_body_view
 
     @property


### PR DESCRIPTION
# Description

Fixes a spurious PhysX tensor warning when the Newton visualizer requests scene-data transforms for assets whose joint prims share names with rigid-body prims, such as Ant and Humanoid.

The PhysX scene-data backend already discovers exact rigid-body prims from USD, so this change creates the rigid-body view from those exact paths instead of broad `/World/envs/env_*` wildcard patterns that can also match same-named joint prims.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

Manual verification:

- `./isaaclab.sh -f`
- `timeout 60s ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Ant-v0 --num_envs 128 --viz newton presets=physx`
- `timeout 60s ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Humanoid-v0 --num_envs 128 --viz newton presets=physx`

The Ant and Humanoid repro commands start without the previous `[omni.physx.tensors.plugin] Failed to find rigid body at .../Robot/joints/...` warnings.