### PR TITLE
Fix AutoMate SoftDTW import fallback

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-automate-softdtw-numba-cuda-import.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-automate-softdtw-numba-cuda-import.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed AutoMate assembly environment imports when the optional SoftDTW CUDA
+  backend cannot be imported from the installed Numba/Numba-CUDA stack.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
@@ -27,13 +27,46 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 import math
+import warnings
 
-import numba.cuda as cuda
 import numpy as np
 import torch
 import torch.cuda
-from numba import jit, prange
 from torch.autograd import Function
+
+
+def _identity_jit(*jit_args, **jit_kwargs):
+    """Return the wrapped function unchanged when Numba is unavailable."""
+    if jit_args and callable(jit_args[0]) and len(jit_args) == 1 and not jit_kwargs:
+        return jit_args[0]
+
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+try:
+    from numba import jit, prange
+except (AttributeError, ImportError):
+    jit = _identity_jit
+    prange = range
+
+try:
+    import numba.cuda as cuda
+except (AttributeError, ImportError) as exc:
+    _CUDA_IMPORT_ERROR = exc
+
+    class _UnavailableCuda:
+        @staticmethod
+        def jit(*jit_args, **jit_kwargs):
+            return _identity_jit(*jit_args, **jit_kwargs)
+
+    cuda = _UnavailableCuda()
+else:
+    _CUDA_IMPORT_ERROR = None
+
+_CUDA_FALLBACK_WARNED = False
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -316,6 +349,8 @@ class SoftDTW(torch.nn.Module):
         """
         Checks the inputs and selects the proper implementation to use.
         """
+        global _CUDA_FALLBACK_WARNED
+
         bx, lx, dx = x.shape
         by, ly, dy = y.shape
         # Make sure the dimensions match
@@ -323,6 +358,18 @@ class SoftDTW(torch.nn.Module):
         assert dx == dy  # Equal feature dimensions
 
         use_cuda = self.use_cuda
+
+        if use_cuda and _CUDA_IMPORT_ERROR is not None:
+            if not _CUDA_FALLBACK_WARNED:
+                warnings.warn(
+                    "SoftDTW CUDA backend is unavailable because numba.cuda failed to import "
+                    f"({type(_CUDA_IMPORT_ERROR).__name__}: {_CUDA_IMPORT_ERROR}). "
+                    "Falling back to CPU SoftDTW.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                _CUDA_FALLBACK_WARNED = True
+            use_cuda = False
 
         if use_cuda and (lx > 1024 or ly > 1024):  # We should be able to spawn enough threads in CUDA
             print(

--- a/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw_cuda.py
+++ b/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw_cuda.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _load_soft_dtw_module():
+    module_path = (
+        Path(__file__).parents[2]
+        / "isaaclab_tasks"
+        / "contrib"
+        / "automate"
+        / "soft_dtw_cuda.py"
+    )
+    spec = importlib.util.spec_from_file_location("automate_soft_dtw_cuda_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_soft_dtw_falls_back_to_cpu_when_numba_cuda_import_fails(monkeypatch):
+    soft_dtw_cuda = _load_soft_dtw_module()
+    monkeypatch.setattr(soft_dtw_cuda, "_CUDA_IMPORT_ERROR", AttributeError("missing NPDatetime"))
+    monkeypatch.setattr(soft_dtw_cuda, "_CUDA_FALLBACK_WARNED", False)
+
+    criterion = soft_dtw_cuda.SoftDTW(use_cuda=True, device="cpu", gamma=0.01)
+    x = torch.zeros((1, 2, 3), dtype=torch.float32)
+    y = torch.zeros((1, 2, 3), dtype=torch.float32)
+
+    with pytest.warns(RuntimeWarning, match="numba.cuda failed to import"):
+        func_dtw = criterion._get_func_dtw(x, y)
+
+    assert getattr(func_dtw, "__self__", None) is soft_dtw_cuda._SoftDTW


### PR DESCRIPTION
## Summary
- Make the AutoMate SoftDTW module importable when the optional `numba.cuda` backend fails to import.
- Fall back to the existing CPU SoftDTW implementation when `SoftDTW(use_cuda=True)` is requested but the CUDA backend is unavailable.
- Add a focused regression test that simulates the reported `numba.cuda.types.NPDatetime` import failure.

## Reproduction / Verification
- Checked the provided failure path: `assembly_env.py` imports `SoftDTW` from `soft_dtw_cuda.py`, which previously imported and decorated `numba.cuda` kernels at module import time.
- In an existing beta2 virtualenv with broken Numba imports, verified the patched `soft_dtw_cuda.py` imports successfully and a small `SoftDTW(use_cuda=True)` call falls back to CPU.

## Tests
- `git diff --cached --check`
- Parsed modified Python files with `ast.parse`
- `/home/zhengyuz/Projects/IsaacLab.wt/develop/.venv/bin/python -m pytest source/isaaclab_tasks/test/contrib/test_automate_soft_dtw_cuda.py -q`
- `/home/zhengyuz/Projects/IsaacLab.wt/beta2-automate-collision-stack/.venv/bin/python -m pytest source/isaaclab_tasks/test/contrib/test_automate_soft_dtw_cuda.py -q`
- Direct patched-module import/fallback check in `beta2-automate-collision-stack/.venv`