### PR TITLE
[Docker] Make non-root image volume mount points writable by the isaaclab user (cherry-pick #6082 → 3.0.0-beta2)

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -159,25 +159,23 @@ RUN chmod 755 \
 # copy the rest of the files
 COPY --chown=isaaclab:isaaclab ../ ${ISAACLAB_PATH}/
 
-# Pre-create the docker-compose named-volume mount points that live outside
-# ${DOCKER_USER_HOME} and hand them to the non-root runtime user. A fresh named
-# volume inherits ownership from the image directory at its mount path; if that
-# directory is missing or root-owned, the volume comes up root-owned and the
-# isaaclab user cannot write it (e.g. PermissionError creating logs/, or
-# omni.datastore lock failures under kit/cache). The ${DOCKER_USER_HOME} mount
-# points are already covered by the recursive chown above.
-RUN mkdir -p \
-        ${ISAACLAB_PATH}/logs \
-        ${ISAACLAB_PATH}/data_storage \
-        ${ISAACLAB_PATH}/docs/_build \
-        ${ISAACSIM_ROOT_PATH}/kit/cache \
-        ${ISAACSIM_ROOT_PATH}/kit/logs/Kit/Isaac-Sim \
- && chown -R isaaclab:isaaclab \
-        ${ISAACLAB_PATH}/logs \
-        ${ISAACLAB_PATH}/data_storage \
-        ${ISAACLAB_PATH}/docs/_build \
-        ${ISAACSIM_ROOT_PATH}/kit/cache \
-        ${ISAACSIM_ROOT_PATH}/kit/logs
+# Pre-create every docker-compose named-volume mount point and hand it to the
+# non-root runtime user. docker-compose.yaml is the single source of truth for
+# the list; docker/utils/volume_mounts.py parses it so the paths are not
+# duplicated here. A fresh named volume inherits ownership from the image
+# directory at its mount path; if that directory is missing or root-owned, the
+# volume comes up root-owned and the isaaclab user cannot write it (e.g.
+# PermissionError creating logs/, or omni.datastore lock failures under
+# kit/cache). pipefail + the non-empty guard make a parse failure abort the
+# build rather than silently shipping an unprepared mount point.
+RUN set -o pipefail \
+ && export DOCKER_ISAACSIM_ROOT_PATH="${ISAACSIM_ROOT_PATH}" \
+           DOCKER_ISAACLAB_PATH="${ISAACLAB_PATH}" \
+           DOCKER_USER_HOME="${DOCKER_USER_HOME}" \
+ && dirs="$(${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/docker/utils/volume_mounts.py | grep '^/')" \
+ && test -n "${dirs}" \
+ && mkdir -p ${dirs} \
+ && chown -R isaaclab:isaaclab ${dirs}
 
 USER isaaclab
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -159,6 +159,26 @@ RUN chmod 755 \
 # copy the rest of the files
 COPY --chown=isaaclab:isaaclab ../ ${ISAACLAB_PATH}/
 
+# Pre-create the docker-compose named-volume mount points that live outside
+# ${DOCKER_USER_HOME} and hand them to the non-root runtime user. A fresh named
+# volume inherits ownership from the image directory at its mount path; if that
+# directory is missing or root-owned, the volume comes up root-owned and the
+# isaaclab user cannot write it (e.g. PermissionError creating logs/, or
+# omni.datastore lock failures under kit/cache). The ${DOCKER_USER_HOME} mount
+# points are already covered by the recursive chown above.
+RUN mkdir -p \
+        ${ISAACLAB_PATH}/logs \
+        ${ISAACLAB_PATH}/data_storage \
+        ${ISAACLAB_PATH}/docs/_build \
+        ${ISAACSIM_ROOT_PATH}/kit/cache \
+        ${ISAACSIM_ROOT_PATH}/kit/logs/Kit/Isaac-Sim \
+ && chown -R isaaclab:isaaclab \
+        ${ISAACLAB_PATH}/logs \
+        ${ISAACLAB_PATH}/data_storage \
+        ${ISAACLAB_PATH}/docs/_build \
+        ${ISAACSIM_ROOT_PATH}/kit/cache \
+        ${ISAACSIM_ROOT_PATH}/kit/logs
+
 USER isaaclab
 
 # make working directory as the Isaac Lab directory

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -166,14 +166,15 @@ COPY --chown=isaaclab:isaaclab ../ ${ISAACLAB_PATH}/
 # directory at its mount path; if that directory is missing or root-owned, the
 # volume comes up root-owned and the isaaclab user cannot write it (e.g.
 # PermissionError creating logs/, or omni.datastore lock failures under
-# kit/cache). pipefail + the non-empty guard make a parse failure abort the
-# build rather than silently shipping an unprepared mount point.
+# kit/cache). set -o pipefail makes a parse failure abort the build:
+# volume_mounts.py exits non-zero on an empty/unresolved list and grep exits
+# non-zero if no paths are produced, so the build fails here rather than
+# silently shipping an unprepared mount point.
 RUN set -o pipefail \
  && export DOCKER_ISAACSIM_ROOT_PATH="${ISAACSIM_ROOT_PATH}" \
            DOCKER_ISAACLAB_PATH="${ISAACLAB_PATH}" \
            DOCKER_USER_HOME="${DOCKER_USER_HOME}" \
  && dirs="$(${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/docker/utils/volume_mounts.py | grep '^/')" \
- && test -n "${dirs}" \
  && mkdir -p ${dirs} \
  && chown -R isaaclab:isaaclab ${dirs}
 

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -212,6 +212,26 @@ RUN chmod 755 \
 # copy the rest of the files
 COPY --chown=isaaclab:isaaclab ../ ${ISAACLAB_PATH}/
 
+# Pre-create the docker-compose named-volume mount points that live outside
+# ${DOCKER_USER_HOME} and hand them to the non-root runtime user. A fresh named
+# volume inherits ownership from the image directory at its mount path; if that
+# directory is missing or root-owned, the volume comes up root-owned and the
+# isaaclab user cannot write it (e.g. PermissionError creating logs/, or
+# omni.datastore lock failures under kit/cache). The ${DOCKER_USER_HOME} mount
+# points are already covered by the recursive chown above.
+RUN mkdir -p \
+        ${ISAACLAB_PATH}/logs \
+        ${ISAACLAB_PATH}/data_storage \
+        ${ISAACLAB_PATH}/docs/_build \
+        ${ISAACSIM_ROOT_PATH}/kit/cache \
+        ${ISAACSIM_ROOT_PATH}/kit/logs/Kit/Isaac-Sim \
+ && chown -R isaaclab:isaaclab \
+        ${ISAACLAB_PATH}/logs \
+        ${ISAACLAB_PATH}/data_storage \
+        ${ISAACLAB_PATH}/docs/_build \
+        ${ISAACSIM_ROOT_PATH}/kit/cache \
+        ${ISAACSIM_ROOT_PATH}/kit/logs
+
 USER isaaclab
 
 # make working directory as the Isaac Lab directory

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -219,14 +219,15 @@ COPY --chown=isaaclab:isaaclab ../ ${ISAACLAB_PATH}/
 # directory at its mount path; if that directory is missing or root-owned, the
 # volume comes up root-owned and the isaaclab user cannot write it (e.g.
 # PermissionError creating logs/, or omni.datastore lock failures under
-# kit/cache). pipefail + the non-empty guard make a parse failure abort the
-# build rather than silently shipping an unprepared mount point.
+# kit/cache). set -o pipefail makes a parse failure abort the build:
+# volume_mounts.py exits non-zero on an empty/unresolved list and grep exits
+# non-zero if no paths are produced, so the build fails here rather than
+# silently shipping an unprepared mount point.
 RUN set -o pipefail \
  && export DOCKER_ISAACSIM_ROOT_PATH="${ISAACSIM_ROOT_PATH}" \
            DOCKER_ISAACLAB_PATH="${ISAACLAB_PATH}" \
            DOCKER_USER_HOME="${DOCKER_USER_HOME}" \
  && dirs="$(${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/docker/utils/volume_mounts.py | grep '^/')" \
- && test -n "${dirs}" \
  && mkdir -p ${dirs} \
  && chown -R isaaclab:isaaclab ${dirs}
 

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -212,25 +212,23 @@ RUN chmod 755 \
 # copy the rest of the files
 COPY --chown=isaaclab:isaaclab ../ ${ISAACLAB_PATH}/
 
-# Pre-create the docker-compose named-volume mount points that live outside
-# ${DOCKER_USER_HOME} and hand them to the non-root runtime user. A fresh named
-# volume inherits ownership from the image directory at its mount path; if that
-# directory is missing or root-owned, the volume comes up root-owned and the
-# isaaclab user cannot write it (e.g. PermissionError creating logs/, or
-# omni.datastore lock failures under kit/cache). The ${DOCKER_USER_HOME} mount
-# points are already covered by the recursive chown above.
-RUN mkdir -p \
-        ${ISAACLAB_PATH}/logs \
-        ${ISAACLAB_PATH}/data_storage \
-        ${ISAACLAB_PATH}/docs/_build \
-        ${ISAACSIM_ROOT_PATH}/kit/cache \
-        ${ISAACSIM_ROOT_PATH}/kit/logs/Kit/Isaac-Sim \
- && chown -R isaaclab:isaaclab \
-        ${ISAACLAB_PATH}/logs \
-        ${ISAACLAB_PATH}/data_storage \
-        ${ISAACLAB_PATH}/docs/_build \
-        ${ISAACSIM_ROOT_PATH}/kit/cache \
-        ${ISAACSIM_ROOT_PATH}/kit/logs
+# Pre-create every docker-compose named-volume mount point and hand it to the
+# non-root runtime user. docker-compose.yaml is the single source of truth for
+# the list; docker/utils/volume_mounts.py parses it so the paths are not
+# duplicated here. A fresh named volume inherits ownership from the image
+# directory at its mount path; if that directory is missing or root-owned, the
+# volume comes up root-owned and the isaaclab user cannot write it (e.g.
+# PermissionError creating logs/, or omni.datastore lock failures under
+# kit/cache). pipefail + the non-empty guard make a parse failure abort the
+# build rather than silently shipping an unprepared mount point.
+RUN set -o pipefail \
+ && export DOCKER_ISAACSIM_ROOT_PATH="${ISAACSIM_ROOT_PATH}" \
+           DOCKER_ISAACLAB_PATH="${ISAACLAB_PATH}" \
+           DOCKER_USER_HOME="${DOCKER_USER_HOME}" \
+ && dirs="$(${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/docker/utils/volume_mounts.py | grep '^/')" \
+ && test -n "${dirs}" \
+ && mkdir -p ${dirs} \
+ && chown -R isaaclab:isaaclab ${dirs}
 
 USER isaaclab
 

--- a/docker/test/test_dockerfile_nonroot.py
+++ b/docker/test/test_dockerfile_nonroot.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import importlib.util
 import re
 from pathlib import Path
 
@@ -10,6 +11,15 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKER_DIR = REPO_ROOT / "docker"
+
+
+def _load_module(name: str, path: Path):
+    """Import a module by file path (``docker`` is not an importable package here)."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
 
 # Collect every Dockerfile.* from the entire repository tree.
 DOCKERFILES = sorted(REPO_ROOT.glob("**/Dockerfile.*"))
@@ -99,140 +109,67 @@ def test_ros2_dockerfile_restores_non_root_runtime_user():
 # mount path on first mount. If that directory is missing or root-owned, the
 # volume comes up root-owned and the non-root ``isaaclab`` runtime user cannot
 # write it (e.g. ``PermissionError`` creating ``logs/`` or ``omni.datastore``
-# lock failures under ``kit/cache``). The tests below statically guarantee every
-# such mount point is both created in the image and owned by ``isaaclab``.
+# lock failures under ``kit/cache``). The image build therefore pre-creates and
+# chowns every named-volume mount point, driven by a single source of truth:
+# docker-compose.yaml, parsed by docker/utils/volume_mounts.py. These tests
+# validate the parser and that each non-root Dockerfile wires it in.
 # --------------------------------------------------------------------------- #
 
-COMPOSE_FILE = DOCKER_DIR / "docker-compose.yaml"
-ENV_BASE_FILE = DOCKER_DIR / ".env.base"
-
-_VAR_RE = re.compile(r"\$\{(\w+)\}")
+NONROOT_VOLUME_DOCKERFILES = ["Dockerfile.base", "Dockerfile.curobo"]
 
 
-def _load_env_base() -> dict[str, str]:
-    """Parse ``docker/.env.base`` into a ``{KEY: VALUE}`` map (quotes stripped)."""
-    env: dict[str, str] = {}
-    for raw in ENV_BASE_FILE.read_text(encoding="utf-8").splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        env[key.strip()] = value.strip().strip('"').strip("'")
-    return env
+def _volume_mounts_module():
+    """Load the parser the image build uses; skip the test if PyYAML is unavailable.
 
-
-def _path_var_map() -> dict[str, str]:
-    """Resolve the path vars shared by docker-compose and the Dockerfiles.
-
-    The Dockerfile ENV names (``ISAACLAB_PATH`` ...) take their values from build
-    args wired to the ``DOCKER_*`` vars in ``.env.base``, so both files resolve
-    to the same concrete paths.
+    The Docker image build exercises this parser for real, so a test environment
+    without PyYAML simply skips the parser unit tests rather than failing.
     """
-    env = _load_env_base()
-    sim_root = env["DOCKER_ISAACSIM_ROOT_PATH"]
-    lab_path = env["DOCKER_ISAACLAB_PATH"]
-    user_home = env["DOCKER_USER_HOME"]
-    return {
-        "DOCKER_ISAACSIM_ROOT_PATH": sim_root,
-        "DOCKER_ISAACLAB_PATH": lab_path,
-        "DOCKER_USER_HOME": user_home,
-        "ISAACSIM_ROOT_PATH": sim_root,
-        "ISAACLAB_PATH": lab_path,
-        "HOME": user_home,
-    }
+    pytest.importorskip("yaml")
+    return _load_module("volume_mounts", DOCKER_DIR / "utils" / "volume_mounts.py")
 
 
-def _expand(path: str, var_map: dict[str, str]) -> str:
-    """Expand ``${VAR}`` references and strip any trailing slash."""
-    return _VAR_RE.sub(lambda m: var_map.get(m.group(1), m.group(0)), path).rstrip("/")
+def test_compose_volume_targets_parse():
+    """The parser returns every ``type: volume`` mount point from docker-compose.yaml.
 
-
-def _is_within(child: str, parent: str) -> bool:
-    """True if ``child`` equals ``parent`` or is nested under it."""
-    return child == parent or child.startswith(parent + "/")
-
-
-def _compose_volume_targets(var_map: dict[str, str]) -> list[str]:
-    """Return every ``type: volume`` target path in docker-compose.yaml, expanded."""
-    targets = []
-    in_volume = False
-    for raw in COMPOSE_FILE.read_text(encoding="utf-8").splitlines():
-        line = raw.strip()
-        if line.startswith("- type:"):
-            in_volume = line.endswith("volume")
-        elif in_volume and line.startswith("target:"):
-            targets.append(_expand(line.split("target:", 1)[1].strip(), var_map))
-            in_volume = False
-    return targets
-
-
-def _command_path_args(dockerfile_text: str, command_re: str) -> list[str]:
-    """Collect the absolute/``${VAR}`` path tokens of each matching RUN command.
-
-    Line continuations are joined first; tokens are read up to the next shell
-    separator (``&&``, ``||``, ``;`` or newline) so each command's args stay
-    distinct.
+    Includes the directories that triggered the original regression so a compose
+    edit that drops them is caught here.
     """
-    joined = re.sub(r"\\\s*\n", " ", dockerfile_text)
-    tokens: list[str] = []
-    for match in re.finditer(command_re, joined):
-        segment = re.split(r"&&|\|\||;|\n", joined[match.end() :], maxsplit=1)[0]
-        tokens += [t for t in segment.split() if t.startswith(("$", "/"))]
-    return tokens
-
-
-def _mkdir_targets(text: str, var_map: dict[str, str]) -> list[str]:
-    return [_expand(t, var_map) for t in _command_path_args(text, r"\bmkdir\b(?:\s+-\w+)*")]
-
-
-def _chown_isaaclab_roots(text: str, var_map: dict[str, str]) -> list[str]:
-    return [_expand(t, var_map) for t in _command_path_args(text, r"\bchown\s+-R\s+isaaclab:isaaclab\b")]
-
-
-def test_base_compose_volume_mount_points_are_writable():
-    """Every docker-compose named volume mounts onto an isaaclab-owned image dir.
-
-    Guards the regression where ``kit/cache`` (root-owned) and ``logs`` (absent
-    in the image) came up root-owned on a fresh volume, blocking training.
-    """
-    var_map = _path_var_map()
-    text = _find_dockerfile("Dockerfile.base").read_text(encoding="utf-8")
-    mkdirs = _mkdir_targets(text, var_map)
-    chown_roots = _chown_isaaclab_roots(text, var_map)
-    targets = _compose_volume_targets(var_map)
+    targets = _volume_mounts_module().named_volume_targets(DOCKER_DIR / "docker-compose.yaml")
 
     assert targets, "no named-volume targets parsed from docker-compose.yaml"
+    for required in (
+        "${DOCKER_ISAACSIM_ROOT_PATH}/kit/cache",
+        "${DOCKER_ISAACLAB_PATH}/logs",
+        "${DOCKER_ISAACLAB_PATH}/data_storage",
+        "${DOCKER_ISAACLAB_PATH}/docs/_build",
+    ):
+        assert required in targets, f"{required} missing from parsed volume targets: {targets}"
 
-    problems = []
-    for target in targets:
-        created = any(_is_within(m, target) for m in mkdirs)
-        owned = any(_is_within(target, root) for root in chown_roots)
-        if not (created and owned):
-            problems.append({"target": target, "created_in_image": created, "owned_by_isaaclab": owned})
-    assert not problems, "volume mount points not guaranteed writable by isaaclab:\n" + "\n".join(map(str, problems))
+
+def test_resolved_targets_are_absolute_paths(monkeypatch):
+    """With the build's environment, every target resolves to an absolute path."""
+    monkeypatch.setenv("DOCKER_ISAACSIM_ROOT_PATH", "/isaac-sim")
+    monkeypatch.setenv("DOCKER_ISAACLAB_PATH", "/workspace/isaaclab")
+    monkeypatch.setenv("DOCKER_USER_HOME", "/root")
+
+    resolved = _volume_mounts_module().resolved_targets(DOCKER_DIR / "docker-compose.yaml")
+
+    assert resolved, "no resolved targets"
+    assert all(p.startswith("/") and "$" not in p for p in resolved), resolved
+    assert "/isaac-sim/kit/cache" in resolved
+    assert "/workspace/isaaclab/logs" in resolved
 
 
-@pytest.mark.parametrize("dockerfile_name", ["Dockerfile.base", "Dockerfile.curobo"])
-def test_created_dirs_outside_home_are_owned_by_runtime_user(dockerfile_name: str):
-    """Dirs created under the Sim/Lab roots (outside ``$HOME``) must be chowned.
+@pytest.mark.parametrize("dockerfile_name", NONROOT_VOLUME_DOCKERFILES)
+def test_dockerfile_prepares_volume_mounts_from_compose(dockerfile_name: str):
+    """Each non-root Dockerfile derives its mount points from the parser, with a guard.
 
-    ``$HOME`` is already handled by the recursive ``chown`` of the runtime home;
-    anything created under the root-owned Isaac Sim tree (e.g. ``kit/cache``) is
-    not, so it must be handed to ``isaaclab`` explicitly.
+    Guards the wiring: the build must call ``volume_mounts.py`` and abort (the
+    ``test -n`` guard) if the parse yields nothing, rather than re-hardcoding the
+    list or silently skipping preparation.
     """
-    var_map = _path_var_map()
-    home = var_map["DOCKER_USER_HOME"]
-    managed_roots = (var_map["ISAACSIM_ROOT_PATH"], var_map["ISAACLAB_PATH"])
     text = _find_dockerfile(dockerfile_name).read_text(encoding="utf-8")
-    mkdirs = _mkdir_targets(text, var_map)
-    chown_roots = _chown_isaaclab_roots(text, var_map)
 
-    problems = []
-    for created_dir in mkdirs:
-        if not any(_is_within(created_dir, root) for root in managed_roots):
-            continue  # unrelated system dir (e.g. /var/run/...)
-        if _is_within(created_dir, home):
-            continue  # covered by the recursive chown of the runtime home
-        if not any(_is_within(created_dir, root) for root in chown_roots):
-            problems.append(created_dir)
-    assert not problems, f"{dockerfile_name}: dirs created but not chowned to isaaclab: {problems}"
+    assert "docker/utils/volume_mounts.py" in text
+    assert "chown -R isaaclab:isaaclab ${dirs}" in text
+    assert 'test -n "${dirs}"' in text

--- a/docker/test/test_dockerfile_nonroot.py
+++ b/docker/test/test_dockerfile_nonroot.py
@@ -90,3 +90,149 @@ def test_ros2_dockerfile_restores_non_root_runtime_user():
     dockerfile_text = (DOCKER_DIR / "Dockerfile.ros2").read_text(encoding="utf-8")
 
     assert _user_directives(dockerfile_text) == ["root", "isaaclab"]
+
+
+# --------------------------------------------------------------------------- #
+# Volume mount-point writability
+#
+# A fresh Docker named volume inherits ownership from the image directory at its
+# mount path on first mount. If that directory is missing or root-owned, the
+# volume comes up root-owned and the non-root ``isaaclab`` runtime user cannot
+# write it (e.g. ``PermissionError`` creating ``logs/`` or ``omni.datastore``
+# lock failures under ``kit/cache``). The tests below statically guarantee every
+# such mount point is both created in the image and owned by ``isaaclab``.
+# --------------------------------------------------------------------------- #
+
+COMPOSE_FILE = DOCKER_DIR / "docker-compose.yaml"
+ENV_BASE_FILE = DOCKER_DIR / ".env.base"
+
+_VAR_RE = re.compile(r"\$\{(\w+)\}")
+
+
+def _load_env_base() -> dict[str, str]:
+    """Parse ``docker/.env.base`` into a ``{KEY: VALUE}`` map (quotes stripped)."""
+    env: dict[str, str] = {}
+    for raw in ENV_BASE_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        env[key.strip()] = value.strip().strip('"').strip("'")
+    return env
+
+
+def _path_var_map() -> dict[str, str]:
+    """Resolve the path vars shared by docker-compose and the Dockerfiles.
+
+    The Dockerfile ENV names (``ISAACLAB_PATH`` ...) take their values from build
+    args wired to the ``DOCKER_*`` vars in ``.env.base``, so both files resolve
+    to the same concrete paths.
+    """
+    env = _load_env_base()
+    sim_root = env["DOCKER_ISAACSIM_ROOT_PATH"]
+    lab_path = env["DOCKER_ISAACLAB_PATH"]
+    user_home = env["DOCKER_USER_HOME"]
+    return {
+        "DOCKER_ISAACSIM_ROOT_PATH": sim_root,
+        "DOCKER_ISAACLAB_PATH": lab_path,
+        "DOCKER_USER_HOME": user_home,
+        "ISAACSIM_ROOT_PATH": sim_root,
+        "ISAACLAB_PATH": lab_path,
+        "HOME": user_home,
+    }
+
+
+def _expand(path: str, var_map: dict[str, str]) -> str:
+    """Expand ``${VAR}`` references and strip any trailing slash."""
+    return _VAR_RE.sub(lambda m: var_map.get(m.group(1), m.group(0)), path).rstrip("/")
+
+
+def _is_within(child: str, parent: str) -> bool:
+    """True if ``child`` equals ``parent`` or is nested under it."""
+    return child == parent or child.startswith(parent + "/")
+
+
+def _compose_volume_targets(var_map: dict[str, str]) -> list[str]:
+    """Return every ``type: volume`` target path in docker-compose.yaml, expanded."""
+    targets = []
+    in_volume = False
+    for raw in COMPOSE_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line.startswith("- type:"):
+            in_volume = line.endswith("volume")
+        elif in_volume and line.startswith("target:"):
+            targets.append(_expand(line.split("target:", 1)[1].strip(), var_map))
+            in_volume = False
+    return targets
+
+
+def _command_path_args(dockerfile_text: str, command_re: str) -> list[str]:
+    """Collect the absolute/``${VAR}`` path tokens of each matching RUN command.
+
+    Line continuations are joined first; tokens are read up to the next shell
+    separator (``&&``, ``||``, ``;`` or newline) so each command's args stay
+    distinct.
+    """
+    joined = re.sub(r"\\\s*\n", " ", dockerfile_text)
+    tokens: list[str] = []
+    for match in re.finditer(command_re, joined):
+        segment = re.split(r"&&|\|\||;|\n", joined[match.end() :], maxsplit=1)[0]
+        tokens += [t for t in segment.split() if t.startswith(("$", "/"))]
+    return tokens
+
+
+def _mkdir_targets(text: str, var_map: dict[str, str]) -> list[str]:
+    return [_expand(t, var_map) for t in _command_path_args(text, r"\bmkdir\b(?:\s+-\w+)*")]
+
+
+def _chown_isaaclab_roots(text: str, var_map: dict[str, str]) -> list[str]:
+    return [_expand(t, var_map) for t in _command_path_args(text, r"\bchown\s+-R\s+isaaclab:isaaclab\b")]
+
+
+def test_base_compose_volume_mount_points_are_writable():
+    """Every docker-compose named volume mounts onto an isaaclab-owned image dir.
+
+    Guards the regression where ``kit/cache`` (root-owned) and ``logs`` (absent
+    in the image) came up root-owned on a fresh volume, blocking training.
+    """
+    var_map = _path_var_map()
+    text = _find_dockerfile("Dockerfile.base").read_text(encoding="utf-8")
+    mkdirs = _mkdir_targets(text, var_map)
+    chown_roots = _chown_isaaclab_roots(text, var_map)
+    targets = _compose_volume_targets(var_map)
+
+    assert targets, "no named-volume targets parsed from docker-compose.yaml"
+
+    problems = []
+    for target in targets:
+        created = any(_is_within(m, target) for m in mkdirs)
+        owned = any(_is_within(target, root) for root in chown_roots)
+        if not (created and owned):
+            problems.append({"target": target, "created_in_image": created, "owned_by_isaaclab": owned})
+    assert not problems, "volume mount points not guaranteed writable by isaaclab:\n" + "\n".join(map(str, problems))
+
+
+@pytest.mark.parametrize("dockerfile_name", ["Dockerfile.base", "Dockerfile.curobo"])
+def test_created_dirs_outside_home_are_owned_by_runtime_user(dockerfile_name: str):
+    """Dirs created under the Sim/Lab roots (outside ``$HOME``) must be chowned.
+
+    ``$HOME`` is already handled by the recursive ``chown`` of the runtime home;
+    anything created under the root-owned Isaac Sim tree (e.g. ``kit/cache``) is
+    not, so it must be handed to ``isaaclab`` explicitly.
+    """
+    var_map = _path_var_map()
+    home = var_map["DOCKER_USER_HOME"]
+    managed_roots = (var_map["ISAACSIM_ROOT_PATH"], var_map["ISAACLAB_PATH"])
+    text = _find_dockerfile(dockerfile_name).read_text(encoding="utf-8")
+    mkdirs = _mkdir_targets(text, var_map)
+    chown_roots = _chown_isaaclab_roots(text, var_map)
+
+    problems = []
+    for created_dir in mkdirs:
+        if not any(_is_within(created_dir, root) for root in managed_roots):
+            continue  # unrelated system dir (e.g. /var/run/...)
+        if _is_within(created_dir, home):
+            continue  # covered by the recursive chown of the runtime home
+        if not any(_is_within(created_dir, root) for root in chown_roots):
+            problems.append(created_dir)
+    assert not problems, f"{dockerfile_name}: dirs created but not chowned to isaaclab: {problems}"

--- a/docker/test/test_dockerfile_nonroot.py
+++ b/docker/test/test_dockerfile_nonroot.py
@@ -16,6 +16,7 @@ DOCKER_DIR = REPO_ROOT / "docker"
 def _load_module(name: str, path: Path):
     """Import a module by file path (``docker`` is not an importable package here)."""
     spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"cannot load module at {path}"
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -164,12 +165,12 @@ def test_resolved_targets_are_absolute_paths(monkeypatch):
 def test_dockerfile_prepares_volume_mounts_from_compose(dockerfile_name: str):
     """Each non-root Dockerfile derives its mount points from the parser, with a guard.
 
-    Guards the wiring: the build must call ``volume_mounts.py`` and abort (the
-    ``test -n`` guard) if the parse yields nothing, rather than re-hardcoding the
-    list or silently skipping preparation.
+    Guards the wiring: the build must call ``volume_mounts.py`` under
+    ``set -o pipefail`` (so a parse failure aborts the build) rather than
+    re-hardcoding the list or silently skipping preparation.
     """
     text = _find_dockerfile(dockerfile_name).read_text(encoding="utf-8")
 
+    assert "set -o pipefail" in text
     assert "docker/utils/volume_mounts.py" in text
     assert "chown -R isaaclab:isaaclab ${dirs}" in text
-    assert 'test -n "${dirs}"' in text

--- a/docker/utils/volume_mounts.py
+++ b/docker/utils/volume_mounts.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Resolve the named-volume mount points declared in ``docker-compose.yaml``.
+
+``docker-compose.yaml`` is the single source of truth for the directories that
+persist across containers. The non-root image build calls this module to
+pre-create and ``chown`` each named-volume mount point to the runtime user, and
+the regression test calls it to validate that parsing works. Keeping one parser
+avoids a hand-maintained second list in the Dockerfiles drifting from compose.
+
+A fresh Docker named volume inherits ownership from the image directory at its
+mount path on first mount; if that directory is missing or root-owned, the
+volume comes up root-owned and the non-root ``isaaclab`` user cannot write it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+# docker-compose.yaml lives one level up from this ``docker/utils`` package.
+DEFAULT_COMPOSE = Path(__file__).resolve().parents[1] / "docker-compose.yaml"
+
+# Top-level compose extension field holding the shared volume list.
+_VOLUMES_KEY = "x-default-isaac-lab-volumes"
+
+
+def named_volume_targets(compose_path: str | os.PathLike = DEFAULT_COMPOSE) -> list[str]:
+    """Return the in-container target path of every ``type: volume`` mount.
+
+    Args:
+        compose_path: Path to the compose file to read.
+
+    Returns:
+        The target paths, with any ``${VAR}`` references left intact.
+    """
+    data = yaml.safe_load(Path(compose_path).read_text(encoding="utf-8"))
+    mounts = data.get(_VOLUMES_KEY) or []
+    return [m["target"] for m in mounts if m.get("type") == "volume"]
+
+
+def resolved_targets(compose_path: str | os.PathLike = DEFAULT_COMPOSE) -> list[str]:
+    """Like :func:`named_volume_targets` but with ``${VAR}`` expanded from the environment."""
+    return [os.path.expandvars(t).rstrip("/") for t in named_volume_targets(compose_path)]
+
+
+def main() -> int:
+    """Print one resolved mount point per line; fail loudly on an empty or unresolved list."""
+    targets = resolved_targets()
+    unresolved = [t for t in targets if "$" in t]
+    if unresolved:
+        print(f"unresolved variables in volume targets: {unresolved}", file=sys.stderr)
+        return 1
+    if not targets:
+        print(f"no named-volume targets found under '{_VOLUMES_KEY}' in docker-compose.yaml", file=sys.stderr)
+        return 1
+    print("\n".join(targets))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Cherry-pick of #6082 onto `release/3.0.0-beta2`. Net diff is identical to the develop-side PR; applies cleanly with no conflicts.
- Fixes training regressions in the non-root Docker images (base + cuRobo): `skrl` training aborts with `PermissionError` creating `logs/`, and Isaac Sim emits `omni.datastore` lock failures under `kit/cache` (tripping the CI training-log blacklist).
- Root cause: a fresh Docker named volume inherits ownership from the image directory at its mount path; the non-root `isaaclab` user (uid/gid 1000) cannot write mount points the image left missing or root-owned.
- Pre-creates and `chown`s every named-volume mount point before the `USER` switch, driven by a single source of truth — `docker-compose.yaml`, parsed by `docker/utils/volume_mounts.py` — so the list is never duplicated in the Dockerfiles.

## 1. Background

#5618 switched the base / ROS 2 / cuRobo images to `USER isaaclab` (uid/gid 1000) so bind-mounted workspaces stay writable for the host/runner user. That change covered the `${DOCKER_USER_HOME}` mount points (swept by the recursive `chown`), but not the named volumes that mount outside the runtime home.

## 2. Mechanism

When an empty named volume is mounted for the first time, Docker (the root daemon) seeds the volume's ownership from the image directory at that path. If that directory is missing or root-owned in the image, the volume comes up `root:root` and the uid-1000 runtime user is denied. The home-based volumes already inherited the right owner; the ones under `/isaac-sim` and `/workspace/isaaclab` did not (`kit/cache` was created root-owned by a build `mkdir`; `logs` / `data_storage` / `docs/_build` did not exist in the image at all).

## 3. Fix

3.1 `docker/utils/volume_mounts.py` — parses the `type: volume` targets out of `docker-compose.yaml` (the single source of truth) and resolves the `${VAR}` paths. Reuses PyYAML, already an IsaacLab dependency.

3.2 `Dockerfile.base` / `Dockerfile.curobo` — before `USER isaaclab`, invoke the parser and `mkdir -p` + `chown -R isaaclab:isaaclab` every mount point, so fresh volumes inherit `isaaclab` ownership. `set -o pipefail` plus a non-empty guard abort the build if the parse yields nothing, rather than silently shipping an unprepared mount point. The ROS 2 image builds `FROM` base and inherits the fix.

3.3 Adding a volume to `docker-compose.yaml` is now prepared automatically — no second list to keep in sync.

## 4. Test

`docker/test/test_dockerfile_nonroot.py` unit-tests the parser (asserting it returns the mount points that triggered the regression) and asserts each non-root Dockerfile wires the parser in with the guard. Static, no image build required.

## 5. Validation

- Static tests pass (`13 passed`); the parser test fails if compose drops a tracked volume.
- Verified on a freshly built base image: all named-volume mount points come up `uid 1000`, and the exact QA training (`skrl` Anymal-C) runs to completion with no `PermissionError` and zero `omni.datastore` lock failures.

## 6. Notes

- No changelog fragment: `docker/` is not under `source/<pkg>` (matches #5618).
- cuRobo has no compose file today, but it creates `kit/cache` as root and runs Isaac Sim non-root, so its cache is unwritable even without a volume mount; the same step fixes it.
