### PR TITLE
Revert disk cleanup

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -23,6 +23,32 @@ jobs:
       with:
         filter: tree:0
 
+    # - name: Install jq
+    #   run: sudo apt-get update && sudo apt-get install -y jq
+
+    - name: Clean up disk space
+      run: |
+        # Remove pre-installed tools
+        rm -rf /opt/hostedtoolcache
+        rm -rf /usr/share/dotnet
+        rm -rf /opt/ghc
+        sudo rm -rf /usr/local/lib/android
+        rm -rf /usr/share/swift
+        rm -rf /usr/local/share/boost
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/local/lib/node_modules
+        sudo rm -rf /usr/local/share/chromium
+        sudo rm -rf /usr/local/share/powershell
+        # Clean apt cache
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/*
+        # Docker cleanup
+        docker container prune -f
+        docker image prune -af
+        docker volume prune -f
+        docker system prune -af
+
+
     - name: Set up uv
       uses: astral-sh/setup-uv@v6
       with:


### PR DESCRIPTION
# Description

Revert the removal of disk cleanup in the licence-check CI test. It runs out of space without this disk cleanup

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
