### PR TITLE
Fix bin_packing.py and Refactor with Wrapper APIs

### DIFF
--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -159,7 +159,7 @@ def reset_object_collections(
         noise: If True, apply pose and velocity noise before writing.
 
     Returns:
-        None: This function updates ``states`` and the underlying PhysX view in-place.
+        None: This function updates ``view_states`` and the underlying PhysX view in-place.
     """
     rigid_object_collection: RigidObjectCollection = scene[asset_name]
     flat_states = view_states.view(-1, view_states.shape[-1])
@@ -283,7 +283,7 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     cached_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
     spawn_w = default_state_w.clone()
 
-    groceries_mask_helper = torch.arange(num_objects, device=device).view(1, num_objects)
+    groceries_mask_helper = torch.arange(num_objects * num_envs, device=device) % num_objects
     # Precompute a helper mask to toggle objects between active and cached sets.
     # Precompute XY bounds [[x_min,y_min],[x_max,y_max]]
     bounds_xy = torch.as_tensor(BIN_XY_BOUND, device=device, dtype=spawn_w.dtype)
@@ -295,7 +295,7 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
             count = 0
             # Randomly choose how many groceries stay active in each environment.
             num_active_groceries = torch.randint(MIN_OBJECTS_PER_BIN, num_objects, (num_envs, 1), device=device)
-            groceries_mask = (groceries_mask_helper < num_active_groceries).unsqueeze(-1)
+            groceries_mask = (groceries_mask_helper.view(num_envs, -1) < num_active_groceries).unsqueeze(-1)
             spawn_w[..., :7] = cached_spawn_poses * (~groceries_mask) + active_spawn_poses * groceries_mask
             # Retrieve positions
             with Timer("[INFO] Time to reset scene: "):

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -145,13 +145,13 @@ def reset_object_collections(
     scene: InteractiveScene,
     asset_name: str,
     poses: torch.Tensor,
-    vel: torch.Tensor,
+    vels: torch.Tensor,
     view_ids: torch.Tensor,
     noise: bool = False,
 ) -> None:
     """Apply poses and velocities to a subset of a collection, with optional noise.
 
-    Updates ``poses`` and ``vel`` in-place for ``view_ids`` and writes them
+    Updates ``poses`` and ``vels`` in-place for ``view_ids`` and writes them
     to the PhysX view for the collection ``asset_name``. When ``noise`` is True, adds
     uniform perturbations to pose (XYZ + Euler) and velocities using ``POSE_RANGE`` and
     ``VELOCITY_RANGE``.
@@ -160,16 +160,16 @@ def reset_object_collections(
         scene: Interactive scene containing the collection.
         asset_name: Key in the scene (e.g., ``"groceries"``) for the RigidObjectCollection.
         poses: Env-major body poses [m, rad], shape ``(num_envs, num_bodies, 7)``.
-        vel: Env-major body velocities [m/s, rad/s], shape ``(num_envs, num_bodies, 6)``.
-        view_ids: 1D tensor of env-major flattened indices into ``poses`` and ``vel`` to update.
+        vels: Env-major body velocities [m/s, rad/s], shape ``(num_envs, num_bodies, 6)``.
+        view_ids: 1D tensor of env-major flattened indices into ``poses`` and ``vels`` to update.
         noise: If True, apply pose and velocity noise before writing.
 
     Returns:
-        None: This function updates ``poses``, ``vel``, and the underlying PhysX view in-place.
+        None: This function updates ``poses``, ``vels``, and the underlying PhysX view in-place.
     """
     rigid_object_collection: RigidObjectCollection = scene[asset_name]
     flat_poses = poses.view(-1, poses.shape[-1])
-    flat_velocities = vel.view(-1, vel.shape[-1])
+    flat_velocities = vels.view(-1, vels.shape[-1])
     selected_poses = flat_poses[view_ids]
     positions = selected_poses[:, :3]
     orientations = selected_poses[:, 3:7]

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -144,14 +144,14 @@ class MultiObjectSceneCfg(InteractiveSceneCfg):
 def reset_object_collections(
     scene: InteractiveScene,
     asset_name: str,
-    body_poses: torch.Tensor,
-    body_velocities: torch.Tensor,
+    poses: torch.Tensor,
+    vel: torch.Tensor,
     view_ids: torch.Tensor,
     noise: bool = False,
 ) -> None:
     """Apply poses and velocities to a subset of a collection, with optional noise.
 
-    Updates ``body_poses`` and ``body_velocities`` in-place for ``view_ids`` and writes them
+    Updates ``poses`` and ``vel`` in-place for ``view_ids`` and writes them
     to the PhysX view for the collection ``asset_name``. When ``noise`` is True, adds
     uniform perturbations to pose (XYZ + Euler) and velocities using ``POSE_RANGE`` and
     ``VELOCITY_RANGE``.
@@ -159,17 +159,17 @@ def reset_object_collections(
     Args:
         scene: Interactive scene containing the collection.
         asset_name: Key in the scene (e.g., ``"groceries"``) for the RigidObjectCollection.
-        body_poses: Env-major body poses [m, rad], shape ``(num_envs, num_bodies, 7)``.
-        body_velocities: Env-major body velocities [m/s, rad/s], shape ``(num_envs, num_bodies, 6)``.
-        view_ids: 1D tensor of env-major flattened indices into ``body_poses`` and ``body_velocities`` to update.
+        poses: Env-major body poses [m, rad], shape ``(num_envs, num_bodies, 7)``.
+        vel: Env-major body velocities [m/s, rad/s], shape ``(num_envs, num_bodies, 6)``.
+        view_ids: 1D tensor of env-major flattened indices into ``poses`` and ``vel`` to update.
         noise: If True, apply pose and velocity noise before writing.
 
     Returns:
-        None: This function updates ``body_poses``, ``body_velocities``, and the underlying PhysX view in-place.
+        None: This function updates ``poses``, ``vel``, and the underlying PhysX view in-place.
     """
     rigid_object_collection: RigidObjectCollection = scene[asset_name]
-    flat_poses = body_poses.view(-1, body_poses.shape[-1])
-    flat_velocities = body_velocities.view(-1, body_velocities.shape[-1])
+    flat_poses = poses.view(-1, poses.shape[-1])
+    flat_velocities = vel.view(-1, vel.shape[-1])
     selected_poses = flat_poses[view_ids]
     positions = selected_poses[:, :3]
     orientations = selected_poses[:, 3:7]
@@ -198,8 +198,8 @@ def reset_object_collections(
     flat_poses[view_ids, 3:7] = orientations
     flat_velocities[view_ids] = new_velocities
 
-    rigid_object_collection.write_body_link_pose_to_sim_index(body_poses=body_poses)
-    rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=body_velocities)
+    rigid_object_collection.write_body_link_pose_to_sim_index(body_poses=poses)
+    rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=vel)
 
 
 def build_grocery_defaults(
@@ -276,9 +276,9 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     num_envs = scene.num_envs
     device = scene.device
     view_indices = torch.arange(num_envs * num_objects, device=device)
-    default_body_poses_w = groceries.data.default_body_pose.torch.clone()
-    default_body_poses_w[..., :3] = default_body_poses_w[..., :3] + scene.env_origins.unsqueeze(1)
-    default_body_velocities_w = groceries.data.default_body_vel.torch.clone()
+    default_poses_w = groceries.data.default_body_pose.torch.clone()
+    default_poses_w[..., :3] = default_poses_w[..., :3] + scene.env_origins.unsqueeze(1)
+    default_vel_w = groceries.data.default_body_vel.torch.clone()
     # Define simulation stepping
     sim_dt = sim.get_physics_dt()
     count = 0
@@ -288,8 +288,8 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     # Offset poses into each environment's world frame.
     active_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
     cached_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
-    spawn_poses_w = default_body_poses_w.clone()
-    spawn_vel_w = default_body_velocities_w.clone()
+    spawn_poses_w = default_poses_w.clone()
+    spawn_vel_w = default_vel_w.clone()
 
     groceries_mask_helper = torch.arange(num_objects * num_envs, device=device) % num_objects
     # Precompute a helper mask to toggle objects between active and cached sets.

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -154,7 +154,7 @@ def reset_object_collections(
     Args:
         scene: Interactive scene containing the collection.
         asset_name: Key in the scene (e.g., ``"groceries"``) for the RigidObjectCollection.
-        view_states: Flat env-major tensor (N, 13) with [x, y, z, qx, qy, qz, qw, lin(3), ang(3)] in world frame.
+        view_states: Env-major tensor (num_envs, num_bodies, 13) with [pos(3), quat(4), lin(3), ang(3)] in world frame.
         view_ids: 1D tensor of env-major flattened indices into ``view_states`` to update.
         noise: If True, apply pose and velocity noise before writing.
 
@@ -318,7 +318,7 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
             # Teleport stray objects back into the active stack to keep the bin tidy.
             states_w = torch.cat([groceries.data.body_link_pose_w.torch, groceries.data.body_com_vel_w.torch], dim=-1)
             states_w.view(-1, 13)[out_bound] = spawn_w.view(-1, 13)[out_bound]
-            reset_object_collections(scene, "groceries", states_w, out_bound)  # Increment counter
+            reset_object_collections(scene, "groceries", states_w, out_bound)
         count += 1
         # Update buffers
         scene.update(sim_dt)

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -46,6 +46,7 @@ simulation_app = app_launcher.app
 import math
 
 import torch
+import warp as wp
 
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
@@ -141,6 +142,15 @@ class MultiObjectSceneCfg(InteractiveSceneCfg):
     )
 
 
+def reshape_data_to_view_3d(
+    rigid_object_collection: RigidObjectCollection, data: torch.Tensor, data_dim: int, device: str
+) -> torch.Tensor:
+    """Reshape env-major ``(num_envs, num_bodies, data_dim)`` data to body-major view order."""
+
+    data_wp = wp.from_torch(data.contiguous(), dtype=wp.float32)
+    return wp.to_torch(rigid_object_collection.reshape_data_to_view_3d(data_wp, data_dim, device=device))
+
+
 def reset_object_collections(
     scene: InteractiveScene, asset_name: str, view_states: torch.Tensor, view_ids: torch.Tensor, noise: bool = False
 ) -> None:
@@ -189,8 +199,10 @@ def reset_object_collections(
     view_states[view_ids, :7] = torch.concat((positions, orientations), dim=-1)
     view_states[view_ids, 7:] = new_velocities
 
-    rigid_object_collection.root_view.set_transforms(view_states[:, :7], indices=view_ids)
-    rigid_object_collection.root_view.set_velocities(view_states[:, 7:], indices=view_ids)
+    states = view_states.view(rigid_object_collection.num_bodies, scene.num_envs, 13).transpose(0, 1).contiguous()
+
+    rigid_object_collection.write_body_link_pose_to_sim_index(body_poses=states[..., :7])
+    rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=states[..., 7:])
 
 
 def build_grocery_defaults(
@@ -263,7 +275,7 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     # Extract scene entities
     # note: we only do this here for readability.
     groceries: RigidObjectCollection = scene["groceries"]
-    num_objects = groceries.num_objects
+    num_objects = groceries.num_bodies
     num_envs = scene.num_envs
     device = scene.device
     view_indices = torch.arange(num_envs * num_objects, device=device)
@@ -280,11 +292,12 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     # Offset poses into each environment's world frame.
     active_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
     cached_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
-    active_spawn_poses = groceries.reshape_data_to_view(active_spawn_poses)
-    cached_spawn_poses = groceries.reshape_data_to_view(cached_spawn_poses)
-    spawn_w = groceries.reshape_data_to_view(default_state_w).clone()
+    active_spawn_poses = reshape_data_to_view_3d(groceries, active_spawn_poses, 7, device)
+    cached_spawn_poses = reshape_data_to_view_3d(groceries, cached_spawn_poses, 7, device)
+    spawn_w = reshape_data_to_view_3d(groceries, default_state_w, 13, device).clone()
 
-    groceries_mask_helper = torch.arange(num_objects * num_envs, device=device) % num_objects
+    # Match root_view order: body_0/env_0..env_N, body_1/env_0..env_N, ...
+    groceries_mask_helper = torch.arange(num_objects, device=device).view(num_objects, 1)
     # Precompute a helper mask to toggle objects between active and cached sets.
     # Precompute XY bounds [[x_min,y_min],[x_max,y_max]]
     bounds_xy = torch.as_tensor(BIN_XY_BOUND, device=device, dtype=spawn_w.dtype)
@@ -296,16 +309,15 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
             count = 0
             # Randomly choose how many groceries stay active in each environment.
             num_active_groceries = torch.randint(MIN_OBJECTS_PER_BIN, num_objects, (num_envs, 1), device=device)
-            groceries_mask = (groceries_mask_helper.view(num_envs, -1) < num_active_groceries).view(-1, 1)
+            groceries_mask = (groceries_mask_helper < num_active_groceries.view(1, num_envs)).reshape(-1, 1)
             spawn_w[:, :7] = cached_spawn_poses * (~groceries_mask) + active_spawn_poses * groceries_mask
             # Retrieve positions
             with Timer("[INFO] Time to reset scene: "):
                 reset_object_collections(scene, "groceries", spawn_w, view_indices[~groceries_mask.view(-1)])
                 reset_object_collections(scene, "groceries", spawn_w, view_indices[groceries_mask.view(-1)], noise=True)
                 # Vary the mass and gravity settings so cached objects stay parked.
-                random_masses = torch.rand(groceries.num_instances * num_objects, device=device) * 0.2 + 0.2
-                groceries.root_view.set_masses(random_masses.cpu(), view_indices.cpu())
-                groceries.root_view.set_disable_gravities((~groceries_mask).cpu(), indices=view_indices.cpu())
+                random_masses = torch.rand((groceries.num_instances, num_objects), device=device) * 0.2 + 0.2
+                groceries.set_masses_index(masses=random_masses)
                 scene.reset()
 
         # Write data to sim
@@ -314,11 +326,17 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
         sim.step()
 
         # Bring out-of-bounds objects back to the bin in one pass.
-        xy = groceries.reshape_data_to_view(groceries.data.object_pos_w - scene.env_origins.unsqueeze(1))[:, :2]
+        body_pos_b = groceries.data.body_link_pos_w.torch - scene.env_origins.unsqueeze(1)
+        xy = reshape_data_to_view_3d(groceries, body_pos_b, 3, device)[:, :2]
         out_bound = torch.nonzero(~((xy >= bounds_xy[0]) & (xy <= bounds_xy[1])).all(dim=1), as_tuple=False).flatten()
         if out_bound.numel():
             # Teleport stray objects back into the active stack to keep the bin tidy.
-            reset_object_collections(scene, "groceries", spawn_w, out_bound)
+            current_state_w = torch.cat(
+                [groceries.data.body_link_pose_w.torch, groceries.data.body_com_vel_w.torch], dim=-1
+            )
+            current_state_w = reshape_data_to_view_3d(groceries, current_state_w, 13, device)
+            current_state_w[out_bound] = spawn_w[out_bound]
+            reset_object_collections(scene, "groceries", current_state_w, out_bound)
         # Increment counter
         count += 1
         # Update buffers

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -46,7 +46,6 @@ simulation_app = app_launcher.app
 import math
 
 import torch
-import warp as wp
 
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
@@ -142,19 +141,10 @@ class MultiObjectSceneCfg(InteractiveSceneCfg):
     )
 
 
-def reshape_data_to_view_3d(
-    rigid_object_collection: RigidObjectCollection, data: torch.Tensor, data_dim: int, device: str
-) -> torch.Tensor:
-    """Reshape env-major ``(num_envs, num_bodies, data_dim)`` data to body-major view order."""
-
-    data_wp = wp.from_torch(data.contiguous(), dtype=wp.float32)
-    return wp.to_torch(rigid_object_collection.reshape_data_to_view_3d(data_wp, data_dim, device=device))
-
-
 def reset_object_collections(
     scene: InteractiveScene, asset_name: str, view_states: torch.Tensor, view_ids: torch.Tensor, noise: bool = False
 ) -> None:
-    """Apply states to a subset of a collection, with optional noise.
+    """Apply view_states to a subset of a collection, with optional noise.
 
     Updates ``view_states`` in-place for ``view_ids`` and writes transforms/velocities
     to the PhysX view for the collection ``asset_name``. When ``noise`` is True, adds
@@ -164,15 +154,16 @@ def reset_object_collections(
     Args:
         scene: Interactive scene containing the collection.
         asset_name: Key in the scene (e.g., ``"groceries"``) for the RigidObjectCollection.
-        view_states: Flat tensor (N, 13) with [x, y, z, qx, qy, qz, qw, lin(3), ang(3)] in world frame.
-        view_ids: 1D tensor of indices into ``view_states`` to update.
+        view_states: Env-major tensor with shape ``(num_envs, num_bodies, 13)``.
+        view_ids: 1D tensor of env-major flattened indices into ``view_states`` to update.
         noise: If True, apply pose and velocity noise before writing.
 
     Returns:
-        None: This function updates ``view_states`` and the underlying PhysX view in-place.
+        None: This function updates ``states`` and the underlying PhysX view in-place.
     """
     rigid_object_collection: RigidObjectCollection = scene[asset_name]
-    sel_view_states = view_states[view_ids]
+    flat_states = view_states.view(-1, view_states.shape[-1])
+    sel_view_states = flat_states[view_ids]
     positions = sel_view_states[:, :3]
     orientations = sel_view_states[:, 3:7]
     # poses
@@ -196,13 +187,11 @@ def reset_object_collections(
     else:
         new_velocities[:] = 0.0
 
-    view_states[view_ids, :7] = torch.concat((positions, orientations), dim=-1)
-    view_states[view_ids, 7:] = new_velocities
+    flat_states[view_ids, :7] = torch.concat((positions, orientations), dim=-1)
+    flat_states[view_ids, 7:] = new_velocities
 
-    states = view_states.view(rigid_object_collection.num_bodies, scene.num_envs, 13).transpose(0, 1).contiguous()
-
-    rigid_object_collection.write_body_link_pose_to_sim_index(body_poses=states[..., :7])
-    rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=states[..., 7:])
+    rigid_object_collection.write_body_link_pose_to_sim_index(body_poses=view_states[..., :7])
+    rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=view_states[..., 7:])
 
 
 def build_grocery_defaults(
@@ -292,12 +281,9 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     # Offset poses into each environment's world frame.
     active_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
     cached_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
-    active_spawn_poses = reshape_data_to_view_3d(groceries, active_spawn_poses, 7, device)
-    cached_spawn_poses = reshape_data_to_view_3d(groceries, cached_spawn_poses, 7, device)
-    spawn_w = reshape_data_to_view_3d(groceries, default_state_w, 13, device).clone()
+    spawn_w = default_state_w.clone()
 
-    # Match root_view order: body_0/env_0..env_N, body_1/env_0..env_N, ...
-    groceries_mask_helper = torch.arange(num_objects, device=device).view(num_objects, 1)
+    groceries_mask_helper = torch.arange(num_objects, device=device).view(1, num_objects)
     # Precompute a helper mask to toggle objects between active and cached sets.
     # Precompute XY bounds [[x_min,y_min],[x_max,y_max]]
     bounds_xy = torch.as_tensor(BIN_XY_BOUND, device=device, dtype=spawn_w.dtype)
@@ -309,8 +295,8 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
             count = 0
             # Randomly choose how many groceries stay active in each environment.
             num_active_groceries = torch.randint(MIN_OBJECTS_PER_BIN, num_objects, (num_envs, 1), device=device)
-            groceries_mask = (groceries_mask_helper < num_active_groceries.view(1, num_envs)).reshape(-1, 1)
-            spawn_w[:, :7] = cached_spawn_poses * (~groceries_mask) + active_spawn_poses * groceries_mask
+            groceries_mask = (groceries_mask_helper < num_active_groceries).unsqueeze(-1)
+            spawn_w[..., :7] = cached_spawn_poses * (~groceries_mask) + active_spawn_poses * groceries_mask
             # Retrieve positions
             with Timer("[INFO] Time to reset scene: "):
                 reset_object_collections(scene, "groceries", spawn_w, view_indices[~groceries_mask.view(-1)])
@@ -326,16 +312,15 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
         sim.step()
 
         # Bring out-of-bounds objects back to the bin in one pass.
-        body_pos_b = groceries.data.body_link_pos_w.torch - scene.env_origins.unsqueeze(1)
-        xy = reshape_data_to_view_3d(groceries, body_pos_b, 3, device)[:, :2]
-        out_bound = torch.nonzero(~((xy >= bounds_xy[0]) & (xy <= bounds_xy[1])).all(dim=1), as_tuple=False).flatten()
+        xy = (groceries.data.body_link_pos_w.torch - scene.env_origins.unsqueeze(1))[..., :2]
+        out_bound_mask = ~((xy >= bounds_xy[0]) & (xy <= bounds_xy[1])).all(dim=-1)
+        out_bound = torch.nonzero(out_bound_mask.view(-1), as_tuple=False).flatten()
         if out_bound.numel():
             # Teleport stray objects back into the active stack to keep the bin tidy.
             current_state_w = torch.cat(
                 [groceries.data.body_link_pose_w.torch, groceries.data.body_com_vel_w.torch], dim=-1
             )
-            current_state_w = reshape_data_to_view_3d(groceries, current_state_w, 13, device)
-            current_state_w[out_bound] = spawn_w[out_bound]
+            current_state_w.view(-1, 13)[out_bound] = spawn_w.view(-1, 13)[out_bound]
             reset_object_collections(scene, "groceries", current_state_w, out_bound)
         # Increment counter
         count += 1

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -199,7 +199,7 @@ def reset_object_collections(
     flat_velocities[view_ids] = new_velocities
 
     rigid_object_collection.write_body_link_pose_to_sim_index(body_poses=poses)
-    rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=vel)
+    rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=vels)
 
 
 def build_grocery_defaults(
@@ -276,8 +276,8 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     num_envs = scene.num_envs
     device = scene.device
     view_indices = torch.arange(num_envs * num_objects, device=device)
-    default_poses_w = groceries.data.default_body_pose.torch.clone()
-    default_poses_w[..., :3] = default_poses_w[..., :3] + scene.env_origins.unsqueeze(1)
+    default_pose_w = groceries.data.default_body_pose.torch.clone()
+    default_pose_w[..., :3] = default_pose_w[..., :3] + scene.env_origins.unsqueeze(1)
     default_vel_w = groceries.data.default_body_vel.torch.clone()
     # Define simulation stepping
     sim_dt = sim.get_physics_dt()
@@ -288,7 +288,7 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     # Offset poses into each environment's world frame.
     active_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
     cached_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
-    spawn_poses_w = default_poses_w.clone()
+    spawn_poses_w = default_pose_w.clone()
     spawn_vel_w = default_vel_w.clone()
 
     groceries_mask_helper = torch.arange(num_objects * num_envs, device=device) % num_objects
@@ -326,11 +326,11 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
         out_bound = torch.nonzero((~((xy >= bounds_xy[0]) & (xy <= bounds_xy[1])).all(dim=-1)).view(-1)).flatten()
         if out_bound.numel():
             # Teleport stray objects back into the active stack to keep the bin tidy.
-            body_poses_w = groceries.data.body_link_pose_w.torch.clone()
-            body_velocities_w = groceries.data.body_com_vel_w.torch.clone()
-            body_poses_w.view(-1, 7)[out_bound] = spawn_poses_w.view(-1, 7)[out_bound]
-            body_velocities_w.view(-1, 6)[out_bound] = spawn_vel_w.view(-1, 6)[out_bound]
-            reset_object_collections(scene, "groceries", body_poses_w, body_velocities_w, out_bound)
+            body_pose_w = groceries.data.body_link_pose_w.torch.clone()
+            body_vel_w = groceries.data.body_com_vel_w.torch.clone()
+            body_pose_w.view(-1, 7)[out_bound] = spawn_poses_w.view(-1, 7)[out_bound]
+            body_vel_w.view(-1, 6)[out_bound] = spawn_vel_w.view(-1, 6)[out_bound]
+            reset_object_collections(scene, "groceries", body_pose_w, body_vel_w, out_bound)
         # Increment counter
         count += 1
         # Update buffers

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -313,16 +313,12 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
 
         # Bring out-of-bounds objects back to the bin in one pass.
         xy = (groceries.data.body_link_pos_w.torch - scene.env_origins.unsqueeze(1))[..., :2]
-        out_bound_mask = ~((xy >= bounds_xy[0]) & (xy <= bounds_xy[1])).all(dim=-1)
-        out_bound = torch.nonzero(out_bound_mask.view(-1), as_tuple=False).flatten()
+        out_bound = torch.nonzero((~((xy >= bounds_xy[0]) & (xy <= bounds_xy[1])).all(dim=-1)).view(-1)).flatten()
         if out_bound.numel():
             # Teleport stray objects back into the active stack to keep the bin tidy.
-            current_state_w = torch.cat(
-                [groceries.data.body_link_pose_w.torch, groceries.data.body_com_vel_w.torch], dim=-1
-            )
-            current_state_w.view(-1, 13)[out_bound] = spawn_w.view(-1, 13)[out_bound]
-            reset_object_collections(scene, "groceries", current_state_w, out_bound)
-        # Increment counter
+            states_w = torch.cat([groceries.data.body_link_pose_w.torch, groceries.data.body_com_vel_w.torch], dim=-1)
+            states_w.view(-1, 13)[out_bound] = spawn_w.view(-1, 13)[out_bound]
+            reset_object_collections(scene, "groceries", states_w, out_bound)  # Increment counter
         count += 1
         # Update buffers
         scene.update(sim_dt)

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -319,6 +319,7 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
             states_w = torch.cat([groceries.data.body_link_pose_w.torch, groceries.data.body_com_vel_w.torch], dim=-1)
             states_w.view(-1, 13)[out_bound] = spawn_w.view(-1, 13)[out_bound]
             reset_object_collections(scene, "groceries", states_w, out_bound)
+        # Increment counter
         count += 1
         # Update buffers
         scene.update(sim_dt)

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -142,11 +142,16 @@ class MultiObjectSceneCfg(InteractiveSceneCfg):
 
 
 def reset_object_collections(
-    scene: InteractiveScene, asset_name: str, view_states: torch.Tensor, view_ids: torch.Tensor, noise: bool = False
+    scene: InteractiveScene,
+    asset_name: str,
+    body_poses: torch.Tensor,
+    body_velocities: torch.Tensor,
+    view_ids: torch.Tensor,
+    noise: bool = False,
 ) -> None:
-    """Apply states to a subset of a collection, with optional noise.
+    """Apply poses and velocities to a subset of a collection, with optional noise.
 
-    Updates ``view_states`` in-place for ``view_ids`` and writes transforms/velocities
+    Updates ``body_poses`` and ``body_velocities`` in-place for ``view_ids`` and writes them
     to the PhysX view for the collection ``asset_name``. When ``noise`` is True, adds
     uniform perturbations to pose (XYZ + Euler) and velocities using ``POSE_RANGE`` and
     ``VELOCITY_RANGE``.
@@ -154,18 +159,20 @@ def reset_object_collections(
     Args:
         scene: Interactive scene containing the collection.
         asset_name: Key in the scene (e.g., ``"groceries"``) for the RigidObjectCollection.
-        view_states: Env-major tensor (num_envs, num_bodies, 13) with [pos(3), quat(4), lin(3), ang(3)] in world frame.
-        view_ids: 1D tensor of env-major flattened indices into ``view_states`` to update.
+        body_poses: Env-major body poses [m, rad], shape ``(num_envs, num_bodies, 7)``.
+        body_velocities: Env-major body velocities [m/s, rad/s], shape ``(num_envs, num_bodies, 6)``.
+        view_ids: 1D tensor of env-major flattened indices into ``body_poses`` and ``body_velocities`` to update.
         noise: If True, apply pose and velocity noise before writing.
 
     Returns:
-        None: This function updates ``view_states`` and the underlying PhysX view in-place.
+        None: This function updates ``body_poses``, ``body_velocities``, and the underlying PhysX view in-place.
     """
     rigid_object_collection: RigidObjectCollection = scene[asset_name]
-    flat_states = view_states.view(-1, view_states.shape[-1])
-    sel_view_states = flat_states[view_ids]
-    positions = sel_view_states[:, :3]
-    orientations = sel_view_states[:, 3:7]
+    flat_poses = body_poses.view(-1, body_poses.shape[-1])
+    flat_velocities = body_velocities.view(-1, body_velocities.shape[-1])
+    selected_poses = flat_poses[view_ids]
+    positions = selected_poses[:, :3]
+    orientations = selected_poses[:, 3:7]
     # poses
     if noise:
         range_list = [POSE_RANGE.get(key, (0.0, 0.0)) for key in ["x", "y", "z", "roll", "pitch", "yaw"]]
@@ -178,7 +185,7 @@ def reset_object_collections(
         orientations = math_utils.quat_mul(orientations, orientations_delta)
 
     # velocities
-    new_velocities = sel_view_states[:, 7:13]
+    new_velocities = flat_velocities[view_ids]
     if noise:
         range_list = [VELOCITY_RANGE.get(key, (0.0, 0.0)) for key in ["x", "y", "z", "roll", "pitch", "yaw"]]
         ranges = torch.tensor(range_list, device=scene.device)
@@ -187,11 +194,12 @@ def reset_object_collections(
     else:
         new_velocities[:] = 0.0
 
-    flat_states[view_ids, :7] = torch.concat((positions, orientations), dim=-1)
-    flat_states[view_ids, 7:] = new_velocities
+    flat_poses[view_ids, :3] = positions
+    flat_poses[view_ids, 3:7] = orientations
+    flat_velocities[view_ids] = new_velocities
 
-    rigid_object_collection.write_body_link_pose_to_sim_index(body_poses=view_states[..., :7])
-    rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=view_states[..., 7:])
+    rigid_object_collection.write_body_link_pose_to_sim_index(body_poses=body_poses)
+    rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=body_velocities)
 
 
 def build_grocery_defaults(
@@ -268,10 +276,9 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     num_envs = scene.num_envs
     device = scene.device
     view_indices = torch.arange(num_envs * num_objects, device=device)
-    default_pose_w = groceries.data.default_body_pose.torch.clone()
-    default_pose_w[..., :3] = default_pose_w[..., :3] + scene.env_origins.unsqueeze(1)
-    default_vel_w = groceries.data.default_body_vel.torch.clone()
-    default_state_w = torch.cat([default_pose_w, default_vel_w], dim=-1)
+    default_body_poses_w = groceries.data.default_body_pose.torch.clone()
+    default_body_poses_w[..., :3] = default_body_poses_w[..., :3] + scene.env_origins.unsqueeze(1)
+    default_body_velocities_w = groceries.data.default_body_vel.torch.clone()
     # Define simulation stepping
     sim_dt = sim.get_physics_dt()
     count = 0
@@ -281,12 +288,13 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
     # Offset poses into each environment's world frame.
     active_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
     cached_spawn_poses[..., :3] += scene.env_origins.view(-1, 1, 3)
-    spawn_w = default_state_w.clone()
+    spawn_poses_w = default_body_poses_w.clone()
+    spawn_vel_w = default_body_velocities_w.clone()
 
     groceries_mask_helper = torch.arange(num_objects * num_envs, device=device) % num_objects
     # Precompute a helper mask to toggle objects between active and cached sets.
     # Precompute XY bounds [[x_min,y_min],[x_max,y_max]]
-    bounds_xy = torch.as_tensor(BIN_XY_BOUND, device=device, dtype=spawn_w.dtype)
+    bounds_xy = torch.as_tensor(BIN_XY_BOUND, device=device, dtype=spawn_poses_w.dtype)
     # Simulation loop
     while simulation_app.is_running():
         # Reset
@@ -296,11 +304,13 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
             # Randomly choose how many groceries stay active in each environment.
             num_active_groceries = torch.randint(MIN_OBJECTS_PER_BIN, num_objects, (num_envs, 1), device=device)
             groceries_mask = (groceries_mask_helper.view(num_envs, -1) < num_active_groceries).unsqueeze(-1)
-            spawn_w[..., :7] = cached_spawn_poses * (~groceries_mask) + active_spawn_poses * groceries_mask
+            spawn_poses_w[:] = cached_spawn_poses * (~groceries_mask) + active_spawn_poses * groceries_mask
             # Retrieve positions
             with Timer("[INFO] Time to reset scene: "):
-                reset_object_collections(scene, "groceries", spawn_w, view_indices[~groceries_mask.view(-1)])
-                reset_object_collections(scene, "groceries", spawn_w, view_indices[groceries_mask.view(-1)], noise=True)
+                active_indices = view_indices[~groceries_mask.view(-1)]
+                reset_object_collections(scene, "groceries", spawn_poses_w, spawn_vel_w, active_indices)
+                cached_indices = view_indices[groceries_mask.view(-1)]
+                reset_object_collections(scene, "groceries", spawn_poses_w, spawn_vel_w, cached_indices, noise=True)
                 # Vary the mass and gravity settings so cached objects stay parked.
                 random_masses = torch.rand((groceries.num_instances, num_objects), device=device) * 0.2 + 0.2
                 groceries.set_masses_index(masses=random_masses)
@@ -316,9 +326,11 @@ def run_simulator(sim: SimulationContext, scene: InteractiveScene) -> None:
         out_bound = torch.nonzero((~((xy >= bounds_xy[0]) & (xy <= bounds_xy[1])).all(dim=-1)).view(-1)).flatten()
         if out_bound.numel():
             # Teleport stray objects back into the active stack to keep the bin tidy.
-            states_w = torch.cat([groceries.data.body_link_pose_w.torch, groceries.data.body_com_vel_w.torch], dim=-1)
-            states_w.view(-1, 13)[out_bound] = spawn_w.view(-1, 13)[out_bound]
-            reset_object_collections(scene, "groceries", states_w, out_bound)
+            body_poses_w = groceries.data.body_link_pose_w.torch.clone()
+            body_velocities_w = groceries.data.body_com_vel_w.torch.clone()
+            body_poses_w.view(-1, 7)[out_bound] = spawn_poses_w.view(-1, 7)[out_bound]
+            body_velocities_w.view(-1, 6)[out_bound] = spawn_vel_w.view(-1, 6)[out_bound]
+            reset_object_collections(scene, "groceries", body_poses_w, body_velocities_w, out_bound)
         # Increment counter
         count += 1
         # Update buffers

--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -144,7 +144,7 @@ class MultiObjectSceneCfg(InteractiveSceneCfg):
 def reset_object_collections(
     scene: InteractiveScene, asset_name: str, view_states: torch.Tensor, view_ids: torch.Tensor, noise: bool = False
 ) -> None:
-    """Apply view_states to a subset of a collection, with optional noise.
+    """Apply states to a subset of a collection, with optional noise.
 
     Updates ``view_states`` in-place for ``view_ids`` and writes transforms/velocities
     to the PhysX view for the collection ``asset_name``. When ``noise`` is True, adds
@@ -154,7 +154,7 @@ def reset_object_collections(
     Args:
         scene: Interactive scene containing the collection.
         asset_name: Key in the scene (e.g., ``"groceries"``) for the RigidObjectCollection.
-        view_states: Env-major tensor with shape ``(num_envs, num_bodies, 13)``.
+        view_states: Flat env-major tensor (N, 13) with [x, y, z, qx, qy, qz, qw, lin(3), ang(3)] in world frame.
         view_ids: 1D tensor of env-major flattened indices into ``view_states`` to update.
         noise: If True, apply pose and velocity noise before writing.
 


### PR DESCRIPTION
# Description

This PR updates the `scripts/demos/bin_packing.py` demo to use the current `RigidObjectCollection` body pose and velocity APIs instead of manipulating flat PhysX root-view tensors directly.

The demo now keeps body poses and body velocities in separate env-major buffers, avoiding the deprecated combined state pattern. It also switches mass updates to the collection-level `set_masses_index()` API and uses `body_link_pos_w`, `body_link_pose_w`, and `body_com_vel_w` data accessors for out-of-bounds recovery.

No new dependencies are required.

Fixes `bin_packing.py`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Screenshots

<img width="960" height="527" alt="bin_packing_10s" src="https://github.com/user-attachments/assets/2ac3619d-ca63-48c0-a448-32d44523e3a0" />

## Testing

- `./isaaclab.sh -p scripts/demos/bin_packing.py --num_envs 32`
- `./isaaclab.sh -f`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh -f`
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
