### PR TITLE
Adds note about binary sim + virtual env and surface gripper envs

### DIFF
--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -187,7 +187,7 @@ for the lift-cube environment:
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+------------------------------+
     | |surface-gripper|       | |long-suction-link|          | Stack three cubes (bottom to top: blue, red, green)                         |                              |
     |                         |                              | with the UR10 arm and long surface gripper                                  |                              |
-    |                         | |short-suction-link|         | or short surface gripper.                                                   |                              |
+    |                         | |short-suction-link|         | or short surface gripper (cpu only).                                        |                              |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+------------------------------+
     | |cabi-franka|           | |cabi-franka-link|           | Grasp the handle of a cabinet's drawer and open it with the Franka robot    | **physics=** ``physx``,      |
     |                         |                              |                                                                             | ``newton_mjwarp``            |

--- a/docs/source/setup/installation/binaries_installation.rst
+++ b/docs/source/setup/installation/binaries_installation.rst
@@ -5,6 +5,15 @@ Installation using Isaac Sim Pre-built Binaries
 
 The following steps first installs Isaac Sim from its pre-built binaries, then Isaac Lab from source code.
 
+.. caution::
+
+   Combining an Isaac Sim **binary** installation with a conda, uv, or venv virtual environment
+   is **no longer supported**. Use Isaac Sim's bundled Python via ``./isaaclab.sh -p`` (or
+   ``isaaclab.bat -p`` on Windows) instead.
+
+   If you need a dedicated virtual environment, install Isaac Sim via pip and follow the
+   :doc:`pip_installation` guide.
+
 Installing Isaac Sim
 --------------------
 

--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -152,6 +152,8 @@ Use this table to decide:
 +---------------------+------------------------------+------------------------------+-------------------------------+------------+
 | Binary + Source     | |:inbox_tray:| binary        | |:floppy_disk:| source (git) | Users preferring binary       | Easy       |
 |                     | download                     |                              | install of Isaac Sim          |            |
+|                     |                              |                              | *(conda/uv/venv unsupported;  |            |
+|                     |                              |                              | use bundled Python or pip)*   |            |
 +---------------------+------------------------------+------------------------------+-------------------------------+------------+
 | Full Source Build   | |:floppy_disk:| source (git) | |:floppy_disk:| source (git) | Developers modifying both     | Advanced   |
 +---------------------+------------------------------+------------------------------+-------------------------------+------------+


### PR DESCRIPTION
# Description

Updates documentation highlighting dropped support of binary installed Isaac Sim in virtual environments.
Also highlights that surface gripper environments require CPU.

## Type of change

- Documentation update


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
