### PR TITLE
Fixes wheel submodules discoverability

### DIFF
--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -31,8 +31,6 @@ pip extras include:
      - What it installs
    * - ``isaacsim``
      - Isaac Sim (``isaacsim[all,extscache]==6.0.0.*``) from `pypi.nvidia.com <https://pypi.nvidia.com>`_
-   * - ``rl-games``
-     - RL-Games framework dependencies
    * - ``all``
      - RL frameworks (SB3, SKRL, RL-Games, RSL-RL). Combine with ``isaacsim`` for a full install.
 

--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -20,8 +20,8 @@ To learn about how to set up your own project on top of Isaac Lab, please see :r
 Installing Isaac Lab
 ~~~~~~~~~~~~~~~~~~~~
 
-The ``isaaclab`` pip wheel bundles all Isaac Lab extensions. Two optional pip
-extras are supported:
+The ``isaaclab`` pip wheel bundles all Isaac Lab extensions. Common optional
+pip extras include:
 
 .. list-table::
    :header-rows: 1
@@ -31,8 +31,10 @@ extras are supported:
      - What it installs
    * - ``isaacsim``
      - Isaac Sim (``isaacsim[all,extscache]==6.0.0.*``) from `pypi.nvidia.com <https://pypi.nvidia.com>`_
+   * - ``rl-games``
+     - RL-Games framework dependencies
    * - ``all``
-     - RL frameworks (SB3, SKRL, RSL-RL). Combine with ``isaacsim`` for a full install.
+     - RL frameworks (SB3, SKRL, RL-Games, RSL-RL). Combine with ``isaacsim`` for a full install.
 
 Install with ``isaaclab[isaacsim,all]`` for the full workflow.
 
@@ -131,13 +133,6 @@ Installing dependencies
             When using ``./isaaclab.sh -p``, this is handled automatically.
             When using a conda environment,
             the preload is set up via the conda activation hook.
-
--  ``rl_games`` is not included in ``[all]``. To use it, install its Python 3.11+
-   enabled fork manually:
-
-   .. code-block:: none
-
-      pip install git+https://github.com/isaac-sim/rl_games.git@python3.11
 
 .. include:: include/pip_verify_isaacsim.rst
 

--- a/source/isaaclab/changelog.d/fix-wheel-extension-discovery.rst
+++ b/source/isaaclab/changelog.d/fix-wheel-extension-discovery.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed the pip wheel build so that extensions promoted to top-level packages
+  (e.g. ``isaaclab_assets``, ``isaaclab_tasks``, ``isaaclab_rl``) keep their
+  ``config/extension.toml`` under ``isaaclab/source/`` where the bundled Kit
+  experience files search for them. Without this, launching a Kit app from the
+  wheel failed during dependency resolution with
+  ``isaaclab_assets ... (none found)`` before the simulator started.

--- a/source/isaaclab/changelog.d/wheel-rl-games.rst
+++ b/source/isaaclab/changelog.d/wheel-rl-games.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added the ``rl-games`` optional dependency to the ``isaaclab`` wheel and
+  included it in the wheel's ``all`` extra.

--- a/source/isaaclab/test/install_ci/misc/test_wheel_builder_smoke.py
+++ b/source/isaaclab/test/install_ci/misc/test_wheel_builder_smoke.py
@@ -11,6 +11,7 @@ Setup:
 Tests:
     - import isaaclab -> verify importable
     - from isaaclab import __version__ -> verify version matches wheel filename
+    - from isaaclab import _deprioritize_prebundle_paths -> verify wheel exports path sanitizer
     - from isaaclab.app import AppLauncher -> verify importable
     - from isaaclab.envs import ViewerCfg -> verify importable
     - from isaaclab_assets.robots.allegro import ALLEGRO_HAND_CFG -> verify importable
@@ -90,6 +91,14 @@ class Test_Wheel_Builder_Smoke(UV_Mixin):
             f"isaaclab.__version__ mismatch: expected {expected_version}, got {imported_version}"
         )
 
