### PR TITLE
Fix lula discovery for pip-based Isaac Sim installs

### DIFF
--- a/source/isaaclab/changelog.d/rmpflow-lula-pip-discovery.rst
+++ b/source/isaaclab/changelog.d/rmpflow-lula-pip-discovery.rst
@@ -1,0 +1,14 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.controllers.utils.import_lula` failing to locate the ``lula`` module on
+  pip-based Isaac Sim installs by extending :func:`~isaaclab.controllers.utils.find_lula_prebundle_dir`
+  to also search the ``extscache/<name>-<version>`` and ``extsDeprecated/<name>`` layouts used by pip
+  installs (the Isaac Sim 6.0 pip packages ship ``isaacsim.robot_motion.lula`` under
+  ``extsDeprecated``, where the Kit resolver reports it as unavailable), in addition to the
+  ``exts/<name>`` layout used by binary installs. :func:`~isaaclab.controllers.utils.import_lula` now
+  adds the prebundle to ``sys.path`` before attempting to enable the Kit extension, avoiding a spurious
+  ``Failed to resolve extension dependencies`` error logged when Kit tries to enable the deprecated
+  ``isaacsim.robot_motion.lula`` extension even though ``lula`` itself loads correctly. When ``lula``
+  still cannot be found, a clear, actionable :class:`ModuleNotFoundError` is raised instead of the bare
+  import error.

--- a/source/isaaclab/isaaclab/controllers/rmp_flow.py
+++ b/source/isaaclab/isaaclab/controllers/rmp_flow.py
@@ -28,6 +28,11 @@ class _LulaRmpFlow:
     backends -- Kit and kitless (e.g. the Newton visualizer) -- since ``lula`` is importable in both.
     It assumes IsaacLab conventions: a meter-scaled stage and an identity robot base pose (the
     controller never relocates the base), and it does not manage obstacles or visuals.
+
+    Note:
+        ``lula`` is deprecated as of Isaac Sim 6.0 and slated for removal in a future release; cuMotion
+        (``isaacsim.robot_motion.cumotion``) is the long-term replacement. See the migration notes at
+        :data:`isaaclab.controllers.utils._LULA_EXT_NAME`.
     """
 
     def __init__(

--- a/source/isaaclab/isaaclab/controllers/utils.py
+++ b/source/isaaclab/isaaclab/controllers/utils.py
@@ -9,6 +9,7 @@ This module provides utility functions to help with controller implementations.
 """
 
 import contextlib
+import glob
 import logging
 import os
 import re
@@ -16,6 +17,11 @@ import sys
 
 # import logger
 logger = logging.getLogger(__name__)
+
+# NOTE: As of Isaac Sim 6.0, ``isaacsim.robot_motion.lula`` (and ``isaacsim.robot_motion.motion_generation``)
+# are deprecated -- ``lula`` has been subsumed by cuMotion (``isaacsim.robot_motion.cumotion``), which is
+# built on the new experimental motion-generation API and is the long-term replacement for RMPFlow here.
+# ``lula`` is still shipped (under ``extsDeprecated`` in pip installs) so this controller keeps working,
 
 _LULA_EXT_NAME = "isaacsim.robot_motion.lula"
 _RMPFLOW_EXT_PREFIX = "rmpflow_ext:"
@@ -167,7 +173,10 @@ def find_lula_prebundle_dir() -> str | None:
 
     ``lula`` is prebundled inside the ``isaacsim.robot_motion.lula`` extension, under the Isaac Sim
     install directory exposed via the ``ISAAC_PATH`` environment variable (importing ``isaacsim`` sets
-    it as a side effect).
+    it as a side effect). The extension lives under different sub-trees depending on the install:
+    ``exts/<name>`` for binary installs, ``extscache/<name>-<version>`` for pip caches, and
+    ``extsDeprecated/<name>`` for the Isaac Sim 6.0 pip packages (where the Kit resolver reports it as
+    unavailable even though the prebundled module is present). All layouts are searched.
     """
     isaac_path = os.environ.get("ISAAC_PATH")
     if not isaac_path:
@@ -176,18 +185,26 @@ def find_lula_prebundle_dir() -> str | None:
         isaac_path = os.environ.get("ISAAC_PATH")
     if not isaac_path:
         return None
-    prebundle = os.path.join(isaac_path, "exts", _LULA_EXT_NAME, "pip_prebundle")
-    return prebundle if os.path.isdir(prebundle) else None
+    candidates = [os.path.join(isaac_path, "exts", _LULA_EXT_NAME, "pip_prebundle")]
+    for parent in ("extscache", "extsDeprecated", "exts"):
+        candidates.extend(sorted(glob.glob(os.path.join(isaac_path, parent, f"{_LULA_EXT_NAME}*", "pip_prebundle"))))
+    for prebundle in candidates:
+        if os.path.isdir(prebundle):
+            return prebundle
+    return None
 
 
 def import_lula():
     """Import and return the ``lula`` library, making it importable across backends.
 
     ``lula`` ships as a prebundled module of the ``isaacsim.robot_motion.lula`` Isaac Sim extension.
-    It imports directly when the Isaac Sim ``pip_prebundle`` paths are already on :data:`sys.path`
-    (e.g. when launched via ``isaaclab.sh``). Otherwise -- under a running Kit app the owning extension
-    is enabled to register the path, and in the kitless Newton visualizer (a bare interpreter) the
-    prebundle directory is located and added to :data:`sys.path` directly.
+    Resolution proceeds in order: import directly when the ``pip_prebundle`` paths are already on
+    :data:`sys.path` (e.g. when launched via ``isaaclab.sh``); otherwise locate the prebundle directory
+    and add it to :data:`sys.path` (works under both Kit and the kitless Newton visualizer); and only as
+    a last resort ask a running Kit app to enable the owning extension. The prebundle is tried before
+    :func:`enable_extension` on purpose -- in Isaac Sim 6.0 the extension is deprecated and unresolvable
+    by Kit, so enabling it first would log a spurious "failed to resolve extension dependencies" error
+    even though ``lula`` itself loads fine from the prebundle.
     """
     try:
         import lula
@@ -196,7 +213,19 @@ def import_lula():
     except ModuleNotFoundError:
         pass
 
-    # Under a running Kit app, enabling the owning extension registers its prebundle on ``sys.path``.
+    # Locate the prebundle and add it ourselves -- works under both Kit and kitless, and avoids asking
+    # Kit to enable the (in 6.0, deprecated and unresolvable) extension.
+    prebundle = find_lula_prebundle_dir()
+    if prebundle is not None and prebundle not in sys.path:
+        sys.path.insert(0, prebundle)
+        try:
+            import lula
+
+            return lula
+        except ModuleNotFoundError:
+            pass
+
+    # Last resort: under a running Kit app, enabling the owning extension registers its prebundle.
     try:
         from isaacsim.core.experimental.utils.app import enable_extension
     except (ImportError, ModuleNotFoundError):
@@ -210,10 +239,10 @@ def import_lula():
         except ModuleNotFoundError:
             pass
 
-    # Kitless (or the extension did not register its path): locate the prebundle and add it ourselves.
-    prebundle = find_lula_prebundle_dir()
-    if prebundle is not None and prebundle not in sys.path:
-        sys.path.insert(0, prebundle)
-    import lula
-
-    return lula
+    raise ModuleNotFoundError(
+        "Could not import 'lula', which is required by the RMPFlow controller. It ships with the"
+        f" '{_LULA_EXT_NAME}' Isaac Sim extension, which was not found in this Isaac Sim install."
+        " The Isaac Sim 6.0 pip packages (early developer release) do not yet include this"
+        " extension; use a binary Isaac Sim install, or select a task that does not rely on"
+        " RMPFlow."
+    )


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

## Fixes (nvbug 6282434)
RMPFlow tasks crashed with "No module named lula" on pip Isaac Sim 6.0. 'lula' still ships, but under 'extsDeprecated', which discovery and the Kit resolver both missed.

- Search extscache/ and extsDeprecated/ layouts, not just exts/.
- Add the prebundle to sys.path before enabling the extension, avoiding a spurious Kit "failed to resolve dependencies" error.
- Raise an actionable error when lula is truly missing.
- Note lula's deprecation in favor of cuMotion.


<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
