### PR TITLE
Fix RMPFlow teleoperation related bugs

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -503,6 +503,14 @@ follows.
      - **Arm:** relative IK end-effector control. Gripper disabled.
 
 
+.. note::
+
+   Humanoid arms (e.g. Galbot, Agibot) have joint limits that inverse kinematics must respect.
+   The differential IK controller ignores these limits, so RMPFlow is preferred for teleoperating
+   them as it enforces joint limits while solving IK. Consequently, the arm may occasionally stop
+   responding when the commanded target pose is unreachable within those limits -- this is expected,
+   not a bug.
+
 .. _isaac-teleop-switching-input-mode:
 
 Switch Between Controllers and Hand Tracking

--- a/source/isaaclab/changelog.d/fix-rmpflow-orientation-quat-convention.rst
+++ b/source/isaaclab/changelog.d/fix-rmpflow-orientation-quat-convention.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed a quaternion convention bug in :class:`~isaaclab.controllers.rmp_flow.RmpFlowController`
+  where the end-effector orientation target was re-converted to ``(x, y, z, w)`` even though
+  IsaacLab quaternions are already in that order. The spurious conversion scrambled the target
+  orientation handed to RMPFlow, causing the arm to drift away from its commanded pose (e.g. the
+  Agibot RMPFlow place tasks no longer hold their reset pose under a zero relative command).

--- a/source/isaaclab/isaaclab/controllers/rmp_flow.py
+++ b/source/isaaclab/isaaclab/controllers/rmp_flow.py
@@ -12,7 +12,7 @@ import torch
 
 import isaaclab.sim as sim_utils
 from isaaclab.utils.assets import retrieve_file_path
-from isaaclab.utils.math import convert_quat, matrix_from_quat
+from isaaclab.utils.math import matrix_from_quat
 
 from .rmp_flow_cfg import RmpFlowControllerCfg  # noqa: F401
 from .utils import import_lula, resolve_rmpflow_path
@@ -100,9 +100,8 @@ class _LulaRmpFlow:
         else:
             self._policy.clear_end_effector_position_attractor()
         if target_orientation is not None:
-            # lula expects a rotation matrix; IsaacLab quaternions are (w, x, y, z)
-            quat_xyzw = convert_quat(torch.as_tensor(target_orientation, dtype=torch.float64), to="xyzw")
-            rot = matrix_from_quat(quat_xyzw).numpy()
+            # lula expects a rotation matrix; IsaacLab quaternions are already (x, y, z, w) convention.
+            rot = matrix_from_quat(torch.as_tensor(target_orientation, dtype=torch.float64)).numpy()
             self._policy.set_end_effector_orientation_attractor(self._lula.Rotation3(rot))
         else:
             self._policy.clear_end_effector_orientation_attractor()

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
@@ -21,7 +21,6 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.sensors import ContactSensorCfg, FrameTransformerCfg
-from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import MassPropertiesCfg, RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
@@ -306,7 +305,6 @@ class RmpFlowAgibotPlaceToy2BoxEnvCfg(PlaceToy2BoxEnvCfg):
             body_name="right_gripper_center",
             controller=AGIBOT_RIGHT_ARM_RMPFLOW_CFG,
             scale=1.0,
-            body_offset=RMPFlowActionCfg.OffsetCfg(pos=[0.0, 0.0, 0.0]),
             use_relative_mode=self.use_relative_mode,
         )
 
@@ -373,9 +371,6 @@ class RmpFlowAgibotPlaceToy2BoxEnvCfg(PlaceToy2BoxEnvCfg):
                 FrameTransformerCfg.FrameCfg(
                     prim_path="{ENV_REGEX_NS}/Robot/right_gripper_center",
                     name="end_effector",
-                    offset=OffsetCfg(
-                        pos=[0.0, 0.0, 0.0],
-                    ),
                 ),
             ],
         )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/config/agibot/place_upright_mug_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/place/config/agibot/place_upright_mug_rmp_rel_env_cfg.py
