### PR TITLE
Remove AutoMate Numba SoftDTW dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ explicit = true
 [tool.uv]
 index-strategy = "unsafe-best-match"
 prerelease = "allow"
-override-dependencies = ["numpy>=2"]
+override-dependencies = ["numpy>=2,<2.5"]
 python-preference = "only-managed"
 package = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ explicit = true
 [tool.uv]
 index-strategy = "unsafe-best-match"
 prerelease = "allow"
-override-dependencies = ["numpy>=2,<2.5"]
+override-dependencies = ["numpy>=2"]
 python-preference = "only-managed"
 package = false
 

--- a/source/isaaclab_tasks/changelog.d/fix-automate-numba-constraints.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-automate-numba-constraints.rst
@@ -1,5 +1,5 @@
 Fixed
 ^^^^^
 
-* Constrained AutoMate's Numba dependency and uv's NumPy override to avoid
-  incompatible pre-release Numba/NumPy stacks that break SoftDTW CUDA imports.
+* Removed AutoMate's Numba dependency by replacing the SoftDTW helper with a
+  Torch implementation.

--- a/source/isaaclab_tasks/changelog.d/fix-automate-numba-constraints.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-automate-numba-constraints.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Constrained AutoMate's Numba dependency and uv's NumPy override to avoid
+  incompatible pre-release Numba/NumPy stacks that break SoftDTW CUDA imports.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/automate_algo_utils.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/automate_algo_utils.py
@@ -88,23 +88,50 @@ def get_imitation_reward_from_dtw(ref_traj, curr_ee_pos, prev_ee_traj, criterion
     prev_ee_pos = prev_ee_traj[:, 0, :]  # select the first ee pos in robot traj
     min_dist_traj_idx, min_dist_step_idx, min_dist_per_env = get_closest_state_idx(ref_traj, prev_ee_pos)
 
+    eef_traj = torch.cat((prev_ee_traj[:, 1:, :], curr_ee_pos.unsqueeze(1)), dim=1)
+    selected_trajs: list[torch.Tensor] = []
+    selected_traj_lengths = torch.empty((curr_ee_pos.shape[0],), dtype=torch.long, device=device)
+    max_selected_traj_len = 0
+
     for i in range(curr_ee_pos.shape[0]):
-        traj_idx = min_dist_traj_idx[i]
-        step_idx = min_dist_step_idx[i]
+        traj_idx = int(min_dist_traj_idx[i].item())
+        step_idx = int(min_dist_step_idx[i].item())
         curr_ee_pos_i = curr_ee_pos[i].reshape(1, 3)
 
         # NOTE: in reference trajectories, larger index -> closer to goal
         traj = ref_traj[traj_idx, step_idx:, :].reshape((1, -1, 3))
 
         _, curr_step_idx, _ = get_closest_state_idx(traj, curr_ee_pos_i)
+        curr_step_idx = int(curr_step_idx.item())
 
         if curr_step_idx == 0:
-            selected_pos = ref_traj[traj_idx, step_idx, :].reshape((1, 1, 3))
-            selected_traj = torch.cat([selected_pos, selected_pos], dim=1)
+            selected_traj = ref_traj[traj_idx, step_idx, :].reshape((1, 3)).repeat(2, 1)
         else:
-            selected_traj = ref_traj[traj_idx, step_idx : (curr_step_idx + step_idx), :].reshape((1, -1, 3))
-        eef_traj = torch.cat((prev_ee_traj[i, 1:, :], curr_ee_pos_i)).reshape((1, -1, 3))
-        soft_dtw[i] = criterion(eef_traj, selected_traj)
+            selected_traj = ref_traj[traj_idx, step_idx : (curr_step_idx + step_idx), :]
+
+        traj_len = selected_traj.shape[0]
+        selected_trajs.append(selected_traj)
+        selected_traj_lengths[i] = traj_len
+        max_selected_traj_len = max(max_selected_traj_len, traj_len)
+
+    if hasattr(criterion, "forward_with_lengths") and not getattr(criterion, "normalize", False):
+        padded_selected_trajs = torch.zeros(
+            (curr_ee_pos.shape[0], max_selected_traj_len, ref_traj.shape[-1]), dtype=ref_traj.dtype, device=device
+        )
+        for i, selected_traj in enumerate(selected_trajs):
+            padded_selected_trajs[i, : selected_traj.shape[0], :] = selected_traj
+        soft_dtw = criterion.forward_with_lengths(eef_traj, padded_selected_trajs, selected_traj_lengths)
+    else:
+        selected_trajs_by_len: dict[int, list[torch.Tensor]] = {}
+        env_ids_by_len: dict[int, list[int]] = {}
+        for i, selected_traj in enumerate(selected_trajs):
+            traj_len = selected_traj.shape[0]
+            selected_trajs_by_len.setdefault(traj_len, []).append(selected_traj)
+            env_ids_by_len.setdefault(traj_len, []).append(i)
+
+        for traj_len, selected_trajs_by_curr_len in selected_trajs_by_len.items():
+            env_ids = torch.tensor(env_ids_by_len[traj_len], dtype=torch.long, device=device)
+            soft_dtw[env_ids] = criterion(eef_traj[env_ids], torch.stack(selected_trajs_by_curr_len, dim=0))
 
     w_task_progress = 1 - (min_dist_step_idx / ref_traj.shape[1])
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_w_id.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/run_w_id.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import argparse
-import os
 import re
 import subprocess
 import sys
@@ -59,10 +58,6 @@ def main():
 
     update_task_param(args.cfg_path, args.assembly_id, args.train, args.log_eval)
 
-    # avoid the warning of low GPU occupancy for SoftDTWCUDA function
-    env = os.environ.copy()
-    env["NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS"] = "0"
-
     # build the command
     if sys.platform.startswith("win"):
         command = ["isaaclab.bat"]
@@ -91,7 +86,7 @@ def main():
         command.append(f"--checkpoint={args.checkpoint}")
 
     # Run the command
-    subprocess.run(command, env=env, check=True)
+    subprocess.run(command, check=True)
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
@@ -66,7 +66,7 @@ def _soft_dtw_no_grad(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.
         i = torch.arange(max(1, diag - len_y), min(len_x, diag - 1) + 1, device=D.device)
         j = diag - i
 
-        if 0 < bandwidth:
+        if bandwidth > 0:
             keep = torch.abs(i - j) <= bandwidth
             i = i[keep]
             j = j[keep]
@@ -100,7 +100,7 @@ def _soft_dtw_variable_y_no_grad(
         i = torch.arange(max(1, diag - len_y), min(len_x, diag - 1) + 1, device=D.device)
         j = diag - i
 
-        if 0 < bandwidth:
+        if bandwidth > 0:
             keep = torch.abs(i - j) <= bandwidth
             i = i[keep]
             j = j[keep]

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
@@ -29,8 +29,8 @@
 import torch
 
 
-def _soft_dtw(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
-    """Compute SoftDTW from a batched pairwise distance matrix using Torch ops."""
+def _soft_dtw_autograd(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
+    """Compute SoftDTW using Torch ops that preserve autograd."""
     batch_size, len_x, len_y = D.shape
     inf = torch.full((batch_size,), float("inf"), device=D.device, dtype=D.dtype)
     prev_row = [inf] * (len_y + 2)
@@ -52,6 +52,78 @@ def _soft_dtw(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
         prev_row = curr_row
 
     return prev_row[len_y]
+
+
+def _soft_dtw_no_grad(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
+    """Compute SoftDTW by evaluating each dynamic-programming anti-diagonal in one batched op."""
+    batch_size, len_x, len_y = D.shape
+    R = torch.full((batch_size, len_x + 2, len_y + 2), float("inf"), device=D.device, dtype=D.dtype)
+    R[:, 0, 0] = 0
+
+    for diag in range(2, len_x + len_y + 1):
+        i = torch.arange(max(1, diag - len_y), min(len_x, diag - 1) + 1, device=D.device)
+        j = diag - i
+
+        if 0 < bandwidth:
+            keep = torch.abs(i - j) <= bandwidth
+            i = i[keep]
+            j = j[keep]
+            if i.numel() == 0:
+                continue
+
+        if gamma == 0:
+            softmin = torch.minimum(torch.minimum(R[:, i - 1, j - 1], R[:, i - 1, j]), R[:, i, j - 1])
+        else:
+            previous_costs = torch.stack((R[:, i - 1, j - 1], R[:, i - 1, j], R[:, i, j - 1]))
+            softmin = -gamma * torch.logsumexp(-previous_costs / gamma, dim=0)
+
+        R[:, i, j] = D[:, i - 1, j - 1] + softmin
+
+    return R[:, len_x, len_y]
+
+
+def _soft_dtw_variable_y_no_grad(
+    D: torch.Tensor, y_lengths: torch.Tensor, gamma: float, bandwidth: float
+) -> torch.Tensor:
+    """Compute SoftDTW for a batch where each Y sequence can have a different length."""
+    batch_size, len_x, len_y = D.shape
+    y_lengths = y_lengths.to(device=D.device, dtype=torch.long)
+    if y_lengths.min().item() < 1 or y_lengths.max().item() > len_y:
+        raise ValueError("y_lengths entries must be in [1, len_y]")
+
+    R = torch.full((batch_size, len_x + 2, len_y + 2), float("inf"), device=D.device, dtype=D.dtype)
+    R[:, 0, 0] = 0
+
+    for diag in range(2, len_x + len_y + 1):
+        i = torch.arange(max(1, diag - len_y), min(len_x, diag - 1) + 1, device=D.device)
+        j = diag - i
+
+        if 0 < bandwidth:
+            keep = torch.abs(i - j) <= bandwidth
+            i = i[keep]
+            j = j[keep]
+            if i.numel() == 0:
+                continue
+
+        if gamma == 0:
+            softmin = torch.minimum(torch.minimum(R[:, i - 1, j - 1], R[:, i - 1, j]), R[:, i, j - 1])
+        else:
+            previous_costs = torch.stack((R[:, i - 1, j - 1], R[:, i - 1, j], R[:, i, j - 1]))
+            softmin = -gamma * torch.logsumexp(-previous_costs / gamma, dim=0)
+
+        values = D[:, i - 1, j - 1] + softmin
+        valid_y = j.unsqueeze(0) <= y_lengths.unsqueeze(1)
+        R[:, i, j] = torch.where(valid_y, values, torch.full_like(values, float("inf")))
+
+    batch_ids = torch.arange(batch_size, device=D.device)
+    return R[batch_ids, len_x, y_lengths]
+
+
+def _soft_dtw(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
+    """Compute SoftDTW from a batched pairwise distance matrix using Torch ops."""
+    if torch.is_grad_enabled() and D.requires_grad:
+        return _soft_dtw_autograd(D, gamma, bandwidth)
+    return _soft_dtw_no_grad(D, gamma, bandwidth)
 
 
 class SoftDTW(torch.nn.Module):
@@ -107,3 +179,17 @@ class SoftDTW(torch.nn.Module):
 
         D_xy = self.dist_func(X, Y)
         return _soft_dtw(D_xy, self.gamma, self.bandwidth)
+
+    def forward_with_lengths(self, X, Y, y_lengths):
+        """Compute SoftDTW when each Y sequence is padded to a per-sample length."""
+        if self.normalize:
+            raise ValueError("forward_with_lengths does not support normalize=True")
+
+        if torch.is_grad_enabled() and (X.requires_grad or Y.requires_grad):
+            outputs = []
+            for batch_id, y_length in enumerate(y_lengths.tolist()):
+                outputs.append(self.forward(X[batch_id : batch_id + 1], Y[batch_id : batch_id + 1, : int(y_length)]))
+            return torch.cat(outputs)
+
+        D_xy = self.dist_func(X, Y)
+        return _soft_dtw_variable_y_no_grad(D_xy, y_lengths, self.gamma, self.bandwidth)

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
@@ -32,26 +32,28 @@ import torch
 def _soft_dtw_autograd(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
     """Compute SoftDTW using Torch ops that preserve autograd."""
     batch_size, len_x, len_y = D.shape
-    inf = torch.full((batch_size,), float("inf"), device=D.device, dtype=D.dtype)
-    prev_row = [inf] * (len_y + 2)
-    prev_row[0] = torch.zeros((batch_size,), device=D.device, dtype=D.dtype)
+    R = torch.full((batch_size, len_x + 2, len_y + 2), float("inf"), device=D.device, dtype=D.dtype)
+    R[:, 0, 0] = 0
 
+    band_size = int(bandwidth) if bandwidth > 0 else max(len_x, len_y)
     for i in range(1, len_x + 1):
-        curr_row = [inf] * (len_y + 2)
-        for j in range(1, len_y + 1):
-            if 0 < bandwidth < abs(i - j):
-                continue
+        j_start = max(1, i - band_size)
+        j_end = min(len_y, i + band_size) + 1
+
+        for j in range(j_start, j_end):
+            r0 = R[:, i - 1, j - 1]
+            r1 = R[:, i - 1, j]
+            r2 = R[:, i, j - 1]
 
             if gamma == 0:
-                softmin = torch.minimum(torch.minimum(prev_row[j - 1], prev_row[j]), curr_row[j - 1])
+                softmin = torch.minimum(torch.minimum(r0, r1), r2)
             else:
-                previous_costs = torch.stack((prev_row[j - 1], prev_row[j], curr_row[j - 1]))
+                previous_costs = torch.stack((r0, r1, r2))
                 softmin = -gamma * torch.logsumexp(-previous_costs / gamma, dim=0)
 
-            curr_row[j] = D[:, i - 1, j - 1] + softmin
-        prev_row = curr_row
+            R[:, i, j] = D[:, i - 1, j - 1] + softmin
 
-    return prev_row[len_y]
+    return R[:, len_x, len_y]
 
 
 def _soft_dtw_no_grad(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
@@ -120,7 +122,13 @@ def _soft_dtw_variable_y_no_grad(
 
 
 def _soft_dtw(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
-    """Compute SoftDTW from a batched pairwise distance matrix using Torch ops."""
+    """Compute batched SoftDTW from a pairwise distance tensor.
+
+    Args:
+        D: Pairwise distance tensor of shape ``(batch, len_x, len_y)``.
+        gamma: SoftDTW smoothing parameter. Set to 0 to compute hard DTW.
+        bandwidth: Optional Sakoe-Chiba bandwidth. Values <= 0 disable the band constraint.
+    """
     if torch.is_grad_enabled() and D.requires_grad:
         return _soft_dtw_autograd(D, gamma, bandwidth)
     return _soft_dtw_no_grad(D, gamma, bandwidth)

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/soft_dtw_cuda.py
@@ -26,427 +26,84 @@
 # SOFTWARE.
 # ----------------------------------------------------------------------------------------------------------------------
 
-import math
-
-import numba.cuda as cuda
-import numpy as np
 import torch
-import torch.cuda
-from numba import jit, prange
-from torch.autograd import Function
 
 
-# ----------------------------------------------------------------------------------------------------------------------
-@cuda.jit
-def compute_softdtw_cuda(D, gamma, bandwidth, max_i, max_j, n_passes, R):
-    """
-    :param seq_len: The length of the sequence (both inputs are assumed to be of the same size)
-    :param n_passes: 2 * seq_len - 1 (The number of anti-diagonals)
-    """
-    # Each block processes one pair of examples
-    b = cuda.blockIdx.x
-    # We have as many threads as seq_len, because the most number of threads we need
-    # is equal to the number of elements on the largest anti-diagonal
-    tid = cuda.threadIdx.x
+def _soft_dtw(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
+    """Compute SoftDTW from a batched pairwise distance matrix using Torch ops."""
+    batch_size, len_x, len_y = D.shape
+    inf = torch.full((batch_size,), float("inf"), device=D.device, dtype=D.dtype)
+    prev_row = [inf] * (len_y + 2)
+    prev_row[0] = torch.zeros((batch_size,), device=D.device, dtype=D.dtype)
 
-    inv_gamma = 1.0 / gamma
+    for i in range(1, len_x + 1):
+        curr_row = [inf] * (len_y + 2)
+        for j in range(1, len_y + 1):
+            if 0 < bandwidth < abs(i - j):
+                continue
 
-    # Go over each anti-diagonal. Only process threads that fall on the current on the anti-diagonal
-    for p in range(n_passes):
-        # The index is actually 'p - tid' but need to force it in-bounds
-        J = max(0, min(p - tid, max_j - 1))
+            if gamma == 0:
+                softmin = torch.minimum(torch.minimum(prev_row[j - 1], prev_row[j]), curr_row[j - 1])
+            else:
+                previous_costs = torch.stack((prev_row[j - 1], prev_row[j], curr_row[j - 1]))
+                softmin = -gamma * torch.logsumexp(-previous_costs / gamma, dim=0)
 
-        # For simplicity, we define i, j which start from 1 (offset from I, J)
-        i = tid + 1
-        j = J + 1
+            curr_row[j] = D[:, i - 1, j - 1] + softmin
+        prev_row = curr_row
 
-        # Only compute if element[i, j] is on the current anti-diagonal, and also is within bounds
-        if tid + J == p and (tid < max_i and max_j > J):
-            # Don't compute if outside bandwidth
-            if not (abs(i - j) > bandwidth > 0):
-                r0 = -R[b, i - 1, j - 1] * inv_gamma
-                r1 = -R[b, i - 1, j] * inv_gamma
-                r2 = -R[b, i, j - 1] * inv_gamma
-                rmax = max(max(r0, r1), r2)
-                rsum = math.exp(r0 - rmax) + math.exp(r1 - rmax) + math.exp(r2 - rmax)
-                softmin = -gamma * (math.log(rsum) + rmax)
-                R[b, i, j] = D[b, i - 1, j - 1] + softmin
-
-        # Wait for other threads in this block
-        cuda.syncthreads()
+    return prev_row[len_y]
 
 
-# ----------------------------------------------------------------------------------------------------------------------
-@cuda.jit
-def compute_softdtw_backward_cuda(D, R, inv_gamma, bandwidth, max_i, max_j, n_passes, E):
-    k = cuda.blockIdx.x
-    tid = cuda.threadIdx.x
-
-    # Indexing logic is the same as above, however, the anti-diagonal needs to
-    # progress backwards
-
-    for p in range(n_passes):
-        # Reverse the order to make the loop go backward
-        rev_p = n_passes - p - 1
-
-        # convert tid to I, J, then i, j
-        J = max(0, min(rev_p - tid, max_j - 1))
-
-        i = tid + 1
-        j = J + 1
-
-        # Only compute if element[i, j] is on the current anti-diagonal, and also is within bounds
-        if tid + J == rev_p and (tid < max_i and max_j > J):
-            if math.isinf(R[k, i, j]):
-                R[k, i, j] = -math.inf
-
-            # Don't compute if outside bandwidth
-            if not (abs(i - j) > bandwidth > 0):
-                a = math.exp((R[k, i + 1, j] - R[k, i, j] - D[k, i + 1, j]) * inv_gamma)
-                b = math.exp((R[k, i, j + 1] - R[k, i, j] - D[k, i, j + 1]) * inv_gamma)
-                c = math.exp((R[k, i + 1, j + 1] - R[k, i, j] - D[k, i + 1, j + 1]) * inv_gamma)
-                E[k, i, j] = E[k, i + 1, j] * a + E[k, i, j + 1] * b + E[k, i + 1, j + 1] * c
-
-        # Wait for other threads in this block
-        cuda.syncthreads()
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-class _SoftDTWCUDA(Function):
-    """
-    CUDA implementation is inspired by the diagonal one proposed in https://ieeexplore.ieee.org/document/8400444:
-    "Developing a pattern discovery method in time series data and its GPU acceleration"
-    """
-
-    @staticmethod
-    def forward(ctx, D, device, gamma, bandwidth):
-        dev = D.device
-        dtype = D.dtype
-        gamma = torch.tensor([gamma], dtype=torch.float, device=device)
-        bandwidth = torch.tensor([bandwidth], dtype=torch.float, device=device)
-
-        B = D.shape[0]
-        N = D.shape[1]
-        M = D.shape[2]
-        threads_per_block = max(N, M)
-        n_passes = 2 * threads_per_block - 1
-
-        # Prepare the output array
-        R = torch.ones((B, N + 2, M + 2), device=dev, dtype=dtype) * math.inf
-        R[:, 0, 0] = 0
-
-        # Run the CUDA kernel.
-        # Set CUDA's grid size to be equal to the batch size (every CUDA block processes one sample pair)
-        # Set the CUDA block size to be equal to the length of the longer sequence
-        # (equal to the size of the largest diagonal)
-        compute_softdtw_cuda[B, threads_per_block](
-            cuda.as_cuda_array(D.detach()), gamma.item(), bandwidth.item(), N, M, n_passes, cuda.as_cuda_array(R)
-        )
-        ctx.save_for_backward(D, R.clone(), gamma, bandwidth)
-        return R[:, -2, -2]
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        dev = grad_output.device
-        dtype = grad_output.dtype
-        D, R, gamma, bandwidth = ctx.saved_tensors
-
-        B = D.shape[0]
-        N = D.shape[1]
-        M = D.shape[2]
-        threads_per_block = max(N, M)
-        n_passes = 2 * threads_per_block - 1
-
-        D_ = torch.zeros((B, N + 2, M + 2), dtype=dtype, device=dev)
-        D_[:, 1 : N + 1, 1 : M + 1] = D
-
-        R[:, :, -1] = -math.inf
-        R[:, -1, :] = -math.inf
-        R[:, -1, -1] = R[:, -2, -2]
-
-        E = torch.zeros((B, N + 2, M + 2), dtype=dtype, device=dev)
-        E[:, -1, -1] = 1
-
-        # Grid and block sizes are set same as done above for the forward() call
-        compute_softdtw_backward_cuda[B, threads_per_block](
-            cuda.as_cuda_array(D_),
-            cuda.as_cuda_array(R),
-            1.0 / gamma.item(),
-            bandwidth.item(),
-            N,
-            M,
-            n_passes,
-            cuda.as_cuda_array(E),
-        )
-        E = E[:, 1 : N + 1, 1 : M + 1]
-        return grad_output.view(-1, 1, 1).expand_as(E) * E, None, None
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-#
-# The following is the CPU implementation based on https://github.com/Sleepwalking/pytorch-softdtw
-# Credit goes to Kanru Hua.
-# I've added support for batching and pruning.
-#
-# ----------------------------------------------------------------------------------------------------------------------
-@jit(nopython=True, parallel=True)
-def compute_softdtw(D, gamma, bandwidth):
-    B = D.shape[0]
-    N = D.shape[1]
-    M = D.shape[2]
-    R = np.ones((B, N + 2, M + 2)) * np.inf
-    R[:, 0, 0] = 0
-    for b in prange(B):
-        for j in range(1, M + 1):
-            for i in range(1, N + 1):
-                # Check the pruning condition
-                if 0 < bandwidth < np.abs(i - j):
-                    continue
-
-                r0 = -R[b, i - 1, j - 1] / gamma
-                r1 = -R[b, i - 1, j] / gamma
-                r2 = -R[b, i, j - 1] / gamma
-                rmax = max(max(r0, r1), r2)
-                rsum = np.exp(r0 - rmax) + np.exp(r1 - rmax) + np.exp(r2 - rmax)
-                softmin = -gamma * (np.log(rsum) + rmax)
-                R[b, i, j] = D[b, i - 1, j - 1] + softmin
-    return R
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-@jit(nopython=True, parallel=True)
-def compute_softdtw_backward(D_, R, gamma, bandwidth):
-    B = D_.shape[0]
-    N = D_.shape[1]
-    M = D_.shape[2]
-    D = np.zeros((B, N + 2, M + 2))
-    E = np.zeros((B, N + 2, M + 2))
-    D[:, 1 : N + 1, 1 : M + 1] = D_
-    E[:, -1, -1] = 1
-    R[:, :, -1] = -np.inf
-    R[:, -1, :] = -np.inf
-    R[:, -1, -1] = R[:, -2, -2]
-    for k in prange(B):
-        for j in range(M, 0, -1):
-            for i in range(N, 0, -1):
-                if np.isinf(R[k, i, j]):
-                    R[k, i, j] = -np.inf
-
-                # Check the pruning condition
-                if 0 < bandwidth < np.abs(i - j):
-                    continue
-
-                a0 = (R[k, i + 1, j] - R[k, i, j] - D[k, i + 1, j]) / gamma
-                b0 = (R[k, i, j + 1] - R[k, i, j] - D[k, i, j + 1]) / gamma
-                c0 = (R[k, i + 1, j + 1] - R[k, i, j] - D[k, i + 1, j + 1]) / gamma
-                a = np.exp(a0)
-                b = np.exp(b0)
-                c = np.exp(c0)
-                E[k, i, j] = E[k, i + 1, j] * a + E[k, i, j + 1] * b + E[k, i + 1, j + 1] * c
-    return E[:, 1 : N + 1, 1 : M + 1]
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-class _SoftDTW(Function):
-    """
-    CPU implementation based on https://github.com/Sleepwalking/pytorch-softdtw
-    """
-
-    @staticmethod
-    def forward(ctx, D, device, gamma, bandwidth):
-        dev = D.device
-        dtype = D.dtype
-        gamma = torch.Tensor([gamma]).to(dev).type(dtype)  # dtype fixed
-        bandwidth = torch.Tensor([bandwidth]).to(dev).type(dtype)
-        D_ = D.detach().cpu().numpy()
-        g_ = gamma.item()
-        b_ = bandwidth.item()
-        R = torch.Tensor(compute_softdtw(D_, g_, b_)).to(dev).type(dtype)
-        ctx.save_for_backward(D, R, gamma, bandwidth)
-        return R[:, -2, -2]
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        dev = grad_output.device
-        dtype = grad_output.dtype
-        D, R, gamma, bandwidth = ctx.saved_tensors
-        D_ = D.detach().cpu().numpy()
-        R_ = R.detach().cpu().numpy()
-        g_ = gamma.item()
-        b_ = bandwidth.item()
-        E = torch.Tensor(compute_softdtw_backward(D_, R_, g_, b_)).to(dev).type(dtype)
-        return grad_output.view(-1, 1, 1).expand_as(E) * E, None, None
-
-
-# ----------------------------------------------------------------------------------------------------------------------
 class SoftDTW(torch.nn.Module):
-    """
-    The soft DTW implementation that optionally supports CUDA
+    """Soft Dynamic Time Warping implemented with Torch tensor operations.
+
+    The ``use_cuda`` and ``device`` arguments are kept for compatibility with the
+    previous AutoMate SoftDTW helper. The implementation runs on the device of the
+    input tensors and does not require Numba.
     """
 
     def __init__(self, use_cuda, device, gamma=1.0, normalize=False, bandwidth=None, dist_func=None):
-        """Initializes a new instance using the supplied parameters
+        """Initializes a new instance using the supplied parameters.
 
         Args:
-
-            use_cuda: Whether to use the CUDA implementation.
-            device: The device to run the SoftDTW computation.
-            gamma: The SoftDTW's gamma parameter. Default is 1.0.
+            use_cuda: Preserved for API compatibility. Inputs already determine the execution device.
+            device: Preserved for API compatibility. Inputs already determine the execution device.
+            gamma: The SoftDTW gamma parameter. Set to 0 for original DTW without smoothing.
             normalize: Whether to perform normalization. Default is False.
-                (as discussed in https://github.com/mblondel/soft-dtw/issues/10#issuecomment-383564790)
             bandwidth: Sakoe-Chiba bandwidth for pruning. Default is None, which disables pruning.
-                If provided, must be a float.
-            dist_func: The point-wise distance function to use. Default is None, which
-                uses a default Euclidean distance function.
+            dist_func: The point-wise distance function to use. Default is squared Euclidean distance.
         """
         super().__init__()
         self.normalize = normalize
-        self.gamma = gamma
+        self.gamma = float(gamma)
         self.bandwidth = 0 if bandwidth is None else float(bandwidth)
         self.use_cuda = use_cuda
         self.device = device
 
-        # Set the distance function
         if dist_func is not None:
             self.dist_func = dist_func
         else:
             self.dist_func = SoftDTW._euclidean_dist_func
 
-    def _get_func_dtw(self, x, y):
-        """
-        Checks the inputs and selects the proper implementation to use.
-        """
-        bx, lx, dx = x.shape
-        by, ly, dy = y.shape
-        # Make sure the dimensions match
-        assert bx == by  # Equal batch sizes
-        assert dx == dy  # Equal feature dimensions
-
-        use_cuda = self.use_cuda
-
-        if use_cuda and (lx > 1024 or ly > 1024):  # We should be able to spawn enough threads in CUDA
-            print(
-                "SoftDTW: Cannot use CUDA because the sequence length > 1024 (the maximum block size supported by CUDA)"
-            )
-            use_cuda = False
-
-        # Finally, return the correct function
-        return _SoftDTWCUDA.apply if use_cuda else _SoftDTW.apply
-
     @staticmethod
     def _euclidean_dist_func(x, y):
-        """
-        Calculates the Euclidean distance between each element in x and y per timestep
-        """
-        n = x.size(1)
-        m = y.size(1)
-        d = x.size(2)
-        x = x.unsqueeze(2).expand(-1, n, m, d)
-        y = y.unsqueeze(1).expand(-1, n, m, d)
+        """Calculates the squared Euclidean distance between each element in x and y per timestep."""
+        num_x = x.size(1)
+        num_y = y.size(1)
+        dims = x.size(2)
+        x = x.unsqueeze(2).expand(-1, num_x, num_y, dims)
+        y = y.unsqueeze(1).expand(-1, num_x, num_y, dims)
         return torch.pow(x - y, 2).sum(3)
 
     def forward(self, X, Y):
-        """
-        Compute the soft-DTW value between X and Y
-        :param X: One batch of examples, batch_size x seq_len x dims
-        :param Y: The other batch of examples, batch_size x seq_len x dims
-        :return: The computed results
-        """
-
-        # Check the inputs and get the correct implementation
-        func_dtw = self._get_func_dtw(X, Y)
-
+        """Compute the SoftDTW value between ``X`` and ``Y``."""
         if self.normalize:
-            # Stack everything up and run
             x = torch.cat([X, X, Y])
             y = torch.cat([Y, X, Y])
             D = self.dist_func(x, y)
-            out = func_dtw(D, self.device, self.gamma, self.bandwidth)
+            out = _soft_dtw(D, self.gamma, self.bandwidth)
             out_xy, out_xx, out_yy = torch.split(out, X.shape[0])
-            return out_xy - 1 / 2 * (out_xx + out_yy)
-        else:
-            D_xy = self.dist_func(X, Y)
-            return func_dtw(D_xy, self.device, self.gamma, self.bandwidth)
+            return out_xy - 0.5 * (out_xx + out_yy)
 
-
-# ----------------------------------------------------------------------------------------------------------------------
-def timed_run(a, b, sdtw):
-    """
-    Runs a and b through sdtw, and times the forward and backward passes.
-    Assumes that a requires gradients.
-    :return: timing, forward result, backward result
-    """
-
-    from timeit import default_timer as timer
-
-    # Forward pass
-    start = timer()
-    forward = sdtw(a, b)
-    end = timer()
-    t = end - start
-
-    grad_outputs = torch.ones_like(forward)
-
-    # Backward
-    start = timer()
-    grads = torch.autograd.grad(forward, a, grad_outputs=grad_outputs)[0]
-    end = timer()
-
-    # Total time
-    t += end - start
-
-    return t, forward, grads
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-def profile(batch_size, seq_len_a, seq_len_b, dims, tol_backward):
-    sdtw = SoftDTW(False, gamma=1.0, normalize=False)
-    sdtw_cuda = SoftDTW(True, gamma=1.0, normalize=False)
-    n_iters = 6
-
-    print(
-        f"Profiling forward() + backward() times for batch_size={batch_size}, seq_len_a={seq_len_a},"
-        f" seq_len_b={seq_len_b}, dims={dims}..."
-    )
-
-    times_cpu = []
-    times_gpu = []
-
-    for i in range(n_iters):
-        a_cpu = torch.rand((batch_size, seq_len_a, dims), requires_grad=True)
-        b_cpu = torch.rand((batch_size, seq_len_b, dims))
-        a_gpu = a_cpu.cuda()
-        b_gpu = b_cpu.cuda()
-
-        # GPU
-        t_gpu, forward_gpu, backward_gpu = timed_run(a_gpu, b_gpu, sdtw_cuda)
-
-        # CPU
-        t_cpu, forward_cpu, backward_cpu = timed_run(a_cpu, b_cpu, sdtw)
-
-        # Verify the results
-        assert torch.allclose(forward_cpu, forward_gpu.cpu())
-        assert torch.allclose(backward_cpu, backward_gpu.cpu(), atol=tol_backward)
-
-        # Ignore the first time we run, in case this is a cold start
-        # (because timings are off at a cold start of the script)
-        if i > 0:
-            times_cpu += [t_cpu]
-            times_gpu += [t_gpu]
-
-    # Average and log
-    avg_cpu = np.mean(times_cpu)
-    avg_gpu = np.mean(times_gpu)
-    print("  CPU:     ", avg_cpu)
-    print("  GPU:     ", avg_gpu)
-    print("  Speedup: ", avg_cpu / avg_gpu)
-    print()
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-if __name__ == "__main__":
-    torch.manual_seed(1234)
-
-    profile(128, 17, 15, 2, tol_backward=1e-6)
-    profile(512, 64, 64, 2, tol_backward=1e-4)
-    profile(512, 256, 256, 2, tol_backward=1e-3)
+        D_xy = self.dist_func(X, Y)
+        return _soft_dtw(D_xy, self.gamma, self.bandwidth)

--- a/source/isaaclab_tasks/pyproject.toml
+++ b/source/isaaclab_tasks/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "torchvision>=0.25.0",
     "protobuf>=4.25.8,!=5.26.0",
     "tensorboard",
-    "numba>=0.63.1,<0.66",
 ]
 
 [project.urls]

--- a/source/isaaclab_tasks/pyproject.toml
+++ b/source/isaaclab_tasks/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "torchvision>=0.25.0",
     "protobuf>=4.25.8,!=5.26.0",
     "tensorboard",
-    "numba>=0.63.1",
+    "numba>=0.63.1,<0.66",
 ]
 
 [project.urls]

--- a/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw.py
+++ b/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw.py
@@ -72,3 +72,17 @@ def test_soft_dtw_forward_with_lengths_matches_unpadded_calls():
         )
 
     assert torch.allclose(actual, expected, atol=1e-6)
+
+
+def test_soft_dtw_backward_produces_finite_gradients():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=False, device="cpu", gamma=0.01)
+
+    torch.manual_seed(17)
+    x = torch.randn((2, 4, 3), dtype=torch.float32, requires_grad=True)
+    y = torch.randn((2, 5, 3), dtype=torch.float32)
+
+    criterion(x, y).sum().backward()
+
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()

--- a/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw.py
+++ b/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw.py
@@ -11,13 +11,7 @@ import torch
 
 
 def _load_soft_dtw_module():
-    module_path = (
-        Path(__file__).parents[2]
-        / "isaaclab_tasks"
-        / "contrib"
-        / "automate"
-        / "soft_dtw_cuda.py"
-    )
+    module_path = Path(__file__).parents[2] / "isaaclab_tasks" / "contrib" / "automate" / "soft_dtw_cuda.py"
     spec = importlib.util.spec_from_file_location("automate_soft_dtw_under_test", module_path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None

--- a/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw.py
+++ b/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _load_soft_dtw_module():
+    module_path = (
+        Path(__file__).parents[2]
+        / "isaaclab_tasks"
+        / "contrib"
+        / "automate"
+        / "soft_dtw_cuda.py"
+    )
+    spec = importlib.util.spec_from_file_location("automate_soft_dtw_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_soft_dtw_use_cuda_does_not_require_numba():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=True, device="cuda", gamma=0.01)
+
+    x = torch.zeros((1, 2, 3), dtype=torch.float32)
+    y = torch.zeros((1, 2, 3), dtype=torch.float32)
+
+    assert criterion(x, y).shape == (1,)
+
+
+def test_soft_dtw_hard_dtw_value():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=False, device="cpu", gamma=0.0)
+
+    x = torch.tensor([[[0.0], [1.0]]])
+    y = torch.tensor([[[0.0], [2.0]]])
+
+    assert criterion(x, y) == pytest.approx(torch.tensor([1.0]))
+
+
+def test_normalized_soft_dtw_identical_sequences_are_zero():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=True, device="cuda", gamma=0.1, normalize=True)
+
+    x = torch.tensor([[[0.0, 0.0], [1.0, 0.5], [2.0, 1.0]]])
+
+    assert criterion(x, x) == pytest.approx(torch.zeros(1), abs=1e-6)

--- a/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw.py
+++ b/source/isaaclab_tasks/test/contrib/test_automate_soft_dtw.py
@@ -52,3 +52,23 @@ def test_normalized_soft_dtw_identical_sequences_are_zero():
     x = torch.tensor([[[0.0, 0.0], [1.0, 0.5], [2.0, 1.0]]])
 
     assert criterion(x, x) == pytest.approx(torch.zeros(1), abs=1e-6)
+
+
+def test_soft_dtw_forward_with_lengths_matches_unpadded_calls():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=False, device="cpu", gamma=0.01)
+
+    torch.manual_seed(11)
+    x = torch.randn((3, 3, 2), dtype=torch.float32)
+    y = torch.zeros((3, 5, 2), dtype=torch.float32)
+    y_lengths = torch.tensor([2, 4, 5], dtype=torch.long)
+    for batch_id, y_length in enumerate(y_lengths.tolist()):
+        y[batch_id, :y_length] = torch.randn((y_length, 2), dtype=torch.float32)
+
+    with torch.no_grad():
+        actual = criterion.forward_with_lengths(x, y, y_lengths)
+        expected = torch.cat(
+            [criterion(x[i : i + 1], y[i : i + 1, : int(y_lengths[i].item())]) for i in range(x.shape[0])]
+        )
+
+    assert torch.allclose(actual, expected, atol=1e-6)


### PR DESCRIPTION
## Summary
- Remove `numba` from `isaaclab_tasks` dependencies.
- Replace AutoMate's Numba CUDA/CPU-JIT SoftDTW helper with a Torch implementation that runs on the input tensor device.
- Add a no-grad anti-diagonal SoftDTW path plus `forward_with_lengths(...)` so the AutoMate reward evaluates padded variable-length reference segments in one batched call instead of one SoftDTW call per environment.
- Clean up the autograd SoftDTW path to use a Torch DP table instead of Python row lists, with a clearer docstring.
- Remove the Numba CUDA warning environment variable from `run_w_id.py`.
- Add focused SoftDTW tests for the no-Numba path, hard DTW, normalized SoftDTW, variable-length padded SoftDTW, and finite backward gradients.

## Rationale
The original failure is not a sustainable place to solve with a NumPy pin. AutoMate only needs SoftDTW values for reward computation; it does not require the copied differentiable Numba implementation as a package-level dependency. Keeping Numba also exposes a second failure mode on RTX 5090: the old Numba CUDA kernel can fail at compile time with `CUDA_ERROR_UNSUPPORTED_PTX_VERSION` / unsupported PTX version.

This removes the dependency instead of constraining global NumPy resolution.

## Verification
- Focused tests pass in the develop venv: `python -m pytest source/isaaclab_tasks/test/contrib/test_automate_soft_dtw.py -q` (`5 passed`).
- Focused tests pass in the beta2 venv where Numba import is broken (`5 passed`).
- `git diff --check` passes.
- `py_compile` passes for the touched Python files.
- Old-vs-new SoftDTW CPU forward parity: 594 finite cases across `gamma={0.01,0.1,1.0}`, normalized/non-normalized valid cases, bandwidth `{None,2,20}`, and sequence lengths up to `B=8,N=10,M=100`; max absolute difference was `1.526e-04`.
- Mustafa's row/column Torch DP variant matched the current no-grad implementation exactly in direct forward checks; for `B=128,N=10,M=100`, it measured `82.497 ms` on CUDA versus `14.038 ms` for the anti-diagonal no-grad SoftDTW path, so this PR keeps the anti-diagonal path for reward inference while using the cleaner Torch DP-table style for autograd.
- For `gamma=0`, the old implementation returns `nan` on a simple hard-DTW case; the new implementation returns the expected hard-DTW value `1.0`.
- New SoftDTW autograd smoke test produces finite gradients.
- AutoMate reward parity: optimized length-aware reward path matches the original per-env reward loop on synthetic AutoMate-shaped data (`128` envs, `10` robot waypoints, `ref_len=100`, `gamma=0.01`); max absolute error was `0.0` on CPU and CUDA.

## Performance
Synthetic AutoMate-shaped reward benchmark on RTX 5090 with Torch `2.10.0+cu128`, `128` envs, `10` robot waypoints, `ref_len=100`, `gamma=0.01`, `no_grad`:

| Path | CPU median | CUDA median | CUDA peak allocated delta |
| --- | ---: | ---: | ---: |
| Per-env Torch reward loop | `141.617 ms` | `355.131 ms` | `15.372 MB` |
| Batched length-aware Torch reward | `13.483 ms` | `25.824 ms` | `15.372 MB` |

The peak CUDA allocation in this reward benchmark is dominated by the closest-state `torch.cdist` calculation, not by the SoftDTW table.

The previous Numba CUDA path could not be timed on this RTX 5090 because it fails locally with `CUDA_ERROR_UNSUPPORTED_PTX_VERSION`; the performance comparison above is against the direct per-env Torch replacement path that this PR would otherwise have used.
