### PR TITLE
docs: clarify preserve_order descriptions and fix comma typo in string utils

### DIFF
--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -290,7 +290,7 @@ def resolve_matching_names_values(
     appear first, then those matching the second key, and so on).
 
     For example, consider the dictionary is {"a|d|e": 1, "b|c": 2}, the list of strings is ['a', 'b', 'c', 'd', 'e'].
-    If :attr:`preserve_order` is False, then the function will return the indices of the matched strings and the values as: ([0, 1, 2, 3, 4], ['a', 'b', 'c', 'd', 'e'], [1, 2, 2, 1, 1]). When
+    If :attr:`preserve_order` is False, then the function will return the matched indices, names, and values as: ([0, 1, 2, 3, 4], ['a', 'b', 'c', 'd', 'e'], [1, 2, 2, 1, 1]). When
     :attr:`preserve_order` is True, it will return them as:
     ([0, 3, 4, 1, 2], ['a', 'd', 'e', 'b', 'c'], [1, 1, 1, 2, 2]).
 

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -183,12 +183,13 @@ def resolve_matching_names(
     When a list of query regular expressions is provided, the function checks each target string against each
     query regular expression and returns the indices of the matched strings and the matched strings.
 
-    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
-    of the provided list of strings. This means that the ordering is dictated by the order of the target strings
-    and not the order of the query regular expressions.
+    If :attr:`preserve_order` is False, the matched indices and names are returned in the iteration order
+    of the provided list of strings (the results appear in the order of the target strings,
+    not the order of the query regular expressions).
 
-    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
-    of the provided list of query regular expressions.
+    If :attr:`preserve_order` is True, the matched indices and names are reordered to follow the order
+    of the provided list of query regular expressions (all strings matching the first regex key
+    appear first, then those matching the second key, and so on).
 
     For example, consider the list of strings is ['a', 'b', 'c', 'd', 'e'] and the regular expressions are ['a|c', 'b'].
     If :attr:`preserve_order` is False, then the function will return the indices of the matched strings and the
@@ -280,16 +281,16 @@ def resolve_matching_names_values(
     """Match a list of regular expressions in a dictionary against a list of strings and return
     the matched indices, names, and values.
 
-    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
-    of the provided list of strings. This means that the ordering is dictated by the order of the target strings
-    and not the order of the query regular expressions.
+    If :attr:`preserve_order` is False, the matched indices and names are returned in the iteration order
+    of the provided list of strings (the results appear in the order of the target strings,
+    not the order of the query regular expressions).
 
-    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
-    of the provided list of query regular expressions.
+    If :attr:`preserve_order` is True, the matched indices and names are reordered to follow the order
+    of the provided list of query regular expressions (all strings matching the first regex key
+    appear first, then those matching the second key, and so on).
 
     For example, consider the dictionary is {"a|d|e": 1, "b|c": 2}, the list of strings is ['a', 'b', 'c', 'd', 'e'].
-    If :attr:`preserve_order` is False, then the function will return the indices of the matched strings, the
-    matched strings, and the values as: ([0, 1, 2, 3, 4], ['a', 'b', 'c', 'd', 'e'], [1, 2, 2, 1, 1]). When
+    If :attr:`preserve_order` is False, then the function will return the indices of the matched strings and the values as: ([0, 1, 2, 3, 4], ['a', 'b', 'c', 'd', 'e'], [1, 2, 2, 1, 1]). When
     :attr:`preserve_order` is True, it will return them as:
     ([0, 3, 4, 1, 2], ['a', 'd', 'e', 'b', 'c'], [1, 1, 1, 2, 2]).
 


### PR DESCRIPTION
## Summary

- Clarified the `preserve_order` parameter descriptions in `resolve_matching_names` and `resolve_matching_names_values`
- The original wording ("the ordering is the same as the order of") could be misread as describing the opposite behavior
- Changed to explicit language: False = iteration order of target strings, True = reordered to follow query key order
- Fixed a redundant phrase in the second function's docstring example text

Fixes #4493

## Test Plan

- [ ] Docstrings now clearly describe the actual function behavior shown by the existing examples
- [ ] No code logic changes — documentation only