### PR TITLE
[Fix] Make h1_locomotion demo runnable on main: migrate deprecated RSL-RL config and checkpoint

### DIFF
--- a/scripts/demos/h1_locomotion.py
+++ b/scripts/demos/h1_locomotion.py
@@ -18,6 +18,7 @@ This script demonstrates an interactive demo with the H1 rough terrain environme
 import argparse
 import os
 import sys
+from importlib import metadata
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.."))
 import scripts.reinforcement_learning.rsl_rl.cli_args as cli_args  # isort: skip
@@ -55,7 +56,7 @@ from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.utils.math import quat_apply
 
-from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper
+from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper, handle_deprecated_rsl_rl_cfg
 from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
 from isaaclab_tasks.manager_based.locomotion.velocity.config.h1.rough_env_cfg import H1RoughEnvCfg_PLAY
@@ -83,6 +84,7 @@ class H1RoughDemo:
         """Initializes environment config designed for the interactive model and sets up the environment,
         loads pre-trained checkpoints, and registers keyboard events."""
         agent_cfg: RslRlOnPolicyRunnerCfg = cli_args.parse_rsl_rl_cfg(TASK, args_cli)
+        agent_cfg = handle_deprecated_rsl_rl_cfg(agent_cfg, metadata.version("rsl-rl-lib"))
         # load the trained jit policy
         checkpoint = get_published_pretrained_checkpoint(RL_LIBRARY, TASK)
         # create envionrment

--- a/scripts/demos/h1_locomotion.py
+++ b/scripts/demos/h1_locomotion.py
@@ -56,7 +56,12 @@ from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.utils.math import quat_apply
 
-from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper, handle_deprecated_rsl_rl_cfg
+from isaaclab_rl.rsl_rl import (
+    RslRlOnPolicyRunnerCfg,
+    RslRlVecEnvWrapper,
+    handle_deprecated_rsl_rl_cfg,
+    handle_deprecated_rsl_rl_checkpoint,
+)
 from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
 from isaaclab_tasks.manager_based.locomotion.velocity.config.h1.rough_env_cfg import H1RoughEnvCfg_PLAY
@@ -87,6 +92,8 @@ class H1RoughDemo:
         agent_cfg = handle_deprecated_rsl_rl_cfg(agent_cfg, metadata.version("rsl-rl-lib"))
         # load the trained jit policy
         checkpoint = get_published_pretrained_checkpoint(RL_LIBRARY, TASK)
+        # convert pre-5.0 published checkpoints to the layout expected by rsl-rl >= 5.0
+        checkpoint = handle_deprecated_rsl_rl_checkpoint(checkpoint, metadata.version("rsl-rl-lib"))
         # create envionrment
         env_cfg = H1RoughEnvCfg_PLAY()
         env_cfg.scene.num_envs = 25

--- a/scripts/reinforcement_learning/rsl_rl/play.py
+++ b/scripts/reinforcement_learning/rsl_rl/play.py
@@ -84,6 +84,7 @@ from isaaclab_rl.rsl_rl import (
     export_policy_as_jit,
     export_policy_as_onnx,
     handle_deprecated_rsl_rl_cfg,
+    handle_deprecated_rsl_rl_checkpoint,
 )
 from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
@@ -162,6 +163,8 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
         runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
     else:
         raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+    # convert pre-5.0 published checkpoints to the layout expected by rsl-rl >= 5.0 (no-op otherwise)
+    resume_path = handle_deprecated_rsl_rl_checkpoint(resume_path, installed_version)
     runner.load(resume_path)
 
     # obtain the trained policy for inference

--- a/source/isaaclab_rl/config/extension.toml
+++ b/source/isaaclab_rl/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.1"
+version = "0.5.2"
 
 # Description
 title = "Isaac Lab RL"

