### PR TITLE
Fix memory leak in ManagerBasedEnv.close

### DIFF
--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -551,6 +551,11 @@ class ManagerBasedEnv:
             # Stop simulation first to allow physics to clean up properly
             self.sim.stop()
 
+            # Drop cached observation tensors so they don't survive close via
+            # gymnasium's wrapper chain.
+            if isinstance(getattr(self, "obs_buf", None), dict):
+                self.obs_buf.clear()
+
             # destructor is order-sensitive
             del self.viewport_camera_controller
             del self.action_manager

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -311,6 +311,12 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
             del self.reward_manager
             del self.termination_manager
             del self.curriculum_manager
+            # Release gym.spaces.Box bounds arrays set in _configure_gym_env_spaces;
+            # without this they survive close via gymnasium's wrapper chain.
+            self.single_observation_space = None
+            self.single_action_space = None
+            self.observation_space = None
+            self.action_space = None
             # call the parent class to close the environment
             super().close()
 

--- a/source/isaaclab/test/envs/test_manager_based_env_close_leak.py
+++ b/source/isaaclab/test/envs/test_manager_based_env_close_leak.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression test for the ``ManagerBasedEnv.close`` memory leak fixed in this PR."""
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True).app
+
+"""Rest everything follows."""
+
+import gymnasium as gym
+import pytest
+import torch
+
+import isaaclab_tasks  # noqa: F401 -- registers Isaac-* env IDs with gymnasium
+from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
+
+
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_close_clears_obs_buf_and_releases_spaces(device):
+    """``ManagerBasedEnv.close`` should release the cached observation buffer and the
+    gym space attributes attached to the env.
+
+    Without the release, gymnasium's wrapper chain (e.g. ``OrderEnforcing`` plus the
+    ``make()`` registry) keeps the env reachable past ``close``, so ``self.obs_buf``
+    (the dict of cached observation tensors — tens of MB per image sensor) and the
+    ``observation_space`` / ``action_space`` ``gym.spaces.Box`` attributes (~110 MB
+    of numpy bounds-array memory per image-observation Box at ``(num_envs, H, W, C)``
+    float32) survive the call and accumulate on each construct/teardown cycle.
+    """
+    env_cfg = parse_env_cfg("Isaac-Cartpole-v0", device=device, num_envs=2)
+    env = gym.make("Isaac-Cartpole-v0", cfg=env_cfg)
+    env.reset()
+    # Step once so the ObservationManager populates ``obs_buf``.
+    action = torch.zeros((2, env.action_space.shape[-1]), device=env.unwrapped.device)
+    env.step(action)
+    assert env.unwrapped.obs_buf, "precondition: obs_buf should be populated after step"
+    assert env.unwrapped.observation_space is not None, "precondition: observation_space should be set"
+    assert env.unwrapped.action_space is not None, "precondition: action_space should be set"
+
+    env.close()
+
+    assert not env.unwrapped.obs_buf, "obs_buf was not cleared on close"
+    assert env.unwrapped.observation_space is None, "observation_space was not released on close"
+    assert env.unwrapped.action_space is None, "action_space was not released on close"


### PR DESCRIPTION
# Description

`ManagerBasedEnv.close()` does not release two categories of per-instance state, both of which then survive `close()` because gymnasium's wrapper chain (`OrderEnforcing` plus the `make()` registry) keeps the wrapped env reachable:

1. **`self.obs_buf`** — the dict of cached observation tensors populated by every `step()` / `reset()`. For image sensors at `(num_envs, H, W, C)` this is tens of MB per camera.
2. **`self.observation_space` / `self.action_space`** (and the vectorised-API `single_*_space` variants set by `ManagerBasedRLEnv`). Each `gym.spaces.Box` for an image observation at `(4, 720, 1280, 3)` float32 pins ~110 MB of bounds arrays (`low`, `high` as float32 + `bounded_below`, `bounded_above` as bool).

Net effect: ~one env's worth of `gym.spaces.Box` bounds arrays plus the last observation buffer are retained for the lifetime of the process even after `close()` returns. In evaluation loops that rebuild envs across tasks — or in any context where module reloads orphan multiple env instances against type-equality replacement — the leak compounds into multi-GB territory and ultimately OOMs the process.

No associated issue (found while debugging an evaluation-sweep OOM in a downstream project).

Fixes # (no associated issue)

## Repro & regression test

Two commits in this PR:

1. **The fix** in `ManagerBasedEnv.close` — clears `obs_buf`, nulls space attributes.
2. **A regression test** at `source/isaaclab/test/envs/test_manager_based_env_close_leak.py` that builds `Isaac-Cartpole-v0` via `gym.make`, runs reset + one step, calls `close()`, and asserts `obs_buf` is empty and the space attributes are `None`. Parametrised over `cuda:0` and `cpu`.

Verified the test:
- **Fails** on the pre-fix `close()` with `AssertionError: obs_buf was not cleared on close`.
- **Passes** with the fix applied.

A standalone runnable repro that demonstrates the leak magnitude visually (live `gym.spaces.Box` count and total bounds-array MB across cycles, with a `--patched` toggle) is in companion draft PR #5898. Run it as::

    ./isaaclab.sh -p source/isaaclab/test/envs/check_manager_based_env_close_leak.py
    # pre-fix: live Boxes=4, bounds-arrays held: 131.8 MB
    ./isaaclab.sh -p source/isaaclab/test/envs/check_manager_based_env_close_leak.py --patched
    # post-fix: live Boxes=0, bounds-arrays held: 0.0 MB

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation — N/A, internal lifecycle method
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file — followed the new `changelog.d/` workflow in AGENTS.md; happy to add a fragment if maintainers want a patch-bump entry
- [ ] I have added my name to the `CONTRIBUTORS.md` — happy to add if maintainers want
