### PR TITLE
Enable Spot Newton MJWarp preset

### DIFF
--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -31,14 +31,17 @@ class PhysicsCfg(PresetCfg):
     default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
-            njmax=45,
-            nconmax=30,
+            njmax=130,
+            nconmax=40,
             cone="pyramidal",
             impratio=1,
             integrator="implicitfast",
+            use_mujoco_contacts=False,
         ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
         num_substeps=1,
         debug_mode=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
 
 


### PR DESCRIPTION
## Summary
- Enabled the Spot Newton MJWarp preset to use the Newton collision pipeline instead of MuJoCo contacts.
- Increased Spot MJWarp constraint/contact capacity and set the Newton shape margin used by other rough-terrain locomotion presets.

## Test Plan
- [x] `./isaaclab.sh -p -c "from isaaclab_tasks.core.velocity.config.spot.flat_env_cfg import PhysicsCfg; cfg = PhysicsCfg().newton_mjwarp; print(cfg.solver_cfg.njmax, cfg.solver_cfg.nconmax, cfg.solver_cfg.use_mujoco_contacts, cfg.collision_cfg.max_triangle_pairs, cfg.default_shape_cfg.margin)"`
- [x] `SKIP=check-git-lfs-pointers ./isaaclab.sh -f`
- [ ] `./isaaclab.sh -f` (blocked locally because `git-lfs` is not installed)