### PR TITLE
[MGPU] Sim: honor device kwarg over sim_cfg.device in build_simulation_context

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-fix-build-sim-context-device.rst
+++ b/source/isaaclab/changelog.d/jichuanh-fix-build-sim-context-device.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed :func:`isaaclab.sim.build_simulation_context` silently ignoring the
+  ``device`` kwarg when ``sim_cfg`` is also provided. Most test callers pass
+  both kwargs together; the helper now applies the explicit ``device`` over
+  ``sim_cfg.device`` so the caller's choice wins. Without this, warp kernel
+  launches in :mod:`isaaclab_newton.assets.articulation` raised device
+  mismatch errors on non-default GPUs (``env_ids`` allocated on the test's
+  device while the articulation's resolved device came from the untouched
+  ``sim_cfg`` default ``cuda:0``).

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -958,7 +958,7 @@ class SimulationContext:
 def build_simulation_context(
     create_new_stage: bool = True,
     gravity_enabled: bool = True,
-    device: str = "cuda:0",
+    device: str | None = None,
     dt: float = 0.01,
     sim_cfg: SimulationCfg | None = None,
     add_ground_plane: bool = False,
@@ -971,7 +971,11 @@ def build_simulation_context(
     Args:
         create_new_stage: Whether to create a new stage. Defaults to True.
         gravity_enabled: Whether to enable gravity. Defaults to True.
-        device: Device to run the simulation on. Defaults to "cuda:0".
+        device: Device to run the simulation on. When given alongside ``sim_cfg``,
+            overrides ``sim_cfg.device`` so the caller's explicit choice wins
+            (most test callers pass both, expecting this behavior). Defaults to
+            ``None``, meaning ``sim_cfg.device`` is left untouched and a freshly
+            built ``sim_cfg`` uses :class:`SimulationCfg`'s default device.
         dt: Time step for the simulation. Defaults to 0.01.
         sim_cfg: SimulationCfg to use. Defaults to None.
         add_ground_plane: Whether to add a ground plane. Defaults to False.
@@ -993,7 +997,17 @@ def build_simulation_context(
 
         if sim_cfg is None:
             gravity = (0.0, 0.0, -9.81) if gravity_enabled else (0.0, 0.0, 0.0)
-            sim_cfg = SimulationCfg(device=device, dt=dt, gravity=gravity)
+            sim_cfg = SimulationCfg(dt=dt, gravity=gravity)
+        if device is not None:
+            # Honor the explicit device kwarg in both branches: when sim_cfg is
+            # freshly built, this picks the device; when sim_cfg is passed in,
+            # this overrides its (possibly default) device. Without the override,
+            # callers passing both ``sim_cfg=<built-with-default-device>`` and
+            # ``device=cuda:N`` silently got sim_cfg's device, causing warp
+            # kernel-launch mismatches when test fixtures allocated tensors on
+            # the requested device while assets resolved their device from the
+            # untouched sim_cfg.
+            sim_cfg.device = device
 
         sim = SimulationContext(sim_cfg)
 

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -1006,8 +1006,9 @@ def build_simulation_context(
             # ``device=cuda:N`` silently got sim_cfg's device, causing warp
             # kernel-launch mismatches when test fixtures allocated tensors on
             # the requested device while assets resolved their device from the
-            # untouched sim_cfg.
-            sim_cfg.device = device
+            # untouched sim_cfg. ``replace`` returns a copy so a caller-owned
+            # sim_cfg is not mutated in-place and stays reusable across calls.
+            sim_cfg = sim_cfg.replace(device=device)
 
         sim = SimulationContext(sim_cfg)
 

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -1006,9 +1006,8 @@ def build_simulation_context(
             # ``device=cuda:N`` silently got sim_cfg's device, causing warp
             # kernel-launch mismatches when test fixtures allocated tensors on
             # the requested device while assets resolved their device from the
-            # untouched sim_cfg. ``replace`` returns a copy so a caller-owned
-            # sim_cfg is not mutated in-place and stays reusable across calls.
-            sim_cfg = sim_cfg.replace(device=device)
+            # untouched sim_cfg.
+            sim_cfg.device = device
 
         sim = SimulationContext(sim_cfg)
 

--- a/source/isaaclab/test/sim/test_build_simulation_context_headless.py
+++ b/source/isaaclab/test/sim/test_build_simulation_context_headless.py
@@ -75,7 +75,14 @@ def test_build_simulation_context_auto_add_lighting(add_lighting, auto_add_light
 
 @pytest.mark.isaacsim_ci
 def test_build_simulation_context_cfg():
-    """Test that the simulation context is built with the correct cfg and values don't get overridden."""
+    """Test that the simulation context honors sim_cfg's values, with an explicit
+    device override winning when both ``sim_cfg`` and ``device`` are passed.
+
+    Most test callers pass both kwargs together expecting the device kwarg to
+    win; the override branch in :func:`build_simulation_context` exists for
+    that case. ``gravity`` and ``dt`` are not overridable by the helper's
+    kwargs (only sim_cfg's values are used).
+    """
     dt = 0.001
     # Non-standard gravity
     gravity = (0.0, 0.0, -1.81)
@@ -87,8 +94,14 @@ def test_build_simulation_context_cfg():
         dt=dt,
     )
 
-    with build_simulation_context(sim_cfg=cfg, gravity_enabled=False, dt=0.01, device="cpu") as sim:
-        # Values from sim_cfg should not be overridden by build_simulation_context args
+    # Pass only sim_cfg: gravity, device, dt all come from sim_cfg (kwargs ignored).
+    with build_simulation_context(sim_cfg=cfg, gravity_enabled=False, dt=0.01) as sim:
         assert sim.cfg.gravity == gravity
         assert sim.cfg.device == device
+        assert sim.cfg.dt == dt
+
+    # Pass sim_cfg and an explicit device override: device kwarg wins.
+    with build_simulation_context(sim_cfg=cfg, device="cpu") as sim:
+        assert sim.cfg.gravity == gravity
+        assert sim.cfg.device == "cpu"
         assert sim.cfg.dt == dt

--- a/source/isaaclab/test/sim/test_build_simulation_context_nonheadless.py
+++ b/source/isaaclab/test/sim/test_build_simulation_context_nonheadless.py
@@ -70,8 +70,14 @@ def test_build_simulation_context_auto_add_lighting(add_lighting, auto_add_light
 
 
 def test_build_simulation_context_cfg():
-    """Test that the simulation context is built with the correct cfg and values don't get overridden."""
+    """Test that the simulation context honors sim_cfg's values, with an explicit
+    device override winning when both ``sim_cfg`` and ``device`` are passed.
 
+    Most test callers pass both kwargs together expecting the device kwarg to
+    win; the override branch in :func:`build_simulation_context` exists for
+    that case. ``gravity`` and ``dt`` are not overridable by the helper's
+    kwargs (only sim_cfg's values are used).
+    """
     dt = 0.001
     # Non-standard gravity
     gravity = (0.0, 0.0, -1.81)
@@ -83,8 +89,14 @@ def test_build_simulation_context_cfg():
         dt=dt,
     )
 
-    with build_simulation_context(sim_cfg=cfg, gravity_enabled=False, dt=0.01, device="cpu") as sim:
-        # Values from sim_cfg should not be overridden by build_simulation_context args
+    # Pass only sim_cfg: gravity, device, dt all come from sim_cfg (kwargs ignored).
+    with build_simulation_context(sim_cfg=cfg, gravity_enabled=False, dt=0.01) as sim:
         assert sim.cfg.gravity == gravity
         assert sim.cfg.device == device
+        assert sim.cfg.dt == dt
+
+    # Pass sim_cfg and an explicit device override: device kwarg wins.
+    with build_simulation_context(sim_cfg=cfg, device="cpu") as sim:
+        assert sim.cfg.gravity == gravity
+        assert sim.cfg.device == "cpu"
         assert sim.cfg.dt == dt


### PR DESCRIPTION
## Summary

- `build_simulation_context(device="cuda:N", sim_cfg=...)` silently dropped the explicit `device` kwarg when a `sim_cfg` was passed, falling back to `sim_cfg.device` (default `cuda:0`).
- The multi-GPU CI lane sets `ISAACLAB_SIM_DEVICE=cuda:N` per shard, so tests that pass `device="cuda:N"` got `cuda:0` instead. Downstream Warp kernels then ran on `cuda:0` while the rest of the test believed it was on `cuda:N`:
  ```
  RuntimeError: Error launching kernel 'set_root_link_pose_to_sim_index',
  trying to launch on device='cuda:0',
  but input array for argument 'env_ids' is on device=cuda:2.
  ```
- Fix: make `device`'s default `None` (sentinel) and apply it as an override after `sim_cfg` is resolved, so an explicit kwarg wins whether or not a `sim_cfg` was supplied.

## 1. The bug

```python
def build_simulation_context(..., device: str = "cuda:0", sim_cfg=None, ...):
    if sim_cfg is None:
        sim_cfg = SimulationCfg(device=device, ...)
    # ^^ explicit `device` only used in the no-sim_cfg path; otherwise ignored
```

When a caller passed both `sim_cfg=<built with default device>` and `device="cuda:2"`, the kwarg was thrown away. Code that pulled the active device from `sim_cfg.device` saw `cuda:0`; Warp arrays allocated against the cfg device landed on `cuda:0` while torch ops driven by the kwarg ran on `cuda:2` — the cross-device kernel-launch error above.

## 2. Fix

```python
def build_simulation_context(..., device: str | None = None, sim_cfg=None, ...):
    if sim_cfg is None:
        gravity = (0.0, 0.0, -9.81) if gravity_enabled else (0.0, 0.0, 0.0)
        sim_cfg = SimulationCfg(dt=dt, gravity=gravity)
    if device is not None:
        sim_cfg.device = device   # explicit kwarg wins in both branches
```

`device=None` (default) means "use whatever the cfg already has". `device="cuda:N"` is honored even when a cfg is also passed.

## 3. Validation

`source/isaaclab/test/sim/test_build_simulation_context_{headless,nonheadless}.py::test_build_simulation_context_cfg` is updated to assert the new override semantics (explicit `device` wins over `sim_cfg.device`). On local multi-GPU/MIG hardware, `build_simulation_context(sim_cfg=cfg, device="cuda:N")` previously hit the kernel-launch assertion; with the fix it runs on the requested device. Consumed by the multi-GPU CI lane (#5823).
