### PR TITLE
Switches to nightly build for Docker builds and multi-version docs

### DIFF
--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Shared image config for CI workflows. Loaded by the `config` job in each
+# workflow via yq and exposed as job outputs (see e.g. .github/workflows/build.yaml).
+isaacsim_image_name: nvcr.io/nvidian/isaac-sim
+isaacsim_image_tag: latest-develop
+isaaclab_image_name: nvcr.io/nvidian/isaac-lab

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,6 +16,11 @@ on:
     # we're skipping the branches and paths filter to allow docs to be built on any PR because heredoc is used
     # additionally, we have a check that determines what version of docs will be built
     types: [opened, synchronize, reopened]
+  # Nightly multi-version rebuild + deploy from develop tip. Picks up every
+  # develop commit accumulated since the previous nightly in a single run.
+  schedule:
+    - cron: '0 3 * * *'  # 7pm PST / 8pm PDT
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,13 +34,13 @@ jobs:
       trigger-deploy: ${{ steps.trigger-deploy.outputs.defined }}
     steps:
     - id: info
-      run: echo "repo=github.repository=${{ github.repository }}, ref=github.ref=${{ github.ref }}"
+      run: echo "repo=github.repository=${{ github.repository }}, ref=github.ref=${{ github.ref }}, event=github.event_name=${{ github.event_name }}"
     - id: trigger-deploy
       env:
         REPO_NAME: ${{ secrets.REPO_NAME }}
-      # develop, main, release/ trigger multi-version build, then deployment to gh-pages
-      # all others - just the current docs without deployment
-      if: "${{ github.repository == env.REPO_NAME && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')) }}"
+      # Nightly schedule and workflow_dispatch trigger multi-version deploy.
+      # All branch pushes (including main) build current-docs only; deploy waits for the cron above.
+      if: "${{ github.repository == env.REPO_NAME && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}"
       run: echo "defined=true" >> "$GITHUB_OUTPUT"; echo "Docs will be built multi-version and deployed"
 
   build-latest-docs:
@@ -79,6 +84,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        # On schedule, always rebuild from the develop tip regardless of
+        # which ref the cron run defaults to. Other events use github.ref.
+        ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
 
     - name: Setup python
       uses: actions/setup-python@v5

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ on:
   # Nightly multi-version rebuild + deploy from develop tip. Picks up every
   # develop commit accumulated since the previous nightly in a single run.
   schedule:
-    - cron: '0 3 * * *'  # 7pm PST / 8pm PDT
+    - cron: '0 2 * * *'  # 6pm PST / 7pm PDT
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -6,25 +6,60 @@
 name: Publish Docker Images
 
 on:
-  # Daily build + publish from develop tip (latest-develop tags).
-  # No push triggers — use workflow_dispatch to publish main or release images on demand.
+  # Nightly build + publish from develop, main, and the active release branches
+  # listed in CRON_RELEASE_BRANCHES below. No push triggers — workflow_dispatch
+  # also accepts any publishable branch.
   schedule:
     - cron: '0 3 * * *'  # 7pm PST / 8pm PDT
-  # Manual trigger.
   workflow_dispatch:
-
-# Concurrency control to prevent parallel runs
-concurrency:
-  group: publish-images-${{ github.ref }}
-  cancel-in-progress: true
+    inputs:
+      branch:
+        description: 'Branch to build and publish (e.g. develop, release/3.0.0-beta2, main)'
+        required: true
+        type: string
 
 permissions:
   contents: read
 
+# Active release branches the nightly cron publishes, alongside develop and main.
+# Single source of truth — append a ref here when a new release/* is cut and drop
+# it once that release is retired, so stale release branches aren't rebuilt nightly.
+# Mirrors CRON_BRANCHES in nightly-changelog.yml. Whitespace per entry is stripped.
 env:
   NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+  CRON_RELEASE_BRANCHES: release/3.0.0-beta2
 
 jobs:
