### PR TITLE
WIP: Kamino Implicit Joint

### DIFF
--- a/source/isaaclab/isaaclab/actuators/actuator_base.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_base.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import torch
 
@@ -41,6 +41,16 @@ class ActuatorBase(ABC):
     """Flag indicating if the actuator is an implicit or explicit actuator model.
 
     If a class inherits from :class:`ImplicitActuator`, then this flag should be set to :obj:`True`.
+    """
+
+    route_torque_to: ClassVar[Literal["joint_f", "joint_act"]] = "joint_f"
+    """Where the per-step actuator-computed torque is written into Newton's ``Control``.
+
+    - ``"joint_f"`` (default): torque is written to ``Control.joint_f`` and enters the
+      body wrench, integrated semi-explicitly. This matches PhysX/MuJoCo semantics.
+    - ``"joint_act"``: torque is written to ``Control.joint_act`` instead. For the Kamino
+      solver this enters the joint dynamic-constraint row of the PADMM solve, getting 
+      backward-Euler treatment of joint armature and damping.
     """
 
     computed_effort: torch.Tensor

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -311,6 +311,7 @@ class Articulation(BaseArticulation):
             # Standard Lab actuator path
             self._apply_actuator_model()
             self.data._sim_bind_joint_effort.assign(self._joint_effort_target_sim)
+            self.data._sim_bind_joint_act.assign(self._joint_act_target_sim)
             if self._has_implicit_actuators:
                 self.data._sim_bind_joint_position_target.assign(self._joint_pos_target_sim)
                 self.data._sim_bind_joint_velocity_target.assign(self._joint_vel_target_sim)
@@ -3486,6 +3487,7 @@ class Articulation(BaseArticulation):
         self._joint_pos_target_sim = wp.zeros_like(self.data.joint_pos_target.warp, device=self.device)
         self._joint_vel_target_sim = wp.zeros_like(self.data.joint_pos_target.warp, device=self.device)
         self._joint_effort_target_sim = wp.zeros_like(self.data.joint_pos_target.warp, device=self.device)