+    # from isaaclab import _deprioritize_prebundle_paths
+    def test_isaaclab_prebundle_path_sanitizer_exported(self):
+        """Verify the wheel exports the prebundle path sanitizer used by AppLauncher."""
+        result = self.run_in_uv_env(
+            ["python", "-c", "from isaaclab import _deprioritize_prebundle_paths; _deprioritize_prebundle_paths()"]
+        )
+        assert result.returncode == 0, f"import path sanitizer failed:\n{result.stdout}\n{result.stderr}"
+
     # from isaaclab.app import AppLauncher
     def test_isaaclab_app_importable(self):
         """Verify isaaclab.app and AppLauncher are importable."""
@@ -144,14 +153,16 @@ class Test_Wheel_Builder_Smoke(UV_Mixin):
         # ``config/extension.toml`` (the core ``isaaclab`` package is handled separately and is
         # not promoted, so it is intentionally excluded here).
         promoted = sorted(
-            {match.group(1) for name in names if (match := re.fullmatch(r"(isaaclab_[^/]+)/config/extension.toml", name))}
+            {
+                match.group(1)
+                for name in names
+                if (match := re.fullmatch(r"(isaaclab_[^/]+)/config/extension.toml", name))
+            }
         )
         assert promoted, f"No promoted extensions found in wheel {self._wheel}; namelist may have changed."
         assert "isaaclab_assets" in promoted, f"Expected isaaclab_assets among promoted extensions, got: {promoted}"
 
