### PR TITLE
Validate typed presets resolve against their backend during Hydra resolution

### DIFF
--- a/scripts/benchmarks/benchmark_non_rl.py
+++ b/scripts/benchmarks/benchmark_non_rl.py
@@ -15,7 +15,7 @@ import time
 
 from isaaclab.app import AppLauncher
 
-from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+from isaaclab_tasks.utils import setup_preset_cli
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Train an RL agent with RL-Games.")
@@ -50,7 +50,6 @@ parser.add_argument("--output_path", type=str, default=".", help="Path to output
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-hydra_args = fold_preset_tokens(hydra_args)
 sys.argv = [sys.argv[0]] + hydra_args
 if args_cli.video:
     args_cli.enable_cameras = True

--- a/scripts/benchmarks/benchmark_rlgames.py
+++ b/scripts/benchmarks/benchmark_rlgames.py
@@ -15,7 +15,7 @@ import time
 
 from isaaclab.app import AppLauncher
 
-from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+from isaaclab_tasks.utils import setup_preset_cli
 
 from scripts.benchmarks.early_stop import (
     RlGamesEarlyStopObserver,
@@ -67,7 +67,6 @@ add_success_cli_args(parser)
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-hydra_args = fold_preset_tokens(hydra_args)
 sys.argv = [sys.argv[0]] + hydra_args
 if args_cli.video:
     args_cli.enable_cameras = True

--- a/scripts/benchmarks/benchmark_rsl_rl.py
+++ b/scripts/benchmarks/benchmark_rsl_rl.py
@@ -15,7 +15,7 @@ import time
 
 from isaaclab.app import AppLauncher
 
-from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+from isaaclab_tasks.utils import setup_preset_cli
 
 from scripts.benchmarks.early_stop import (
     RslRlEarlyStopWrapper,
@@ -72,7 +72,6 @@ cli_args.add_rsl_rl_args(parser)
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-hydra_args = fold_preset_tokens(hydra_args)
 sys.argv = [sys.argv[0]] + hydra_args
 if args_cli.video:
     args_cli.enable_cameras = True

--- a/scripts/benchmarks/benchmark_startup.py
+++ b/scripts/benchmarks/benchmark_startup.py
@@ -19,7 +19,7 @@ import time
 
 from isaaclab.app import AppLauncher
 
-from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+from isaaclab_tasks.utils import setup_preset_cli
 
 # -- CLI arguments -----------------------------------------------------------
 
@@ -60,7 +60,6 @@ parser.add_argument(
 # append AppLauncher cli args (provides --device, --headless, etc.)
 AppLauncher.add_app_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-hydra_args = fold_preset_tokens(hydra_args)
 sys.argv = [sys.argv[0]] + hydra_args
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.."))

--- a/scripts/environments/random_agent.py
+++ b/scripts/environments/random_agent.py
@@ -19,7 +19,6 @@ with contextlib.suppress(ImportError):
 from isaaclab.app import add_launcher_args, launch_simulation
 
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     resolve_task_config,
     setup_preset_cli,
 )
@@ -34,7 +33,7 @@ parser.add_argument("--task", type=str, default=None, help="Name of the task.")
 # append AppLauncher cli args
 add_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 # PLACEHOLDER: Extension template (do not remove this comment)
 

--- a/scripts/environments/zero_agent.py
+++ b/scripts/environments/zero_agent.py
@@ -19,7 +19,6 @@ with contextlib.suppress(ImportError):
 from isaaclab.app import add_launcher_args, launch_simulation
 
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     resolve_task_config,
     setup_preset_cli,
 )
@@ -34,7 +33,7 @@ parser.add_argument("--task", type=str, default=None, help="Name of the task.")
 # append AppLauncher cli args
 add_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 # PLACEHOLDER: Extension template (do not remove this comment)
 MAX_STEPS = 100

--- a/scripts/reinforcement_learning/leapp/rsl_rl/export.py
+++ b/scripts/reinforcement_learning/leapp/rsl_rl/export.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from isaaclab.app import AppLauncher
 
-from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+from isaaclab_tasks.utils import setup_preset_cli
 
 _RSL_RL_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "rsl_rl"
 if str(_RSL_RL_SCRIPTS_DIR) not in sys.path:
@@ -363,9 +363,8 @@ def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str]) -
     from isaaclab_tasks.utils.hydra import hydra_task_config
 
     original_argv = sys.argv
-    # Fold typed preset selectors into a single ``presets=<csv>`` token before
-    # Hydra reads sys.argv; remainder still carries plain Hydra path overrides.
-    sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+    # Hydra reads the preset tokens (physics=/renderer=/presets=) from sys.argv directly.
+    sys.argv = [sys.argv[0]] + hydra_args
     exported = False
 
     try:

--- a/scripts/reinforcement_learning/rl_games/play.py
+++ b/scripts/reinforcement_learning/rl_games/play.py
@@ -40,7 +40,6 @@ from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_che
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     get_checkpoint_path,
     resolve_task_config,
     setup_preset_cli,
@@ -77,7 +76,7 @@ parser.add_argument(
 parser.add_argument("--real-time", action="store_true", default=False, help="Run in real-time, if possible.")
 add_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 if args_cli.video:
     args_cli.enable_cameras = True

--- a/scripts/reinforcement_learning/rl_games/play_rl_games.py
+++ b/scripts/reinforcement_learning/rl_games/play_rl_games.py
@@ -29,7 +29,6 @@ from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_che
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     get_checkpoint_path,
     resolve_task_config,
     setup_preset_cli,
@@ -70,7 +69,7 @@ args_cli, hydra_args = setup_preset_cli(parser)
 if args_cli.video:
     args_cli.enable_cameras = True
 
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 
 def main():

--- a/scripts/reinforcement_learning/rl_games/train.py
+++ b/scripts/reinforcement_learning/rl_games/train.py
@@ -42,7 +42,6 @@ from isaaclab_rl.rl_games import MultiObserver, PbtAlgoObserver, RlGamesGpuEnv, 
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     resolve_task_config,
     setup_preset_cli,
 )
@@ -87,7 +86,7 @@ parser.add_argument(
 )
 add_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 if args_cli.video:
     args_cli.enable_cameras = True

--- a/scripts/reinforcement_learning/rl_games/train_rl_games.py
+++ b/scripts/reinforcement_learning/rl_games/train_rl_games.py
@@ -60,14 +60,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         const=True,
         help="if toggled, this experiment will be tracked with Weights and Biases",
     )
-    from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+    from isaaclab_tasks.utils import setup_preset_cli
 
     add_isaaclab_launcher_args(parser)
-    # setup_preset_cli registers preset-selection help text + runs parse_known_args;
-    # fold_preset_tokens rewrites typed selectors (physics=, renderer=, presets=) post-argparse.
+    # setup_preset_cli registers preset-selection help text + runs parse_known_args; the
+    # physics=/renderer=/presets= tokens pass through the remainder for hydra to parse later.
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     enable_cameras_for_video(args_cli)
-    set_hydra_args(fold_preset_tokens(hydra_args))
+    set_hydra_args(hydra_args)
     return args_cli
 
 

--- a/scripts/reinforcement_learning/rsl_rl/play.py
+++ b/scripts/reinforcement_learning/rsl_rl/play.py
@@ -45,7 +45,6 @@ from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_che
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     get_checkpoint_path,
     setup_preset_cli,
 )
@@ -99,7 +98,7 @@ if args_cli.external_callback:
 # intersection are pre-fold (the callback reads the user's original sys.argv), so
 # preset tokens like ``physics=NAME`` compare correctly here. Fold runs after.
 remaining_args = list_intersection(remaining_args, remaining_args_env_registration)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(remaining_args)
+sys.argv = [sys.argv[0]] + remaining_args
 
 # Check for installed RSL-RL version
 installed_version = metadata.version("rsl-rl-lib")

--- a/scripts/reinforcement_learning/rsl_rl/play_rsl_rl.py
+++ b/scripts/reinforcement_learning/rsl_rl/play_rsl_rl.py
@@ -34,7 +34,6 @@ from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_che
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     get_checkpoint_path,
     setup_preset_cli,
 )
@@ -86,7 +85,7 @@ if args_cli.external_callback:
 # The remaining arguments are the arguments that were not consumed by both this scripts
 # argparser and (optionally) the external callback function.
 remaining_args = list_intersection(remaining_args, remaining_args_env_registration)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(remaining_args)
+sys.argv = [sys.argv[0]] + remaining_args
 
 # Check for installed RSL-RL version
 installed_version = metadata.version("rsl-rl-lib")

--- a/scripts/reinforcement_learning/rsl_rl/train.py
+++ b/scripts/reinforcement_learning/rsl_rl/train.py
@@ -40,7 +40,7 @@ from isaaclab.utils.string import list_intersection, string_to_callable
 from isaaclab_rl.rsl_rl import RslRlBaseRunnerCfg, RslRlVecEnvWrapper, handle_deprecated_rsl_rl_cfg
 
 import isaaclab_tasks  # noqa: F401
-from isaaclab_tasks.utils import fold_preset_tokens, get_checkpoint_path, setup_preset_cli
+from isaaclab_tasks.utils import get_checkpoint_path, setup_preset_cli
 from isaaclab_tasks.utils.hydra import hydra_task_config
 
 # local imports
@@ -97,10 +97,10 @@ if args_cli.external_callback:
 # clear out sys.argv for Hydra
 # The remaining arguments are the arguments that were not consumed by both this scripts
 # argparser and (optionally) the external callback function. Both sides of this
-# intersection are pre-fold (the callback reads the user's original sys.argv), so
-# preset tokens like ``physics=NAME`` compare correctly here. Fold runs after.
+# intersection share the same token vocabulary (the callback reads the user's
+# original sys.argv), so preset tokens like ``physics=NAME`` compare correctly.
 remaining_args = list_intersection(remaining_args, remaining_args_env_registration)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(remaining_args)
