### PR TITLE
Fix kamino reset for closed-loop systems.

### DIFF
--- a/source/isaaclab_newton/changelog.d/rgrandia-fix-kamino-reset.rst
+++ b/source/isaaclab_newton/changelog.d/rgrandia-fix-kamino-reset.rst
@@ -1,0 +1,13 @@
+Fixed
+^^^^^
+
+* Fixed environment resets writing reconciled state into the wrong
+  double-buffered simulation state when ``use_cuda_graph`` was disabled. With an
+  odd number of substeps the canonical state flipped buffers each step, so reset
+  writes landed in the stale buffer and left reset environments in an
+  inconsistent state for solvers that keep separate input/output states (e.g.
+  :class:`~isaaclab_newton.physics.NewtonKaminoManager`).
+* Fixed forward kinematics for the Kamino solver so that
+  :meth:`~isaaclab_newton.physics.NewtonManager.forward` reconciles body state
+  through a solver-specialized hook instead of Newton's articulated ``eval_fk``,
+  which produced incorrect poses for closed-loop systems on environment resets.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -124,11 +124,12 @@ class ArticulationData(BaseArticulationData):
     def _ensure_fk_fresh(self) -> None:
         """Run forward kinematics if joint state has changed since the last FK update.
 
-        Newton's ``state.body_q`` (per-body world transforms) is updated by ``eval_fk``,
-        invoked here through ``SimulationManager.forward()``. After a manual joint or root
-        write that bypassed the sim step (``write_*_to_sim_*``), ``_fk_timestamp`` is set
-        to ``-1.0`` to force a refresh on the next read of any property that depends on
-        body poses (``body_link_pose_w``, the Jacobian properties, ``mass_matrix``).
+        Newton's ``state.body_q`` (per-body world transforms) is updated by the active
+        solver manager's ``forward()``, which calls a solver-specific FK hook.
+        After a manual joint or root write that bypassed the sim step
+        (``write_*_to_sim_*``), ``_fk_timestamp`` is set to ``-1.0`` to force a refresh
+        on the next read of any property that depends on body poses
+        (``body_link_pose_w``, the Jacobian properties, ``mass_matrix``).
         """
         if self._fk_timestamp < self._sim_timestamp:
             SimulationManager.forward()

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -11,15 +11,74 @@ import logging
 
 import warp as wp
 from newton import Model, eval_fk
+from newton._src.solvers.kamino._src.core.joints import JointDoFType
+from newton._src.solvers.kamino._src.core.types import vec6f
+from newton._src.solvers.kamino._src.kinematics.joints import (
+    extract_actuators_state_from_joints,
+)
+from newton._src.solvers.kamino._src.kinematics.resets import _reset_joints_of_select_worlds
 from newton.solvers import SolverKamino
 
 from isaaclab.physics import PhysicsManager
-from isaaclab.utils.timer import Timer
 
 from .kamino_manager_cfg import KaminoSolverCfg
 from .newton_manager import NewtonManager
 
 logger = logging.getLogger(__name__)
