### PR TITLE
[cherry pick] use lazy runtime imports to import leapp in export.py

### DIFF
--- a/scripts/reinforcement_learning/leapp/rsl_rl/export.py
+++ b/scripts/reinforcement_learning/leapp/rsl_rl/export.py
@@ -15,12 +15,10 @@ import sys
 import time
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
 from isaaclab.app import AppLauncher
 
-if TYPE_CHECKING:
-    import torch as torch_type
+from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
 
 _RSL_RL_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "rsl_rl"
 if str(_RSL_RL_SCRIPTS_DIR) not in sys.path:
@@ -104,8 +102,6 @@ def create_arg_parser() -> argparse.ArgumentParser:
 
 def parse_export_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, list[str]]:
     """Parse export arguments and return remaining Hydra overrides."""
-    from isaaclab_tasks.utils import setup_preset_cli
-
     parser = create_arg_parser()
     # setup_preset_cli attaches the preset-selection help group then parses;
     # remainder still carries typed selectors (physics=/renderer=/presets=)
@@ -186,9 +182,7 @@ def get_actor_memory_module(policy_nn):
     return None
 
 
-def ensure_actor_hidden_state_initialized(
-    policy_nn, batch_size: int, device: torch_type.device, dtype: torch_type.dtype
-):
+def ensure_actor_hidden_state_initialized(policy_nn, batch_size: int, device, dtype):
     """Initialize and return the actor hidden state when a recurrent policy has not created it yet."""
     actor_state, _ = policy_nn.get_hidden_states()
     if actor_state is not None:
@@ -357,24 +351,10 @@ def export_rsl_rl_agent(
     return True
 
 
-def prepare_cli_export_runtime() -> None:
-    """Apply CLI runtime setup that batched export tests perform per task."""
-    import isaaclab.sim as sim_utils
-    from isaaclab.app.settings_manager import get_settings_manager
-
-    sim_utils.create_new_stage()
-    settings_manager = get_settings_manager()
-    settings_manager.set_bool("/isaaclab/render/rtx_sensors", False)
-    settings_manager.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
-
-
 def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str]) -> bool:
     """Resolve Hydra task configuration and export one RSL-RL policy."""
-    from isaaclab_tasks.utils import fold_preset_tokens
-    from isaaclab_tasks.utils.hydra import hydra_task_config as hydra_task_config_import
+    from isaaclab_tasks.utils.hydra import hydra_task_config
     from isaaclab_tasks.utils.sim_launcher import launch_simulation
-
-    hydra_task_config_fn: Any = hydra_task_config_import
 
     original_argv = sys.argv
     # Fold typed preset selectors into a single ``presets=<csv>`` token before
@@ -384,15 +364,13 @@ def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str]) -
 
     try:
 
-        @hydra_task_config_fn(args_cli.task, args_cli.agent)
+        @hydra_task_config(args_cli.task, args_cli.agent)
         def _main(env_cfg, agent_cfg) -> None:
             nonlocal exported
             with launch_simulation(env_cfg, args_cli):
-                prepare_cli_export_runtime()
                 exported = export_rsl_rl_agent(args_cli, env_cfg, agent_cfg)
 
-        main_fn: Any = _main
-        main_fn()
+        _main()
     finally:
         sys.argv = original_argv
 

--- a/scripts/reinforcement_learning/leapp/rsl_rl/export.py
+++ b/scripts/reinforcement_learning/leapp/rsl_rl/export.py
@@ -15,22 +15,12 @@ import sys
 import time
 from collections.abc import Mapping
 from pathlib import Path
-
-import torch
-
-try:
-    import leapp
-    from leapp import annotate
-except ImportError as e:
-    raise ImportError("LEAPP package is required for policy export. Install with: pip install leapp") from e
-
-# Disable TorchScript before importing task/environment modules so any
-# @torch.jit.script helpers resolve to plain Python functions during export.
-torch.jit._state.disable()
+from typing import TYPE_CHECKING
 
 from isaaclab.app import AppLauncher
 
-from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+if TYPE_CHECKING:
+    import torch as torch_type
 
 _RSL_RL_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "rsl_rl"
 if str(_RSL_RL_SCRIPTS_DIR) not in sys.path:
@@ -40,6 +30,9 @@ import cli_args  # isort: skip
 
 _RUNTIME_IMPORTS_LOADED = False
 
+torch = None
+leapp = None
+annotate = None
 gym = None
 DistillationRunner = None
 OnPolicyRunner = None
@@ -111,6 +104,8 @@ def create_arg_parser() -> argparse.ArgumentParser:
 
 def parse_export_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, list[str]]:
     """Parse export arguments and return remaining Hydra overrides."""