+sys.argv = [sys.argv[0]] + remaining_args
 
 # -- check RSL-RL version ----------------------------------------------------
 installed_version = metadata.version("rsl-rl-lib")

--- a/scripts/reinforcement_learning/rsl_rl/train_rsl_rl.py
+++ b/scripts/reinforcement_learning/rsl_rl/train_rsl_rl.py
@@ -66,7 +66,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse RSL-RL training arguments."""
     from isaaclab.utils.string import list_intersection, string_to_callable
 
-    from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+    from isaaclab_tasks.utils import setup_preset_cli
 
     parser = argparse.ArgumentParser(description="Train an RL agent with RSL-RL.")
     add_common_train_args(
@@ -90,8 +90,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         external_callback_function = string_to_callable(args_cli.external_callback, separator=".")
         remaining_args_env_registration = external_callback_function()
 
-    # fold_preset_tokens rewrites typed selectors (physics=, renderer=, presets=) post-argparse
-    set_hydra_args(fold_preset_tokens(list_intersection(remaining_args, remaining_args_env_registration)))
+    # physics=/renderer=/presets= tokens pass through the remainder for hydra to parse later
+    set_hydra_args(list_intersection(remaining_args, remaining_args_env_registration))
     return args_cli
 
 

--- a/scripts/reinforcement_learning/sb3/play.py
+++ b/scripts/reinforcement_learning/sb3/play.py
@@ -38,7 +38,6 @@ from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_che
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     get_checkpoint_path,
     resolve_task_config,
     setup_preset_cli,
@@ -81,7 +80,7 @@ parser.add_argument(
 )
 add_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 if args_cli.video:
     args_cli.enable_cameras = True

--- a/scripts/reinforcement_learning/sb3/play_sb3.py
+++ b/scripts/reinforcement_learning/sb3/play_sb3.py
@@ -27,7 +27,6 @@ from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_che
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     get_checkpoint_path,
     resolve_task_config,
     setup_preset_cli,
@@ -74,7 +73,7 @@ args_cli, hydra_args = setup_preset_cli(parser)
 if args_cli.video:
     args_cli.enable_cameras = True
 
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 
 def main():

--- a/scripts/reinforcement_learning/sb3/train.py
+++ b/scripts/reinforcement_learning/sb3/train.py
@@ -43,7 +43,6 @@ from isaaclab_rl.sb3 import Sb3VecEnvWrapper, process_sb3_cfg
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     resolve_task_config,
     setup_preset_cli,
 )
@@ -80,7 +79,7 @@ parser.add_argument(
 )
 add_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 if args_cli.video:
     args_cli.enable_cameras = True

--- a/scripts/reinforcement_learning/sb3/train_sb3.py
+++ b/scripts/reinforcement_learning/sb3/train_sb3.py
@@ -67,14 +67,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=False,
         help="Use a slower SB3 wrapper but keep all the extra training info.",
     )
-    from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+    from isaaclab_tasks.utils import setup_preset_cli
 
     add_isaaclab_launcher_args(parser)
-    # setup_preset_cli registers preset-selection help text + runs parse_known_args;
-    # fold_preset_tokens rewrites typed selectors (physics=, renderer=, presets=) post-argparse.
+    # setup_preset_cli registers preset-selection help text + runs parse_known_args; the
+    # physics=/renderer=/presets= tokens pass through the remainder for hydra to parse later.
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     enable_cameras_for_video(args_cli)
-    set_hydra_args(fold_preset_tokens(hydra_args))
+    set_hydra_args(hydra_args)
     return args_cli
 
 

--- a/scripts/reinforcement_learning/skrl/play.py
+++ b/scripts/reinforcement_learning/skrl/play.py
@@ -41,7 +41,6 @@ from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_che
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     get_checkpoint_path,
     resolve_task_config,
     setup_preset_cli,
@@ -95,7 +94,7 @@ parser.add_argument(
 parser.add_argument("--real-time", action="store_true", default=False, help="Run in real-time, if possible.")
 add_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 if args_cli.video:
     args_cli.enable_cameras = True

--- a/scripts/reinforcement_learning/skrl/play_skrl.py
+++ b/scripts/reinforcement_learning/skrl/play_skrl.py
@@ -30,7 +30,6 @@ from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_che
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     get_checkpoint_path,
     resolve_task_config,
     setup_preset_cli,
@@ -88,7 +87,7 @@ args_cli, hydra_args = setup_preset_cli(parser)
 if args_cli.video:
     args_cli.enable_cameras = True
 
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 # -- check skrl version ------------------------------------------------------
 if version.parse(skrl.__version__) < version.parse(SKRL_VERSION):

--- a/scripts/reinforcement_learning/skrl/train.py
+++ b/scripts/reinforcement_learning/skrl/train.py
@@ -44,7 +44,6 @@ from isaaclab_rl.skrl import SkrlVecEnvWrapper
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
-    fold_preset_tokens,
     resolve_task_config,
     setup_preset_cli,
 )
@@ -99,7 +98,7 @@ parser.add_argument(
 )
 add_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 
 if args_cli.video:
     args_cli.enable_cameras = True

--- a/scripts/reinforcement_learning/skrl/train_skrl.py
+++ b/scripts/reinforcement_learning/skrl/train_skrl.py
@@ -66,14 +66,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         choices=["AMP", "PPO", "IPPO", "MAPPO"],
         help="The RL algorithm used for training the skrl agent.",
     )
-    from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+    from isaaclab_tasks.utils import setup_preset_cli
 
     add_isaaclab_launcher_args(parser)
-    # setup_preset_cli registers preset-selection help text + runs parse_known_args;
-    # fold_preset_tokens rewrites typed selectors (physics=, renderer=, presets=) post-argparse.
+    # setup_preset_cli registers preset-selection help text + runs parse_known_args; the
+    # physics=/renderer=/presets= tokens pass through the remainder for hydra to parse later.
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     enable_cameras_for_video(args_cli)
-    set_hydra_args(fold_preset_tokens(hydra_args))
+    set_hydra_args(hydra_args)
     return args_cli
 
 

--- a/scripts/reinforcement_learning/test/test_typed_preset_cli_train_play.py
+++ b/scripts/reinforcement_learning/test/test_typed_preset_cli_train_play.py
@@ -9,22 +9,22 @@ unified train/play entrypoint.
 The four supported RL libraries (rl_games, rsl_rl, sb3, skrl) each have a
 ``train_<library>.py`` / ``play_<library>.py`` script that the unified
 ``scripts/reinforcement_learning/{train,play}.py`` dispatchers route to via
-``--rl_library``. Each entrypoint must wire the typed preset CLI
-(``setup_preset_cli`` + ``fold_preset_tokens`` from
-:mod:`isaaclab_tasks.utils.preset_cli`) so that user-typed ``physics=NAME``
-/ ``renderer=NAME`` / ``presets=NAME`` tokens are folded into the canonical
-form Hydra consumes. Without the fold, those tokens hit Hydra as a struct
-override against a non-existent top-level key and raise
-``Key 'physics' is not in struct`` -- the original symptom of the #5715
-regression.
+``--rl_library``. Each entrypoint must wire :func:`setup_preset_cli` and pass
+its remainder through to Hydra so that user-typed ``physics=NAME`` /
+``renderer=NAME`` / ``presets=NAME`` tokens reach
+:func:`~isaaclab_tasks.utils.hydra.register_task`, which parses them directly.
+If an entrypoint dropped the remainder (or routed the token to Hydra as a raw
+override), the token would hit Hydra as a struct override against a
+non-existent top-level key and raise ``Key 'physics' is not in struct`` -- the
+original symptom of the #5715 regression.
 
 This test invokes each entrypoint via the unified dispatcher with
 ``physics=does_not_exist`` and asserts:
 
-* the Hydra struct error is **absent** (would indicate the fold did not
-  run), and
-* the resolver's own ``Unknown preset(s)`` error is **present** (the
-  fold ran and the resolver received the canonical token).
+* the Hydra struct error is **absent** (would indicate the token was not
+  routed to ``register_task``), and
+* the resolver's own ``Unknown preset(s)`` error is **present** (the token
+  reached the resolver).
 
 Resolve fails before any Kit/sim launch, so each subprocess exits in a
 few seconds without needing GPU.
@@ -57,11 +57,10 @@ _ENTRYPOINT_CASES = [
 def test_typed_preset_reaches_resolver(action: str, library: str) -> None:
     """``physics=<unknown>`` must reach the resolver, not crash Hydra's struct check.
 
