### PR TITLE
Document non-root Docker volume fix for XR teleop startup

### DIFF
--- a/docs/source/deployment/docker.rst
+++ b/docs/source/deployment/docker.rst
@@ -324,6 +324,21 @@ To pull the minimal Isaac Lab container, run:
 
   docker pull nvcr.io/nvidia/isaac-lab:3.0.0-beta1
 
+.. attention::
+
+  If the pre-built image you use runs as a **non-root** user (uid/gid 1000) -- as Isaac Lab
+  3.0.0-beta2 and later do -- the bind-mounted host directories below must be writable by that
+  user. Docker creates any missing bind-mount source directory as ``root``, which the non-root
+  runtime user cannot write to, leading to startup errors such as
+  ``PermissionError: [Errno 13] Permission denied: '/root/.local/share/ov/data/exts'``.
+  Pre-create the host directories and make them writable by uid/gid 1000 before running the
+  container:
+
+  .. code:: bash
+
+     mkdir -p ~/docker/isaac-sim/{cache/kit,cache/ov,cache/pip,cache/glcache,cache/computecache,logs,data,documents}
+     sudo chown -R 1000:1000 ~/docker/isaac-sim
+
 To run the Isaac Lab container with an interactive bash session, run:
 
 .. code:: bash

--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -448,6 +448,41 @@ components run inside one container with Isaac Lab in this release.
 The CloudXR runtime auto-launches when a teleop script is started, so no separate
 runtime command is needed.
 
+.. attention::
+
+   Recent Isaac Lab Docker images (3.0.0-beta2 and later) run as a **non-root** user
+   (uid/gid 1000). Persistent named volumes or host directories that were created by an
+   earlier root-based image are owned by ``root`` and are **not writable** by the runtime
+   user. The XR teleop workflow trips on this first, because it writes the extension
+   registry cache under the runtime home. The failure looks like::
+
+      [Error] [carb.scripting-python.plugin] PermissionError: [Errno 13] Permission denied: '/root/.local/share/ov/data/exts'
+
+   followed by a cascade of extension-registry errors that abort the app *before* the XR
+   session can start::
+
+      [Error] [omni.ext.plugin] Syncing with extension registry unavailable.
+      [Error] [omni.ext.plugin] Failed to resolve extension dependencies. Failure hints:
+        * No versions of omni.kit.xr.bundle.generic that satisfies: isaaclab.python.xr.openxr-3.0.0 ...
+      [Error] [omni.kit.app.plugin] Exiting app because of dependency solver failure...
+
+   The XR bundle is not actually missing -- the registry never synced because its cache
+   directory could not be created. To fix it, make the persistent storage writable by
+   uid/gid 1000 before relaunching:
+
+   * **Docker Compose:** recreate the named volumes, e.g.
+
+     .. code-block:: bash
+
+        docker compose --file docker-compose.yaml --profile base --env-file .env.base down --volumes
+
+     See :ref:`deployment-docker` for details. To preserve cached data instead of
+     deleting it, ``chown`` the volume: ``docker run --rm -v docker_isaac-data:/data alpine
+     chown -R 1000:1000 /data``.
+   * **Single container with bind mounts:** pre-create the host directories and
+     ``sudo chown -R 1000:1000`` them before launching, so the non-root user can write to
+     them.
+
 Run the teleop script (e.g. ``record_demos.py`` to record demonstrations):
 
 .. code-block:: bash


### PR DESCRIPTION
# Description

Since the non-root Docker migration (https://github.com/isaac-sim/IsaacLab/pull/5618, first shipped in 3.0.0-beta2), the
container runs as user isaaclab (uid/gid 1000) with HOME=/root. Persistent
mounts at /root/.local/share/ov/data that were created by an older root-based
image (stale named volumes) or by Docker as auto-created bind-mount dirs are
owned by root, so the runtime user cannot write the extension-registry cache.
For XR teleop this aborts startup with a confusing, seemingly-unrelated error:
PermissionError: [Errno 13] Permission denied: '/root/.local/share/ov/data/exts'
...
No versions of omni.kit.xr.bundle.generic that satisfies: isaaclab.python.xr.openxr-3.0.0 ...
Exiting app because of dependency solver failure...
The XR bundle isn't actually missing — the registry never synced because its
cache dir couldn't be created. This PR documents the cause and fix:

docs/source/how-to/cloudxr_teleoperation.rst: adds an admonition to the
"Run with Docker" section explaining the failure and the fix (recreate/chown
volumes for Compose, pre-create/chown host dirs for single-container).
docs/source/deployment/docker.rst: warns that non-root prebuilt images
need bind-mount host dirs pre-created and chowned to uid/gid 1000, with a
copy-paste snippet.
Docs-only; no code changes and no changelog fragment (no source/<pkg>/ package
touched).

Fixes # (issue)

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there