### PR TITLE
ci: add Docker-based FabricFrameView multi-GPU test workflow

### DIFF
--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -72,6 +72,10 @@ inputs:
   container-name:
     description: 'Docker container name prefix (run-id is appended automatically)'
     required: true
+  multi-gpu:
+    description: 'Enable multi-GPU tests (sets ISAACLAB_TEST_MULTI_GPU=1 inside the container)'
+    default: 'false'
+    required: false
 runs:
   using: composite
   steps:
@@ -150,6 +154,7 @@ runs:
         include-files: ${{ inputs.include-files }}
         volume-mount-source: ${{ github.workspace }}
         extra-pip-packages: ${{ inputs.extra-pip-packages }}
+        multi-gpu: ${{ inputs.multi-gpu }}
 
     - name: Check Test Results
       if: always()

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -69,6 +69,10 @@ inputs:
     description: 'Space-separated pip packages to install inside the Docker container before pytest starts'
     default: ''
     required: false
+  multi-gpu:
+    description: 'Enable multi-GPU tests (sets ISAACLAB_TEST_MULTI_GPU=1 inside the container)'
+    default: 'false'
+    required: false
 
 runs:
   using: composite
@@ -93,6 +97,7 @@ runs:
           local shard_count="${13}"
           local volume_mount_source="${14}"
           local extra_pip_packages="${15}"
+          local multi_gpu="${16}"
           local logs_pid=""
           local wait_pid=""
           local docker_wait_file="/tmp/.docker_exit_${container_name}"
@@ -160,6 +165,11 @@ runs:
           if [ "$quarantined_only" = "true" ]; then
             docker_env_vars="$docker_env_vars -e TEST_QUARANTINED_ONLY=true"
             echo "Setting TEST_QUARANTINED_ONLY=true"
+          fi
+
+          if [ "$multi_gpu" = "true" ]; then
+            docker_env_vars="$docker_env_vars -e ISAACLAB_TEST_MULTI_GPU=1"
+            echo "Setting ISAACLAB_TEST_MULTI_GPU=1"
           fi
 
           if [ -n "$include_files" ]; then
@@ -392,7 +402,7 @@ runs:
         }
 
         # Call the function with provided parameters
-        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "${{ inputs.pytest-options }}" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}"
+        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "${{ inputs.pytest-options }}" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.multi-gpu }}"
 
     - name: Kill container on cancellation
       if: cancelled()

--- a/.github/workflows/test-fabric-multi-gpu.yaml
+++ b/.github/workflows/test-fabric-multi-gpu.yaml
@@ -9,61 +9,103 @@
 # source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py on the
 # dedicated multi-GPU runner.  Kept separate from test-multi-gpu.yaml so
 # changes to FabricFrameView do not gate distributed-training validation and
-# vice versa.  Runner preconditions (label, install step, GPU pre-flight) are
-# identical to the training workflow.
+# vice versa.
+#
+# Uses the same Docker-based approach as build.yaml to ensure the test runs
+# against the Kit version baked into the Isaac Sim container (not a stale
+# pip-installed version).
 
 name: FabricFrameView Multi-GPU Tests
 
-# DISABLED: No self-hosted runner with the 'multi-gpu' label is currently
-# registered.  All runs queue indefinitely.  Re-enable once infra provisions
-# a multi-GPU runner (see also .github/workflows/test-multi-gpu.yaml which
-# has the same issue).
-#
-# on:
-#   pull_request:
-#     paths:
-#       - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
-#       - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
-#       - ".github/workflows/test-fabric-multi-gpu.yaml"
-#   workflow_dispatch:
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py"
+      - "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
+      - ".github/workflows/test-fabric-multi-gpu.yaml"
+    branches:
+      - main
+      - develop
+      - 'release/**'
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CI_IMAGE_TAG: isaac-lab-ci:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+  NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+
 jobs:
