### PR TITLE
Cherry-pick to fix the flash-attn installation

### DIFF
--- a/docs/source/experimental-features/rlinf_vla_posttraining.rst
+++ b/docs/source/experimental-features/rlinf_vla_posttraining.rst
@@ -85,8 +85,23 @@ From the Isaac Lab root directory:
    uv pip install -e ".[base]" --no-deps
    cd ../
 
-   # Step 4: Install flash-attn (must be built against the installed PyTorch)
+   # Step 4: Install flash-attn (see "Skipping flash-attn" below if this fails)
    pip install flash-attn==2.8.3 --no-build-isolation --no-deps
+
+.. _rlinf-skipping-flash-attn:
+
+Skipping flash-attn
+~~~~~~~~~~~~~~~~~~~
+
+If Step 4 fails, skip installation of flash-attn and apply this patch instead:
+
+.. code-block:: bash
+
+   cd Isaac-GR00T
+   git apply ~/IsaacLab/scripts/imitation_learning/locomanipulation_sdg/gr00t/no_flash_attn.patch
+
+The patch switches GR00T to PyTorch SDPA, so flash-attn is no longer required.
+The training and evaluation commands below work unchanged.
 
 Quick Start
 -----------

--- a/docs/source/experimental-features/rlinf_vla_posttraining.rst
+++ b/docs/source/experimental-features/rlinf_vla_posttraining.rst
@@ -98,7 +98,7 @@ If Step 4 fails, skip installation of flash-attn and apply this patch instead:
 .. code-block:: bash
 
    cd Isaac-GR00T
-   git apply ~/IsaacLab/scripts/imitation_learning/locomanipulation_sdg/gr00t/no_flash_attn.patch
+   git apply /path/to/IsaacLab/scripts/imitation_learning/locomanipulation_sdg/gr00t/no_flash_attn.patch
 
 The patch switches GR00T to PyTorch SDPA, so flash-attn is no longer required.
 The training and evaluation commands below work unchanged.


### PR DESCRIPTION
# Description
Fixes the flash-attn installation by applying patch for GR00T to use SDPA instead of flash-attn.

Fixes # (issue)
Fixes flash-attn installation fails in Windows and Blackwell GPus like 5090.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

