### PR TITLE
Fix cartpole-camera frame-stacking performance regression

### DIFF
--- a/source/isaaclab/changelog.d/jmart-framestack-perf.minor.rst
+++ b/source/isaaclab/changelog.d/jmart-framestack-perf.minor.rst
@@ -1,0 +1,23 @@
+Added
+^^^^^
+
+* Added :paramref:`~isaaclab.utils.buffers.CircularBuffer.stack_dim` constructor argument
+  and :attr:`~isaaclab.utils.buffers.CircularBuffer.stacked` property: when ``stack_dim`` is
+  set, the internal storage is rearranged so ``stacked`` returns the ``K`` frames merged
+  along the chosen dim as a free contiguous view.
+* Added :mod:`isaaclab.utils.images` with :func:`~isaaclab.utils.images.normalize_camera_image`
+  and the ``is_rgb_like`` / ``is_depth_like`` / ``is_normals_like`` predicates, shared
+  between the DirectRLEnv and ManagerBasedEnv camera observation paths.
+* Added :func:`isaaclab.utils.warp.ops.normalize_image_uint8`, a fused Warp-kernel
+  implementation of ``(uint8 / 255) - per-image-channel mean`` for RGB-like camera
+  observations.
+* Added a ``clone`` kwarg to :func:`isaaclab.envs.mdp.observations.image`; callers that
+  immediately copy the result into their own storage (e.g. a frame-stack buffer) can pass
+  ``clone=False`` to skip the redundant allocation.
+
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab.envs.mdp.observations.stacked_image` to use the new ``stack_dim``
+  ``CircularBuffer`` layout and defer normalization past the frame-stack buffer for RGB-like
+  data types, eliminating a per-frame float32 upcast and large transpose.

--- a/source/isaaclab/changelog.d/jmart-framestack-perf.minor.rst
+++ b/source/isaaclab/changelog.d/jmart-framestack-perf.minor.rst
@@ -10,7 +10,9 @@ Added
   between the DirectRLEnv and ManagerBasedEnv camera observation paths.
 * Added :func:`isaaclab.utils.warp.ops.normalize_image_uint8`, a fused Warp-kernel
   implementation of ``(uint8 / 255) - per-image-channel mean`` for RGB-like camera
-  observations.
+  observations. Supports both ``(B, H, W, C)`` and ``(B, C, H, W)`` inputs via a
+  ``channel_dim`` argument (``-1`` / ``3`` for BHWC, ``-3`` / ``1`` for BCHW); the
+  argument is also forwarded by :func:`~isaaclab.utils.images.normalize_camera_image`.
 * Added a ``clone`` kwarg to :func:`isaaclab.envs.mdp.observations.image`; callers that
   immediately copy the result into their own storage (e.g. a frame-stack buffer) can pass
   ``clone=False`` to skip the redundant allocation.

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -393,14 +393,19 @@ def image(
 ) -> torch.Tensor:
     """Images of a specific datatype from the camera sensor.
 
+    If the flag :attr:`normalize` is True, post-processing of the images are performed based on their
+    data-types:
+
+    - "rgb": Scales the image to (0, 1) and subtracts with the mean of the current image batch.
+    - "depth" or "distance_to_camera" or "distance_to_plane": Replaces infinity values with zero.
+
     Args:
         env: The environment the cameras are placed within.
         sensor_cfg: The desired sensor to read from. Defaults to SceneEntityCfg("tiled_camera").
         data_type: The data type to pull from the desired camera. Defaults to "rgb".
         convert_perspective_to_orthogonal: Whether to orthogonalize perspective depth images.
             This is used only when the data type is "distance_to_camera". Defaults to False.
-        normalize: If True, post-process the image via
-            :func:`~isaaclab.utils.images.normalize_camera_image` (dispatched on ``data_type``).
+        normalize: Whether to normalize the images. This depends on the selected data type.
             Defaults to True.
         permute: Whether to permute the image to (num_envs, channel, height, width). Defaults to False.
         clone: Whether to return a fresh clone of the result. Defaults to True (defensive: protects
@@ -409,7 +414,7 @@ def image(
             to skip the redundant allocation.
 
     Returns:
-        The images produced at the last time-step.
+        The images produced at the last time-step
     """
     # extract the used quantities (to enable type-hinting)
     sensor: Camera | RayCasterCamera = env.scene.sensors[sensor_cfg.name]

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -20,6 +20,7 @@ from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers.manager_base import ManagerTermBase
 from isaaclab.managers.manager_term_cfg import ObservationTermCfg
 from isaaclab.utils.buffers import CircularBuffer
+from isaaclab.utils.images import is_rgb_like, normalize_camera_image
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation, RigidObject
@@ -392,19 +393,14 @@ def image(
 ) -> torch.Tensor:
     """Images of a specific datatype from the camera sensor.
 
-    If the flag :attr:`normalize` is True, post-processing of the images are performed based on their
-    data-types:
-
-    - "rgb": Scales the image to (0, 1) and subtracts with the mean of the current image batch.
-    - "depth" or "distance_to_camera" or "distance_to_plane": Replaces infinity values with zero.
-
     Args:
         env: The environment the cameras are placed within.
         sensor_cfg: The desired sensor to read from. Defaults to SceneEntityCfg("tiled_camera").
         data_type: The data type to pull from the desired camera. Defaults to "rgb".
         convert_perspective_to_orthogonal: Whether to orthogonalize perspective depth images.
             This is used only when the data type is "distance_to_camera". Defaults to False.
-        normalize: Whether to normalize the images. This depends on the selected data type.
+        normalize: If True, post-process the image via
+            :func:`~isaaclab.utils.images.normalize_camera_image` (dispatched on ``data_type``).
             Defaults to True.
         permute: Whether to permute the image to (num_envs, channel, height, width). Defaults to False.
         clone: Whether to return a fresh clone of the result. Defaults to True (defensive: protects
@@ -413,7 +409,7 @@ def image(
             to skip the redundant allocation.
 
     Returns:
-        The images produced at the last time-step
+        The images produced at the last time-step.
     """
     # extract the used quantities (to enable type-hinting)
     sensor: Camera | RayCasterCamera = env.scene.sensors[sensor_cfg.name]
@@ -425,16 +421,8 @@ def image(
     if (data_type == "distance_to_camera") and convert_perspective_to_orthogonal:
         images = math_utils.orthogonalize_perspective_depth(images, sensor.data.intrinsic_matrices)
 
-    # rgb/depth/normals image normalization
     if normalize:
-        if data_type == "rgb":
-            images = images.float() / 255.0
-            mean_tensor = torch.mean(images, dim=(1, 2), keepdim=True)
-            images -= mean_tensor
-        elif "distance_to" in data_type or "depth" in data_type:
-            images[images == float("inf")] = 0
-        elif "normals" in data_type:
-            images = (images + 1.0) * 0.5
+        images = normalize_camera_image(images, data_type)
 
     if permute:
         images = images.permute(0, 3, 1, 2)
@@ -702,9 +690,10 @@ class stacked_image(ManagerTermBase):
 
         # K=1 is a documented passthrough; no buffer needed.
         self._buffer: CircularBuffer | None = None
+        # Reused across steps to avoid allocating a fresh output every call.
+        self._normalized_output: torch.Tensor | None = None
         if frame_stack > 1:
-            # Channel-stack mode: buffer storage is laid out so that .stacked is a free
-            # contiguous reshape into (B, H, W, K*C) -- no per-step permute/reshape alloc.
+            # Channel-stack: K frames concatenated along C; .stacked is a free contiguous view.
             self._buffer = CircularBuffer(
                 max_len=frame_stack,
                 batch_size=env.num_envs,
@@ -725,7 +714,6 @@ class stacked_image(ManagerTermBase):
         convert_perspective_to_orthogonal: bool = False,
         normalize: bool = True,
     ) -> torch.Tensor:
-        # K=1 passthrough: no buffer allocated; rely on image()'s defensive clone.
         if self._buffer is None:
             return image(
                 env=env,
@@ -735,24 +723,24 @@ class stacked_image(ManagerTermBase):
                 normalize=normalize,
             )
 
-        # Defer RGB normalize past the buffer so the ring stores native uint8 (4x cheaper
-        # per-step copies). Other data types let image() normalize per-frame as usual.
-        defer_rgb = normalize and data_type == "rgb"
+        # RGB-like camera output is uint8; defer normalize so the buffer can hold it raw.
+        # Depth / normals output is float32 — leave normalize per-frame in image().
+        defer_normalize = normalize and is_rgb_like(data_type)
         single_frame = image(
             env=env,
             sensor_cfg=sensor_cfg,
             data_type=data_type,
             convert_perspective_to_orthogonal=convert_perspective_to_orthogonal,
-            normalize=normalize and not defer_rgb,
+            normalize=normalize and not defer_normalize,
             clone=False,
         )
         self._buffer.append(single_frame)
         stacked = self._buffer.stacked
 
-        if defer_rgb:
-            out = stacked.float() / 255.0
-            out -= torch.mean(out, dim=(1, 2), keepdim=True)
-            return out
+        if defer_normalize:
+            if self._normalized_output is None:
+                self._normalized_output = torch.empty(stacked.shape, dtype=torch.float32, device=env.device)
+            return normalize_camera_image(stacked, data_type, out=self._normalized_output)
         return stacked
 
 

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -690,8 +690,6 @@ class stacked_image(ManagerTermBase):
 
         # K=1 is a documented passthrough; no buffer needed.
         self._buffer: CircularBuffer | None = None
-        # Reused across steps to avoid allocating a fresh output every call.
-        self._normalized_output: torch.Tensor | None = None
         if frame_stack > 1:
             # Channel-stack: K frames concatenated along C; .stacked is a free contiguous view.
             self._buffer = CircularBuffer(
@@ -738,10 +736,16 @@ class stacked_image(ManagerTermBase):
         stacked = self._buffer.stacked
 
         if defer_normalize:
-            if self._normalized_output is None:
-                self._normalized_output = torch.empty(stacked.shape, dtype=torch.float32, device=env.device)
-            return normalize_camera_image(stacked, data_type, out=self._normalized_output)
-        return stacked
+            # No ``out=`` -- a fresh float32 tensor is allocated per call. The caching
+            # allocator returns a different block than the previous step's (still
+            # referenced by the trainer), so the previous-iteration ``observations``
+            # is not overwritten before ``record_transition`` reads it. See
+            # :func:`isaaclab.utils.warp.ops.normalize_image_uint8` for the aliasing
+            # hazard documentation.
+            return normalize_camera_image(stacked, data_type)
+        # ``stacked`` is a view of the ring buffer storage which is overwritten on the next
+        # ``env.step``; clone so the returned tensor outlives the next step.
+        return stacked.clone()
 
 
 """

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -730,12 +730,10 @@ class stacked_image(ManagerTermBase):
 
         self._buffer.append(single_frame)
 
-        # CircularBuffer.buffer is (B, K, H, W, C) in oldest->newest order along dim 1.
-        # Channel-stack: move K next to C, then flatten so the last dim reads
-        # oldest_C, ..., newest_C.
+        # CircularBuffer.buffer is (B, K, H, W, C); flatten K next to C for oldest->newest channels.
         stacked = self._buffer.buffer
         b, k, h, w, c = stacked.shape
-        return stacked.permute(0, 2, 3, 1, 4).reshape(b, h, w, k * c).clone()
+        return stacked.permute(0, 2, 3, 1, 4).reshape(b, h, w, k * c)
 
 
 """

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -388,6 +388,7 @@ def image(
     convert_perspective_to_orthogonal: bool = False,
     normalize: bool = True,
     permute: bool = False,
+    clone: bool = True,
 ) -> torch.Tensor:
     """Images of a specific datatype from the camera sensor.
 
@@ -406,6 +407,11 @@ def image(
         normalize: Whether to normalize the images. This depends on the selected data type.
             Defaults to True.
         permute: Whether to permute the image to (num_envs, channel, height, width). Defaults to False.
+        clone: Whether to return a fresh clone of the result. Defaults to True (defensive: protects
+            against downstream in-place mutation of the camera buffer). Callers that immediately
+            copy the result into their own storage (e.g. a frame-stack buffer) can pass ``False``
+            to skip the redundant allocation.
+
     Returns:
         The images produced at the last time-step
     """
@@ -433,7 +439,7 @@ def image(
     if permute:
         images = images.permute(0, 3, 1, 2)
 
-    return images.clone()
+    return images.clone() if clone else images
 
 
 class image_features(ManagerTermBase):
@@ -716,24 +722,35 @@ class stacked_image(ManagerTermBase):
         convert_perspective_to_orthogonal: bool = False,
         normalize: bool = True,
     ) -> torch.Tensor:
+        # K=1 passthrough: no buffer allocated; rely on image()'s defensive clone.
+        if self._buffer is None:
+            return image(
+                env=env,
+                sensor_cfg=sensor_cfg,
+                data_type=data_type,
+                convert_perspective_to_orthogonal=convert_perspective_to_orthogonal,
+                normalize=normalize,
+            )
+
+        # Stacked path: skip image()'s defensive clone — append() copies into the buffer below.
         single_frame = image(
             env=env,
             sensor_cfg=sensor_cfg,
             data_type=data_type,
             convert_perspective_to_orthogonal=convert_perspective_to_orthogonal,
             normalize=normalize,
+            clone=False,
         )
-
-        # K=1 passthrough: no buffer allocated. ``image()`` already clones.
-        if self._buffer is None:
-            return single_frame
-
         self._buffer.append(single_frame)
 
-        # CircularBuffer.buffer is (B, K, H, W, C); flatten K next to C for oldest->newest channels.
-        stacked = self._buffer.buffer
-        b, k, h, w, c = stacked.shape
-        return stacked.permute(0, 2, 3, 1, 4).reshape(b, h, w, k * c)
+        b, *spatial, c = single_frame.shape
+        out = torch.empty(
+            (b, *spatial, c * self._buffer.max_length),
+            dtype=single_frame.dtype,
+            device=single_frame.device,
+        )
+        self._buffer.copy_to_stacked(out)
+        return out
 
 
 """

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -735,17 +735,25 @@ class stacked_image(ManagerTermBase):
                 normalize=normalize,
             )
 
-        # Stacked path: skip image()'s defensive clone — append() copies into the buffer below.
+        # Defer RGB normalize past the buffer so the ring stores native uint8 (4x cheaper
+        # per-step copies). Other data types let image() normalize per-frame as usual.
+        defer_rgb = normalize and data_type == "rgb"
         single_frame = image(
             env=env,
             sensor_cfg=sensor_cfg,
             data_type=data_type,
             convert_perspective_to_orthogonal=convert_perspective_to_orthogonal,
-            normalize=normalize,
+            normalize=normalize and not defer_rgb,
             clone=False,
         )
         self._buffer.append(single_frame)
-        return self._buffer.stacked
+        stacked = self._buffer.stacked
+
+        if defer_rgb:
+            out = stacked.float() / 255.0
+            out -= torch.mean(out, dim=(1, 2), keepdim=True)
+            return out
+        return stacked
 
 
 """

--- a/source/isaaclab/isaaclab/envs/mdp/observations.py
+++ b/source/isaaclab/isaaclab/envs/mdp/observations.py
@@ -703,10 +703,13 @@ class stacked_image(ManagerTermBase):
         # K=1 is a documented passthrough; no buffer needed.
         self._buffer: CircularBuffer | None = None
         if frame_stack > 1:
+            # Channel-stack mode: buffer storage is laid out so that .stacked is a free
+            # contiguous reshape into (B, H, W, K*C) -- no per-step permute/reshape alloc.
             self._buffer = CircularBuffer(
                 max_len=frame_stack,
                 batch_size=env.num_envs,
                 device=env.device,
+                stack_dim=-1,
             )
 
     def reset(self, env_ids: torch.Tensor | None = None):
@@ -742,15 +745,7 @@ class stacked_image(ManagerTermBase):
             clone=False,
         )
         self._buffer.append(single_frame)
-
-        b, *spatial, c = single_frame.shape
-        out = torch.empty(
-            (b, *spatial, c * self._buffer.max_length),
-            dtype=single_frame.dtype,
-            device=single_frame.device,
-        )
-        self._buffer.copy_to_stacked(out)
-        return out
+        return self._buffer.stacked
 
 
 """

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -20,7 +20,7 @@ class CircularBuffer:
     The shape of the appended data is expected to be (batch_size, ...), where the first dimension is the
     batch dimension. Correspondingly, the shape of the ring buffer is (max_len, batch_size, ...).
 
-    When :paramref:`stack_dim` is set, the internal layout is rearranged so that :attr:`stacked`
+    When ``stack_dim`` is set, the internal layout is rearranged so that :attr:`stacked`
     returns the K frames merged into the chosen dim as a free contiguous view; :meth:`__getitem__`
     is disabled in this mode.
     """

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -39,7 +39,7 @@ class CircularBuffer:
                 :meth:`append`. Defaults to ``None`` (legacy layout).
 
         Raises:
-            ValueError: If ``max_len < 1`` or ``stack_dim == 0``.
+            ValueError: If the buffer size is less than one, or ``stack_dim == 0``.
         """
         if max_len < 1:
             raise ValueError(f"The buffer size should be greater than zero. However, it is set to {max_len}!")
@@ -52,7 +52,9 @@ class CircularBuffer:
 
         # CPU mirror of max_len; avoids a GPU sync via ``.item()`` on every property access.
         self._max_len_int: int = max_len
+        # max length tensor for comparisons
         self._max_len = torch.full((batch_size,), max_len, dtype=torch.int, device=device)
+        # number of data pushes passed since the last call to :meth:`reset`
         self._num_pushes = torch.zeros(batch_size, dtype=torch.long, device=device)
         # CPU gate; lets ``append`` skip a ``torch.any`` GPU sync on the steady-state path.
         self._need_reset: bool = True
@@ -140,6 +142,8 @@ class CircularBuffer:
         self._num_pushes[batch_ids_resolved] = 0
         self._need_reset = True
         if self._buffer is not None:
+            # set buffer at batch_id reset indices to 0.0 so that the buffer() getter returns
+            # the cleared circular buffer after reset.
             if self._stack_dim_internal is None:
                 self._buffer[:, batch_ids_resolved] = 0.0
             else:
@@ -242,5 +246,7 @@ class CircularBuffer:
 
         # Clamp to [0, ..] so batches with _num_pushes == 0 return the zeroed slot.
         valid_keys = torch.clamp(torch.minimum(key, self._num_pushes - 1), min=0)
+        # The buffer is stored oldest->newest along dimension 0, so the most
+        # recent item lives at the last index.
         index_in_buffer = (self._max_len_int - 1 - valid_keys).to(dtype=torch.long)
         return self._buffer[index_in_buffer, self._ALL_INDICES]

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -39,12 +39,14 @@ class CircularBuffer:
         self._device = device
         self._ALL_INDICES = torch.arange(batch_size, device=device)
 
-        # max length tensor for comparisons
+        # CPU mirror of max_len; avoids a GPU sync via ``.item()`` on every property access.
+        self._max_len_int: int = max_len
         self._max_len = torch.full((batch_size,), max_len, dtype=torch.int, device=device)
-        # number of data pushes passed since the last call to :meth:`reset`
         self._num_pushes = torch.zeros(batch_size, dtype=torch.long, device=device)
-        # the actual buffer for data storage
-        # note: this is initialized on the first call to :meth:`append`
+        self._pointer: int = -1
+        # CPU gate; lets ``append`` skip a ``torch.any`` GPU sync on the steady-state path.
+        self._need_reset: bool = True
+        # Lazily allocated on the first ``append``.
         self._buffer: torch.Tensor = None  # type: ignore
 
     """
@@ -64,7 +66,7 @@ class CircularBuffer:
     @property
     def max_length(self) -> int:
         """The maximum length of the ring buffer."""
-        return int(self._max_len[0].item())
+        return self._max_len_int
 
     @property
     def current_length(self) -> torch.Tensor:
@@ -83,7 +85,12 @@ class CircularBuffer:
             Complete circular buffer with most recent entry at the end and oldest entry at the beginning of
             dimension 1. The shape is [batch_size, max_length, data.shape[1:]].
         """
-        return torch.transpose(self._buffer, dim0=0, dim1=1)
+        # Storage is in physical write order; rotate on read to honor the docstring layout.
+        if self._pointer == self._max_len_int - 1:
+            rolled = self._buffer
+        else:
+            rolled = torch.roll(self._buffer, shifts=self._max_len_int - 1 - self._pointer, dims=0)
+        return torch.transpose(rolled, dim0=0, dim1=1)
 
     """
     Operations.
@@ -100,12 +107,10 @@ class CircularBuffer:
             batch_ids_resolved = slice(None)
         else:
             batch_ids_resolved = batch_ids
-        # reset the number of pushes for the specified batch indices
         self._num_pushes[batch_ids_resolved] = 0
+        self._need_reset = True
         if self._buffer is not None:
-            # set buffer at batch_id reset indices to 0.0 so that the buffer() getter returns
-            # the cleared circular buffer after reset.
-            self._buffer[:, batch_ids_resolved] = 0.0
+            self._buffer[:, batch_ids_resolved].zero_()
 
     def append(self, data: torch.Tensor):
         """Append the data to the circular buffer.
@@ -121,20 +126,17 @@ class CircularBuffer:
         if data.shape[0] != self.batch_size:
             raise ValueError(f"The input data has '{data.shape[0]}' batch size while expecting '{self.batch_size}'")
 
-        # move the data to the device
         data = data.to(self._device)
-        is_first_push = self._num_pushes == 0
         if self._buffer is None:
-            self._buffer = data.unsqueeze(0).expand(self.max_length, *data.shape).clone()
-        if torch.any(is_first_push):
-            self._buffer[:, is_first_push] = data[is_first_push]
-        # increment number of number of pushes for all batches
-        self._append(data)
+            self._buffer = torch.empty((self._max_len_int, *data.shape), dtype=data.dtype, device=self._device)
+        self._pointer = (self._pointer + 1) % self._max_len_int
+        self._buffer[self._pointer] = data
+        if self._need_reset:
+            is_first_push = self._num_pushes == 0
+            if torch.any(is_first_push):
+                self._buffer[:, is_first_push] = data[is_first_push]
+            self._need_reset = False
         self._num_pushes += 1
-
-    def _append(self, data: torch.Tensor):
-        self._buffer = torch.roll(self._buffer, shifts=-1, dims=0)
-        self._buffer[-1] = data
 
     def __getitem__(self, key: torch.Tensor) -> torch.Tensor:
         """Retrieve the data from the circular buffer in last-in-first-out (LIFO) fashion.
@@ -159,11 +161,7 @@ class CircularBuffer:
         if self._buffer is None:
             raise RuntimeError("The buffer is empty. Please append data before retrieving.")
 
-        # admissible lag — clamp to [0, ..] so batches with _num_pushes == 0
-        # return the zeroed-out slot instead of indexing out of bounds.
+        # Clamp to [0, ..] so batches with _num_pushes == 0 return the zeroed slot.
         valid_keys = torch.clamp(torch.minimum(key, self._num_pushes - 1), min=0)
-        # The buffer is stored oldest->newest along dimension 0, so the most
-        # recent item lives at the last index.
-        index_in_buffer = (self.max_length - 1 - valid_keys).to(dtype=torch.long)
-        # return output
+        index_in_buffer = ((self._pointer - valid_keys) % self._max_len_int).to(dtype=torch.long)
         return self._buffer[index_in_buffer, self._ALL_INDICES]

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -43,7 +43,6 @@ class CircularBuffer:
         self._max_len_int: int = max_len
         self._max_len = torch.full((batch_size,), max_len, dtype=torch.int, device=device)
         self._num_pushes = torch.zeros(batch_size, dtype=torch.long, device=device)
-        self._pointer: int = -1
         # CPU gate; lets ``append`` skip a ``torch.any`` GPU sync on the steady-state path.
         self._need_reset: bool = True
         # Lazily allocated on the first ``append``.
@@ -85,12 +84,8 @@ class CircularBuffer:
             Complete circular buffer with most recent entry at the end and oldest entry at the beginning of
             dimension 1. The shape is [batch_size, max_length, data.shape[1:]].
         """
-        # Storage is in physical write order; rotate on read to honor the docstring layout.
-        if self._pointer == self._max_len_int - 1:
-            rolled = self._buffer
-        else:
-            rolled = torch.roll(self._buffer, shifts=self._max_len_int - 1 - self._pointer, dims=0)
-        return torch.transpose(rolled, dim0=0, dim1=1)
+        # Storage invariant: oldest at slot 0, newest at slot K-1. Read is a free view.
+        return torch.transpose(self._buffer, dim0=0, dim1=1)
 
     """
     Operations.
@@ -129,8 +124,11 @@ class CircularBuffer:
         data = data.to(self._device)
         if self._buffer is None:
             self._buffer = torch.empty((self._max_len_int, *data.shape), dtype=data.dtype, device=self._device)
-        self._pointer = (self._pointer + 1) % self._max_len_int
-        self._buffer[self._pointer] = data
+        # Shift older slots up so the newest write always lands at slot K-1.
+        # Iterating front-to-back keeps adjacent-slot copies non-overlapping.
+        for i in range(self._max_len_int - 1):
+            self._buffer[i].copy_(self._buffer[i + 1])
+        self._buffer[-1] = data
         if self._need_reset:
             is_first_push = self._num_pushes == 0
             if torch.any(is_first_push):
@@ -163,5 +161,5 @@ class CircularBuffer:
 
         # Clamp to [0, ..] so batches with _num_pushes == 0 return the zeroed slot.
         valid_keys = torch.clamp(torch.minimum(key, self._num_pushes - 1), min=0)
-        index_in_buffer = ((self._pointer - valid_keys) % self._max_len_int).to(dtype=torch.long)
+        index_in_buffer = (self._max_len_int - 1 - valid_keys).to(dtype=torch.long)
         return self._buffer[index_in_buffer, self._ALL_INDICES]

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -19,22 +19,33 @@ class CircularBuffer:
 
     The shape of the appended data is expected to be (batch_size, ...), where the first dimension is the
     batch dimension. Correspondingly, the shape of the ring buffer is (max_len, batch_size, ...).
+
+    When :paramref:`stack_dim` is set, the internal layout is rearranged so that :attr:`stacked`
+    returns the K frames merged into the chosen dim as a free contiguous view; :meth:`__getitem__`
+    is disabled in this mode.
     """
 
-    def __init__(self, max_len: int, batch_size: int, device: str):
+    def __init__(self, max_len: int, batch_size: int, device: str, stack_dim: int | None = None):
         """Initialize the circular buffer.
 
         Args:
             max_len: The maximum length of the circular buffer. The minimum allowed value is 1.
             batch_size: The batch dimension of the data.
             device: The device used for processing.
+            stack_dim: If set, the buffer arranges its internal storage so :attr:`stacked` returns
+                the K stored frames merged into ``data.shape[stack_dim]`` of the appended data
+                as a free contiguous view. Negative indexing supported; ``0`` is invalid (batch
+                dim). Validation against the actual data rank is deferred to the first
+                :meth:`append`. Defaults to ``None`` (legacy layout).
 
         Raises:
-            ValueError: If the buffer size is less than one.
+            ValueError: If ``max_len < 1`` or ``stack_dim == 0``.
         """
         if max_len < 1:
             raise ValueError(f"The buffer size should be greater than zero. However, it is set to {max_len}!")
-        # set the parameters
+        if stack_dim is not None and stack_dim == 0:
+            raise ValueError("stack_dim must not be 0 (cannot stack along the batch dimension).")
+
         self._batch_size = batch_size
         self._device = device
         self._ALL_INDICES = torch.arange(batch_size, device=device)
@@ -47,6 +58,10 @@ class CircularBuffer:
         self._need_reset: bool = True
         # Lazily allocated on the first ``append``.
         self._buffer: torch.Tensor = None  # type: ignore
+
+        self._stack_dim_arg: int | None = stack_dim
+        # Normalized position of K in internal storage; set on first append. None == legacy mode.
+        self._stack_dim_internal: int | None = None
 
     """
     Properties.
@@ -84,8 +99,32 @@ class CircularBuffer:
             Complete circular buffer with most recent entry at the end and oldest entry at the beginning of
             dimension 1. The shape is [batch_size, max_length, data.shape[1:]].
         """
-        # Storage invariant: oldest at slot 0, newest at slot K-1. Read is a free view.
-        return torch.transpose(self._buffer, dim0=0, dim1=1)
+        if self._stack_dim_internal is None:
+            return torch.transpose(self._buffer, dim0=0, dim1=1)
+        return torch.movedim(self._buffer, source=self._stack_dim_internal, destination=1)
+
+    @property
+    def stacked(self) -> torch.Tensor:
+        """Buffer contents with K frames merged along the configured ``stack_dim``.
+
+        Frames appear in oldest -> newest order along the merged dim. The result is a view of
+        the internal storage; callers must not mutate it.
+
+        Returns:
+            View of shape ``(batch_size, *frame_shape)`` with ``frame_shape[stack_dim]`` multiplied by ``max_length``.
+
+        Raises:
+            RuntimeError: If ``stack_dim`` was not set at construction or no data has been appended.
+        """
+        if self._stack_dim_internal is None:
+            raise RuntimeError(
+                "stacked is only available when CircularBuffer was created with stack_dim set."
+            )
+        if self._buffer is None:
+            raise RuntimeError("The buffer is empty. Please append data before retrieving.")
+        k_pos = self._stack_dim_internal
+        s = self._buffer.shape
+        return self._buffer.reshape(*s[:k_pos], s[k_pos] * s[k_pos + 1], *s[k_pos + 2:])
 
     """
     Operations.
@@ -105,7 +144,10 @@ class CircularBuffer:
         self._num_pushes[batch_ids_resolved] = 0
         self._need_reset = True
         if self._buffer is not None:
-            self._buffer[:, batch_ids_resolved].zero_()
+            if self._stack_dim_internal is None:
+                self._buffer[:, batch_ids_resolved].zero_()
+            else:
+                self._buffer[batch_ids_resolved].zero_()
 
     def append(self, data: torch.Tensor):
         """Append the data to the circular buffer.
@@ -116,47 +158,65 @@ class CircularBuffer:
 
         Raises:
             ValueError: If the input data has a different batch size than the buffer.
+            IndexError: On the first call, if the configured ``stack_dim`` is invalid for the
+                appended data's rank.
         """
         # check the batch size
         if data.shape[0] != self.batch_size:
             raise ValueError(f"The input data has '{data.shape[0]}' batch size while expecting '{self.batch_size}'")
 
         data = data.to(self._device)
+
         if self._buffer is None:
-            self._buffer = torch.empty((self._max_len_int, *data.shape), dtype=data.dtype, device=self._device)
-        # Shift older slots up so the newest write always lands at slot K-1.
-        # Iterating front-to-back keeps adjacent-slot copies non-overlapping.
-        for i in range(self._max_len_int - 1):
-            self._buffer[i].copy_(self._buffer[i + 1])
-        self._buffer[-1] = data
+            self._allocate_buffer(data)
+
+        # Shift slots so the newest write lands at the last K slot. Iterating front-to-back
+        # keeps adjacent-slot copies non-overlapping.
+        if self._stack_dim_internal is None:
+            for i in range(self._max_len_int - 1):
+                self._buffer[i].copy_(self._buffer[i + 1])
+            self._buffer[-1] = data
+        else:
+            k_pos = self._stack_dim_internal
+            k = self._max_len_int
+            for i in range(k - 1):
+                self._buffer.narrow(k_pos, i, 1).copy_(self._buffer.narrow(k_pos, i + 1, 1))
+            self._buffer.narrow(k_pos, k - 1, 1).copy_(data.unsqueeze(k_pos))
+
         if self._need_reset:
             is_first_push = self._num_pushes == 0
             if torch.any(is_first_push):
-                self._buffer[:, is_first_push] = data[is_first_push]
+                if self._stack_dim_internal is None:
+                    self._buffer[:, is_first_push] = data[is_first_push]
+                else:
+                    self._buffer[is_first_push] = data[is_first_push].unsqueeze(self._stack_dim_internal)
             self._need_reset = False
+
         self._num_pushes += 1
 
-    def copy_to_stacked(self, out: torch.Tensor) -> None:
-        """Fill a pre-allocated tensor with the buffer contents in oldest-to-newest channel order.
+    def _allocate_buffer(self, data: torch.Tensor) -> None:
+        """Allocate the internal buffer and finalize the storage layout on first append."""
+        if self._stack_dim_arg is None:
+            self._buffer = torch.empty(
+                (self._max_len_int, *data.shape), dtype=data.dtype, device=self._device
+            )
+            return
 
-        The output's last dimension is partitioned into ``max_length`` equal-sized channel slots.
-        Slot 0 receives the oldest stored frame's channels; slot ``max_length - 1`` receives the
-        newest. This avoids the ``permute().reshape()`` non-contiguous allocation that the
-        :attr:`buffer` getter requires for the same effect.
-
-        Args:
-            out: Pre-allocated tensor of shape ``(batch_size, *frame_shape[:-1], max_length * C)``,
-                where ``frame_shape`` is the per-frame shape of appended data and ``C`` is the
-                last-dim size of an appended frame. Will be written into in-place.
-
-        Raises:
-            RuntimeError: If no data has been appended yet.
-        """
-        if self._buffer is None:
-            raise RuntimeError("The buffer is empty. Please append data before retrieving.")
-        c = self._buffer.shape[-1]
-        for k in range(self._max_len_int):
-            out[..., k * c : (k + 1) * c].copy_(self._buffer[k])
+        ndim = data.ndim
+        k_pos = self._stack_dim_arg
+        if k_pos < 0:
+            k_pos += ndim
+        if k_pos < 1 or k_pos >= ndim:
+            raise IndexError(
+                f"stack_dim={self._stack_dim_arg} resolves to position {k_pos} for data with"
+                f" ndim={ndim}; must be in [1, {ndim - 1}] or [-{ndim - 1}, -1]."
+            )
+        self._stack_dim_internal = k_pos
+        self._buffer = torch.empty(
+            (*data.shape[:k_pos], self._max_len_int, *data.shape[k_pos:]),
+            dtype=data.dtype,
+            device=self._device,
+        )
 
     def __getitem__(self, key: torch.Tensor) -> torch.Tensor:
         """Retrieve the data from the circular buffer in last-in-first-out (LIFO) fashion.
@@ -174,7 +234,13 @@ class CircularBuffer:
         Raises:
             ValueError: If the input key has a different batch size than the buffer.
             RuntimeError: If the buffer is empty.
+            NotImplementedError: If the buffer was created with ``stack_dim`` set.
         """
+        if self._stack_dim_internal is not None:
+            raise NotImplementedError(
+                "Indexing via __getitem__ is not supported in stacked-output mode."
+                " Use .stacked or .buffer instead."
+            )
         # check the batch size
         if len(key) != self.batch_size:
             raise ValueError(f"The argument 'key' has length {key.shape[0]}, while expecting {self.batch_size}")

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -136,6 +136,28 @@ class CircularBuffer:
             self._need_reset = False
         self._num_pushes += 1
 
+    def copy_to_stacked(self, out: torch.Tensor) -> None:
+        """Fill a pre-allocated tensor with the buffer contents in oldest-to-newest channel order.
+
+        The output's last dimension is partitioned into ``max_length`` equal-sized channel slots.
+        Slot 0 receives the oldest stored frame's channels; slot ``max_length - 1`` receives the
+        newest. This avoids the ``permute().reshape()`` non-contiguous allocation that the
+        :attr:`buffer` getter requires for the same effect.
+
+        Args:
+            out: Pre-allocated tensor of shape ``(batch_size, *frame_shape[:-1], max_length * C)``,
+                where ``frame_shape`` is the per-frame shape of appended data and ``C`` is the
+                last-dim size of an appended frame. Will be written into in-place.
+
+        Raises:
+            RuntimeError: If no data has been appended yet.
+        """
+        if self._buffer is None:
+            raise RuntimeError("The buffer is empty. Please append data before retrieving.")
+        c = self._buffer.shape[-1]
+        for k in range(self._max_len_int):
+            out[..., k * c : (k + 1) * c].copy_(self._buffer[k])
+
     def __getitem__(self, key: torch.Tensor) -> torch.Tensor:
         """Retrieve the data from the circular buffer in last-in-first-out (LIFO) fashion.
 

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -122,7 +122,9 @@ class CircularBuffer:
             RuntimeError: If ``stack_dim`` was not set at construction.
         """
         if self._stack_dim_internal is None:
-            raise RuntimeError("stacked is only available when CircularBuffer was created with stack_dim set.")
+            if self._stack_dim_arg is None:
+                raise RuntimeError("stacked is only available when CircularBuffer was created with stack_dim set.")
+            raise RuntimeError("stacked is not yet available: call append() at least once to initialize the buffer.")
         k_pos = self._stack_dim_internal
         s = self._buffer.shape
         return self._buffer.reshape(*s[:k_pos], s[k_pos] * s[k_pos + 1], *s[k_pos + 2 :])

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -34,9 +34,12 @@ class CircularBuffer:
             device: The device used for processing.
             stack_dim: If set, the buffer arranges its internal storage so :attr:`stacked` returns
                 the K stored frames merged into ``data.shape[stack_dim]`` of the appended data
-                as a free contiguous view. Negative indexing supported; ``0`` is invalid (batch
-                dim). Validation against the actual data rank is deferred to the first
-                :meth:`append`. Defaults to ``None`` (legacy layout).
+                as a free contiguous view. Any non-zero dim index in the appended data is valid
+                (positive or negative); ``0`` (the batch dim) is invalid. Range validation against
+                the actual data rank is deferred to the first :meth:`append`. For example,
+                ``stack_dim=-1`` on a ``(B, H, W, C)`` input stacks K frames along the channel
+                dim, yielding :attr:`stacked` shape ``(B, H, W, K*C)``. Defaults to ``None``
+                (legacy layout).
 
         Raises:
             ValueError: If the buffer size is less than one, or ``stack_dim == 0``.
@@ -171,7 +174,7 @@ class CircularBuffer:
             self._allocate_buffer(data)
 
         # Shift slots so the newest write lands at the last K slot. Iterating front-to-back
-        # keeps adjacent-slot copies non-overlapping.
+        # keeps adjacent-slot copies non-overlapping. Cheap at the typical frame-stack K=2-4.
         if self._stack_dim_internal is None:
             for i in range(self._max_len_int - 1):
                 self._buffer[i].copy_(self._buffer[i + 1])

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -114,17 +114,13 @@ class CircularBuffer:
             View of shape ``(batch_size, *frame_shape)`` with ``frame_shape[stack_dim]`` multiplied by ``max_length``.
 
         Raises:
-            RuntimeError: If ``stack_dim`` was not set at construction or no data has been appended.
+            RuntimeError: If ``stack_dim`` was not set at construction.
         """
         if self._stack_dim_internal is None:
-            raise RuntimeError(
-                "stacked is only available when CircularBuffer was created with stack_dim set."
-            )
-        if self._buffer is None:
-            raise RuntimeError("The buffer is empty. Please append data before retrieving.")
+            raise RuntimeError("stacked is only available when CircularBuffer was created with stack_dim set.")
         k_pos = self._stack_dim_internal
         s = self._buffer.shape
-        return self._buffer.reshape(*s[:k_pos], s[k_pos] * s[k_pos + 1], *s[k_pos + 2:])
+        return self._buffer.reshape(*s[:k_pos], s[k_pos] * s[k_pos + 1], *s[k_pos + 2 :])
 
     """
     Operations.
@@ -145,9 +141,9 @@ class CircularBuffer:
         self._need_reset = True
         if self._buffer is not None:
             if self._stack_dim_internal is None:
-                self._buffer[:, batch_ids_resolved].zero_()
+                self._buffer[:, batch_ids_resolved] = 0.0
             else:
-                self._buffer[batch_ids_resolved].zero_()
+                self._buffer[batch_ids_resolved] = 0.0
 
     def append(self, data: torch.Tensor):
         """Append the data to the circular buffer.
@@ -197,9 +193,7 @@ class CircularBuffer:
     def _allocate_buffer(self, data: torch.Tensor) -> None:
         """Allocate the internal buffer and finalize the storage layout on first append."""
         if self._stack_dim_arg is None:
-            self._buffer = torch.empty(
-                (self._max_len_int, *data.shape), dtype=data.dtype, device=self._device
-            )
+            self._buffer = torch.empty((self._max_len_int, *data.shape), dtype=data.dtype, device=self._device)
             return
 
         ndim = data.ndim
@@ -238,8 +232,7 @@ class CircularBuffer:
         """
         if self._stack_dim_internal is not None:
             raise NotImplementedError(
-                "Indexing via __getitem__ is not supported in stacked-output mode."
-                " Use .stacked or .buffer instead."
+                "Indexing via __getitem__ is not supported in stacked-output mode. Use .stacked or .buffer instead."
             )
         # check the batch size
         if len(key) != self.batch_size:

--- a/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
@@ -171,5 +171,7 @@ class DelayBuffer:
         Returns:
             The delayed version of the data from the stored buffer. Shape is (batch_size, ...).
         """
+        # add the new data to the last layer
         self._circular_buffer.append(data)
+        # return output
         return self._circular_buffer[self._time_lags]

--- a/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
@@ -171,8 +171,5 @@ class DelayBuffer:
         Returns:
             The delayed version of the data from the stored buffer. Shape is (batch_size, ...).
         """
-        # add the new data to the last layer
         self._circular_buffer.append(data)
-        # return output
-        delayed_data = self._circular_buffer[self._time_lags]
-        return delayed_data.clone()
+        return self._circular_buffer[self._time_lags]

--- a/source/isaaclab/isaaclab/utils/images.py
+++ b/source/isaaclab/isaaclab/utils/images.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Camera-image processing helpers shared between DirectRLEnv and ManagerBasedEnv paths.
+
+Provides :func:`normalize_camera_image` for data-type-aware normalization plus the ``is_*``
+predicates used by callers that need to gate other behavior on the data-type family.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab.utils.warp.ops import normalize_image_uint8
+
+_RGB_LIKE_PREFIXES: tuple[str, ...] = ("rgb", "albedo", "simple_shading")
+_DEPTH_LIKE_PATTERNS: tuple[str, ...] = ("depth", "distance_to")
+_NORMALS_PREFIXES: tuple[str, ...] = ("normals",)
+
+
+def is_rgb_like(data_type: str) -> bool:
+    """Whether ``data_type`` is one of the RGB-like camera outputs (rgb, albedo, simple_shading_*).
+
+    Args:
+        data_type: The camera data-type string from ``sensor.data.output`` / ``TiledCameraCfg``.
+
+    Returns:
+        True if the data type should receive the ``(x / 255) - mean`` normalize.
+    """
+    return data_type.startswith(_RGB_LIKE_PREFIXES)
+
+
+def is_depth_like(data_type: str) -> bool:
+    """Whether ``data_type`` is one of the depth-like camera outputs (depth, distance_to_*)."""
+    return any(p in data_type for p in _DEPTH_LIKE_PATTERNS)
+
+
+def is_normals_like(data_type: str) -> bool:
+    """Whether ``data_type`` is one of the surface-normals camera outputs."""
+    return data_type.startswith(_NORMALS_PREFIXES)
+
+
+def normalize_camera_image(
+    images: torch.Tensor,
+    data_type: str,
+    out: torch.Tensor | None = None,
+    channel_dim: int = -1,
+) -> torch.Tensor:
+    """Normalize a camera-observation tensor according to its ``data_type``.
+
+    Dispatch (in order of check):
+
+    - :func:`is_rgb_like` and ``images.dtype == torch.uint8`` and contiguous 4D: routes to the
+      fused Warp kernel via :func:`~isaaclab.utils.warp.ops.normalize_image_uint8`. ``out`` and
+      ``channel_dim`` are forwarded so callers can reuse a pre-allocated float32 buffer and
+      select the image layout.
+    - :func:`is_rgb_like` and any other dtype/shape: pure-PyTorch ``(x.float() / 255.0) - mean``
+      with the same math. ``out`` is ignored on this branch; ``channel_dim`` selects the spatial
+      reduction axes.
+    - :func:`is_depth_like`: in-place ``images[images == inf] = 0``. ``images`` is returned as-is.
+    - :func:`is_normals_like`: returns ``(images + 1.0) * 0.5``.
+    - Otherwise: ``images`` is returned unchanged.
+
+    Args:
+        images: The camera-observation tensor. Shape and dtype vary by ``data_type``; the
+            RGB-like Warp fast path requires 4D contiguous uint8 with the channel axis at
+            position ``channel_dim``.
+        data_type: The camera data-type string. Drives the dispatch.
+        out: Optional pre-allocated float32 output for the RGB-like Warp fast path. Reused
+            across steps to eliminate per-step allocation. Ignored on the PyTorch fallback
+            and on non-RGB branches. Defaults to None.
+        channel_dim: Position of the channel axis for the RGB-like branches. ``-1`` (BHWC,
+            default) or ``-3`` / ``1`` (BCHW). Ignored on non-RGB branches.
+
+    Returns:
+        The normalized tensor. For RGB-like input this is a fresh (or pre-allocated) float32
+        tensor; for depth-like input it is ``images`` itself (mutated in place); for
+        normals-like input it is a new tensor; for anything else, ``images`` unchanged.
+    """
+    if is_rgb_like(data_type):
+        if images.dtype == torch.uint8 and images.ndim == 4 and images.is_contiguous():
+            return normalize_image_uint8(images, channel_dim=channel_dim, out=out)
+        # PyTorch fallback for callers that pre-floated or pass a strided view.
+        resolved_channel_dim = channel_dim + images.ndim if channel_dim < 0 else channel_dim
+        spatial_dims = tuple(d for d in range(1, images.ndim) if d != resolved_channel_dim)
+        images = images.float() / 255.0
+        return images - torch.mean(images, dim=spatial_dims, keepdim=True)
+    if is_depth_like(data_type):
+        images[images == float("inf")] = 0
+        return images
+    if is_normals_like(data_type):
+        return (images + 1.0) * 0.5
+    return images

--- a/source/isaaclab/isaaclab/utils/images.py
+++ b/source/isaaclab/isaaclab/utils/images.py
@@ -24,7 +24,7 @@ def is_rgb_like(data_type: str) -> bool:
     """Whether ``data_type`` is one of the RGB-like camera outputs (rgb, albedo, simple_shading_*).
 
     Args:
-        data_type: The camera data-type string from ``sensor.data.output`` / ``TiledCameraCfg``.
+        data_type: The camera data-type string from ``sensor.data.output`` / ``CameraCfg``.
 
     Returns:
         True if the data type should receive the ``(x / 255) - mean`` normalize.
@@ -86,7 +86,8 @@ def normalize_camera_image(
         resolved_channel_dim = channel_dim + images.ndim if channel_dim < 0 else channel_dim
         spatial_dims = tuple(d for d in range(1, images.ndim) if d != resolved_channel_dim)
         images = images.float() / 255.0
-        return images - torch.mean(images, dim=spatial_dims, keepdim=True)
+        images -= torch.mean(images, dim=spatial_dims, keepdim=True)
+        return images
     if is_depth_like(data_type):
         images[images == float("inf")] = 0
         return images

--- a/source/isaaclab/isaaclab/utils/warp/kernels.py
+++ b/source/isaaclab/isaaclab/utils/warp/kernels.py
@@ -686,25 +686,23 @@ def reset_wrench_composer_index(
 
 
 @wp.kernel(enable_backward=False)
-def normalize_image_uint8_kernel(
+def normalize_image_uint8(
     src: wp.array4d(dtype=wp.uint8),
     mean: wp.array2d(dtype=wp.float32),
     out: wp.array4d(dtype=wp.float32),
     channel_dim: wp.int32,
 ):
-    """Compute ``out = src / 255.0 - mean`` in a single fused pass.
+    """Compute ``out = src / 255.0 - mean`` per element, with ``mean`` broadcast over the spatial dims.
 
-    Single-launch fusion of dtype cast, scalar scale, and per-image-channel mean subtract;
-    ``src`` is read once and ``out`` is written once. ``mean`` is broadcast over the spatial
-    dims and must be precomputed by the caller as the mean of ``src / 255.0`` along the two
-    non-batch, non-channel axes.
+    ``mean`` must be precomputed by the caller as the per-(batch, channel) mean of
+    ``src / 255.0`` along the two non-batch, non-channel axes.
 
     Dispatch with ``dim=src.shape``. The spatial axes are symmetric; only the channel index
     lookup differs between BHWC and BCHW layouts.
 
     Args:
         src: Input uint8 image. Shape is ``(B, H, W, C)`` or ``(B, C, H, W)``.
-        mean: Per-env, per-channel mean of ``src / 255.0``. Shape is ``(B, C)``.
+        mean: Per-(batch, channel) mean of ``src / 255.0``. Shape is ``(B, C)``.
         out: Output float32 tensor. Same shape as ``src``.
         channel_dim: Resolved positive position of the channel axis -- ``1`` (BCHW) or
             ``3`` (BHWC). Constant across all threads; the wrapper validates the value
@@ -716,6 +714,45 @@ def normalize_image_uint8_kernel(
     else:
         c = l
     out[i, j, k, l] = wp.float32(src[i, j, k, l]) / 255.0 - mean[i, c]
+
+
+@wp.kernel(enable_backward=False)
+def spatial_sum_uint8_tiled(
+    src: wp.array4d(dtype=wp.uint8),
+    partials: wp.array3d(dtype=wp.int32),
+    tile_size: wp.int32,
+    channel_dim: wp.int32,
+):
+    """Tiled int32 partial sums of a uint8 image along its spatial axes.
+
+    Caller collapses the result with ``partials.sum(dim=1)`` to recover the per-``(b, c)``
+    total. Dispatch with ``dim=(B, NUM_TILES, C)`` where ``NUM_TILES = ceil(H / tile_size)``;
+    C innermost gives stride-1 reads on src's contiguous trailing dim for BHWC inputs.
+
+    Args:
+        src: Input image. Shape is ``(B, H, W, C)`` or ``(B, C, H, W)``.
+        partials: Output partial sums. Shape is ``(B, NUM_TILES, C)``.
+        tile_size: Number of H rows reduced per thread.
+        channel_dim: Resolved positive position of the channel axis -- ``1`` (BCHW) or
+            ``3`` (BHWC). Constant across all threads; selects which spatial axes to
+            iterate and where to read the channel index.
+    """
+    b, tile, c = wp.tid()
+    h_start = tile * tile_size
+    s = wp.int32(0)
+    if channel_dim == 1:
+        # BCHW: spatial axes are (2, 3); first spatial axis (H) is at position 2.
+        h_end = wp.min(h_start + tile_size, src.shape[2])
+        for i in range(h_start, h_end):
+            for j in range(src.shape[3]):
+                s += wp.int32(src[b, c, i, j])
+    else:
+        # BHWC: spatial axes are (1, 2); first spatial axis (H) is at position 1.
+        h_end = wp.min(h_start + tile_size, src.shape[1])
+        for i in range(h_start, h_end):
+            for j in range(src.shape[2]):
+                s += wp.int32(src[b, i, j, c])
+    partials[b, tile, c] = s
 
 
 @wp.kernel

--- a/source/isaaclab/isaaclab/utils/warp/kernels.py
+++ b/source/isaaclab/isaaclab/utils/warp/kernels.py
@@ -680,6 +680,44 @@ def reset_wrench_composer_index(
     out_torque_b[ei, tid_body] = z
 
 
+##
+# Image normalization
+##
+
+
+@wp.kernel(enable_backward=False)
+def normalize_image_uint8_kernel(
+    src: wp.array4d(dtype=wp.uint8),
+    mean: wp.array2d(dtype=wp.float32),
+    out: wp.array4d(dtype=wp.float32),
+    channel_dim: wp.int32,
+):
+    """Compute ``out = src / 255.0 - mean`` in a single fused pass.
+
+    Single-launch fusion of dtype cast, scalar scale, and per-image-channel mean subtract;
+    ``src`` is read once and ``out`` is written once. ``mean`` is broadcast over the spatial
+    dims and must be precomputed by the caller as the mean of ``src / 255.0`` along the two
+    non-batch, non-channel axes.
+
+    Dispatch with ``dim=src.shape``. The spatial axes are symmetric; only the channel index
+    lookup differs between BHWC and BCHW layouts.
+
+    Args:
+        src: Input uint8 image. Shape is ``(B, H, W, C)`` or ``(B, C, H, W)``.
+        mean: Per-env, per-channel mean of ``src / 255.0``. Shape is ``(B, C)``.
+        out: Output float32 tensor. Same shape as ``src``.
+        channel_dim: Resolved positive position of the channel axis -- ``1`` (BCHW) or
+            ``3`` (BHWC). Constant across all threads; the wrapper validates the value
+            and resolves negatives before launch.
+    """
+    i, j, k, l = wp.tid()
+    if channel_dim == 1:
+        c = j
+    else:
+        c = l
+    out[i, j, k, l] = wp.float32(src[i, j, k, l]) / 255.0 - mean[i, c]
+
+
 @wp.kernel
 def reset_wrench_composer_mask(
     env_mask: wp.array(dtype=wp.bool),

--- a/source/isaaclab/isaaclab/utils/warp/kernels.py
+++ b/source/isaaclab/isaaclab/utils/warp/kernels.py
@@ -708,12 +708,12 @@ def normalize_image_uint8(
             ``3`` (BHWC). Constant across all threads; the wrapper validates the value
             and resolves negatives before launch.
     """
-    i, j, k, l = wp.tid()
+    b, d1, d2, d3 = wp.tid()
     if channel_dim == 1:
-        c = j
+        c = d1
     else:
-        c = l
-    out[i, j, k, l] = wp.float32(src[i, j, k, l]) / 255.0 - mean[i, c]
+        c = d3
+    out[b, d1, d2, d3] = wp.float32(src[b, d1, d2, d3]) / 255.0 - mean[b, c]
 
 
 @wp.kernel(enable_backward=False)

--- a/source/isaaclab/isaaclab/utils/warp/ops.py
+++ b/source/isaaclab/isaaclab/utils/warp/ops.py
@@ -38,8 +38,10 @@ _uint8_sum_partials_cache: dict[tuple[tuple[int, ...], str, int], torch.Tensor] 
 def _uint8_spatial_mean(src: torch.Tensor, scale: float, channel_dim: int = 3) -> torch.Tensor:
     """Per-(batch, channel) mean of a uint8 image scaled by ``1 / scale``.
 
-    Equivalent to ``src.sum(dim=spatial_dims, dtype=int32).float() / scale`` where
-    ``spatial_dims`` is the pair of non-batch, non-channel axes.
+    Equivalent to ``src.sum(dim=spatial_dims, dtype=int64).float() / scale`` where
+    ``spatial_dims`` is the pair of non-batch, non-channel axes. The int64
+    promotion is safe at any resolution; the per-tile Warp accumulator stays
+    int32 (overflow-safe up to ~16M values per tile).
 
     Args:
         src: Input image. Shape is ``(B, H, W, C)`` (BHWC) or ``(B, C, H, W)`` (BCHW),
@@ -73,7 +75,7 @@ def _uint8_spatial_mean(src: torch.Tensor, scale: float, channel_dim: int = 3) -
         inputs=[src_wp, partials_wp, _UINT8_SUM_TILE_HW, channel_dim],
         device=device_str,
     )
-    return partials.sum(dim=1).float() / scale
+    return partials.sum(dim=1, dtype=torch.int64).float() / scale
 
 
 def raycast_mesh(

--- a/source/isaaclab/isaaclab/utils/warp/ops.py
+++ b/source/isaaclab/isaaclab/utils/warp/ops.py
@@ -24,12 +24,14 @@ from . import kernels
 _all_env_mask_cache: dict[tuple[int, str], wp.array] = {}
 
 
-# Tile size for the spatial-axis split in :func:`_uint8_spatial_mean`.
+# Tile size for the spatial-axis split in :func:`_uint8_spatial_mean`. Tuned on L40;
+# robust across modern NVIDIA arches (Ampere/Ada/Hopper) at R256.
 _UINT8_SUM_TILE_HW: int = 32
 
 # Cache of int32 partials scratch tensors keyed by (src.shape, device, channel_dim). Avoids
 # per-call allocation in :func:`_uint8_spatial_mean`. channel_dim is part of the key so
-# BCHW and BHWC inputs with otherwise-identical shape get separate scratch slots.
+# BCHW and BHWC inputs with otherwise-identical shape get separate scratch slots. Typically
+# holds one entry per training run (camera resolution, device, and layout are all fixed).
 _uint8_sum_partials_cache: dict[tuple[tuple[int, ...], str, int], torch.Tensor] = {}
 
 

--- a/source/isaaclab/isaaclab/utils/warp/ops.py
+++ b/source/isaaclab/isaaclab/utils/warp/ops.py
@@ -24,6 +24,57 @@ from . import kernels
 _all_env_mask_cache: dict[tuple[int, str], wp.array] = {}
 
 
+# Tile size for the spatial-axis split in :func:`_uint8_spatial_mean`.
+_UINT8_SUM_TILE_HW: int = 32
+
+# Cache of int32 partials scratch tensors keyed by (src.shape, device). Avoids per-call
+# allocation in :func:`_uint8_spatial_mean`.
+_uint8_sum_partials_cache: dict[tuple[tuple[int, ...], str], tuple[torch.Tensor, int]] = {}
+
+
+def _uint8_spatial_mean(src: torch.Tensor, scale: float, channel_dim: int = 3) -> torch.Tensor:
+    """Per-(batch, channel) mean of a uint8 image scaled by ``1 / scale``.
+
+    Equivalent to ``src.sum(dim=spatial_dims, dtype=int32).float() / scale`` where
+    ``spatial_dims`` is the pair of non-batch, non-channel axes.
+
+    Args:
+        src: Input image. Shape is ``(B, H, W, C)`` (BHWC) or ``(B, C, H, W)`` (BCHW),
+            dtype ``torch.uint8``, contiguous.
+        scale: Multiplier for the per-channel sum. Pass ``H * W * 255`` to get the mean
+            of ``src / 255``.
+        channel_dim: Resolved positive position of the channel axis -- ``1`` (BCHW) or
+            ``3`` (BHWC). Defaults to ``3`` (BHWC) for back-compat with internal callers.
+
+    Returns:
+        Per-(batch, channel) mean as float32. Shape is ``(B, C)``.
+    """
+    if channel_dim == 1:
+        b, c, h, _ = src.shape
+    else:
+        b, h, _, c = src.shape
+    device_str = str(src.device)
+    cache_key = (src.shape, device_str, channel_dim)
+    cached = _uint8_sum_partials_cache.get(cache_key)
+    if cached is None:
+        num_tiles = (h + _UINT8_SUM_TILE_HW - 1) // _UINT8_SUM_TILE_HW
+        # C innermost: adjacent threads stride-1 along src's contiguous trailing dim (BHWC fast path).
+        partials = torch.empty((b, num_tiles, c), dtype=torch.int32, device=src.device)
+        _uint8_sum_partials_cache[cache_key] = (partials, num_tiles)
+    else:
+        partials, num_tiles = cached
+
+    src_wp = wp.from_torch(src, dtype=wp.uint8)
+    partials_wp = wp.from_torch(partials, dtype=wp.int32)
+    wp.launch(
+        kernel=kernels.spatial_sum_uint8_tiled,
+        dim=(b, num_tiles, c),
+        inputs=[src_wp, partials_wp, _UINT8_SUM_TILE_HW, channel_dim],
+        device=device_str,
+    )
+    return partials.sum(dim=1).float() / scale
+
+
 def raycast_mesh(
     ray_starts: torch.Tensor,
     ray_directions: torch.Tensor,
@@ -413,8 +464,8 @@ def normalize_image_uint8(
 ) -> torch.Tensor:
     """Compute ``(src / 255.0) - mean(src / 255.0, spatial_dims, keepdim=True)`` via a fused Warp kernel.
 
-    Equivalent to the pure-PyTorch expression to within float32 precision, but reads ``src``
-    once and writes ``out`` once. Pass an ``out`` tensor to reuse storage across steps.
+    Equivalent to the pure-PyTorch expression to within float32 precision. Pass an ``out``
+    tensor to reuse storage across steps.
 
     Supports both image layouts via ``channel_dim``:
 
@@ -466,14 +517,13 @@ def normalize_image_uint8(
     # Spatial dims = the two non-batch, non-channel axes; mean is shape (B, C) for both layouts.
     spatial_dims = tuple(d for d in (1, 2, 3) if d != resolved_channel_dim)
     spatial_size = src.shape[spatial_dims[0]] * src.shape[spatial_dims[1]]
-    # torch.sum on uint8 promotes to int64; dividing once at the end avoids a float32 transient.
-    mean = src.sum(dim=spatial_dims, dtype=torch.int64).to(torch.float32) / (spatial_size * 255.0)
+    mean = _uint8_spatial_mean(src, spatial_size * 255.0, channel_dim=resolved_channel_dim)
 
     src_wp = wp.from_torch(src, dtype=wp.uint8)
     mean_wp = wp.from_torch(mean, dtype=wp.float32)
     out_wp = wp.from_torch(out, dtype=wp.float32)
     wp.launch(
-        kernel=kernels.normalize_image_uint8_kernel,
+        kernel=kernels.normalize_image_uint8,
         dim=src.shape,
         inputs=[src_wp, mean_wp, out_wp, resolved_channel_dim],
         device=str(src.device),

--- a/source/isaaclab/isaaclab/utils/warp/ops.py
+++ b/source/isaaclab/isaaclab/utils/warp/ops.py
@@ -27,9 +27,10 @@ _all_env_mask_cache: dict[tuple[int, str], wp.array] = {}
 # Tile size for the spatial-axis split in :func:`_uint8_spatial_mean`.
 _UINT8_SUM_TILE_HW: int = 32
 
-# Cache of int32 partials scratch tensors keyed by (src.shape, device). Avoids per-call
-# allocation in :func:`_uint8_spatial_mean`.
-_uint8_sum_partials_cache: dict[tuple[tuple[int, ...], str], tuple[torch.Tensor, int]] = {}
+# Cache of int32 partials scratch tensors keyed by (src.shape, device, channel_dim). Avoids
+# per-call allocation in :func:`_uint8_spatial_mean`. channel_dim is part of the key so
+# BCHW and BHWC inputs with otherwise-identical shape get separate scratch slots.
+_uint8_sum_partials_cache: dict[tuple[tuple[int, ...], str, int], torch.Tensor] = {}
 
 
 def _uint8_spatial_mean(src: torch.Tensor, scale: float, channel_dim: int = 3) -> torch.Tensor:
@@ -55,20 +56,18 @@ def _uint8_spatial_mean(src: torch.Tensor, scale: float, channel_dim: int = 3) -
         b, h, _, c = src.shape
     device_str = str(src.device)
     cache_key = (src.shape, device_str, channel_dim)
-    cached = _uint8_sum_partials_cache.get(cache_key)
-    if cached is None:
+    partials = _uint8_sum_partials_cache.get(cache_key)
+    if partials is None:
         num_tiles = (h + _UINT8_SUM_TILE_HW - 1) // _UINT8_SUM_TILE_HW
         # C innermost: adjacent threads stride-1 along src's contiguous trailing dim (BHWC fast path).
         partials = torch.empty((b, num_tiles, c), dtype=torch.int32, device=src.device)
-        _uint8_sum_partials_cache[cache_key] = (partials, num_tiles)
-    else:
-        partials, num_tiles = cached
+        _uint8_sum_partials_cache[cache_key] = partials
 
     src_wp = wp.from_torch(src, dtype=wp.uint8)
     partials_wp = wp.from_torch(partials, dtype=wp.int32)
     wp.launch(
         kernel=kernels.spatial_sum_uint8_tiled,
-        dim=(b, num_tiles, c),
+        dim=partials.shape,
         inputs=[src_wp, partials_wp, _UINT8_SUM_TILE_HW, channel_dim],
         device=device_str,
     )
@@ -483,6 +482,16 @@ def normalize_image_uint8(
             Negative values are supported (``-1`` == BHWC, ``-3`` == BCHW). Defaults to ``-1``.
         out: Optional pre-allocated float32 output. Same shape as ``src``, contiguous, on the
             same device. If omitted, a fresh tensor is allocated. Defaults to None.
+
+            .. warning::
+
+                If you pass the same ``out`` tensor across calls that happen on either
+                side of an environment-step boundary (i.e., the result of one call is
+                still being read by the RL trainer when the next call is made), the
+                returned observation will alias the latest call's output and the
+                trainer will see overwritten data. Use a ping-pong of two ``out``
+                buffers, or omit ``out`` entirely, when the result lifetime crosses
+                ``env.step()`` boundaries.
 
     Returns:
         The normalized float32 tensor. Same object as ``out`` when provided.

--- a/source/isaaclab/isaaclab/utils/warp/ops.py
+++ b/source/isaaclab/isaaclab/utils/warp/ops.py
@@ -404,3 +404,78 @@ def convert_to_warp_mesh(points: np.ndarray, indices: np.ndarray, device: str) -
         points=wp.array(points.astype(np.float32), dtype=wp.vec3, device=device),
         indices=wp.array(indices.astype(np.int32).flatten(), dtype=wp.int32, device=device),
     )
+
+
+def normalize_image_uint8(
+    src: torch.Tensor,
+    channel_dim: int = -1,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute ``(src / 255.0) - mean(src / 255.0, spatial_dims, keepdim=True)`` via a fused Warp kernel.
+
+    Equivalent to the pure-PyTorch expression to within float32 precision, but reads ``src``
+    once and writes ``out`` once. Pass an ``out`` tensor to reuse storage across steps.
+
+    Supports both image layouts via ``channel_dim``:
+
+    - BHWC (``channel_dim=-1`` or ``3``, the default): mean is taken over axes (1, 2).
+    - BCHW (``channel_dim=-3`` or ``1``): mean is taken over axes (2, 3).
+
+    Note:
+        Most callers should go through :func:`isaaclab.utils.images.normalize_camera_image`,
+        which dispatches non-uint8 / non-RGB inputs to a PyTorch fallback.
+
+    Args:
+        src: Input uint8 image tensor. Shape is ``(B, H, W, C)`` or ``(B, C, H, W)``.
+            Must be contiguous.
+        channel_dim: Position of the channel axis. Must resolve to ``1`` (BCHW) or ``3`` (BHWC).
+            Negative values are supported (``-1`` == BHWC, ``-3`` == BCHW). Defaults to ``-1``.
+        out: Optional pre-allocated float32 output. Same shape as ``src``, contiguous, on the
+            same device. If omitted, a fresh tensor is allocated. Defaults to None.
+
+    Returns:
+        The normalized float32 tensor. Same object as ``out`` when provided.
+
+    Raises:
+        ValueError: If ``src`` is not 4D uint8, not contiguous, ``channel_dim`` does not
+            resolve to 1 or 3, or ``out``'s shape / dtype / device does not match.
+    """
+    if src.dtype != torch.uint8 or src.ndim != 4:
+        raise ValueError(f"src must be a 4D uint8 tensor; got dtype={src.dtype}, ndim={src.ndim}")
+    if not src.is_contiguous():
+        raise ValueError("src must be contiguous (Warp kernel reads it as a 4D wp.array)")
+
+    # Resolve negative channel_dim to its positive index in [1, src.ndim - 1].
+    resolved_channel_dim = channel_dim + src.ndim if channel_dim < 0 else channel_dim
+    if resolved_channel_dim not in (1, 3):
+        raise ValueError(
+            f"channel_dim must resolve to 1 (BCHW) or 3 (BHWC) for 4D input;"
+            f" got channel_dim={channel_dim} -> {resolved_channel_dim}"
+        )
+
+    if out is None:
+        out = torch.empty(src.shape, dtype=torch.float32, device=src.device)
+    elif out.shape != src.shape or out.dtype != torch.float32 or out.device != src.device:
+        raise ValueError(
+            f"out shape/dtype/device mismatch: expected {tuple(src.shape)}/float32/{src.device},"
+            f" got {tuple(out.shape)}/{out.dtype}/{out.device}"
+        )
+    elif not out.is_contiguous():
+        raise ValueError("out must be contiguous")
+
+    # Spatial dims = the two non-batch, non-channel axes; mean is shape (B, C) for both layouts.
+    spatial_dims = tuple(d for d in (1, 2, 3) if d != resolved_channel_dim)
+    spatial_size = src.shape[spatial_dims[0]] * src.shape[spatial_dims[1]]
+    # torch.sum on uint8 promotes to int64; dividing once at the end avoids a float32 transient.
+    mean = src.sum(dim=spatial_dims, dtype=torch.int64).to(torch.float32) / (spatial_size * 255.0)
+
+    src_wp = wp.from_torch(src, dtype=wp.uint8)
+    mean_wp = wp.from_torch(mean, dtype=wp.float32)
+    out_wp = wp.from_torch(out, dtype=wp.float32)
+    wp.launch(
+        kernel=kernels.normalize_image_uint8_kernel,
+        dim=src.shape,
+        inputs=[src_wp, mean_wp, out_wp, resolved_channel_dim],
+        device=str(src.device),
+    )
+    return out

--- a/source/isaaclab/test/envs/test_stacked_image_mdp.py
+++ b/source/isaaclab/test/envs/test_stacked_image_mdp.py
@@ -188,3 +188,56 @@ class TestStackedImage:
         torch.testing.assert_close(out[..., :CHANNELS], expected_old)
         torch.testing.assert_close(out[..., CHANNELS:], expected_new)
 
+    def test_consecutive_rgb_calls_return_independent_storage(self):
+        """Two consecutive RGB-normalize-deferred calls must return tensors with distinct storage.
+
+        Regression: a prior implementation reused a single pre-allocated normalize-output
+        buffer across calls, so the trainer's previous-iteration ``observations`` (held by
+        reference across the next ``env.step``) would be overwritten before
+        ``record_transition`` could read it. This test mimics the trainer's
+        two-references-alive pattern; under the bug both returns share storage.
+        """
+        env = _make_env()
+        term = stacked_image(_make_cfg(frame_stack=2), env)
+        f1 = torch.randint(0, 255, (NUM_ENVS, HEIGHT, WIDTH, CHANNELS), dtype=torch.uint8)
+        f2 = torch.randint(0, 255, (NUM_ENVS, HEIGHT, WIDTH, CHANNELS), dtype=torch.uint8)
+        with mock.patch("isaaclab.envs.mdp.observations.image") as patched:
+            patched.return_value = f1
+            out_a = term(env, normalize=True, data_type="rgb")
+            # Keep ``out_a`` alive across the next call — this is what the RL trainer does.
+            patched.return_value = f2
+            out_b = term(env, normalize=True, data_type="rgb")
+        assert out_a.data_ptr() != out_b.data_ptr(), (
+            "Consecutive calls returned aliased storage; previous-iteration obs would be overwritten."
+        )
+
+
+def _make_image_env_with_sensor(camera_buf: torch.Tensor) -> SimpleNamespace:
+    """Mock env exposing ``env.scene.sensors[name].data.output[type]`` = ``camera_buf``."""
+    sensor = SimpleNamespace(data=SimpleNamespace(output={"rgb": camera_buf}))
+    scene = SimpleNamespace(sensors={"tiled_camera": sensor})
+    return SimpleNamespace(scene=scene, num_envs=NUM_ENVS, device="cpu")
+
+
+class TestImageFunctionCloneKwarg:
+    """The ``image()`` function's ``clone`` kwarg controls whether the camera buffer is copied."""
+
+    def test_clone_false_returns_camera_buffer_view(self):
+        """With ``clone=False, normalize=False`` the returned tensor shares storage with the camera buffer."""
+        from isaaclab.envs.mdp.observations import image
+
+        camera_buf = torch.randint(0, 255, (NUM_ENVS, HEIGHT, WIDTH, CHANNELS), dtype=torch.uint8)
+        env = _make_image_env_with_sensor(camera_buf)
+        cfg = SimpleNamespace(name="tiled_camera")
+        out = image(env, sensor_cfg=cfg, data_type="rgb", normalize=False, clone=False)
+        assert out.data_ptr() == camera_buf.data_ptr()
+
+    def test_clone_true_returns_independent_copy(self):
+        """The default ``clone=True`` path returns a fresh tensor independent of the camera buffer."""
+        from isaaclab.envs.mdp.observations import image
+
+        camera_buf = torch.randint(0, 255, (NUM_ENVS, HEIGHT, WIDTH, CHANNELS), dtype=torch.uint8)
+        env = _make_image_env_with_sensor(camera_buf)
+        cfg = SimpleNamespace(name="tiled_camera")
+        out = image(env, sensor_cfg=cfg, data_type="rgb", normalize=False, clone=True)
+        assert out.data_ptr() != camera_buf.data_ptr()

--- a/source/isaaclab/test/envs/test_stacked_image_mdp.py
+++ b/source/isaaclab/test/envs/test_stacked_image_mdp.py
@@ -58,7 +58,7 @@ class TestStackedImage:
         env = _make_env()
         term = stacked_image(_make_cfg(frame_stack=2), env)
         with mock.patch("isaaclab.envs.mdp.observations.image", return_value=_frame(7)):
-            out = term(env)
+            out = term(env, normalize=False)
         f7 = _frame(7)
         assert torch.equal(out[..., :CHANNELS], f7)
         assert torch.equal(out[..., CHANNELS:], f7)
@@ -69,11 +69,11 @@ class TestStackedImage:
         term = stacked_image(_make_cfg(frame_stack=3), env)
         with mock.patch("isaaclab.envs.mdp.observations.image") as patched:
             patched.return_value = _frame(10)
-            term(env)  # init: all 3 slots = 10
+            term(env, normalize=False)  # init: all 3 slots = 10
             patched.return_value = _frame(20)
-            term(env)  # slots: [10, 10, 20]
+            term(env, normalize=False)  # slots: [10, 10, 20]
             patched.return_value = _frame(30)
-            out = term(env)  # slots: [10, 20, 30]
+            out = term(env, normalize=False)  # slots: [10, 20, 30]
         assert torch.equal(out[..., :CHANNELS], _frame(10))
         assert torch.equal(out[..., CHANNELS : 2 * CHANNELS], _frame(20))
         assert torch.equal(out[..., 2 * CHANNELS :], _frame(30))
@@ -84,12 +84,12 @@ class TestStackedImage:
         term = stacked_image(_make_cfg(frame_stack=2), env)
         with mock.patch("isaaclab.envs.mdp.observations.image") as patched:
             patched.return_value = _frame(1)
-            term(env)
+            term(env, normalize=False)
             patched.return_value = _frame(2)
-            term(env)  # ring filled
+            term(env, normalize=False)  # ring filled
             term.reset()
             patched.return_value = _frame(50)
-            out = term(env)
+            out = term(env, normalize=False)
         assert torch.equal(out[..., :CHANNELS], _frame(50))
         assert torch.equal(out[..., CHANNELS:], _frame(50))
 
@@ -99,12 +99,12 @@ class TestStackedImage:
         term = stacked_image(_make_cfg(frame_stack=2), env)
         with mock.patch("isaaclab.envs.mdp.observations.image") as patched:
             patched.return_value = _frame(1)
-            term(env)
+            term(env, normalize=False)
             patched.return_value = _frame(2)
-            term(env)
+            term(env, normalize=False)
             term.reset(torch.tensor([0]))
             patched.return_value = _frame(9)
-            out = term(env)
+            out = term(env, normalize=False)
         per_env_shape = (HEIGHT, WIDTH, CHANNELS)
         nines = torch.full(per_env_shape, 9, dtype=torch.float32)
         twos = torch.full(per_env_shape, 2, dtype=torch.float32)
@@ -137,7 +137,7 @@ class TestStackedImage:
         with mock.patch("isaaclab.envs.mdp.observations.image") as patched:
             for i in range(11):
                 patched.return_value = _frame(i)
-                out = term(env)
+                out = term(env, normalize=False)
         # 11 frames with values 0..10; final ring holds the 3 most recent in oldest→newest order.
         assert torch.equal(out[..., :CHANNELS], _frame(8))
         assert torch.equal(out[..., CHANNELS : 2 * CHANNELS], _frame(9))
@@ -150,9 +150,41 @@ class TestStackedImage:
         term = stacked_image(_make_cfg(frame_stack=2), env)
         cuda_frame = torch.full((NUM_ENVS, HEIGHT, WIDTH, CHANNELS), 7.0, dtype=torch.float32, device="cuda")
         with mock.patch("isaaclab.envs.mdp.observations.image", return_value=cuda_frame):
-            out = term(env)
+            out = term(env, normalize=False)
         assert out.device.type == "cuda"
         assert out.shape == (NUM_ENVS, HEIGHT, WIDTH, CHANNELS * 2)
         # Init path fires; both slots hold the same frame.
         assert torch.equal(out[..., :CHANNELS], cuda_frame)
         assert torch.equal(out[..., CHANNELS:], cuda_frame)
+
+    def test_rgb_buffer_stores_uint8_for_uint8_input(self):
+        """Camera output is uint8; the ring buffer must store uint8 (not upcast to float)."""
+        env = _make_env()
+        term = stacked_image(_make_cfg(frame_stack=2), env)
+        u8_frame = torch.full((NUM_ENVS, HEIGHT, WIDTH, CHANNELS), 200, dtype=torch.uint8)
+        with mock.patch("isaaclab.envs.mdp.observations.image", return_value=u8_frame):
+            term(env, normalize=True, data_type="rgb")
+        assert term._buffer._buffer.dtype == torch.uint8
+
+    def test_rgb_normalize_matches_per_frame_math(self):
+        """Post-stack normalize on uint8 must equal per-frame (x/255 - mean) applied independently."""
+        env = _make_env()
+        term = stacked_image(_make_cfg(frame_stack=2), env)
+        # Two distinct non-uniform frames so the mean-subtract is non-trivial.
+        f1 = torch.randint(0, 255, (NUM_ENVS, HEIGHT, WIDTH, CHANNELS), dtype=torch.uint8)
+        f2 = torch.randint(0, 255, (NUM_ENVS, HEIGHT, WIDTH, CHANNELS), dtype=torch.uint8)
+        with mock.patch("isaaclab.envs.mdp.observations.image") as patched:
+            patched.return_value = f1
+            term(env, normalize=True, data_type="rgb")
+            patched.return_value = f2
+            out = term(env, normalize=True, data_type="rgb")
+
+        def per_frame_normalize(f):
+            x = f.float() / 255.0
+            return x - torch.mean(x, dim=(1, 2), keepdim=True)
+
+        expected_old = per_frame_normalize(f1)
+        expected_new = per_frame_normalize(f2)
+        torch.testing.assert_close(out[..., :CHANNELS], expected_old)
+        torch.testing.assert_close(out[..., CHANNELS:], expected_new)
+

--- a/source/isaaclab/test/envs/test_stacked_image_obs_manager.py
+++ b/source/isaaclab/test/envs/test_stacked_image_obs_manager.py
@@ -40,7 +40,9 @@ CHANNELS = 3
 DEVICE = "cuda:0"
 
 
-def _fake_image(env, sensor_cfg=None, data_type="rgb", convert_perspective_to_orthogonal=False, normalize=True):
+def _fake_image(
+    env, sensor_cfg=None, data_type="rgb", convert_perspective_to_orthogonal=False, normalize=True, clone=True
+):
     """Stand-in for ``isaaclab.envs.mdp.observations.image`` — returns a constant frame.
 
     The value is keyed to the call count so consecutive calls produce distinct frames

--- a/source/isaaclab/test/utils/test_circular_buffer.py
+++ b/source/isaaclab/test/utils/test_circular_buffer.py
@@ -178,6 +178,36 @@ def test_return_buffer_prop(circular_buffer):
 # ---------------------------------------------------------------------------
 
 
+def test_reset_subset_zeroes_buffer_storage_default_mode():
+    """reset(batch_ids=[i]) must zero the buffer slots for the reset rows (default mode).
+
+    Regression: a prior implementation used ``self._buffer[:, ids].zero_()`` which is
+    getitem-then-inplace; advanced indexing with a list/tensor returns a copy, so
+    ``.zero_()`` zeroed the temporary and left the original buffer untouched.
+    """
+    buf = CircularBuffer(max_len=3, batch_size=4, device="cpu")
+    buf.append(torch.full((4, 2), 5.0))
+    buf.append(torch.full((4, 2), 5.0))
+    buf.reset(batch_ids=[1, 3])
+    # Reset rows must read as zero in the raw buffer; non-reset rows must still hold 5.0.
+    torch.testing.assert_close(buf._buffer[:, [1, 3]], torch.zeros((3, 2, 2)))
+    torch.testing.assert_close(buf._buffer[:, [0, 2]], torch.full((3, 2, 2), 5.0))
+
+
+def test_reset_subset_zeroes_buffer_storage_stack_dim_mode():
+    """reset(batch_ids=[i]) must zero the buffer slots for the reset rows (stack_dim mode).
+
+    Same regression as :func:`test_reset_subset_zeroes_buffer_storage_default_mode` but for
+    the stack_dim layout where the batch dim is dim 0 of the internal storage.
+    """
+    buf = CircularBuffer(max_len=2, batch_size=4, device="cpu", stack_dim=-1)
+    buf.append(torch.full((4, 8, 8, 3), 5.0))
+    buf.append(torch.full((4, 8, 8, 3), 5.0))
+    buf.reset(batch_ids=[1, 3])
+    torch.testing.assert_close(buf._buffer[[1, 3]], torch.zeros((2, 8, 8, 2, 3)))
+    torch.testing.assert_close(buf._buffer[[0, 2]], torch.full((2, 8, 8, 2, 3), 5.0))
+
+
 def test_stack_dim_zero_rejected():
     """stack_dim=0 (batch dim) must be rejected at construction."""
     with pytest.raises(ValueError, match="stack_dim must not be 0"):

--- a/source/isaaclab/test/utils/test_circular_buffer.py
+++ b/source/isaaclab/test/utils/test_circular_buffer.py
@@ -171,3 +171,126 @@ def test_return_buffer_prop(circular_buffer):
     # check that it is returned oldest first
     for idx in range(circular_buffer.max_length - 1):
         assert torch.all(torch.le(retrieved_buffer[:, idx], retrieved_buffer[:, idx + 1]))
+
+
+# ---------------------------------------------------------------------------
+# Stacked-output mode (stack_dim) tests
+# ---------------------------------------------------------------------------
+
+
+def test_stack_dim_zero_rejected():
+    """stack_dim=0 (batch dim) must be rejected at construction."""
+    with pytest.raises(ValueError, match="stack_dim must not be 0"):
+        CircularBuffer(max_len=2, batch_size=4, device="cpu", stack_dim=0)
+
+
+def test_stack_dim_out_of_range_rejected_on_first_append():
+    """Invalid stack_dim for the appended data's rank raises on first append."""
+    buf = CircularBuffer(max_len=2, batch_size=4, device="cpu", stack_dim=-5)
+    data = torch.zeros(4, 8, 8, 3)  # ndim=4, valid stack_dim range is [-3,-1] or [1,3]
+    with pytest.raises(IndexError, match="stack_dim=-5"):
+        buf.append(data)
+
+
+def test_stack_dim_minus_one_output_shape():
+    """stack_dim=-1 on (B,H,W,C) data yields .stacked shape (B,H,W,K*C)."""
+    B, H, W, C, K = 4, 8, 8, 3, 2
+    buf = CircularBuffer(max_len=K, batch_size=B, device="cpu", stack_dim=-1)
+    data = torch.zeros(B, H, W, C)
+    buf.append(data)
+    assert buf.stacked.shape == (B, H, W, K * C)
+    # And .buffer still honors the legacy (B, K, *frame_shape) contract.
+    assert buf.buffer.shape == (B, K, H, W, C)
+
+
+def test_stack_dim_oldest_to_newest_channel_order():
+    """Channels must appear in oldest-to-newest order along the stacked dim."""
+    B, H, W, C, K = 2, 4, 4, 3, 2
+    buf = CircularBuffer(max_len=K, batch_size=B, device="cpu", stack_dim=-1)
+    # First frame: all 1s
+    f1 = torch.ones(B, H, W, C)
+    buf.append(f1)
+    # Second frame: all 2s
+    f2 = torch.full((B, H, W, C), 2.0)
+    buf.append(f2)
+    stacked = buf.stacked  # (B, H, W, 2*C)
+    # Oldest C channels should equal f1 (i.e., 1.0); newest C channels should equal f2 (i.e., 2.0).
+    torch.testing.assert_close(stacked[..., :C], torch.ones(B, H, W, C))
+    torch.testing.assert_close(stacked[..., C:], torch.full((B, H, W, C), 2.0))
+
+
+def test_stack_dim_warmup_fills_all_slots_with_first_frame():
+    """The first append must fill all K slots with the first frame (warmup contract)."""
+    B, H, W, C, K = 2, 4, 4, 3, 2
+    buf = CircularBuffer(max_len=K, batch_size=B, device="cpu", stack_dim=-1)
+    f1 = torch.full((B, H, W, C), 7.0)
+    buf.append(f1)
+    stacked = buf.stacked
+    # Both K slots should be 7.0 after the warmup.
+    torch.testing.assert_close(stacked, torch.full((B, H, W, K * C), 7.0))
+
+
+def test_stack_dim_minus_three_output_shape():
+    """stack_dim=-3 (height-stack) on (B,H,W,C) yields .stacked shape (B,K*H,W,C)."""
+    B, H, W, C, K = 2, 4, 5, 3, 3
+    buf = CircularBuffer(max_len=K, batch_size=B, device="cpu", stack_dim=-3)
+    data = torch.zeros(B, H, W, C)
+    buf.append(data)
+    assert buf.stacked.shape == (B, K * H, W, C)
+
+
+def test_stack_dim_positive_index_equivalent_to_negative():
+    """stack_dim=3 should behave identically to stack_dim=-1 for 4D data."""
+    B, H, W, C, K = 2, 4, 4, 3, 2
+    buf_neg = CircularBuffer(max_len=K, batch_size=B, device="cpu", stack_dim=-1)
+    buf_pos = CircularBuffer(max_len=K, batch_size=B, device="cpu", stack_dim=3)
+    f1 = torch.randn(B, H, W, C)
+    f2 = torch.randn(B, H, W, C)
+    buf_neg.append(f1)
+    buf_neg.append(f2)
+    buf_pos.append(f1)
+    buf_pos.append(f2)
+    torch.testing.assert_close(buf_neg.stacked, buf_pos.stacked)
+
+
+def test_stack_dim_ring_shift_after_overflow():
+    """After K+1 frames, the oldest slot must be frame 1 (frame 0 evicted), newest = last."""
+    B, H, W, C, K = 2, 4, 4, 3, 2
+    buf = CircularBuffer(max_len=K, batch_size=B, device="cpu", stack_dim=-1)
+    f0 = torch.full((B, H, W, C), 0.0)
+    f1 = torch.full((B, H, W, C), 1.0)
+    f2 = torch.full((B, H, W, C), 2.0)
+    buf.append(f0)
+    buf.append(f1)
+    buf.append(f2)
+    stacked = buf.stacked  # K=2, so slots are [f1, f2]
+    torch.testing.assert_close(stacked[..., :C], torch.full((B, H, W, C), 1.0))
+    torch.testing.assert_close(stacked[..., C:], torch.full((B, H, W, C), 2.0))
+
+
+def test_stack_dim_reset_clears_buffer():
+    """reset() should re-trigger warmup behavior on the next append."""
+    B, H, W, C, K = 2, 4, 4, 3, 2
+    buf = CircularBuffer(max_len=K, batch_size=B, device="cpu", stack_dim=-1)
+    buf.append(torch.full((B, H, W, C), 1.0))
+    buf.append(torch.full((B, H, W, C), 2.0))
+    buf.reset()
+    # Next append should be a warmup fill: both K slots equal the new frame.
+    buf.append(torch.full((B, H, W, C), 9.0))
+    torch.testing.assert_close(buf.stacked, torch.full((B, H, W, K * C), 9.0))
+
+
+def test_stack_dim_getitem_raises():
+    """__getitem__ is not supported in stack_dim mode."""
+    buf = CircularBuffer(max_len=2, batch_size=4, device="cpu", stack_dim=-1)
+    buf.append(torch.zeros(4, 8, 8, 3))
+    with pytest.raises(NotImplementedError, match="stacked-output mode"):
+        _ = buf[torch.zeros(4, dtype=torch.long)]
+
+
+def test_stack_dim_stacked_raises_when_default_mode():
+    """.stacked must raise in default mode (legacy CircularBuffer use)."""
+    buf = CircularBuffer(max_len=2, batch_size=4, device="cpu")  # no stack_dim
+    buf.append(torch.zeros(4, 3))
+    with pytest.raises(RuntimeError, match="stack_dim"):
+        _ = buf.stacked

--- a/source/isaaclab/test/utils/test_delay_buffer.py
+++ b/source/isaaclab/test/utils/test_delay_buffer.py
@@ -89,3 +89,17 @@ def test_random_time_lags(delay_buffer):
         for i in range(delay_buffer.batch_size):
             error = delayed_data[i] - all_data[true_delayed_index[i]][i]
             assert torch.all(error == 0)
+
+
+def test_compute_result_independent_of_internal_buffer(delay_buffer):
+    """``compute()``'s returned tensor must not alias the internal circular buffer storage.
+
+    Regression: ``DelayBuffer.compute`` previously called ``.clone()`` defensively. After
+    dropping the clone (advanced indexing returns a copy), this asserts the contract is
+    preserved — mutating the result in place must not affect the next ``compute()`` output.
+    """
+    delay_buffer.set_time_lag(0)
+    first = delay_buffer.compute(torch.full((delay_buffer.batch_size, 1), 1, dtype=torch.int))
+    first.fill_(999)  # mutate the returned tensor
+    second = delay_buffer.compute(torch.full((delay_buffer.batch_size, 1), 2, dtype=torch.int))
+    assert torch.all(second == 2), "Mutation of a prior compute() result leaked into the next call"

--- a/source/isaaclab/test/utils/test_images.py
+++ b/source/isaaclab/test/utils/test_images.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for :mod:`isaaclab.utils.images`."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import warp as wp
+
+wp.config.quiet = True
+wp.init()
+
+
+@pytest.fixture(params=["cpu", "cuda:0"] if torch.cuda.is_available() else ["cpu"])
+def device(request):
+    return request.param
+
+
+class TestPredicates:
+    """The is_* dispatch predicates."""
+
+    @pytest.mark.parametrize(
+        "data_type",
+        ["rgb", "rgba", "albedo", "simple_shading_constant_diffuse", "simple_shading_diffuse_mdl"],
+    )
+    def test_is_rgb_like_matches(self, data_type):
+        from isaaclab.utils.images import is_rgb_like
+
+        assert is_rgb_like(data_type)
+
+    @pytest.mark.parametrize("data_type", ["depth", "distance_to_camera", "normals", "semantic_segmentation"])
+    def test_is_rgb_like_rejects_non_rgb(self, data_type):
+        from isaaclab.utils.images import is_rgb_like
+
+        assert not is_rgb_like(data_type)
+
+    @pytest.mark.parametrize("data_type", ["depth", "depth_linear", "distance_to_camera", "distance_to_plane"])
+    def test_is_depth_like_matches(self, data_type):
+        from isaaclab.utils.images import is_depth_like
+
+        assert is_depth_like(data_type)
+
+    @pytest.mark.parametrize("data_type", ["rgb", "albedo", "normals"])
+    def test_is_depth_like_rejects(self, data_type):
+        from isaaclab.utils.images import is_depth_like
+
+        assert not is_depth_like(data_type)
+
+    @pytest.mark.parametrize("data_type", ["normals", "normals_object_frame"])
+    def test_is_normals_like_matches(self, data_type):
+        from isaaclab.utils.images import is_normals_like
+
+        assert is_normals_like(data_type)
+
+
+class TestNormalizeCameraImageRGBLike:
+    """RGB-like dispatch: rgb, albedo, simple_shading_*."""
+
+    @pytest.mark.parametrize("data_type", ["rgb", "albedo", "simple_shading_diffuse_mdl"])
+    def test_uint8_routes_to_warp_fast_path(self, device, data_type):
+        """uint8 contiguous 4D input produces float32 ``(x/255 - per-image mean)`` output."""
+        from isaaclab.utils.images import normalize_camera_image
+
+        torch.manual_seed(0)
+        src = torch.randint(0, 255, (2, 8, 8, 3), dtype=torch.uint8, device=device)
+        out = normalize_camera_image(src, data_type)
+
+        expected = src.float() / 255.0
+        expected = expected - torch.mean(expected, dim=(1, 2), keepdim=True)
+        torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
+        assert out.dtype == torch.float32
+
+    def test_uint8_preallocated_output_reused(self, device):
+        """``out`` kwarg is forwarded so callers can reuse storage."""
+        from isaaclab.utils.images import normalize_camera_image
+
+        src = torch.randint(0, 255, (2, 8, 8, 6), dtype=torch.uint8, device=device)
+        out = torch.empty(src.shape, dtype=torch.float32, device=device)
+        ptr = out.data_ptr()
+        result = normalize_camera_image(src, "rgb", out=out)
+        assert result is out
+        assert result.data_ptr() == ptr
+
+    def test_float_input_takes_pytorch_fallback(self, device):
+        """Non-uint8 input routes through the PyTorch fallback with equivalent math."""
+        from isaaclab.utils.images import normalize_camera_image
+
+        torch.manual_seed(0)
+        src_f = torch.randint(0, 255, (2, 8, 8, 3), dtype=torch.uint8, device=device).float()
+        out = normalize_camera_image(src_f, "rgb")
+
+        expected = src_f / 255.0
+        expected = expected - torch.mean(expected, dim=(1, 2), keepdim=True)
+        torch.testing.assert_close(out, expected)
+        assert out.dtype == torch.float32
+
+    def test_non_contiguous_uint8_takes_pytorch_fallback(self, device):
+        """Strided uint8 input falls back instead of raising in the Warp wrapper."""
+        from isaaclab.utils.images import normalize_camera_image
+
+        torch.manual_seed(0)
+        base = torch.randint(0, 255, (2, 8, 8, 12), dtype=torch.uint8, device=device)
+        src = base[..., ::2]
+        assert not src.is_contiguous()
+        out = normalize_camera_image(src, "rgb")
+
+        ref = src.float() / 255.0
+        expected = ref - torch.mean(ref, dim=(1, 2), keepdim=True)
+        torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
+
+    def test_bchw_uint8_routes_to_warp_fast_path(self, device):
+        """``channel_dim=1`` produces a BCHW-correct normalize via the Warp fast path."""
+        from isaaclab.utils.images import normalize_camera_image
+
+        torch.manual_seed(0)
+        src = torch.randint(0, 255, (2, 3, 8, 8), dtype=torch.uint8, device=device)
+        out = normalize_camera_image(src, "rgb", channel_dim=1)
+
+        expected = src.float() / 255.0
+        expected = expected - torch.mean(expected, dim=(2, 3), keepdim=True)
+        torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
+        assert out.dtype == torch.float32
+
+    def test_bchw_float_input_takes_pytorch_fallback(self, device):
+        """Non-uint8 BCHW input routes through the PyTorch fallback with BCHW reduction axes."""
+        from isaaclab.utils.images import normalize_camera_image
+
+        torch.manual_seed(0)
+        src_f = torch.randint(0, 255, (2, 3, 8, 8), dtype=torch.uint8, device=device).float()
+        out = normalize_camera_image(src_f, "rgb", channel_dim=1)
+
+        expected = src_f / 255.0
+        expected = expected - torch.mean(expected, dim=(2, 3), keepdim=True)
+        torch.testing.assert_close(out, expected)
+
+
+class TestNormalizeCameraImageDepth:
+    """Depth-like dispatch: in-place ``inf -> 0``."""
+
+    @pytest.mark.parametrize("data_type", ["depth", "distance_to_camera", "distance_to_plane"])
+    def test_inf_replaced_with_zero_in_place(self, device, data_type):
+        from isaaclab.utils.images import normalize_camera_image
+
+        src = torch.tensor([[1.0, float("inf"), 3.0], [float("inf"), 2.0, 4.0]], device=device)
+        out = normalize_camera_image(src, data_type)
+        assert out is src
+        expected = torch.tensor([[1.0, 0.0, 3.0], [0.0, 2.0, 4.0]], device=device)
+        torch.testing.assert_close(out, expected)
+
+
+class TestNormalizeCameraImageNormals:
+    """Normals dispatch: ``[-1, 1] -> [0, 1]``."""
+
+    def test_range_remap(self, device):
+        from isaaclab.utils.images import normalize_camera_image
+
+        src = torch.tensor([-1.0, -0.5, 0.0, 0.5, 1.0], device=device)
+        out = normalize_camera_image(src, "normals")
+        expected = torch.tensor([0.0, 0.25, 0.5, 0.75, 1.0], device=device)
+        torch.testing.assert_close(out, expected)
+
+
+class TestNormalizeCameraImagePassthrough:
+    """Unknown data_types return the input unchanged."""
+
+    @pytest.mark.parametrize("data_type", ["semantic_segmentation", "instance_segmentation", "motion_vectors"])
+    def test_unknown_type_passthrough(self, device, data_type):
+        from isaaclab.utils.images import normalize_camera_image
+
+        src = torch.ones((2, 4, 4, 3), device=device)
+        out = normalize_camera_image(src, data_type)
+        assert out is src

--- a/source/isaaclab/test/utils/test_images.py
+++ b/source/isaaclab/test/utils/test_images.py
@@ -56,6 +56,12 @@ class TestPredicates:
 
         assert is_normals_like(data_type)
 
+    @pytest.mark.parametrize("data_type", ["rgb", "albedo", "depth", "distance_to_camera"])
+    def test_is_normals_like_rejects(self, data_type):
+        from isaaclab.utils.images import is_normals_like
+
+        assert not is_normals_like(data_type)
+
 
 class TestNormalizeCameraImageRGBLike:
     """RGB-like dispatch: rgb, albedo, simple_shading_*."""

--- a/source/isaaclab/test/utils/warp/test_image_ops.py
+++ b/source/isaaclab/test/utils/warp/test_image_ops.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for :func:`isaaclab.utils.warp.ops.normalize_image_uint8`."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import warp as wp
+
+wp.config.quiet = True
+wp.init()
+
+
+def _pytorch_reference(src: torch.Tensor, channel_dim: int = -1) -> torch.Tensor:
+    """Reference normalize: ``(x / 255 - per-image-channel mean)`` in pure PyTorch."""
+    x = src.float() / 255.0
+    resolved = channel_dim + x.ndim if channel_dim < 0 else channel_dim
+    spatial_dims = tuple(d for d in range(1, x.ndim) if d != resolved)
+    return x - torch.mean(x, dim=spatial_dims, keepdim=True)
+
+
+@pytest.fixture(params=["cpu", "cuda:0"] if torch.cuda.is_available() else ["cpu"])
+def device(request):
+    """Parametrize across CPU and CUDA."""
+    return request.param
+
+
+class TestNormalizeImageUint8:
+    """Tests for the Warp-backed fused uint8 normalize wrapper."""
+
+    def test_matches_pytorch_reference_constant_input(self, device):
+        """A constant-valued uint8 input must normalize to all zeros (mean equals every pixel)."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        src = torch.full((2, 4, 4, 6), 128, dtype=torch.uint8, device=device)
+        out = normalize_image_uint8(src)
+        torch.testing.assert_close(out, torch.zeros_like(out))
+
+    def test_matches_pytorch_reference_random_input(self, device):
+        """Output must match the pure-PyTorch reference on randomized input."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        torch.manual_seed(0)
+        src = torch.randint(0, 255, (3, 16, 16, 6), dtype=torch.uint8, device=device)
+        out = normalize_image_uint8(src)
+        expected = _pytorch_reference(src)
+        torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
+
+    def test_matches_pytorch_reference_disjoint_channel_slices(self, device):
+        """Two frames concatenated along C must each normalize independently per-channel-slice."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        torch.manual_seed(1)
+        c = 3
+        f1 = torch.randint(0, 255, (2, 8, 8, c), dtype=torch.uint8, device=device)
+        f2 = torch.randint(0, 255, (2, 8, 8, c), dtype=torch.uint8, device=device)
+        stacked = torch.cat([f1, f2], dim=-1).contiguous()
+        out = normalize_image_uint8(stacked)
+        torch.testing.assert_close(out[..., :c], _pytorch_reference(f1), atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(out[..., c:], _pytorch_reference(f2), atol=1e-5, rtol=1e-5)
+
+    def test_preallocated_output_reused(self, device):
+        """When ``out`` is passed in, the wrapper writes into it and returns the same object."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        src = torch.randint(0, 255, (2, 8, 8, 6), dtype=torch.uint8, device=device)
+        out = torch.empty(src.shape, dtype=torch.float32, device=device)
+        ptr_before = out.data_ptr()
+        result = normalize_image_uint8(src, out=out)
+        assert result is out
+        assert result.data_ptr() == ptr_before
+
+        src2 = torch.randint(0, 255, (2, 8, 8, 6), dtype=torch.uint8, device=device)
+        result2 = normalize_image_uint8(src2, out=out)
+        assert result2 is out
+        assert result2.data_ptr() == ptr_before
+        torch.testing.assert_close(result2, _pytorch_reference(src2), atol=1e-5, rtol=1e-5)
+
+    def test_rejects_non_uint8_input(self, device):
+        """Float input is a programming error and must raise."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        src = torch.zeros((2, 4, 4, 3), dtype=torch.float32, device=device)
+        with pytest.raises(ValueError, match="4D uint8"):
+            normalize_image_uint8(src)
+
+    def test_rejects_wrong_ndim(self, device):
+        """3D uint8 input is rejected (kernel expects (B, H, W, C))."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        src = torch.zeros((4, 4, 3), dtype=torch.uint8, device=device)
+        with pytest.raises(ValueError, match="4D uint8"):
+            normalize_image_uint8(src)
+
+    def test_rejects_non_contiguous_input(self, device):
+        """Non-contiguous src is rejected."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        base = torch.randint(0, 255, (2, 8, 8, 12), dtype=torch.uint8, device=device)
+        src = base[..., ::2]
+        assert not src.is_contiguous()
+        with pytest.raises(ValueError, match="contiguous"):
+            normalize_image_uint8(src)
+
+    def test_rejects_out_shape_mismatch(self, device):
+        """A pre-allocated ``out`` of the wrong shape must raise."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        src = torch.zeros((2, 4, 4, 6), dtype=torch.uint8, device=device)
+        bad_out = torch.empty((2, 4, 4, 3), dtype=torch.float32, device=device)
+        with pytest.raises(ValueError, match="out shape/dtype/device"):
+            normalize_image_uint8(src, out=bad_out)
+
+    def test_rejects_out_dtype_mismatch(self, device):
+        """A pre-allocated ``out`` of the wrong dtype must raise."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        src = torch.zeros((2, 4, 4, 6), dtype=torch.uint8, device=device)
+        bad_out = torch.empty(src.shape, dtype=torch.float16, device=device)
+        with pytest.raises(ValueError, match="out shape/dtype/device"):
+            normalize_image_uint8(src, out=bad_out)
+
+    def test_bchw_matches_pytorch_reference(self, device):
+        """``channel_dim=1`` (BCHW) must match a BCHW-layout PyTorch reference."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        torch.manual_seed(2)
+        src = torch.randint(0, 255, (3, 6, 16, 16), dtype=torch.uint8, device=device)
+        out = normalize_image_uint8(src, channel_dim=1)
+        torch.testing.assert_close(out, _pytorch_reference(src, channel_dim=1), atol=1e-5, rtol=1e-5)
+
+    def test_bchw_negative_index_equivalent_to_positive(self, device):
+        """``channel_dim=-3`` must produce the same output as ``channel_dim=1`` for 4D input."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        torch.manual_seed(3)
+        src = torch.randint(0, 255, (2, 4, 8, 8), dtype=torch.uint8, device=device)
+        out_pos = normalize_image_uint8(src, channel_dim=1)
+        out_neg = normalize_image_uint8(src, channel_dim=-3)
+        torch.testing.assert_close(out_pos, out_neg)
+
+    def test_bhwc_explicit_positive_index_matches_default(self, device):
+        """``channel_dim=3`` and the default ``channel_dim=-1`` must agree on BHWC input."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        torch.manual_seed(4)
+        src = torch.randint(0, 255, (2, 8, 8, 4), dtype=torch.uint8, device=device)
+        out_default = normalize_image_uint8(src)
+        out_explicit = normalize_image_uint8(src, channel_dim=3)
+        torch.testing.assert_close(out_default, out_explicit)
+
+    def test_bchw_disjoint_channel_slices(self, device):
+        """K frames concatenated along C in BCHW must each normalize independently per-channel."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        torch.manual_seed(5)
+        c = 3
+        f1 = torch.randint(0, 255, (2, c, 8, 8), dtype=torch.uint8, device=device)
+        f2 = torch.randint(0, 255, (2, c, 8, 8), dtype=torch.uint8, device=device)
+        stacked = torch.cat([f1, f2], dim=1).contiguous()
+        out = normalize_image_uint8(stacked, channel_dim=1)
+        torch.testing.assert_close(out[:, :c], _pytorch_reference(f1, channel_dim=1), atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(out[:, c:], _pytorch_reference(f2, channel_dim=1), atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize("bad_dim", [0, 2, 4, -2, -4, -5])
+    def test_rejects_invalid_channel_dim(self, device, bad_dim):
+        """Only ``channel_dim`` resolving to 1 or 3 is accepted for 4D input."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        src = torch.zeros((2, 4, 4, 3), dtype=torch.uint8, device=device)
+        with pytest.raises(ValueError, match="channel_dim must resolve to 1 .BCHW. or 3 .BHWC."):
+            normalize_image_uint8(src, channel_dim=bad_dim)

--- a/source/isaaclab/test/utils/warp/test_image_ops.py
+++ b/source/isaaclab/test/utils/warp/test_image_ops.py
@@ -264,11 +264,11 @@ class TestNormalizeImageUint8:
 
         warp_ops.normalize_image_uint8(src_a)
         size_after_first = len(warp_ops._uint8_sum_partials_cache)
-        first_scratch_ptr = warp_ops._uint8_sum_partials_cache[(shape, device, 3)][0].data_ptr()
+        first_scratch_ptr = warp_ops._uint8_sum_partials_cache[(shape, device, 3)].data_ptr()
 
         warp_ops.normalize_image_uint8(src_b)
         size_after_second = len(warp_ops._uint8_sum_partials_cache)
-        second_scratch_ptr = warp_ops._uint8_sum_partials_cache[(shape, device, 3)][0].data_ptr()
+        second_scratch_ptr = warp_ops._uint8_sum_partials_cache[(shape, device, 3)].data_ptr()
 
         assert size_after_first == 1
         assert size_after_second == size_after_first

--- a/source/isaaclab/test/utils/warp/test_image_ops.py
+++ b/source/isaaclab/test/utils/warp/test_image_ops.py
@@ -174,3 +174,102 @@ class TestNormalizeImageUint8:
         src = torch.zeros((2, 4, 4, 3), dtype=torch.uint8, device=device)
         with pytest.raises(ValueError, match="channel_dim must resolve to 1 .BCHW. or 3 .BHWC."):
             normalize_image_uint8(src, channel_dim=bad_dim)
+
+    def test_multi_tile_h_axis(self, device):
+        """H > tile_size must produce NUM_TILES > 1 partial sums and reduce correctly."""
+        from isaaclab.utils.warp.ops import _UINT8_SUM_TILE_HW, normalize_image_uint8
+
+        # H = 2 * TILE forces NUM_TILES=2 (evenly split).
+        h = 2 * _UINT8_SUM_TILE_HW
+        torch.manual_seed(2)
+        src = torch.randint(0, 255, (2, h, 8, 6), dtype=torch.uint8, device=device)
+        out = normalize_image_uint8(src)
+        torch.testing.assert_close(out, _pytorch_reference(src), atol=1e-5, rtol=1e-5)
+
+    def test_non_divisible_h_last_tile_clamps(self, device):
+        """H not divisible by tile_size: last tile's row range must clamp via ``wp.min``."""
+        from isaaclab.utils.warp.ops import _UINT8_SUM_TILE_HW, normalize_image_uint8
+
+        # H = 2*TILE + 1 forces a 3rd tile with a single row.
+        h = 2 * _UINT8_SUM_TILE_HW + 1
+        torch.manual_seed(3)
+        src = torch.randint(0, 255, (2, h, 8, 6), dtype=torch.uint8, device=device)
+        out = normalize_image_uint8(src)
+        torch.testing.assert_close(out, _pytorch_reference(src), atol=1e-5, rtol=1e-5)
+
+    def test_bchw_multi_tile_h_axis(self, device):
+        """H > tile_size on BCHW (H at axis 2) must reduce correctly across multiple tiles."""
+        from isaaclab.utils.warp.ops import _UINT8_SUM_TILE_HW, normalize_image_uint8
+
+        h = 2 * _UINT8_SUM_TILE_HW + 1
+        torch.manual_seed(6)
+        src = torch.randint(0, 255, (2, 6, h, 8), dtype=torch.uint8, device=device)
+        out = normalize_image_uint8(src, channel_dim=1)
+        torch.testing.assert_close(out, _pytorch_reference(src, channel_dim=1), atol=1e-5, rtol=1e-5)
+
+    def test_bchw_constant_input(self, device):
+        """A constant-valued BCHW uint8 input must normalize to all zeros."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        src = torch.full((2, 6, 4, 4), 128, dtype=torch.uint8, device=device)
+        out = normalize_image_uint8(src, channel_dim=1)
+        torch.testing.assert_close(out, torch.zeros_like(out))
+
+    def test_bchw_preallocated_output_reused(self, device):
+        """``out`` kwarg on the BCHW path is written-into and the same object is returned."""
+        from isaaclab.utils.warp.ops import normalize_image_uint8
+
+        src = torch.randint(0, 255, (2, 6, 8, 8), dtype=torch.uint8, device=device)
+        out = torch.empty(src.shape, dtype=torch.float32, device=device)
+        ptr_before = out.data_ptr()
+        result = normalize_image_uint8(src, channel_dim=1, out=out)
+        assert result is out
+        assert result.data_ptr() == ptr_before
+        torch.testing.assert_close(result, _pytorch_reference(src, channel_dim=1), atol=1e-5, rtol=1e-5)
+
+        src2 = torch.randint(0, 255, (2, 6, 8, 8), dtype=torch.uint8, device=device)
+        result2 = normalize_image_uint8(src2, channel_dim=1, out=out)
+        assert result2.data_ptr() == ptr_before
+        torch.testing.assert_close(result2, _pytorch_reference(src2, channel_dim=1), atol=1e-5, rtol=1e-5)
+
+    def test_partials_cache_keyed_by_channel_dim(self, device):
+        """BCHW and BHWC inputs of identical shape must land in separate cache slots."""
+        from isaaclab.utils.warp import ops as warp_ops
+
+        shape = (2, 6, 8, 8)  # ambiguous shape: works as both BHWC (B=2,H=6,W=8,C=8) and BCHW (B=2,C=6,H=8,W=8)
+        src_bhwc = torch.randint(0, 255, shape, dtype=torch.uint8, device=device)
+        src_bchw = torch.randint(0, 255, shape, dtype=torch.uint8, device=device)
+
+        warp_ops._uint8_sum_partials_cache.clear()
+
+        warp_ops.normalize_image_uint8(src_bhwc)  # channel_dim defaults to -1 -> resolves to 3
+        warp_ops.normalize_image_uint8(src_bchw, channel_dim=1)
+
+        # Both calls had shape ``shape`` but different channel_dim, so the cache key
+        # (shape, device, channel_dim) must distinguish them: two entries, not one.
+        assert (shape, device, 3) in warp_ops._uint8_sum_partials_cache
+        assert (shape, device, 1) in warp_ops._uint8_sum_partials_cache
+        assert len(warp_ops._uint8_sum_partials_cache) == 2
+
+    def test_partials_cache_reuses_scratch_across_calls(self, device):
+        """Repeat calls with the same shape must hit the partials cache, not grow it."""
+        from isaaclab.utils.warp import ops as warp_ops
+
+        shape = (2, warp_ops._UINT8_SUM_TILE_HW + 4, 8, 6)
+        src_a = torch.randint(0, 255, shape, dtype=torch.uint8, device=device)
+        src_b = torch.randint(0, 255, shape, dtype=torch.uint8, device=device)
+
+        # Clear the cache to isolate this test from prior tests' state.
+        warp_ops._uint8_sum_partials_cache.clear()
+
+        warp_ops.normalize_image_uint8(src_a)
+        size_after_first = len(warp_ops._uint8_sum_partials_cache)
+        first_scratch_ptr = warp_ops._uint8_sum_partials_cache[(shape, device, 3)][0].data_ptr()
+
+        warp_ops.normalize_image_uint8(src_b)
+        size_after_second = len(warp_ops._uint8_sum_partials_cache)
+        second_scratch_ptr = warp_ops._uint8_sum_partials_cache[(shape, device, 3)][0].data_ptr()
+
+        assert size_after_first == 1
+        assert size_after_second == size_after_first
+        assert first_scratch_ptr == second_scratch_ptr

--- a/source/isaaclab_tasks/changelog.d/jmart-framestack-perf.rst
+++ b/source/isaaclab_tasks/changelog.d/jmart-framestack-perf.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_tasks.direct.cartpole.cartpole_camera_env.CartpoleCameraEnv`
+  and its presets subclass to route image normalization through
+  :func:`isaaclab.utils.images.normalize_camera_image` and defer the normalize past the
+  frame-stack buffer for RGB-like data types, improving cartpole-camera frame-stacking
+  throughput.