-    Confirms that the dispatched entrypoint wired ``setup_preset_cli`` +
-    ``fold_preset_tokens`` correctly: the typed selector got rewritten into
-    the canonical ``presets=<csv>`` form before Hydra received it, and the
-    resolver then surfaced its own ``Unknown preset(s)`` error against the
-    deliberately invalid name.
+    Confirms that the dispatched entrypoint wired ``setup_preset_cli`` and
+    passed its remainder through, so the typed selector reached
+    ``register_task``, which surfaced its own ``Unknown preset(s)`` error
+    against the deliberately invalid name.
     """
     dispatcher = REPO_ROOT / "scripts" / "reinforcement_learning" / f"{action}.py"
     assert dispatcher.exists(), f"missing dispatcher: {dispatcher}"
@@ -89,13 +88,13 @@ def test_typed_preset_reaches_resolver(action: str, library: str) -> None:
     label = f"{action}.py --rl_library {library}"
     assert "is not in struct" not in combined, (
         f"{label}: Hydra's struct-override error reached the user, meaning the typed preset "
-        f"selector was NOT folded before Hydra processed it. The entrypoint must call "
-        f"setup_preset_cli + fold_preset_tokens before set_hydra_args / sys.argv assignment.\n"
+        f"selector was routed to Hydra as a raw override instead of register_task. The entrypoint "
+        f"must call setup_preset_cli and pass its remainder through to set_hydra_args / sys.argv.\n"
         f"--- stderr tail ---\n{result.stderr[-2000:]}\n"
         f"--- stdout tail ---\n{result.stdout[-2000:]}\n"
     )
     assert "Unknown preset(s): does_not_exist" in combined, (
-        f"{label}: resolver's 'Unknown preset(s)' error did not appear. Either the fold did not "
+        f"{label}: resolver's 'Unknown preset(s)' error did not appear. Either the token did not "
         f"reach the resolver, or the script exited earlier with a different error.\n"
         f"--- stderr tail ---\n{result.stderr[-2000:]}\n"
         f"--- stdout tail ---\n{result.stdout[-2000:]}\n"

--- a/scripts/sim2sim_transfer/rsl_rl_transfer.py
+++ b/scripts/sim2sim_transfer/rsl_rl_transfer.py
@@ -13,7 +13,7 @@ import sys
 
 from isaaclab.app import AppLauncher
 
-from isaaclab_tasks.utils import fold_preset_tokens, setup_preset_cli
+from isaaclab_tasks.utils import setup_preset_cli
 
 # local imports
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.."))
@@ -45,7 +45,7 @@ cli_args.add_rsl_rl_args(parser)
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 args_cli, hydra_args = setup_preset_cli(parser)
-sys.argv = [sys.argv[0]] + fold_preset_tokens(hydra_args)
+sys.argv = [sys.argv[0]] + hydra_args
 if args_cli.video:
     args_cli.enable_cameras = True
 

--- a/source/isaaclab_tasks/changelog.d/fix-hydra-typed-preset-validation.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-hydra-typed-preset-validation.rst
@@ -1,16 +1,21 @@
-Fixed
+Added
 ^^^^^
 
-* Fixed silent backend mismatches when selecting a typed preset that a task
-  does not actually declare on its typed config. Names reserved for a typed
-  :class:`~isaaclab_tasks.utils.preset_target.PresetTarget` (e.g. the Newton
-  physics solvers ``newton_mjwarp`` / ``newton_kamino`` for
-  :attr:`~isaaclab_tasks.utils.preset_target.PresetTarget.PHYSICS`) must now
-  resolve through that target -- i.e. replace at least one
-  :class:`~isaaclab.physics.PhysicsCfg` -- at least once. Selecting such a
-  preset on a task where it only matches unrelated scalar or sensor presets
-  (e.g. ``presets=newton_mjwarp`` on a task with no Newton physics) now raises
-  a descriptive :class:`ValueError` instead of leaving PhysX active while
-  applying Newton-tuned values. Reserved names are declared per target in
-  :mod:`isaaclab_tasks.utils.preset_target`, so the check generalizes to any
-  typed target without hardcoding solver names in the resolver.
+* Added validation for the typed preset selectors ``physics=NAME`` and
+  ``renderer=NAME`` during Hydra resolution. A typed selector is now enforced
+  to resolve against a config of that type (a
+  :class:`~isaaclab.physics.PhysicsCfg` / renderer config) at least once;
+  selecting one on a task that only exposes the name as an unrelated preset
+  (e.g. a scalar or sensor variant) raises a descriptive :class:`ValueError`
+  instead of silently leaving the backend unchanged. The free-form
+  ``presets=NAME`` broadcast is trusted and not enforced.
+
+Changed
+^^^^^^^
+
+* **Breaking:** Removed ``isaaclab_tasks.utils.fold_preset_tokens``.
+  :func:`~isaaclab_tasks.utils.preset_cli.setup_preset_cli` now returns the
+  ``physics=`` / ``renderer=`` / ``presets=`` tokens verbatim, and
+  :func:`~isaaclab_tasks.utils.hydra.register_task` parses them directly.
+  Scripts assign the remainder to ``sys.argv`` unchanged (drop the
+  ``fold_preset_tokens(...)`` wrapper).

--- a/source/isaaclab_tasks/changelog.d/fix-hydra-typed-preset-validation.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-hydra-typed-preset-validation.rst
@@ -1,0 +1,16 @@
+Fixed
+^^^^^
+
+* Fixed silent backend mismatches when selecting a typed preset that a task
+  does not actually declare on its typed config. Names reserved for a typed
+  :class:`~isaaclab_tasks.utils.preset_target.PresetTarget` (e.g. the Newton
+  physics solvers ``newton_mjwarp`` / ``newton_kamino`` for
+  :attr:`~isaaclab_tasks.utils.preset_target.PresetTarget.PHYSICS`) must now
+  resolve through that target -- i.e. replace at least one
+  :class:`~isaaclab.physics.PhysicsCfg` -- at least once. Selecting such a
+  preset on a task where it only matches unrelated scalar or sensor presets
+  (e.g. ``presets=newton_mjwarp`` on a task with no Newton physics) now raises
+  a descriptive :class:`ValueError` instead of leaving PhysX active while
+  applying Newton-tuned values. Reserved names are declared per target in
+  :mod:`isaaclab_tasks.utils.preset_target`, so the check generalizes to any
+  typed target without hardcoding solver names in the resolver.

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/__init__.pyi
@@ -14,10 +14,9 @@ __all__ = [
     "hydra_task_config",
     "resolve_presets",
     "setup_preset_cli",
-    "fold_preset_tokens",
 ]
 
 from .hydra import PresetCfg, preset, hydra_task_config, resolve_task_config, resolve_presets
 from .importer import import_packages
 from .parse_cfg import get_checkpoint_path, load_cfg_from_registry, parse_env_cfg
-from .preset_cli import fold_preset_tokens, setup_preset_cli
+from .preset_cli import setup_preset_cli

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -15,9 +15,11 @@ presets and their paths automatically, including inside dict-valued fields.
 
 Override categories (applied in order):
     1. Global presets: ``presets=inference,newton_mjwarp`` -- apply everywhere matching
-    2. Path presets: ``env.backend=newton_mjwarp`` -- REPLACE specific section
-    3. Preset-path scalars: ``env.backend.dt=0.001`` -- handled by us
-    4. Global scalars: ``env.decimation=10`` -- handled by Hydra
+    2. Typed selectors: ``physics=newton_mjwarp`` / ``renderer=NAME`` -- like a
+       global preset, but must resolve against a config of that type or it errors
+    3. Path presets: ``env.backend=newton_mjwarp`` -- REPLACE specific section
+    4. Preset-path scalars: ``env.backend.dt=0.001`` -- handled by us
+    5. Global scalars: ``env.decimation=10`` -- handled by Hydra
 
 Example usage::
 
@@ -279,7 +281,7 @@ def _pick_alternative(
     path: str = "",
     explicit_name: str | None = None,
     consumed_selected: set[str] | None = None,
-    typed_hits: set[str] | None = None,
+    typed_hits: dict[str, set[PresetTarget]] | None = None,
 ):
     """Choose the best alternative from a PresetCfg.
 
