### PR TITLE
Fix per-env gravity randomization on Newton backend

### DIFF
--- a/source/isaaclab/changelog.d/gravity-vec-w-bind-model-gravity.rst
+++ b/source/isaaclab/changelog.d/gravity-vec-w-bind-model-gravity.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.envs.mdp.body_projected_gravity_b` to normalize
+  ``GRAVITY_VEC_W`` before projecting it into the body frame, so the observation
+  stays a unit direction when the Newton backend exposes gravity as a raw
+  m/s\ :sup:`2` vector. This is a no-op for the PhysX/OvPhysX backends, whose
+  ``GRAVITY_VEC_W`` is already unit length.

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -183,7 +183,10 @@ def body_projected_gravity_b(
     asset: Articulation = env.scene[asset_cfg.name]
 
     body_quat = asset.data.body_quat_w.torch[:, asset_cfg.body_ids]
-    gravity_dir = asset.data.GRAVITY_VEC_W.torch.unsqueeze(1)
+    # ``GRAVITY_VEC_W`` carries the per-env world-frame gravity in m/s^2 (Newton
+    # backend) or scene-wide gravity (PhysX backend).
+    gravity_w = asset.data.GRAVITY_VEC_W.torch
+    gravity_dir = torch.nn.functional.normalize(gravity_w, dim=-1).unsqueeze(1)
     return math_utils.quat_apply_inverse(body_quat, gravity_dir).view(env.num_envs, -1)
 
 

--- a/source/isaaclab_experimental/changelog.d/gravity-vec-w-bind-model-gravity.rst
+++ b/source/isaaclab_experimental/changelog.d/gravity-vec-w-bind-model-gravity.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed the Warp gravity kernels behind
+  :func:`~isaaclab_experimental.envs.mdp.projected_gravity` and
+  :func:`~isaaclab_experimental.envs.mdp.flat_orientation_l2` to read per-env
+  gravity and normalize it, instead of reading env 0's vector. Per-env gravity
+  randomization is now respected by the observation and the flat-orientation
+  reward on the Newton backend.

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/mdp/observations.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/mdp/observations.py
@@ -168,7 +168,7 @@ def _projected_gravity_kernel(
     out: wp.array(dtype=wp.float32, ndim=2),
 ):
     i = wp.tid()
-    g = rotate_vec_to_body_frame(gravity_w[0], root_pose_w[i])
+    g = rotate_vec_to_body_frame(wp.normalize(gravity_w[i]), root_pose_w[i])
     out[i, 0] = g[0]
     out[i, 1] = g[1]
     out[i, 2] = g[2]

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/mdp/rewards.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/mdp/rewards.py
@@ -132,8 +132,10 @@ def _flat_orientation_l2_kernel(
     gravity_w: wp.array(dtype=wp.vec3f),
     out: wp.array(dtype=wp.float32),
 ):
+    # ``gravity_w`` is per-env and may carry magnitude (Newton, m/s^2), so index
+    # per env and normalize before projecting.
     i = wp.tid()
-    g = rotate_vec_to_body_frame(gravity_w[0], root_pose_w[i])
+    g = rotate_vec_to_body_frame(wp.normalize(gravity_w[i]), root_pose_w[i])
     out[i] = g[0] * g[0] + g[1] * g[1]
 
 

--- a/source/isaaclab_experimental/test/envs/mdp/parity_helpers.py
+++ b/source/isaaclab_experimental/test/envs/mdp/parity_helpers.py
@@ -218,8 +218,10 @@ class MockArticulationData:
         vel_np[:, 3:] = ang_vel_w_np
         self.root_com_vel_w = proxy_array(vel_np, dtype=wp.spatial_vectorf, device=device)
 
-        # Gravity direction constant (1D array to match kernel signatures)
-        self.GRAVITY_VEC_W = proxy_array([0.0, 0.0, -1.0], dtype=wp.vec3f, device=device)
+        # Gravity in world frame (m/s^2), per-env to mirror Newton's ``model.gravity``.
+        # Kernels and the torch path normalize before projecting, so magnitude is kept.
+        gravity_vec_w = np.full((num_envs, 3), (0.0, 0.0, -9.81), dtype=np.float32)
+        self.GRAVITY_VEC_W = ProxyArray(wp.array(gravity_vec_w, dtype=wp.vec3f, device=device))
 
         # Derived body-frame quantities (consistent with Tier 1 compounds)
         self.root_lin_vel_b = proxy_array(quat_rotate_inv_np(quat_np, lin_vel_w_np), dtype=wp.vec3f, device=device)

--- a/source/isaaclab_newton/changelog.d/gravity-vec-w-bind-model-gravity.rst
+++ b/source/isaaclab_newton/changelog.d/gravity-vec-w-bind-model-gravity.rst
@@ -1,0 +1,15 @@
+Fixed
+^^^^^
+
+* Fixed :attr:`~isaaclab_newton.assets.ArticulationData.GRAVITY_VEC_W` (and the
+  matching attribute on :class:`~isaaclab_newton.assets.RigidObjectData` and
+  :class:`~isaaclab_newton.assets.RigidObjectCollectionData`) to bind directly
+  to Newton's per-world ``model.gravity`` array. Previously the constructor
+  snapshotted env 0's gravity as a unit vector and broadcast it to every
+  environment, so per-env gravity randomization (e.g.
+  :class:`~isaaclab.envs.mdp.randomize_physics_scene_gravity`) was invisible to
+  every consumer of ``GRAVITY_VEC_W`` and to the lazily-recomputed
+  :attr:`~isaaclab_newton.assets.ArticulationData.projected_gravity_b`.
+  ``GRAVITY_VEC_W`` now carries the actual world-frame gravity vector
+  (m/s\\ :sup:`2`); ``projected_gravity_b`` continues to expose a unit vector
+  in the body frame via a new dedicated kernel that normalizes internally.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -9,12 +9,11 @@ import warnings
 import weakref
 from typing import TYPE_CHECKING
 
-import torch
+import numpy as np
 import warp as wp
 
 from isaaclab.assets.articulation.base_articulation_data import BaseArticulationData
 from isaaclab.utils.buffers import TimestampedBufferWarp as TimestampedBuffer
-from isaaclab.utils.math import normalize
 from isaaclab.utils.warp import ProxyArray
 from isaaclab.utils.warp.utils import capture_unsafe
 
@@ -75,16 +74,11 @@ class ArticulationData(BaseArticulationData):
         self._is_primed = False
         self._fk_timestamp = 0.0
 
-        # Convert to direction vector
-        gravity = wp.to_torch(SimulationManager.get_model().gravity)[0]
-        gravity_dir = torch.tensor((gravity[0], gravity[1], gravity[2]), device=self.device)
-        gravity_dir = normalize(gravity_dir.unsqueeze(0)).squeeze(0)
-        gravity_dir = gravity_dir.repeat(self._root_view.count, 1)
-        forward_vec = torch.tensor((1.0, 0.0, 0.0), device=self.device).repeat(self._root_view.count, 1)
-
-        # Initialize constants
-        self.GRAVITY_VEC_W = ProxyArray(wp.from_torch(gravity_dir, dtype=wp.vec3f))
-        self.FORWARD_VEC_B = ProxyArray(wp.from_torch(forward_vec, dtype=wp.vec3f))
+        # Bind ``GRAVITY_VEC_W`` to Newton's per-env ``model.gravity`` (m/s^2) so
+        # per-env gravity randomization stays live; consumers normalize on read.
+        self.GRAVITY_VEC_W = ProxyArray(SimulationManager.get_model().gravity)
+        forward_vec = np.full((self._root_view.count, 3), (1.0, 0.0, 0.0), dtype=np.float32)
+        self.FORWARD_VEC_B = ProxyArray(wp.array(forward_vec, dtype=wp.vec3f, device=self.device))
 
         self._create_simulation_bindings()
         self._create_buffers()
@@ -1008,7 +1002,7 @@ class ArticulationData(BaseArticulationData):
         """
         if self._projected_gravity_b.timestamp < self._sim_timestamp:
             wp.launch(
-                shared_kernels.quat_apply_inverse_1D_kernel,
+                shared_kernels.projected_gravity_b_kernel,
                 dim=self._num_instances,
                 inputs=[self.GRAVITY_VEC_W.warp, self.root_link_quat_w.warp],
                 outputs=[self._projected_gravity_b.data],

--- a/source/isaaclab_newton/isaaclab_newton/assets/kernels.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/kernels.py
@@ -442,6 +442,46 @@ def quat_apply_inverse_2D_kernel(
 
 
 @wp.kernel
+def projected_gravity_b_kernel(
+    gravity_w: wp.array(dtype=wp.vec3f),
+    quat: wp.array(dtype=wp.quatf),
+    projected_gravity_b: wp.array(dtype=wp.vec3f),
+):
+    """Project per-env world-frame gravity into the base frame as a unit vector.
+
+    ``gravity_w`` carries magnitude (m/s^2) and is normalized internally, so the
+    result stays direction-only under per-env gravity randomization.
+    ``wp.normalize`` maps a zero vector to zero, so disabled gravity is safe.
+
+    Args:
+        gravity_w: World-frame gravity vector per env. Shape is (num_envs,).
+        quat: Per-env body quaternion. Shape is (num_envs,).
+        projected_gravity_b: Output unit-vector projection. Shape is (num_envs,).
+    """
+    i = wp.tid()
+    projected_gravity_b[i] = wp.quat_rotate_inv(quat[i], wp.normalize(gravity_w[i]))
+
+
+@wp.kernel
+def projected_gravity_b_2D_kernel(
+    gravity_w: wp.array(dtype=wp.vec3f),
+    quat: wp.array2d(dtype=wp.quatf),
+    projected_gravity_b: wp.array2d(dtype=wp.vec3f),
+):
+    """Project per-env world-frame gravity into per-body base frame as a unit vector.
+
+    Broadcasts the per-env ``gravity_w[i]`` across all bodies of env ``i``.
+
+    Args:
+        gravity_w: World-frame gravity vector per env. Shape is (num_envs,).
+        quat: Per-body quaternion. Shape is (num_envs, num_bodies).
+        projected_gravity_b: Output unit-vector projection. Shape is (num_envs, num_bodies).
+    """
+    i, j = wp.tid()
+    projected_gravity_b[i, j] = wp.quat_rotate_inv(quat[i, j], wp.normalize(gravity_w[i]))
+
+
+@wp.kernel
 def body_heading_w(
     forward_vec: wp.array2d(dtype=wp.vec3f),
     quat: wp.array2d(dtype=wp.quatf),

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object_data.py
@@ -9,12 +9,11 @@ import warnings
 import weakref
 from typing import TYPE_CHECKING
 
-import torch
+import numpy as np
 import warp as wp
 
 from isaaclab.assets.rigid_object.base_rigid_object_data import BaseRigidObjectData
 from isaaclab.utils.buffers import TimestampedBufferWarp as TimestampedBuffer
-from isaaclab.utils.math import normalize
 from isaaclab.utils.warp import ProxyArray
 from isaaclab.utils.warp.utils import capture_unsafe
 
@@ -78,16 +77,11 @@ class RigidObjectData(BaseRigidObjectData):
         self._is_primed = False
         self._fk_timestamp = 0.0
 
-        # Convert to direction vector
-        gravity = wp.to_torch(SimulationManager.get_model().gravity)[0]
-        gravity_dir = torch.tensor((gravity[0], gravity[1], gravity[2]), device=self.device)
-        gravity_dir = normalize(gravity_dir.unsqueeze(0)).squeeze(0)
-        gravity_dir = gravity_dir.repeat(self._root_view.count, 1)
-        forward_vec = torch.tensor((1.0, 0.0, 0.0), device=self.device).repeat(self._root_view.count, 1)
-
-        # Initialize constants
-        self.GRAVITY_VEC_W = ProxyArray(wp.from_torch(gravity_dir, dtype=wp.vec3f))
-        self.FORWARD_VEC_B = ProxyArray(wp.from_torch(forward_vec, dtype=wp.vec3f))
+        # Bind ``GRAVITY_VEC_W`` to Newton's per-env ``model.gravity`` (m/s^2) so
+        # per-env gravity randomization stays live; consumers normalize on read.
+        self.GRAVITY_VEC_W = ProxyArray(SimulationManager.get_model().gravity)
+        forward_vec = np.full((self._root_view.count, 3), (1.0, 0.0, 0.0), dtype=np.float32)
+        self.FORWARD_VEC_B = ProxyArray(wp.array(forward_vec, dtype=wp.vec3f, device=self.device))
 
         self._create_simulation_bindings()
         self._create_buffers()
@@ -414,7 +408,7 @@ class RigidObjectData(BaseRigidObjectData):
         """
         if self._projected_gravity_b.timestamp < self._sim_timestamp:
             wp.launch(
-                shared_kernels.quat_apply_inverse_1D_kernel,
+                shared_kernels.projected_gravity_b_kernel,
                 dim=self._num_instances,
                 inputs=[self.GRAVITY_VEC_W.warp, self.root_link_quat_w.warp],
                 outputs=[self._projected_gravity_b.data],

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -9,12 +9,11 @@ import warnings
 import weakref
 from typing import TYPE_CHECKING
 
-import torch
+import numpy as np
 import warp as wp
 
 from isaaclab.assets.rigid_object_collection.base_rigid_object_collection_data import BaseRigidObjectCollectionData
 from isaaclab.utils.buffers import TimestampedBufferWarp as TimestampedBuffer
-from isaaclab.utils.math import normalize
 from isaaclab.utils.warp import ProxyArray
 
 from isaaclab_newton.assets import kernels as shared_kernels
@@ -70,21 +69,11 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
         self._sim_timestamp = 0.0
         self._is_primed = False
 
-        # Convert gravity to direction vector
-        gravity = wp.to_torch(SimulationManager.get_model().gravity)[0]
-        gravity_dir = torch.tensor((gravity[0], gravity[1], gravity[2]), device=self.device)
-        gravity_dir = normalize(gravity_dir.unsqueeze(0)).squeeze(0)
-
-        # Initialize constants
-        self.GRAVITY_VEC_W = ProxyArray(
-            wp.from_torch(gravity_dir.repeat(self.num_instances, self.num_bodies, 1), dtype=wp.vec3f)
-        )
-        self.FORWARD_VEC_B = ProxyArray(
-            wp.from_torch(
-                torch.tensor((1.0, 0.0, 0.0), device=self.device).repeat(self.num_instances, self.num_bodies, 1),
-                dtype=wp.vec3f,
-            )
-        )
+        # Bind ``GRAVITY_VEC_W`` to Newton's per-env ``model.gravity`` (m/s^2); the
+        # projected_gravity_b kernel broadcasts each env's vector across its bodies.
+        self.GRAVITY_VEC_W = ProxyArray(SimulationManager.get_model().gravity)
+        forward_vec = np.full((self.num_instances, self.num_bodies, 3), (1.0, 0.0, 0.0), dtype=np.float32)
+        self.FORWARD_VEC_B = ProxyArray(wp.array(forward_vec, dtype=wp.vec3f, device=self.device))
 
         self._create_simulation_bindings()
         self._create_buffers()
@@ -357,7 +346,7 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
         """
         if self._projected_gravity_b.timestamp < self._sim_timestamp:
             wp.launch(
-                shared_kernels.quat_apply_inverse_2D_kernel,
+                shared_kernels.projected_gravity_b_2D_kernel,
                 dim=(self.num_instances, self.num_bodies),
                 inputs=[self.GRAVITY_VEC_W.warp, self.body_link_quat_w.warp],
                 outputs=[self._projected_gravity_b.data],

--- a/source/isaaclab_newton/test/assets/test_articulation.py
+++ b/source/isaaclab_newton/test/assets/test_articulation.py
@@ -533,6 +533,47 @@ def test_initialization_floating_base_non_root(sim, num_articulations, device, a
         articulation.update(sim.cfg.dt)
 
 
+@pytest.mark.isaacsim_ci
+@pytest.mark.parametrize("num_articulations", [2, 3])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("add_ground_plane", [True])
+@pytest.mark.parametrize("articulation_type", ["humanoid"])
+def test_gravity_vec_w_tracks_model_gravity(sim, num_articulations, device, add_ground_plane, articulation_type):
+    """Per-env mutations to Newton's ``model.gravity`` reach ``GRAVITY_VEC_W`` and ``projected_gravity_b``.
+
+    Regression for the pre-fix snapshot: ``GRAVITY_VEC_W`` used to be env 0's
+    gravity broadcast to every env, hiding per-env gravity randomization (e.g.
+    :class:`~isaaclab.envs.mdp.randomize_physics_scene_gravity`).
+    """
+    articulation_cfg = generate_articulation_cfg(articulation_type=articulation_type, stiffness=0.0, damping=0.0)
+    articulation, _ = generate_articulation(articulation_cfg, num_articulations, device=device)
+    sim.reset()
+
+    # GRAVITY_VEC_W must share storage with Newton's per-env gravity array.
+    model_gravity_arr = SimulationManager.get_model().gravity
+    assert articulation.data.GRAVITY_VEC_W.warp.ptr == model_gravity_arr.ptr
+
+    # Mutate model.gravity per-env in place, as randomize_physics_scene_gravity does.
+    new_gravity = torch.tensor(
+        [[0.1 * (i + 1), 0.2 * (i + 1), -3.0 - float(i)] for i in range(num_articulations)],
+        device=device,
+        dtype=torch.float32,
+    )
+    wp.to_torch(model_gravity_arr).copy_(new_gravity)
+    SimulationManager.add_model_change(SolverNotifyFlags.MODEL_PROPERTIES)
+
+    # Live view: new per-env values are visible immediately, no invalidation step.
+    torch.testing.assert_close(articulation.data.GRAVITY_VEC_W.torch, new_gravity)
+
+    # Recompute the lazily-cached projected_gravity_b without sim.step (which would
+    # drift root orientation from the reset state). Project against the same quat
+    # buffer the kernel reads so the expectation holds for any default orientation.
+    articulation.update(sim.cfg.dt)
+    root_quat = articulation.data.root_link_quat_w.torch
+    expected = math_utils.quat_apply_inverse(root_quat, torch.nn.functional.normalize(new_gravity, dim=-1))
+    torch.testing.assert_close(articulation.data.projected_gravity_b.torch, expected, atol=1e-5, rtol=1e-5)
+
+
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])

--- a/source/isaaclab_newton/test/assets/test_rigid_object.py
+++ b/source/isaaclab_newton/test/assets/test_rigid_object.py
@@ -888,17 +888,15 @@ def test_gravity_vec_w(num_cubes, device, gravity_enabled):
 
         # Obtain gravity direction
         if gravity_enabled:
-            gravity_dir = (0.0, 0.0, -1.0)
+            expected_g = (0.0, 0.0, -9.81)
         else:
-            gravity_dir = (0.0, 0.0, 0.0)
+            expected_g = (0.0, 0.0, 0.0)
 
         # Play sim
         sim.reset()
 
         # Check that gravity is set correctly
-        assert cube_object.data.GRAVITY_VEC_W.torch[0, 0] == gravity_dir[0]
-        assert cube_object.data.GRAVITY_VEC_W.torch[0, 1] == gravity_dir[1]
-        assert cube_object.data.GRAVITY_VEC_W.torch[0, 2] == gravity_dir[2]
+        torch.testing.assert_close(cube_object.data.GRAVITY_VEC_W.torch[0], torch.tensor(expected_g, device=device))
 
         # Simulate physics
         for _ in range(2):
@@ -913,6 +911,44 @@ def test_gravity_vec_w(num_cubes, device, gravity_enabled):
                 gravity[:, :, 2] = -9.81
             # Check the body accelerations are correct
             torch.testing.assert_close(cube_object.data.body_acc_w.torch, gravity)
+
+
+@pytest.mark.isaacsim_ci
+@pytest.mark.parametrize("num_cubes", [2, 3])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_gravity_vec_w_tracks_model_gravity(num_cubes, device):
+    """Per-env mutations to Newton's ``model.gravity`` reach ``GRAVITY_VEC_W`` and ``projected_gravity_b``.
+
+    Regression for the pre-fix snapshot: ``GRAVITY_VEC_W`` used to be env 0's
+    gravity broadcast to every env, hiding per-env gravity randomization (e.g.
+    :class:`~isaaclab.envs.mdp.randomize_physics_scene_gravity`).
+    """
+    with _newton_sim_context(device, gravity_enabled=True) as sim:
+        sim._app_control_on_stop_handle = None
+        cube_object, _ = generate_cubes_scene(num_cubes=num_cubes, device=device)
+        sim.reset()
+
+        # GRAVITY_VEC_W must share storage with Newton's per-env gravity array.
+        model_gravity_arr = SimulationManager.get_model().gravity
+        assert cube_object.data.GRAVITY_VEC_W.warp.ptr == model_gravity_arr.ptr
+
+        # Mutate model.gravity per-env in place, as randomize_physics_scene_gravity does.
+        new_gravity = torch.tensor(
+            [[0.1 * (i + 1), 0.2 * (i + 1), -3.0 - float(i)] for i in range(num_cubes)],
+            device=device,
+            dtype=torch.float32,
+        )
+        wp.to_torch(model_gravity_arr).copy_(new_gravity)
+        SimulationManager.add_model_change(SolverNotifyFlags.MODEL_PROPERTIES)
+
+        # Live view: new per-env values are visible immediately, no invalidation step.
+        torch.testing.assert_close(cube_object.data.GRAVITY_VEC_W.torch, new_gravity)
+
+        # Recompute the lazily-cached projected_gravity_b without sim.step, so cube
+        # orientation stays at identity and the projection equals unit-direction gravity.
+        cube_object.update(sim.cfg.dt)
+        expected = torch.nn.functional.normalize(new_gravity, dim=-1)
+        torch.testing.assert_close(cube_object.data.projected_gravity_b.torch, expected, atol=1e-5, rtol=1e-5)
 
 
 @pytest.mark.isaacsim_ci

--- a/source/isaaclab_newton/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab_newton/test/assets/test_rigid_object_collection.py
@@ -557,16 +557,17 @@ def test_gravity_vec_w(num_envs, num_cubes, device, gravity_enabled):
         sim._app_control_on_stop_handle = None
         object_collection, _ = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
 
-        # Obtain gravity direction
-        gravity_dir = (0.0, 0.0, -1.0) if gravity_enabled else (0.0, 0.0, 0.0)
+        # GRAVITY_VEC_W now binds to Newton's per-env gravity array directly,
+        # so it carries full m/s^2 values and is shaped per-instance (not
+        # per-instance-per-body).
+        expected_g = (0.0, 0.0, -9.81) if gravity_enabled else (0.0, 0.0, 0.0)
 
         sim.reset()
 
         # Check if gravity vector is set correctly
-        gravity_vec = object_collection.data.GRAVITY_VEC_W.torch
-        assert gravity_vec[0, 0, 0] == gravity_dir[0]
-        assert gravity_vec[0, 0, 1] == gravity_dir[1]
-        assert gravity_vec[0, 0, 2] == gravity_dir[2]
+        torch.testing.assert_close(
+            object_collection.data.GRAVITY_VEC_W.torch[0], torch.tensor(expected_g, device=device)
+        )
 
         # Perform simulation
         for _ in range(2):
@@ -580,6 +581,43 @@ def test_gravity_vec_w(num_envs, num_cubes, device, gravity_enabled):
 
             # Check the body accelerations are correct
             torch.testing.assert_close(object_collection.data.body_com_acc_w.torch, gravity)
+
+
+@pytest.mark.isaacsim_ci
+@pytest.mark.parametrize("num_envs", [2, 3])
+@pytest.mark.parametrize("num_cubes", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_gravity_vec_w_tracks_model_gravity(num_envs, num_cubes, device):
+    """Per-env mutations to Newton's ``model.gravity`` reach ``GRAVITY_VEC_W`` and ``projected_gravity_b``.
+
+    Regression for the pre-fix snapshot: ``GRAVITY_VEC_W`` used to be env 0's
+    gravity broadcast to every env and body, hiding per-env gravity
+    randomization (e.g. :class:`~isaaclab.envs.mdp.randomize_physics_scene_gravity`).
+    """
+    with _newton_sim_context(device, gravity_enabled=True, auto_add_lighting=True) as sim:
+        sim._app_control_on_stop_handle = None
+        object_collection, _ = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
+        sim.reset()
+
+        # GRAVITY_VEC_W must share storage with Newton's per-env gravity array.
+        model_gravity_arr = SimulationManager.get_model().gravity
+        assert object_collection.data.GRAVITY_VEC_W.warp.ptr == model_gravity_arr.ptr
+
+        # Mutate model.gravity per-env in place, as randomize_physics_scene_gravity does.
+        new_gravity = torch.tensor(
+            [[0.1 * (i + 1), 0.2 * (i + 1), -3.0 - float(i)] for i in range(num_envs)],
+            device=device,
+            dtype=torch.float32,
+        )
+        wp.to_torch(model_gravity_arr).copy_(new_gravity)
+        SimulationManager.add_model_change(SolverNotifyFlags.MODEL_PROPERTIES)
+
+        # Recompute the lazily-cached projected_gravity_b without sim.step: bodies stay
+        # at identity orientation, so each env's unit gravity broadcasts across its bodies.
+        object_collection.update(sim.cfg.dt)
+        expected_per_env = torch.nn.functional.normalize(new_gravity, dim=-1)
+        expected = expected_per_env.unsqueeze(1).expand(-1, num_cubes, -1).contiguous()
+        torch.testing.assert_close(object_collection.data.projected_gravity_b.torch, expected, atol=1e-5, rtol=1e-5)
 
 
 @pytest.mark.parametrize("num_envs", [1, 4])

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/humanoid/mdp/observations.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/humanoid/mdp/observations.py
@@ -73,7 +73,7 @@ def _base_up_proj_kernel(
 ):
     """Project base up vector onto world up: -gravity_b[2]."""
     i = wp.tid()
-    out[i, 0] = -rotate_vec_to_body_frame(gravity_w[0], root_pose_w[i])[2]
+    out[i, 0] = -rotate_vec_to_body_frame(wp.normalize(gravity_w[i]), root_pose_w[i])[2]
 
 
 @generic_io_descriptor_warp(out_dim=1, observation_type="RootState")

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/humanoid/mdp/rewards.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/humanoid/mdp/rewards.py
@@ -48,7 +48,7 @@ def _upright_posture_bonus_kernel(
     out: wp.array(dtype=wp.float32),
 ):
     i = wp.tid()
-    up_proj = -rotate_vec_to_body_frame(gravity_w[0], root_pose_w[i])[2]
+    up_proj = -rotate_vec_to_body_frame(wp.normalize(gravity_w[i]), root_pose_w[i])[2]
     out[i] = wp.where(up_proj > threshold, 1.0, 0.0)
 
 


### PR DESCRIPTION
## Summary

`GRAVITY_VEC_W` on Newton's `ArticulationData`, `RigidObjectData`, and `RigidObjectCollectionData` was snapshotted from env 0 at construction, normalized to a unit direction, and broadcast to every env (and every body for the collection). Any in-place mutation of Newton's per-world `model.gravity` array — including the `randomize_physics_scene_gravity` event term, which writes per-env values via `model.gravity[env_ids] = ...` — was invisible to every consumer of `GRAVITY_VEC_W` and to the lazily-recomputed `projected_gravity_b`.

This PR binds `GRAVITY_VEC_W` directly to `SimulationManager.get_model().gravity` so it is a live view of the source of truth. The field now carries world-frame m/s² (per-env) instead of a unit direction; downstream consumers that need a unit projection normalize on read.

- New dedicated `projected_gravity_b_kernel` / `projected_gravity_b_2D_kernel` in `isaaclab_newton.assets.kernels` replace the generic `quat_apply_inverse_*` calls for gravity and normalize internally.
- `body_projected_gravity_b` in `isaaclab.envs.mdp.observations` normalizes the torch view (no-op for PhysX/OvPhysX, which still pre-normalize at construction).
- Warp kernels in `isaaclab_experimental` (`_projected_gravity_kernel`, `_flat_orientation_l2_kernel`) and humanoid task kernels (`_base_up_proj_kernel`, `_upright_posture_bonus_kernel`) switch from `gravity_w[0]` to `wp.normalize(gravity_w[i])` so per-env randomized gravity is respected.
- The parity-test mock provides a per-env `GRAVITY_VEC_W` shaped to match Newton's `model.gravity`.

PhysX and OvPhysX backends are unchanged: their `GRAVITY_VEC_W` remains a pre-normalized unit vector, and the added `F.normalize` on the torch path is a no-op there.

### Behavior change to note

`isaaclab_newton.assets.{ArticulationData,RigidObjectData,RigidObjectCollectionData}.GRAVITY_VEC_W` now exposes the raw m/s² gravity vector instead of a unit direction. Code that consumed it directly (rather than going through `projected_gravity_b`) needs to normalize before use. `RigidObjectCollectionData.GRAVITY_VEC_W` is now shaped `(num_instances, 3)` instead of `(num_instances, num_bodies, 3)`; `projected_gravity_b` retains its `(num_instances, num_bodies, 3)` shape via the dedicated 2D kernel.

## Test plan

Added `test_gravity_vec_w_tracks_model_gravity` to the three Newton asset test suites:

- `source/isaaclab_newton/test/assets/test_articulation.py`
- `source/isaaclab_newton/test/assets/test_rigid_object.py`
- `source/isaaclab_newton/test/assets/test_rigid_object_collection.py`

Each test pointer-equality-checks `GRAVITY_VEC_W.warp.ptr` against `SimulationManager.get_model().gravity.ptr`, mutates `model.gravity` per env in place, then asserts both `GRAVITY_VEC_W` and `projected_gravity_b` reflect the new values without `sim.step()` (avoiding orientation drift).

- [ ] `./isaaclab.sh -p -m pytest source/isaaclab_newton/test/assets/test_articulation.py::test_gravity_vec_w_tracks_model_gravity`
- [ ] `./isaaclab.sh -p -m pytest source/isaaclab_newton/test/assets/test_rigid_object.py::test_gravity_vec_w_tracks_model_gravity`
- [ ] `./isaaclab.sh -p -m pytest source/isaaclab_newton/test/assets/test_rigid_object_collection.py::test_gravity_vec_w_tracks_model_gravity`
- [ ] Sanity-check `randomize_physics_scene_gravity` is observable in a quick locomotion config (e.g. shadow_hand).
- [ ] Verify regression tests fail when the fix is reverted (per AGENTS.md).