### PR TITLE
Fix OvPhysX Kit visualizer guard

### DIFF
--- a/docs/source/features/hydra.rst
+++ b/docs/source/features/hydra.rst
@@ -394,7 +394,8 @@ to make intent explicit on the command line.
    * - ``newton_kamino``
      - Newton physics with the Kamino solver (beta; limited tasks — see :ref:`hydra-backend-solver-presets`)
    * - ``ovphysx``
-     - OV PhysX backend (kit-less mode; select classic tasks only)
+     - OV PhysX backend (kit-less mode; select classic tasks only;
+       incompatible with ``--visualizer kit``)
 
 **Available renderer backends** (provided by :class:`~isaaclab_tasks.utils.presets.MultiBackendRendererCfg`):
 

--- a/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
@@ -8,6 +8,15 @@ OvPhysX Backend
     development. Expect feature coverage and test commands to change between
     Isaac Lab 3.0 beta releases.
 
+.. warning::
+
+    Do not combine OvPhysX with the Kit visualizer. Commands such as
+    ``presets=ovphysx --visualizer kit`` are unsupported because OvPhysX
+    loads USD-dependent PhysX plugins from its own package, while Kit already
+    owns a separate USD/plugin stack in the same process. Use
+    ``--visualizer newton``, ``--visualizer rerun``, ``--visualizer viser``,
+    or omit ``--visualizer`` for headless execution.
+
 OvPhysX is a kit-less variant of the PhysX backend. It drives PhysX directly
 (without the Omniverse Kit runtime) and reads scene-level solver parameters
 from the USD ``PhysicsScene`` prim rather than from a Python config. The Python

--- a/docs/source/overview/core-concepts/visualization.rst
+++ b/docs/source/overview/core-concepts/visualization.rst
@@ -3,9 +3,16 @@ Visualization
 
 .. currentmodule:: isaaclab
 
-Isaac Lab offers several lightweight visualizers for real-time simulation inspection and debugging. Unlike renderers that process sensor data, visualizers are meant for fast, interactive feedback.
+Isaac Lab offers several lightweight visualizers for real-time simulation
+inspection and debugging. Unlike renderers that process sensor data,
+visualizers are meant for fast, interactive feedback.
 
-You can use any visualizer regardless of your chosen physics engine or rendering backend.
+Most visualizers can be combined with any physics engine or rendering backend.
+The exception is the Kit visualizer with kit-less OV backends:
+``--visualizer kit`` cannot be used with ``presets=ovphysx`` or
+``ovrtx_renderer`` in the same process. Use ``--visualizer newton``,
+``--visualizer rerun``, ``--visualizer viser``, or omit ``--visualizer``
+for headless execution.
 
 
 Overview

--- a/source/isaaclab_tasks/changelog.d/antoiner-ovphysx-kit-visualizer.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-ovphysx-kit-visualizer.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Reported a clear error when ``--visualizer kit`` is used with the
+  ``ovphysx`` preset, since OvPhysX cannot run alongside the Kit visualizer
+  in the same process.

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
@@ -76,6 +76,11 @@ def _is_kit_physics(node) -> bool:
     return isinstance(node, PhysicsCfg) and type(node).__name__ == "PhysxCfg"
 
 
+def _is_ovphysx_physics(node) -> bool:
+    """True when the node is an OvPhysX physics config."""
+    return isinstance(node, PhysicsCfg) and type(node).__name__ == "OvPhysxCfg"
+
+
 def _is_ovrtx_renderer(node) -> bool:
     """True when the node is an OVRTX renderer config."""
     return isinstance(node, RendererCfg) and getattr(node, "renderer_type", None) == "ovrtx"
