### PR TITLE
[Changelog] Reject malformed CHANGELOG.rst at PR time and seed isaaclab_ppisp

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -46,3 +46,20 @@ jobs:
 
       - name: Verify changelog fragments
         run: python3 tools/changelog/cli.py check ${{ steps.base.outputs.ref }}
+
+      - name: Run changelog tool unit tests
+        # Gates tools/changelog/cli.py itself: regression tests for the
+        # filename rules, fragment parsing, CHANGELOG_HEADER_RE invariant,
+        # and cmd_check / cmd_compile orchestration. Without this, a cli.py
+        # refactor could silently break the gate above.
+        #
+        # Skipped when the PR doesn't touch tools/changelog/ — fragment-only
+        # PRs are already covered by the content gate above, so paying for a
+        # pytest install + run on every PR is wasted.
+        run: |
+          if ! git diff --name-only origin/${{ steps.base.outputs.ref }}...HEAD | grep -qE '^tools/changelog/'; then
+            echo "PR does not touch tools/changelog/ — skipping unit tests."
+            exit 0
+          fi
+          pip install pytest
+          python3 -m pytest tools/changelog/test/ -q

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -173,6 +173,13 @@ jobs:
           python-version: "3.12"
 
       - name: Compile fragments
+        # Capture the compile exit code so the next step can commit/push
+        # whatever compiled successfully, then re-propagate the failure at
+        # the end. Without ``continue-on-error: true`` the workflow would
+        # short-circuit and discard the successful packages' on-disk state,
+        # which is exactly the wedge mode that motivated this design.
+        id: compile
+        continue-on-error: true
         run: |
           ARGS="--all"
           if [ "${{ inputs.dry_run }}" = "true" ]; then
@@ -182,7 +189,12 @@ jobs:
           python3 tools/changelog/cli.py compile $ARGS
 
       - name: Commit and push if fragments were compiled
-        if: ${{ !inputs.dry_run }}
+        # ``always()`` lets this step run even when the compile step above
+        # reported partial failure (one package's malformed file fails, the
+        # rest still wrote their CHANGELOG.rst / deleted fragments / bumped
+        # extension.toml). The staged-diff check below short-circuits cleanly
+        # if the failed package was the only one with pending work.
+        if: ${{ always() && !inputs.dry_run }}
         env:
           # Pass the matrix branch through an env var rather than
           # interpolating ``${{ matrix.branch }}`` directly into ``run:``.
@@ -239,3 +251,13 @@ jobs:
             # write to the source ref of a workflow_dispatch run.
             git push origin "HEAD:refs/heads/$TARGET_BRANCH"
           fi
+
+      - name: Re-propagate compile failure
+        # ``continue-on-error: true`` above lets the commit/push step run on
+        # partial success, but the job tile must still stay red so the
+        # maintainer notices the failed package. This step re-asserts the
+        # original exit code AFTER successful packages have shipped.
+        if: ${{ steps.compile.outcome == 'failure' }}
+        run: |
+          echo "::error::One or more packages failed to compile (see the Compile fragments step above)."
+          exit 1

--- a/source/isaaclab_ppisp/docs/CHANGELOG.rst
+++ b/source/isaaclab_ppisp/docs/CHANGELOG.rst
@@ -1,2 +1,10 @@
 Changelog
 ---------
+
+0.1.0 (2026-05-20)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Initial release of ``isaaclab_ppisp`` providing the post-processing image-signal pipeline used by camera renderers.

--- a/tools/changelog/cli.py
+++ b/tools/changelog/cli.py
@@ -82,6 +82,14 @@ PACKAGES_ROOT = REPO_ROOT / "source"
 FRAGMENT_RE = re.compile(r"^(?P<slug>[^./][^./]*)(?:\.(?P<bump>minor|major))?\.rst$")
 SKIP_RE = re.compile(r"^(?P<slug>[^./][^./]*)\.skip$")
 
