### PR TITLE
[STRESS / DO NOT MERGE] Enable FabricFrameView cuda:1 tests in multi-GPU CI

### DIFF
--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -85,15 +85,11 @@ jobs:
           fi
 
       - name: Run FabricFrameView multi-GPU unit tests
-        # ``ISAACLAB_TEST_MULTI_GPU=1`` enables the three cuda:1-parameterised
-        # tests in test_views_xform_prim_fabric.py added by PR #5514.  These
-        # tests target FabricFrameView's SelectPrims path on non-zero CUDA
-        # devices and currently hang indefinitely on real multi-GPU hardware
-        # (reproduced locally on 3x RTX 6000 Pro Blackwell and on the
-        # [self-hosted, ..., multi-gpu] runner pool).  The 60-min workflow
-        # timeout will cancel the job and surface the regression in CI for
-        # the FabricFrameView maintainers.  Land this PR once the hang is
-        # fixed in source/isaaclab_physx/.../fabric_frame_view.py.
+        # ``ISAACLAB_TEST_MULTI_GPU=1`` enables the focused cuda:1 repro in
+        # test_views_xform_prim_fabric.py.  The world-pose roundtrip test is
+        # the hanging case on real multi-GPU hardware, so keep the PR pipeline
+        # narrowed to this single node id while debugging the FabricFrameView
+        # SelectPrims path on non-zero CUDA devices.
         env:
           OMNI_KIT_ACCEPT_EULA: "yes"
           ACCEPT_EULA: "Y"
@@ -101,4 +97,5 @@ jobs:
           ISAACLAB_TEST_MULTI_GPU: "1"
         run: |
           ./isaaclab.sh -p -m pytest \
-            source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py -v
+            "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_world_pose_roundtrip[cuda:1]" \
+            -v

--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -9,8 +9,11 @@
 # source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py on the
 # dedicated multi-GPU runner.  Kept separate from test-multi-gpu.yaml so
 # changes to FabricFrameView do not gate distributed-training validation and
-# vice versa.  Runner preconditions (label, install step, GPU pre-flight) are
-# identical to the training workflow.
+# vice versa.
+#
+# Uses the same Docker-based approach as build.yaml to ensure the test runs
+# against the Kit version baked into the Isaac Sim container (not a stale
+# pip-installed version).
 
 name: FabricFrameView Multi-GPU Tests
 
