### PR TITLE
Fix Newton preset validation

### DIFF
--- a/source/isaaclab_tasks/changelog.d/antoiner-fix-newton-preset-validation.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-fix-newton-preset-validation.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed ``presets=newton_mjwarp`` and ``presets=newton_kamino`` validation so
+  tasks without active Newton physics presets now raise instead of applying only
+  non-physics presets.

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -42,6 +42,8 @@ from isaaclab.utils.configclass import configclass
 from .preset_target import PresetTarget
 
 _LITERAL_MAP = {"true": True, "false": False, "none": None, "null": None}
+# Canonical Newton solver presets that must resolve through an active PhysicsCfg.
+_NEWTON_PHYSICS_PRESETS = {"newton_mjwarp", "newton_kamino"}
 
 
 def _user_stacklevel() -> int:
@@ -551,18 +553,24 @@ def _format_unknown_presets_error(unknown: set[str], name_to_paths: dict[str, li
 def _selected_newton_physics_presets(selected: list[str]) -> set[str]:
     """Return canonical Newton physics preset names requested by the user."""
     aliases = PresetTarget.PHYSICS.legacy_aliases
-    newton_names = set(aliases.values())
-    return {aliases.get(name, name) for name in selected if aliases.get(name, name) in newton_names}
+    return {
+        name
+        for selected_name in selected
+        for name in [aliases.get(selected_name, selected_name)]
+        if name in _NEWTON_PHYSICS_PRESETS
+    }
 
 
 def _validate_selected_newton_physics_presets(
-    selected: list[str], consumed_selected_targets: dict[str, set[PresetTarget]]
+    selected: list[str],
+    consumed_selected: set[str],
+    consumed_selected_targets: dict[str, set[PresetTarget]],
 ) -> None:
     """Raise when a Newton solver preset did not apply to active physics config."""
     missing = sorted(
         name
         for name in _selected_newton_physics_presets(selected)
-        if PresetTarget.PHYSICS not in consumed_selected_targets.get(name, set())
+        if name in consumed_selected and PresetTarget.PHYSICS not in consumed_selected_targets.get(name, set())
     )
     if missing:
         raise ValueError(
@@ -629,7 +637,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
             consumed_explicit=consumed_explicit,
         )
 
-    _validate_selected_newton_physics_presets(global_presets, consumed_preset_targets)
+    _validate_selected_newton_physics_presets(global_presets, consumed_presets, consumed_preset_targets)
 
     unknown_presets = set(global_presets) - consumed_presets
     if unknown_presets:

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -74,6 +74,11 @@ def _known_preset_names(presets: dict) -> set[str]:
     return {name for section in presets.values() for fields in section.values() for name in fields}
 
 
+def _preset_targets(value) -> set[PresetTarget]:
+    """Return typed preset targets matched by a preset alternative value."""
+    return {target for target in PresetTarget if target.base_classes and isinstance(value, target.base_classes)}
+
+
 def _normalize_preset_name(name: str, known_names: set[str]) -> str:
     """Map a deprecated preset name to its replacement and emit a warning.
 
@@ -279,6 +284,7 @@ def _pick_alternative(
     path: str = "",
     explicit_name: str | None = None,
     consumed_selected: set[str] | None = None,
+    consumed_selected_targets: dict[str, set[PresetTarget]] | None = None,
 ):
     """Choose the best alternative from a PresetCfg.
 
@@ -310,16 +316,21 @@ def _pick_alternative(
         name = _normalize_preset_name(raw_name, field_names)
         if name not in fields or name == match_name:
             continue
+        val = fields[name]
         if consumed_selected is not None:
             consumed_selected.add(raw_name)
             consumed_selected.add(name)
+        if consumed_selected_targets is not None:
+            targets = _preset_targets(val)
+            if targets:
+                consumed_selected_targets.setdefault(raw_name, set()).update(targets)
+                consumed_selected_targets.setdefault(name, set()).update(targets)
         if match_name is not None:
-            val = fields[name]
             if match_value is not val and match_value != val:
                 raise ValueError(
                     f"Conflicting global presets: '{match_name}' and '{name}' both define preset for '{path}'"
                 )
-        match_name, match_value = name, fields[name]
+        match_name, match_value = name, val
     if match_name is not None:
         return match_value
     if "default" in fields:
@@ -338,6 +349,7 @@ def _resolve_active_presets(
     *,
     strict_explicit: bool = True,
     consumed_selected: set[str] | None = None,
+    consumed_selected_targets: dict[str, set[PresetTarget]] | None = None,
     consumed_explicit: set[str] | None = None,
 ):
     """Resolve presets by walking only the currently active tree.
@@ -364,6 +376,7 @@ def _resolve_active_presets(
                 path=path,
                 explicit_name=explicit.get(path),
                 consumed_selected=consumed_selected,
+                consumed_selected_targets=consumed_selected_targets,
             )
         return val
 
@@ -535,6 +548,30 @@ def _format_unknown_presets_error(unknown: set[str], name_to_paths: dict[str, li
     return "\n".join(lines)
 
 
+def _selected_newton_physics_presets(selected: list[str]) -> set[str]:
+    """Return canonical Newton physics preset names requested by the user."""
+    aliases = PresetTarget.PHYSICS.legacy_aliases
+    newton_names = set(aliases.values())
+    return {aliases.get(name, name) for name in selected if aliases.get(name, name) in newton_names}
+
+
+def _validate_selected_newton_physics_presets(
+    selected: list[str], consumed_selected_targets: dict[str, set[PresetTarget]]
+) -> None:
+    """Raise when a Newton solver preset did not apply to active physics config."""
+    missing = sorted(
+        name
+        for name in _selected_newton_physics_presets(selected)
+        if PresetTarget.PHYSICS not in consumed_selected_targets.get(name, set())
+    )
+    if missing:
+        raise ValueError(
+            f"Selected Newton physics preset(s) {', '.join(missing)} did not match any active physics preset. "
+            "This task does not declare Newton physics support for the selected solver. "
+            "Remove the Newton preset or choose a task that declares it on a PhysicsCfg."
+        )
+
+
 def register_task(task_name: str, agent_entry: str) -> tuple:
     """Load configs, collect presets recursively, register base config to Hydra.
 
@@ -566,6 +603,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
 
     explicit = {key: val for key, val, _arg in override_items}
     consumed_presets: set[str] = set()
+    consumed_preset_targets: dict[str, set[PresetTarget]] = {}
     consumed_explicit: set[str] = set()
     env_explicit = {path: name for path, name in explicit.items() if path == "env" or path.startswith("env.")}
     agent_explicit = {path: name for path, name in explicit.items() if path == "agent" or path.startswith("agent.")}
@@ -576,6 +614,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
         root_path="env",
         strict_explicit=False,
         consumed_selected=consumed_presets,
+        consumed_selected_targets=consumed_preset_targets,
         consumed_explicit=consumed_explicit,
     )
     if agent_cfg is not None:
@@ -586,8 +625,11 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
             root_path="agent",
             strict_explicit=False,
             consumed_selected=consumed_presets,
+            consumed_selected_targets=consumed_preset_targets,
             consumed_explicit=consumed_explicit,
         )
+
+    _validate_selected_newton_physics_presets(global_presets, consumed_preset_targets)
 
     unknown_presets = set(global_presets) - consumed_presets
     if unknown_presets:


### PR DESCRIPTION
# Description

This fixes Newton solver preset validation during Hydra config resolution.
When a user selects ``presets=newton_mjwarp`` or ``presets=newton_kamino``, the selected solver now has to match an active ``PhysicsCfg`` preset. This prevents tasks that only expose non-physics presets with the same name, such as scalar actuator or sensor variants, from silently creating mixed PhysX/Newton configurations.

Fixes #

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
  - Full `./isaaclab.sh -f` was attempted twice, but the local environment is missing `git-lfs`, so `check Git LFS pointers` fails before it can run. `SKIP=check-git-lfs-pointers ./isaaclab.sh -f` passes.
- [x] I have made corresponding changes to the documentation
  - Not applicable beyond the changelog fragment.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - No tests added by request; verified with direct config-resolution probes.
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Verification

- `./isaaclab.sh -p -m pytest source/isaaclab_tasks/test/core/test_hydra.py -q` -> 78 passed
- Navigation config probe: ``Isaac-Navigation-Flat-Anymal-C-v0`` with ``presets=newton_mjwarp`` raises ``Selected Newton physics preset(s) newton_mjwarp did not match any active physics preset``.
- Locomotion config probe: ``Isaac-Velocity-Flat-Anymal-C-v0``, ``Isaac-Velocity-Rough-Anymal-C-v0``, ``Isaac-Velocity-Flat-Anymal-D-v0``, and ``Isaac-Velocity-Rough-Unitree-Go2-v0`` still resolve ``presets=newton_mjwarp`` to ``NewtonCfg``.
- `./isaaclab.sh -f` -> failed only because `git-lfs` is not installed in this environment.
- `SKIP=check-git-lfs-pointers ./isaaclab.sh -f` -> passed.
