### PR TITLE
Fix multidoc build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ BUILDDIR      = _build
 
 .PHONY: multi-docs
 multi-docs:
-	@sphinx-multiversion "$(SOURCEDIR)" "$(BUILDDIR)" -j auto $(SPHINXOPTS)
+	@sphinx-multiversion "$(SOURCEDIR)" "$(BUILDDIR)" --jobs=auto $(SPHINXOPTS)
 	@cp _redirect/index.html $(BUILDDIR)/index.html
 
 .PHONY: current-docs


### PR DESCRIPTION
# Description

Fix the multi-doc build, the new -j argument is not getting parsed correctly.


## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there