### PR TITLE
[Newton] Declare physics presets for warp-only experimental envs

### DIFF
--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/direct/allegro_hand/allegro_hand_warp_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/direct/allegro_hand/allegro_hand_warp_env_cfg.py
@@ -16,7 +16,30 @@ from isaaclab.sim.spawners.materials.physics_materials_cfg import RigidBodyMater
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from isaaclab_assets.robots.allegro import ALLEGRO_HAND_CFG
+
+
+@configclass
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            solver="newton",
+            integrator="implicitfast",
+            njmax=80,
+            nconmax=70,
+            impratio=10.0,
+            cone="elliptic",
+            update_data_interval=2,
+            iterations=100,
+            ls_iterations=15,
+            # save_to_mjcf="AllegroHand.xml",
+        ),
+        num_substeps=2,
+        debug_mode=False,
+    )
+    default = newton_mjwarp
 
 
 @configclass
@@ -30,24 +53,6 @@ class AllegroHandWarpEnvCfg(DirectRLEnvCfg):
     asymmetric_obs = False
     obs_type = "full"
 
-    solver_cfg = MJWarpSolverCfg(
-        solver="newton",
-        integrator="implicitfast",
-        njmax=80,
-        nconmax=70,
-        impratio=10.0,
-        cone="elliptic",
-        update_data_interval=2,
-        iterations=100,
-        ls_iterations=15,
-        # save_to_mjcf="AllegroHand.xml",
-    )
-
-    newton_cfg = NewtonCfg(
-        solver_cfg=solver_cfg,
-        num_substeps=2,
-        debug_mode=False,
-    )
     # simulation
     sim: SimulationCfg = SimulationCfg(
         dt=1 / 120,
@@ -56,7 +61,7 @@ class AllegroHandWarpEnvCfg(DirectRLEnvCfg):
             static_friction=1.0,
             dynamic_friction=1.0,
         ),
-        physics=newton_cfg,
+        physics=PhysicsCfg(),
     )
     # robot
     robot_cfg: ArticulationCfg = ALLEGRO_HAND_CFG.replace(prim_path="/World/envs/env_.*/Robot")

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/direct/ant/ant_env_warp_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/direct/ant/ant_env_warp_cfg.py
@@ -15,7 +15,26 @@ from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from isaaclab_assets import ANT_CFG
+
+
+@configclass
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=45,
+            nconmax=25,
+            cone="pyramidal",
+            integrator="implicitfast",
+            impratio=1,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=True,
+    )
+    default = newton_mjwarp
 
 
 @configclass
@@ -28,22 +47,8 @@ class AntWarpEnvCfg(DirectRLEnvCfg):
     observation_space = 36
     state_space = 0
 
-    solver_cfg = MJWarpSolverCfg(
-        njmax=45,
-        nconmax=25,
-        cone="pyramidal",
-        integrator="implicitfast",
-        impratio=1,
-    )
-    newton_cfg = NewtonCfg(
-        solver_cfg=solver_cfg,
-        num_substeps=1,
-        debug_mode=False,
-        use_cuda_graph=True,
-    )
-
     # simulation
-    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=newton_cfg)
+    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=PhysicsCfg())
     terrain = TerrainImporterCfg(
         prim_path="/World/ground",
         terrain_type="plane",

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/direct/cartpole/cartpole_warp_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/direct/cartpole/cartpole_warp_env_cfg.py
@@ -13,7 +13,26 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from isaaclab_assets.robots.cartpole import CARTPOLE_CFG
+
+
+@configclass
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=5,
+            nconmax=3,
+            cone="pyramidal",
+            integrator="implicitfast",
+            impratio=1,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=True,
+    )
+    default = newton_mjwarp
 
 
 @configclass
@@ -26,23 +45,8 @@ class CartpoleWarpEnvCfg(DirectRLEnvCfg):
     observation_space = 4
     state_space = 0
 
-    solver_cfg = MJWarpSolverCfg(
-        njmax=5,
-        nconmax=3,
-        cone="pyramidal",
-        integrator="implicitfast",
-        impratio=1,
-    )
-
-    newton_cfg = NewtonCfg(
-        solver_cfg=solver_cfg,
-        num_substeps=1,
-        debug_mode=False,
-        use_cuda_graph=True,
-    )
-
     # simulation
