### PR TITLE
[release/3.0.0-beta2] Fix Newton FrameView cloned camera pose

### DIFF
--- a/source/isaaclab_newton/changelog.d/huidongc-fix-incorrect-camera-pose.rst
+++ b/source/isaaclab_newton/changelog.d/huidongc-fix-incorrect-camera-pose.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed incorrect camera pose in :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView`.

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -14,7 +14,7 @@ import warp as wp
 from pxr import UsdPhysics
 
 import isaaclab.sim as sim_utils
-from isaaclab.cloner.cloner_utils import iter_clone_plan_matches
+from isaaclab.cloner.cloner_utils import get_suffix, iter_clone_plan_matches
 from isaaclab.physics import PhysicsEvent
 from isaaclab.sim.views.base_frame_view import BaseFrameView
 from isaaclab.utils.string import resolve_matching_names
@@ -322,11 +322,11 @@ class NewtonSiteFrameView(BaseFrameView):
             body_prim = body_prim.GetParent()
 
         ref_path = source_root
-        if source_root is not None and destination_template is not None and "{}" in destination_template:
-            destination_prefix, _ = destination_template.split("{}", 1)
-            if destination_prefix and source_root.startswith(destination_prefix):
-                source_instance = source_root[len(destination_prefix) :].split("/", 1)[0]
-                ref_path = destination_prefix + source_instance
+        if source_root is not None and destination_template is not None:
+            instance_template = destination_template.partition("{}")[0] + "{}"
+            source_suffix = get_suffix(source_root, instance_template)
+            if source_suffix is not None:
+                ref_path = source_root[: -len(source_suffix)] if source_suffix else source_root
         ref_prim = stage.GetPrimAtPath(ref_path) if ref_path is not None else None
         pos, quat = sim_utils.resolve_prim_pose(prim, ref_prim if ref_prim and ref_prim.IsValid() else None)
         return None, wp.transform(pos, quat), source_root is not None, env_ids

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -321,7 +321,13 @@ class NewtonSiteFrameView(BaseFrameView):
                 return body_patterns, wp.transform(pos, quat), False, env_ids
             body_prim = body_prim.GetParent()
 
-        ref_prim = stage.GetPrimAtPath(source_root) if source_root is not None else None
+        ref_path = source_root
+        if source_root is not None and destination_template is not None and "{}" in destination_template:
+            destination_prefix, _ = destination_template.split("{}", 1)
+            if destination_prefix and source_root.startswith(destination_prefix):
+                source_instance = source_root[len(destination_prefix) :].split("/", 1)[0]
+                ref_path = destination_prefix + source_instance
+        ref_prim = stage.GetPrimAtPath(ref_path) if ref_path is not None else None
         pos, quat = sim_utils.resolve_prim_pose(prim, ref_prim if ref_prim and ref_prim.IsValid() else None)
         return None, wp.transform(pos, quat), source_root is not None, env_ids
 


### PR DESCRIPTION
## Summary
- Backport current PR #6047 head into release/3.0.0-beta2
- Fix NewtonSiteFrameView bodyless cloned-frame pose resolution using the existing clone-plan get_suffix utility
- Add the Newton changelog fragment from #6047

## Validation
- git diff --check refs/remotes/upstream/release/3.0.0-beta2...HEAD
- python3 -m py_compile source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py

## Notes
- Source PR #6047 was still open at the time of this backport; this PR cherry-picks its current two-commit head.