### PR TITLE
Fix Newton Fabric body binding initialization

### DIFF
--- a/source/isaaclab_newton/changelog.d/fix-newton-fabric-body-binding.rst
+++ b/source/isaaclab_newton/changelog.d/fix-newton-fabric-body-binding.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed Newton RTX/Fabric body binding to derive per-body Fabric bindings from
+  clone-plan source rows while labels are rewritten, avoiding invalid Fabric
+  attribute writes without cloning USD specs for each environment.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
@@ -188,7 +188,7 @@ def _rename_builder_labels(
     destinations: Sequence[str],
     env_ids: torch.Tensor,
     mapping: torch.Tensor,
-) -> None:
+) -> list[tuple[str, str, int]]:
     """Rename builder labels/keys from source roots to destination roots.
 
     Walks both built-in label arrays (see :data:`_BUILTIN_LABEL_TYPES`) and any
@@ -205,7 +205,13 @@ def _rename_builder_labels(
         destinations: Destination prim path templates.
         env_ids: Environment ids corresponding to mapping columns.
         mapping: Boolean source-to-environment mapping matrix.
+
+    Returns:
+        Fabric body binding records as ``(fabric_body_path, body_index)``.
     """
+    fabric_body_bindings: list[tuple[str, int]] = []
+    bound_body_indices: set[int] = set()
+
     # per-source, per-world renaming (strict prefix swap), compact style preserved
     for i, src_path in enumerate(sources):
         # Canonicalize the source root (drop any trailing ``/``) so the
