### PR TITLE
[cherry-pick] Document RTX - Minimal cold-start teleop limitation

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -999,6 +999,20 @@ Optimize XR Performance
    materials, or when you have already configured ``sim.dt`` and ``sim.render_interval`` and
    still see dropped frames.
 
+   .. admonition:: Known issue
+      :class: important
+
+      Starting an XR session while RTX - Minimal is already the active renderer is a known
+      issue: robot control inputs may never be applied and teleoperation stays non-functional,
+      with no error reported. Switching to RTX - Minimal *after* the XR session has started and
+      teleoperation is confirmed working is not affected.
+
+      As a workaround, start under the default renderer before switching to RTX - Minimal:
+
+      #. Launch Isaac Lab with the default renderer and start the XR session.
+      #. Confirm that teleoperation is working (the robot responds to your hand motions).
+      #. Switch the viewport renderer to **RTX - Minimal** as described below.
+
    To enable it, click the renderer dropdown at the top-left of the Isaac Lab viewport and
    select **RTX - Minimal**:
 


### PR DESCRIPTION
# Description

- Cherry-pick of the RTX - Minimal cold-start teleop limitation docs onto `release/3.0.0-beta2`.
- Same content as the `develop` PR: warns that starting XR teleop while RTX - Minimal is already active can silently leave teleop non-functional, and gives the recommended start-up sequence.

Fixes # (issue)

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there