+
+# Kamino joint DoF type for a 6-DoF free joint (a floating base's root joint).
+_FREE_DOF_TYPE = wp.constant(int(JointDoFType.FREE))
+
+
+@wp.kernel(enable_backward=False)
+def _gather_base_state_from_joints(
+    base_joint_index: wp.array(dtype=wp.int32),
+    joint_dof_type: wp.array(dtype=wp.int32),
+    joint_coords_offset: wp.array(dtype=wp.int32),
+    joint_dofs_offset: wp.array(dtype=wp.int32),
+    joint_q: wp.array(dtype=wp.float32),
+    joint_qd: wp.array(dtype=wp.float32),
+    # outputs
+    base_q: wp.array(dtype=wp.transformf),
+    base_u: wp.array(dtype=vec6f),
+):
+    """Gather each world's base pose/twist from the base joint coordinates in the joint state.
+
+    For each world ``wid``, when its base joint (``base_joint_index[wid]``) is a free joint,
+    its 7 coordinates in ``joint_q`` (position + ``xyzw`` quaternion) and 6 DoFs in
+    ``joint_qd`` (linear + angular twist) are exactly the base body's pose/twist relative to
+    the world, expressed in the base joint frame -- i.e. precisely the ``base_q`` / ``base_u``
+    the Kamino FK reset expects. They are written into the dense per-world output arrays.
+
+    Reading from ``joint_q`` / ``joint_qd`` (NOT ``body_q``) is required: for a floating base,
+    a root pose/velocity write (``write_root_*_to_sim``) lands in the free joint's
+    ``joint_q[0:7]`` / ``joint_qd[0:6]`` head, while ``body_q`` is only refreshed *by* this FK
+    reconcile and is stale at this point.
+
+    Fixed-based systems carry no base pose in the joint state, so the output defaults to identity
+    pose / zero twist; the FK solver then keeps the base at its reference pose. Worlds without a
+    base joint (``base_joint_index < 0``) are likewise left at the default.
+    """
+    wid = wp.tid()
+    # Default: identity pose / zero twist (keeps fixed / anchored bases at their reference).
+    base_q[wid] = wp.transform_identity()
+    base_u[wid] = vec6f(0.0)
+
+    base_jid = base_joint_index[wid]
+    if base_jid < 0:
+        return
+    if joint_dof_type[base_jid] != _FREE_DOF_TYPE:
+        return
+
+    c = joint_coords_offset[base_jid]
+    d = joint_dofs_offset[base_jid]
+    base_q[wid] = wp.transformf(
+        wp.vec3(joint_q[c + 0], joint_q[c + 1], joint_q[c + 2]),
+        wp.quat(joint_q[c + 3], joint_q[c + 4], joint_q[c + 5], joint_q[c + 6]),
+    )
+    base_u[wid] = vec6f(
+        joint_qd[d + 0], joint_qd[d + 1], joint_qd[d + 2], joint_qd[d + 3], joint_qd[d + 4], joint_qd[d + 5]
+    )
 
 
 class NewtonKaminoManager(NewtonManager):
@@ -30,87 +89,149 @@ class NewtonKaminoManager(NewtonManager):
     Kamino's internal collision detector handles contact generation.
     """
 
+    _base_q: wp.array | None = None
+    """Persistent per-world base body poses fed to the FK reset. Shape ``(num_worlds,)``, dtype ``wp.transformf``."""
+
+    _base_u: wp.array | None = None
+    """Persistent per-world base body twists fed to the FK reset. Shape ``(num_worlds,)``, dtype ``vec6f``."""
+
+    @classmethod
+    def _get_kamino_solver_cfg(cls) -> KaminoSolverCfg:
+        cfg = PhysicsManager._cfg
+        if cfg is None:
+            raise RuntimeError("Physics manager is not initialized.")
+        solver_cfg = getattr(cfg, "solver_cfg", None)
+        if not isinstance(solver_cfg, KaminoSolverCfg):
+            raise TypeError(f"Expected KaminoSolverCfg, got {type(solver_cfg).__name__}.")
+        return solver_cfg
+
+    @classmethod
+    def _eval_fk(cls, world_mask: wp.array | None, fk_mask: wp.array | None) -> None:
+        """Reconcile body state from joint coordinates for the Kamino solver.
+
+        Uses Kamino's loop-closure FK (:meth:`_forward_kamino`) when
+        :attr:`KaminoSolverCfg.use_fk_solver` is enabled.
+
+        For the Kamino (maximal-coordinate) solver, ``_forward_kamino`` runs ``solver.reset()``,
+        which overwrites the authoritative ``state_0.body_q`` / ``body_qd``. Restricting the
+        solve to ``world_mask`` keeps in-flight (non-reset) worlds untouched; a ``None``
+        ``world_mask`` reconciles all worlds (the full-reconcile path used by
+        :meth:`forward` when :attr:`_forward_full_reconcile` is set, and at initial setup).
+
+        Args:
+            world_mask: Per-world mask of worlds to reconcile (``None`` means all).
+            fk_mask: Per-articulation mask, used only on the non-``use_fk_solver`` ``eval_fk``
+                fallback.
+        """
+        if cls._get_kamino_solver_cfg().use_fk_solver:
+            cls._forward_kamino(world_mask=world_mask)
+        else:
+            eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, fk_mask)
+
     @classmethod
     def _forward_kamino(cls, world_mask: wp.array | None = None) -> None:
         """Kamino-specific forward kinematics via ``solver.reset()``.
 