-        missing = [
-            ext for ext in promoted if f"isaaclab/source/{ext}/config/extension.toml" not in names
-        ]
+        missing = [ext for ext in promoted if f"isaaclab/source/{ext}/config/extension.toml" not in names]
         assert not missing, (
             "Promoted extensions are missing their Kit-discoverable config/extension.toml under "
             f"isaaclab/source/ (Kit dependency resolution will fail for these): {missing}"

--- a/source/isaaclab/test/install_ci/misc/test_wheel_builder_smoke.py
+++ b/source/isaaclab/test/install_ci/misc/test_wheel_builder_smoke.py
@@ -17,12 +17,16 @@ Tests:
     - from isaaclab.scene import InteractiveSceneCfg -> verify importable
     - python -m isaaclab --help -> verify CLI functional
     - import pinocchio -> verify importable
+    - inspect built wheel -> verify each promoted extension keeps
+        isaaclab/source/<ext>/config/extension.toml for Kit discovery
 """
 
 from __future__ import annotations
 
 import glob
+import re
 import shutil
+import zipfile
 
 import pytest
 from utils import UV_Mixin, run_cmd
@@ -121,3 +125,34 @@ class Test_Wheel_Builder_Smoke(UV_Mixin):
         """Verify pinocchio is importable and has the expected version."""
         result = self.run_in_uv_env(["python", "-c", "import pinocchio as pin; print(pin.__version__)"])
         assert result.returncode == 0, f"import pinocchio failed:\n{result.stdout}\n{result.stderr}"
+
+    # inspect the built wheel's file layout
+    def test_promoted_extensions_remain_discoverable_under_source(self):
+        """Each promoted extension must keep ``isaaclab/source/<ext>/config/extension.toml``.
+
+        The ``apps/*.kit`` experience files register ``${app}/../source`` as a Kit extension
+        search folder. ``build.sh`` promotes each extension's Python package to the top level
+        (for ``import isaaclab_<ext>``); if it also drops the extension from ``source/`` then Kit
+        cannot resolve it and the dependency solver aborts with
+        ``isaaclab_assets ... (none found)`` before the app starts. This guards against that
+        regression by checking the wheel layout directly.
+        """
+        with zipfile.ZipFile(self._wheel) as wheel:
+            names = set(wheel.namelist())
+
+        # Promoted extensions are top-level packages named ``isaaclab_<ext>`` that ship a
+        # ``config/extension.toml`` (the core ``isaaclab`` package is handled separately and is
+        # not promoted, so it is intentionally excluded here).
+        promoted = sorted(
+            {match.group(1) for name in names if (match := re.fullmatch(r"(isaaclab_[^/]+)/config/extension.toml", name))}
+        )
+        assert promoted, f"No promoted extensions found in wheel {self._wheel}; namelist may have changed."
+        assert "isaaclab_assets" in promoted, f"Expected isaaclab_assets among promoted extensions, got: {promoted}"
+
+        missing = [
+            ext for ext in promoted if f"isaaclab/source/{ext}/config/extension.toml" not in names
+        ]
+        assert not missing, (
+            "Promoted extensions are missing their Kit-discoverable config/extension.toml under "
+            f"isaaclab/source/ (Kit dependency resolution will fail for these): {missing}"
+        )

--- a/source/isaaclab_physx/changelog.d/fix-wheel-submodules.rst
+++ b/source/isaaclab_physx/changelog.d/fix-wheel-submodules.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed PhysX tensor imports when using wheel-installed Isaac Sim packages.

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -45,7 +45,7 @@ from .articulation_data import ArticulationData
 if TYPE_CHECKING:
     from isaaclab_newton.actuators import NewtonActuatorAdapter
 
-    import omni.physics.tensors.api as physx
+    import omni.physics.tensors as physx
 
     from isaaclab.assets.articulation.articulation_cfg import ArticulationCfg
 

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation_data.py
@@ -22,7 +22,7 @@ from isaaclab_physx.assets.articulation import kernels as articulation_kernels
 from isaaclab_physx.physics import PhysxManager as SimulationManager
 
 if TYPE_CHECKING:
-    import omni.physics.tensors.api as physx
+    import omni.physics.tensors as physx
 
 # import logger
 logger = logging.getLogger(__name__)

--- a/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object.py
@@ -14,7 +14,6 @@ import numpy as np
 import torch
 import warp as wp
 
-import omni.physics.tensors as physx
 from pxr import UsdShade
 
 import isaaclab.sim as sim_utils
@@ -35,6 +34,8 @@ from .kernels import (
 )
 
 if TYPE_CHECKING:
+    import omni.physics.tensors as physx
+
     from .deformable_object_cfg import DeformableObjectCfg
 
 # import logger

--- a/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 import warp as wp
 
-import omni.physics.tensors.api as physx
+import omni.physics.tensors as physx
 from pxr import UsdShade
 
 import isaaclab.sim as sim_utils

--- a/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object_data.py
@@ -2,17 +2,20 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 
 import weakref
+from typing import TYPE_CHECKING
 
 import warp as wp
-
-import omni.physics.tensors as physx
 
 from isaaclab.utils.buffers import TimestampedBufferWarp as TimestampedBuffer
 from isaaclab.utils.warp import ProxyArray
 
 from .kernels import compute_mean_vec3f_over_vertices, compute_nodal_state_w, vec6f
+
+if TYPE_CHECKING:
+    import omni.physics.tensors as physx
 
 
 class DeformableObjectData:

--- a/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object_data.py
@@ -7,7 +7,7 @@ import weakref
 
 import warp as wp
 
-import omni.physics.tensors.api as physx
+import omni.physics.tensors as physx
 
 from isaaclab.utils.buffers import TimestampedBufferWarp as TimestampedBuffer
 from isaaclab.utils.warp import ProxyArray

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
@@ -26,7 +26,7 @@ from isaaclab_physx.physics import PhysxManager as SimulationManager
 from .rigid_object_data import RigidObjectData
 
 if TYPE_CHECKING:
-    import omni.physics.tensors.api as physx
+    import omni.physics.tensors as physx
 
     from isaaclab.assets.rigid_object.rigid_object_cfg import RigidObjectCfg
 

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object_data.py
@@ -21,7 +21,7 @@ from isaaclab_physx.assets import kernels as shared_kernels
 from isaaclab_physx.physics import PhysxManager as SimulationManager
 
 if TYPE_CHECKING:
-    import omni.physics.tensors.api as physx
+    import omni.physics.tensors as physx
 
 # import logger
 logger = logging.getLogger(__name__)

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch
 import warp as wp
 
-import omni.physics.tensors.api as physx
+import omni.physics.tensors as physx
 from pxr import UsdPhysics
 
 import isaaclab.sim as sim_utils

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -21,7 +21,7 @@ from isaaclab_physx.assets import kernels as shared_kernels
 from isaaclab_physx.physics import PhysxManager as SimulationManager
 
 if TYPE_CHECKING:
-    import omni.physics.tensors.api as physx
+    import omni.physics.tensors as physx
 
 # import logger
 logger = logging.getLogger(__name__)

--- a/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 import torch
 import warp as wp
 
-import omni.physics.tensors.api as physx
+import omni.physics.tensors as physx
 
 from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.markers import VisualizationMarkers

--- a/source/isaaclab_physx/isaaclab_physx/sensors/joint_wrench/joint_wrench_sensor.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/joint_wrench/joint_wrench_sensor.py
@@ -25,7 +25,7 @@ from .joint_wrench_sensor_data import JointWrenchSensorData
 from .kernels import joint_wrench_reset_kernel, joint_wrench_split_kernel
 
 if TYPE_CHECKING:
-    import omni.physics.tensors.api as physx
+    import omni.physics.tensors as physx
 
     from isaaclab.sensors.joint_wrench import JointWrenchSensorCfg
 

--- a/tools/wheel_builder/build.sh
+++ b/tools/wheel_builder/build.sh
@@ -65,8 +65,14 @@ for ext_dir in "$BUILD_DIR"/src/isaaclab/source/isaaclab_*; do
         # the package dir rather than one level up.
         sed -i 's|os\.path\.join(os\.path\.dirname(__file__), "\.\./"|os.path.join(os.path.dirname(__file__), ""|g' \
             "$BUILD_DIR/src/$pkg/__init__.py"
-        # Remove the original from inside the isaaclab bundle to avoid duplication
-        rm -rf "$ext_dir"
+        # Keep the extension discoverable by Kit under source/. The .kit experience
+        # files in apps/ register "${app}/../source" as an extension search folder,
+        # so each extension's config/extension.toml must remain there or the Kit
+        # dependency solver fails with "isaaclab_assets ... (none found)". We drop
+        # the inner Python package (imported from the promoted top-level copy above)
+        # and the duplicated data/ to avoid a second copy on sys.path and bloat,
+        # but leave config/extension.toml in place for discovery.
+        rm -rf "$inner" "$ext_dir/data"
     fi
 done
 

--- a/tools/wheel_builder/res/__init__.py
+++ b/tools/wheel_builder/res/__init__.py
@@ -14,6 +14,79 @@ __version__ = version("isaaclab")
 # nested source tree are importable as isaaclab.app, isaaclab.envs, etc.
 __path__.append(os.path.join(os.path.dirname(__file__), "source", "isaaclab", "isaaclab"))
 
+
+def _deprioritize_prebundle_paths():
+    """Move Isaac Sim ``pip_prebundle`` and known conflicting extension directories to the end of ``sys.path``.
+
+    Isaac Sim's ``setup_python_env.sh`` injects ``pip_prebundle`` directories
+    onto ``PYTHONPATH``. These contain older copies of packages like torch,
+    warp, and nvidia-cudnn that shadow the versions installed by Isaac Lab,
+    causing CUDA runtime errors.
+
+    Additionally, certain Isaac Sim kit extensions (such as ``omni.warp.core``)
+    bundle their own copies of Python packages that conflict with pip-installed
+    versions. When loaded by the extension system these paths can appear on
+    ``sys.path`` before ``site-packages``, leading to version mismatches.
+
+    Rather than removing these paths entirely (which would break packages like
+    ``sympy`` that only exist in the prebundle), this function moves them to
+    the **end** of ``sys.path`` so that pip-installed packages in
+    ``site-packages`` take priority.
+
+    The ``PYTHONPATH`` environment variable is also rewritten so that child
+    processes inherit the corrected ordering.
+    """
+
+    # Extension directory fragments that are known to ship Python packages
+    # which conflict with Isaac Lab's pip-installed versions.
+    _CONFLICTING_EXT_FRAGMENTS = (
+        "omni.warp.core",
+        "omni.isaac.ml_archive",
+        "omni.isaac.core_archive",
+        "omni.kit.pip_archive",
+        "isaacsim.pip.newton",
+    )
+
+    def _should_demote(path: str) -> bool:
+        norm = path.replace("\\", "/").lower()
+        if "pip_prebundle" in norm:
+            return True
+        for frag in _CONFLICTING_EXT_FRAGMENTS:
+            if frag.lower() in norm:
+                return True
+        return False
+
+    # Partition: keep non-conflicting in place, collect conflicting.
+    clean = []
+    demoted = []
+    for p in sys.path:
+        if _should_demote(p):
+            demoted.append(p)
+        else:
+            clean.append(p)
+
+    if not demoted:
+        return
+
+    # Rebuild sys.path: originals first, then demoted at the very end.
+    sys.path[:] = clean + demoted
+
+    # Rewrite PYTHONPATH with the same ordering for subprocesses.
+    if "PYTHONPATH" in os.environ:
+        parts = os.environ["PYTHONPATH"].split(os.pathsep)
+        env_clean = []
+        env_demoted = []
+        for p in parts:
+            if _should_demote(p):
+                env_demoted.append(p)
+            else:
+                env_clean.append(p)
+        os.environ["PYTHONPATH"] = os.pathsep.join(env_clean + env_demoted)
+
+
+_deprioritize_prebundle_paths()
+
+
 # TODO(myurasov-nv): bootstrap_kernel() is ported from the internal GitLab wheel builder
 # for backwards compatibility. It is not called currently, but may be needed if Isaac Sim
 # requires explicit kernel bootstrapping before use. Remove once confirmed unnecessary.
@@ -29,6 +102,7 @@ def bootstrap_kernel():
         if find_spec("carb") is not None:
             import carb
             carb.log_info(f"Isaac Lab path: {isaaclab_path}")
+
 
 def main():
     """Entry point for the ``isaaclab`` console script (python -m isaaclab)."""

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -97,8 +97,12 @@ pyproject.optional-dependencies.all = [
     # RL libraries
     { "sb3" = ["stable-baselines3>=2.6", "tqdm", "rich"] },
     { "skrl" = ["skrl>=2.1.0"] },
-    # { "rl-games" = ["rl-games==1.6.1"] },  # TODO: re-enable when rl-games Python package supports Python 3.11
-    # { "rl_games" = ["rl-games==1.6.1"] },  # TODO: re-enable when rl-games Python package supports Python 3.11
+    # Do not pin aiohttp here: isaacsim-kernel==6.0.0.0 pins aiohttp==3.12.14.
+    { "rl-games" = [
+        "rl-games @ git+https://github.com/isaac-sim/rl_games.git@python3.11",
+        "gym",
+        "standard-distutils",
+    ] },
     { "rsl-rl" = ["rsl-rl-lib==5.0.1", "onnxscript>=0.5"] },
     { "rsl_rl" = ["rsl-rl-lib==5.0.1", "onnxscript>=0.5"] },
     # ================================================================================
@@ -114,7 +118,9 @@ pyproject.optional-dependencies.all = [
         "tqdm",
         "rich",
         "skrl>=2.1.0",
-        # "rl-games==1.6.1",  # TODO: re-enable when rl-games Python package supports Python 3.11
+        "rl-games @ git+https://github.com/isaac-sim/rl_games.git@python3.11",
+        "gym",
+        "standard-distutils",
         "rsl-rl-lib==5.0.1",
         "onnxscript>=0.5",
     ] },


### PR DESCRIPTION
# Description

Fix wheel building process to make submodules discoverable on existing .kit files.
Add rlgames back into the prebuilt wheel.


## Type of change

- Documentation update


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