@@ -316,10 +318,11 @@ def _pick_alternative(
             consumed_selected.add(raw_name)
             consumed_selected.add(name)
         if typed_hits is not None:
-            # mark a reserved typed name (e.g. newton_mjwarp) that landed on its own backend type
-            target = PresetTarget.reserved_preset_targets().get(name)
-            if target is not None and isinstance(val, target.base_classes):
-                typed_hits.add(name)
+            # record which typed targets (physics/renderer) this name landed on
+            targets = {t for t in PresetTarget if t.base_classes and isinstance(val, t.base_classes)}
+            if targets:
+                typed_hits.setdefault(raw_name, set()).update(targets)
+                typed_hits.setdefault(name, set()).update(targets)
         if match_name is not None:
             if match_value is not val and match_value != val:
                 raise ValueError(
@@ -344,7 +347,7 @@ def _resolve_active_presets(
     *,
     strict_explicit: bool = True,
     consumed_selected: set[str] | None = None,
-    typed_hits: set[str] | None = None,
+    typed_hits: dict[str, set[PresetTarget]] | None = None,
     consumed_explicit: set[str] | None = None,
 ):
     """Resolve presets by walking only the currently active tree.
@@ -543,27 +546,33 @@ def _format_unknown_presets_error(unknown: set[str], name_to_paths: dict[str, li
     return "\n".join(lines)
 
 
-def _validate_typed_presets(selected: list[str], consumed: set[str], typed_hits: set[str]) -> None:
-    """Check that each selected physics/renderer preset actually hit its backend.
+def _validate_typed_presets(
+    requested: dict[PresetTarget, set[str]],
+    typed_hits: dict[str, set[PresetTarget]],
+) -> None:
+    """Check that each typed selector landed on a config of its own type.
 
-    Names like ``newton_mjwarp`` are reserved for a backend (physics). If a task
-    reuses that name on something unrelated (a scalar, a sensor variant),
-    selecting it would tune those fields while leaving the real backend
-    untouched -- a silent backend mix. So if a reserved name was used somewhere
-    (``consumed``) but never landed on a config of its own type (``typed_hits``),
-    raise. Names that matched nothing are left for the unknown-preset error.
+    A typed selector (``physics=NAME`` / ``renderer=NAME``) is an explicit
+    request for a backend of that type, so ``NAME`` must replace at least one
+    config of that type during resolution. If it only matched unrelated presets
+    that happen to share the name (a scalar, a sensor variant), the backend
+    silently stays unchanged, so raise. The free-form ``presets=NAME`` broadcast
+    is intentionally *not* checked -- there the user makes no typing claim.
 
     Raises:
-        ValueError: If a reserved name was applied but not to its own backend.
+        ValueError: If a ``physics=`` / ``renderer=`` name never resolved
+            against a config of that target's type.
     """
     aliases = PresetTarget.all_legacy_aliases()
-    reserved = PresetTarget.reserved_preset_targets()
-    missing = sorted({i for raw in selected for i in [aliases.get(raw, raw)] if i in reserved} & consumed - typed_hits)
+    missing = sorted(
+        (t.value, n) for t, ns in requested.items() for n in ns if t not in typed_hits.get(aliases.get(n, n), set())
+    )
     if missing:
-        targets = ", ".join(sorted({reserved[i].value for i in missing}))
+        clauses = ", ".join(f"{label}={name}" for label, name in missing)
         raise ValueError(
-            f"Selected preset(s) {', '.join(missing)} never applied to a '{targets}' config for this task. "
-            "The name only matched unrelated presets, which would silently mix backends. "
+            f"Typed preset selector(s) {clauses} did not match any preset of that type for this task. "
+            "The name only matched unrelated presets (or nothing), so the backend would stay unchanged. "
+            "Use a task that declares it on the matching config, or drop the selector."
         )
 
 
@@ -583,7 +592,12 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
     env_cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
     agent_cfg = load_cfg_from_registry(task_name, agent_entry) if agent_entry else None
 
+    # CLI preset tokens: ``presets=NAME[,...]`` broadcasts (no typing claim),
+    # while ``physics=NAME`` / ``renderer=NAME`` are typed selectors that must
+    # resolve against a config of that type (enforced after resolution).
+    typed_labels = {target.value: target for target in PresetTarget if target.base_classes}
     global_presets: list[str] = []
+    requested_targets: dict[PresetTarget, set[str]] = {}
     override_items: list[tuple[str, str, str]] = []
     hydra_args: list[str] = []
     for arg in sys.argv[1:]:
@@ -591,14 +605,19 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
             hydra_args.append(arg)
             continue
         key, val = arg.split("=", 1)
-        if key.lstrip("-") == "presets":
+        token = key.lstrip("-")
+        if token == PresetTarget.DOMAIN.value:
             global_presets.extend(v.strip() for v in val.split(",") if v.strip())
+        elif token in typed_labels:
+            for name in (v.strip() for v in val.split(",") if v.strip()):
+                global_presets.append(name)
+                requested_targets.setdefault(typed_labels[token], set()).add(name)
         else:
             override_items.append((key, val, arg))
 
     explicit = {key: val for key, val, _arg in override_items}
     consumed_presets: set[str] = set()
-    typed_hits: set[str] = set()
+    typed_hits: dict[str, set[PresetTarget]] = {}
     consumed_explicit: set[str] = set()
     env_explicit = {path: name for path, name in explicit.items() if path == "env" or path.startswith("env.")}
     agent_explicit = {path: name for path, name in explicit.items() if path == "agent" or path.startswith("agent.")}
@@ -645,8 +664,8 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
             display = {n: p for n, p in name_to_paths.items() if n != "default"}
             raise ValueError(_format_unknown_presets_error(unknown, display))
 
-    # Reserved typed presets (e.g. Newton physics solvers) must have landed on a cfg of their type
-    _validate_typed_presets(global_presets, consumed_presets, typed_hits)
+    # Typed selectors (physics=/renderer=) must have landed on a cfg of their type
+    _validate_typed_presets(requested_targets, typed_hits)
 
     cfgs = {"env": env_cfg, "agent": agent_cfg}
     for key, val, arg in override_items:

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -279,6 +279,7 @@ def _pick_alternative(
     path: str = "",
     explicit_name: str | None = None,
     consumed_selected: set[str] | None = None,
+    typed_hits: set[str] | None = None,
 ):
     """Choose the best alternative from a PresetCfg.
 
@@ -310,16 +311,21 @@ def _pick_alternative(
         name = _normalize_preset_name(raw_name, field_names)
         if name not in fields or name == match_name:
             continue
+        val = fields[name]
         if consumed_selected is not None:
             consumed_selected.add(raw_name)
             consumed_selected.add(name)
+        if typed_hits is not None:
+            # mark a reserved typed name (e.g. newton_mjwarp) that landed on its own backend type
+            target = PresetTarget.reserved_preset_targets().get(name)
+            if target is not None and isinstance(val, target.base_classes):
+                typed_hits.add(name)
         if match_name is not None:
-            val = fields[name]
             if match_value is not val and match_value != val:
                 raise ValueError(
                     f"Conflicting global presets: '{match_name}' and '{name}' both define preset for '{path}'"
                 )
-        match_name, match_value = name, fields[name]
+        match_name, match_value = name, val
     if match_name is not None:
         return match_value
     if "default" in fields:
@@ -338,6 +344,7 @@ def _resolve_active_presets(
     *,
     strict_explicit: bool = True,
     consumed_selected: set[str] | None = None,
+    typed_hits: set[str] | None = None,
     consumed_explicit: set[str] | None = None,
 ):
     """Resolve presets by walking only the currently active tree.
@@ -364,6 +371,7 @@ def _resolve_active_presets(
                 path=path,
                 explicit_name=explicit.get(path),
                 consumed_selected=consumed_selected,
+                typed_hits=typed_hits,
             )
         return val
 
@@ -535,6 +543,30 @@ def _format_unknown_presets_error(unknown: set[str], name_to_paths: dict[str, li
     return "\n".join(lines)
 
 
+def _validate_typed_presets(selected: list[str], consumed: set[str], typed_hits: set[str]) -> None:
+    """Check that each selected physics/renderer preset actually hit its backend.
+
+    Names like ``newton_mjwarp`` are reserved for a backend (physics). If a task
+    reuses that name on something unrelated (a scalar, a sensor variant),
+    selecting it would tune those fields while leaving the real backend
+    untouched -- a silent backend mix. So if a reserved name was used somewhere
+    (``consumed``) but never landed on a config of its own type (``typed_hits``),
+    raise. Names that matched nothing are left for the unknown-preset error.
+
+    Raises:
+        ValueError: If a reserved name was applied but not to its own backend.
+    """
+    aliases = PresetTarget.all_legacy_aliases()
+    reserved = PresetTarget.reserved_preset_targets()
+    missing = sorted({i for raw in selected for i in [aliases.get(raw, raw)] if i in reserved} & consumed - typed_hits)
+    if missing:
+        targets = ", ".join(sorted({reserved[i].value for i in missing}))
+        raise ValueError(
+            f"Selected preset(s) {', '.join(missing)} never applied to a '{targets}' config for this task. "
+            "The name only matched unrelated presets, which would silently mix backends. "
+        )
+
+
 def register_task(task_name: str, agent_entry: str) -> tuple:
     """Load configs, collect presets recursively, register base config to Hydra.
 
@@ -566,6 +598,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
 
     explicit = {key: val for key, val, _arg in override_items}
     consumed_presets: set[str] = set()
+    typed_hits: set[str] = set()
     consumed_explicit: set[str] = set()
     env_explicit = {path: name for path, name in explicit.items() if path == "env" or path.startswith("env.")}
     agent_explicit = {path: name for path, name in explicit.items() if path == "agent" or path.startswith("agent.")}
@@ -576,6 +609,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
         root_path="env",
         strict_explicit=False,
         consumed_selected=consumed_presets,
+        typed_hits=typed_hits,
         consumed_explicit=consumed_explicit,
     )
     if agent_cfg is not None:
@@ -586,6 +620,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
             root_path="agent",
             strict_explicit=False,
             consumed_selected=consumed_presets,
+            typed_hits=typed_hits,
             consumed_explicit=consumed_explicit,
         )
 
@@ -609,6 +644,9 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
         if unknown:
             display = {n: p for n, p in name_to_paths.items() if n != "default"}
             raise ValueError(_format_unknown_presets_error(unknown, display))
+
+    # Reserved typed presets (e.g. Newton physics solvers) must have landed on a cfg of their type
+    _validate_typed_presets(global_presets, consumed_presets, typed_hits)
 
     cfgs = {"env": env_cfg, "agent": agent_cfg}
     for key, val, arg in override_items:

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
@@ -11,20 +11,13 @@ Recognizes three ``key=value`` tokens (no leading dashes) on ``sys.argv``:
 * ``renderer=NAME``           -- typed selector for ``RendererCfg`` variants.
 * ``presets=NAME[,NAME,...]`` -- broadcast applied to every matching ``PresetCfg``.
 
-Two responsibilities, split across two functions:
-
-* :func:`setup_preset_cli` -- register the preset-selection help description on
-  the parser and run ``parse_known_args``. Returns the raw pre-fold remainder.
-* :func:`fold_preset_tokens` -- rewrite typed selectors and any free-form
-  ``presets=...`` tokens into a single ``presets=<csv>`` token that hydra's
-  :func:`~isaaclab_tasks.utils.hydra.resolve_presets` consumes. The resolver,
-  alias rewriting, and unknown-name errors are unchanged.
-
-Splitting the fold out lets callers intersect the pre-fold remainder with
-external sources (e.g. ``rsl_rl`` scripts' ``--external_callback`` hook, which
-reads the user's unmutated ``sys.argv`` and returns pre-fold tokens) in the
-same vocabulary. The fold runs exactly once, at the caller's final
-``sys.argv`` assignment.
+:func:`setup_preset_cli` registers the preset-selection help description on the
+parser and runs ``parse_known_args``, returning the verbatim remainder. The
+tokens above are passed through unchanged; hydra's
+:func:`~isaaclab_tasks.utils.hydra.register_task` parses them directly (applying
+the names as presets and enforcing that ``physics=``/``renderer=`` resolve
+against a config of that type). Callers simply assign the remainder to
+``sys.argv``; no rewriting step is needed.
 
 No argparse arguments are registered for the typed selectors -- discoverability
 lives in the ``argument_group`` description, so the parsed Namespace gains no
@@ -37,16 +30,17 @@ Typical script setup::
     # ... script-specific args ...
     add_launcher_args(parser)
     args_cli, remaining = setup_preset_cli(parser)
-    sys.argv = [sys.argv[0]] + fold_preset_tokens(remaining)
+    sys.argv = [sys.argv[0]] + remaining
 
-Scripts that need to intersect the remainder with external-callback output do
-the intersection first (both sides pre-fold, vocabulary matches), then fold::
+Scripts that intersect the remainder with external-callback output (e.g.
+``rsl_rl`` scripts' ``--external_callback`` hook) do the intersection on the
+remainder before assigning ``sys.argv`` -- both sides share the same token
+vocabulary::
 
     args_cli, remaining = setup_preset_cli(parser)
     if args_cli.external_callback:
-        cb_remainder = external_callback_function()
-        remaining = list_intersection(remaining, cb_remainder)
-    sys.argv = [sys.argv[0]] + fold_preset_tokens(remaining)
+        remaining = list_intersection(remaining, external_callback_function())
+    sys.argv = [sys.argv[0]] + remaining
 
 ``setup_preset_cli`` does NOT add AppLauncher flags itself -- callers add them
 explicitly via :func:`isaaclab.app.add_launcher_args` before calling.
@@ -73,18 +67,14 @@ def setup_preset_cli(
     registered on ``parser`` -- otherwise those unknown tokens land in
     ``parse_known_args``'s remainder.
 
-    Does NOT fold typed selectors. The returned remainder still contains the
-    user-typed ``physics=`` / ``renderer=`` / ``presets=`` tokens verbatim,
-    alongside any Hydra path overrides and any unknown argparse flags. Call
-    :func:`fold_preset_tokens` on the remainder before assigning ``sys.argv``;
-    keeping parse and fold separate lets callers run other filters (notably
-    ``rsl_rl``'s ``--external_callback`` intersection) on the pre-fold list,
-    where vocabularies match.
+    The returned remainder contains the user-typed ``physics=`` / ``renderer=``
+    / ``presets=`` tokens verbatim, alongside any Hydra path overrides and any
+    unknown argparse flags, ready to assign to ``sys.argv`` for hydra to parse.
 
     Does not mutate ``sys.argv``; the caller assigns
-    ``sys.argv = [sys.argv[0]] + fold_preset_tokens(remaining)`` when ready, so
-    any argv-aware logic that re-reads ``sys.argv`` (e.g. an external callback)
-    runs against the user's original command line.
+    ``sys.argv = [sys.argv[0]] + remaining`` when ready, so any argv-aware logic
+    that re-reads ``sys.argv`` (e.g. an external callback) runs against the
+    user's original command line first.
 
     Args:
         parser: Caller's argument parser. An ``argument_group`` is attached
@@ -99,8 +89,8 @@ def setup_preset_cli(
 
     Returns:
         ``(args, remaining)`` where ``remaining`` is the verbatim output of
-        ``parser.parse_known_args(argv)``. Apply :func:`fold_preset_tokens`
-        to ``remaining`` before handing it to Hydra.
+        ``parser.parse_known_args(argv)``, ready to hand to Hydra via
+        ``sys.argv``.
     """
     # --help short-circuits parsing, so help text that depends on --task has to
     # find it before argparse runs. Gate the env_cfg load on --help to keep
@@ -123,58 +113,6 @@ def setup_preset_cli(
     parser.add_argument_group("preset selection", description=_DescriptionBuilder.build(actual_variants))
 
     return parser.parse_known_args(argv)
-
-
-def fold_preset_tokens(tokens: list[str]) -> list[str]:
-    """Fold preset selector tokens into a single ``presets=<csv>`` token.
-
-    Recognises ``physics=NAME`` / ``renderer=NAME`` / ``presets=NAME[,NAME,...]``
-    in *tokens* (exact key match; dotted keys like ``env.sim.physics=NAME`` are
-    path-targeted overrides and pass through unchanged). All recognised names
-    are deduped in first-occurrence order and emitted as a leading
-    ``presets=<csv>`` token; every other token in *tokens* is appended in its
-    original position.
-
-    Call this on the remainder returned by :func:`setup_preset_cli` before
-    assigning ``sys.argv``. Scripts that intersect the remainder with
-    callback-returned tokens (e.g. ``rsl_rl/{train,play}.py``'s
-    ``--external_callback`` flow) must do the intersection *first* (both sides
-    pre-fold) and then call this function.
-
-    Args:
-        tokens: Pre-fold token list (typically the second element of the
-            tuple returned by :func:`setup_preset_cli`).
-
-    Returns:
-        A new list with selector tokens folded into one leading
-        ``presets=<csv>`` token if any were present; otherwise the input list
-        is returned unchanged.
-    """
-    typed_labels = {t.value for t in PresetTarget if t.base_classes}
-    names: list[str] = []
-    kept: list[str] = []
-    for token in tokens:
-        if "=" not in token:
-            kept.append(token)
-            continue
-        key, val = token.split("=", 1)
-        if key in typed_labels:
-            # Typed selector value is a single name; commas are reserved for ``presets=`` broadcast.
-            stripped = val.strip()
-            if stripped:
-                names.append(stripped)
-        elif key == PresetTarget.DOMAIN.value:
-            names.extend(name.strip() for name in val.split(",") if name.strip())
-        else:
-            kept.append(token)
-
-    if not names:
-        return list(kept)
-
-    # Dedupe, preserve first-occurrence order.
-    seen: set[str] = set()
-    deduped = [name for name in names if not (name in seen or seen.add(name))]
-    return [f"presets={','.join(deduped)}", *kept]
 
 
 # ============================================================================

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
@@ -17,9 +17,15 @@ needs to know about that category in one place:
   "no typed target matched".
 * ``legacy_aliases`` -- deprecated-name to canonical-name table for this
   target, aggregated for hydra's resolver via :meth:`all_legacy_aliases`.
+* ``preset_names`` -- the canonical preset names that belong to this target
+  (e.g. the Newton solvers for ``PHYSICS``). Picking one of these must end up
+  replacing a config of this target's type; if it only matched something else,
+  hydra raises. See
+  :func:`~isaaclab_tasks.utils.hydra._validate_typed_presets`.
 
 Adding a new typed target = appending one enum member with its label, base
-classes, and (optional) legacy alias map. The CLI layer needs no other wiring.
+classes, (optional) legacy alias map, and (optional) preset names. The CLI
+layer needs no other wiring.
 """
 
 from __future__ import annotations
@@ -52,10 +58,16 @@ class PresetTarget(enum.Enum):
     Adding a new target = appending one enum member.
     """
 
-    # Members. Tuple values are (label, base_classes, legacy_aliases); the
-    # enum metaclass collects the whole namespace before constructing members,
-    # so ``__new__`` below unpacks each tuple regardless of declaration order.
-    PHYSICS = ("physics", (PhysicsCfg,), {"newton": "newton_mjwarp", "kamino": "newton_kamino"})
+    # Members. Tuple values are (label, base_classes, legacy_aliases,
+    # preset_names); the enum metaclass collects the whole namespace before
+    # constructing members, so ``__new__`` below unpacks each tuple regardless
+    # of declaration order.
+    PHYSICS = (
+        "physics",
+        (PhysicsCfg,),
+        {"newton": "newton_mjwarp", "kamino": "newton_kamino"},
+        {"newton_mjwarp", "newton_kamino"},
+    )
     """Physics backends -- ``physics=NAME`` selector.
 
     Legacy aliases ``newton`` -> ``newton_mjwarp`` and ``kamino`` -> ``newton_kamino``
@@ -66,9 +78,20 @@ class PresetTarget(enum.Enum):
     :func:`~isaaclab_tasks.utils.hydra._normalize_preset_name`) consults these
     and emits a :class:`FutureWarning`; the aliases will be removed in a
     future release.
+
+    ``preset_names`` lists the Newton solver backends. Picking one of these on a
+    task that has no Newton physics would otherwise keep PhysX running while
+    only tweaking Newton-named scalars or sensors, so hydra rejects it instead.
+    ``physx`` and ``ovphysx`` are left out on purpose: PhysX is the default, so
+    asking for it on a task without a physics preset is harmless.
     """
 
-    RENDERER = ("renderer", (RendererCfg,))
+    RENDERER = (
+        "renderer",
+        (RendererCfg,),
+        None,
+        {"newton_renderer", "isaacsim_rtx_renderer", "ovrtx_renderer"},
+    )
     """Camera-sensor renderers -- ``renderer=NAME`` selector."""
 
     DOMAIN = ("presets",)
@@ -87,8 +110,9 @@ class PresetTarget(enum.Enum):
         label: str,
         base_classes: tuple[type, ...] = (),
         legacy_aliases: dict[str, str] | None = None,
+        preset_names: frozenset[str] | set[str] | None = None,
     ):
-        """Construct a member from its ``(label, base_classes, legacy_aliases)`` tuple.
+        """Construct a member from its ``(label, base_classes, legacy_aliases, preset_names)`` tuple.
 
         Args:
             label: Hydra-style selector key (e.g. ``"physics"`` is recognized
@@ -98,15 +122,20 @@ class PresetTarget(enum.Enum):
                 routing).
             legacy_aliases: Optional deprecated-to-canonical map for this
                 target; copied so members cannot alias each other's tables.
+            preset_names: Optional canonical preset names reserved for this
+                target; copied so members cannot alias each other's sets. A
+                reserved name must resolve through this target at least once.
 
         Returns:
             A new enum member with ``_value_`` set to *label*, plus
-            ``base_classes`` and ``legacy_aliases`` attributes.
+            ``base_classes``, ``legacy_aliases`` and ``preset_names``
+            attributes.
         """
         obj = object.__new__(cls)
         obj._value_ = label
         obj.base_classes = tuple(base_classes)
         obj.legacy_aliases = dict(legacy_aliases) if legacy_aliases else {}
+        obj.preset_names = frozenset(preset_names) if preset_names else frozenset()
         return obj
 
     @classmethod
@@ -126,3 +155,15 @@ class PresetTarget(enum.Enum):
             aggregated across all members.
         """
         return {name: rep for target in cls for name, rep in target.legacy_aliases.items()}
+
+    @classmethod
+    @functools.cache
+    def reserved_preset_targets(cls) -> dict[str, PresetTarget]:
+        """Look up which target owns each reserved preset name.
+
+        Returns ``{name: target}``, e.g. ``{"newton_mjwarp": PHYSICS, ...}``.
+        Hydra uses it to check a selected name landed on the right backend.
+        Cached (the sets never change after class construction); do not mutate
+        the result.
+        """
+        return {name: target for target in cls for name in target.preset_names}

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
@@ -17,15 +17,9 @@ needs to know about that category in one place:
   "no typed target matched".
 * ``legacy_aliases`` -- deprecated-name to canonical-name table for this
   target, aggregated for hydra's resolver via :meth:`all_legacy_aliases`.
-* ``preset_names`` -- the canonical preset names that belong to this target
-  (e.g. the Newton solvers for ``PHYSICS``). Picking one of these must end up
-  replacing a config of this target's type; if it only matched something else,
-  hydra raises. See
-  :func:`~isaaclab_tasks.utils.hydra._validate_typed_presets`.
 
 Adding a new typed target = appending one enum member with its label, base
-classes, (optional) legacy alias map, and (optional) preset names. The CLI
-layer needs no other wiring.
+classes, and (optional) legacy alias map. The CLI layer needs no other wiring.
 """
 
 from __future__ import annotations
@@ -58,16 +52,10 @@ class PresetTarget(enum.Enum):
     Adding a new target = appending one enum member.
     """
 
-    # Members. Tuple values are (label, base_classes, legacy_aliases,
-    # preset_names); the enum metaclass collects the whole namespace before
-    # constructing members, so ``__new__`` below unpacks each tuple regardless
-    # of declaration order.
-    PHYSICS = (
-        "physics",
-        (PhysicsCfg,),
-        {"newton": "newton_mjwarp", "kamino": "newton_kamino"},
-        {"newton_mjwarp", "newton_kamino"},
-    )
+    # Members. Tuple values are (label, base_classes, legacy_aliases); the
+    # enum metaclass collects the whole namespace before constructing members,
+    # so ``__new__`` below unpacks each tuple regardless of declaration order.
+    PHYSICS = ("physics", (PhysicsCfg,), {"newton": "newton_mjwarp", "kamino": "newton_kamino"})
     """Physics backends -- ``physics=NAME`` selector.
 
     Legacy aliases ``newton`` -> ``newton_mjwarp`` and ``kamino`` -> ``newton_kamino``
@@ -78,20 +66,9 @@ class PresetTarget(enum.Enum):
     :func:`~isaaclab_tasks.utils.hydra._normalize_preset_name`) consults these
     and emits a :class:`FutureWarning`; the aliases will be removed in a
     future release.
-
-    ``preset_names`` lists the Newton solver backends. Picking one of these on a
-    task that has no Newton physics would otherwise keep PhysX running while
-    only tweaking Newton-named scalars or sensors, so hydra rejects it instead.
-    ``physx`` and ``ovphysx`` are left out on purpose: PhysX is the default, so
-    asking for it on a task without a physics preset is harmless.
     """
 
-    RENDERER = (
-        "renderer",
-        (RendererCfg,),
-        None,
-        {"newton_renderer", "isaacsim_rtx_renderer", "ovrtx_renderer"},
-    )
+    RENDERER = ("renderer", (RendererCfg,))
     """Camera-sensor renderers -- ``renderer=NAME`` selector."""
 
     DOMAIN = ("presets",)
@@ -110,9 +87,8 @@ class PresetTarget(enum.Enum):
         label: str,
         base_classes: tuple[type, ...] = (),
         legacy_aliases: dict[str, str] | None = None,
-        preset_names: frozenset[str] | set[str] | None = None,
     ):
-        """Construct a member from its ``(label, base_classes, legacy_aliases, preset_names)`` tuple.
+        """Construct a member from its ``(label, base_classes, legacy_aliases)`` tuple.
 
         Args:
             label: Hydra-style selector key (e.g. ``"physics"`` is recognized
@@ -122,20 +98,15 @@ class PresetTarget(enum.Enum):
                 routing).
             legacy_aliases: Optional deprecated-to-canonical map for this
                 target; copied so members cannot alias each other's tables.
-            preset_names: Optional canonical preset names reserved for this
-                target; copied so members cannot alias each other's sets. A
-                reserved name must resolve through this target at least once.
 
         Returns:
             A new enum member with ``_value_`` set to *label*, plus
-            ``base_classes``, ``legacy_aliases`` and ``preset_names``
-            attributes.
+            ``base_classes`` and ``legacy_aliases`` attributes.
         """
         obj = object.__new__(cls)
         obj._value_ = label
         obj.base_classes = tuple(base_classes)
         obj.legacy_aliases = dict(legacy_aliases) if legacy_aliases else {}
-        obj.preset_names = frozenset(preset_names) if preset_names else frozenset()
         return obj
 
     @classmethod
@@ -155,15 +126,3 @@ class PresetTarget(enum.Enum):
             aggregated across all members.
         """
         return {name: rep for target in cls for name, rep in target.legacy_aliases.items()}
-
-    @classmethod
-    @functools.cache
-    def reserved_preset_targets(cls) -> dict[str, PresetTarget]:
-        """Look up which target owns each reserved preset name.
-
-        Returns ``{name: target}``, e.g. ``{"newton_mjwarp": PHYSICS, ...}``.
-        Hydra uses it to check a selected name landed on the right backend.
-        Cached (the sets never change after class construction); do not mutate
-        the result.
-        """
-        return {name: target for target in cls for name in target.preset_names}

--- a/source/isaaclab_tasks/test/core/test_hydra.py
+++ b/source/isaaclab_tasks/test/core/test_hydra.py
@@ -1426,11 +1426,12 @@ def test_resolve_presets_errors_on_cyclic_preset_at_root():
 
 
 # =============================================================================
-# Tests: typed-preset validation (reserved physics/renderer presets must hit
-# their typed target)
+# Tests: typed-selector validation (physics=/renderer= must hit their type)
 # =============================================================================
 
 from isaaclab.physics import PhysicsCfg as _RealPhysicsCfg  # noqa: E402
+
+from isaaclab_tasks.utils.preset_target import PresetTarget  # noqa: E402
 
 
 @configclass
@@ -1445,35 +1446,28 @@ class _PhysxPhysicsCfg(_RealPhysicsCfg):
     dt: float = 0.005
 
 
-def test_validate_typed_presets_passes_when_reserved_name_hits_its_target():
-    """A reserved physics name that landed on its backend does not raise."""
-    hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed={"newton_mjwarp"}, typed_hits={"newton_mjwarp"})
+def test_validate_typed_presets_passes_when_selector_hits_its_type():
+    """``physics=newton_mjwarp`` that landed on a PhysicsCfg does not raise."""
+    hydra_mod._validate_typed_presets(
+        {PresetTarget.PHYSICS: {"newton_mjwarp"}},
+        typed_hits={"newton_mjwarp": {PresetTarget.PHYSICS}},
+    )
 
 
-def test_validate_typed_presets_raises_when_reserved_name_hits_only_unrelated():
-    """A reserved physics name used but never on a PhysicsCfg must raise."""
-    with pytest.raises(ValueError, match="silently mix backends"):
-        hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed={"newton_mjwarp"}, typed_hits=set())
+def test_validate_typed_presets_raises_when_selector_misses_its_type():
+    """``physics=newton_mjwarp`` that never landed on a PhysicsCfg must raise."""
+    with pytest.raises(ValueError, match="physics=newton_mjwarp"):
+        hydra_mod._validate_typed_presets({PresetTarget.PHYSICS: {"newton_mjwarp"}}, typed_hits={})
 
 
-def test_validate_typed_presets_ignores_unconsumed_reserved_name():
-    """A reserved name that was never used is left for the unknown-preset path."""
-    hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed=set(), typed_hits=set())
+def test_validate_typed_presets_ignores_broadcast_presets():
+    """A plain ``presets=`` broadcast is never in ``requested``, so it is trusted."""
+    # No typed selectors requested -> nothing to validate, even with no hits.
+    hydra_mod._validate_typed_presets({}, typed_hits={})
 
 
-def test_validate_typed_presets_ignores_unreserved_physics_default():
-    """``physx`` is not reserved, so selecting it without a PhysicsCfg never raises."""
-    hydra_mod._validate_typed_presets(["physx"], consumed={"physx"}, typed_hits=set())
-
-
-def test_validate_typed_presets_canonicalizes_legacy_alias():
-    """A legacy alias (``newton``) is validated as its canonical name."""
-    with pytest.raises(ValueError, match="newton_mjwarp"):
-        hydra_mod._validate_typed_presets(["newton"], consumed={"newton", "newton_mjwarp"}, typed_hits=set())
-
-
-def test_resolve_active_presets_records_typed_hit_for_reserved_name():
-    """End-to-end: a reserved name on a real PhysicsCfg is recorded as a typed hit."""
+def test_resolve_active_presets_records_physics_hit_for_selector():
+    """End-to-end: selecting a name that resolves to a real PhysicsCfg records a PHYSICS hit."""
 
     @configclass
     class PhysicsPresetCfg(PresetCfg):
