### PR TITLE
Fix sensor ancestor suffix trimming

### DIFF
--- a/source/isaaclab/changelog.d/fix-sensor-base-ancestor-suffix.rst
+++ b/source/isaaclab/changelog.d/fix-sensor-base-ancestor-suffix.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed rigid-body ancestor resolution for sensor paths whose terminal child path
+  is repeated earlier in the prim path.

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -472,6 +472,12 @@ class SensorBase(ABC):
             return target_expr, None, None
 
         relative_path = prim.GetPath().MakeRelativePath(ancestor_prim.GetPath()).pathString
-        rigid_parent_expr = target_expr.replace("/" + relative_path, "")
+        suffix = "/" + relative_path
+        if not target_expr.endswith(suffix):
+            raise RuntimeError(
+                f"Failed to build rigid body ancestor expression: target expression {target_expr!r} does not end "
+                f"with relative path {relative_path!r}."
+            )
+        rigid_parent_expr = target_expr[: -len(suffix)]
         fixed_pos_b, fixed_quat_b = resolve_prim_pose(prim, ancestor_prim)
         return rigid_parent_expr, fixed_pos_b, fixed_quat_b

--- a/source/isaaclab/test/sensors/test_sensor_base.py
+++ b/source/isaaclab/test/sensors/test_sensor_base.py
@@ -21,6 +21,8 @@ import pytest
 import torch
 import warp as wp
 
+from pxr import UsdPhysics
+
 import isaaclab.sim as sim_utils
 from isaaclab.sensors import SensorBase, SensorBaseCfg
 from isaaclab.utils.configclass import configclass
@@ -228,3 +230,25 @@ def test_sensor_reset(create_dummy_sensor, device):
             sensor.data.count[cont_ids],
             torch.tensor(k + 6, device=device, dtype=torch.int32).repeat(len(cont_ids)),
         )
+
+
+@pytest.mark.parametrize("device", ("cpu",))
+def test_rigid_body_ancestor_expr_trims_only_terminal_suffix(create_dummy_sensor, device):
+    """Test that ancestor expression trimming keeps repeated path segments above the sensor."""
+    sensor_cfg, _, _ = create_dummy_sensor
+
+    parent_path = "/World/envs/env_00/Robot/link"
+    child_path = parent_path + "/link"
+    sim_utils.create_prim(parent_path, "Xform")
+    sim_utils.create_prim(child_path, "Xform")
+    UsdPhysics.RigidBodyAPI.Apply(sim_utils.get_current_stage().GetPrimAtPath(parent_path))
+    sim_utils.update_stage()
+
+    sensor_cfg.prim_path = "/World/envs/env_.*/Robot/link/link"
+    sensor = DummySensor(cfg=sensor_cfg)
+
+    rigid_parent_expr, fixed_pos_b, fixed_quat_b = sensor._resolve_rigid_body_ancestor_expr()
+
+    assert rigid_parent_expr == "/World/envs/env_.*/Robot/link"
+    assert fixed_pos_b is not None
+    assert fixed_quat_b is not None


### PR DESCRIPTION
# Description

Fixes rigid-body ancestor expression resolution for sensors mounted under a
non-rigid child when the terminal child suffix also appears earlier in the path.
The old implementation used an unbounded ``str.replace()``, which could remove
more than the sensor-relative suffix.

Simple example:

```text
target_expr   = /World/envs/env_.*/Robot/link/link
relative_path = link
old result    = /World/envs/env_.*/Robot
new result    = /World/envs/env_.*/Robot/link
```

The fix verifies that the relative path is a terminal suffix and slices only that
end segment.

No issue filed.

Validation:

- `./isaaclab.sh -p -m pytest source/isaaclab/test/sensors/test_sensor_base.py::test_rigid_body_ancestor_expr_trims_only_terminal_suffix -q`
- `PATH=/tmp/git-lfs-v3.7.1:$PATH ./isaaclab.sh -f`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation, or documentation is not required for this change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
