### PR TITLE
Add torch support to collection reshape helper

### DIFF
--- a/source/isaaclab/changelog.d/antoiner-fix-issue-5893.skip
+++ b/source/isaaclab/changelog.d/antoiner-fix-issue-5893.skip
@@ -1,0 +1,1 @@
+Rigid object collection interface test-only changes; no user-facing isaaclab changelog entry.

--- a/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
@@ -374,6 +374,9 @@ _default_devices = pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 _index_resolution_backends = pytest.mark.parametrize(
     "backend", [backend for backend in ("physx", "newton") if backend in BACKENDS], indirect=False
 )
+_reshape_3d_backends = pytest.mark.parametrize(
+    "backend", [backend for backend in ("physx", "ovphysx") if backend in BACKENDS], indirect=False
+)
 
 
 # ---------------------------------------------------------------------------
@@ -483,6 +486,79 @@ class TestCollectionIndexResolution:
 
         assert resolved_full.shape[0] == 4
         assert resolved_view.shape[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: View reshape helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionViewReshape:
+    """Test backend-specific view reshape helpers."""
+
+    @_reshape_3d_backends
+    @_default_devices
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+    def test_reshape_data_to_view_3d_accepts_torch_tensor(self, backend, device, dtype):
+        if device.startswith("cuda") and not torch.cuda.is_available():
+            pytest.skip("CUDA is not available")
+
+        num_instances = 2
+        num_bodies = 3
+        data_dim = 4
+        obj, _ = get_rigid_object_collection(backend, num_instances=num_instances, num_bodies=num_bodies, device=device)
+        data = torch.arange(num_instances * num_bodies * data_dim, dtype=dtype, device=device).reshape(
+            num_instances, num_bodies, data_dim
+        )
+
+        view = obj.reshape_data_to_view_3d(data, data_dim, device=device)
+
+        assert isinstance(view, torch.Tensor)
+        assert view.dtype == dtype
+        assert view.device == data.device
+        assert view.is_contiguous()
+        torch.testing.assert_close(view, data.permute(1, 0, 2).reshape(num_bodies * num_instances, data_dim))
+
+    @_reshape_3d_backends
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+    def test_reshape_data_to_view_3d_moves_torch_tensor_to_requested_device(self, backend):
+        num_instances = 2
+        num_bodies = 3
+        data_dim = 4
+        obj, _ = get_rigid_object_collection(
+            backend, num_instances=num_instances, num_bodies=num_bodies, device="cuda:0"
+        )
+        data = torch.arange(num_instances * num_bodies * data_dim, dtype=torch.float32, device="cuda:0").reshape(
+            num_instances, num_bodies, data_dim
+        )
+
+        view = obj.reshape_data_to_view_3d(data, data_dim, device="cpu")
+
+        assert view.device.type == "cpu"
+        torch.testing.assert_close(view, data.permute(1, 0, 2).reshape(num_bodies * num_instances, data_dim).cpu())
+
+    @_reshape_3d_backends
+    @_default_devices
+    def test_reshape_data_to_view_3d_keeps_warp_array_behavior(self, backend, device):
+        if device.startswith("cuda") and not torch.cuda.is_available():
+            pytest.skip("CUDA is not available")
+
+        num_instances = 2
+        num_bodies = 3
+        data_dim = 4
+        obj, _ = get_rigid_object_collection(backend, num_instances=num_instances, num_bodies=num_bodies, device=device)
+        data = torch.arange(num_instances * num_bodies * data_dim, dtype=torch.float32, device=device).reshape(
+            num_instances, num_bodies, data_dim
+        )
+
+        torch_view = obj.reshape_data_to_view_3d(data, data_dim, device=device)
+        warp_view = obj.reshape_data_to_view_3d(wp.from_torch(data, dtype=wp.float32), data_dim, device=device)
+
+        assert isinstance(warp_view, wp.array)
+        assert warp_view.shape == (num_bodies * num_instances, data_dim)
+        assert warp_view.dtype == wp.float32
+        assert str(warp_view.device) == device
+        torch.testing.assert_close(wp.to_torch(warp_view), torch_view)
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
@@ -375,7 +375,7 @@ _index_resolution_backends = pytest.mark.parametrize(
     "backend", [backend for backend in ("physx", "newton") if backend in BACKENDS], indirect=False
 )
 _reshape_3d_backends = pytest.mark.parametrize(
-    "backend", [backend for backend in ("physx", "ovphysx") if backend in BACKENDS], indirect=False
+    "backend", [backend for backend in ("physx", "newton", "ovphysx") if backend in BACKENDS], indirect=False
 )
 
 

--- a/source/isaaclab_newton/changelog.d/antoiner-fix-issue-5893.rst
+++ b/source/isaaclab_newton/changelog.d/antoiner-fix-issue-5893.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added torch tensor input support to
+  :meth:`~isaaclab_newton.assets.RigidObjectCollection.reshape_data_to_view_3d`.

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
@@ -1071,6 +1071,39 @@ class RigidObjectCollection(BaseRigidObjectCollection):
     Internal helper.
     """
 
+    def reshape_data_to_view_3d(
+        self, data: wp.array | torch.Tensor, data_dim: int, device: str | None = None
+    ) -> wp.array | torch.Tensor:
+        """Reshape instance-major ``(num_instances, num_bodies, data_dim)`` data to body-major view order.
+
+        Args:
+            data: Source buffer with shape ``(num_instances, num_bodies, data_dim)``.
+                Supports Warp arrays and torch tensors.
+            data_dim: Trailing per-element dimension size.
+            device: Optional target device for the output. Defaults to ``data.device``.
+
+        Returns:
+            Contiguous body-major buffer with shape ``(num_bodies * num_instances, data_dim)``.
+            Torch inputs return torch tensors, and Warp inputs return Warp arrays.
+        """
+        if isinstance(data, torch.Tensor):
+            if device is None:
+                device = data.device
+            return data.transpose(0, 1).reshape(self.num_bodies * self.num_instances, data_dim).to(device).contiguous()
+
+        if device is None:
+            device = str(data.device)
+        element_size = wp.types.type_size_in_bytes(data.dtype)
+        row_size = element_size * data_dim
+        strided_view = wp.array(
+            ptr=data.ptr,
+            shape=(self.num_bodies, self.num_instances, data_dim),
+            dtype=data.dtype,
+            strides=(row_size, self.num_bodies * row_size, element_size),
+            device=str(data.device),
+        )
+        return wp.clone(strided_view, device=device).reshape((self.num_bodies * self.num_instances, data_dim))
+
     def _initialize_impl(self):
         # clear body names list to prevent double counting on re-initialization
         self._body_names_list.clear()

--- a/source/isaaclab_ovphysx/changelog.d/antoiner-fix-issue-5893.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-fix-issue-5893.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added torch tensor input support to
+  :meth:`~isaaclab_ovphysx.assets.RigidObjectCollection.reshape_data_to_view_3d`.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
@@ -1212,7 +1212,9 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         )
         return wp.clone(strided_view, device=device).reshape((self.num_bodies * self.num_instances,))
 
-    def reshape_data_to_view_3d(self, data: wp.array, data_dim: int, device: str | None = None) -> wp.array:
+    def reshape_data_to_view_3d(
+        self, data: wp.array | torch.Tensor, data_dim: int, device: str | None = None
+    ) -> wp.array | torch.Tensor:
         """Reshape instance-major ``(num_instances, num_bodies, data_dim)`` data to body-major view order.
 
         Companion of :meth:`reshape_data_to_view_2d` for 3D buffers (e.g. inertia
@@ -1220,12 +1222,19 @@ class RigidObjectCollection(BaseRigidObjectCollection):
 
         Args:
             data: Source buffer with shape ``(num_instances, num_bodies, data_dim)``.
+                Supports Warp arrays and torch tensors.
             data_dim: Trailing per-element dimension size.
-            device: Optional target device for the cloned output.  Defaults to ``data.device``.
+            device: Optional target device for the output. Defaults to ``data.device``.
 
         Returns:
             Contiguous body-major buffer with shape ``(num_bodies * num_instances, data_dim)``.
+            Torch inputs return torch tensors, and Warp inputs return Warp arrays.
         """
+        if isinstance(data, torch.Tensor):
+            if device is None:
+                device = data.device
+            return data.transpose(0, 1).reshape(self.num_bodies * self.num_instances, data_dim).to(device).contiguous()
+
         if device is None:
             device = str(data.device)
         element_size = wp.types.type_size_in_bytes(data.dtype)

--- a/source/isaaclab_physx/changelog.d/antoiner-fix-issue-5893.rst
+++ b/source/isaaclab_physx/changelog.d/antoiner-fix-issue-5893.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added torch tensor input support to
+  :meth:`~isaaclab_physx.assets.RigidObjectCollection.reshape_data_to_view_3d`.

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
@@ -1119,7 +1119,9 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         # Clone to make contiguous (now row-major num_bodies x num_instances), then flatten
         return wp.clone(strided_view, device=device).reshape((self.num_bodies * self.num_instances,))
 
-    def reshape_data_to_view_3d(self, data: wp.array, data_dim: int, device: str = "cpu") -> wp.array:
+    def reshape_data_to_view_3d(
+        self, data: wp.array | torch.Tensor, data_dim: int, device: str | None = "cpu"
+    ) -> wp.array | torch.Tensor:
         """Reshapes and arranges 3D data to (num_bodies * num_instances, data_dim).
 
         Our internal methods consume and return data arranged as ``(num_instances, num_bodies, data_dim)``::
@@ -1136,11 +1138,19 @@ class RigidObjectCollection(BaseRigidObjectCollection):
 
         Args:
             data: The data to be formatted for the view. Shape is (num_instances, num_bodies, data_dim).
+                Supports Warp arrays and torch tensors.
             data_dim: The trailing dimension size.
+            device: The target device for the output.
 
         Returns:
             The data formatted for the view. Shape is (num_bodies * num_instances, data_dim).
+            Torch inputs return torch tensors, and Warp inputs return Warp arrays.
         """
+        if isinstance(data, torch.Tensor):
+            if device is None:
+                device = data.device
+            return data.transpose(0, 1).reshape(self.num_bodies * self.num_instances, data_dim).to(device).contiguous()
+
         element_size = wp.types.type_size_in_bytes(data.dtype)
         row_size = element_size * data_dim
         strided_view = wp.array(


### PR DESCRIPTION
# Description

Adds `torch.Tensor` input support to `RigidObjectCollection.reshape_data_to_view_3d()` for the PhysX, Newton, and OVPhysX backends. Torch inputs now reshape from instance-major `(num_instances, num_bodies, data_dim)` to body-major `(num_bodies * num_instances, data_dim)`, preserve dtype, return a contiguous torch tensor, and honor the requested output device.

The existing Warp array paths remain unchanged after the torch type check where the helper already existed. Newton now exposes the same helper for backend API consistency.

Fixes #5893

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

N/A

## Test Plan

- `PYTHONPATH=/home/antoiner/Documents/IsaacLab_Newton/.worktrees/fix-issue-5893/source/isaaclab_newton:/home/antoiner/Documents/IsaacLab_Newton/.worktrees/fix-issue-5893/source/isaaclab_ovphysx:/home/antoiner/Documents/IsaacLab_Newton/.worktrees/fix-issue-5893/source/isaaclab_physx:/home/antoiner/Documents/IsaacLab_Newton/.worktrees/fix-issue-5893/source/isaaclab:$PYTHONPATH ./isaaclab.sh -p -m pytest source/isaaclab/test/assets/test_rigid_object_collection_iface.py::TestCollectionViewReshape -q`
  - Result: 21 passed
- `git diff --check`
  - Result: passed
- `./isaaclab.sh --format`
  - Result: ruff, format, whitespace, spelling, RST, and other non-LFS hooks passed; `check-git-lfs-pointers` failed because `git-lfs` is not installed in this local environment.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format` (ran the exact command; blocked only by missing local `git-lfs`)
- [x] I have made corresponding changes to the documentation (N/A: no user-facing docs page change needed for this helper-only API update)
- [x] My changes generate no new warnings (targeted tests emit existing deprecation warnings unrelated to this change)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
