### PR TITLE
[Changelog] Make isaaclab_visualizers a managed changelog package

### DIFF
--- a/source/isaaclab_visualizers/config/extension.toml
+++ b/source/isaaclab_visualizers/config/extension.toml
@@ -1,0 +1,27 @@
+[package]
+
+# Semantic Versioning is used: https://semver.org/
+version = "0.1.0"
+
+# Description
+category = "isaaclab"
+readme = "README.md"
+
+title = "Isaac Lab Visualizers"
+author = "Isaac Lab Project Developers"
+maintainer = "Isaac Lab Project Developers"
+description = "Visualizer backends for Isaac Lab (Kit, Newton, Rerun, Viser)."
+repository = "https://github.com/isaac-sim/IsaacLab.git"
+keywords = ["extension", "isaaclab", "visualization"]
+
+[dependencies]
+"isaaclab" = {}
+# NOTE: Add additional dependencies here
+
+[core]
+reloadable = false
+
+[[python.module]]
+name = "isaaclab_visualizers"
+
+[isaaclab_settings]

--- a/source/isaaclab_visualizers/docs/CHANGELOG.rst
+++ b/source/isaaclab_visualizers/docs/CHANGELOG.rst
@@ -1,0 +1,11 @@
+Changelog
+---------
+
+0.1.0 (2026-06-02)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Initial version of the :mod:`isaaclab_visualizers` extension, providing
+  visualizer backends for Isaac Lab across Kit, Newton, Rerun, and Viser.


### PR DESCRIPTION
## Summary

- `isaaclab_visualizers` has accumulated **8 changelog fragments** in `source/isaaclab_visualizers/changelog.d/`, but the nightly changelog compiler silently skipped the package, so none ever compiled into a `CHANGELOG.rst` or got cleaned up.
- `tools/changelog/cli.py` treats a package as *managed* only when it has BOTH `config/extension.toml` (the version file the compiler bumps) and `docs/CHANGELOG.rst`. `isaaclab_visualizers` had neither, so `discover()` excluded it.
- This adds both files so the package is discovered and compiled like every other source extension.

## 1. Changes

1.1 Added `source/isaaclab_visualizers/config/extension.toml` — the Kit extension manifest, with `version = "0.1.0"` matching `pyproject.toml`. The compiler cross-checks the two and errors on a mismatch, so they are kept in lockstep (and `write_version` bumps both).

1.2 Added `source/isaaclab_visualizers/docs/CHANGELOG.rst` — initialized with the canonical `Changelog` header the compiler anchors on, plus a baseline `0.1.0` entry.

1.3 Added a `.skip` fragment for this infrastructure change (no entry, no version bump).

## 2. Effect

With the package now managed, a dry-run compile picks up the pending fragments and would produce a `0.1.1` entry:

```
isaaclab_visualizers: 8 fragment(s) → version 0.1.1 (bump: patch)
```

The next nightly run compiles and clears the backlog automatically. `python3 tools/changelog/cli.py check develop` passes, and pre-commit is clean.