### PR TITLE
Fix subtitle list lengths in cameras demo

### DIFF
--- a/scripts/demos/sensors/cameras.py
+++ b/scripts/demos/sensors/cameras.py
@@ -243,7 +243,7 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
             rgb_images = [scene["camera"].data.output["rgb"][0, ..., :3], scene["tiled_camera"].data.output["rgb"][0]]
             save_images_grid(
                 rgb_images,
-                subtitles=["Camera"],
+                subtitles=["Camera", "TiledCamera"],
                 title="RGB Image: Cam0",
                 filename=os.path.join(output_dir, "rgb", f"{count:04d}.jpg"),
             )
@@ -257,7 +257,7 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
             save_images_grid(
                 depth_images,
                 cmap="turbo",
-                subtitles=["Camera", "RaycasterCamera"],
+                subtitles=["Camera", "TiledCamera", "RaycasterCamera"],
                 title="Depth Image: Cam0",
                 filename=os.path.join(output_dir, "distance_to_camera", f"{count:04d}.jpg"),
             )


### PR DESCRIPTION
## Summary

The `scripts/demos/sensors/cameras.py` demo crashes on its first image-grid save with an `IndexError: list index out of range` because two `save_images_grid` calls pass subtitle lists shorter than the image lists they label.

```
Traceback (most recent call last):
  File "scripts/demos/sensors/cameras.py", line 299, in main
    run_simulator(sim, scene)
  File "scripts/demos/sensors/cameras.py", line 244, in run_simulator
    save_images_grid(
  File "scripts/demos/sensors/cameras.py", line 155, in save_images_grid
    ax.set_title(subtitles[idx])
                 ~~~~~~~~~^^^^^
IndexError: list index out of range
```

## Root cause

PR #5377 dropped the `"TiledCamera"` subtitle entries from two `save_images_grid` calls but kept the corresponding images in the `rgb_images` and `depth_images` lists:

- `rgb_images` has 2 entries (`Camera`, `TiledCamera`) but `subtitles=["Camera"]` had 1
- `depth_images` has 3 entries (`Camera`, `TiledCamera`, `RaycasterCamera`) but `subtitles=["Camera", "RaycasterCamera"]` had 2

`save_images_grid` iterates `enumerate(zip(images, axes))` and indexes `subtitles[idx]`, so as soon as `idx >= len(subtitles)` the demo crashes.

## Fix

Restore the missing `"TiledCamera"` subtitle entries.

## Test plan

- [x] Reproduced the failure with a minimal standalone harness that calls `save_images_grid(2_images, subtitles=["Camera"])` and observed the same `IndexError`
- [x] Re-ran the same harness after the fix with subtitle lists of matching lengths — all four `save_images_grid` call shapes (2/3/N images) produce JPEGs without error
- [x] Reviewer to run `./isaaclab.sh -p scripts/demos/sensors/cameras.py --enable_cameras --headless` end-to-end and confirm no crash