### PR TITLE
Compass document bug fix

### DIFF
--- a/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
+++ b/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
@@ -369,7 +369,7 @@ Where:
 - ``--environment nova_carter-galileo``: Specifies the NuRec Real2Sim Galileo environment
 
 The training will run for the number of iterations specified in the config file (default: 1000 iterations).
-The resulting checkpoint will be stored in ``<output_dir>/checkpoints/`` with the filename ``model_<iteration_number>.pt``.
+Checkpoints are saved directly under ``<output_dir>/`` with the filename ``model_<iteration_number>.pt`` (e.g., ``model_0.pt``, ``model_50.pt``, ``model_100.pt``), written every 50 iterations.
 Videos will be saved in ``<output_dir>/videos/``.
 
 .. note::
@@ -441,7 +441,7 @@ Execute the following command from the ``COMPASS`` directory to evaluate the tra
 
 Where:
 
-- ``<path/to/residual_policy_ckpt>``: Path to the trained residual policy checkpoint (e.g., ``<output_dir>/checkpoints/model_1000.pt``)
+- ``<path/to/residual_policy_ckpt>``: Path to the trained residual policy checkpoint (e.g., ``<output_dir>/model_1000.pt``)
 - ``--video``: Enable video recording during evaluation
 - ``--video_interval``: Record video every N iterations
 


### PR DESCRIPTION
# Description
Bug : 6247480

Observation:
1. Documented checkpoint save path <output_dir>/checkpoints/ does not match actual
   behavior — checkpoints are saved directly under <output_dir>/

The doc states:
  "The resulting checkpoint will be stored in <output_dir>/checkpoints/ with the filename
   model_<iteration_number>.pt"

Actual directory layout after training completes:

  ~/compass-nurec/output/galileo_spot/
  ├── model_0.pt
  ├── model_50.pt
  ├── model_100.pt
  ├── model_150.pt
  ├── model_200.pt
  ├── debug_images/
  ├── tensorboard/
  └── videos/

No checkpoints/ subdirectory is created. Checkpoint files are written directly to the
output root. Any user or test step that follows the doc and checks
<output_dir>/checkpoints/ for verification will get:

  ls: cannot access '<output_dir>/checkpoints/': No such file or directory

Command:

${ISAACLAB_PATH:?}/isaaclab.sh -p run.py \ -c configs/train_config_real2sim.gin \ -o ~/compass-nurec/output/galileo_spot \ -b ~/compass-nurec/X-Mobility/x_mobility-nav2-semantic_action_path.ckpt \ --embodiment spot \ --environment nova_carter-galileo \ --num_envs 64 \ --video --video_interval 1 \ --visualizer kit \ --enable_cameras \ --precompute_valid_poses

File: docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst

Doc:
https://isaac-sim.github.io/IsaacLab/release/3.0.0-beta2/index.html

Error Logs: N/A
Expected:
Doc should state checkpoints are saved directly at <output_dir>/model_<N>.pt. Checkpoint save interval is every 50 iterations (confirmed: model_0.pt, model_50.pt, model_100.pt, etc.).

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
