### PR TITLE
Guard env destructors during Python shutdown

### DIFF
--- a/source/isaaclab/changelog.d/fix-env-del-shutdown.rst
+++ b/source/isaaclab/changelog.d/fix-env-del-shutdown.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Prevented environment destructors from emitting cleanup tracebacks after Python import shutdown begins.

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -82,6 +82,9 @@ class DirectMARLEnv(gym.Env):
             RuntimeError: If a simulation context already exists. The environment must always create one
                 since it configures the simulation context and controls the simulation.
         """
+        # The env remains closed until initialization completes.
+        self._is_closed = True
+
         # check that the config is valid
         cfg.validate()
         # Resolve any preset-wrapper fields (PresetCfg subclasses or old-style ``presets`` dicts)
@@ -92,7 +95,6 @@ class DirectMARLEnv(gym.Env):
         # store the render mode
         self.render_mode = render_mode
         # initialize internal variables
-        self._is_closed = False
         self._physics_handles_decimation = False
 
         # set the seed for the environment
@@ -114,6 +116,7 @@ class DirectMARLEnv(gym.Env):
         except Exception:
             self.sim.clear_instance()
             raise
+        self._is_closed = False
 
     def _init_sim(self, render_mode: str | None = None, **kwargs):
         """Complete environment initialization after the SimulationContext is created.
@@ -266,9 +269,9 @@ class DirectMARLEnv(gym.Env):
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
 
-    def __del__(self, _sys_is_finalizing=sys.is_finalizing):
+    def __del__(self, _sys=sys):
         """Cleanup for the environment."""
-        if not _sys_is_finalizing():
+        if not self._is_closed and not _sys.is_finalizing() and _sys.meta_path is not None:
             self.close()
 
     """

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -87,6 +87,9 @@ class DirectRLEnv(gym.Env):
             RuntimeError: If a simulation context already exists. The environment must always create one
                 since it configures the simulation context and controls the simulation.
         """
+        # The env remains closed until initialization completes.
+        self._is_closed = True
+
         # check that the config is valid
         cfg.validate()
         # Resolve any preset-wrapper fields to their default variant so that downstream
@@ -97,7 +100,6 @@ class DirectRLEnv(gym.Env):
         # store the render mode
         self.render_mode = render_mode
         # initialize internal variables
-        self._is_closed = False
         self._physics_handles_decimation = False
 
         # set the seed for the environment
@@ -119,6 +121,7 @@ class DirectRLEnv(gym.Env):
         except Exception:
             self.sim.clear_instance()
             raise
+        self._is_closed = False
 
     def _init_sim(self, render_mode: str | None = None, **kwargs):
         """Complete environment initialization after the SimulationContext is created.
@@ -288,9 +291,9 @@ class DirectRLEnv(gym.Env):
         # print the environment information
         print("[INFO]: Completed setting up the environment...")
 
-    def __del__(self, _sys_is_finalizing=sys.is_finalizing):
+    def __del__(self, _sys=sys):
         """Cleanup for the environment."""
-        if not _sys_is_finalizing():
+        if not self._is_closed and not _sys.is_finalizing() and _sys.meta_path is not None:
             self.close()
 
     """

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -86,6 +86,9 @@ class ManagerBasedEnv:
             RuntimeError: If a simulation context already exists. The environment must always create one
                 since it configures the simulation context and controls the simulation.
         """
+        # The env remains closed until initialization completes.
+        self._is_closed = True
+
         # check that the config is valid
         cfg.validate()
         # Resolve any preset-wrapper fields (PresetCfg subclasses or old-style ``presets`` dicts)
@@ -94,7 +97,6 @@ class ManagerBasedEnv:
         # store inputs to class
         self.cfg = cfg
         # initialize internal variables
-        self._is_closed = False
         self._physics_handles_decimation = False
 
         # set the seed for the environment
@@ -125,6 +127,7 @@ class ManagerBasedEnv:
             if created_sim:
                 self.sim.clear_instance()
             raise
+        self._is_closed = False
 
     def _init_sim(self):
         """Complete environment initialization after the SimulationContext is created.
