### PR TITLE
Fix Newton mesh approximation import controls

### DIFF
--- a/source/isaaclab/changelog.d/fix-nested-mesh-collision-cfg.rst
+++ b/source/isaaclab/changelog.d/fix-nested-mesh-collision-cfg.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Added the missing nested mesh-collision property field to collision configs so
+  authored mesh approximation settings can be dispatched through collision props.

--- a/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
@@ -301,6 +301,15 @@ class CollisionBaseCfg:
     attribute via its PhysX-bridge resolver.
     """
 
+    mesh_collision_property: MeshCollisionBaseCfg | None = None
+    """Optional mesh-collision approximation to author on this collider.
+
+    When set, it is dispatched to :meth:`~isaaclab.sim.schemas.modify_mesh_collision_properties`
+    so the ``physics:approximation`` token and backend mesh-collision tuning are written on the collision mesh
+    prim. Use this to override a file-spawned USD asset's authored collision approximation, for example convex
+    hull or convex decomposition. ``None`` leaves the USD-authored approximation untouched.
+    """
+
 
 @configclass
 class MassPropertiesCfg:

--- a/source/isaaclab_newton/changelog.d/fix-newton-mesh-approximation.rst
+++ b/source/isaaclab_newton/changelog.d/fix-newton-mesh-approximation.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Updated Newton replication to honor per-collider mesh approximation tokens
+  instead of approximating every imported mesh as a convex hull.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_replicate.py
@@ -37,7 +37,9 @@ def _build_newton_builder_from_mapping(
         positions: Optional per-environment world positions.
         quaternions: Optional per-environment orientations in xyzw order.
         up_axis: Up axis for the Newton model builder.
-        simplify_meshes: Whether to run convex-hull mesh approximation.
+        simplify_meshes: Whether to honor per-shape ``physics:approximation`` tokens
+            authored on colliders during import. SDF colliders are never approximated
+            regardless of this flag.
 
     Returns:
         Tuple of the populated Newton model builder, stage metadata returned
@@ -85,16 +87,17 @@ def _build_newton_builder_from_mapping(
     for src_path in sources:
         p = NewtonManager.create_builder(up_axis=up_axis)
         solvers.SolverMuJoCo.register_custom_attributes(p)
+        # Honor per-shape ``physics:approximation`` tokens so callers can opt
+        # individual mesh colliders into convex-hull or decomposition handling while
+        # leaving SDF and primitive colliders untouched.
         p.add_usd(
             stage,
             root_path=src_path,
             load_visual_shapes=True,
-            skip_mesh_approximation=True,
+            skip_mesh_approximation=not simplify_meshes,
             schema_resolvers=schema_resolvers,
             ignore_paths=_deformable_ignore_paths if _deformable_ignore_paths else None,
         )
-        if simplify_meshes:
-            p.approximate_meshes("convex_hull", keep_visual_shapes=True)
         protos[src_path] = p
 
     # Inject registered sites into prototypes (and global sites into main builder)
@@ -286,7 +289,9 @@ def newton_physics_replicate(
         quaternions: Optional per-environment orientations in xyzw order.
         device: Device used by the finalized Newton model builder.
         up_axis: Up axis for the Newton model builder.
-        simplify_meshes: Whether to run convex-hull mesh approximation.
+        simplify_meshes: Whether to honor per-shape ``physics:approximation`` tokens
+            authored on colliders during import. SDF colliders are never approximated
+            regardless of this flag.
 
     Returns:
         Tuple of the populated Newton model builder and stage metadata.
@@ -344,7 +349,9 @@ def newton_visualizer_prebuild(
         quaternions: Optional per-environment orientations in xyzw order.
         device: Device used by the finalized Newton model.
         up_axis: Up axis for the Newton model builder.
-        simplify_meshes: Whether to run convex-hull mesh approximation.
+        simplify_meshes: Whether to honor per-shape ``physics:approximation`` tokens
+            authored on colliders during import. SDF colliders are never approximated
+            regardless of this flag.
 
     Returns:
         Tuple of finalized Newton model and state.

--- a/source/isaaclab_newton/test/sim/test_newton_schemas.py
+++ b/source/isaaclab_newton/test/sim/test_newton_schemas.py
@@ -232,6 +232,26 @@ def test_newton_mesh_collision_no_schema_when_none(setup_sim):
     assert "NewtonMeshCollisionAPI" not in applied
 
 
+@pytest.mark.isaacsim_ci
+def test_newton_mesh_collision_nested_cfg_written(setup_sim):
+    """Nested mesh-collision cfgs must be accepted by base collision cfgs and dispatched."""
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim("/World/mesh_nested", prim_type="Cube", translation=(5.5, 0.0, 0.5))
+    schemas.define_collision_properties(
+        "/World/mesh_nested",
+        NewtonCollisionPropertiesCfg(
+            mesh_collision_property=NewtonMeshCollisionPropertiesCfg(
+                mesh_approximation_name="convexHull",
+                max_hull_vertices=24,
+            ),
+        ),
+    )
+    prim = stage.GetPrimAtPath("/World/mesh_nested")
+    assert prim.GetAttribute("physics:approximation").Get() == "convexHull"
+    assert prim.GetAttribute("newton:maxHullVertices").Get() == 24
+    assert "NewtonMeshCollisionAPI" in prim.GetAppliedSchemas()
+
+
 # ---------------------------------------------------------------------------
 # Newton SDF collision
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add the missing nested mesh-collision property field to collision configs so collision props can dispatch authored mesh approximation settings
- update Newton replication to honor per-collider `physics:approximation` tokens instead of approximating every imported mesh as a convex hull
- add a Newton schema regression test for nested mesh-collision config dispatch

## Tests
- `git diff --cached --check` before commit
- syntax parsed modified Python files with `ast.parse`
- Not run: `./isaaclab.sh -p -m pytest source/isaaclab_newton/test/sim/test_newton_schemas.py -k test_newton_mesh_collision_nested_cfg_written -q` cannot collect locally because Python is missing `lazy_loader`