+        self._joint_act_target_sim = wp.zeros_like(self.data.joint_pos_target.warp, device=self.device)
 
         # soft joint position limits (recommended not to be too close to limits).
         wp.launch(
@@ -3889,6 +3891,9 @@ class Articulation(BaseArticulation):
                 gear_ratio = actuator.gear_ratio
             else:
                 gear_ratio = None
+            target_torque_buf = (
+                self._joint_act_target_sim if actuator.route_torque_to == "joint_act" else self._joint_effort_target_sim
+            )
             wp.launch(
                 articulation_kernels.update_targets,
                 dim=(self.num_instances, joint_indices.shape[0]),
@@ -3901,7 +3906,7 @@ class Articulation(BaseArticulation):
                 outputs=[
                     self._joint_pos_target_sim,
                     self._joint_vel_target_sim,
-                    self._joint_effort_target_sim,
+                    target_torque_buf,
                 ],
                 device=self.device,
             )

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -321,6 +321,20 @@ class ArticulationData(BaseArticulationData):
         """
         return self._applied_torque_ta
 
+    @property
+    def joint_act_target(self) -> ProxyArray:
+        """Per-DOF feedforward actuation written to Newton's ``Control.joint_act``.
+
+        Shape is (num_instances, num_joints), dtype = wp.float32. In torch this resolves to
+        (num_instances, num_joints).
+
+        Populated each ``write_data_to_sim`` from the per-actuator computed torques whose
+        :attr:`~isaaclab.actuators.ActuatorBase.route_torque_to` is set to ``"joint_act"``.
+        For the Kamino solver this becomes ``pd_tau_j_ff`` and feeds the implicit joint
+        dynamic-constraint row.
+        """
+        return self._joint_act_target_ta
+
     """
     Joint properties
     """
@@ -1787,6 +1801,7 @@ class ArticulationData(BaseArticulationData):
             self._joint_pos_limits_upper_ta = ProxyArray(self._sim_bind_joint_pos_limits_upper)
             self._joint_vel_limits_ta = ProxyArray(self._sim_bind_joint_vel_limits_sim)
             self._joint_effort_limits_ta = ProxyArray(self._sim_bind_joint_effort_limits_sim)
+            self._joint_act_target_ta = ProxyArray(self._sim_bind_joint_act)
             self._body_mass_ta = ProxyArray(self._sim_bind_body_mass)
             self._body_inertia_ta = ProxyArray(self._sim_bind_body_inertia)
             self._body_com_pos_b_ta = ProxyArray(self._sim_bind_body_com_pos_b)
@@ -1818,6 +1833,7 @@ class ArticulationData(BaseArticulationData):
             self._joint_pos_limits_upper_ta = ProxyArray(self._sim_bind_joint_pos_limits_upper)
             self._joint_vel_limits_ta = ProxyArray(self._sim_bind_joint_vel_limits_sim)
             self._joint_effort_limits_ta = ProxyArray(self._sim_bind_joint_effort_limits_sim)
+            self._joint_act_target_ta = ProxyArray(self._sim_bind_joint_act)
             self._soft_joint_pos_limits_ta = ProxyArray(self._soft_joint_pos_limits)
             self._soft_joint_vel_limits_ta = ProxyArray(self._soft_joint_vel_limits)
             self._gear_ratio_ta = ProxyArray(self._gear_ratio)

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -119,7 +119,20 @@ class NewtonKaminoManager(NewtonManager):
         Sets :attr:`NewtonManager._needs_collision_pipeline` to ``True`` only
         when ``use_collision_detector=False`` (Kamino's internal detector
         handles contacts otherwise).
+
+        Applies :attr:`KaminoSolverCfg.max_contacts_per_world`, when set, by overriding
+        ``model.rigid_contact_max`` before solver construction. This bounds GPU memory
+        for contact-rich multi-env training that would otherwise over-allocate from
+        ``geoms.world_minimum_contacts``.
         """
+        if solver_cfg.max_contacts_per_world is not None:
+            model.rigid_contact_max = int(solver_cfg.max_contacts_per_world) * model.world_count
+            logger.info(
+                "[KAMINO] Capping rigid_contact_max to %d (%d/world * %d worlds)",
+                model.rigid_contact_max,
+                solver_cfg.max_contacts_per_world,
+                model.world_count,
+            )
         NewtonManager._solver = SolverKamino(model, solver_cfg.to_solver_config())
         NewtonManager._use_single_state = False
         NewtonManager._needs_collision_pipeline = not solver_cfg.use_collision_detector

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
@@ -145,6 +145,16 @@ class KaminoSolverCfg(NewtonSolverCfg):
     Only used when :attr:`use_collision_detector` is ``True``. If ``None``, Newton's default is used.
     """
 
+    max_contacts_per_world: int | None = None
+    """Cap the per-world contact pre-allocation handed to Kamino.
+
+    When ``None``, Kamino falls back to ``geoms.world_minimum_contacts`` derived from the
+    collision pipeline, which over-allocates dramatically for contact-rich assets. Set this
+    to bound GPU memory for multi-env training of contact-heavy tasks (e.g. legged
+    locomotion or manipulation). The total ``model.rigid_contact_max`` is computed as
+    ``max_contacts_per_world * model.world_count`` before solver construction.
+    """
+
     dynamics_preconditioning: bool = True
     """Whether to use preconditioning in the constrained dynamics solver.
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env_cfg.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
@@ -38,6 +38,7 @@ class HumanoidPhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
+    kamino: NewtonCfg = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
     ovphysx: OvPhysxCfg = OvPhysxCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid/humanoid_env_cfg.py
@@ -38,7 +38,7 @@ class HumanoidPhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    kamino: NewtonCfg = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
+    newton_kamino: NewtonCfg = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
     ovphysx: OvPhysxCfg = OvPhysxCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
@@ -122,6 +122,7 @@ class ShadowHandEventCfg(PresetCfg):
     physx = PhysxEventCfg()
     newton_mjwarp = NewtonEventCfg()
     default = physx
+    kamino = newton
 
 
 @configclass
@@ -193,6 +194,7 @@ class ShadowHandRobotCfg(PresetCfg):
         soft_joint_pos_limit_factor=1.0,
     )
     default = physx
+    kamino = newton
 
 
 @configclass
@@ -232,6 +234,7 @@ class ObjectCfg(PresetCfg):
         articulation_root_prim_path="",
     )
     default = physx
+    kamino = newton
 
 
 @configclass
@@ -249,6 +252,7 @@ class ShadowHandSceneCfg(PresetCfg):
         num_envs=8192, env_spacing=0.75, replicate_physics=True, clone_in_fabric=False
     )
     default: InteractiveSceneCfg = physx
+    kamino = newton
 
 
 @configclass
@@ -273,6 +277,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     default = physx
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand/shadow_hand_env_cfg.py
@@ -122,7 +122,7 @@ class ShadowHandEventCfg(PresetCfg):
     physx = PhysxEventCfg()
     newton_mjwarp = NewtonEventCfg()
     default = physx
-    kamino = newton
+    newton_kamino = newton_mjwarp
 
 
 @configclass
@@ -194,7 +194,7 @@ class ShadowHandRobotCfg(PresetCfg):
         soft_joint_pos_limit_factor=1.0,
     )
     default = physx
-    kamino = newton
+    newton_kamino = newton_mjwarp
 
 
 @configclass
@@ -234,7 +234,7 @@ class ObjectCfg(PresetCfg):
         articulation_root_prim_path="",
     )
     default = physx
-    kamino = newton
+    newton_kamino = newton_mjwarp
 
 
 @configclass
@@ -252,7 +252,7 @@ class ShadowHandSceneCfg(PresetCfg):
         num_envs=8192, env_spacing=0.75, replicate_physics=True, clone_in_fabric=False
     )
     default: InteractiveSceneCfg = physx
-    kamino = newton
+    newton_kamino = newton_mjwarp
 
 
 @configclass
