### PR TITLE
Add ParticleMeshCounter Warp utility for particle-in-mesh counting

### DIFF
--- a/source/isaaclab/changelog.d/particle-mesh-counter.minor.rst
+++ b/source/isaaclab/changelog.d/particle-mesh-counter.minor.rst
@@ -1,0 +1,11 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab.utils.warp.ParticleMeshCounter` for fast, training-time counting of
+  particles inside closed (watertight) region meshes via robust winding-number point queries.
+  The counter supports multiple, independently posed region meshes per environment, sanitizes
+  non-finite particle positions, and returns both per-region counts and the per-particle
+  containment mask.
+* Added the :func:`~isaaclab.utils.warp.make_box_region_mesh` and
+  :func:`~isaaclab.utils.warp.make_frustum_region_mesh` helpers for building watertight,
+  outward-oriented region meshes (axis-aligned boxes and capped circular frusta / cup cavities).

--- a/source/isaaclab/isaaclab/utils/warp/__init__.pyi
+++ b/source/isaaclab/isaaclab/utils/warp/__init__.pyi
@@ -4,12 +4,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 __all__ = [
+    "ParticleMeshCounter",
     "ProxyArray",
     "convert_to_warp_mesh",
+    "make_box_region_mesh",
+    "make_frustum_region_mesh",
     "raycast_dynamic_meshes",
     "raycast_mesh",
     "raycast_single_mesh",
 ]
 
 from .ops import convert_to_warp_mesh, raycast_dynamic_meshes, raycast_mesh, raycast_single_mesh
+from .particle_mesh import ParticleMeshCounter, make_box_region_mesh, make_frustum_region_mesh
 from .proxy_array import ProxyArray

--- a/source/isaaclab/isaaclab/utils/warp/particle_mesh.py
+++ b/source/isaaclab/isaaclab/utils/warp/particle_mesh.py
@@ -80,6 +80,7 @@ def count_particles_in_meshes_kernel(
         region_tf = wp.transform(region_pos[region_id, env_id], region_quat[region_id, env_id])
         point_local = wp.transform_point(wp.transform_inverse(region_tf), point)
         query = wp.mesh_query_point_sign_winding_number(region_mesh_ids[region_id], point_local, max_query_dist)
+        # Warp convention: a negative winding-number sign means the point is inside the mesh.
         if query.result and query.sign < 0.0:
             flag = wp.float32(1.0)
     inside[env_id, particle_id, region_id] = flag
@@ -96,6 +97,10 @@ class ParticleMeshCounter:
     Positions and region transforms must be expressed in a *common* frame (typically the per-env
     frame or the world frame). The counter does not assume any particular frame.
 
+    Note on input layouts: region transforms are region-major (``(num_regions, num_envs, ...)``)
+    while particle positions are env-major (``(num_envs, num_particles, 3)``). Keep this
+    transposition in mind when assembling inputs.
+
     Example:
         .. code-block:: python
 
@@ -107,8 +112,9 @@ class ParticleMeshCounter:
     Args:
         region_meshes: One entry per region, each either a built :class:`warp.Mesh` or a
             ``(vertices, indices)`` pair. ``vertices`` is shape ``(num_vertices, 3)`` [m]; ``indices``
-            is the flattened or ``(num_faces, 3)`` triangle index array. Pre-built meshes are used
-            as-is and should be created with ``support_winding_number=True``.
+            is the flattened or ``(num_faces, 3)`` triangle index array. A pre-built mesh is rebuilt
+            on :paramref:`device` with winding-number support, so it need not have been created with
+            ``support_winding_number=True``.
         num_envs: Number of environments.
         device: Torch device string the counter operates on (e.g. ``"cuda:0"`` or ``"cpu"``).
         max_query_dist: Maximum distance for the closest-point search [m]. Defaults to a large value
@@ -192,19 +198,22 @@ class ParticleMeshCounter:
             :paramref:`return_mask` is ``True``, a tuple of the counts and the boolean containment
             mask of shape ``(num_envs, num_particles, num_regions)``.
         """
-        inside = self.compute_inside_mask(particle_positions, region_positions, region_orientations)
+        inside = self._compute_inside_mask(particle_positions, region_positions, region_orientations)
         counts = inside.sum(dim=1)
         if return_mask:
             return counts, inside > 0.5
         return counts
 
-    def compute_inside_mask(
+    def _compute_inside_mask(
         self,
         particle_positions: torch.Tensor,
         region_positions: torch.Tensor,
         region_orientations: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Compute the per-particle containment mask for every region.
+        """Compute the per-particle containment mask for every region (internal helper).
+
+        Returns the reused internal buffer; the public :meth:`count` (with
+        ``return_mask=True``) is the supported way to obtain a standalone mask.
 
         Args:
             particle_positions: Particle positions in a common frame, shape
@@ -248,10 +257,18 @@ class ParticleMeshCounter:
     """Helper functions."""
 
     def _as_winding_mesh(self, mesh: wp.Mesh | tuple[np.ndarray, np.ndarray]) -> wp.Mesh:
-        """Return a winding-number-capable :class:`warp.Mesh` for ``mesh``."""
+        """Build a winding-number-capable :class:`warp.Mesh` on the counter's device.
+
+        ``mesh_query_point_sign_winding_number`` silently returns wrong signs for a
+        mesh built without ``support_winding_number=True``, and Warp does not expose
+        that flag on an existing :class:`warp.Mesh`. A pre-built mesh is therefore
+        rebuilt from its points and indices so the winding-number BVH is guaranteed
+        to exist; region meshes are built once, so this cost is paid only at setup.
+        """
         if isinstance(mesh, wp.Mesh):
-            return mesh
-        vertices, indices = mesh
+            vertices, indices = mesh.points.numpy(), mesh.indices.numpy()
+        else:
+            vertices, indices = mesh
         vertices = np.asarray(vertices, dtype=np.float32).reshape(-1, 3)
         indices = np.asarray(indices, dtype=np.int32).reshape(-1)
         return wp.Mesh(
@@ -265,7 +282,9 @@ class ParticleMeshCounter:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Validate and broadcast region transforms to ``(num_regions, num_envs, {3,4})``."""
         region_pos = region_positions.to(device=self._device, dtype=torch.float32)
-        if region_pos.dim() == 2:
+        # Only broadcast the (num_regions, 3) form; an ill-shaped 2-D input falls through to the
+        # shape check below so it raises a clear ValueError instead of a raw expand() error.
+        if region_pos.dim() == 2 and tuple(region_pos.shape) == (self._num_regions, 3):
             region_pos = region_pos.unsqueeze(1).expand(self._num_regions, self._num_envs, 3)
         if tuple(region_pos.shape) != (self._num_regions, self._num_envs, 3):
             raise ValueError(
@@ -278,7 +297,7 @@ class ParticleMeshCounter:
             region_quat[..., 3] = 1.0
         else:
             region_quat = region_orientations.to(device=self._device, dtype=torch.float32)
-            if region_quat.dim() == 2:
+            if region_quat.dim() == 2 and tuple(region_quat.shape) == (self._num_regions, 4):
                 region_quat = region_quat.unsqueeze(1).expand(self._num_regions, self._num_envs, 4)
             if tuple(region_quat.shape) != (self._num_regions, self._num_envs, 4):
                 raise ValueError(
@@ -312,6 +331,8 @@ def make_box_region_mesh(
         ``(12, 3)`` int32.
     """
     hx, hy, hz = (float(half_extents[0]), float(half_extents[1]), float(half_extents[2]))
+    if hx <= 0.0 or hy <= 0.0 or hz <= 0.0:
+        raise ValueError(f"`half_extents` must be positive, got {(hx, hy, hz)}.")
     cx, cy, cz = (float(center[0]), float(center[1]), float(center[2]))
     vertices = np.array(
         [
@@ -373,6 +394,10 @@ def make_frustum_region_mesh(
     n = int(num_segments)
     if n < 3:
         raise ValueError(f"`num_segments` must be >= 3, got {num_segments}.")
+    if radius_bottom <= 0.0 or radius_top <= 0.0:
+        raise ValueError(f"Radii must be positive, got bottom={radius_bottom}, top={radius_top}.")
+    if z_bottom >= z_top:
+        raise ValueError(f"`z_bottom` must be < `z_top`, got {z_bottom} >= {z_top}.")
     angles = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
     cos_a, sin_a = np.cos(angles), np.sin(angles)
     bottom = np.stack([radius_bottom * cos_a, radius_bottom * sin_a, np.full(n, z_bottom)], axis=1)

--- a/source/isaaclab/isaaclab/utils/warp/particle_mesh.py
+++ b/source/isaaclab/isaaclab/utils/warp/particle_mesh.py
@@ -33,18 +33,7 @@ import numpy as np
 import torch
 import warp as wp
 
-# Disable Warp's init banner and initialize the module so the kernel below is registered at import
-# time (matches the pattern used in :mod:`isaaclab.utils.warp.ops`).
-wp.config.quiet = True
-wp.init()
-
-
-@wp.func
-def _is_finite_vec3(v: wp.vec3) -> bool:
-    """Return ``True`` when all components of ``v`` are finite (no NaN / Inf)."""
-    return not (
-        wp.isnan(v[0]) or wp.isnan(v[1]) or wp.isnan(v[2]) or wp.isinf(v[0]) or wp.isinf(v[1]) or wp.isinf(v[2])
-    )
+from .proxy_array import ProxyArray
 
 
 @wp.kernel
@@ -60,7 +49,7 @@ def count_particles_in_meshes_kernel(
 
     The thread grid is ``(num_envs, num_particles, num_regions)``. Each particle position is
     transformed into the region's local frame using the region's rigid transform and tested for
-    containment with the mesh winding number. Non-finite particle positions are treated as outside.
+    containment with the mesh winding number.
 
     Args:
         particle_pos: Particle positions in a common frame, shape ``(num_envs, num_particles)``.
@@ -76,23 +65,22 @@ def count_particles_in_meshes_kernel(
     env_id, particle_id, region_id = wp.tid()
     point = particle_pos[env_id, particle_id]
     flag = wp.float32(0.0)
-    if _is_finite_vec3(point):
-        region_tf = wp.transform(region_pos[region_id, env_id], region_quat[region_id, env_id])
-        point_local = wp.transform_point(wp.transform_inverse(region_tf), point)
-        query = wp.mesh_query_point_sign_winding_number(region_mesh_ids[region_id], point_local, max_query_dist)
-        # Warp convention: a negative winding-number sign means the point is inside the mesh.
-        if query.result and query.sign < 0.0:
-            flag = wp.float32(1.0)
+    region_tf = wp.transform(region_pos[region_id, env_id], region_quat[region_id, env_id])
+    point_local = wp.transform_point(wp.transform_inverse(region_tf), point)
+    query = wp.mesh_query_point_sign_winding_number(region_mesh_ids[region_id], point_local, max_query_dist)
+    # Warp convention: a negative winding-number sign means the point is inside the mesh.
+    if query.result and query.sign < 0.0:
+        flag = wp.float32(1.0)
     inside[env_id, particle_id, region_id] = flag
 
 
 class ParticleMeshCounter:
     """Counts particles inside closed region meshes using Warp winding-number point queries.
 
-    The counter owns one Warp mesh per region (built once with winding-number support) and, on every
-    :meth:`count` call, transforms each environment's particles into each region's local frame to
-    test containment. Regions may move and rotate between calls (e.g. a scoop bowl welded to a
-    gripper); only their transforms are passed in, the geometry is fixed in its local frame.
+    The counter owns one Warp mesh per region and, on every :meth:`count` call, transforms each
+    environment's particles into each region's local frame to test containment. Regions may move and
+    rotate between calls (e.g. a scoop bowl welded to a gripper); only their transforms are passed
+    in, the geometry is fixed in its local frame.
 
     Positions and region transforms must be expressed in a *common* frame (typically the per-env
     frame or the world frame). The counter does not assume any particular frame.
@@ -112,9 +100,8 @@ class ParticleMeshCounter:
     Args:
         region_meshes: One entry per region, each either a built :class:`warp.Mesh` or a
             ``(vertices, indices)`` pair. ``vertices`` is shape ``(num_vertices, 3)`` [m]; ``indices``
-            is the flattened or ``(num_faces, 3)`` triangle index array. A pre-built mesh is rebuilt
-            on :paramref:`device` with winding-number support, so it need not have been created with
-            ``support_winding_number=True``.
+            is the flattened or ``(num_faces, 3)`` triangle index array. Pre-built meshes are used
+            as-is and must be on :paramref:`device` with winding-number support enabled.
         num_envs: Number of environments.
         device: Torch device string the counter operates on (e.g. ``"cuda:0"`` or ``"cpu"``).
         max_query_dist: Maximum distance for the closest-point search [m]. Defaults to a large value
@@ -132,23 +119,16 @@ class ParticleMeshCounter:
         if len(region_meshes) == 0:
             raise ValueError("`region_meshes` must contain at least one region mesh.")
         self._device = str(device)
-        self._wp_device = wp.device_from_torch(torch.device(self._device))
         self._num_envs = int(num_envs)
         self._max_query_dist = float(max_query_dist)
-        self._meshes: list[wp.Mesh] = [self._as_winding_mesh(mesh) for mesh in region_meshes]
-        self._num_regions = len(self._meshes)
-        self._mesh_ids = wp.array([mesh.id for mesh in self._meshes], dtype=wp.uint64, device=self._wp_device)
-        # buffers sized on first use (depend on the per-call particle count)
-        self._num_particles = 0
-        self._inside_torch: torch.Tensor | None = None
-        self._inside_wp: wp.array | None = None
-
-    """Public properties."""
+        self._meshes: tuple[wp.Mesh, ...] = tuple(self._make_region_mesh(mesh) for mesh in region_meshes)
+        self._mesh_ids = wp.array([mesh.id for mesh in self._meshes], dtype=wp.uint64, device=self._device)
+        self._inside: ProxyArray | None = None
 
     @property
     def num_regions(self) -> int:
         """Number of region meshes."""
-        return self._num_regions
+        return len(self._meshes)
 
     @property
     def num_envs(self) -> int:
@@ -159,18 +139,6 @@ class ParticleMeshCounter:
     def device(self) -> str:
         """Torch device string the counter operates on."""
         return self._device
-
-    @property
-    def meshes(self) -> list[wp.Mesh]:
-        """The region meshes, one per region."""
-        return self._meshes
-
-    @property
-    def mesh_ids(self) -> wp.array:
-        """Warp mesh ids of the region meshes, shape ``(num_regions,)``."""
-        return self._mesh_ids
-
-    """Operations."""
 
     def count(
         self,
@@ -198,37 +166,6 @@ class ParticleMeshCounter:
             :paramref:`return_mask` is ``True``, a tuple of the counts and the boolean containment
             mask of shape ``(num_envs, num_particles, num_regions)``.
         """
-        inside = self._compute_inside_mask(particle_positions, region_positions, region_orientations)
-        counts = inside.sum(dim=1)
-        if return_mask:
-            return counts, inside > 0.5
-        return counts
-
-    def _compute_inside_mask(
-        self,
-        particle_positions: torch.Tensor,
-        region_positions: torch.Tensor,
-        region_orientations: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        """Compute the per-particle containment mask for every region (internal helper).
-
-        Returns the reused internal buffer; the public :meth:`count` (with
-        ``return_mask=True``) is the supported way to obtain a standalone mask.
-
-        Args:
-            particle_positions: Particle positions in a common frame, shape
-                ``(num_envs, num_particles, 3)`` [m].
-            region_positions: Region origins in the same frame, shape ``(num_regions, num_envs, 3)``
-                or ``(num_regions, 3)`` (broadcast) [m].
-            region_orientations: Region orientations as ``(x, y, z, w)`` quaternions, shape
-                ``(num_regions, num_envs, 4)`` or ``(num_regions, 4)`` (broadcast), or ``None`` for
-                identity.
-
-        Returns:
-            The containment mask (``1.0`` inside, ``0.0`` outside), shape
-            ``(num_envs, num_particles, num_regions)``, float. The returned tensor is an internal,
-            reused buffer; clone it if you need to retain it across calls.
-        """
         points = particle_positions.to(device=self._device, dtype=torch.float32)
         if points.dim() != 3 or points.shape[0] != self._num_envs or points.shape[2] != 3:
             raise ValueError(
@@ -238,42 +175,36 @@ class ParticleMeshCounter:
         points = points.contiguous()
         num_particles = points.shape[1]
         region_pos, region_quat = self._prepare_region_transforms(region_positions, region_orientations)
-        self._ensure_buffers(num_particles)
+        inside_buffer = self._resize_inside_buffer(num_particles)
         wp.launch(
             count_particles_in_meshes_kernel,
-            dim=(self._num_envs, num_particles, self._num_regions),
+            dim=(self._num_envs, num_particles, self.num_regions),
             inputs=[
                 wp.from_torch(points, dtype=wp.vec3),
                 self._mesh_ids,
                 wp.from_torch(region_pos, dtype=wp.vec3),
                 wp.from_torch(region_quat, dtype=wp.quat),
                 self._max_query_dist,
-                self._inside_wp,
+                inside_buffer.warp,
             ],
-            device=self._wp_device,
+            device=self._device,
         )
-        return self._inside_torch
+        inside = inside_buffer.torch
+        counts = inside.sum(dim=1)
+        if return_mask:
+            return counts, inside > 0.5
+        return counts
 
-    """Helper functions."""
-
-    def _as_winding_mesh(self, mesh: wp.Mesh | tuple[np.ndarray, np.ndarray]) -> wp.Mesh:
-        """Build a winding-number-capable :class:`warp.Mesh` on the counter's device.
-
-        ``mesh_query_point_sign_winding_number`` silently returns wrong signs for a
-        mesh built without ``support_winding_number=True``, and Warp does not expose
-        that flag on an existing :class:`warp.Mesh`. A pre-built mesh is therefore
-        rebuilt from its points and indices so the winding-number BVH is guaranteed
-        to exist; region meshes are built once, so this cost is paid only at setup.
-        """
+    def _make_region_mesh(self, mesh: wp.Mesh | tuple[np.ndarray, np.ndarray]) -> wp.Mesh:
+        """Build tuple-backed region meshes on the counter's device."""
         if isinstance(mesh, wp.Mesh):
-            vertices, indices = mesh.points.numpy(), mesh.indices.numpy()
-        else:
-            vertices, indices = mesh
+            return mesh
+        vertices, indices = mesh
         vertices = np.asarray(vertices, dtype=np.float32).reshape(-1, 3)
         indices = np.asarray(indices, dtype=np.int32).reshape(-1)
         return wp.Mesh(
-            points=wp.array(vertices, dtype=wp.vec3, device=self._wp_device),
-            indices=wp.array(indices, dtype=wp.int32, device=self._wp_device),
+            points=wp.array(vertices, dtype=wp.vec3, device=self._device),
+            indices=wp.array(indices, dtype=wp.int32, device=self._device),
             support_winding_number=True,
         )
 
@@ -282,39 +213,34 @@ class ParticleMeshCounter:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Validate and broadcast region transforms to ``(num_regions, num_envs, {3,4})``."""
         region_pos = region_positions.to(device=self._device, dtype=torch.float32)
-        # Only broadcast the (num_regions, 3) form; an ill-shaped 2-D input falls through to the
-        # shape check below so it raises a clear ValueError instead of a raw expand() error.
-        if region_pos.dim() == 2 and tuple(region_pos.shape) == (self._num_regions, 3):
-            region_pos = region_pos.unsqueeze(1).expand(self._num_regions, self._num_envs, 3)
-        if tuple(region_pos.shape) != (self._num_regions, self._num_envs, 3):
+        if region_pos.dim() == 2:
+            region_pos = region_pos.unsqueeze(1).expand(-1, self._num_envs, -1)
+        if tuple(region_pos.shape) != (self.num_regions, self._num_envs, 3):
             raise ValueError(
-                f"`region_positions` must broadcast to (num_regions={self._num_regions},"
+                f"`region_positions` must broadcast to (num_regions={self.num_regions},"
                 f" num_envs={self._num_envs}, 3), got {tuple(region_positions.shape)}."
             )
 
         if region_orientations is None:
-            region_quat = torch.zeros((self._num_regions, self._num_envs, 4), device=self._device, dtype=torch.float32)
+            region_quat = torch.zeros((self.num_regions, self._num_envs, 4), device=self._device, dtype=torch.float32)
             region_quat[..., 3] = 1.0
         else:
             region_quat = region_orientations.to(device=self._device, dtype=torch.float32)
-            if region_quat.dim() == 2 and tuple(region_quat.shape) == (self._num_regions, 4):
-                region_quat = region_quat.unsqueeze(1).expand(self._num_regions, self._num_envs, 4)
-            if tuple(region_quat.shape) != (self._num_regions, self._num_envs, 4):
+            if region_quat.dim() == 2:
+                region_quat = region_quat.unsqueeze(1).expand(-1, self._num_envs, -1)
+            if tuple(region_quat.shape) != (self.num_regions, self._num_envs, 4):
                 raise ValueError(
-                    f"`region_orientations` must broadcast to (num_regions={self._num_regions},"
+                    f"`region_orientations` must broadcast to (num_regions={self.num_regions},"
                     f" num_envs={self._num_envs}, 4), got {tuple(region_orientations.shape)}."
                 )
         return region_pos.contiguous(), region_quat.contiguous()
 
-    def _ensure_buffers(self, num_particles: int) -> None:
-        """(Re)allocate the containment buffer when the particle count changes."""
-        if self._inside_torch is not None and self._num_particles == num_particles:
-            return
-        self._num_particles = num_particles
-        self._inside_torch = torch.zeros(
-            (self._num_envs, num_particles, self._num_regions), device=self._device, dtype=torch.float32
-        )
-        self._inside_wp = wp.from_torch(self._inside_torch, dtype=wp.float32)
+    def _resize_inside_buffer(self, num_particles: int) -> ProxyArray:
+        """Return the containment buffer, resizing it when the particle count changes."""
+        shape = (self._num_envs, num_particles, self.num_regions)
+        if self._inside is None or self._inside.shape != shape:
+            self._inside = ProxyArray(wp.empty(shape, dtype=wp.float32, device=self._device))
+        return self._inside
 
 
 def make_box_region_mesh(

--- a/source/isaaclab/isaaclab/utils/warp/particle_mesh.py
+++ b/source/isaaclab/isaaclab/utils/warp/particle_mesh.py
@@ -1,0 +1,396 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Counting particles inside closed meshes using Warp point-mesh queries.
+
+This module provides :class:`ParticleMeshCounter`, a fast, solver-agnostic utility for counting
+how many particles fall inside one or more closed (watertight) *region* meshes. It is intended for
+training-time, privileged measurements such as "how many MPM media particles are inside the scoop
+bowl / the source container / the target container" without relying on hand-tuned analytic regions.
+
+The counter is built on Warp's BVH-accelerated point-mesh query
+(:func:`warp.mesh_query_point_sign_winding_number`): each particle is transformed into a region's
+local frame and tested for containment via the mesh winding number. The winding-number sign method
+is robust for poorly conditioned, non-watertight meshes, which makes it a good default for region
+geometry that is generated procedurally or extracted from USD assets.
+
+Region meshes are static in their own local frame; only their per-environment world (or environment)
+transform changes from step to step, so the BVH is built once and reused. The cost is therefore
+``O(num_envs * num_particles * num_regions)`` queries, each ``O(log(num_faces))`` on the GPU.
+
+The :func:`make_box_region_mesh` and :func:`make_frustum_region_mesh` helpers build watertight,
+outward-oriented region meshes for the two most common regions of interest (axis-aligned boxes and
+capped circular frusta / cup cavities).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import torch
+import warp as wp
+
+# Disable Warp's init banner and initialize the module so the kernel below is registered at import
+# time (matches the pattern used in :mod:`isaaclab.utils.warp.ops`).
+wp.config.quiet = True
+wp.init()
+
+
+@wp.func
+def _is_finite_vec3(v: wp.vec3) -> bool:
+    """Return ``True`` when all components of ``v`` are finite (no NaN / Inf)."""
+    return not (
+        wp.isnan(v[0]) or wp.isnan(v[1]) or wp.isnan(v[2]) or wp.isinf(v[0]) or wp.isinf(v[1]) or wp.isinf(v[2])
+    )
+
+
+@wp.kernel
+def count_particles_in_meshes_kernel(
+    particle_pos: wp.array2d(dtype=wp.vec3),
+    region_mesh_ids: wp.array(dtype=wp.uint64),
+    region_pos: wp.array2d(dtype=wp.vec3),
+    region_quat: wp.array2d(dtype=wp.quat),
+    max_query_dist: wp.float32,
+    inside: wp.array3d(dtype=wp.float32),
+):
+    """Mark, per environment/particle/region, whether the particle is inside the region mesh.
+
+    The thread grid is ``(num_envs, num_particles, num_regions)``. Each particle position is
+    transformed into the region's local frame using the region's rigid transform and tested for
+    containment with the mesh winding number. Non-finite particle positions are treated as outside.
+
+    Args:
+        particle_pos: Particle positions in a common frame, shape ``(num_envs, num_particles)``.
+        region_mesh_ids: Warp mesh ids of the region meshes, shape ``(num_regions,)``.
+        region_pos: Region origins in the same frame as ``particle_pos``, shape
+            ``(num_regions, num_envs)``.
+        region_quat: Region orientations as ``(x, y, z, w)`` quaternions, shape
+            ``(num_regions, num_envs)``.
+        max_query_dist: Maximum distance for the closest-point search [m].
+        inside: Output containment flags (``1.0`` inside, ``0.0`` outside), shape
+            ``(num_envs, num_particles, num_regions)``.
+    """
+    env_id, particle_id, region_id = wp.tid()
+    point = particle_pos[env_id, particle_id]
+    flag = wp.float32(0.0)
+    if _is_finite_vec3(point):
+        region_tf = wp.transform(region_pos[region_id, env_id], region_quat[region_id, env_id])
+        point_local = wp.transform_point(wp.transform_inverse(region_tf), point)
+        query = wp.mesh_query_point_sign_winding_number(region_mesh_ids[region_id], point_local, max_query_dist)
+        if query.result and query.sign < 0.0:
+            flag = wp.float32(1.0)
+    inside[env_id, particle_id, region_id] = flag
+
+
+class ParticleMeshCounter:
+    """Counts particles inside closed region meshes using Warp winding-number point queries.
+
+    The counter owns one Warp mesh per region (built once with winding-number support) and, on every
+    :meth:`count` call, transforms each environment's particles into each region's local frame to
+    test containment. Regions may move and rotate between calls (e.g. a scoop bowl welded to a
+    gripper); only their transforms are passed in, the geometry is fixed in its local frame.
+
+    Positions and region transforms must be expressed in a *common* frame (typically the per-env
+    frame or the world frame). The counter does not assume any particular frame.
+
+    Example:
+        .. code-block:: python
+
+            verts, faces = make_frustum_region_mesh(0.02, 0.04, -0.02, 0.03)
+            counter = ParticleMeshCounter([(verts, faces)], num_envs=128, device="cuda:0")
+            counts = counter.count(particle_pos_e, region_pos, region_quat)  # (num_envs, num_regions)
+            in_bowl = counts[:, 0]
+
+    Args:
+        region_meshes: One entry per region, each either a built :class:`warp.Mesh` or a
+            ``(vertices, indices)`` pair. ``vertices`` is shape ``(num_vertices, 3)`` [m]; ``indices``
+            is the flattened or ``(num_faces, 3)`` triangle index array. Pre-built meshes are used
+            as-is and should be created with ``support_winding_number=True``.
+        num_envs: Number of environments.
+        device: Torch device string the counter operates on (e.g. ``"cuda:0"`` or ``"cpu"``).
+        max_query_dist: Maximum distance for the closest-point search [m]. Defaults to a large value
+            so the winding-number sign is always resolved regardless of how deep a point sits inside.
+    """
+
+    def __init__(
+        self,
+        region_meshes: Sequence[wp.Mesh | tuple[np.ndarray, np.ndarray]],
+        num_envs: int,
+        device: str,
+        *,
+        max_query_dist: float = 1.0e6,
+    ) -> None:
+        if len(region_meshes) == 0:
+            raise ValueError("`region_meshes` must contain at least one region mesh.")
+        self._device = str(device)
+        self._wp_device = wp.device_from_torch(torch.device(self._device))
+        self._num_envs = int(num_envs)
+        self._max_query_dist = float(max_query_dist)
+        self._meshes: list[wp.Mesh] = [self._as_winding_mesh(mesh) for mesh in region_meshes]
+        self._num_regions = len(self._meshes)
+        self._mesh_ids = wp.array([mesh.id for mesh in self._meshes], dtype=wp.uint64, device=self._wp_device)
+        # buffers sized on first use (depend on the per-call particle count)
+        self._num_particles = 0
+        self._inside_torch: torch.Tensor | None = None
+        self._inside_wp: wp.array | None = None
+
+    """Public properties."""
+
+    @property
+    def num_regions(self) -> int:
+        """Number of region meshes."""
+        return self._num_regions
+
+    @property
+    def num_envs(self) -> int:
+        """Number of environments."""
+        return self._num_envs
+
+    @property
+    def device(self) -> str:
+        """Torch device string the counter operates on."""
+        return self._device
+
+    @property
+    def meshes(self) -> list[wp.Mesh]:
+        """The region meshes, one per region."""
+        return self._meshes
+
+    @property
+    def mesh_ids(self) -> wp.array:
+        """Warp mesh ids of the region meshes, shape ``(num_regions,)``."""
+        return self._mesh_ids
+
+    """Operations."""
+
+    def count(
+        self,
+        particle_positions: torch.Tensor,
+        region_positions: torch.Tensor,
+        region_orientations: torch.Tensor | None = None,
+        *,
+        return_mask: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        """Count particles inside each region, per environment.
+
+        Args:
+            particle_positions: Particle positions in a common frame, shape
+                ``(num_envs, num_particles, 3)`` [m].
+            region_positions: Region origins in the same frame, shape ``(num_regions, num_envs, 3)``
+                [m]. A ``(num_regions, 3)`` tensor is broadcast across environments (useful for
+                regions that are static in the common frame).
+            region_orientations: Region orientations as ``(x, y, z, w)`` quaternions, shape
+                ``(num_regions, num_envs, 4)`` or ``(num_regions, 4)`` (broadcast). Defaults to
+                identity for every region when ``None``.
+            return_mask: When ``True``, also return the per-particle containment mask.
+
+        Returns:
+            The per-environment, per-region counts, shape ``(num_envs, num_regions)``, float. When
+            :paramref:`return_mask` is ``True``, a tuple of the counts and the boolean containment
+            mask of shape ``(num_envs, num_particles, num_regions)``.
+        """
+        inside = self.compute_inside_mask(particle_positions, region_positions, region_orientations)
+        counts = inside.sum(dim=1)
+        if return_mask:
+            return counts, inside > 0.5
+        return counts
+
+    def compute_inside_mask(
+        self,
+        particle_positions: torch.Tensor,
+        region_positions: torch.Tensor,
+        region_orientations: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Compute the per-particle containment mask for every region.
+
+        Args:
+            particle_positions: Particle positions in a common frame, shape
+                ``(num_envs, num_particles, 3)`` [m].
+            region_positions: Region origins in the same frame, shape ``(num_regions, num_envs, 3)``
+                or ``(num_regions, 3)`` (broadcast) [m].
+            region_orientations: Region orientations as ``(x, y, z, w)`` quaternions, shape
+                ``(num_regions, num_envs, 4)`` or ``(num_regions, 4)`` (broadcast), or ``None`` for
+                identity.
+
+        Returns:
+            The containment mask (``1.0`` inside, ``0.0`` outside), shape
+            ``(num_envs, num_particles, num_regions)``, float. The returned tensor is an internal,
+            reused buffer; clone it if you need to retain it across calls.
+        """
+        points = particle_positions.to(device=self._device, dtype=torch.float32)
+        if points.dim() != 3 or points.shape[0] != self._num_envs or points.shape[2] != 3:
+            raise ValueError(
+                f"`particle_positions` must have shape (num_envs={self._num_envs}, num_particles, 3),"
+                f" got {tuple(particle_positions.shape)}."
+            )
+        points = points.contiguous()
+        num_particles = points.shape[1]
+        region_pos, region_quat = self._prepare_region_transforms(region_positions, region_orientations)
+        self._ensure_buffers(num_particles)
+        wp.launch(
+            count_particles_in_meshes_kernel,
+            dim=(self._num_envs, num_particles, self._num_regions),
+            inputs=[
+                wp.from_torch(points, dtype=wp.vec3),
+                self._mesh_ids,
+                wp.from_torch(region_pos, dtype=wp.vec3),
+                wp.from_torch(region_quat, dtype=wp.quat),
+                self._max_query_dist,
+                self._inside_wp,
+            ],
+            device=self._wp_device,
+        )
+        return self._inside_torch
+
+    """Helper functions."""
+
+    def _as_winding_mesh(self, mesh: wp.Mesh | tuple[np.ndarray, np.ndarray]) -> wp.Mesh:
+        """Return a winding-number-capable :class:`warp.Mesh` for ``mesh``."""
+        if isinstance(mesh, wp.Mesh):
+            return mesh
+        vertices, indices = mesh
+        vertices = np.asarray(vertices, dtype=np.float32).reshape(-1, 3)
+        indices = np.asarray(indices, dtype=np.int32).reshape(-1)
+        return wp.Mesh(
+            points=wp.array(vertices, dtype=wp.vec3, device=self._wp_device),
+            indices=wp.array(indices, dtype=wp.int32, device=self._wp_device),
+            support_winding_number=True,
+        )
+
+    def _prepare_region_transforms(
+        self, region_positions: torch.Tensor, region_orientations: torch.Tensor | None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Validate and broadcast region transforms to ``(num_regions, num_envs, {3,4})``."""
+        region_pos = region_positions.to(device=self._device, dtype=torch.float32)
+        if region_pos.dim() == 2:
+            region_pos = region_pos.unsqueeze(1).expand(self._num_regions, self._num_envs, 3)
+        if tuple(region_pos.shape) != (self._num_regions, self._num_envs, 3):
+            raise ValueError(
+                f"`region_positions` must broadcast to (num_regions={self._num_regions},"
+                f" num_envs={self._num_envs}, 3), got {tuple(region_positions.shape)}."
+            )
+
+        if region_orientations is None:
+            region_quat = torch.zeros((self._num_regions, self._num_envs, 4), device=self._device, dtype=torch.float32)
+            region_quat[..., 3] = 1.0
+        else:
+            region_quat = region_orientations.to(device=self._device, dtype=torch.float32)
+            if region_quat.dim() == 2:
+                region_quat = region_quat.unsqueeze(1).expand(self._num_regions, self._num_envs, 4)
+            if tuple(region_quat.shape) != (self._num_regions, self._num_envs, 4):
+                raise ValueError(
+                    f"`region_orientations` must broadcast to (num_regions={self._num_regions},"
+                    f" num_envs={self._num_envs}, 4), got {tuple(region_orientations.shape)}."
+                )
+        return region_pos.contiguous(), region_quat.contiguous()
+
+    def _ensure_buffers(self, num_particles: int) -> None:
+        """(Re)allocate the containment buffer when the particle count changes."""
+        if self._inside_torch is not None and self._num_particles == num_particles:
+            return
+        self._num_particles = num_particles
+        self._inside_torch = torch.zeros(
+            (self._num_envs, num_particles, self._num_regions), device=self._device, dtype=torch.float32
+        )
+        self._inside_wp = wp.from_torch(self._inside_torch, dtype=wp.float32)
+
+
+def make_box_region_mesh(
+    half_extents: Sequence[float], center: Sequence[float] = (0.0, 0.0, 0.0)
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build a closed, axis-aligned box region mesh with outward-facing triangles.
+
+    Args:
+        half_extents: Box half-extents ``(hx, hy, hz)`` [m].
+        center: Box center in the mesh-local frame [m].
+
+    Returns:
+        A tuple of the vertices, shape ``(8, 3)`` float32 [m], and the triangle indices, shape
+        ``(12, 3)`` int32.
+    """
+    hx, hy, hz = (float(half_extents[0]), float(half_extents[1]), float(half_extents[2]))
+    cx, cy, cz = (float(center[0]), float(center[1]), float(center[2]))
+    vertices = np.array(
+        [
+            [-hx, -hy, -hz],
+            [hx, -hy, -hz],
+            [hx, hy, -hz],
+            [-hx, hy, -hz],
+            [-hx, -hy, hz],
+            [hx, -hy, hz],
+            [hx, hy, hz],
+            [-hx, hy, hz],
+        ],
+        dtype=np.float32,
+    ) + np.array([cx, cy, cz], dtype=np.float32)
+    faces = np.array(
+        [
+            [0, 2, 1],
+            [0, 3, 2],  # -z
+            [4, 5, 6],
+            [4, 6, 7],  # +z
+            [0, 1, 5],
+            [0, 5, 4],  # -y
+            [1, 2, 6],
+            [1, 6, 5],  # +x
+            [2, 3, 7],
+            [2, 7, 6],  # +y
+            [3, 0, 4],
+            [3, 4, 7],  # -x
+        ],
+        dtype=np.int32,
+    )
+    return vertices, faces
+
+
+def make_frustum_region_mesh(
+    radius_bottom: float,
+    radius_top: float,
+    z_bottom: float,
+    z_top: float,
+    num_segments: int = 24,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build a closed (capped) circular frustum region mesh aligned with the local +Z axis.
+
+    This is the natural "cup cavity" region: a frustum that interpolates linearly in radius from
+    :paramref:`radius_bottom` at :paramref:`z_bottom` to :paramref:`radius_top` at :paramref:`z_top`,
+    capped at both ends so the mesh is watertight. Triangles face outward.
+
+    Args:
+        radius_bottom: Radius at the bottom ring [m].
+        radius_top: Radius at the top ring [m].
+        z_bottom: Local Z of the bottom ring [m].
+        z_top: Local Z of the top ring [m].
+        num_segments: Number of angular segments around the axis.
+
+    Returns:
+        A tuple of the vertices, shape ``(2 * num_segments + 2, 3)`` float32 [m], and the triangle
+        indices, shape ``(4 * num_segments, 3)`` int32.
+    """
+    n = int(num_segments)
+    if n < 3:
+        raise ValueError(f"`num_segments` must be >= 3, got {num_segments}.")
+    angles = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
+    cos_a, sin_a = np.cos(angles), np.sin(angles)
+    bottom = np.stack([radius_bottom * cos_a, radius_bottom * sin_a, np.full(n, z_bottom)], axis=1)
+    top = np.stack([radius_top * cos_a, radius_top * sin_a, np.full(n, z_top)], axis=1)
+    center_bottom = np.array([[0.0, 0.0, z_bottom]])
+    center_top = np.array([[0.0, 0.0, z_top]])
+    vertices = np.concatenate([bottom, top, center_bottom, center_top], axis=0).astype(np.float32)
+
+    idx_center_bottom, idx_center_top = 2 * n, 2 * n + 1
+    faces = []
+    for i in range(n):
+        j = (i + 1) % n
+        b_i, b_j, t_i, t_j = i, j, n + i, n + j
+        # side wall (outward)
+        faces.append([b_i, b_j, t_j])
+        faces.append([b_i, t_j, t_i])
+        # bottom cap (outward = -Z)
+        faces.append([idx_center_bottom, b_j, b_i])
+        # top cap (outward = +Z)
+        faces.append([idx_center_top, t_i, t_j])
+    return vertices, np.array(faces, dtype=np.int32)

--- a/source/isaaclab/test/utils/warp/test_particle_mesh.py
+++ b/source/isaaclab/test/utils/warp/test_particle_mesh.py
@@ -11,9 +11,6 @@ import pytest
 import torch
 import warp as wp
 
-wp.config.quiet = True
-wp.init()
-
 from isaaclab.utils.warp import ParticleMeshCounter, make_box_region_mesh, make_frustum_region_mesh
 
 
@@ -176,18 +173,7 @@ class TestParticleMeshCounterMultiRegion:
 
 
 class TestParticleMeshCounterRobustness:
-    """Sanitization, buffer reuse, prebuilt meshes, and input validation."""
-
-    def test_nan_inf_treated_as_outside(self, device):
-        """Non-finite particle positions never count as inside."""
-        counter = ParticleMeshCounter([make_box_region_mesh((0.1, 0.1, 0.1))], num_envs=1, device=device)
-        points = torch.tensor(
-            [[[0.0, 0, 0], [float("nan"), 0, 0], [0.0, float("inf"), 0], [0.0, 0, float("-inf")]]],
-            device=device,
-        )
-        counts, mask = counter.count(points, torch.zeros(1, 1, 3, device=device), return_mask=True)
-        assert counts[0, 0].item() == 1.0
-        assert mask[0, :, 0].int().tolist() == [1, 0, 0, 0]
+    """Buffer reuse, prebuilt meshes, and input validation."""
 
     def test_return_mask_consistency(self, device):
         """The boolean mask sums to the reported counts."""
@@ -215,19 +201,6 @@ class TestParticleMeshCounterRobustness:
             points=wp.array(verts, dtype=wp.vec3, device=wp_device),
             indices=wp.array(faces.flatten(), dtype=wp.int32, device=wp_device),
             support_winding_number=True,
-        )
-        counter = ParticleMeshCounter([mesh], num_envs=1, device=device)
-        points = torch.tensor([[[0.0, 0, 0], [0.5, 0, 0]]], device=device)
-        assert counter.count(points, torch.zeros(1, 1, 3, device=device))[0, 0].item() == 1.0
-
-    def test_prebuilt_mesh_without_winding_support_is_rebuilt(self, device):
-        """A pre-built mesh lacking winding support is rebuilt, so counts stay correct."""
-        verts, faces = make_box_region_mesh((0.1, 0.1, 0.1))
-        wp_device = wp.device_from_torch(torch.device(device))
-        # Built WITHOUT support_winding_number: querying it directly would return zero counts.
-        mesh = wp.Mesh(
-            points=wp.array(verts, dtype=wp.vec3, device=wp_device),
-            indices=wp.array(faces.flatten(), dtype=wp.int32, device=wp_device),
         )
         counter = ParticleMeshCounter([mesh], num_envs=1, device=device)
         points = torch.tensor([[[0.0, 0, 0], [0.5, 0, 0]]], device=device)

--- a/source/isaaclab/test/utils/warp/test_particle_mesh.py
+++ b/source/isaaclab/test/utils/warp/test_particle_mesh.py
@@ -220,6 +220,19 @@ class TestParticleMeshCounterRobustness:
         points = torch.tensor([[[0.0, 0, 0], [0.5, 0, 0]]], device=device)
         assert counter.count(points, torch.zeros(1, 1, 3, device=device))[0, 0].item() == 1.0
 
+    def test_prebuilt_mesh_without_winding_support_is_rebuilt(self, device):
+        """A pre-built mesh lacking winding support is rebuilt, so counts stay correct."""
+        verts, faces = make_box_region_mesh((0.1, 0.1, 0.1))
+        wp_device = wp.device_from_torch(torch.device(device))
+        # Built WITHOUT support_winding_number: querying it directly would return zero counts.
+        mesh = wp.Mesh(
+            points=wp.array(verts, dtype=wp.vec3, device=wp_device),
+            indices=wp.array(faces.flatten(), dtype=wp.int32, device=wp_device),
+        )
+        counter = ParticleMeshCounter([mesh], num_envs=1, device=device)
+        points = torch.tensor([[[0.0, 0, 0], [0.5, 0, 0]]], device=device)
+        assert counter.count(points, torch.zeros(1, 1, 3, device=device))[0, 0].item() == 1.0
+
     def test_invalid_inputs_raise(self):
         """Empty mesh list and malformed input shapes raise ValueError."""
         with pytest.raises(ValueError):
@@ -231,6 +244,8 @@ class TestParticleMeshCounterRobustness:
             counter.count(torch.zeros(3, 4, 3), torch.zeros(1, 3, 3))  # wrong num_envs
         with pytest.raises(ValueError):
             counter.count(torch.zeros(2, 4, 3), torch.zeros(1, 5, 3))  # bad region shape
+        with pytest.raises(ValueError):
+            counter.count(torch.zeros(2, 4, 3), torch.zeros(5, 3))  # malformed 2-D region shape
 
 
 class TestRegionMeshFactories:
@@ -250,3 +265,17 @@ class TestRegionMeshFactories:
     def test_frustum_rejects_too_few_segments(self):
         with pytest.raises(ValueError):
             make_frustum_region_mesh(0.02, 0.04, -0.01, 0.03, num_segments=2)
+
+    def test_box_rejects_non_positive_half_extents(self):
+        with pytest.raises(ValueError):
+            make_box_region_mesh((0.1, 0.0, 0.1))
+        with pytest.raises(ValueError):
+            make_box_region_mesh((-0.1, 0.1, 0.1))
+
+    def test_frustum_rejects_non_positive_radius(self):
+        with pytest.raises(ValueError):
+            make_frustum_region_mesh(0.0, 0.04, -0.01, 0.03)
+
+    def test_frustum_rejects_inverted_z(self):
+        with pytest.raises(ValueError):
+            make_frustum_region_mesh(0.02, 0.04, 0.03, -0.01)

--- a/source/isaaclab/test/utils/warp/test_particle_mesh.py
+++ b/source/isaaclab/test/utils/warp/test_particle_mesh.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the ParticleMeshCounter particle-in-mesh utility."""
+
+import math
+
+import pytest
+import torch
+import warp as wp
+
+wp.config.quiet = True
+wp.init()
+
+from isaaclab.utils.warp import ParticleMeshCounter, make_box_region_mesh, make_frustum_region_mesh
+
+
+@pytest.fixture(params=["cpu", "cuda:0"])
+def device(request):
+    """Parametrize tests across CPU and CUDA devices."""
+    if request.param.startswith("cuda") and not torch.cuda.is_available():
+        pytest.skip("CUDA device not available")
+    return request.param
+
+
+def _box_inside_analytic(points: torch.Tensor, region_pos: torch.Tensor, half) -> torch.Tensor:
+    """Ground-truth containment for an axis-aligned box, shape (num_envs, num_particles)."""
+    half_t = torch.tensor(half, device=points.device, dtype=torch.float32)
+    # points: (E, P, 3); region_pos: (E, 3)
+    local = points - region_pos.unsqueeze(1)
+    return (local.abs() < half_t).all(dim=-1)
+
+
+def _frustum_inside_analytic(points: torch.Tensor, r_b, r_t, z_b, z_t) -> torch.Tensor:
+    """Ground-truth containment for a +Z frustum centered on the local axis."""
+    z = points[..., 2]
+    t = ((z - z_b) / (z_t - z_b)).clamp(0.0, 1.0)
+    radius = r_b + t * (r_t - r_b)
+    radial = torch.linalg.norm(points[..., :2], dim=-1)
+    return (z > z_b) & (z < z_t) & (radial < radius)
+
+
+class TestParticleMeshCounterBox:
+    """Containment against an exact (non-discretized) box region mesh."""
+
+    def test_box_counts_and_mask_match_analytic(self, device):
+        """Random points against an offset box match the analytic ground truth exactly."""
+        torch.manual_seed(0)
+        num_envs, num_particles = 4, 512
+        half = (0.1, 0.15, 0.08)
+        region_pos_e = torch.tensor([0.2, -0.1, 0.05], device=device)
+        # spread points well beyond the box so both inside and outside are represented
+        points = (torch.rand(num_envs, num_particles, 3, device=device) - 0.5) * 0.8 + region_pos_e
+
+        counter = ParticleMeshCounter([make_box_region_mesh(half)], num_envs=num_envs, device=device)
+        region_pos = region_pos_e.expand(1, num_envs, 3)  # (num_regions=1, num_envs, 3)
+        counts, mask = counter.count(points, region_pos, return_mask=True)
+
+        expected_mask = _box_inside_analytic(points, region_pos_e.expand(num_envs, 3), half)
+        assert mask.shape == (num_envs, num_particles, 1)
+        assert torch.equal(mask[..., 0], expected_mask)
+        assert torch.equal(counts[:, 0], expected_mask.sum(dim=1).float())
+        # sanity: the box covers a non-trivial fraction of the points
+        assert (counts[:, 0] > 0).all() and (counts[:, 0] < num_particles).all()
+
+    def test_region_positions_broadcast_matches_explicit(self, device):
+        """A (num_regions, 3) region position broadcasts identically to the per-env form."""
+        num_envs, num_particles = 3, 64
+        points = (torch.rand(num_envs, num_particles, 3, device=device) - 0.5) * 0.6
+        counter = ParticleMeshCounter([make_box_region_mesh((0.1, 0.1, 0.1))], num_envs=num_envs, device=device)
+        broadcast = counter.count(points, torch.zeros(1, 3, device=device)).clone()
+        explicit = counter.count(points, torch.zeros(1, num_envs, 3, device=device)).clone()
+        assert torch.equal(broadcast, explicit)
+
+
+class TestParticleMeshCounterFrustum:
+    """Containment against a capped circular frustum (cup cavity)."""
+
+    def test_frustum_targeted_points(self, device):
+        """Hand-picked points inside / outside a frustum are classified correctly."""
+        r_b, r_t, z_b, z_t = 0.02, 0.04, -0.02, 0.03
+        verts_faces = make_frustum_region_mesh(r_b, r_t, z_b, z_t, num_segments=48)
+        counter = ParticleMeshCounter([verts_faces], num_envs=1, device=device)
+        points = torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 0.0],  # on-axis mid -> inside
+                    [0.0, 0.0, z_b + 1e-3],  # just above floor -> inside
+                    [0.03, 0.0, 0.02],  # within top radius -> inside
+                    [0.05, 0.0, 0.0],  # beyond radius -> outside
+                    [0.0, 0.0, z_t + 0.02],  # above top cap -> outside
+                    [0.0, 0.0, z_b - 0.02],  # below bottom cap -> outside
+                ]
+            ],
+            device=device,
+        )
+        _, mask = counter.count(points, torch.zeros(1, 1, 3, device=device), return_mask=True)
+        assert mask[0, :, 0].int().tolist() == [1, 1, 1, 0, 0, 0]
+
+    def test_frustum_matches_analytic_away_from_surface(self, device):
+        """Random points (excluding a thin shell near the surface) match the analytic frustum."""
+        torch.manual_seed(1)
+        r_b, r_t, z_b, z_t = 0.02, 0.05, -0.03, 0.04
+        counter = ParticleMeshCounter(
+            [make_frustum_region_mesh(r_b, r_t, z_b, z_t, num_segments=64)], num_envs=1, device=device
+        )
+        pts = torch.zeros(1, 2000, 3, device=device)
+        pts[0, :, 0] = (torch.rand(2000, device=device) - 0.5) * 0.16
+        pts[0, :, 1] = (torch.rand(2000, device=device) - 0.5) * 0.16
+        pts[0, :, 2] = (torch.rand(2000, device=device) - 0.5) * 0.16
+
+        expected = _frustum_inside_analytic(pts, r_b, r_t, z_b, z_t)
+        # exclude points within a small band of the lateral/cap surfaces (mesh is a 64-gon approx)
+        z = pts[0, :, 2]
+        t = ((z - z_b) / (z_t - z_b)).clamp(0.0, 1.0)
+        radius = r_b + t * (r_t - r_b)
+        radial = torch.linalg.norm(pts[0, :, :2], dim=-1)
+        margin = 0.004
+        near_surface = (
+            (radial > radius - margin) & (radial < radius + margin)
+            | (z > z_b - margin) & (z < z_b + margin)
+            | (z > z_t - margin) & (z < z_t + margin)
+        )
+        keep = ~near_surface
+        _, mask = counter.count(pts, torch.zeros(1, 1, 3, device=device), return_mask=True)
+        assert torch.equal(mask[0, keep, 0], expected[0, keep])
+
+
+class TestParticleMeshCounterTransforms:
+    """Per-environment and rotated region transforms."""
+
+    def test_multi_env_independent_transforms(self, device):
+        """Each environment uses its own region transform."""
+        counter = ParticleMeshCounter([make_box_region_mesh((0.1, 0.1, 0.1))], num_envs=2, device=device)
+        # region at x=0 for env0, x=1 for env1
+        region_pos = torch.tensor([[[0.0, 0, 0], [1.0, 0, 0]]], device=device)
+        points = torch.tensor(
+            [
+                [[0.05, 0, 0], [0.05, 0, 0], [0.5, 0, 0]],  # env0: in, in, out
+                [[0.05, 0, 0], [1.05, 0, 0], [1.5, 0, 0]],  # env1: out, in, out
+            ],
+            device=device,
+        )
+        counts = counter.count(points, region_pos)
+        assert counts[:, 0].tolist() == [2.0, 1.0]
+
+    def test_rotated_region(self, device):
+        """A thin box rotated 90 deg about Z excludes a point that was inside when axis-aligned."""
+        counter = ParticleMeshCounter([make_box_region_mesh((0.3, 0.02, 0.02))], num_envs=1, device=device)
+        point = torch.tensor([[[0.2, 0.0, 0.0]]], device=device)
+        region_pos = torch.zeros(1, 1, 3, device=device)
+        q_identity = torch.tensor([[[0.0, 0.0, 0.0, 1.0]]], device=device)
+        q_z90 = torch.tensor([[[0.0, 0.0, math.sin(math.pi / 4), math.cos(math.pi / 4)]]], device=device)
+        assert counter.count(point, region_pos, q_identity)[0, 0].item() == 1.0
+        assert counter.count(point, region_pos, q_z90)[0, 0].item() == 0.0
+
+
+class TestParticleMeshCounterMultiRegion:
+    """Multiple region meshes per counter."""
+
+    def test_disjoint_regions(self, device):
+        """A point inside one region is not counted in a far-away region."""
+        counter = ParticleMeshCounter(
+            [make_box_region_mesh((0.1, 0.1, 0.1)), make_box_region_mesh((0.1, 0.1, 0.1))],
+            num_envs=1,
+            device=device,
+        )
+        region_pos = torch.tensor([[[0.0, 0, 0]], [[1.0, 0, 0]]], device=device)  # (2 regions, 1 env, 3)
+        points = torch.tensor([[[0.0, 0, 0], [1.0, 0, 0], [5.0, 0, 0]]], device=device)
+        counts = counter.count(points, region_pos)
+        assert counts.shape == (1, 2)
+        assert counts[0].tolist() == [1.0, 1.0]
+        assert counter.num_regions == 2
+
+
+class TestParticleMeshCounterRobustness:
+    """Sanitization, buffer reuse, prebuilt meshes, and input validation."""
+
+    def test_nan_inf_treated_as_outside(self, device):
+        """Non-finite particle positions never count as inside."""
+        counter = ParticleMeshCounter([make_box_region_mesh((0.1, 0.1, 0.1))], num_envs=1, device=device)
+        points = torch.tensor(
+            [[[0.0, 0, 0], [float("nan"), 0, 0], [0.0, float("inf"), 0], [0.0, 0, float("-inf")]]],
+            device=device,
+        )
+        counts, mask = counter.count(points, torch.zeros(1, 1, 3, device=device), return_mask=True)
+        assert counts[0, 0].item() == 1.0
+        assert mask[0, :, 0].int().tolist() == [1, 0, 0, 0]
+
+    def test_return_mask_consistency(self, device):
+        """The boolean mask sums to the reported counts."""
+        torch.manual_seed(2)
+        counter = ParticleMeshCounter([make_box_region_mesh((0.12, 0.12, 0.12))], num_envs=3, device=device)
+        points = (torch.rand(3, 128, 3, device=device) - 0.5) * 0.6
+        counts, mask = counter.count(points, torch.zeros(1, 3, device=device), return_mask=True)
+        assert mask.dtype == torch.bool
+        assert torch.equal(counts, mask.sum(dim=1).float())
+
+    def test_buffer_reuse_changing_particle_count(self, device):
+        """The internal buffer resizes correctly when the particle count changes between calls."""
+        counter = ParticleMeshCounter([make_box_region_mesh((0.1, 0.1, 0.1))], num_envs=1, device=device)
+        region_pos = torch.zeros(1, 1, 3, device=device)
+        small = torch.tensor([[[0.0, 0, 0], [0.5, 0, 0]]], device=device)
+        assert counter.count(small, region_pos)[0, 0].item() == 1.0
+        big = torch.tensor([[[0.0, 0, 0], [0.01, 0, 0], [0.02, 0, 0], [0.5, 0, 0]]], device=device)
+        assert counter.count(big, region_pos)[0, 0].item() == 3.0
+
+    def test_prebuilt_warp_mesh_accepted(self, device):
+        """A pre-built warp mesh can be passed directly."""
+        verts, faces = make_box_region_mesh((0.1, 0.1, 0.1))
+        wp_device = wp.device_from_torch(torch.device(device))
+        mesh = wp.Mesh(
+            points=wp.array(verts, dtype=wp.vec3, device=wp_device),
+            indices=wp.array(faces.flatten(), dtype=wp.int32, device=wp_device),
+            support_winding_number=True,
+        )
+        counter = ParticleMeshCounter([mesh], num_envs=1, device=device)
+        points = torch.tensor([[[0.0, 0, 0], [0.5, 0, 0]]], device=device)
+        assert counter.count(points, torch.zeros(1, 1, 3, device=device))[0, 0].item() == 1.0
+
+    def test_invalid_inputs_raise(self):
+        """Empty mesh list and malformed input shapes raise ValueError."""
+        with pytest.raises(ValueError):
+            ParticleMeshCounter([], num_envs=1, device="cpu")
+        counter = ParticleMeshCounter([make_box_region_mesh((0.1, 0.1, 0.1))], num_envs=2, device="cpu")
+        with pytest.raises(ValueError):
+            counter.count(torch.zeros(2, 4), torch.zeros(1, 2, 3))  # particles not 3D
+        with pytest.raises(ValueError):
+            counter.count(torch.zeros(3, 4, 3), torch.zeros(1, 3, 3))  # wrong num_envs
+        with pytest.raises(ValueError):
+            counter.count(torch.zeros(2, 4, 3), torch.zeros(1, 5, 3))  # bad region shape
+
+
+class TestRegionMeshFactories:
+    """Shape/scale checks for the region-mesh factories."""
+
+    def test_box_mesh_shapes(self):
+        verts, faces = make_box_region_mesh((0.1, 0.2, 0.3))
+        assert verts.shape == (8, 3)
+        assert faces.shape == (12, 3)
+
+    def test_frustum_mesh_shapes(self):
+        n = 16
+        verts, faces = make_frustum_region_mesh(0.02, 0.04, -0.01, 0.03, num_segments=n)
+        assert verts.shape == (2 * n + 2, 3)
+        assert faces.shape == (4 * n, 3)
+
+    def test_frustum_rejects_too_few_segments(self):
+        with pytest.raises(ValueError):
+            make_frustum_region_mesh(0.02, 0.04, -0.01, 0.03, num_segments=2)


### PR DESCRIPTION
# Description

This PR adds `isaaclab.utils.warp.ParticleMeshCounter`, a fast, solver-agnostic Warp utility for counting
how many particles fall inside one or more closed (watertight) region meshes.

**What's added**

- **`ParticleMeshCounter`** — counts particles inside region meshes using Warp's BVH-accelerated
  winding-number point query (`wp.mesh_query_point_sign_winding_number`). It supports multiple,
  independently posed region meshes per environment (region geometry is fixed in its local frame and the
  BVH is built once and reused; only per-environment transforms change between calls), sanitizes
  non-finite particle positions, and returns per-region counts and/or the per-particle containment mask.
- **`make_box_region_mesh` / `make_frustum_region_mesh`** — helpers that build watertight, outward-oriented
  region meshes (axis-aligned boxes and capped circular frusta / "cup cavity" regions).

It lives next to the existing Warp helpers (`raycast_mesh`, `convert_to_warp_mesh`) in
`isaaclab.utils.warp`, as a single cohesive `particle_mesh.py` module (mirroring the package's existing
feature modules such as `proxy_array.py`).

**Motivation / context**

This enables training-time / privileged measurements such as "how many media particles are inside the
scoop bowl / source container / target container" without relying on hand-tuned analytic regions. It is
pure Warp + Torch with no physics-backend dependency, so it works for any particle source (MPM, PhysX
particles, point clouds).

**Dependencies**

None beyond what Isaac Lab already ships (Warp + Torch).

Fixes # (N/A — no tracking issue)

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

N/A — non-visual utility (validated by unit tests against analytic ground truth).

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there