### PR TITLE
Fixes drone navigation, camera benchmark, and kitless shutdown errors

### DIFF
--- a/scripts/benchmarks/benchmark_cameras.py
+++ b/scripts/benchmarks/benchmark_cameras.py
@@ -287,19 +287,10 @@ def create_camera_base(
     instantiate: bool = True,
 ) -> Camera | CameraCfg | None:
     """Generalized function to create a camera or tiled camera sensor."""
-    # Determine prim prefix based on the camera class
-    name = camera_cfg.class_type.__name__
-
-    if instantiate:
-        # Create the necessary prims
-        for idx in range(num_cams):
-            sim_utils.create_prim(f"/World/{name}_{idx:02d}", "Xform")
-    if prim_path is None:
-        prim_path = f"/World/{name}_.*/{name}"
     # If valid camera settings are provided, create the camera
     if num_cams > 0 and len(data_types) > 0 and height > 0 and width > 0:
         cfg = camera_cfg(
-            prim_path=prim_path,
+            prim_path=prim_path if prim_path is not None else "",
             update_period=0,
             height=height,
             width=width,
@@ -308,8 +299,16 @@ def create_camera_base(
                 focal_length=24, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 1e4)
             ),
         )
+        # Determine prim prefix based on the resolved camera class.
+        name = cfg.class_type.__name__
         if instantiate:
-            return camera_cfg.class_type(cfg=cfg)
+            # Create the necessary prims
+            for idx in range(num_cams):
+                sim_utils.create_prim(f"/World/{name}_{idx:02d}", "Xform")
+        if prim_path is None:
+            cfg.prim_path = f"/World/{name}_.*/{name}"
+        if instantiate:
+            return cfg.class_type(cfg=cfg)
         else:
             return cfg
     else:

--- a/scripts/benchmarks/benchmark_cameras.py
+++ b/scripts/benchmarks/benchmark_cameras.py
@@ -25,6 +25,7 @@ through the auto-tune functionality.
 
 import argparse
 from collections.abc import Callable
+from dataclasses import MISSING
 
 from isaaclab.app import AppLauncher
 
@@ -277,6 +278,21 @@ Camera Creation
 """
 
 
+def _get_camera_class_name(camera_cfg: type[CameraCfg]) -> str:
+    """Return the configured camera sensor class name."""
+    class_type_field = camera_cfg.__dataclass_fields__["class_type"]
+    if class_type_field.default is not MISSING:
+        class_type = class_type_field.default
+    elif class_type_field.default_factory is not MISSING:
+        class_type = class_type_field.default_factory()
+    else:
+        raise AttributeError(f"{camera_cfg.__name__} has no default class_type.")
+
+    if hasattr(class_type, "__name__"):
+        return class_type.__name__
+    return str(class_type).rsplit(":", maxsplit=1)[-1]
+
+
 def create_camera_base(
     camera_cfg: type[CameraCfg],
     num_cams: int,
@@ -288,31 +304,27 @@ def create_camera_base(
 ) -> Camera | CameraCfg | None:
     """Generalized function to create a camera or tiled camera sensor."""
     # If valid camera settings are provided, create the camera
-    if num_cams > 0 and len(data_types) > 0 and height > 0 and width > 0:
-        cfg = camera_cfg(
-            prim_path=prim_path if prim_path is not None else "",
-            update_period=0,
-            height=height,
-            width=width,
-            data_types=data_types,
-            spawn=sim_utils.PinholeCameraCfg(
-                focal_length=24, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 1e4)
-            ),
-        )
-        # Determine prim prefix based on the resolved camera class.
-        name = cfg.class_type.__name__
-        if instantiate:
-            # Create the necessary prims
-            for idx in range(num_cams):
-                sim_utils.create_prim(f"/World/{name}_{idx:02d}", "Xform")
-        if prim_path is None:
-            cfg.prim_path = f"/World/{name}_.*/{name}"
-        if instantiate:
-            return cfg.class_type(cfg=cfg)
-        else:
-            return cfg
-    else:
+    if num_cams <= 0 or len(data_types) <= 0 or height <= 0 or width <= 0:
         return None
+
+    name = _get_camera_class_name(camera_cfg)
+    cfg = camera_cfg(
+        prim_path=prim_path if prim_path is not None else f"/World/{name}_.*/{name}",
+        update_period=0,
+        height=height,
+        width=width,
+        data_types=data_types,
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=24, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 1e4)
+        ),
+    )
+    if instantiate:
+        # Create the necessary prims
+        for idx in range(num_cams):
+            sim_utils.create_prim(f"/World/{name}_{idx:02d}", "Xform")
+        return cfg.class_type(cfg=cfg)
+
+    return cfg
 
 
 def create_tiled_cameras(

--- a/source/isaaclab/changelog.d/fix-env-shutdown-traceback.rst
+++ b/source/isaaclab/changelog.d/fix-env-shutdown-traceback.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ignored shutdown traceback from environment destructors when Python import
+  machinery has already finalized.

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import inspect
 import logging
 import math
+import sys
 import weakref
 from abc import abstractmethod
 from collections.abc import Sequence
@@ -265,11 +266,9 @@ class DirectMARLEnv(gym.Env):
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
 
-    def __del__(self):
+    def __del__(self, _sys_is_finalizing=sys.is_finalizing):
         """Cleanup for the environment."""
-        import sys
-
-        if not sys.is_finalizing():
+        if not _sys_is_finalizing():
             self.close()
 
     """

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import inspect
 import logging
 import math