--- a/source/isaaclab_tasks/changelog.d/jmart-framestack-perf.rst
+++ b/source/isaaclab_tasks/changelog.d/jmart-framestack-perf.rst
@@ -1,8 +1,8 @@
 Changed
 ^^^^^^^
 
-* Changed :class:`~isaaclab_tasks.direct.cartpole.cartpole_camera_env.CartpoleCameraEnv`
-  and its presets subclass to route image normalization through
+* Changed :class:`~isaaclab_tasks.core.cartpole.cartpole_direct_camera_env.CartpoleCameraEnv`
+  to route image normalization through
   :func:`isaaclab.utils.images.normalize_camera_image` and defer the normalize past the
   frame-stack buffer for RGB-like data types, improving cartpole-camera frame-stacking
   throughput.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -75,7 +75,11 @@ class CartpoleCameraEnv(CartpoleEnv):
 
         self._stack: CircularBuffer | None = None
         if frame_stack > 1:
-            self._stack = CircularBuffer(max_len=frame_stack, batch_size=self.num_envs, device=self.device)
+            # Channel-stack mode: buffer storage is laid out so that .stacked is a free
+            # contiguous reshape into (B, K*C, H, W) -- no per-step permute/reshape alloc.
+            self._stack = CircularBuffer(
+                max_len=frame_stack, batch_size=self.num_envs, device=self.device, stack_dim=1
+            )
 
     def _setup_scene(self):
         """Setup the scene with the cartpole and camera (no ground plane, which obstructs the view)."""
