### PR TITLE
Document PPISP camera demo usage

### DIFF
--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -322,6 +322,24 @@ backend allocates its own HDR scratch buffer when the user did not request
 ``"rgb_hdr"`` in :attr:`~sensors.CameraCfg.data_types`, and dispatches the
 PPISP kernel into ``rgb`` / ``rgba`` after every render tick.
 
+Usage example
+^^^^^^^^^^^^^
+
+For a runnable usage example, see ``scripts/demos/sensors/ppisp_camera.py``.
+It loads a PPISP-authored USD or USDZ Gaussian scene, creates baseline and
+PPISP camera sensors for the selected camera, and saves baseline, PPISP, and
+absolute-difference images.
+
+.. code-block:: bash
+
+   ./isaaclab.sh -p scripts/demos/sensors/ppisp_camera.py \
+       --renderer newton --visualizer none --max_steps 60
+
+Use ``--renderer isaac_rtx`` to run the same workflow with Isaac RTX. Pass
+``--input_scene`` for a custom scene and ``--camera_prim_path`` if the stage
+contains multiple PPISP-bound cameras. Images are written to
+``scripts/demos/sensors/output/ppisp_camera`` unless ``--output_dir`` is set.
+
 Known limitations
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
 # Description

  This MR adds a compact usage example for the supported `scripts/demos/sensors/ppisp_camera.py` workflow in the camera sensor documentation.

  Dependencies: none.

  Fixes # N/A

  ## Type of change

  - Bug fix (non-breaking change which fixes an issue)
  - Documentation update

  ## Screenshots

  N/A. Documentation-only addition plus removal of an unusable demo script.

  ## Checklist

  - [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
  - [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
  - [x] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
  - [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there