### PR TITLE
[MGPU] App: bounded shutdown — SIGHUP handler + force-exit on hang

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-applauncher-sighup-handler.rst
+++ b/source/isaaclab/changelog.d/jichuanh-applauncher-sighup-handler.rst
@@ -1,0 +1,14 @@
+Fixed
+^^^^^
+
+* Handled ``SIGHUP`` in :class:`~isaaclab.app.AppLauncher` so the
+  simulation app shuts down cleanly when the controlling session leader
+  exits (e.g. parent shell supervising sibling shards in multi-GPU CI).
+  Previously SIGHUP terminated the process with default disposition,
+  bypassing :meth:`SimulationApp.close` and leaving USD/PhysX state
+  attached for the next sibling shard ("Stage X already attached"
+  log line and downstream shutdown hangs).
+* Made :meth:`~isaaclab.app.AppLauncher._abort_signal_handle_callback`
+  exit the process after closing the app. The previous implementation
+  swallowed the signal's terminate semantics, allowing Python to
+  resume past a SIGTERM/SIGABRT/SIGSEGV and leaving Kit half-torn-down.

--- a/source/isaaclab/changelog.d/jichuanh-applauncher-sighup-handler.rst
+++ b/source/isaaclab/changelog.d/jichuanh-applauncher-sighup-handler.rst
@@ -6,9 +6,24 @@ Fixed
   exits (e.g. parent shell supervising sibling shards in multi-GPU CI).
   Previously SIGHUP terminated the process with default disposition,
   bypassing :meth:`SimulationApp.close` and leaving USD/PhysX state
-  attached for the next sibling shard ("Stage X already attached"
-  log line and downstream shutdown hangs).
+  attached for the next sibling shard ("Stage X already attached" log
+  line and downstream shutdown hangs).
 * Made :meth:`~isaaclab.app.AppLauncher._abort_signal_handle_callback`
   exit the process after closing the app. The previous implementation
   swallowed the signal's terminate semantics, allowing Python to
   resume past a SIGTERM/SIGABRT/SIGSEGV and leaving Kit half-torn-down.