@@ -1484,17 +1478,17 @@ def test_resolve_active_presets_records_typed_hit_for_reserved_name():
     class EnvWithPhysicsCfg:
         physics: PhysicsPresetCfg = PhysicsPresetCfg()
 
-    consumed: set[str] = set()
-    typed_hits: set[str] = set()
+    typed_hits: dict[str, set[PresetTarget]] = {}
     hydra_mod._resolve_active_presets(
-        EnvWithPhysicsCfg(), ["newton_mjwarp"], {}, root_path="env", consumed_selected=consumed, typed_hits=typed_hits
+        EnvWithPhysicsCfg(), ["newton_mjwarp"], {}, root_path="env", typed_hits=typed_hits
     )
-    assert "newton_mjwarp" in typed_hits
-    hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed, typed_hits)  # passes
+    assert PresetTarget.PHYSICS in typed_hits.get("newton_mjwarp", set())
+    # physics=newton_mjwarp therefore validates.
+    hydra_mod._validate_typed_presets({PresetTarget.PHYSICS: {"newton_mjwarp"}}, typed_hits)
 
 
-def test_resolve_active_presets_no_typed_hit_for_scalar_preset():
-    """A reserved name on a non-physics scalar is consumed but not a typed hit, so validation raises."""
+def test_resolve_active_presets_no_physics_hit_for_scalar_preset():
+    """A name resolving only to a scalar records no typed hit, so a physics= selector raises."""
 
     @configclass
     class EnvWithScalarOnlyCfg:
