### PR TITLE
Add maximal-coordinate solver hooks to core env and actuators

### DIFF
--- a/source/isaaclab/changelog.d/aserifi-kamino-core-hooks.minor.rst
+++ b/source/isaaclab/changelog.d/aserifi-kamino-core-hooks.minor.rst
@@ -1,0 +1,13 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab.actuators.ActuatorBase.route_torque_to` to select whether
+  actuator torque is written to Newton ``Control.joint_f`` or ``Control.joint_act``,
+  enabling backward-Euler joint treatment under the Kamino solver.
+
+Fixed
+^^^^^
+
+* Fixed stale reset poses for maximal-coordinate solvers (e.g. Kamino) by refreshing
+  kinematics and derived buffers after in-step resets in
+  :meth:`~isaaclab.envs.ManagerBasedRLEnv.step` (no-op for other backends).

--- a/source/isaaclab/isaaclab/actuators/actuator_base.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_base.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import torch
 
@@ -41,6 +41,16 @@ class ActuatorBase(ABC):
     """Flag indicating if the actuator is an implicit or explicit actuator model.
 
     If a class inherits from :class:`ImplicitActuator`, then this flag should be set to :obj:`True`.
+    """
+
+    route_torque_to: ClassVar[Literal["joint_f", "joint_act"]] = "joint_f"
+    """Where the per-step actuator-computed torque is written into Newton's ``Control``.
+
+    - ``"joint_f"`` (default): torque is written to ``Control.joint_f`` and enters the
+      body wrench, integrated semi-explicitly. This matches PhysX/MuJoCo semantics.
+    - ``"joint_act"``: torque is written to ``Control.joint_act`` instead. For the Kamino
+      solver this enters the joint dynamic-constraint row of the PADMM solve, getting
+      backward-Euler treatment of joint armature and damping.
     """
 
     computed_effort: torch.Tensor

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -252,6 +252,13 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
 
             self._reset_idx(reset_env_ids)
 
+            # Refresh kinematics and derived buffers for the just-reset envs so the
+            # observations / terminations below reflect the reset pose. Maximal-coordinate
+            # solvers (e.g. Kamino) apply reset FK one step late; for others this is a no-op.
+            self.scene.write_data_to_sim()
+            self.sim.forward()
+            self.scene.update(dt=self.physics_dt)
+
             # if sensors are added to the scene, make sure we render to reflect changes in reset
             if self.render_enabled and is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):


### PR DESCRIPTION
# Description

This is part of the Kamino integration into IsaacLab work.

Two small core additions that let maximal-coordinate solvers (Kamino) integrate cleanly. No behavior change for existing PhysX / MuJoCo-Warp setups.

- Add `ActuatorBase.route_torque_to` to choose whether actuator torque is written to Newton's `Control.joint_f` (default, semi-explicit, PhysX/MuJoCo-like) or `Control.joint_act` (backward-Euler joint treatment for the Kamino solver).
- Refresh kinematics and derived buffers after in-step resets in `ManagerBasedRLEnv`, so post-reset observations and terminations reflect the reset pose for maximal-coordinate solvers (no-op for other backends).