@@ -215,7 +221,7 @@ def _rename_builder_labels(
         # Map Newton world IDs (sequential) to destination paths using env_ids
         world_roots = {int(env_ids[c]): destinations[i].format(int(env_ids[c])) for c in world_cols}
 
-        def _rename_pair(values, worlds):
+        def _rename_pair(values, worlds, *, collect_body_bindings: bool = False):
             if len(values) != len(worlds):
                 raise ValueError(f"label/world column length mismatch: {len(values)} vs {len(worlds)}")
             for k in range(len(values)):
@@ -239,7 +245,11 @@ def _rename_builder_labels(
                 #                        when src_root is "/Sources/protoA" -> skip.
                 if suffix and not suffix.startswith("/"):
                     continue
-                values[k] = world_roots[world_id] + suffix
+                renamed_value = world_roots[world_id] + suffix
+                if collect_body_bindings:
+                    fabric_body_bindings.append((renamed_value, k))
+                    bound_body_indices.add(k)
+                values[k] = renamed_value
 
         # Pass 1: built-in label arrays. Each has a paired ``*_world`` int column.
         # Use ``is None`` (not ``or``) so an empty-but-defined ``*_label`` column
@@ -252,7 +262,7 @@ def _rename_builder_labels(
             worlds_arr = getattr(builder, f"{t}_world", None)
             if labels is None or worlds_arr is None:
                 continue
-            _rename_pair(labels, worlds_arr)
+            _rename_pair(labels, worlds_arr, collect_body_bindings=t == "body")
 
         # Pass 2: string-typed custom-attribute columns (e.g. ``mujoco:tendon_label``)
         # paired with a world companion declared via ``references="world"``. Index
@@ -273,6 +283,12 @@ def _rename_builder_labels(
             if not values or not worlds:
                 continue
             _rename_pair(values, worlds)
+
+    for index, label in enumerate(builder.body_label):
+        if index not in bound_body_indices:
+            fabric_body_bindings.append((label, index))
+
+    return fabric_body_bindings
 
 
 class NewtonReplicateContext:
@@ -397,9 +413,10 @@ class NewtonReplicateContext:
             up_axis=self.up_axis,
             simplify_meshes=self.simplify_meshes,
         )
-        _rename_builder_labels(builder, sources, destinations, env_ids, mapping)
+        fabric_body_bindings = _rename_builder_labels(builder, sources, destinations, env_ids, mapping)
         if self.commit_to_manager:
             NewtonManager._cl_site_index_map = site_index_map
+            NewtonManager._cl_fabric_body_bindings = fabric_body_bindings
             NewtonManager._world_xforms = world_xforms
             NewtonManager.set_builder(builder)
             NewtonManager._num_envs = mapping.size(1)

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -11,7 +11,7 @@ import contextlib
 import ctypes
 import logging
 from abc import abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
 import warp as wp
@@ -284,6 +284,7 @@ class NewtonManager(PhysicsManager):
     _LocalSite = tuple[None, list[list[int]]]
     _SiteEntry = _GlobalSite | _LocalSite
     _cl_site_index_map: dict[str, _SiteEntry] = {}
+    _cl_fabric_body_bindings: list[tuple[str, int]] | None = None
     _world_xforms: list[wp.transform] | None = None
 
     @classmethod
@@ -692,6 +693,7 @@ class NewtonManager(PhysicsManager):
         NewtonManager._scene_data_backend = None
         NewtonManager._cl_pending_sites = {}
         NewtonManager._cl_site_index_map = {}
+        NewtonManager._cl_fabric_body_bindings = None
         NewtonManager._world_xforms = None
         NewtonManager._pending_extended_state_attributes = set()
         NewtonManager._pending_extended_contact_attributes = set()
@@ -1017,30 +1019,43 @@ class NewtonManager(PhysicsManager):
         if not cls._clone_physics_only:
             import usdrt
 
-            body_paths = getattr(cls._model, "body_label", None) or getattr(cls._model, "body_key", None)
-            if not body_paths:
-                logger.warning(
-                    "NewtonManager: model has no rigid bodies (body_label/body_key is empty). "
-                    "USD/Fabric body sync for RTX is skipped. "
-                    "Particle-only scenes (e.g. cloth) must register their own USD mesh update."
-                )
-                NewtonManager._usdrt_stage = None
-            else:
-                NewtonManager._usdrt_stage = get_current_stage(fabric=True)
-                for i, prim_path in enumerate(body_paths):
-                    prim = cls._usdrt_stage.GetPrimAtPath(prim_path)
-                    prim.CreateAttribute(cls._newton_index_attr, usdrt.Sdf.ValueTypeNames.UInt, True)
-                    prim.GetAttribute(cls._newton_index_attr).Set(i)
-                    # Tag with PhysicsRigidBodyAPI so cubric's eRigidBody mode
-                    # applies Inverse propagation (preserves Newton's world
-                    # transforms and derives local) instead of Forward.
-                    prim.AddAppliedSchema("PhysicsRigidBodyAPI")
-                    xformable_prim = usdrt.Rt.Xformable(prim)
-                    if not xformable_prim.HasWorldXform():
-                        xformable_prim.SetWorldXformFromUsd()
+            body_paths = list(cls._model.body_label)
+            NewtonManager._usdrt_stage = get_current_stage(fabric=True)
+            body_bindings = NewtonManager._cl_fabric_body_bindings
+            if body_bindings is None:
+                # Non-replicated Newton stages do not pass through NewtonReplicateContext.
+                body_bindings = [(body_path, i) for i, body_path in enumerate(body_paths)]
 
-                cls._mark_transforms_dirty()
-                cls.sync_transforms_to_usd()
+            fabric_hierarchy = usdrt.hierarchy.IFabricHierarchy().get_fabric_hierarchy(
+                cls._usdrt_stage.GetFabricId(), cls._usdrt_stage.GetStageIdAsStageId()
+            )
+
+            NewtonManager._initialize_fabric_body_prims(cls._usdrt_stage, fabric_hierarchy, usdrt, body_bindings)
+
+            cls._mark_transforms_dirty()
+            cls.sync_transforms_to_usd()
+
+    @staticmethod
+    def _initialize_fabric_body_prims(stage, fabric_hierarchy, usdrt, body_bindings: Sequence[tuple[str, int]]) -> None:
+        """Initialize Fabric body prims used by Newton transform sync."""
+        for prim_path, body_index in body_bindings:
+            prim = stage.GetPrimAtPath(prim_path)
+            if prim.IsValid():
+                xformable_prim = usdrt.Rt.Xformable(prim)
+                xformable_prim.SetWorldXformFromUsd()
+            else:
+                prim = stage.DefinePrim(prim_path, "Xform")
+                xformable_prim = usdrt.Rt.Xformable(prim)
+                xformable_prim.CreateFabricHierarchyWorldMatrixAttr()
+
+            prim.CreateAttribute(NewtonManager._newton_index_attr, usdrt.Sdf.ValueTypeNames.UInt, custom=True)
+            prim.GetAttribute(NewtonManager._newton_index_attr).Set(body_index)
+            # Tag with PhysicsRigidBodyAPI so cubric's eRigidBody mode applies
+            # Inverse propagation (preserves Newton's world transforms and derives
+            # local) instead of Forward.
+            prim.AddAppliedSchema("PhysicsRigidBodyAPI")
+
+        fabric_hierarchy.update_world_xforms()
 
     @classmethod
     def instantiate_builder_from_stage(cls):

--- a/source/isaaclab_newton/test/physics/test_newton_fabric_body_sync.py
+++ b/source/isaaclab_newton/test/physics/test_newton_fabric_body_sync.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for Newton USD/Fabric body binding initialization."""
+
+from __future__ import annotations
+
+from isaaclab.app import AppLauncher
+
+# Launch Isaac Sim before importing Newton modules so USD schema bindings are initialized.
+simulation_app = AppLauncher(headless=True).app
+
+from isaaclab_newton.physics import NewtonManager
+
+
+class _FakeAttribute:
+    def __init__(self, value_type, custom):
+        self.value_type = value_type
+        self.custom = custom
+        self.value = None
+
+    def Set(self, value):
+        self.value = value
+
+
+class _FakePrim:
+    def __init__(self, valid=True):
+        self.valid = valid
+        self.attributes = {}
+        self.applied_schemas = []
+        self.created_world_matrix_attrs = 0
+        self.set_world_xform_from_usd = 0
+
+    def IsValid(self):
+        return self.valid
+
+    def CreateAttribute(self, name, value_type, custom=False):
+        self.attributes[name] = _FakeAttribute(value_type, custom)
+        return self.attributes[name]
+
+    def GetAttribute(self, name):
+        return self.attributes[name]
+
+    def AddAppliedSchema(self, schema):
+        self.applied_schemas.append(schema)
+
+
+class _FakeStage:
+    def __init__(self, prims=None):
+        self.prims = prims or {}
+        self.defined_prims = []
+
+    def GetPrimAtPath(self, path):
+        return self.prims.get(path, _FakePrim(valid=False))
+
+    def DefinePrim(self, path, prim_type):
+        prim = _FakePrim()
+        self.prims[path] = prim
+        self.defined_prims.append((path, prim_type))
+        return prim
+
+
+class _FakeXformable:
+    def __init__(self, prim):
+        self.prim = prim
+
+    def SetWorldXformFromUsd(self):
+        self.prim.set_world_xform_from_usd += 1
+
+    def CreateFabricHierarchyWorldMatrixAttr(self):
+        self.prim.created_world_matrix_attrs += 1
+
+
+class _FakeFabricHierarchy:
+    def __init__(self):
+        self.update_world_xforms_count = 0
+
+    def update_world_xforms(self):
+        self.update_world_xforms_count += 1
+
+
+class _FakeRt:
+    Xformable = _FakeXformable
+
+
+class _FakeValueTypeNames:
+    UInt = "UInt"
+
+
+class _FakeSdf:
+    ValueTypeNames = _FakeValueTypeNames
+
+
+class _FakeUsdrt:
+    Rt = _FakeRt
+    Sdf = _FakeSdf
+
+
+def test_initialize_fabric_body_prims_uses_existing_fabric_prim():
+    prim = _FakePrim()
+    stage = _FakeStage({"/World/envs/env_0/Robot/base": prim})
+    fabric_hierarchy = _FakeFabricHierarchy()
+
+    NewtonManager._initialize_fabric_body_prims(
+        stage, fabric_hierarchy, _FakeUsdrt, [("/World/envs/env_0/Robot/base", 3)]
+    )
+
+    assert stage.defined_prims == []
+    assert prim.set_world_xform_from_usd == 1
+    assert prim.created_world_matrix_attrs == 0
+    assert prim.GetAttribute("newton:index").value_type == "UInt"
+    assert prim.GetAttribute("newton:index").custom is True
+    assert prim.GetAttribute("newton:index").value == 3
+    assert prim.applied_schemas == ["PhysicsRigidBodyAPI"]
+    assert fabric_hierarchy.update_world_xforms_count == 1
+
+
+def test_initialize_fabric_body_prims_creates_missing_body_as_xform():
+    stage = _FakeStage()
+    fabric_hierarchy = _FakeFabricHierarchy()
+
+    NewtonManager._initialize_fabric_body_prims(
+        stage, fabric_hierarchy, _FakeUsdrt, [("/World/envs/env_1/Robot/joints/forearm", 7)]
+    )
+
+    prim = stage.prims["/World/envs/env_1/Robot/joints/forearm"]
+    assert stage.defined_prims == [("/World/envs/env_1/Robot/joints/forearm", "Xform")]
+    assert prim.set_world_xform_from_usd == 0
+    assert prim.created_world_matrix_attrs == 1
+    assert prim.GetAttribute("newton:index").value_type == "UInt"
+    assert prim.GetAttribute("newton:index").custom is True
+    assert prim.GetAttribute("newton:index").value == 7
+    assert prim.applied_schemas == ["PhysicsRigidBodyAPI"]
+    assert fabric_hierarchy.update_world_xforms_count == 1


### PR DESCRIPTION
## Summary

- initialize Fabric world matrix attributes before assigning `newton:index` during Newton USD/Fabric body binding
- skip missing Fabric body prims and invalid index attributes instead of writing through invalid attributes
- update the Fabric hierarchy once after body binding, matching the existing Fabric frame view initialization pattern

## Motivation

Dexsuite startup with Newton + Isaac RTX rendering can hang after contact sensor initialization with:

```
Currently unsupported type (unknown) for UsdAttribute.Set() at <invalid UsdAttribute>
```

The body binding loop was creating and setting `newton:index` before Fabric hierarchy world matrix state was initialized for each body prim. This mirrors the safer setup order used by `FabricFrameView`.

## Validation

- `pre-commit run --files source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py source/isaaclab_newton/changelog.d/fix-newton-fabric-body-binding.rst`
- `python3 tools/changelog/cli.py check develop`
- `python3 -m py_compile source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py`
- `git diff --check`

I attempted the reported training startup locally with `--max_iterations 1`, but this checkout has no active Isaac Lab Python environment and `isaaclab.sh` selected `/usr/bin/python3.12`, which is missing `gymnasium`.
