### PR TITLE
docs: Update RL entrypoint examples

### DIFF
--- a/docs/source/experimental-features/rlinf_vla_posttraining.rst
+++ b/docs/source/experimental-features/rlinf_vla_posttraining.rst
@@ -151,7 +151,7 @@ Quick Start
 
 .. code-block:: bash
 
-   python scripts/reinforcement_learning/rlinf/train.py \
+   ./isaaclab.sh train --rl_library rlinf \
        --config_name isaaclab_ppo_gr00t_assemble_trocar \
        --model_path /path/to/checkpoint
 
@@ -159,7 +159,7 @@ Quick Start
 
 .. code-block:: bash
 
-   python scripts/reinforcement_learning/rlinf/play.py \
+   ./isaaclab.sh play --rl_library rlinf \
        --config_name isaaclab_ppo_gr00t_assemble_trocar \
        --model_path /path/to/base_model \
        --video
@@ -168,7 +168,7 @@ Quick Start
 
 .. code-block:: bash
 
-   python scripts/reinforcement_learning/rlinf/play.py \
+   ./isaaclab.sh play --rl_library rlinf \
        --config_name isaaclab_ppo_gr00t_assemble_trocar \
        --model_path /path/to/base_model \
        --rl_model_path /path/to/checkpoints/global_step_N \

--- a/docs/source/features/hydra.rst
+++ b/docs/source/features/hydra.rst
@@ -25,30 +25,30 @@ As a result, training with hydra arguments can be run with the following syntax:
 
         .. code-block:: shell
 
-            python scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Cartpole --headless env.actions.joint_effort.scale=10.0 agent.seed=2024
+            ./isaaclab.sh train --rl_library rsl_rl --task=Isaac-Cartpole --headless env.actions.joint_effort.scale=10.0 agent.seed=2024
 
     .. tab-item:: rl_games
         :sync: rl_games
 
         .. code-block:: shell
 
-            python scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole --headless env.actions.joint_effort.scale=10.0 agent.params.seed=2024
+            ./isaaclab.sh train --rl_library rl_games --task=Isaac-Cartpole --headless env.actions.joint_effort.scale=10.0 agent.params.seed=2024
 
     .. tab-item:: skrl
         :sync: skrl
 
         .. code-block:: shell
 
-            python scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole --headless env.actions.joint_effort.scale=10.0 agent.seed=2024
+            ./isaaclab.sh train --rl_library skrl --task=Isaac-Cartpole --headless env.actions.joint_effort.scale=10.0 agent.seed=2024
 
     .. tab-item:: sb3
         :sync: sb3
 
         .. code-block:: shell
 
-            python scripts/reinforcement_learning/sb3/train.py --task=Isaac-Cartpole --headless env.actions.joint_effort.scale=10.0 agent.seed=2024
+            ./isaaclab.sh train --rl_library sb3 --task=Isaac-Cartpole --headless env.actions.joint_effort.scale=10.0 agent.seed=2024
 
-The above command will run the training script with the task ``Isaac-Cartpole`` in headless mode, and set the
+The above command will run training with the task ``Isaac-Cartpole`` in headless mode, and set the
 ``env.actions.joint_effort.scale`` parameter to 10.0 and the ``agent.seed`` parameter to 2024.
 
 .. note::
@@ -413,12 +413,12 @@ to make intent explicit on the command line.
      - OV RTX renderer
 
 Domain presets (observation modes, camera configurations, etc.) are task-specific.
-Pass ``--task=<task-name> --help`` to a training script to see all presets available
+Pass ``--task=<task-name> --help`` to a training command to see all presets available
 for that task, grouped by selector type:
 
 .. code-block:: bash
 
-    python scripts/reinforcement_learning/rsl_rl/train.py \
+    ./isaaclab.sh train --rl_library rsl_rl \
         --task Isaac-Cartpole-Camera-Direct --help
 
 .. note::

--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -96,14 +96,14 @@ To train with multiple GPUs, use the following command, where ``--nproc_per_node
 
         .. code-block:: shell
 
-            python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole --headless --distributed
+            python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/train.py --rl_library rl_games --task=Isaac-Cartpole --headless --distributed
 
     .. tab-item:: rsl_rl
         :sync: rsl_rl
 
         .. code-block:: shell
 
-            python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Cartpole --headless --distributed
+            python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/train.py --rl_library rsl_rl --task=Isaac-Cartpole --headless --distributed
 
     .. tab-item:: skrl
         :sync: skrl
@@ -115,14 +115,14 @@ To train with multiple GPUs, use the following command, where ``--nproc_per_node
 
                 .. code-block:: shell
 
-                    python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole --headless --distributed
+                    python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --headless --distributed
 
             .. tab-item:: JAX
                 :sync: jax
 
                 .. code-block:: shell
 
-                    python -m skrl.utils.distributed.jax --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole --headless --distributed --ml_framework jax
+                    python -m skrl.utils.distributed.jax --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --headless --distributed --ml_framework jax
 
 .. _multi-gpu-nccl-troubleshooting:
 
@@ -182,14 +182,14 @@ For the master node, use the following command, where ``--nproc_per_node`` repre
 
         .. code-block:: shell
 
-            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole --headless --distributed
+            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library rl_games --task=Isaac-Cartpole --headless --distributed
 
     .. tab-item:: rsl_rl
         :sync: rsl_rl
 
         .. code-block:: shell
 
-            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Cartpole --headless --distributed
+            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library rsl_rl --task=Isaac-Cartpole --headless --distributed
 
     .. tab-item:: skrl
         :sync: skrl
@@ -201,14 +201,14 @@ For the master node, use the following command, where ``--nproc_per_node`` repre
 
                 .. code-block:: shell
 
-                    python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole --headless --distributed
+                    python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --headless --distributed
 
             .. tab-item:: JAX
                 :sync: jax
 
                 .. code-block:: shell
 
-                    python -m skrl.utils.distributed.jax --nproc_per_node=2 --nnodes=2 --node_rank=0 --coordinator_address=ip_of_master_machine:5555 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole --headless --distributed --ml_framework jax
+                    python -m skrl.utils.distributed.jax --nproc_per_node=2 --nnodes=2 --node_rank=0 --coordinator_address=ip_of_master_machine:5555 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --headless --distributed --ml_framework jax
 
 Note that the port (``5555``) can be replaced with any other available port.
 
@@ -222,14 +222,14 @@ For non-master nodes, use the following command, replacing ``--node_rank`` with 
 
         .. code-block:: shell
 
-            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole --headless --distributed
+            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library rl_games --task=Isaac-Cartpole --headless --distributed
 
     .. tab-item:: rsl_rl
         :sync: rsl_rl
 
         .. code-block:: shell
 
-            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Cartpole --headless --distributed
+            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library rsl_rl --task=Isaac-Cartpole --headless --distributed
 
     .. tab-item:: skrl
         :sync: skrl
@@ -241,14 +241,14 @@ For non-master nodes, use the following command, replacing ``--node_rank`` with 
 
                 .. code-block:: shell
 
-                    python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole --headless --distributed
+                    python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --headless --distributed
 
             .. tab-item:: JAX
                 :sync: jax
 
                 .. code-block:: shell
 
-                    python -m skrl.utils.distributed.jax --nproc_per_node=2 --nnodes=2 --node_rank=1 --coordinator_address=ip_of_master_machine:5555 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole --headless --distributed --ml_framework jax
+                    python -m skrl.utils.distributed.jax --nproc_per_node=2 --nnodes=2 --node_rank=1 --coordinator_address=ip_of_master_machine:5555 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --headless --distributed --ml_framework jax
 
 For more details on multi-node training with PyTorch, please visit the
 `PyTorch documentation <https://pytorch.org/tutorials/intermediate/ddp_series_multinode.html>`_.

--- a/docs/source/features/population_based_training.rst
+++ b/docs/source/features/population_based_training.rst
@@ -114,7 +114,7 @@ Launch *N* workers, where *n* indicates each worker index:
 .. code-block:: bash
 
    # Run this once per worker (n = 0..N-1), all pointing to the same directory/workspace
-   ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/train.py \
+   ./isaaclab.sh train --rl_library rl_games \
      --seed=<n> \
      --task=Isaac-Repose-Cube-Shadow-Direct-v0 \
      --num_envs=8192 \

--- a/docs/source/features/ray.rst
+++ b/docs/source/features/ray.rst
@@ -138,7 +138,6 @@ In a different terminal, run the following.
     --cfg_file scripts/reinforcement_learning/ray/hyperparameter_tuning/vision_cartpole_cfg.py \
     --cfg_class CartpoleTheiaJobCfg \
     --run_mode local \
-    --workflow scripts/reinforcement_learning/rl_games/train.py \
     --num_workers_per_node <NUMBER_OF_GPUS_IN_COMPUTER>
 
 

--- a/docs/source/features/ray.rst
+++ b/docs/source/features/ray.rst
@@ -138,7 +138,18 @@ In a different terminal, run the following.
     --cfg_file scripts/reinforcement_learning/ray/hyperparameter_tuning/vision_cartpole_cfg.py \
     --cfg_class CartpoleTheiaJobCfg \
     --run_mode local \