-        Kamino's ``joint_q`` / ``joint_u`` include coordinates for **all** joints
-        (including free joints), so we pass Newton's full state arrays directly.
+        Used when :attr:`KaminoSolverCfg.use_fk_solver` is ``True``. Extracts actuated
+        coordinates from Newton ``joint_q`` / ``joint_qd`` and passes ``actuator_q`` /
+        ``actuator_u`` so Kamino FK resolves passive joints.
+
+        The per-environment base (root) pose and twist are gathered from the base joint's
+        coordinates in ``state_0.joint_q`` / ``joint_qd`` and passed as ``base_q`` / ``base_u``.
+        This anchors the FK solve to the per-environment root state that resets write into the
+        free joint's ``joint_q[0:7]`` / ``joint_qd[0:6]`` head (floating bases). Fixed
+        bases carry no base pose in the joint state and keep their original pose.
 
         Args:
             world_mask: Per-world mask indicating which worlds to reset.
                 Shape ``(num_worlds,)``, dtype ``wp.int32``. If None, resets all worlds.
         """
-        cls._solver.reset(
-            state_out=cls._state_0,
+
+        solver_kamino = cls._solver._solver_kamino
+        model_kamino = cls._solver._model_kamino
+        effective_world_mask = world_mask if world_mask is not None else solver_kamino._all_worlds_mask
+
+        # Extract the actuated joint state from the full joint state.
+        extract_actuators_state_from_joints(
+            model=model_kamino,
+            world_mask=effective_world_mask,
             joint_q=cls._state_0.joint_q,
             joint_u=cls._state_0.joint_qd,
+            actuator_q=solver_kamino._actuators_q,
+            actuator_u=solver_kamino._actuators_u,
+        )
+
+        # Gather the per-world base pose/twist from the base joint coordinates in the joint
+        # state (where a floating base's root pose/velocity write lands).
+        wp.launch(
+            _gather_base_state_from_joints,
+            dim=model_kamino.size.num_worlds,
+            inputs=[
+                model_kamino.info.base_joint_index,
+                model_kamino.joints.dof_type,
+                model_kamino.joints.coords_offset,
+                model_kamino.joints.dofs_offset,
+                cls._state_0.joint_q,
+                cls._state_0.joint_qd,
+            ],
+            outputs=[
+                cls._base_q,
+                cls._base_u,
+            ],
+            device=model_kamino.device,
+        )
+
+        # Run FK
+        cls._solver.reset(
+            state_out=cls._state_0,
+            actuator_q=solver_kamino._actuators_q,
+            actuator_u=solver_kamino._actuators_u,
+            base_q=cls._base_q,
+            base_u=cls._base_u,
             world_mask=world_mask,
         )
 
-    @classmethod
-    def step(cls) -> None:
-        """Step the physics simulation."""
-        sim = PhysicsManager._sim
-        if sim is None or not sim.is_playing():
-            return
-
-        # Kamino: run solver.reset() with the accumulated world mask to reinitialise
-        # internal state (warm-start containers, constraint multipliers) for reset worlds.
-        # Note: runs every step. solver.reset() with an all-False world_mask is a no-op
-        # (kernels check mask per-world and skip). The cost of a no-op launch is negligible
-        # compared to the complexity of maintaining a separate boolean guard.
-        cls._forward_kamino(world_mask=cls._world_reset_mask)
-
-        # Notify solver of model changes
-        if cls._model_changes:
-            with wp.ScopedDevice(PhysicsManager._device):
-                for change in cls._model_changes:
-                    cls._solver.notify_model_changed(change)
-                NewtonManager._model_changes = set()
-
-        # Lazy CUDA graph capture: deferred from initialize_solver() when RTX was active.
-        # By the time step() is first called, RTX has fully initialized (all cudaImportExternalMemory
-        # calls are done) and is idle between render frames — giving us a clean capture window.
-        cfg = PhysicsManager._cfg
-        device = PhysicsManager._device
-        if cls._graph_capture_pending and cfg is not None and cfg.use_cuda_graph and "cuda" in device:  # type: ignore[union-attr]
-            NewtonManager._graph_capture_pending = False
-            NewtonManager._graph = cls._capture_relaxed_graph(device)
-            if cls._graph is not None:
-                # Kamino: StateKamino.from_newton() lazily allocates body_f_total,
-                # joint_q_prev, and joint_lambdas via wp.clone/wp.zeros during the
-                # first step() inside graph capture. Replay once to pin those
-                # memory-pool addresses before any eager solver.reset() call.
-                wp.capture_launch(cls._graph)
-                logger.info("Newton CUDA graph captured (deferred relaxed mode, RTX-compatible)")
-            else:
-                logger.warning("Newton deferred CUDA graph capture failed; using eager execution")
-
-        # Ensure body_q is up-to-date before collision detection.
-        # After env resets, joint_q is written but body_q (used by
-        # broadphase/narrowphase) is stale until FK runs.
-        # Only runs FK for dirtied articulations via the accumulated mask.
-        if cls._needs_collision_pipeline:
-            eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, cls._fk_reset_mask)
-
-        # Zero both masks after consumption
-        NewtonManager._world_reset_mask.zero_()
-        NewtonManager._fk_reset_mask.zero_()
-
-        # Step simulation (graphed or not; _graph is None when capture is disabled or failed)
-        if cfg is not None and cfg.use_cuda_graph and cls._graph is not None and "cuda" in device:  # type: ignore[union-attr]
-            wp.capture_launch(cls._graph)
-        else:
-            with wp.ScopedDevice(device):
-                cls._simulate_physics_only()
-        if cls._usdrt_stage is not None:
-            cls._mark_transforms_dirty()
-
-        # Launch solver-specific debug logging after stepping.
-        cls._log_solver_debug()
-
-        PhysicsManager._sim_time += cls._solver_dt * cls._num_substeps
+        # The Kamino FK reset only writes the *actuated* joint coordinates back into the joint
+        # state; passive joint coordinates/velocities are left stale. Recompute the full joint
+        # state from the reconciled body poses so reads of ``joint_pos`` / ``joint_vel`` reflect
+        # the FK solution.
+        # TODO: remove once Kamino FK writes the full joint state.
+        joints = model_kamino.joints
+        scratch = solver_kamino._data.joints
+        wp.launch(
+            _reset_joints_of_select_worlds,
+            dim=model_kamino.size.sum_of_num_joints,
+            inputs=[
+                True,  # reset_constraints: only touches the scratch reaction buffer
+                effective_world_mask,
+                joints.wid,
+                joints.dof_type,
+                joints.num_dynamic_cts,
+                joints.num_kinematic_cts,
+                joints.coords_offset,
+                joints.dofs_offset,
+                joints.dynamic_cts_offset_joint_cts,
+                joints.kinematic_cts_offset_joint_cts,
+                joints.bid_B,
+                joints.bid_F,
+                joints.B_r_Bj,
+                joints.F_r_Fj,
+                joints.X_j,
+                joints.q_j_0,
+                cls._state_0.body_q,
+                cls._state_0.body_qd,
+                scratch.lambda_j,
+            ],
+            outputs=[
+                scratch.p_j,
+                scratch.r_j,
+                scratch.dr_j,
+                cls._state_0.joint_q,
+                cls._state_0.joint_qd,
+                scratch.lambda_j,
+            ],
+            device=model_kamino.device,
+        )
 
     @classmethod
     def _build_solver(cls, model: Model, solver_cfg: KaminoSolverCfg) -> None:
@@ -119,40 +240,26 @@ class NewtonKaminoManager(NewtonManager):
         Sets :attr:`NewtonManager._needs_collision_pipeline` to ``True`` only
         when ``use_collision_detector=False`` (Kamino's internal detector
         handles contacts otherwise).
+
+        Configures the shared FK-reconcile flags for the Kamino (maximal-coordinate)
+        solver.
+
+        Also allocates the persistent per-world base pose/twist buffers (:attr:`_base_q` /
+        :attr:`_base_u`) used by :meth:`_forward_kamino` to feed the FK reset with the
+        per-environment root state.
         """
         NewtonManager._solver = SolverKamino(model, solver_cfg.to_solver_config())
         NewtonManager._use_single_state = False
         NewtonManager._needs_collision_pipeline = not solver_cfg.use_collision_detector
 
