### PR TITLE
Invalidate body velocities after joint velocity writes

### DIFF
--- a/source/isaaclab_newton/changelog.d/joint-qd-write-invalidates.rst
+++ b/source/isaaclab_newton/changelog.d/joint-qd-write-invalidates.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed Newton articulation joint velocity writers to invalidate derived body
+  velocity state after joint velocity writes, preventing stale body velocities
+  after resets.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -1241,6 +1241,20 @@ class Articulation(BaseArticulation):
             ],
             device=self.device,
         )
+        # Joint velocities affect body spatial velocities, so FK/body-velocity state
+        # must be recomputed before consumers read state.body_qd again.
+        self.data._fk_timestamp = -1.0
+        SimulationManager.invalidate_fk(env_ids=env_ids, articulation_ids=self._root_view.articulation_ids)
+        if self.data._body_link_vel_w is not None:
+            self.data._body_link_vel_w.timestamp = -1.0
+        if self.data._body_com_acc_w is not None:
+            self.data._body_com_acc_w.timestamp = -1.0
+        if self.data._body_state_w is not None:
+            self.data._body_state_w.timestamp = -1.0
+        if self.data._body_link_state_w is not None:
+            self.data._body_link_state_w.timestamp = -1.0
+        if self.data._body_com_state_w is not None:
+            self.data._body_com_state_w.timestamp = -1.0
 
     def write_joint_velocity_to_sim_mask(
         self,
@@ -1281,6 +1295,20 @@ class Articulation(BaseArticulation):
             ],
             device=self.device,
         )
+        # Joint velocities affect body spatial velocities, so FK/body-velocity state
+        # must be recomputed before consumers read state.body_qd again.
+        self.data._fk_timestamp = -1.0
+        SimulationManager.invalidate_fk(env_mask=env_mask, articulation_ids=self._root_view.articulation_ids)
+        if self.data._body_link_vel_w is not None:
+            self.data._body_link_vel_w.timestamp = -1.0
+        if self.data._body_com_acc_w is not None:
+            self.data._body_com_acc_w.timestamp = -1.0
+        if self.data._body_state_w is not None:
+            self.data._body_state_w.timestamp = -1.0
+        if self.data._body_link_state_w is not None:
+            self.data._body_link_state_w.timestamp = -1.0
+        if self.data._body_com_state_w is not None:
+            self.data._body_com_state_w.timestamp = -1.0
 
     """
     Operations - Simulation Parameters Writers.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -744,6 +744,7 @@ class ArticulationData(BaseArticulationData):
         This quantity contains the linear and angular velocities of the articulation links' center of mass frame
         relative to the world.
         """
+        self._ensure_fk_fresh()
         return self._body_com_vel_w_ta
 
     @property
@@ -755,6 +756,7 @@ class ArticulationData(BaseArticulationData):
 
         All values are relative to the world.
         """
+        self._ensure_fk_fresh()
         if self._body_com_acc_w.timestamp < self._sim_timestamp:
             wp.launch(
                 shared_kernels.derive_body_acceleration_from_body_com_velocities,


### PR DESCRIPTION
# Description

Fixes stale derived body velocities after Newton articulation joint velocity writes. Previously, `write_joint_velocity_to_sim_*()` updated `joint_qd` but did not mark FK/body velocity state dirty, so solvers (in particular, Kamino) could keep using stale `state.body_qd` after resets.

### Changes

- Marked articulation FK/body velocity state dirty after joint velocity writes.
- Invalidated cached body velocity/state buffers affected by joint velocity writes.
- Ensured body COM velocity/acceleration accessors refresh derived body state before reading Newton state.body_qd.


### Validation

- Verified Cartpole Kamino reset logs no longer show pre-reset body linear velocity after reset.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