@@ -1502,7 +1496,7 @@ def test_resolve_active_presets_no_typed_hit_for_scalar_preset():
         armature: PresetCfg = preset(default=0.0, newton_mjwarp=0.01)
 
     consumed: set[str] = set()
-    typed_hits: set[str] = set()
+    typed_hits: dict[str, set[PresetTarget]] = {}
     hydra_mod._resolve_active_presets(
         EnvWithScalarOnlyCfg(),
         ["newton_mjwarp"],
@@ -1511,6 +1505,9 @@ def test_resolve_active_presets_no_typed_hit_for_scalar_preset():
         consumed_selected=consumed,
         typed_hits=typed_hits,
     )
-    assert "newton_mjwarp" in consumed and "newton_mjwarp" not in typed_hits
-    with pytest.raises(ValueError, match="silently mix backends"):
-        hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed, typed_hits)
+    assert "newton_mjwarp" in consumed and PresetTarget.PHYSICS not in typed_hits.get("newton_mjwarp", set())
+    # presets=newton_mjwarp (broadcast) is trusted: no entry in ``requested`` -> no error.
+    hydra_mod._validate_typed_presets({}, typed_hits)
+    # physics=newton_mjwarp (typed selector) must error.
+    with pytest.raises(ValueError, match="physics=newton_mjwarp"):
+        hydra_mod._validate_typed_presets({PresetTarget.PHYSICS: {"newton_mjwarp"}}, typed_hits)

