### PR TITLE
Fix kitless OVPhysX scene cloning

### DIFF
--- a/source/isaaclab/changelog.d/fix-kitless-fabric-notices.rst
+++ b/source/isaaclab/changelog.d/fix-kitless-fabric-notices.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.cloner.disabled_fabric_change_notifies` to no-op
+  when ``usdrt`` is unavailable in kitless runtimes.

--- a/source/isaaclab/isaaclab/cloner/_fabric_notices.py
+++ b/source/isaaclab/isaaclab/cloner/_fabric_notices.py
@@ -184,7 +184,13 @@ def disabled_fabric_change_notifies(stage: Usd.Stage, *, restore: bool = True) -
         return
 
     # usdrt only works with a live Kit app — defer import so module load stays cheap.
-    import usdrt
+    try:
+        import usdrt
+    except ModuleNotFoundError as exc:
+        if exc.name != "usdrt":
+            raise
+        yield
+        return
 
     # Avoid leaking a strong reference into the global ``StageCache`` for stages we did not
     # author into the cache: ``Insert`` keeps the stage alive for the rest of the process.

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from pxr import UsdGeom
+from pxr import Usd, UsdGeom
 
 import isaaclab.sim as sim_utils
 from isaaclab.cloner import (
@@ -118,6 +118,31 @@ def test_usd_replicate_context_queue_and_replicate(sim):
 
     assert stage.GetPrimAtPath("/World/envs/env_0/A").IsValid()
     assert stage.GetPrimAtPath("/World/envs/env_1/A").IsValid()
+
+
+def test_disabled_fabric_change_notifies_noops_when_usdrt_unavailable(monkeypatch):
+    """Fabric notice suspension no-ops when Carbonite bindings exist but ``usdrt`` does not."""
+    import builtins
+
+    from isaaclab.cloner import _fabric_notices
+
+    class _FakeBindings:
+        def validate_with(self, fabric_id: int) -> bool:
+            raise AssertionError("missing usdrt should prevent fabric-id lookup")
+
+    monkeypatch.setattr(_fabric_notices, "get_bindings", lambda: _FakeBindings())
+
+    real_import = builtins.__import__
+
+    def _import_without_usdrt(name, *args, **kwargs):
+        if name == "usdrt":
+            raise ModuleNotFoundError("No module named 'usdrt'", name="usdrt")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import_without_usdrt)
+
+    with _fabric_notices.disabled_fabric_change_notifies(Usd.Stage.CreateInMemory()):
+        pass
 
 
 def test_usd_replicate_depth_order_parent_child(sim):

--- a/source/isaaclab_ovphysx/changelog.d/skip-usd-replication.rst
+++ b/source/isaaclab_ovphysx/changelog.d/skip-usd-replication.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Stopped OVPhysX assets from enqueueing redundant USD replication work
+  during scene cloning.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
@@ -23,7 +23,6 @@ from pxr import UsdPhysics
 import isaaclab.sim as sim_utils
 from isaaclab.assets.articulation.articulation_cfg import ArticulationCfg
 from isaaclab.assets.articulation.base_articulation import BaseArticulation
-from isaaclab.cloner import queue_usd_replication
 from isaaclab.physics import PhysicsManager
 from isaaclab.utils.string import resolve_matching_names
 from isaaclab.utils.wrench_composer import WrenchComposer
@@ -86,7 +85,6 @@ class Articulation(BaseArticulation):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
-        queue_usd_replication(cfg)
         queue_ovphysx_replication(cfg)
         # bindings are populated eagerly in ``_initialize_impl``; the dict
         # also caches any tensor type the user explicitly queries later

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object/rigid_object.py
@@ -20,7 +20,6 @@ from pxr import UsdPhysics
 
 from isaaclab.assets.rigid_object.base_rigid_object import BaseRigidObject
 from isaaclab.assets.rigid_object.rigid_object_cfg import RigidObjectCfg
-from isaaclab.cloner import queue_usd_replication
 from isaaclab.sim.utils.queries import get_all_matching_child_prims, resolve_matching_prims_from_source
 from isaaclab.utils.string import resolve_matching_names
 from isaaclab.utils.wrench_composer import WrenchComposer
@@ -64,7 +63,6 @@ class RigidObject(BaseRigidObject):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
-        queue_usd_replication(cfg)
         queue_ovphysx_replication(cfg)
         # Bindings are created lazily (on first access) to avoid allocating
         # handles for tensor types the user never queries.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
@@ -18,7 +18,6 @@ from pxr import UsdPhysics
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets.rigid_object_collection.base_rigid_object_collection import BaseRigidObjectCollection
-from isaaclab.cloner import queue_usd_replication
 from isaaclab.utils.string import resolve_matching_names
 from isaaclab.utils.wrench_composer import WrenchComposer
 
@@ -89,7 +88,6 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             matching_prims = sim_utils.find_matching_prims(rigid_body_cfg.prim_path)
             if len(matching_prims) == 0:
                 raise RuntimeError(f"Could not find prim with path {rigid_body_cfg.prim_path}.")
-            queue_usd_replication(cfg.rigid_objects[rigid_body_name])
             queue_ovphysx_replication(cfg.rigid_objects[rigid_body_name])
         # stores object names
         self._body_names_list: list[str] = []


### PR DESCRIPTION
# Description

OVPhysX can run kitless in a state where Carbonite exposes the Fabric USD notice interface but the Python `usdrt` module is not importable. In that state, `disabled_fabric_change_notifies()` should fall back to its intended no-op behavior instead of failing during scene cloning.

This PR keeps Fabric notice suspension active when `usdrt` is available, but treats only a missing top-level `usdrt` module as unavailable Fabric notice suspension. It also removes redundant `queue_usd_replication(...)` calls from the OVPhysX `RigidObject`, `Articulation`, and `RigidObjectCollection` constructors. OVPhysX assets continue to enqueue `queue_ovphysx_replication(...)` for backend runtime cloning.

Fixes #

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh -f`
- [x] I have made corresponding changes to the documentation, or no documentation update is required
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Testing

- `./isaaclab.sh -p -m pytest -q source/isaaclab/test/sim/test_cloner.py::test_disabled_fabric_change_notifies_noops_when_usdrt_unavailable` (`1 passed`)
- `./isaaclab.sh -p -m pytest -q source/isaaclab_physx/test/sim/test_cloner.py::test_disabled_fabric_change_notifies_toggles_ifabricusd_flag` (`2 passed`)
- `./isaaclab.sh -p -m pytest -q source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py::test_world_pose_equals_parent_plus_offset -k cpu` (`1 passed, 1 deselected`)
- `./isaaclab.sh -p -m pytest -q source/isaaclab_ovphysx/test/sim/test_views_xform_prim_ovphysx.py::test_world_pose_equals_parent_plus_offset -k cuda` (`1 passed, 1 deselected`)
- `PATH=/tmp/git-lfs-v3.7.1:$PATH ./isaaclab.sh -f`
