### PR TITLE
[CI] Restore nightly changelog cron: pyproject staging + per-package failure tolerance

### DIFF
--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -173,6 +173,13 @@ jobs:
           python-version: "3.12"
 
       - name: Compile fragments
+        # Capture the compile exit code so the next step can commit/push
+        # whatever compiled successfully, then re-propagate the failure at
+        # the end. Without ``continue-on-error: true`` the workflow would
+        # short-circuit and discard the successful packages' on-disk state,
+        # which is exactly the wedge mode that motivated this design.
+        id: compile
+        continue-on-error: true
         run: |
           ARGS="--all"
           if [ "${{ inputs.dry_run }}" = "true" ]; then
@@ -182,7 +189,12 @@ jobs:
           python3 tools/changelog/cli.py compile $ARGS
 
       - name: Commit and push if fragments were compiled
-        if: ${{ !inputs.dry_run }}
+        # ``always()`` lets this step run even when the compile step above
+        # reported partial failure (one package's malformed file fails, the
+        # rest still wrote their CHANGELOG.rst / deleted fragments / bumped
+        # extension.toml). The staged-diff check below short-circuits cleanly
+        # if the failed package was the only one with pending work.
+        if: ${{ always() && !inputs.dry_run }}
         env:
           # Pass the matrix branch through an env var rather than
           # interpolating ``${{ matrix.branch }}`` directly into ``run:``.
@@ -239,3 +251,13 @@ jobs:
             # write to the source ref of a workflow_dispatch run.
             git push origin "HEAD:refs/heads/$TARGET_BRANCH"
           fi
+
+      - name: Re-propagate compile failure
+        # ``continue-on-error: true`` above lets the commit/push step run on
+        # partial success, but the job tile must still stay red so the
+        # maintainer notices the failed package. This step re-asserts the
+        # original exit code AFTER successful packages have shipped.
+        if: ${{ steps.compile.outcome == 'failure' }}
+        run: |
+          echo "::error::One or more packages failed to compile (see the Compile fragments step above)."
+          exit 1

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -208,9 +208,15 @@ jobs:
           # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
           git config user.name "isaaclab-bot[bot]"
           git config user.email "282401363+isaaclab-bot[bot]@users.noreply.github.com"
+          # ``pyproject.toml`` is staged alongside ``extension.toml`` because
+          # ``Package.write_version`` bumps both when a ``[project]`` block
+          # exists. Missing it leaves the pyproject write unstaged, which
+          # makes the subsequent ``git pull --rebase`` refuse with
+          # ``cannot pull with rebase: You have unstaged changes``.
           git add source/*/changelog.d/ \
                   source/*/docs/CHANGELOG.rst \
