### PR TITLE
Fix multi-backend architecture docs

### DIFF
--- a/docs/source/overview/core-concepts/multi_backend_architecture.rst
+++ b/docs/source/overview/core-concepts/multi_backend_architecture.rst
@@ -2,8 +2,8 @@ Multi-Backend Architecture
 ==========================
 
 Isaac Lab 3.0 introduced a multi-backend architecture that enables running simulations with
-different physics engines (PhysX and Newton) while maintaining a unified API. This page explains
-how the backend system works and how to extend it.
+different physics backends (PhysX, Newton, and OvPhysX) while maintaining a unified API.
+This page explains how the backend system works and how to extend it.
 
 Overview
 --------
@@ -17,12 +17,15 @@ dispatch object creation to backend-specific implementations at runtime. When yo
 
     robot = Articulation(cfg)
 
-The ``Articulation`` class is a factory that automatically creates a
-:class:`~isaaclab_physx.assets.articulation.Articulation` or
-:class:`~isaaclab_newton.assets.articulation.Articulation` depending on which physics backend
-is active. Your code never needs to import backend-specific modules directly.
+The ``Articulation`` class is a factory that automatically creates an instance of
+the active backend implementation, such as
+:class:`PhysX Articulation <isaaclab_physx.assets.Articulation>`,
+:class:`Newton Articulation <isaaclab_newton.assets.Articulation>`, or
+:class:`OvPhysX Articulation <isaaclab_ovphysx.assets.Articulation>`. Your code never
+needs to import backend-specific modules directly.
 
-This pattern applies to all simulation components:
+This pattern applies across simulation components, though not every backend implements every
+component yet:
 
 .. list-table::
    :header-rows: 1
@@ -31,38 +34,47 @@ This pattern applies to all simulation components:
      - Core API (``isaaclab``)
      - PhysX (``isaaclab_physx``)
      - Newton (``isaaclab_newton``)
+     - OvPhysX (``isaaclab_ovphysx``)
    * - Physics Manager
      - :class:`~isaaclab.physics.PhysicsManager`
      - :class:`~isaaclab_physx.physics.PhysxManager`
      - :class:`~isaaclab_newton.physics.NewtonManager`
+     - :class:`~isaaclab_ovphysx.physics.OvPhysxManager`
    * - Articulation
      - :class:`~isaaclab.assets.Articulation`
      - :class:`~isaaclab_physx.assets.Articulation`
      - :class:`~isaaclab_newton.assets.Articulation`
+     - :class:`~isaaclab_ovphysx.assets.Articulation`
    * - Rigid Object
      - :class:`~isaaclab.assets.RigidObject`
      - :class:`~isaaclab_physx.assets.RigidObject`
      - :class:`~isaaclab_newton.assets.RigidObject`
+     - :class:`~isaaclab_ovphysx.assets.RigidObject`
    * - Deformable Object
      - :class:`~isaaclab.assets.DeformableObject`
      - :class:`~isaaclab_physx.assets.DeformableObject`
      - :class:`~isaaclab_newton.assets.DeformableObject`
+     - Not supported
    * - Contact Sensor
      - :class:`~isaaclab.sensors.ContactSensor`
      - :class:`~isaaclab_physx.sensors.ContactSensor`
      - :class:`~isaaclab_newton.sensors.ContactSensor`
+     - :class:`~isaaclab_ovphysx.sensors.ContactSensor`
    * - Renderer
      - :class:`~isaaclab.renderers.Renderer`
      - :class:`~isaaclab_physx.renderers.IsaacRtxRenderer`
      - :class:`~isaaclab_newton.renderers.NewtonWarpRenderer`
+     - Not supported
    * - Scene Data Backend
      - :class:`~isaaclab.scene_data.SceneDataBackend`
      - ``PhysxSceneDataBackend`` (in :mod:`isaaclab_physx.physics`)
      - ``NewtonSceneDataBackend`` (in :mod:`isaaclab_newton.physics`)
+     - ``OvPhysxSceneDataBackend`` (in :mod:`isaaclab_ovphysx.physics`)
    * - Cloner
      - :func:`~isaaclab.cloner.usd_replicate`
      - :func:`~isaaclab_physx.cloner.physx_replicate`
      - :func:`~isaaclab_newton.cloner.newton_physics_replicate`
+     - :func:`~isaaclab_ovphysx.cloner.ovphysx_replicate`
 
 The Factory Pattern
 -------------------
@@ -74,7 +86,8 @@ All factories inherit from :class:`~isaaclab.utils.backend_utils.FactoryBase`, w
    ``SimulationContext.physics_manager``.
 2. The factory's module path is used to derive the backend module path by replacing ``isaaclab``
    with ``isaaclab_{backend}``. For example, ``isaaclab.assets.articulation`` maps to
-   ``isaaclab_physx.assets.articulation`` or ``isaaclab_newton.assets.articulation``.
+   ``isaaclab_physx.assets.articulation``, ``isaaclab_newton.assets.articulation``, or
+   ``isaaclab_ovphysx.assets.articulation``.
 3. The backend module is lazily imported and the implementation class is cached in a registry.
 
 .. code-block:: text
@@ -84,7 +97,7 @@ All factories inherit from :class:`~isaaclab.utils.backend_utils.FactoryBase`, w
         ▼
     FactoryBase.__new__()
         │
-        ├─ _get_backend()       → "physx" or "newton"
+        ├─ _get_backend()       → "physx", "newton", or "ovphysx"
         │    (reads SimulationContext.physics_manager)
         │
         ├─ _get_module_name()   → "isaaclab_physx.assets.articulation"
@@ -120,8 +133,9 @@ The physics backend is selected via the ``physics`` field in
 .. code-block:: python
 
     from isaaclab.sim import SimulationCfg