@@ -114,12 +118,7 @@ class CartpoleCameraEnv(CartpoleEnv):
 
         if self._stack is not None:
             self._stack.append(obs)
-            # CircularBuffer.buffer is (B, K, C, H, W) oldest->newest along dim 1.
-            # Channel-stack: flatten the adjacent (K, C) dims so the channel axis
-            # reads oldest_C, ..., newest_C.
-            stacked = self._stack.buffer
-            b, k, c, h, w = stacked.shape
-            obs = stacked.reshape(b, k * c, h, w)
+            obs = self._stack.stacked
 
         if self.cfg.write_image_to_file:
             save_images_to_file(self._tiled_camera.data.output[data_type] / 255.0, f"cartpole_{data_type}.png")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -103,10 +103,16 @@ class CartpoleCameraEnv(CartpoleEnv):
         data_type = self.cfg.tiled_camera.data_types[0]
         camera_data = self._tiled_camera.data.output[data_type]
 
-        if data_type == "albedo" or data_type == "rgb" or data_type in SIMPLE_SHADING_TYPES:
+        is_rgb_like = data_type == "albedo" or data_type == "rgb" or data_type in SIMPLE_SHADING_TYPES
+        # Defer normalize past the ring buffer when stacking RGB-like data so the ring holds
+        # uint8 (4x cheaper per-step copies). Math is identical -- K frames live in disjoint
+        # channel slices of (B, K*C, H, W).
+        defer_normalize = self._stack is not None and is_rgb_like
+
+        if data_type == "albedo":
             # albedo carries an extra alpha channel that the policy does not use