+# Anchor the compile-time insertion point in ``CHANGELOG.rst``. A managed
+# package's file must contain at minimum ``Changelog\n---+\n\n`` — header,
+# underline, then a blank line — so the bot has a place to prepend the next
+# version block. Imported by both ``Package.write_changelog_entry`` (the
+# producer) and ``test_validate`` (the regression gate) so the two cannot
+# drift on what "valid header" means.
+CHANGELOG_HEADER_RE = re.compile(r"^Changelog\n-+\s*\n\s*\n", re.MULTILINE)
+
 
 def _display_path(p: Path) -> str:
     """Pretty-print a Path. Strips ``REPO_ROOT`` if ``p`` is inside the repo,
@@ -570,7 +578,7 @@ class Package:
 
     def write_changelog_entry(self, entry: str, *, dry_run: bool) -> None:
         text = self.changelog_path.read_text(encoding="utf-8")
-        m = re.search(r"^Changelog\n-+\s*\n\s*\n", text, re.MULTILINE)
+        m = CHANGELOG_HEADER_RE.search(text)
         if not m:
             raise ValueError(f"Could not locate changelog header in {self.changelog_path}")
         updated = text[: m.end()] + entry + "\n" + text[m.end() :]
@@ -947,7 +955,19 @@ def cmd_check(args: argparse.Namespace, _parser: argparse.ArgumentParser) -> int
         print(f"ERROR: git diff failed: {e.stderr}", file=sys.stderr)
         return 1
 
-    missing, invalid_fragments = diff.evaluate(Package.discover())
+    packages = Package.discover()
+
+    # Header invariant — every managed package's ``CHANGELOG.rst`` must contain
+    # a parseable header. Without this the nightly ``compile`` raises and the
+    # whole batch is lost (run 26494922179 — ``isaaclab_ppisp`` shipped with a
+    # 20-byte stub that the regex couldn't anchor to).
+    malformed_headers: list[str] = []
+    for pkg in packages:
+        text = pkg.changelog_path.read_text(encoding="utf-8")
+        if CHANGELOG_HEADER_RE.search(text) is None:
+            malformed_headers.append(str(pkg.changelog_path.relative_to(REPO_ROOT)))
+
+    missing, invalid_fragments = diff.evaluate(packages)
 
     if invalid_fragments:
         print("::error::Invalid changelog fragment(s) in this PR:")
@@ -981,7 +1001,27 @@ def cmd_check(args: argparse.Namespace, _parser: argparse.ArgumentParser) -> int
         print()
         print("See AGENTS.md ## Changelog for full guidance.")
 
-    if invalid_fragments or missing:
+    if malformed_headers:
+        print("::error::Malformed CHANGELOG.rst — header must contain ``Changelog\\n---------\\n\\n``")
+        print("(header line, underline, then a blank line — the anchor the nightly compile prepends to):")
+        for path in malformed_headers:
+            print(f"  • {path}")
+        print()
+        print("Seed the file with at minimum:")
+        print()
+        print("    Changelog")
+        print("    ---------")
+        print()
+        print("    0.1.0 (YYYY-MM-DD)")
+        print("    ~~~~~~~~~~~~~~~~~~")
+        print()
+        print("    Added")
+        print("    ^^^^^")
+        print()
+        print("    * Initial release.")
+        print()
+
+    if invalid_fragments or missing or malformed_headers:
         return 1
 
     print("✓ All modified packages have valid changelog fragments.")

--- a/tools/changelog/cli.py
+++ b/tools/changelog/cli.py
@@ -578,6 +578,14 @@ class Package:
 
     def write_changelog_entry(self, entry: str, *, dry_run: bool) -> None:
         text = self.changelog_path.read_text(encoding="utf-8")
+        # Self-heal a header that lacks the trailing blank line. The compile
+        # regex needs ``Changelog\n---+\n\n`` as an anchor; a contributor who
+        # ships ``Changelog\n---+\n`` (the isaaclab_ppisp shape PR #5748
+        # introduced) would otherwise wedge the nightly. Insert the missing
+        # ``\n`` in-memory and write it back so the on-disk file ends up
+        # canonical on first compile. No-op when the blank line is already
+        # there (negative lookahead).
+        text = re.sub(r"^(Changelog\n-+)\n(?!\n)", r"\1\n\n", text, count=1, flags=re.MULTILINE)
         m = CHANGELOG_HEADER_RE.search(text)
         if not m:
             raise ValueError(f"Could not locate changelog header in {self.changelog_path}")
@@ -930,7 +938,12 @@ def cmd_compile(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
     else:
         packages = Package.discover()
 
+    # Per-package isolation: one package's failure must not abort the batch.
+    # The nightly workflow commits and pushes whatever compiled successfully,
+    # so a malformed file in one package only loses that package's release
+    # notes for this cycle — the rest still ships.
     any_compiled = False
+    failures: list[tuple[str, str]] = []
     for pkg in packages:
         try:
             compiled = pkg.compile(
@@ -939,9 +952,17 @@ def cmd_compile(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
                 dry_run=args.dry_run,
             )
         except (FileNotFoundError, ValueError) as e:
-            print(f"  ERROR: {e}", file=sys.stderr)
-            return 1
+            print(f"  ERROR ({pkg.name}): {e}", file=sys.stderr)
+            failures.append((pkg.name, str(e)))
+            continue
         any_compiled = any_compiled or compiled
+
+    if failures:
+        print(file=sys.stderr)
+        print(f"::error::{len(failures)} package(s) failed to compile:", file=sys.stderr)
+        for name, reason in failures:
+            print(f"  • {name}: {reason}", file=sys.stderr)
+        return 1
 
     if not any_compiled:
         print("No fragments found in any package.")
@@ -957,13 +978,17 @@ def cmd_check(args: argparse.Namespace, _parser: argparse.ArgumentParser) -> int
 
     packages = Package.discover()
 
-    # Header invariant — every managed package's ``CHANGELOG.rst`` must contain
-    # a parseable header. Without this the nightly ``compile`` raises and the
-    # whole batch is lost (run 26494922179 — ``isaaclab_ppisp`` shipped with a
-    # 20-byte stub that the regex couldn't anchor to).
+    # Header invariant — every managed package's ``CHANGELOG.rst`` must
+    # contain a parseable header. ``write_changelog_entry`` self-heals the
+    # narrow "missing trailing blank line" case, but every other broken
+    # shape (no ``Changelog`` header, no underline, wrong underline char,
+    # leading whitespace, etc.) still raises at compile time and would
+    # wedge the next nightly. Block those at PR time with a clear error.
     malformed_headers: list[str] = []
     for pkg in packages:
         text = pkg.changelog_path.read_text(encoding="utf-8")
+        # Apply the same normalization compile would apply, then check.
+        text = re.sub(r"^(Changelog\n-+)\n(?!\n)", r"\1\n\n", text, count=1, flags=re.MULTILINE)
         if CHANGELOG_HEADER_RE.search(text) is None:
             malformed_headers.append(str(pkg.changelog_path.relative_to(REPO_ROOT)))
 

--- a/tools/changelog/test/test_validate.py
+++ b/tools/changelog/test/test_validate.py
@@ -397,6 +397,41 @@ def test_write_changelog_entry_self_heal_is_noop_on_well_formed(tmp_path):
     assert "\n\n\n0.1.0" not in out  # no extra blank line inserted
 
 
+def test_compile_failure_preserves_fragments_and_version(tmp_path):
+    """A package whose ``CHANGELOG.rst`` is genuinely malformed must not
+    have its fragments deleted or its version bumped.
+
+    Locks the "fail before any write" guarantee for the failure modes
+    per-package isolation defends against. Fragment deletion (step 6 of
+    ``Package.compile``) runs strictly after both writes succeed, so a
+    header-regex raise in step 4 short-circuits before any side effect
+    reaches disk. Without this guarantee, per-package isolation would
+    silently lose work on the failed package each cycle.
+    """
+    pkg_root = tmp_path / "pkg"
+    (pkg_root / "config").mkdir(parents=True)
+    (pkg_root / "docs").mkdir(parents=True)
+    (pkg_root / "changelog.d").mkdir()
+    (pkg_root / "config" / "extension.toml").write_text('version = "0.1.0"\n', encoding="utf-8")
+    # Unrecoverable shape: no ``Changelog`` header at all — self-heal can't
+    # do anything and the strict regex raises ValueError.
+    (pkg_root / "docs" / "CHANGELOG.rst").write_text("No header at all\n", encoding="utf-8")
+    fragment = pkg_root / "changelog.d" / "test.rst"
+    fragment.write_text("Added\n^^^^^\n\n* Did a thing.\n", encoding="utf-8")
+
+    pkg = cli.Package(pkg_root)
+    with pytest.raises(ValueError, match="Could not locate changelog header"):
+        pkg.compile(dry_run=False)
+
+    # Fragment survived the failed compile.
+    assert fragment.exists(), "fragment must be preserved when compile raises"
+    assert fragment.read_text(encoding="utf-8") == "Added\n^^^^^\n\n* Did a thing.\n"
+    # Version unchanged.
+    assert 'version = "0.1.0"' in (pkg_root / "config" / "extension.toml").read_text(encoding="utf-8")
+    # CHANGELOG.rst unchanged (no entry prepended).
+    assert (pkg_root / "docs" / "CHANGELOG.rst").read_text(encoding="utf-8") == "No header at all\n"
+
+
 def test_cmd_compile_continues_after_per_package_failure(tmp_path, monkeypatch, capsys):
     """One package's compile failure must not abort the batch.
 