+    from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+    from isaaclab_ovphysx.physics import OvPhysxCfg
     from isaaclab_physx.physics import PhysxCfg
-    from isaaclab_newton.physics import NewtonCfg, MJWarpSolverCfg
 
     # Use PhysX (default)
     sim_cfg = SimulationCfg(physics=PhysxCfg())
@@ -132,6 +146,9 @@ The physics backend is selected via the ``physics`` field in
         num_substeps=4,
     ))
 
+    # Use OvPhysX
+    sim_cfg = SimulationCfg(physics=OvPhysxCfg())
+
 Once the :class:`~isaaclab.sim.SimulationContext` is initialized, all subsequent factory
 instantiations automatically use the selected backend.
 
@@ -139,14 +156,18 @@ Multi-Backend Environments with Presets
 ---------------------------------------
 
 Environments can support multiple backends simultaneously using the :doc:`preset system
-</source/features/hydra>`. Each backend gets its own configuration variant:
+</source/features/hydra>`. Each backend gets its own configuration variant. The example
+below shows only the physics-related fields:
 
 .. code-block:: python
 
+    from isaaclab.envs import DirectRLEnvCfg
+    from isaaclab.sim import SimulationCfg
     from isaaclab.utils.configclass import configclass
-    from isaaclab_tasks.utils import PresetCfg
+    from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+    from isaaclab_ovphysx.physics import OvPhysxCfg
     from isaaclab_physx.physics import PhysxCfg
-    from isaaclab_newton.physics import NewtonCfg, MJWarpSolverCfg
+    from isaaclab_tasks.utils import PresetCfg
 
     @configclass
     class CartpolePhysicsCfg(PresetCfg):
@@ -155,20 +176,24 @@ Environments can support multiple backends simultaneously using the :doc:`preset
         newton_mjwarp: NewtonCfg = NewtonCfg(
             solver_cfg=MJWarpSolverCfg(njmax=5, nconmax=3)
         )
+        ovphysx: OvPhysxCfg = OvPhysxCfg()
 
     @configclass
-    class CartpoleEnvCfg(ManagerBasedRLEnvCfg):
+    class CartpoleEnvCfg(DirectRLEnvCfg):
         sim: SimulationCfg = SimulationCfg(physics=CartpolePhysicsCfg())
 
-Users then select the MJWarp Newton preset at the command line:
+Users then select a physics backend at the command line:
 
 .. code-block:: bash
 
     # Default (PhysX)
-    python train.py --task Isaac-Cartpole-v0
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole-Direct-v0
 
     # MJWarp (Newton backend)
-    python train.py --task Isaac-Cartpole-v0 presets=newton_mjwarp
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole-Direct-v0 physics=newton_mjwarp
+
+    # OvPhysX backend
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole-Direct-v0 physics=ovphysx
 
 The Physics Manager
 -------------------
@@ -223,11 +248,12 @@ Assets and sensors follow the same pattern. Each has:
 1. **A base class** in ``isaaclab`` defining the interface (e.g., ``BaseArticulation``,
    ``BaseContactSensor``)
 2. **A factory class** that inherits from both ``FactoryBase`` and the base class
-3. **Backend implementations** in ``isaaclab_physx`` and ``isaaclab_newton``
+3. **Backend implementations** in ``isaaclab_physx``, ``isaaclab_newton``, and
+   ``isaaclab_ovphysx`` where supported
 
 The base classes define the public API contract — properties, methods, and data accessors
-that all backends must provide. Both backends use ``wp.array`` (Warp arrays) as their
-primary data type for asset and sensor data.
+that all backends must provide. Current backend implementations use ``wp.array``
+(Warp arrays) as their primary data type for asset and sensor data.
 
 Data classes follow the same pattern with their own factories (e.g.,
 ``ArticulationData(FactoryBase, BaseArticulationData)``).
@@ -378,8 +404,8 @@ Key Design Principles
   (``isaaclab.X.Y`` → ``isaaclab_{backend}.X.Y``), so no manual registration is needed.
 - **Independent selection**: Physics backend, renderer, and visualizer are selected
   independently — you can use any combination.
-- **Warp-native data types**: Both backends return ``wp.array`` for asset and sensor data.
-  Use ``wp.to_torch()`` when interoperating with PyTorch-based code.
+- **Warp-native data types**: Backend implementations return ``wp.array`` for asset and
+  sensor data. Use ``wp.to_torch()`` when interoperating with PyTorch-based code.
 - **Zero runtime overhead**: Backend selection happens at instantiation time. There are no
   if-statements or dispatch logic on the hot path.
 


### PR DESCRIPTION
# Description

Clarifies the Multi-Backend Architecture documentation so the factory overview renders distinct backend implementation names instead of repeated `Articulation` links. The page now mentions OvPhysX alongside PhysX and Newton where the backend is supported, and the Cartpole examples use root-runnable `./isaaclab.sh train --rl_library rsl_rl ...` commands.

No new dependencies are required.

No linked issue.

## Type of change

- Documentation update

## Screenshots

Not applicable. This is an RST documentation text update.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (not verified with a full docs build)
- [ ] I have added tests that prove my fix is effective or that my feature works (not added; docs-only change)
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (not added; top-level docs-only change)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Validation

- `./isaaclab.sh -f`
- `./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole-Direct-v0 --help`
- `./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole-Direct-v0 --help physics=newton_mjwarp`
- `./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole-Direct-v0 --help physics=ovphysx`
- `./isaaclab.sh -p -c "from isaaclab_ovphysx.physics import OvPhysxManager, OvPhysxCfg; from isaaclab_ovphysx.assets import Articulation, RigidObject; from isaaclab_ovphysx.sensors import ContactSensor; from isaaclab_ovphysx.cloner import ovphysx_replicate"`