### PR TITLE
Fix daily compatibility result reporting

### DIFF
--- a/.github/actions/test_workflow_local_actions.py
+++ b/.github/actions/test_workflow_local_actions.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for local action references in GitHub workflows."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+_LOCAL_ACTION_RE = re.compile(r"^\s*uses:\s*[\"']?(?P<path>\./\.github/actions/[^\"'\s#]+)", re.MULTILINE)
+
+
+def test_workflow_local_action_references_have_action_metadata():
+    missing_actions = []
+
+    for workflow_path in sorted(_WORKFLOWS_DIR.glob("*.y*ml")):
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        for match in _LOCAL_ACTION_RE.finditer(workflow_text):
+            action_path = _REPO_ROOT / match.group("path")
+            if not (action_path / "action.yml").is_file() and not (action_path / "action.yaml").is_file():
+                missing_actions.append(f"{workflow_path.relative_to(_REPO_ROOT)} -> {match.group('path')}")
+
+    assert not missing_actions, "Missing local GitHub action metadata:\n" + "\n".join(missing_actions)

--- a/.github/workflows/daily-compatibility.yml
+++ b/.github/workflows/daily-compatibility.yml
@@ -188,19 +188,12 @@ jobs:
         compression-level: 9
 
   combine-compat-results:
+    name: Report Compatibility Results
     needs: [test-isaaclab-tasks-compat, test-general-compat]
     runs-on: ubuntu-latest
     if: always()
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 1
-        lfs: false
-        sparse-checkout: .github/actions
-        sparse-checkout-cone-mode: true
-
     - name: Create Reports Directory
       run: |
         mkdir -p reports
@@ -213,18 +206,13 @@ jobs:
         merge-multiple: true
       continue-on-error: true
 
-    - name: Combine All Test Results
-      uses: ./.github/actions/combine-results
-      with:
-        tests-dir: "reports"
-        output-file: "reports/combined-compat-results.xml"
-
-    - name: Upload Combined Test Results
+    - name: Upload Test Results
       uses: actions/upload-artifact@v7
       if: always()
       with:
-        name: daily-compat-${{ github.run_id }}-combined-test-results
-        path: reports/combined-compat-results.xml
+        name: daily-compat-${{ github.run_id }}-test-results
+        path: reports/**/*.xml
+        if-no-files-found: warn
         retention-days: 30
         compression-level: 9
 
@@ -233,7 +221,7 @@ jobs:
       if: always()
       with:
         name: IsaacLab Compatibility Test Results (${{ github.event_name }})
-        path: reports/combined-compat-results.xml
+        path: reports/**/*.xml
         reporter: java-junit
         max-annotations: '50'
         report-title: "IsaacLab Compatibility Test Results - ${{ github.event_name }} - ${{ github.ref_name }}"
@@ -244,14 +232,6 @@ jobs:
     if: always()
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 1
-        lfs: false
-        sparse-checkout: .github/actions
-        sparse-checkout-cone-mode: true
-
     - name: Create Compatibility Report
       run: |
         TRIGGER_INFO="**Trigger:** ${{ github.event_name }}"
@@ -268,7 +248,7 @@ jobs:
         echo "- Results: ${{ needs.combine-compat-results.result }}" >> compatibility-report.md
         echo "" >> compatibility-report.md
         echo "### Artifacts:" >> compatibility-report.md
-        echo "- [Combined Test Results](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> compatibility-report.md
+        echo "- [Test Results](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> compatibility-report.md
         echo "" >> compatibility-report.md
         echo "---" >> compatibility-report.md
         echo "*This report was generated automatically by the daily compatibility workflow.*" >> compatibility-report.md


### PR DESCRIPTION
## Summary
- Removed the stale daily compatibility workflow call to the deleted local `combine-results` action.
- Report and upload the downloaded compatibility JUnit XML files directly with wildcard paths.
- Added a static workflow test that catches missing local action metadata before runtime.

## Test Plan
- `./isaaclab.sh -p -m pytest .github/actions/test_workflow_local_actions.py .github/actions/run-package-tests/test_cleanup_docker_storage.py`
- `PATH=/tmp/git-lfs-codex/git-lfs-3.7.1:$PATH ./isaaclab.sh -f`
- `git diff --check HEAD~1..HEAD`