### PR TITLE
Bumps versions for released Isaac Sim 6.0 and Newton 1.2.1 (#6015)

### DIFF
--- a/.github/workflows/license-exceptions.json
+++ b/.github/workflows/license-exceptions.json
@@ -470,7 +470,7 @@
   },
   {
     "package": "typing_extensions",
-    "license": "PSF-2.0",
+    "license": "Python Software Foundation License",
     "comment": "PSF-2.0 / OSRB"
   },
   {

--- a/apps/isaaclab.python.headless.kit
+++ b/apps/isaaclab.python.headless.kit
@@ -210,6 +210,6 @@ enabled=true # Enable this for DLSS
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"

--- a/apps/isaaclab.python.headless.rendering.kit
+++ b/apps/isaaclab.python.headless.rendering.kit
@@ -160,6 +160,6 @@ UJITSO.enabled = true
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"

--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -306,6 +306,6 @@ fabricUseGPUInterop = true
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"

--- a/apps/isaaclab.python.rendering.kit
+++ b/apps/isaaclab.python.rendering.kit
@@ -143,6 +143,6 @@ UJITSO.enabled = true
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"

--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -70,6 +70,6 @@ UJITSO.geometry = true
 UJITSO.enabled = true
 
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"

--- a/apps/isaaclab.python.xr.openxr.kit
+++ b/apps/isaaclab.python.xr.openxr.kit
@@ -97,6 +97,6 @@ UJITSO.enabled = true
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0"

--- a/docs/_extensions/isaaclab_docs.py
+++ b/docs/_extensions/isaaclab_docs.py
@@ -160,7 +160,7 @@ def _quickstart_isaacsim(branch: str, platform: str) -> str:
    uv venv --python 3.12 --seed env_isaaclab
    source env_isaaclab/bin/activate
    uv pip install --upgrade pip
-   uv pip install "isaacsim[all,extscache]==6.0.0" \\
+   uv pip install "isaacsim[all,extscache]==6.0.0.1" \\
      --extra-index-url https://pypi.nvidia.com \\
      --index-strategy unsafe-best-match --prerelease=allow
    uv pip install -U torch==2.10.0 torchvision==0.25.0 \\
@@ -178,7 +178,7 @@ def _quickstart_isaacsim(branch: str, platform: str) -> str:
    uv venv --python 3.12 --seed env_isaaclab
    env_isaaclab\\Scripts\\activate
    uv pip install --upgrade pip
-   uv pip install "isaacsim[all,extscache]==6.0.0" ^
+   uv pip install "isaacsim[all,extscache]==6.0.0.1" ^
      --extra-index-url https://pypi.nvidia.com ^
      --index-strategy unsafe-best-match --prerelease=allow
    uv pip install -U torch==2.10.0 torchvision==0.25.0 ^

--- a/docs/source/overview/core-concepts/physical-backends/newton/installation.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/installation.rst
@@ -53,7 +53,7 @@ Ensure pip is up to date:
 
 .. code-block:: bash
 
-    uv pip install "isaacsim[all,extscache]==6.0.0" --extra-index-url https://pypi.nvidia.com --index-strategy unsafe-best-match --prerelease=allow
+    uv pip install "isaacsim[all,extscache]==6.0.0.1" --extra-index-url https://pypi.nvidia.com --index-strategy unsafe-best-match --prerelease=allow
 
 Install the correct version of torch and torchvision:
 

--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -482,10 +482,12 @@ Environments based on legged locomotion tasks.
     +------------------------------+----------------------------------------------+------------------------------------------------------------------------------+------------------------------+
     | |velocity-flat-anymal-c|     | |velocity-flat-anymal-c-link|                | Track a velocity command on flat terrain with the Anymal C robot             | **physics=** ``physx``,      |
     |                              |                                              |                                                                              | ``newton_mjwarp``            |
+    |                              |                                              |                                                                              | (Manager-based only)         |
     |                              | |velocity-flat-anymal-c-direct-link|         |                                                                              |                              |
     +------------------------------+----------------------------------------------+------------------------------------------------------------------------------+------------------------------+
     | |velocity-rough-anymal-c|    | |velocity-rough-anymal-c-link|               | Track a velocity command on rough terrain with the Anymal C robot            | **physics=** ``physx``,      |
     |                              |                                              |                                                                              | ``newton_mjwarp``            |
+    |                              |                                              |                                                                              | (Manager-based only)         |
     |                              | |velocity-rough-anymal-c-direct-link|        |                                                                              |                              |
     +------------------------------+----------------------------------------------+------------------------------------------------------------------------------+------------------------------+
     | |velocity-flat-anymal-d|     | |velocity-flat-anymal-d-link|                | Track a velocity command on flat terrain with the Anymal D robot             | **physics=** ``physx``,      |

--- a/docs/source/overview/imitation-learning/humanoids_imitation.rst
+++ b/docs/source/overview/imitation-learning/humanoids_imitation.rst
@@ -162,7 +162,7 @@ Generate the dataset
 ^^^^^^^^^^^^^^^^^^^^
 
 If you skipped the prior collection and annotation step, download the pre-recorded annotated dataset ``dataset_annotated_gr1.hdf5`` from
-here: `[Annotated GR1 Dataset] <https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/pick_place_datasets/dataset_annotated_gr1.hdf5>`_.
+here: `[Annotated GR1 Dataset] <https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/pick_place_datasets/dataset_annotated_gr1.hdf5>`_.
 Place the file under ``IsaacLab/datasets`` and run the following command to generate a new dataset with 1000 demonstrations.
 
 .. code:: bash
@@ -250,7 +250,7 @@ Demo 2: Visuomotor Policy for a Humanoid Robot
 Download the Dataset
 ^^^^^^^^^^^^^^^^^^^^
 
-Download the pre-generated dataset from `here <https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/pick_place_datasets/generated_dataset_gr1_nut_pouring.hdf5>`__ and place it under ``IsaacLab/datasets/generated_dataset_gr1_nut_pouring.hdf5``
+Download the pre-generated dataset from `here <https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/pick_place_datasets/generated_dataset_gr1_nut_pouring.hdf5>`__ and place it under ``IsaacLab/datasets/generated_dataset_gr1_nut_pouring.hdf5``
 (**Note: The dataset size is approximately 15GB**). The dataset contains 1000 demonstrations of a humanoid robot performing a pouring/placing task that was
 generated using Isaac Lab Mimic for the ``Isaac-NutPour-GR1T2-Pink-IK-Abs-Mimic-v0`` task.
 
@@ -467,7 +467,7 @@ Follow the same data collection, annotation, and generation process as demonstra
 
 
 If you skipped the prior collection and annotation step, download the pre-recorded annotated dataset ``dataset_annotated_g1_locomanip.hdf5`` from
-here: `[Annotated G1 Dataset] <https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/pick_place_datasets/dataset_annotated_g1_locomanip.hdf5>`_.
+here: `[Annotated G1 Dataset] <https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/pick_place_datasets/dataset_annotated_g1_locomanip.hdf5>`_.
 Place the file under ``IsaacLab/datasets`` and run the following command to generate a new dataset with 1000 demonstrations.
 
 .. code:: bash

--- a/docs/source/overview/imitation-learning/skillgen.rst
+++ b/docs/source/overview/imitation-learning/skillgen.rst
@@ -135,7 +135,7 @@ The dataset contains:
 Download and Setup
 ^^^^^^^^^^^^^^^^^^
 
-1. Download the pre-annotated dataset by clicking `here <https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/franka_stack_datasets/annotated_dataset_skillgen.hdf5>`__.
+1. Download the pre-annotated dataset by clicking `here <https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/franka_stack_datasets/annotated_dataset_skillgen.hdf5>`__.
 
 2. Prepare the datasets directory and move the downloaded file:
 

--- a/docs/source/overview/imitation-learning/teleop_imitation.rst
+++ b/docs/source/overview/imitation-learning/teleop_imitation.rst
@@ -299,7 +299,7 @@ Step 2: Synthetic Data Generation using Isaac Lab Mimic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We provide a pre-recorded HDF5 dataset containing 10 human demonstrations for the cube stacking task
-here: `[Cube Stacking Human Dataset] <https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/franka_stack_datasets/dataset.hdf5>`__.
+here: `[Cube Stacking Human Dataset] <https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/IsaacLab/Mimic/franka_stack_datasets/dataset.hdf5>`__.
 If you skipped :ref:`Step 1: Human Data Collection <teleop-imitation-step-1-human-data-collection>`, you can download this dataset and use it in the remaining tutorial steps.
 
 Place the dataset in the ``IsaacLab/datasets`` folder. You may need to create the folder if you skipped Step 1 and

--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -30,7 +30,7 @@ pip extras include:
    * - Extra
      - What it installs
    * - ``isaacsim``
-     - Isaac Sim (``isaacsim[all,extscache]==6.0.0.*``) from `pypi.nvidia.com <https://pypi.nvidia.com>`_
+     - Isaac Sim (``isaacsim[all,extscache]==6.0.0.1``) from `pypi.nvidia.com <https://pypi.nvidia.com>`_
    * - ``all``
      - RL frameworks (SB3, SKRL, RL-Games, RSL-RL). Combine with ``isaacsim`` for a full install.
 

--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -51,7 +51,7 @@ Installing dependencies
 
    .. code-block:: bash
 
-      uv pip install "isaacsim[all,extscache]==6.0.0" --extra-index-url https://pypi.nvidia.com --index-strategy unsafe-best-match --prerelease=allow
+      uv pip install "isaacsim[all,extscache]==6.0.0.1" --extra-index-url https://pypi.nvidia.com --index-strategy unsafe-best-match --prerelease=allow
 
 -  Install a CUDA-enabled PyTorch build that matches your system architecture:
 

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -55,8 +55,8 @@ INSTALL_REQUIRES = [
     "psutil",
     # cross-platform file locking (used to serialize USD spawn across distributed ranks)
     "filelock",
-    # Required by pydantic-core/imgui_bundle on Python 3.12 (Sentinel symbol).
-    "typing_extensions>=4.14.0",
+    # keep consistent with isaac sim version
+    "typing_extensions==4.12.2",
     "lazy_loader>=0.4",
 ]
 

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -55,8 +55,10 @@ INSTALL_REQUIRES = [
     "psutil",
     # cross-platform file locking (used to serialize USD spawn across distributed ranks)
     "filelock",
-    # keep consistent with isaac sim version
+    # Match isaacsim-core. pydantic>=2.12 pulls pydantic-core>=2.37, which needs
+    # typing_extensions>=4.14.1 (Sentinel); cap pydantic for kit-less coexistence.
     "typing_extensions==4.12.2",
+    "pydantic>=2.7,<2.12",
     "lazy_loader>=0.4",
 ]
 

--- a/source/isaaclab_contrib/setup.py
+++ b/source/isaaclab_contrib/setup.py
@@ -21,6 +21,8 @@ EXTRAS_REQUIRE = {
         # -- safe to resolve alongside isaaclab core --
         "ray[default]>=2.47.0",
         "av>=12.3.0",
+        # numpydantic pulls pydantic>=2.7; cap for typing_extensions==4.12.2 (see isaaclab).
+        "pydantic>=2.7,<2.12",
         "numpydantic>=1.7.0",
         "albumentations>=1.4.18",
         "decord2",

--- a/source/isaaclab_newton/setup.py
+++ b/source/isaaclab_newton/setup.py
@@ -39,7 +39,7 @@ EXTRAS_REQUIRE = {
     "all": [
         "prettytable==3.3.0",
         "PyOpenGL-accelerate==3.1.10",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.1rc2",
+        "newton[sim]==1.2.1",
     ],
 }
 

--- a/source/isaaclab_physx/setup.py
+++ b/source/isaaclab_physx/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = ["isaaclab_ppisp"]
 
 EXTRAS_REQUIRE = {
     "newton": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.1rc2",
+        "newton[sim]==1.2.1",
     ],
 }
 

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -28,6 +28,7 @@ EXTRAS_REQUIRE = {
         "PyOpenGL-accelerate",
         "imgui-bundle>=1.92.601",
         "typing-extensions==4.12.2",
+        "pydantic>=2.7,<2.12",
     ],
     "rerun": [
         "newton[sim]==1.2.1",

--- a/source/isaaclab_visualizers/setup.py
+++ b/source/isaaclab_visualizers/setup.py
@@ -24,18 +24,18 @@ EXTRAS_REQUIRE = {
     "kit": [],
     "newton": [
         "warp-lang",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.1rc2",
+        "newton[sim]==1.2.1",
         "PyOpenGL-accelerate",
-        "imgui-bundle>=1.92.5",
-        "typing-extensions>=4.15.0",
+        "imgui-bundle>=1.92.601",
+        "typing-extensions==4.12.2",
     ],
     "rerun": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.1rc2",
+        "newton[sim]==1.2.1",
         "rerun-sdk>=0.29.0",
         "pyarrow==22.0.0",
     ],
     "viser": [
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.1rc2",
+        "newton[sim]==1.2.1",
         "viser>=1.0.16",
     ],
 }

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -39,7 +39,7 @@ pyproject.dependencies.all = [
     "flaky",
     "packaging",
     # visualizers
-    "imgui-bundle==1.92.4",
+    "imgui-bundle==1.92.601",
     "rerun-sdk>=0.29.0",
     "pyarrow==22.0.0",
     # viser is intentionally not a base dep: viser>=1.0.16 pulls websockets>=13.1,
@@ -82,13 +82,13 @@ pyproject.dependencies.all = [
 ]
 pyproject.optional-dependencies.all = [
     # Isaac Sim
-    { "isaacsim" = ["isaacsim[all,extscache]==6.0.0.*"] },
+    { "isaacsim" = ["isaacsim[all,extscache]==6.0.0.1"] },
     # ================================================================================
     # https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab_newton/setup.py
     # ================================================================================
     { "newton" = [
         "warp-lang==1.13.0",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.2.1rc2",
+        "newton[sim]==1.2.1",
         "PyOpenGL-accelerate==3.1.10"
     ] },
     # ================================================================================

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -47,6 +47,8 @@ pyproject.dependencies.all = [
     # visualizer install isaaclab[viser] explicitly (see the optional-dependencies
     # block below).
     "typing_extensions==4.12.2",
+    # pydantic>=2.12 needs typing_extensions>=4.14.1; cap for isaacsim/kit-less coexistence.
+    "pydantic>=2.7,<2.12",
     "lazy_loader>=0.4",
     "pin ; platform_system == 'Linux'",
     "pin-pink>=2.3.6 ; platform_system == 'Linux'",


### PR DESCRIPTION
# Description

Updates references of Isaac Sim pip wheel to point to the latest release 6.0.0.1 build.
Updates staging S3 path to production.
Updates Newton 1.2.1 to released pip wheel.

# Type of Change
<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

# Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task -->

