### PR TITLE
Make PPISP a peer IsaacLab extension dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "isaaclab-ov",
     "isaaclab-ovphysx",
     "isaaclab-physx[newton]",
+    "isaaclab-ppisp",
     "isaaclab-rl[rsl-rl]",
     "isaaclab-tasks",
     "isaaclab-tasks-experimental",
@@ -232,6 +233,7 @@ isaaclab = { path = "source/isaaclab", editable = true }
 "isaaclab-ov" = { path = "source/isaaclab_ov", editable = true }
 "isaaclab-ovphysx" = { path = "source/isaaclab_ovphysx", editable = true }
 "isaaclab-physx" = { path = "source/isaaclab_physx", editable = true }
+"isaaclab-ppisp" = { path = "source/isaaclab_ppisp", editable = true }
 "isaaclab-rl" = { path = "source/isaaclab_rl", editable = true }
 "isaaclab-tasks" = { path = "source/isaaclab_tasks", editable = true }
 "isaaclab-tasks-experimental" = { path = "source/isaaclab_tasks_experimental", editable = true }

--- a/source/isaaclab/changelog.d/nicolasm-ppisp-extension-dependency.rst
+++ b/source/isaaclab/changelog.d/nicolasm-ppisp-extension-dependency.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed ``isaaclab`` install metadata to include ``isaaclab_ppisp`` as a peer extension.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -466,8 +466,8 @@ def _install_isaacsim() -> None:
 
 # Source directories installed on every ./isaaclab.sh -i invocation (even "core").
 # Order matters: isaaclab must be first so dependents resolve against the local copy,