-            if data_type == "albedo":
-                camera_data = camera_data[..., :3]
+            camera_data = camera_data[..., :3]
+        if is_rgb_like and not defer_normalize:
             # scale to [0, 1] and mean-center per image for better training results
             camera_data = camera_data / 255.0
             camera_data -= torch.mean(camera_data, dim=(1, 2), keepdim=True)
@@ -119,6 +125,11 @@ class CartpoleCameraEnv(CartpoleEnv):
         if self._stack is not None:
             self._stack.append(obs)
             obs = self._stack.stacked
+
+        if defer_normalize:
+            # BCHW: spatial mean is over axes (H, W) = (2, 3); produces (B, K*C, 1, 1).
+            obs = obs.float() / 255.0
+            obs -= torch.mean(obs, dim=(2, 3), keepdim=True)
 
         if self.cfg.write_image_to_file:
             save_images_to_file(self._tiled_camera.data.output[data_type] / 255.0, f"cartpole_{data_type}.png")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -15,6 +15,7 @@ from isaaclab.assets import Articulation
 from isaaclab.sensors import Camera, save_images_to_file
 from isaaclab.utils.buffers import CircularBuffer
 from isaaclab.utils.configclass import resolve_cfg_presets
+from isaaclab.utils.images import is_rgb_like, normalize_camera_image
 
 from isaaclab_tasks.core.cartpole.cartpole_direct_env import CartpoleEnv
 