+    --workflow scripts/reinforcement_learning/rl_games/train.py \
     --num_workers_per_node <NUMBER_OF_GPUS_IN_COMPUTER>
+
+The Ray tuner currently launches training through its ``--workflow`` script path. The built-in
+example configs still use the library-specific RL-Games workflow shown above. Custom Ray configs
+can use the unified training entrypoint by setting:
+
+.. code-block:: python
+
+  cfg["runner_args"]["--rl_library"] = "rl_games"
+
+and passing ``--workflow scripts/reinforcement_learning/train.py``.
 
 
 To view the training logs, in a different terminal, run the following and visit ``localhost:6006`` in a browser afterwards.

--- a/docs/source/features/reproducibility.rst
+++ b/docs/source/features/reproducibility.rst
@@ -28,7 +28,7 @@ After the simulation app starts, :class:`~isaaclab.app.app_launcher.AppLauncher`
 settings via :meth:`~isaaclab.app.app_launcher.AppLauncher.apply_rtx_determinism_settings`.
 
 **Strict PyTorch determinism** (calling :meth:`~isaaclab.utils.seed.configure_seed` with
-``torch_deterministic=True`` when you pass ``--deterministic``) is wired into the RL training scripts
+``torch_deterministic=True`` when you pass ``--deterministic``) is wired into the RL training entrypoints
 for **RL-Games**, **skrl**, **RSL-RL**, and **Stable-Baselines3**: each calls
 :meth:`~isaaclab.utils.seed.configure_seed` after constructing its framework runner or agent object
 so library initialization is not disturbed, then training proceeds with the requested global RNG and
@@ -40,7 +40,7 @@ To enable deterministic RTX settings from the app launcher, pass ``--determinist
 
 .. code-block:: bash
 
-  ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/train.py \
+  ./isaaclab.sh train --rl_library rl_games \
     --task Isaac-Cartpole-Camera --enable_cameras --headless --deterministic
 
 For results on our determinacy testing for RL training, please check the GitHub Pull Request `#940`_.

--- a/docs/source/how-to/profile_with_nsys.rst
+++ b/docs/source/how-to/profile_with_nsys.rst
@@ -42,7 +42,7 @@ The following command shows how to capture a profile for the ``Isaac-Cartpole`` 
        -t nvtx,cuda \
        --python-functions-trace=scripts/benchmarks/nsys_trace.json \
        -o my_profile \
-       ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+       ./isaaclab.sh train --rl_library rsl_rl \
            --task=Isaac-Cartpole \
            --headless \
            --max_iterations=3

--- a/docs/source/how-to/record_video.rst
+++ b/docs/source/how-to/record_video.rst
@@ -21,7 +21,7 @@ Example usage:
 
 .. code-block:: shell
 
-    python scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole --headless --video --video_length 100 --video_interval 500
+    ./isaaclab.sh train --rl_library rl_games --task=Isaac-Cartpole --headless --video --video_length 100 --video_interval 500
 
 
 The recorded videos will be saved in the same directory as the training checkpoints, under

--- a/docs/source/migration/migrating_from_isaacgymenvs.rst
+++ b/docs/source/migration/migrating_from_isaacgymenvs.rst
@@ -916,7 +916,7 @@ To launch a training in Isaac Lab, use the command:
 
 .. code-block:: bash
 
-   python scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole-Direct --headless
+   ./isaaclab.sh train --rl_library rl_games --task=Isaac-Cartpole-Direct --headless
 
 Launching Inferencing
 ~~~~~~~~~~~~~~~~~~~~~
@@ -925,7 +925,7 @@ To launch inferencing in Isaac Lab, use the command:
 
 .. code-block:: bash
 
-   python scripts/reinforcement_learning/rl_games/play.py --task=Isaac-Cartpole-Direct --num_envs=25 --checkpoint=<path/to/checkpoint>
+   ./isaaclab.sh play --rl_library rl_games --task=Isaac-Cartpole-Direct --num_envs=25 --checkpoint=<path/to/checkpoint>
 
 
 Additional Resources

--- a/docs/source/migration/migrating_from_omniisaacgymenvs.rst
+++ b/docs/source/migration/migrating_from_omniisaacgymenvs.rst
@@ -983,7 +983,7 @@ To launch a training in Isaac Lab, use the command:
 
 .. code-block:: bash
 
-   python scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole-Direct --headless
+   ./isaaclab.sh train --rl_library rl_games --task=Isaac-Cartpole-Direct --headless
 
 Launching Inferencing
 ~~~~~~~~~~~~~~~~~~~~~
@@ -992,7 +992,7 @@ To launch inferencing in Isaac Lab, use the command:
 
 .. code-block:: bash
 
-   python scripts/reinforcement_learning/rl_games/play.py --task=Isaac-Cartpole-Direct --num_envs=25 --checkpoint=<path/to/checkpoint>
+   ./isaaclab.sh play --rl_library rl_games --task=Isaac-Cartpole-Direct --num_envs=25 --checkpoint=<path/to/checkpoint>
 
 
 .. _`OmniIsaacGymEnvs`: https://github.com/isaac-sim/OmniIsaacGymEnvs

--- a/docs/source/migration/migrating_to_isaaclab_3-0.rst
+++ b/docs/source/migration/migrating_to_isaaclab_3-0.rst
@@ -34,6 +34,42 @@ For the full behavior of visualizer resolution, with the visualizer CLI arg, vis
 and ``--headless``, see :ref:`visualization-common-modes`.
 
 
+Reinforcement Learning CLI Entrypoints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Isaac Lab 3.0 provides unified reinforcement learning entrypoints for training
+and play. Instead of launching library-specific scripts under
+``scripts/reinforcement_learning/<library>/``, select the library with
+``--rl_library``.
+
+.. code-block:: bash
+
+   # Isaac Lab 2.x/deprecated
+   ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole --headless
+
+   # Isaac Lab 3.0
+   ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole --headless
+
+The same pattern applies to the play workflow:
+
+.. code-block:: bash
+
+   ./isaaclab.sh play --rl_library rsl_rl --task Isaac-Cartpole --checkpoint /PATH/TO/model.pt
+
+Supported reinforcement learning libraries are ``rsl_rl``, ``rl_games``, ``skrl``,
+``sb3``, and ``rlinf``. The old per-library ``train.py`` and ``play.py`` scripts
+remain available as deprecated compatibility entrypoints and emit a
+``DeprecationWarning`` when used.
+
+For distributed launchers that execute a Python script directly, use the unified
+script path and pass ``--rl_library`` to it:
+
+.. code-block:: bash
+
+   python -m torch.distributed.run --nproc_per_node=2 scripts/reinforcement_learning/train.py \
+      --rl_library rsl_rl --task Isaac-Cartpole --headless --distributed
+
+
 Multi-Backend Architecture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/overview/core-concepts/physical-backends/newton/kamino-solver.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/kamino-solver.rst
@@ -66,18 +66,18 @@ You can select the preset globally:
 
 .. code-block:: bash
 
-    ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Cartpole physics=newton_kamino
+    ./isaaclab.sh train --rl_library rsl_rl --task=Isaac-Cartpole physics=newton_kamino
 
 or select the physics field directly:
 
 .. code-block:: bash
 
-    ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Cartpole env.sim.physics=newton_kamino
+    ./isaaclab.sh train --rl_library rsl_rl --task=Isaac-Cartpole env.sim.physics=newton_kamino
 
 Use the direct path override when only one task field should use the Kamino preset.
 Use ``physics=newton_kamino`` when you want every matching preset field in the task config
 to resolve to ``newton_kamino``.
-Isaac Lab training scripts accept these Hydra overrides after the regular command
+Isaac Lab training commands accept these Hydra overrides after the regular command
 line flags; no separator is needed for the examples above.
 
 

--- a/docs/source/overview/core-concepts/physical-backends/newton/using-vbd-solver.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/using-vbd-solver.rst
@@ -91,17 +91,17 @@ You can select the deformable Newton preset globally:
 
 .. code-block:: bash
 
-    ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Lift-Soft-Franka-v0 physics=newton_mjwarp_vbd
+    ./isaaclab.sh train --rl_library rsl_rl --task=Isaac-Lift-Soft-Franka-v0 physics=newton_mjwarp_vbd
 
 or select the physics field directly:
 
 .. code-block:: bash
 
-    ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Lift-Soft-Franka-v0 env.sim.physics=newton_mjwarp_vbd
+    ./isaaclab.sh train --rl_library rsl_rl --task=Isaac-Lift-Soft-Franka-v0 env.sim.physics=newton_mjwarp_vbd
 
 Use the direct path override when only one task field should use the VBD preset.
 Use ``physics=newton_mjwarp_vbd`` when you want every matching preset field in
-the task config to resolve to that preset. Isaac Lab training scripts accept
+the task config to resolve to that preset. Isaac Lab training commands accept
 these Hydra overrides after the regular command line flags; no separator is
 needed for the examples above.
 

--- a/docs/source/overview/core-concepts/physical-backends/newton/warp-environments.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/warp-environments.rst
@@ -71,11 +71,11 @@ Quick Start
 .. code-block:: bash
 
     # Direct workflow
