### PR TITLE
[Fix] Defer pxr loading in isaaclab.sim, .assets, .scene, and .sim/utils (#5826)

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-defer-asset-pxr-imports.rst
+++ b/source/isaaclab/changelog.d/jichuanh-defer-asset-pxr-imports.rst
@@ -1,0 +1,16 @@
+Fixed
+^^^^^
+
+* Fixed module-import-time ``from pxr import …`` in :mod:`isaaclab.sim.simulation_context`,
+  :mod:`isaaclab.assets.asset_base`, :mod:`isaaclab.scene.interactive_scene`,
+  :mod:`isaaclab.sim.spawners.from_files.from_files`, :mod:`isaaclab.sim.utils.prims`,
+  :mod:`isaaclab.sim.utils.queries`, :mod:`isaaclab.sim.utils.semantics`,
+  :mod:`isaaclab.sim.utils.stage`, and :mod:`isaaclab.sim.utils.transforms`.  Previously,
+  ``from isaaclab.assets import Articulation`` or ``from isaaclab.sim import SimulationContext``
+  forced ``pxr`` (USD) into ``sys.modules`` before :class:`~isaaclab.app.AppLauncher`,
+  which broke Kit's USD binding registration with a cascade of
+  ``TfNotice`` / ``UsdAPISchemaBase`` / ``GfVec3f`` converter errors during
+  ``SimulationApp.startup``.  Kit-less env-cfg parsing followed by ``--visualizer kit``
+  now succeeds without any pxr modules preloaded.  Type hints stay under
+  ``TYPE_CHECKING``; where pxr is used at runtime, the ``from pxr import …`` is deferred
+  into the function body that needs it.

--- a/source/isaaclab/isaaclab/assets/asset_base.py
+++ b/source/isaaclab/isaaclab/assets/asset_base.py
@@ -15,14 +15,14 @@ from typing import TYPE_CHECKING, Any
 import torch
 import warp as wp
 
-from pxr import Usd
-
 import isaaclab.sim as sim_utils
 from isaaclab.physics import PhysicsEvent, PhysicsManager
 from isaaclab.sim.simulation_context import SimulationContext
 from isaaclab.sim.utils.stage import get_current_stage
 
 if TYPE_CHECKING:
+    from pxr import Usd
+
     from .asset_base_cfg import AssetBaseCfg
 
 

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 import torch
 import warp as wp
 
-from pxr import Sdf
-
 import isaaclab.sim as sim_utils
 from isaaclab import cloner
 from isaaclab.assets import (
@@ -45,6 +43,9 @@ from isaaclab.utils.version import has_kit
 from isaaclab_contrib.sensors.tacsl_sensor import VisuoTactileSensorCfg
 
 from .interactive_scene_cfg import InteractiveSceneCfg
+
+if TYPE_CHECKING:
+    from pxr import Sdf  # noqa: F401
 
 # import logger
 logger = logging.getLogger(__name__)
@@ -308,6 +309,8 @@ class InteractiveScene:
         # PhysX-only: set env id bit count for replicated physics. Newton handles env separation in its own API.
         # Intentionally matches both physx and ovphysx (both are PhysX-based)
         if self.cfg.replicate_physics and "physx" in self.physics_backend:
+            from pxr import Sdf  # noqa: PLC0415
+
             prim = self.stage.GetPrimAtPath("/physicsScene")
             prim.CreateAttribute("physxScene:envIdInBoundsBitCount", Sdf.ValueTypeNames.Int).Set(4)
 

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -17,8 +17,6 @@ from typing import TYPE_CHECKING, Any
 import toml
 import torch
 
-from pxr import Gf, Usd, UsdGeom, UsdPhysics, UsdUtils
-
 import isaaclab.sim as sim_utils
 import isaaclab.sim.utils.stage as stage_utils
 from isaaclab.app.settings_manager import SettingsManager
@@ -38,6 +36,8 @@ from isaaclab.utils.version import has_kit
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
 
 if TYPE_CHECKING:
+    from pxr import Usd
+
     from isaaclab.cloner.clone_plan import ClonePlan
 
 from .simulation_cfg import SimulationCfg
@@ -110,6 +110,8 @@ class SimulationContext:
         """
         if type(self)._instance is not None:
             return  # Already initialized
+
+        from pxr import UsdUtils  # noqa: PLC0415
 
         # Store config
         self.cfg = SimulationCfg() if cfg is None else cfg
@@ -322,6 +324,8 @@ class SimulationContext:
 
     def _init_usd_physics_scene(self) -> None:
         """Create and configure the USD physics scene."""
+        from pxr import Gf, UsdGeom, UsdPhysics  # noqa: PLC0415
+
         cfg = self.cfg
         with sim_utils.use_stage(self.stage):
             # Set stage conventions for metric units
@@ -984,6 +988,7 @@ def build_simulation_context(
     sim: SimulationContext | None = None
     try:
         if create_new_stage:
+            # ``create_new_stage`` is shadowed here by the bool parameter, so call via the namespace.
             sim_utils.create_new_stage()
 
         if sim_cfg is None:

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -13,8 +13,6 @@ from typing import TYPE_CHECKING
 
 from filelock import FileLock
 
-from pxr import Gf, Sdf, Usd, UsdGeom
-
 from isaaclab.sim import converters, schemas
 from isaaclab.sim.spawners.materials import RigidBodyMaterialCfg, SurfaceDeformableBodyMaterialBaseCfg
 from isaaclab.sim.utils import (
@@ -33,6 +31,8 @@ from isaaclab.utils.assets import check_file_path, retrieve_file_path
 from isaaclab.utils.version import has_kit
 
 if TYPE_CHECKING:
+    from pxr import Gf, Sdf, Usd, UsdGeom  # noqa: F401
+
     from . import from_files_cfg
 
 # import logger
@@ -236,6 +236,8 @@ def spawn_ground_plane(
     # Change the color of the plane
     # Warning: This is specific to the default grid plane asset.
     if cfg.color is not None:
+        from pxr import Gf, Sdf  # noqa: PLC0415
+
         # change the color
         change_prim_property(
             prop_path=f"{prim_path}/Looks/theGrid/Shader.inputs:diffuse_tint",
@@ -247,6 +249,8 @@ def spawn_ground_plane(
     # It isn't bright enough and messes up with the user's lighting settings
     light_prim = stage.GetPrimAtPath(f"{prim_path}/SphereLight")
     if light_prim.IsValid():
+        from pxr import UsdGeom  # noqa: PLC0415
+
         imageable = UsdGeom.Imageable(light_prim)
         imageable.MakeInvisible()
 

--- a/source/isaaclab/isaaclab/sim/utils/prims.py
+++ b/source/isaaclab/isaaclab/sim/utils/prims.py
@@ -16,8 +16,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
-from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade, UsdUtils
-
 from isaaclab.utils.assets import check_file_path, retrieve_file_path
 from isaaclab.utils.string import to_camel_case
 from isaaclab.utils.version import has_kit
@@ -28,6 +26,8 @@ from .stage import get_current_stage, resolve_paths
 from .transforms import convert_world_pose_to_local, standardize_xform_ops
 
 if TYPE_CHECKING:
+    from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade, UsdUtils  # noqa: F401
+
     from isaaclab.sim.spawners.spawner_cfg import SpawnerCfg
 
 # import logger
@@ -131,6 +131,8 @@ def create_prim(
         ... )
         Usd.Prim(</World/Parent/Sphere>)
     """
+    from pxr import UsdGeom  # noqa: PLC0415
+
     # Ensure that user doesn't provide both position and translation
     if position is not None and translation is not None:
         raise ValueError("Cannot provide both position and translation. Please provide only one.")
@@ -200,6 +202,8 @@ def delete_prim(prim_path: str | Sequence[str], stage: Usd.Stage | None = None) 
         >>>
         >>> sim_utils.delete_prim("/World/Cube")
     """
+    from pxr import UsdUtils  # noqa: PLC0415
+
     # convert prim_path to list if it is a string
     if isinstance(prim_path, str):
         prim_path = [prim_path]
@@ -243,6 +247,8 @@ def make_uninstanceable(prim_path: str | Sdf.Path, stage: Usd.Stage | None = Non
     Raises:
         ValueError: If the prim path is not global (i.e: does not start with '/').
     """
+    from pxr import Usd  # noqa: PLC0415
+
     # get stage handle
     if stage is None:
         stage = get_current_stage()
@@ -288,6 +294,8 @@ def set_prim_visibility(prim: Usd.Prim, visible: bool) -> None:
         >>> prim = sim_utils.get_prim_at_path("/World/Cube")
         >>> sim_utils.set_prim_visibility(prim, False)
     """
+    from pxr import UsdGeom  # noqa: PLC0415
+
     imageable = UsdGeom.Imageable(prim)
     if visible:
         imageable.MakeVisible()
@@ -345,6 +353,8 @@ def safe_set_attribute_on_usd_prim(prim: Usd.Prim, attr_name: str, value: Any, c
         value: The value to set the attribute to.
         camel_case: Whether to convert the attribute name to camel case.
     """
+    from pxr import Sdf  # noqa: PLC0415
+
     # if value is None, do nothing
     if value is None:
         return
@@ -431,6 +441,8 @@ def change_prim_property(
         ... )
         True
     """
+    from pxr import Sdf, Usd  # noqa: PLC0415
+
     # get stage handle
     stage = get_current_stage() if stage is None else stage
 
@@ -493,6 +505,8 @@ def export_prim_to_file(
     Raises:
         ValueError: If the prim paths are not global (i.e: do not start with '/').
     """
+    from pxr import Sdf, Usd, UsdGeom  # noqa: PLC0415
+
     # get stage handle
     if stage is None:
         stage = get_current_stage()
@@ -643,6 +657,8 @@ def clone(func: Callable) -> Callable:
 
     @functools.wraps(func)
     def wrapper(prim_path: str | Sdf.Path, cfg: SpawnerCfg, *args, **kwargs):
+        from pxr import Sdf, UsdGeom  # noqa: PLC0415
+
         # get stage handle
         stage = get_current_stage()
 
@@ -819,6 +835,8 @@ def bind_physics_material(
     Raises:
         ValueError: If the provided prim paths do not exist on stage.
     """
+    from pxr import UsdPhysics, UsdShade  # noqa: PLC0415
+
     # get stage handle
     if stage is None:
         stage = get_current_stage()

--- a/source/isaaclab/isaaclab/sim/utils/queries.py
+++ b/source/isaaclab/isaaclab/sim/utils/queries.py
@@ -10,13 +10,15 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable
-
-from pxr import Sdf, Usd, UsdPhysics
+from typing import TYPE_CHECKING
 
 from isaaclab.cloner.cloner_utils import resolve_clone_plan_source
 from isaaclab.sim.simulation_context import SimulationContext
 
 from .stage import get_current_stage
+
+if TYPE_CHECKING:
+    from pxr import Sdf, Usd, UsdPhysics  # noqa: F401
 
 # import logger
 logger = logging.getLogger(__name__)
@@ -46,6 +48,8 @@ def get_next_free_prim_path(path: str, stage: Usd.Stage | None = None) -> str:
         >>> sim_utils.get_next_free_prim_path("/World/Cube")
         /World/Cube_02
     """
+    from pxr import Sdf  # noqa: PLC0415
+
     # get current stage
     stage = get_current_stage() if stage is None else stage
 
@@ -163,6 +167,8 @@ def get_first_matching_child_prim(
     Raises:
         ValueError: If the prim path is not global (i.e: does not start with '/').
     """
+    from pxr import Usd  # noqa: PLC0415
+
     # get stage handle
     if stage is None:
         stage = get_current_stage()
@@ -230,6 +236,8 @@ def get_all_matching_child_prims(
     Raises:
         ValueError: If the prim path is not global (i.e: does not start with '/').
     """
+    from pxr import Usd  # noqa: PLC0415
+
     # get stage handle
     if stage is None:
         stage = get_current_stage()
@@ -488,6 +496,8 @@ def find_global_fixed_joint_prim(
         ValueError: If the prim path is not global (i.e: does not start with '/').
         ValueError: If the prim path does not exist on the stage.
     """
+    from pxr import Usd, UsdPhysics  # noqa: PLC0415
+
     # get stage handle
     if stage is None:
         stage = get_current_stage()

--- a/source/isaaclab/isaaclab/sim/utils/semantics.py
+++ b/source/isaaclab/isaaclab/sim/utils/semantics.py
@@ -8,10 +8,12 @@
 from __future__ import annotations
 
 import logging
-
-from pxr import Usd, UsdGeom, UsdSemantics
+from typing import TYPE_CHECKING
 
 from .stage import get_current_stage
+
+if TYPE_CHECKING:
+    from pxr import Usd, UsdGeom, UsdSemantics  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +32,8 @@ def add_labels(prim: Usd.Prim, labels: list[str], instance_name: str = "class", 
         overwrite: Whether to overwrite existing labels for this instance. If False,
           the new labels are appended to existing ones (if any). Defaults to True.
     """
+    from pxr import UsdSemantics  # noqa: PLC0415
+
     labels_api = UsdSemantics.LabelsAPI.Apply(prim, instance_name)
     labels_attr = labels_api.CreateLabelsAttr()
     if overwrite:
@@ -53,6 +57,8 @@ def get_labels(prim: Usd.Prim) -> dict[str, list[str]]:
         A dictionary mapping instance names to a list of labels.
         If no labels are found, it returns an empty dictionary.
     """
+    from pxr import UsdSemantics  # noqa: PLC0415
+
     result = {}
     for schema_name in prim.GetAppliedSchemas():
         if schema_name.startswith("SemanticsLabelsAPI:"):
@@ -77,6 +83,7 @@ def remove_labels(prim: Usd.Prim, instance_name: str | None = None, include_desc
         include_descendants: Whether to also traverse children and remove labels recursively.
             Defaults to False.
     """
+    from pxr import Usd, UsdSemantics  # noqa: PLC0415
 
     def _remove_single_prim_labels(target_prim: Usd.Prim):
         """Helper function to remove labels from a single prim."""
@@ -111,6 +118,8 @@ def check_missing_labels(prim_path: str | None = None, stage: Usd.Stage | None =
     Returns:
         A list containing prim paths to prims with no labels applied.
     """
+    from pxr import Usd, UsdGeom  # noqa: PLC0415
+
     # check if stage is valid
     stage = stage if stage else get_current_stage()
 
@@ -151,6 +160,8 @@ def count_total_labels(prim_path: str | None = None, stage: Usd.Stage | None = N
         A dictionary mapping individual labels to their total count across all instances.
         The dictionary includes a 'missing_labels' count for prims with no labels.
     """
+    from pxr import Usd, UsdGeom  # noqa: PLC0415
+
     stage = stage if stage else get_current_stage()
 
     start_prim = stage.GetPrimAtPath(prim_path) if prim_path else stage.GetPseudoRoot()

--- a/source/isaaclab/isaaclab/sim/utils/stage.py
+++ b/source/isaaclab/isaaclab/sim/utils/stage.py
@@ -12,10 +12,12 @@ import logging
 import os
 import threading
 from collections.abc import Callable, Generator
-
-from pxr import Sdf, Usd, UsdUtils
+from typing import TYPE_CHECKING
 
 from isaaclab.utils.version import get_isaac_sim_version, has_kit
+
+if TYPE_CHECKING:
+    from pxr import Sdf, Usd, UsdUtils  # noqa: F401
 
 # import logger
 logger = logging.getLogger(__name__)
@@ -88,6 +90,8 @@ def resolve_paths(
         >>> sim_utils.resolve_paths(source_layer.identifier, target_layer.identifier)
         >>> target_layer.Save()
     """
+    from pxr import Sdf, UsdUtils  # noqa: PLC0415
+
     src_layer = Sdf.Layer.FindOrOpen(src_layer_identifier)
     dst_layer = Sdf.Layer.FindOrOpen(dst_layer_identifier)
 
@@ -150,6 +154,8 @@ def create_new_stage() -> Usd.Stage:
                        sessionLayer=Sdf.Find('anon:0x7fba6c01c5c0:World7-session.usda'),
                        pathResolverContext=<invalid repr>)
     """
+    from pxr import Usd, UsdUtils  # noqa: PLC0415
+
     stage: Usd.Stage = Usd.Stage.CreateInMemory()
     _context.stage = stage
     UsdUtils.StageCache.Get().Insert(stage)
@@ -207,6 +213,8 @@ def open_stage(usd_path: str) -> Usd.Stage:
         ValueError: When input path is not a supported file type by USD.
         RuntimeError: When failed to open the stage.
     """
+    from pxr import Usd  # noqa: PLC0415
+
     if not Usd.Stage.IsSupportedFile(usd_path):
         raise ValueError(f"The USD file at path '{usd_path}' is not supported.")
 
@@ -250,6 +258,8 @@ def use_stage(stage: Usd.Stage) -> Generator[None, None, None]:
         ...     pass
         >>> # operate on the default stage attached to the USD context
     """
+    from pxr import Usd  # noqa: PLC0415
+
     if has_kit() and get_isaac_sim_version().major < 5:
         logger.warning("Isaac Sim < 5.0 does not support thread-local stage contexts. Skipping use_stage().")
         yield  # no-op
@@ -339,6 +349,8 @@ def save_stage(usd_path: str, save_and_reload_in_place: bool = True) -> bool:
         ValueError: When input path is not a supported file type by USD.
         RuntimeError: When layer creation or save operation fails.
     """
+    from pxr import Sdf, Usd  # noqa: PLC0415
+
     # check if USD file is supported
     if not Usd.Stage.IsSupportedFile(usd_path):
         raise ValueError(f"The USD file at path '{usd_path}' is not supported.")
@@ -389,6 +401,8 @@ def close_stage() -> bool:
         >>> sim_utils.close_stage()
         True
     """
+    from pxr import UsdUtils  # noqa: PLC0415
+
     # Close Kit's USD context first (while the stage is still in the cache),
     # then clear the cache. Reversing this order causes Kit to fail with
     # "Removal of UsdStage from cache failed" and can hang during teardown.
@@ -522,6 +536,8 @@ def get_current_stage_id() -> int:
         >>> sim_utils.get_current_stage_id()
         1234567890
     """
+    from pxr import UsdUtils  # noqa: PLC0415
+
     # get current stage
     stage = get_current_stage()
     if stage is None:

--- a/source/isaaclab/isaaclab/sim/utils/transforms.py
+++ b/source/isaaclab/isaaclab/sim/utils/transforms.py
@@ -15,11 +15,14 @@ transforms in a consistent way across different USD assets.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
-from pxr import Gf, Sdf, Usd, UsdGeom
+if TYPE_CHECKING:
+    from pxr import Gf, Sdf, Usd, UsdGeom  # noqa: F401
 
 # import logger
 logger = logging.getLogger(__name__)
+
 
 _INVALID_XFORM_OPS = [
     "xformOp:rotateX",
@@ -124,6 +127,8 @@ def standardize_xform_ops(
         >>> for prim in prims_to_standardize:
         ...     sim_utils.standardize_xform_ops(prim)  # Each call uses Sdf.ChangeBlock
     """
+    from pxr import Gf, Sdf, UsdGeom  # noqa: PLC0415
+
     # Validate prim
     if not prim.IsValid():
         raise ValueError(f"Prim at path '{prim.GetPath()}' is not valid.")
@@ -240,6 +245,8 @@ def validate_standard_xform_ops(prim: Usd.Prim) -> bool:
     Args:
         prim: The USD prim to validate.
     """
+    from pxr import UsdGeom  # noqa: PLC0415
+
     # check if prim is valid
     if not prim.IsValid():
         logger.error(f"Prim at path '{prim.GetPath().pathString}' is not valid.")
@@ -310,6 +317,8 @@ def resolve_prim_pose(
         >>> print(f"Position: {pos}")
         >>> print(f"Orientation: {quat}")
     """
+    from pxr import Sdf, Usd, UsdGeom  # noqa: PLC0415
+
     # check if prim is valid
     if not prim.IsValid():
         raise ValueError(f"Prim at path '{prim.GetPath().pathString}' is not valid.")
@@ -371,6 +380,8 @@ def resolve_prim_scale(prim: Usd.Prim) -> tuple[float, float, float]:
         >>> scale = sim_utils.resolve_prim_scale(prim)
         >>> print(f"Scale: {scale}")
     """
+    from pxr import Usd, UsdGeom  # noqa: PLC0415
+
     # check if prim is valid
     if not prim.IsValid():
         raise ValueError(f"Prim at path '{prim.GetPath().pathString}' is not valid.")
@@ -431,6 +442,8 @@ def convert_world_pose_to_local(
         >>> print(f"Local position: {local_pos}")
         >>> print(f"Local orientation: {local_quat}")
     """
+    from pxr import Gf, Sdf, Usd, UsdGeom  # noqa: PLC0415
+
     # Check if prim is valid
     if not ref_prim.IsValid():
         raise ValueError(f"Reference prim at path '{ref_prim.GetPath().pathString}' is not valid.")


### PR DESCRIPTION
Cherry-pick of #5826 (https://github.com/isaac-sim/IsaacLab/pull/5826) into ``release/3.0.0-beta2``.

## 1. Summary

- Closes NVBug 6121889 on the 3.0 beta 2 release branch: direct Cartpole (Warp) + ``--visualizer kit`` crashed during ``SimulationApp.startup`` with the ``TfNotice`` / ``UsdAPISchemaBase`` / ``GfVec3f`` converter cascade.
- Fix defers module-level ``from pxr import ...`` into the function bodies that use it across 9 modules on the env-cfg parse path, so Kit's USD-binding registration runs against a clean ``pxr`` instead of a partially-initialized one.

## 2. Cherry-pick details

- Squash-merge commit ``feba3705d72`` from develop, single-parent — clean cherry-pick, ``Auto-merging`` only (no conflict resolution needed) on ``isaaclab/sim/simulation_context.py`` and ``isaaclab/sim/utils/queries.py``.
- 10 files changed, +113 / -17. No public API change — import placement only.

## 3. Verification on this branch

- ``./isaaclab.sh -f`` clean.
- Structural guard ``test_env_cfg_no_forbidden_imports.py::[Isaac-Cartpole-Direct-v0]`` passes inside ``nvcr.io/nvidian/isaac-lab:latest-develop`` (env-cfg parse loads 0 ``pxr``/``omni``/``carb``/``isaacsim`` modules).
- Full ``rl_games`` train (5 epochs, ``--visualizer kit``) completes; Kit visualizer backend registers, checkpoint written, ``Simulation App Shutting Down`` clean.
- Literal failing command ``play.py --task Isaac-Cartpole-Direct-v0 --use_last_checkpoint --visualizer kit`` advances past ``SimulationApp.startup`` and Kit visualizer registration without the ``GfVec3f`` / ``TfNotice`` / ``UsdAPISchemaBase`` cascade.

## 4. Test plan

- [x] Pre-commit clean
- [x] Env-cfg structural guard (no backend imports on parse path)
- [x] Cartpole-Direct (Warp) + ``--visualizer kit`` train end-to-end
- [x] Cartpole-Direct (Warp) + ``--visualizer kit`` play with checkpoint reaches scene setup