--- a/source/isaaclab_tasks/test/core/test_hydra.py
+++ b/source/isaaclab_tasks/test/core/test_hydra.py
@@ -1423,3 +1423,94 @@ def test_resolve_presets_errors_on_cyclic_preset_at_root():
 
     with pytest.raises(ValueError, match="[Cc]ycl"):
         resolve_presets(RootCyclicA())
+
+
+# =============================================================================
+# Tests: typed-preset validation (reserved physics/renderer presets must hit
+# their typed target)
+# =============================================================================
+
+from isaaclab.physics import PhysicsCfg as _RealPhysicsCfg  # noqa: E402
+
+
+@configclass
+class _NewtonPhysicsCfg(_RealPhysicsCfg):
+    """Minimal real ``PhysicsCfg`` subclass so isinstance bucketing routes to PHYSICS."""
+
+    dt: float = 0.002
+
+
+@configclass
+class _PhysxPhysicsCfg(_RealPhysicsCfg):
+    dt: float = 0.005
+
+
+def test_validate_typed_presets_passes_when_reserved_name_hits_its_target():
+    """A reserved physics name that landed on its backend does not raise."""
+    hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed={"newton_mjwarp"}, typed_hits={"newton_mjwarp"})
+
+
+def test_validate_typed_presets_raises_when_reserved_name_hits_only_unrelated():
+    """A reserved physics name used but never on a PhysicsCfg must raise."""
+    with pytest.raises(ValueError, match="silently mix backends"):
+        hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed={"newton_mjwarp"}, typed_hits=set())
+
+
+def test_validate_typed_presets_ignores_unconsumed_reserved_name():
+    """A reserved name that was never used is left for the unknown-preset path."""
+    hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed=set(), typed_hits=set())
+
+
+def test_validate_typed_presets_ignores_unreserved_physics_default():
+    """``physx`` is not reserved, so selecting it without a PhysicsCfg never raises."""
+    hydra_mod._validate_typed_presets(["physx"], consumed={"physx"}, typed_hits=set())
+
+
+def test_validate_typed_presets_canonicalizes_legacy_alias():
+    """A legacy alias (``newton``) is validated as its canonical name."""
+    with pytest.raises(ValueError, match="newton_mjwarp"):
+        hydra_mod._validate_typed_presets(["newton"], consumed={"newton", "newton_mjwarp"}, typed_hits=set())
+
+
+def test_resolve_active_presets_records_typed_hit_for_reserved_name():
+    """End-to-end: a reserved name on a real PhysicsCfg is recorded as a typed hit."""
+
+    @configclass
+    class PhysicsPresetCfg(PresetCfg):
+        default: _PhysxPhysicsCfg = _PhysxPhysicsCfg()
+        newton_mjwarp: _NewtonPhysicsCfg = _NewtonPhysicsCfg()
+
+    @configclass
+    class EnvWithPhysicsCfg:
+        physics: PhysicsPresetCfg = PhysicsPresetCfg()
+
+    consumed: set[str] = set()
+    typed_hits: set[str] = set()
+    hydra_mod._resolve_active_presets(
+        EnvWithPhysicsCfg(), ["newton_mjwarp"], {}, root_path="env", consumed_selected=consumed, typed_hits=typed_hits
+    )
+    assert "newton_mjwarp" in typed_hits
+    hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed, typed_hits)  # passes
+
+
+def test_resolve_active_presets_no_typed_hit_for_scalar_preset():
+    """A reserved name on a non-physics scalar is consumed but not a typed hit, so validation raises."""
+
+    @configclass
+    class EnvWithScalarOnlyCfg:
+        # ``newton_mjwarp`` here only tunes a scalar -- no PhysicsCfg involved.
+        armature: PresetCfg = preset(default=0.0, newton_mjwarp=0.01)
+
+    consumed: set[str] = set()
+    typed_hits: set[str] = set()
+    hydra_mod._resolve_active_presets(
+        EnvWithScalarOnlyCfg(),
+        ["newton_mjwarp"],
+        {},
+        root_path="env",
+        consumed_selected=consumed,
+        typed_hits=typed_hits,
+    )
+    assert "newton_mjwarp" in consumed and "newton_mjwarp" not in typed_hits
+    with pytest.raises(ValueError, match="silently mix backends"):
+        hydra_mod._validate_typed_presets(["newton_mjwarp"], consumed, typed_hits)

--- a/source/isaaclab_tasks/test/core/test_preset_cli.py
+++ b/source/isaaclab_tasks/test/core/test_preset_cli.py
@@ -3,23 +3,15 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Tests for the typed-preset CLI translator.
+"""Tests for the typed-preset CLI front-end.
 
-Two functions cover the translator:
+:func:`setup_preset_cli` registers the preset-selection help description and
+runs ``parse_known_args``, returning the verbatim remainder. The
+``physics=``/``renderer=``/``presets=`` tokens are passed through unchanged;
+Hydra's :func:`~isaaclab_tasks.utils.hydra.register_task` parses them directly.
 
-* :func:`setup_preset_cli` -- register help description and parse argv.
-  Returns the raw pre-fold remainder; no folding happens inside.
-* :func:`fold_preset_tokens` -- fold typed selectors (``physics=``,
-  ``renderer=``) and free-form ``presets=`` into a single
-  ``presets=<csv>`` token consumed by Hydra's resolver.
-
-Splitting parse from fold lets callers (notably ``rsl_rl/{train,play}.py``)
-intersect the pre-fold remainder with an ``--external_callback`` return list
-in matching vocabulary before folding once at the end. Tests below cover both
-functions individually plus the bug-fix scenario they were split for.
-
-Name validation, alias rewriting, and resolution all live in
-:mod:`isaaclab_tasks.utils.hydra` and have their own tests in
+Name validation, alias rewriting, typed-selector enforcement, and resolution
+all live in :mod:`isaaclab_tasks.utils.hydra` and have their own tests in
 ``test_hydra.py``; this file does not re-cover them.
 """
 
@@ -84,9 +76,9 @@ def test_setup_preset_cli_returns_remainder_only(monkeypatch):
 
 
 def test_setup_preset_cli_passes_typed_tokens_verbatim(monkeypatch):
