### PR TITLE
Guard set_merge_fixed_ignore_inertia for Isaac Sim version compatibility

### DIFF
--- a/source/isaaclab/isaaclab/sim/converters/urdf_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/urdf_converter.py
@@ -140,7 +140,8 @@ class UrdfConverter(AssetConverterBase):
         import_config.set_collision_from_visuals(self.cfg.collision_from_visuals)
         # consolidating links that are connected by fixed joints
         import_config.set_merge_fixed_joints(self.cfg.merge_fixed_joints)
-        import_config.set_merge_fixed_ignore_inertia(self.cfg.merge_fixed_joints)
+        if hasattr(import_config, "set_merge_fixed_ignore_inertia"):
+            import_config.set_merge_fixed_ignore_inertia(self.cfg.merge_fixed_joints)
         # -- physics settings
         # create fix joint for base link
         import_config.set_fix_base(self.cfg.fix_base)


### PR DESCRIPTION
## Description

`UrdfConverter._convert_asset` unconditionally calls
`import_config.set_merge_fixed_ignore_inertia(...)`. This method is **not present on
every Isaac Sim URDF importer version**, so importing a URDF raises

```
AttributeError: 'ImportConfig' object has no attribute 'set_merge_fixed_ignore_inertia'
```

on those builds, breaking asset conversion.

## Fix

Call the setter only when it exists:

```python
import_config.set_merge_fixed_joints(self.cfg.merge_fixed_joints)
if hasattr(import_config, "set_merge_fixed_ignore_inertia"):
    import_config.set_merge_fixed_ignore_inertia(self.cfg.merge_fixed_joints)
```

When the setter is absent, the importer behavior matches its default, so guarding the
call is safe and restores URDF import across Isaac Sim versions.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have signed off all commits (DCO)
- [ ] I have updated the changelog / docs as needed