### PR TITLE
[Fix] Stop gitignore from silently ignoring new `__init__.py` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,9 +80,6 @@ _build
 # Ruff cache
 **/.ruff_cache/
 
-# Dev-time files, generated stuff
-**/__*
-
 # Isaac Lab CI environments in native mode
 **/_isaaclab_install_ci_*
 


### PR DESCRIPTION
## Summary

- Removes the `**/__*` rule from `.gitignore` (introduced in #5343), which matched every untracked path component starting with `__` at any depth — silently ignoring all new `__init__.py` / `__init__.pyi` files.
- Any Python package added after #5343 had its init files dropped from `git add`, causing import failures on a clean checkout that are hard to trace back to `.gitignore`. On the current `develop` working tree this already hides **199** untracked `__init__.py` / `__init__.pyi` files under newly added `isaaclab_tasks` subpackages.
- No loss of coverage: the pattern's only concrete target, `__pycache__/`, is already handled by the pre-existing `**/__pycache__/` rule (line 20).

## 1. Problem

The `# Dev-time files, generated stuff` block added `**/__*` as a catch-all. Git applies `.gitignore` to untracked files, so while already-tracked init files are unaffected, every *new* package's `__init__.py` is silently ignored:

```
$ git check-ignore -v source/isaaclab_tasks/isaaclab_tasks/core/__init__.py
.gitignore:84:**/__*	source/isaaclab_tasks/isaaclab_tasks/core/__init__.py
```

This produces "module not found" failures after a clean checkout that give no hint they originate from `.gitignore`.

## 2. Fix

Remove the `**/__*` line and its comment. The block's only real target was `__pycache__/`, which `**/__pycache__/` already covers.

```diff
 # Ruff cache
 **/.ruff_cache/
 
-# Dev-time files, generated stuff
-**/__*
-
 # Isaac Lab CI environments in native mode
 **/_isaaclab_install_ci_*
```

## 3. Verification

```
# new package init files are tracked again:
$ git check-ignore -v source/isaaclab_tasks/isaaclab_tasks/core/__init__.py
(no output — not ignored)

# __pycache__ is still ignored via the existing rule:
$ git check-ignore -v foo/__pycache__/bar.pyc
.gitignore:20:**/__pycache__/	foo/__pycache__/bar.pyc
```

Dev-infra/tooling change with no user-facing effect, so no changelog fragment is added (the changelog gate only requires fragments for managed packages touched under `source/`).