### PR TITLE
Fix docs build for CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -49,15 +49,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Setup python
-      uses: actions/setup-python@v5
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
-        architecture: x64
 
     - name: Install dev requirements
-      working-directory: ./docs
-      run: pip install -r requirements.txt
+      run: |
+        uv venv
+        uv pip install -r docs/requirements.txt
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
     - name: Build current version docs
       working-directory: ./docs
@@ -80,15 +81,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Setup python
-      uses: actions/setup-python@v5
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
-        architecture: x64
 
     - name: Install dev requirements
-      working-directory: ./docs
-      run: pip install -r requirements.txt
+      run: |
+        uv venv
+        uv pip install -r docs/requirements.txt
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
     - name: Generate multi-version docs
       working-directory: ./docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,10 +10,10 @@ BUILDDIR      = _build
 
 .PHONY: multi-docs
 multi-docs:
-	@sphinx-multiversion "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	@sphinx-multiversion "$(SOURCEDIR)" "$(BUILDDIR)" -j auto $(SPHINXOPTS)
 	@cp _redirect/index.html $(BUILDDIR)/index.html
 
 .PHONY: current-docs
 current-docs:
 	@rm -rf "$(BUILDDIR)/current"
-	@$(SPHINXBUILD) -W --keep-going "$(SOURCEDIR)" "$(BUILDDIR)/current" $(SPHINXOPTS)
+	@$(SPHINXBUILD) -W --keep-going -j auto "$(SOURCEDIR)" "$(BUILDDIR)/current" $(SPHINXOPTS)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,6 +90,7 @@ extensions = [
     "sphinxcontrib.icon",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx_paramlinks",
     "sphinx_tabs.tabs",  # backwards compatibility for building docs on v1.0.0
     "sphinx_multiversion",
     "isaaclab_docs",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,7 @@ autodocsumm
 sphinx-copybutton
 sphinx-icon
 sphinx_design
+sphinx-paramlinks
 sphinxemoji
 sphinx-tabs # backwards compatibility for building docs on v1.0.0
 sphinx-multiversion==0.2.4


### PR DESCRIPTION
# Description

Fix failing docs build due to missing build requirement.

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
