### PR TITLE
Point docs to versioned Isaac Teleop web client URL (#5997)

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -41,7 +41,7 @@ input modes, which determine which retargeters and control schemes are available
    * - Meta Quest 3
      - Motion controllers (triggers, thumbsticks, squeeze), hand tracking
      - CloudXR.js WebXR client (browser)
-     - `CloudXR client <https://nvidia.github.io/IsaacTeleop/client>`__; see :ref:`connection guide <connect-quest-pico>`
+     - `CloudXR client <https://nvidia.github.io/IsaacTeleop/client/release-1.3.x>`__; see :ref:`connection guide <connect-quest-pico>`
    * - Pico 4 Ultra
      - Motion controllers, hand tracking
      - CloudXR.js WebXR client (browser)

--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -213,7 +213,14 @@ choose the tab that matches your hardware.
          start automatically.
 
       #. Open the browser on your headset and navigate to the hosted CloudXR.js client:
-         `<https://nvidia.github.io/IsaacTeleop/client>`_.
+         `<https://nvidia.github.io/IsaacTeleop/client/release-1.3.x>`_.
+
+         .. note::
+
+            The web client URL is versioned. The ``release-1.3.x`` path corresponds to the
+            Isaac Teleop version Isaac Lab is pinned to (``isaacteleop~=1.3.0`` in
+            ``source/isaaclab_teleop/pyproject.toml``). When Isaac Lab bumps its Isaac Teleop
+            pin, update this link to the matching client release.
 
          .. tip::
 

--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -219,7 +219,7 @@ choose the tab that matches your hardware.
 
             The web client URL is versioned. The ``release-1.3.x`` path corresponds to the
             Isaac Teleop version Isaac Lab is pinned to (``isaacteleop~=1.3.0`` in
-            ``source/isaaclab_teleop/pyproject.toml``). When Isaac Lab bumps its Isaac Teleop
+            ``source/isaaclab_teleop/setup.py``). When Isaac Lab bumps its Isaac Teleop
             pin, update this link to the matching client release.
 
          .. tip::


### PR DESCRIPTION
# Description

Backport of #5997 to `release/3.0.0-beta2` (cherry-pick of commit `c11f9a89127`).
- Update the CloudXR.js web client links in the docs from the unversioned
  `nvidia.github.io/IsaacTeleop/client` to the versioned
  `nvidia.github.io/IsaacTeleop/client/release-1.3.x`.
- Add a note in the CloudXR teleoperation how-to clarifying that the client URL
  is versioned and tracks the Isaac Teleop pin in Isaac Lab
  (`isaacteleop~=1.3.0` in `source/isaaclab_teleop/pyproject.toml`), with a
  reminder to bump the link whenever the pin changes.

Fixes # (issue)

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there