### PR TITLE
[release/3.0.0-beta2] Fix kitless OVPhysX scene cloning

### DIFF
--- a/source/isaaclab/changelog.d/fix-kitless-fabric-notices.rst
+++ b/source/isaaclab/changelog.d/fix-kitless-fabric-notices.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.cloner.disabled_fabric_change_notifies` to no-op
+  when ``usdrt`` is unavailable in kitless runtimes.

--- a/source/isaaclab/isaaclab/cloner/cloner_utils.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_utils.py
@@ -205,7 +205,13 @@ def disabled_fabric_change_notifies(stage: Usd.Stage, *, restore: bool = True) -
         return
 
     # usdrt only works with a live Kit app — defer import so module load stays cheap.
-    import usdrt
+    try:
+        import usdrt
+    except ModuleNotFoundError as exc:
+        if exc.name != "usdrt":
+            raise
+        yield
+        return
 
     # Avoid leaking a strong reference into the global ``StageCache`` for stages we did not
     # author into the cache: ``Insert`` keeps the stage alive for the rest of the process.

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -17,7 +17,7 @@ simulation_app = AppLauncher(headless=True).app
 import pytest
 import torch
 
-from pxr import UsdGeom
+from pxr import Usd, UsdGeom
 
 import isaaclab.sim as sim_utils
 from isaaclab.cloner import ClonePlan, make_clone_plan, sequential, usd_replicate
@@ -74,6 +74,31 @@ def test_usd_replicate_with_positions_and_mask(sim):
     xform = UsdGeom.Xformable(prim)
     ops = xform.GetOrderedXformOps()
     assert any(op.GetOpType() == UsdGeom.XformOp.TypeTranslate for op in ops)
+
+
+def test_disabled_fabric_change_notifies_noops_when_usdrt_unavailable(monkeypatch):
+    """Fabric notice suspension no-ops when Carbonite bindings exist but ``usdrt`` does not."""
+    import builtins
+
+    import isaaclab.cloner.cloner_utils as cloner_utils
+
+    class _FakeBindings:
+        def validate_with(self, fabric_id: int) -> bool:
+            raise AssertionError("missing usdrt should prevent fabric-id lookup")
+
+    monkeypatch.setattr(cloner_utils._fabric_notices, "get_bindings", lambda: _FakeBindings())
+
+    real_import = builtins.__import__
+
+    def _import_without_usdrt(name, *args, **kwargs):
+        if name == "usdrt":
+            raise ModuleNotFoundError("No module named 'usdrt'", name="usdrt")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import_without_usdrt)
+
+    with cloner_utils.disabled_fabric_change_notifies(Usd.Stage.CreateInMemory()):
+        pass
 
 
 def test_usd_replicate_depth_order_parent_child(sim):


### PR DESCRIPTION
## Summary

Backports #6072 to `release/3.0.0-beta2`.

This fixes kitless OVPhysX scene cloning when Carbonite exposes the Fabric USD notice interface but the Python `usdrt` module is unavailable. In that case, `disabled_fabric_change_notifies()` now falls back to the intended no-op behavior instead of raising during scene cloning.

## Backport notes

The beta2 branch keeps `disabled_fabric_change_notifies()` in `source/isaaclab/isaaclab/cloner/cloner_utils.py`, while `develop` has since moved this logic into `_fabric_notices.py`. The develop commit also touched OVPhysX queued replication code from a later refactor that is not present on beta2, so those constructor hunks were resolved to the beta2 side.

## Testing

- `./isaaclab.sh -p -c <direct disabled_fabric_change_notifies behavior probe>` -> passed with `behavior-ok`.
- Temporarily restored the old unconditional `import usdrt` and reran the same probe -> failed with `ModuleNotFoundError: No module named 'usdrt'`, confirming the regression coverage.
- `./isaaclab.sh -p -m pytest -q source/isaaclab/test/sim/test_cloner.py::test_disabled_fabric_change_notifies_noops_when_usdrt_unavailable` -> blocked in this local worktree during collection because the Python environment is missing `lazy_loader`.
- `./isaaclab.sh -f` -> passed.