--- a/source/isaaclab_rl/docs/CHANGELOG.rst
+++ b/source/isaaclab_rl/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.5.2 (2026-06-01)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :func:`~isaaclab_rl.rsl_rl.handle_deprecated_rsl_rl_checkpoint` to convert pre-5.0 rsl-rl
+  checkpoints (single combined ``model_state_dict``) into the ``actor``/``critic`` layout expected by
+  rsl-rl >= 5.0. This lets older published pretrained checkpoints load without
+  ``KeyError: 'actor_state_dict'``.
+
+
 0.5.1 (2026-04-21)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/__init__.py
@@ -21,4 +21,4 @@ from .rl_cfg import *
 from .rnd_cfg import RslRlRndCfg
 from .symmetry_cfg import RslRlSymmetryCfg
 from .vecenv_wrapper import RslRlVecEnvWrapper
-from .utils import handle_deprecated_rsl_rl_cfg
+from .utils import handle_deprecated_rsl_rl_cfg, handle_deprecated_rsl_rl_checkpoint

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/utils.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/utils.py
@@ -200,6 +200,69 @@ def handle_deprecated_rsl_rl_cfg(agent_cfg: RslRlBaseRunnerCfg, installed_versio
     return agent_cfg
 
 
+def handle_deprecated_rsl_rl_checkpoint(checkpoint_path: str, installed_version) -> str:
+    """Convert a pre-5.0 rsl-rl checkpoint to the layout expected by rsl-rl >= 5.0.
+
+    Older rsl-rl versions saved a single combined ``model_state_dict`` (with ``actor.*``, ``critic.*``
+    and a top-level ``std`` parameter). rsl-rl >= 5.0 instead expects separate ``actor_state_dict`` and
+    ``critic_state_dict`` entries, so the published pretrained checkpoints shipped with older asset
+    releases fail to load with ``KeyError: 'actor_state_dict'``. This converts such a checkpoint into a
+    sibling file and returns its path. New-layout checkpoints, unrecognized payloads, and installations
+    of rsl-rl < 5.0 are returned unchanged.
+
+    Args:
+        checkpoint_path: Path to the checkpoint to (possibly) convert.
+        installed_version: Installed ``rsl-rl-lib`` version string.
+
+    Returns:
+        Path to a checkpoint compatible with the installed rsl-rl version.
+
+    Raises:
+        ValueError: If the checkpoint uses the deprecated combined layout but contains a key that does
+            not map to the ``actor``/``critic``/``std`` structure expected from older rsl-rl versions.
+    """
+    import os
+
+    import torch
+
+    if version.parse(str(installed_version)) < _V5_0_0:
+        return checkpoint_path
+
+    loaded = torch.load(checkpoint_path, weights_only=False, map_location="cpu")
+    # Only the deprecated combined layout needs conversion; leave new-layout/unknown payloads untouched.
+    if not isinstance(loaded, dict) or "actor_state_dict" in loaded or "model_state_dict" not in loaded:
+        return checkpoint_path
+
+    actor_state_dict: dict = {}
+    critic_state_dict: dict = {}
+    for key, value in loaded["model_state_dict"].items():
+        if key == "std":
+            actor_state_dict["distribution.std_param"] = value
+        elif key.startswith("actor."):
+            actor_state_dict["mlp." + key[len("actor.") :]] = value
+        elif key.startswith("critic."):
+            critic_state_dict["mlp." + key[len("critic.") :]] = value
+        else:
+            raise ValueError(
+                f"Unrecognized key '{key}' while converting deprecated rsl-rl checkpoint '{checkpoint_path}'."
+                " Only MLP actor-critic checkpoints from rsl-rl < 5.0 are supported for automatic conversion."
+            )
+
+    converted = {
+        "actor_state_dict": actor_state_dict,
+        "critic_state_dict": critic_state_dict,
+        # Carry the remaining payload so the runner's loader behaves as it does for native checkpoints.
+        "optimizer_state_dict": loaded.get("optimizer_state_dict"),
+        "iter": loaded.get("iter", 0),
+        "infos": loaded.get("infos"),
+    }
+    root, ext = os.path.splitext(checkpoint_path)
+    converted_path = f"{root}_rslrl5{ext}"
+    torch.save(converted, converted_path)
+    print(f"[INFO]: Converted deprecated rsl-rl checkpoint to '{converted_path}'.")
+    return converted_path
+
+
 def _is_missing(value) -> bool:
     return isinstance(value, type(MISSING))
 

--- a/source/isaaclab_rl/test/test_rsl_rl_cfg_deprecation.py
+++ b/source/isaaclab_rl/test/test_rsl_rl_cfg_deprecation.py
@@ -17,6 +17,7 @@ simulation_app = app_launcher.app
 from dataclasses import MISSING
 
 import pytest
+import torch
 
 from isaaclab_rl.rsl_rl import (
     RslRlDistillationAlgorithmCfg,
@@ -30,7 +31,7 @@ from isaaclab_rl.rsl_rl import (
     RslRlPpoAlgorithmCfg,
     RslRlRNNModelCfg,
 )
-from isaaclab_rl.rsl_rl.utils import _is_missing, handle_deprecated_rsl_rl_cfg
+from isaaclab_rl.rsl_rl.utils import _is_missing, handle_deprecated_rsl_rl_cfg, handle_deprecated_rsl_rl_checkpoint
 
 
 def _ppo_algo():
@@ -531,3 +532,54 @@ class TestV5:
     def test_returns_same_object(self):
         cfg = _on_policy_runner(policy=_ppo_mlp_policy(), algorithm=_ppo_algo())
         assert handle_deprecated_rsl_rl_cfg(cfg, "5.0.0") is cfg
+
+
+def _deprecated_checkpoint() -> dict:
+    """A pre-5.0 rsl-rl checkpoint: single combined ``model_state_dict`` with ``actor.*``/``critic.*``/``std``."""
+    return {
+        "model_state_dict": {
+            "std": torch.ones(3),
+            "actor.0.weight": torch.zeros(4, 5),
+            "actor.0.bias": torch.zeros(4),
+            "critic.0.weight": torch.zeros(1, 5),
+            "critic.0.bias": torch.zeros(1),
+        },
+        "optimizer_state_dict": {"state": {}, "param_groups": []},
+        "iter": 42,
+        "infos": None,
+    }
+
+
+class TestHandleDeprecatedRslRlCheckpoint:
+    def test_converts_combined_state_dict(self, tmp_path):
+        path = str(tmp_path / "checkpoint.pt")
+        torch.save(_deprecated_checkpoint(), path)
+
+        out = handle_deprecated_rsl_rl_checkpoint(path, "5.0.1")
+
+        assert out != path
+        converted = torch.load(out, weights_only=False)
+        assert set(converted["actor_state_dict"]) == {"distribution.std_param", "mlp.0.weight", "mlp.0.bias"}
+        assert set(converted["critic_state_dict"]) == {"mlp.0.weight", "mlp.0.bias"}
+        assert converted["iter"] == 42
+        # values are preserved through the remap
+        torch.testing.assert_close(converted["actor_state_dict"]["distribution.std_param"], torch.ones(3))
+
+    def test_new_layout_passthrough(self, tmp_path):
+        path = str(tmp_path / "checkpoint.pt")
+        torch.save({"actor_state_dict": {}, "critic_state_dict": {}, "iter": 0, "infos": None}, path)
+        assert handle_deprecated_rsl_rl_checkpoint(path, "5.0.1") == path
+
+    def test_old_rsl_rl_passthrough(self, tmp_path):
+        path = str(tmp_path / "checkpoint.pt")
+        torch.save(_deprecated_checkpoint(), path)
+        # rsl-rl < 5.0 reads the combined layout natively, so no conversion should happen
+        assert handle_deprecated_rsl_rl_checkpoint(path, "4.1.0") == path
+
+    def test_unrecognized_key_raises(self, tmp_path):
+        path = str(tmp_path / "checkpoint.pt")
+        ckpt = _deprecated_checkpoint()
+        ckpt["model_state_dict"]["unexpected.0.weight"] = torch.zeros(2)
+        torch.save(ckpt, path)
+        with pytest.raises(ValueError):
+            handle_deprecated_rsl_rl_checkpoint(path, "5.0.1")


### PR DESCRIPTION
## 1. Summary

- Fixes NVBug 6120938 (P0): ``./isaaclab.sh -p scripts/demos/h1_locomotion.py`` crashes on ``main`` (Isaac Sim 5.1.0, ``rsl-rl-lib==5.0.1``). Two sequential incompatibilities with rsl-rl 5.x; both fixed here.
- Crash 1 — ``KeyError: 'class_name'`` at ``OnPolicyRunner`` construction: the H1 agent config uses the deprecated ``policy`` field; rsl-rl 5.x expects per-model ``actor``/``critic`` configs. Fixed by ``handle_deprecated_rsl_rl_cfg`` in the demo (as ``train.py``/``play.py`` already do).
- Crash 2 — ``KeyError: 'actor_state_dict'`` at ``runner.load()``: the published H1 checkpoint (Isaac 5.1 assets) was saved in the pre-5.0 layout (single combined ``model_state_dict``), while rsl-rl 5.x expects separate ``actor_state_dict``/``critic_state_dict``. Fixed by a new ``handle_deprecated_rsl_rl_checkpoint`` helper that remaps the old layout, applied before loading.

## 2. Why both are needed

The cfg migration alone unblocks construction but the demo then fails loading the old-format published checkpoint. ``develop``'s demo avoids the second crash only because its newer (Isaac 6.0) assets ship the checkpoint in the new layout — there is no conversion code there. On ``main`` (5.1 assets) the checkpoint must be converted.

## 3. Changes

- ``source/isaaclab_rl/isaaclab_rl/rsl_rl/utils.py``: add ``handle_deprecated_rsl_rl_checkpoint`` — remaps ``actor.N``→``actor_state_dict.mlp.N``, ``critic.N``→``critic_state_dict.mlp.N``, ``std``→``actor_state_dict.distribution.std_param``; new-layout checkpoints and rsl-rl < 5.0 pass through unchanged; raises on unrecognized keys.
- ``scripts/demos/h1_locomotion.py``: migrate the agent config, then convert the checkpoint before ``ppo_runner.load``.
- ``scripts/reinforcement_learning/rsl_rl/play.py``: apply the same converter to the resolved checkpoint before ``runner.load`` (covers ``--use_pretrained_checkpoint``, which loads the same old published checkpoint; no-op for locally-trained checkpoints).
- ``source/isaaclab_rl/test/test_rsl_rl_cfg_deprecation.py``: unit tests for the converter.
- ``isaaclab_rl`` version bump + changelog.

## 4. Verification

In an Isaac Sim 5.1.0 + ``rsl-rl-lib==5.0.1`` container (the demo's GUI viewport needs a display the CI host lacks; the bug is upstream of rendering, so validated headless on the real code paths):

- Demo, unmodified → ``KeyError: 'class_name'``; cfg-only → ``KeyError: 'actor_state_dict'``; with both fixes → the real ``h1_locomotion`` module's ``__init__`` completes (config migrates, checkpoint converts via strict-matching ``load_state_dict``, ``runner.load`` succeeds) and the policy steps with finite joint targets.
- ``play.py --use_pretrained_checkpoint``: unmodified → ``KeyError: 'actor_state_dict'`` at ``runner.load``; with the converter → checkpoint converts, loads, and the policy runs.
- Converter unit tests: 4 passed. ``./isaaclab.sh -f`` clean.

## 5. Test plan

- [x] Container repro of both demo crashes (unmodified / cfg-only).
- [x] Real ``h1_locomotion`` module runs headless end-to-end with both fixes (init completes + inference).
- [x] ``play.py --use_pretrained_checkpoint`` FAIL→PASS with the converter.
- [x] Converter unit tests + pre-commit clean.