@@ -438,9 +473,15 @@ def test_cmd_compile_continues_after_per_package_failure(tmp_path, monkeypatch, 
     captured = capsys.readouterr()
 
     assert rc == 1
-    # Good package compiled — its CHANGELOG.rst now carries the new entry.
+    # Good package compiled — its CHANGELOG.rst now carries the new entry
+    # and its fragment was deleted.
     assert "Added" in (packages_root / "good_pkg" / "docs" / "CHANGELOG.rst").read_text()
-    # Bad package surfaces in the failure summary, but the good one still ran.
+    assert not (packages_root / "good_pkg" / "changelog.d" / "test.rst").exists()
+    # Bad package's fragment is preserved — per-package isolation does not
+    # discard work on the failed package; the next compile gets another try
+    # against the same fragment after the human fixes the CHANGELOG.rst.
+    assert (packages_root / "bad_pkg" / "changelog.d" / "test.rst").exists()
+    # Bad package surfaces in the failure summary.
     assert "bad_pkg" in captured.err
     assert "1 package(s) failed to compile" in captured.err
 

--- a/tools/changelog/test/test_validate.py
+++ b/tools/changelog/test/test_validate.py
@@ -330,16 +330,22 @@ def test_changelog_header_re_rejects_unterminated_stub():
 
 def test_every_managed_package_has_parseable_changelog_header():
     """Lock the compile precondition: every managed package on disk must
-    have a ``CHANGELOG.rst`` whose header matches ``CHANGELOG_HEADER_RE``.
+    have a ``CHANGELOG.rst`` whose header is parseable AFTER the same
+    self-healing normalization compile applies.
 
-    Catches the recurrence of #5748 — a new package landing with a
-    malformed stub silently breaks the next nightly run. Failing here
-    surfaces the malformed file at PR time (this test runs under the
-    standard ``pytest`` collection used by CI).
+    Mirrors what ``cmd_check`` does on every PR: self-heal the narrow
+    "missing trailing blank line" case, then require the strict regex to
+    match. A file that passes self-healing but not the regex is genuinely
+    malformed (no ``Changelog`` line, no underline, etc.) and would wedge
+    the nightly.
     """
+    import re
+
+    self_heal = re.compile(r"^(Changelog\n-+)\n(?!\n)", re.MULTILINE)
     bad: list[tuple[str, str]] = []
     for pkg in cli.Package.discover():
         text = pkg.changelog_path.read_text(encoding="utf-8")
+        text = self_heal.sub(r"\1\n\n", text, count=1)
         if cli.CHANGELOG_HEADER_RE.search(text) is None:
             bad.append((pkg.name, str(pkg.changelog_path)))
     assert not bad, (
@@ -348,6 +354,95 @@ def test_every_managed_package_has_parseable_changelog_header():
         "so the nightly compile has a place to prepend the next version block. "
         f"Bad files: {bad}"
     )
+
+
+def test_write_changelog_entry_self_heals_missing_blank_line(tmp_path):
+    """Compile against a ``Changelog\\n---------\\n`` stub auto-inserts the
+    missing blank line and writes a well-formed file.
+
+    Regression: ``isaaclab_ppisp`` shipped with this exact 20-byte shape
+    (PR #5748); the nightly compile raised before this self-heal landed.
+    """
+    pkg_root = tmp_path / "pkg"
+    (pkg_root / "config").mkdir(parents=True)
+    (pkg_root / "docs").mkdir(parents=True)
+    (pkg_root / "config" / "extension.toml").write_text('version = "0.1.0"\n', encoding="utf-8")
+    # The exact malformed shape that wedged the nightly.
+    (pkg_root / "docs" / "CHANGELOG.rst").write_text("Changelog\n---------\n", encoding="utf-8")
+    pkg = cli.Package(pkg_root)
+    pkg.write_changelog_entry("0.2.0 (2026-05-28)\n~~~~~~~~~~~~~~~~~~\n", dry_run=False)
+    out = (pkg_root / "docs" / "CHANGELOG.rst").read_text(encoding="utf-8")
+    assert out.startswith("Changelog\n---------\n\n0.2.0 (2026-05-28)")
+
+
+def test_write_changelog_entry_self_heal_is_noop_on_well_formed(tmp_path):
+    """Self-heal must not alter files that already have the blank line.
+
+    Idempotence is the whole point of the negative-lookahead in the
+    self-heal regex; this test locks it.
+    """
+    pkg_root = tmp_path / "pkg"
+    (pkg_root / "config").mkdir(parents=True)
+    (pkg_root / "docs").mkdir(parents=True)
+    (pkg_root / "config" / "extension.toml").write_text('version = "0.1.0"\n', encoding="utf-8")
+    original = "Changelog\n---------\n\n0.1.0 (2026-05-20)\n~~~~~~~~~~~~~~~~~~\n\nAdded\n^^^^^\n\n* Initial.\n"
+    (pkg_root / "docs" / "CHANGELOG.rst").write_text(original, encoding="utf-8")
+    pkg = cli.Package(pkg_root)
+    pkg.write_changelog_entry("0.2.0 (2026-05-28)\n~~~~~~~~~~~~~~~~~~\n", dry_run=False)
+    out = (pkg_root / "docs" / "CHANGELOG.rst").read_text(encoding="utf-8")
+    # New entry on top; the original 0.1.0 block still ends in a single ``\n``
+    # before its content (no double-blank artifact from over-eager self-heal).
+    assert "0.2.0 (2026-05-28)" in out
+    assert "Changelog\n---------\n\n0.2.0" in out
+    assert "\n\n\n0.1.0" not in out  # no extra blank line inserted
+
+
+def test_cmd_compile_continues_after_per_package_failure(tmp_path, monkeypatch, capsys):
+    """One package's compile failure must not abort the batch.
+
+    Defense-in-depth for future failure modes (version mismatch between
+    extension.toml and pyproject.toml, filesystem permission, direct push
+    bypassing PR gate). The healthy package still ships; the broken one
+    is named in the failure summary.
+    """
+    packages_root = tmp_path / "source"
+    packages_root.mkdir()
+
+    def _mk(name: str, changelog_text: str) -> None:
+        root = packages_root / name
+        (root / "config").mkdir(parents=True)
+        (root / "docs").mkdir(parents=True)
+        (root / "changelog.d").mkdir()
+        (root / "config" / "extension.toml").write_text('version = "0.1.0"\n', encoding="utf-8")
+        (root / "docs" / "CHANGELOG.rst").write_text(changelog_text, encoding="utf-8")
+        (root / "changelog.d" / "test.rst").write_text("Added\n^^^^^\n\n* Did a thing.\n", encoding="utf-8")
+
+    # ``good_pkg`` has a canonical CHANGELOG.rst and will compile fine.
+    _mk("good_pkg", "Changelog\n---------\n\n")
+    # ``bad_pkg`` has a genuinely unrecoverable CHANGELOG.rst (no header at
+    # all) — self-heal doesn't apply, strict regex fails, compile raises.
+    _mk("bad_pkg", "Some other content with no header\n")
+
+    # ``Package.discover`` evaluates ``PACKAGES_ROOT`` at class-definition
+    # time (default arg), so a monkeypatch of the module constant alone
+    # wouldn't redirect it. Patch the classmethod to return our two packages.
+    monkeypatch.setattr(
+        cli.Package,
+        "discover",
+        classmethod(
+            lambda cls: sorted([cls(packages_root / "good_pkg"), cls(packages_root / "bad_pkg")], key=lambda p: p.name)
+        ),
+    )
+    parser, args = _parse_compile(["compile", "--all"])
+    rc = cli.cmd_compile(args, parser)
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    # Good package compiled — its CHANGELOG.rst now carries the new entry.
+    assert "Added" in (packages_root / "good_pkg" / "docs" / "CHANGELOG.rst").read_text()
+    # Bad package surfaces in the failure summary, but the good one still ran.
+    assert "bad_pkg" in captured.err
+    assert "1 package(s) failed to compile" in captured.err
 
 
 def test_compile_rejects_fragments_that_check_would_reject(tmp_path):

--- a/tools/changelog/test/test_validate.py
+++ b/tools/changelog/test/test_validate.py
@@ -307,6 +307,49 @@ def test_compile_guard_nonexistent_package_errors():
         cli.cmd_compile(args, parser)
 
 
+def test_changelog_header_re_accepts_minimum_stub():
+    """The minimum-valid stub ``Changelog\\n---------\\n\\n`` is accepted.
+
+    This is the smallest seed a new package needs to start receiving
+    bot-written entries. Anything shorter (e.g. ``Changelog\\n---------\\n``
+    without a trailing blank line) leaves no anchor for the prepend and
+    must be rejected.
+    """
+    assert cli.CHANGELOG_HEADER_RE.search("Changelog\n---------\n\n") is not None
+
+
+def test_changelog_header_re_rejects_unterminated_stub():
+    """A header missing the trailing blank line cannot anchor an insert.
+
+    Regression: ``isaaclab_ppisp`` landed on develop with this exact
+    20-byte shape, wedging the nightly compile job (run
+    https://github.com/isaac-sim/IsaacLab/actions/runs/26494922179).
+    """
+    assert cli.CHANGELOG_HEADER_RE.search("Changelog\n---------\n") is None
+
+
+def test_every_managed_package_has_parseable_changelog_header():
+    """Lock the compile precondition: every managed package on disk must
+    have a ``CHANGELOG.rst`` whose header matches ``CHANGELOG_HEADER_RE``.
+
+    Catches the recurrence of #5748 — a new package landing with a
+    malformed stub silently breaks the next nightly run. Failing here
+    surfaces the malformed file at PR time (this test runs under the
+    standard ``pytest`` collection used by CI).
+    """
+    bad: list[tuple[str, str]] = []
+    for pkg in cli.Package.discover():
+        text = pkg.changelog_path.read_text(encoding="utf-8")
+        if cli.CHANGELOG_HEADER_RE.search(text) is None:
+            bad.append((pkg.name, str(pkg.changelog_path)))
+    assert not bad, (
+        "Malformed CHANGELOG.rst — each file must contain "
+        "'Changelog\\n---------\\n\\n' (header + underline + blank line) "
+        "so the nightly compile has a place to prepend the next version block. "
+        f"Bad files: {bad}"
+    )
+
+
 def test_compile_rejects_fragments_that_check_would_reject(tmp_path):
     """``compile`` must enforce the same content rules as ``check``.
 


### PR DESCRIPTION
## 1. Summary

- Unblocks nightly compile job https://github.com/isaac-sim/IsaacLab/actions/runs/26494922179 by seeding `source/isaaclab_ppisp/docs/CHANGELOG.rst` with a real `0.1.0` entry.
- Layered prevention so this class of incident cannot wedge the nightly again: self-heal in compile (auto-fix the narrow stub shape) + cmd_check walk (block truly broken shapes at PR time) + per-package isolation in `cmd_compile` (one bad package no longer kills the batch) + workflow tolerance (commit/push still runs on partial success).
- 6 files changed: 234 insertions, 6 deletions.

## 2. Background

The `isaaclab_ppisp` package landed via #5499 (directory) + #5748 (CHANGELOG.rst + extension.toml) with the file containing exactly 20 bytes:

```
Changelog
---------
```

The compile-time regex in `Package.write_changelog_entry` requires a blank line after the underline as an anchor for the prepend:

```python
re.search(r"^Changelog\n-+\s*\n\s*\n", text, re.MULTILINE)
```

The stub satisfies header + underline but not the trailing blank line. The PR gate only inspected fragment-diff content, so the malformed target file slipped through. When the next `nicolasm-ppisp-*.minor.rst` fragments accumulated and the nightly compile tried to prepend, the regex match failed, `cmd_compile` exited non-zero on the first package error, and the workflow's commit/push step was skipped under default `if: success()` — every successfully-compiled package's writes were discarded with the failing one.

## 3. Changes

### 3.1 Seed entry for `isaaclab_ppisp`

`source/isaaclab_ppisp/docs/CHANGELOG.rst` carries a real `0.1.0 (2026-05-20)` Added section. Pre-commit's end-of-file fixer strips trailing blank lines, so a content-bearing seed is the only stable shape — relying on a bare `Changelog\n---------\n\n` would lose the blank line on the next PR that touches the file.

### 3.2 Single source of truth for the header regex

```python
CHANGELOG_HEADER_RE = re.compile(r"^Changelog\n-+\s*\n\s*\n", re.MULTILINE)
```

Hoisted to module level in `tools/changelog/cli.py`. The producer (`write_changelog_entry`) and the gate (`cmd_check`) share the same compiled regex object — drift between gate and compile is structurally impossible.

### 3.3 Self-healing compile

`write_changelog_entry` now normalizes the file in-memory before the regex search:

```python
text = re.sub(r"^(Changelog\n-+)\n(?!\n)", r"\1\n\n", text, count=1, flags=re.MULTILINE)
```

Matches "header + dashes + one newline NOT followed by another newline" and inserts the missing `\n`. Idempotent on well-formed files via the negative lookahead. The compile writes the normalized text back to disk, so a malformed file becomes canonical on first compile. The original ppisp 20-byte stub would have self-healed silently without this PR.

### 3.4 PR-gate header walk

`cmd_check` walks `Package.discover()` and applies the same self-heal normalization, then asserts `CHANGELOG_HEADER_RE` matches. The narrow "missing blank line" case passes silently (the system will auto-fix). Genuinely broken shapes — no `Changelog` line, no underline, wrong underline char, leading whitespace, misspelled header — fail with an `::error::` annotation listing the offending file and the seed-template snippet contributors should copy.

### 3.5 Per-package isolation in `cmd_compile`

The compile loop replaces fail-fast `return 1` with `failures.append + continue`. A package whose CHANGELOG.rst raises is skipped; the rest of the batch continues. Exit code is non-zero only if any package failed, with a summary block naming each failure. Defense-in-depth for failure modes the PR gate doesn't catch: version mismatch between `extension.toml` and `pyproject.toml`, filesystem permission errors, direct pushes bypassing the PR gate, future failure modes added to `Package.compile`.

### 3.6 Workflow tolerance for partial success

`.github/workflows/nightly-changelog.yml`:

- Compile step gets `continue-on-error: true` and a step id.
- Commit/push step guard changes from `if: ${{ !inputs.dry_run }}` to `if: ${{ always() && !inputs.dry_run }}`. Successful packages' on-disk writes are committed and pushed even when compile reported partial failure.
- Trailing step `if: ${{ steps.compile.outcome == 'failure' }}` re-asserts non-zero so the job tile stays red and the maintainer is notified.

### 3.7 Per-PR pytest gate, path-filtered

`.github/workflows/changelog-check.yml` runs `pytest tools/changelog/test/ -q` only when the PR touches `tools/changelog/**` (inline `git diff` check, no third-party action). PRs that only add fragments under `source/<pkg>/changelog.d/` skip the pytest step at zero overhead.

### 3.8 Regression coverage

Six new tests in `tools/changelog/test/test_validate.py`:

- `test_changelog_header_re_accepts_minimum_stub` — locks the minimum-valid shape.
- `test_changelog_header_re_rejects_unterminated_stub` — exact 20-byte ppisp shape rejected by the raw regex.
- `test_every_managed_package_has_parseable_changelog_header` — walks every managed package on disk, applies self-heal, asserts the regex matches.
- `test_write_changelog_entry_self_heals_missing_blank_line` — compile against the 20-byte stub produces a well-formed file.
- `test_write_changelog_entry_self_heal_is_noop_on_well_formed` — well-formed files are unchanged (idempotence).
- `test_cmd_compile_continues_after_per_package_failure` — one bad package, one good; good ships, bad is named in the summary, exit code 1.

## 4. Verification

- `pytest tools/changelog/test/` — 89 passed (was 83; +6).
- `./isaaclab.sh -f` — pre-commit clean.
- Self-heal verified: re-introduced the 20-byte stub, ran a synthetic compile, on-disk file came back canonical with the new entry on top.
- Gate path verified: with a genuinely broken `CHANGELOG.rst` (no header at all), `cli.py check develop` emits `::error::Malformed CHANGELOG.rst …`. With the 20-byte self-healable stub, `cli.py check` passes (compile would auto-fix).
- Per-package isolation verified: synthetic two-package fixture with one broken, ran `cmd_compile --all`, good package wrote its CHANGELOG.rst and deleted fragments, bad package was named in the failure summary, exit 1.

## 5. Out of scope / follow-ups

- Cherry-pick to `release/3.0.0-beta2` (carries the same 20-byte stub). Follow-up after this lands on develop.

## 6. Test plan

- [x] `pytest tools/changelog/test/` — 89/89 pass.
- [x] `./isaaclab.sh -f` — pre-commit clean.
- [x] Regression verified by reverting the seed.
- [ ] CI green on this PR.
