### PR TITLE
[CI] Drop OVPhysX tests from the Isaac Sim short CI

### DIFF
--- a/source/isaaclab_ovphysx/changelog.d/unmark-ovphysx-isaacsim-ci.skip
+++ b/source/isaaclab_ovphysx/changelog.d/unmark-ovphysx-isaacsim-ci.skip
@@ -1,0 +1,4 @@
+Test-only: removed the ``isaacsim_ci`` marker from all isaaclab_ovphysx tests
+so they no longer run in the Isaac Sim short CI (kitless OVPhysX locks onto the
+first device, so mixing CPU and CUDA in one process is unsupported). No
+user-facing change, no version bump.

--- a/source/isaaclab_ovphysx/test/assets/test_articulation.py
+++ b/source/isaaclab_ovphysx/test/assets/test_articulation.py
@@ -331,7 +331,6 @@ def sim(request):
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
-@pytest.mark.isaacsim_ci
 def test_initialization_floating_base_non_root(sim, num_articulations, device, add_ground_plane):
     """Test initialization for a floating-base with articulation root on a rigid body.
 
@@ -394,7 +393,6 @@ def test_initialization_floating_base_non_root(sim, num_articulations, device, a
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
-@pytest.mark.isaacsim_ci
 def test_initialization_floating_base(sim, num_articulations, device, add_ground_plane):
     """Test initialization for a floating-base with articulation root on provided prim path.
 
