### PR TITLE
Defer eager submodule imports via lazy .pyi stubs

### DIFF
--- a/source/isaaclab/changelog.d/fix-fix_lazy_export.skip
+++ b/source/isaaclab/changelog.d/fix-fix_lazy_export.skip
@@ -1,0 +1,1 @@
+Internal import-hygiene cleanup: moved eager submodule imports into the lazy ``.pyi`` stubs; no user-facing changelog entry.

--- a/source/isaaclab/isaaclab/envs/__init__.py
+++ b/source/isaaclab/isaaclab/envs/__init__.py
@@ -42,8 +42,6 @@ For more information about the workflow design patterns, see the `Task Design Wo
 .. _`Task Design Workflows`: https://docs.isaacsim.omniverse.nvidia.com/latest/introduction/workflows.html
 """
 
-from . import mdp, ui
-
 from isaaclab.utils.module import lazy_export
 
 lazy_export()

--- a/source/isaaclab/isaaclab/envs/__init__.pyi
+++ b/source/isaaclab/isaaclab/envs/__init__.pyi
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 __all__ = [
+    "mdp",
+    "ui",
     "VecEnvObs",
     "VecEnvStepReturn",
     "ViewerCfg",
@@ -26,6 +28,7 @@ __all__ = [
     "MimicEnvCfg",
 ]
 
+from . import mdp, ui
 from .common import VecEnvObs, VecEnvStepReturn, ViewerCfg
 from .direct_marl_env import DirectMARLEnv
 from .direct_marl_env_cfg import DirectMARLEnvCfg

--- a/source/isaaclab/isaaclab/sensors/ray_caster/__init__.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/__init__.py
@@ -15,8 +15,6 @@ Corresponding camera implementations are also provided for each of the sensor im
 the same ray-casting operations as the sensor implementations, but return the results as images.
 """
 
-from . import patterns
-
 from isaaclab.utils.module import lazy_export
 
 lazy_export()


### PR DESCRIPTION
## Summary

- `lazy_export()` packages declare their export surface in a sibling `.pyi` stub, and relative submodule imports (`from . import <sub>`) belong in that stub so they resolve lazily. A few `__init__.py` files still imported submodules eagerly, which forced the submodule (and its transitive imports) to load at package-import time and defeated the lazy stub.
- `isaaclab/envs/__init__.py`: moved `from . import mdp, ui` into `envs/__init__.pyi` (added to the stub imports and `__all__`).
- `isaaclab/sensors/ray_caster/__init__.py`: removed the redundant `from . import patterns` — the stub already declared `patterns`.

After the change, `import isaaclab.envs` no longer pulls `mdp`/`ui` eagerly (verified they are absent from `sys.modules` until first access), while `isaaclab.envs.mdp`, `from isaaclab.envs import mdp`, `ui`, `ray_caster.patterns`, and all named class exports still resolve correctly.

Left intentionally unchanged: `isaaclab/utils/warp/__init__.py` eagerly runs `wp.init()` and monkeypatches `wp.to_torch` (its `ProxyArray` import feeds that runtime shim), so it is genuine eager initialization rather than a re-export.

## Test plan

- [x] `import isaaclab.envs` → `mdp`/`ui` not in `sys.modules`; resolve on access.
- [x] `from isaaclab.envs import mdp, ManagerBasedRLEnv` and `import isaaclab.sensors.ray_caster; ray_caster.patterns` all resolve.
- [x] `pre-commit` (ruff / ruff-format) passes on the changed files.