### PR TITLE
Pin ovphysx runtime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -701,7 +701,7 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_tasks"
-        extra-pip-packages: "ovrtx ovphysx"
+        extra-pip-packages: "ovrtx ovphysx==0.4.13"
         include-files: "test_rendering_cartpole_kitless.py,test_rendering_dexsuite_kuka_kitless.py,test_rendering_shadow_hand_kitless.py"
         container-name: isaac-lab-rendering-correctness-kitless-test
   #endregion

--- a/.github/workflows/daily-compatibility.yml
+++ b/.github/workflows/daily-compatibility.yml
@@ -111,7 +111,7 @@ jobs:
         image-tag: ${{ env.DOCKER_IMAGE_TAG }}
         pytest-options: ""
         filter-pattern: "isaaclab_tasks"
-        extra-pip-packages: "ovrtx ovphysx"
+        extra-pip-packages: "ovrtx ovphysx==0.4.13"
 
     - name: Copy All Test Results from IsaacLab Tasks Container
       run: |

--- a/source/isaaclab_ovphysx/changelog.d/antoiner-pin-ovphysx-0-4-13.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-pin-ovphysx-0-4-13.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the OVPhysX optional runtime dependency to install ``ovphysx==0.4.13``
+  instead of accepting newer breaking releases.

--- a/source/isaaclab_ovphysx/pyproject.toml
+++ b/source/isaaclab_ovphysx/pyproject.toml
@@ -23,7 +23,7 @@ Homepage = "https://github.com/isaac-sim/IsaacLab"
 Repository = "https://github.com/isaac-sim/IsaacLab"
 
 [project.optional-dependencies]
-ovphysx = ["ovphysx"]
+ovphysx = ["ovphysx==0.4.13"]
 
 [tool.setuptools]
 include-package-data = true

--- a/source/isaaclab_ovphysx/test/assets/test_articulation.py
+++ b/source/isaaclab_ovphysx/test/assets/test_articulation.py
@@ -28,7 +28,7 @@ and the public setters (:meth:`set_masses_index`, :meth:`set_coms_index`,
 Process-global device lock
 --------------------------
 
-``ovphysx<=0.3.7`` binds device mode (CPU vs GPU) at the C++ layer on the
+The OVPhysX runtime binds device mode (CPU vs GPU) at the C++ layer on the
 first ``ovphysx.PhysX(device=...)`` call and cannot release/swap it without a
 process restart.  :class:`~isaaclab_ovphysx.physics.OvPhysxManager` tracks
 this on ``_locked_device`` and raises :exc:`RuntimeError` if a later
@@ -125,7 +125,7 @@ _LOCKED_DEVICE: list[str | None] = [None]
 def _ovphysx_skip_other_device(request):
     """Skip tests whose ``device`` parameter mismatches the session-locked device.
 
-    ``ovphysx<=0.3.7`` locks the process-global device mode on the first
+    The OVPhysX runtime locks the process-global device mode on the first
     ``ovphysx.PhysX(device=...)`` call, so any test parametrized to a different
     device after the first ``sim.reset()`` would hit
     :exc:`ovphysx.types.PhysXDeviceError`.  We detect the locked device on the

--- a/source/isaaclab_ovphysx/test/assets/test_rigid_object.py
+++ b/source/isaaclab_ovphysx/test/assets/test_rigid_object.py
@@ -11,7 +11,7 @@
 
 Run via ``./scripts/run_ovphysx.sh -m pytest`` (kitless, no ``AppLauncher``).
 
-``ovphysx<=0.3.7`` binds device mode (CPU vs GPU) at the C++ layer on the
+The OVPhysX runtime binds device mode (CPU vs GPU) at the C++ layer on the
 first ``ovphysx.PhysX(device=...)`` construction and cannot swap it without a
 process restart.  Full coverage therefore requires two separate pytest
 invocations -- once with ``-k 'cpu'`` and once with ``-k 'cuda:0'``.  The

--- a/source/isaaclab_ovphysx/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/test/assets/test_rigid_object_collection.py
@@ -11,7 +11,7 @@
 
 Run via ``./scripts/run_ovphysx.sh -m pytest`` (kitless, no ``AppLauncher``).
 
-``ovphysx<=0.3.7`` binds device mode (CPU vs GPU) at the C++ layer on the
+The OVPhysX runtime binds device mode (CPU vs GPU) at the C++ layer on the
 first ``ovphysx.PhysX(device=...)`` construction and cannot swap it without a
 process restart.  Full coverage therefore requires two separate pytest
 invocations -- once with ``-k 'cpu'`` and once with ``-k 'cuda:0'``.  The

--- a/source/isaaclab_ovphysx/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_ovphysx/test/sensors/test_contact_sensor.py
@@ -12,7 +12,7 @@ Run via ``./isaaclab.sh -p -m pytest``; the ovphysx wheel is now invocable
 through the standard Kit Python entrypoint, so the older kitless
 ``./scripts/run_ovphysx.sh`` wrapper is no longer required.
 
-``ovphysx<=0.3.7`` binds device mode (CPU vs GPU) at the C++ layer on the
+The OVPhysX runtime binds device mode (CPU vs GPU) at the C++ layer on the
 first ``ovphysx.PhysX(device=...)`` construction and cannot swap it without a
 process restart.  Full coverage therefore requires two separate pytest
 invocations -- once with ``-k 'cpu'`` and once with ``-k 'cuda:0'``.  The


### PR DESCRIPTION
## Summary
- Pins the OVPhysX optional runtime dependency to `ovphysx==0.4.13`.
- Pins CI direct OV runtime installs to the same `ovphysx` version.
- Adds an `isaaclab_ovphysx` changelog fragment.

## Test Plan
- `PATH=/tmp/git-lfs-local/root/usr/bin:$PATH ./isaaclab.sh -f`
- `./isaaclab.sh -p tools/changelog/cli.py check develop`
- `./isaaclab.sh -p -c "import tomllib; tomllib.load(open(\"source/isaaclab_ovphysx/pyproject.toml\",\"rb\")); tomllib.load(open(\"pyproject.toml\",\"rb\")); print(\"toml ok\")"`

No tests added per request.