### PR TITLE
Document AgiBot keyboard/SpaceMouse teleop environments

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -491,6 +491,14 @@ follows.
    * - ``Isaac-Stack-Cube-Galbot-Left-Arm-Gripper-Visuomotor-v0``
      - Keyboard, SpaceMouse
      - Same as left-arm gripper above with camera observations.
+   * - ``Isaac-Place-Mug-Agibot-Left-Arm-RmpFlow-v0``
+     - Keyboard, SpaceMouse
+     - **Arm:** left-arm end-effector pose via RMPFlow.
+       **Gripper:** ``K`` on keyboard, left button on SpaceMouse.
+   * - ``Isaac-Place-Toy2Box-Agibot-Right-Arm-RmpFlow-v0``
+     - Keyboard, SpaceMouse
+     - **Arm:** right-arm end-effector pose via RMPFlow.
+       **Gripper:** ``K`` on keyboard, left button on SpaceMouse.
    * - ``Isaac-Stack-Cube-UR10-Long-Suction-IK-Rel-v0``
      - Keyboard, SpaceMouse
      - **Arm:** relative IK end-effector control.


### PR DESCRIPTION
# Description

Adds the two AgiBot place tasks to the **Keyboard and SpaceMouse Environments**
reference table in `docs/source/features/isaac_teleop.rst`:
- `Isaac-Place-Mug-Agibot-Left-Arm-RmpFlow-v0`
- `Isaac-Place-Toy2Box-Agibot-Right-Arm-RmpFlow-v0`
Both environments expose `teleop_devices` (keyboard, SpaceMouse) and use RMPFlow
arm control with a binary gripper, but were absent from the table even though
their Galbot/UR10 peers are listed. They use the legacy `isaaclab.devices` stack,
so they belong

Fixes # (issue)

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there