### PR TITLE
Make PPISP a peer IsaacLab extension dependency

### DIFF
--- a/source/isaaclab/changelog.d/nicolasm-ppisp-extension-dependency.rst
+++ b/source/isaaclab/changelog.d/nicolasm-ppisp-extension-dependency.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed the ``isaaclab[all]`` extra to include ``isaaclab_ppisp`` as a peer extension.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -466,8 +466,8 @@ def _install_isaacsim() -> None:
 
 # Source directories installed on every ./isaaclab.sh -i invocation (even "core").
 # Order matters: isaaclab must be first so dependents resolve against the local copy,
-# and isaaclab_ppisp must precede the renderer backends (newton/ov/physx) that
-# declare it as an INSTALL_REQUIRES bare-name dep.
+# and isaaclab_ppisp should precede renderer backends (newton/ov/physx) so local
+# camera ISP support is available when CameraCfg.isp_cfg is used.
 CORE_ISAACLAB_SUBMODULES: list[str] = [
     "isaaclab",
     "isaaclab_ppisp",

--- a/source/isaaclab/pyproject.toml
+++ b/source/isaaclab/pyproject.toml
@@ -92,6 +92,7 @@ all = [
     "isaaclab_ov",
     "isaaclab_ovphysx",
     "isaaclab_physx[newton]",
+    "isaaclab_ppisp",
     "isaaclab_rl[all]",
     "isaaclab_tasks",
     "isaaclab_tasks_experimental",

--- a/source/isaaclab_newton/changelog.d/nicolasm-ppisp-extension-dependency.rst
+++ b/source/isaaclab_newton/changelog.d/nicolasm-ppisp-extension-dependency.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Newton package resolution so ``isaaclab_ppisp`` is only required when camera ``isp_cfg`` is set.

--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -13,7 +13,6 @@ keywords = ["robotics", "simulation", "newton"]
 
 [dependencies]
 "isaaclab" = {}
-"isaaclab_ppisp" = {}
 
 [core]
 reloadable = false

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -39,6 +39,8 @@ _PPISP_IMPORT_ERROR_MESSAGE = (
 
 
 def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
+    # Only translate missing isaaclab_ppisp imports into the optional-dependency hint;
+    # unrelated missing modules should surface unchanged for easier debugging.
     if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
         raise exc
     raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import newton
 import torch
@@ -30,6 +30,18 @@ if TYPE_CHECKING:
     from isaaclab.utils.warp import ProxyArray
 
 logger = logging.getLogger(__name__)
+
+_PPISP_IMPORT_ERROR_MESSAGE = (
+    "isaaclab_ppisp is required when CameraCfg.isp_cfg is set. "
+    "Install Isaac Lab with the 'all' extra (`pip install isaaclab[all]`) or install the "
+    "isaaclab-ppisp extension from the Isaac Lab source checkout."
+)
+
+
+def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
+    if exc.name != "isaaclab_ppisp":
+        raise exc
+    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE) from exc
 
 
 class RenderData:
@@ -71,7 +83,10 @@ class RenderData:
         # ``isp_cfg`` is already fully normalised by Camera by the time it reaches here.
         self.ppisp_pipeline: PpispPipeline | None = None
         if spec.cfg.isp_cfg is not None:
-            from isaaclab_ppisp import PpispPipeline
+            try:
+                from isaaclab_ppisp import PpispPipeline
+            except ModuleNotFoundError as exc:
+                _raise_missing_ppisp_error(exc)
 
             self.ppisp_pipeline = PpispPipeline(spec.cfg.isp_cfg)
         self._hdr_scratch_wp: wp.array | None = None
@@ -263,7 +278,10 @@ class NewtonWarpRenderer(BaseRenderer):
         """
         if spec.cfg.isp_cfg is None or not spec.camera_prim_paths:
             return
-        from isaaclab_ppisp import resolve_and_normalize
+        try:
+            from isaaclab_ppisp import resolve_and_normalize
+        except ModuleNotFoundError as exc:
+            _raise_missing_ppisp_error(exc)
 
         spec.cfg.isp_cfg = resolve_and_normalize(spec.cfg.isp_cfg, stage, spec.camera_prim_paths[0])
 

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -39,9 +39,9 @@ _PPISP_IMPORT_ERROR_MESSAGE = (
 
 
 def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
-    if exc.name != "isaaclab_ppisp":
+    if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
         raise exc
-    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE) from exc
+    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc
 
 
 class RenderData:
@@ -80,7 +80,7 @@ class RenderData:
         self.width = getattr(spec.cfg, "width", 100)
         self.height = getattr(spec.cfg, "height", 100)
         # Post-render PPISP pipeline composed when ``spec.cfg.isp_cfg`` is set.
-        # ``isp_cfg`` is already fully normalised by Camera by the time it reaches here.
+        # ``isp_cfg`` is already fully normalized by ``prepare_cameras`` by the time it reaches here.
         self.ppisp_pipeline: PpispPipeline | None = None
         if spec.cfg.isp_cfg is not None:
             try:

--- a/source/isaaclab_newton/pyproject.toml
+++ b/source/isaaclab_newton/pyproject.toml
@@ -16,9 +16,7 @@ authors = [{name = "Isaac Lab Project Developers"}]
 maintainers = [{name = "Isaac Lab Project Developers"}]
 keywords = ["robotics", "simulation", "newton"]
 requires-python = ">=3.12"
-dependencies = [
-    "isaaclab_ppisp",
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/isaac-sim/IsaacLab"

--- a/source/isaaclab_ov/changelog.d/nicolasm-ppisp-extension-dependency.rst
+++ b/source/isaaclab_ov/changelog.d/nicolasm-ppisp-extension-dependency.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed OVRTX package resolution so ``isaaclab_ppisp`` is only required when camera ``isp_cfg`` is set.

--- a/source/isaaclab_ov/config/extension.toml
+++ b/source/isaaclab_ov/config/extension.toml
@@ -9,4 +9,3 @@ keywords = ["robotics", "simulation", "rendering", "ovrtx", "omniverse"]
 
 [dependencies]
 "isaaclab" = {}
-"isaaclab_ppisp" = {}

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -84,9 +84,9 @@ _PPISP_IMPORT_ERROR_MESSAGE = (
 
 
 def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
-    if exc.name != "isaaclab_ppisp":
+    if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
         raise exc
-    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE) from exc
+    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc
 
 
 def _resolve_rtx_minimal_mode(data_types: list[str]) -> int | None:
@@ -131,7 +131,7 @@ class OVRTXRenderData:
         self.num_rows = math.ceil(self.num_envs / self.num_cols)
         self.warp_buffers: dict[str, wp.array] = {}
         # Post-render PPISP pipeline composed when ``spec.cfg.isp_cfg`` is set.
-        # ``isp_cfg`` is already fully normalised by the time it reaches here (Camera does it).
+        # ``isp_cfg`` is already fully normalized by ``prepare_cameras`` by the time it reaches here.
         self.ppisp_pipeline: PpispPipeline | None = None
         if spec.cfg.isp_cfg is not None:
             try:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -84,6 +84,8 @@ _PPISP_IMPORT_ERROR_MESSAGE = (
 
 
 def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
+    # Only translate missing isaaclab_ppisp imports into the optional-dependency hint;
+    # unrelated missing modules should surface unchanged for easier debugging.
     if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
         raise exc
     raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -23,7 +23,7 @@ import logging
 import math
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +76,18 @@ _RTX_MINIMAL_MODES = {
     RenderBufferKind.SIMPLE_SHADING_FULL_MDL.value: 3,
 }
 
+_PPISP_IMPORT_ERROR_MESSAGE = (
+    "isaaclab_ppisp is required when CameraCfg.isp_cfg is set. "
+    "Install Isaac Lab with the 'all' extra (`pip install isaaclab[all]`) or install the "
+    "isaaclab-ppisp extension from the Isaac Lab source checkout."
+)
+
+
+def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
+    if exc.name != "isaaclab_ppisp":
+        raise exc
+    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE) from exc
+
 
 def _resolve_rtx_minimal_mode(data_types: list[str]) -> int | None:
     """Resolve the RTX minimal mode from data types.
@@ -122,7 +134,10 @@ class OVRTXRenderData:
         # ``isp_cfg`` is already fully normalised by the time it reaches here (Camera does it).
         self.ppisp_pipeline: PpispPipeline | None = None
         if spec.cfg.isp_cfg is not None:
-            from isaaclab_ppisp import PpispPipeline
+            try:
+                from isaaclab_ppisp import PpispPipeline
+            except ModuleNotFoundError as exc:
+                _raise_missing_ppisp_error(exc)
 
             self.ppisp_pipeline = PpispPipeline(spec.cfg.isp_cfg)
 
@@ -197,16 +212,19 @@ class OVRTXRenderer(BaseRenderer):
     def prepare_cameras(self, stage: Any, spec: CameraRenderSpec) -> None:
         """Resolve the camera's PPISP cfg and apply OVRTX-specific USD overrides.
 
-        First resolves ``spec.cfg.isp_cfg`` (sentinel discovery + normalization)
-        via :func:`isaaclab_ppisp.resolve_and_normalize` so :mod:`isaaclab` does
-        not need to know about PPISP. Then, when an ISP is configured, pins
+        When ``spec.cfg.isp_cfg`` is set, resolves it (sentinel discovery +
+        normalization) via :func:`isaaclab_ppisp.resolve_and_normalize` so
+        :mod:`isaaclab` does not need to know about PPISP. Then pins
         ``exposure:*`` to neutral and applies ``OmniRtxCameraExposureAPI_1`` so
         the RTX exposure model OVRTX embeds does not compound on top of the
         ISP. Without an ISP, the camera prim's authored exposure is left alone.
         """
-        if not spec.camera_prim_paths:
+        if not spec.camera_prim_paths or spec.cfg.isp_cfg is None:
             return
-        from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+        try:
+            from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+        except ModuleNotFoundError as exc:
+            _raise_missing_ppisp_error(exc)
 
         spec.cfg.isp_cfg = resolve_and_normalize(spec.cfg.isp_cfg, stage, spec.camera_prim_paths[0])
         if spec.cfg.isp_cfg is None:

--- a/source/isaaclab_ov/pyproject.toml
+++ b/source/isaaclab_ov/pyproject.toml
@@ -16,9 +16,7 @@ authors = [{name = "Isaac Lab Project Developers"}]
 maintainers = [{name = "Isaac Lab Project Developers"}]
 keywords = ["robotics", "simulation", "rendering", "ovrtx", "omniverse"]
 requires-python = ">=3.12"
-dependencies = [
-    "isaaclab_ppisp",
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/isaac-sim/IsaacLab"

--- a/source/isaaclab_physx/changelog.d/nicolasm-ppisp-extension-dependency.rst
+++ b/source/isaaclab_physx/changelog.d/nicolasm-ppisp-extension-dependency.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Isaac RTX package resolution so ``isaaclab_ppisp`` is only required when camera ``isp_cfg`` is set.

--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -13,7 +13,6 @@ keywords = ["robotics", "simulation", "physx"]
 
 [dependencies]
 "isaaclab" = {}
-"isaaclab_ppisp" = {}
 
 [core]
 reloadable = false

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -46,6 +46,8 @@ _PPISP_IMPORT_ERROR_MESSAGE = (
 
 
 def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
+    # Only translate missing isaaclab_ppisp imports into the optional-dependency hint;
+    # unrelated missing modules should surface unchanged for easier debugging.
     if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
         raise exc
     raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -46,9 +46,9 @@ _PPISP_IMPORT_ERROR_MESSAGE = (
 
 
 def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
-    if exc.name != "isaaclab_ppisp":
+    if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
         raise exc
-    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE) from exc
+    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc
 
 
 # RTX simple-shading constants.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -11,7 +11,7 @@ import json
 import logging
 import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import numpy as np
 import warp as wp
@@ -37,6 +37,19 @@ if TYPE_CHECKING:
     from isaaclab.utils.warp import ProxyArray
 
 from .isaac_rtx_renderer_cfg import IsaacRtxRendererCfg
+
+_PPISP_IMPORT_ERROR_MESSAGE = (
+    "isaaclab_ppisp is required when CameraCfg.isp_cfg is set. "
+    "Install Isaac Lab with the 'all' extra (`pip install isaaclab[all]`) or install the "
+    "isaaclab-ppisp extension from the Isaac Lab source checkout."
+)
+
+
+def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
+    if exc.name != "isaaclab_ppisp":
+        raise exc
+    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE) from exc
+
 
 # RTX simple-shading constants.
 #
@@ -106,16 +119,19 @@ class IsaacRtxRenderer(BaseRenderer):
     def prepare_cameras(self, stage: Any, spec: CameraRenderSpec) -> None:
         """Resolve the camera's PPISP cfg and apply RTX-specific USD overrides.
 
-        First resolves ``spec.cfg.isp_cfg`` (sentinel discovery + normalization)
-        via :func:`isaaclab_ppisp.resolve_and_normalize` so :mod:`isaaclab` does
-        not need to know about PPISP. Then, when an ISP is configured, pins
+        When ``spec.cfg.isp_cfg`` is set, resolves it (sentinel discovery +
+        normalization) via :func:`isaaclab_ppisp.resolve_and_normalize` so
+        :mod:`isaaclab` does not need to know about PPISP. Then pins
         ``exposure:*`` to neutral and applies ``OmniRtxCameraExposureAPI_1`` so
         RTX's physical-camera exposure model does not compound on top of the
         ISP. Without an ISP, the camera prim's authored exposure is left alone.
         """
-        if not spec.camera_prim_paths:
+        if not spec.camera_prim_paths or spec.cfg.isp_cfg is None:
             return
-        from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+        try:
+            from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+        except ModuleNotFoundError as exc:
+            _raise_missing_ppisp_error(exc)
 
         spec.cfg.isp_cfg = resolve_and_normalize(spec.cfg.isp_cfg, stage, spec.camera_prim_paths[0])
         if spec.cfg.isp_cfg is None:
@@ -340,7 +356,10 @@ class IsaacRtxRenderer(BaseRenderer):
 
         ppisp_pipeline = None
         if spec.cfg.isp_cfg is not None:
-            from isaaclab_ppisp import PpispPipeline
+            try:
+                from isaaclab_ppisp import PpispPipeline
+            except ModuleNotFoundError as exc:
+                _raise_missing_ppisp_error(exc)
 
             ppisp_pipeline = PpispPipeline(spec.cfg.isp_cfg, stage=stage)
 

--- a/source/isaaclab_physx/pyproject.toml
+++ b/source/isaaclab_physx/pyproject.toml
@@ -16,9 +16,7 @@ authors = [{name = "Isaac Lab Project Developers"}]
 maintainers = [{name = "Isaac Lab Project Developers"}]
 keywords = ["robotics", "simulation", "physx"]
 requires-python = ">=3.12"
-dependencies = [
-    "isaaclab_ppisp",
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/isaac-sim/IsaacLab"


### PR DESCRIPTION
 # Description

  This PR fixes dependency resolution for non-camera Newton/PhysX/OV workflows by making isaaclab_ppisp a peer IsaacLab extension instead of a hard dependency of isaaclab_newton,
  isaaclab_physx, and isaaclab_ov.

  Previously, installing or resolving isaaclab-newton[all] could fail when isaaclab-ppisp was unavailable from the package registry, even for workloads that do not use camera ISP. This
  change keeps PPISP available through isaaclab[all], while renderer code imports it only when CameraCfg.isp_cfg is set. If PPISP is missing and ISP is requested, the renderer now raises an
  actionable install error.

  Dependencies required: none beyond existing IsaacLab extension dependencies. isaaclab_ppisp remains required only when using camera isp_cfg.

  Fixes # (issue)

  ## Type of change

  - Bug fix (non-breaking change which fixes an issue)

  ## Screenshots

  Not applicable.

  ## Checklist

  - [x] I have read and understood the contribution guidelines (https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
  - [x] I have run the pre-commit checks (https://pre-commit.com/) with ./isaaclab.sh --format
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have updated the changelog and the corresponding version in the extension's config/extension.toml file
  - [ ] I have added my name to the CONTRIBUTORS.md or my name already exists there