-    ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+    ./isaaclab.sh train --rl_library rsl_rl \
         --task Isaac-Cartpole-Direct-Warp-v0 --num_envs 4096 --headless
 
     # Manager-based workflow
-    ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+    ./isaaclab.sh train --rl_library rsl_rl \
         --task Isaac-Velocity-Flat-Anymal-C-Warp-v0 --num_envs 4096 --headless
 
 All RL libraries with warp-compatible wrappers are supported: RSL-RL, RL Games, SKRL, and

--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -173,7 +173,7 @@ When using the RTX renderer, add ``--enable_cameras`` when launching:
 
 .. code-block:: shell
 
-    python scripts/reinforcement_learning/rl_games/train.py \
+    ./isaaclab.sh train --rl_library rl_games \
         --task=Isaac-Cartpole-Camera-Direct --headless --enable_cameras
 
 

--- a/docs/source/overview/core-concepts/visualization.rst
+++ b/docs/source/overview/core-concepts/visualization.rst
@@ -70,20 +70,20 @@ Launch visualizers from the command line with ``--visualizer`` (or ``--viz`` ali
 .. code-block:: bash
 
     # Launch all visualizers (comma-delimited list, no spaces)
-    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole --viz kit,newton,rerun
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole --viz kit,newton,rerun
 
     # Launch only the Newton visualizer
-    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole --viz newton
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole --viz newton
 
     # Launch the Viser web-based visualizer
-    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole --viz viser
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole --viz viser
 
 
 To run in headless mode, omit the ``--viz`` argument:
 
 .. code-block:: bash
 
-    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole
 
 .. note::
 
@@ -590,7 +590,7 @@ the num of environments can be overwritten and decreased using ``--num_envs``:
 
 .. code-block:: bash
 
-    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole --viz rerun --num_envs 512
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole --viz rerun --num_envs 512
 
 
 **Rerun Visualizer FPS Control**

--- a/docs/source/overview/own-project/template.rst
+++ b/docs/source/overview/own-project/template.rst
@@ -178,14 +178,14 @@ Here are some general commands to get started with it:
 
         .. code-block:: bash
 
-          python scripts/reinforcement_learning/<specific-rl-library>/train.py --task=<Task-Name>
+          ./isaaclab.sh train --rl_library <library> --task=<Task-Name>
 
     .. tab-item:: :icon:`fa-brands fa-windows` Windows
         :sync: windows
 
         .. code-block:: batch
 
-          python scripts\reinforcement_learning\<specific-rl-library>\train.py --task=<Task-Name>
+          isaaclab.bat train --rl_library <library> --task=<Task-Name>
 
 * Run a task with dummy agents.
 

--- a/docs/source/overview/reinforcement-learning/rl_existing_scripts.rst
+++ b/docs/source/overview/reinforcement-learning/rl_existing_scripts.rst
@@ -1,5 +1,5 @@
-Reinforcement Learning Scripts
-==============================
+Reinforcement Learning Workflows
+================================
 
 We provide wrappers to different reinforcement libraries. These wrappers convert the data
 from the environments into the respective libraries function argument and return types.
@@ -7,23 +7,23 @@ from the environments into the respective libraries function argument and return
 Preset Selectors
 ----------------
 
-All training and play scripts accept ``physics=NAME``, ``renderer=NAME``, and
+All training and play commands accept ``physics=NAME``, ``renderer=NAME``, and
 ``presets=NAME[,NAME,...]`` tokens appended directly to the command (no leading dashes).
 See :doc:`/source/features/hydra` for all available names and how the selectors work.
 
 .. code:: bash
 
    # Switch physics backend
-   ./isaaclab.sh -p scripts/reinforcement_learning/<framework>/train.py \
+   ./isaaclab.sh train --rl_library <library> \
        --task <task-name> --headless physics=newton_mjwarp
 
    # Switch renderer (camera environments)
-   ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+   ./isaaclab.sh train --rl_library rsl_rl \
        --task Isaac-Cartpole-Camera-Direct --headless \
        --enable_cameras renderer=newton_renderer
 
    # Combine selectors freely
-   ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+   ./isaaclab.sh train --rl_library rsl_rl \
        --task Isaac-Cartpole-Camera-Direct --headless \
        --enable_cameras physics=newton_mjwarp renderer=newton_renderer presets=rgb
 
@@ -43,7 +43,7 @@ Observation-mode Presets
 
 Some environments support multiple observation modes selectable via ``presets=``.
 Unlike physics or renderer presets, **observation-mode presets affect the checkpoint
-structure**: you must pass the same preset to both the training and play scripts.
+structure**: you must pass the same preset to both the training and play commands.
 Using a different preset (or none) at play time will cause a model-architecture
 mismatch when loading the checkpoint.
 
@@ -53,12 +53,12 @@ For example, ``Isaac-Repose-Cube-Shadow-Vision-Direct-v0`` defaults to RGB + dep
 .. code:: bash
 
    # Train with RGB-only observations
-   ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+   ./isaaclab.sh train --rl_library rsl_rl \
        --task Isaac-Repose-Cube-Shadow-Vision-Direct-v0 --headless \
        --enable_cameras presets=rgb
 
    # Play — must use the same preset to load the matching checkpoint
-   ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/play.py \
+   ./isaaclab.sh play --rl_library rsl_rl \
        --task Isaac-Repose-Cube-Shadow-Vision-Direct-Play-v0 \
        --enable_cameras presets=rgb
 
@@ -90,14 +90,14 @@ RL-Games
 
             # install python module (for rl-games)
             ./isaaclab.sh -i rl_games
-            # run script for training
-            ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/train.py --task Isaac-Ant-v0 --headless
-            # run script for training with Newton backend
-            ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/train.py --task Isaac-Ant-v0 --headless physics=newton_mjwarp
-            # run script for playing with 32 environments
-            ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/play.py --task Isaac-Ant-v0 --num_envs 32 --checkpoint /PATH/TO/model.pth
-            # run script for recording video of a trained agent (requires installing `ffmpeg`)
-            ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/play.py --task Isaac-Ant-v0 --headless --video --video_length 200
+            # run command for training
+            ./isaaclab.sh train --rl_library rl_games --task Isaac-Ant-v0 --headless
+            # run command for training with Newton backend
+            ./isaaclab.sh train --rl_library rl_games --task Isaac-Ant-v0 --headless physics=newton_mjwarp
+            # run command for playing with 32 environments
+            ./isaaclab.sh play --rl_library rl_games --task Isaac-Ant-v0 --num_envs 32 --checkpoint /PATH/TO/model.pth
+            # run command for recording video of a trained agent (requires installing `ffmpeg`)
+            ./isaaclab.sh play --rl_library rl_games --task Isaac-Ant-v0 --headless --video --video_length 200
 
       .. tab-item:: :icon:`fa-brands fa-windows` Windows
          :sync: windows
@@ -106,14 +106,14 @@ RL-Games
 
             :: install python module (for rl-games)
             isaaclab.bat -i rl_games
-            :: run script for training
-            isaaclab.bat -p scripts\reinforcement_learning\rl_games\train.py --task Isaac-Ant-v0 --headless
-            :: run script for training with Newton backend
-            isaaclab.bat -p scripts\reinforcement_learning\rl_games\train.py --task Isaac-Ant-v0 --headless physics=newton_mjwarp
-            :: run script for playing with 32 environments
-            isaaclab.bat -p scripts\reinforcement_learning\rl_games\play.py --task Isaac-Ant-v0 --num_envs 32 --checkpoint /PATH/TO/model.pth
-            :: run script for recording video of a trained agent (requires installing `ffmpeg`)
-            isaaclab.bat -p scripts\reinforcement_learning\rl_games\play.py --task Isaac-Ant-v0 --headless --video --video_length 200
+            :: run command for training
+            isaaclab.bat train --rl_library rl_games --task Isaac-Ant-v0 --headless
+            :: run command for training with Newton backend
+            isaaclab.bat train --rl_library rl_games --task Isaac-Ant-v0 --headless physics=newton_mjwarp
+            :: run command for playing with 32 environments
+            isaaclab.bat play --rl_library rl_games --task Isaac-Ant-v0 --num_envs 32 --checkpoint /PATH/TO/model.pth
+            :: run command for recording video of a trained agent (requires installing `ffmpeg`)
+            isaaclab.bat play --rl_library rl_games --task Isaac-Ant-v0 --headless --video --video_length 200
 
 RSL-RL
 ------
@@ -131,14 +131,14 @@ RSL-RL
 
             # install python module (for rsl-rl)
             ./isaaclab.sh -i rsl_rl
-            # run script for training
-            ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Reach-Franka-v0 --headless
-            # run script for training with Newton backend
-            ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Reach-Franka-v0 --headless physics=newton_mjwarp
-            # run script for playing with 32 environments
-            ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/play.py --task Isaac-Reach-Franka-v0 --num_envs 32 --load_run run_folder_name --checkpoint /PATH/TO/model.pt
-            # run script for recording video of a trained agent (requires installing `ffmpeg`)
-            ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/play.py --task Isaac-Reach-Franka-v0 --headless --video --video_length 200
+            # run command for training
+            ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Reach-Franka-v0 --headless
+            # run command for training with Newton backend
+            ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Reach-Franka-v0 --headless physics=newton_mjwarp
+            # run command for playing with 32 environments
+            ./isaaclab.sh play --rl_library rsl_rl --task Isaac-Reach-Franka-v0 --num_envs 32 --load_run run_folder_name --checkpoint /PATH/TO/model.pt
+            # run command for recording video of a trained agent (requires installing `ffmpeg`)
+            ./isaaclab.sh play --rl_library rsl_rl --task Isaac-Reach-Franka-v0 --headless --video --video_length 200
 
       .. tab-item:: :icon:`fa-brands fa-windows` Windows
          :sync: windows
@@ -147,14 +147,14 @@ RSL-RL
 
             :: install python module (for rsl-rl)
             isaaclab.bat -i rsl_rl
-            :: run script for training
-            isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py --task Isaac-Reach-Franka-v0 --headless
-            :: run script for training with Newton backend
-            isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py --task Isaac-Reach-Franka-v0 --headless physics=newton_mjwarp
-            :: run script for playing with 32 environments
-            isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\play.py --task Isaac-Reach-Franka-v0 --num_envs 32 --load_run run_folder_name --checkpoint /PATH/TO/model.pt
-            :: run script for recording video of a trained agent (requires installing `ffmpeg`)
-            isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\play.py --task Isaac-Reach-Franka-v0 --headless --video --video_length 200
+            :: run command for training
+            isaaclab.bat train --rl_library rsl_rl --task Isaac-Reach-Franka-v0 --headless
+            :: run command for training with Newton backend
+            isaaclab.bat train --rl_library rsl_rl --task Isaac-Reach-Franka-v0 --headless physics=newton_mjwarp
+            :: run command for playing with 32 environments
+            isaaclab.bat play --rl_library rsl_rl --task Isaac-Reach-Franka-v0 --num_envs 32 --load_run run_folder_name --checkpoint /PATH/TO/model.pt
+            :: run command for recording video of a trained agent (requires installing `ffmpeg`)
+            isaaclab.bat play --rl_library rsl_rl --task Isaac-Reach-Franka-v0 --headless --video --video_length 200
 
 -  Training and distilling an agent with
    `RSL-RL <https://github.com/leggedrobotics/rsl_rl>`__ on ``Isaac-Velocity-Flat-Anymal-D-v0``:
@@ -169,14 +169,14 @@ RSL-RL
 
             # install python module (for rsl-rl)
             ./isaaclab.sh -i rsl_rl
-            # run script for rl training of the teacher agent
-            ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --headless
-            # run script for rl training of the teacher agent with Newton backend
-            ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --headless physics=newton_mjwarp
-            # run script for distilling the teacher agent into a student agent
-            ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --headless --agent rsl_rl_distillation_cfg_entry_point --load_run teacher_run_folder_name
-            # run script for playing the student with 64 environments
-            ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/play.py --task Isaac-Velocity-Flat-Anymal-D-v0 --num_envs 64 --agent rsl_rl_distillation_cfg_entry_point
+            # run command for rl training of the teacher agent
+            ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Velocity-Flat-Anymal-D-v0 --headless
+            # run command for rl training of the teacher agent with Newton backend
+            ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Velocity-Flat-Anymal-D-v0 --headless physics=newton_mjwarp
+            # run command for distilling the teacher agent into a student agent
+            ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Velocity-Flat-Anymal-D-v0 --headless --agent rsl_rl_distillation_cfg_entry_point --load_run teacher_run_folder_name
+            # run command for playing the student with 64 environments
+            ./isaaclab.sh play --rl_library rsl_rl --task Isaac-Velocity-Flat-Anymal-D-v0 --num_envs 64 --agent rsl_rl_distillation_cfg_entry_point
 
       .. tab-item:: :icon:`fa-brands fa-windows` Windows
          :sync: windows
@@ -185,14 +185,14 @@ RSL-RL
 
             :: install python module (for rsl-rl)
             isaaclab.bat -i rsl_rl
-            :: run script for rl training of the teacher agent
-            isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --headless
-            :: run script for rl training of the teacher agent with Newton backend
-            isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --headless physics=newton_mjwarp
-            :: run script for distilling the teacher agent into a student agent
-            isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --headless --agent rsl_rl_distillation_cfg_entry_point --load_run teacher_run_folder_name
-            :: run script for playing the student with 64 environments
-            isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\play.py --task Isaac-Velocity-Flat-Anymal-D-v0 --num_envs 64 --agent rsl_rl_distillation_cfg_entry_point
+            :: run command for rl training of the teacher agent
+            isaaclab.bat train --rl_library rsl_rl --task Isaac-Velocity-Flat-Anymal-D-v0 --headless
+            :: run command for rl training of the teacher agent with Newton backend
+            isaaclab.bat train --rl_library rsl_rl --task Isaac-Velocity-Flat-Anymal-D-v0 --headless physics=newton_mjwarp
+            :: run command for distilling the teacher agent into a student agent
+            isaaclab.bat train --rl_library rsl_rl --task Isaac-Velocity-Flat-Anymal-D-v0 --headless --agent rsl_rl_distillation_cfg_entry_point --load_run teacher_run_folder_name
+            :: run command for playing the student with 64 environments
+            isaaclab.bat play --rl_library rsl_rl --task Isaac-Velocity-Flat-Anymal-D-v0 --num_envs 64 --agent rsl_rl_distillation_cfg_entry_point
 
 SKRL
 ----
@@ -214,14 +214,14 @@ SKRL
 
                      # install python module (for skrl)
                      ./isaaclab.sh -i skrl
-                     # run script for training
-                     ./isaaclab.sh -p scripts/reinforcement_learning/skrl/train.py --task Isaac-Reach-Franka-v0 --headless
-                     # run script for training with Newton backend
-                     ./isaaclab.sh -p scripts/reinforcement_learning/skrl/train.py --task Isaac-Reach-Franka-v0 --headless physics=newton_mjwarp
-                     # run script for playing with 32 environments
-                     ./isaaclab.sh -p scripts/reinforcement_learning/skrl/play.py --task Isaac-Reach-Franka-v0 --num_envs 32 --checkpoint /PATH/TO/model.pt
-                     # run script for recording video of a trained agent (requires installing `ffmpeg`)
-                     ./isaaclab.sh -p scripts/reinforcement_learning/skrl/play.py --task Isaac-Reach-Franka-v0 --headless --video --video_length 200
+                     # run command for training
+                     ./isaaclab.sh train --rl_library skrl --task Isaac-Reach-Franka-v0 --headless
+                     # run command for training with Newton backend
+                     ./isaaclab.sh train --rl_library skrl --task Isaac-Reach-Franka-v0 --headless physics=newton_mjwarp
+                     # run command for playing with 32 environments
+                     ./isaaclab.sh play --rl_library skrl --task Isaac-Reach-Franka-v0 --num_envs 32 --checkpoint /PATH/TO/model.pt
+                     # run command for recording video of a trained agent (requires installing `ffmpeg`)
+                     ./isaaclab.sh play --rl_library skrl --task Isaac-Reach-Franka-v0 --headless --video --video_length 200
 
                .. tab-item:: :icon:`fa-brands fa-windows` Windows
                   :sync: windows
@@ -230,14 +230,14 @@ SKRL
 
                      :: install python module (for skrl)
                      isaaclab.bat -i skrl
-                     :: run script for training
-                     isaaclab.bat -p scripts\reinforcement_learning\skrl\train.py --task Isaac-Reach-Franka-v0 --headless
-                     :: run script for training with Newton backend
-                     isaaclab.bat -p scripts\reinforcement_learning\skrl\train.py --task Isaac-Reach-Franka-v0 --headless physics=newton_mjwarp
-                     :: run script for playing with 32 environments
-                     isaaclab.bat -p scripts\reinforcement_learning\skrl\play.py --task Isaac-Reach-Franka-v0 --num_envs 32 --checkpoint /PATH/TO/model.pt
-                     :: run script for recording video of a trained agent (requires installing `ffmpeg`)
-                     isaaclab.bat -p scripts\reinforcement_learning\skrl\play.py --task Isaac-Reach-Franka-v0 --headless --video --video_length 200
+                     :: run command for training
+                     isaaclab.bat train --rl_library skrl --task Isaac-Reach-Franka-v0 --headless
+                     :: run command for training with Newton backend
+                     isaaclab.bat train --rl_library skrl --task Isaac-Reach-Franka-v0 --headless physics=newton_mjwarp
+                     :: run command for playing with 32 environments
+                     isaaclab.bat play --rl_library skrl --task Isaac-Reach-Franka-v0 --num_envs 32 --checkpoint /PATH/TO/model.pt
+                     :: run command for recording video of a trained agent (requires installing `ffmpeg`)
+                     isaaclab.bat play --rl_library skrl --task Isaac-Reach-Franka-v0 --headless --video --video_length 200
 
       .. tab-item:: JAX
 
@@ -284,14 +284,14 @@ SKRL
 
          .. code:: bash
 
-            # run script for training
-            ./isaaclab.sh -p scripts/reinforcement_learning/skrl/train.py --task Isaac-Reach-Franka-v0 --headless --ml_framework jax
-            # run script for training with Newton backend
-            ./isaaclab.sh -p scripts/reinforcement_learning/skrl/train.py --task Isaac-Reach-Franka-v0 --headless --ml_framework jax presets=newton_mjwarp
-            # run script for playing with 32 environments
-            ./isaaclab.sh -p scripts/reinforcement_learning/skrl/play.py --task Isaac-Reach-Franka-v0 --num_envs 32  --ml_framework jax --checkpoint /PATH/TO/model.pt
-            # run script for recording video of a trained agent (requires installing `ffmpeg`)
-            ./isaaclab.sh -p scripts/reinforcement_learning/skrl/play.py --task Isaac-Reach-Franka-v0 --headless --ml_framework jax --video --video_length 200
+            # run command for training
+            ./isaaclab.sh train --rl_library skrl --task Isaac-Reach-Franka-v0 --headless --ml_framework jax
+            # run command for training with Newton backend
+            ./isaaclab.sh train --rl_library skrl --task Isaac-Reach-Franka-v0 --headless --ml_framework jax presets=newton_mjwarp
+            # run command for playing with 32 environments
+            ./isaaclab.sh play --rl_library skrl --task Isaac-Reach-Franka-v0 --num_envs 32  --ml_framework jax --checkpoint /PATH/TO/model.pt
+            # run command for recording video of a trained agent (requires installing `ffmpeg`)
+            ./isaaclab.sh play --rl_library skrl --task Isaac-Reach-Franka-v0 --headless --ml_framework jax --video --video_length 200
 
    - Training the multi-agent environment ``Isaac-Shadow-Hand-Over-Direct-v0`` with skrl:
 
@@ -305,10 +305,10 @@ SKRL
 
             # install python module (for skrl)
             ./isaaclab.sh -i skrl
-            # run script for training with the MAPPO algorithm (IPPO is also supported)
-            ./isaaclab.sh -p scripts/reinforcement_learning/skrl/train.py --task Isaac-Shadow-Hand-Over-Direct-v0 --headless --algorithm MAPPO
-            # run script for playing with 32 environments with the MAPPO algorithm (IPPO is also supported)
-            ./isaaclab.sh -p scripts/reinforcement_learning/skrl/play.py --task Isaac-Shadow-Hand-Over-Direct-v0 --num_envs 32 --algorithm MAPPO --checkpoint /PATH/TO/model.pt
+            # run command for training with the MAPPO algorithm (IPPO is also supported)
+            ./isaaclab.sh train --rl_library skrl --task Isaac-Shadow-Hand-Over-Direct-v0 --headless --algorithm MAPPO
+            # run command for playing with 32 environments with the MAPPO algorithm (IPPO is also supported)
+            ./isaaclab.sh play --rl_library skrl --task Isaac-Shadow-Hand-Over-Direct-v0 --num_envs 32 --algorithm MAPPO --checkpoint /PATH/TO/model.pt
 
       .. tab-item:: :icon:`fa-brands fa-windows` Windows
          :sync: windows
@@ -317,10 +317,10 @@ SKRL
 
             :: install python module (for skrl)
             isaaclab.bat -i skrl
-            :: run script for training with the MAPPO algorithm (IPPO is also supported)
-            isaaclab.bat -p scripts\reinforcement_learning\skrl\train.py --task Isaac-Shadow-Hand-Over-Direct-v0 --headless --algorithm MAPPO
-            :: run script for playing with 32 environments with the MAPPO algorithm (IPPO is also supported)
-            isaaclab.bat -p scripts\reinforcement_learning\skrl\play.py --task Isaac-Shadow-Hand-Over-Direct-v0 --num_envs 32 --algorithm MAPPO --checkpoint /PATH/TO/model.pt
+            :: run command for training with the MAPPO algorithm (IPPO is also supported)
+            isaaclab.bat train --rl_library skrl --task Isaac-Shadow-Hand-Over-Direct-v0 --headless --algorithm MAPPO
+            :: run command for playing with 32 environments with the MAPPO algorithm (IPPO is also supported)
+            isaaclab.bat play --rl_library skrl --task Isaac-Shadow-Hand-Over-Direct-v0 --num_envs 32 --algorithm MAPPO --checkpoint /PATH/TO/model.pt
 
 Stable-Baselines3
 -----------------
@@ -339,14 +339,14 @@ Stable-Baselines3
 
             # install python module (for stable-baselines3)
             ./isaaclab.sh -i sb3
-            # run script for training
-            ./isaaclab.sh -p scripts/reinforcement_learning/sb3/train.py --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless
-            # run script for training with Newton backend
-            ./isaaclab.sh -p scripts/reinforcement_learning/sb3/train.py --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless physics=newton_mjwarp
-            # run script for playing with 32 environments
-            ./isaaclab.sh -p scripts/reinforcement_learning/sb3/play.py --task Isaac-Velocity-Flat-Unitree-A1-v0 --num_envs 32 --checkpoint /PATH/TO/model.zip
-            # run script for recording video of a trained agent (requires installing `ffmpeg`)
-            ./isaaclab.sh -p scripts/reinforcement_learning/sb3/play.py --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless --video --video_length 200
+            # run command for training
+            ./isaaclab.sh train --rl_library sb3 --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless
+            # run command for training with Newton backend
+            ./isaaclab.sh train --rl_library sb3 --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless physics=newton_mjwarp
+            # run command for playing with 32 environments
+            ./isaaclab.sh play --rl_library sb3 --task Isaac-Velocity-Flat-Unitree-A1-v0 --num_envs 32 --checkpoint /PATH/TO/model.zip
+            # run command for recording video of a trained agent (requires installing `ffmpeg`)
+            ./isaaclab.sh play --rl_library sb3 --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless --video --video_length 200
 
       .. tab-item:: :icon:`fa-brands fa-windows` Windows
          :sync: windows
@@ -355,14 +355,14 @@ Stable-Baselines3
 
             :: install python module (for stable-baselines3)
             isaaclab.bat -i sb3
-            :: run script for training
-            isaaclab.bat -p scripts\reinforcement_learning\sb3\train.py --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless
-            :: run script for training with Newton backend
-            isaaclab.bat -p scripts\reinforcement_learning\sb3\train.py --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless physics=newton_mjwarp
-            :: run script for playing with 32 environments
-            isaaclab.bat -p scripts\reinforcement_learning\sb3\play.py --task Isaac-Velocity-Flat-Unitree-A1-v0 --num_envs 32 --checkpoint /PATH/TO/model.zip
-            :: run script for recording video of a trained agent (requires installing `ffmpeg`)
-            isaaclab.bat -p scripts\reinforcement_learning\sb3\play.py --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless --video --video_length 200
+            :: run command for training
+            isaaclab.bat train --rl_library sb3 --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless
+            :: run command for training with Newton backend
+            isaaclab.bat train --rl_library sb3 --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless physics=newton_mjwarp
+            :: run command for playing with 32 environments
+            isaaclab.bat play --rl_library sb3 --task Isaac-Velocity-Flat-Unitree-A1-v0 --num_envs 32 --checkpoint /PATH/TO/model.zip
+            :: run command for recording video of a trained agent (requires installing `ffmpeg`)
+            isaaclab.bat play --rl_library sb3 --task Isaac-Velocity-Flat-Unitree-A1-v0 --headless --video --video_length 200
 
 RLinf
 -----
@@ -379,7 +379,7 @@ For installation instructions, see :ref:`rlinf-post-training`.
    .. code:: bash
 
       # Train with a specific config
-      ./isaaclab.sh -p scripts/reinforcement_learning/rlinf/train.py \
+      ./isaaclab.sh train --rl_library rlinf \
           --config_name isaaclab_ppo_gr00t_assemble_trocar \
           --model_path /path/to/checkpoint
 
@@ -388,15 +388,15 @@ For installation instructions, see :ref:`rlinf-post-training`.
    .. code:: bash
 
       # Evaluate with video recording
-      ./isaaclab.sh -p scripts/reinforcement_learning/rlinf/play.py \
+      ./isaaclab.sh play --rl_library rlinf \
           --config_name isaaclab_ppo_gr00t_assemble_trocar \
           --model_path /path/to/checkpoint --video
 
 
-All the scripts above log the training progress to `Tensorboard`_ in the ``logs`` directory in the root of
+All the commands above log the training progress to `Tensorboard`_ in the ``logs`` directory in the root of
 the repository. The logs directory follows the pattern ``logs/<library>/<task>/<date-time>``, where ``<library>``
 is the name of the learning framework, ``<task>`` is the task name, and ``<date-time>`` is the timestamp at
-which the training script was executed.
+which the training command was executed.
 
 To view the logs, run:
 

--- a/docs/source/overview/reinforcement-learning/rl_frameworks.rst
+++ b/docs/source/overview/reinforcement-learning/rl_frameworks.rst
@@ -106,7 +106,7 @@ Training commands (check for the *'Training time: XXX seconds'* line in the term
 
 .. code:: bash
 
-    python scripts/reinforcement_learning/rl_games/train.py --task Isaac-Humanoid-v0 --max_iterations 500 --headless
-    python scripts/reinforcement_learning/skrl/train.py --task Isaac-Humanoid-v0 --max_iterations 500 --headless
-    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Humanoid-v0 --max_iterations 500 --headless
-    python scripts/reinforcement_learning/sb3/train.py --task Isaac-Humanoid-v0 --max_iterations 500 --headless
+    ./isaaclab.sh train --rl_library rl_games --task Isaac-Humanoid-v0 --max_iterations 500 --headless
+    ./isaaclab.sh train --rl_library skrl --task Isaac-Humanoid-v0 --max_iterations 500 --headless
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Humanoid-v0 --max_iterations 500 --headless
+    ./isaaclab.sh train --rl_library sb3 --task Isaac-Humanoid-v0 --max_iterations 500 --headless

--- a/docs/source/policy_deployment/01_io_descriptors/io_descriptors_101.rst
+++ b/docs/source/policy_deployment/01_io_descriptors/io_descriptors_101.rst
@@ -78,10 +78,10 @@ This can be done by setting the ``export_io_descriptors`` flag in the command li
 
 .. code-block:: bash
 
-   ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --export_io_descriptors
-   ./isaaclab.sh -p scripts/reinforcement_learning/sb3/train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --export_io_descriptors
-   ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --export_io_descriptors
-   ./isaaclab.sh -p scripts/reinforcement_learning/skrl/train.py --task Isaac-Velocity-Flat-Anymal-D-v0 --export_io_descriptors
+   ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Velocity-Flat-Anymal-D-v0 --export_io_descriptors
+   ./isaaclab.sh train --rl_library sb3 --task Isaac-Velocity-Flat-Anymal-D-v0 --export_io_descriptors
+   ./isaaclab.sh train --rl_library rl_games --task Isaac-Velocity-Flat-Anymal-D-v0 --export_io_descriptors
+   ./isaaclab.sh train --rl_library skrl --task Isaac-Velocity-Flat-Anymal-D-v0 --export_io_descriptors
 
 
 Attaching IO Descriptors to Custom Observation Terms

--- a/docs/source/policy_deployment/02_gear_assembly/gear_assembly_policy.rst
+++ b/docs/source/policy_deployment/02_gear_assembly/gear_assembly_policy.rst
@@ -263,7 +263,7 @@ These friction values were determined through iterative visual comparison:
 
            .. code-block:: bash
 
-               python scripts/reinforcement_learning/rsl_rl/train.py \
+               ./isaaclab.sh train --rl_library rsl_rl \
                    --task Isaac-Deploy-GearAssembly-UR10e-2F140-v0 \
                    --headless \
                    --video --video_length 800 --video_interval 5000
@@ -272,7 +272,7 @@ These friction values were determined through iterative visual comparison:
 
            .. code-block:: bash
 
-               python scripts/reinforcement_learning/rsl_rl/train.py \
+               ./isaaclab.sh train --rl_library rsl_rl \
                    --task Isaac-Deploy-GearAssembly-Rizon4s-Grav-ROS-Inference-v0 \
                    --headless \
                    --video --video_length 800 --video_interval 5000
@@ -650,7 +650,7 @@ First, launch the training with a small number of environments and visualization
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-GearAssembly-UR10e-2F140-ROS-Inference-v0 \
                 --num_envs 4 \
                 --visualizer kit
@@ -659,7 +659,7 @@ First, launch the training with a small number of environments and visualization
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-GearAssembly-UR10e-2F85-ROS-Inference-v0 \
                 --num_envs 4 \
                 --visualizer kit
@@ -668,7 +668,7 @@ First, launch the training with a small number of environments and visualization
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-GearAssembly-Rizon4s-Grav-ROS-Inference-v0 \
                 --num_envs 4 \
                 --visualizer kit
@@ -697,7 +697,7 @@ Now launch the full training run with more parallel environments in headless mod
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-GearAssembly-UR10e-2F140-ROS-Inference-v0 \
                 --headless \
                 --num_envs 256 \
@@ -707,7 +707,7 @@ Now launch the full training run with more parallel environments in headless mod
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-GearAssembly-UR10e-2F85-ROS-Inference-v0 \
                 --headless \
                 --num_envs 256 \
@@ -717,7 +717,7 @@ Now launch the full training run with more parallel environments in headless mod
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-GearAssembly-Rizon4s-Grav-ROS-Inference-v0 \
                 --headless \
                 --num_envs 256 \
@@ -823,7 +823,7 @@ CUDA Out of Memory
 
    .. code-block:: bash
 
-       python scripts/reinforcement_learning/rsl_rl/train.py \
+       ./isaaclab.sh train --rl_library rsl_rl \
            --task Isaac-Deploy-GearAssembly-UR10e-2F140-v0 \
            --headless \
            --num_envs 128  # Reduce from 256 to 128, 64, etc.
@@ -854,7 +854,7 @@ CUDA Out of Memory
 
    .. code-block:: bash
 
-       python scripts/reinforcement_learning/rsl_rl/train.py \
+       ./isaaclab.sh train --rl_library rsl_rl \
            --task Isaac-Deploy-GearAssembly-UR10e-2F140-v0 \
            --headless \
            --num_envs 256
@@ -870,11 +870,11 @@ deterministic setup for debugging policy behavior against a specific real-world 
 All randomization is disabled and observation noise is turned off, so the simulation is
 identical on every reset.
 
-To use it, run the standard ``play.py`` script:
+To use it, run the standard play command:
 
 .. code-block:: bash
 
-    python scripts/reinforcement_learning/rsl_rl/play.py \
+    ./isaaclab.sh play --rl_library rsl_rl \
         --task Isaac-Deploy-GearAssembly-Rizon4s-Grav-Play-v0 \
         --num_envs 1 \
         --checkpoint <path_to_model.pt>
@@ -898,7 +898,7 @@ To match a specific real-world setup, edit the constants at the top of the
         OBS_SHAFT_QUAT: tuple | None = None  # e.g. (0.0, 0.0, 0.70711, -0.70711)
 
 When ``OBS_SHAFT_POS`` or ``OBS_SHAFT_QUAT`` are set (not ``None``), the
-``play.py`` script automatically overwrites the corresponding portions of the
+play command automatically overwrites the corresponding portions of the
 policy's observation tensor every step, regardless of simulation state.  This
 lets you test what the policy does when given a specific observation (e.g. a
 pose captured from the real robot).

--- a/docs/source/policy_deployment/04_reach/reach_policy.rst
+++ b/docs/source/policy_deployment/04_reach/reach_policy.rst
@@ -421,7 +421,7 @@ Before starting full training, launch a quick visualization run to verify the en
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-Reach-UR10e-ROS-Inference-v0 \
                 --num_envs 4 \
                 --visualizer kit
@@ -430,7 +430,7 @@ Before starting full training, launch a quick visualization run to verify the en
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-Reach-Rizon4s-ROS-Inference-v0 \
                 --num_envs 4 \
                 --visualizer kit
@@ -465,7 +465,7 @@ Launch full training with many parallel environments in headless mode:
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-Reach-UR10e-ROS-Inference-v0 \
                 --headless \
                 --num_envs 4096 \
@@ -475,7 +475,7 @@ Launch full training with many parallel environments in headless mode:
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/train.py \
+            ./isaaclab.sh train --rl_library rsl_rl \
                 --task Isaac-Deploy-Reach-Rizon4s-ROS-Inference-v0 \
                 --headless \
                 --num_envs 4096 \
@@ -575,7 +575,7 @@ Once training completes, evaluate the policy in the play environment:
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/play.py \
+            ./isaaclab.sh play --rl_library rsl_rl \
                 --task Isaac-Deploy-Reach-UR10e-Play-v0 \
                 --num_envs 50 \
                 --visualizer kit
@@ -584,7 +584,7 @@ Once training completes, evaluate the policy in the play environment:
 
         .. code-block:: bash
 
-            python scripts/reinforcement_learning/rsl_rl/play.py \
+            ./isaaclab.sh play --rl_library rsl_rl \
                 --task Isaac-Deploy-Reach-Rizon4s-Play-v0 \
                 --num_envs 50 \
                 --visualizer kit
@@ -593,19 +593,21 @@ The play environments disable observation corruption for cleaner evaluation and 
 
 **Checkpoint Loading:**
 
-By default, ``play.py`` automatically loads the most recent checkpoint from the most recent training run. The script searches in ``logs/rsl_rl/<experiment_name>/`` and selects the latest run folder and checkpoint file (sorted alphabetically).
+By default, the play command automatically loads the most recent checkpoint from the most recent training run.
+It searches in ``logs/rsl_rl/<experiment_name>/`` and selects the latest run folder and checkpoint file
+(sorted alphabetically).
 
 To load a specific checkpoint, use these arguments:
 
 .. code-block:: bash
 
     # Load from a specific run folder
-    python scripts/reinforcement_learning/rsl_rl/play.py \
+    ./isaaclab.sh play --rl_library rsl_rl \
         --task Isaac-Deploy-Reach-UR10e-Play-v0 \
         --load_run 2025-01-15_14-30-00
 
     # Load a specific checkpoint file
-    python scripts/reinforcement_learning/rsl_rl/play.py \
+    ./isaaclab.sh play --rl_library rsl_rl \
         --task Isaac-Deploy-Reach-UR10e-Play-v0 \
         --checkpoint /path/to/model_1500.pt
 

--- a/docs/source/setup/installation/cloud_installation.rst
+++ b/docs/source/setup/installation/cloud_installation.rst
@@ -153,7 +153,7 @@ To run Isaac Lab commands, open a terminal on the workstation:
 
 .. code-block:: bash
 
-   ~/IsaacLab/isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+   ~/IsaacLab/isaaclab.sh train --rl_library rsl_rl \
      --task=Isaac-Cartpole-Direct --headless
 
 

--- a/docs/source/setup/installation/include/src_verify_isaaclab.rst
+++ b/docs/source/setup/installation/include/src_verify_isaaclab.rst
@@ -65,14 +65,14 @@ We recommend adding ``--headless`` for faster training.
 
       .. code:: bash
 
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Ant-v0 --headless
+         ./isaaclab.sh train --rl_library rsl_rl --task=Isaac-Ant-v0 --headless
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows
       :sync: windows
 
       .. code:: batch
 
-         isaaclab.bat -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Ant-v0 --headless
+         isaaclab.bat train --rl_library rsl_rl --task=Isaac-Ant-v0 --headless
 
 ... Or a robot dog!
 
@@ -84,14 +84,14 @@ We recommend adding ``--headless`` for faster training.
 
       .. code:: bash
 
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 --headless
+         ./isaaclab.sh train --rl_library rsl_rl --task=Isaac-Velocity-Rough-Anymal-C-v0 --headless
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows
       :sync: windows
 
       .. code:: batch
 
-         isaaclab.bat -p scripts/reinforcement_learning/rsl_rl/train.py --task=Isaac-Velocity-Rough-Anymal-C-v0 --headless
+         isaaclab.bat train --rl_library rsl_rl --task=Isaac-Velocity-Rough-Anymal-C-v0 --headless
 
 Isaac Lab provides the tools you'll need to create your own **Tasks** and **Workflows** for whatever your project needs may be.
 Take a look at our :ref:`how-to` like :ref:`Adding your own learning Library <how-to-add-library>` or :ref:`Wrapping Environments <how-to-env-wrappers>` for details.

--- a/docs/source/setup/installation/kitless_installation.rst
+++ b/docs/source/setup/installation/kitless_installation.rst
@@ -33,7 +33,7 @@ and kickoff training with MJWarp physics and the Newton visualizer:
          ./isaaclab.sh --install   # or ./isaaclab.sh -i
 
          # Kickoff training with MJWarp physics and Newton visualizer
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+         ./isaaclab.sh train --rl_library rsl_rl \
          --task=Isaac-Cartpole-Direct \
          --num_envs=16 --max_iterations=10 \
          physics=newton_mjwarp --visualizer newton
@@ -48,7 +48,7 @@ and kickoff training with MJWarp physics and the Newton visualizer:
          isaaclab.bat --install
 
          :: Kickoff training with MJWarp physics and Newton visualizer
-         isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py ^
+         isaaclab.bat train --rl_library rsl_rl ^
          --task=Isaac-Cartpole-Direct ^
          --num_envs=16 --max_iterations=10 ^
          physics=newton_mjwarp --visualizer newton

--- a/docs/source/setup/quickstart.rst
+++ b/docs/source/setup/quickstart.rst
@@ -75,7 +75,7 @@ your workflow:
 Run Training
 ------------
 
-Training scripts live under ``scripts/reinforcement_learning/``. Pass a **task name** and use
+Use the reinforcement learning training command with a **task name** and
 ``physics=``, ``renderer=``, and ``presets=`` to select backends and task-specific options:
 
 .. tab-set::
@@ -87,19 +87,19 @@ Training scripts live under ``scripts/reinforcement_learning/``. Pass a **task n
       .. code-block:: bash
 
          # Kit-less: Newton MJWarp physics + Newton visualizer
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+         ./isaaclab.sh train --rl_library rsl_rl \
            --task=Isaac-Cartpole-Direct \
            --num_envs=16 --max_iterations=10 \
            physics=newton_mjwarp --visualizer newton
 
          # With Isaac Sim: PhysX physics (default renderer)
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+         ./isaaclab.sh train --rl_library rsl_rl \
            --task=Isaac-Cartpole-Direct \
            --num_envs=4096 \
            physics=physx
 
          # Camera task: typed physics + renderer + domain preset
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+         ./isaaclab.sh train --rl_library rsl_rl \
            --task=Isaac-Cartpole-Camera-Direct \
            physics=newton_mjwarp renderer=newton_renderer presets=rgb
 
@@ -108,12 +108,12 @@ Training scripts live under ``scripts/reinforcement_learning/``. Pass a **task n
 
       .. code-block:: batch
 
-         isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py ^
+         isaaclab.bat train --rl_library rsl_rl ^
            --task=Isaac-Cartpole-Direct ^
            --num_envs=16 --max_iterations=10 ^
            physics=newton_mjwarp --visualizer newton
 
-         isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py ^
+         isaaclab.bat train --rl_library rsl_rl ^
            --task=Isaac-Cartpole-Direct ^
            --num_envs=4096 ^
            physics=physx

--- a/docs/source/setup/quickstart_details.rst
+++ b/docs/source/setup/quickstart_details.rst
@@ -33,24 +33,24 @@ options (observation modes, camera configs, etc.). They fold into Hydra override
       .. code-block:: bash
 
          # Kit-less: Newton MJWarp + Newton visualizer
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+         ./isaaclab.sh train --rl_library rsl_rl \
            --task=Isaac-Cartpole-Direct \
            --num_envs=4096 \
            physics=newton_mjwarp --visualizer newton
 
          # With Isaac Sim: PhysX
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+         ./isaaclab.sh train --rl_library rsl_rl \
            --task=Isaac-Cartpole-Direct \
            --num_envs=4096 \
            physics=physx
 
          # Camera task: physics + renderer + domain preset
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+         ./isaaclab.sh train --rl_library rsl_rl \
            --task=Isaac-Cartpole-Camera-Direct \
            physics=newton_mjwarp renderer=newton_renderer presets=rgb
 
          # OVRTX rendering (kit-less, no Kit visualizer)
-         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+         ./isaaclab.sh train --rl_library rsl_rl \
            --task=Isaac-Repose-Cube-Shadow-Vision-Benchmark-Direct-v0 \
            --headless --enable_cameras --num_envs=16 --max_iterations=10 \
            physics=newton_mjwarp renderer=ovrtx_renderer presets=simple_shading_diffuse_mdl
@@ -60,7 +60,7 @@ options (observation modes, camera configs, etc.). They fold into Hydra override
 
       .. code-block:: batch
 
-         isaaclab.bat -p scripts\reinforcement_learning\rsl_rl\train.py ^
+         isaaclab.bat train --rl_library rsl_rl ^
            --task=Isaac-Cartpole-Direct ^
            --num_envs=4096 ^
            physics=newton_mjwarp --visualizer newton

--- a/docs/source/setup/walkthrough/training_jetbot_reward_exploration.rst
+++ b/docs/source/setup/walkthrough/training_jetbot_reward_exploration.rst
@@ -43,7 +43,7 @@ we can finally run training!  Let's see what happens!
 
 .. code-block:: bash
 
-    python scripts/reinforcement_learning/skrl/train.py --task=Template-Isaac-Lab-Tutorial-Direct-v0
+    ./isaaclab.sh train --rl_library skrl --task=Template-Isaac-Lab-Tutorial-Direct-v0
 
 
 .. figure:: https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/walkthrough_naive_webp.webp

--- a/docs/source/tutorials/03_envs/configuring_rl_training.rst
+++ b/docs/source/tutorials/03_envs/configuring_rl_training.rst
@@ -84,23 +84,22 @@ The second code block is equivalent to the first one, but it leads to import of 
 class which slows down the import time. This is why we recommend using strings for the configuration
 entry point.
 
-All the scripts in the ``scripts/reinforcement_learning`` directory are configured by default to read the
+The reinforcement learning entrypoints are configured by default to read the
 ``<library_name>_cfg_entry_point`` from the ``kwargs`` dictionary to retrieve the configuration instance.
 
-For instance, the following code block shows how the ``train.py`` script reads the configuration
-instance for the Stable-Baselines3 library:
+For instance, the following code block shows how the Stable-Baselines3 training implementation
+reads the configuration instance:
 
-.. dropdown:: Code for train.py with SB3
+.. dropdown:: Code for train_sb3.py with SB3
     :icon: code
 
-    .. literalinclude:: ../../../../scripts/reinforcement_learning/sb3/train.py
+    .. literalinclude:: ../../../../scripts/reinforcement_learning/sb3/train_sb3.py
       :language: python
-      :emphasize-lines: 26-28, 102-103
       :linenos:
 
-The argument ``--agent`` is used to specify the learning library to use. This is used to
-retrieve the configuration instance from the ``kwargs`` dictionary. You can manually specify
-alternate configuration instances by passing the ``--agent`` argument.
+The argument ``--rl_library`` selects the reinforcement learning library. The ``--agent``
+argument selects the library-specific configuration entry point from the ``kwargs``
+dictionary, so you can manually specify alternate configuration instances.
 
 The Code Execution
 ------------------
@@ -113,7 +112,7 @@ we can use the ``--agent`` argument to specify the configuration instance to use
   .. code-block:: bash
 
     # standard PPO training
-    ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole --headless \
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole --headless \
       --run_name ppo
 
 * Training with the PPO configuration with symmetry augmentation:
@@ -121,12 +120,12 @@ we can use the ``--agent`` argument to specify the configuration instance to use
   .. code-block:: bash
 
     # PPO training with symmetry augmentation
-    ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole --headless \
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole --headless \
       --agent rsl_rl_with_symmetry_cfg_entry_point \
       --run_name ppo_with_symmetry_data_augmentation
 
     # you can use hydra to disable symmetry augmentation but enable mirror loss computation
-    ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole --headless \
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole --headless \
       --agent rsl_rl_with_symmetry_cfg_entry_point \
       --run_name ppo_without_symmetry_data_augmentation \
       agent.algorithm.symmetry_cfg.use_data_augmentation=false

--- a/docs/source/tutorials/03_envs/configuring_rl_training.rst
+++ b/docs/source/tutorials/03_envs/configuring_rl_training.rst
@@ -96,6 +96,7 @@ reads the configuration instance:
     .. literalinclude:: ../../../../scripts/reinforcement_learning/sb3/train_sb3.py
       :language: python
       :linenos:
+      :emphasize-lines: 56-60, 97-98
 
 The argument ``--rl_library`` selects the reinforcement learning library. The ``--agent``
 argument selects the library-specific configuration entry point from the ``kwargs``

--- a/docs/source/tutorials/03_envs/create_direct_rl_env.rst
+++ b/docs/source/tutorials/03_envs/create_direct_rl_env.rst
@@ -205,7 +205,7 @@ To run training for the direct workflow Cartpole environment, we can use the fol
 
 .. code-block:: bash
 
-   ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/train.py --task=Isaac-Cartpole-Direct
+   ./isaaclab.sh train --rl_library rl_games --task=Isaac-Cartpole-Direct
 
 .. figure:: ../../_static/tutorials/tutorial_create_direct_workflow.jpg
     :align: center

--- a/docs/source/tutorials/03_envs/modify_direct_rl_env.rst
+++ b/docs/source/tutorials/03_envs/modify_direct_rl_env.rst
@@ -111,7 +111,7 @@ After the minor modification has been done, and similar to the previous tutorial
 
 .. code-block:: bash
 
-  ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/train.py --task Isaac-H1-Direct-v0 --headless
+  ./isaaclab.sh train --rl_library rl_games --task Isaac-H1-Direct-v0 --headless
 
 When the training is finished, we can visualize the result with the following command.
 To stop the simulation, you can either close the window, or press ``Ctrl+C`` in the terminal
@@ -119,7 +119,7 @@ where you started the simulation.
 
 .. code-block:: bash
 
-  ./isaaclab.sh -p scripts/reinforcement_learning/rl_games/play.py --task Isaac-H1-Direct-v0 --num_envs 64 --viz kit
+  ./isaaclab.sh play --rl_library rl_games --task Isaac-H1-Direct-v0 --num_envs 64 --viz kit
 
 .. figure:: ../../_static/tutorials/tutorial_modify_direct_rl_env.jpg
     :align: center

--- a/docs/source/tutorials/03_envs/policy_inference_in_usd.rst
+++ b/docs/source/tutorials/03_envs/policy_inference_in_usd.rst
@@ -42,7 +42,7 @@ First, we need to train the ``Isaac-Velocity-Rough-H1-v0`` task by running the f
 
 .. code-block:: bash
 
-  ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Velocity-Rough-H1-v0 --headless
+  ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Velocity-Rough-H1-v0 --headless
 
 When the training is finished, we can visualize the result with the following command.
 To stop the simulation, you can either close the window, or press ``Ctrl+C`` in the terminal
@@ -50,7 +50,7 @@ where you started the simulation.
 
 .. code-block:: bash
 
-  ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/play.py --task Isaac-Velocity-Rough-H1-v0 --num_envs 64 --checkpoint logs/rsl_rl/h1_rough/EXPERIMENT_NAME/POLICY_FILE.pt --viz kit
+  ./isaaclab.sh play --rl_library rsl_rl --task Isaac-Velocity-Rough-H1-v0 --num_envs 64 --checkpoint logs/rsl_rl/h1_rough/EXPERIMENT_NAME/POLICY_FILE.pt --viz kit
 
 
 After running the play script, the policy will be exported to jit and onnx files under the experiment logs directory.

--- a/docs/source/tutorials/03_envs/run_rl_training.rst
+++ b/docs/source/tutorials/03_envs/run_rl_training.rst
@@ -34,15 +34,14 @@ cartpole balancing task.
 The Code
 --------
 
-For this tutorial, we use the training script from `Stable-Baselines3`_ workflow in the
+For this tutorial, we use the training implementation from `Stable-Baselines3`_ workflow in the
 ``scripts/reinforcement_learning/sb3`` directory.
 
-.. dropdown:: Code for train.py
+.. dropdown:: Code for train_sb3.py
     :icon: code
 
-    .. literalinclude:: ../../../../scripts/reinforcement_learning/sb3/train.py
+    .. literalinclude:: ../../../../scripts/reinforcement_learning/sb3/train_sb3.py
       :language: python
-      :emphasize-lines: 57, 66, 68-70, 81, 90-98, 100, 105-113, 115-116, 121-126, 133-136
       :linenos:
 
 The Code Explained
@@ -88,7 +87,7 @@ Rendering can still be active for sensor/camera data capture when enabled by the
 
 .. code-block:: bash
 
-  ./isaaclab.sh -p scripts/reinforcement_learning/sb3/train.py --task Isaac-Cartpole --num_envs 64
+  ./isaaclab.sh train --rl_library sb3 --task Isaac-Cartpole --num_envs 64
 
 
 Headless execution with off-screen render
@@ -100,7 +99,7 @@ in the workflow and pass ``--video`` to record the agent behavior.
 
 .. code-block:: bash
 
-  ./isaaclab.sh -p scripts/reinforcement_learning/sb3/train.py --task Isaac-Cartpole --num_envs 64 --video
+  ./isaaclab.sh train --rl_library sb3 --task Isaac-Cartpole --num_envs 64 --video
 
 The videos are saved to the ``logs/sb3/Isaac-Cartpole/<run-dir>/videos/train`` directory. You can open these videos
 using any video player.
@@ -112,11 +111,11 @@ Interactive execution
 
 While the above two methods are useful for training the agent, they don't allow you to interact with the
 simulation to see what is happening. In this case, run the
-training script as follows:
+training command as follows:
 
 .. code-block:: bash
 
-  ./isaaclab.sh -p scripts/reinforcement_learning/sb3/train.py --task Isaac-Cartpole --num_envs 64 --viz kit
+  ./isaaclab.sh train --rl_library sb3 --task Isaac-Cartpole --num_envs 64 --viz kit
 
 This will open the Kit visualizer window and you can see the agent training in the environment. However, this
 can slow down the training process because interactive visual feedback is enabled. As a workaround, you
@@ -142,7 +141,7 @@ Once the training is complete, you can visualize the trained agent by executing 
 .. code:: bash
 
    # execute from the root directory of the repository
-   ./isaaclab.sh -p scripts/reinforcement_learning/sb3/play.py --task Isaac-Cartpole --num_envs 32 --use_last_checkpoint --viz kit
+   ./isaaclab.sh play --rl_library sb3 --task Isaac-Cartpole --num_envs 32 --use_last_checkpoint --viz kit
 
 The above command will load the latest checkpoint from the ``logs/sb3/Isaac-Cartpole``
 directory. You can also specify a specific checkpoint by passing the ``--checkpoint`` flag.

--- a/docs/source/tutorials/03_envs/run_rl_training.rst
+++ b/docs/source/tutorials/03_envs/run_rl_training.rst
@@ -43,6 +43,7 @@ For this tutorial, we use the training implementation from `Stable-Baselines3`_ 
     .. literalinclude:: ../../../../scripts/reinforcement_learning/sb3/train_sb3.py
       :language: python
       :linenos:
+      :emphasize-lines: 97-100, 104-109, 121-137, 145-157, 164-170
 
 The Code Explained
 ------------------


### PR DESCRIPTION
# Description

Updates the documentation to use the unified reinforcement learning train/play entrypoints with ``--rl_library`` instead of deprecated per-library script paths. Also documents this migration in the Isaac Lab 3.0 migration guide and updates related wording from scripts to commands/workflows where appropriate.

No new dependencies are required.

Issue: N/A

## Type of change

- Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
  - Full `./isaaclab.sh -f` was attempted, but `check-git-lfs-pointers` failed because `git-lfs` is not installed in this environment.
  - `SKIP=check-git-lfs-pointers ./isaaclab.sh -f` passed all remaining hooks.
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - Not applicable: documentation-only change; no tests added.
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
  - Not applicable: documentation-only change; no package was touched.
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
