### PR TITLE
Fix transformation matrix docstrings on develop

### DIFF
--- a/source/isaaclab/changelog.d/antoiner-fix-transform-docs-develop.skip
+++ b/source/isaaclab/changelog.d/antoiner-fix-transform-docs-develop.skip
@@ -1,0 +1,1 @@
+Docstring correction only; no user-facing changelog entry.

--- a/source/isaaclab/isaaclab/utils/math.py
+++ b/source/isaaclab/isaaclab/utils/math.py
@@ -812,7 +812,7 @@ def combine_frame_transforms(
     r"""Combine transformations between two reference frames into a stationary frame.
 
     It performs the following transformation operation: :math:`T_{02} = T_{01} \times T_{12}`,
-    where :math:`T_{AB}` is the homogeneous transformation matrix from frame A to B.
+    where :math:`T_{AB}` is the homogeneous transformation matrix from frame B to A.
 
     Args:
         t01: Position of frame 1 w.r.t. frame 0. Shape is (N, 3).
@@ -884,7 +884,7 @@ def subtract_frame_transforms(
     r"""Subtract transformations between two reference frames into a stationary frame.
 
     It performs the following transformation operation: :math:`T_{12} = T_{01}^{-1} \times T_{02}`,
-    where :math:`T_{AB}` is the homogeneous transformation matrix from frame A to B.
+    where :math:`T_{AB}` is the homogeneous transformation matrix from frame B to A.
 
     Args:
         t01: Position of frame 1 w.r.t. frame 0. Shape is (N, 3).


### PR DESCRIPTION
# Description

Updates the transformation-matrix docstrings in `combine_frame_transforms()` and `subtract_frame_transforms()` on `develop` to state that `T_{AB}` maps from frame B to frame A, matching #5819 on `main`.

No new dependencies.

Fixes # N/A - follow-up to #5819 for `develop`.

## Type of change

- Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format` (`./isaaclab.sh -f`; all hooks pass except `check-git-lfs-pointers`, which fails because `git-lfs` is not installed locally)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (not applicable: docstring-only change)
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (`source/isaaclab/changelog.d/antoiner-fix-transform-docs-develop.skip`)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there (`Antoine Richard`)
