### PR TITLE
Fix quadruped tutorial noise import

### DIFF
--- a/scripts/tutorials/03_envs/create_quadruped_base_env.py
+++ b/scripts/tutorials/03_envs/create_quadruped_base_env.py
@@ -54,7 +54,7 @@ from isaaclab.sensors import RayCasterCfg, patterns
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, check_file_path, read_file
 from isaaclab.utils.configclass import configclass
-from isaaclab.utils.noise import AdditiveUniformNoiseCfg as Unoise
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 ##
 # Pre-defined configs


### PR DESCRIPTION
## Summary
- Update the quadruped base tutorial to import UniformNoiseCfg, which is the beta2 noise config API used elsewhere in the repo.
- Preserve behavior: UniformNoiseCfg defaults to additive noise, matching the tutorial usage.

## Validation
- python3 -m py_compile scripts/tutorials/03_envs/create_quadruped_base_env.py
- python3 tools/changelog/cli.py check release/3.0.0-beta2
- pre-commit run --files scripts/tutorials/03_envs/create_quadruped_base_env.py

Full Kit launch was not run locally; this environment does not have the prepared Isaac Lab runtime dependencies installed.
