### PR TITLE
Fix AutoMate PhysX sizing and assembly ID validation

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-automate-collision-stack.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-automate-collision-stack.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Increased the AutoMate assembly and disassembly PhysX GPU collision stack to avoid dropped contacts at the default 128 environments.
+* Updated AutoMate run helpers and docs to reject placeholder assembly IDs before launching simulation.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/assembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/assembly_env_cfg.py
@@ -118,6 +118,7 @@ class AssemblyEnvCfg(DirectRLEnvCfg):
             friction_correlation_distance=0.00625,
             gpu_max_rigid_contact_count=2**23,
             gpu_max_rigid_patch_count=2**23,
+            gpu_collision_stack_size=2**27,
             gpu_max_num_partitions=1,  # Important for stable simulation.
         ),
         physics_material=RigidBodyMaterialCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/disassembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/disassembly_env_cfg.py
@@ -119,6 +119,7 @@ class DisassemblyEnvCfg(DirectRLEnvCfg):
             friction_correlation_distance=0.00625,
             gpu_max_rigid_contact_count=2**23,
             gpu_max_rigid_patch_count=2**23,
+            gpu_collision_stack_size=2**27,
             gpu_max_num_partitions=1,  # Important for stable simulation.
         ),
         physics_material=RigidBodyMaterialCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_disassembly_w_id.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_disassembly_w_id.py
@@ -53,6 +53,9 @@ def main():
     parser.add_argument("--seed", type=int, default=-1, help="Random seed.")
     args = parser.parse_args()
 
+    if args.assembly_id == "ASSEMBLY_ID":
+        parser.error("replace ASSEMBLY_ID with an AutoMate assembly ID, for example 00032")
+
     os.makedirs(args.disassembly_dir, exist_ok=True)
 
     update_task_param(

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_w_id.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_w_id.py
@@ -57,6 +57,9 @@ def main():
     parser.add_argument("--max_iterations", type=int, default=1500, help="Number of iteration for policy learning.")
     args = parser.parse_args()
 
+    if args.assembly_id == "ASSEMBLY_ID":
+        parser.error("replace ASSEMBLY_ID with an AutoMate assembly ID, for example 00032")
+
     update_task_param(args.cfg_path, args.assembly_id, args.train, args.log_eval)
 
     # avoid the warning of low GPU occupancy for SoftDTWCUDA function


### PR DESCRIPTION
## Summary
- increase AutoMate assembly/disassembly PhysX GPU collision stack size from the default 2**26 to 2**27
- reject placeholder/non-5-digit AutoMate assembly IDs in the run helpers before they mutate config or launch simulation
- update AutoMate docs to use a concrete runnable assembly ID example
- add a lightweight config/helper regression test and an isaaclab_tasks changelog fragment

## Rationale
The reported Windows beta2 disassembly run for assembly_id 00032 asks PhysX for a collision stack of roughly 75-86 MB, above the default 2**26 bytes. This keeps the memory change scoped to AutoMate's high-contact 128-env tasks instead of raising the global PhysX default for unrelated environments.

A second reported DGX Spark command passed the literal docs placeholder `ASSEMBLY_ID`, which was written into the task config and only failed later as a missing remote USD path. The helpers now fail fast with an argparse message before launching Kit.

## Validation
- `python3 tools/changelog/cli.py check develop`
- `python3 -m py_compile source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_w_id.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_disassembly_w_id.py source/isaaclab_tasks/test/contrib/test_automate_cfg.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/disassembly_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/assembly_env_cfg.py`
- `.venv/bin/python -m pytest source/isaaclab_tasks/test/contrib/test_automate_cfg.py`
- `uvx ruff==0.14.10 check --fix source/isaaclab_tasks/test/contrib/test_automate_cfg.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_w_id.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_disassembly_w_id.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/disassembly_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/assembly_env_cfg.py`
- `uvx ruff==0.14.10 format source/isaaclab_tasks/test/contrib/test_automate_cfg.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_w_id.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_disassembly_w_id.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/disassembly_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/contrib/automate/assembly_env_cfg.py`
- `git diff --check`
- `.venv/bin/python source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_w_id.py --assembly_id=ASSEMBLY_ID --train --max_iterations 10` exits at argparse with the placeholder-specific message and does not mutate the task config

Could not run the full PhysX/Kit repro locally because this machine's uv environment does not have Isaac Sim/Kit on PYTHONPATH; the command fails before simulation with Isaac Sim not installed.