@@ -178,8 +183,8 @@ def validate_runtime_compatibility(
     renderer that runs without Isaac Sim / Omniverse Kit. Combining it with Kit-based
     runtimes — Isaac Sim PhysX physics (``PhysxCfg``) or the Kit visualizer
     (``--visualizer kit`` / a ``visualizer_cfgs`` entry with ``visualizer_type="kit"``) —
-    is unsupported. When such a combination is detected this function raises with a
-    message that points the user at the correct ``isaacsim_rtx_renderer`` preset.
+    is unsupported. OvPhysX physics (``OvPhysxCfg``) also cannot share a process with
+    the Kit visualizer.
 
     Args:
         env_cfg: Resolved environment config (e.g. from :func:`resolve_task_config`).
@@ -187,15 +192,25 @@ def validate_runtime_compatibility(
 
     Raises:
         ValueError: If the OVRTX renderer is combined with Kit-based physics or the
-            Kit visualizer.
+            Kit visualizer, or if OvPhysX physics is combined with the Kit visualizer.
     """
-    has_kit_physics, has_ovrtx_renderer = _scan_config(env_cfg, [_is_kit_physics, _is_ovrtx_renderer])
-    if not has_ovrtx_renderer:
-        return
-
+    has_kit_physics, has_ovrtx_renderer, has_ovphysx_physics = _scan_config(
+        env_cfg, [_is_kit_physics, _is_ovrtx_renderer, _is_ovphysx_physics]
+    )
     visualizer_intent = _compute_visualizer_intent(env_cfg)
     visualizer_types = _get_visualizer_types(launcher_args)
     has_kit_visualizer = "kit" in visualizer_types or visualizer_intent.get("has_kit_visualizer", False)
+
+    if has_ovphysx_physics and has_kit_visualizer:
+        raise ValueError(
+            "Invalid backend combination: OvPhysX physics (`OvPhysxCfg`) is kitless and cannot be used together "
+            'with the Kit visualizer (`--visualizer kit` / `visualizer_type="kit"`). Use a kitless visualizer '
+            "such as `--visualizer newton`, `--visualizer rerun`, or `--visualizer viser`, or omit the visualizer "
+            "argument for headless execution."
+        )
+
+    if not has_ovrtx_renderer:
+        return
 
     if not has_kit_physics and not has_kit_visualizer:
         return

--- a/source/isaaclab_tasks/test/test_runtime_compatibility.py
+++ b/source/isaaclab_tasks/test/test_runtime_compatibility.py
@@ -79,6 +79,29 @@ def test_kit_visualizer_dict_args_plus_ovrtx_raises():
 
 
 # ---------------------------------------------------------------------------
+# Invalid: OvPhysX physics + Kit visualizer
+# ---------------------------------------------------------------------------
+
+
+def test_ovphysx_plus_kit_visualizer_raises():
+    """OvPhysX cannot share a process with the Kit visualizer."""
+    env_cfg = _resolve_with_presets("ovphysx,isaacsim_rtx_renderer")
+    launcher_args = argparse.Namespace(visualizer="kit")
+    with pytest.raises(ValueError) as excinfo:
+        validate_runtime_compatibility(env_cfg, launcher_args)
+    msg = str(excinfo.value)
+    assert "OvPhysX" in msg
+    assert "Kit visualizer" in msg
+
+
+def test_ovphysx_dict_args_plus_kit_visualizer_raises():
+    """The dict launcher-args form must also reject OvPhysX with Kit visualization."""
+    env_cfg = _resolve_with_presets("ovphysx,isaacsim_rtx_renderer")
+    with pytest.raises(ValueError, match=r"OvPhysX.*Kit visualizer"):
+        validate_runtime_compatibility(env_cfg, {"visualizer": "kit,newton"})
+
+
+# ---------------------------------------------------------------------------
 # Valid combinations: must NOT raise
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Description

Adds an early launcher error for `--viz kit` with `presets=ovphysx`, before `AppLauncher` starts, because OvPhysX cannot share a process with the Kit USD/plugin stack. Updates the OvPhysX backend, visualization, and Hydra preset docs with the supported alternatives.

Fixes: N/A

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Screenshots

N/A. This is a launcher validation and documentation change.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Test Plan

- [x] `./isaaclab.sh -p -m pytest source/isaaclab_tasks/test/test_sim_launcher_visualizer_intent.py source/isaaclab_tasks/test/test_preset_kit_decision.py -q`
- [x] `./isaaclab.sh -f`

Focused tests emit existing deprecation warnings from shared config classes.