-    @classmethod
-    def _capture_or_defer_cuda_graph(cls) -> None:
-        """Capture the physics CUDA graph, or defer if RTX is initializing."""
-        cfg = PhysicsManager._cfg
-        device = PhysicsManager._device
-        use_cuda_graph = cfg is not None and cfg.use_cuda_graph and "cuda" in device  # type: ignore[union-attr]
+        # Because Kamino treats body states as the simulation state. Environments that
+        # have been reset (via joint states) therefore must be reconciled before each step.
+        NewtonManager._reconcile_fk_before_step = True
+        # For Kamino we should not run FK for worlds that were not reset.
+        # This would modify the body states of the worlds that were not reset.
+        NewtonManager._forward_full_reconcile = False
 
-        with Timer(name="newton_cuda_graph", msg="CUDA graph took:"):
-            if not use_cuda_graph:
-                NewtonManager._graph = None
-                return
-            if cls._usdrt_stage is None:
-                # No RTX active — use standard Warp capture (cudaStreamCaptureModeGlobal).
-                with wp.ScopedCapture() as capture:
-                    cls._simulate_physics_only()
-                NewtonManager._graph = capture.graph
-                logger.info("Newton CUDA graph captured (standard Warp mode)")
-
-                # TODO: streamline this with base NewtonManager
-                # Kamino: StateKamino.from_newton() lazily allocates body_f_total,
-                # joint_q_prev, and joint_lambdas via wp.clone/wp.zeros during the
-                # first step() inside graph capture. Replay once to pin those
-                # memory-pool addresses before any eager solver.reset() call.
-                wp.capture_launch(cls._graph)
-            else:
-                # RTX is active during initialization — cudaImportExternalMemory and other
-                # non-capturable RTX ops run on background CUDA streams right now.
-                # Defer capture to the first step() call, after RTX is fully initialized
-                # and idle between render frames (clean capture window).
-                NewtonManager._graph = None
-                NewtonManager._graph_capture_pending = True
-                logger.info("Newton CUDA graph capture deferred until first step() (RTX active)")
+        model_kamino = NewtonManager._solver._model_kamino
+        num_worlds = model_kamino.size.num_worlds
+        cls._base_q = wp.zeros(num_worlds, dtype=wp.transformf, device=model_kamino.device)
+        cls._base_u = wp.zeros(num_worlds, dtype=vec6f, device=model_kamino.device)

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
@@ -51,8 +51,15 @@ class KaminoSolverCfg(NewtonSolverCfg):
     use_fk_solver: bool = True
     """Whether to enable the forward kinematics solver for state resets.
 
-    Required for proper environment resets. The FK solver computes consistent body poses
-    from joint angles after state writes, which is essential for maximal-coordinate solvers.
+    When ``True``, :meth:`NewtonKaminoManager._forward_kamino` passes root and actuated
+    coordinates only (``actuator_q`` / ``actuator_u``) to :meth:`SolverKamino.reset`.
+    Kamino's FK solver computes body poses and resolves passive / loop-closure joints.
+    Environment resets should only write actuated DOFs in ``joint_q``; passive values
+    are filled in by FK.
+
+    When ``False``, an articulated FK is used instead using the full``joint_q`` / ``joint_qd``.
+    It is then up to the user to specify constraint consistent values. This is
+    the faster option in case the system is an articulated system.
     """
 
     sparse_jacobian: bool = False

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -170,6 +170,18 @@ class NewtonSceneDataBackend(SceneDataBackend):
         return NewtonManager.get_state_0()
 
 
