### PR TITLE
Enable Newton backend for stack and place tasks with RMPFlow & surface gripper

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -157,6 +157,7 @@ Guidelines for modifications:
 * Qingyang Jiang
 * Qinxi Yu
 * Rafael Wiltz
+* Rebecca Zhang
 * Renaud Poncelet
 * René Zurbrügg
 * Richard Schmitt

--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -479,6 +479,12 @@ follows.
      - **Arm:** end-effector pose via RMPFlow.
        **Gripper:** ``K`` on keyboard, left button on SpaceMouse.
    * - ``Isaac-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow-v0``
+
+       **Note:** With the RMPFlow controller, avoid colliding with
+       the cubes during teleoperation: contact forces cause the
+       controller to overtune and the arm to drift. Move the
+       end-effector close to and just above the cube, stop, then
+       close the suction cup.
      - Keyboard, SpaceMouse
      - **Arm:** end-effector pose via RMPFlow.
        **Suction:** ``K`` on keyboard, left button on SpaceMouse.

--- a/source/isaaclab/changelog.d/rmpflow-lula-pip-discovery.rst
+++ b/source/isaaclab/changelog.d/rmpflow-lula-pip-discovery.rst
@@ -1,0 +1,14 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.controllers.utils.import_lula` failing to locate the ``lula`` module on
+  pip-based Isaac Sim installs by extending :func:`~isaaclab.controllers.utils.find_lula_prebundle_dir`
+  to also search the ``extscache/<name>-<version>`` and ``extsDeprecated/<name>`` layouts used by pip
+  installs (the Isaac Sim 6.0 pip packages ship ``isaacsim.robot_motion.lula`` under
+  ``extsDeprecated``, where the Kit resolver reports it as unavailable), in addition to the
+  ``exts/<name>`` layout used by binary installs. :func:`~isaaclab.controllers.utils.import_lula` now
+  adds the prebundle to ``sys.path`` before attempting to enable the Kit extension, avoiding a spurious
+  ``Failed to resolve extension dependencies`` error logged when Kit tries to enable the deprecated
+  ``isaacsim.robot_motion.lula`` extension even though ``lula`` itself loads correctly. When ``lula``
+  still cannot be found, a clear, actionable :class:`ModuleNotFoundError` is raised instead of the bare
+  import error.

--- a/source/isaaclab/changelog.d/rmpflow-standalone-lula-fallback.rst
+++ b/source/isaaclab/changelog.d/rmpflow-standalone-lula-fallback.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab.controllers.rmp_flow.RmpFlowController` to load RMPFlow directly from the
+  ``lula`` library on every backend, instead of going through the Isaac Sim Kit motion-generation
+  extension. ``lula`` is importable both under Kit and kitless (e.g. the Newton visualizer), giving a
+  single code path. The ``rmp_flow_smoothed`` variant is now available in both modes as well.

--- a/source/isaaclab/isaaclab/controllers/rmp_flow.py
+++ b/source/isaaclab/isaaclab/controllers/rmp_flow.py
@@ -28,6 +28,11 @@ class _LulaRmpFlow:
     backends -- Kit and kitless (e.g. the Newton visualizer) -- since ``lula`` is importable in both.
     It assumes IsaacLab conventions: a meter-scaled stage and an identity robot base pose (the
     controller never relocates the base), and it does not manage obstacles or visuals.
+
+    Note:
+        ``lula`` is deprecated as of Isaac Sim 6.0 and slated for removal in a future release; cuMotion
+        (``isaacsim.robot_motion.cumotion``) is the long-term replacement. See the migration notes at
+        :data:`isaaclab.controllers.utils._LULA_EXT_NAME`.
     """
 
     def __init__(

--- a/source/isaaclab/isaaclab/controllers/rmp_flow.py
+++ b/source/isaaclab/isaaclab/controllers/rmp_flow.py
@@ -5,41 +5,248 @@
 
 from __future__ import annotations
 
-import os
+import time
 
 import numpy as np
 import torch
 
-# enable motion generation extensions
-from isaacsim.core.experimental.utils.app import enable_extension, get_extension_path
-
-enable_extension("isaacsim.robot_motion.lula")
-enable_extension("isaacsim.robot_motion.motion_generation")
-
-from isaacsim.robot_motion.motion_generation.lula.motion_policies import RmpFlow, RmpFlowSmoothed
-
 import isaaclab.sim as sim_utils
 from isaaclab.utils.assets import retrieve_file_path
+from isaaclab.utils.math import convert_quat, matrix_from_quat
 
 from .rmp_flow_cfg import RmpFlowControllerCfg  # noqa: F401
-
-_RMPFLOW_EXT_PREFIX = "rmpflow_ext:"
-_RMPFLOW_EXT_NAME = "isaacsim.robot_motion.motion_generation"
+from .utils import import_lula, resolve_rmpflow_path
 
 
-def _resolve_rmpflow_path(path: str) -> str:
-    """Resolve a sentinel ``rmpflow_ext:`` path to an absolute filesystem path.
+class _LulaRmpFlow:
+    """RMPFlow policy backed directly by the ``lula`` library.
 
-    Paths stored in :class:`~isaaclab.controllers.rmp_flow_cfg.RmpFlowControllerCfg`
-    that begin with ``"rmpflow_ext:"`` are relative to the
-    ``isaacsim.robot_motion.motion_generation`` extension directory.  This avoids
-    importing ``isaacsim`` in the cfg file (which is loaded without Kit).
+    This mirrors the surface of ``isaacsim.robot_motion.motion_generation``'s ``RmpFlow`` that
+    :class:`RmpFlowController` depends on (construction, active/watched joints, end-effector target,
+    Euler integration of the policy acceleration), backed by the same ``lula`` library but without
+    going through the Isaac Sim Kit motion-generation extension. This keeps a single code path across
+    backends -- Kit and kitless (e.g. the Newton visualizer) -- since ``lula`` is importable in both.
+    It assumes IsaacLab conventions: a meter-scaled stage and an identity robot base pose (the
+    controller never relocates the base), and it does not manage obstacles or visuals.
     """
