### PR TITLE
Keep USD cloning enabled for OVRTX scenes

### DIFF
--- a/source/isaaclab/changelog.d/zhengyuz-fix-ovrtx-usd-cloning.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-fix-ovrtx-usd-cloning.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed OVRTX-backed Newton scenes to keep USD cloning enabled when OVRTX is requested.

--- a/source/isaaclab/changelog.d/zhengyuz-fix-ovrtx-usd-cloning.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-fix-ovrtx-usd-cloning.rst
@@ -1,4 +1,4 @@
 Fixed
 ^^^^^
 
-* Fixed OVRTX-backed Newton scenes to keep USD cloning enabled when OVRTX is requested.
+* Fixed OVRTX-backed Newton scenes to keep USD cloning enabled and preserve env-local camera transforms in heterogeneous clone plans.

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -146,6 +146,7 @@ class InteractiveScene:
         self.stage_id = get_current_stage_id()
         self.physics_backend = self.sim.physics_manager.__name__.lower()
         requested_viz_types = set(self.sim.resolve_visualizer_types())
+        requested_renderer_types = set(self._cfg_renderer_types())
         if self.physics_backend.startswith("ovphysx"):
             from isaaclab_ovphysx.cloner import ovphysx_replicate
 
@@ -171,7 +172,7 @@ class InteractiveScene:
             clone_in_fabric=self.cfg.clone_in_fabric,
             device=self.device,
             physics_clone_fn=physics_clone_fn,
-            clone_usd=not is_newton_replicated_scene or has_kit(),
+            clone_usd=not is_newton_replicated_scene or has_kit() or "ovrtx" in requested_renderer_types,
         )
 
         # create source prim
@@ -352,6 +353,17 @@ class InteractiveScene:
         requirements = aggregate_requirements((current_req, discovered_req))
         if requirements != current_req:
             self.sim.update_scene_data_requirements(requirements)
+
+    def _cfg_renderer_types(self) -> list[str]:
+        """Return renderer type names declared by scene cfg entries before sensors are constructed."""
+        cfg_fields = InteractiveSceneCfg.__dataclass_fields__
+        renderer_types: list[str] = []
+        for asset_cfg in (v for k, v in self.cfg.__dict__.items() if k not in cfg_fields and v is not None):
+            cfgs = asset_cfg.rigid_objects.values() if isinstance(asset_cfg, RigidObjectCollectionCfg) else [asset_cfg]
+            for cfg in cfgs:
+                if (rcfg := getattr(cfg, "renderer_cfg", None)) is not None:
+                    renderer_types.append(getattr(rcfg, "renderer_type", "default"))
+        return renderer_types
 
     def _sensor_renderer_types(self) -> list[str]:
         """Return renderer type names used by scene sensors (skipping any without a renderer cfg)."""

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -146,7 +146,6 @@ class InteractiveScene:
         self.stage_id = get_current_stage_id()
         self.physics_backend = self.sim.physics_manager.__name__.lower()
         requested_viz_types = set(self.sim.resolve_visualizer_types())
-        requested_renderer_types = set(self._cfg_renderer_types())
         if self.physics_backend.startswith("ovphysx"):
             from isaaclab_ovphysx.cloner import ovphysx_replicate
 
@@ -166,13 +165,16 @@ class InteractiveScene:
         # prepare cloner for environment replication
         self.env_prim_paths = [f"{self.env_ns}/env_{i}" for i in range(self.cfg.num_envs)]
         is_newton_replicated_scene = self.cfg.replicate_physics and self.physics_backend.startswith("newton")
+        needs_kit = self.sim.get_setting("/isaaclab/runtime/needs_kit")
+        needs_kit = has_kit() if needs_kit is None else bool(needs_kit)
+        has_ovrtx_renderer = bool(self.sim.get_setting("/isaaclab/runtime/has_ovrtx_renderer"))
 
         self.cloner_cfg = cloner.CloneCfg(
             clone_regex=self.env_regex_ns,
             clone_in_fabric=self.cfg.clone_in_fabric,
             device=self.device,
             physics_clone_fn=physics_clone_fn,
-            clone_usd=not is_newton_replicated_scene or has_kit() or "ovrtx" in requested_renderer_types,
+            clone_usd=not is_newton_replicated_scene or needs_kit or has_ovrtx_renderer,
         )
 
         # create source prim
@@ -353,17 +355,6 @@ class InteractiveScene:
         requirements = aggregate_requirements((current_req, discovered_req))
         if requirements != current_req:
             self.sim.update_scene_data_requirements(requirements)
-
-    def _cfg_renderer_types(self) -> list[str]:
-        """Return renderer type names declared by scene cfg entries before sensors are constructed."""
-        cfg_fields = InteractiveSceneCfg.__dataclass_fields__
-        renderer_types: list[str] = []
-        for asset_cfg in (v for k, v in self.cfg.__dict__.items() if k not in cfg_fields and v is not None):
-            cfgs = asset_cfg.rigid_objects.values() if isinstance(asset_cfg, RigidObjectCollectionCfg) else [asset_cfg]
-            for cfg in cfgs:
-                if (rcfg := getattr(cfg, "renderer_cfg", None)) is not None:
-                    renderer_types.append(getattr(rcfg, "renderer_type", "default"))
-        return renderer_types
 
     def _sensor_renderer_types(self) -> list[str]:
         """Return renderer type names used by scene sensors (skipping any without a renderer cfg)."""