+  config:
+    name: Load Config
+    runs-on: ubuntu-latest
+    outputs:
+      isaacsim_image_name: ${{ steps.load.outputs.isaacsim_image_name }}
+      isaacsim_image_tag: ${{ steps.load.outputs.isaacsim_image_tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          sparse-checkout: .github/workflows/config.yaml
+          sparse-checkout-cone-mode: false
+      - id: load
+        run: |
+          set -euo pipefail
+          f=.github/workflows/config.yaml
+          echo "isaacsim_image_name=$(yq -r .isaacsim_image_name "$f")" >> "$GITHUB_OUTPUT"
+          echo "isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$f")" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build Base Docker Image
+    needs: config
+    runs-on: [self-hosted, linux, x64, multi-gpu]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          lfs: true
+
+      - name: Build and push to ECR
+        uses: ./.github/actions/ecr-build-push-pull
+        with:
+          image-tag: ${{ env.CI_IMAGE_TAG }}
+          isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
+          isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
+          dockerfile-path: docker/Dockerfile.base
+          cache-tag: cache-base
+
   test-fabric-multi-gpu:
     name: FabricFrameView multi-GPU unit tests
-    runs-on: [self-hosted, linux, x64, gpu, multi-gpu]
-    timeout-minutes: 30
+    needs: [build, config]
+    runs-on: [self-hosted, linux, x64, multi-gpu]
+    timeout-minutes: 60
+    if: needs.build.result == 'success'
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Isaac Lab
-        run: ./isaaclab.sh --install
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          lfs: true
 
       - name: Verify multi-GPU availability
-        # Fail loud if the runner regressed to a single GPU.  Without this, the
-        # test helper's ``_skip_if_unavailable`` would skip every ``cuda:1`` case
-        # and the job would go green with no real coverage.
         run: |
           echo "=== GPU Info ==="
           nvidia-smi --query-gpu=index,name,memory.total --format=csv
-
-          GPU_COUNT=$(./isaaclab.sh -p -c "import torch; print(torch.cuda.device_count())")
+          GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
           echo "Detected $GPU_COUNT GPU(s)"
-
           if [ "$GPU_COUNT" -lt 2 ]; then
             echo "::error::At least 2 GPUs required for Fabric multi-GPU tests, found $GPU_COUNT"
             exit 1
           fi
 
       - name: Run FabricFrameView multi-GPU unit tests
-        env:
-          ISAACLAB_TEST_MULTI_GPU: "1"
-        run: |
-          ./isaaclab.sh -p -m pytest \
-            source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py -v
+        uses: ./.github/actions/run-package-tests
+        with:
+          image-tag: ${{ env.CI_IMAGE_TAG }}
+          isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
+          isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
+          include-files: "source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py"
+          container-name: fabric-mgpu-test
+          multi-gpu: "true"

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -341,6 +341,7 @@ def run_individual_tests(test_files, workspace_root, isaacsim_ci):
             sys.executable,
             "-m",
             "pytest",
+            "-v",
             "-s",
             "--no-header",
             f"--config-file={workspace_root}/pyproject.toml",


### PR DESCRIPTION
## Summary

Adds a CI workflow that runs FabricFrameView `cuda:1` unit tests on multi-GPU runners using Docker — consistent with how all other test jobs run in `build.yaml`.

## Problem

The previous bare-metal approach installed `isaacsim==6.0.0` via pip, which bundled Kit 110.0. This silently ran tests against a stale Kit version instead of the Kit 111.0 shipped in the `nvcr.io/nvidian/isaac-sim:latest-develop` container image.

## Solution

Use the same `run-package-tests` composite action as all other CI test jobs:
1. Build/pull the Docker image from ECR via `ecr-build-push-pull`
2. Run pytest inside the container (correct Kit version guaranteed)
3. Volume-mount the workspace so the PR's test source is used

## Workflow triggers

- `source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py`
- `source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py`
- `.github/workflows/test-fabric-multi-gpu.yaml`
- Manual dispatch

## Testing

Validated in PR #5822 — tests pass with the correct Kit 111.0 version.