### PR TITLE
Clarify wording in pytetwild spark limitation

### DIFF
--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -99,9 +99,9 @@ Other notable limitations with respect to Isaac Lab include...
 
 #. :ref:`Running Cosmos Transfer1 <running-cosmos>` is not currently supported on the DGX Spark.
 
-#. Newton VBD deformable support is limited on DGX Spark due to the availability of the
-   ``pytetwild`` library on ARM (aarch64). ``pytetwild`` is required for automatic
-   tetrahedral mesh generation of volume deformables.
+#. Newton VBD deformable support is limited on DGX Spark because no pre-built
+   ``pytetwild`` wheel is available for ARM (aarch64). ``pytetwild`` is required for
+   automatic tetrahedral mesh generation of volume deformables.
 
 .. note::
 


### PR DESCRIPTION
# Description

Clarify wording in pytetwild spark limitation to make it clear that the package is not built on arm.

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
