### PR TITLE
Fixed incorrect camera pose in :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView`

### DIFF
--- a/source/isaaclab_newton/changelog.d/huidongc-fix-incorrect-camera-pose.rst
+++ b/source/isaaclab_newton/changelog.d/huidongc-fix-incorrect-camera-pose.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed incorrect camera pose in :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView`.

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -14,7 +14,7 @@ import warp as wp
 from pxr import UsdPhysics
 
 import isaaclab.sim as sim_utils
-from isaaclab.cloner.cloner_utils import iter_clone_plan_matches
+from isaaclab.cloner.cloner_utils import get_suffix, iter_clone_plan_matches
 from isaaclab.physics import PhysicsEvent
 from isaaclab.sim.views.base_frame_view import BaseFrameView
 from isaaclab.utils.string import resolve_matching_names
@@ -322,11 +322,11 @@ class NewtonSiteFrameView(BaseFrameView):
             body_prim = body_prim.GetParent()
 
         ref_path = source_root
-        if source_root is not None and destination_template is not None and "{}" in destination_template:
-            destination_prefix, _ = destination_template.split("{}", 1)
-            if destination_prefix and source_root.startswith(destination_prefix):
-                source_instance = source_root[len(destination_prefix) :].split("/", 1)[0]
-                ref_path = destination_prefix + source_instance
+        if source_root is not None and destination_template is not None:
+            instance_template = destination_template.partition("{}")[0] + "{}"
+            source_suffix = get_suffix(source_root, instance_template)
+            if source_suffix is not None:
+                ref_path = source_root[: -len(source_suffix)] if source_suffix else source_root
         ref_prim = stage.GetPrimAtPath(ref_path) if ref_path is not None else None
         pos, quat = sim_utils.resolve_prim_pose(prim, ref_prim if ref_prim and ref_prim.IsValid() else None)
         return None, wp.transform(pos, quat), source_root is not None, env_ids

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -321,7 +321,13 @@ class NewtonSiteFrameView(BaseFrameView):
                 return body_patterns, wp.transform(pos, quat), False, env_ids
             body_prim = body_prim.GetParent()
 
-        ref_prim = stage.GetPrimAtPath(source_root) if source_root is not None else None
+        ref_path = source_root
+        if source_root is not None and destination_template is not None and "{}" in destination_template:
+            destination_prefix, _ = destination_template.split("{}", 1)
+            if destination_prefix and source_root.startswith(destination_prefix):
+                source_instance = source_root[len(destination_prefix) :].split("/", 1)[0]
+                ref_path = destination_prefix + source_instance
+        ref_prim = stage.GetPrimAtPath(ref_path) if ref_path is not None else None
         pos, quat = sim_utils.resolve_prim_pose(prim, ref_prim if ref_prim and ref_prim.IsValid() else None)
         return None, wp.transform(pos, quat), source_root is not None, env_ids
 


### PR DESCRIPTION
# Description

Fixed incorrect camera pose in :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView`.

The code change is cherry-picked from #5979 .

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
