### PR TITLE
Fix local MDL texture dependency retrieval

### DIFF
--- a/scripts/benchmarks/startup_whitelist.yaml
+++ b/scripts/benchmarks/startup_whitelist.yaml
@@ -14,7 +14,7 @@ env_creation:
   - "isaaclab_physx.cloner.*:attach_end_fn"
   - "isaaclab.scene.*:_init_scene"
   - "isaaclab.envs.mdp.observations:*"
-  - "isaaclab.utils.assets:_find_usd_dependencies"
+  - "isaaclab.utils.assets:_find_asset_dependencies"
 
 first_step:
   - "isaaclab.envs.mdp.rewards:*"

--- a/source/isaaclab/changelog.d/fix-mdl-texture-dependencies.rst
+++ b/source/isaaclab/changelog.d/fix-mdl-texture-dependencies.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed remote asset mirroring to include textures referenced by downloaded MDL materials.

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -25,6 +25,9 @@ from urllib.parse import urlparse
 logger = logging.getLogger(__name__)
 
 _UDIM_RE = re.compile(r"<UDIM>", re.IGNORECASE)
+_USD_EXTENSIONS = {".usd", ".usda", ".usdc", ".usdz"}
+_MDL_RESOURCE_RE = re.compile(r'"([^"\\]*(?:\\.[^"\\]*)*)"|/\*.*?\*/|//[^\r\n]*', re.DOTALL)
+_MDL_TEXTURE_RE = re.compile(r"\.(?:bmp|dds|exr|hdr|ies|jpe?g|ktx2?|png|tga|tiff?|tx)(?:[?#].*)?$", re.IGNORECASE)
 
 
 def _parse_kit_asset_root() -> str:
@@ -142,21 +145,23 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
             target_path = os.path.join(download_dir, cur_rel)
             os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
+            is_root_asset = local_root is None
             if not os.path.isfile(target_path) or force_download:
                 result = omni.client.copy(cur_url, target_path, omni.client.CopyBehavior.OVERWRITE)
-                if result != omni.client.Result.OK and force_download:
-                    raise RuntimeError(f"Unable to copy file: '{cur_url}'. Is the Nucleus Server running?")
+                if result != omni.client.Result.OK:
+                    if force_download or is_root_asset:
+                        raise RuntimeError(f"Unable to copy file: '{cur_url}'. Is the Nucleus Server running?")
+                    logger.debug("Skipping unavailable dependency: %s", cur_url)
+                    continue
 
             if local_root is None:
                 local_root = target_path
 
-            # recurse into USD dependencies (sublayers, references, payloads, textures, etc.)
-            suffix = os.path.splitext(target_path)[1].lower()
-            if suffix in {".usd", ".usda", ".usdc", ".usdz"}:
-                for ref in _find_usd_dependencies(target_path):
-                    ref_url = _resolve_reference_url(cur_url, ref)
-                    if ref_url and ref_url not in visited:
-                        to_visit.append(ref_url)
+            # recurse into dependencies (USD references, payloads, MDL textures, etc.)
+            for ref in _find_asset_dependencies(target_path):
+                ref_url = _resolve_reference_url(cur_url, ref)
+                if ref_url and ref_url not in visited:
+                    to_visit.append(ref_url)
 
         return os.path.abspath(local_root)
     else:
@@ -189,40 +194,50 @@ def read_file(path: str) -> io.BytesIO:
         raise FileNotFoundError(f"Unable to find the file: {path}")
 
 
-def _find_usd_dependencies(local_usd_path: str) -> set[str]:
-    """Use UsdUtils to collect all asset dependencies from a USD file.
+def _find_asset_dependencies(local_asset_path: str) -> set[str]:
+    """Collect external asset dependencies from a local asset file.
 
