### PR TITLE
Update licence check workflow to use full uv

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -49,30 +49,30 @@ jobs:
         docker system prune -af
 
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: '3.12'
+        enable-cache: true
 
-    - name: Install dependencies using ./isaaclab.sh -i
+    - name: Install dependencies with uv
       env:
-        DEBUG: 1
         OMNI_KIT_ACCEPT_EULA: yes
         ACCEPT_EULA: Y
         ISAACSIM_ACCEPT_EULA: YES
       run: |
-        # first install isaac sim
-        pip install --upgrade pip
-        pip install 'isaacsim[all,extscache]==${{ vars.ISAACSIM_BASE_VERSION || '6.0.0' }}' --extra-index-url https://pypi.nvidia.com
-        chmod +x ./isaaclab.sh  # Make sure the script is executable
-        # install all lab dependencies
-        ./isaaclab.sh -i
-
-    - name: Install pip-licenses
-      run: |
-        pip install --no-cache-dir pip-licenses
-        pip install --no-cache-dir -r tools/template/requirements.txt
-        pip install --no-cache-dir -r docs/requirements.txt
+        # Resolve and install the full Isaac Lab dev closure (all extras) from the
+        # locked sources. This replaces the slow pip-based `./isaaclab.sh -i` path.
+        uv sync --all-extras
+        # Add Isaac Sim into the same environment (not part of the dev pyproject).
+        # `uv sync` runs first so it does not prune the packages installed below.
+        uv pip install 'isaacsim[all,extscache]==${{ vars.ISAACSIM_BASE_VERSION || '6.0.0' }}'
+        # Tools used by the license report and the project template / docs deps.
+        uv pip install pip-licenses pipdeptree \
+          -r tools/template/requirements.txt \
+          -r docs/requirements.txt
+        # Expose the venv to subsequent steps so pip-licenses / pipdeptree are on PATH.
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
     # Optional: Print the license report for visibility
     - name: Print License Report
@@ -80,11 +80,7 @@ jobs:
 
     # Print pipdeptree
     - name: Print pipdeptree
-      run: |
-        # clean up pip cache
-        pip cache purge
-        pip install pipdeptree
-        pipdeptree
+      run: pipdeptree
 
     - name: Check licenses against whitelist and exceptions
       run: |

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -61,17 +61,13 @@ jobs:
         ACCEPT_EULA: Y
         ISAACSIM_ACCEPT_EULA: YES
       run: |
-        # Resolve and install the full Isaac Lab dev closure (all extras) from the
-        # locked sources. This replaces the slow pip-based `./isaaclab.sh -i` path.
-        uv sync --all-extras
-        # Add Isaac Sim into the same environment (not part of the dev pyproject).
-        # `uv sync` runs first so it does not prune the packages installed below.
+        uv sync --extra all
+        # Isaac Sim isn't in the dev pyproject; sync first so it isn't pruned.
         uv pip install 'isaacsim[all,extscache]==${{ vars.ISAACSIM_BASE_VERSION || '6.0.0' }}'
-        # Tools used by the license report and the project template / docs deps.
         uv pip install pip-licenses pipdeptree \
           -r tools/template/requirements.txt \
           -r docs/requirements.txt
-        # Expose the venv to subsequent steps so pip-licenses / pipdeptree are on PATH.
+        # Put the venv on PATH for later steps.
         echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
     # Optional: Print the license report for visibility


### PR DESCRIPTION
# Description

MIgrate the licence-check workflow to use uv.

Reduced the install part of this workflow from **~11 minutes** to **~2.5 minutes**

Functionally the check is the same as uv pulls in the same dependencies


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there