### PR TITLE
[Fix] Allow USD-level randomization with replicate_physics=True

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-remove-stale-usd-randomization-guards.rst
+++ b/source/isaaclab/changelog.d/jichuanh-remove-stale-usd-randomization-guards.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Removed the ``replicate_physics`` guards that raised ``RuntimeError`` on USD-level randomization
+  (scale, visual color, and visual texture) in :class:`~isaaclab.managers.EventManager` and the
+  ``randomize_*`` event functions. The Isaac Lab cloner now replicates per-object when environments
+  differ, so prestartup USD randomization is preserved per-environment with ``replicate_physics=True``.

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -67,9 +67,9 @@ def randomize_rigid_body_scale(
         event mode named "usd". Using it at simulation time, may lead to unpredictable behaviors.
 
     .. note::
-        When randomizing the scale of individual assets, please make sure to set
-        :attr:`isaaclab.scene.InteractiveSceneCfg.replicate_physics` to False. This ensures that physics
-        parser will parse the individual asset properties separately.
+        The Isaac Lab cloner replicates per-object when environments differ, so per-environment scales
+        are parsed individually by the physics engine regardless of the
+        :attr:`isaaclab.scene.InteractiveSceneCfg.replicate_physics` setting.
     """
     # check if sim is running
     if env.sim.is_playing():
@@ -2115,9 +2115,9 @@ class randomize_visual_texture_material(ManagerTermBase):
         from the asset converters in Isaac Lab.
 
     .. note::
-        When randomizing the texture of individual assets, please make sure to set
-        :attr:`isaaclab.scene.InteractiveSceneCfg.replicate_physics` to False. This ensures that physics
-        parser will parse the individual asset properties separately.
+        The Isaac Lab cloner replicates per-object when environments differ, so per-environment USD
+        material edits are preserved regardless of the
+        :attr:`isaaclab.scene.InteractiveSceneCfg.replicate_physics` setting.
     """
 
     def __init__(self, cfg: EventTermCfg, env: ManagerBasedEnv):
@@ -2128,16 +2128,6 @@ class randomize_visual_texture_material(ManagerTermBase):
             env: The environment instance.
         """
         super().__init__(cfg, env)
-
-        # check to make sure replicate_physics is set to False, else raise error
-        # note: We add an explicit check here since texture randomization can happen outside of 'prestartup' mode
-        #   and the event manager doesn't check in that case.
-        if env.cfg.scene.replicate_physics:
-            raise RuntimeError(
-                "Unable to randomize visual texture material with scene replication enabled."
-                " For stable USD-level randomization, please disable scene replication"
-                " by setting 'replicate_physics' to False in 'InteractiveSceneCfg'."
-            )
 
         # enable replicator extension if not already enabled (local: isaacsim only available with Kit)
         from isaacsim.core.experimental.utils.app import enable_extension  # noqa: PLC0415
@@ -2296,9 +2286,9 @@ class randomize_visual_color(ManagerTermBase):
     If a dictionary is used, the function will sample random colors from the given ranges.
 
     .. note::
-        When randomizing the color of individual assets, please make sure to set
-        :attr:`isaaclab.scene.InteractiveSceneCfg.replicate_physics` to False. This ensures that physics
-        parser will parse the individual asset properties separately.
+        The Isaac Lab cloner replicates per-object when environments differ, so per-environment USD
+        material edits are preserved regardless of the
+        :attr:`isaaclab.scene.InteractiveSceneCfg.replicate_physics` setting.
     """
 
     def __init__(self, cfg: EventTermCfg, env: ManagerBasedEnv):
@@ -2320,16 +2310,6 @@ class randomize_visual_color(ManagerTermBase):
         # read parameters from the configuration
         asset_cfg: SceneEntityCfg = cfg.params.get("asset_cfg")
         mesh_name: str = cfg.params.get("mesh_name", "")  # type: ignore
-
-        # check to make sure replicate_physics is set to False, else raise error
-        # note: We add an explicit check here since texture randomization can happen outside of 'prestartup' mode
-        #   and the event manager doesn't check in that case.
-        if env.cfg.scene.replicate_physics:
-            raise RuntimeError(
-                "Unable to randomize visual color with scene replication enabled."
-                " For stable USD-level randomization, please disable scene replication"
-                " by setting 'replicate_physics' to False in 'InteractiveSceneCfg'."
-            )
 
         # obtain the asset entity
         asset = env.scene[asset_cfg.name]

--- a/source/isaaclab/isaaclab/managers/event_manager.py
+++ b/source/isaaclab/isaaclab/managers/event_manager.py
@@ -374,16 +374,6 @@ class EventManager(ManagerBase):
             # resolve common parameters
             self._resolve_common_term_cfg(term_name, term_cfg, min_argc=2)
 
-            # check if mode is pre-startup and scene replication is enabled
-            if term_cfg.mode == "prestartup" and self._env.scene.cfg.replicate_physics:
-                raise RuntimeError(
-                    "Scene replication is enabled, which may affect USD-level randomization."
-                    " When assets are replicated, their properties are shared across instances,"
-                    " potentially leading to unintended behavior."
-                    " For stable USD-level randomization, please disable scene replication"
-                    " by setting 'replicate_physics' to False in 'InteractiveSceneCfg'."
-                )
-
             # for event terms with mode "prestartup", we assume a callable class term
             # can be initialized before the simulation starts.
             # this is done to ensure that the USD-level randomization is possible before the simulation starts.

--- a/source/isaaclab/test/envs/test_scale_randomization.py
+++ b/source/isaaclab/test/envs/test_scale_randomization.py
@@ -336,15 +336,31 @@ def test_scale_randomization(device):
     env.close()
 
 
-def test_scale_randomization_failure_replicate_physics():
-    """Test scale randomization failure when replicate physics is set to True."""
+def test_scale_randomization_with_replicate_physics():
+    """Scale randomization stays per-environment with replicate_physics=True.
+
+    The Isaac Lab cloner replicates per-object when environments differ, so the per-environment
+    USD scales are preserved (and parsed individually by the physics engine).
+    """
     # create a new stage
     sim_utils.create_new_stage()
     # set the arguments
-    cfg_failure = CubeEnvCfg()
-    cfg_failure.scene.replicate_physics = True
+    env_cfg = CubeEnvCfg()
+    env_cfg.scene.replicate_physics = True
 
-    # run the test
-    with pytest.raises(RuntimeError):
-        env = ManagerBasedEnv(cfg_failure)
-        env.close()
+    # building the environment must not raise
+    env = ManagerBasedEnv(cfg=env_cfg)
+
+    # the randomized scales must still be distinct across environments
+    applied_scaling_randomization = set()
+    prim_paths = sim_utils.find_matching_prim_paths("/World/envs/env_.*/cube1")
+    stage = sim_utils.get_current_stage()
+    for i in range(3):
+        prim_spec = Sdf.CreatePrimInLayer(stage.GetRootLayer(), prim_paths[i])
+        scale_spec = prim_spec.GetAttributeAtPath(prim_paths[i] + ".xformOp:scale")
+        assert scale_spec.default not in applied_scaling_randomization, (
+            "Detected repeat in applied scale values - scaling randomization is not per-environment."
+        )
+        applied_scaling_randomization.add(scale_spec.default)
+
+    env.close()

--- a/source/isaaclab/test/envs/test_texture_randomization.py
+++ b/source/isaaclab/test/envs/test_texture_randomization.py
@@ -214,21 +214,24 @@ def test_texture_randomization(device):
         sim_utils.close_stage()
 
 
-def test_texture_randomization_failure_replicate_physics():
-    """Test texture randomization failure when replicate physics is set to True."""
+def test_texture_randomization_with_replicate_physics():
+    """Texture randomization works with replicate_physics=True.
+
+    The Isaac Lab cloner replicates per-object when environments differ, so per-environment USD
+    material edits are preserved and building the environment must not raise.
+    """
     # Create a new stage
     sim_utils.create_new_stage()
 
     try:
         # Set the arguments
-        cfg_failure = CartpoleEnvCfg()
-        cfg_failure.scene.num_envs = 16
-        cfg_failure.scene.replicate_physics = True
+        env_cfg = CartpoleEnvCfg()
+        env_cfg.scene.num_envs = 16
+        env_cfg.scene.replicate_physics = True
 
-        # Test that creating the environment raises RuntimeError
-        with pytest.raises(RuntimeError):
-            env = ManagerBasedEnv(cfg_failure)
-            env.close()
+        # building the environment must not raise
+        env = ManagerBasedEnv(env_cfg)
+        env.close()
     finally:
         # Clean up stage
         sim_utils.close_stage()


### PR DESCRIPTION
## 1. Summary

* USD-level randomization (scale / visual color / visual texture) raised ``RuntimeError`` whenever ``replicate_physics=True``, blocking it outright — this is what crashes the ``create_cube_base_env`` tutorial (NVBug 6269154).
* The guard's premise ("replicated assets share properties across instances") no longer holds after the cloner refactor in #4649: the Isaac Lab cloner replicates per-object when environments differ, so per-environment USD edits are preserved.
* Removes the obsolete guards (the prestartup check in :class:`~isaaclab.managers.EventManager` and the per-function checks in ``randomize_visual_color`` / ``randomize_visual_texture``), updates docstrings, and converts the two ``_failure_replicate_physics`` tests into positive tests.

## 2. Verification (Isaac Sim 6.0.0.1, guards removed, ``replicate_physics=True``)

* **color** (visual, backend-agnostic) — 196 distinct per-env ``diffuse_color_constant`` values; replicator finds per-env prims and de-instances them.
* **texture** (visual, backend-agnostic) — ``num_prims == num_envs``, de-instanced, per-prim materials, runs clean.
* **scale, PhysX** — physics-correct per-env: free cubes under gravity rest at ``rest_z = 0.1 × scale_z`` for every env (constant ratio), identical to ``replicate_physics=False``.

## 3. Backend caveat — Newton/MJWarp scale (pre-existing, out of scope)

* Under the Newton backend, ``randomize_rigid_body_scale`` does **not** reach the collision geometry in **either** ``replicate_physics`` mode: per-env resting heights are uniform (``rest_z`` constant) despite distinct authored USD scales. So Newton ignores per-env ``xformOp:scale`` independent of this guard.
* This means the guard never protected the Newton scale path (``False`` is equally affected), so removing it does not regress Newton; color/texture still work on Newton (they are USD/replicator visual edits, independent of the physics backend).
* The Newton scale-randomization gap is a separate issue worth a dedicated fix/ticket; flagging it here for visibility.

## 4. Tests

* ``test_{scale,color,texture}_randomization`` (``replicate_physics=False``): still pass.
* ``test_scale_randomization_with_replicate_physics`` (new): per-env scales stay distinct with ``True``.
* ``test_texture_randomization_with_replicate_physics`` (new): env builds with ``True``.

## 5. Relationship to other PRs

* #5996 sets the tutorial's ``replicate_physics=False`` as the immediate low-risk fix for NVBug 6269154. This PR removes the underlying stale guards. Complementary.

## 6. Notes for reviewers

* Behavioral-contract change (the guards previously hard-raised). Flagging @kellyguo11 and @ooctipus (#4649 cloner author) — please confirm per-object replication is the intended supported path, and weigh in on the Newton scale gap in §3.

Refs: NVBug 6269154