### PR TITLE
Juana/update tacsl

### DIFF
--- a/docs/source/experimental-features/visuo_tactile_sensor.rst
+++ b/docs/source/experimental-features/visuo_tactile_sensor.rst
@@ -114,8 +114,7 @@ To use the tactile sensor in a simulation environment, run the demo:
 
 .. code-block:: bash
 
-    cd scripts/demos/sensors
-    python tacsl_sensor.py --use_tactile_rgb --use_tactile_ff --tactile_compliance_stiffness 100.0 --tactile_compliant_damping 1.0 --contact_object_type nut --num_envs 16 --save_viz --enable_cameras
+    ./isaaclab.sh -p scripts/demos/sensors/tacsl_sensor.py --use_tactile_rgb --use_tactile_ff --tactile_compliance_stiffness 100.0 --tactile_compliant_damping 1.0 --contact_object_type nut --num_envs 16 --save_viz --enable_cameras --viz kit
 
 Available command-line options include:
 
@@ -129,15 +128,24 @@ Available command-line options include:
 * ``--normal_contact_stiffness``: Normal contact stiffness for force field computation
 * ``--tangential_stiffness``: Tangential stiffness for shear forces
 * ``--friction_coefficient``: Friction coefficient for shear forces
+* ``--viz``: Select one or more visualizers, such as ``kit`` or ``newton``
 * ``--debug_sdf_closest_pts``: Visualize closest SDF points for debugging
 * ``--debug_tactile_sensor_pts``: Visualize tactile sensor points for debugging
 * ``--trimesh_vis_tactile_points``: Enable trimesh-based visualization of tactile points
+
+.. note::
+
+   Since Isaac Lab 3.0, visualizers are selected independently from the simulation backend. Use the ``--viz``
+   argument to choose the visualizer backend, such as ``kit`` or ``newton``. The TacSL demo currently supports
+   only the PhysX simulation backend; running the tactile sensor simulation with the Newton backend is not
+   supported.
+
 
 For a complete list of available options:
 
 .. code-block:: bash
 
-    python tacsl_sensor.py -h
+    ./isaaclab.sh -p scripts/demos/sensors/tacsl_sensor.py -h
 
 .. note::
    The demo examples are based on the Gelsight R1.5, which is a prototype sensor that is now discontinued. The same procedure can be adapted for other visuotactile sensors.

--- a/scripts/demos/sensors/tacsl_sensor.py
+++ b/scripts/demos/sensors/tacsl_sensor.py
@@ -19,7 +19,8 @@ tactile sensing with the GelSight finger setup.
         --num_envs 16 \
         --contact_object_type nut \
         --save_viz \
