### PR TITLE
Fix documentation for transformation matrix references

### DIFF
--- a/source/isaaclab/isaaclab/utils/math.py
+++ b/source/isaaclab/isaaclab/utils/math.py
@@ -804,7 +804,7 @@ def combine_frame_transforms(
     r"""Combine transformations between two reference frames into a stationary frame.
 
     It performs the following transformation operation: :math:`T_{02} = T_{01} \times T_{12}`,
-    where :math:`T_{AB}` is the homogeneous transformation matrix from frame A to B.
+    where :math:`T_{AB}` is the homogeneous transformation matrix from frame B to A.
 
     Args:
         t01: Position of frame 1 w.r.t. frame 0. Shape is (N, 3).
@@ -876,7 +876,7 @@ def subtract_frame_transforms(
     r"""Subtract transformations between two reference frames into a stationary frame.
 
     It performs the following transformation operation: :math:`T_{12} = T_{01}^{-1} \times T_{02}`,
-    where :math:`T_{AB}` is the homogeneous transformation matrix from frame A to B.
+    where :math:`T_{AB}` is the homogeneous transformation matrix from frame B to A.
 
     Args:
         t01: Position of frame 1 w.r.t. frame 0. Shape is (N, 3).


### PR DESCRIPTION
Updated description for correct frame transformation: T_AB = "**from frame B to A**" (old: "from frame A to B") . 

# Description 

Updated docstring text for `combine_frame_transformations` and `subtract_frame_transformations` inside `isaaclab.utils.math`, specifically this misleading part:

> where :math:T_{AB} is the homogeneous transformation matrix **from frame A to B**.

In the corrected description, A and B are swapped:

> T_{AB} is the homogeneous transformation matrix **from frame B to A**.

Fixes #5772.  

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

_Left pre-commit, test, changelog, and CONTRIBUTORS.md boxes unchecked because this is a minor docstring text correction._
