### PR TITLE
[release/3.0.0-beta2] Fix optional loading of Kit wheeled robot extensions

### DIFF
--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -30,8 +30,8 @@ keywords = ["experience", "app", "usd"]
 "isaacsim.replicator.behavior" = {}
 "isaacsim.robot.policy.examples" = {}
 "isaacsim.robot.schema" = {}
-"isaacsim.robot.experimental.wheeled_robots" = {}
-"isaacsim.robot.wheeled_robots.nodes" = {}
+"isaacsim.robot.experimental.wheeled_robots" = { optional = true }
+"isaacsim.robot.wheeled_robots.nodes" = { optional = true }
 "isaacsim.sensors.experimental.physics" = {}
 "isaacsim.sensors.experimental.rtx" = {}
 "isaacsim.simulation_app" = {}

--- a/source/isaaclab/changelog.d/fix-kit-wheeled-robots-optional.rst
+++ b/source/isaaclab/changelog.d/fix-kit-wheeled-robots-optional.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed the ``isaaclab.python.kit`` GUI experience failing to start with a Kit
+  dependency-solver error on Isaac Sim builds that do not ship
+  ``isaacsim.robot.experimental.wheeled_robots`` or
+  ``isaacsim.robot.wheeled_robots.nodes``. These extensions are not imported by
+  Isaac Lab and are now declared optional, so the experience loads regardless of
+  the Isaac Sim build.


### PR DESCRIPTION
## Summary
- Cherry-pick #6045 from develop into release/3.0.0-beta2
- Mark isaacsim.robot.experimental.wheeled_robots and isaacsim.robot.wheeled_robots.nodes optional in isaaclab.python.kit
- Add the Isaac Lab changelog fragment

## Validation
- git diff --check refs/remotes/upstream/release/3.0.0-beta2...HEAD

## Notes
- Tried parsing apps/isaaclab.python.kit with Python tomllib, but the existing Kit file uses repeated [settings] tables and tomllib rejects it before this change.