@@ -74,6 +75,8 @@ class CartpoleCameraEnv(CartpoleEnv):
             )
 
         self._stack: CircularBuffer | None = None
+        # Reused across steps to avoid allocating a fresh output every call.
+        self._normalized_output: torch.Tensor | None = None
         if frame_stack > 1:
             # Channel-stack mode: buffer storage is laid out so that .stacked is a free
             # contiguous reshape into (B, K*C, H, W) -- no per-step permute/reshape alloc.
@@ -103,19 +106,17 @@ class CartpoleCameraEnv(CartpoleEnv):
         data_type = self.cfg.tiled_camera.data_types[0]
         camera_data = self._tiled_camera.data.output[data_type]
 
-        is_rgb_like = data_type == "albedo" or data_type == "rgb" or data_type in SIMPLE_SHADING_TYPES
+        rgb_like = is_rgb_like(data_type)
         # Defer normalize past the ring buffer when stacking RGB-like data so the ring holds
         # uint8 (4x cheaper per-step copies). Math is identical -- K frames live in disjoint
         # channel slices of (B, K*C, H, W).
-        defer_normalize = self._stack is not None and is_rgb_like
+        defer_normalize = self._stack is not None and rgb_like
 
         if data_type == "albedo":
             # albedo carries an extra alpha channel that the policy does not use
             camera_data = camera_data[..., :3]