--- a/source/isaaclab_tasks/changelog.d/zhengyuz-fix-ovrtx-usd-cloning.rst
+++ b/source/isaaclab_tasks/changelog.d/zhengyuz-fix-ovrtx-usd-cloning.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed launch-time runtime metadata for OVRTX-backed scenes so kitless visualizer flows preserve the expected USD cloning behavior.

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/sim_launcher.py
@@ -14,6 +14,7 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from typing import Any
 
+from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.physics.physics_manager_cfg import PhysicsCfg
 from isaaclab.renderers.renderer_cfg import RendererCfg
 from isaaclab.sensors.camera.camera_cfg import CameraCfg
@@ -371,23 +372,21 @@ def launch_simulation(
     # loading both in the same process causes a dynamic-linker crash.  Use
     # --visualizer newton instead, which is compatible with ovrtx presets.
     early_visualizer_types = _get_visualizer_types(launcher_args)
-    if "kit" in early_visualizer_types:
-        has_ovrtx = _scan_config(
-            env_cfg, [lambda node: isinstance(node, RendererCfg) and getattr(node, "renderer_type", None) == "ovrtx"]
-        )[0]
-        if has_ovrtx:
-            raise ValueError(
-                "[launch_simulation] '--visualizer kit' is incompatible with 'ovrtx_renderer'. "
-                "Both Kit (Isaac Sim) and ovrtx ship conflicting RTX hydra libraries "
-                "(librtx.hydra.so, liblegacy.hydra.so) compiled against different USD namespaces, "
-                "which causes a dynamic-linker crash when loaded into the same process. "
-                "Use '--visualizer newton' instead, which is fully compatible with ovrtx presets."
-            )
+    has_ovrtx_renderer = _scan_config(env_cfg, [_is_ovrtx_renderer])[0]
+    if "kit" in early_visualizer_types and has_ovrtx_renderer:
+        raise ValueError(
+            "[launch_simulation] '--visualizer kit' is incompatible with 'ovrtx_renderer'. "
+            "Both Kit (Isaac Sim) and ovrtx ship conflicting RTX hydra libraries "
+            "(librtx.hydra.so, liblegacy.hydra.so) compiled against different USD namespaces, "
+            "which causes a dynamic-linker crash when loaded into the same process. "
+            "Use '--visualizer newton' instead, which is fully compatible with ovrtx presets."
+        )
 
     validate_runtime_compatibility(env_cfg, launcher_args)
     _ensure_livestream_kit_visualizer(launcher_args)
     needs_kit, has_kit_cameras, visualizer_types = compute_kit_requirements(env_cfg, launcher_args)
     visualizer_intent = _compute_visualizer_intent(env_cfg)
+    has_kit_visualizer = "kit" in visualizer_types or visualizer_intent.get("has_kit_visualizer", False)
     _set_visualizer_intent_on_launcher_args(launcher_args, visualizer_intent)
 
     if needs_kit and has_kit_cameras:
@@ -473,7 +472,14 @@ def launch_simulation(
             if sim_cfg is not None and hasattr(app_launcher, "device"):
                 sim_cfg.device = app_launcher.device
             close_fn = app_launcher.app.close
-    elif visualizer_types or visualizer_explicit_none:
+
+    settings = get_settings_manager()
+    settings.set_bool("/isaaclab/runtime/needs_kit", bool(needs_kit))
+    settings.set_bool("/isaaclab/runtime/has_kit_cameras", bool(has_kit_cameras))
+    settings.set_bool("/isaaclab/runtime/has_kit_visualizer", bool(has_kit_visualizer))
+    settings.set_bool("/isaaclab/runtime/has_ovrtx_renderer", bool(has_ovrtx_renderer))
+
+    if not needs_kit and (visualizer_types or visualizer_explicit_none):
         # Newton path without Kit: AppLauncher is skipped, so manually store the visualizer
         # selection in SettingsManager (works in standalone mode via plain dict) so that
         # SimulationContext._get_cli_visualizer_types() can find it.


### PR DESCRIPTION
## Summary
- Keep USD cloning enabled at `CloneCfg` creation when the scene config requests an OVRTX renderer.
- Add the required `isaaclab` changelog fragment.

## Testing
- pre-commit run ruff-format --files source/isaaclab/isaaclab/scene/interactive_scene.py source/isaaclab/changelog.d/zhengyuz-fix-ovrtx-usd-cloning.rst
- pre-commit run ruff --files source/isaaclab/isaaclab/scene/interactive_scene.py
- python3 -m py_compile source/isaaclab/isaaclab/scene/interactive_scene.py
- python3 tools/changelog/cli.py check release/3.0.0-beta2
- git diff --check release/3.0.0-beta2