### PR TITLE
Expose Newton visualizer particle options

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/max-newton-visualizer-particles.rst
+++ b/source/isaaclab_visualizers/changelog.d/max-newton-visualizer-particles.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added Newton visualizer configuration options for showing particles and
+  setting their color.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -76,6 +76,10 @@ class NewtonViewerGL(ViewerGL):
         self._fallback_draw_controls = False
         self._update_frequency = update_frequency
         self._color_edit3_prefers_sequence: bool | None = None
+        self.particle_color: tuple[float, float, float] | None = None
+        self._particle_color_buffer: wp.array | None = None
+        self._particle_color_buffer_count = 0
+        self._particle_color_buffer_value: tuple[float, float, float] | None = None
 
         try:
             self.register_ui_callback(self._render_training_controls, position="side")
@@ -147,6 +151,37 @@ class NewtonViewerGL(ViewerGL):
         if hasattr(color, "x") and hasattr(color, "y") and hasattr(color, "z"):
             return (float(color.x), float(color.y), float(color.z))
         return (float(color[0]), float(color[1]), float(color[2]))
+
+    def _particle_color_array(self, count: int) -> wp.array:
+        """Return a cached Warp color array for Newton's particle point batch."""
+        color = self._coerce_color3(self.particle_color)
+        if (
+            self._particle_color_buffer is None
+            or self._particle_color_buffer_count != count
+            or self._particle_color_buffer_value != color
+        ):
+            self._particle_color_buffer = wp.full(
+                shape=count,
+                value=wp.vec3(*color),
+                dtype=wp.vec3,
+                device=self.device,
+            )
+            self._particle_color_buffer_count = count
+            self._particle_color_buffer_value = color
+        return self._particle_color_buffer
+
+    def log_points(self, name, points, radii=None, colors=None, hidden=False):
+        """Apply configured model-particle appearance while preserving Newton's point logging.
+
+        The configured particle color only applies to Newton's canonical
+        ``/model/particles`` point batch. User-defined point clouds retain the
+        colors provided by their own ``log_points`` calls.
+        """
+        if name != "/model/particles" or points is None or self.particle_color is None:
+            return super().log_points(name, points, radii, colors, hidden)
+
+        colors = self._particle_color_array(len(points))
+        return super().log_points(name, points, radii, colors, hidden)
 
     def _color_edit3_compat(self, imgui, label: str, color):
         """
@@ -228,6 +263,9 @@ class NewtonViewerGL(ViewerGL):
 
                     show_com = self.show_com
                     changed, self.show_com = imgui.checkbox("Show Center of Mass", show_com)
+
+                    show_particles = self.show_particles
+                    changed, self.show_particles = imgui.checkbox("Show Particles", show_particles)
 
             imgui.set_next_item_open(True, imgui.Cond_.appearing)
             if imgui.collapsing_header("Rendering Options"):
@@ -430,6 +468,8 @@ class NewtonVisualizer(BaseVisualizer):
             self._viewer.show_springs = self.cfg.show_springs
             self._viewer.show_inertia_boxes = self.cfg.show_inertia_boxes
             self._viewer.show_com = self.cfg.show_com
+            self._viewer.show_particles = self.cfg.show_particles
+            self._viewer.particle_color = self.cfg.particle_color
 
             self._viewer.renderer.draw_shadows = self.cfg.enable_shadows
             self._viewer.renderer.draw_sky = self.cfg.enable_sky
@@ -459,6 +499,8 @@ class NewtonVisualizer(BaseVisualizer):
                 ("tiled_cam_num", self.cfg.tiled_cam_num),
                 ("num_visualized_envs", num_visualized_envs),
                 ("headless", self.cfg.headless),
+                ("show_particles", self.cfg.show_particles),
+                ("particle_color", self.cfg.particle_color),
             ],
         )
         self._is_initialized = True

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer_cfg.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer_cfg.py
@@ -46,6 +46,15 @@ class NewtonVisualizerCfg(VisualizerCfg):
     show_com: bool = False
     """Show center of mass visualization."""
 
+    show_particles: bool = False
+    """Show particle visualization."""
+
+    particle_color: tuple[float, float, float] | None = None
+    """Optional particle color RGB [0, 1]. If None, use Newton viewer defaults.
+
+    Values are passed through to the Newton viewer unchanged.
+    """
+
     enable_shadows: bool = True
     """Enable shadow rendering."""
 

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import numpy as np
 import torch
+import warp as wp
 from isaaclab_visualizers.newton import NewtonVisualizer, NewtonVisualizerCfg
+from isaaclab_visualizers.newton.newton_visualizer import NewtonViewerGL
 from isaaclab_visualizers.newton_adapter import (
     VISUALIZER_INFINITE_PLANE_SIZE,
     apply_viewer_visible_worlds,
@@ -99,6 +102,59 @@ def test_apply_viewer_visible_worlds_delegates_to_resolved():
 
     apply_viewer_visible_worlds(_V(), env_ids=None, max_visible_envs=None, num_envs=3)
     assert calls[-1] is None
+
+
+def test_newton_visualizer_cfg_exposes_particle_options():
+    cfg = NewtonVisualizerCfg(show_particles=True, particle_color=(0.1, 0.2, 0.3))
+
+    assert cfg.show_particles is True
+    assert cfg.particle_color == (0.1, 0.2, 0.3)
+
+
+def test_newton_viewer_particle_color_override(monkeypatch):
+    from newton.viewer import ViewerGL
+
+    viewer = NewtonViewerGL.__new__(NewtonViewerGL)
+    viewer.device = "cpu"
+    viewer.particle_color = (0.1, 0.2, 0.3)
+    viewer._particle_color_buffer = None
+    viewer._particle_color_buffer_count = 0
+    viewer._particle_color_buffer_value = None
+    points = wp.zeros(4, dtype=wp.vec3, device="cpu")
+    calls = []
+
+    def _log_points(self, name, points, radii=None, colors=None, hidden=False):
+        calls.append((name, points, radii, colors, hidden))
+
+    monkeypatch.setattr(ViewerGL, "log_points", _log_points)
+
+    viewer.log_points("/model/particles", points, colors=None)
+
+    name, _, _, colors, hidden = calls[-1]
+    assert name == "/model/particles"
+    assert hidden is False
+    assert isinstance(colors, wp.array)
+    assert colors.shape[0] == 4
+    np.testing.assert_allclose(colors.numpy()[0], np.array([0.1, 0.2, 0.3], dtype=np.float32), rtol=1.0e-6)
+
+
+def test_newton_viewer_particle_color_override_leaves_other_points_unchanged(monkeypatch):
+    from newton.viewer import ViewerGL
+
+    viewer = NewtonViewerGL.__new__(NewtonViewerGL)
+    viewer.particle_color = (0.1, 0.2, 0.3)
+    points = wp.zeros(1, dtype=wp.vec3, device="cpu")
+    original_colors = object()
+    calls = []
+
+    def _log_points(self, name, points, radii=None, colors=None, hidden=False):
+        calls.append((name, colors))
+
+    monkeypatch.setattr(ViewerGL, "log_points", _log_points)
+
+    viewer.log_points("/debug/points", points, colors=original_colors)
+
+    assert calls[-1] == ("/debug/points", original_colors)
 
 
 class _BodyQ:


### PR DESCRIPTION
# Description

  This PR adds particle visualization controls to `NewtonVisualizerCfg`.

  It exposes:
  - `show_particles` to enable Newton particle rendering through config.
  - `particle_color` to optionally override the Newton viewer particle color for `/model/particles`.

  Motivation: MPM and particle-based demos currently need to reach into the private Newton viewer instance to show particles
  or customize particle appearance. This keeps that behavior on the public visualizer config surface and preserves Newton’s
  default behavior when `particle_color=None`.

  Fixes # N/A

  ## Type of change

  - New feature (non-breaking change which adds functionality)

  ## Screenshots

  Not applicable.

  ## Checklist

  - [x] I have added tests that prove my feature works
  - [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