-        if is_rgb_like and not defer_normalize:
-            # scale to [0, 1] and mean-center per image for better training results
-            camera_data = camera_data / 255.0
-            camera_data -= torch.mean(camera_data, dim=(1, 2), keepdim=True)
+        if rgb_like and not defer_normalize:
+            camera_data = normalize_camera_image(camera_data, data_type)
         elif data_type == "depth":
             camera_data[camera_data == float("inf")] = 0
 
@@ -127,9 +128,9 @@ class CartpoleCameraEnv(CartpoleEnv):
             obs = self._stack.stacked
 
         if defer_normalize:
-            # BCHW: spatial mean is over axes (H, W) = (2, 3); produces (B, K*C, 1, 1).
-            obs = obs.float() / 255.0
-            obs -= torch.mean(obs, dim=(2, 3), keepdim=True)
+            if self._normalized_output is None:
+                self._normalized_output = torch.empty(obs.shape, dtype=torch.float32, device=self.device)
+            obs = normalize_camera_image(obs, data_type, out=self._normalized_output, channel_dim=1)
 
         if self.cfg.write_image_to_file:
             save_images_to_file(self._tiled_camera.data.output[data_type] / 255.0, f"cartpole_{data_type}.png")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -119,7 +119,7 @@ class CartpoleCameraEnv(CartpoleEnv):
             # reads oldest_C, ..., newest_C.
             stacked = self._stack.buffer
             b, k, c, h, w = stacked.shape