@@ -457,7 +455,6 @@ def test_initialization_floating_base(sim, num_articulations, device, add_ground
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_initialization_fixed_base(sim, num_articulations, device):
     """Test initialization for fixed base.
 
@@ -529,7 +526,6 @@ def test_initialization_fixed_base(sim, num_articulations, device):
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
-@pytest.mark.isaacsim_ci
 def test_initialization_fixed_base_single_joint(sim, num_articulations, device, add_ground_plane):
     """Test initialization for fixed base articulation with a single joint.
 
@@ -600,7 +596,6 @@ def test_initialization_fixed_base_single_joint(sim, num_articulations, device, 
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_initialization_hand_with_tendons(sim, num_articulations, device):
     """Test initialization for fixed base articulated hand with tendons.
 
@@ -660,7 +655,6 @@ def test_initialization_hand_with_tendons(sim, num_articulations, device):
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
-@pytest.mark.isaacsim_ci
 @pytest.mark.xfail(reason=_OMNI_PHYSX_SCHEMAS_GAP_REASON, strict=False)
 def test_initialization_floating_base_made_fixed_base(sim, num_articulations, device, add_ground_plane):
     """Test initialization for a floating-base articulation made fixed-base using schema properties.
@@ -728,7 +722,6 @@ def test_initialization_floating_base_made_fixed_base(sim, num_articulations, de
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
-@pytest.mark.isaacsim_ci
 def test_initialization_fixed_base_made_floating_base(sim, num_articulations, device, add_ground_plane):
     """Test initialization for fixed base made floating-base using schema properties.
 
@@ -787,7 +780,6 @@ def test_initialization_fixed_base_made_floating_base(sim, num_articulations, de
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
-@pytest.mark.isaacsim_ci
 def test_out_of_range_default_joint_pos(sim, num_articulations, device, add_ground_plane):
     """Test that the default joint position from configuration is out of range.
 
@@ -817,7 +809,6 @@ def test_out_of_range_default_joint_pos(sim, num_articulations, device, add_grou
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_out_of_range_default_joint_vel(sim, device):
     """Test that the default joint velocity from configuration is out of range.
 
@@ -843,7 +834,6 @@ def test_out_of_range_default_joint_vel(sim, device):
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
-@pytest.mark.isaacsim_ci
 def test_joint_pos_limits(sim, num_articulations, device, add_ground_plane):
     """Test write_joint_limits_to_sim API and when default pos falls outside of the new limits.
 
@@ -951,7 +941,6 @@ def test_joint_effort_limits(sim, num_articulations, device, add_ground_plane):
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_buffer(sim, num_articulations, device):
     """Test if external force buffer correctly updates in the force value is zero case.
 
@@ -1036,7 +1025,6 @@ def test_external_force_buffer(sim, num_articulations, device):
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_on_single_body(sim, num_articulations, device):
     """Test application of external force on the base of the articulation.
 
@@ -1094,7 +1082,6 @@ def test_external_force_on_single_body(sim, num_articulations, device):
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_on_single_body_at_position(sim, num_articulations, device):
     """Test application of external force on the base of the articulation at a given position.
 
@@ -1189,7 +1176,6 @@ def test_external_force_on_single_body_at_position(sim, num_articulations, devic
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_on_multiple_bodies(sim, num_articulations, device):
     """Test application of external force on the legs of the articulation.
 
@@ -1249,7 +1235,6 @@ def test_external_force_on_multiple_bodies(sim, num_articulations, device):
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_on_multiple_bodies_at_position(sim, num_articulations, device):
     """Test application of external force on the legs of the articulation at a given position.
 
@@ -1343,7 +1328,6 @@ def test_external_force_on_multiple_bodies_at_position(sim, num_articulations, d
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_loading_gains_from_usd(sim, num_articulations, device):
     """Test that gains are loaded from USD file if actuator model has them as None.
 
@@ -1406,7 +1390,6 @@ def test_loading_gains_from_usd(sim, num_articulations, device):
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
-@pytest.mark.isaacsim_ci
 def test_setting_gains_from_cfg(sim, num_articulations, device, add_ground_plane):
     """Test that gains are loaded from the configuration correctly.
 
@@ -1440,7 +1423,6 @@ def test_setting_gains_from_cfg(sim, num_articulations, device, add_ground_plane
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_setting_gains_from_cfg_dict(sim, num_articulations, device):
     """Test that gains are loaded from the configuration dictionary correctly.
 
@@ -1476,7 +1458,6 @@ def test_setting_gains_from_cfg_dict(sim, num_articulations, device):
 @pytest.mark.parametrize("vel_limit_sim", [1e5, None])
 @pytest.mark.parametrize("vel_limit", [1e2, None])
 @pytest.mark.parametrize("add_ground_plane", [False])
-@pytest.mark.isaacsim_ci
 def test_setting_velocity_limit_implicit(sim, num_articulations, device, vel_limit_sim, vel_limit, add_ground_plane):
     """Test setting of velocity limit for implicit actuators.
 
@@ -1543,7 +1524,6 @@ def test_setting_velocity_limit_implicit(sim, num_articulations, device, vel_lim
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("vel_limit_sim", [1e5, None])
 @pytest.mark.parametrize("vel_limit", [1e2, None])
-@pytest.mark.isaacsim_ci
 def test_setting_velocity_limit_explicit(sim, num_articulations, device, vel_limit_sim, vel_limit):
     """Test setting of velocity limit for explicit actuators."""
     articulation_cfg = generate_articulation_cfg(
@@ -1597,7 +1577,6 @@ def test_setting_velocity_limit_explicit(sim, num_articulations, device, vel_lim
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("effort_limit_sim", [1e5, None])
 @pytest.mark.parametrize("effort_limit", [1e2, 80.0, None])
-@pytest.mark.isaacsim_ci
 def test_setting_effort_limit_implicit(sim, num_articulations, device, effort_limit_sim, effort_limit):
     """Test setting of effort limit for implicit actuators.
 
@@ -1650,7 +1629,6 @@ def test_setting_effort_limit_implicit(sim, num_articulations, device, effort_li
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("effort_limit_sim", [1e5, None])
 @pytest.mark.parametrize("effort_limit", [80.0, 1e2, None])
-@pytest.mark.isaacsim_ci
 def test_setting_effort_limit_explicit(sim, num_articulations, device, effort_limit_sim, effort_limit):
     """Test setting of effort limit for explicit actuators.
 
@@ -1710,7 +1688,6 @@ def test_setting_effort_limit_explicit(sim, num_articulations, device, effort_li
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_reset(sim, num_articulations, device):
     """Test that reset method works properly."""
     articulation_cfg = generate_articulation_cfg(articulation_type="humanoid")
@@ -1755,7 +1732,6 @@ def test_reset(sim, num_articulations, device):
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
-@pytest.mark.isaacsim_ci
 def test_apply_joint_command(sim, num_articulations, device, add_ground_plane):
     """Test applying of joint position target functions correctly for a robotic arm."""
     articulation_cfg = generate_articulation_cfg(articulation_type="panda")
@@ -1795,7 +1771,6 @@ def test_apply_joint_command(sim, num_articulations, device, add_ground_plane):
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("with_offset", [True, False])
-@pytest.mark.isaacsim_ci
 def test_body_root_state(sim, num_articulations, device, with_offset):
     """Test for reading the `body_state_w` property.
 
@@ -1924,7 +1899,6 @@ def test_body_root_state(sim, num_articulations, device, with_offset):
 @pytest.mark.parametrize("with_offset", [True, False])
 @pytest.mark.parametrize("state_location", ["com", "link"])
 @pytest.mark.parametrize("gravity_enabled", [False])
-@pytest.mark.isaacsim_ci
 def test_write_root_state(sim, num_articulations, device, with_offset, state_location, gravity_enabled):
     """Test the setters for root_state using both the link frame and center of mass as reference frame.
 
@@ -2006,7 +1980,6 @@ def test_write_root_state(sim, num_articulations, device, with_offset, state_loc
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_body_incoming_joint_wrench_b_single_joint(sim, num_articulations, device):
     """Test the data.body_incoming_joint_wrench_b buffer is populated correctly and statically correct for single joint.
 
@@ -2107,7 +2080,6 @@ def test_body_incoming_joint_wrench_b_single_joint(sim, num_articulations, devic
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_setting_articulation_root_prim_path(sim, device):
     """Test that the articulation root prim path can be set explicitly."""
     sim._app_control_on_stop_handle = None
@@ -2126,7 +2098,6 @@ def test_setting_articulation_root_prim_path(sim, device):
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_setting_invalid_articulation_root_prim_path(sim, device):
     """Test that the articulation root prim path can be set explicitly."""
     sim._app_control_on_stop_handle = None
@@ -2146,7 +2117,6 @@ def test_setting_invalid_articulation_root_prim_path(sim, device):
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("gravity_enabled", [False])
-@pytest.mark.isaacsim_ci
 def test_write_joint_state_data_consistency(sim, num_articulations, device, gravity_enabled):
     """Test the setters for root_state using both the link frame and center of mass as reference frame.
 
@@ -2397,7 +2367,6 @@ def test_write_joint_frictions_to_sim(sim, num_articulations, device, add_ground
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("articulation_type", ["panda"])
-@pytest.mark.isaacsim_ci
 @pytest.mark.xfail(reason=_MATERIAL_GAP_REASON, strict=False)
 def test_set_material_properties(sim, num_articulations, device, add_ground_plane, articulation_type):
     """Test getting and setting material properties (friction/restitution) of articulation shapes."""

--- a/source/isaaclab_ovphysx/test/assets/test_rigid_object.py
+++ b/source/isaaclab_ovphysx/test/assets/test_rigid_object.py
@@ -177,7 +177,6 @@ _MATERIAL_GAP_REASON = (
 
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_initialization(num_cubes, device):
     """Test initialization for prim with rigid body API at the provided prim path."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -210,7 +209,6 @@ def test_initialization(num_cubes, device):
 
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_initialization_with_kinematic_enabled(num_cubes, device):
     """Test that initialization for prim with kinematic flag enabled."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -247,7 +245,6 @@ def test_initialization_with_kinematic_enabled(num_cubes, device):
 
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_initialization_with_no_rigid_body(num_cubes, device):
     """Test that initialization fails when no rigid body is found at the provided prim path."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -264,7 +261,6 @@ def test_initialization_with_no_rigid_body(num_cubes, device):
 
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_initialization_with_articulation_root(num_cubes, device):
     """Test that initialization fails when an articulation root is found at the provided prim path."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -280,7 +276,6 @@ def test_initialization_with_articulation_root(num_cubes, device):
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_buffer(device):
     """Test if external force buffer correctly updates in the force value is zero case.
 
@@ -348,7 +343,6 @@ def test_external_force_buffer(device):
 
 @pytest.mark.parametrize("num_cubes", [2, 4])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_on_single_body(num_cubes, device):
     """Test application of external force on the base of the object.
 
@@ -529,7 +523,6 @@ def test_external_force_on_single_body_at_position(num_cubes, device):
 
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_set_rigid_object_state(num_cubes, device):
     """Test setting the state of the rigid object.
 
@@ -594,7 +587,6 @@ def test_set_rigid_object_state(num_cubes, device):
 
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_reset_rigid_object(num_cubes, device):
     """Test resetting the state of the rigid object."""
     with _ovphysx_sim_context(device=device, gravity_enabled=True, auto_add_lighting=True) as sim:
@@ -637,7 +629,6 @@ def test_reset_rigid_object(num_cubes, device):
 @pytest.mark.xfail(reason=_MATERIAL_GAP_REASON, strict=False)
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_rigid_body_set_material_properties(num_cubes, device):
     """Test getting and setting material properties of rigid object."""
     raise NotImplementedError(_MATERIAL_GAP_REASON)
@@ -646,7 +637,6 @@ def test_rigid_body_set_material_properties(num_cubes, device):
 @pytest.mark.xfail(reason=_MATERIAL_GAP_REASON, strict=False)
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_set_material_properties_via_view(num_cubes, device):
     """Test setting material properties via the PhysX view-level API."""
     raise NotImplementedError(_MATERIAL_GAP_REASON)
@@ -655,7 +645,6 @@ def test_set_material_properties_via_view(num_cubes, device):
 @pytest.mark.xfail(reason=_MATERIAL_GAP_REASON, strict=False)
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_rigid_body_no_friction(num_cubes, device):
     """Test that a rigid object with no friction will maintain it's velocity when sliding across a plane."""
     raise NotImplementedError(_MATERIAL_GAP_REASON)
@@ -664,7 +653,6 @@ def test_rigid_body_no_friction(num_cubes, device):
 @pytest.mark.xfail(reason=_MATERIAL_GAP_REASON, strict=False)
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_rigid_body_with_static_friction(num_cubes, device):
     """Test that static friction applied to rigid object works as expected.
 
@@ -679,7 +667,6 @@ def test_rigid_body_with_static_friction(num_cubes, device):
 @pytest.mark.xfail(reason=_MATERIAL_GAP_REASON, strict=False)
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_rigid_body_with_restitution(num_cubes, device):
     """Test that restitution when applied to rigid object works as expected.
 
@@ -693,7 +680,6 @@ def test_rigid_body_with_restitution(num_cubes, device):
 
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_rigid_body_set_mass(num_cubes, device):
     """Test getting and setting mass of rigid object."""
     with _ovphysx_sim_context(
@@ -738,7 +724,6 @@ def test_rigid_body_set_mass(num_cubes, device):
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("gravity_enabled", [True, False])
-@pytest.mark.isaacsim_ci
 def test_gravity_vec_w(num_cubes, device, gravity_enabled):
     """Test that gravity vector direction is set correctly for the rigid object."""
     with _ovphysx_sim_context(device=device, gravity_enabled=gravity_enabled) as sim:
@@ -777,7 +762,6 @@ def test_gravity_vec_w(num_cubes, device, gravity_enabled):
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("with_offset", [True, False])
-@pytest.mark.isaacsim_ci
 @flaky(max_runs=3, min_passes=1)
 def test_body_root_state_properties(num_cubes, device, with_offset):
     """Test the root_com_state_w, root_link_state_w, body_com_state_w, and body_link_state_w properties."""
@@ -895,7 +879,6 @@ def test_body_root_state_properties(num_cubes, device, with_offset):
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("with_offset", [True, False])
 @pytest.mark.parametrize("state_location", ["com", "link"])
-@pytest.mark.isaacsim_ci
 def test_write_root_state(num_cubes, device, with_offset, state_location):
     """Test the setters for root_state using both the link frame and center of mass as reference frame."""
     with _ovphysx_sim_context(device=device, gravity_enabled=False, auto_add_lighting=True) as sim:
@@ -967,7 +950,6 @@ def test_write_root_state(num_cubes, device, with_offset, state_location):
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("with_offset", [True])
 @pytest.mark.parametrize("state_location", ["com", "link", "root"])
-@pytest.mark.isaacsim_ci
 def test_write_state_functions_data_consistency(num_cubes, device, with_offset, state_location):
     """Test the setters for root_state using both the link frame and center of mass as reference frame."""
     with _ovphysx_sim_context(device=device, gravity_enabled=False, auto_add_lighting=True) as sim:
@@ -1079,7 +1061,6 @@ def test_write_state_functions_data_consistency(num_cubes, device, with_offset, 
             torch.testing.assert_close(root_com_vel_w[:, 3:], root_link_vel_w[:, 3:])
 
 
-@pytest.mark.isaacsim_ci
 def test_warmup_attach_stage_not_called_for_cpu():
     """Regression test: ``physx.warmup_gpu()`` must not be called for CPU.
 

--- a/source/isaaclab_ovphysx/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/test/assets/test_rigid_object_collection.py
@@ -173,7 +173,6 @@ def generate_cubes_scene(
 @pytest.mark.parametrize("num_envs", [1, 2])
 @pytest.mark.parametrize("num_cubes", [1, 3])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_initialization(num_envs, num_cubes, device):
     """Test initialization for prim with rigid body API at the provided prim path."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -202,7 +201,6 @@ def test_initialization(num_envs, num_cubes, device):
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_id_conversion(device):
     """Test environment and object index conversion to physics view indices."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -242,7 +240,6 @@ def test_id_conversion(device):
 @pytest.mark.parametrize("num_envs", [1, 2])
 @pytest.mark.parametrize("num_cubes", [1, 3])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_initialization_with_kinematic_enabled(num_envs, num_cubes, device):
     """Test that initialization for prim with kinematic flag enabled."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -278,7 +275,6 @@ def test_initialization_with_kinematic_enabled(num_envs, num_cubes, device):
 
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_initialization_with_no_rigid_body(num_cubes, device):
     """Test that initialization fails when no rigid body is found at the provided prim path."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -293,7 +289,6 @@ def test_initialization_with_no_rigid_body(num_cubes, device):
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_buffer(device):
     """Test if external force buffer correctly updates in the force value is zero case."""
     num_envs = 2
@@ -349,7 +344,6 @@ def test_external_force_buffer(device):
 @pytest.mark.parametrize("num_envs", [1, 2])
 @pytest.mark.parametrize("num_cubes", [1, 4])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_on_single_body(num_envs, num_cubes, device):
     """Test application of external force on the base of the object."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -411,7 +405,6 @@ def test_external_force_on_single_body(num_envs, num_cubes, device):
 @pytest.mark.parametrize("num_envs", [1, 2])
 @pytest.mark.parametrize("num_cubes", [1, 4])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_external_force_on_single_body_at_position(num_envs, num_cubes, device):
     """Test application of external force on the base of the object at a specific position.
 
@@ -495,7 +488,6 @@ def test_external_force_on_single_body_at_position(num_envs, num_cubes, device):
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("gravity_enabled", [False])
-@pytest.mark.isaacsim_ci
 def test_set_object_state(num_envs, num_cubes, device, gravity_enabled):
     """Test setting the state of the object.
 
@@ -567,7 +559,6 @@ def test_set_object_state(num_envs, num_cubes, device, gravity_enabled):
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("with_offset", [True, False])
 @pytest.mark.parametrize("gravity_enabled", [False])
-@pytest.mark.isaacsim_ci
 def test_object_state_properties(num_envs, num_cubes, device, with_offset, gravity_enabled):
     """Test the object_com_state_w and object_link_state_w properties."""
     with _ovphysx_sim_context(device=device, gravity_enabled=gravity_enabled, auto_add_lighting=True) as sim:
@@ -668,7 +659,6 @@ def test_object_state_properties(num_envs, num_cubes, device, with_offset, gravi
 @pytest.mark.parametrize("with_offset", [True, False])
 @pytest.mark.parametrize("state_location", ["com", "link"])
 @pytest.mark.parametrize("gravity_enabled", [False])
-@pytest.mark.isaacsim_ci
 def test_write_object_state(num_envs, num_cubes, device, with_offset, state_location, gravity_enabled):
     """Test the setters for object_state using both the link frame and center of mass as reference frame."""
     with _ovphysx_sim_context(device=device, gravity_enabled=gravity_enabled, auto_add_lighting=True) as sim:
@@ -744,7 +734,6 @@ def test_write_object_state(num_envs, num_cubes, device, with_offset, state_loca
 @pytest.mark.parametrize("num_envs", [1, 3])
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_reset_object_collection(num_envs, num_cubes, device):
     """Test resetting the state of the rigid object."""
     with _ovphysx_sim_context(device=device, auto_add_lighting=True) as sim:
@@ -780,7 +769,6 @@ def test_reset_object_collection(num_envs, num_cubes, device):
 @pytest.mark.parametrize("num_envs", [1, 3])
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_set_material_properties(num_envs, num_cubes, device):
     """Test getting and setting material properties of rigid object."""
     raise NotImplementedError(_MATERIAL_GAP_REASON)
@@ -790,7 +778,6 @@ def test_set_material_properties(num_envs, num_cubes, device):
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("gravity_enabled", [True, False])
-@pytest.mark.isaacsim_ci
 def test_gravity_vec_w(num_envs, num_cubes, device, gravity_enabled):
     """Test that gravity vector direction is set correctly for the rigid object."""
     with _ovphysx_sim_context(device=device, gravity_enabled=gravity_enabled, auto_add_lighting=True) as sim:
@@ -827,7 +814,6 @@ def test_gravity_vec_w(num_envs, num_cubes, device, gravity_enabled):
 @pytest.mark.parametrize("with_offset", [True])
 @pytest.mark.parametrize("state_location", ["com", "link", "root"])
 @pytest.mark.parametrize("gravity_enabled", [False])
-@pytest.mark.isaacsim_ci
 def test_write_object_state_functions_data_consistency(
     num_envs, num_cubes, device, with_offset, state_location, gravity_enabled
 ):

--- a/source/isaaclab_ovphysx/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_ovphysx/test/sensors/test_contact_sensor.py
@@ -319,7 +319,6 @@ _TERRAINS = [FLAT_TERRAIN_CFG, COBBLESTONE_TERRAIN_CFG]
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @flaky(max_runs=5, min_passes=1)
-@pytest.mark.isaacsim_ci
 def test_cube_contact_time(device):
     """Checks contact sensor values for contact time and air time for a cube collision primitive."""
     _run_contact_sensor_test(CUBE_CFG, _SIM_DT, device, _TERRAINS, _DURATIONS)
@@ -327,7 +326,6 @@ def test_cube_contact_time(device):
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @flaky(max_runs=5, min_passes=1)
-@pytest.mark.isaacsim_ci
 def test_sphere_contact_time(device):
     """Checks contact sensor values for contact time and air time for a sphere collision primitive."""
     _run_contact_sensor_test(SPHERE_CFG, _SIM_DT, device, _TERRAINS, _DURATIONS)
@@ -335,7 +333,6 @@ def test_sphere_contact_time(device):
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("num_envs", [1, 6, 24])
-@pytest.mark.isaacsim_ci
 def test_cube_stack_contact_filtering(device, num_envs):
     """Checks contact sensor reporting for filtering stacked cube prims."""
     with _ovphysx_sim_context(device=device, dt=_SIM_DT, add_lighting=True) as sim:
@@ -397,7 +394,6 @@ def test_cube_stack_contact_filtering(device, num_envs):
         assert contact_sensor.data.net_forces_w.torch.sum().item() > 0.0
 
 
-@pytest.mark.isaacsim_ci
 def test_no_contact_reporting():
     """Test that OVPhysX contact sensor returns zero forces when no filter is configured.
 
@@ -463,7 +459,6 @@ def test_no_contact_reporting():
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("num_envs", [1, 3])
-@pytest.mark.isaacsim_ci
 def test_multi_body_per_sensor_indexing(device, num_envs):
     """Ground-truth body-index check for a single sensor that resolves to two bodies.
 
@@ -526,7 +521,6 @@ def test_multi_body_per_sensor_indexing(device, num_envs):
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_sensor_print(device):
     """Test sensor print is working correctly."""
     with _ovphysx_sim_context(device=device, dt=_SIM_DT, add_lighting=False) as sim:
@@ -549,7 +543,6 @@ def test_sensor_print(device):
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_contact_sensor_threshold(device):
     """Test that the contact sensor USD threshold attribute is set to 0.0."""
     with _ovphysx_sim_context(device=device, dt=_SIM_DT, add_lighting=False) as sim:
@@ -594,7 +587,6 @@ def test_contact_sensor_threshold(device):
 )
 @pytest.mark.parametrize("grav_dir", [(-10.0, 0.0, -0.1), (0.0, -10.0, -0.1)])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_friction_reporting(device, grav_dir):
     """Test friction force reporting for contact sensors.
 
@@ -655,7 +647,6 @@ def test_friction_reporting(device, grav_dir):
     )
 )
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_invalid_prim_paths_config(device):
     """Test that a ValueError is raised when track_friction_forces=True and filter_prim_paths_expr is empty."""
     sim_cfg = SimulationCfg(physics=OvPhysxCfg(), dt=_SIM_DT, device=device)
@@ -690,7 +681,6 @@ def test_invalid_prim_paths_config(device):
     )
 )
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-@pytest.mark.isaacsim_ci
 def test_invalid_max_contact_points_config(device):
     """Test that a ValueError is raised when track_friction_forces=True and max_contact_data_count_per_prim=0."""
     sim_cfg = SimulationCfg(physics=OvPhysxCfg(), dt=_SIM_DT, device=device)


### PR DESCRIPTION
## Summary

- Removes the `@pytest.mark.isaacsim_ci` marker from all `isaaclab_ovphysx` tests (74 decorators across 4 files), so they no longer run in the Isaac Sim integration CI's per-MR ("short") run.
- No product code touched; tests remain runnable locally and in the IsaacLab test suite.

## 1. Background

The Isaac Sim integration CI (in the `omni_isaac_sim` repo) clones IsaacLab and runs its test suite. For per-MR runs it appends `-m isaacsim_ci` to pytest, so only tests tagged `@pytest.mark.isaacsim_ci` execute there. The full nightly run drops that filter and executes everything.

The `isaaclab_ovphysx` tests are **kitless**, and kitless OVPhysX locks onto the first device it runs on. The tests parametrize over both `cuda:0` and `cpu`, so running both in the same pytest process crashes or times out on the Isaac Sim runner:

```
test_contact_sensor.py            | FAILED  |  9/27
test_articulation.py              | TIMEOUT | 95/100
```

These failures do not reproduce on the IsaacLab-side CI and provide no useful signal for the Isaac Sim build.

## 2. Change

Drop the `isaacsim_ci` marker from every `isaaclab_ovphysx` test:

| File | Markers removed |
|---|---|
| `test/assets/test_articulation.py` | 31 |
| `test/assets/test_rigid_object.py` | 19 |
| `test/assets/test_rigid_object_collection.py` | 14 |
| `test/sensors/test_contact_sensor.py` | 10 |

All other markers (`parametrize`, `flaky`) are preserved.

## 3. Scope and follow-up

- The nightly run executes the full suite without the marker filter, so it is **unaffected** — these tests will still run there and could still hit the device-lock issue. If we want them out of nightly too, the next step is adding them to `TESTS_TO_SKIP` in `tools/test_settings.py`; that is intentionally out of scope here, matching the request to remove them from the Isaac Sim short CI.