-    """``setup_preset_cli`` no longer folds; preset tokens come back in
-    their original ``physics=`` / ``renderer=`` / ``presets=`` form so callers
-    can intersect with callback returns in matching vocabulary before folding."""
+    """Preset tokens come back in their original ``physics=`` / ``renderer=`` /
+    ``presets=`` form so hydra can parse them directly and callers can intersect
+    with callback returns in matching vocabulary."""
     monkeypatch.setattr(
         "sys.argv",
         [
@@ -113,15 +105,15 @@ def test_setup_preset_cli_does_not_mutate_sys_argv(monkeypatch):
     """``setup_preset_cli`` must not mutate ``sys.argv`` -- mutation is the
     caller's responsibility. Locks the contract that ``rsl_rl/{train,play}.py``
     rely on so an ``--external_callback`` hook invoked after ``setup_preset_cli``
-    can still read the user's original command line and return pre-fold tokens
-    that the caller intersects against the pre-fold remainder."""
+    can still read the user's original command line and return tokens that the
+    caller intersects against the remainder."""
     original = ["train.py", "--task=Foo-v0", "physics=newton_mjwarp", "env.sim.dt=0.001"]
     monkeypatch.setattr("sys.argv", original)
     from isaaclab_tasks.utils.preset_cli import setup_preset_cli
 
     _, remaining = setup_preset_cli(_make_parser())
     assert sys.argv == original
-    # Remainder is pre-fold (typed selector unchanged).
+    # Remainder carries the typed selector unchanged.
     assert remaining == ["physics=newton_mjwarp", "env.sim.dt=0.001"]
 
 
@@ -177,180 +169,26 @@ def test_setup_preset_cli_does_not_leak_into_app_launcher_sim_app_intersection(m
 
 
 # ---------------------------------------------------------------------------
-# fold_preset_tokens: typed + broadcast tokens fold into one presets=<csv> token
-# ---------------------------------------------------------------------------
-
-
-def test_fold_returns_empty_input_unchanged():
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens([]) == []
-
-
-def test_fold_no_preset_tokens_returns_input_unchanged():
-    """Path-targeted overrides and unknown ``--flag``s pass through verbatim."""
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(["env.sim.dt=0.001"]) == ["env.sim.dt=0.001"]
-    assert fold_preset_tokens(["--my_flag=42", "agent.lr=3e-4"]) == ["--my_flag=42", "agent.lr=3e-4"]
-
-
-def test_fold_physics_token_to_presets_token():
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(["physics=newton_mjwarp", "env.sim.dt=0.001"]) == [
-        "presets=newton_mjwarp",
-        "env.sim.dt=0.001",
-    ]
-
-
-def test_fold_three_selectors_merge_into_one_token():
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(
-        [
-            "physics=newton_mjwarp",
-            "renderer=newton_renderer",
-            "presets=albedo,depth",
-        ]
-    ) == ["presets=newton_mjwarp,newton_renderer,albedo,depth"]
-
-
-def test_fold_dedupes_repeated_names():
-    """A name appearing in both a typed selector and the broadcast list
-    survives once in the folded token."""
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(["physics=newton_mjwarp", "presets=newton_mjwarp,albedo"]) == [
-        "presets=newton_mjwarp,albedo"
-    ]
-
-
-def test_fold_path_targeted_overrides_pass_through():
-    """``env.sim.physics=NAME`` is a Hydra path-targeted override (dotted key)
-    not a typed preset selector (bare ``physics``); it must pass through the
-    fold untouched and reach the resolver in its original form."""
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(["physics=newton_mjwarp", "env.sim.physics=newton_mjwarp", "env.lr=3e-4"]) == [
-        "presets=newton_mjwarp",
-        "env.sim.physics=newton_mjwarp",
-        "env.lr=3e-4",
-    ]
-
-
-def test_fold_unknown_argparse_flag_passes_through():
-    """Anything starting with ``--`` is not a preset token; the fold leaves
-    callback-owned flags in place so the caller's intersection step can drop
-    them via the callback's claim."""
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(["--my_callback_flag=42", "physics=newton_mjwarp"]) == [
-        "presets=newton_mjwarp",
-        "--my_callback_flag=42",
-    ]
-
-
-def test_fold_unknown_name_passes_through_silently(capsys):
-    """A name unknown to the registry is passed through verbatim with no
-    warning. The resolver has the loaded task's full vocabulary and produces
-    the rich error at resolve time if the name truly doesn't exist."""
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(["physics=newton_mujoco"]) == ["presets=newton_mujoco"]
-    assert capsys.readouterr().err == ""
-
-
-def test_fold_custom_task_preset_via_broadcast_passes_through(capsys):
-    """A task-local custom preset name (e.g. Dexsuite's ``cube``) is accepted
-    via the broadcast selector with no fuss -- the registry is a hint, not a gate."""
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(["presets=cube,peg_insert_4mm,mayank_solver"]) == [
-        "presets=cube,peg_insert_4mm,mayank_solver"
-    ]
-    assert capsys.readouterr().err == ""
-
-
-def test_fold_keeps_relative_order_of_non_preset_tokens():
-    """Non-preset tokens retain their relative order; the folded
-    ``presets=<csv>`` token is prepended."""
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(["env.a=1", "physics=newton_mjwarp", "env.b=2", "env.c=3"]) == [
-        "presets=newton_mjwarp",
-        "env.a=1",
-        "env.b=2",
-        "env.c=3",
-    ]
-
-
-def test_fold_drops_empty_typed_value():
-    """An empty typed-selector value (``physics=``) is skipped, not folded
-    as an empty name."""
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    assert fold_preset_tokens(["physics=", "env.sim.dt=0.001"]) == ["env.sim.dt=0.001"]
-
-
-# ---------------------------------------------------------------------------
-# Bug fix regression: intersection-then-fold preserves typed preset selections
+# External-callback intersection: typed selectors survive on the raw remainder
 #
-# Reproduces the rsl_rl/{train,play}.py + --external_callback failure mode
-# (PR #5587 review): a callback that reads the user's pre-fold sys.argv and
-# returns pre-fold tokens must be intersected before folding so vocabularies
-# match. Folding first would put ``presets=NAME`` on one side and
-# ``physics=NAME`` on the other, dropping the preset by string mismatch.
+# rsl_rl/{train,play}.py intersect the parsed remainder with an
+# ``--external_callback`` return list before assigning ``sys.argv``. Because
+# nothing rewrites the tokens, both sides share the same vocabulary and a typed
+# selector present in both survives the intersection unchanged.
 # ---------------------------------------------------------------------------
 
 
-def test_intersection_then_fold_preserves_typed_selection():
-    """The bug-fix order: list_intersection on pre-fold tokens, then fold once.
-
-    Models the rsl_rl callback path. With this order, a typed selector
-    (``physics=newton_mjwarp``) appearing in both the main remainder and the
-    callback's pre-fold return survives the intersection and folds correctly.
-    """
+def test_intersection_preserves_typed_selection():
+    """A typed selector present in both the remainder and the callback return
+    survives ``list_intersection`` verbatim; a callback-owned flag is dropped."""
     from isaaclab.utils.string import list_intersection
 
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
+    main_remainder = ["physics=newton_mjwarp", "--my_callback_flag=42", "env.lr=3e-4"]
+    callback_remainder = ["physics=newton_mjwarp", "env.lr=3e-4"]
 
-    main_remainder_pre_fold = [
-        "physics=newton_mjwarp",
-        "--my_callback_flag=42",  # main parser doesn't know this; callback owns it
-        "env.lr=3e-4",
-    ]
-    # Callback reads (untouched) sys.argv, consumes its --my_callback_flag, returns the rest.
-    callback_remainder_pre_fold = ["physics=newton_mjwarp", "env.lr=3e-4"]
+    intersected = list_intersection(main_remainder, callback_remainder)
 
-    intersected = list_intersection(main_remainder_pre_fold, callback_remainder_pre_fold)
-    folded = fold_preset_tokens(intersected)
-
-    # Preset selection survives; callback-owned flag is correctly dropped.
-    assert folded == ["presets=newton_mjwarp", "env.lr=3e-4"]
-
-
-def test_fold_then_intersection_would_lose_typed_selection():
-    """Document the wrong order. If the caller folded first and intersected
-    second, the post-fold ``presets=newton_mjwarp`` would not match the
-    callback's pre-fold ``physics=newton_mjwarp`` and the preset would be
-    silently dropped. This test pins the bug shape so a future caller doesn't
-    accidentally re-introduce it.
-    """
-    from isaaclab.utils.string import list_intersection
-
-    from isaaclab_tasks.utils.preset_cli import fold_preset_tokens
-
-    main_remainder_pre_fold = ["physics=newton_mjwarp", "--my_callback_flag=42", "env.lr=3e-4"]
-    callback_remainder_pre_fold = ["physics=newton_mjwarp", "env.lr=3e-4"]
-
-    # Wrong order: fold main first, then intersect against pre-fold callback.
-    folded_first = fold_preset_tokens(main_remainder_pre_fold)
-    intersected = list_intersection(folded_first, callback_remainder_pre_fold)
-
-    # Preset is gone -- this is exactly the bug to avoid in rsl_rl scripts.
-    assert intersected == ["env.lr=3e-4"]
-    assert "presets=newton_mjwarp" not in intersected
+    assert intersected == ["physics=newton_mjwarp", "env.lr=3e-4"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

alternative to #5939

- Selecting a typed preset (e.g. `presets=newton_mjwarp`) on a task that does **not** declare that name on a `PhysicsCfg`/`RendererCfg` previously created a silent mixed configuration: the name would match an unrelated scalar/sensor preset that happens to share the name, tuning those fields while leaving the real backend (e.g. PhysX) untouched. This adds a post-resolution check that a selected *reserved* typed name actually landed on a config of its own type at least once, and raises a clear `ValueError` otherwise.
- The set of reserved canonical names is declared per typed target in `PresetTarget` (`preset_target.py`) — `PHYSICS = {newton_mjwarp, newton_kamino}`, plus the known renderer backends. New solvers/renderers opt in by adding their name there; the resolver hardcodes nothing. `physx`/`ovphysx` are intentionally **not** reserved (PhysX is the default backend, so selecting it on a task without a physics preset is harmless rather than a silent mismatch).
- Implementation is minimal: one `typed_hits: set[str]` threaded through `_pick_alternative`/`_resolve_active_presets` records when a reserved name resolves to a value of its target type; `_validate_typed_presets` then flags `reserved-selected ∩ consumed − typed_hits`. Truly-unknown names continue to flow to the existing "Unknown preset(s)" error path.

## Behavior

| Invocation | Result |
|---|---|
| `Isaac-Velocity-Flat-Anymal-C-v0 presets=newton_mjwarp` | resolves (lands on `NewtonCfg`) |
| `Isaac-Navigation-Flat-Anymal-C-v0 presets=newton_mjwarp` | `ValueError` (no Newton physics; only matched a sensor/scalar) |
| `Isaac-Navigation-Flat-Anymal-C-v0 presets=physx` | resolves (PhysX not reserved, benign) |
| `Isaac-Navigation-Flat-Anymal-C-v0 presets=newton_kamino` | "Unknown preset(s)" (unchanged path) |
| legacy alias `presets=newton` on navigation | `ValueError` (canonicalized to `newton_mjwarp`) |

## Test plan

- [x] `./isaaclab.sh -p -m pytest source/isaaclab_tasks/test/core/test_hydra.py` (added 7 regression tests for the validator + end-to-end resolution; full file passes)
- [x] `test_preset_cli.py`, `test_newton_solver_preset_names.py`, `test_preset_kit_decision.py` pass
- [x] Config-resolution probes for the table above
- [x] `pre-commit` (ruff/format/codespell/rst/license) green
- [ ] CI

A changelog fragment is included under `source/isaaclab_tasks/changelog.d/`.