### PR TITLE
Fix Newton visualization ClonePlan handling

### DIFF
--- a/source/isaaclab_newton/changelog.d/fix-newton-visualization-cloneplan.rst
+++ b/source/isaaclab_newton/changelog.d/fix-newton-visualization-cloneplan.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the Newton shadow visualization model to honor ClonePlan source
+  selection for heterogeneous cloned scenes.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1659,15 +1659,274 @@ class NewtonManager(PhysicsManager):
             NewtonManager._model = None
             NewtonManager._state_0 = None
 
+    _VISUALIZATION_LABEL_ATTRS = ("body_label", "articulation_label", "joint_label", "shape_label")
+
+    @staticmethod
+    def _visualization_world_transform(stage, xform_cache, path: str) -> wp.transform | None:
+        prim = stage.GetPrimAtPath(path)
+        if not prim or not prim.IsValid():
+            return None
+
+        world_gf = xform_cache.GetLocalToWorldTransform(prim)
+        translation = world_gf.ExtractTranslation()
+        rotation = world_gf.ExtractRotationQuat()
+        return wp.transform(
+            (translation[0], translation[1], translation[2]),
+            # Warp quaternions use xyzw layout; USD exposes real + imaginary accessors.
+            (
+                rotation.GetImaginary()[0],
+                rotation.GetImaginary()[1],
+                rotation.GetImaginary()[2],
+                rotation.GetReal(),
+            ),
+        )
+
+    @classmethod
+    def _visualization_relative_transform(
+        cls, stage, xform_cache, source_path: str, destination_path: str
+    ) -> wp.transform | None:
+        source_tf = cls._visualization_world_transform(stage, xform_cache, source_path)
+        destination_tf = cls._visualization_world_transform(stage, xform_cache, destination_path)
+        if source_tf is None or destination_tf is None:
+            return None
+        return wp.transform_multiply(destination_tf, wp.transform_inverse(source_tf))
+
+    @classmethod
+    def _visualization_destination_for_env(
+        cls, stage, xform_cache, destination_template: str, env_id: int, env_path: str
+    ) -> str:
+        """Return the best-effort ClonePlan destination path for an env.
+
+        The returned path may not exist; callers must validate it before using
+        it for transforms.
+        """
+        destination_root = destination_template.format(env_id)
+        if cls._visualization_world_transform(stage, xform_cache, destination_root) is not None:
+            return destination_root
+
+        env_name = env_path.rsplit("/", 1)[-1]
+        if env_name != str(env_id):
+            named_destination_root = destination_template.format(env_name)
+            if cls._visualization_world_transform(stage, xform_cache, named_destination_root) is not None:
+                return named_destination_root
+
+        return destination_root
+
+    @staticmethod
+    def _rewrite_visualization_label_prefix(label: str, source_root: str, destination_root: str) -> str:
+        stripped_source = source_root.rstrip("/")
+        stripped_destination = destination_root.rstrip("/")
+        if label in (source_root, stripped_source):
+            return stripped_destination
+        prefix = stripped_source + "/"
+        if label.startswith(prefix):
+            return stripped_destination + label[len(stripped_source) :]
+        return label
+
+    @classmethod
+    def _rewrite_visualization_labels(
+        cls, builder: ModelBuilder, label_starts: dict[str, int], source_root: str, destination_root: str
+    ) -> None:
+        for attr in cls._VISUALIZATION_LABEL_ATTRS:
+            labels = getattr(builder, attr)
+            for i in range(label_starts[attr], len(labels)):
+                labels[i] = cls._rewrite_visualization_label_prefix(labels[i], source_root, destination_root)
+
+    @staticmethod
+    def _visualization_builder_has_geometry(builder: ModelBuilder) -> bool:
+        return (
+            builder.body_count > 0 or builder.shape_count > 0 or builder.joint_count > 0 or builder.particle_count > 0
+        )
+
+    @staticmethod
+    def _clone_plan_selects_visualization_source(clone_mask, source_index: int, env_id: int) -> bool:
+        if len(clone_mask.shape) != 2:
+            logger.warning(
+                "[NewtonManager] ClonePlan clone_mask must be 2D for visualization, got shape %s.",
+                tuple(clone_mask.shape),
+            )
+            return False
+        if source_index >= clone_mask.shape[0]:
+            logger.warning(
+                "[NewtonManager] ClonePlan source index %d exceeds clone_mask row count %d; "
+                "skipping it in visualization.",
+                source_index,
+                clone_mask.shape[0],
+            )
+            return False
+        if env_id >= clone_mask.shape[1]:
+            logger.warning(
+                "[NewtonManager] ClonePlan env id %d exceeds clone_mask column count %d; skipping it in visualization.",
+                env_id,
+                clone_mask.shape[1],
+            )
+            return False
+        return bool(clone_mask[source_index, env_id].item())
+
+    @classmethod
+    def _add_clone_plan_visualization_worlds(
+        cls,
+        stage,
+        builder: ModelBuilder,
+        up_axis: Axis,
+        schema_resolvers: list[object],
+        env_paths: list[tuple[int, str]],
+        clone_plan,
+        xform_cache,
+    ) -> None:
+        source_builders: dict[str, ModelBuilder | None] = {}
+        clone_mask = clone_plan.clone_mask
+
+        for env_id, env_path in env_paths:
+            builder.begin_world()
+            added_any = False
+            for source_index, (source_root, destination_template) in enumerate(
+                zip(clone_plan.sources, clone_plan.destinations, strict=True)
+            ):
+                if "{}" not in destination_template:
+                    continue
+                if not cls._clone_plan_selects_visualization_source(clone_mask, source_index, env_id):
+                    continue
+
+                destination_root = cls._visualization_destination_for_env(
+                    stage, xform_cache, destination_template, env_id, env_path
+                )
+                asset_builder = cls._get_clone_plan_visualization_source_builder(
+                    stage, up_axis, schema_resolvers, source_builders, source_root, xform_cache
+                )
+                if asset_builder is None or not cls._visualization_builder_has_geometry(asset_builder):
+                    continue
+
+                relative_tf = cls._visualization_relative_transform(stage, xform_cache, source_root, destination_root)
+                if relative_tf is None:
+                    logger.warning(
+                        "[NewtonManager] ClonePlan destination prim %s is missing; skipping %s in visualization.",
+                        destination_root,
+                        source_root,
+                    )
+                    continue
+
+                label_starts = {attr: len(getattr(builder, attr)) for attr in cls._VISUALIZATION_LABEL_ATTRS}
+                builder.add_builder(asset_builder, xform=relative_tf)
+                cls._rewrite_visualization_labels(builder, label_starts, source_root, destination_root)
+                added_any = True
+
+            if not added_any:
+                logger.debug(
+                    "[NewtonManager] ClonePlan added no geometry for %s; falling back to direct env import.",
+                    env_path,
+                )
+                builder.add_usd(
+                    stage,
+                    root_path=env_path,
+                    schema_resolvers=schema_resolvers,
+                )
+            builder.end_world()
+
+    @classmethod
+    def _get_clone_plan_visualization_source_builder(
+        cls,
+        stage,
+        up_axis: Axis,
+        schema_resolvers: list[object],
+        source_builders: dict[str, ModelBuilder | None],
+        source_root: str,
+        xform_cache,
+    ) -> ModelBuilder | None:
+        if source_root in source_builders:
+            return source_builders[source_root]
+
+        if cls._visualization_world_transform(stage, xform_cache, source_root) is None:
+            logger.warning(
+                "[NewtonManager] ClonePlan source prim %s is missing; skipping it in visualization.",
+                source_root,
+            )
+            source_builders[source_root] = None
+        else:
+            source_builder = ModelBuilder(up_axis=up_axis)
+            source_builder.add_usd(
+                stage,
+                root_path=source_root,
+                schema_resolvers=schema_resolvers,
+            )
+            source_builders[source_root] = source_builder
+
+        return source_builders[source_root]
+
+    @classmethod
+    def _add_env0_prototype_visualization_worlds(
+        cls,
+        stage,
+        builder: ModelBuilder,
+        up_axis: Axis,
+        schema_resolvers: list[object],
+        env_paths: list[tuple[int, str]],
+        xform_cache,
+    ) -> None:
+        # Build env_0 as a prototype, then replicate across envs.
+        proto_env_path = env_paths[0][1]
+        proto = ModelBuilder(up_axis=up_axis)
+        proto.add_usd(
+            stage,
+            root_path=proto_env_path,
+            schema_resolvers=schema_resolvers,
+        )
+
+        # ``add_builder`` copies the prototype's ``body_label`` (and sibling label arrays)
+        # verbatim into each replicated world, so all worlds end up with prim paths under
+        # the prototype env (e.g. ``/World/envs/env_0/...``). The visualization sync uses
+        # these labels to map PhysX transforms (which carry distinct per-env paths) into
+        # ``state.body_q``; without rewriting, ``paths.index()`` resolves every match to
+        # world 0 and worlds 1..N never receive fresh poses. Rewrite the newly-added
+        # labels after each ``add_builder`` so each world references its own env prim path.
+        label_starts = {attr: len(getattr(builder, attr)) for attr in cls._VISUALIZATION_LABEL_ATTRS}
+
+        # ``proto.add_usd`` ingests env_0's bodies at their absolute world positions
+        # (``UsdPhysics.LoadUsdPhysicsFromRange`` reports world-space transforms), so
+        # ``proto.body_q`` already encodes env_0's world transform. ``add_builder``
+        # composes its ``xform`` onto every imported body, so passing each env's
+        # absolute world transform here would double the offset; the correct xform is
+        # the env's pose relative to the prototype (identity for env_0, env_X * env_0^-1
+        # for the rest). Dynamic bodies are overwritten in ``update_visualization_state``
+        # via the PhysX sync, but static bodies (e.g. the table) keep this initial pose
+        # and render at the wrong position when env_0 is not at the world origin.
+        proto_world_tf = cls._visualization_world_transform(stage, xform_cache, proto_env_path)
+        if proto_world_tf is None:
+            logger.warning(
+                "[NewtonManager] Prototype env prim %s is missing; skipping visualization world replication.",
+                proto_env_path,
+            )
+            return
+        proto_world_tf_inv = wp.transform_inverse(proto_world_tf)
+
+        for _, env_path in env_paths:
+            env_world_tf = cls._visualization_world_transform(stage, xform_cache, env_path)
+            if env_world_tf is None:
+                logger.warning(
+                    "[NewtonManager] Env prim %s is missing; skipping it in visualization.",
+                    env_path,
+                )
+                continue
+
+            relative_tf = wp.transform_multiply(env_world_tf, proto_world_tf_inv)
+            builder.begin_world()
+            builder.add_builder(proto, xform=relative_tf)
+            if env_path != proto_env_path:
+                cls._rewrite_visualization_labels(builder, label_starts, proto_env_path, env_path)
+            for attr in cls._VISUALIZATION_LABEL_ATTRS:
+                label_starts[attr] = len(getattr(builder, attr))
+            builder.end_world()
+
     @classmethod
     def _build_visualization_model_from_stage(cls, stage) -> ModelBuilder | None:
         """Build a fresh Newton ``ModelBuilder`` from the USD stage for visualization.
 
         Walks IsaacLab's ``/World/envs/env_<id>`` convention and adds each env as
-        its own Newton world. When the env subtree is identical across envs (the
-        common cloned-scene case) a single env_0 prototype is built once and
-        replicated via :meth:`ModelBuilder.add_builder`; otherwise each env is
-        ingested independently with :meth:`ModelBuilder.add_usd`.
+        its own Newton world. When a ClonePlan is available, each world is
+        assembled from the selected planned source rows so heterogeneous cloned
+        assets render with the same source choices as PhysX. Without a ClonePlan,
+        a single env_0 prototype is built once and replicated via
+        :meth:`ModelBuilder.add_builder`.
 
         This routine is intentionally independent of
         :meth:`instantiate_builder_from_stage` (which targets the live-sim path
@@ -1723,75 +1982,39 @@ class NewtonManager(PhysicsManager):
             schema_resolvers=schema_resolvers,
         )
 
-        # Build env_0 as a prototype, then replicate across envs.
-        proto_env_path = env_paths[0][1]
-        proto = ModelBuilder(up_axis=up_axis)
-        proto.add_usd(
-            stage,
-            root_path=proto_env_path,
-            schema_resolvers=schema_resolvers,
-        )
-
         xform_cache = UsdGeom.XformCache()
+        clone_plan = None
+        try:
+            from isaaclab.sim import SimulationContext
 
-        # ``add_builder`` copies the prototype's ``body_label`` (and sibling label arrays)
-        # verbatim into each replicated world, so all worlds end up with prim paths under
-        # the prototype env (e.g. ``/World/envs/env_0/...``). The visualization sync uses
-        # these labels to map PhysX transforms (which carry distinct per-env paths) into
-        # ``state.body_q``; without rewriting, ``paths.index()`` resolves every match to
-        # world 0 and worlds 1..N never receive fresh poses. Rewrite the newly-added
-        # labels after each ``add_builder`` so each world references its own env prim path.
-        label_attrs = ("body_label", "articulation_label", "joint_label", "shape_label")
-        label_starts = {attr: len(getattr(builder, attr)) for attr in label_attrs}
-
-        # ``proto.add_usd`` ingests env_0's bodies at their absolute world positions
-        # (``UsdPhysics.LoadUsdPhysicsFromRange`` reports world-space transforms), so
-        # ``proto.body_q`` already encodes env_0's world transform. ``add_builder``
-        # composes its ``xform`` onto every imported body, so passing each env's
-        # absolute world transform here would double the offset; the correct xform is
-        # the env's pose relative to the prototype (identity for env_0, env_X * env_0^-1
-        # for the rest). Dynamic bodies are overwritten in ``update_visualization_state``
-        # via the PhysX sync, but static bodies (e.g. the table) keep this initial pose
-        # and render at the wrong position when env_0 is not at the world origin.
-        proto_world_gf = xform_cache.GetLocalToWorldTransform(stage.GetPrimAtPath(proto_env_path))
-        proto_translation = proto_world_gf.ExtractTranslation()
-        proto_rotation = proto_world_gf.ExtractRotationQuat()
-        proto_world_tf = wp.transform(
-            (proto_translation[0], proto_translation[1], proto_translation[2]),
-            (
-                proto_rotation.GetImaginary()[0],
-                proto_rotation.GetImaginary()[1],
-                proto_rotation.GetImaginary()[2],
-                proto_rotation.GetReal(),
-            ),
-        )
-        proto_world_tf_inv = wp.transform_inverse(proto_world_tf)
-
-        for _, env_path in env_paths:
-            world_xform = xform_cache.GetLocalToWorldTransform(stage.GetPrimAtPath(env_path))
-            translation = world_xform.ExtractTranslation()
-            rotation = world_xform.ExtractRotationQuat()
-            env_world_tf = wp.transform(
-                (translation[0], translation[1], translation[2]),
-                (
-                    rotation.GetImaginary()[0],
-                    rotation.GetImaginary()[1],
-                    rotation.GetImaginary()[2],
-                    rotation.GetReal(),
-                ),
+            sim = SimulationContext.instance()
+            clone_plan = sim.get_clone_plan() if sim is not None else None
+        except (ImportError, AttributeError):
+            logger.debug(
+                "[NewtonManager] ClonePlan unavailable for visualization; falling back to env_0 prototype.",
+                exc_info=True,
             )
-            relative_tf = wp.transform_multiply(env_world_tf, proto_world_tf_inv)
-            builder.begin_world()
-            builder.add_builder(proto, xform=relative_tf)
-            if env_path != proto_env_path:
-                for attr in label_attrs:
-                    labels = getattr(builder, attr)
-                    for i in range(label_starts[attr], len(labels)):
-                        labels[i] = labels[i].replace(proto_env_path, env_path, 1)
-            for attr in label_attrs:
-                label_starts[attr] = len(getattr(builder, attr))
-            builder.end_world()
 
+        if clone_plan is not None:
+            cls._add_clone_plan_visualization_worlds(
+                stage,
+                builder,
+                up_axis,
+                schema_resolvers,
+                env_paths,
+                clone_plan,
+                xform_cache,
+            )
+            return builder
+
+        cls._add_env0_prototype_visualization_worlds(
+            stage,
+            builder,
+            up_axis,
+            schema_resolvers,
+            env_paths,
+            xform_cache,
+        )
         return builder
 
     @classmethod

--- a/source/isaaclab_newton/test/physics/test_newton_visualization_clone_plan.py
+++ b/source/isaaclab_newton/test/physics/test_newton_visualization_clone_plan.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression tests for ClonePlan-aware Newton visualization model assembly."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from isaaclab_newton.physics import newton_manager as newton_manager_module
+from isaaclab_newton.physics.newton_manager import NewtonManager
+
+from pxr import Usd, UsdGeom
+
+from isaaclab.cloner import ClonePlan
+from isaaclab.sim import SimulationContext
+
+_LABEL_ATTRS = ("body_label", "articulation_label", "joint_label", "shape_label")
+_LABEL_SUFFIXES = {
+    "body_label": "Body",
+    "articulation_label": "Articulation",
+    "joint_label": "Joint",
+    "shape_label": "Shape",
+}
+
+
+class _FakeModelBuilder:
+    """Small ``ModelBuilder`` substitute that records source copies and rewritten labels."""
+
+    instances: list["_FakeModelBuilder"] = []
+
+    def __init__(self, up_axis=None):
+        self.up_axis = up_axis
+        self.body_label: list[str] = []
+        self.articulation_label: list[str] = []
+        self.joint_label: list[str] = []
+        self.shape_label: list[str] = []
+        self.geometry_sources: list[str] = []
+        self.add_usd_roots: list[str | None] = []
+        self.world_slices: list[list[tuple[int, int, int, int]]] = []
+        self._current_world: int | None = None
+        self.instances.append(self)
+
+    @property
+    def body_count(self) -> int:
+        return len(self.body_label)
+
+    @property
+    def shape_count(self) -> int:
+        return len(self.shape_label)
+
+    @property
+    def joint_count(self) -> int:
+        return len(self.joint_label)
+
+    @property
+    def particle_count(self) -> int:
+        return 0
+
+    def begin_world(self) -> None:
+        self._current_world = len(self.world_slices)
+        self.world_slices.append([])
+
+    def end_world(self) -> None:
+        self._current_world = None
+
+    def add_usd(self, stage, root_path=None, ignore_paths=None, schema_resolvers=None) -> None:
+        del stage, ignore_paths, schema_resolvers
+        self.add_usd_roots.append(root_path)
+        if root_path is None:
+            return
+
+        label_start = len(self.body_label)
+        geometry_start = len(self.geometry_sources)
+        for attr in _LABEL_ATTRS:
+            getattr(self, attr).append(f"{root_path}/{_LABEL_SUFFIXES[attr]}")
+        self.geometry_sources.append(root_path)
+        self._record_world_slice(label_start, len(self.body_label), geometry_start, len(self.geometry_sources))
+
+    def add_builder(self, builder: "_FakeModelBuilder", xform=None) -> None:
+        del xform
+        label_start = len(self.body_label)
+        geometry_start = len(self.geometry_sources)
+        for attr in _LABEL_ATTRS:
+            getattr(self, attr).extend(getattr(builder, attr))
+        self.geometry_sources.extend(builder.geometry_sources)
+        self._record_world_slice(label_start, len(self.body_label), geometry_start, len(self.geometry_sources))
+
+    def labels_for_world(self, world_id: int, attr: str) -> list[str]:
+        labels = getattr(self, attr)
+        return [
+            label
+            for label_start, label_end, _, _ in self.world_slices[world_id]
+            for label in labels[label_start:label_end]
+        ]
+
+    def geometry_sources_for_world(self, world_id: int) -> list[str]:
+        return [
+            source
+            for _, _, geometry_start, geometry_end in self.world_slices[world_id]
+            for source in self.geometry_sources[geometry_start:geometry_end]
+        ]
+
+    def _record_world_slice(self, label_start: int, label_end: int, geometry_start: int, geometry_end: int) -> None:
+        if self._current_world is not None:
+            self.world_slices[self._current_world].append((label_start, label_end, geometry_start, geometry_end))
+
+
+def _define_xform(stage: Usd.Stage, path: str, translation: tuple[float, float, float] | None = None) -> None:
+    xform = UsdGeom.Xform.Define(stage, path)
+    if translation is not None:
+        xform.AddTranslateOp().Set(translation)
+
+
+@pytest.fixture
+def clone_plan_visualization_stage() -> Usd.Stage:
+    stage = Usd.Stage.CreateInMemory()
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+    _define_xform(stage, "/World")
+    _define_xform(stage, "/World/envs")
+
+    for env_id in range(3):
+        _define_xform(stage, f"/World/envs/env_{env_id}", (float(env_id) * 3.0, 0.0, 0.0))
+        _define_xform(stage, f"/World/envs/env_{env_id}/Object")
+
+    _define_xform(stage, "/World/envs/env_0/Object/source_0_visual")
+    _define_xform(stage, "/World/envs/env_1/Object/source_1_visual")
+    assert not stage.GetPrimAtPath("/World/envs/env_2/Object/source_0_visual").IsValid()
+    return stage
+
+
+def _build_with_clone_plan(stage: Usd.Stage, clone_plan: ClonePlan, monkeypatch: pytest.MonkeyPatch):
+    _FakeModelBuilder.instances = []
+    monkeypatch.setattr(newton_manager_module, "ModelBuilder", _FakeModelBuilder)
+    monkeypatch.setattr(newton_manager_module, "SchemaResolverNewton", lambda: object())
+    monkeypatch.setattr(newton_manager_module, "SchemaResolverPhysx", lambda: object())
+    monkeypatch.setattr(
+        SimulationContext,
+        "instance",
+        staticmethod(lambda: SimpleNamespace(get_clone_plan=lambda: clone_plan)),
+    )
+    monkeypatch.setattr(NewtonManager, "_num_envs", None)
+    return NewtonManager._build_visualization_model_from_stage(stage)
+
+
+def test_visualization_builder_uses_clone_plan_sources_and_rewrites_destination_labels(
+    clone_plan_visualization_stage: Usd.Stage,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The PhysX-backed shadow model must mirror heterogeneous ClonePlan choices.
+
+    Env 2 intentionally has no destination child geometry. The visualization
+    model should still copy source env 0's geometry for env 2 while rewriting
+    copied labels to env 2 paths so scene-data pose sync can find them.
+    """
+    clone_plan = ClonePlan(
+        sources=("/World/envs/env_0/Object", "/World/envs/env_1/Object"),
+        destinations=("/World/envs/env_{}/Object", "/World/envs/env_{}/Object"),
+        clone_mask=torch.tensor(
+            [
+                [True, False, True],
+                [False, True, False],
+            ],
+            dtype=torch.bool,
+        ),
+    )
+
+    builder = _build_with_clone_plan(clone_plan_visualization_stage, clone_plan, monkeypatch)
+
+    assert isinstance(builder, _FakeModelBuilder)
+    assert NewtonManager.get_num_envs() == 3
+    assert len(builder.world_slices) == 3
+    assert builder.geometry_sources_for_world(0) == ["/World/envs/env_0/Object"]
+    assert builder.geometry_sources_for_world(1) == ["/World/envs/env_1/Object"]
+    assert builder.geometry_sources_for_world(2) == ["/World/envs/env_0/Object"]
+
+    for attr in _LABEL_ATTRS:
+        suffix = _LABEL_SUFFIXES[attr]
+        assert builder.labels_for_world(0, attr) == [f"/World/envs/env_0/Object/{suffix}"]
+        assert builder.labels_for_world(1, attr) == [f"/World/envs/env_1/Object/{suffix}"]
+        assert builder.labels_for_world(2, attr) == [f"/World/envs/env_2/Object/{suffix}"]
+
+
+def test_rewrite_visualization_label_prefix_handles_trailing_source_slash():
+    """Trailing slashes on ClonePlan roots must not drop the separator after the destination."""
+    assert (
+        NewtonManager._rewrite_visualization_label_prefix(
+            "/World/envs/env_0/Object/Body",
+            "/World/envs/env_0/Object/",
+            "/World/envs/env_2/Object/",
+        )
+        == "/World/envs/env_2/Object/Body"
+    )
+
+
+def test_visualization_builder_falls_back_when_clone_mask_source_row_is_missing(
+    clone_plan_visualization_stage: Usd.Stage,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Malformed ClonePlan masks should warn and fall back instead of raising ``IndexError``."""
+    clone_plan = ClonePlan(
+        sources=("/World/envs/env_0/Object", "/World/envs/env_1/Object"),
+        destinations=("/World/envs/env_{}/Object", "/World/envs/env_{}/Object"),
+        clone_mask=torch.tensor([[True, False, False]], dtype=torch.bool),
+    )
+
+    with caplog.at_level("WARNING", logger="isaaclab_newton.physics.newton_manager"):
+        builder = _build_with_clone_plan(clone_plan_visualization_stage, clone_plan, monkeypatch)
+
+    assert isinstance(builder, _FakeModelBuilder)
+    assert builder.geometry_sources_for_world(0) == ["/World/envs/env_0/Object"]
+    assert builder.geometry_sources_for_world(1) == ["/World/envs/env_1"]
+    assert builder.geometry_sources_for_world(2) == ["/World/envs/env_2"]
+    assert any("exceeds clone_mask row count" in record.message for record in caplog.records)


### PR DESCRIPTION
# Description

Newton's PhysX-backed shadow visualization model ignored the active `ClonePlan` and built every rendered world by importing `env_0` once, then replicating that prototype across all worlds. That made Newton RGB/depth visualization homogeneous even when the PhysX scene used heterogeneous cloned sources, for example different object prototypes per environment.

This change builds the Newton shadow visualization model from the active `ClonePlan` when available:

- caches one Newton `ModelBuilder` per ClonePlan source prototype
- assembles each render world from the source rows selected by `clone_mask`
- rewrites copied Newton labels from source paths to destination env paths so PhysX scene-data transform sync continues to map poses correctly
- keeps the existing `env_0` prototype fallback for scenes without a ClonePlan

Fixes # (not filed)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A. This was validated with a downstream Dextrah Newton RGB distillation video smoke; env 0/1/2 rendered different object geometries after the fix.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

Validation run:

- `python -m py_compile source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py`
- `python -m pytest source/isaaclab_newton/test/physics/test_newton_visualization_clone_plan.py -q`
- `./isaaclab.sh --format`
- downstream Dextrah Newton distillation smoke with video recording enabled
