### PR TITLE
Frlai/fix rnn leapp tracing (#6000)

### DIFF
--- a/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
+++ b/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
@@ -22,7 +22,8 @@ ROS will add direct support for running LEAPP-exported policies in a future rele
 Prerequisites
 -------------
 
-LEAPP requires Python >= 3.8 and PyTorch >= 2.6. Install it with:
+This export flow requires ``leapp>=0.5.2``, Python >= 3.8, and PyTorch >= 2.6. Install
+LEAPP with:
 
 .. tab-set::
    :sync-group: os
@@ -64,7 +65,7 @@ consumers can run the policy without reconstructing observation ordering, comman
 targets, or policy feedback loops themselves.
 
 For a detailed description of LEAPP's generated artifacts and APIs, refer to the
-`LEAPP documentation <https://github.com/nvidia-isaac/leapp/tree/main/docs>`__.
+`LEAPP documentation <https://nvidia-isaac.github.io/leapp/>`_.
 
 
 Exporting a Policy
@@ -278,6 +279,34 @@ Isaac Lab provides :class:`~envs.LeappDeploymentEnv` for running exported polici
 simulation without the training infrastructure. This is the Isaac Lab deployment path for
 LEAPP-exported policies and is useful for validating that the packaged policy still behaves
 correctly when driven through the deployment stack instead of the training stack.
+
+Run the deployment script with the task name and the exported LEAPP ``.yaml`` file.
+
+By default, Isaac Lab launches headless when no visualization option is selected. If you expect
+to see the policy running in a viewport, pass a visualization option such as ``--viz kit``:
+
+.. tab-set::
+   :sync-group: os
+
+   .. tab-item:: :icon:`fa-brands fa-linux` Linux
+      :sync: linux
+
+      .. code-block:: bash
+
+         ./isaaclab.sh -p scripts/reinforcement_learning/leapp/deploy.py \
+             --task <TASK_NAME> \
+             --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
+             --viz kit
+
+   .. tab-item:: :icon:`fa-brands fa-windows` Windows
+      :sync: windows
+
+      .. code-block:: batch
+
+         isaaclab.bat -p scripts\reinforcement_learning\leapp\deploy.py ^
+             --task <TASK_NAME> ^
+             --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
+             --viz kit
 
 For Direct workflow policies, see the
 :doc:`Direct workflow LEAPP export tutorial </source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp>`.

--- a/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
+++ b/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
@@ -8,6 +8,9 @@ LEAPP. If your policy is manager-based, use the
 :doc:`manager-based LEAPP export guide </source/policy_deployment/05_leapp/exporting_policies_with_leapp>`
 instead.
 
+For background on LEAPP concepts, supported node patterns, state feedback, and
+runtime validation, see the `LEAPP documentation <https://nvidia-isaac.github.io/leapp/>`__.
+
 
 Overview
 ~~~~~~~~
@@ -23,7 +26,8 @@ This tutorial uses ``scripts/tutorials/06_deploy/anymal_c_env.py`` as a concrete
 example of adding LEAPP annotations to a Direct workflow environment. Apply the same
 annotation pattern to your own Direct RL environment.
 
-Before exporting, install LEAPP into the Isaac Lab Python environment:
+This export flow requires ``leapp>=0.5.2``. Before exporting, install LEAPP into
+the Isaac Lab Python environment:
 
 .. tab-set::
    :sync-group: os

--- a/scripts/reinforcement_learning/leapp/rsl_rl/export.py
+++ b/scripts/reinforcement_learning/leapp/rsl_rl/export.py
@@ -26,8 +26,14 @@ if str(_RSL_RL_SCRIPTS_DIR) not in sys.path:
 import cli_args  # isort: skip
 
 
+RSL_RL_MIN_VERSION = "5.0.1"
 _RUNTIME_IMPORTS_LOADED = False
 
+# Keep heavy/runtime-sensitive imports out of module import time. The CLI needs
+# to parse launcher arguments and start Isaac Sim/Kit before importing torch,
+# LEAPP, RSL-RL, and task modules; importing them earlier has caused launcher
+# import-order failures. ``_load_runtime_dependencies()`` populates these
+# globals immediately before export execution.
 torch = None
 leapp = None
 annotate = None
@@ -43,6 +49,7 @@ ensure_env_spec_id = None
 get_published_pretrained_checkpoint = None
 get_checkpoint_path = None
 hydra_task_config = None
+installed_version = None
 
 
 def create_arg_parser() -> argparse.ArgumentParser:
@@ -117,6 +124,7 @@ def _load_runtime_dependencies() -> None:
     global annotate, leapp, torch
     global DistillationRunner, ManagerBasedRLEnv, OnPolicyRunner, RslRlVecEnvWrapper, get_checkpoint_path, gym
     global ensure_env_spec_id, get_published_pretrained_checkpoint, handle_deprecated_rsl_rl_cfg, hydra_task_config
+    global installed_version
     global patch_env_for_export, retrieve_file_path
 
     if _RUNTIME_IMPORTS_LOADED:
@@ -130,6 +138,7 @@ def _load_runtime_dependencies() -> None:
 
     import gymnasium as gym_module
     import torch as torch_module
+    from packaging import version as packaging_version_module
     from rsl_rl.runners import DistillationRunner as DistillationRunnerCls
     from rsl_rl.runners import OnPolicyRunner as OnPolicyRunnerCls
 
@@ -152,6 +161,13 @@ def _load_runtime_dependencies() -> None:
     from isaaclab_tasks.utils import get_checkpoint_path as get_checkpoint_path_fn
     from isaaclab_tasks.utils.hydra import hydra_task_config as hydra_task_config_fn
 
+    installed_version = metadata.version("rsl-rl-lib")
+    if packaging_version_module.parse(installed_version) < packaging_version_module.parse(RSL_RL_MIN_VERSION):
+        print(
+            f"[WARNING] LEAPP RSL-RL export is validated with rsl-rl-lib {RSL_RL_MIN_VERSION} or newer. "
+            f"Installed version is '{installed_version}'."
+        )
+
     torch = torch_module
     leapp = leapp_module
     annotate = annotate_module
@@ -170,25 +186,43 @@ def _load_runtime_dependencies() -> None:
     _RUNTIME_IMPORTS_LOADED = True
 
 
-installed_version = metadata.version("rsl-rl-lib")
-
-
-def get_actor_memory_module(policy_nn):
-    """Return the actor-side recurrent memory module when the policy exposes one."""
-    if hasattr(policy_nn, "memory_a"):
-        return policy_nn.memory_a
-    if hasattr(policy_nn, "memory_s"):
-        return policy_nn.memory_s
+def get_actor_memory_module(policy):
+    """Return the actor-side RNN module for supported RSL-RL recurrent policies."""
+    if hasattr(policy, "rnn"):
+        return policy.rnn
     return None
 
 
-def ensure_actor_hidden_state_initialized(policy_nn, batch_size: int, device, dtype):
+def is_actor_recurrent_policy(policy) -> bool:
+    """Return whether the actor policy has a supported recurrent state container."""
+    return bool(getattr(policy, "is_recurrent", False) and get_actor_memory_module(policy) is not None)
+
+
+def get_actor_hidden_state(policy):
+    """Return the actor-side recurrent hidden state for supported RSL-RL policy APIs."""
+    if hasattr(policy, "get_hidden_state"):
+        return policy.get_hidden_state()
+    memory = get_actor_memory_module(policy)
+    return None if memory is None else getattr(memory, "hidden_state", None)
+
+
+def set_actor_hidden_state(policy, actor_hidden) -> None:
+    """Assign the actor-side recurrent hidden state for supported RSL-RL policy APIs."""
+    memory = get_actor_memory_module(policy)
+    if memory is not None:
+        memory.hidden_state = actor_hidden
+
+
+def ensure_actor_hidden_state_initialized(policy, batch_size: int, device, dtype):
     """Initialize and return the actor hidden state when a recurrent policy has not created it yet."""
-    actor_state, _ = policy_nn.get_hidden_states()
+    # ``torch`` is a lazy runtime global populated by ``_load_runtime_dependencies()``
+    # after Isaac Sim launches and before export calls this helper.
+    assert torch is not None
+    actor_state = get_actor_hidden_state(policy)
     if actor_state is not None:
         return actor_state
 
-    memory = get_actor_memory_module(policy_nn)
+    memory = get_actor_memory_module(policy)
     if memory is None or not hasattr(memory, "rnn"):
         return None
 
@@ -199,7 +233,7 @@ def ensure_actor_hidden_state_initialized(policy_nn, batch_size: int, device, dt
         actor_state = (zeros.clone(), zeros.clone())
     else:
         actor_state = zeros
-    memory.hidden_state = actor_state
+    set_actor_hidden_state(policy, actor_state)
     return actor_state
 
 
@@ -298,7 +332,6 @@ def export_rsl_rl_agent(
         runner.load(resume_path)
 
         policy = runner.get_inference_policy(device=env.unwrapped.device)
-        policy_nn = getattr(policy, "__self__", None)
 
         if args_cli.export_save_path is not None:
             save_path = args_cli.export_save_path
@@ -316,25 +349,23 @@ def export_rsl_rl_agent(
 
         for _ in range(max(args_cli.validation_steps, 2)):
             with torch.inference_mode():
-                if policy_nn is not None and getattr(policy_nn, "is_recurrent", False):
+                if is_actor_recurrent_policy(policy):
                     actor_hidden = ensure_actor_hidden_state_initialized(
-                        policy_nn,
+                        policy,
                         batch_size=env.num_envs,
                         device=env.unwrapped.device,
-                        dtype=next(policy_nn.parameters()).dtype,
+                        dtype=next(policy.parameters()).dtype,
                     )
                     registered_state = annotate.state_tensors(
                         policy_node_name,
                         state_dict_from_actor_hidden(actor_hidden),
                     )
-                    actor_memory = get_actor_memory_module(policy_nn)
-                    if actor_memory is not None:
-                        actor_memory.hidden_state = actor_hidden_from_registered(registered_state, actor_hidden)
+                    set_actor_hidden_state(policy, actor_hidden_from_registered(registered_state, actor_hidden))
 
                 actions = policy(obs)
 
-                if policy_nn is not None and getattr(policy_nn, "is_recurrent", False):
-                    actor_hidden_after = policy_nn.get_hidden_states()[0]
+                if is_actor_recurrent_policy(policy):
+                    actor_hidden_after = get_actor_hidden_state(policy)
                     annotate.update_state(
                         policy_node_name,
                         state_dict_from_actor_hidden(actor_hidden_after),

--- a/source/isaaclab_rl/changelog.d/frlai-fix_rnn_leapp_tracing.rst
+++ b/source/isaaclab_rl/changelog.d/frlai-fix_rnn_leapp_tracing.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed LEAPP export of RSL-RL recurrent policies to preserve actor hidden
+  state across supported RSL-RL policy APIs.

--- a/source/isaaclab_rl/test/export/test_rsl_rl_export_flow.py
+++ b/source/isaaclab_rl/test/export/test_rsl_rl_export_flow.py
@@ -16,9 +16,12 @@ import os
 import shutil
 import subprocess
 import sys
+import types
 from pathlib import Path
 
 import pytest
+
+torch = pytest.importorskip("torch")
 
 # Root of the repository (three levels up from this file).
 _REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -136,17 +139,68 @@ def _leapp_log_tail(export_dir: str) -> str:
 def _load_export_module():
     """Load the LEAPP RSL-RL export script as an importable module."""
     module = sys.modules.get(_EXPORT_MODULE_NAME)
-    if module is not None:
+    if module is not None and hasattr(module, "ensure_actor_hidden_state_initialized"):
         return module
 
+    sys.modules.pop(_EXPORT_MODULE_NAME, None)
     spec = importlib.util.spec_from_file_location(_EXPORT_MODULE_NAME, _EXPORT_SCRIPT)
     if spec is None or spec.loader is None:
         raise ImportError(f"Could not create module spec for {_EXPORT_SCRIPT}")
 
     module = importlib.util.module_from_spec(spec)
     sys.modules[_EXPORT_MODULE_NAME] = module
-    spec.loader.exec_module(module)
+    original_modules = {
+        name: sys.modules.get(name) for name in ("isaaclab", "isaaclab.app", "isaaclab_tasks", "isaaclab_tasks.utils")
+    }
+    isaaclab_module = types.ModuleType("isaaclab")
+    isaaclab_app_module = types.ModuleType("isaaclab.app")
+    isaaclab_tasks_module = types.ModuleType("isaaclab_tasks")
+    isaaclab_tasks_utils_module = types.ModuleType("isaaclab_tasks.utils")
+
+    class _AppLauncher:
+        @staticmethod
+        def add_app_launcher_args(parser):
+            return None
+
+    setattr(isaaclab_app_module, "AppLauncher", _AppLauncher)
+    setattr(isaaclab_tasks_utils_module, "fold_preset_tokens", lambda args: args)
+    setattr(isaaclab_tasks_utils_module, "setup_preset_cli", lambda parser, argv=None: parser.parse_known_args(argv))
+    sys.modules["isaaclab"] = isaaclab_module
+    sys.modules["isaaclab.app"] = isaaclab_app_module
+    sys.modules["isaaclab_tasks"] = isaaclab_tasks_module
+    sys.modules["isaaclab_tasks.utils"] = isaaclab_tasks_utils_module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, original_module in original_modules.items():
+            if original_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original_module
+    setattr(module, "torch", torch)
     return module
+
+
+class _ModularRNN(torch.nn.Module):
+    """Minimal RSL-RL 5.x RNN wrapper shape."""
+
+    def __init__(self):
+        super().__init__()
+        self.rnn = torch.nn.LSTM(input_size=2, hidden_size=4, num_layers=2)
+        self.hidden_state = None
+
+
+class _ModularRecurrentPolicy(torch.nn.Module):
+    """Minimal RSL-RL 5.x RNNModel shape."""
+
+    is_recurrent = True
+
+    def __init__(self):
+        super().__init__()
+        self.rnn = _ModularRNN()
+
+    def get_hidden_state(self):
+        return self.rnn.hidden_state
 
 
 @contextlib.contextmanager
@@ -240,6 +294,26 @@ def _run_export_batch_entrypoint() -> None:
     if not tasks:
         raise ValueError("Expected at least one task for --export-flow-batch")
     _run_export_batch(tasks)
+
+
+def test_recurrent_state_helpers_support_modular_rnn_model_lstm():
+    """Verify LSTM state registration helpers support RSL-RL 5.x RNNModel."""
+    export_module = _load_export_module()
+    policy = _ModularRecurrentPolicy()
+
+    actor_state = export_module.ensure_actor_hidden_state_initialized(
+        policy, batch_size=1, device=torch.device("cpu"), dtype=torch.float32
+    )
+    registered_state = tuple(tensor + 1.0 for tensor in actor_state)
+    export_module.set_actor_hidden_state(
+        policy,
+        export_module.actor_hidden_from_registered(registered_state, actor_state),
+    )
+
+    assert export_module.is_actor_recurrent_policy(policy)
+    assert export_module.get_actor_memory_module(policy) is policy.rnn
+    assert export_module.get_actor_hidden_state(policy) is registered_state
+    assert policy.rnn.hidden_state is registered_state
 
 
 @pytest.mark.parametrize("task_names", _task_batches(TASKS), ids=_batch_id)


### PR DESCRIPTION
# Description
Fixes leapp lstm policy export. Previously it hooked onto structures in
rslrl=3.1.2. The update now makes it work for rslrl=5.0.1, same version
as the one in the pyproject.toml. Added a regression test to test if
rslrl rnns work new test generates a dummy policy with rnn and tests the
export. Previous it was assumed that there was one policy with a
pretrained checkpoint that had an rnn but turns out there isn't any that
by default run rnns so this error slipped through.

## Type of change

<!-- As you go through the list, delete the ones that are not
applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution
guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with
`./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my
feature works
- [x] I have updated the changelog and the corresponding version in the
extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already
exists there