### PR TITLE
Adds git asset cache helper

### DIFF
--- a/source/isaaclab/changelog.d/antoine-git-newton-assets.rst
+++ b/source/isaaclab/changelog.d/antoine-git-newton-assets.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added :func:`~isaaclab.utils.assets.retrieve_git_asset_path` to pull assets
+  from a git repository into a local cache, and
+  :data:`~isaaclab.utils.assets.NEWTON_ASSET_DIR` for Newton asset defaults.

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -206,7 +206,7 @@ def _run_git_command(command: list[str]) -> None:
         RuntimeError: When git is missing or the command fails.
     """
     try:
-        subprocess.run(command, check=True)
+        subprocess.run(command, check=True, capture_output=True)
     except FileNotFoundError as exc:
         raise RuntimeError("git is required to clone git asset repositories.") from exc
     except subprocess.CalledProcessError as exc:

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -18,6 +18,7 @@ import logging
 import os
 import posixpath
 import re
+import subprocess
 import tempfile
 from typing import Literal
 from urllib.parse import urlparse
@@ -31,7 +32,11 @@ _MDL_TEXTURE_RE = re.compile(r"\.(?:bmp|dds|exr|hdr|ies|jpe?g|ktx2?|png|tga|tiff
 
 
 def _parse_kit_asset_root() -> str:
-    """Parse ``persistent.isaac.asset_root.cloud`` from ``apps/isaaclab.python.kit``."""
+    """Parse the configured Isaac asset root.
+
+    Returns:
+        Value of ``persistent.isaac.asset_root.cloud`` from ``isaaclab.python.kit``.
+    """
     _ISAACLAB_ROOT = os.path.join(os.path.dirname(__file__), *([".."] * 4))
     kit_path = os.path.normpath(os.path.join(_ISAACLAB_ROOT, "apps", "isaaclab.python.kit"))
     with open(kit_path) as f:
@@ -53,6 +58,189 @@ ISAAC_NUCLEUS_DIR: str = f"{NUCLEUS_ASSET_ROOT_DIR}/Isaac"
 
 ISAACLAB_NUCLEUS_DIR: str = f"{ISAAC_NUCLEUS_DIR}/IsaacLab"
 """Path to the ``Isaac/IsaacLab`` directory on the NVIDIA Nucleus Server."""
+
+NEWTON_ASSET_REPO_URL: str = "https://github.com/newton-physics/newton-assets.git"
+"""URL of the Newton asset repository."""
+
+NEWTON_ASSET_DIR: str = os.environ.get("NEWTON_ASSET_DIR", NEWTON_ASSET_REPO_URL)
+"""Git repository URL or local checkout directory used for Newton assets."""
+
+GIT_ASSET_CACHE_DIR: str = os.path.join(tempfile.gettempdir(), "asset_cache")
+"""Default local directory where git asset repositories are cached."""
+
+_GIT_SSH_RE = re.compile(r"^[^@/:]+@[^:]+:.+")
+
+
+def retrieve_git_asset_path(
+    git_path: str, local_path: str, cache_dir: str | None = None, force_update: bool = False
+) -> str:
+    """Return a local path for an asset stored in a git repository.
+
+    Remote repositories are cached under :data:`GIT_ASSET_CACHE_DIR`. If the requested
+    asset is already cached, it is returned without running git.
+
+    Args:
+        git_path: Git repository URL, SSH path, or existing local checkout directory.
+        local_path: Asset path relative to the git repository, or an absolute path inside it.
+        cache_dir: Directory where remote repositories are cached. Defaults to
+            :data:`GIT_ASSET_CACHE_DIR`.
+        force_update: Whether to run ``git pull --ff-only`` for an existing checkout.
+
+    Returns:
+        Local path to the requested asset.
+
+    Raises:
+        FileNotFoundError: When :paramref:`git_path` points to a missing local directory, or the asset is missing.
+        RuntimeError: When the git repository cannot be cloned or updated.
+        ValueError: When :paramref:`local_path` is a URL, resolves outside the git repository, or a cache directory
+            cannot be derived from :paramref:`git_path`.
+    """
+    if _is_git_remote_path(git_path):
+        git_asset_dir = _get_git_asset_cache_dir(git_path, cache_dir)
+        source_path = _resolve_git_asset_source_path(local_path, git_asset_dir)
+        if not force_update and os.path.exists(source_path):
+            return source_path
+
+    git_asset_dir = _get_git_asset_dir(git_path, cache_dir, force_update)
+    source_path = _resolve_git_asset_source_path(local_path, git_asset_dir)
+    if not os.path.exists(source_path):
+        raise FileNotFoundError(f"Unable to find git asset: {source_path}")
+    return source_path
+
+
+def _get_git_asset_dir(git_path: str, cache_dir: str | None = None, force_update: bool = False) -> str:
+    """Return a local checkout for a git asset repository.
+
+    Args:
+        git_path: Git repository URL, SSH path, or existing local checkout directory.
+        cache_dir: Directory where remote repositories are cached.
+        force_update: Whether to update an existing checkout.
+
+    Returns:
+        Path to a local repository checkout.
+
+    Raises:
+        FileNotFoundError: When a local :paramref:`git_path` does not exist.
+        RuntimeError: When a remote checkout cannot be prepared.
+    """
+    if not _is_git_remote_path(git_path):
+        git_asset_dir = os.path.abspath(os.path.expanduser(git_path))
+        if not os.path.isdir(git_asset_dir):
+            raise FileNotFoundError(f"Git asset path does not point to an existing directory: {git_asset_dir}")
+        if force_update and os.path.isdir(os.path.join(git_asset_dir, ".git")):
+            _run_git_command(["git", "-C", git_asset_dir, "pull", "--ff-only"])
+        return git_asset_dir
+
+    git_asset_dir = _get_git_asset_cache_dir(git_path, cache_dir)
+
+    if os.path.isdir(os.path.join(git_asset_dir, ".git")):
+        if force_update:
+            _run_git_command(["git", "-C", git_asset_dir, "pull", "--ff-only"])
+    elif os.path.exists(git_asset_dir):
+        raise RuntimeError(f"Git asset cache exists but is not a git repository: {git_asset_dir}")
+    else:
+        os.makedirs(os.path.dirname(git_asset_dir), exist_ok=True)
+        _run_git_command(["git", "clone", "--depth", "1", git_path, git_asset_dir])
+
+    return git_asset_dir
+
+
+def _get_git_asset_cache_dir(git_path: str, cache_dir: str | None = None) -> str:
+    """Return the cache directory for a remote git repository.
+
+    Args:
+        git_path: Git repository URL or SSH path.
+        cache_dir: Root cache directory. Defaults to :data:`GIT_ASSET_CACHE_DIR`.
+
+    Returns:
+        Cache checkout path for :paramref:`git_path`.
+    """
+    if cache_dir is None:
+        cache_dir = GIT_ASSET_CACHE_DIR
+    cache_dir = os.path.abspath(os.path.expanduser(cache_dir))
+    return os.path.join(cache_dir, _get_git_asset_repo_name(git_path))
+
+
+def _is_git_remote_path(git_path: str) -> bool:
+    """Return whether a git path is remote.
+
+    Args:
+        git_path: Git repository path.
+
+    Returns:
+        True if :paramref:`git_path` is a URL or SSH git path.
+    """
+    return bool(urlparse(git_path).scheme) or _GIT_SSH_RE.match(git_path) is not None
+
+
+def _get_git_asset_repo_name(git_path: str) -> str:
+    """Return the cache directory name for a git repository.
+
+    Args:
+        git_path: Git repository URL or SSH path.
+
+    Returns:
+        Repository name without a trailing ``.git`` suffix.
+
+    Raises:
+        ValueError: When a repository name cannot be derived.
+    """
+    repo_path = urlparse(git_path).path
+    if not repo_path and _GIT_SSH_RE.match(git_path):
+        repo_path = git_path.rsplit(":", 1)[-1]
+    repo_name = os.path.basename(repo_path.rstrip("/"))
+    if repo_name.endswith(".git"):
+        repo_name = repo_name[:-4]
+    if not repo_name:
+        raise ValueError(f"Unable to determine git asset cache directory from git path: {git_path}")
+    return repo_name
+
+
+def _run_git_command(command: list[str]) -> None:
+    """Run a git command.
+
+    Args:
+        command: Git command and arguments.
+
+    Raises:
+        RuntimeError: When git is missing or the command fails.
+    """
+    try:
+        subprocess.run(command, check=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError("git is required to clone git asset repositories.") from exc
+    except subprocess.CalledProcessError as exc:
+        command_str = " ".join(command)
+        raise RuntimeError(f"Unable to run git asset repository command: {command_str}") from exc
+
+
+def _resolve_git_asset_source_path(local_path: str, git_asset_dir: str) -> str:
+    """Resolve an asset path inside a git checkout.
+
+    Args:
+        local_path: Asset path relative to :paramref:`git_asset_dir`, or an absolute path inside it.
+        git_asset_dir: Local git repository checkout directory.
+
+    Returns:
+        Absolute asset path.
+
+    Raises:
+        ValueError: When :paramref:`local_path` is a URL or escapes :paramref:`git_asset_dir`.
+    """
+    if urlparse(local_path).scheme and not os.path.isabs(local_path):
+        raise ValueError(f"Git asset paths must be local paths, got: {local_path}")
+
+    if os.path.isabs(local_path):
+        source_path = os.path.abspath(os.path.expanduser(local_path))
+    else:
+        source_path = os.path.abspath(os.path.join(git_asset_dir, os.path.expanduser(local_path)))
+
+    try:
+        if os.path.commonpath([git_asset_dir, source_path]) != git_asset_dir:
+            raise ValueError(f"Git asset path resolves outside git repository: {local_path}")
+    except ValueError as exc:
+        raise ValueError(f"Git asset path resolves outside git repository: {local_path}") from exc
+    return source_path
 
 
 def check_file_path(path: str) -> Literal[0, 1, 2]:
@@ -235,6 +423,14 @@ def _find_asset_dependencies(local_asset_path: str) -> set[str]:
     refs: set[str] = set()
 
     def _collect(path: str) -> str:
+        """Record an asset path.
+
+        Args:
+            path: Asset path from the USD layer.
+
+        Returns:
+            The input path unchanged.
+        """
         if path:
             refs.add(path)
         return path
@@ -245,7 +441,15 @@ def _find_asset_dependencies(local_asset_path: str) -> set[str]:
 
 
 def _resolve_reference_url(base_url: str, ref: str) -> str:
-    """Resolve a USD asset reference against a base URL (http/local)."""
+    """Resolve a USD reference against a base URL.
+
+    Args:
+        base_url: URL or local path containing the reference.
+        ref: Referenced asset path.
+
+    Returns:
+        Resolved URL or local path.
+    """
     ref = ref.strip()
     if not ref:
         return ref

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -6,6 +6,11 @@
 from __future__ import annotations
 
 """Launch Isaac Sim Simulator first."""
+import importlib
+from pathlib import Path
+
+import pytest
+
 import isaaclab.utils.assets as assets_utils
 
 
@@ -64,3 +69,91 @@ def test_find_asset_dependencies_missing_mdl_does_not_log_traceback(tmp_path, ca
 
     assert assets_utils._find_asset_dependencies(str(missing_mdl)) == set()
     assert "Traceback (most recent call last):" not in caplog.text
+
+
+def test_retrieve_git_asset_path_uses_local_repo_path(tmp_path):
+    """Test retrieving an asset from a local git asset repository."""
+    repo_dir = tmp_path / "newton-assets"
+    asset_dir = repo_dir / "Robots" / "Disney" / "ExampleBot"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
+
+    asset_path = Path(assets_utils.retrieve_git_asset_path(str(repo_dir), "Robots/Disney/ExampleBot"))
+
+    assert asset_path == asset_dir
+    assert (asset_path / "example_bot.usd").read_text(encoding="utf-8") == "#usda 1.0\n"
+
+
+def test_retrieve_git_asset_path_clones_default_repo_cache(tmp_path, monkeypatch):
+    """Test that git assets are pulled into the default asset cache directory."""
+    git_commands = []
+    git_path = "https://example.com/example-assets.git"
+
+    def mock_run_git_command(command):
+        git_commands.append(command)
+        repo_dir = tmp_path / "tmp" / "asset_cache" / "example-assets"
+        asset_dir = repo_dir / "Robots" / "Disney" / "ExampleBot"
+        asset_dir.mkdir(parents=True)
+        (repo_dir / ".git").mkdir()
+        (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(assets_utils, "GIT_ASSET_CACHE_DIR", str(tmp_path / "tmp" / "asset_cache"))
+    monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
+
+    asset_path = Path(assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot"))
+
+    assert asset_path == tmp_path / "tmp" / "asset_cache" / "example-assets" / "Robots" / "Disney" / "ExampleBot"
+    assert (asset_path / "example_bot.usd").read_text(encoding="utf-8") == "#usda 1.0\n"
+    assert git_commands == [
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            git_path,
+            str(tmp_path / "tmp" / "asset_cache" / "example-assets"),
+        ]
+    ]
+
+
+def test_retrieve_git_asset_path_uses_cached_asset_without_git(tmp_path, monkeypatch):
+    """Test that cached git assets can be used without running git commands."""
+    git_path = "https://example.com/example-assets.git"
+    cache_dir = tmp_path / "asset_cache"
+    asset_dir = cache_dir / "example-assets" / "Robots" / "Disney" / "ExampleBot"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
+
+    def fail_run_git_command(command):
+        raise AssertionError(f"git should not be called for cached asset: {command}")
+
+    monkeypatch.setattr(assets_utils, "_run_git_command", fail_run_git_command)
+
+    asset_path = Path(
+        assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
+    )
+
+    assert asset_path == asset_dir
+    assert (asset_path / "example_bot.usd").read_text(encoding="utf-8") == "#usda 1.0\n"
+
+
+def test_retrieve_git_asset_path_raises_for_missing_asset(tmp_path):
+    """Test that git asset retrieval raises when the requested asset is missing."""
+    repo_dir = tmp_path / "newton-assets"
+    repo_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="Unable to find git asset"):
+        assets_utils.retrieve_git_asset_path(str(repo_dir), "Robots/Disney/ExampleBot")
+
+
+def test_newton_asset_dir_uses_environment_override(tmp_path, monkeypatch):
+    """Test that the Newton asset directory is defined from the environment."""
+    repo_dir = tmp_path / "newton-assets"
+    monkeypatch.setenv("NEWTON_ASSET_DIR", str(repo_dir))
+
+    try:
+        module = importlib.reload(assets_utils)
+        assert str(repo_dir) == module.NEWTON_ASSET_DIR
+    finally:
+        monkeypatch.delenv("NEWTON_ASSET_DIR", raising=False)
+        importlib.reload(assets_utils)


### PR DESCRIPTION
## Summary
- add `retrieve_git_asset_path(git_path, local_path)` for resolving assets from any git repository
- remote repositories are cached under `GIT_ASSET_CACHE_DIR/<repo-name>`, which defaults to `/tmp/asset_cache/<repo-name>` on Linux
- return an already-cached requested asset before running any git command, so cache hits are offline-friendly; `force_update=True` remains the explicit refresh path
- define `NEWTON_ASSET_DIR` centrally in `isaaclab.utils.assets`, defaulting to `NEWTON_ASSET_REPO_URL` with an environment override for local checkouts
- keep existing Nucleus/S3 constants and asset configs unchanged
- add focused resolver tests and an `isaaclab` changelog fragment

## Real asset probe
- resolved `disneyresearch/dr_legs/usd/dr_legs.usda` from the Newton assets repo through the git helper using the workspace-local cache and opened it with OpenUSD via Isaac Sim Python, verifying default prim `/DR_Legs` plus 31 mesh prims

## Verification
- red tests: cache-hit offline test failed with `Git asset cache exists but is not a git repository`, and `NEWTON_ASSET_DIR` test failed with `AttributeError` before implementation
- `./isaaclab.sh -p -m pytest source/isaaclab/test/utils/test_assets.py::test_retrieve_git_asset_path_uses_local_repo_path source/isaaclab/test/utils/test_assets.py::test_retrieve_git_asset_path_clones_default_repo_cache source/isaaclab/test/utils/test_assets.py::test_retrieve_git_asset_path_uses_cached_asset_without_git source/isaaclab/test/utils/test_assets.py::test_retrieve_git_asset_path_raises_for_missing_asset source/isaaclab/test/utils/test_assets.py::test_newton_asset_dir_uses_environment_override -q` -> 5 passed
- `./isaaclab.sh -p -m py_compile source/isaaclab/isaaclab/utils/assets.py source/isaaclab/test/utils/test_assets.py source/isaaclab_assets/isaaclab_assets/robots/universal_robots.py` -> passed
- `git diff --check` / `git diff --cached --check` -> passed
- `SKIP=check-git-lfs-pointers ./isaaclab.sh -f` -> passed

## Note
Full `./isaaclab.sh -f` still cannot run here because `git-lfs` is not installed. `sudo apt-get update` was also attempted after maintainer approval, but this environment rejects privilege-escalation utilities, so the LFS hook could not be enabled here.