### PR TITLE
Backport safe lambda callable resolution to beta2

### DIFF
--- a/source/isaaclab/changelog.d/fix-safe-lambda-callables.rst
+++ b/source/isaaclab/changelog.d/fix-safe-lambda-callables.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :func:`isaaclab.utils.string.string_to_callable` to validate lambda
+  expression strings before evaluating them and to evaluate them without
+  Python builtins.

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -89,6 +89,8 @@ def string_to_slice(s: str):
 String <-> Callable operations.
 """
 
+_FORBIDDEN_LAMBDA_NODES = (ast.Call, ast.Attribute, ast.NamedExpr)
+
 
 def is_lambda_expression(name: str) -> bool:
     """Checks if the input string is a lambda expression.
@@ -100,10 +102,20 @@ def is_lambda_expression(name: str) -> bool:
         Whether the input string is a lambda expression.
     """
     try:
-        ast.parse(name)
-        return isinstance(ast.parse(name).body[0], ast.Expr) and isinstance(ast.parse(name).body[0].value, ast.Lambda)
+        tree = ast.parse(name, mode="eval")
+        return isinstance(tree.body, ast.Lambda)
     except SyntaxError:
         return False
+
+
+def _validate_lambda_expression(name: str) -> None:
+    """Validate that a lambda expression string cannot execute arbitrary code."""
+    tree = ast.parse(name, mode="eval")
+    for node in ast.walk(tree):
+        if isinstance(node, _FORBIDDEN_LAMBDA_NODES):
+            raise ValueError(f"Unsafe lambda expression '{name}': disallowed syntax '{type(node).__name__}'.")
+        if isinstance(node, ast.Name) and node.id.startswith("__"):
+            raise ValueError(f"Unsafe lambda expression '{name}': dunder name '{node.id}' is not allowed.")
 
 
 def callable_to_string(value: Callable, separator: str = ":") -> str:
@@ -152,9 +164,13 @@ def string_to_callable(name: str, separator: str = ":") -> Callable:
     Returns:
         Callable: The function loaded from the module.
     """
+    name_is_lambda = is_lambda_expression(name)
+    if name_is_lambda:
+        _validate_lambda_expression(name)
+
     try:
-        if is_lambda_expression(name):
-            callable_object = eval(name)
+        if name_is_lambda:
+            callable_object = eval(name, {"__builtins__": {}}, {})
         else:
             mod_name, attr_name = name.rsplit(separator, 1)
             mod = importlib.import_module(mod_name)

--- a/source/isaaclab/test/utils/test_string.py
+++ b/source/isaaclab/test/utils/test_string.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import math
 import random
 
 import pytest
@@ -59,6 +60,32 @@ def test_case_conversion():
     assert string_utils.to_camel_case("snake_case", to="CC") == "SnakeCase"
     assert string_utils.to_camel_case("snake_case_string", to="CC") == "SnakeCaseString"
     assert string_utils.to_camel_case("snake_case_string", to="cC") == "snakeCaseString"
+
+
+def test_string_to_callable_allows_safe_lambdas():
+    """Test that simple lambda expressions and module references resolve to callables."""
+    assert string_utils.string_to_callable("lambda x: x + 1")(5) == 6
+    assert string_utils.string_to_callable("lambda x: x**2")(3) == 9
+    assert string_utils.string_to_callable("lambda x: x[0] if x else 0")([7, 8]) == 7
+    assert string_utils.string_to_callable("lambda x: x > 0 and x < 10")(5) is True
+    assert string_utils.string_to_callable("math:sqrt") is math.sqrt
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        'lambda x: __import__("os").system("id")',
+        'lambda x: eval("1")',
+        "lambda x: (lambda: 1)()",
+        "lambda x: x.__class__",
+        "lambda x: __builtins__",
+        "lambda x: (y := 1)",
+    ],
+)
+def test_string_to_callable_blocks_unsafe_lambdas(payload):
+    """Test that lambda strings cannot execute code or traverse Python internals."""
+    with pytest.raises(ValueError, match="Unsafe lambda expression"):
+        string_utils.string_to_callable(payload)
 
 
 def test_resolve_matching_names_with_basic_strings():


### PR DESCRIPTION
## Summary
- Backport #6112 to `release/3.0.0-beta2`.
- Validate lambda strings before resolving them with `string_to_callable`.
- Evaluate supported lambda expressions without Python builtins.
- Add focused tests for safe lambdas and unsafe payloads.

## Cherry-pick
- Cherry-picked `ffe85a4ccc9521cae079bac1c33f7e632e6da26e` with `-x`.

## Testing
- `pre-commit run --files source/isaaclab/changelog.d/fix-safe-lambda-callables.rst source/isaaclab/isaaclab/utils/string.py source/isaaclab/test/utils/test_string.py`
- `PYTHONPATH=/home/zhengyuz/Projects/IsaacLab.wt/beta2-safe-lambda-string-to-callable/source/isaaclab /home/zhengyuz/Projects/IsaacLab.wt/beta2-automate-collision-stack/.venv/bin/python -m pytest source/isaaclab/test/utils/test_string.py source/isaaclab/test/utils/test_dict.py -q` (26 passed)
- `/home/zhengyuz/Projects/IsaacLab.wt/beta2-automate-collision-stack/.venv/bin/python tools/changelog/cli.py check release/3.0.0-beta2`