-            obs = stacked.reshape(b, k * c, h, w).clone()
+            obs = stacked.reshape(b, k * c, h, w)
 
         if self.cfg.write_image_to_file:
             save_images_to_file(self._tiled_camera.data.output[data_type] / 255.0, f"cartpole_{data_type}.png")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -75,8 +75,6 @@ class CartpoleCameraEnv(CartpoleEnv):
             )
 
         self._stack: CircularBuffer | None = None
-        # Reused across steps to avoid allocating a fresh output every call.
-        self._normalized_output: torch.Tensor | None = None
         if frame_stack > 1:
             # Channel-stack mode: buffer storage is laid out so that .stacked is a free
             # contiguous reshape into (B, K*C, H, W) -- no per-step permute/reshape alloc.
@@ -128,9 +126,17 @@ class CartpoleCameraEnv(CartpoleEnv):
             obs = self._stack.stacked
 
         if defer_normalize:
-            if self._normalized_output is None:
-                self._normalized_output = torch.empty(obs.shape, dtype=torch.float32, device=self.device)
-            obs = normalize_camera_image(obs, data_type, out=self._normalized_output, channel_dim=1)
+            # No ``out=`` -- a fresh float32 tensor is allocated per call. The caching
+            # allocator returns a different block than the previous step's (still
+            # referenced by the trainer), so the previous-iteration ``observations``
+            # is not overwritten before ``record_transition`` reads it. See
+            # :func:`isaaclab.utils.warp.ops.normalize_image_uint8` for the aliasing
+            # hazard documentation.
+            obs = normalize_camera_image(obs, data_type, channel_dim=1)
+        elif self._stack is not None:
+            # ``stacked`` is a view of the ring buffer storage which is overwritten on
+            # the next ``env.step``; clone so the returned tensor outlives the next step.
+            obs = obs.clone()
 
         if self.cfg.write_image_to_file:
             save_images_to_file(self._tiled_camera.data.output[data_type] / 255.0, f"cartpole_{data_type}.png")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-import torch
