### PR TITLE
Fix termination manager reset comments

### DIFF
--- a/source/isaaclab/isaaclab/managers/termination_manager.py
+++ b/source/isaaclab/isaaclab/managers/termination_manager.py
@@ -127,14 +127,14 @@ class TerminationManager(ManagerBase):
     """
 
     def reset(self, env_ids: Sequence[int] | None = None) -> dict[str, torch.Tensor]:
-        """Returns the episodic counts of individual termination terms.
+        """Returns the per-term mean activation across environments.
 
         Args:
             env_ids: The environment ids. Defaults to None, in which case
                 all environments are considered.
 
         Returns:
-            Dictionary of episodic sum of individual reward terms.
+            Dictionary mapping each termination term to its mean activation.
         """
         # resolve environment ids
         if env_ids is None:
@@ -145,7 +145,7 @@ class TerminationManager(ManagerBase):
         for i, key in enumerate(self._term_names):
             # store information
             extras["Episode_Termination/" + key] = last_episode_done_stats[i].item()
-        # reset all the reward terms
+        # reset all the termination terms
         for term_cfg in self._class_term_cfgs:
             term_cfg.func.reset(env_ids=env_ids)
         # return logged information


### PR DESCRIPTION
# Description

Corrects stale terminology in `TerminationManager.reset()` while preserving the original documentation fix:

- Replaces the stale references to reward terms with termination terms.
- Clarifies that the logged per-term metric is a mean activation across environments, rather than an episodic sum or count.

## Type of change

- Documentation update

## Validation

- `./isaaclab.sh -f`
- `git diff --check`