### PR TITLE
Adds isaaclab_teleop as dependency of isaaclab_mimic during mimic only install

### DIFF
--- a/source/isaaclab/changelog.d/peterd-mimic-installs-teleop.rst
+++ b/source/isaaclab/changelog.d/peterd-mimic-installs-teleop.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* ``./isaaclab.sh -i mimic`` now also installs ``isaaclab_teleop`` as an editable
+  submodule, since :mod:`isaaclab_mimic` declares it as a required dependency.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -487,7 +487,7 @@ CORE_ISAACLAB_SUBMODULES: list[str] = [
 # Optional submodules — only installed when explicitly requested or with 'all'.
 # Maps the short CLI name to one or more source directory names under source/.
 OPTIONAL_ISAACLAB_SUBMODULES: dict[str, tuple[str, ...]] = {
-    "mimic": ("isaaclab_mimic",),
+    "mimic": ("isaaclab_teleop", "isaaclab_mimic"),
     "teleop": ("isaaclab_teleop",),
 }
 

--- a/source/isaaclab/test/cli/test_install_command_parsing.py
+++ b/source/isaaclab/test/cli/test_install_command_parsing.py
@@ -122,7 +122,7 @@ class TestInstallConstants:
 
     def test_optional_submodules_contains_expected_packages(self):
         assert set(OPTIONAL_ISAACLAB_SUBMODULES.keys()) == {"mimic", "teleop"}
-        assert OPTIONAL_ISAACLAB_SUBMODULES["mimic"] == ("isaaclab_mimic",)
+        assert OPTIONAL_ISAACLAB_SUBMODULES["mimic"] == ("isaaclab_teleop", "isaaclab_mimic")
         assert OPTIONAL_ISAACLAB_SUBMODULES["teleop"] == ("isaaclab_teleop",)
 
     def test_valid_extra_features(self):

--- a/source/isaaclab_mimic/changelog.d/isaaclab-teleop-dep.rst
+++ b/source/isaaclab_mimic/changelog.d/isaaclab-teleop-dep.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Declared ``isaaclab_teleop`` as a required sibling extension of
+  ``isaaclab_mimic`` in ``config/extension.toml``. ``./isaaclab.sh -i mimic``
+  now installs ``isaaclab_teleop`` alongside ``isaaclab_mimic``.

--- a/source/isaaclab_mimic/changelog.d/isaaclab-teleop-dep.rst
+++ b/source/isaaclab_mimic/changelog.d/isaaclab-teleop-dep.rst
@@ -1,6 +1,6 @@
 Changed
 ^^^^^^^
 
-* Declared ``isaaclab_teleop`` as a required sibling extension of
-  ``isaaclab_mimic`` in ``config/extension.toml``. ``./isaaclab.sh -i mimic``
+* Declared ``isaaclab_teleop`` as a required extension of
+  ``isaaclab_mimic`` in ``install.py``. ``./isaaclab.sh -i mimic``
   now installs ``isaaclab_teleop`` alongside ``isaaclab_mimic``.


### PR DESCRIPTION
# Description

Adds isaaclab_teleop as a dep to isaaclab_mimic when using `./isaaclab.sh -i mimic`

Fixes # (issue)

Previously when a user installs just mimic and tried to run data generation, an error would occur as isaaclab teleop was not installed. This change fixes the import error. 

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
