### PR TITLE
Fix skrl MARL observation space config keys

### DIFF
--- a/source/isaaclab/changelog.d/antoiner-fix-skrl-marl-observation-spaces.rst
+++ b/source/isaaclab/changelog.d/antoiner-fix-skrl-marl-observation-spaces.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed Hydra space deserialization for direct MARL environment configs so
+  per-agent observation and action spaces remain populated for skrl multi-agent
+  wrappers.

--- a/source/isaaclab/isaaclab/envs/utils/spaces.py
+++ b/source/isaaclab/isaaclab/envs/utils/spaces.py
@@ -212,7 +212,7 @@ def replace_env_cfg_spaces_with_strings(env_cfg: object) -> object:
 
 
 def replace_strings_with_env_cfg_spaces(env_cfg: object) -> object:
-    """Replace spaces objects with their serialized JSON representations in an environment config.
+    """Replace serialized JSON space strings with space definitions in an environment config.
 
     Args:
         env_cfg: Environment config instance.
@@ -230,6 +230,6 @@ def replace_strings_with_env_cfg_spaces(env_cfg: object) -> object:
             setattr(
                 env_cfg,
                 attr,
-                {k: deserialize_space(v) for k, v in getattr(env_cfg, attr).items() if isinstance(v, str)},
+                {k: deserialize_space(v) if isinstance(v, str) else v for k, v in getattr(env_cfg, attr).items()},
             )
     return env_cfg

--- a/source/isaaclab/test/envs/test_spaces_utils.py
+++ b/source/isaaclab/test/envs/test_spaces_utils.py
@@ -12,7 +12,13 @@ import numpy as np
 import torch
 from gymnasium.spaces import Box, Dict, Discrete, MultiDiscrete, Tuple
 
-from isaaclab.envs.utils.spaces import deserialize_space, sample_space, serialize_space, spec_to_gym_space
+from isaaclab.envs.utils.spaces import (
+    deserialize_space,
+    replace_strings_with_env_cfg_spaces,
+    sample_space,
+    serialize_space,
+    spec_to_gym_space,
+)
 
 
 def test_spec_to_gym_space():
@@ -140,6 +146,19 @@ def test_space_serialization_deserialization():
     assert len(output) == 2
     assert isinstance(output["box"], Box)
     assert isinstance(output["discrete"], Discrete)
+
+
+def test_replace_strings_with_env_cfg_spaces_preserves_unserialized_marl_spaces():
+    """Test per-agent space dictionaries keep entries that Hydra did not serialize."""
+
+    class EnvCfg:
+        observation_spaces = {"cart": 4, "pendulum": serialize_space(3)}
+        action_spaces = {"cart": 1, "pendulum": serialize_space(1)}
+
+    env_cfg = replace_strings_with_env_cfg_spaces(EnvCfg())
+
+    assert env_cfg.observation_spaces == {"cart": 4, "pendulum": 3}
+    assert env_cfg.action_spaces == {"cart": 1, "pendulum": 1}
 
 
 def _check_tensorized(sample, batch_size):


### PR DESCRIPTION
# Description

Fixes MARL environment config space deserialization so non-serialized per-agent
space specs are preserved when Hydra resolves task configs. This keeps
`cfg.observation_spaces` and `cfg.action_spaces` populated for all agents in
`cfg.possible_agents`, including:

- `Isaac-Cart-Double-Pendulum-Direct-v0` (`cart`, `pendulum`)
- `Isaac-Shadow-Hand-Over-Direct-v0` (`right_hand`, `left_hand`)

Fixes: N/A (reported from local reproduction)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Test Plan

- [x] `./isaaclab.sh -p -m pytest source/isaaclab/test/envs/test_spaces_utils.py::test_replace_strings_with_env_cfg_spaces_preserves_unserialized_marl_spaces -q`
- [x] `./isaaclab.sh -p -m pytest source/isaaclab/test/envs/test_spaces_utils.py -q`
- [x] Verified `resolve_task_config()` preserves observation/action spaces for Cart Double Pendulum and Shadow Hand Over with `skrl_ippo_cfg_entry_point` and `skrl_mappo_cfg_entry_point`.
- [x] `./isaaclab.sh -f`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (N/A; no docs change needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