-    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=newton_cfg)
+    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=PhysicsCfg())
 
     # robot
     robot_cfg: ArticulationCfg = CARTPOLE_CFG.replace(prim_path="/World/envs/env_.*/Robot")

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/direct/humanoid/humanoid_warp_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/direct/humanoid/humanoid_warp_env_cfg.py
@@ -15,7 +15,27 @@ from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from isaaclab_assets import HUMANOID_CFG
+
+
+@configclass
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=80,
+            nconmax=25,
+            cone="pyramidal",
+            integrator="implicitfast",
+            update_data_interval=2,
+            impratio=1,
+        ),
+        num_substeps=2,
+        debug_mode=False,
+        use_cuda_graph=True,
+    )
+    default = newton_mjwarp
 
 
 @configclass
@@ -28,23 +48,8 @@ class HumanoidWarpEnvCfg(DirectRLEnvCfg):
     observation_space = 75
     state_space = 0
 
-    solver_cfg = MJWarpSolverCfg(
-        njmax=80,
-        nconmax=25,
-        cone="pyramidal",
-        integrator="implicitfast",
-        update_data_interval=2,
-        impratio=1,
-    )
-    newton_cfg = NewtonCfg(
-        solver_cfg=solver_cfg,
-        num_substeps=2,
-        debug_mode=False,
-        use_cuda_graph=True,
-    )
-
     # simulation
-    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=newton_cfg)
+    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=PhysicsCfg())
     terrain = TerrainImporterCfg(
         prim_path="/World/ground",
         terrain_type="plane",

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/ant/ant_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/ant/ant_env_cfg.py
@@ -19,6 +19,8 @@ from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 import isaaclab_tasks_experimental.manager_based.classic.humanoid.mdp as mdp
 
 ##
@@ -155,24 +157,28 @@ class TerminationsCfg:
 
 
 @configclass
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=38,
+            nconmax=15,
+            ls_iterations=10,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
+    )
+    default = newton_mjwarp
+
+
+@configclass
 class AntEnvCfg(ManagerBasedRLEnvCfg):
     """Configuration for the MuJoCo-style Ant walking environment."""
 
     # Simulation settings
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=38,
-                nconmax=15,
-                ls_iterations=10,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
-    )
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     # Scene settings
     scene: MySceneCfg = MySceneCfg(num_envs=4096, env_spacing=5.0, clone_in_fabric=True)

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/cartpole/cartpole_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/cartpole/cartpole_env_cfg.py
@@ -20,6 +20,8 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 import isaaclab_tasks_experimental.manager_based.classic.cartpole.mdp as mdp
 
 ##
@@ -158,6 +160,23 @@ class TerminationsCfg:
 
 
 @configclass
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=5,
+            nconmax=3,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=True,
+    )
+    default = newton_mjwarp
+
+
+@configclass
 class CartpoleEnvCfg(ManagerBasedRLEnvCfg):
     """Configuration for the cartpole environment."""
 
@@ -171,20 +190,7 @@ class CartpoleEnvCfg(ManagerBasedRLEnvCfg):
     rewards: RewardsCfg = RewardsCfg()
     terminations: TerminationsCfg = TerminationsCfg()
     # Simulation settings
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=5,
-                nconmax=3,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-            use_cuda_graph=True,
-        )
-    )
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     # Post initialization
     def __post_init__(self) -> None:

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/humanoid/humanoid_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/classic/humanoid/humanoid_env_cfg.py
@@ -18,6 +18,8 @@ from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 import isaaclab_tasks_experimental.manager_based.classic.humanoid.mdp as mdp
 
 from isaaclab_assets.robots.humanoid import HUMANOID_CFG  # isort:skip
@@ -190,6 +192,24 @@ class TerminationsCfg:
 
 
 @configclass
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=80,
+            nconmax=25,
+            ls_iterations=15,
+            cone="pyramidal",
+            update_data_interval=2,
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=2,
+        debug_mode=False,
+    )
+    default = newton_mjwarp
+
+
+@configclass
 class HumanoidEnvCfg(ManagerBasedRLEnvCfg):
     """Configuration for the MuJoCo-style Humanoid walking environment."""
 
@@ -209,22 +229,7 @@ class HumanoidEnvCfg(ManagerBasedRLEnvCfg):
         self.decimation = 2
         self.episode_length_s = 16.0
         # simulation settings