+import sys
 import warnings
 import weakref
 from abc import abstractmethod
@@ -287,11 +288,9 @@ class DirectRLEnv(gym.Env):
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
 
-    def __del__(self):
+    def __del__(self, _sys_is_finalizing=sys.is_finalizing):
         """Cleanup for the environment."""
-        import sys
-
-        if not sys.is_finalizing():
+        if not _sys_is_finalizing():
             self.close()
 
     """

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import builtins
 import logging
+import sys
 import warnings
 from collections.abc import Sequence
 from typing import Any
@@ -257,11 +258,9 @@ class ManagerBasedEnv:
             if self.cfg.num_rerenders_on_reset == 0:
                 self.cfg.num_rerenders_on_reset = 1
 
-    def __del__(self):
+    def __del__(self, _sys_is_finalizing=sys.is_finalizing):
         """Cleanup for the environment."""
-        import sys
-
-        if not sys.is_finalizing():
+        if not _sys_is_finalizing():
             self.close()
 
     """

--- a/source/isaaclab_tasks/changelog.d/drone-arl-navigation-num-envs.rst
+++ b/source/isaaclab_tasks/changelog.d/drone-arl-navigation-num-envs.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed the default number of environments for
+  ``Isaac-Navigation-3DObstacles-ARL-Robot-1-v0`` to ``1024``. Set
+  ``--num_envs`` or ``env.scene.num_envs`` to use a different value.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/navigation/config/arl_robot_1/agents/rl_games_rough_ppo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/navigation/config/arl_robot_1/agents/rl_games_rough_ppo_cfg.yaml
@@ -47,7 +47,7 @@ params:
     device: 'cuda:0'
     device_name: 'cuda:0'
     env_config:
-      num_envs: 8192
+      num_envs: 1024
 
     reward_shaper:
       # min_val: -1

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/navigation/config/arl_robot_1/navigation_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/drone_arl/navigation/config/arl_robot_1/navigation_env_cfg.py
@@ -312,7 +312,7 @@ class NavigationVelocityFloatingObstacleEnvCfg(ManagerBasedRLEnvCfg):
     """Configuration for the locomotion velocity-tracking environment."""
 
     # Scene settings
-    scene: ArlNavigationSceneCfg = ArlNavigationSceneCfg(num_envs=4096, env_spacing=20.5)
+    scene: ArlNavigationSceneCfg = ArlNavigationSceneCfg(num_envs=1024, env_spacing=20.5)
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()
     actions: ActionsCfg = ActionsCfg()


### PR DESCRIPTION
# Description

Environment shutdown fix (isaaclab/envs/) All three env classes (DirectRLEnv, DirectMARLEnv, ManagerBasedEnv) had a race condition in __del__: the lazy import sys inside the destructor could fail or produce a spurious traceback once Python's import machinery had already finalized at interpreter shutdown. The fix captures sys.is_finalizing as a default argument at class definition time (before finalization), so the check always works safely.

Drone ARL navigation default env count (isaaclab_tasks/) Reduced the default num_envs for Isaac-Navigation-3DObstacles-ARL-Robot-1-v0 from 4096/8192 to 1024 in both the env config and the rl_games PPO config. Users can override with --num_envs or env.scene.num_envs.

Camera benchmark fix (scripts/benchmarks/benchmark_cameras.py) Moved prim creation and prim_path assignment to after the camera config object is built, so class_type is resolved from the instantiated config rather than the unresolved camera_cfg callable. Also uses the config's class_type (not the original camera_cfg.class_type) when calling the constructor, fixing a subtle bug when the config overrides the class.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
