### PR TITLE
Fix pink ik dep pinning

### DIFF
--- a/source/isaaclab/pyproject.toml
+++ b/source/isaaclab/pyproject.toml
@@ -49,10 +49,10 @@ dependencies = [
     # cross-platform file locking
     "filelock",
     "lazy_loader>=0.4",
-    # IK controller (Linux x86_64 + ARM64)
+    # IK controller (Linux x86_64 + ARM64), requires pinning to 3.1.0 and 0.8.5 to avoid breaking change
     "pin ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
-    "pin-pink>=3.1.0 ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
-    "daqp>=0.8.5 ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
+    "pin-pink==3.1.0 ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
+    "daqp==0.8.5 ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
     # OpenUSD (kit-less mode)
     "usd-core>=25.0.0 ; platform_machine in 'x86_64 AMD64'",
     "usd-exchange>=2.2 ; platform_machine in 'x86_64 AMD64 aarch64 arm64'",


### PR DESCRIPTION
# Description

Fixes pink IK dependency

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