@@ -27,92 +30,86 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  config:
+    name: Load Config
+    runs-on: ubuntu-latest
+    outputs:
+      isaacsim_image_name: ${{ steps.load.outputs.isaacsim_image_name }}
+      isaacsim_image_tag: ${{ steps.load.outputs.isaacsim_image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/workflows/config.yaml
+      - id: load
+        run: |
+          f=".github/workflows/config.yaml"
+          echo "isaacsim_image_name=$(yq -r .isaacsim_image_name "$f")" >> "$GITHUB_OUTPUT"
+          echo "isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$f")" >> "$GITHUB_OUTPUT"
+
+  build-base:
+    name: Build Base Docker Image
+    needs: config
+    runs-on: [self-hosted, linux, x64, multi-gpu]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Build/Pull Docker Image
+        uses: ./.github/actions/ecr-build-push-pull
+        with:
+          image-tag: isaac-lab-ci:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+          isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
+          isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
+          dockerfile-path: docker/Dockerfile.base
+          cache-tag: cache-base
+
   test-fabric-multi-gpu:
     name: FabricFrameView multi-GPU unit tests
+    needs: [config, build-base]
     runs-on: [self-hosted, linux, x64, multi-gpu]
     timeout-minutes: 60
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/checkout@v4
         with:
-          python-version: "3.12"
-
-      - name: Install cmake via pip (avoid sudo apt path)
-        # install.py skips its sudo apt-get block when ``cmake`` is already on
-        # PATH (source/isaaclab/isaaclab/cli/commands/install.py:35).  The
-        # pip wheel provides a cmake shim under the setup-python venv's bin/,
-        # which is on PATH, so installing it here bypasses the apt branch.
-        run: pip install cmake
-
-      - name: Install Isaac Lab
-        # ``--install none`` = core submodules only (no mimic, no teleop, no
-        # auto-extra features).  The FabricFrameView cuda:1 tests only need
-        # isaaclab core + isaaclab_physx + Isaac Sim.  Avoids building
-        # robomimic's egl_probe wheel, which requires libEGL/X11 headers
-        # that the multi-GPU runner image lacks.
-        run: ./isaaclab.sh --install none
-
-      - name: Install Isaac Sim
-        # Isaac Sim is an optional extra in source/isaaclab/setup.py and is
-        # not pulled by ``--install none``.  Without it, AppLauncher's
-        # ``import isaacsim`` is silently caught by
-        # ``contextlib.suppress(ModuleNotFoundError)``, ``EXP_PATH`` stays
-        # unset, and test collection crashes with ``KeyError: 'EXP_PATH'``.
-        #
-        # Pinned to 6.0.0.0 because that is the only release line with a
-        # Python 3.12 wheel.  The 5.x line on PyPI requires Python 3.11
-        # (and source/isaaclab/setup.py's ``isaacsim==5.1.0`` pin is stale
-        # relative to the 3.12 baseline declared in pyproject.toml).
-        run: pip install 'isaacsim[all,extscache]==${{ vars.ISAACSIM_BASE_VERSION || '6.0.0' }}' --extra-index-url https://pypi.nvidia.com
-
-      - name: Reinstall test harness after Isaac Sim dependency resolution
-        # The Isaac Sim wheel install churns the active Python environment and
-        # can leave pytest unavailable even though ``./isaaclab.sh --install
-        # none`` installed IsaacLab's test requirements earlier.  Reassert only
-        # the missing test-runner stack after Isaac Sim so the focused repro
-        # reaches the cuda:1 FabricFrameView test instead of failing in setup.
-        # Do not reinstall coverage here: isaacsim-kernel 6.0.0.0 pins
-        # coverage==7.4.4, and changing it creates an avoidable resolver
-        # conflict while debugging this single repro.
-        run: pip install pytest pytest-mock junitparser
+          lfs: true
 
       - name: Verify multi-GPU availability
-        # Fail loud if the runner regressed to a single GPU.  Without this, the
-        # test helper's ``_skip_if_unavailable`` would skip every ``cuda:1`` case
-        # and the job would go green with no real coverage.
         run: |
           echo "=== GPU Info ==="
           nvidia-smi --query-gpu=index,name,memory.total --format=csv
-
-          GPU_COUNT=$(./isaaclab.sh -p -c "import torch; print(torch.cuda.device_count())" | awk '/^[0-9]+$/ { value=$0 } END { print value }')
+          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
           echo "Detected $GPU_COUNT GPU(s)"
-
-          if [ -z "$GPU_COUNT" ] || [ "$GPU_COUNT" -lt 2 ]; then
+          if [ "$GPU_COUNT" -lt 2 ]; then
             echo "::error::At least 2 GPUs required for Fabric multi-GPU tests, found $GPU_COUNT"
             exit 1
           fi
 
       - name: Run FabricFrameView multi-GPU unit tests
-        # ``ISAACLAB_TEST_MULTI_GPU=1`` enables the focused cuda:1 repro in
-        # test_views_xform_prim_fabric.py.  The world-pose roundtrip test is
-        # the hanging case on real multi-GPU hardware, so keep the PR pipeline
-        # narrowed to this single node id while debugging the FabricFrameView
-        # SelectPrims path on non-zero CUDA devices.
-        env:
-          OMNI_KIT_ACCEPT_EULA: "yes"
-          ACCEPT_EULA: "Y"
-          ISAAC_SIM_HEADLESS: "1"
-          ISAACLAB_TEST_MULTI_GPU: "1"
-        run: |
-          set -o pipefail
-          ./isaaclab.sh -p -m pytest \
-            "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_world_pose_roundtrip[cuda:1]" \
-            -v -s --tb=short 2>&1 | tee /tmp/fabric-frameview-pytest.log
+        uses: ./.github/actions/run-tests
+        with:
+          test-path: "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_world_pose_roundtrip[cuda:1]"
+          result-file: "fabric-multi-gpu-report.xml"
+          container-name: "fabric-mgpu-${{ github.run_id }}-${{ github.run_attempt }}"
+          image-tag: isaac-lab-ci:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+          pytest-options: "-v -s --tb=short"
+          volume-mount-source: ${{ github.workspace }}
 
-          if ! grep -Eq "[[:space:]][1-9][0-9]* passed" /tmp/fabric-frameview-pytest.log; then
-            echo "::error::Focused FabricFrameView pytest did not report a passing test"
+      - name: Check Test Results
+        if: always()
+        run: |
+          if [ -f "reports/fabric-multi-gpu-report.xml" ]; then
+            if grep -qE 'failures="[1-9][0-9]*"' reports/fabric-multi-gpu-report.xml || \
+               grep -qE 'errors="[1-9][0-9]*"' reports/fabric-multi-gpu-report.xml; then
+              echo "::error::FabricFrameView multi-GPU tests failed"
+              exit 1
+            fi
+            if ! grep -qE 'tests="[1-9]' reports/fabric-multi-gpu-report.xml; then
+              echo "::error::No tests were actually executed (all skipped?)"
+              exit 1
+            fi
+            echo "✅ FabricFrameView multi-GPU tests passed"
+          else
+            echo "::error::No test results file found"
             exit 1
           fi

--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -68,6 +68,14 @@ jobs:
         # relative to the 3.12 baseline declared in pyproject.toml).
         run: pip install 'isaacsim[all,extscache]==${{ vars.ISAACSIM_BASE_VERSION || '6.0.0' }}' --extra-index-url https://pypi.nvidia.com
 
+      - name: Reinstall test harness after Isaac Sim dependency resolution
+        # The Isaac Sim wheel install churns the active Python environment and
+        # can leave pytest unavailable even though ``./isaaclab.sh --install
+        # none`` installed IsaacLab's test requirements earlier.  Reassert the
+        # minimal test runner stack after Isaac Sim so the focused repro reaches
+        # the cuda:1 FabricFrameView test instead of failing in setup.
+        run: pip install pytest pytest-mock junitparser coverage==7.6.1
+
       - name: Verify multi-GPU availability
         # Fail loud if the runner regressed to a single GPU.  Without this, the
         # test helper's ``_skip_if_unavailable`` would skip every ``cuda:1`` case

--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -29,6 +29,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CI_IMAGE_TAG: isaac-lab-ci:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+
 jobs:
   config:
     name: Load Config
@@ -37,7 +40,7 @@ jobs:
       isaacsim_image_name: ${{ steps.load.outputs.isaacsim_image_name }}
       isaacsim_image_tag: ${{ steps.load.outputs.isaacsim_image_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: .github/workflows/config.yaml
       - id: load
@@ -46,19 +49,20 @@ jobs:
           echo "isaacsim_image_name=$(yq -r .isaacsim_image_name "$f")" >> "$GITHUB_OUTPUT"
           echo "isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$f")" >> "$GITHUB_OUTPUT"
 
-  build-base:
+  build:
     name: Build Base Docker Image
     needs: config
     runs-on: [self-hosted, linux, x64, multi-gpu]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
+          fetch-depth: 1
           lfs: true
 
-      - name: Build/Pull Docker Image
+      - name: Build and push to ECR
         uses: ./.github/actions/ecr-build-push-pull
         with:
-          image-tag: isaac-lab-ci:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+          image-tag: ${{ env.CI_IMAGE_TAG }}
           isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
           isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
           dockerfile-path: docker/Dockerfile.base
@@ -66,12 +70,14 @@ jobs:
 
   test-fabric-multi-gpu:
     name: FabricFrameView multi-GPU unit tests
-    needs: [config, build-base]
+    needs: [build, config]
     runs-on: [self-hosted, linux, x64, multi-gpu]
     timeout-minutes: 60
+    if: needs.build.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
+          fetch-depth: 1
           lfs: true
 
       - name: Verify multi-GPU availability
@@ -86,30 +92,11 @@ jobs:
           fi
 
       - name: Run FabricFrameView multi-GPU unit tests
-        uses: ./.github/actions/run-tests
+        uses: ./.github/actions/run-package-tests
         with:
-          test-path: "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_world_pose_roundtrip[cuda:1]"
-          result-file: "fabric-multi-gpu-report.xml"
-          container-name: "fabric-mgpu-${{ github.run_id }}-${{ github.run_attempt }}"
-          image-tag: isaac-lab-ci:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+          image-tag: ${{ env.CI_IMAGE_TAG }}
+          isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
+          isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
+          include-files: "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
           pytest-options: "-v -s --tb=short"
-          volume-mount-source: ${{ github.workspace }}
-
-      - name: Check Test Results
-        if: always()
-        run: |
-          if [ -f "reports/fabric-multi-gpu-report.xml" ]; then
-            if grep -qE 'failures="[1-9][0-9]*"' reports/fabric-multi-gpu-report.xml || \
-               grep -qE 'errors="[1-9][0-9]*"' reports/fabric-multi-gpu-report.xml; then
-              echo "::error::FabricFrameView multi-GPU tests failed"
-              exit 1
-            fi
-            if ! grep -qE 'tests="[1-9]' reports/fabric-multi-gpu-report.xml; then
-              echo "::error::No tests were actually executed (all skipped?)"
-              exit 1
-            fi
-            echo "✅ FabricFrameView multi-GPU tests passed"
-          else
-            echo "::error::No test results file found"
-            exit 1
-          fi
+          container-name: fabric-mgpu-test

--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -71,10 +71,13 @@ jobs:
       - name: Reinstall test harness after Isaac Sim dependency resolution
         # The Isaac Sim wheel install churns the active Python environment and
         # can leave pytest unavailable even though ``./isaaclab.sh --install
-        # none`` installed IsaacLab's test requirements earlier.  Reassert the
-        # minimal test runner stack after Isaac Sim so the focused repro reaches
-        # the cuda:1 FabricFrameView test instead of failing in setup.
-        run: pip install pytest pytest-mock junitparser coverage==7.6.1
+        # none`` installed IsaacLab's test requirements earlier.  Reassert only
+        # the missing test-runner stack after Isaac Sim so the focused repro
+        # reaches the cuda:1 FabricFrameView test instead of failing in setup.
+        # Do not reinstall coverage here: isaacsim-kernel 6.0.0.0 pins
+        # coverage==7.4.4, and changing it creates an avoidable resolver
+        # conflict while debugging this single repro.
+        run: pip install pytest pytest-mock junitparser
 
       - name: Verify multi-GPU availability
         # Fail loud if the runner regressed to a single GPU.  Without this, the
@@ -84,10 +87,10 @@ jobs:
           echo "=== GPU Info ==="
           nvidia-smi --query-gpu=index,name,memory.total --format=csv
 
-          GPU_COUNT=$(./isaaclab.sh -p -c "import torch; print(torch.cuda.device_count())")
+          GPU_COUNT=$(./isaaclab.sh -p -c "import torch; print(torch.cuda.device_count())" | awk '/^[0-9]+$/ { value=$0 } END { print value }')
           echo "Detected $GPU_COUNT GPU(s)"
 
-          if [ "$GPU_COUNT" -lt 2 ]; then
+          if [ -z "$GPU_COUNT" ] || [ "$GPU_COUNT" -lt 2 ]; then
             echo "::error::At least 2 GPUs required for Fabric multi-GPU tests, found $GPU_COUNT"
             exit 1
           fi
@@ -104,6 +107,12 @@ jobs:
           ISAAC_SIM_HEADLESS: "1"
           ISAACLAB_TEST_MULTI_GPU: "1"
         run: |
+          set -o pipefail
           ./isaaclab.sh -p -m pytest \
             "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_world_pose_roundtrip[cuda:1]" \
-            -v -s --tb=short
+            -v -s --tb=short 2>&1 | tee /tmp/fabric-frameview-pytest.log
+
+          if ! grep -Eq "[[:space:]][1-9][0-9]* passed" /tmp/fabric-frameview-pytest.log; then
+            echo "::error::Focused FabricFrameView pytest did not report a passing test"
+            exit 1
+          fi

--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -14,19 +14,12 @@
 
 name: FabricFrameView Multi-GPU Tests
 
-# DISABLED: No self-hosted runner with the 'multi-gpu' label is currently
-# registered.  All runs queue indefinitely.  Re-enable once infra provisions
-# a multi-GPU runner (see also .github/workflows/test-multi-gpu.yaml which
-# has the same issue).
-#
-# on:
-#   pull_request:
-#     paths:
-#       - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
-#       - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
-#       - ".github/workflows/test-fabric-multi-gpu.yaml"
-#   workflow_dispatch:
 on:
+  pull_request:
+    paths:
+      - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
+      - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
+      - ".github/workflows/test-fabric-multi-gpu.yaml"
   workflow_dispatch:
 
 concurrency:
@@ -36,14 +29,44 @@ concurrency:
 jobs:
   test-fabric-multi-gpu:
     name: FabricFrameView multi-GPU unit tests
-    runs-on: [self-hosted, linux, x64, gpu, multi-gpu]
-    timeout-minutes: 30
+    runs-on: [self-hosted, linux, x64, multi-gpu]
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install cmake via pip (avoid sudo apt path)
+        # install.py skips its sudo apt-get block when ``cmake`` is already on
+        # PATH (source/isaaclab/isaaclab/cli/commands/install.py:35).  The
+        # pip wheel provides a cmake shim under the setup-python venv's bin/,
+        # which is on PATH, so installing it here bypasses the apt branch.
+        run: pip install cmake
+
       - name: Install Isaac Lab
-        run: ./isaaclab.sh --install
+        # ``--install none`` = core submodules only (no mimic, no teleop, no
+        # auto-extra features).  The FabricFrameView cuda:1 tests only need
+        # isaaclab core + isaaclab_physx + Isaac Sim.  Avoids building
+        # robomimic's egl_probe wheel, which requires libEGL/X11 headers
+        # that the multi-GPU runner image lacks.
+        run: ./isaaclab.sh --install none
+
+      - name: Install Isaac Sim
+        # Isaac Sim is an optional extra in source/isaaclab/setup.py and is
+        # not pulled by ``--install none``.  Without it, AppLauncher's
+        # ``import isaacsim`` is silently caught by
+        # ``contextlib.suppress(ModuleNotFoundError)``, ``EXP_PATH`` stays
+        # unset, and test collection crashes with ``KeyError: 'EXP_PATH'``.
+        #
+        # Pinned to 6.0.0.0 because that is the only release line with a
+        # Python 3.12 wheel.  The 5.x line on PyPI requires Python 3.11
+        # (and source/isaaclab/setup.py's ``isaacsim==5.1.0`` pin is stale
+        # relative to the 3.12 baseline declared in pyproject.toml).
+        run: pip install 'isaacsim[all,extscache]==${{ vars.ISAACSIM_BASE_VERSION || '6.0.0' }}' --extra-index-url https://pypi.nvidia.com
 
       - name: Verify multi-GPU availability
         # Fail loud if the runner regressed to a single GPU.  Without this, the
@@ -62,7 +85,19 @@ jobs:
           fi
 
       - name: Run FabricFrameView multi-GPU unit tests
+        # ``ISAACLAB_TEST_MULTI_GPU=1`` enables the three cuda:1-parameterised
+        # tests in test_views_xform_prim_fabric.py added by PR #5514.  These
+        # tests target FabricFrameView's SelectPrims path on non-zero CUDA
+        # devices and currently hang indefinitely on real multi-GPU hardware
+        # (reproduced locally on 3x RTX 6000 Pro Blackwell and on the
+        # [self-hosted, ..., multi-gpu] runner pool).  The 60-min workflow
+        # timeout will cancel the job and surface the regression in CI for
+        # the FabricFrameView maintainers.  Land this PR once the hang is
+        # fixed in source/isaaclab_physx/.../fabric_frame_view.py.
         env:
+          OMNI_KIT_ACCEPT_EULA: "yes"
+          ACCEPT_EULA: "Y"
+          ISAAC_SIM_HEADLESS: "1"
           ISAACLAB_TEST_MULTI_GPU: "1"
         run: |
           ./isaaclab.sh -p -m pytest \

--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -98,4 +98,4 @@ jobs:
         run: |
           ./isaaclab.sh -p -m pytest \
             "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_world_pose_roundtrip[cuda:1]" \
-            -v
+            -v -s --tb=short

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -24,6 +24,11 @@ from isaaclab.utils.warp import fabric as fabric_utils
 logger = logging.getLogger(__name__)
 
 
+def _fabric_diag(message: str) -> None:
+    """Emit flush-safe diagnostics for Fabric multi-GPU CI debugging."""
+    print(f"[FabricFrameView] {message}", flush=True)
+
+
 def _to_float32_2d(a: wp.array | torch.Tensor) -> wp.array | torch.Tensor:
     """Ensure array is compatible with Fabric kernels (2-D float32).
 
@@ -139,18 +144,32 @@ class FabricFrameView(BaseFrameView):
     # ------------------------------------------------------------------
 
     def set_world_poses(self, positions=None, orientations=None, indices=None):
+        _fabric_diag(
+            f"set_world_poses enter use_fabric={self._use_fabric} device={self._device} "
+            f"initialized={self._fabric_initialized} positions_type={type(positions)} "
+            f"orientations_type={type(orientations)} indices_type={type(indices)}"
+        )
         if not self._use_fabric:
+            _fabric_diag("set_world_poses: USD fallback start")
             self._usd_view.set_world_poses(positions, orientations, indices)
+            _fabric_diag("set_world_poses: USD fallback done")
             return
 
         if not self._fabric_initialized:
+            _fabric_diag("set_world_poses: initialize_fabric start")
             self._initialize_fabric()
+            _fabric_diag("set_world_poses: initialize_fabric done")
 
+        _fabric_diag("set_world_poses: prepare_for_reuse start")
         self._prepare_for_reuse()
+        _fabric_diag("set_world_poses: prepare_for_reuse done")
 
+        _fabric_diag("set_world_poses: resolve_indices start")
         indices_wp = self._resolve_indices_wp(indices)
         count = indices_wp.shape[0]
+        _fabric_diag(f"set_world_poses: resolve_indices done count={count} indices_device={indices_wp.device}")
 
+        _fabric_diag("set_world_poses: allocate/convert inputs start")
         dummy = wp.zeros((0, 3), dtype=wp.float32, device=self._device)
         positions_wp = _to_float32_2d(positions) if positions is not None else dummy
         orientations_wp = (
@@ -158,7 +177,15 @@ class FabricFrameView(BaseFrameView):
             if orientations is not None
             else wp.zeros((0, 4), dtype=wp.float32, device=self._device)
         )
+        _fabric_diag(
+            f"set_world_poses: allocate/convert inputs done dummy_device={dummy.device} "
+            f"positions_shape={getattr(positions_wp, 'shape', None)} "
+            f"positions_device={getattr(positions_wp, 'device', None)} "
+            f"orientations_shape={getattr(orientations_wp, 'shape', None)} "
+            f"orientations_device={getattr(orientations_wp, 'device', None)} fabric_device={self._fabric_device}"
+        )
 
+        _fabric_diag("set_world_poses: compose kernel launch start")
         wp.launch(
             kernel=fabric_utils.compose_fabric_transformation_matrix_from_warp_arrays,
             dim=count,
@@ -175,24 +202,42 @@ class FabricFrameView(BaseFrameView):
             ],
             device=self._fabric_device,
         )
+        _fabric_diag("set_world_poses: compose kernel launch returned; synchronize start")
         wp.synchronize()
+        _fabric_diag("set_world_poses: synchronize done")
 
+        _fabric_diag("set_world_poses: update_world_xforms start")
         self._fabric_hierarchy.update_world_xforms()
+        _fabric_diag("set_world_poses: update_world_xforms done")
         self._fabric_usd_sync_done = True
+        _fabric_diag("set_world_poses exit")
 
     def get_world_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
+        _fabric_diag(
+            f"get_world_poses enter use_fabric={self._use_fabric} device={self._device} "
+            f"initialized={self._fabric_initialized} sync_done={self._fabric_usd_sync_done} "
+            f"indices_type={type(indices)}"
+        )
         if not self._use_fabric:
+            _fabric_diag("get_world_poses: USD fallback start")
             return self._usd_view.get_world_poses(indices)
 
         if not self._fabric_initialized:
+            _fabric_diag("get_world_poses: initialize_fabric start")
             self._initialize_fabric()
+            _fabric_diag("get_world_poses: initialize_fabric done")
         if not self._fabric_usd_sync_done:
+            _fabric_diag("get_world_poses: sync_fabric_from_usd_once start")
             self._sync_fabric_from_usd_once()
+            _fabric_diag("get_world_poses: sync_fabric_from_usd_once done")
 
+        _fabric_diag("get_world_poses: resolve_indices start")
         indices_wp = self._resolve_indices_wp(indices)
         count = indices_wp.shape[0]
+        _fabric_diag(f"get_world_poses: resolve_indices done count={count} indices_device={indices_wp.device}")
 
         use_cached = indices is None or indices == slice(None)
+        _fabric_diag(f"get_world_poses: use_cached={use_cached}")
         if use_cached:
             positions_wp = self._fabric_positions_buf
             orientations_wp = self._fabric_orientations_buf
@@ -200,6 +245,10 @@ class FabricFrameView(BaseFrameView):
             positions_wp = wp.zeros((count, 3), dtype=wp.float32, device=self._device)
             orientations_wp = wp.zeros((count, 4), dtype=wp.float32, device=self._device)
 
+        _fabric_diag(
+            f"get_world_poses: decompose kernel launch start positions_device={positions_wp.device} "
+            f"orientations_device={orientations_wp.device} fabric_device={self._fabric_device}"
+        )
         wp.launch(
             kernel=fabric_utils.decompose_fabric_transformation_matrix_to_warp_arrays,
             dim=count,
@@ -213,10 +262,14 @@ class FabricFrameView(BaseFrameView):
             ],
             device=self._fabric_device,
         )
+        _fabric_diag("get_world_poses: decompose kernel launch returned")
 
         if use_cached:
+            _fabric_diag("get_world_poses: synchronize start")
             wp.synchronize()
+            _fabric_diag("get_world_poses: synchronize done; returning cached proxy arrays")
             return self._fabric_positions_ta, self._fabric_orientations_ta
+        _fabric_diag("get_world_poses: returning uncached proxy arrays")
         return ProxyArray(positions_wp), ProxyArray(orientations_wp)
 
     # ------------------------------------------------------------------
@@ -325,12 +378,17 @@ class FabricFrameView(BaseFrameView):
            must be rebuilt.
         """
         if self._fabric_selection is None:
+            _fabric_diag("_prepare_for_reuse: no selection; return")
             return
 
+        _fabric_diag("_prepare_for_reuse: PrepareForReuse call start")
         topology_changed = self._fabric_selection.PrepareForReuse()
+        _fabric_diag(f"_prepare_for_reuse: PrepareForReuse done topology_changed={topology_changed}")
         if topology_changed:
             logger.info("Fabric topology changed — rebuilding view-to-fabric index mapping.")
+            _fabric_diag("_prepare_for_reuse: rebuild start")
             self._rebuild_fabric_arrays()
+            _fabric_diag("_prepare_for_reuse: rebuild done")
 
     def _rebuild_fabric_arrays(self) -> None:
         """Rebuild fabricarray and view↔fabric mappings after a topology change.
@@ -344,18 +402,25 @@ class FabricFrameView(BaseFrameView):
             f"Prim count changed ({self.count} vs {self._default_view_indices.shape[0]}). "
             "Fabric topology change added/removed tracked prims — full re-initialization required."
         )
+        _fabric_diag("_rebuild_fabric_arrays: allocate view_to_fabric start")
         self._view_to_fabric = wp.zeros((self.count,), dtype=wp.uint32, device=self._fabric_device)
+        _fabric_diag("_rebuild_fabric_arrays: fabric_to_view fabricarray start")
         self._fabric_to_view = wp.fabricarray(self._fabric_selection, self._view_index_attr)
 
+        _fabric_diag("_rebuild_fabric_arrays: set_view_to_fabric kernel start")
         wp.launch(
             kernel=fabric_utils.set_view_to_fabric_array,
             dim=self._fabric_to_view.shape[0],
             inputs=[self._fabric_to_view, self._view_to_fabric],
             device=self._fabric_device,
         )
+        _fabric_diag("_rebuild_fabric_arrays: set_view_to_fabric kernel returned; synchronize start")
         wp.synchronize()
+        _fabric_diag("_rebuild_fabric_arrays: synchronize done")
 
+        _fabric_diag("_rebuild_fabric_arrays: world_matrices fabricarray start")
         self._fabric_world_matrices = wp.fabricarray(self._fabric_selection, "omni:fabric:worldMatrix")
+        _fabric_diag("_rebuild_fabric_arrays: world_matrices fabricarray done")
 
     # ------------------------------------------------------------------
     # Internal — Fabric initialization
@@ -366,37 +431,59 @@ class FabricFrameView(BaseFrameView):
         import usdrt  # noqa: PLC0415
         from usdrt import Rt  # noqa: PLC0415
 
+        _fabric_diag(f"_initialize_fabric enter count={self.count} device={self._device} prim_paths={self.prim_paths}")
         stage_id = sim_utils.get_current_stage_id()
+        _fabric_diag(f"_initialize_fabric: stage_id={stage_id}; attach start")
         fabric_stage = usdrt.Usd.Stage.Attach(stage_id)
+        _fabric_diag("_initialize_fabric: attach done")
 
         for i in range(self.count):
+            _fabric_diag(f"_initialize_fabric: prim {i} GetPrimAtPath start path={self.prim_paths[i]}")
             rt_prim = fabric_stage.GetPrimAtPath(self.prim_paths[i])
+            _fabric_diag(f"_initialize_fabric: prim {i} Rt.Xformable start")
             rt_xformable = Rt.Xformable(rt_prim)
 
+            _fabric_diag(f"_initialize_fabric: prim {i} HasFabricHierarchyWorldMatrixAttr start")
             has_attr = (
                 rt_xformable.HasFabricHierarchyWorldMatrixAttr()
                 if hasattr(rt_xformable, "HasFabricHierarchyWorldMatrixAttr")
                 else False
             )
+            _fabric_diag(f"_initialize_fabric: prim {i} has_attr={has_attr}")
             if not has_attr:
+                _fabric_diag(f"_initialize_fabric: prim {i} CreateFabricHierarchyWorldMatrixAttr start")
                 rt_xformable.CreateFabricHierarchyWorldMatrixAttr()
+                _fabric_diag(f"_initialize_fabric: prim {i} CreateFabricHierarchyWorldMatrixAttr done")
 
+            _fabric_diag(f"_initialize_fabric: prim {i} SetWorldXformFromUsd start")
             rt_xformable.SetWorldXformFromUsd()
+            _fabric_diag(f"_initialize_fabric: prim {i} SetWorldXformFromUsd done")
 
+            _fabric_diag(f"_initialize_fabric: prim {i} CreateAttribute view_index start")
             rt_prim.CreateAttribute(self._view_index_attr, usdrt.Sdf.ValueTypeNames.UInt, custom=True)
+            _fabric_diag(f"_initialize_fabric: prim {i} Set view_index start")
             rt_prim.GetAttribute(self._view_index_attr).Set(i)
+            _fabric_diag(f"_initialize_fabric: prim {i} Set view_index done")
 
+        _fabric_diag("_initialize_fabric: get_fabric_hierarchy start")
         self._fabric_hierarchy = usdrt.hierarchy.IFabricHierarchy().get_fabric_hierarchy(
             fabric_stage.GetFabricId(), fabric_stage.GetStageIdAsStageId()
         )
+        _fabric_diag("_initialize_fabric: update_world_xforms start")
         self._fabric_hierarchy.update_world_xforms()
+        _fabric_diag("_initialize_fabric: update_world_xforms done")
 
+        _fabric_diag("_initialize_fabric: default_view_indices zeros start")
         self._default_view_indices = wp.zeros((self.count,), dtype=wp.uint32, device=self._device)
+        _fabric_diag("_initialize_fabric: arange kernel start")
         wp.launch(
             kernel=fabric_utils.arange_k, dim=self.count, inputs=[self._default_view_indices], device=self._device
         )
+        _fabric_diag("_initialize_fabric: arange kernel returned; synchronize start")
         wp.synchronize()
+        _fabric_diag("_initialize_fabric: arange synchronize done")
 
+        _fabric_diag("_initialize_fabric: SelectPrims start")
         self._fabric_selection = fabric_stage.SelectPrims(
             require_attrs=[
                 (usdrt.Sdf.ValueTypeNames.UInt, self._view_index_attr, usdrt.Usd.Access.Read),
@@ -404,30 +491,41 @@ class FabricFrameView(BaseFrameView):
             ],
             device=self._device,
         )
+        _fabric_diag(f"_initialize_fabric: SelectPrims done selection={self._fabric_selection}")
 
+        _fabric_diag("_initialize_fabric: view_to_fabric zeros start")
         self._view_to_fabric = wp.zeros((self.count,), dtype=wp.uint32, device=self._device)
+        _fabric_diag("_initialize_fabric: fabric_to_view fabricarray start")
         self._fabric_to_view = wp.fabricarray(self._fabric_selection, self._view_index_attr)
+        _fabric_diag(f"_initialize_fabric: fabric_to_view fabricarray done shape={self._fabric_to_view.shape}")
 
+        _fabric_diag("_initialize_fabric: set_view_to_fabric kernel start")
         wp.launch(
             kernel=fabric_utils.set_view_to_fabric_array,
             dim=self._fabric_to_view.shape[0],
             inputs=[self._fabric_to_view, self._view_to_fabric],
             device=self._device,
         )
+        _fabric_diag("_initialize_fabric: set_view_to_fabric kernel returned; synchronize start")
         wp.synchronize()
+        _fabric_diag("_initialize_fabric: set_view_to_fabric synchronize done")
 
+        _fabric_diag("_initialize_fabric: allocate buffers start")
         self._fabric_positions_buf = wp.zeros((self.count, 3), dtype=wp.float32, device=self._device)
         self._fabric_orientations_buf = wp.zeros((self.count, 4), dtype=wp.float32, device=self._device)
         self._fabric_positions_ta = ProxyArray(self._fabric_positions_buf)
         self._fabric_orientations_ta = ProxyArray(self._fabric_orientations_buf)
         self._fabric_scales_buf = wp.zeros((self.count, 3), dtype=wp.float32, device=self._device)
         self._fabric_dummy_buffer = wp.zeros((0, 3), dtype=wp.float32, device=self._device)
+        _fabric_diag("_initialize_fabric: world_matrices fabricarray start")
         self._fabric_world_matrices = wp.fabricarray(self._fabric_selection, "omni:fabric:worldMatrix")
+        _fabric_diag("_initialize_fabric: world_matrices fabricarray done")
         self._fabric_stage = fabric_stage
         self._fabric_device = self._device
 
         self._fabric_initialized = True
         self._fabric_usd_sync_done = False
+        _fabric_diag("_initialize_fabric exit")
 
     def _sync_fabric_from_usd_once(self) -> None:
         """Sync Fabric world matrices from USD once, on the first read.

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -22,6 +22,25 @@ from isaaclab.app import AppLauncher
 
 simulation_app = AppLauncher(headless=True).app
 
+# --- Version diagnostics: print Kit / Fabric / UsdRT versions ---
+import carb  # noqa: E402
+import omni.kit.app  # noqa: E402
+
+_app = omni.kit.app.get_app()
+_tokens = carb.tokens.get_tokens_interface()
+_ext_mgr = _app.get_extension_manager()
+print("\n" + "=" * 70)
+print(f"Kit version:        {_app.get_kit_version()}")
+print(f"Kit kernel version: {_app.get_kernel_version()}")
+print(f"Kit git hash:       {_tokens.resolve('${kit_git_hash}')}")
+print(f"Kit version short:  {_tokens.resolve('${kit_version_short}')}")
+for _ext_name in ["omni.fabric.core", "omni.usdrt.core", "omni.usdrt.scenegraph", "omni.physx"]:
+    _eid = _ext_mgr.get_enabled_extension_id(_ext_name)
+    print(f"  {_ext_name}: {_eid}")
+print("=" * 70 + "\n", flush=True)
+del _app, _tokens, _ext_mgr, _eid, _ext_name
+# --- End version diagnostics ---
+
 import pytest  # noqa: E402
 import torch  # noqa: E402
 import warp as wp  # noqa: E402

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -10,8 +10,10 @@ Imports the shared contract tests and provides the Fabric-specific
 Camera prim type for Fabric SelectPrims compatibility).
 """
 
+import faulthandler
 import os
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "isaaclab" / "test" / "sim"))
@@ -35,22 +37,34 @@ pytestmark = pytest.mark.isaacsim_ci
 PARENT_POS = (0.0, 0.0, 1.0)
 
 
+def _diag(message: str) -> None:
+    print(f"[fabric-mgpu-test {time.monotonic():.6f}] {message}", flush=True)
+
+
 @pytest.fixture(autouse=True)
 def test_setup_teardown():
+    _diag("fixture setup: create_new_stage start")
     sim_utils.create_new_stage()
+    _diag("fixture setup: update_stage start")
     sim_utils.update_stage()
+    _diag("fixture setup: yield")
     yield
+    _diag("fixture teardown: clear_stage start")
     sim_utils.clear_stage()
+    _diag("fixture teardown: clear SimulationContext start")
     sim_utils.SimulationContext.clear_instance()
+    _diag("fixture teardown: done")
 
 
 def _skip_if_unavailable(device: str):
+    _diag(f"skip check start: device={device}")
     if not device.startswith("cuda"):
         return
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     idx = int(device.split(":")[1]) if ":" in device else 0
     n = torch.cuda.device_count()
+    _diag(f"skip check CUDA state: is_available=True device_count={n} requested_index={idx}")
     if idx >= n:
         # Always skip rather than fail: the dedicated multi-GPU workflow does its own
         # pre-flight ``torch.cuda.device_count() >= 2`` check before invoking pytest, so
@@ -98,15 +112,22 @@ def view_factory():
     """Fabric factory: Camera child at CHILD_OFFSET under parent Xforms, with Fabric enabled."""
 
     def factory(num_envs: int, device: str) -> ViewBundle:
+        _diag(f"view_factory start: num_envs={num_envs} device={device}")
         _skip_if_unavailable(device)
 
+        _diag("view_factory: get_current_stage start")
         stage = sim_utils.get_current_stage()
         for i in range(num_envs):
+            _diag(f"view_factory: create parent {i} start")
             sim_utils.create_prim(f"/World/Parent_{i}", "Xform", translation=PARENT_POS, stage=stage)
+            _diag(f"view_factory: create child {i} start")
             sim_utils.create_prim(f"/World/Parent_{i}/Child", "Camera", translation=CHILD_OFFSET, stage=stage)
 
+        _diag("view_factory: SimulationContext start")
         sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01, device=device, use_fabric=True))
+        _diag("view_factory: FrameView init start")
         view = FrameView("/World/Parent_.*/Child", device=device)
+        _diag(f"view_factory: FrameView init done count={view.count} prim_paths={view.prim_paths}")
         return ViewBundle(
             view=view,
             get_parent_pos=_get_parent_positions,
@@ -263,17 +284,38 @@ def test_fabric_cuda1_world_pose_roundtrip(device, view_factory):
     Verifies that FabricFrameView operates correctly on a non-primary CUDA
     device without falling back to the USD path.
     """
-    bundle = view_factory(2, device)
-    view = bundle.view
+    faulthandler.dump_traceback_later(120, repeat=True)
+    try:
+        _diag("test start: cuda1 world pose roundtrip")
+        _diag("test: view_factory call start")
+        bundle = view_factory(2, device)
+        _diag("test: view_factory call done")
+        view = bundle.view
 
-    new_pos = wp.zeros((2, 3), dtype=wp.float32, device=device)
-    wp.launch(kernel=_fill_position, dim=2, inputs=[new_pos, 10.0, 20.0, 30.0], device=device)
-    view.set_world_poses(positions=new_pos)
+        _diag("test: wp.zeros new_pos start")
+        new_pos = wp.zeros((2, 3), dtype=wp.float32, device=device)
+        _diag(f"test: wp.zeros new_pos done shape={new_pos.shape} device={new_pos.device}")
+        _diag("test: fill_position launch start")
+        wp.launch(kernel=_fill_position, dim=2, inputs=[new_pos, 10.0, 20.0, 30.0], device=device)
+        _diag("test: fill_position launch returned; synchronize start")
+        wp.synchronize()
+        _diag("test: fill_position synchronize done")
+        _diag("test: set_world_poses start")
+        view.set_world_poses(positions=new_pos)
+        _diag("test: set_world_poses done")
 
-    ret_pos, _ = view.get_world_poses()
-    pos_torch = torch.as_tensor(ret_pos, device=device)
-    expected = torch.tensor([[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]], device=device)
-    assert torch.allclose(pos_torch, expected, atol=1e-7), f"Roundtrip failed on {device}: {pos_torch}"
+        _diag("test: get_world_poses start")
+        ret_pos, _ = view.get_world_poses()
+        _diag(f"test: get_world_poses done ret_pos_type={type(ret_pos)}")
+        _diag("test: torch.as_tensor start")
+        pos_torch = torch.as_tensor(ret_pos, device=device)
+        _diag(f"test: torch.as_tensor done shape={pos_torch.shape} device={pos_torch.device}")
+        expected = torch.tensor([[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]], device=device)
+        _diag("test: allclose assertion start")
+        assert torch.allclose(pos_torch, expected, atol=1e-7), f"Roundtrip failed on {device}: {pos_torch}"
+        _diag("test: allclose assertion done")
+    finally:
+        faulthandler.cancel_dump_traceback_later()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## 1. Summary

- Recreates #5788 on top of latest `develop` from `pv-nvidia:pv/fabric-mgpu-ci-stress`.
- Enables the FabricFrameView multi-GPU workflow for PRs and sets `ISAACLAB_TEST_MULTI_GPU=1` so the cuda:1 tests added by #5514 run in CI.
- Adds the setup needed for the self-hosted multi-GPU runner path: Python 3.12, pip-installed cmake, `./isaaclab.sh --install none`, and Isaac Sim from `https://pypi.nvidia.com`.

## 2. Status

Draft / stress-test PR. This is intended to reproduce and monitor the FabricFrameView cuda:1 behavior in CI, not to be merged until the runtime behavior is understood/fixed.

## 3. Local reproduction

```bash
cd <IsaacLab worktree>   # must be on a checkout that has PR #5514 merged (latest develop)
conda activate env_isaaclab

timeout 90 env \
  ISAACLAB_TEST_MULTI_GPU=1 \
  OMNI_KIT_ACCEPT_EULA=yes \
  ACCEPT_EULA=Y \
  ISAAC_SIM_HEADLESS=1 \
  ./isaaclab.sh -p -m pytest \
    "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_world_pose_roundtrip" \
    "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_no_usd_writeback" \
    "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py::test_fabric_cuda1_scales_roundtrip" \
    -v --tb=short
```

## 4. Bug surface

- File: `source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py`
- Code path: USDRT `SelectPrims` / FabricFrameView initialization with non-zero CUDA device indices.
- Context: #5514 removed the previous `cuda:0`-only Fabric allowlist because USDRT was expected to support arbitrary CUDA device indices.

## 5. Test plan

- [ ] Workflow appears in checks on this draft PR.
- [ ] Multi-GPU runner is selected.
- [ ] cuda:1 FabricFrameView tests run with `ISAACLAB_TEST_MULTI_GPU=1`.

Recreated from #5788.