### PR TITLE
[Test] Quadrupeds: relax import order (depends on #5826 + #5771)

### DIFF
--- a/scripts/demos/demo_helper.py
+++ b/scripts/demos/demo_helper.py
@@ -14,7 +14,8 @@ from contextlib import contextmanager
 def resolve_backend_and_visualizer(args, newton_cfg=None):
     """Resolve physics + visualizer cfgs from ``--physics`` / ``--visualizer``.
 
-    Yields ``(physics_cfg, visualizer_cfg)``. Kit is closed automatically on exit.
+    Yields ``(physics_cfg, visualizer_cfg)``. Kit is launched when required by
+    either the visualizer or the physics backend, and closed automatically on exit.
     """
 
     # Resolve physics cfg
@@ -42,8 +43,9 @@ def resolve_backend_and_visualizer(args, newton_cfg=None):
         raise ValueError(f"Unsupported --physics value: {args.physics}")
 
     # Resolve visualizer cfg
-    DEFAULT_VISUALIZER = "kit"
-    viz_type = args.visualizer or DEFAULT_VISUALIZER
+    if not isinstance(args.visualizer, list) or len(args.visualizer) != 1:
+        raise ValueError("Demos support exactly one --visualizer value: kit or newton.")
+    viz_type = args.visualizer[0]
     if viz_type == "kit":
         from isaaclab_visualizers.kit import KitVisualizerCfg
 
@@ -55,9 +57,10 @@ def resolve_backend_and_visualizer(args, newton_cfg=None):
     else:
         raise ValueError(f"Unsupported --visualizer value: {viz_type}")
 
-    # Kit needs to be closed by explicitly calling AppLauncher.close()
+    # PhysX requires Isaac Sim Kit extensions even when rendering through a
+    # standalone visualizer such as Newton.
     close_fn = None
-    if viz_type == "kit":
+    if viz_type == "kit" or args.physics == "physx":
         from isaaclab.app import AppLauncher
 
         args.visualizer = [viz_type]

--- a/scripts/demos/demo_helper.py
+++ b/scripts/demos/demo_helper.py
@@ -69,4 +69,5 @@ def resolve_backend_and_visualizer(args, newton_cfg=None):
 
 def has_no_alive_visualizer_window(sim) -> bool:
     """Check if there are no alive visualizer windows."""
-    return bool(sim.visualizers and not any(v.is_running() and not v.is_closed for v in sim.visualizers))
+    visualizers = sim.visualizers or ()
+    return not any(v.is_running() and not v.is_closed for v in visualizers)

--- a/scripts/demos/demo_helper.py
+++ b/scripts/demos/demo_helper.py
@@ -7,6 +7,7 @@
 This script contains helper functions for the demos.
 """
 
+import textwrap
 from contextlib import contextmanager
 
 
@@ -78,3 +79,13 @@ def has_no_alive_visualizer_window(sim) -> bool:
     """Check if there are no alive visualizer windows."""
     visualizers = sim.visualizers or ()
     return not any(v.is_running() and not v.is_closed for v in visualizers)
+
+
+def get_usage_examples(doc: str) -> str:
+    """Return usage examples from the module docstring."""
+    marker = ".. code-block:: bash"
+    if marker not in doc:
+        return ""
+
+    examples = textwrap.dedent(doc.split(marker, maxsplit=1)[1]).strip()
+    return "Examples:\n" + textwrap.indent(examples, "  ")

--- a/scripts/demos/demo_helper.py
+++ b/scripts/demos/demo_helper.py
@@ -20,9 +20,11 @@ def resolve_backend_and_visualizer(args, newton_cfg=None):
     # Resolve physics cfg
     if args.physics == "physx":
         from isaaclab_physx.physics import PhysxCfg
+
         physics_cfg = PhysxCfg()
     elif args.physics == "newton_mjwarp":
         from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+
         DEFAULT_NEWTON_CFG = NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=70,
@@ -44,9 +46,11 @@ def resolve_backend_and_visualizer(args, newton_cfg=None):
     viz_type = args.visualizer or DEFAULT_VISUALIZER
     if viz_type == "kit":
         from isaaclab_visualizers.kit import KitVisualizerCfg
+
         visualizer_cfg = KitVisualizerCfg()
     elif viz_type == "newton":
         from isaaclab_visualizers.newton import NewtonVisualizerCfg
+
         visualizer_cfg = NewtonVisualizerCfg()
     else:
         raise ValueError(f"Unsupported --visualizer value: {viz_type}")

--- a/scripts/demos/demo_helper.py
+++ b/scripts/demos/demo_helper.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+This script resolves the physics + visualizer cfgs from ``--physics`` / ``--visualizer``.
+"""
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def resolve_backend_and_visualizer(args, newton_cfg=None):
+    """Resolve physics + visualizer cfgs from ``--physics`` / ``--visualizer``.
+
+    Yields ``(physics_cfg, visualizer_cfg)``. Kit is closed automatically on exit.
+    """
+
+    # Resolve physics cfg
+    if args.physics == "physx":
+        from isaaclab_physx.physics import PhysxCfg
+        physics_cfg = PhysxCfg()
+    elif args.physics == "newton_mjwarp":
+        from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+        DEFAULT_NEWTON_CFG = NewtonCfg(
+            solver_cfg=MJWarpSolverCfg(
+                njmax=70,
+                nconmax=70,
+                ls_iterations=40,
+                cone="elliptic",
+                impratio=100,
+                ls_parallel=False,
+                integrator="implicitfast",
+            ),
+            num_substeps=2,
+        )
+        physics_cfg = newton_cfg or DEFAULT_NEWTON_CFG
+    else:
+        raise ValueError(f"Unsupported --physics value: {args.physics}")
+
+    # Resolve visualizer cfg
+    DEFAULT_VISUALIZER = "kit"
+    viz_type = args.visualizer or DEFAULT_VISUALIZER
+    if viz_type == "kit":
+        from isaaclab_visualizers.kit import KitVisualizerCfg
+        visualizer_cfg = KitVisualizerCfg()
+    elif viz_type == "newton":
+        from isaaclab_visualizers.newton import NewtonVisualizerCfg
+        visualizer_cfg = NewtonVisualizerCfg()
+    else:
+        raise ValueError(f"Unsupported --visualizer value: {viz_type}")
+
+    # Kit needs to be closed by explicitly calling AppLauncher.close()
+    needs_kit = (viz_type == "kit")
+    close_fn = None
+    if needs_kit:
+        from isaaclab.app import AppLauncher
+
+        args.visualizer = [viz_type]
+        close_fn = AppLauncher(args).app.close
+
+    try:
+        yield physics_cfg, visualizer_cfg
+    finally:
+        # No-op for the newton visualizer
+        if close_fn is not None:
+            close_fn()
+
+
+def has_no_alive_visualizer_window(sim) -> bool:
+    return bool(sim.visualizers and not any(v.is_running() and not v.is_closed for v in sim.visualizers))

--- a/scripts/demos/demo_helper.py
+++ b/scripts/demos/demo_helper.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 """
-This script resolves the physics + visualizer cfgs from ``--physics`` / ``--visualizer``.
+This script contains helper functions for the demos.
 """
 
 from contextlib import contextmanager
@@ -52,9 +52,8 @@ def resolve_backend_and_visualizer(args, newton_cfg=None):
         raise ValueError(f"Unsupported --visualizer value: {viz_type}")
 
     # Kit needs to be closed by explicitly calling AppLauncher.close()
-    needs_kit = (viz_type == "kit")
     close_fn = None
-    if needs_kit:
+    if viz_type == "kit":
         from isaaclab.app import AppLauncher
 
         args.visualizer = [viz_type]
@@ -63,10 +62,11 @@ def resolve_backend_and_visualizer(args, newton_cfg=None):
     try:
         yield physics_cfg, visualizer_cfg
     finally:
-        # No-op for the newton visualizer
+        # No-op for the newton visualizer; close Kit automatically upon exit
         if close_fn is not None:
             close_fn()
 
 
 def has_no_alive_visualizer_window(sim) -> bool:
+    """Check if there are no alive visualizer windows."""
     return bool(sim.visualizers and not any(v.is_running() and not v.is_closed for v in sim.visualizers))

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -52,6 +52,13 @@ args_cli = parser.parse_args()
 import numpy as np
 import torch
 
+import isaaclab.sim as sim_utils
+from isaaclab.assets import Articulation
+
+from isaaclab_assets.robots.anymal import ANYMAL_B_CFG, ANYMAL_C_CFG, ANYMAL_D_CFG  # isort:skip
+from isaaclab_assets.robots.spot import SPOT_CFG  # isort:skip
+from isaaclab_assets.robots.unitree import UNITREE_A1_CFG, UNITREE_GO1_CFG, UNITREE_GO2_CFG  # isort:skip
+
 
 def define_origins(num_origins: int, spacing: float) -> list[list[float]]:
     """Defines the origins of the scene."""
@@ -70,12 +77,6 @@ def define_origins(num_origins: int, spacing: float) -> list[list[float]]:
 
 def design_scene() -> tuple[dict, list[list[float]]]:
     """Designs the scene."""
-    import isaaclab.sim as sim_utils
-    from isaaclab.assets import Articulation
-    from isaaclab_assets.robots.anymal import ANYMAL_B_CFG, ANYMAL_C_CFG, ANYMAL_D_CFG  # isort:skip
-    from isaaclab_assets.robots.spot import SPOT_CFG  # isort:skip
-    from isaaclab_assets.robots.unitree import UNITREE_A1_CFG, UNITREE_GO1_CFG, UNITREE_GO2_CFG  # isort:skip
-
     # Ground-plane
     cfg = sim_utils.GroundPlaneCfg()
     cfg.func("/World/defaultGroundPlane", cfg)
@@ -188,8 +189,6 @@ def run_simulator(sim, entities: dict, origins):
 def main():
     """Main function."""
     with resolve_backend_and_visualizer(args_cli) as (physics_cfg, visualizer_cfg):
-        import isaaclab.sim as sim_utils
-
         # define simulation configuration
         sim_cfg = sim_utils.SimulationCfg(
             dt=0.005, device=args_cli.device, physics=physics_cfg, visualizer_cfgs=[visualizer_cfg]

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -82,6 +82,7 @@ def design_scene() -> tuple[dict, list[list[float]]]:
     sim_utils.create_prim("/World/Origin1", "Xform", translation=origins[0])
     # -- Robot
     anymal_b = Articulation(ANYMAL_B_CFG.replace(prim_path="/World/Origin1/Robot"))
+
     # Origin 2 with Anymal C
     sim_utils.create_prim("/World/Origin2", "Xform", translation=origins[1])
     # -- Robot
@@ -181,9 +182,8 @@ def main():
         import isaaclab.sim as sim_utils
 
         # define simulation time step
-        dt = 1 / 200
         # define simulation configuration
-        sim_cfg = sim_utils.SimulationCfg(dt=dt, device=args_cli.device, physics=physics_cfg, visualizer_cfgs=[visualizer_cfg])
+        sim_cfg = sim_utils.SimulationCfg(dt=0.005, device=args_cli.device, physics=physics_cfg, visualizer_cfgs=[visualizer_cfg])
         # Initialize the simulation context
         sim = sim_utils.SimulationContext(sim_cfg)
         # Set main camera

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -42,6 +42,9 @@ import numpy as np
 import torch
 
 from demo_helper import has_no_alive_visualizer_window, resolve_backend_and_visualizer
+from isaaclab_assets.robots.anymal import ANYMAL_B_CFG, ANYMAL_C_CFG, ANYMAL_D_CFG  # isort:skip
+from isaaclab_assets.robots.spot import SPOT_CFG  # isort:skip
+from isaaclab_assets.robots.unitree import UNITREE_A1_CFG, UNITREE_GO1_CFG, UNITREE_GO2_CFG  # isort:skip
 
 
 def define_origins(num_origins: int, spacing: float) -> list[list[float]]:
@@ -62,10 +65,7 @@ def define_origins(num_origins: int, spacing: float) -> list[list[float]]:
 def design_scene() -> tuple[dict, list[list[float]]]:
     """Designs the scene."""
     import isaaclab.sim as sim_utils
-
-    from isaaclab_assets.robots.anymal import ANYMAL_B_CFG, ANYMAL_C_CFG, ANYMAL_D_CFG  # isort:skip
-    from isaaclab_assets.robots.spot import SPOT_CFG  # isort:skip
-    from isaaclab_assets.robots.unitree import UNITREE_A1_CFG, UNITREE_GO1_CFG, UNITREE_GO2_CFG  # isort:skip
+    from isaaclab.assets import Articulation
 
     # Ground-plane
     cfg = sim_utils.GroundPlaneCfg()
@@ -81,43 +81,36 @@ def design_scene() -> tuple[dict, list[list[float]]]:
     # Origin 1 with Anymal B
     sim_utils.create_prim("/World/Origin1", "Xform", translation=origins[0])
     # -- Robot
-    anymal_b_cfg = ANYMAL_B_CFG.replace(prim_path="/World/Origin1/Robot")
-    anymal_b = anymal_b_cfg.class_type(anymal_b_cfg)
+    anymal_b = Articulation(ANYMAL_B_CFG.replace(prim_path="/World/Origin1/Robot"))
     # Origin 2 with Anymal C
     sim_utils.create_prim("/World/Origin2", "Xform", translation=origins[1])
     # -- Robot
-    anymal_c_cfg = ANYMAL_C_CFG.replace(prim_path="/World/Origin2/Robot")
-    anymal_c = anymal_c_cfg.class_type(anymal_c_cfg)
+    anymal_c = Articulation(ANYMAL_C_CFG.replace(prim_path="/World/Origin2/Robot"))
 
     # Origin 3 with Anymal D
     sim_utils.create_prim("/World/Origin3", "Xform", translation=origins[2])
     # -- Robot
-    anymal_d_cfg = ANYMAL_D_CFG.replace(prim_path="/World/Origin3/Robot")
-    anymal_d = anymal_d_cfg.class_type(anymal_d_cfg)
+    anymal_d = Articulation(ANYMAL_D_CFG.replace(prim_path="/World/Origin3/Robot"))
 
     # Origin 4 with Unitree A1
     sim_utils.create_prim("/World/Origin4", "Xform", translation=origins[3])
     # -- Robot
-    unitree_a1_cfg = UNITREE_A1_CFG.replace(prim_path="/World/Origin4/Robot")
-    unitree_a1 = unitree_a1_cfg.class_type(unitree_a1_cfg)
+    unitree_a1 = Articulation(UNITREE_A1_CFG.replace(prim_path="/World/Origin4/Robot"))
 
     # Origin 5 with Unitree Go1
     sim_utils.create_prim("/World/Origin5", "Xform", translation=origins[4])
     # -- Robot
-    unitree_go1_cfg = UNITREE_GO1_CFG.replace(prim_path="/World/Origin5/Robot")
-    unitree_go1 = unitree_go1_cfg.class_type(unitree_go1_cfg)
+    unitree_go1 = Articulation(UNITREE_GO1_CFG.replace(prim_path="/World/Origin5/Robot"))
 
     # Origin 6 with Unitree Go2
     sim_utils.create_prim("/World/Origin6", "Xform", translation=origins[5])
     # -- Robot
-    unitree_go2_cfg = UNITREE_GO2_CFG.replace(prim_path="/World/Origin6/Robot")
-    unitree_go2 = unitree_go2_cfg.class_type(unitree_go2_cfg)
+    unitree_go2 = Articulation(UNITREE_GO2_CFG.replace(prim_path="/World/Origin6/Robot"))
 
     # Origin 7 with Boston Dynamics Spot
     sim_utils.create_prim("/World/Origin7", "Xform", translation=origins[6])
     # -- Robot
-    spot_cfg = SPOT_CFG.replace(prim_path="/World/Origin7/Robot")
-    spot = spot_cfg.class_type(spot_cfg)
+    spot = Articulation(SPOT_CFG.replace(prim_path="/World/Origin7/Robot"))
 
     # return the scene information
     scene_entities = {
@@ -139,10 +132,8 @@ def run_simulator(sim, entities: dict, origins):
     sim_time = 0.0
     count = 0
     # Simulate physics
-    while True:
-        # Exit when every visualizer window has been closed (works for kit and newton)
-        if has_no_alive_visualizer_window(sim):
-            break
+    # Exit when every visualizer window has been closed (works for kit and newton)
+    while not has_no_alive_visualizer_window(sim):
         # reset
         if count % 200 == 0:
             # reset counters

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -42,6 +42,10 @@ import numpy as np
 import torch
 
 from demo_helper import has_no_alive_visualizer_window, resolve_backend_and_visualizer
+
+##
+# Pre-defined configs
+##
 from isaaclab_assets.robots.anymal import ANYMAL_B_CFG, ANYMAL_C_CFG, ANYMAL_D_CFG  # isort:skip
 from isaaclab_assets.robots.spot import SPOT_CFG  # isort:skip
 from isaaclab_assets.robots.unitree import UNITREE_A1_CFG, UNITREE_GO1_CFG, UNITREE_GO2_CFG  # isort:skip

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -44,6 +44,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument("--physics", default="physx", choices=["physx", "newton_mjwarp"], help="Physics backend.")
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
+# demos should open Kit visualizer by default
 parser.set_defaults(visualizer=["kit"])
 # parse the arguments
 args_cli = parser.parse_args()
@@ -210,4 +211,5 @@ def main():
 
 
 if __name__ == "__main__":
+    # run the main function
     main()

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -31,10 +31,16 @@ This script demonstrates different legged robots.
 
 import argparse
 
+from demo_helper import get_usage_examples, has_no_alive_visualizer_window, resolve_backend_and_visualizer
+
 from isaaclab.app import AppLauncher
 
 # add argparse arguments
-parser = argparse.ArgumentParser(description="This script demonstrates different legged robots.")
+parser = argparse.ArgumentParser(
+    description="This script demonstrates different legged robots.",
+    epilog=get_usage_examples(str(__doc__)),
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
 parser.add_argument("--physics", default="physx", choices=["physx", "newton_mjwarp"], help="Physics backend.")
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
@@ -44,8 +50,6 @@ args_cli = parser.parse_args()
 
 import numpy as np
 import torch
-
-from demo_helper import has_no_alive_visualizer_window, resolve_backend_and_visualizer
 
 
 def define_origins(num_origins: int, spacing: float) -> list[list[float]]:
@@ -186,7 +190,9 @@ def main():
         import isaaclab.sim as sim_utils
 
         # define simulation configuration
-        sim_cfg = sim_utils.SimulationCfg(dt=0.005, device=args_cli.device, physics=physics_cfg, visualizer_cfgs=[visualizer_cfg])
+        sim_cfg = sim_utils.SimulationCfg(
+            dt=0.005, device=args_cli.device, physics=physics_cfg, visualizer_cfgs=[visualizer_cfg]
+        )
         # Initialize the simulation context
         sim = sim_utils.SimulationContext(sim_cfg)
         # Set main camera

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -10,9 +10,13 @@ This script demonstrates different legged robots.
 
     # Usage with the default PhysX backend (launches Isaac Sim Kit by default).
     ./isaaclab.sh -p scripts/demos/quadrupeds.py
+    ./isaaclab.sh -p scripts/demos/quadrupeds.py --visualizer kit
+    ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics physx
+    ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics physx --visualizer kit
 
     # Usage with the kit-less Newton (MJWarp) backend (launches Isaac Sim Kit by default).
     ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics newton_mjwarp
+    ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics newton_mjwarp --visualizer kit
 
     # Usage with the Newton (MJWarp) backend without Kit (launches Newton visualizer).
     ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics newton_mjwarp --visualizer newton

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -21,8 +21,8 @@ This script demonstrates different legged robots.
     # Usage with the Newton (MJWarp) backend without Kit (launches Newton visualizer).
     ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics newton_mjwarp --visualizer newton
 
-    # Usage with the PhysX backend without Kit (launches Newton visualizer).
-    # TODO(yizew@nvidia.com): Not supported yet. Investigation needed.
+    # Usage with the PhysX backend and Newton visualizer.
+    # PhysX still launches Isaac Sim Kit headless because it depends on Kit extensions.
     ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics physx --visualizer newton
 
 """
@@ -34,11 +34,11 @@ import argparse
 from isaaclab.app import AppLauncher
 
 # add argparse arguments
-parser = argparse.ArgumentParser(description="This script demonstrates different legged robots.", conflict_handler="resolve")
+parser = argparse.ArgumentParser(description="This script demonstrates different legged robots.")
+parser.add_argument("--physics", default="physx", choices=["physx", "newton_mjwarp"], help="Physics backend.")
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
-parser.add_argument("--physics", default="physx", choices=["physx", "newton_mjwarp"], help="Physics backend.")
-parser.add_argument("--visualizer", default="kit", choices=["kit", "newton"], help="Visualizer backend.")
+parser.set_defaults(visualizer=["kit"])
 # parse the arguments
 args_cli = parser.parse_args()
 

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -43,13 +43,6 @@ import torch
 
 from demo_helper import has_no_alive_visualizer_window, resolve_backend_and_visualizer
 
-##
-# Pre-defined configs
-##
-from isaaclab_assets.robots.anymal import ANYMAL_B_CFG, ANYMAL_C_CFG, ANYMAL_D_CFG  # isort:skip
-from isaaclab_assets.robots.spot import SPOT_CFG  # isort:skip
-from isaaclab_assets.robots.unitree import UNITREE_A1_CFG, UNITREE_GO1_CFG, UNITREE_GO2_CFG  # isort:skip
-
 
 def define_origins(num_origins: int, spacing: float) -> list[list[float]]:
     """Defines the origins of the scene."""
@@ -70,6 +63,9 @@ def design_scene() -> tuple[dict, list[list[float]]]:
     """Designs the scene."""
     import isaaclab.sim as sim_utils
     from isaaclab.assets import Articulation
+    from isaaclab_assets.robots.anymal import ANYMAL_B_CFG, ANYMAL_C_CFG, ANYMAL_D_CFG  # isort:skip
+    from isaaclab_assets.robots.spot import SPOT_CFG  # isort:skip
+    from isaaclab_assets.robots.unitree import UNITREE_A1_CFG, UNITREE_GO1_CFG, UNITREE_GO2_CFG  # isort:skip
 
     # Ground-plane
     cfg = sim_utils.GroundPlaneCfg()
@@ -185,7 +181,6 @@ def main():
     with resolve_backend_and_visualizer(args_cli) as (physics_cfg, visualizer_cfg):
         import isaaclab.sim as sim_utils
 
-        # define simulation time step
         # define simulation configuration
         sim_cfg = sim_utils.SimulationCfg(dt=0.005, device=args_cli.device, physics=physics_cfg, visualizer_cfgs=[visualizer_cfg])
         # Initialize the simulation context
@@ -194,6 +189,7 @@ def main():
         sim.set_camera_view(eye=[2.5, 2.5, 2.5], target=[0.0, 0.0, 0.0])
         # design scene
         scene_entities, scene_origins = design_scene()
+        # convert origins to tensor
         scene_origins = torch.tensor(scene_origins, device=sim.device)
         # Play the simulator
         sim.reset()

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -8,44 +8,39 @@ This script demonstrates different legged robots.
 
 .. code-block:: bash
 
-    # Usage
+    # Usage with the default PhysX backend (launches Isaac Sim Kit by default).
     ./isaaclab.sh -p scripts/demos/quadrupeds.py
+
+    # Usage with the kit-less Newton (MJWarp) backend (launches Isaac Sim Kit by default).
+    ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics newton_mjwarp
+
+    # Usage with the Newton (MJWarp) backend without Kit (launches Newton visualizer).
+    ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics newton_mjwarp --visualizer newton
+
+    # Usage with the PhysX backend without Kit (launches Newton visualizer).
+    ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics physx --visualizer newton
 
 """
 
-"""Launch Isaac Sim Simulator first."""
+"""Parse CLI first so we can decide whether to launch Isaac Sim Kit."""
 
 import argparse
 
 from isaaclab.app import AppLauncher
 
 # add argparse arguments
-parser = argparse.ArgumentParser(description="This script demonstrates different legged robots.")
+parser = argparse.ArgumentParser(description="This script demonstrates different legged robots.", conflict_handler="resolve")
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
-# demos should open Kit visualizer by default
-parser.set_defaults(visualizer=["kit"])
+parser.add_argument("--physics", default="physx", choices=["physx", "newton_mjwarp"], help="Physics backend.")
+parser.add_argument("--visualizer", default="kit", choices=["kit", "newton"], help="Visualizer backend.")
 # parse the arguments
 args_cli = parser.parse_args()
-
-# launch omniverse app
-app_launcher = AppLauncher(args_cli)
-simulation_app = app_launcher.app
-
-"""Rest everything follows."""
 
 import numpy as np
 import torch
 
-import isaaclab.sim as sim_utils
-from isaaclab.assets import Articulation
-
-##
-# Pre-defined configs
-##
-from isaaclab_assets.robots.anymal import ANYMAL_B_CFG, ANYMAL_C_CFG, ANYMAL_D_CFG  # isort:skip
-from isaaclab_assets.robots.spot import SPOT_CFG  # isort:skip
-from isaaclab_assets.robots.unitree import UNITREE_A1_CFG, UNITREE_GO1_CFG, UNITREE_GO2_CFG  # isort:skip
+from demo_helper import has_no_alive_visualizer_window, resolve_backend_and_visualizer
 
 
 def define_origins(num_origins: int, spacing: float) -> list[list[float]]:
@@ -65,6 +60,12 @@ def define_origins(num_origins: int, spacing: float) -> list[list[float]]:
 
 def design_scene() -> tuple[dict, list[list[float]]]:
     """Designs the scene."""
+    import isaaclab.sim as sim_utils
+
+    from isaaclab_assets.robots.anymal import ANYMAL_B_CFG, ANYMAL_C_CFG, ANYMAL_D_CFG  # isort:skip
+    from isaaclab_assets.robots.spot import SPOT_CFG  # isort:skip
+    from isaaclab_assets.robots.unitree import UNITREE_A1_CFG, UNITREE_GO1_CFG, UNITREE_GO2_CFG  # isort:skip
+
     # Ground-plane
     cfg = sim_utils.GroundPlaneCfg()
     cfg.func("/World/defaultGroundPlane", cfg)
@@ -79,37 +80,43 @@ def design_scene() -> tuple[dict, list[list[float]]]:
     # Origin 1 with Anymal B
     sim_utils.create_prim("/World/Origin1", "Xform", translation=origins[0])
     # -- Robot
-    anymal_b = Articulation(ANYMAL_B_CFG.replace(prim_path="/World/Origin1/Robot"))
-
+    anymal_b_cfg = ANYMAL_B_CFG.replace(prim_path="/World/Origin1/Robot")
+    anymal_b = anymal_b_cfg.class_type(anymal_b_cfg)
     # Origin 2 with Anymal C
     sim_utils.create_prim("/World/Origin2", "Xform", translation=origins[1])
     # -- Robot
-    anymal_c = Articulation(ANYMAL_C_CFG.replace(prim_path="/World/Origin2/Robot"))
+    anymal_c_cfg = ANYMAL_C_CFG.replace(prim_path="/World/Origin2/Robot")
+    anymal_c = anymal_c_cfg.class_type(anymal_c_cfg)
 
     # Origin 3 with Anymal D
     sim_utils.create_prim("/World/Origin3", "Xform", translation=origins[2])
     # -- Robot
-    anymal_d = Articulation(ANYMAL_D_CFG.replace(prim_path="/World/Origin3/Robot"))
+    anymal_d_cfg = ANYMAL_D_CFG.replace(prim_path="/World/Origin3/Robot")
+    anymal_d = anymal_d_cfg.class_type(anymal_d_cfg)
 
     # Origin 4 with Unitree A1
     sim_utils.create_prim("/World/Origin4", "Xform", translation=origins[3])
     # -- Robot
-    unitree_a1 = Articulation(UNITREE_A1_CFG.replace(prim_path="/World/Origin4/Robot"))
+    unitree_a1_cfg = UNITREE_A1_CFG.replace(prim_path="/World/Origin4/Robot")
+    unitree_a1 = unitree_a1_cfg.class_type(unitree_a1_cfg)
 
     # Origin 5 with Unitree Go1
     sim_utils.create_prim("/World/Origin5", "Xform", translation=origins[4])
     # -- Robot
-    unitree_go1 = Articulation(UNITREE_GO1_CFG.replace(prim_path="/World/Origin5/Robot"))
+    unitree_go1_cfg = UNITREE_GO1_CFG.replace(prim_path="/World/Origin5/Robot")
+    unitree_go1 = unitree_go1_cfg.class_type(unitree_go1_cfg)
 
     # Origin 6 with Unitree Go2
     sim_utils.create_prim("/World/Origin6", "Xform", translation=origins[5])
     # -- Robot
-    unitree_go2 = Articulation(UNITREE_GO2_CFG.replace(prim_path="/World/Origin6/Robot"))
+    unitree_go2_cfg = UNITREE_GO2_CFG.replace(prim_path="/World/Origin6/Robot")
+    unitree_go2 = unitree_go2_cfg.class_type(unitree_go2_cfg)
 
     # Origin 7 with Boston Dynamics Spot
     sim_utils.create_prim("/World/Origin7", "Xform", translation=origins[6])
     # -- Robot
-    spot = Articulation(SPOT_CFG.replace(prim_path="/World/Origin7/Robot"))
+    spot_cfg = SPOT_CFG.replace(prim_path="/World/Origin7/Robot")
+    spot = spot_cfg.class_type(spot_cfg)
 
     # return the scene information
     scene_entities = {
@@ -124,14 +131,17 @@ def design_scene() -> tuple[dict, list[list[float]]]:
     return scene_entities, origins
 
 
-def run_simulator(sim: sim_utils.SimulationContext, entities: dict[str, Articulation], origins: torch.Tensor):
+def run_simulator(sim, entities: dict, origins):
     """Runs the simulation loop."""
     # Define simulation stepping
     sim_dt = sim.get_physics_dt()
     sim_time = 0.0
     count = 0
     # Simulate physics
-    while simulation_app.is_running():
+    while True:
+        # Exit when every visualizer window has been closed (works for kit and newton)
+        if has_no_alive_visualizer_window(sim):
+            break
         # reset
         if count % 200 == 0:
             # reset counters
@@ -175,24 +185,27 @@ def run_simulator(sim: sim_utils.SimulationContext, entities: dict[str, Articula
 
 def main():
     """Main function."""
+    with resolve_backend_and_visualizer(args_cli) as (physics_cfg, visualizer_cfg):
+        import isaaclab.sim as sim_utils
 
-    # Initialize the simulation context
-    sim = sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01))
-    # Set main camera
-    sim.set_camera_view(eye=[2.5, 2.5, 2.5], target=[0.0, 0.0, 0.0])
-    # design scene
-    scene_entities, scene_origins = design_scene()
-    scene_origins = torch.tensor(scene_origins, device=sim.device)
-    # Play the simulator
-    sim.reset()
-    # Now we are ready!
-    print("[INFO]: Setup complete...")
-    # Run the simulator
-    run_simulator(sim, scene_entities, scene_origins)
+        # define simulation time step
+        dt = 1 / 200
+        # define simulation configuration
+        sim_cfg = sim_utils.SimulationCfg(dt=dt, device=args_cli.device, physics=physics_cfg, visualizer_cfgs=[visualizer_cfg])
+        # Initialize the simulation context
+        sim = sim_utils.SimulationContext(sim_cfg)
+        # Set main camera
+        sim.set_camera_view(eye=[2.5, 2.5, 2.5], target=[0.0, 0.0, 0.0])
+        # design scene
+        scene_entities, scene_origins = design_scene()
+        scene_origins = torch.tensor(scene_origins, device=sim.device)
+        # Play the simulator
+        sim.reset()
+        # Now we are ready!
+        print("[INFO]: Setup complete...")
+        # Run the simulator
+        run_simulator(sim, scene_entities, scene_origins)
 
 
 if __name__ == "__main__":
-    # run the main function
     main()
-    # close sim app
-    simulation_app.close()

--- a/scripts/demos/quadrupeds.py
+++ b/scripts/demos/quadrupeds.py
@@ -18,6 +18,7 @@ This script demonstrates different legged robots.
     ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics newton_mjwarp --visualizer newton
 
     # Usage with the PhysX backend without Kit (launches Newton visualizer).
+    # TODO(yizew@nvidia.com): Not supported yet. Investigation needed.
     ./isaaclab.sh -p scripts/demos/quadrupeds.py --physics physx --visualizer newton
 
 """

--- a/source/isaaclab/changelog.d/jichuanh-defer-asset-pxr-imports.rst
+++ b/source/isaaclab/changelog.d/jichuanh-defer-asset-pxr-imports.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.assets.AssetBase` and :class:`~isaaclab.assets.BaseArticulation`
+  loading ``pxr`` at module-import time, which forced :class:`~isaaclab.app.AppLauncher`
+  to run before any ``from isaaclab.assets import Articulation`` and blocked
+  kit-less workflows that import asset classes at module top.

--- a/source/isaaclab/changelog.d/jichuanh-defer-asset-pxr-imports.rst
+++ b/source/isaaclab/changelog.d/jichuanh-defer-asset-pxr-imports.rst
@@ -1,7 +1,7 @@
 Fixed
 ^^^^^
 
-* Fixed :class:`~isaaclab.assets.AssetBase` and :class:`~isaaclab.assets.BaseArticulation`
+* Fixed ``from isaaclab.assets import Articulation`` and ``from isaaclab.sim import SimulationContext``
   loading ``pxr`` at module-import time, which forced :class:`~isaaclab.app.AppLauncher`
-  to run before any ``from isaaclab.assets import Articulation`` and blocked
-  kit-less workflows that import asset classes at module top.
+  to run before any such import and blocked kit-less workflows that bind these
+  classes at module top.

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 import torch
 import warp as wp
 
-from ...sim import SimulationContext
 from ...utils.leapp.leapp_semantics import OutputKindEnum, joint_names_resolver, leapp_tensor_semantics
 from ..asset_base import AssetBase
 
@@ -96,6 +95,8 @@ class BaseArticulation(AssetBase):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
+        from ...sim import SimulationContext
+
         sim_ctx = SimulationContext.instance()
         self._sim_cfg = sim_ctx.cfg if sim_ctx is not None else None
 

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import torch
 import warp as wp
 
+from ...sim import SimulationContext
 from ...utils.leapp.leapp_semantics import OutputKindEnum, joint_names_resolver, leapp_tensor_semantics
 from ..asset_base import AssetBase
 
@@ -95,8 +96,6 @@ class BaseArticulation(AssetBase):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
-        from ...sim import SimulationContext
-
         sim_ctx = SimulationContext.instance()
         self._sim_cfg = sim_ctx.cfg if sim_ctx is not None else None
 

--- a/source/isaaclab/isaaclab/assets/asset_base.py
+++ b/source/isaaclab/isaaclab/assets/asset_base.py
@@ -15,14 +15,12 @@ from typing import TYPE_CHECKING, Any
 import torch
 import warp as wp
 
-from pxr import Usd
-
 import isaaclab.sim as sim_utils
 from isaaclab.physics import PhysicsEvent, PhysicsManager
-from isaaclab.sim.simulation_context import SimulationContext
-from isaaclab.sim.utils.stage import get_current_stage
 
 if TYPE_CHECKING:
+    from pxr import Usd
+
     from .asset_base_cfg import AssetBaseCfg
 
 
@@ -81,7 +79,7 @@ class AssetBase(ABC):
         # flag for whether the asset is initialized
         self._is_initialized = False
         # get stage handle
-        self.stage: Usd.Stage = get_current_stage()
+        self.stage: Usd.Stage = sim_utils.get_current_stage()
 
         # spawn the asset
         # determine path where prims should exist after spawn
@@ -208,11 +206,11 @@ class AssetBase(ABC):
         # toggle debug visualization handles (Kit/omni only for PhysX backend)
         if debug_vis:
             if self._debug_vis_handle is None:
-                sim_ctx = SimulationContext.instance()
+                sim_ctx = sim_utils.SimulationContext.instance()
                 if sim_ctx is not None:
                     self._debug_vis_handle = sim_ctx.vis_marker_registry.add_debug_vis_callback(self)
         else:
-            sim_ctx = SimulationContext.instance()
+            sim_ctx = sim_utils.SimulationContext.instance()
             if sim_ctx is not None:
                 sim_ctx.vis_marker_registry.clear_debug_vis_callback(self)
             else:
@@ -353,7 +351,7 @@ class AssetBase(ABC):
 
     def _register_callbacks(self):
         """Registers physics lifecycle callbacks via the current backend's physics manager."""
-        physics_mgr_cls = SimulationContext.instance().physics_manager
+        physics_mgr_cls = sim_utils.SimulationContext.instance().physics_manager
 
         # note: use weakref on callbacks to ensure that this object can be deleted when its destructor is called.
         obj_ref = weakref.proxy(self)
@@ -397,15 +395,15 @@ class AssetBase(ABC):
             :attr:`PhysicsEvent.PHYSICS_READY` is dispatched by the current backend.
         """
         if not self._is_initialized:
-            self._backend = SimulationContext.instance().physics_manager.get_backend()
-            self._device = SimulationContext.instance().physics_manager.get_device()
+            self._backend = sim_utils.SimulationContext.instance().physics_manager.get_backend()
+            self._device = sim_utils.SimulationContext.instance().physics_manager.get_device()
             self._initialize_impl()
             self._is_initialized = True
 
     def _invalidate_initialize_callback(self, event):
         """Invalidates the scene elements."""
         self._is_initialized = False
-        sim_ctx = SimulationContext.instance()
+        sim_ctx = sim_utils.SimulationContext.instance()
         if sim_ctx is not None:
             sim_ctx.vis_marker_registry.clear_debug_vis_callback(self)
         else:
@@ -438,7 +436,7 @@ class AssetBase(ABC):
         if self._prim_deletion_handle is not None:
             self._prim_deletion_handle.deregister()
             self._prim_deletion_handle = None
-        sim_ctx = SimulationContext.instance()
+        sim_ctx = sim_utils.SimulationContext.instance()
         if sim_ctx is not None:
             sim_ctx.vis_marker_registry.clear_debug_vis_callback(self)
         else:

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -17,10 +17,7 @@ from typing import TYPE_CHECKING, Any
 import toml
 import torch
 
-from pxr import Gf, Usd, UsdGeom, UsdPhysics, UsdUtils
-
 import isaaclab.sim as sim_utils
-import isaaclab.sim.utils.stage as stage_utils
 from isaaclab.app.settings_manager import SettingsManager
 from isaaclab.envs.utils.recording_hooks import run_recording_hooks_after_visualizers
 from isaaclab.markers.vis_marker_registry import VisMarkerRegistry
@@ -32,12 +29,13 @@ from isaaclab.physics.scene_data_requirements import (
 from isaaclab.renderers.render_context import RenderContext
 from isaaclab.scene_data import SceneDataProvider
 from isaaclab.sim.service_locator import ServiceLocator
-from isaaclab.sim.utils import create_new_stage
 from isaaclab.utils.string import clear_resolve_matching_names_cache
 from isaaclab.utils.version import has_kit
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
 
 if TYPE_CHECKING:
+    from pxr import Usd
+
     from isaaclab.cloner.clone_plan import ClonePlan
 
 from .simulation_cfg import SimulationCfg
@@ -111,13 +109,17 @@ class SimulationContext:
         if type(self)._instance is not None:
             return  # Already initialized
 
+        from pxr import UsdUtils  # noqa: PLC0415
+
+        from isaaclab.sim.utils import stage as stage_utils  # noqa: PLC0415
+
         # Store config
         self.cfg = SimulationCfg() if cfg is None else cfg
 
         # Get or create stage based on config
         stage_cache = UsdUtils.StageCache.Get()
         if self.cfg.create_stage_in_memory:
-            self.stage = create_new_stage()
+            self.stage = sim_utils.create_new_stage()
         else:
             # Prefer the thread-local current stage (set by create_new_stage / test fixtures)
             # over cache lookup, since the cache may contain stale stages from prior tests.
@@ -126,7 +128,7 @@ class SimulationContext:
                 self.stage = current
             else:
                 all_stages = stage_cache.GetAllStages() if stage_cache.Size() > 0 else []  # type: ignore[union-attr]
-                self.stage = all_stages[0] if all_stages else create_new_stage()
+                self.stage = all_stages[0] if all_stages else sim_utils.create_new_stage()
 
         # Ensure stage is in the USD cache
         stage_id = stage_cache.GetId(self.stage).ToLongInt()  # type: ignore[union-attr]
@@ -322,6 +324,8 @@ class SimulationContext:
 
     def _init_usd_physics_scene(self) -> None:
         """Create and configure the USD physics scene."""
+        from pxr import Gf, UsdGeom, UsdPhysics  # noqa: PLC0415
+
         cfg = self.cfg
         with sim_utils.use_stage(self.stage):
             # Set stage conventions for metric units
@@ -913,7 +917,7 @@ class SimulationContext:
 
             # Tear down the stage. We skip clear_stage() (prim-by-prim deletion) since
             # close_stage() + app shutdown destroy the entire stage at once.
-            stage_utils.close_stage()
+            sim_utils.close_stage()
 
             # Discard cached name-resolution data from destroyed assets
             clear_resolve_matching_names_cache()


### PR DESCRIPTION
## 1. Summary

- Demonstrates that PR 5826's producer-side pxr deferral, applied on top of PR 5771's `resolve_backend_and_visualizer` helper, lets the demo script keep imports at module top — the canonical IsaacLab idiom
- The deferred-imports-inside-`design_scene()` workaround in PR 5771 is no longer needed
- 1 demo script touched (8 lines moved)

## 2. Branch composition

This branch chains three sets of changes for review-as-one. Diff order against `develop`:

1. PR https://github.com/isaac-sim/IsaacLab/pull/5826 commits (`80b86a01070`, `33d40434df5`): producer-side pxr deferral in `source/isaaclab/isaaclab/assets/asset_base.py` and `source/isaaclab/isaaclab/sim/simulation_context.py`.
2. PR https://github.com/isaac-sim/IsaacLab/pull/5771 commits (merged at `6c292c1802b`): YizeWang's `scripts/demos/demo_helper.py` and `scripts/demos/quadrupeds.py` with `resolve_backend_and_visualizer`.
3. This branch's commit `690f2805f09`: lift the deferred imports back to module top in `scripts/demos/quadrupeds.py`.

## 3. Mechanism

After (1), `from isaaclab.assets import Articulation`, `from isaaclab.sim import SimulationContext`, and `import isaaclab.sim as sim_utils` all keep `sys.modules` free of ``pxr``/``omni``/``carb``/``isaacsim`` until a runtime touch (e.g. ``sim_utils.SimulationContext.instance()``).

(3) takes advantage of this: the 7 deferred imports inside `design_scene()` and 1 inside `main()` move back to module top, ordered after `args_cli = parser.parse_args()` to match the existing ``"""Parse CLI first so we can decide whether to launch Isaac Sim Kit."""`` block.

`resolve_backend_and_visualizer` from PR 5771 still gates the conditional `AppLauncher` launch inside the `with` block; the script's behavior under `--physics newton_mjwarp --visualizer newton` (no Kit) is unchanged.

## 4. Verification

Ran the script end-to-end (step-capped, headless) for all four backend combinations from the docstring:

| Combo | Outcome |
|---|---|
| `--physics newton_mjwarp --visualizer newton` (kit-less) | `[INFO]: Setup complete`, sim stepped, rc=0 |
| `--physics newton_mjwarp --visualizer kit` | rc=0 |
| `--physics physx --visualizer newton` | rc=0 |
| `--physics physx --visualizer kit` | rc=0 |

Plus an `assert "pxr" not in sys.modules` immediately after the module-top asset imports — passed in every case.

## 5. Out of scope

- This PR does not propose merging on its own. It chains 5826 and 5771 into a reviewable single state so reviewers can see the end shape if both land.
- If PR 5771 merges first, the relaxation here becomes a one-commit follow-up on top of 5826.
- If PR 5826 merges first, the relaxation here can be folded into PR 5771's branch directly.

## 6. Test plan

- [x] `./isaaclab.sh -f` clean
- [x] End-to-end run of `quadrupeds.py` across all 4 backend combinations
- [ ] Existing demo / tutorial tests still green on PhysX backend
- [ ] Existing Newton kitless demo tests still green