### PR TITLE
Fix navigation MJWarp preset resolution

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-navigation-mjwarp-preset.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-navigation-mjwarp-preset.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed the ANYmal-C navigation task's ``newton_mjwarp`` preset so physics and contact sensors resolve to Newton together.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/navigation_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/navigation_env_cfg.py
@@ -12,6 +12,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
 
@@ -124,6 +125,7 @@ class NavigationEnvCfg(ManagerBasedRLEnvCfg):
     """Configuration for the navigation environment."""
 
     # environment settings
+    sim: SimulationCfg = LOW_LEVEL_ENV_CFG.sim
     scene: SceneEntityCfg = LOW_LEVEL_ENV_CFG.scene
     actions: ActionsCfg = ActionsCfg()
     observations: ObservationsCfg = ObservationsCfg()


### PR DESCRIPTION
## Summary
- expose the embedded ANYmal-C low-level sim config on the navigation env so `presets=newton_mjwarp` resolves physics and contact sensors together
- add a regression test for `Isaac-Navigation-Flat-Anymal-C-v0` resolving Newton physics and Newton contact sensors with the reported preset
- add changelog fragment

## Validation
- `python3 -m py_compile source/isaaclab_tasks/isaaclab_tasks/manager_based/navigation/config/anymal_c/navigation_env_cfg.py source/isaaclab_tasks/test/test_navigation_presets.py`
- `python3 tools/changelog/cli.py check release/3.0.0-beta2`
- `git diff --check`

Note: this targets `release/3.0.0-beta2` because the active `develop` branch in this checkout does not contain the preset-based navigation env that reproduces the reported issue.