-        --enable_cameras
+        --enable_cameras \
+        --viz kit/newton
 
 """
 
@@ -123,11 +124,13 @@ class TactileSensorsSceneCfg(InteractiveSceneCfg):
                 solver_position_iteration_count=12,
                 solver_velocity_iteration_count=1,
             ),
-            collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.001, rest_offset=-0.0005),
+            collision_props=sim_utils.CollisionPropertiesCfg(
+                contact_offset=0.001, rest_offset=-0.0005
+            ),
         ),
         init_state=ArticulationCfg.InitialStateCfg(
             pos=(0.0, 0.0, 0.5),
-            rot=(math.sqrt(2) / 2, -math.sqrt(2) / 2, 0.0, 0.0),  # 90° rotation
+            rot=(-math.sqrt(2) / 2, 0.0, 0.0, math.sqrt(2) / 2),  # 90° rotation
             joint_pos={},
             joint_vel={},
         ),
@@ -139,7 +142,6 @@ class TactileSensorsSceneCfg(InteractiveSceneCfg):
     # TacSL Tactile Sensor
     tactile_sensor = VisuoTactileSensorCfg(
         prim_path="{ENV_REGEX_NS}/Robot/elastomer/tactile_sensor",
-        history_length=0,
         debug_vis=args_cli.debug_tactile_sensor_pts or args_cli.debug_sdf_closest_pts,
         # Sensor configuration
         render_cfg=GELSIGHT_R15_CFG,
@@ -185,7 +187,7 @@ class CubeTactileSceneCfg(TactileSensorsSceneCfg):
             physics_material=sim_utils.RigidBodyMaterialCfg(),
             visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.1, 0.1)),
         ),
-        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0 + 0.06776, 0.51), rot=(1.0, 0.0, 0.0, 0.0)),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0 + 0.06776, 0.51), rot=(0.0, 0.0, 0.0, 1.0)),
     )
 
 
@@ -210,7 +212,7 @@ class NutTactileSceneCfg(TactileSensorsSceneCfg):
         ),
         init_state=RigidObjectCfg.InitialStateCfg(
             pos=(0.0, 0.0 + 0.06776, 0.498),
-            rot=(1.0, 0.0, 0.0, 0.0),
+            rot=(0.0, 0.0, 0.0, 1.0),
         ),
     )
 
@@ -382,12 +384,14 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
 
 def main():
     """Main function."""
+    from isaaclab_physx.physics import PhysxCfg
+
     # Initialize simulation
     # Note: We set the gpu_collision_stack_size to prevent buffer overflow in contact-rich environments.
     sim_cfg = sim_utils.SimulationCfg(
         dt=0.005,
         device=args_cli.device,
-        physx=sim_utils.PhysxCfg(gpu_collision_stack_size=2**30),
+        physics=PhysxCfg(gpu_collision_stack_size=2**30),
     )
     sim = sim_utils.SimulationContext(sim_cfg)
 
@@ -414,8 +418,20 @@ def main():
 
     scene = InteractiveScene(scene_cfg)
 
+
     # Initialize simulation
     sim.reset()
+
+    # The tactile RGB path internally uses an RTX camera that may request only non-color render products.
+    # Isaac RTX can disable color rendering for that case, which makes the Kit viewport black even though
+    # the sensor images are produced correctly. Keep color rendering enabled when a Kit viewport is active.
+    visualizers = args_cli.visualizer
+    if isinstance(visualizers, str):
+        visualizers = [token.strip() for token in visualizers.split(",")]
+    if args_cli.use_tactile_rgb and "kit" in visualizers:
+        print("[INFO]: Keeping RTX color rendering enabled for Kit viewport visualization.")
+        sim.set_setting("/rtx/sdg/force/disableColorRender", False)
+
     print("[INFO]: Setup complete...")
 
     # Get initial render

--- a/scripts/demos/sensors/tacsl_sensor.py
+++ b/scripts/demos/sensors/tacsl_sensor.py
@@ -20,7 +20,7 @@ tactile sensing with the GelSight finger setup.
         --contact_object_type nut \
         --save_viz \
         --enable_cameras \
-        --viz kit/newton
+        --viz kit/newton 
 
 """
 