-
 import isaaclab.sim as sim_utils
 from isaaclab.assets import Articulation
 from isaaclab.sensors import Camera, save_images_to_file
@@ -78,9 +76,7 @@ class CartpoleCameraEnv(CartpoleEnv):
         if frame_stack > 1:
             # Channel-stack mode: buffer storage is laid out so that .stacked is a free
             # contiguous reshape into (B, K*C, H, W) -- no per-step permute/reshape alloc.
-            self._stack = CircularBuffer(
-                max_len=frame_stack, batch_size=self.num_envs, device=self.device, stack_dim=1
-            )
+            self._stack = CircularBuffer(max_len=frame_stack, batch_size=self.num_envs, device=self.device, stack_dim=1)
 
     def _setup_scene(self):
         """Setup the scene with the cartpole and camera (no ground plane, which obstructs the view)."""


### PR DESCRIPTION
# Description

Frame-stacking was added to cartpole-camera by #5574 to make the task solvable on the Newton+Warp backend. Single-frame RGB observations don't carry pole velocity, so a single-image policy can only recover ~100/300 mean episode reward. On PhysX+RTX, implicit damping in the dynamics plus temporal antialiasing in the renderer leak enough adjacent-frame correlation that a single-frame policy still hits ~296. Newton+Warp has neither, so explicit frame stacking is required for the task to be solvable on this backend.

The implementation regressed throughput by 42% (54.6 → 31.7 FPS) and inflated peak VRAM 2.7× (3.13 → 8.37 GB) at R256, 1024 envs. PR #5574 added a `CircularBuffer` ring + a `stacked_image` MDP term that:

1. Stored frames as **float32** even when the camera output was uint8 → 4× ring memory and 4× shift bandwidth.
2. Ran the per-frame normalize (`x/255 - mean(x)`) **before** the buffer, forcing the buffer to be float32.
3. Re-rolled the buffer with `torch.roll` on every append → ring-sized temporary per env.step.
4. Built the channel-stacked policy obs via `permute + reshape + clone` → fresh `(B, H, W, K*C)` float32 tensor per env.step.
5. Inlined the normalize math at 5 call sites across DirectRLEnv and ManagerBasedEnv paths.

This PR rewrites the frame-stacking hot path; the result runs **24% faster than the pre-framestack baseline** with identical PPO convergence.

| Change | Why |
|---|---|
| **uint8 ring buffer.** Defer the `x/255 − mean` normalize past the frame-stack buffer for RGB-like data types. | Ring is 4× smaller; shift bandwidth per env.step drops 4×. |
| **Free contiguous stacked output.** New `CircularBuffer.stack_dim` arg + `.stacked` property arrange storage so the channel-stacked output is a contiguous view of internal storage. | Eliminates one `(B, H, W, K*C)`-sized allocation and a permute kernel per env.step. |
| **Drop `torch.roll` on append.** Replace with a front-to-back memmove. | One fewer ring-sized allocation and one fewer kernel launch per env.step. |
| **Fused Warp normalize kernel** (`normalize_image_uint8`). One kernel: `(uint8 / 255) − per-(batch, channel) mean → float32`. | Replaces upcast + reduce + subtract (three PyTorch passes) with one fused launch over the K-stacked input. |
| **Tiled int32 partial-sum reduction kernel** (`spatial_sum_uint8_tiled`). Warp kernel writes `(B, NUM_TILES, C)` int32 partials along H; PyTorch collapses the partial dim. | int32 accumulator is safe up to H·W·255 (128× headroom at R256) and ~3× faster than int64 / float32 on PyTorch's auto-tuned reduce path. C-innermost launch shape gives stride-1 reads on src's contiguous trailing dim. |
| **Shared `isaaclab.utils.images.normalize_camera_image` dispatch.** One helper used by both `image()` (DirectRLEnv) and `stacked_image.__call__` (ManagerBasedEnv); routes uint8 contiguous inputs through the Warp fast path and falls back to PyTorch otherwise. | Removes inline normalize math duplicated across 5 sites; the fast path picks itself up automatically. |
| **`image(clone=False)` opt-out.** Callers that immediately copy into their own storage skip the defensive clone. | Saves one obs-sized allocation per env.step at the consumer site (frame-stack buffer). |
| **Allocator-managed obs lifetime.** `_get_observations` allocates the normalize output fresh each call (no persistent `out=` buffer). | The RL trainer holds a reference to the previous-iteration observation until `record_transition` returns; reusing one buffer across env.step boundaries aliases the trainer's prior obs. Fresh allocation lets PyTorch's caching allocator hand out a different block while the prior is still referenced. |

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Results

R256 (256×256), 1024 envs, PPO via skrl 2.1.0, seed 42, on NVIDIA L40. Perf via non_rl measured over n=3 warm trials:

| Stage | FPS | step_ms | Peak VRAM | Mean reward |
|---|---|---|---|---|
| Pre-framestack baseline | 54.62 | 18.67 | 3.13 GB | ~102 (unsolvable — no temporal info) |
| Frame stacking from #5574 | 31.72 | 32.07 | 8.37 GB | 297.68 |
| This PR (pre-rebase) | 67.87 | 15.32 | 4.41 GB | 297.60 |
| **This PR (post-rebase)** | **69.50** | **14.94** | **4.57 GB** | **293.43** |

## Screenshots

<img width="1432" height="989" alt="pr_figure_v2" src="https://github.com/user-attachments/assets/39791fc5-64ea-456d-83f5-d1faf2358ac9" />

## Environment

NVIDIA L40 (48 GB), driver 570.158.01. Newton+Warp backend (`presets=newton_mjwarp,newton_renderer`). skrl 2.1.0 trainer.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation *(N/A - frame stacking already documented, these changes are implementation details)*
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there