+    from isaaclab_tasks.utils import setup_preset_cli
+
     parser = create_arg_parser()
     # setup_preset_cli attaches the preset-selection help group then parses;
     # remainder still carries typed selectors (physics=/renderer=/presets=)
@@ -120,9 +115,18 @@ def parse_export_args(argv: list[str] | None = None) -> tuple[argparse.Namespace
     return args_cli, hydra_args
 
 
+def parse_prelaunch_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse enough CLI state to launch Isaac Sim before task utilities are imported."""
+    parser = create_arg_parser()
+    args_cli, _ = parser.parse_known_args(argv)
+    args_cli.headless = True
+    return args_cli
+
+
 def _load_runtime_dependencies() -> None:
     """Import runtime dependencies after Isaac Sim has been launched."""
     global _RUNTIME_IMPORTS_LOADED
+    global annotate, leapp, torch
     global DistillationRunner, ManagerBasedRLEnv, OnPolicyRunner, RslRlVecEnvWrapper, get_checkpoint_path, gym
     global ensure_env_spec_id, get_published_pretrained_checkpoint, handle_deprecated_rsl_rl_cfg, hydra_task_config
     global patch_env_for_export, retrieve_file_path
@@ -130,9 +134,20 @@ def _load_runtime_dependencies() -> None:
     if _RUNTIME_IMPORTS_LOADED:
         return
 
+    try:
+        import leapp as leapp_module
+    except ImportError as e:
+        raise ImportError("LEAPP package is required for policy export. Install with: pip install leapp") from e
+    annotate_module = getattr(leapp_module, "annotate")
+
     import gymnasium as gym_module
+    import torch as torch_module
     from rsl_rl.runners import DistillationRunner as DistillationRunnerCls
     from rsl_rl.runners import OnPolicyRunner as OnPolicyRunnerCls
+
+    # Disable TorchScript before importing task/environment modules so any
+    # @torch.jit.script helpers resolve to plain Python functions during export.
+    torch_module.jit._state.disable()
 
     from isaaclab.envs import ManagerBasedRLEnv as ManagerBasedRLEnvCls
     from isaaclab.utils.assets import retrieve_file_path as retrieve_file_path_fn
@@ -149,6 +164,9 @@ def _load_runtime_dependencies() -> None:
     from isaaclab_tasks.utils import get_checkpoint_path as get_checkpoint_path_fn
     from isaaclab_tasks.utils.hydra import hydra_task_config as hydra_task_config_fn
 
+    torch = torch_module
+    leapp = leapp_module
+    annotate = annotate_module
     gym = gym_module
     DistillationRunner = DistillationRunnerCls
     OnPolicyRunner = OnPolicyRunnerCls
@@ -176,7 +194,9 @@ def get_actor_memory_module(policy_nn):
     return None
 
 
-def ensure_actor_hidden_state_initialized(policy_nn, batch_size: int, device: torch.device, dtype: torch.dtype):
+def ensure_actor_hidden_state_initialized(
+    policy_nn, batch_size: int, device: torch_type.device, dtype: torch_type.dtype
+):
     """Initialize and return the actor hidden state when a recurrent policy has not created it yet."""
     actor_state, _ = policy_nn.get_hidden_states()
     if actor_state is not None:
@@ -344,9 +364,21 @@ def export_rsl_rl_agent(
     return True
 
 
+def prepare_cli_export_runtime() -> None:
+    """Apply CLI runtime setup that batched export tests perform per task."""
+    import isaaclab.sim as sim_utils
+    from isaaclab.app.settings_manager import get_settings_manager
+
+    sim_utils.create_new_stage()
+    settings_manager = get_settings_manager()
+    settings_manager.set_bool("/isaaclab/render/rtx_sensors", False)
+    settings_manager.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+
+
 def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str], simulation_app) -> bool:
     """Resolve Hydra task configuration and export one RSL-RL policy."""
     _load_runtime_dependencies()
+    from isaaclab_tasks.utils import fold_preset_tokens
 
     original_argv = sys.argv
     # Fold typed preset selectors into a single ``presets=<csv>`` token before
@@ -359,6 +391,7 @@ def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str], s
         @hydra_task_config(args_cli.task, args_cli.agent)
         def _main(env_cfg, agent_cfg) -> None:
             nonlocal exported
+            prepare_cli_export_runtime()
             exported = export_rsl_rl_agent(args_cli, env_cfg, agent_cfg, simulation_app)
 
         _main()
@@ -370,12 +403,12 @@ def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str], s
 
 def main_cli(argv: list[str] | None = None) -> bool:
     """Run the command-line export flow."""
-    args_cli, hydra_args = parse_export_args(argv)
-
-    app_launcher = AppLauncher(args_cli)
+    prelaunch_args = parse_prelaunch_args(argv)
+    app_launcher = AppLauncher(prelaunch_args)
     simulation_app = app_launcher.app
 
     try:
+        args_cli, hydra_args = parse_export_args(argv)
         return run_export_with_hydra(args_cli, hydra_args, simulation_app)
     finally:
         simulation_app.close()

--- a/scripts/reinforcement_learning/leapp/rsl_rl/export.py
+++ b/scripts/reinforcement_learning/leapp/rsl_rl/export.py
@@ -15,7 +15,7 @@ import sys
 import time
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from isaaclab.app import AppLauncher
 
@@ -113,14 +113,6 @@ def parse_export_args(argv: list[str] | None = None) -> tuple[argparse.Namespace
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     args_cli.headless = True
     return args_cli, hydra_args
-
-
-def parse_prelaunch_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """Parse enough CLI state to launch Isaac Sim before task utilities are imported."""
-    parser = create_arg_parser()
-    args_cli, _ = parser.parse_known_args(argv)
-    args_cli.headless = True
-    return args_cli
 
 
 def _load_runtime_dependencies() -> None:
@@ -239,7 +231,7 @@ def export_rsl_rl_agent(
     args_cli: argparse.Namespace,
     env_cfg,
     agent_cfg,
-    simulation_app,
+    simulation_app=None,
 ) -> bool:
     """Export a RSL-RL agent."""
     _load_runtime_dependencies()
@@ -319,8 +311,9 @@ def export_rsl_rl_agent(
         leapp.start(graph_name, save_path=save_path, max_cached_io=max(args_cli.validation_steps, 2))
         leapp_started = True
         obs = env.reset()[0]
-        while not simulation_app.is_running():
-            time.sleep(0.5)
+        if simulation_app is not None:
+            while not simulation_app.is_running():
+                time.sleep(0.5)
 
         for _ in range(max(args_cli.validation_steps, 2)):
             with torch.inference_mode():
@@ -375,10 +368,13 @@ def prepare_cli_export_runtime() -> None:
     settings_manager.set_bool("/physics/cooking/ujitsoCollisionCooking", False)
 
 
-def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str], simulation_app) -> bool:
+def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str]) -> bool:
     """Resolve Hydra task configuration and export one RSL-RL policy."""
-    _load_runtime_dependencies()
     from isaaclab_tasks.utils import fold_preset_tokens
+    from isaaclab_tasks.utils.hydra import hydra_task_config as hydra_task_config_import
+    from isaaclab_tasks.utils.sim_launcher import launch_simulation
+
+    hydra_task_config_fn: Any = hydra_task_config_import
 
     original_argv = sys.argv
     # Fold typed preset selectors into a single ``presets=<csv>`` token before
@@ -388,13 +384,15 @@ def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str], s
 
     try:
 
-        @hydra_task_config(args_cli.task, args_cli.agent)
+        @hydra_task_config_fn(args_cli.task, args_cli.agent)
         def _main(env_cfg, agent_cfg) -> None:
             nonlocal exported
-            prepare_cli_export_runtime()
-            exported = export_rsl_rl_agent(args_cli, env_cfg, agent_cfg, simulation_app)
+            with launch_simulation(env_cfg, args_cli):
+                prepare_cli_export_runtime()
+                exported = export_rsl_rl_agent(args_cli, env_cfg, agent_cfg)
 
-        _main()
+        main_fn: Any = _main
+        main_fn()
     finally:
         sys.argv = original_argv
 
@@ -403,15 +401,8 @@ def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str], s
 
 def main_cli(argv: list[str] | None = None) -> bool:
     """Run the command-line export flow."""
-    prelaunch_args = parse_prelaunch_args(argv)
-    app_launcher = AppLauncher(prelaunch_args)
-    simulation_app = app_launcher.app
-
-    try:
-        args_cli, hydra_args = parse_export_args(argv)
-        return run_export_with_hydra(args_cli, hydra_args, simulation_app)
-    finally:
-        simulation_app.close()
+    args_cli, hydra_args = parse_export_args(argv)
+    return run_export_with_hydra(args_cli, hydra_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
cherry pick of https://github.com/isaac-sim/IsaacLab/pull/5869

Fixes # (issue)

Following https://github.com/isaac-sim/IsaacLab/pull/5633, the CLI path broke due to an error in import order. That resulted in a failure inside the simulation setup which would cause a silent failure when running the CLI. This fix conforms to the new `_load_runtime_dependencies()` pattern introduced by the previous PR and fixes the runtime for the export. New export script follows these steps:

1. Parse minimal launcher args.
2. Start AppLauncher / Kit.
3. Import torch, leapp, RSL-RL, task utilities, and Hydra helpers.
4. Resolve task config.
5. Create the env with gym.make().
6. Patch for LEAPP and export.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there