### PR TITLE
[release/3.0.0-beta2] Fix quadruped tutorial noise import

### DIFF
--- a/scripts/tutorials/03_envs/create_quadruped_base_env.py
+++ b/scripts/tutorials/03_envs/create_quadruped_base_env.py
@@ -54,7 +54,7 @@ from isaaclab.sensors import RayCasterCfg, patterns
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR, check_file_path, read_file
 from isaaclab.utils.configclass import configclass
-from isaaclab.utils.noise import AdditiveUniformNoiseCfg as Unoise
+from isaaclab.utils.noise import UniformNoiseCfg as Unoise
 
 ##
 # Pre-defined configs


### PR DESCRIPTION
## Summary
- Backports #6033 to `release/3.0.0-beta2`.
- Updates the quadruped tutorial noise import from `AdditiveUniformNoiseCfg` to `UniformNoiseCfg`.

## Source
- Upstream PR: #6033
- Source commit: 8f701c371b977b76822182f36e5057a10a6e0d7e

## Tests
- `git diff --check upstream/release/3.0.0-beta2..HEAD`
- Parsed `scripts/tutorials/03_envs/create_quadruped_base_env.py` with `ast.parse`