### PR TITLE
Fixes lazyloader import on main

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,5 +14,6 @@ sphinx-multiversion==0.2.4
 numpy
 matplotlib
 warp-lang
+lazy_loader>=0.4
 # learning
 gymnasium


### PR DESCRIPTION
# Description

Multi-version doc build job was failing because the main branch did not introduce the lazy loader dependency.
Patching it so that we include the dependency for main.

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