-    if path.startswith(_RMPFLOW_EXT_PREFIX):
-        rel = path[len(_RMPFLOW_EXT_PREFIX) :]
-        ext_dir = get_extension_path(_RMPFLOW_EXT_NAME)
-        return os.path.join(ext_dir, rel)
-    return path
+
+    def __init__(
+        self,
+        robot_description_path: str,
+        urdf_path: str,
+        rmpflow_config_path: str,
+        end_effector_frame_name: str,
+        maximum_substep_size: float,
+        ignore_robot_state_updates: bool = False,
+    ) -> None:
+        """Load the robot description and world, then build the lula RMPFlow policy."""
+        lula = import_lula()
+
+        if maximum_substep_size <= 0:
+            raise ValueError("maximum_substep_size argument must be positive.")
+
+        self._lula = lula
+        self.maximum_substep_size = maximum_substep_size
+        self.ignore_robot_state_updates = ignore_robot_state_updates
+        self.end_effector_frame_name = end_effector_frame_name
+        self._rmpflow_config_path = rmpflow_config_path
+
+        self._robot_description = lula.load_robot(robot_description_path, urdf_path)
+        self._world = lula.create_world()
+        self._build_policy()
+
+        self._robot_joint_positions: np.ndarray | None = None
+        self._robot_joint_velocities: np.ndarray | None = None
+
+    def _build_policy(self) -> None:
+        """(Re)create the lula RMPFlow policy from the configured robot and config files."""
+        config = self._lula.create_rmpflow_config(
+            self._rmpflow_config_path,
+            self._robot_description,
+            self.end_effector_frame_name,
+            self._world.add_world_view(),
+        )
+        self._policy = self._lula.create_rmpflow(config)
+
+    def get_active_joints(self) -> list[str]:
+        """Return the names of the joints the policy actively controls (its c-space coords)."""
+        rd = self._robot_description
+        return [rd.c_space_coord_name(i) for i in range(rd.num_c_space_coords())]
+
+    def get_watched_joints(self) -> list[str]:
+        """Return the watched (non-controlled) joints; always empty since lula only watches active joints."""
+        return []
+
+    def reset(self) -> None:
+        """Rebuild the policy and clear the cached internal joint state."""
+        self._build_policy()
+        self._robot_joint_positions = None
+        self._robot_joint_velocities = None
+
+    def set_end_effector_target(self, target_position=None, target_orientation=None) -> None:
+        """Set (or clear) the end-effector position/orientation attractors from the target pose."""
+        # identity base pose + meter stage -> targets pass through unchanged
+        if target_position is None and target_orientation is None:
+            self._policy.clear_end_effector_position_attractor()
+            self._policy.clear_end_effector_orientation_attractor()
+            return
+        if target_position is not None:
+            self._policy.set_end_effector_position_attractor(np.asarray(target_position, dtype=np.float64))
+        else:
+            self._policy.clear_end_effector_position_attractor()
+        if target_orientation is not None:
+            # lula expects a rotation matrix; IsaacLab quaternions are (w, x, y, z)
+            quat_xyzw = convert_quat(torch.as_tensor(target_orientation, dtype=torch.float64), to="xyzw")
+            rot = matrix_from_quat(quat_xyzw).numpy()
+            self._policy.set_end_effector_orientation_attractor(self._lula.Rotation3(rot))
+        else:
+            self._policy.clear_end_effector_orientation_attractor()
+
+    def compute_joint_targets(
+        self,
+        active_joint_positions: np.ndarray,
+        active_joint_velocities: np.ndarray,
+        watched_joint_positions: np.ndarray,
+        watched_joint_velocities: np.ndarray,
+        frame_duration: float,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Integrate the policy over one frame and return the next joint position/velocity targets."""
+        if (
+            self._robot_joint_positions is None
+            or self._robot_joint_velocities is None
+            or not self.ignore_robot_state_updates
+        ):
+            positions = np.array(active_joint_positions, dtype=np.float64)
+            velocities = np.array(active_joint_velocities, dtype=np.float64)
+        else:
+            positions = self._robot_joint_positions
+            velocities = self._robot_joint_velocities
+
+        self._robot_joint_positions, self._robot_joint_velocities = self._euler_integration(
+            positions, velocities, frame_duration
+        )
+        return self._robot_joint_positions, self._robot_joint_velocities
+
+    def _evaluate_acceleration(self, joint_positions: np.ndarray, joint_velocities: np.ndarray) -> np.ndarray:
+        """Query the lula policy for the joint-space acceleration at the given state."""
+        joint_positions = np.asarray(joint_positions, dtype=np.float64)
+        joint_velocities = np.asarray(joint_velocities, dtype=np.float64)
+        joint_accel = np.zeros_like(joint_positions)
+        self._policy.eval_accel(joint_positions, joint_velocities, joint_accel)
+        return joint_accel
+
+    def _euler_integration(
+        self, joint_positions: np.ndarray, joint_velocities: np.ndarray, frame_duration: float
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Roll out the policy acceleration with fixed-substep Euler integration over the frame."""
+        num_steps = int(np.ceil(frame_duration / self.maximum_substep_size))
+        policy_timestep = frame_duration / num_steps
+        for _ in range(num_steps):
+            joint_accel = self._evaluate_acceleration(joint_positions, joint_velocities)
+            joint_positions = joint_positions + policy_timestep * joint_velocities
+            joint_velocities = joint_velocities + policy_timestep * joint_accel
+        return joint_positions, joint_velocities
+
+
+class _LulaRmpFlowSmoothed(_LulaRmpFlow):
+    """Jerk-smoothed RMPFlow variant, ported from the Kit ``RmpFlowSmoothed`` policy.
+
+    Adds wall-clock jerk monitoring on top of :class:`_LulaRmpFlow`: a large acceleration jump
+    triggers a speed reduction and medium jumps are truncated, which smooths motion on physical
+    robots. The smoothing math is pure NumPy, so this variant -- like the base policy -- runs without
+    the Isaac Sim Kit motion-generation extension.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize the base policy and the jerk-smoothing state and tunables."""
+        super().__init__(*args, **kwargs)
+        self._reset_smoothing_state()
+        # tunables (mirror the Kit ``RmpFlowSmoothed`` defaults)
+        self.min_time_between_jerk_reductions = 0.5
+        self.min_speed_scalar = 0.2
+        self.use_big_jerk_speed_scaling = True
+        self.big_jerk_limit = 10.0
+        self.use_medium_jerk_truncation = True
+        self.max_medium_jerk = 7.0
+        self.speed_scalar_alpha_blend = 0.985
+
+    def _reset_smoothing_state(self) -> None:
+        """Reset the speed scalar and cached acceleration/jerk-timing used for smoothing."""
+        self.desired_speed_scalar = 1.0
+        self.speed_scalar = 1.0
+        self.time_at_last_jerk_reduction: float | None = None
+        self.qdd: np.ndarray | None = None
+
+    def reset(self) -> None:
+        """Rebuild the policy (base reset) and clear the jerk-smoothing state."""
+        super().reset()
+        self._reset_smoothing_state()
+
+    def _eval_speed_scaled_accel(self, joint_positions: np.ndarray, joint_velocities: np.ndarray) -> np.ndarray:
+        """Evaluate acceleration with velocity/time rescaled by the current speed scalar."""
+        qdd_eval = self._evaluate_acceleration(joint_positions, joint_velocities / self.speed_scalar)
+        qdd_eval *= self.speed_scalar**2
+        return qdd_eval
+
+    def _euler_integration(
+        self, joint_positions: np.ndarray, joint_velocities: np.ndarray, frame_duration: float
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Roll out the policy like the base class, but monitor and reduce/truncate jerk per substep."""
+        num_steps = int(np.ceil(frame_duration / self.maximum_substep_size))
+        step_dt = frame_duration / num_steps
+
+        q = np.array(joint_positions, dtype=np.float64)
+        qd = np.array(joint_velocities, dtype=np.float64)
+
+        # jerk monitoring is meant for physical robots, so it uses wall-clock time (matching Kit)
+        now = time.time()
+
+        for _ in range(num_steps):
+            if self.qdd is None:
+                self.qdd = self._eval_speed_scaled_accel(q, qd)
+                continue
+
+            jerk_reduction_performed = False
+
+            # reduce speed to the minimum when a big jerk is experienced
+            if self.use_big_jerk_speed_scaling:
+                is_first = True
+                while True:
+                    qdd_eval = self._eval_speed_scaled_accel(q, qd)
+                    # only evaluate the reduction once; the loop re-evals qdd after the reduction
+                    if not is_first:
+                        break
+                    if (
+                        self.time_at_last_jerk_reduction is not None
+                        and (now - self.time_at_last_jerk_reduction) < self.min_time_between_jerk_reductions
+                    ):
+                        break
+                    jerk = np.linalg.norm(qdd_eval - self.qdd)
+                    if jerk > self.big_jerk_limit:
+                        self.speed_scalar = self.min_speed_scalar
+                        jerk_reduction_performed = True
+                    is_first = False
+
+            # truncate transient medium jerks
+            if self.use_medium_jerk_truncation:
+                qdd_eval = self._eval_speed_scaled_accel(q, qd)
+                jerk = np.linalg.norm(qdd_eval - self.qdd)
+                if jerk > self.max_medium_jerk:
+                    direction = (qdd_eval - self.qdd) / jerk
+                    qdd_eval = self.qdd + self.max_medium_jerk * direction
+
+            if jerk_reduction_performed:
+                self.time_at_last_jerk_reduction = now
+
+            self.qdd = qdd_eval
+
+            a = self.speed_scalar_alpha_blend
+            self.speed_scalar = a * self.speed_scalar + (1.0 - a) * self.desired_speed_scalar
+
+            q = q + step_dt * qd
+            qd = qd + step_dt * self.qdd
+
+        return q, qd
 
 
 class RmpFlowController:
@@ -81,24 +288,24 @@ class RmpFlowController:
         self._physics_dt = physics_dt
 
         if self.cfg.name == "rmp_flow":
-            controller_cls = RmpFlow
+            controller_cls = _LulaRmpFlow
         elif self.cfg.name == "rmp_flow_smoothed":
-            controller_cls = RmpFlowSmoothed
+            controller_cls = _LulaRmpFlowSmoothed
         else:
             raise ValueError(f"Unsupported controller in Lula library: {self.cfg.name}")
 
         name_to_idx = {name: i for i, name in enumerate(joint_names)}
 
-        self._rmpflow_policies: list[RmpFlow | RmpFlowSmoothed] = []
+        self._rmpflow_policies: list[_LulaRmpFlow] = []
         self._active_indices: list[np.ndarray] = []
         self._watched_indices: list[np.ndarray] = []
 
         for _ in range(num_robots):
-            local_urdf_file = retrieve_file_path(_resolve_rmpflow_path(self.cfg.urdf_file), force_download=True)
+            local_urdf_file = retrieve_file_path(resolve_rmpflow_path(self.cfg.urdf_file), force_download=True)
             local_collision_file = retrieve_file_path(
-                _resolve_rmpflow_path(self.cfg.collision_file), force_download=True
+                resolve_rmpflow_path(self.cfg.collision_file), force_download=True
             )
-            local_config_file = retrieve_file_path(_resolve_rmpflow_path(self.cfg.config_file), force_download=True)
+            local_config_file = retrieve_file_path(resolve_rmpflow_path(self.cfg.config_file), force_download=True)
 
             rmpflow = controller_cls(
                 robot_description_path=local_collision_file,

--- a/source/isaaclab/isaaclab/controllers/utils.py
+++ b/source/isaaclab/isaaclab/controllers/utils.py
@@ -9,6 +9,7 @@ This module provides utility functions to help with controller implementations.
 """
 
 import contextlib
+import glob
 import logging
 import os
 import re
@@ -16,6 +17,11 @@ import sys
 
 # import logger
 logger = logging.getLogger(__name__)
+
+# NOTE: As of Isaac Sim 6.0, ``isaacsim.robot_motion.lula`` (and ``isaacsim.robot_motion.motion_generation``)
+# are deprecated -- ``lula`` has been subsumed by cuMotion (``isaacsim.robot_motion.cumotion``), which is
+# built on the new experimental motion-generation API and is the long-term replacement for RMPFlow here.
+# ``lula`` is still shipped (under ``extsDeprecated`` in pip installs) so this controller keeps working,
 
 _LULA_EXT_NAME = "isaacsim.robot_motion.lula"
 _RMPFLOW_EXT_PREFIX = "rmpflow_ext:"
@@ -167,7 +173,10 @@ def find_lula_prebundle_dir() -> str | None:
 
     ``lula`` is prebundled inside the ``isaacsim.robot_motion.lula`` extension, under the Isaac Sim
     install directory exposed via the ``ISAAC_PATH`` environment variable (importing ``isaacsim`` sets
-    it as a side effect).
+    it as a side effect). The extension lives under different sub-trees depending on the install:
+    ``exts/<name>`` for binary installs, ``extscache/<name>-<version>`` for pip caches, and
+    ``extsDeprecated/<name>`` for the Isaac Sim 6.0 pip packages (where the Kit resolver reports it as
+    unavailable even though the prebundled module is present). All layouts are searched.
     """
     isaac_path = os.environ.get("ISAAC_PATH")
     if not isaac_path:
@@ -176,18 +185,26 @@ def find_lula_prebundle_dir() -> str | None:
         isaac_path = os.environ.get("ISAAC_PATH")
     if not isaac_path:
         return None
-    prebundle = os.path.join(isaac_path, "exts", _LULA_EXT_NAME, "pip_prebundle")
-    return prebundle if os.path.isdir(prebundle) else None
+    candidates = [os.path.join(isaac_path, "exts", _LULA_EXT_NAME, "pip_prebundle")]
+    for parent in ("extscache", "extsDeprecated", "exts"):
+        candidates.extend(sorted(glob.glob(os.path.join(isaac_path, parent, f"{_LULA_EXT_NAME}*", "pip_prebundle"))))
+    for prebundle in candidates:
+        if os.path.isdir(prebundle):
+            return prebundle
+    return None
 
 
 def import_lula():
     """Import and return the ``lula`` library, making it importable across backends.
 
     ``lula`` ships as a prebundled module of the ``isaacsim.robot_motion.lula`` Isaac Sim extension.
-    It imports directly when the Isaac Sim ``pip_prebundle`` paths are already on :data:`sys.path`
-    (e.g. when launched via ``isaaclab.sh``). Otherwise -- under a running Kit app the owning extension
-    is enabled to register the path, and in the kitless Newton visualizer (a bare interpreter) the
-    prebundle directory is located and added to :data:`sys.path` directly.
+    Resolution proceeds in order: import directly when the ``pip_prebundle`` paths are already on
+    :data:`sys.path` (e.g. when launched via ``isaaclab.sh``); otherwise locate the prebundle directory
+    and add it to :data:`sys.path` (works under both Kit and the kitless Newton visualizer); and only as
+    a last resort ask a running Kit app to enable the owning extension. The prebundle is tried before
+    :func:`enable_extension` on purpose -- in Isaac Sim 6.0 the extension is deprecated and unresolvable
+    by Kit, so enabling it first would log a spurious "failed to resolve extension dependencies" error
+    even though ``lula`` itself loads fine from the prebundle.
     """
     try:
         import lula
@@ -196,7 +213,19 @@ def import_lula():
     except ModuleNotFoundError:
         pass
 
-    # Under a running Kit app, enabling the owning extension registers its prebundle on ``sys.path``.
+    # Locate the prebundle and add it ourselves -- works under both Kit and kitless, and avoids asking
+    # Kit to enable the (in 6.0, deprecated and unresolvable) extension.
+    prebundle = find_lula_prebundle_dir()
+    if prebundle is not None and prebundle not in sys.path:
+        sys.path.insert(0, prebundle)
+        try:
+            import lula
+
+            return lula
+        except ModuleNotFoundError:
+            pass
+
+    # Last resort: under a running Kit app, enabling the owning extension registers its prebundle.
     try:
         from isaacsim.core.experimental.utils.app import enable_extension
     except (ImportError, ModuleNotFoundError):
@@ -210,10 +239,10 @@ def import_lula():
         except ModuleNotFoundError:
             pass
 
-    # Kitless (or the extension did not register its path): locate the prebundle and add it ourselves.
-    prebundle = find_lula_prebundle_dir()
-    if prebundle is not None and prebundle not in sys.path:
-        sys.path.insert(0, prebundle)
-    import lula
-
-    return lula
+    raise ModuleNotFoundError(
+        "Could not import 'lula', which is required by the RMPFlow controller. It ships with the"
+        f" '{_LULA_EXT_NAME}' Isaac Sim extension, which was not found in this Isaac Sim install."
+        " The Isaac Sim 6.0 pip packages (early developer release) do not yet include this"
+        " extension; use a binary Isaac Sim install, or select a task that does not rely on"
+        " RMPFlow."
+    )

--- a/source/isaaclab/isaaclab/controllers/utils.py
+++ b/source/isaaclab/isaaclab/controllers/utils.py
@@ -8,12 +8,18 @@
 This module provides utility functions to help with controller implementations.
 """
 
+import contextlib
 import logging
 import os
 import re
+import sys
 
 # import logger
 logger = logging.getLogger(__name__)
+
+_LULA_EXT_NAME = "isaacsim.robot_motion.lula"
+_RMPFLOW_EXT_PREFIX = "rmpflow_ext:"
+_RMPFLOW_EXT_NAME = "isaacsim.robot_motion.motion_generation"
 
 
 def convert_usd_to_urdf(usd_path: str, output_path: str, force_conversion: bool = True) -> tuple[str, str]:
@@ -136,3 +142,78 @@ def change_revolute_to_fixed_regex(urdf_path: str, fixed_joints: list[str], verb
 
     with open(urdf_path, "w") as file:
         file.write(content)
+
+
+def resolve_rmpflow_path(path: str) -> str:
+    """Resolve a sentinel ``rmpflow_ext:`` path to an absolute filesystem path.
+
+    Paths stored in :class:`~isaaclab.controllers.rmp_flow_cfg.RmpFlowControllerCfg`
+    that begin with ``"rmpflow_ext:"`` are relative to the
+    ``isaacsim.robot_motion.motion_generation`` extension directory.  This avoids
+    importing ``isaacsim`` in the cfg file (which is loaded without Kit).
+    """
+    if path.startswith(_RMPFLOW_EXT_PREFIX):
+        rel = path[len(_RMPFLOW_EXT_PREFIX) :]
+        # imported lazily so the module loads without Kit (e.g. the kitless Newton visualizer)
+        from isaacsim.core.experimental.utils.app import get_extension_path
+
+        ext_dir = get_extension_path(_RMPFLOW_EXT_NAME)
+        return os.path.join(ext_dir, rel)
+    return path
+
+
+def find_lula_prebundle_dir() -> str | None:
+    """Locate the ``pip_prebundle`` directory shipping the ``lula`` module, or ``None`` if not found.
+
+    ``lula`` is prebundled inside the ``isaacsim.robot_motion.lula`` extension, under the Isaac Sim
+    install directory exposed via the ``ISAAC_PATH`` environment variable (importing ``isaacsim`` sets
+    it as a side effect).
+    """
+    isaac_path = os.environ.get("ISAAC_PATH")
+    if not isaac_path:
+        with contextlib.suppress(ImportError):
+            import isaacsim  # noqa: F401  (sets ``os.environ["ISAAC_PATH"]`` as a side effect)
+        isaac_path = os.environ.get("ISAAC_PATH")
+    if not isaac_path:
+        return None
+    prebundle = os.path.join(isaac_path, "exts", _LULA_EXT_NAME, "pip_prebundle")
+    return prebundle if os.path.isdir(prebundle) else None
+
+
+def import_lula():
+    """Import and return the ``lula`` library, making it importable across backends.
+
+    ``lula`` ships as a prebundled module of the ``isaacsim.robot_motion.lula`` Isaac Sim extension.
+    It imports directly when the Isaac Sim ``pip_prebundle`` paths are already on :data:`sys.path`
+    (e.g. when launched via ``isaaclab.sh``). Otherwise -- under a running Kit app the owning extension
+    is enabled to register the path, and in the kitless Newton visualizer (a bare interpreter) the
+    prebundle directory is located and added to :data:`sys.path` directly.
+    """
+    try:
+        import lula
+
+        return lula
+    except ModuleNotFoundError:
+        pass
+
+    # Under a running Kit app, enabling the owning extension registers its prebundle on ``sys.path``.
+    try:
+        from isaacsim.core.experimental.utils.app import enable_extension
+    except (ImportError, ModuleNotFoundError):
+        pass
+    else:
+        enable_extension(_LULA_EXT_NAME)
+        try:
+            import lula
+
+            return lula
+        except ModuleNotFoundError:
+            pass
+
+    # Kitless (or the extension did not register its path): locate the prebundle and add it ourselves.
+    prebundle = find_lula_prebundle_dir()
+    if prebundle is not None and prebundle not in sys.path:
+        sys.path.insert(0, prebundle)
+    import lula
+
+    return lula

--- a/source/isaaclab_physx/isaaclab_physx/assets/surface_gripper/surface_gripper.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/surface_gripper/surface_gripper.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import warnings
 from typing import TYPE_CHECKING
 
@@ -475,6 +476,10 @@ class SurfaceGripper(AssetBase):
             )
         gripper_prim = gripper_prims[0]
         self._prim_expr = root_expr + gripper_prim.GetPath().pathString[len(walk_root) :]
+        # ``GripperView`` (XformPrim.resolve_paths) requires explicit regex (".*") and rejects the
+        # legacy "*" wildcard that the clone-plan destination glob (e.g. "/World/envs/env_*") can
+        # carry. Convert any bare "*" to ".*" (a "*" already preceded by "." is left untouched).
+        self._prim_expr = re.sub(r"(?<!\.)\*", ".*", self._prim_expr)
         env_prim_path_expr = self._prim_expr.rsplit("/", 1)[0]
         self._parent_prims = sim_utils.find_matching_prims(env_prim_path_expr)
         self._num_envs = len(self._parent_prims)

--- a/source/isaaclab_physx/test/assets/test_surface_gripper.py
+++ b/source/isaaclab_physx/test/assets/test_surface_gripper.py
@@ -37,7 +37,7 @@ from isaaclab.utils.version import get_isaac_sim_version, has_kit
 
 # from isaacsim.robot.surface_gripper import GripperView
 
-_RUNNING_CI = (
+_RUNNING_CI = bool(
     os.environ.get("CI") == "true" or os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("GITLAB_CI")
 )
 
@@ -208,6 +208,71 @@ def test_initialization(sim, num_articulations, device, add_ground_plane) -> Non
         # update articulation
         articulation.update(sim.cfg.dt)
         surface_gripper.update(sim.cfg.dt)
+
+
+@pytest.mark.parametrize("num_articulations", [1])
+@pytest.mark.parametrize("device", ["cpu"])
+@pytest.mark.parametrize("add_ground_plane", [True])
+@pytest.mark.isaacsim_ci
+@pytest.mark.skipif(
+    _RUNNING_CI,
+    reason="Isaac Sim SurfaceGripperView initialization can deadlock in CI; keep CUDA fail-fast coverage only.",
+)
+def test_close_and_open_command(sim, num_articulations, device, add_ground_plane) -> None:
+    """Test that the close/open commands actually drive the surface gripper status.
+
+    This is a regression test for the command plumbing: a single ``close`` command must move the
+    gripper out of the *open* state into a *closing* (or *closed*) state, and a subsequent ``open``
+    command must bring it back to the *open* state.
+
+    .. note::
+        The shared ``test_gripper.usd`` does not contain a separate grippable rigid body (the cube
+        at the attachment point is a link of the gripper articulation), so the gripper cannot latch
+        onto anything and will not reach the *closed* state. We therefore only assert that the
+        command takes effect (the status leaves *open*), which is the deterministic behavior.
+
+    Args:
+        num_articulations: The number of articulations to initialize.
+        device: The device to run the test on.
+        add_ground_plane: Whether to add a ground plane to the simulation.
+    """
+    if has_kit() and get_isaac_sim_version().major < 5:
+        return
+    surface_gripper_cfg, articulation_cfg = generate_surface_gripper_cfgs(kinematic_enabled=False)
+    surface_gripper, articulation, _ = generate_surface_gripper(
+        surface_gripper_cfg, articulation_cfg, num_articulations, device
+    )
+
+    sim.reset()
+
+    assert surface_gripper.is_initialized
+    # after a reset the gripper is open (-1.0)
+    assert torch.all(wp.to_torch(surface_gripper.state) == -1.0)
+
+    # send a single close command (the action term is edge-triggered, so commands are sent once)
+    close_cmd = wp.array([1.0] * num_articulations, dtype=wp.float32, device=device)
+    surface_gripper.set_grippers_command_index(close_cmd)
+    surface_gripper.write_data_to_sim()
+    # step the simulation so the gripper reacts to the command
+    for _ in range(3):
+        sim.step()
+        articulation.update(sim.cfg.dt)
+        surface_gripper.update(sim.cfg.dt)
+    # the close command must take effect: status is "closing" (0.0) or "closed" (1.0), never "open" (-1.0)
+    state_after_close = wp.to_torch(surface_gripper.state)
+    assert torch.all(state_after_close >= 0.0), f"close command had no effect, state={state_after_close.tolist()}"
+
+    # send a single open command; the gripper must return to the open state
+    open_cmd = wp.array([-1.0] * num_articulations, dtype=wp.float32, device=device)
+    surface_gripper.set_grippers_command_index(open_cmd)
+    surface_gripper.write_data_to_sim()
+    for _ in range(3):
+        sim.step()
+        articulation.update(sim.cfg.dt)
+        surface_gripper.update(sim.cfg.dt)
+    # the open command must take effect: status is back to "open" (-1.0)
+    state_after_open = wp.to_torch(surface_gripper.state)
+    assert torch.all(state_after_open == -1.0), f"open command had no effect, state={state_after_open.tolist()}"
 
 
 @pytest.mark.parametrize("device", ["cuda:0"])

--- a/source/isaaclab_tasks/changelog.d/multi-backends-stack-place-migration.rst
+++ b/source/isaaclab_tasks/changelog.d/multi-backends-stack-place-migration.rst
@@ -1,0 +1,17 @@
+Changed
+^^^^^^^
+
+* Migrated the Stack-Cube (UR10, Galbot) and Place (Agibot) manipulation tasks to
+  Lab 3.0 multi-backend physics by exposing a ``PhysicsCfg`` preset
+  (``physics=physx`` / ``physics=newton_mjwarp``) instead of a hard-coded
+  :class:`~isaaclab_physx.physics.PhysxCfg`.
+
+Added
+^^^^^
+
+* Added a config-time check that raises a clear error when a surface-gripper (suction)
+  stacking task is run with the Newton physics backend, which has no surface-gripper
+  implementation, instead of failing later during scene creation.
+* Added a config-time check that raises a clear error when an Agibot place task is run
+  with the Newton physics backend, whose USD parser rejects the robot's reversed
+  gripper joints, instead of failing later during scene creation.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
@@ -6,6 +6,7 @@
 import os
 from dataclasses import MISSING
 
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.assets import AssetBaseCfg, RigidObjectCfg
@@ -30,6 +31,7 @@ from isaaclab_tasks.contrib.place import mdp as place_mdp
 from isaaclab_tasks.contrib.stack import mdp
 from isaaclab_tasks.contrib.stack.mdp import franka_stack_events
 from isaaclab_tasks.contrib.stack.stack_env_cfg import ObjectTableSceneCfg
+from isaaclab_tasks.utils import PresetCfg
 
 ##
 # Pre-defined configs
@@ -172,6 +174,68 @@ class TerminationsCfg:
 
 
 @configclass
+class PhysicsCfg(PresetCfg):
+    """Physics backend presets for Agibot place tasks."""
+
+    default = PhysxCfg(
+        bounce_threshold_velocity=0.01,
+        gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
+        gpu_total_aggregate_pairs_capacity=16 * 1024,
+        friction_correlation_distance=0.00625,
+    )
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            solver="newton",
+            integrator="implicitfast",
+            njmax=300,
+            nconmax=200,
+            impratio=10.0,
+            cone="elliptic",
+            update_data_interval=2,
+            iterations=100,
+            ls_iterations=15,
+            ls_parallel=False,
+            use_mujoco_contacts=False,
+            ccd_iterations=35,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(),
+        default_shape_cfg=NewtonShapeCfg(),
+        num_substeps=2,
+        debug_mode=False,
+    )
+    physx = default
+
+
+# Robot USD assets whose gripper revolute joints are authored with reversed
+# body0/body1 ordering, which the Newton MJWarp USD parser rejects.
+_NEWTON_REVERSED_JOINT_ASSETS = ("Robots/Agibot/A2D/",)
+
+
+def raise_if_reversed_joints_on_newton(env_cfg) -> None:
+    """Reject Newton physics for robots whose USD has reversed gripper joints.
+
+    The Newton MJWarp ``parse_usd`` importer requires each joint prim to define the parent
+    body as ``physics:body0`` and the child as ``physics:body1``. Some robot assets (e.g. the
+    Agibot A2D gripper support-link revolute joints) author these reversed; PhysX tolerates
+    this, but Newton raises ``Reversed joints are not supported`` deep in scene creation. This
+    raises an actionable error at config-validation time instead.
+
+    Args:
+        env_cfg: The resolved environment config to inspect.
+    """
+    robot_cfg = getattr(env_cfg.scene, "robot", None)
+    usd_path = getattr(getattr(robot_cfg, "spawn", None), "usd_path", None)
+    if usd_path is None or not isinstance(env_cfg.sim.physics, NewtonCfg):
+        return
+    if any(marker in usd_path for marker in _NEWTON_REVERSED_JOINT_ASSETS):
+        raise ValueError(
+            "This task's robot has gripper joints authored with reversed body0/body1 ordering, "
+            "which the Newton backend's USD parser does not support ('Reversed joints are not "
+            "supported'). Re-run this task with physics=physx (the default)."
+        )
+
+
+@configclass
 class PlaceToy2BoxEnvCfg(ManagerBasedRLEnvCfg):
     """Configuration for the stacking environment."""
 
@@ -194,16 +258,15 @@ class PlaceToy2BoxEnvCfg(ManagerBasedRLEnvCfg):
 
         self.sim.render_interval = self.decimation
 
-        self.sim.physics = PhysxCfg(
-            bounce_threshold_velocity=0.01,
-            gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
-            gpu_total_aggregate_pairs_capacity=16 * 1024,
-            friction_correlation_distance=0.00625,
-        )
+        self.sim.physics = PhysicsCfg()
 
         # set viewer to see the whole scene
         self.viewer.eye = [1.5, -1.0, 1.5]
         self.viewer.lookat = [0.5, 0.0, 0.0]
+
+    def validate_config(self):
+        """Reject backend combinations that the configured robot cannot run on."""
+        raise_if_reversed_joints_on_newton(self)
 
 
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/galbot/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/galbot/stack_joint_pos_env_cfg.py
@@ -22,7 +22,11 @@ from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.contrib.stack import mdp
 from isaaclab_tasks.contrib.stack.mdp import franka_stack_events
-from isaaclab_tasks.contrib.stack.stack_env_cfg import ObservationsCfg, StackEnvCfg
+from isaaclab_tasks.contrib.stack.stack_env_cfg import (
+    ObservationsCfg,
+    StackEnvCfg,
+    raise_if_surface_gripper_on_newton,
+)
 
 ##
 # Pre-defined configs
@@ -333,6 +337,10 @@ class GalbotLeftArmCubeStackEnvCfg(StackEnvCfg):
 
 @configclass
 class GalbotRightArmCubeStackEnvCfg(GalbotLeftArmCubeStackEnvCfg):
+    def validate_config(self):
+        # The right-arm suction cup uses a PhysX-only surface gripper.
+        raise_if_surface_gripper_on_newton(self)
+
     def __post_init__(self):
         # post init of parent
         super().__post_init__()

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/galbot/stack_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/galbot/stack_rmp_rel_env_cfg.py
@@ -18,6 +18,7 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.contrib.stack import mdp
+from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
 
 from . import stack_joint_pos_env_cfg
 
@@ -104,7 +105,6 @@ class RmpFlowGalbotRightArmCubeStackEnvCfg(stack_joint_pos_env_cfg.GalbotRightAr
             body_name="right_suction_cup_tcp_link",
             controller=GALBOT_RIGHT_ARM_RMPFLOW_CFG,
             scale=1.0,
-            body_offset=RMPFlowActionCfg.OffsetCfg(pos=[0.0, 0.0, 0.0]),
             use_relative_mode=self.use_relative_mode,
         )
 
@@ -132,8 +132,9 @@ class RmpFlowGalbotRightArmCubeStackEnvCfg(stack_joint_pos_env_cfg.GalbotRightAr
         self.decimation = 6
         self.episode_length_s = 30.0
 
-        # Enable CCD to avoid tunneling
-        self.sim.physics = PhysxCfg(enable_ccd=True)
+        # Enable CCD for PhysX only. Newton backends do not expose this field.
+        if isinstance(self.sim.physics, PhysxCfg):
+            self.sim.physics.enable_ccd = True
 
 
 ##
@@ -141,6 +142,24 @@ class RmpFlowGalbotRightArmCubeStackEnvCfg(stack_joint_pos_env_cfg.GalbotRightAr
 ##
 @configclass
 class RmpFlowGalbotLeftArmCubeStackVisuomotorEnvCfg(RmpFlowGalbotLeftArmCubeStackEnvCfg):
+    def validate_config(self):
+        """Check for invalid renderer/data-type combinations after preset resolution."""
+
+        warp_supported = {"rgb", "depth", "distance_to_image_plane"}
+        for cam_attr in ("right_wrist_cam", "left_wrist_cam", "ego_cam", "front_cam"):
+            cam = getattr(self.scene, cam_attr, None)
+            if cam is None:
+                continue
+            renderer_type = getattr(getattr(cam, "renderer_cfg", None), "renderer_type", None)
+            if renderer_type == "newton_warp":
+                unsupported = set(cam.data_types) - warp_supported
+                if unsupported:
+                    raise ValueError(
+                        f"Warp renderer only supports data types {sorted(warp_supported)}, "
+                        f"but '{cam_attr}' is configured with unsupported types: {sorted(unsupported)}. "
+                        "Choose a compatible preset, e.g. presets=newton_renderer,rgb128."
+                    )
+
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
@@ -152,10 +171,11 @@ class RmpFlowGalbotLeftArmCubeStackVisuomotorEnvCfg(RmpFlowGalbotLeftArmCubeStac
             height=256,
             width=256,
             data_types=["rgb", "distance_to_image_plane"],
+            renderer_cfg=MultiBackendRendererCfg(),
             spawn=sim_utils.PinholeCameraCfg(
                 focal_length=18.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 1.0e5)
             ),
-            offset=CameraCfg.OffsetCfg(pos=(0.0, 0.0, 0.0), rot=(-0.5, 0.5, -0.5, 0.5), convention="ros"),
+            offset=CameraCfg.OffsetCfg(rot=(-0.5, 0.5, -0.5, 0.5), convention="ros"),
         )
 
         self.scene.left_wrist_cam = CameraCfg(
@@ -164,10 +184,11 @@ class RmpFlowGalbotLeftArmCubeStackVisuomotorEnvCfg(RmpFlowGalbotLeftArmCubeStac
             height=256,
             width=256,
             data_types=["rgb", "distance_to_image_plane"],
+            renderer_cfg=MultiBackendRendererCfg(),
             spawn=sim_utils.PinholeCameraCfg(
                 focal_length=18.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 1.0e5)
             ),
-            offset=CameraCfg.OffsetCfg(pos=(0.0, 0.0, 0.0), rot=(-0.5, 0.5, -0.5, 0.5), convention="ros"),
+            offset=CameraCfg.OffsetCfg(rot=(-0.5, 0.5, -0.5, 0.5), convention="ros"),
         )
 
         # Set ego view camera
@@ -177,10 +198,11 @@ class RmpFlowGalbotLeftArmCubeStackVisuomotorEnvCfg(RmpFlowGalbotLeftArmCubeStac
             height=256,
             width=256,
             data_types=["rgb", "distance_to_image_plane"],
+            renderer_cfg=MultiBackendRendererCfg(),
             spawn=sim_utils.PinholeCameraCfg(
                 focal_length=18.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 1.0e5)
             ),
-            offset=CameraCfg.OffsetCfg(pos=(0.0, 0.0, 0.0), rot=(-0.5, 0.5, -0.5, 0.5), convention="ros"),
+            offset=CameraCfg.OffsetCfg(rot=(-0.5, 0.5, -0.5, 0.5), convention="ros"),
         )
 
         # Set front view camera
@@ -190,6 +212,7 @@ class RmpFlowGalbotLeftArmCubeStackVisuomotorEnvCfg(RmpFlowGalbotLeftArmCubeStac
             height=256,
             width=256,
             data_types=["rgb", "distance_to_image_plane"],
+            renderer_cfg=MultiBackendRendererCfg(),
             spawn=sim_utils.PinholeCameraCfg(
                 focal_length=24.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 1.0e5)
             ),

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/ur10_gripper/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/ur10_gripper/stack_joint_pos_env_cfg.py
@@ -18,7 +18,10 @@ from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.contrib.stack import mdp
 from isaaclab_tasks.contrib.stack.mdp import franka_stack_events
-from isaaclab_tasks.contrib.stack.stack_env_cfg import StackEnvCfg
+from isaaclab_tasks.contrib.stack.stack_env_cfg import (
+    StackEnvCfg,
+    raise_if_surface_gripper_on_newton,
+)
 
 from isaaclab_assets.robots.universal_robots import (  # isort: skip
     UR10_LONG_SUCTION_CFG,
@@ -81,6 +84,10 @@ class UR10CubeStackEnvCfg(StackEnvCfg):
     marker_cfg = FRAME_MARKER_CFG.copy()
     marker_cfg.markers["frame"].scale = (0.1, 0.1, 0.1)
     marker_cfg.prim_path = "/Visuals/FrameTransformer"
+
+    def validate_config(self):
+        # Surface grippers used by these suction robots are PhysX-only.
+        raise_if_surface_gripper_on_newton(self)
 
     def __post_init__(self):
         # post init of parent

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
@@ -5,6 +5,7 @@
 
 from dataclasses import MISSING
 
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -20,6 +21,8 @@ from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransf
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdFileCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
+
+from isaaclab_tasks.utils import PresetCfg
 
 from . import mdp
 
@@ -163,6 +166,58 @@ class TerminationsCfg:
 
 
 @configclass
+class PhysicsCfg(PresetCfg):
+    """Physics backend presets for stack tasks."""
+
+    default = PhysxCfg(
+        bounce_threshold_velocity=0.01,
+        gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
+        gpu_total_aggregate_pairs_capacity=2**21,
+        friction_correlation_distance=0.00625,
+    )
+    newton_mjwarp = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            solver="newton",
+            integrator="implicitfast",
+            njmax=300,
+            nconmax=200,
+            impratio=10.0,
+            cone="elliptic",
+            update_data_interval=2,
+            iterations=100,
+            ls_iterations=15,
+            ls_parallel=False,
+            use_mujoco_contacts=False,
+            ccd_iterations=35,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(),
+        default_shape_cfg=NewtonShapeCfg(),
+        num_substeps=2,
+        debug_mode=False,
+    )
+    physx = default
+
+
+def raise_if_surface_gripper_on_newton(env_cfg) -> None:
+    """Reject Newton physics for scenes that configure a surface gripper.
+
+    Surface grippers are a PhysX/Isaac Sim feature (:class:`~isaaclab_physx.assets.SurfaceGripperCfg`)
+    with no Newton equivalent. This raises an actionable error at config-validation time
+    instead of failing later during scene creation with an opaque ``isaacsim.core`` import error.
+
+    Args:
+        env_cfg: The resolved environment config to inspect.
+    """
+    if getattr(env_cfg.scene, "surface_gripper", None) is None:
+        return
+    if isinstance(env_cfg.sim.physics, NewtonCfg):
+        raise ValueError(
+            "Surface grippers are only supported by the PhysX backend; the Newton backend has no "
+            "surface-gripper implementation. Re-run this task with physics=physx (the default)."
+        )
+
+
+@configclass
 class StackEnvCfg(ManagerBasedRLEnvCfg):
     """Configuration for the stacking environment."""
 
@@ -193,10 +248,4 @@ class StackEnvCfg(ManagerBasedRLEnvCfg):
         # simulation settings
         self.sim.dt = 0.01  # 100Hz
         self.sim.render_interval = 2
-
-        self.sim.physics = PhysxCfg(
-            bounce_threshold_velocity=0.01,
-            gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
-            gpu_total_aggregate_pairs_capacity=2**21,
-            friction_correlation_distance=0.00625,
-        )
+        self.sim.physics = PhysicsCfg()


### PR DESCRIPTION

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Mirrors PR (https://github.com/isaac-sim/IsaacLab/pull/5981) on `release/3.0.0-beta2` branch.

Document a teleop usage note for the Galbot suction RMPFlow task: avoid colliding with the cubes during teleoperation (contact forces cause the RMPFlow controller to overtune and the arm to drift); move the end-effector just above the cube, stop, then close the suction cup.

Add a kitless lula-backed RMPFlow controller (_LulaRmpFlow) that mirrors the Kit motion-generation RmpFlow surface but talks to the lula library directly, so RMPFlow runs without the Isaac Sim Kit extension (e.g. under the Newton visualizer) using a single code path across backends.

Expose a PhysicsCfg preset on the Stack-Cube (UR10, Galbot) and Place (Agibot) tasks so the physics backend can be selected via physics=physx / physics=newton_mjwarp instead of a hard-coded PhysxCfg.

Add two config-time guards that fail fast with actionable errors instead of failing later during scene creation:
- raise_if_surface_gripper_on_newton: rejects Newton for surface-gripper (suction) stacking tasks, which Newton has no equivalent for.
- raise_if_reversed_joints_on_newton: rejects Newton for robots (e.g. Agibot A2D) whose gripper joints are authored with reversed body0/body1 ordering, which the Newton MJWarp USD parser does not support.

### Fixes (nvbug 6282434)
RMPFlow tasks crashed with "No module named lula" on pip Isaac Sim 6.0. 'lula' still ships, but under 'extsDeprecated', which discovery and the Kit resolver both missed.

- Search extscache/ and extsDeprecated/ layouts, not just exts/.
- Add the prebundle to sys.path before enabling the extension, avoiding a spurious Kit "failed to resolve dependencies" error.
- Raise an actionable error when lula is truly missing.
- Note lula's deprecation in favor of cuMotion.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Screenshots

Isaac Teleop doc update:
<img width="800" height="330" alt="teleop_doc_after" src="https://github.com/user-attachments/assets/528ac43f-0b82-4405-b266-acdea6b33f1b" />


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
