### PR TITLE
Fixes doc build failure

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -132,4 +132,3 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build
         keep_files: false
-        force_orphan: true


### PR DESCRIPTION
# Description

Merge from main introduced a bad change in the doc building job that prevented updates from being pushed to the compiled docs. Reverting `force_orphan: true` as it creates an orphan gh-pages branch and pushes it with --force, which violates the branch rule. Without it, peaceiris/actions-gh-pages should use a normal push.