+def _reconcile_fk_unbound(world_mask: wp.array | None, fk_mask: wp.array | None) -> None:
+    """Default :attr:`NewtonManager._reconcile_fk` value before a solver is initialized.
+
+    Raises so a stray ``forward()`` / ``step()`` before ``initialize_solver()`` fails loudly
+    instead of silently running a wrong (or no) FK reconcile.
+    """
+    raise RuntimeError(
+        "FK reconcile hook is not bound. NewtonManager.initialize_solver() must run "
+        "(via reset()) before forward()/step() can reconcile body state."
+    )
+
+
 class NewtonManager(PhysicsManager):
     """Abstract Newton physics manager for Isaac Lab.
 
@@ -230,6 +242,13 @@ class NewtonManager(PhysicsManager):
     # Per-world reset masks (allocated in start_simulation, consumed in step)
     _world_reset_mask: wp.array | None = None  # (num_envs,) wp.int32 — for SolverKamino.reset(world_mask=...)
     _fk_reset_mask: wp.array | None = None  # (articulation_count,) wp.bool — for eval_fk(mask=...)
+
+    # Forward-kinematics reconcile (solver-specialized). Bound in initialize_solver to the active
+    # subclass's :meth:`_eval_fk` so :meth:`forward` / :meth:`step` dispatch correctly even when
+    # called through the base class. Flags follow the "set in _build_solver, reset in clear" pattern.
+    _reconcile_fk: Callable[[wp.array | None, wp.array | None], None] = _reconcile_fk_unbound
+    _reconcile_fk_before_step: bool = False  # step() reconciles body state from joints before stepping
+    _forward_full_reconcile: bool = True  # forward() reconciles all worlds (unmasked) vs only the dirtied mask
 
     # Newton actuator adapter (owns actuators and double-buffered states)
     _adapter: NewtonActuatorAdapter | None = None
@@ -327,16 +346,38 @@ class NewtonManager(PhysicsManager):
             cls.initialize_solver()
 
     @classmethod
+    def _eval_fk(cls, world_mask: wp.array | None, fk_mask: wp.array | None) -> None:
+        """Computes the body state from the joint coordinates.
+
+        Can be overwritten with a solver-specialized forward kinematics.
+        The base implementation runs Newton's generic ``eval_fk`` over the articulations.
+
+        TODO: merge the masks once Kamino supports a bool reset mask.
+
+        Args:
+            world_mask: Per-world mask of worlds to reconcile (``None`` means all). Used by
+                solvers that reset in world space (e.g. Kamino); ignored by the base.
+            fk_mask: Per-articulation mask of articulations to reconcile (``None`` means all).
+        """
+        eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, fk_mask)
+
+    @classmethod
     def forward(cls) -> None:
         """Update articulation kinematics without stepping physics.
 
