### PR TITLE
[Fix] Bump daqp pin to 0.8.5 to fix Pink IK solver no-op on main CI

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.54.3"
+version = "0.54.4"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+0.54.4 (2026-06-01)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the Pink IK controller (:class:`~isaaclab.controllers.pink_ik.PinkIKController`)
+  producing a fixed ~26 mm end-effector offset that broke
+  ``test/controllers/test_pink_ik.py`` in CI. ``qpsolvers`` 4.12.0 enabled DAQP warm
+  starts, which require the ``primal_start`` argument that ``daqp`` only exposes from
+  0.8.0 onward; the pinned ``daqp==0.7.2`` lacked it. Bumped the pin to ``daqp==0.8.5``.
+
+
 0.54.3 (2026-02-04)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -52,8 +52,11 @@ SUPPORTED_ARCHS_ARM = "platform_machine in 'x86_64,AMD64,aarch64,arm64'"
 SUPPORTED_ARCHS = "platform_machine in 'x86_64,AMD64'"
 INSTALL_REQUIRES += [
     # required by isaaclab.isaaclab.controllers.pink_ik
+    # daqp>=0.8.0 is required: qpsolvers 4.12.0 enables DAQP warm starts, which need
+    # the ``primal_start`` argument that daqp only exposes from 0.8.0 onward. Pinned to
+    # 0.8.5 to match develop and avoid runtime-behavior changes in later releases.
     f"pin-pink==3.1.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
-    f"daqp==0.7.2 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
+    f"daqp==0.8.5 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
     # required by isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1_t2_dex_retargeting_utils
     f"dex-retargeting==0.4.6 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
 ]


### PR DESCRIPTION
## 1. Summary

- Fixes the ``test/controllers/test_pink_ik.py`` failures on ``main`` CI (24 failing parametrizations, ~3 weeks running, identical fixed ~26 mm end-effector offset).
- Root cause: ``qpsolvers`` 4.12.0 (2026-05-05) enabled DAQP warm starts and now passes a ``primal_start`` argument into ``daqp.solve()``. The pinned ``daqp==0.7.2`` does not accept it and raises ``TypeError: solve() got an unexpected keyword argument 'primal_start'`` on every solve. ``PinkIKController`` catches the exception and returns the joints unchanged, so Pink IK becomes a no-op and the end effectors stay at the reset pose — a fixed offset, not a kinematic error.
- Fix: bump the pin to ``daqp==0.8.5`` (the release that exposes ``primal_start``), aligning ``main`` with ``develop``.

## 2. Why it surfaced now

- ``qpsolvers`` is unpinned on ``main`` (transitive via ``pin-pink==3.1.0``, which requires ``qpsolvers>=4.3.1``), so it floats to the latest release.
- The last passing CI resolved ``qpsolvers==4.11.0``; the first failing CI resolved the just-released ``qpsolvers==4.12.0``. No ``main`` source changed between them — only the resolved dependency.
- ``daqp`` was pinned ``0.7.2`` in both the passing and failing runs, so the trigger is the ``qpsolvers`` bump interacting with the too-old ``daqp``.

## 3. Verification

Reproduced and fixed locally in the CI-equivalent container, isolating the single variable:

| qpsolvers | daqp | ``primal_start`` | test_pink_ik (GR1T2) |
|---|---|---|---|
| 4.11.0 | 0.7.2 | n/a | PASS (error ~1e-6 m) |
| 4.12.0 | 0.7.2 | absent | FAIL — ``Left hand IK position error (0.026841)`` |
| 4.12.0 | 0.8.5 | present | PASS — all variants, error collapses to <1e-3 m |

- The failing CI log contains ``solve() got an unexpected keyword argument 'primal_start'`` (the swallowed ``TypeError``); the passing CI log does not.
- The install smoke check already asserts ``'primal_start' in inspect.signature(daqp.solve).parameters``, consistent with this being the required ``daqp`` API.

## 4. Scope

- One-line dependency pin change in ``source/isaaclab/setup.py`` plus the extension version bump and changelog entry (``main`` convention).
- The broad ``except`` in ``PinkIKController`` that silently swallowed the solver error is the reason this was masked; surfacing it loudly is a larger controller change already present on ``develop`` and is intentionally out of scope for this minimal CI hotfix.

## 5. Test plan

- [x] Local repro: ``qpsolvers==4.12.0`` + ``daqp==0.7.2`` fails with the exact 26 mm offset.
- [x] Local fix: ``qpsolvers==4.12.0`` + ``daqp==0.8.5`` passes all GR1T2 ``test_pink_ik.py`` variants.
- [x] ``./isaaclab.sh -f`` clean.