### PR TITLE
docs: headless doc cleanup

### DIFF
--- a/docs/source/features/hydra.rst
+++ b/docs/source/features/hydra.rst
@@ -48,8 +48,8 @@ As a result, training with hydra arguments can be run with the following syntax:
 
             ./isaaclab.sh train --rl_library sb3 --task=Isaac-Cartpole env.actions.joint_effort.scale=10.0 agent.seed=2024
 
-The above command will run training with the task ``Isaac-Cartpole`` in headless mode, and set the
-``env.actions.joint_effort.scale`` parameter to 10.0 and the ``agent.seed`` parameter to 2024.
+The above command will run training with the task ``Isaac-Cartpole`` without selecting a visualizer,
+and set the ``env.actions.joint_effort.scale`` parameter to 10.0 and the ``agent.seed`` parameter to 2024.
 
 .. note::
 

--- a/docs/source/how-to/save_camera_output.rst
+++ b/docs/source/how-to/save_camera_output.rst
@@ -94,7 +94,7 @@ To run the accompanying script, execute the following command:
    # Usage with saving and drawing
    python scripts/tutorials/04_sensors/run_usd_camera.py --save --draw --enable_cameras
 
-   # Usage with saving only in headless mode
+   # Usage with saving only (no visualizer)
    python scripts/tutorials/04_sensors/run_usd_camera.py --save --enable_cameras
 
 

--- a/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
@@ -110,7 +110,7 @@ syntax as the other backends:
 
 .. code-block:: bash
 
-    ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Cartpole-Direct --num_envs 128 presets=ovphysx
+    ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Cartpole-Direct --num_envs 128 --viz none presets=ovphysx
 
 This command starts a headless zero-action rollout; stop it with ``Ctrl+C``
 after the environment has started and stepped successfully.

--- a/scripts/tutorials/04_sensors/run_usd_camera.py
+++ b/scripts/tutorials/04_sensors/run_usd_camera.py
@@ -14,8 +14,8 @@ the simulator or OpenGL convention for the camera, we use the robotics or ROS co
     # Usage with GUI
     ./isaaclab.sh -p scripts/tutorials/04_sensors/run_usd_camera.py --enable_cameras --viz kit
 
-    # Usage with headless
-    ./isaaclab.sh -p scripts/tutorials/04_sensors/run_usd_camera.py --headless --enable_cameras
+    # Usage with no visualizer
+    ./isaaclab.sh -p scripts/tutorials/04_sensors/run_usd_camera.py --enable_cameras
 
 """
 


### PR DESCRIPTION
# Description

Follow-up to merged PR #6102. This addresses review comments that landed after the original documentation cleanup was merged:

- Removes dangling trailing backslashes from three Hover policy shell snippets.
- Rewords stale `headless mode` prose in the Hydra docs to say the command runs without selecting a visualizer.
- Rewords the OVPhysX zero-agent rollout prose to avoid implying `--headless` is required.
- Rewords the camera-output example comment from `headless mode` to `no visualizer`.

No new dependencies.

Fixes # N/A

## Type of change

- Documentation update

## Screenshots

N/A.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (docs build not run separately)
- [x] I have added tests that prove my fix is effective or that my feature works (N/A, documentation-only)
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (N/A, no package source touched)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there