### PR TITLE
[release/3.0.0-beta2] Remove AutoMate Numba SoftDTW dependency

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-automate-numba-constraints.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-automate-numba-constraints.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Removed AutoMate's Numba dependency by replacing the SoftDTW helper with a
+  Torch implementation.

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/automate_algo_utils.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/automate_algo_utils.py
@@ -88,23 +88,50 @@ def get_imitation_reward_from_dtw(ref_traj, curr_ee_pos, prev_ee_traj, criterion
     prev_ee_pos = prev_ee_traj[:, 0, :]  # select the first ee pos in robot traj
     min_dist_traj_idx, min_dist_step_idx, min_dist_per_env = get_closest_state_idx(ref_traj, prev_ee_pos)
 
+    eef_traj = torch.cat((prev_ee_traj[:, 1:, :], curr_ee_pos.unsqueeze(1)), dim=1)
+    selected_trajs: list[torch.Tensor] = []
+    selected_traj_lengths = torch.empty((curr_ee_pos.shape[0],), dtype=torch.long, device=device)
+    max_selected_traj_len = 0
+
     for i in range(curr_ee_pos.shape[0]):
-        traj_idx = min_dist_traj_idx[i]
-        step_idx = min_dist_step_idx[i]
+        traj_idx = int(min_dist_traj_idx[i].item())
+        step_idx = int(min_dist_step_idx[i].item())
         curr_ee_pos_i = curr_ee_pos[i].reshape(1, 3)
 
         # NOTE: in reference trajectories, larger index -> closer to goal
         traj = ref_traj[traj_idx, step_idx:, :].reshape((1, -1, 3))
 
         _, curr_step_idx, _ = get_closest_state_idx(traj, curr_ee_pos_i)
+        curr_step_idx = int(curr_step_idx.item())
 
         if curr_step_idx == 0:
-            selected_pos = ref_traj[traj_idx, step_idx, :].reshape((1, 1, 3))
-            selected_traj = torch.cat([selected_pos, selected_pos], dim=1)
+            selected_traj = ref_traj[traj_idx, step_idx, :].reshape((1, 3)).repeat(2, 1)
         else:
-            selected_traj = ref_traj[traj_idx, step_idx : (curr_step_idx + step_idx), :].reshape((1, -1, 3))
-        eef_traj = torch.cat((prev_ee_traj[i, 1:, :], curr_ee_pos_i)).reshape((1, -1, 3))
-        soft_dtw[i] = criterion(eef_traj, selected_traj)
+            selected_traj = ref_traj[traj_idx, step_idx : (curr_step_idx + step_idx), :]
+
+        traj_len = selected_traj.shape[0]
+        selected_trajs.append(selected_traj)
+        selected_traj_lengths[i] = traj_len
+        max_selected_traj_len = max(max_selected_traj_len, traj_len)
+
+    if hasattr(criterion, "forward_with_lengths") and not getattr(criterion, "normalize", False):
+        padded_selected_trajs = torch.zeros(
+            (curr_ee_pos.shape[0], max_selected_traj_len, ref_traj.shape[-1]), dtype=ref_traj.dtype, device=device
+        )
+        for i, selected_traj in enumerate(selected_trajs):
+            padded_selected_trajs[i, : selected_traj.shape[0], :] = selected_traj
+        soft_dtw = criterion.forward_with_lengths(eef_traj, padded_selected_trajs, selected_traj_lengths)
+    else:
+        selected_trajs_by_len: dict[int, list[torch.Tensor]] = {}
+        env_ids_by_len: dict[int, list[int]] = {}
+        for i, selected_traj in enumerate(selected_trajs):
+            traj_len = selected_traj.shape[0]
+            selected_trajs_by_len.setdefault(traj_len, []).append(selected_traj)
+            env_ids_by_len.setdefault(traj_len, []).append(i)
+
+        for traj_len, selected_trajs_by_curr_len in selected_trajs_by_len.items():
+            env_ids = torch.tensor(env_ids_by_len[traj_len], dtype=torch.long, device=device)
+            soft_dtw[env_ids] = criterion(eef_traj[env_ids], torch.stack(selected_trajs_by_curr_len, dim=0))
 
     w_task_progress = 1 - (min_dist_step_idx / ref_traj.shape[1])
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_w_id.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_w_id.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import argparse
-import os
 import re
 import subprocess
 import sys
@@ -59,10 +58,6 @@ def main():
 
     update_task_param(args.cfg_path, args.assembly_id, args.train, args.log_eval)
 
-    # avoid the warning of low GPU occupancy for SoftDTWCUDA function
-    env = os.environ.copy()
-    env["NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS"] = "0"
-
     # build the command
     if sys.platform.startswith("win"):
         command = ["isaaclab.bat"]
@@ -91,7 +86,7 @@ def main():
         command.append(f"--checkpoint={args.checkpoint}")
 
     # Run the command
-    subprocess.run(command, env=env, check=True)
+    subprocess.run(command, check=True)
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/automate/soft_dtw_cuda.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/automate/soft_dtw_cuda.py
@@ -26,427 +26,178 @@
 # SOFTWARE.
 # ----------------------------------------------------------------------------------------------------------------------
 
-import math
-
-import numba.cuda as cuda
-import numpy as np
 import torch
-import torch.cuda
-from numba import jit, prange
-from torch.autograd import Function
 
 
-# ----------------------------------------------------------------------------------------------------------------------
-@cuda.jit
-def compute_softdtw_cuda(D, gamma, bandwidth, max_i, max_j, n_passes, R):
-    """
-    :param seq_len: The length of the sequence (both inputs are assumed to be of the same size)
-    :param n_passes: 2 * seq_len - 1 (The number of anti-diagonals)
-    """
-    # Each block processes one pair of examples
-    b = cuda.blockIdx.x
-    # We have as many threads as seq_len, because the most number of threads we need
-    # is equal to the number of elements on the largest anti-diagonal
-    tid = cuda.threadIdx.x
-
-    inv_gamma = 1.0 / gamma
-
-    # Go over each anti-diagonal. Only process threads that fall on the current on the anti-diagonal
-    for p in range(n_passes):
-        # The index is actually 'p - tid' but need to force it in-bounds
-        J = max(0, min(p - tid, max_j - 1))
-
-        # For simplicity, we define i, j which start from 1 (offset from I, J)
-        i = tid + 1
-        j = J + 1
-
-        # Only compute if element[i, j] is on the current anti-diagonal, and also is within bounds
-        if tid + J == p and (tid < max_i and max_j > J):
-            # Don't compute if outside bandwidth
-            if not (abs(i - j) > bandwidth > 0):
-                r0 = -R[b, i - 1, j - 1] * inv_gamma
-                r1 = -R[b, i - 1, j] * inv_gamma
-                r2 = -R[b, i, j - 1] * inv_gamma
-                rmax = max(max(r0, r1), r2)
-                rsum = math.exp(r0 - rmax) + math.exp(r1 - rmax) + math.exp(r2 - rmax)
-                softmin = -gamma * (math.log(rsum) + rmax)
-                R[b, i, j] = D[b, i - 1, j - 1] + softmin
-
-        # Wait for other threads in this block
-        cuda.syncthreads()
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-@cuda.jit
-def compute_softdtw_backward_cuda(D, R, inv_gamma, bandwidth, max_i, max_j, n_passes, E):
-    k = cuda.blockIdx.x
-    tid = cuda.threadIdx.x
-
-    # Indexing logic is the same as above, however, the anti-diagonal needs to
-    # progress backwards
-
-    for p in range(n_passes):
-        # Reverse the order to make the loop go backward
-        rev_p = n_passes - p - 1
-
-        # convert tid to I, J, then i, j
-        J = max(0, min(rev_p - tid, max_j - 1))
-
-        i = tid + 1
-        j = J + 1
-
-        # Only compute if element[i, j] is on the current anti-diagonal, and also is within bounds
-        if tid + J == rev_p and (tid < max_i and max_j > J):
-            if math.isinf(R[k, i, j]):
-                R[k, i, j] = -math.inf
-
-            # Don't compute if outside bandwidth
-            if not (abs(i - j) > bandwidth > 0):
-                a = math.exp((R[k, i + 1, j] - R[k, i, j] - D[k, i + 1, j]) * inv_gamma)
-                b = math.exp((R[k, i, j + 1] - R[k, i, j] - D[k, i, j + 1]) * inv_gamma)
-                c = math.exp((R[k, i + 1, j + 1] - R[k, i, j] - D[k, i + 1, j + 1]) * inv_gamma)
-                E[k, i, j] = E[k, i + 1, j] * a + E[k, i, j + 1] * b + E[k, i + 1, j + 1] * c
-
-        # Wait for other threads in this block
-        cuda.syncthreads()
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-class _SoftDTWCUDA(Function):
-    """
-    CUDA implementation is inspired by the diagonal one proposed in https://ieeexplore.ieee.org/document/8400444:
-    "Developing a pattern discovery method in time series data and its GPU acceleration"
-    """
-
-    @staticmethod
-    def forward(ctx, D, device, gamma, bandwidth):
-        dev = D.device
-        dtype = D.dtype
-        gamma = torch.tensor([gamma], dtype=torch.float, device=device)
-        bandwidth = torch.tensor([bandwidth], dtype=torch.float, device=device)
-
-        B = D.shape[0]
-        N = D.shape[1]
-        M = D.shape[2]
-        threads_per_block = max(N, M)
-        n_passes = 2 * threads_per_block - 1
-
-        # Prepare the output array
-        R = torch.ones((B, N + 2, M + 2), device=dev, dtype=dtype) * math.inf
-        R[:, 0, 0] = 0
-
-        # Run the CUDA kernel.
-        # Set CUDA's grid size to be equal to the batch size (every CUDA block processes one sample pair)
-        # Set the CUDA block size to be equal to the length of the longer sequence
-        # (equal to the size of the largest diagonal)
-        compute_softdtw_cuda[B, threads_per_block](
-            cuda.as_cuda_array(D.detach()), gamma.item(), bandwidth.item(), N, M, n_passes, cuda.as_cuda_array(R)
-        )
-        ctx.save_for_backward(D, R.clone(), gamma, bandwidth)
-        return R[:, -2, -2]
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        dev = grad_output.device
-        dtype = grad_output.dtype
-        D, R, gamma, bandwidth = ctx.saved_tensors
-
-        B = D.shape[0]
-        N = D.shape[1]
-        M = D.shape[2]
-        threads_per_block = max(N, M)
-        n_passes = 2 * threads_per_block - 1
-
-        D_ = torch.zeros((B, N + 2, M + 2), dtype=dtype, device=dev)
-        D_[:, 1 : N + 1, 1 : M + 1] = D
-
-        R[:, :, -1] = -math.inf
-        R[:, -1, :] = -math.inf
-        R[:, -1, -1] = R[:, -2, -2]
-
-        E = torch.zeros((B, N + 2, M + 2), dtype=dtype, device=dev)
-        E[:, -1, -1] = 1
-
-        # Grid and block sizes are set same as done above for the forward() call
-        compute_softdtw_backward_cuda[B, threads_per_block](
-            cuda.as_cuda_array(D_),
-            cuda.as_cuda_array(R),
-            1.0 / gamma.item(),
-            bandwidth.item(),
-            N,
-            M,
-            n_passes,
-            cuda.as_cuda_array(E),
-        )
-        E = E[:, 1 : N + 1, 1 : M + 1]
-        return grad_output.view(-1, 1, 1).expand_as(E) * E, None, None
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-#
-# The following is the CPU implementation based on https://github.com/Sleepwalking/pytorch-softdtw
-# Credit goes to Kanru Hua.
-# I've added support for batching and pruning.
-#
-# ----------------------------------------------------------------------------------------------------------------------
-@jit(nopython=True, parallel=True)
-def compute_softdtw(D, gamma, bandwidth):
-    B = D.shape[0]
-    N = D.shape[1]
-    M = D.shape[2]
-    R = np.ones((B, N + 2, M + 2)) * np.inf
+def _soft_dtw_autograd(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
+    """Compute SoftDTW using Torch ops that preserve autograd."""
+    batch_size, len_x, len_y = D.shape
+    R = torch.full((batch_size, len_x + 2, len_y + 2), float("inf"), device=D.device, dtype=D.dtype)
     R[:, 0, 0] = 0
-    for b in prange(B):
-        for j in range(1, M + 1):
-            for i in range(1, N + 1):
-                # Check the pruning condition
-                if 0 < bandwidth < np.abs(i - j):
-                    continue
 
-                r0 = -R[b, i - 1, j - 1] / gamma
-                r1 = -R[b, i - 1, j] / gamma
-                r2 = -R[b, i, j - 1] / gamma
-                rmax = max(max(r0, r1), r2)
-                rsum = np.exp(r0 - rmax) + np.exp(r1 - rmax) + np.exp(r2 - rmax)
-                softmin = -gamma * (np.log(rsum) + rmax)
-                R[b, i, j] = D[b, i - 1, j - 1] + softmin
-    return R
+    band_size = int(bandwidth) if bandwidth > 0 else max(len_x, len_y)
+    for i in range(1, len_x + 1):
+        j_start = max(1, i - band_size)
+        j_end = min(len_y, i + band_size) + 1
 
+        for j in range(j_start, j_end):
+            r0 = R[:, i - 1, j - 1]
+            r1 = R[:, i - 1, j]
+            r2 = R[:, i, j - 1]
 
-# ----------------------------------------------------------------------------------------------------------------------
-@jit(nopython=True, parallel=True)
-def compute_softdtw_backward(D_, R, gamma, bandwidth):
-    B = D_.shape[0]
-    N = D_.shape[1]
-    M = D_.shape[2]
-    D = np.zeros((B, N + 2, M + 2))
-    E = np.zeros((B, N + 2, M + 2))
-    D[:, 1 : N + 1, 1 : M + 1] = D_
-    E[:, -1, -1] = 1
-    R[:, :, -1] = -np.inf
-    R[:, -1, :] = -np.inf
-    R[:, -1, -1] = R[:, -2, -2]
-    for k in prange(B):
-        for j in range(M, 0, -1):
-            for i in range(N, 0, -1):
-                if np.isinf(R[k, i, j]):
-                    R[k, i, j] = -np.inf
+            if gamma == 0:
+                softmin = torch.minimum(torch.minimum(r0, r1), r2)
+            else:
+                previous_costs = torch.stack((r0, r1, r2))
+                softmin = -gamma * torch.logsumexp(-previous_costs / gamma, dim=0)
 
-                # Check the pruning condition
-                if 0 < bandwidth < np.abs(i - j):
-                    continue
+            R[:, i, j] = D[:, i - 1, j - 1] + softmin
 
-                a0 = (R[k, i + 1, j] - R[k, i, j] - D[k, i + 1, j]) / gamma
-                b0 = (R[k, i, j + 1] - R[k, i, j] - D[k, i, j + 1]) / gamma
-                c0 = (R[k, i + 1, j + 1] - R[k, i, j] - D[k, i + 1, j + 1]) / gamma
-                a = np.exp(a0)
-                b = np.exp(b0)
-                c = np.exp(c0)
-                E[k, i, j] = E[k, i + 1, j] * a + E[k, i, j + 1] * b + E[k, i + 1, j + 1] * c
-    return E[:, 1 : N + 1, 1 : M + 1]
+    return R[:, len_x, len_y]
 
 
-# ----------------------------------------------------------------------------------------------------------------------
-class _SoftDTW(Function):
+def _soft_dtw_no_grad(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
+    """Compute SoftDTW by evaluating each dynamic-programming anti-diagonal in one batched op."""
+    batch_size, len_x, len_y = D.shape
+    R = torch.full((batch_size, len_x + 2, len_y + 2), float("inf"), device=D.device, dtype=D.dtype)
+    R[:, 0, 0] = 0
+
+    for diag in range(2, len_x + len_y + 1):
+        i = torch.arange(max(1, diag - len_y), min(len_x, diag - 1) + 1, device=D.device)
+        j = diag - i
+
+        if bandwidth > 0:
+            keep = torch.abs(i - j) <= bandwidth
+            i = i[keep]
+            j = j[keep]
+            if i.numel() == 0:
+                continue
+
+        if gamma == 0:
+            softmin = torch.minimum(torch.minimum(R[:, i - 1, j - 1], R[:, i - 1, j]), R[:, i, j - 1])
+        else:
+            previous_costs = torch.stack((R[:, i - 1, j - 1], R[:, i - 1, j], R[:, i, j - 1]))
+            softmin = -gamma * torch.logsumexp(-previous_costs / gamma, dim=0)
+
+        R[:, i, j] = D[:, i - 1, j - 1] + softmin
+
+    return R[:, len_x, len_y]
+
+
+def _soft_dtw_variable_y_no_grad(
+    D: torch.Tensor, y_lengths: torch.Tensor, gamma: float, bandwidth: float
+) -> torch.Tensor:
+    """Compute SoftDTW for a batch where each Y sequence can have a different length."""
+    batch_size, len_x, len_y = D.shape
+    y_lengths = y_lengths.to(device=D.device, dtype=torch.long)
+    if y_lengths.min().item() < 1 or y_lengths.max().item() > len_y:
+        raise ValueError("y_lengths entries must be in [1, len_y]")
+
+    R = torch.full((batch_size, len_x + 2, len_y + 2), float("inf"), device=D.device, dtype=D.dtype)
+    R[:, 0, 0] = 0
+
+    for diag in range(2, len_x + len_y + 1):
+        i = torch.arange(max(1, diag - len_y), min(len_x, diag - 1) + 1, device=D.device)
+        j = diag - i
+
+        if bandwidth > 0:
+            keep = torch.abs(i - j) <= bandwidth
+            i = i[keep]
+            j = j[keep]
+            if i.numel() == 0:
+                continue
+
+        if gamma == 0:
+            softmin = torch.minimum(torch.minimum(R[:, i - 1, j - 1], R[:, i - 1, j]), R[:, i, j - 1])
+        else:
+            previous_costs = torch.stack((R[:, i - 1, j - 1], R[:, i - 1, j], R[:, i, j - 1]))
+            softmin = -gamma * torch.logsumexp(-previous_costs / gamma, dim=0)
+
+        values = D[:, i - 1, j - 1] + softmin
+        valid_y = j.unsqueeze(0) <= y_lengths.unsqueeze(1)
+        R[:, i, j] = torch.where(valid_y, values, torch.full_like(values, float("inf")))
+
+    batch_ids = torch.arange(batch_size, device=D.device)
+    return R[batch_ids, len_x, y_lengths]
+
+
+def _soft_dtw(D: torch.Tensor, gamma: float, bandwidth: float) -> torch.Tensor:
+    """Compute batched SoftDTW from a pairwise distance tensor.
+
+    Args:
+        D: Pairwise distance tensor of shape ``(batch, len_x, len_y)``.
+        gamma: SoftDTW smoothing parameter. Set to 0 to compute hard DTW.
+        bandwidth: Optional Sakoe-Chiba bandwidth. Values <= 0 disable the band constraint.
     """
-    CPU implementation based on https://github.com/Sleepwalking/pytorch-softdtw
-    """
-
-    @staticmethod
-    def forward(ctx, D, device, gamma, bandwidth):
-        dev = D.device
-        dtype = D.dtype
-        gamma = torch.Tensor([gamma]).to(dev).type(dtype)  # dtype fixed
-        bandwidth = torch.Tensor([bandwidth]).to(dev).type(dtype)
-        D_ = D.detach().cpu().numpy()
-        g_ = gamma.item()
-        b_ = bandwidth.item()
-        R = torch.Tensor(compute_softdtw(D_, g_, b_)).to(dev).type(dtype)
-        ctx.save_for_backward(D, R, gamma, bandwidth)
-        return R[:, -2, -2]
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        dev = grad_output.device
-        dtype = grad_output.dtype
-        D, R, gamma, bandwidth = ctx.saved_tensors
-        D_ = D.detach().cpu().numpy()
-        R_ = R.detach().cpu().numpy()
-        g_ = gamma.item()
-        b_ = bandwidth.item()
-        E = torch.Tensor(compute_softdtw_backward(D_, R_, g_, b_)).to(dev).type(dtype)
-        return grad_output.view(-1, 1, 1).expand_as(E) * E, None, None
+    if torch.is_grad_enabled() and D.requires_grad:
+        return _soft_dtw_autograd(D, gamma, bandwidth)
+    return _soft_dtw_no_grad(D, gamma, bandwidth)
 
 
-# ----------------------------------------------------------------------------------------------------------------------
 class SoftDTW(torch.nn.Module):
-    """
-    The soft DTW implementation that optionally supports CUDA
+    """Soft Dynamic Time Warping implemented with Torch tensor operations.
+
+    The ``use_cuda`` and ``device`` arguments are kept for compatibility with the
+    previous AutoMate SoftDTW helper. The implementation runs on the device of the
+    input tensors and does not require Numba.
     """
 
     def __init__(self, use_cuda, device, gamma=1.0, normalize=False, bandwidth=None, dist_func=None):
-        """Initializes a new instance using the supplied parameters
+        """Initializes a new instance using the supplied parameters.
 
         Args:
-
-            use_cuda: Whether to use the CUDA implementation.
-            device: The device to run the SoftDTW computation.
-            gamma: The SoftDTW's gamma parameter. Default is 1.0.
+            use_cuda: Preserved for API compatibility. Inputs already determine the execution device.
+            device: Preserved for API compatibility. Inputs already determine the execution device.
+            gamma: The SoftDTW gamma parameter. Set to 0 for original DTW without smoothing.
             normalize: Whether to perform normalization. Default is False.
-                (as discussed in https://github.com/mblondel/soft-dtw/issues/10#issuecomment-383564790)
             bandwidth: Sakoe-Chiba bandwidth for pruning. Default is None, which disables pruning.
-                If provided, must be a float.
-            dist_func: The point-wise distance function to use. Default is None, which
-                uses a default Euclidean distance function.
+            dist_func: The point-wise distance function to use. Default is squared Euclidean distance.
         """
         super().__init__()
         self.normalize = normalize
-        self.gamma = gamma
+        self.gamma = float(gamma)
         self.bandwidth = 0 if bandwidth is None else float(bandwidth)
         self.use_cuda = use_cuda
         self.device = device
 
-        # Set the distance function
         if dist_func is not None:
             self.dist_func = dist_func
         else:
             self.dist_func = SoftDTW._euclidean_dist_func
 
-    def _get_func_dtw(self, x, y):
-        """
-        Checks the inputs and selects the proper implementation to use.
-        """
-        bx, lx, dx = x.shape
-        by, ly, dy = y.shape
-        # Make sure the dimensions match
-        assert bx == by  # Equal batch sizes
-        assert dx == dy  # Equal feature dimensions
-
-        use_cuda = self.use_cuda
-
-        if use_cuda and (lx > 1024 or ly > 1024):  # We should be able to spawn enough threads in CUDA
-            print(
-                "SoftDTW: Cannot use CUDA because the sequence length > 1024 (the maximum block size supported by CUDA)"
-            )
-            use_cuda = False
-
-        # Finally, return the correct function
-        return _SoftDTWCUDA.apply if use_cuda else _SoftDTW.apply
-
     @staticmethod
     def _euclidean_dist_func(x, y):
-        """
-        Calculates the Euclidean distance between each element in x and y per timestep
-        """
-        n = x.size(1)
-        m = y.size(1)
-        d = x.size(2)
-        x = x.unsqueeze(2).expand(-1, n, m, d)
-        y = y.unsqueeze(1).expand(-1, n, m, d)
+        """Calculates the squared Euclidean distance between each element in x and y per timestep."""
+        num_x = x.size(1)
+        num_y = y.size(1)
+        dims = x.size(2)
+        x = x.unsqueeze(2).expand(-1, num_x, num_y, dims)
+        y = y.unsqueeze(1).expand(-1, num_x, num_y, dims)
         return torch.pow(x - y, 2).sum(3)
 
     def forward(self, X, Y):
-        """
-        Compute the soft-DTW value between X and Y
-        :param X: One batch of examples, batch_size x seq_len x dims
-        :param Y: The other batch of examples, batch_size x seq_len x dims
-        :return: The computed results
-        """
-
-        # Check the inputs and get the correct implementation
-        func_dtw = self._get_func_dtw(X, Y)
-
+        """Compute the SoftDTW value between ``X`` and ``Y``."""
         if self.normalize:
-            # Stack everything up and run
             x = torch.cat([X, X, Y])
             y = torch.cat([Y, X, Y])
             D = self.dist_func(x, y)
-            out = func_dtw(D, self.device, self.gamma, self.bandwidth)
+            out = _soft_dtw(D, self.gamma, self.bandwidth)
             out_xy, out_xx, out_yy = torch.split(out, X.shape[0])
-            return out_xy - 1 / 2 * (out_xx + out_yy)
-        else:
-            D_xy = self.dist_func(X, Y)
-            return func_dtw(D_xy, self.device, self.gamma, self.bandwidth)
+            return out_xy - 0.5 * (out_xx + out_yy)
 
+        D_xy = self.dist_func(X, Y)
+        return _soft_dtw(D_xy, self.gamma, self.bandwidth)
 
-# ----------------------------------------------------------------------------------------------------------------------
-def timed_run(a, b, sdtw):
-    """
-    Runs a and b through sdtw, and times the forward and backward passes.
-    Assumes that a requires gradients.
-    :return: timing, forward result, backward result
-    """
+    def forward_with_lengths(self, X, Y, y_lengths):
+        """Compute SoftDTW when each Y sequence is padded to a per-sample length."""
+        if self.normalize:
+            raise ValueError("forward_with_lengths does not support normalize=True")
 
-    from timeit import default_timer as timer
+        if torch.is_grad_enabled() and (X.requires_grad or Y.requires_grad):
+            outputs = []
+            for batch_id, y_length in enumerate(y_lengths.tolist()):
+                outputs.append(self.forward(X[batch_id : batch_id + 1], Y[batch_id : batch_id + 1, : int(y_length)]))
+            return torch.cat(outputs)
 
-    # Forward pass
-    start = timer()
-    forward = sdtw(a, b)
-    end = timer()
-    t = end - start
-
-    grad_outputs = torch.ones_like(forward)
-
-    # Backward
-    start = timer()
-    grads = torch.autograd.grad(forward, a, grad_outputs=grad_outputs)[0]
-    end = timer()
-
-    # Total time
-    t += end - start
-
-    return t, forward, grads
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-def profile(batch_size, seq_len_a, seq_len_b, dims, tol_backward):
-    sdtw = SoftDTW(False, gamma=1.0, normalize=False)
-    sdtw_cuda = SoftDTW(True, gamma=1.0, normalize=False)
-    n_iters = 6
-
-    print(
-        f"Profiling forward() + backward() times for batch_size={batch_size}, seq_len_a={seq_len_a},"
-        f" seq_len_b={seq_len_b}, dims={dims}..."
-    )
-
-    times_cpu = []
-    times_gpu = []
-
-    for i in range(n_iters):
-        a_cpu = torch.rand((batch_size, seq_len_a, dims), requires_grad=True)
-        b_cpu = torch.rand((batch_size, seq_len_b, dims))
-        a_gpu = a_cpu.cuda()
-        b_gpu = b_cpu.cuda()
-
-        # GPU
-        t_gpu, forward_gpu, backward_gpu = timed_run(a_gpu, b_gpu, sdtw_cuda)
-
-        # CPU
-        t_cpu, forward_cpu, backward_cpu = timed_run(a_cpu, b_cpu, sdtw)
-
-        # Verify the results
-        assert torch.allclose(forward_cpu, forward_gpu.cpu())
-        assert torch.allclose(backward_cpu, backward_gpu.cpu(), atol=tol_backward)
-
-        # Ignore the first time we run, in case this is a cold start
-        # (because timings are off at a cold start of the script)
-        if i > 0:
-            times_cpu += [t_cpu]
-            times_gpu += [t_gpu]
-
-    # Average and log
-    avg_cpu = np.mean(times_cpu)
-    avg_gpu = np.mean(times_gpu)
-    print("  CPU:     ", avg_cpu)
-    print("  GPU:     ", avg_gpu)
-    print("  Speedup: ", avg_cpu / avg_gpu)
-    print()
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-if __name__ == "__main__":
-    torch.manual_seed(1234)
-
-    profile(128, 17, 15, 2, tol_backward=1e-6)
-    profile(512, 64, 64, 2, tol_backward=1e-4)
-    profile(512, 256, 256, 2, tol_backward=1e-3)
+        D_xy = self.dist_func(X, Y)
+        return _soft_dtw_variable_y_no_grad(D_xy, y_lengths, self.gamma, self.bandwidth)

--- a/source/isaaclab_tasks/setup.py
+++ b/source/isaaclab_tasks/setup.py
@@ -24,7 +24,6 @@ INSTALL_REQUIRES = [
     "protobuf>=4.25.8,!=5.26.0",
     # basic logger
     "tensorboard",
-    "numba>=0.63.1",
 ]
 
 PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu128"]

--- a/source/isaaclab_tasks/test/test_automate_soft_dtw.py
+++ b/source/isaaclab_tasks/test/test_automate_soft_dtw.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _load_soft_dtw_module():
+    module_path = Path(__file__).parents[1] / "isaaclab_tasks" / "direct" / "automate" / "soft_dtw_cuda.py"
+    spec = importlib.util.spec_from_file_location("automate_soft_dtw_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_soft_dtw_use_cuda_does_not_require_numba():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=True, device="cuda", gamma=0.01)
+
+    x = torch.zeros((1, 2, 3), dtype=torch.float32)
+    y = torch.zeros((1, 2, 3), dtype=torch.float32)
+
+    assert criterion(x, y).shape == (1,)
+
+
+def test_soft_dtw_hard_dtw_value():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=False, device="cpu", gamma=0.0)
+
+    x = torch.tensor([[[0.0], [1.0]]])
+    y = torch.tensor([[[0.0], [2.0]]])
+
+    assert criterion(x, y) == pytest.approx(torch.tensor([1.0]))
+
+
+def test_normalized_soft_dtw_identical_sequences_are_zero():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=True, device="cuda", gamma=0.1, normalize=True)
+
+    x = torch.tensor([[[0.0, 0.0], [1.0, 0.5], [2.0, 1.0]]])
+
+    assert criterion(x, x) == pytest.approx(torch.zeros(1), abs=1e-6)
+
+
+def test_soft_dtw_forward_with_lengths_matches_unpadded_calls():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=False, device="cpu", gamma=0.01)
+
+    torch.manual_seed(11)
+    x = torch.randn((3, 3, 2), dtype=torch.float32)
+    y = torch.zeros((3, 5, 2), dtype=torch.float32)
+    y_lengths = torch.tensor([2, 4, 5], dtype=torch.long)
+    for batch_id, y_length in enumerate(y_lengths.tolist()):
+        y[batch_id, :y_length] = torch.randn((y_length, 2), dtype=torch.float32)
+
+    with torch.no_grad():
+        actual = criterion.forward_with_lengths(x, y, y_lengths)
+        expected = torch.cat(
+            [criterion(x[i : i + 1], y[i : i + 1, : int(y_lengths[i].item())]) for i in range(x.shape[0])]
+        )
+
+    assert torch.allclose(actual, expected, atol=1e-6)
+
+
+def test_soft_dtw_backward_produces_finite_gradients():
+    soft_dtw = _load_soft_dtw_module()
+    criterion = soft_dtw.SoftDTW(use_cuda=False, device="cpu", gamma=0.01)
+
+    torch.manual_seed(17)
+    x = torch.randn((2, 4, 3), dtype=torch.float32, requires_grad=True)
+    y = torch.randn((2, 5, 3), dtype=torch.float32)
+
+    criterion(x, y).sum().backward()
+
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()


### PR DESCRIPTION
Backports #6040 to release/3.0.0-beta2.

Beta2-specific conflict resolution:
- kept beta2's existing pyproject.toml packaging shape
- removed numba from source/isaaclab_tasks/setup.py, where beta2 still declares install_requires
- placed the new SoftDTW test under source/isaaclab_tasks/test and updated it to load isaaclab_tasks/direct/automate/soft_dtw_cuda.py

Validation:
- git diff --check refs/remotes/upstream/release/3.0.0-beta2...HEAD
- python3 -m py_compile source/isaaclab_tasks/isaaclab_tasks/direct/automate/automate_algo_utils.py source/isaaclab_tasks/isaaclab_tasks/direct/automate/run_w_id.py source/isaaclab_tasks/isaaclab_tasks/direct/automate/soft_dtw_cuda.py source/isaaclab_tasks/test/test_automate_soft_dtw.py source/isaaclab_tasks/setup.py
- python3 -m pytest source/isaaclab_tasks/test/test_automate_soft_dtw.py -q could not run locally because the active system Python does not have torch installed