-                  source/*/config/extension.toml
+                  source/*/config/extension.toml \
+                  source/*/pyproject.toml
           if git diff --staged --quiet; then
             echo "No changelog fragments found — nothing to commit."
           else

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -189,12 +189,14 @@ jobs:
           python3 tools/changelog/cli.py compile $ARGS
 
       - name: Commit and push if fragments were compiled
-        # ``always()`` lets this step run even when the compile step above
-        # reported partial failure (one package's malformed file fails, the
-        # rest still wrote their CHANGELOG.rst / deleted fragments / bumped
-        # extension.toml). The staged-diff check below short-circuits cleanly
-        # if the failed package was the only one with pending work.
-        if: ${{ always() && !inputs.dry_run }}
+        # Fires when compile succeeded cleanly OR raised on at least one
+        # package (``continue-on-error: true`` above turned that conclusion
+        # to success while preserving the outcome — the surviving packages
+        # still ship). Explicitly NOT ``always()``: cancellation (timeout /
+        # maintainer cancel) leaves a partial on-disk state and the
+        # re-propagate step below wouldn't fire on ``outcome == 'cancelled'``,
+        # so this guard skips the commit/push entirely on cancel.
+        if: ${{ (success() || steps.compile.outcome == 'failure') && !inputs.dry_run }}
         env:
           # Pass the matrix branch through an env var rather than
           # interpolating ``${{ matrix.branch }}`` directly into ``run:``.


### PR DESCRIPTION
## 1. Summary

- Restores the scheduled nightly changelog cron after two failures on the develop and release/3.0.0-beta2 matrix entries this morning (https://github.com/isaac-sim/IsaacLab/actions/runs/26621920244).
- Two commits, both edit ``.github/workflows/nightly-changelog.yml`` on main (the cron-host copy is the only one the schedule reads).
- 1 file changed, 30 insertions, 2 deletions.

## 2. Background

The cron at 06:27 UTC on 2026-05-29 short-circuited both matrix entries:

1. develop matrix exited 128 in the commit/push step with ``error: cannot pull with rebase: You have unstaged changes``. ``tools/changelog/cli.py``'s ``Package.write_version`` bumps both ``config/extension.toml`` AND ``pyproject.toml`` when a ``[project]`` block exists. #5785 added ``[project] version`` lines to every managed package's pyproject.toml — activating a write path in cli.py that the workflow's commit step never staged. The unstaged pyproject changes made ``git pull --rebase`` refuse.

2. release/3.0.0-beta2 matrix exited 1 with ``remote: error: GH013: Repository rule violations``. The isaaclab-bot App isn't on ruleset 16056339's bypass-actor list for ``refs/heads/release/*``. Orthogonal to this PR — repo-admin bypass-list edit handled separately.

This PR addresses failure 1. It also bundles the workflow tolerance piece from #5831, which was previously merged onto develop's copy of the file but never reached main — so the cron has been running without the partial-success guarantees #5831 was meant to provide.

## 3. Commits

### 3.1 Tolerate per-package compile failures (cherry-pick of #5831 workflow piece)

- ``id: compile`` + ``continue-on-error: true`` on the Compile step.
- Commit/push gate becomes ``if: ${{ always() && !inputs.dry_run }}`` so successful packages still ship when one package raised.
- Trailing ``Re-propagate compile failure`` step re-asserts the non-zero exit so the job tile stays red.

#5831 wedged this on develop's copy of the workflow file, but the cron only reads main's copy, so the partial-success behavior was dead code until this commit.

### 3.2 Stage pyproject.toml in the auto-commit

- Adds ``source/*/pyproject.toml`` to the existing ``git add`` glob.
- Five-line comment naming the failure mode for future maintainers.

The downstream ``Bumped packages`` loop explicitly filters ``source/*/config/extension.toml``, so the new staged paths don't affect commit-body composition.

## 4. Why both on main, not develop / release

The scheduled cron only registers on the default branch and only reads main's copy of ``nightly-changelog.yml``. Develop and release/3.0.0-beta2 each carry their own copies of the workflow, but those copies are consumed only via manual ``workflow_dispatch`` (and even then, only if the maintainer picks that branch in the "Use workflow from" dropdown). Bug fixes to the cron behavior have to land on main to actually take effect.

## 5. Verification

- ``./isaaclab.sh -f`` clean.
- Logic check: with the glob fix, compile's write to pyproject.toml gets staged; the staged-diff check ``git diff --staged --quiet`` correctly reports work pending; commit composes; the existing ``git pull --rebase`` runs against a clean working tree.
- Runtime confirmation deferred to the next scheduled run (2026-05-30 06:27 UTC) or a manual ``workflow_dispatch`` against a sacrificial branch (see Test plan).

## 6. Out of scope

- release/3.0.0-beta2 bypass-actor on ruleset 16056339 — repo-admin UI edit, not a code change.
- The auto-bump / GitRepo / AutoBumpRun refactor that would move the entire commit/push/rebase lifecycle into cli.py and make the workflow's git-add glob obsolete — sequel PR, design discussed in the iteration thread.

## 7. Test plan

- [x] ``./isaaclab.sh -f`` clean.
- [x] Authorship audit: both commits authored by jichuanh.
- [ ] Optional pre-merge: ``workflow_dispatch`` against a throwaway target branch (cut from develop, single trivial fragment) to confirm end-to-end compile → stage → commit → rebase → push.
- [ ] Post-merge: next scheduled cron green for the develop matrix entry.