### PR TITLE
[Fix] Make create_cube_base_env tutorial run with USD-level randomization

### DIFF
--- a/scripts/tutorials/03_envs/create_cube_base_env.py
+++ b/scripts/tutorials/03_envs/create_cube_base_env.py
@@ -288,7 +288,7 @@ class CubeEnvCfg(ManagerBasedEnvCfg):
     # The flag 'replicate_physics' is set to False, which means that the cube is not replicated
     # across multiple environments but rather each environment gets its own cube instance.
     # This allows modifying the cube's properties independently for each environment.
-    scene: MySceneCfg = MySceneCfg(num_envs=args_cli.num_envs, env_spacing=2.5, replicate_physics=True)
+    scene: MySceneCfg = MySceneCfg(num_envs=args_cli.num_envs, env_spacing=2.5, replicate_physics=False)
 
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()

--- a/source/isaaclab/changelog.d/jichuanh-fix-cube-base-env-replicate-physics.rst
+++ b/source/isaaclab/changelog.d/jichuanh-fix-cube-base-env-replicate-physics.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the ``create_cube_base_env`` tutorial crashing at startup with a ``RuntimeError``
+  because its prestartup USD-level randomization terms ran while scene replication was enabled.


### PR DESCRIPTION
## 1. Summary

* The ``create_cube_base_env`` tutorial crashed at startup with ``RuntimeError: Scene replication is enabled ...`` from the event manager: the scene was constructed with ``replicate_physics=True`` while declaring two ``prestartup`` USD-level randomization terms (``randomize_scale``, ``randomize_color``).
* One-line fix: ``replicate_physics=True`` → ``False`` on the scene cfg — matching the tutorial's docstring and the comment directly above the line, both of which already state it should be ``False``.
* Regression from #4649 (cloner refactor), which flipped this line without updating the comment or accounting for the prestartup guard.

## 2. Verification (Isaac Sim 6.0.0.1, headless)

* Before (``True``): ``RuntimeError`` raised in ``EventManager._prepare_terms``; 0 simulation steps.
* After (``False``): both prestartup terms active; the env runs 64,588 steps with the cube-tracking error converging 63.5 → 0.19.

## 3. Test plan

* [x] Reproduced the crash on develop as-is
* [x] Verified the fix runs the tutorial headless with USD-level randomization active

Refs: NVBug 6269154