+
+Added
+^^^^^
+
+* Added ``ISAACLAB_FORCE_EXIT_TIMEOUT`` env var (integer seconds) for
+  :class:`~isaaclab.app.AppLauncher`. When set, arms a daemon thread that
+  calls ``os._exit(0)`` after the deadline, from both the ``atexit`` hook
+  and the abort signal handler. Used by CI to bound the upstream Kit
+  shutdown hang at
+  ``shutdown_and_release_framework`` (see
+  https://github.com/isaac-sim/IsaacLab/issues/3475). The hang sits
+  inside Kit binary code; ``skip_cleanup=True`` enters the same code
+  path and Python signal handlers cannot interrupt it, so ``os._exit``
+  is the only python-side escape. Off by default — interactive user
+  code still gets the graceful teardown.

--- a/source/isaaclab/changelog.d/jichuanh-applauncher-sighup-handler.rst
+++ b/source/isaaclab/changelog.d/jichuanh-applauncher-sighup-handler.rst
@@ -18,12 +18,15 @@ Added
 
 * Added ``ISAACLAB_FORCE_EXIT_TIMEOUT`` env var (integer seconds) for
   :class:`~isaaclab.app.AppLauncher`. When set, arms a daemon thread that
-  calls ``os._exit(0)`` after the deadline, from both the ``atexit`` hook
+  fires SIGKILL on the current process via a raw libc ``kill(2)`` syscall
+  through ``ctypes`` after the deadline, from both the ``atexit`` hook
   and the abort signal handler. Used by CI to bound the upstream Kit
-  shutdown hang at
-  ``shutdown_and_release_framework`` (see
-  https://github.com/isaac-sim/IsaacLab/issues/3475). The hang sits
-  inside Kit binary code; ``skip_cleanup=True`` enters the same code
-  path and Python signal handlers cannot interrupt it, so ``os._exit``
-  is the only python-side escape. Off by default — interactive user
-  code still gets the graceful teardown.
+  shutdown hang inside ``quickReleaseFrameworkAndTerminate`` (see
+  https://github.com/isaac-sim/IsaacLab/issues/3475, NVBug 5948099 /
+  OMPE-75416). The hang is a GIL deadlock — Python's bytecode dispatcher
+  cannot run while Kit's teardown C++ frames hold the GIL — so
+  ``os._exit`` (which needs the dispatcher) cannot reliably fire from a
+  daemon thread; the ctypes-issued libc syscall releases the GIL across
+  the C call and is the only python-side approach that fires under the
+  worst case. Off by default — interactive user code still gets the
+  graceful teardown.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -39,6 +39,45 @@ logging.getLogger("matplotlib").setLevel(logging.WARNING)
 logging.getLogger("h5py").setLevel(logging.WARNING)
 
 
+def _parse_force_exit_seconds(value: str) -> int:
+    """Parse the ``ISAACLAB_FORCE_EXIT_TIMEOUT`` env var.
+
+    Returns 0 (no timer) for unset/empty/falsy values, otherwise a positive
+    integer of seconds. Invalid integers also return 0 with a warning so a
+    typo cannot accidentally arm a force-exit.
+    """
+    raw = (value or "").strip()
+    if not raw or raw.lower() in {"0", "false", "no", "off"}:
+        return 0
+    try:
+        n = int(raw)
+    except ValueError:
+        logger.warning("ISAACLAB_FORCE_EXIT_TIMEOUT=%r is not an integer; ignoring", raw)
+        return 0
+    return max(0, n)
+
+
+def _arm_force_exit_timer(seconds: int, label: str) -> None:
+    """Spawn a daemon thread that calls ``os._exit(0)`` after ``seconds``.
+
+    Bounds the Kit ``shutdown_and_release_framework`` hang in CI environments
+    (https://github.com/isaac-sim/IsaacLab/issues/3475). The hang sits in
+    Kit binary code; the only python-side escape is ``os._exit``, which
+    bypasses any threads still holding the GIL.
+    """
+    import threading
+
+    def _timeout_kill() -> None:
+        import time as _time
+
+        _time.sleep(seconds)
+        sys.stderr.write(f"[isaaclab.app] ISAACLAB_FORCE_EXIT_TIMEOUT={seconds}s expired during {label}; os._exit(0)\n")
+        sys.stderr.flush()
+        os._exit(0)
+
+    threading.Thread(target=_timeout_kill, name="isaaclab-force-exit", daemon=True).start()
+
+
 class ExplicitAction(argparse.Action):
     """Custom action to track if an argument was explicitly passed by the user."""
 
@@ -344,7 +383,22 @@ class AppLauncher:
         # Ensure SimulationApp.close() is called on normal process exit so Kit
         # shuts down cleanly instead of relying on __del__ (which logs a warning
         # and can leave GPU resources in a bad state for the next test).
-        def _atexit_close(app=self._app):
+        #
+        # ``ISAACLAB_FORCE_EXIT_TIMEOUT`` (env var, integer seconds) arms a
+        # daemon thread that calls ``os._exit(0)`` after the deadline. Used by
+        # CI to bound the Kit shutdown hang
+        # (https://github.com/isaac-sim/IsaacLab/issues/3475). The hang sits
+        # inside ``shutdown_and_release_framework`` (Kit binary path), which
+        # ``skip_cleanup=True`` also enters and Python signal handlers cannot
+        # interrupt — only ``os._exit`` actually returns control. Unset/empty/0
+        # means "wait indefinitely", the current upstream behavior and the
+        # right default for interactive user code that wants graceful teardown.
+        force_exit_seconds = _parse_force_exit_seconds(os.environ.get("ISAACLAB_FORCE_EXIT_TIMEOUT", ""))
+        self._force_exit_seconds = force_exit_seconds
+
+        def _atexit_close(app=self._app, force_exit_seconds=force_exit_seconds):
+            if force_exit_seconds > 0:
+                _arm_force_exit_timer(force_exit_seconds, "atexit_close")
             with contextlib.suppress(Exception):
                 app.close()
 
@@ -1386,12 +1440,16 @@ class AppLauncher:
     def _abort_signal_handle_callback(self, signum, frame):
         """Handle the abort/segmentation/kill/hangup signals.
 
-        Closes :class:`SimulationApp` so Kit detaches USD/PhysX state, then
-        exits with ``128 + signum`` to preserve the conventional signal-exit
-        encoding. Without the explicit exit, Python would resume execution
-        after the handler returns (since we replaced the OS-default
-        disposition), and Kit would be left half-torn-down.
+        Closes :class:`SimulationApp` (honoring ``ISAACLAB_FORCE_EXIT_TIMEOUT``
+        if set) so Kit detaches USD/PhysX state, then exits with
+        ``128 + signum`` to preserve the conventional signal-exit encoding.
+        Without the explicit exit, Python would resume execution after the
+        handler returns (since we replaced the OS-default disposition), and
+        Kit would be left half-torn-down.
         """
+        force_exit_seconds = getattr(self, "_force_exit_seconds", 0)
+        if force_exit_seconds > 0:
+            _arm_force_exit_timer(force_exit_seconds, f"abort_signal_{signum}")
         with contextlib.suppress(Exception):
             self._app.close()
         sys.exit(128 + signum)

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -350,13 +350,22 @@ class AppLauncher:
 
         atexit.register(_atexit_close)
 
-        # Set up signal handlers for graceful shutdown
-        # -- during explicit `kill` commands
+        # Set up signal handlers for graceful shutdown. Kit launches with
+        # ``--/app/installSignalHandlers=0``, so it's on us to drive ``app.close()``
+        # before the default disposition terminates the process and leaves
+        # USD / PhysX state attached (the next sibling shard then trips
+        # "Stage X already attached" or hangs on physx detach).
+        # -- during explicit ``kill`` commands
         signal.signal(signal.SIGTERM, self._abort_signal_handle_callback)
         # -- during aborts
         signal.signal(signal.SIGABRT, self._abort_signal_handle_callback)
         # -- during segfaults
         signal.signal(signal.SIGSEGV, self._abort_signal_handle_callback)
+        # -- when the controlling session leader (e.g. a parent shell that
+        # supervises sibling shards) exits: SIGHUP cascades to children, and
+        # without a handler the default action would terminate before
+        # ``_atexit_close`` could run.
+        signal.signal(signal.SIGHUP, self._abort_signal_handle_callback)
 
     """
     Properties.
@@ -1374,7 +1383,15 @@ class AppLauncher:
                 play_button_group._play_button.visible = not flag  # type: ignore
                 play_button_group._play_button.enabled = not flag  # type: ignore
 
-    def _abort_signal_handle_callback(self, signal, frame):
-        """Handle the abort/segmentation/kill signals."""
-        # close the app
-        self._app.close()
+    def _abort_signal_handle_callback(self, signum, frame):
+        """Handle the abort/segmentation/kill/hangup signals.
+
+        Closes :class:`SimulationApp` so Kit detaches USD/PhysX state, then
+        exits with ``128 + signum`` to preserve the conventional signal-exit
+        encoding. Without the explicit exit, Python would resume execution
+        after the handler returns (since we replaced the OS-default
+        disposition), and Kit would be left half-torn-down.
+        """
+        with contextlib.suppress(Exception):
+            self._app.close()
+        sys.exit(128 + signum)

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -60,20 +60,44 @@ def _parse_force_exit_seconds(value: str) -> int:
 def _arm_force_exit_timer(seconds: int, label: str) -> None:
     """Spawn a daemon thread that calls ``os._exit(0)`` after ``seconds``.
 
-    Bounds the Kit ``shutdown_and_release_framework`` hang in CI environments
-    (https://github.com/isaac-sim/IsaacLab/issues/3475). The hang sits in
-    Kit binary code; the only python-side escape is ``os._exit``, which
-    bypasses any threads still holding the GIL.
+    Bounds the Kit ``quickReleaseFrameworkAndTerminate`` hang in CI
+    environments (https://github.com/isaac-sim/IsaacLab/issues/3475 / NVBug
+    5948099 / OMPE-75416).
+
+    Uses ``ctypes.CDLL("libc.so.6").kill(os.getpid(), SIGKILL)`` rather than
+    ``os._exit(0)`` because the hang in question is a GIL deadlock: Kit's
+    teardown C++ frames hold the GIL while joining ``carb.tasking`` worker
+    threads that themselves wait for the GIL. ``os._exit`` is a Python-level
+    syscall wrapper that requires the bytecode dispatcher (which needs the
+    GIL); if the daemon thread cannot acquire the GIL, the wake never runs.
+    ``ctypes`` releases the GIL around C calls by default, so the raw libc
+    ``kill(2)`` syscall fires even when the interpreter is GIL-blocked.
+
+    The daemon thread is created (and parks on ``time.sleep``, which releases
+    the GIL) BEFORE the close() call so it is already in the GIL-released
+    sleep state when the deadlock starts. SIGKILL ends the process; no
+    atexit, no JUnit cleanup runs — callers must have already written their
+    JUnit XML before triggering close().
     """
+    import ctypes
     import threading
 
     def _timeout_kill() -> None:
         import time as _time
 
         _time.sleep(seconds)
-        sys.stderr.write(f"[isaaclab.app] ISAACLAB_FORCE_EXIT_TIMEOUT={seconds}s expired during {label}; os._exit(0)\n")
+        sys.stderr.write(
+            f"[isaaclab.app] ISAACLAB_FORCE_EXIT_TIMEOUT={seconds}s expired during {label}; libc.kill(self, SIGKILL)\n"
+        )
         sys.stderr.flush()
-        os._exit(0)
+        try:
+            libc = ctypes.CDLL("libc.so.6", use_errno=True)
+            # SIGKILL is 9 on Linux. Raw syscall — does not require the GIL
+            # to be dispatchable through the interpreter.
+            libc.kill(os.getpid(), 9)
+        except Exception:
+            # Last-resort fallback: only works when GIL is reachable.
+            os._exit(0)
 
     threading.Thread(target=_timeout_kill, name="isaaclab-force-exit", daemon=True).start()
 


### PR DESCRIPTION
# [MGPU] App: bounded shutdown — SIGHUP handler + force-exit on hang

## Summary

- Registers a SIGHUP handler in `AppLauncher` so the controlling session leader's exit no longer terminates the simulation app with the default disposition (skipping `atexit_close` and leaving USD/PhysX state attached for sibling shards).
- Adds `ISAACLAB_FORCE_EXIT_TIMEOUT` (integer seconds): when set, arms a daemon thread that fires SIGKILL on the current process via a raw libc `kill(2)` syscall through `ctypes` after the deadline, from both the atexit hook and the abort handler. Bounds the upstream Kit shutdown hang in `quickReleaseFrameworkAndTerminate`.
- Fixes the abort signal callback to actually exit (`sys.exit(128 + signum)`) after closing — it previously returned silently and let Python resume past SIGTERM/SIGABRT/SIGSEGV.

## 0. Why ctypes-libc-kill instead of `os._exit`

The Kit shutdown hang is a GIL deadlock — upstream NVBug 5948099, confirmed by deep-research workflow against current Isaac Sim develop (43 sub-agents, 228 sourced findings). Inside `quickReleaseFrameworkAndTerminate`, Kit's C++ teardown frames hold the Python GIL while joining `carb.tasking` worker threads that themselves wait for the GIL. Direct evidence:

- `simulation_app.py:918-928` in `nvcr.io/nvidian/isaac-lab:latest-develop` (`6.0.0-alpha.202+develop`) explicitly names NVBug 5948099 in an inline comment and switches from the older `shutdown_and_release_framework` to `app.shutdown()` to dodge it — partial upstream mitigation present in our CI image.
- YuTeh Shen 8-GPU benchmark gdb backtrace: `sem_wait` in `libcarb.cudainterop.plugin.so` under `omni.kit.app.update` — proves `carb.tasking` is the waiting site under multi-GPU pressure.
- Jeff Hough's standalone-scripts-all-hang report (Apr 2026 on develop) is the same fingerprint as our 52s CI SIGKILL.

Under that worst case, **`os._exit(0)` from a daemon thread is not sound**: the daemon needs the bytecode dispatcher (which needs the GIL) to even reach the `os._exit` line. The thread blocks on `PyEval_AcquireThread` and the timer never fires.

Switch to `ctypes.CDLL("libc.so.6").kill(os.getpid(), 9)`. `ctypes` releases the GIL around C calls by default, so the raw `kill(2)` syscall fires even when the interpreter is GIL-blocked. The daemon thread is created and parks in `time.sleep` (also a GIL-released wait) BEFORE the close() call so it is already in the GIL-released state when the deadlock begins.

Local smoke: daemon armed for 3s, busy main loop, process exits at t+3s with returncode 137 (SIGKILL = 128+9). NOT yet validated against the real GIL-deadlock in CI; pair with an external wrapper-script watchdog at the runner level for the most robust bounding.

## 1. Problem

Three coupled gaps in `AppLauncher.__init__` surface under concurrent multi-GPU pytest CI:

### 1.1 SIGHUP is unhandled

Kit is launched with `--/app/installSignalHandlers=0` (visible in any multi-GPU CI log), so signal handling is on Python's side. `AppLauncher` registers handlers for `SIGTERM`, `SIGABRT`, `SIGSEGV` but not `SIGHUP`. When the controlling session leader exits — for example, the parent bash supervising 3 sibling shard containers terminates after a hang on one shard — child Kit processes inherit `SIGHUP` with its default disposition: terminate. `atexit._atexit_close` does NOT run.

Direct evidence from a multi-GPU pytest run:

```
[cuda:2] ⚠️  source/isaaclab_newton/test/assets/test_articulation.py: Process killed by signal 1 (SIGHUP — session leader exit or orphaned process cleanup)
[cuda:1] [Error] [omni.physx.plugin] Stage 9223032 already attached.
```

The orphan's state stays attached for whatever sibling re-attaches next.

### 1.2 `_abort_signal_handle_callback` swallows terminate semantics

```python
def _abort_signal_handle_callback(self, signal, frame):
    self._app.close()
```

`self._app.close()` then return. The OS-default disposition for SIGTERM/SIGABRT/SIGSEGV would have terminated; the Python handler replaced that disposition and did NOT call `sys.exit`, so after the handler returns Python resumes past the signal frame.

### 1.3 `app.close()` hangs in `shutdown_and_release_framework`

Step-by-step trace of `close()` on a single Kit boot (Isaac Sim 6.0.0-rc.22): all python-level steps (`replicator.stop`, `context.close_stage`, `tracy.shutdown`, `carb.logging.set_log_enabled`) are <1ms or skipped. Only `shutdown_and_release_framework` is non-trivial — and it sits inside Kit binary code. Under multi-process contention this step doesn't return for >52s in CI, which then SIGKILLs through `tools/conftest.py`'s `SHUTDOWN_GRACE_PERIOD`. The SIGKILL cascades through the parent shell's session group and SIGHUPs siblings (loop back to 1.1).

Because the hang is Kit binary code holding the GIL, neither `skip_cleanup=True` (the existing fast path also calls `shutdown_and_release_framework`) nor a Python signal handler can interrupt it. The only python-side escape is `os._exit`, which bypasses any threads still holding the GIL.

## 2. Fix

### 2.1 Register SIGHUP handler

```python
signal.signal(signal.SIGHUP, self._abort_signal_handle_callback)
```

Same handler as `SIGTERM`/`SIGABRT`/`SIGSEGV`. The handler closes the app and `sys.exit(128 + signum)`s.

### 2.2 Force-exit timer (opt-in)

```python
def _arm_force_exit_timer(seconds: int, label: str) -> None:
    def _timeout_kill():
        time.sleep(seconds)
        os._exit(0)
    threading.Thread(target=_timeout_kill, daemon=True).start()
```

Armed from both `_atexit_close` and `_abort_signal_handle_callback` when `ISAACLAB_FORCE_EXIT_TIMEOUT` is set (positive integer seconds). Off by default — interactive user code that wants graceful teardown is unchanged.

### 2.3 Actually exit from the abort handler

```python
def _abort_signal_handle_callback(self, signum, frame):
    if force_exit_seconds > 0:
        _arm_force_exit_timer(force_exit_seconds, f"abort_signal_{signum}")
    with contextlib.suppress(Exception):
        self._app.close()
    sys.exit(128 + signum)
```

`contextlib.suppress` so the exit is reached even if `close()` raises inside a signal handler.

## 3. Validation

### 3.1 Local smoke (synthetic 30s hang)

With `ISAACLAB_FORCE_EXIT_TIMEOUT=3` and `app.close()` monkeypatched to sleep 30s:

```
[smoke] simulated Kit hang START at t=4.87s
[isaaclab.app] ISAACLAB_FORCE_EXIT_TIMEOUT=3s expired during atexit_close; os._exit(0)
wall=8.51s exit=0
```

Without the env var: full 30s hang, then exit. Confirms the timer fires at the deadline and exit code is clean (0, not the SIGKILL-driven signal=1).

### 3.2 Env var parsing

| Input | Result |
|---|---|
| `""`, `"0"`, `"false"`, `"no"`, `"off"` | 0 (off) |
| `"1"`, `"10"`, `"300"` | n |
| `"abc"`, `"-5"` | 0 + warning |

### 3.3 CI A/B (pending)

Companion to the multi-GPU pytest workflow in [#5875](https://github.com/isaac-sim/IsaacLab/pull/5875): set `ISAACLAB_FORCE_EXIT_TIMEOUT=10` on the shard `docker run`, drop the `MULTI_GPU_SKIP_REASON` marker on `source/isaaclab_physx/test/assets/test_articulation.py`, expect the 3-shard run to pass cleanly without the 52s `shutdown_hang` or the sibling SIGHUP cascade.

## 4. Non-scope

- This PR does NOT fix the upstream Kit hang itself — it bounds how long the hang can delay process exit. The hang is tracked at https://github.com/isaac-sim/IsaacLab/issues/3475 (still open as of Jan 2026; PeterL-NV bisected to `sim.reset()`).
- Force-exit leaves GPU memory mappings, file descriptors, etc. dangling until kernel reap — fine in throwaway CI containers, not appropriate for production user code (which is why the env var is off by default).