@@ -159,6 +159,10 @@ class RmpFlowAgibotPlaceUprightMugEnvCfg(place_toy2box_rmp_rel_env_cfg.PlaceToy2
 
         self.events = EventCfgPlaceUprightMug()
 
+        # set viewer to see the robot and objects on the table
+        self.viewer.eye = [1.8, -1.8, 1.8]
+        self.viewer.lookat = [0.3, 0.0, 0.8]
+
         # Set Agibot as robot
         self.scene.robot = AGIBOT_A2D_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
         self.scene.robot.init_state.pos = (-0.60, 0.0, 0.0)
@@ -196,7 +200,7 @@ class RmpFlowAgibotPlaceUprightMugEnvCfg(place_toy2box_rmp_rel_env_cfg.PlaceToy2
             body_name="gripper_center",
             controller=AGIBOT_LEFT_ARM_RMPFLOW_CFG,
             scale=1.0,
-            body_offset=RMPFlowActionCfg.OffsetCfg(pos=[0.0, 0.0, 0.0], rot=[0.0, -0.7071, 0.0, 0.7071]),
+            body_offset=RMPFlowActionCfg.OffsetCfg(rot=[0.0, -0.7071, 0.0, 0.7071]),
             use_relative_mode=self.use_relative_mode,
         )
 

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/galbot/stack_joint_pos_env_cfg.py
@@ -251,6 +251,10 @@ class GalbotLeftArmCubeStackEnvCfg(StackEnvCfg):
         super().__post_init__()
         # MDP settings
 
+        # set viewer to see the robot and objects on the table
+        self.viewer.eye = [1.8, 0.0, 1.8]
+        self.viewer.lookat = [0.3, 0.0, 0.8]
+
         # Set events
         self.events = EventCfg()
         self.observations.policy = ObservationGalbotLeftArmGripperCfg().PolicyCfg()

--- a/source/isaaclab_tasks/test/test_rmpflow_reset_stability.py
+++ b/source/isaaclab_tasks/test/test_rmpflow_reset_stability.py
@@ -77,7 +77,7 @@ def test_rmpflow_reset_pose_is_stable(task_name: str, drift_tol: float):
             arm_joint_ids = list(range(robot.num_joints))
 
         env.reset()
-        q_reset = robot.data.joint_pos[0, arm_joint_ids].clone()
+        q_reset = robot.data.joint_pos.torch[0, arm_joint_ids].clone()
 
         # Zero action => zero relative delta => "hold current pose" command.
         zero_action = torch.zeros((env.unwrapped.num_envs, env.action_space.shape[-1]), device=device)
@@ -86,8 +86,8 @@ def test_rmpflow_reset_pose_is_stable(task_name: str, drift_tol: float):
             for step in range(_SETTLE_STEPS):
                 env.step(zero_action)
                 if step == _SETTLE_STEPS - _SETTLE_WINDOW - 1:
-                    q_window_start = robot.data.joint_pos[0, arm_joint_ids].clone()
-        q_final = robot.data.joint_pos[0, arm_joint_ids].clone()
+                    q_window_start = robot.data.joint_pos.torch[0, arm_joint_ids].clone()
+        q_final = robot.data.joint_pos.torch[0, arm_joint_ids].clone()
 
         # 1) The arm has settled: it is effectively motionless over the final window.
         settle_motion = float((q_final - q_window_start).abs().sum())

--- a/source/isaaclab_tasks/test/test_rmpflow_reset_stability.py
+++ b/source/isaaclab_tasks/test/test_rmpflow_reset_stability.py
@@ -43,7 +43,10 @@ _SETTLE_TOL = 0.3
 
 # Per-task budget for total |Δjoint| (rad) drift away from the reset pose after settling.
 # Values sit comfortably above the corrected behavior yet far below the multi-radian divergence
-# the orientation-convention bug produced. The suction task carries a larger null-space residual.
+# the orientation-convention bug produced (~12 rad on the Agibot right arm). The wide separation
+# between corrected drift and the bug's divergence leaves room to tighten these once the corrected
+# per-task drift is characterized more precisely. The suction task carries a larger null-space
+# residual, hence its higher budget.
 _RMPFLOW_TASKS = [
     ("Isaac-Place-Toy2Box-Agibot-Right-Arm-RmpFlow-v0", 1.5),
     ("Isaac-Place-Mug-Agibot-Left-Arm-RmpFlow-v0", 1.5),
@@ -71,7 +74,9 @@ def test_rmpflow_reset_pose_is_stable(task_name: str, drift_tol: float):
 
     try:
         robot = env.unwrapped.scene["robot"]
-        # Joints actively controlled by the RMPFlow arm action term.
+        # Joints actively controlled by the RMPFlow arm action term. The action term has no public
+        # accessor for its resolved joint indices, so read the private attribute directly; switch to
+        # a public property here if one is ever added.
         arm_joint_ids = env.unwrapped.action_manager.get_term("arm_action")._joint_ids
         if isinstance(arm_joint_ids, slice):
             arm_joint_ids = list(range(robot.num_joints))

--- a/source/isaaclab_tasks/test/test_rmpflow_reset_stability.py
+++ b/source/isaaclab_tasks/test/test_rmpflow_reset_stability.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression tests for RMPFlow task-space control stability after a reset.
+
+Under a zero *relative* command, an RMPFlow-controlled arm must hold the pose it was reset to:
+the commanded end-effector target equals the current end-effector pose, so the arm should settle
+and stay put. A quaternion-convention bug in the controller used to scramble the orientation
+target, making the arm diverge by many radians from its reset configuration over a handful of
+steps (e.g. ~12 rad of total joint drift on the Agibot right arm). These tests pin the corrected
+behavior: the arm settles quickly and stays close to its reset pose.
+"""
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+# launch the simulator
+app_launcher = AppLauncher(headless=True)
+simulation_app = app_launcher.app
+
+
+"""Rest everything follows."""
+
+import gymnasium as gym
+import pytest
+import torch
+
+import isaaclab.sim as sim_utils
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
+
+# Number of environment steps to settle under a zero relative command.
+_SETTLE_STEPS = 60
+# Window (last steps) over which a settled arm must be effectively motionless.
+_SETTLE_WINDOW = 15
+# Max total |Δjoint| (rad) allowed across the arm over the settle window: if the arm is still
+# moving this much near the end, it has not converged (the bug caused continuous divergence).
+_SETTLE_TOL = 0.3
+
+# Per-task budget for total |Δjoint| (rad) drift away from the reset pose after settling.
+# Values sit comfortably above the corrected behavior yet far below the multi-radian divergence
+# the orientation-convention bug produced. The suction task carries a larger null-space residual.
+_RMPFLOW_TASKS = [
+    ("Isaac-Place-Toy2Box-Agibot-Right-Arm-RmpFlow-v0", 1.5),
+    ("Isaac-Place-Mug-Agibot-Left-Arm-RmpFlow-v0", 1.5),
+    ("Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-RmpFlow-v0", 1.5),
+    ("Isaac-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow-v0", 2.5),
+]
+
+
+@pytest.mark.parametrize("task_name, drift_tol", _RMPFLOW_TASKS)
+def test_rmpflow_reset_pose_is_stable(task_name: str, drift_tol: float):
+    """The RMPFlow arm settles and holds its reset pose under a zero relative command."""
+    # RMPFlow tasks (incl. the suction gripper) run on CPU physics.
+    device = "cpu"
+    sim_utils.create_new_stage()
+    try:
+        env_cfg = parse_env_cfg(task_name, device=device, num_envs=1)
+        env = gym.make(task_name, cfg=env_cfg)
+    except Exception as e:  # noqa: BLE001
+        if "env" in locals() and hasattr(env, "_is_closed"):
+            env.close()
+        pytest.fail(f"Failed to set up the environment for task {task_name}. Error: {e}")
+
+    # disable control on stop
+    env.unwrapped.sim._app_control_on_stop_handle = None  # type: ignore
+
+    try:
+        robot = env.unwrapped.scene["robot"]
+        # Joints actively controlled by the RMPFlow arm action term.
+        arm_joint_ids = env.unwrapped.action_manager.get_term("arm_action")._joint_ids
+        if isinstance(arm_joint_ids, slice):
+            arm_joint_ids = list(range(robot.num_joints))
+
+        env.reset()
+        q_reset = robot.data.joint_pos[0, arm_joint_ids].clone()
+
+        # Zero action => zero relative delta => "hold current pose" command.
+        zero_action = torch.zeros((env.unwrapped.num_envs, env.action_space.shape[-1]), device=device)
+        q_window_start = None
+        with torch.inference_mode():
+            for step in range(_SETTLE_STEPS):
+                env.step(zero_action)
+                if step == _SETTLE_STEPS - _SETTLE_WINDOW - 1:
+                    q_window_start = robot.data.joint_pos[0, arm_joint_ids].clone()
+        q_final = robot.data.joint_pos[0, arm_joint_ids].clone()
+
+        # 1) The arm has settled: it is effectively motionless over the final window.
+        settle_motion = float((q_final - q_window_start).abs().sum())
+        assert settle_motion < _SETTLE_TOL, (
+            f"{task_name}: arm still moving {settle_motion:.3f} rad over the last {_SETTLE_WINDOW} steps"
+            f" (tol {_SETTLE_TOL}); RMPFlow did not converge to a steady hold."
+        )
+
+        # 2) The settled pose stays close to the reset pose (no large drift).
+        total_drift = float((q_final - q_reset).abs().sum())
+        assert total_drift < drift_tol, (
+            f"{task_name}: arm drifted {total_drift:.3f} rad from its reset pose under a zero command"
+            f" (tol {drift_tol}); expected it to hold."
+        )
+    finally:
+        env.close()


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

The lula-backed RMPFlow controller re-converted the end-effector orientation target to (x, y, z, w) before building its rotation matrix, even though IsaacLab quaternions are already in that order. Drop the extra conversion so the already-xyzw target feeds matrix_from_quat directly. This makes all RMPFlow tasks hold their reset pose (Agibot right arm total joint drift over 60 zero-action steps drops from ~12.5 to ~0.2 rad) with no regression on the Galbot tasks. Fixes bug (6288451)

Add a parametrized regression test that resets each RMPFlow task and asserts the arm settles and stays close to its reset pose under a zero command. Verified the test fails on the affected tasks when the bug is reintroduced.

Also adjust task defaults made possible by the fix: set sensible default viewer poses for the Agibot upright-mug and Galbot cube-stack tasks, and remove now-redundant zero-valued body offsets. For bug (6288480)

Add documentation for humanoid teleoperation instruction with space mouse/keyboard. For bug (6288401)


## Screenshots
<img width="800" height="200" alt="Screenshot from 2026-06-10 13-08-25" src="https://github.com/user-attachments/assets/78fbd9c1-5d0e-4c02-8c34-077903a28808" />


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- Documentation update



## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