-# and isaaclab_ppisp must precede the renderer backends (newton/ov/physx) that
-# declare it as an INSTALL_REQUIRES bare-name dep.
+# and isaaclab_ppisp should precede renderer backends (newton/ov/physx) so local
+# camera ISP support is available when CameraCfg.isp_cfg is used.
 CORE_ISAACLAB_SUBMODULES: list[str] = [
     "isaaclab",
     "isaaclab_ppisp",

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -111,6 +111,7 @@ EXTRAS_REQUIRE = {
         "isaaclab_ov",
         "isaaclab_ovphysx",
         "isaaclab_physx[newton]",
+        "isaaclab_ppisp",
         "isaaclab_rl[all]",
         "isaaclab_tasks",
         "isaaclab_tasks_experimental",

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -69,7 +69,16 @@ def test_uv_run_base_dependencies_cover_newton_rsl_rl_training():
 
     assert "isaaclab-newton[all]" in dependencies
     assert "isaaclab-physx[newton]" in dependencies
+    assert "isaaclab-ppisp" in dependencies
     assert "isaaclab-rl[rsl-rl]" in dependencies
+
+
+def test_uv_run_maps_ppisp_to_local_source():
+    """The local PPISP peer extension must not resolve from the package registry."""
+    uv_sources = _root_pyproject()["tool"]["uv"]["sources"]
+
+    assert uv_sources["isaaclab-ppisp"]["path"] == "source/isaaclab_ppisp"
+    assert uv_sources["isaaclab-ppisp"]["editable"] is True
 
 
 def test_uv_run_uses_managed_python():

--- a/source/isaaclab_newton/changelog.d/nicolasm-ppisp-extension-dependency.rst
+++ b/source/isaaclab_newton/changelog.d/nicolasm-ppisp-extension-dependency.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Newton package resolution so ``isaaclab_ppisp`` is only required when camera ``isp_cfg`` is set.

--- a/source/isaaclab_newton/config/extension.toml
+++ b/source/isaaclab_newton/config/extension.toml
@@ -13,7 +13,6 @@ keywords = ["robotics", "simulation", "newton"]
 
 [dependencies]
 "isaaclab" = {}
-"isaaclab_ppisp" = {}
 
 [core]
 reloadable = false

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import newton
 import torch
@@ -30,6 +30,18 @@ if TYPE_CHECKING:
     from isaaclab.utils.warp import ProxyArray
 
 logger = logging.getLogger(__name__)
+
+_PPISP_IMPORT_ERROR_MESSAGE = (
+    "isaaclab_ppisp is required when CameraCfg.isp_cfg is set. "
+    "Install Isaac Lab with the 'all' extra (`pip install isaaclab[all]`) or install the "
+    "isaaclab-ppisp extension from the Isaac Lab source checkout."
+)
+
+
+def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
+    if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
+        raise exc
+    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc
 
 
 class RenderData:
@@ -68,10 +80,13 @@ class RenderData:
         self.width = getattr(spec.cfg, "width", 100)
         self.height = getattr(spec.cfg, "height", 100)
         # Post-render PPISP pipeline composed when ``spec.cfg.isp_cfg`` is set.
-        # ``isp_cfg`` is already fully normalised by Camera by the time it reaches here.
+        # ``isp_cfg`` is already fully normalized by ``prepare_cameras`` by the time it reaches here.
         self.ppisp_pipeline: PpispPipeline | None = None
         if spec.cfg.isp_cfg is not None:
-            from isaaclab_ppisp import PpispPipeline
+            try:
+                from isaaclab_ppisp import PpispPipeline
+            except ModuleNotFoundError as exc:
+                _raise_missing_ppisp_error(exc)
 
             self.ppisp_pipeline = PpispPipeline(spec.cfg.isp_cfg)
         self._hdr_scratch_wp: wp.array | None = None
@@ -263,7 +278,10 @@ class NewtonWarpRenderer(BaseRenderer):
         """
         if spec.cfg.isp_cfg is None or not spec.camera_prim_paths:
             return
-        from isaaclab_ppisp import resolve_and_normalize
+        try:
+            from isaaclab_ppisp import resolve_and_normalize
+        except ModuleNotFoundError as exc:
+            _raise_missing_ppisp_error(exc)
 
         spec.cfg.isp_cfg = resolve_and_normalize(spec.cfg.isp_cfg, stage, spec.camera_prim_paths[0])
 

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -33,7 +33,7 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 # Read the extension.toml file
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
-INSTALL_REQUIRES = ["isaaclab_ppisp"]
+INSTALL_REQUIRES = []
 
 EXTRAS_REQUIRE = {
     "all": [

--- a/source/isaaclab_ov/changelog.d/nicolasm-ppisp-extension-dependency.rst
+++ b/source/isaaclab_ov/changelog.d/nicolasm-ppisp-extension-dependency.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed OVRTX package resolution so ``isaaclab_ppisp`` is only required when camera ``isp_cfg`` is set.

--- a/source/isaaclab_ov/config/extension.toml
+++ b/source/isaaclab_ov/config/extension.toml
@@ -9,4 +9,3 @@ keywords = ["robotics", "simulation", "rendering", "ovrtx", "omniverse"]
 
 [dependencies]
 "isaaclab" = {}
-"isaaclab_ppisp" = {}

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -24,7 +24,7 @@ import math
 import os
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +85,18 @@ _RTX_MINIMAL_MODES = {
     RenderBufferKind.SIMPLE_SHADING_FULL_MDL.value: 3,
 }
 
+_PPISP_IMPORT_ERROR_MESSAGE = (
+    "isaaclab_ppisp is required when CameraCfg.isp_cfg is set. "
+    "Install Isaac Lab with the 'all' extra (`pip install isaaclab[all]`) or install the "
+    "isaaclab-ppisp extension from the Isaac Lab source checkout."
+)
+
+
+def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
+    if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
+        raise exc
+    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc
+
 
 def _resolve_rtx_minimal_mode(data_types: list[str]) -> int | None:
     """Resolve the RTX minimal mode from data types.
@@ -128,10 +140,13 @@ class OVRTXRenderData:
         self.num_rows = math.ceil(self.num_envs / self.num_cols)
         self.warp_buffers: dict[str, wp.array] = {}
         # Post-render PPISP pipeline composed when ``spec.cfg.isp_cfg`` is set.
-        # ``isp_cfg`` is already fully normalised by the time it reaches here (Camera does it).
+        # ``isp_cfg`` is already fully normalized by ``prepare_cameras`` by the time it reaches here.
         self.ppisp_pipeline: PpispPipeline | None = None
         if spec.cfg.isp_cfg is not None:
-            from isaaclab_ppisp import PpispPipeline
+            try:
+                from isaaclab_ppisp import PpispPipeline
+            except ModuleNotFoundError as exc:
+                _raise_missing_ppisp_error(exc)
 
             self.ppisp_pipeline = PpispPipeline(spec.cfg.isp_cfg)
 
@@ -207,16 +222,19 @@ class OVRTXRenderer(BaseRenderer):
     def prepare_cameras(self, stage: Any, spec: CameraRenderSpec) -> None:
         """Resolve the camera's PPISP cfg and apply OVRTX-specific USD overrides.
 
-        First resolves ``spec.cfg.isp_cfg`` (sentinel discovery + normalization)
-        via :func:`isaaclab_ppisp.resolve_and_normalize` so :mod:`isaaclab` does
-        not need to know about PPISP. Then, when an ISP is configured, pins
+        When ``spec.cfg.isp_cfg`` is set, resolves it (sentinel discovery +
+        normalization) via :func:`isaaclab_ppisp.resolve_and_normalize` so
+        :mod:`isaaclab` does not need to know about PPISP. Then pins
         ``exposure:*`` to neutral and applies ``OmniRtxCameraExposureAPI_1`` so
         the RTX exposure model OVRTX embeds does not compound on top of the
         ISP. Without an ISP, the camera prim's authored exposure is left alone.
         """
-        if not spec.camera_prim_paths:
+        if not spec.camera_prim_paths or spec.cfg.isp_cfg is None:
             return
-        from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+        try:
+            from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+        except ModuleNotFoundError as exc:
+            _raise_missing_ppisp_error(exc)
 
         spec.cfg.isp_cfg = resolve_and_normalize(spec.cfg.isp_cfg, stage, spec.camera_prim_paths[0])
         if spec.cfg.isp_cfg is None:

--- a/source/isaaclab_ov/setup.py
+++ b/source/isaaclab_ov/setup.py
@@ -35,7 +35,7 @@ setup(
     license="BSD-3-Clause",
     include_package_data=True,
     python_requires=">=3.12",
-    install_requires=["isaaclab_ppisp"],
+    install_requires=[],
     extras_require=EXTRAS_REQUIRE,
     packages=["isaaclab_ov"],
     classifiers=[

--- a/source/isaaclab_physx/changelog.d/nicolasm-ppisp-extension-dependency.rst
+++ b/source/isaaclab_physx/changelog.d/nicolasm-ppisp-extension-dependency.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Isaac RTX package resolution so ``isaaclab_ppisp`` is only required when camera ``isp_cfg`` is set.

--- a/source/isaaclab_physx/config/extension.toml
+++ b/source/isaaclab_physx/config/extension.toml
@@ -13,7 +13,6 @@ keywords = ["robotics", "simulation", "physx"]
 
 [dependencies]
 "isaaclab" = {}
-"isaaclab_ppisp" = {}
 
 [core]
 reloadable = false

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -11,7 +11,7 @@ import json
 import logging
 import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import numpy as np
 import warp as wp
@@ -37,6 +37,19 @@ if TYPE_CHECKING:
     from isaaclab.utils.warp import ProxyArray
 
 from .isaac_rtx_renderer_cfg import IsaacRtxRendererCfg
+
+_PPISP_IMPORT_ERROR_MESSAGE = (
+    "isaaclab_ppisp is required when CameraCfg.isp_cfg is set. "
+    "Install Isaac Lab with the 'all' extra (`pip install isaaclab[all]`) or install the "
+    "isaaclab-ppisp extension from the Isaac Lab source checkout."
+)
+
+
+def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
+    if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
+        raise exc
+    raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc
+
 
 # RTX simple-shading constants.
 #
@@ -106,16 +119,19 @@ class IsaacRtxRenderer(BaseRenderer):
     def prepare_cameras(self, stage: Any, spec: CameraRenderSpec) -> None:
         """Resolve the camera's PPISP cfg and apply RTX-specific USD overrides.
 
-        First resolves ``spec.cfg.isp_cfg`` (sentinel discovery + normalization)
-        via :func:`isaaclab_ppisp.resolve_and_normalize` so :mod:`isaaclab` does
-        not need to know about PPISP. Then, when an ISP is configured, pins
+        When ``spec.cfg.isp_cfg`` is set, resolves it (sentinel discovery +
+        normalization) via :func:`isaaclab_ppisp.resolve_and_normalize` so
+        :mod:`isaaclab` does not need to know about PPISP. Then pins
         ``exposure:*`` to neutral and applies ``OmniRtxCameraExposureAPI_1`` so
         RTX's physical-camera exposure model does not compound on top of the
         ISP. Without an ISP, the camera prim's authored exposure is left alone.
         """
-        if not spec.camera_prim_paths:
+        if not spec.camera_prim_paths or spec.cfg.isp_cfg is None:
             return
-        from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+        try:
+            from isaaclab_ppisp import apply_rtx_exposure_overrides, resolve_and_normalize
+        except ModuleNotFoundError as exc:
+            _raise_missing_ppisp_error(exc)
 
         spec.cfg.isp_cfg = resolve_and_normalize(spec.cfg.isp_cfg, stage, spec.camera_prim_paths[0])
         if spec.cfg.isp_cfg is None:
@@ -310,7 +326,10 @@ class IsaacRtxRenderer(BaseRenderer):
 
         ppisp_pipeline = None
         if spec.cfg.isp_cfg is not None:
-            from isaaclab_ppisp import PpispPipeline
+            try:
+                from isaaclab_ppisp import PpispPipeline
+            except ModuleNotFoundError as exc:
+                _raise_missing_ppisp_error(exc)
 
             ppisp_pipeline = PpispPipeline(spec.cfg.isp_cfg, stage=stage)
 

--- a/source/isaaclab_physx/setup.py
+++ b/source/isaaclab_physx/setup.py
@@ -16,7 +16,7 @@ EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
 EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
 
 # Minimum dependencies required prior to installation
-INSTALL_REQUIRES = ["isaaclab_ppisp"]
+INSTALL_REQUIRES = []
 
 EXTRAS_REQUIRE = {
     "newton": [


### PR DESCRIPTION
 # Description

  This PR fixes dependency resolution for non-camera Newton/PhysX/OV workflows by making isaaclab_ppisp a peer IsaacLab extension instead of a hard dependency of isaaclab_newton,
  isaaclab_physx, and isaaclab_ov.

  Previously, installing or resolving isaaclab-newton[all] could fail when isaaclab-ppisp was unavailable from the package registry, even for workloads that do not use camera ISP. This
  change keeps PPISP available through isaaclab[all], while renderer code imports it only when CameraCfg.isp_cfg is set. If PPISP is missing and ISP is requested, the renderer now raises an
  actionable install error.

  Dependencies required: none beyond existing IsaacLab extension dependencies. isaaclab_ppisp remains required only when using camera isp_cfg.

  Fixes # (issue)

  ## Type of change

  - Bug fix (non-breaking change which fixes an issue)

  ## Screenshots

  Not applicable.

  ## Checklist

  - [x] I have read and understood the contribution guidelines (https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
  - [x] I have run the pre-commit checks (https://pre-commit.com/) with ./isaaclab.sh --format
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have updated the changelog and the corresponding version in the extension's config/extension.toml file
  - [ ] I have added my name to the CONTRIBUTORS.md or my name already exists there