@@ -69,8 +69,6 @@ parser.add_argument(
 
 # Append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
-# demos should open Kit visualizer by default
-parser.set_defaults(visualizer=["kit"])
 # Parse the arguments
 args_cli = parser.parse_args()
 
@@ -86,7 +84,12 @@ from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import CameraCfg
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
-from isaaclab.utils.timer import Timer
+from isaaclab_physx.sim.schemas import (
+    PhysxArticulationRootPropertiesCfg,
+    PhysxCollisionPropertiesCfg,
+    PhysxRigidBodyPropertiesCfg,
+)
+from isaaclab_physx.sim.spawners.materials import PhysxRigidBodyMaterialCfg
 
 from isaaclab_contrib.sensors.tacsl_sensor import VisuoTactileSensorCfg
 from isaaclab_contrib.sensors.tacsl_sensor.visuotactile_render import compute_tactile_shear_image
@@ -112,19 +115,19 @@ class TactileSensorsSceneCfg(InteractiveSceneCfg):
         prim_path="{ENV_REGEX_NS}/Robot",
         spawn=sim_utils.UsdFileWithCompliantContactCfg(
             usd_path=f"{ISAACLAB_NUCLEUS_DIR}/TacSL/gelsight_r15_finger/gelsight_r15_finger.usd",
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            rigid_props=PhysxRigidBodyPropertiesCfg(
                 disable_gravity=True,
                 max_depenetration_velocity=5.0,
             ),
             compliant_contact_stiffness=args_cli.tactile_compliance_stiffness,
             compliant_contact_damping=args_cli.tactile_compliant_damping,
             physics_material_prim_path="elastomer",
-            articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            articulation_props=PhysxArticulationRootPropertiesCfg(
                 enabled_self_collisions=False,
                 solver_position_iteration_count=12,
                 solver_velocity_iteration_count=1,
             ),
-            collision_props=sim_utils.CollisionPropertiesCfg(
+            collision_props=PhysxCollisionPropertiesCfg(
                 contact_offset=0.001, rest_offset=-0.0005
             ),
         ),
@@ -181,10 +184,10 @@ class CubeTactileSceneCfg(TactileSensorsSceneCfg):
         prim_path="{ENV_REGEX_NS}/contact_object",
         spawn=sim_utils.CuboidCfg(
             size=(0.01, 0.01, 0.01),
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True),
+            rigid_props=PhysxRigidBodyPropertiesCfg(disable_gravity=True),
             mass_props=sim_utils.MassPropertiesCfg(mass=0.00327211),
-            collision_props=sim_utils.CollisionPropertiesCfg(),
-            physics_material=sim_utils.RigidBodyMaterialCfg(),
+            collision_props=PhysxCollisionPropertiesCfg(),
+            physics_material=PhysxRigidBodyMaterialCfg(),
             visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.1, 0.1)),
         ),
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0 + 0.06776, 0.51), rot=(0.0, 0.0, 0.0, 1.0)),
@@ -200,15 +203,15 @@ class NutTactileSceneCfg(TactileSensorsSceneCfg):
         prim_path="{ENV_REGEX_NS}/contact_object",
         spawn=sim_utils.UsdFileCfg(
             usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Factory/factory_nut_m16.usd",
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            rigid_props=PhysxRigidBodyPropertiesCfg(
                 disable_gravity=True,
                 solver_position_iteration_count=12,
                 solver_velocity_iteration_count=1,
                 max_angular_velocity=180.0,
             ),
             mass_props=sim_utils.MassPropertiesCfg(mass=0.1),
-            collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005, rest_offset=0),
-            articulation_props=sim_utils.ArticulationRootPropertiesCfg(articulation_enabled=False),
+            collision_props=PhysxCollisionPropertiesCfg(contact_offset=0.005, rest_offset=0),
+            articulation_props=PhysxArticulationRootPropertiesCfg(articulation_enabled=False),
         ),
         init_state=RigidObjectCfg.InitialStateCfg(
             pos=(0.0, 0.0 + 0.06776, 0.498),
@@ -321,10 +324,6 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
     nrows = scene["tactile_sensor"].cfg.tactile_array_size[0]
     ncols = scene["tactile_sensor"].cfg.tactile_array_size[1]
 
-    physics_timer = Timer()
-    physics_total_time = 0.0
-    physics_total_count = 0
-
     entity_list = ["robot"]
     if "contact_object" in scene.keys():
         entity_list.append("contact_object")
@@ -351,15 +350,13 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
                 even_mask = env_indices % 2 == 0
                 torque_tensor[odd_mask, 0, 2] = 10  # rotation for odd environments
                 torque_tensor[even_mask, 0, 2] = -10  # rotation for even environments
-                scene["contact_object"].permanent_wrench_composer.set_forces_and_torques(force_tensor, torque_tensor)
+                scene["contact_object"].permanent_wrench_composer.set_forces_and_torques_index(
+                    forces=force_tensor, torques=torque_tensor
+                )
 
         # Step simulation
         scene.write_data_to_sim()
-        physics_timer.start()
         sim.step()
-        physics_timer.stop()
-        physics_total_time += physics_timer.total_run_time
-        physics_total_count += 1
         sim_time += sim_dt
         count += 1
         scene.update(sim_dt)
@@ -369,17 +366,6 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
 
         if args_cli.save_viz:
             save_viz_helper(dir_path_list, count, tactile_data, num_envs, nrows, ncols)
-
-    # Get timing summary from sensor and add physics timing
-    timing_summary = scene["tactile_sensor"].get_timing_summary()
-
-    # Add physics timing to the summary
-    physics_avg = physics_total_time / (physics_total_count * scene.num_envs) if physics_total_count > 0 else 0.0
-    timing_summary["physics_total"] = physics_total_time
-    timing_summary["physics_average"] = physics_avg
-    timing_summary["physics_fps"] = 1 / physics_avg if physics_avg > 0 else 0.0
-
-    print(timing_summary)
 
 
 def main():
@@ -396,7 +382,7 @@ def main():
     sim = sim_utils.SimulationContext(sim_cfg)
 
     # Set main camera
-    sim.set_camera_view(eye=[0.5, 0.6, 1.0], target=[-0.1, 0.1, 0.5])
+    sim.set_camera_view(eye=(0.5, 0.6, 1.0), target=(-0.1, 0.1, 0.5))
 
     # Create scene based on contact object type
     if args_cli.contact_object_type == "cube":

--- a/scripts/demos/sensors/tacsl_sensor.py
+++ b/scripts/demos/sensors/tacsl_sensor.py
@@ -20,7 +20,7 @@ tactile sensing with the GelSight finger setup.
         --contact_object_type nut \
         --save_viz \
         --enable_cameras \
-        --viz kit/newton 
+        --viz kit/newton
 
 """
 
@@ -78,18 +78,19 @@ simulation_app = app_launcher.app
 
 """Rest everything follows."""
 
-import isaaclab.sim as sim_utils
-from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
-from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
-from isaaclab.sensors import CameraCfg
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
-from isaaclab.utils.configclass import configclass
 from isaaclab_physx.sim.schemas import (
     PhysxArticulationRootPropertiesCfg,
     PhysxCollisionPropertiesCfg,
     PhysxRigidBodyPropertiesCfg,
 )
 from isaaclab_physx.sim.spawners.materials import PhysxRigidBodyMaterialCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import CameraCfg
+from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.configclass import configclass
 
 from isaaclab_contrib.sensors.tacsl_sensor import VisuoTactileSensorCfg
 from isaaclab_contrib.sensors.tacsl_sensor.visuotactile_render import compute_tactile_shear_image
@@ -127,9 +128,7 @@ class TactileSensorsSceneCfg(InteractiveSceneCfg):
                 solver_position_iteration_count=12,
                 solver_velocity_iteration_count=1,
             ),
-            collision_props=PhysxCollisionPropertiesCfg(
-                contact_offset=0.001, rest_offset=-0.0005
-            ),
+            collision_props=PhysxCollisionPropertiesCfg(contact_offset=0.001, rest_offset=-0.0005),
         ),
         init_state=ArticulationCfg.InitialStateCfg(
             pos=(0.0, 0.0, 0.5),
@@ -403,7 +402,6 @@ def main():
         )
 
     scene = InteractiveScene(scene_cfg)
-
 
     # Initialize simulation
     sim.reset()

--- a/source/isaaclab/changelog.d/juana-update-tacsl.rst
+++ b/source/isaaclab/changelog.d/juana-update-tacsl.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed compliant-contact USD spawning to use
+  :class:`~isaaclab_physx.sim.spawners.materials.PhysxRigidBodyMaterialCfg`
+  instead of the deprecated rigid-body material alias.

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -12,6 +12,7 @@ from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 from filelock import FileLock
+from isaaclab_physx.sim.spawners.materials import PhysxRigidBodyMaterialCfg
 
 from isaaclab.sim import converters, schemas
 from isaaclab.sim.spawners.materials import SurfaceDeformableBodyMaterialBaseCfg
@@ -29,7 +30,6 @@ from isaaclab.sim.utils import (
 )
 from isaaclab.utils.assets import check_file_path, retrieve_file_path
 from isaaclab.utils.version import has_kit
-from isaaclab_physx.sim.spawners.materials import PhysxRigidBodyMaterialCfg
 
 if TYPE_CHECKING:
     from pxr import Gf, Sdf, Usd, UsdGeom  # noqa: F401

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from filelock import FileLock
 
 from isaaclab.sim import converters, schemas
-from isaaclab.sim.spawners.materials import RigidBodyMaterialCfg, SurfaceDeformableBodyMaterialBaseCfg
+from isaaclab.sim.spawners.materials import SurfaceDeformableBodyMaterialBaseCfg
 from isaaclab.sim.utils import (
     add_labels,
     bind_physics_material,
@@ -29,6 +29,7 @@ from isaaclab.sim.utils import (
 )
 from isaaclab.utils.assets import check_file_path, retrieve_file_path
 from isaaclab.utils.version import has_kit
+from isaaclab_physx.sim.spawners.materials import PhysxRigidBodyMaterialCfg
 
 if TYPE_CHECKING:
     from pxr import Gf, Sdf, Usd, UsdGeom  # noqa: F401
@@ -478,7 +479,7 @@ def spawn_from_usd_with_compliant_contact_material(
             material_kwargs["compliant_contact_stiffness"] = stiff
         if damp is not None:
             material_kwargs["compliant_contact_damping"] = damp
-        material_cfg = RigidBodyMaterialCfg(**material_kwargs)
+        material_cfg = PhysxRigidBodyMaterialCfg(**material_kwargs)
 
         for path in prim_paths:
             if not path.startswith("/"):

--- a/source/isaaclab_contrib/changelog.d/juana-update-tacsl.rst
+++ b/source/isaaclab_contrib/changelog.d/juana-update-tacsl.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Updated the TacSL visuotactile sensor demo, documentation, and tests to use
+  current PhysX configuration and wrench APIs.

--- a/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_render.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/sensors/tacsl_sensor/visuotactile_render.py
@@ -57,10 +57,11 @@ def compute_tactile_shear_image(
             loc0_y = col * resolution + resolution // 2
             loc1_x = loc0_x + tactile_shear_force[row, col][0] / shear_force_threshold * resolution
             loc1_y = loc0_y + tactile_shear_force[row, col][1] / shear_force_threshold * resolution
+            normalized_normal_force = float(tactile_normal_force[row][col]) / normal_force_threshold
             color = (
                 0.0,
-                max(0.0, 1.0 - tactile_normal_force[row][col] / normal_force_threshold),
-                min(1.0, tactile_normal_force[row][col] / normal_force_threshold),
+                max(0.0, 1.0 - normalized_normal_force),
+                min(1.0, normalized_normal_force),
             )
 
             cv2.arrowedLine(

--- a/source/isaaclab_contrib/test/sensors/test_visuotactile_sensor.py
+++ b/source/isaaclab_contrib/test/sensors/test_visuotactile_sensor.py
@@ -20,6 +20,11 @@ import math
 import pytest
 import torch
 import warp as wp
+from isaaclab_physx.sim.schemas import (
+    PhysxArticulationRootPropertiesCfg,
+    PhysxCollisionPropertiesCfg,
+    PhysxRigidBodyPropertiesCfg,
+)
 
 import omni.replicator.core as rep
 
@@ -29,11 +34,6 @@ from isaaclab.sensors.camera import CameraCfg
 from isaaclab.terrains.trimesh.utils import make_plane
 from isaaclab.terrains.utils import create_prim_from_mesh
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
-from isaaclab_physx.sim.schemas import (
-    PhysxArticulationRootPropertiesCfg,
-    PhysxCollisionPropertiesCfg,
-    PhysxRigidBodyPropertiesCfg,
-)
 
 from isaaclab_contrib.sensors.tacsl_sensor import VisuoTactileSensor, VisuoTactileSensorCfg
 from isaaclab_contrib.sensors.tacsl_sensor.visuotactile_sensor_cfg import GelSightRenderCfg
@@ -173,9 +173,7 @@ def setup(sensor_type: str = "cube"):
         spawn=sim_utils.UsdFileCfg(
             usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Factory/factory_nut_m16.usd",
             rigid_props=PhysxRigidBodyPropertiesCfg(disable_gravity=False),
-            articulation_props=PhysxArticulationRootPropertiesCfg(
-                articulation_enabled=False
-            ),
+            articulation_props=PhysxArticulationRootPropertiesCfg(articulation_enabled=False),
             mass_props=sim_utils.MassPropertiesCfg(mass=0.1),
         ),
         init_state=RigidObjectCfg.InitialStateCfg(

--- a/source/isaaclab_contrib/test/sensors/test_visuotactile_sensor.py
+++ b/source/isaaclab_contrib/test/sensors/test_visuotactile_sensor.py
@@ -29,6 +29,11 @@ from isaaclab.sensors.camera import CameraCfg
 from isaaclab.terrains.trimesh.utils import make_plane
 from isaaclab.terrains.utils import create_prim_from_mesh
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab_physx.sim.schemas import (
+    PhysxArticulationRootPropertiesCfg,
+    PhysxCollisionPropertiesCfg,
+    PhysxRigidBodyPropertiesCfg,
+)
 
 from isaaclab_contrib.sensors.tacsl_sensor import VisuoTactileSensor, VisuoTactileSensorCfg
 from isaaclab_contrib.sensors.tacsl_sensor.visuotactile_sensor_cfg import GelSightRenderCfg
@@ -140,7 +145,7 @@ def setup(sensor_type: str = "cube"):
         prim_path="/World/Robot",
         spawn=sim_utils.UsdFileWithCompliantContactCfg(
             usd_path=usd_file_path,
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True),
+            rigid_props=PhysxRigidBodyPropertiesCfg(disable_gravity=True),
             compliant_contact_stiffness=10.0,
             compliant_contact_damping=1.0,
             physics_material_prim_path="elastomer",
@@ -158,8 +163,8 @@ def setup(sensor_type: str = "cube"):
         prim_path="/World/Cube",
         spawn=sim_utils.CuboidCfg(
             size=(0.1, 0.1, 0.1),
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(),
-            collision_props=sim_utils.CollisionPropertiesCfg(),
+            rigid_props=PhysxRigidBodyPropertiesCfg(),
+            collision_props=PhysxCollisionPropertiesCfg(),
         ),
     )
     # Nut
@@ -167,8 +172,10 @@ def setup(sensor_type: str = "cube"):
         prim_path="/World/Nut",
         spawn=sim_utils.UsdFileCfg(
             usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Factory/factory_nut_m16.usd",
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=False),
-            articulation_props=sim_utils.ArticulationRootPropertiesCfg(articulation_enabled=False),
+            rigid_props=PhysxRigidBodyPropertiesCfg(disable_gravity=False),
+            articulation_props=PhysxArticulationRootPropertiesCfg(
+                articulation_enabled=False
+            ),
             mass_props=sim_utils.MassPropertiesCfg(mass=0.1),
         ),
         init_state=RigidObjectCfg.InitialStateCfg(


### PR DESCRIPTION
# Description

This PR updates the TacSL visuotactile sensor demo, tests, and documentation for the current Isaac Lab / Isaac Sim 6.0 APIs.

The changes replace deprecated PhysX configuration aliases with the current `isaaclab_physx` configuration types, update deprecated wrench application calls, and remove a stale timing-summary call from the TacSL demo. It also updates compliant-contact USD spawning to use `PhysxRigidBodyMaterialCfg` when creating compliant contact materials.

The TacSL documentation is updated to clarify visualizer selection with `--viz`, note that the demo currently supports the PhysX simulation backend only, and describe the Kit viewport behavior when tactile RGB rendering is enabled.

Fixes # nvbug 6160590 (P0)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Screenshots

N/A

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog fragments
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there