### PR TITLE
[CI] Stop deploying docs and publishing images on develop/release pushes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,6 +6,9 @@
 name: Docs
 
 on:
+  # Pushes and PRs still build current-docs (build-latest-docs). The expensive
+  # multi-version deploy is owned by the nightly cron (registered on main); see
+  # the trigger-deploy gate below — develop / release pushes no longer deploy here.
   push:
     branches:
       - main
@@ -33,9 +36,11 @@ jobs:
     - id: trigger-deploy
       env:
         REPO_NAME: ${{ secrets.REPO_NAME }}
-      # develop, main, release/ trigger multi-version build, then deployment to gh-pages
-      # all others - just the current docs without deployment
-      if: "${{ github.repository == env.REPO_NAME && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')) }}"
+      # Multi-version deploy is owned by the nightly cron (registered on main).
+      # schedule / workflow_dispatch only fire from the default branch (main), so on
+      # this branch these are always false: develop / release / feature pushes and PRs
+      # build current-docs only and never deploy here.
+      if: "${{ github.repository == env.REPO_NAME && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}"
       run: echo "defined=true" >> "$GITHUB_OUTPUT"; echo "Docs will be built multi-version and deployed"
 
   build-latest-docs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ on:
   # Nightly multi-version rebuild + deploy from develop tip. Picks up every
   # develop commit accumulated since the previous nightly in a single run.
   schedule:
-    - cron: '0 3 * * *'  # 7pm PST / 8pm PDT
+    - cron: '0 2 * * *'  # 6pm PST / 7pm PDT
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,6 +19,11 @@ on:
     # we're skipping the branches and paths filter to allow docs to be built on any PR because heredoc is used
     # additionally, we have a check that determines what version of docs will be built
     types: [opened, synchronize, reopened]
+  # Nightly multi-version rebuild + deploy from develop tip. Picks up every
+  # develop commit accumulated since the previous nightly in a single run.
+  schedule:
+    - cron: '0 3 * * *'  # 7pm PST / 8pm PDT
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -6,11 +6,9 @@
 name: Publish Docker Images
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-      - release/**
+  # Image publishing is owned by the nightly cron (registered on the default
+  # branch, main). No push triggers — pushes to develop / release no longer publish.
+  workflow_dispatch:
 
 # Concurrency control to prevent parallel runs
 concurrency:

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -76,9 +76,9 @@ jobs:
     - name: Login to NGC
       run: |
         # Only attempt NGC login if API key is available
-        if [ -n "${{ env.NGC_API_KEY }}" ]; then
+        if [ -n "$NGC_API_KEY" ]; then
           echo "🔵 Logging into NGC registry..."
-          if ! docker login -u \$oauthtoken -p ${{ env.NGC_API_KEY }} nvcr.io; then
+          if ! echo "$NGC_API_KEY" | docker login -u '$oauthtoken' --password-stdin nvcr.io; then
             echo "🔴 Failed to log into NGC registry"
             exit 1
           fi

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -101,11 +101,12 @@ jobs:
 
         # Build the list of tags based on the branch.
         #
-        # Tagging scheme:
+        # Tagging scheme (immutable tag uses the full commit SHA so it matches
+        # the nightly cron's tags on main; see publish-images.yaml there):
         #   - Push to develop:    $IMAGE:latest-develop                          (moves to newest develop build)
-        #                         $IMAGE:latest-develop-<run#>-<sha-stub>        (immutable per-build)
+        #                         $IMAGE:latest-develop-<full-sha>               (immutable per-commit)
         #   - Push to release/X:  $IMAGE:latest-release-X                        (moves to newest build on that release branch)
-        #                         $IMAGE:latest-release-X-<run#>-<sha-stub>      (immutable per-build)
+        #                         $IMAGE:latest-release-X-<full-sha>             (immutable per-commit)
         #   - Push to main:       $IMAGE:latest                                  (moves to newest main build)
         #                         $IMAGE:v<VERSION>                              (from the VERSION file, e.g. v3.0.0)
         TAGS=()
@@ -113,7 +114,7 @@ jobs:
         case "$BRANCH_NAME" in
           develop)
             TAGS+=("$IMAGE:latest-develop")
-            TAGS+=("$IMAGE:latest-develop-${{ github.run_number }}-${SHA:0:8}")
+            TAGS+=("$IMAGE:latest-develop-$SHA")
             ;;
           main)
             TAGS+=("$IMAGE:latest")
@@ -129,7 +130,7 @@ jobs:
             # Sanitize the part after release/ for use as a Docker tag suffix.
             RELEASE_SUFFIX=$(echo "${BRANCH_NAME#release/}" | sed 's/[^a-zA-Z0-9._-]/-/g')
             TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX")
-            TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX-${{ github.run_number }}-${SHA:0:8}")
+            TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX-$SHA")
             ;;
           *)
             echo "Branch '$BRANCH_NAME' is not configured for publishing; skipping."

--- a/source/isaaclab/changelog.d/esekkin-develop-ci-push.skip
+++ b/source/isaaclab/changelog.d/esekkin-develop-ci-push.skip
@@ -1,0 +1,4 @@
+CI-only:
+develop / release pushes no longer trigger the multi-version docs deploy or Docker image publish — both are owned by the nightly cron (registered on main).
+Docs pushes and PRs still build current-docs for validation; Docker images build on demand via workflow_dispatch.
+No tag-name changes and no user-facing change to the published site.

--- a/source/isaaclab/changelog.d/esekkin-develop-ci-push.skip
+++ b/source/isaaclab/changelog.d/esekkin-develop-ci-push.skip
@@ -1,4 +1,4 @@
 CI-only:
 develop / release pushes no longer trigger the multi-version docs deploy or Docker image publish — both are owned by the nightly cron (registered on main).
 Docs pushes and PRs still build current-docs for validation; Docker images build on demand via workflow_dispatch.
-No tag-name changes and no user-facing change to the published site.
+Immutable Docker tags now use the full commit SHA (e.g. isaac-lab:latest-develop-<full-sha>, latest-release-X-<full-sha>) instead of the old <run#>-<sha8> suffix, matching the nightly cron's tags; the moving latest-develop / latest-release-X tags are unchanged. No user-facing change to the published docs site.


### PR DESCRIPTION
# Description
!!merge #5970 first then #5971!!

Push events to `develop` / `release/*` no longer run the expensive multi-version docs deploy or publish Docker images. 

Both are now owned by the nightly cron registered on `main` (#5970). This eliminates redundant, resource-heavy work on every integration push while preserving fast per-push/PR validation.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there