+  resolve-branches:
+    name: Resolve publish branches
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      branches: ${{ steps.b.outputs.branches }}
+    steps:
+    - id: b
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        MANUAL_BRANCH: ${{ inputs.branch }}
+        RELEASE_BRANCHES: ${{ env.CRON_RELEASE_BRANCHES }}
+      run: |
+        if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          # Manual trigger: build exactly the one branch the maintainer entered.
+          arr=$(echo "$MANUAL_BRANCH" | jq -R . | jq -s -c .)
+        else
+          # Schedule: develop + main + the configured active release branches.
+          # CSV → newline, trimming surrounding whitespace per entry.
+          releases=$(echo "$RELEASE_BRANCHES" | tr ',' '\n' | xargs -n1 || true)
+          branches=$( { echo develop; echo main; echo "$releases"; } | sed '/^$/d' | sort -u )
+          arr=$(echo "$branches" | jq -R . | jq -s -c .)
+        fi
+        if [ "$(echo "$arr" | jq 'length')" -eq 0 ]; then
+          echo "::error::No branches resolved for publishing"
+          exit 1
+        fi
+        echo "branches=$arr" >> "$GITHUB_OUTPUT"
+        echo "Resolved branches: $arr"
+
   config:
     name: Load Config
     runs-on: ubuntu-latest
@@ -47,9 +82,17 @@ jobs:
         echo "isaaclab_image_name=$(yq -r .isaaclab_image_name "$f")" >> "$GITHUB_OUTPUT"
 
   build-and-push-images:
-    needs: [config]
+    name: Build and Push (${{ matrix.branch }})
+    needs: [config, resolve-branches]
     runs-on: [self-hosted, gpu]
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.resolve-branches.outputs.branches) }}
+    concurrency:
+      group: publish-images-${{ matrix.branch }}
+      cancel-in-progress: true
     environment:
       name: postmerge-production
       url: https://github.com/${{ github.repository }}
@@ -63,8 +106,7 @@ jobs:
       with:
         fetch-depth: 1
         lfs: true
