### PR TITLE
Clarify PhysX backend docs

### DIFF
--- a/docs/source/overview/core-concepts/physical-backends/physx/configuration.rst
+++ b/docs/source/overview/core-concepts/physical-backends/physx/configuration.rst
@@ -2,10 +2,11 @@ PhysX Configuration
 ===================
 
 PhysX scene-level settings live on :class:`~isaaclab_physx.physics.PhysxCfg`,
-which replaces the legacy ``PhysxCfg`` from Isaac Lab 2.x. Per-actor settings
-(such as per-articulation iteration counts, contact filtering, or material
-properties) continue to be authored on the USD schema; see :doc:`../../schema_cfgs`
-for the schema-level configuration helpers.
+which replaces the Isaac Lab 2.x ``PhysxCfg`` imported from ``isaaclab.sim``.
+In Isaac Lab 3.0, import ``PhysxCfg`` from ``isaaclab_physx.physics`` instead.
+Per-actor settings (such as per-articulation iteration counts, contact
+filtering, or material properties) continue to be authored on the USD schema;
+see :doc:`../../schema_cfgs` for the schema-level configuration helpers.
 
 The example below shows a representative ``PhysxCfg`` for a contact-rich
 manipulation task:
@@ -22,7 +23,7 @@ manipulation task:
         min_velocity_iteration_count=1,
         max_velocity_iteration_count=4,
         enable_ccd=False,
-        enable_stabilization=True,
+        enable_stabilization=False,
         bounce_threshold_velocity=0.2,
         friction_offset_threshold=0.04,
         friction_correlation_distance=0.025,
@@ -45,7 +46,9 @@ Solver Selection
   articulated robots; PGS can be more forgiving on stiff legacy assets.
 * ``solve_articulation_contact_last``: alters the articulation solver order so
   that dynamic contact is resolved at the end of the solve. Useful for stiff
-  gripping scenarios. Requires Isaac Sim 5.1+.
+  gripping scenarios. For Isaac Lab 3.0, the supported Isaac Sim versions
+  include this feature; it depends on PhysX schema support introduced in
+  Isaac Sim 5.1.
 
 
 Solver Iterations
@@ -65,9 +68,10 @@ Contact and Stability
 
 * ``enable_ccd``: continuous-collision detection for fast-moving bodies.
 * ``enable_stabilization``: extra solver stabilization pass; recommended only
-  when ``dt`` is large (< 30 Hz). Corrupts contact-sensor force-magnitude
-  readings — disable it if you rely on the contact sensor for force
-  observations.
+  for low-rate simulations, where the simulation timestep ``dt`` is larger
+  than about ``1 / 30`` seconds (below about 30 Hz). This pass can make
+  contact-sensor force magnitudes inaccurate, so keep it disabled if you rely
+  on the contact sensor for force observations.
 * ``bounce_threshold_velocity``: relative velocity threshold [m/s] above which
   contacts bounce.
 * ``friction_offset_threshold``: contact point distance [m] at which friction

--- a/docs/source/overview/core-concepts/physical-backends/physx/supported-features.rst
+++ b/docs/source/overview/core-concepts/physical-backends/physx/supported-features.rst
@@ -62,9 +62,9 @@ Known Caveats
 * PhysX requires Isaac Sim and Omniverse Kit to be installed.
 * GPU buffer sizes are static and must be tuned per task — see
   :doc:`configuration`.
-* ``enable_stabilization`` can corrupt contact-force readings reported through
-  the contact sensor; disable it if you rely on the contact sensor for
-  force-magnitude observations.
+* ``enable_stabilization`` can make contact-force magnitudes reported through
+  the contact sensor inaccurate; disable it if you rely on the contact sensor
+  for force observations.
 * The PhysX TGS solver behaviour can differ from Newton's MJWarp solver on
   stiff contact stacks; if you are porting a task to Newton, expect to retune
   contact-handling parameters.


### PR DESCRIPTION
# Description

Clarifies the PhysX backend documentation around timestep/frequency wording, stabilization guidance, and the Isaac Lab 3.0 `PhysxCfg` import path.

This PR also updates the example configuration to keep `enable_stabilization=False` at `dt=1 / 120`, softens the contact-sensor caveat wording, and clarifies the Isaac Sim version note for `solve_articulation_contact_last`.

No new dependencies are required.

Fixes # (issue)

No linked issue.

## Type of change

- Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (not run: full Sphinx docs build)
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable: docs-only wording change)
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (not applicable: docs-only change under top-level docs)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there