@@ -258,9 +261,9 @@ class ManagerBasedEnv:
             if self.cfg.num_rerenders_on_reset == 0:
                 self.cfg.num_rerenders_on_reset = 1
 
-    def __del__(self, _sys_is_finalizing=sys.is_finalizing):
+    def __del__(self, _sys=sys):
         """Cleanup for the environment."""
-        if not _sys_is_finalizing():
+        if not self._is_closed and not _sys.is_finalizing() and _sys.meta_path is not None:
             self.close()
 
     """

--- a/source/isaaclab/test/envs/test_env_destructors.py
+++ b/source/isaaclab/test/envs/test_env_destructors.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import pytest
+
+from isaaclab.envs import DirectMARLEnv, DirectRLEnv, ManagerBasedEnv
+
+
+@pytest.mark.parametrize("env_cls", [DirectRLEnv, DirectMARLEnv, ManagerBasedEnv])
+def test_env_destructor_closes_before_shutdown(env_cls, monkeypatch):
+    """Environment destructors should still close open envs during normal runtime."""
+
+    closed = False
+
+    def close(_self):
+        nonlocal closed
+        closed = True
+
+    env = object.__new__(env_cls)
+    env._is_closed = False
+    monkeypatch.setattr(env_cls, "close", close)
+
+    env.__del__()
+
+    assert closed
+
+
+@pytest.mark.parametrize("env_cls", [DirectRLEnv, DirectMARLEnv, ManagerBasedEnv])
+def test_env_destructor_skips_close_when_already_closed(env_cls, monkeypatch):
+    """Environment destructors should not re-enter close after normal cleanup."""
+
+    def close(_self):
+        raise AssertionError("close should not be called for an already closed env")
+
+    env = object.__new__(env_cls)
+    env._is_closed = True
+    monkeypatch.setattr(env_cls, "close", close)
+
+    env.__del__()
+
+
+@pytest.mark.parametrize("env_cls", [DirectRLEnv, DirectMARLEnv, ManagerBasedEnv])
+def test_env_destructor_skips_close_after_import_shutdown(env_cls, monkeypatch):
+    """Environment destructors should not run cleanup after import machinery is torn down."""
+
+    def close(_self):
+        raise ImportError("sys.meta_path is None, Python is likely shutting down")
+
+    env = object.__new__(env_cls)
+    env._is_closed = False
+    monkeypatch.setattr(env_cls, "close", close)
+    monkeypatch.setattr("sys.meta_path", None)
+
+    env.__del__()


### PR DESCRIPTION
## Summary
- Skip environment destructor cleanup once Python import shutdown has started (`sys.meta_path is None`).
- Apply the guard consistently to `DirectRLEnv`, `DirectMARLEnv`, and `ManagerBasedEnv`.
- Add regression coverage that verifies destructors still close during normal runtime but do not call `close()` after import shutdown begins.

## Validation
- `PYTHONPATH=/tmp/isaaclab-directrl-del/source/isaaclab /home/zhengyuz/Projects/IsaacLab.wt/decouple-physics-events/env_isaaclab/bin/python -m pytest source/isaaclab/test/envs/test_env_destructors.py -q`
- `git diff --check`
- `python -m py_compile source/isaaclab/isaaclab/envs/direct_rl_env.py source/isaaclab/isaaclab/envs/direct_marl_env.py source/isaaclab/isaaclab/envs/manager_based_env.py source/isaaclab/test/envs/test_env_destructors.py`
- `python3 tools/changelog/cli.py check _tmp-upstream-develop`
- Shortened Newton RL-Games repro completed with no `Exception ignored`, `sys.meta_path is None`, `ImportError`, or shutdown traceback:
  `Isaac-Repose-Cube-Allegro-Direct-v0`, `presets=newton`, `--headless`, `--max_iterations 1`, `--num_envs 2048`
