### PR TITLE
Document Digit closed-loop articulation limitation on Newton

### DIFF
--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -525,14 +525,11 @@ Environments based on legged locomotion tasks.
     | |velocity-rough-g1|          | |velocity-rough-g1-link|                     | Track a velocity command on rough terrain with the Unitree G1 robot          | **physics=** ``physx``,      |
     |                              |                                              |                                                                              | ``newton_mjwarp``            |
     +------------------------------+----------------------------------------------+------------------------------------------------------------------------------+------------------------------+
-    | |velocity-flat-digit|        | |velocity-flat-digit-link|                   | Track a velocity command on flat terrain with the Agility Digit robot        | **physics=** ``physx``,      |
-    |                              |                                              |                                                                              | ``newton_mjwarp``            |
+    | |velocity-flat-digit|        | |velocity-flat-digit-link|                   | Track a velocity command on flat terrain with the Agility Digit robot        | **physics=** ``physx``       |
     +------------------------------+----------------------------------------------+------------------------------------------------------------------------------+------------------------------+
-    | |velocity-rough-digit|       | |velocity-rough-digit-link|                  | Track a velocity command on rough terrain with the Agility Digit robot       | **physics=** ``physx``,      |
-    |                              |                                              |                                                                              | ``newton_mjwarp``            |
+    | |velocity-rough-digit|       | |velocity-rough-digit-link|                  | Track a velocity command on rough terrain with the Agility Digit robot       | **physics=** ``physx``       |
     +------------------------------+----------------------------------------------+------------------------------------------------------------------------------+------------------------------+
-    | |tracking-loco-manip-digit|  | |tracking-loco-manip-digit-link|             | Track a root velocity and hand pose command with the Agility Digit robot     | **physics=** ``physx``,      |
-    |                              |                                              |                                                                              | ``newton_mjwarp``            |
+    | |tracking-loco-manip-digit|  | |tracking-loco-manip-digit-link|             | Track a root velocity and hand pose command with the Agility Digit robot     | **physics=** ``physx``       |
     +------------------------------+----------------------------------------------+------------------------------------------------------------------------------+------------------------------+
 
 .. |velocity-flat-anymal-b-link| replace:: `Isaac-Velocity-Flat-Anymal-B-v0 <../../../source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py>`__
@@ -1118,7 +1115,7 @@ inferencing, including reading from an already trained checkpoint and disabling 
       - Isaac-Tracking-LocoManip-Digit-Play-v0
       - Manager Based
       - **rsl_rl** (PPO)
-      - **physics=** ``physx``, ``newton_mjwarp``
+      - **physics=** ``physx``
     * - Isaac-Navigation-Flat-Anymal-C-v0
       - Isaac-Navigation-Flat-Anymal-C-Play-v0
       - Manager Based
@@ -1384,7 +1381,7 @@ inferencing, including reading from an already trained checkpoint and disabling 
       - Isaac-Velocity-Flat-Digit-Play-v0
       - Manager Based
       - **rsl_rl** (PPO)
-      - **physics=** ``physx``, ``newton_mjwarp``
+      - **physics=** ``physx``
     * - Isaac-Velocity-Flat-G1-v0
       - Isaac-Velocity-Flat-G1-Play-v0
       - Manager Based
@@ -1444,7 +1441,7 @@ inferencing, including reading from an already trained checkpoint and disabling 
       - Isaac-Velocity-Rough-Digit-Play-v0
       - Manager Based
       - **rsl_rl** (PPO)
-      - **physics=** ``physx``, ``newton_mjwarp``
+      - **physics=** ``physx``
     * - Isaac-Velocity-Rough-G1-v0
       - Isaac-Velocity-Rough-G1-Play-v0
       - Manager Based

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -93,6 +93,30 @@ message and continue with terminating the process. On Windows systems, please us
 ``Ctrl+Break`` or ``Ctrl+fn+B`` to terminate the process.
 
 
+Closed-loop articulations on Newton (e.g. Agility Digit)
+--------------------------------------------------------
+
+Robots whose USD encodes a closed kinematic loop -- such as the achilles rod and
+toe push-rods on the Agility Digit -- do not currently run correctly on the
+``newton_mjwarp`` physics preset, even though they work on ``physx``. This affects:
+
+* ``Isaac-Velocity-Flat-Digit-v0`` / ``Isaac-Velocity-Flat-Digit-Play-v0``
+* ``Isaac-Velocity-Rough-Digit-v0`` / ``Isaac-Velocity-Rough-Digit-Play-v0``
+* ``Isaac-Tracking-LocoManip-Digit-v0`` / ``Isaac-Tracking-LocoManip-Digit-Play-v0``
+
+The root cause sits inside Newton's :class:`~newton.selection.ArticulationView`. When
+it builds its per-link axis it walks each joint in the articulation's joint range and
+appends ``model.joint_child[joint_id]`` without deduplicating. A body that is the
+child of multiple joints (the standard closed-loop encoding) therefore occupies
+multiple slots on that axis, so ``view.link_count`` is larger than the number of
+unique physical bodies in the model. On Digit this is 49 link slots versus 43 actual
+bodies (the four loop-closed bodies -- left/right ``tarsus`` and left/right
+``toe_roll`` -- account for the six extra slots).
+
+Until the upstream fix lands in Newton, please use the ``physx`` preset for
+Digit-based environments.
+
+
 URDF Importer: Unresolved references for fixed joints
 -----------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Drop `newton_mjwarp` from the three Digit env rows in `docs/source/overview/environments.rst` (`Isaac-Velocity-Flat-Digit-v0`, `Isaac-Velocity-Rough-Digit-v0`, `Isaac-Tracking-LocoManip-Digit-v0`).
- Add a "Closed-loop articulations on Newton (e.g. Agility Digit)" section to `docs/source/refs/issues.rst` describing the root cause and recommending the `physx` preset until the upstream fix lands.

## Why

Robots with closed kinematic loops (Digit's achilles rod and toe push-rods) do not run correctly under the `newton_mjwarp` physics preset today. Newton's `ArticulationView` builds its per-link axis by walking `model.joint_child` over the articulation's joint range and `sorted()`-ing without deduplication, so a body that is the child of N joints occupies N slots on that axis. On Digit this gives `view.link_count = 49` against 43 unique physical bodies; the four loop-closed bodies (left/right `tarsus`, left/right `toe_roll`) account for the six extra slots. Any code path that assumes one entry per logical body breaks (e.g. tensor-shape mismatches in `feet_slide`-style rewards).

The supported-environments tables previously listed `newton_mjwarp` for Digit, which is misleading. This PR removes that claim and documents the limitation under Known Issues.

## Test plan

- [ ] `./isaaclab.sh -f` (pre-commit) passes locally.
- [ ] Sphinx build renders the new Known Issues entry without warnings and the Digit rows in the environments tables show only `physx`.