### PR TITLE
[release/3.0.0-beta2] Fix skrl JAX multihost import

### DIFF
--- a/source/isaaclab_rl/changelog.d/fix-skrl-jax-multihost-import.rst
+++ b/source/isaaclab_rl/changelog.d/fix-skrl-jax-multihost-import.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab_rl.skrl.SkrlVecEnvWrapper` failing to import the JAX wrapper on recent JAX
+  versions by preloading the ``jax.experimental.multihost_utils`` submodule that skrl's distributed
+  models reference without importing.

--- a/source/isaaclab_rl/isaaclab_rl/skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/skrl.py
@@ -92,6 +92,8 @@ def SkrlVecEnvWrapper(
     if ml_framework.startswith("torch"):
         from skrl.envs.wrappers.torch import wrap_env
     elif ml_framework.startswith("jax"):
+        # preload submodule that skrl's distributed models use without importing (broken on recent JAX)
+        import jax.experimental.multihost_utils  # noqa: F401
         from skrl.envs.wrappers.jax import wrap_env
     elif ml_framework.startswith("warp"):
         from skrl.envs.wrappers.warp import wrap_env


### PR DESCRIPTION
## Summary
- Cherry-pick #6035 from develop into release/3.0.0-beta2
- Preload jax.experimental.multihost_utils before importing skrl's JAX wrapper
- Add the isaaclab_rl changelog fragment

## Validation
- git diff --check refs/remotes/upstream/release/3.0.0-beta2...HEAD
- python3 -m py_compile source/isaaclab_rl/isaaclab_rl/skrl.py