### PR TITLE
[release/3.0.0-beta2] Fix AutoMate PhysX sizing and assembly ID validation

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-automate-collision-stack.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-automate-collision-stack.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Increased the AutoMate assembly and disassembly PhysX GPU collision stack to avoid dropped contacts at the default 128 environments.
+* Updated AutoMate run helpers and docs to reject placeholder assembly IDs before launching simulation.

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env_cfg.py
@@ -118,6 +118,7 @@ class AssemblyEnvCfg(DirectRLEnvCfg):
             friction_correlation_distance=0.00625,
             gpu_max_rigid_contact_count=2**23,
             gpu_max_rigid_patch_count=2**23,
+            gpu_collision_stack_size=2**27,
             gpu_max_num_partitions=1,  # Important for stable simulation.
         ),
         physics_material=RigidBodyMaterialCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env_cfg.py
@@ -119,6 +119,7 @@ class DisassemblyEnvCfg(DirectRLEnvCfg):
             friction_correlation_distance=0.00625,
             gpu_max_rigid_contact_count=2**23,
             gpu_max_rigid_patch_count=2**23,
+            gpu_collision_stack_size=2**27,
             gpu_max_num_partitions=1,  # Important for stable simulation.
         ),
         physics_material=RigidBodyMaterialCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_disassembly_w_id.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_disassembly_w_id.py
@@ -53,6 +53,9 @@ def main():
     parser.add_argument("--seed", type=int, default=-1, help="Random seed.")
     args = parser.parse_args()
 
+    if args.assembly_id == "ASSEMBLY_ID":
+        parser.error("replace ASSEMBLY_ID with an AutoMate assembly ID, for example 00032")
+
     os.makedirs(args.disassembly_dir, exist_ok=True)
 
     update_task_param(

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_w_id.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_w_id.py
@@ -57,6 +57,9 @@ def main():
     parser.add_argument("--max_iterations", type=int, default=1500, help="Number of iteration for policy learning.")
     args = parser.parse_args()
 
+    if args.assembly_id == "ASSEMBLY_ID":
+        parser.error("replace ASSEMBLY_ID with an AutoMate assembly ID, for example 00032")
+
     update_task_param(args.cfg_path, args.assembly_id, args.train, args.log_eval)
 
     # avoid the warning of low GPU occupancy for SoftDTWCUDA function


### PR DESCRIPTION
## Summary
- Cherry-pick #6038 from develop into release/3.0.0-beta2
- Increase AutoMate PhysX GPU collision stack sizing for assembly/disassembly tasks
- Reject the literal ASSEMBLY_ID placeholder before resolving AutoMate asset paths

## Validation
- git diff --check refs/remotes/upstream/release/3.0.0-beta2...HEAD
- python3 -m py_compile source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_w_id.py source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_disassembly_w_id.py source/isaaclab_tasks/isaaclab_tasks/direct/automate/assembly_env_cfg.py source/isaaclab_tasks/isaaclab_tasks/direct/automate/disassembly_env_cfg.py