### PR TITLE
Fix failing doc link checks

### DIFF
--- a/docs/source/policy_deployment/00_hover/hover_policy.rst
+++ b/docs/source/policy_deployment/00_hover/hover_policy.rst
@@ -191,4 +191,4 @@ To deploy the trained policy on the H1 robot,
 .. _README of Sim2Real deployment: https://github.com/NVlabs/HOVER/blob/main/neural_wbc/hw_wrappers/README.md
 .. _Hardware Environment: https://github.com/NVlabs/HOVER/blob/main/neural_wbc/hw_wrappers/README.md
 .. _Mujoco Environment: https://github.com/NVlabs/HOVER/tree/main/neural_wbc/mujoco_wrapper
-.. _Unitree H1 Robot: https://unitree.com/h1
+.. _Unitree H1 Robot: https://www.unitree.com/h1

--- a/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
+++ b/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
@@ -4,7 +4,7 @@ Exporting Policies with LEAPP
 .. currentmodule:: isaaclab
 
 This guide covers how to export trained reinforcement learning policies from Isaac Lab using
-`LEAPP <https://github.com/nvidia-isaac/leapp>`_ (Lightweight Export Annotations for Policy Pipelines).
+`LEAPP <https://github.com/nvidia-isaac/leapp>`__ (Lightweight Export Annotations for Policy Pipelines).
 The main goal of the LEAPP export path is to package the policy together with the input and
 output semantics needed for deployment, so downstream users do not need to reimplement Isaac Lab
 observation preprocessing, action postprocessing, or recurrent-state handling by hand.
@@ -64,7 +64,7 @@ consumers can run the policy without reconstructing observation ordering, comman
 targets, or policy feedback loops themselves.
 
 For a detailed description of LEAPP's generated artifacts and APIs, refer to the
-`LEAPP documentation <https://github.com/nvidia-isaac/leapp/tree/main/docs>`_.
+`LEAPP documentation <https://github.com/nvidia-isaac/leapp/tree/main/docs>`__.
 
 
 Exporting a Policy
@@ -289,6 +289,6 @@ workflow policies are not currently supported by ``scripts/reinforcement_learnin
 Further Reading
 ---------------
 
-- `LEAPP documentation <https://nvidia-isaac.github.io/leapp/>`_
-- `LEAPP API reference <https://nvidia-isaac.github.io/leapp/api/index.html>`_
+- `LEAPP documentation <https://nvidia-isaac.github.io/leapp/>`__
+- `LEAPP API reference <https://nvidia-isaac.github.io/leapp/api/index.html>`__
 - :class:`~envs.LeappDeploymentEnv` API reference

--- a/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
+++ b/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
@@ -289,6 +289,6 @@ workflow policies are not currently supported by ``scripts/reinforcement_learnin
 Further Reading
 ---------------
 
-- `LEAPP documentation <https://github.com/nvidia-isaac/leapp/tree/main/docs>`_
-- `LEAPP API reference <https://github.com/nvidia-isaac/leapp/blob/main/docs/api.md>`_
+- `LEAPP documentation <https://nvidia-isaac.github.io/leapp/>`_
+- `LEAPP API reference <https://nvidia-isaac.github.io/leapp/api/index.html>`_
 - :class:`~envs.LeappDeploymentEnv` API reference

--- a/docs/source/tutorials/00_sim/launch_app.rst
+++ b/docs/source/tutorials/00_sim/launch_app.rst
@@ -178,5 +178,5 @@ For more details on headless mode and launching visualizers, see
 :doc:`/source/migration/migrating_to_isaaclab_3-0`.
 
 
-.. _specification: https://docs.isaacsim.omniverse.nvidia.com/latest/py/source/extensions/isaacsim.simulation_app/docs/index.html#isaacsim.simulation_app.SimulationApp.DEFAULT_LAUNCHER_CONFIG
+.. _specification: https://docs.isaacsim.omniverse.nvidia.com/latest/py/source/extensions/isaacsim.simulation_app/docs/api.html#isaacsim.simulation_app.SimulationApp.DEFAULT_LAUNCHER_CONFIG
 .. _WebRTC Livestreaming: https://docs.isaacsim.omniverse.nvidia.com/latest/installation/manual_livestream_clients.html#isaac-sim-short-webrtc-streaming-client

--- a/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
+++ b/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
@@ -236,6 +236,6 @@ into deployment systems.
 .. note::
 
    Refer to the `LEAPP semantic annotation guide
-   <https://github.com/nvidia-isaac/leapp/blob/main/docs/5_semantic_data_annotation.md>`_
-   and `LEAPP API reference <https://github.com/nvidia-isaac/leapp/blob/main/docs/api.md>`_
+   <https://nvidia-isaac.github.io/leapp/guides/semantics.html>`_
+   and `LEAPP API reference <https://nvidia-isaac.github.io/leapp/api/index.html>`_
    for details on authoring semantic annotations.


### PR DESCRIPTION
# Description

Fix broken docs links due to LEAPP update and IsaacSim update that moved docs around.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there