### PR TITLE
Add Newton visualizer camera view updates

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/newton-visualizer-camera-view.rst
+++ b/source/isaaclab_visualizers/changelog.d/newton-visualizer-camera-view.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed ``set_camera_view`` updates for the Newton visualizer.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -793,10 +793,11 @@ class NewtonVisualizer(BaseVisualizer):
             eye: Camera eye position.
             target: Camera look-at target.
         """
-        if not self._is_initialized:
-            logger.debug("[NewtonVisualizer] set_camera_view() ignored because visualizer is not initialized.")
-            return
-        self._apply_camera_pose((tuple(eye), tuple(target)))
+        eye_t = (float(eye[0]), float(eye[1]), float(eye[2]))
+        target_t = (float(target[0]), float(target[1]), float(target[2]))
+        self.cfg.eye = eye_t
+        self.cfg.lookat = target_t
+        self._apply_camera_pose((eye_t, target_t))
 
     def supports_markers(self) -> bool:
         """Newton OpenGL viewer supports Isaac Lab markers through viewer-side meshes and lines."""

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -111,6 +111,43 @@ def test_newton_visualizer_cfg_exposes_particle_options():
     assert cfg.particle_color == (0.1, 0.2, 0.3)
 
 
+def test_newton_visualizer_set_camera_view_updates_cfg_without_viewer():
+    visualizer = NewtonVisualizer(NewtonVisualizerCfg())
+
+    visualizer.set_camera_view((1, 2, 3), (0, 0, 1))
+
+    assert visualizer.cfg.eye == (1.0, 2.0, 3.0)
+    assert visualizer.cfg.lookat == (0.0, 0.0, 1.0)
+    assert visualizer._resolve_initial_camera_pose() == ((1.0, 2.0, 3.0), (0.0, 0.0, 1.0))
+
+
+def test_newton_visualizer_set_camera_view_updates_active_viewer():
+    """NewtonVisualizer should honor SimulationContext camera updates."""
+
+    class _FakeCamera:
+        def __init__(self):
+            self.pos = None
+            self.look_at_calls = []
+
+        def look_at(self, target):
+            self.look_at_calls.append(tuple(target))
+
+    class _FakeViewer:
+        def __init__(self):
+            self.camera = _FakeCamera()
+
+    viewer = _FakeViewer()
+    visualizer = NewtonVisualizer(NewtonVisualizerCfg())
+    visualizer._viewer = viewer
+
+    visualizer.set_camera_view((1, 2, 3), (0, 0, 1))
+
+    assert (viewer.camera.pos.x, viewer.camera.pos.y, viewer.camera.pos.z) == (1.0, 2.0, 3.0)
+    assert viewer.camera.look_at_calls == [(0.0, 0.0, 1.0)]
+    assert visualizer.cfg.eye == (1.0, 2.0, 3.0)
+    assert visualizer.cfg.lookat == (0.0, 0.0, 1.0)
+
+
 def test_newton_viewer_particle_color_override(monkeypatch):
     from newton.viewer import ViewerGL
 


### PR DESCRIPTION
 # Description

  This PR updates the Newton visualizer so `set_camera_view(eye, target)` applies camera updates consistently.

  Previously, camera view updates from `SimulationContext.set_camera_view(...)` could be ignored when the Newton visualizer was not fully initialized, and the visualizer config was not kept in sync with the requested camera pose. This change stores the requested `eye` and `lookat` values in `NewtonVisualizerCfg` and applies them to the active Newton viewer camera when available.

  No new dependencies are required.

  Fixes # <!-- N/A -->

  ## Type of change

  - Bug fix (non-breaking change which fixes an issue)

  ## Screenshots

  Not applicable.

  ## Checklist

  - [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/
  contributing.html)
  - [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have updated the changelog