### PR TITLE
[Fix] Make create_cube_base_env tutorial run with USD-level randomization (#5996)

### DIFF
--- a/scripts/tutorials/03_envs/create_cube_base_env.py
+++ b/scripts/tutorials/03_envs/create_cube_base_env.py
@@ -288,7 +288,7 @@ class CubeEnvCfg(ManagerBasedEnvCfg):
     # The flag 'replicate_physics' is set to False, which means that the cube is not replicated
     # across multiple environments but rather each environment gets its own cube instance.
     # This allows modifying the cube's properties independently for each environment.
-    scene: MySceneCfg = MySceneCfg(num_envs=args_cli.num_envs, env_spacing=2.5, replicate_physics=True)
+    scene: MySceneCfg = MySceneCfg(num_envs=args_cli.num_envs, env_spacing=2.5, replicate_physics=False)
 
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()

--- a/source/isaaclab/changelog.d/jichuanh-fix-cube-base-env-replicate-physics.rst
+++ b/source/isaaclab/changelog.d/jichuanh-fix-cube-base-env-replicate-physics.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the ``create_cube_base_env`` tutorial crashing at startup with a ``RuntimeError``
+  because its prestartup USD-level randomization terms ran while scene replication was enabled.


### PR DESCRIPTION
Cherry-pick of #5996 into release/3.0.0-beta2.

The create_cube_base_env tutorial set replicate_physics=True while declaring prestartup USD-level randomization terms, crashing at startup with "RuntimeError: Scene replication is enabled ...". One-line fix sets replicate_physics=False, matching the tutorial docstring and the comment directly above the line.

The regression (#4649 cloner refactor) is present on release/3.0.0-beta2 (line 291), so beta2 needs this fix.

Original PR (develop): https://github.com/isaac-sim/IsaacLab/pull/5996
Refs: NVBug 6269154