@@ -277,7 +277,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     default = physx
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
@@ -42,7 +42,7 @@ class HumanoidPhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    kamino: NewtonCfg = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
+    newton_kamino: NewtonCfg = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 ##

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/classic/humanoid/humanoid_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -42,6 +42,7 @@ class HumanoidPhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
+    kamino: NewtonCfg = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 ##

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.managers import SceneEntityCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
@@ -28,7 +28,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -28,6 +28,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -40,6 +40,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 ##
@@ -220,6 +221,7 @@ class SpotEventCfg(PresetCfg):
     default = SpotPhysxEventCfg()
     newton_mjwarp = SpotNewtonEventCfg()
     physx = default
+    kamino = newton
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/spot/flat_env_cfg.py
@@ -40,7 +40,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 ##
@@ -221,7 +221,7 @@ class SpotEventCfg(PresetCfg):
     default = SpotPhysxEventCfg()
     newton_mjwarp = SpotNewtonEventCfg()
     physx = default
-    kamino = newton
+    newton_kamino = newton_mjwarp
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/cabinet_env_cfg.py
@@ -6,7 +6,7 @@
 
 from dataclasses import MISSING
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -72,6 +72,11 @@ class CabinetSimCfg(PresetCfg):
             num_substeps=1,
             debug_mode=False,
         ),
+    )
+    kamino: SimulationCfg = SimulationCfg(
+        dt=1 / 600,
+        render_interval=1,
+        physics=NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=1),
     )
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/cabinet/cabinet_env_cfg.py
@@ -73,7 +73,7 @@ class CabinetSimCfg(PresetCfg):
             debug_mode=False,
         ),
     )
-    kamino: SimulationCfg = SimulationCfg(
+    newton_kamino: SimulationCfg = SimulationCfg(
         dt=1 / 600,
         render_interval=1,
         physics=NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=1),

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/reach_env_cfg.py
@@ -5,7 +5,7 @@
 
 from dataclasses import MISSING
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -49,6 +49,10 @@ class ReachPhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    kamino: NewtonCfg = NewtonCfg(
+        solver_cfg=KaminoSolverCfg(max_contacts_per_world=32),
+        num_substeps=2,
+    )
 
 
 ##
@@ -69,7 +73,7 @@ class TableCfg(PresetCfg):
     newton_mjwarp: ArticulationCfg = ArticulationCfg(
         prim_path="/World/envs/env_.*/Table",
         init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.5, 0.15, -0.5), rot=(0, 0, 0.707, 0.707), joint_pos={}, joint_vel={}
+            pos=(0.5, 0, -0.5), rot=(0, 0, 0.707, 0.707), joint_pos={}, joint_vel={}
         ),
         spawn=sim_utils.CuboidCfg(
             size=(0.9, 1.3, 1.00),
@@ -80,6 +84,7 @@ class TableCfg(PresetCfg):
         articulation_root_prim_path="",
     )
 
+    kamino = newton
     default = physx
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/reach/reach_env_cfg.py
@@ -49,7 +49,7 @@ class ReachPhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    kamino: NewtonCfg = NewtonCfg(
+    newton_kamino: NewtonCfg = NewtonCfg(
         solver_cfg=KaminoSolverCfg(max_contacts_per_world=32),
         num_substeps=2,
     )
@@ -84,7 +84,7 @@ class TableCfg(PresetCfg):
         articulation_root_prim_path="",
     )
 
-    kamino = newton
+    newton_kamino = newton_mjwarp
     default = physx
 
 


### PR DESCRIPTION
# Description

A lot of the Kamino integration has already been done, so this PR has shrunk a lot :)

What this PR still adds:
Wires IsaacLab actuators into Kamino's implicit joint dynamic-constraint row and adds a per-world contact pre-allocation cap.

Note, I'm also working on this Newton PR:
Requires [newton#2822](https://github.com/newton-physics/newton/pull/2822) for manipulation tasks with non-aligned joint frames (Franka, etc.) to run under the Kamino preset.

## Description
- **`ActuatorBase.route_torque_to: Literal["joint_f", "joint_act"]`** — opt-in per-actuator routing of the computed torque. Defaults to `"joint_f"` (PhysX /MuJoCo semantics, written to `Control.joint_f`). `"joint_act"` writes to  `Control.joint_act` instead, giving Kamino backward-Euler treatment of joint armature and damping via the PADMM joint dynamic-constraint row.
- **`ArticulationData.joint_act_target`** — public property exposing the new feedforward array, populated each `write_data_to_sim` from per-actuator computed torques whose `route_torque_to == "joint_act"`. This is important for models with closed loops, as it improves Kamino's stability.
- **`KaminoSolverCfg.max_contacts_per_world`** — bounds Kamino's per-world rigid-contact pre-allocation. Without it, Kamino over-allocates from `geoms.world_minimum_contacts` for contact-rich assets (legged locomotion, manipulation). `NewtonKaminoManager._build_solver` resolves it to `model.rigid_contact_max = max_contacts_per_world * model.world_count` before solver construction.

When using the mentioned Newton PR, tasks like Open-Drawer-Franka initialize correctly and match the newton_mjwarp preset:
`./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/play.py --task Isaac-Open-Drawer-Franka-Play-v0 --use_pretrained_checkpoint --real-time --viz newton presets=newton_kamino`