-        # On schedule, always build from the develop tip regardless of which ref the cron defaults to.
-        ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
+        ref: ${{ matrix.branch }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -94,9 +136,7 @@ jobs:
 
     - name: Build and Push Docker Images
       run: |
-        # Schedule runs check out develop (see Checkout step) but github.ref_name still resolves
-        # to the default branch; mirror the override so tagging matches the code.
-        BRANCH_NAME="${{ github.event_name == 'schedule' && 'develop' || github.ref_name }}"
+        BRANCH_NAME="${{ matrix.branch }}"
         IMAGE_BASE_VERSION="${{ needs.config.outputs.isaacsim_image_tag }}"
         SHA="${{ github.sha }}"
         IMAGE="${{ needs.config.outputs.isaaclab_image_name }}"
@@ -109,11 +149,11 @@ jobs:
         # Build the list of tags based on the branch.
         #
         # Tagging scheme:
-        #   - Push to develop:    $IMAGE:latest-develop                          (moves to newest develop build)
+        #   - develop:            $IMAGE:latest-develop                          (moves to newest develop build)
         #                         $IMAGE:latest-develop-<run#>-<sha-stub>        (immutable per-build)
-        #   - Push to release/X:  $IMAGE:latest-release-X                        (moves to newest build on that release branch)
+        #   - release/X:          $IMAGE:latest-release-X                        (moves to newest build on that release branch)
         #                         $IMAGE:latest-release-X-<run#>-<sha-stub>      (immutable per-build)
-        #   - Push to main:       $IMAGE:latest                                  (moves to newest main build)
+        #   - main:               $IMAGE:latest                                  (moves to newest main build)
         #                         $IMAGE:v<VERSION>                              (from the VERSION file, e.g. v3.0.0)
         TAGS=()
 

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -11,7 +11,7 @@ on:
   # publishable branch. main is intentionally excluded: main images are built
   # by postmerge-ci.yml on push instead.
   schedule:
-    - cron: '0 3 * * *'  # 7pm PST / 8pm PDT
+    - cron: '0 2 * * *'  # 6pm PST / 7pm PDT
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,0 +1,208 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Publish Docker Images
+
+on:
+  # Daily build + publish from develop tip (latest-develop tags).
+  # No push triggers — use workflow_dispatch to publish main or release images on demand.
+  schedule:
+    - cron: '0 3 * * *'  # 7pm PST / 8pm PDT
+  # Manual trigger.
+  workflow_dispatch:
+
+# Concurrency control to prevent parallel runs
+concurrency:
+  group: publish-images-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+
+jobs:
+  config:
+    name: Load Config
+    runs-on: ubuntu-latest
+    outputs:
+      isaacsim_image_name: ${{ steps.load.outputs.isaacsim_image_name }}
+      isaacsim_image_tag: ${{ steps.load.outputs.isaacsim_image_tag }}
+      isaaclab_image_name: ${{ steps.load.outputs.isaaclab_image_name }}
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+        sparse-checkout: .github/workflows/config.yaml
+        sparse-checkout-cone-mode: false
+    - id: load
+      run: |
+        set -euo pipefail
+        f=.github/workflows/config.yaml
+        echo "isaacsim_image_name=$(yq -r .isaacsim_image_name "$f")" >> "$GITHUB_OUTPUT"
+        echo "isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$f")" >> "$GITHUB_OUTPUT"
+        echo "isaaclab_image_name=$(yq -r .isaaclab_image_name "$f")" >> "$GITHUB_OUTPUT"
+
+  build-and-push-images:
+    needs: [config]
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 180
+    environment:
+      name: postmerge-production
+      url: https://github.com/${{ github.repository }}
+    env:
+        DOCKER_HOST: unix:///var/run/docker.sock
+        DOCKER_TLS_CERTDIR: ""
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+        lfs: true
+        # On schedule, always build from the develop tip regardless of which ref the cron defaults to.
+        ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/arm64
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+        driver-opts: |
+          image=moby/buildkit:buildx-stable-1
+
+    - name: Login to NGC
+      run: |
+        # Only attempt NGC login if API key is available
+        if [ -n "${{ env.NGC_API_KEY }}" ]; then
+          echo "🔵 Logging into NGC registry..."
+          if ! docker login -u \$oauthtoken -p ${{ env.NGC_API_KEY }} nvcr.io; then
+            echo "🔴 Failed to log into NGC registry"
+            exit 1
+          fi
+          echo "🟢 Successfully logged into NGC registry"
+        else
+          echo "🟠 NGC_API_KEY not set - skipping NGC login (normal when secrets are not configured)"
+        fi
+
+    - name: Build and Push Docker Images
+      run: |
+        # Schedule runs check out develop (see Checkout step) but github.ref_name still resolves
+        # to the default branch; mirror the override so tagging matches the code.
+        BRANCH_NAME="${{ github.event_name == 'schedule' && 'develop' || github.ref_name }}"
+        IMAGE_BASE_VERSION="${{ needs.config.outputs.isaacsim_image_tag }}"
+        SHA="${{ github.sha }}"
+        IMAGE="${{ needs.config.outputs.isaaclab_image_name }}"
+
+        echo "Branch: $BRANCH_NAME"
+        echo "Commit: $SHA"
+        echo "IsaacSim base image: ${{ needs.config.outputs.isaacsim_image_name }}:$IMAGE_BASE_VERSION"
+        echo "Target Isaac Lab image: $IMAGE"
+
+        # Build the list of tags based on the branch.
+        #
+        # Tagging scheme:
+        #   - Push to develop:    $IMAGE:latest-develop                          (moves to newest develop build)
+        #                         $IMAGE:latest-develop-<run#>-<sha-stub>        (immutable per-build)
+        #   - Push to release/X:  $IMAGE:latest-release-X                        (moves to newest build on that release branch)
+        #                         $IMAGE:latest-release-X-<run#>-<sha-stub>      (immutable per-build)
+        #   - Push to main:       $IMAGE:latest                                  (moves to newest main build)
+        #                         $IMAGE:v<VERSION>                              (from the VERSION file, e.g. v3.0.0)
+        TAGS=()
+
+        case "$BRANCH_NAME" in
+          develop)
+            TAGS+=("$IMAGE:latest-develop")
+            TAGS+=("$IMAGE:latest-develop-${{ github.run_number }}-${SHA:0:8}")
+            ;;
+          main)
+            TAGS+=("$IMAGE:latest")
+            VERSION="$(tr -d '[:space:]' < VERSION)"
+            if [ -n "$VERSION" ]; then
+              TAGS+=("$IMAGE:v$VERSION")
+            else
+              echo "🛑 ERROR: VERSION file is empty or missing. Cannot tag build with version tag."
+              exit 1
+            fi
+            ;;
+          release/*)
+            # Sanitize the part after release/ for use as a Docker tag suffix.
+            RELEASE_SUFFIX=$(echo "${BRANCH_NAME#release/}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+            TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX")
+            TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX-${{ github.run_number }}-${SHA:0:8}")
+            ;;
+          *)
+            echo "Branch '$BRANCH_NAME' is not configured for publishing; skipping."
+            exit 0
+            ;;
+        esac
+
+        # Determine if multiarch is supported by inspecting the base image manifest
+        echo "🔵 Checking if base image supports multiarch..."
+        BASE_IMAGE_FULL="${{ needs.config.outputs.isaacsim_image_name }}:${IMAGE_BASE_VERSION}"
+        ARCHITECTURES=$(docker manifest inspect "$BASE_IMAGE_FULL" 2>/dev/null | grep -o '"architecture": "[^"]*"' | cut -d'"' -f4 | sort -u)
+
+        if [ -z "$ARCHITECTURES" ]; then
+          echo "🟠 Could not inspect base image manifest: $BASE_IMAGE_FULL - defaulting to linux/amd64 only"
+          BUILD_PLATFORMS="linux/amd64"
+        else
+          echo "Base image architectures found:"
+          echo "$ARCHITECTURES" | sed 's/^/  - /'
+
+          HAS_AMD64=$(echo "$ARCHITECTURES" | grep -c "amd64" || true)
+          HAS_ARM64=$(echo "$ARCHITECTURES" | grep -c "arm64" || true)
+
+          if [ "$HAS_AMD64" -gt 0 ] && [ "$HAS_ARM64" -gt 0 ]; then
+            echo "🟢 Base image supports multiarch (amd64 + arm64)"
+            BUILD_PLATFORMS="linux/amd64,linux/arm64"
+          elif [ "$HAS_AMD64" -gt 0 ]; then
+            echo "Base image only supports amd64"
+            BUILD_PLATFORMS="linux/amd64"
+          elif [ "$HAS_ARM64" -gt 0 ]; then
+            echo "Base image only supports arm64"
+            BUILD_PLATFORMS="linux/arm64"
+          else
+            echo "🟠 Unknown architecture support for $BASE_IMAGE_FULL - defaulting to linux/amd64"
+            BUILD_PLATFORMS="linux/amd64"
+          fi
+        fi
+
+        echo "Target platforms: $BUILD_PLATFORMS"
+        echo "Tags to publish:"
+        printf '  - %s\n' "${TAGS[@]}"
+
+        # Compose -t flags for buildx
+        TAG_ARGS=()
+        for t in "${TAGS[@]}"; do
+          TAG_ARGS+=("-t" "$t")
+        done
+
+        echo "🔵 Building and pushing image with tags listed above..."
+        if ! docker buildx build \
+          --platform "$BUILD_PLATFORMS" \
+          --progress=plain \
+          "${TAG_ARGS[@]}" \
+          --build-arg ISAACSIM_BASE_IMAGE_ARG=${{ needs.config.outputs.isaacsim_image_name }} \
+          --build-arg ISAACSIM_VERSION_ARG="$IMAGE_BASE_VERSION" \
+          --build-arg ISAACSIM_ROOT_PATH_ARG=/isaac-sim \
+          --build-arg ISAACLAB_PATH_ARG=/workspace/isaaclab \
+          --build-arg DOCKER_USER_HOME_ARG=/root \
+          --cache-from type=gha \
+          --cache-to type=gha,mode=max \
+          -f docker/Dockerfile.base \
+          --push .; then
+          echo "🔴 docker buildx build/push failed for tags:"
+          printf '  - %s\n' "${TAGS[@]}"
+          exit 1
+        fi
+
+        for t in "${TAGS[@]}"; do
+          echo "🟢 Successfully built and pushed: $t (platforms: $BUILD_PLATFORMS)"
+        done

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -6,28 +6,30 @@
 name: Publish Docker Images
 
 on:
-  # Nightly build + publish from develop, main, and the active release branches
-  # listed in CRON_RELEASE_BRANCHES below. No push triggers — workflow_dispatch
-  # also accepts any publishable branch.
+  # Nightly build + publish from develop and the active release branches listed
+  # in CRON_BRANCHES below. No push triggers — workflow_dispatch also accepts any
+  # publishable branch. main is intentionally excluded: main images are built
+  # by postmerge-ci.yml on push instead.
   schedule:
     - cron: '0 3 * * *'  # 7pm PST / 8pm PDT
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to build and publish (e.g. develop, release/3.0.0-beta2, main)'
+        description: 'Branch to build and publish (e.g. develop, release/3.0.0-beta2)'
         required: true
         type: string
 
 permissions:
   contents: read
 
-# Active release branches the nightly cron publishes, alongside develop and main.
-# Single source of truth — append a ref here when a new release/* is cut and drop
-# it once that release is retired, so stale release branches aren't rebuilt nightly.
-# Mirrors CRON_BRANCHES in nightly-changelog.yml. Whitespace per entry is stripped.
+# Branches the nightly cron publishes. Single source of truth — append a ref
+# here when a new release/* is cut and drop it once that release is retired, so
+# stale branches aren't rebuilt nightly. Mirrors CRON_BRANCHES in
+# nightly-changelog.yml. Whitespace per entry is stripped. main is excluded on
+# purpose (it builds on the public isaac-sim base via postmerge-ci.yml).
 env:
   NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
-  CRON_RELEASE_BRANCHES: release/3.0.0-beta2
+  CRON_BRANCHES: develop,release/3.0.0-beta2
 
 jobs:
   resolve-branches:
@@ -39,20 +41,13 @@ jobs:
     steps:
     - id: b
       env:
-        EVENT_NAME: ${{ github.event_name }}
-        MANUAL_BRANCH: ${{ inputs.branch }}
-        RELEASE_BRANCHES: ${{ env.CRON_RELEASE_BRANCHES }}
+        # Schedule → the CRON_BRANCHES list. Manual → the single branch the
+        # maintainer entered (required input). Same pattern as nightly-changelog.yml.
+        BRANCHES: ${{ github.event_name == 'schedule' && env.CRON_BRANCHES || inputs.branch }}
       run: |
-        if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-          # Manual trigger: build exactly the one branch the maintainer entered.
-          arr=$(echo "$MANUAL_BRANCH" | jq -R . | jq -s -c .)
-        else
-          # Schedule: develop + main + the configured active release branches.
-          # CSV → newline, trimming surrounding whitespace per entry.
-          releases=$(echo "$RELEASE_BRANCHES" | tr ',' '\n' | xargs -n1 || true)
-          branches=$( { echo develop; echo main; echo "$releases"; } | sed '/^$/d' | sort -u )
-          arr=$(echo "$branches" | jq -R . | jq -s -c .)
-        fi
+        # CSV → newline, trimming surrounding whitespace per entry, then to a
+        # compact JSON array. Manual produces a 1-element array; cron N elements.
+        arr=$(echo "$BRANCHES" | tr ',' '\n' | xargs -n1 | jq -R . | jq -s -c .)
         if [ "$(echo "$arr" | jq 'length')" -eq 0 ]; then
           echo "::error::No branches resolved for publishing"
           exit 1
@@ -123,9 +118,9 @@ jobs:
     - name: Login to NGC
       run: |
         # Only attempt NGC login if API key is available
-        if [ -n "${{ env.NGC_API_KEY }}" ]; then
+        if [ -n "$NGC_API_KEY" ]; then
           echo "🔵 Logging into NGC registry..."
-          if ! docker login -u \$oauthtoken -p ${{ env.NGC_API_KEY }} nvcr.io; then
+          if ! echo "$NGC_API_KEY" | docker login -u '$oauthtoken' --password-stdin nvcr.io; then
             echo "🔴 Failed to log into NGC registry"
             exit 1
           fi
@@ -138,51 +133,64 @@ jobs:
       run: |
         BRANCH_NAME="${{ matrix.branch }}"
         IMAGE_BASE_VERSION="${{ needs.config.outputs.isaacsim_image_tag }}"
-        SHA="${{ github.sha }}"
         IMAGE="${{ needs.config.outputs.isaaclab_image_name }}"
 
+        # Use the SHA actually checked out for this branch (the matrix ref), not
+        # github.sha — on a scheduled run github.sha is the default branch (main)
+        # HEAD, which would mis-tag every nightly image.
+        FULL_SHA="$(git rev-parse HEAD)"
+
         echo "Branch: $BRANCH_NAME"
-        echo "Commit: $SHA"
+        echo "Commit: $FULL_SHA"
         echo "IsaacSim base image: ${{ needs.config.outputs.isaacsim_image_name }}:$IMAGE_BASE_VERSION"
         echo "Target Isaac Lab image: $IMAGE"
 
-        # Build the list of tags based on the branch.
+        # Build the tag list for the branch (main is published separately via
+        # postmerge-ci.yml, so it is not handled here).
         #
         # Tagging scheme:
-        #   - develop:            $IMAGE:latest-develop                          (moves to newest develop build)
-        #                         $IMAGE:latest-develop-<run#>-<sha-stub>        (immutable per-build)
-        #   - release/X:          $IMAGE:latest-release-X                        (moves to newest build on that release branch)
-        #                         $IMAGE:latest-release-X-<run#>-<sha-stub>      (immutable per-build)
-        #   - main:               $IMAGE:latest                                  (moves to newest main build)
-        #                         $IMAGE:v<VERSION>                              (from the VERSION file, e.g. v3.0.0)
-        TAGS=()
+        #   - develop:    $IMAGE:latest-develop               (moves to newest develop build)
+        #                 $IMAGE:latest-develop-<full-sha>    (immutable per-commit)
+        #   - release/X:  $IMAGE:latest-release-X             (moves to newest build on that release branch)
+        #                 $IMAGE:latest-release-X-<full-sha>  (immutable per-commit)
+        #
+        # The immutable per-commit tag doubles as the "already published" marker:
+        # if it exists in the registry the branch has not advanced since the last
+        # publish, so the nightly build is skipped (see the guard below).
+        MOVING_TAG=""
+        IMMUTABLE_TAG=""
 
         case "$BRANCH_NAME" in
           develop)
-            TAGS+=("$IMAGE:latest-develop")
-            TAGS+=("$IMAGE:latest-develop-${{ github.run_number }}-${SHA:0:8}")
-            ;;
-          main)
-            TAGS+=("$IMAGE:latest")
-            VERSION="$(tr -d '[:space:]' < VERSION)"
-            if [ -n "$VERSION" ]; then
-              TAGS+=("$IMAGE:v$VERSION")
-            else
-              echo "🛑 ERROR: VERSION file is empty or missing. Cannot tag build with version tag."
-              exit 1
-            fi
+            MOVING_TAG="$IMAGE:latest-develop"
+            IMMUTABLE_TAG="$IMAGE:latest-develop-$FULL_SHA"
             ;;
           release/*)
             # Sanitize the part after release/ for use as a Docker tag suffix.
             RELEASE_SUFFIX=$(echo "${BRANCH_NAME#release/}" | sed 's/[^a-zA-Z0-9._-]/-/g')
-            TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX")
-            TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX-${{ github.run_number }}-${SHA:0:8}")
+            MOVING_TAG="$IMAGE:latest-release-$RELEASE_SUFFIX"
+            IMMUTABLE_TAG="$IMAGE:latest-release-$RELEASE_SUFFIX-$FULL_SHA"
+            ;;
+          main)
+            # main is intentionally not published here; see postmerge-ci.yml for main.
+            echo "Branch 'main' is not published by this workflow; skipping. See postmerge-ci.yml for main."
+            exit 0
             ;;
           *)
             echo "Branch '$BRANCH_NAME' is not configured for publishing; skipping."
             exit 0
             ;;
         esac
+
+        # Skip the (expensive) build when this exact commit was already published.
+        # The immutable per-commit tag is the source of truth for "git advanced":
+        # if it already exists in the registry, nothing new to build for this branch.
+        if docker manifest inspect "$IMMUTABLE_TAG" >/dev/null 2>&1; then
+          echo "🟢 $IMMUTABLE_TAG already exists — $BRANCH_NAME has not advanced since the last publish. Skipping."
+          exit 0
+        fi
+
+        TAGS=("$MOVING_TAG" "$IMMUTABLE_TAG")
 
         # Determine if multiarch is supported by inspecting the base image manifest
         echo "🔵 Checking if base image supports multiarch..."


### PR DESCRIPTION
# Description
!!merge #5970 first then #5971!!

Defer the multi-version sphinx-multiversion docs build off every push and onto a nightly schedule from develop.
Defer develop Docker builds to nightly schedule.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there