### PR TITLE
Fix OvPhysX missing runtime error

### DIFF
--- a/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
@@ -87,7 +87,8 @@ You can also install all OV runtime wheels with:
 
 The ``ov[ovphysx]`` selector installs ``source/isaaclab_ovphysx`` with its
 ``[ovphysx]`` extra. If the wheel is missing, OvPhysX-specific tests skip with
-``ovphysx wheel not installed`` and user code fails at import time.
+``ovphysx wheel not installed`` and user code raises an install hint when it
+first imports the runtime-backed modules.
 
 Testing the Installation
 ------------------------

--- a/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-runtime-guard.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-runtime-guard.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Added an actionable install error when the optional ``ovphysx`` runtime wheel
+  is missing from the :mod:`isaaclab_ovphysx` backend.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/_runtime.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/_runtime.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Helpers for loading optional OvPhysX runtime modules."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+_OVPHYSX_INSTALL_MESSAGE = (
+    "The OvPhysX backend requires the optional 'ovphysx' runtime wheel, which is not installed. "
+    "Install it with: ./isaaclab.sh -i 'ov[ovphysx]' "
+    "(or, manually: pip install --extra-index-url https://pypi.nvidia.com "
+    "-e 'source/isaaclab_ovphysx[ovphysx]')."
+)
+
+
+def import_ovphysx(module_name: str = "ovphysx") -> ModuleType:
+    """Import an optional ``ovphysx`` runtime module with an actionable install error.
+
+    Args:
+        module_name: Name of the ``ovphysx`` module to import.
+
+    Returns:
+        The imported runtime module.
+
+    Raises:
+        ModuleNotFoundError: If the optional ``ovphysx`` runtime wheel is not installed.
+    """
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name != "ovphysx":
+            raise
+        raise ModuleNotFoundError(_OVPHYSX_INSTALL_MESSAGE, name="ovphysx") from exc

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -27,6 +27,8 @@ from pxr import UsdPhysics
 from isaaclab.physics import PhysicsEvent, PhysicsManager
 from isaaclab.scene_data import SceneDataBackend, SceneDataFormat
 
+from isaaclab_ovphysx._runtime import import_ovphysx
+
 if TYPE_CHECKING:
     from isaaclab.sim.simulation_context import SimulationContext
 
@@ -627,13 +629,12 @@ class OvPhysxManager(PhysicsManager):
 
         _hidden_pxr = {k: _sys.modules.pop(k) for k in list(_sys.modules) if k == "pxr" or k.startswith("pxr.")}
         try:
-            import ovphysx as _ovphysx_bootstrap
-
+            _ovphysx_bootstrap = import_ovphysx()
             _ovphysx_bootstrap.bootstrap()
         finally:
             _sys.modules.update(_hidden_pxr)
 
-        import ovphysx
+        ovphysx = import_ovphysx()
 
         physx_kwargs = {"device": ovphysx_device}
         physx_signature = inspect.signature(ovphysx.PhysX)

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/tensor_types.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/tensor_types.py
@@ -16,7 +16,9 @@ ovphysx.types is pure Python with zero native dependencies, so this module is
 always safe to import regardless of USD state or native library loading.
 """
 
-from ovphysx.types import TensorType  # noqa: F401 — re-exported for new code
+from isaaclab_ovphysx._runtime import import_ovphysx
+
+TensorType = import_ovphysx("ovphysx.types").TensorType
 
 _TT = TensorType  # shorter reference for alias block
 

--- a/source/isaaclab_ovphysx/test/test_runtime_imports.py
+++ b/source/isaaclab_ovphysx/test/test_runtime_imports.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for optional OvPhysX runtime imports."""
+
+import importlib
+
+import pytest
+from isaaclab_ovphysx._runtime import _OVPHYSX_INSTALL_MESSAGE, import_ovphysx
+
+
+def test_import_ovphysx_reports_install_command_when_runtime_missing(monkeypatch):
+    """Missing root ``ovphysx`` imports raise the Isaac Lab install hint."""
+
+    def import_module_raises_missing_ovphysx(module_name: str):
+        raise ModuleNotFoundError("No module named 'ovphysx'", name="ovphysx")
+
+    monkeypatch.setattr(importlib, "import_module", import_module_raises_missing_ovphysx)
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        import_ovphysx("ovphysx.types")
+
+    assert str(exc_info.value) == _OVPHYSX_INSTALL_MESSAGE
+    assert exc_info.value.name == "ovphysx"
+    assert exc_info.value.__cause__.name == "ovphysx"
+
+
+def test_import_ovphysx_preserves_nested_missing_dependency(monkeypatch):
+    """Missing dependencies inside ``ovphysx`` are not rewritten as install hints."""
+
+    def import_module_raises_missing_dependency(module_name: str):
+        raise ModuleNotFoundError("No module named 'carb'", name="carb")
+
+    monkeypatch.setattr(importlib, "import_module", import_module_raises_missing_dependency)
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        import_ovphysx()
+
+    assert exc_info.value.name == "carb"
+    assert "carb" in str(exc_info.value)


### PR DESCRIPTION
# Description

Adds an OvPhysX runtime import helper so missing optional `ovphysx` wheel failures report the supported install command instead of a raw `No module named ovphysx` error.

This routes `isaaclab_ovphysx.tensor_types` and `OvPhysxManager` bootstrap imports through the helper, preserves nested missing-dependency errors, updates the OvPhysX backend docs, and adds a focused regression test.

Related to #5991.

Fixes: N/A

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Screenshots

N/A

## Validation

- `./isaaclab.sh -p -m pytest source/isaaclab_ovphysx/test/test_runtime_imports.py` -> 2 passed
- `SKIP=check-git-lfs-pointers ./isaaclab.sh -f` -> passed
- `./isaaclab.sh -f` was attempted before commit and before push; it fails only at `check-git-lfs-pointers` because `git-lfs` is not installed in this local environment.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there