### PR TITLE
Fixes MJCF importer extension and updates stale importer docs

### DIFF
--- a/docs/source/how-to/import_new_asset.rst
+++ b/docs/source/how-to/import_new_asset.rst
@@ -156,7 +156,8 @@ The following shows the steps to clone the repository and run the converter:
           --merge-joints \
           --joint-stiffness 0.0 \
           --joint-damping 0.0 \
-          --joint-target-type none
+          --joint-target-type none \
+          --viz kit
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows
       :sync: windows
@@ -175,7 +176,8 @@ The following shows the steps to clone the repository and run the converter:
           --merge-joints ^
           --joint-stiffness 0.0 ^
           --joint-damping 0.0 ^
-          --joint-target-type none
+          --joint-target-type none ^
+          --viz kit
 
 Executing the above script will create a USD file inside the
 ``source/isaaclab_assets/data/Robots/ANYbotics/anymal/`` directory (the subdirectory name
@@ -192,8 +194,8 @@ is derived automatically from the robot name in the URDF):
    actually used. Delete stale subdirectories manually (or wipe ``usd_dir``) if you do not
    want them to accumulate on disk.
 
-To run the script headless, you can add the ``--headless`` flag. This will not open the GUI and
-exit the script after the conversion is complete.
+The examples above pass ``--viz kit`` to open the GUI and inspect the converted asset.
+To run the script headless and exit after the conversion is complete, omit ``--viz kit``.
 
 You can press play on the opened window to see the asset in the scene. The asset should fall under gravity. If it blows up, then it might be that you have self-collisions present in the URDF.
 
@@ -305,7 +307,8 @@ The following shows the steps to clone the repository and run the converter:
         ./isaaclab.sh -p scripts/tools/convert_mjcf.py \
           ../mujoco_menagerie/unitree_h1/h1.xml \
           source/isaaclab_assets/data/Robots/Unitree/h1.usd \
-          --merge-mesh
+          --merge-mesh \
+          --viz kit
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows
       :sync: windows
@@ -321,7 +324,8 @@ The following shows the steps to clone the repository and run the converter:
         isaaclab.bat -p scripts\tools\convert_mjcf.py ^
           ..\mujoco_menagerie\unitree_h1\h1.xml ^
           source\isaaclab_assets\data\Robots\Unitree\h1.usd ^
-          --merge-mesh
+          --merge-mesh ^
+          --viz kit
 
 Executing the above script will create the USD file inside the
 ``source/isaaclab_assets/data/Robots/Unitree/`` directory:

--- a/docs/source/migration/migrating_to_isaaclab_3-0.rst
+++ b/docs/source/migration/migrating_to_isaaclab_3-0.rst
@@ -1620,7 +1620,8 @@ automatically by the importer based on the robot name and cannot be overridden.
      /output/dir \
      --fix-base \
      --joint-stiffness 100.0 \
-     --joint-damping 1.0
+     --joint-damping 1.0 \
+     --viz kit
 
 .. note::
 
@@ -1774,7 +1775,8 @@ are no longer available.
      ../mujoco_menagerie/unitree_h1/h1.xml \
      source/isaaclab_assets/data/Robots/Unitree/h1.usd \
      --merge-mesh \
-     --self-collision
+     --self-collision \
+     --viz kit
 
 New flags: ``--merge-mesh``, ``--collision-from-visuals``, ``--collision-type``, ``--self-collision``.
 

--- a/source/isaaclab/changelog.d/fix-mjcf-importer-extension.rst
+++ b/source/isaaclab/changelog.d/fix-mjcf-importer-extension.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.sim.converters.MjcfConverter` to enable the Isaac Sim MJCF importer
+  extension before importing MJCF assets.

--- a/source/isaaclab/isaaclab/sim/converters/mjcf_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/mjcf_converter.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import os
 
+import omni.kit.app
+
 from .asset_converter_base import AssetConverterBase
 from .mjcf_converter_cfg import MjcfConverterCfg
 
@@ -47,6 +49,11 @@ class MjcfConverter(AssetConverterBase):
         Args:
             cfg: The configuration instance for MJCF to USD conversion.
         """
+        # enable the MJCF importer extension
+        manager = omni.kit.app.get_app().get_extension_manager()
+        if not manager.is_extension_enabled("isaacsim.asset.importer.mjcf"):
+            manager.set_extension_enabled_immediate("isaacsim.asset.importer.mjcf", True)
+
         # The MJCF importer outputs to: {usd_path}/{robot_name}/{robot_name}.usda
         # Pre-adjust `usd_file_name` to match this output structure so that lazy conversion works correctly.
         file_basename = os.path.splitext(os.path.basename(cfg.asset_path))[0]

--- a/source/isaaclab/test/sim/test_mjcf_converter.py
+++ b/source/isaaclab/test/sim/test_mjcf_converter.py
@@ -16,13 +16,24 @@ import os
 
 import pytest
 
-from isaacsim.core.experimental.utils.app import enable_extension, get_extension_path
+import omni.kit.app
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.sim.converters import MjcfConverter, MjcfConverterCfg
 
 pytestmark = pytest.mark.isaacsim_ci
+
+_MJCF_IMPORTER_EXTENSION = "isaacsim.asset.importer.mjcf"
+
+
+def _get_extension_path_without_enabling(extension_name: str) -> str:
+    """Get the path for an extension without enabling it."""
+    manager = omni.kit.app.get_app().get_extension_manager()
+    for extension in manager.get_extensions():
+        if extension["name"] == extension_name:
+            return extension["path"]
+    raise RuntimeError(f"Extension not found: {extension_name}")
 
 
 @pytest.fixture(autouse=True)
@@ -36,8 +47,7 @@ def test_setup_teardown():
     sim = SimulationContext(SimulationCfg(dt=dt))
 
     # Setup: Create MJCF config
-    enable_extension("isaacsim.asset.importer.mjcf")
-    extension_path = get_extension_path("isaacsim.asset.importer.mjcf")
+    extension_path = _get_extension_path_without_enabling(_MJCF_IMPORTER_EXTENSION)
     config = MjcfConverterCfg(
         asset_path=f"{extension_path}/data/mjcf/nv_ant.xml",
         self_collision=False,
@@ -50,6 +60,19 @@ def test_setup_teardown():
     sim._disable_app_control_on_stop_handle = True  # prevent timeout
     sim.stop()
     sim.clear_instance()
+
+
+def test_converter_enables_importer_extension(test_setup_teardown):
+    """Call conversion with the MJCF importer disabled. This should enable the importer extension."""
+    _, mjcf_config = test_setup_teardown
+
+    manager = omni.kit.app.get_app().get_extension_manager()
+    if manager.is_extension_enabled(_MJCF_IMPORTER_EXTENSION):
+        pytest.skip("MJCF importer extension was already enabled before constructing MjcfConverter.")
+
+    MjcfConverter(mjcf_config)
+
+    assert manager.is_extension_enabled(_MJCF_IMPORTER_EXTENSION)
 
 
 def test_no_change(test_setup_teardown):


### PR DESCRIPTION
# Description

Adds missing isaac sim extension enable call for MJCF importer
Updates stale importer docs to use new visualizer arguments

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