-        Runs Newton's generic forward kinematics (``eval_fk``) over **all**
-        articulations to compute body poses from joint coordinates. This is
-        the full (unmasked) FK path used during initial setup. For incremental
-        per-environment updates after resets, see :meth:`invalidate_fk` which
-        accumulates masks consumed by :meth:`step`.
+        Reconciles body poses from joint coordinates via the solver-specialized FK hook
+        (:attr:`_reconcile_fk`, bound in :meth:`initialize_solver`). When
+        :attr:`_forward_full_reconcile` is ``True`` (base default) all worlds are reconciled;
+        otherwise only the worlds/articulations flagged dirty in the reset masks (see
+        :meth:`invalidate_fk`) are touched. The masks are consumed (zeroed) afterwards so the
+        next :meth:`step` does not redundantly re-solve them.
         """
-        eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, None)
+        if cls._forward_full_reconcile:
+            cls._reconcile_fk(None, None)
+        else:
+            cls._reconcile_fk(cls._world_reset_mask, cls._fk_reset_mask)
+        cls._world_reset_mask.zero_()
+        cls._fk_reset_mask.zero_()
 
     @classmethod
     def pre_render(cls) -> None:
@@ -559,16 +600,22 @@ class NewtonManager(PhysicsManager):
             NewtonManager._graph_capture_pending = False
             NewtonManager._graph = cls._capture_relaxed_graph(device)
             if cls._graph is not None:
+                # Kamino: StateKamino.from_newton() lazily allocates body_f_total,
+                # joint_q_prev, and joint_lambdas via wp.clone/wp.zeros during the
+                # first step() inside graph capture. Replay once to pin those
+                # memory-pool addresses before any eager solver.reset() call.
+                if isinstance(cls._solver, SolverKamino):
+                    wp.capture_launch(cls._graph)
                 logger.info("Newton CUDA graph captured (deferred relaxed mode, RTX-compatible)")
             else:
                 logger.warning("Newton deferred CUDA graph capture failed; using eager execution")
 
-        # Ensure body_q is up-to-date before collision detection.
-        # After env resets, joint_q is written but body_q (used by
-        # broadphase/narrowphase) is stale until FK runs.
-        # Only runs FK for dirtied articulations via the accumulated mask.
-        if cls._needs_collision_pipeline:
-            eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, cls._fk_reset_mask)
+        # Ensure body_q is up-to-date before stepping. After env resets, joint_q is written
+        # but body_q (used by broadphase/narrowphase, and the authoritative state for
+        # maximal-coordinate solvers) is stale until FK runs. Reconcile via the
+        # solver-specialized hook for dirtied articulations only (the accumulated mask).
+        if cls._reconcile_fk_before_step:
+            cls._reconcile_fk(cls._world_reset_mask, cls._fk_reset_mask)
 
         # Zero both masks after consumption
         NewtonManager._world_reset_mask.zero_()
@@ -679,6 +726,10 @@ class NewtonManager(PhysicsManager):
         # Per-world reset masks
         NewtonManager._world_reset_mask = None
         NewtonManager._fk_reset_mask = None
+        # Forward-kinematics reconcile hook and flags
+        NewtonManager._reconcile_fk = _reconcile_fk_unbound
+        NewtonManager._reconcile_fk_before_step = False
+        NewtonManager._forward_full_reconcile = True
         NewtonManager._graph = None
         NewtonManager._graph_capture_pending = False
         NewtonManager._newton_stage_path = None
@@ -996,7 +1047,9 @@ class NewtonManager(PhysicsManager):
         NewtonManager._state_0 = cls._model.state()
         NewtonManager._state_1 = cls._model.state()
         NewtonManager._control = cls._model.control()
-        eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, None)
+        # The initial body-state reconcile from joint coordinates is deferred to the tail of
+        # initialize_solver(), where it runs through the solver-specialized FK hook
+        # (cls._reconcile_fk).
 
         # The single global actuator adapter is built lazily on the first
         # call to ``activate_newton_actuator_path`` from any Newton-fast-path
@@ -1258,6 +1311,21 @@ class NewtonManager(PhysicsManager):
                 )
             cls._initialize_contacts()
 
+            # Bind the solver-specialized FK hook to the active subclass's _eval_fk so that
+            # forward()/step() dispatch correctly even when forward() is invoked through the
+            # base class (the data layer imports NewtonManager directly). cls is the concrete
+            # subclass here, since initialize_solver is reached via sim.physics_manager.reset().
+            NewtonManager._reconcile_fk = cls._eval_fk
+            # Fold the _needs_collision_pipeline need into the _reconcile_fk_before_step flag.
+            # _build_solver ran first. This only ever promotes.
+            if cls._needs_collision_pipeline:
+                NewtonManager._reconcile_fk_before_step = True
+
+            # Establish the initial kinematically-consistent body state through the
+            # solver-specialized FK hook, now that the solver and the hook both exist. It runs
+            # before graph capture below so the capture warmup sees a valid body_q.
+            cls._reconcile_fk(None, None)
+
         if cls._usdrt_stage is not None:
             cls._setup_cubric_bindings()
 
@@ -1480,7 +1548,7 @@ class NewtonManager(PhysicsManager):
                     cls._collision_pipeline.collide(cls._state_0, contacts)
         else:
             cfg = PhysicsManager._cfg
-            need_copy_on_last = (cfg is not None and cfg.use_cuda_graph) and cls._num_substeps % 2 == 1  # type: ignore[union-attr]
+            need_copy_on_last = cfg is not None and cls._num_substeps % 2 == 1  # type: ignore[union-attr]
             for i in range(cls._num_substeps):
                 cls._step_solver(cls._state_0, cls._state_1, cls._control, contacts, cls._solver_dt)
                 if need_copy_on_last and i == cls._num_substeps - 1:

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -25,6 +25,7 @@ Covers:
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 from isaaclab_newton.physics import (
     FeatherstoneSolverCfg,
@@ -360,3 +361,72 @@ def test_collision_decimation_invokes_mid_loop_collide(num_substeps, collision_d
 
         # Expect: 1 (top-of-tick) + expected_mid_loop_collides.
         assert calls["n"] == 1 + expected_mid_loop_collides
+
+
+# ---------------------------------------------------------------------------
+# Regression: an env reset written through the data layer must land in the
+# manager's canonical _state_0 after an odd number of steps when CUDA graphs
+# are disabled (the use_cuda_graph state-swap gating bug).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_steps", [1, 3])
+def test_reset_lands_in_state_0_after_odd_kamino_steps_without_cuda_graph(num_steps):
+    """An env reset written through the data-layer binding lands in ``_state_0``.
+
+    Kamino is double-buffered (``_use_single_state=False``), so each substep
+    ping-pongs ``_state_0`` / ``_state_1``. With a single substep the loop must
+    copy the result back into ``_state_0`` instead of swapping, otherwise after
+    an *odd* number of steps the canonical ``_state_0`` ends up on the other
+    buffer. This copy-on-last was previously gated on ``use_cuda_graph``, so with
+    CUDA graphs disabled ``_state_0`` flipped buffers and env-reset writes landed
+    in the stale buffer.
+
+    :class:`~isaaclab_newton.assets.ArticulationData` binds its joint-state write
+    target to ``_state_0.joint_q`` once at setup (``_sim_bind_joint_pos``) and
+    never re-binds on env resets, so a flipped ``_state_0`` makes reset writes
+    miss the live state. This test reproduces that contract without a full USD
+    articulation: it caches the same ``_state_0.joint_q`` binding, steps Kamino an
+    odd number of times, writes a sentinel through the cached binding (mimicking
+    the reset write), and asserts the manager's ``_state_0`` observes it.
+
+    Without the fix the swap-on-last flips ``_state_0`` for odd ``num_steps`` and
+    the sentinel lands in ``_state_1`` instead, so the final assertion fails.
+    """
+    sentinel = 1.2345
+    sim_cfg = SimulationCfg(
+        dt=1.0 / 120.0,
+        device="cuda:0",
+        gravity=(0.0, 0.0, -9.81),
+        physics=NewtonCfg(
+            solver_cfg=KaminoSolverCfg(),
+            num_substeps=1,
+            use_cuda_graph=False,
+        ),
+    )
+
+    with build_simulation_context(sim_cfg=sim_cfg) as sim:
+        builder = NewtonManager.create_builder()
+        body = builder.add_body(mass=1.0)
+        builder.add_joint_revolute(parent=-1, child=body, axis=(0, 0, 1))
+        NewtonManager.set_builder(builder)
+        sim.reset()
+
+        # Kamino keeps separate input/output states; the bug only exists there.
+        assert NewtonManager._use_single_state is False
+        # The data layer binds its joint-state write target to _state_0 at setup.
+        reset_target = NewtonManager._state_0.joint_q
+        assert reset_target.shape[0] > 0  # guard against a vacuous assertion
+
+        for _ in range(num_steps):
+            sim.step(render=False)
+
+        # An env reset writes joint state through the (still bound) target.
+        reset_target.fill_(sentinel)
+
+        # The reset must be visible in the manager's canonical _state_0; if the
+        # buffer flipped it landed in _state_1 instead.
+        canonical_joint_q = NewtonManager._state_0.joint_q.numpy()
+        assert np.allclose(canonical_joint_q, sentinel), (
+            f"reset write did not land in _state_0 after {num_steps} steps: {canonical_joint_q}"
+        )


### PR DESCRIPTION
# Description

Newton's generic `eval_fk` is an *articulated* (tree) forward kinematics and is
incorrect for the Kamino maximal-coordinate solver, especially for closed-loop
mechanisms. However, the base `NewtonManager.forward()` / `step()` called
`eval_fk` directly. The Kamino manager previously worked around this by
overriding the entire `step()` method, but `forward()` — reached from
`ArticulationData._ensure_fk_fresh()` via `SimulationManager.forward()` after a
manual joint/root write — still ran the wrong articulated FK for Kamino.

This PR refactors `NewtonManager` to allow per-solver specialization of forward
kinematics, removes the Kamino-specific `step()` override, and fixes a
double-buffer state-swap bug that caused environment resets to be written into
the wrong state buffer.

**What changed:**

- **FK specialization hook.** Added a solver-specialized `_eval_fk(world_mask, fk_mask)`
  classmethod plus a `_reconcile_fk` hook (bound in `initialize_solver`) and two
  flags, `_reconcile_fk_before_step` and `_forward_full_reconcile`. Both
  `forward()` and `step()` now dispatch through this hook, so the correct FK runs
  regardless of whether the call enters through the base class or a subclass. The
  initial body-state reconcile is deferred to the tail of `initialize_solver()`.
- **Removed the Kamino-specific `step()` override** (and the duplicated
  `_capture_or_defer_cuda_graph`). `NewtonKaminoManager` now only specializes
  `_eval_fk` / `_forward_kamino` and sets its flags in `_build_solver`.
- **Correct Kamino FK reset.** `_forward_kamino` extracts the actuated joint
  state and gathers the per-world base (root) pose/twist from the base joint's
  coordinates in `joint_q`/`joint_qd`, feeding `actuator_q`/`actuator_u`/`base_q`/`base_u`
  into `SolverKamino.reset`. After the reset it recomputes the full joint state
  from the reconciled body poses so reads of `joint_pos`/`joint_vel` reflect
  passive/loop-closure joints. `KaminoSolverCfg.use_fk_solver=False` falls back to
  articulated `eval_fk` (the faster path for tree systems).
- **Bug fix — `use_cuda_graph` gating the double-buffer swap.** In
  `_run_solver_substeps`, `need_copy_on_last` was gated on `cfg.use_cuda_graph`.
  With double-buffered state (Kamino uses `_use_single_state=False`) and an odd
  substep count, this left the canonical state in `_state_1` while reset writes
  (which target the `_state_0`-bound data layer) landed in the stale buffer when
  CUDA graphs were disabled. The gate is removed so the copy-on-last always runs
  for odd substep counts.

## Type of change

- Bug fix (non-breaking change which fixes an issue) — includes an internal
  refactor of `NewtonManager`'s FK dispatch

## Screenshots

N/A — no visual/UI change.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there