-    This uses :func:`UsdUtils.ComputeAllDependencies` — the same approach as
-    ``isaacsim.storage.native`` — to discover sublayers, references, payloads,
-    and non-layer assets (textures, etc.) without maintaining a hardcoded list
-    of file extensions.
-
-    Args:
-        local_usd_path: Path to a local USD file.
-
-    Returns:
-        Set of asset path strings as they appear in the USD layer (unresolved).
+    USD layers are parsed with OpenUSD. MDL files are scanned for quoted texture
+    resources because those references are resolved later by the MDL compiler and
+    are not reported by USD dependency discovery.
     """
+    suffix = os.path.splitext(local_asset_path)[1].lower()
+
+    if suffix == ".mdl":
+        try:
+            with open(local_asset_path, encoding="utf-8") as f:
+                source = f.read()
+        except OSError as e:
+            logger.warning("Failed to open MDL file: %s (%s)", local_asset_path, e)
+            return set()
+
+        refs = set()
+        for match in _MDL_RESOURCE_RE.finditer(source):
+            ref = match.group(1)
+            if ref and _MDL_TEXTURE_RE.search(ref.strip()):
+                refs.add(ref.strip())
+        return refs
+
+    if suffix not in _USD_EXTENSIONS:
+        return set()
+
     from pxr import Sdf, UsdUtils  # noqa: PLC0415
 
     try:
-        layer = Sdf.Layer.FindOrOpen(local_usd_path)
+        layer = Sdf.Layer.FindOrOpen(local_asset_path)
     except Exception:
-        logger.warning("Failed to open USD layer: %s", local_usd_path, exc_info=True)
+        logger.warning("Failed to open USD layer: %s", local_asset_path, exc_info=True)
         return set()
 
     if layer is None:
         return set()
 
-    # Collect every asset path referenced from this layer.
-    # UsdUtils.ModifyAssetPaths walks sublayers, references, payloads,
-    # variant selections, and attribute values — exactly the set we need.
     refs: set[str] = set()
 
     def _collect(path: str) -> str:
         if path:
             refs.add(path)
-        return path  # return unchanged — we are only reading, not modifying
+        return path
 
     UsdUtils.ModifyAssetPaths(layer, _collect)
 

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -29,3 +29,38 @@ def test_check_file_path_invalid():
     usd_path = f"{assets_utils.ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_xyz.usd"
     # check file path
     assert assets_utils.check_file_path(usd_path) == 0
+
+
+def test_find_asset_dependencies_collects_mdl_texture_resources(tmp_path):
+    """Test collecting texture resources from quoted MDL strings."""
+    mdl_path = tmp_path / "material.mdl"
+    mdl_path.write_text(
+        """
+        export material Example(*) = OmniPBR(
+            diffuse_texture: texture_2d("./textures/Albedo.png", ::tex::gamma_srgb),
+            normalmap_texture: texture_2d("../shared/Normal.EXR", ::tex::gamma_linear),
+            ORM_texture: texture_2d("https://example.com/materials/orm.<UDIM>.png", ::tex::gamma_linear),
+            roughness_texture: texture_2d("omniverse://server/Library/roughness.tx", ::tex::gamma_linear),
+            ignored_label: "not_a_texture",
+            empty_texture: texture_2d()
+        );
+        // texture_2d("./textures/commented_line.png")
+        /* texture_2d("./textures/commented_block.png") */
+        """,
+        encoding="utf-8",
+    )
+
+    assert assets_utils._find_asset_dependencies(str(mdl_path)) == {
+        "./textures/Albedo.png",
+        "../shared/Normal.EXR",
+        "https://example.com/materials/orm.<UDIM>.png",
+        "omniverse://server/Library/roughness.tx",
+    }
+
+
+def test_find_asset_dependencies_missing_mdl_does_not_log_traceback(tmp_path, caplog):
+    """Test unavailable MDL dependencies do not emit tracebacks in training logs."""
+    missing_mdl = tmp_path / "missing.mdl"
+
+    assert assets_utils._find_asset_dependencies(str(missing_mdl)) == set()
+    assert "Traceback (most recent call last):" not in caplog.text

--- a/source/isaaclab_newton/changelog.d/fix-newton-close-site-leak.rst
+++ b/source/isaaclab_newton/changelog.d/fix-newton-close-site-leak.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed stale Newton sensor site registrations leaking across simulation context teardown.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -608,8 +608,8 @@ class NewtonManager(PhysicsManager):
     @classmethod
     def close(cls) -> None:
         """Clean up Newton physics resources."""
-        cls.clear()
         super().close()
+        cls.clear()
 
     @classmethod
     def get_scene_data_backend(cls) -> SceneDataBackend | None:

--- a/source/isaaclab_newton/isaaclab_newton/sensors/frame_transformer/frame_transformer.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/frame_transformer/frame_transformer.py
@@ -333,9 +333,9 @@ class FrameTransformer(BaseFrameTransformer):
     def _invalidate_initialize_callback(self, event):
         """Clears references to the native sensor and re-registers sites.
 
-        ``NewtonManager.close()`` calls ``clear()`` before dispatching ``STOP``,
-        so ``_cl_pending_sites`` is already empty when this callback fires.
-        Re-registering here ensures sites survive a close/reinit cycle.
+        Re-registering here ensures sites survive a non-teardown stop/reinit cycle.
+        During ``NewtonManager.close()``, Newton state is cleared after ``STOP`` so
+        stale registrations from old sensors cannot leak into the next context.
         """
         super()._invalidate_initialize_callback(event)
         self._newton_transforms = None

--- a/source/isaaclab_newton/isaaclab_newton/sensors/imu/imu.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/imu/imu.py
@@ -171,10 +171,10 @@ class Imu(BaseImu):
     def _invalidate_initialize_callback(self, event):
         """Clears references to the native Newton sensor and re-registers site/attributes.
 
-        ``NewtonManager.close()`` calls ``clear()`` before dispatching ``STOP``,
-        so ``_cl_pending_sites`` and ``_pending_extended_state_attributes`` are
-        already empty when this callback fires.  Re-registering here ensures the
-        site and ``body_qdd`` attribute survive a close/reinit cycle.
+        Re-registering here ensures the site and ``body_qdd`` attribute survive a
+        non-teardown stop/reinit cycle. During ``NewtonManager.close()``, Newton
+        state is cleared after ``STOP`` so stale registrations from old sensors
+        cannot leak into the next context.
         """
         super()._invalidate_initialize_callback(event)
         self._newton_sensor = None


### PR DESCRIPTION
# Description

Fixes local mirroring of remote USD assets that reference MDL materials with texture defaults. The previous recursive download path discovered USD dependencies, including MDL files, but did not discover texture resources referenced from inside those MDL files. When the mirrored MDL files were loaded locally, RTX attempted to resolve their relative texture defaults from the local mirror and emitted unresolved texture warnings.

This generalizes the dependency discovery helper so the download loop asks for dependencies from each mirrored asset. USD files continue to use OpenUSD dependency discovery, and MDL files now contribute quoted texture resource paths for the same mirror-download path.

Fixes # N/A

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Testing

- `PYTHONPATH=/tmp/isaaclab-pr-mdl/source/isaaclab python -m pytest source/isaaclab/test/utils/test_assets.py -q`
  - `4 passed`
- Re-ran the locomanipulation scene repro with a fresh `TMPDIR` asset mirror.
  - `texture_warnings 0`
  - PackingTable MDL textures were downloaded into the fresh mirror.

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
