### PR TITLE
Fix optional loading of kit extensions

### DIFF
--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -30,8 +30,8 @@ keywords = ["experience", "app", "usd"]
 "isaacsim.replicator.behavior" = {}
 "isaacsim.robot.policy.examples" = {}
 "isaacsim.robot.schema" = {}
-"isaacsim.robot.experimental.wheeled_robots" = {}
-"isaacsim.robot.wheeled_robots.nodes" = {}
+"isaacsim.robot.experimental.wheeled_robots" = { optional = true }
+"isaacsim.robot.wheeled_robots.nodes" = { optional = true }
 "isaacsim.sensors.experimental.physics" = {}
 "isaacsim.sensors.experimental.rtx" = {}
 "isaacsim.simulation_app" = {}

--- a/source/isaaclab/changelog.d/fix-kit-wheeled-robots-optional.rst
+++ b/source/isaaclab/changelog.d/fix-kit-wheeled-robots-optional.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed the ``isaaclab.python.kit`` GUI experience failing to start with a Kit
+  dependency-solver error on Isaac Sim builds that do not ship
+  ``isaacsim.robot.experimental.wheeled_robots`` or
+  ``isaacsim.robot.wheeled_robots.nodes``. These extensions are not imported by
+  Isaac Lab and are now declared optional, so the experience loads regardless of
+  the Isaac Sim build.


### PR DESCRIPTION
Fix for failure to load the following command:

`python -u scripts/reinforcement_learning/skrl/play.py --task Isaac-Velocity-Rough-Anymal-C-Direct-v0   --visualizer kit `

Due to missing extensions

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there