-        self.sim: SimulationCfg = SimulationCfg(
-            dt=1 / 120.0,
-            physics=NewtonCfg(
-                solver_cfg=MJWarpSolverCfg(
-                    njmax=80,
-                    nconmax=25,
-                    ls_iterations=15,
-                    cone="pyramidal",
-                    update_data_interval=2,
-                    impratio=1,
-                    integrator="implicitfast",
-                ),
-                num_substeps=2,
-                debug_mode=False,
-            ),
-        )
+        self.sim: SimulationCfg = SimulationCfg(dt=1 / 120.0, physics=PhysicsCfg())
         # self.sim.dt = 1 / 120.0
         self.sim.render_interval = self.decimation
         # default friction material

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/a1/flat_env_cfg.py
@@ -8,24 +8,30 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from .rough_env_cfg import UnitreeA1RoughEnvCfg
 
 
 @configclass
-class UnitreeA1FlatEnvCfg(UnitreeA1RoughEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=60,
-                nconmax=30,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=60,
+            nconmax=30,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class UnitreeA1FlatEnvCfg(UnitreeA1RoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         # post init of parent

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/anymal_b/flat_env_cfg.py
@@ -8,24 +8,30 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from .rough_env_cfg import AnymalBRoughEnvCfg
 
 
 @configclass
-class AnymalBFlatEnvCfg(AnymalBRoughEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=75,
-                nconmax=15,
-                cone="elliptic",
-                impratio=100,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=75,
+            nconmax=15,
+            cone="elliptic",
+            impratio=100,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class AnymalBFlatEnvCfg(AnymalBRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         # post init of parent

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/anymal_c/flat_env_cfg.py
@@ -8,24 +8,30 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from .rough_env_cfg import AnymalCRoughEnvCfg
 
 
 @configclass
-class AnymalCFlatEnvCfg(AnymalCRoughEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=120,
-                nconmax=15,
-                cone="elliptic",
-                impratio=100,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=120,
+            nconmax=15,
+            cone="elliptic",
+            impratio=100,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class AnymalCFlatEnvCfg(AnymalCRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         # post init of parent

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/anymal_d/flat_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/anymal_d/flat_env_cfg.py
@@ -8,23 +8,29 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from .rough_env_cfg import AnymalDRoughEnvCfg
 
 
 @configclass
-class AnymalDFlatEnvCfg(AnymalDRoughEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=60,
-                nconmax=25,
-                cone="elliptic",
-                impratio=100.0,
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=60,
+            nconmax=25,
+            cone="elliptic",
+            impratio=100.0,
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class AnymalDFlatEnvCfg(AnymalDRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         super().__post_init__()

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/cassie/flat_env_cfg.py
@@ -8,24 +8,30 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from .rough_env_cfg import CassieRoughEnvCfg
 
 
 @configclass
-class CassieFlatEnvCfg(CassieRoughEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=52,
-                nconmax=15,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=52,
+            nconmax=15,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class CassieFlatEnvCfg(CassieRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         super().__post_init__()

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/g1/flat_env_cfg.py
@@ -9,24 +9,30 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from .rough_env_cfg import G1RoughEnvCfg
 
 
 @configclass
-class G1FlatEnvCfg(G1RoughEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=95,
-                nconmax=10,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=95,
+            nconmax=10,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class G1FlatEnvCfg(G1RoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         super().__post_init__()

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/go1/flat_env_cfg.py
@@ -8,24 +8,30 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from .rough_env_cfg import UnitreeGo1RoughEnvCfg
 
 
 @configclass
-class UnitreeGo1FlatEnvCfg(UnitreeGo1RoughEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=60,
-                nconmax=25,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=60,
+            nconmax=25,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class UnitreeGo1FlatEnvCfg(UnitreeGo1RoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         super().__post_init__()

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/go2/flat_env_cfg.py
@@ -8,24 +8,30 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from .rough_env_cfg import UnitreeGo2RoughEnvCfg
 
 
 @configclass
-class UnitreeGo2FlatEnvCfg(UnitreeGo2RoughEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=65,
-                nconmax=35,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=65,
+            nconmax=35,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class UnitreeGo2FlatEnvCfg(UnitreeGo2RoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         super().__post_init__()

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/locomotion/velocity/config/h1/flat_env_cfg.py
@@ -8,24 +8,30 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 from .rough_env_cfg import H1RoughEnvCfg
 
 
 @configclass
-class H1FlatEnvCfg(H1RoughEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=65,
-                nconmax=15,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=65,
+            nconmax=15,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class H1FlatEnvCfg(H1RoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         super().__post_init__()

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/manipulation/reach/config/franka/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/manipulation/reach/config/franka/joint_pos_env_cfg.py
@@ -10,6 +10,8 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 import isaaclab_tasks_experimental.manager_based.manipulation.reach.mdp as mdp
 from isaaclab_tasks_experimental.manager_based.manipulation.reach.reach_env_cfg import ReachEnvCfg
 
@@ -25,21 +27,24 @@ from isaaclab_assets import FRANKA_PANDA_CFG  # isort: skip
 
 
 @configclass
-class FrankaReachEnvCfg(ReachEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        dt=1 / 60,
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=50,
-                nconmax=20,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=50,
+            nconmax=20,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
         ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class FrankaReachEnvCfg(ReachEnvCfg):
+    sim: SimulationCfg = SimulationCfg(dt=1 / 60, physics=PhysicsCfg())
 
     def __post_init__(self):
         # post init of parent

--- a/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/manipulation/reach/config/ur_10/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks_experimental/isaaclab_tasks_experimental/manager_based/manipulation/reach/config/ur_10/joint_pos_env_cfg.py
@@ -10,6 +10,8 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.utils import PresetCfg
+
 import isaaclab_tasks_experimental.manager_based.manipulation.reach.mdp as mdp
 from isaaclab_tasks_experimental.manager_based.manipulation.reach.reach_env_cfg import ReachEnvCfg
 
@@ -25,20 +27,24 @@ from isaaclab_assets import UR10_CFG  # isort: skip
 
 
 @configclass
-class UR10ReachEnvCfg(ReachEnvCfg):
-    sim: SimulationCfg = SimulationCfg(
-        physics=NewtonCfg(
-            solver_cfg=MJWarpSolverCfg(
-                njmax=50,
-                nconmax=20,
-                cone="pyramidal",
-                impratio=1,
-                integrator="implicitfast",
-            ),
-            num_substeps=1,
-            debug_mode=False,
-        )
+class PhysicsCfg(PresetCfg):
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=50,
+            nconmax=20,
+            cone="pyramidal",
+            impratio=1,
+            integrator="implicitfast",
+        ),
+        num_substeps=1,
+        debug_mode=False,
     )
+    default = newton_mjwarp
+
+
+@configclass
+class UR10ReachEnvCfg(ReachEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
 
     def __post_init__(self):
         # post init of parent


### PR DESCRIPTION
## 1. Summary

- 18 warp env configs in `isaaclab_tasks_experimental` assigned a bare `NewtonCfg` straight to `sim.physics`, bypassing the `PresetCfg` mechanism — so they declared no `default` and did not participate in `presets=` resolution like the migrated `core` envs.
- Each now wraps physics in a module-level `PhysicsCfg(PresetCfg)` with a `newton_mjwarp` variant and `default` aliasing it (warp-only, so no PhysX default is invented), matching the `core/velocity` convention.
- Direct envs additionally had stray `solver_cfg` / `newton_cfg` class attributes (confirmed unreferenced) lifted into the preset class.
- No behavior change: with no preset and with `presets=newton_mjwarp`, resolution returns the same `NewtonCfg` these envs used before.

## 2. Scope

- Locomotion velocity flat (9): `a1, anymal_b, anymal_c, anymal_d, cassie, g1, go1, go2, h1`
- Manipulation reach (2): `franka, ur_10` (`SimulationCfg` `dt` preserved)
- Classic manager-based (3): `ant, cartpole, humanoid` (humanoid builds physics in `__post_init__`)
- Direct warp (4): `allegro_hand_warp_env_cfg`, and the split cfg files `ant/ant_env_warp_cfg`, `cartpole/cartpole_warp_env_cfg`, `humanoid/humanoid_warp_env_cfg` (allegro's `physics_material` preserved)

## 3. Pattern

```python
@configclass
class PhysicsCfg(PresetCfg):
    newton_mjwarp = NewtonCfg(
        solver_cfg=MJWarpSolverCfg(...),
        num_substeps=1,
        debug_mode=False,
    )
    default = newton_mjwarp
```

## 4. Test plan

- [x] Rebased onto latest `develop` (picks up the direct-env cfg split from #5916 and the `ls_parallel` deprecation from #5956)
- [x] `./isaaclab.sh -f` — clean pass
- [x] `py_compile` on all 18 files
- [x] Preset resolution exercised on every distinct `PhysicsCfg`: both `default` (no preset) and `presets=newton_mjwarp` resolve to a `NewtonCfg`