### PR TITLE
Add EventTermCfg.resample_interval_on_reset to EventCfg

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -164,6 +164,7 @@ Guidelines for modifications:
 * Ritvik Singh
 * Rosario Scalise
 * Ruben D'Sa
+* Ruben Grandia
 * Ryan Gresia
 * Ryley McCarroll
 * Sahara Yuta

--- a/source/isaaclab/changelog.d/resample-interval-on-reset.minor.rst
+++ b/source/isaaclab/changelog.d/resample-interval-on-reset.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab.managers.EventTermCfg.resample_interval_on_reset` to allow ``"interval"``
+  event terms to keep their per-environment timer across resets while still firing asynchronously
+  per environment. Defaults to ``True`` to preserve the existing behavior.

--- a/source/isaaclab/isaaclab/managers/event_manager.py
+++ b/source/isaaclab/isaaclab/managers/event_manager.py
@@ -142,7 +142,9 @@ class EventManager(ManagerBase):
                 # sample a new interval and set that as time left
                 # note: global time events are based on simulation time and not episode time
                 #   so we do not reset them
-                if not term_cfg.is_global_time:
+                # note: terms with resample_interval_on_reset=False keep their per-environment
+                #   counter across resets, so we do not resample them either
+                if not term_cfg.is_global_time and term_cfg.resample_interval_on_reset:
                     lower, upper = term_cfg.interval_range_s
                     sampled_interval = torch.rand(num_envs, device=self.device) * (upper - lower) + lower
                     self._interval_term_time_left[index][env_ids] = sampled_interval

--- a/source/isaaclab/isaaclab/managers/manager_term_cfg.py
+++ b/source/isaaclab/isaaclab/managers/manager_term_cfg.py
@@ -293,6 +293,25 @@ class EventTermCfg(ManagerTermBaseCfg):
         This is only used if the mode is ``"interval"``.
     """
 
+    resample_interval_on_reset: bool = True
+    """Whether to resample the interval time when an environment is reset. Defaults to True.
+
+    If True, the time left until the next application of the term is resampled whenever the
+    corresponding environment instance is reset, so the interval counter restarts with the
+    episode.
+
+    If False, the interval counter is preserved across resets and keeps counting down using
+    simulation time. This allows modeling events whose interval is independent of (and may
+    exceed) the episode length.
+
+    This flag is orthogonal to :attr:`is_global_time` and only has an effect when
+    :attr:`is_global_time` is False, since global-time terms use a single shared timer that
+    already ignores resets.
+
+    Note:
+        This is only used if the mode is ``"interval"``.
+    """
+
     min_step_count_between_reset: int = 0
     """The number of environment steps after which the term is applied since its last application. Defaults to 0.
 

--- a/source/isaaclab/test/managers/test_event_manager.py
+++ b/source/isaaclab/test/managers/test_event_manager.py
@@ -329,6 +329,55 @@ def test_apply_interval_mode_with_global_time(env):
             term_2_interval_time = event_man._interval_term_time_left[1].clone()
 
 
+def test_apply_interval_mode_resample_on_reset(env):
+    """Test that the interval timer is (not) resampled on reset based on ``resample_interval_on_reset``.
+
+    Using a fixed (zero-width) interval range makes the resampling deterministic: after one apply
+    the timer should read ``interval - dt``, and on reset it should either be restored to the fixed
+    interval (when resampling) or keep counting down (when not resampling).
+    """
+    interval_s = 1.0  # large compared to env.dt so the term does not fire during the test
+
+    cfg = {
+        # default behavior (resample_interval_on_reset=True): timer is resampled on reset
+        "term_resample": EventTermCfg(
+            func=increment_dummy1_by_one,
+            mode="interval",
+            interval_range_s=(interval_s, interval_s),
+            is_global_time=False,
+        ),
+        # alternative behavior: per-env timer is preserved across resets
+        "term_no_resample": EventTermCfg(
+            func=increment_dummy2_by_one,
+            mode="interval",
+            interval_range_s=(interval_s, interval_s),
+            is_global_time=False,
+            resample_interval_on_reset=False,
+        ),
+    }
+
+    event_man = EventManager(cfg, env)
+
+    # both timers initialize to the fixed interval
+    expected_init = torch.full((env.num_envs,), interval_s, device=env.device)
+    torch.testing.assert_close(event_man._interval_term_time_left[0], expected_init)
+    torch.testing.assert_close(event_man._interval_term_time_left[1], expected_init)
+
+    # apply once to decrement the timers (no firing since interval >> dt)
+    event_man.apply("interval", dt=env.dt)
+    expected_after_apply = torch.full((env.num_envs,), interval_s - env.dt, device=env.device)
+    torch.testing.assert_close(event_man._interval_term_time_left[0], expected_after_apply)
+    torch.testing.assert_close(event_man._interval_term_time_left[1], expected_after_apply)
+
+    # reset all environments
+    event_man.reset(env_ids=torch.arange(env.num_envs, device=env.device))
+
+    # term with resampling is restored to the fixed interval
+    torch.testing.assert_close(event_man._interval_term_time_left[0], expected_init)
+    # term without resampling keeps counting down across the reset
+    torch.testing.assert_close(event_man._interval_term_time_left[1], expected_after_apply)
+
+
 def test_apply_reset_mode(env):
     """Test the application of event terms that are in reset mode."""
     cfg = {

--- a/source/isaaclab_experimental/changelog.d/resample-interval-on-reset.minor.rst
+++ b/source/isaaclab_experimental/changelog.d/resample-interval-on-reset.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added support for :attr:`~isaaclab.managers.EventTermCfg.resample_interval_on_reset` in the
+  experimental Warp-first event manager, allowing ``"interval"`` event terms to keep their
+  per-environment timer across resets while still firing asynchronously per environment.

--- a/source/isaaclab_experimental/isaaclab_experimental/managers/event_manager.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/managers/event_manager.py
@@ -259,9 +259,11 @@ class EventManager(ManagerBase):
                 term_cfg.func.reset(env_mask=env_mask)
 
         # reset interval timers for non-global interval events
+        # note: terms with resample_interval_on_reset=False keep their per-environment counter
+        #   across resets, so we do not resample them either
         if "interval" in self._mode_term_cfgs:
             for i, term_cfg in enumerate(self._mode_term_cfgs["interval"]):
-                if term_cfg.is_global_time:
+                if term_cfg.is_global_time or not term_cfg.resample_interval_on_reset:
                     continue
                 lower, upper = self._interval_term_ranges[i]
                 wp.launch(


### PR DESCRIPTION
# Description

Add a resample_interval_on_reset flag to EventTermCfg, defaulting to True to keep current behavior. This allows a user to skip the interval resampling that currently happens on reset.

See related Issue https://github.com/isaac-sim/IsaacLab/issues/5305

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog, and NOT the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there