### PR TITLE
Fire interval events once at reset instead of every step

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-fire-interval-events-once-at-reset.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-fire-interval-events-once-at-reset.skip
@@ -1,0 +1,2 @@
+Test-only: replaced the "fire every step" interval helper with a
+"fire once at reset" mechanism.

--- a/source/isaaclab_tasks/test/env_test_utils.py
+++ b/source/isaaclab_tasks/test/env_test_utils.py
@@ -232,7 +232,7 @@ def _fire_all_interval_events_once(env) -> None:
     Args:
         env: A constructed env instance.
     """
-    event_manager = getattr(env, "event_manager", None)
+    event_manager = getattr(env.unwrapped, "event_manager", None)
     if event_manager is None:
         return
     if "interval" not in event_manager.available_modes:

--- a/source/isaaclab_tasks/test/env_test_utils.py
+++ b/source/isaaclab_tasks/test/env_test_utils.py
@@ -217,37 +217,28 @@ def setup_environment(
     ]
 
 
-def _force_interval_events_to_fire_immediately(env_cfg) -> None:
-    """Rewrite every interval-mode event term so it fires on the first ``step()``.
+def _fire_all_interval_events_once(env) -> None:
+    """Force every interval-mode event term to fire once.
 
-    The :class:`isaaclab.managers.EventManager` samples ``time_left`` from
-    ``interval_range_s`` at reset, then fires the term once ``time_left < 1e-6``
-    after subtracting ``dt`` each step.  Setting both bounds of the range to
-    ``1e-6`` guarantees the sampled ``time_left`` lands at the trigger threshold
-    on the first step, regardless of ``is_global_time``.
+    Invokes :meth:`~isaaclab.managers.EventManager.apply` with ``mode="interval"``
+    and a ``dt`` larger than any plausible ``interval_range_s`` upper bound, so the
+    trigger condition trips for every term in a single call. The manager re-samples
+    ``time_left`` from each term's original ``interval_range_s`` after firing, so
+    subsequent ``env.step()`` calls observe original interval timing.
 
-    Mutates ``env_cfg.events`` in place.  No-op if ``env_cfg.events`` is ``None``
-    or has no interval-mode terms.
+    No-op for envs without an :class:`~isaaclab.managers.EventManager` or
+    without any ``interval``-mode terms.
 
     Args:
-        env_cfg: A parsed env config.
+        env: A constructed env instance.
     """
-    events_cfg = getattr(env_cfg, "events", None)
-    if events_cfg is None:
+    event_manager = getattr(env, "event_manager", None)
+    if event_manager is None:
         return
-    for term_name in dir(events_cfg):
-        if term_name.startswith("_"):
-            continue
-        try:
-            term = getattr(events_cfg, term_name, None)
-        except AttributeError:
-            continue
-        if (
-            term is not None
-            and getattr(term, "mode", None) == "interval"
-            and getattr(term, "interval_range_s", None) is not None
-        ):
-            term.interval_range_s = (1e-6, 1e-6)
+    if "interval" not in event_manager.available_modes:
+        return
+    # Pass a very large dt for (time_left -= dt) to be less than 1e-6
+    event_manager.apply("interval", dt=1e9)
 
 
 def _run_environments(
@@ -259,7 +250,6 @@ def _run_environments(
     create_stage_in_memory=False,
     disable_clone_in_fabric=False,
     physics_preset_name: str | None = None,
-    force_interval_events: bool = False,
 ):
     """Run all environments and check environments return valid signals.
 
@@ -273,8 +263,6 @@ def _run_environments(
         disable_clone_in_fabric: Whether to disable fabric cloning.
         physics_preset_name: Name of the physics preset to apply (e.g., 'newton_mjwarp').
             If None, uses the environment's default physics.
-        force_interval_events: If True, rewrite interval-mode event terms so they
-            fire on the first ``step()``.
     """
 
     # skip test if stage in memory is not supported
@@ -336,7 +324,6 @@ def _run_environments(
         create_stage_in_memory=create_stage_in_memory,
         disable_clone_in_fabric=disable_clone_in_fabric,
         physics_preset_name=physics_preset_name,
-        force_interval_events=force_interval_events,
     )
     print(f""">>> Closing environment: {task_name}""")
     print("-" * 80)
@@ -351,7 +338,6 @@ def _check_random_actions(
     create_stage_in_memory: bool = False,
     disable_clone_in_fabric: bool = False,
     physics_preset_name: str | None = None,
-    force_interval_events: bool = False,
 ):
     """Run random actions and check environments return valid signals.
 
@@ -365,8 +351,6 @@ def _check_random_actions(
         disable_clone_in_fabric: Whether to disable fabric cloning.
         physics_preset_name: Name of the physics preset to apply (e.g., 'newton_mjwarp').
             If None, uses the environment's default physics.
-        force_interval_events: If True, rewrite interval-mode event terms so they
-            fire on the first ``step()``.
     """
     # create a new context stage, if stage in memory is not enabled
     if not create_stage_in_memory:
@@ -394,9 +378,6 @@ def _check_random_actions(
         env_cfg.sim.create_stage_in_memory = create_stage_in_memory
         if disable_clone_in_fabric:
             env_cfg.scene.clone_in_fabric = False
-
-        if force_interval_events:
-            _force_interval_events_to_fire_immediately(env_cfg)
 
         # filter based off multi agents mode and create env
         if multi_agent:
@@ -431,6 +412,8 @@ def _check_random_actions(
 
         # check signal
         assert _check_valid_tensor(obs)
+
+        _fire_all_interval_events_once(env)
 
         # simulate environment for num_steps
         with torch.inference_mode():

--- a/source/isaaclab_tasks/test/test_environments.py
+++ b/source/isaaclab_tasks/test/test_environments.py
@@ -37,10 +37,4 @@ from env_test_utils import _run_environments, setup_environment  # isort: skip
 @pytest.mark.isaacsim_ci
 def test_environments(task_name, num_envs, device):
     # run environments without stage in memory
-    _run_environments(
-        task_name,
-        device,
-        num_envs,
-        force_interval_events=True,
-        create_stage_in_memory=False,
-    )
+    _run_environments(task_name, device, num_envs, create_stage_in_memory=False)


### PR DESCRIPTION
# Description

This PR removes the helper `_force_interval_events_to_fire_immediately` entirely and replaces it with a post-`env.reset()` call to `EventManager.apply("interval", dt=large_dt)`, which fires each interval term exactly once at start, then lets the env run with production-faithful timing for the remaining steps.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there