### PR TITLE
[3.0.0-beta2] Make isaacteleop import optional for Galbot stack tasks

### DIFF
--- a/source/isaaclab_tasks/changelog.d/galbot-teleop-optional-import.rst
+++ b/source/isaaclab_tasks/changelog.d/galbot-teleop-optional-import.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed the Galbot cube-stack tasks (``Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-RmpFlow-v0``
+  and ``Isaac-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow-v0``) failing to parse with
+  ``No module named 'isaacteleop'`` when the optional ``isaacteleop`` dependency is not
+  installed (e.g. on DGX Spark). The ``isaaclab_teleop`` import and XR pipeline setup are
+  now guarded behind an availability check, matching the Franka stack configs, so
+  keyboard/spacemouse teleoperation works without ``isaacteleop``.

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_joint_pos_env_cfg.py
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+import logging
+
 from isaaclab_physx.assets import SurfaceGripperCfg
-from isaaclab_teleop import IsaacTeleopCfg
 
 from isaaclab.assets import RigidObjectCfg
 from isaaclab.envs.mdp.actions.actions_cfg import SurfaceGripperBinaryActionCfg
@@ -27,6 +28,15 @@ from isaaclab_tasks.manager_based.manipulation.stack.stack_env_cfg import (
     StackEnvCfg,
     raise_if_surface_gripper_on_newton,
 )
+
+try:
+    import isaacteleop  # noqa: F401  -- pipeline builders need isaacteleop at runtime
+    from isaaclab_teleop import IsaacTeleopCfg
+
+    _TELEOP_AVAILABLE = True
+except ImportError:
+    _TELEOP_AVAILABLE = False
+    logging.getLogger(__name__).warning("isaaclab_teleop is not installed. XR teleoperation features will be disabled.")
 
 ##
 # Pre-defined configs
@@ -328,11 +338,12 @@ class GalbotLeftArmCubeStackEnvCfg(StackEnvCfg):
         )
 
         # IsaacTeleop-based teleoperation pipeline (left hand)
-        self.isaac_teleop = IsaacTeleopCfg(
-            pipeline_builder=lambda: _build_se3_abs_gripper_pipeline(hand_side="left"),
-            sim_device=self.sim.device,
-            xr_cfg=self.xr,
-        )
+        if _TELEOP_AVAILABLE:
+            self.isaac_teleop = IsaacTeleopCfg(
+                pipeline_builder=lambda: _build_se3_abs_gripper_pipeline(hand_side="left"),
+                sim_device=self.sim.device,
+                xr_cfg=self.xr,
+            )
 
 
 @configclass
@@ -373,8 +384,9 @@ class GalbotRightArmCubeStackEnvCfg(GalbotLeftArmCubeStackEnvCfg):
         self.scene.ee_frame.target_frames[0].prim_path = "{ENV_REGEX_NS}/Robot/right_suction_cup_tcp_link"
 
         # IsaacTeleop-based teleoperation pipeline (right hand)
-        self.isaac_teleop = IsaacTeleopCfg(
-            pipeline_builder=lambda: _build_se3_abs_gripper_pipeline(hand_side="right"),
-            sim_device=self.sim.device,
-            xr_cfg=self.xr,
-        )
+        if _TELEOP_AVAILABLE:
+            self.isaac_teleop = IsaacTeleopCfg(
+                pipeline_builder=lambda: _build_se3_abs_gripper_pipeline(hand_side="right"),
+                sim_device=self.sim.device,
+                xr_cfg=self.xr,
+            )


### PR DESCRIPTION
# Description

Backport to `release/3.0.0-beta2` of the fix for the Galbot cube-stack RmpFlow tasks
(`Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-RmpFlow-v0` and
`Isaac-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow-v0`) failing to parse with
`No module named 'isaacteleop'` when the optional `isaacteleop` dependency is not
installed (e.g. DGX Spark) — even in the documented keyboard `record_demos.py` flow,
which runs in relative mode and never needs XR teleop.
The `isaaclab_teleop` import and `IsaacTeleopCfg` setup are now guarded behind an
availability check, matching the Franka stack configs already on this branch. When
`isaacteleop` is absent, `isaac_teleop` stays `None` and keyboard/spacemouse
teleoperation works as before.
Cherry-pick of `4556a6793c6` from `develop`. A literal `git cherry-pick` doesn't apply
because that commit edits the post core/contrib-split path; the equivalent guard is
applied here to the `manager_based/manipulation/.../galbot/` config present on the
release branch.
Base branch: `release/3.0.0-beta2`

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there