### PR TITLE
Fix GearAssembly UR10e env count

### DIFF
--- a/source/isaaclab_tasks/changelog.d/antoiner-fix-gearassembly-num-envs.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-fix-gearassembly-num-envs.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the default number of environments for the UR10e Deploy GearAssembly
+  tasks so their training configs use less GPU memory.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/gear_assembly/config/ur_10e/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/deploy/gear_assembly/config/ur_10e/joint_pos_env_cfg.py
@@ -240,6 +240,8 @@ class UR10eGearAssemblyEnvCfg(GearAssemblyEnvCfg):
         # post init of parent
         super().__post_init__()
 
+        self.scene.num_envs = 2048
+
         # Robot-specific parameters (can be overridden for other robots)
         self.end_effector_body_name = "wrist_3_link"  # End effector body name for IK and termination checks
         self.num_arm_joints = 6  # Number of arm joints (excluding gripper)

--- a/source/isaaclab_tasks/test/test_deploy_gear_assembly_cfg.py
+++ b/source/isaaclab_tasks/test/test_deploy_gear_assembly_cfg.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for Deploy GearAssembly environment configuration defaults."""
+
+import pytest
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
+
+
+@pytest.mark.parametrize(
+    "task_name",
+    [
+        "Isaac-Deploy-GearAssembly-UR10e-2F140-v0",
+        "Isaac-Deploy-GearAssembly-UR10e-2F85-v0",
+    ],
+)
+def test_ur10e_gear_assembly_default_num_envs(task_name: str):
+    """UR10e GearAssembly training configs should fit on 16 GB GPUs by default."""
+    env_cfg = parse_env_cfg(task_name)
+
+    assert env_cfg.scene.num_envs == 2048


### PR DESCRIPTION
# Description

Lower the default scene size for the UR10e Deploy GearAssembly training configs from 4096 to 2048 environments. These newly enabled rsl_rl tasks were exhausting GPU memory at the inherited default; 2048 was smoke-tested on a 16 GB RTX 5000 Ada laptop GPU.

No new dependencies are required.

Fixes # (none)

Verification:

- `./isaaclab.sh -p -m pytest source/isaaclab_tasks/test/test_deploy_gear_assembly_cfg.py`
- Red check before the fix: 2 failures, both resolving to `4096` instead of `2048`.
- 2048-env one-step smoke check for `Isaac-Deploy-GearAssembly-UR10e-2F140-v0` and `Isaac-Deploy-GearAssembly-UR10e-2F85-v0` on `NVIDIA RTX 5000 Ada Generation Laptop GPU, 16376 MiB`.
- `./isaaclab.sh -f` before commit and again after commit.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
