### PR TITLE
[Docker] Make kit/data writable by the non-root user

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -14,6 +14,9 @@ x-default-isaac-lab-volumes: &default-isaac-lab-volumes
     source: isaac-cache-kit
     target: ${DOCKER_ISAACSIM_ROOT_PATH}/kit/cache
   - type: volume
+    source: isaac-data-kit
+    target: ${DOCKER_ISAACSIM_ROOT_PATH}/kit/data
+  - type: volume
     source: isaac-cache-ov
     target: ${DOCKER_USER_HOME}/.cache/ov
   - type: volume
@@ -138,6 +141,7 @@ services:
 volumes:
   # isaac-sim
   isaac-cache-kit:
+  isaac-data-kit:
   isaac-cache-ov:
   isaac-cache-pip:
   isaac-cache-gl:


### PR DESCRIPTION
## Summary

Adds a named volume for `${DOCKER_ISAACSIM_ROOT_PATH}/kit/data` so the non-root `isaaclab` user can write the Kit kernel config there.

Fixes the residual `omni.kit.app.plugin` error reported in nvbug 6288406:
```
[Error] [omni.kit.app.plugin] failed to open file '/isaac-sim/kit/data/Kit/IsaacLab/3.0/user.config.json' - unable to save the dictionary
```

## Root cause

PR #6082 made every docker-compose named-volume mount point writable by the non-root user (driven by `docker/utils/volume_mounts.py` + the build-time `chown`). But `kit/data` was **never a declared volume** — pre–non-root migration it was writable simply because the container ran as `root`. Under the non-root image it stays `root:root`, so the Kit kernel cannot write `kit/data/.../user.config.json`. This is **universal to every docker user** (the image bakes `USER isaaclab`; `kit/data` is neither mounted nor chowned), independent of the launch flow.

(The sibling `omni.datastore` lock errors on `kit/cache` in the original report were a QA workflow artifact of a raw `docker run` that bypasses the compose volumes; the documented `container.py`/compose flow already handles those via #6082.)

## Fix

Declare `kit/data` as a named volume. `docker-compose.yaml` is the single source of truth, so this routes it through the existing `volume_mounts.py` + `chown` machinery — the build pre-creates and chowns `/isaac-sim/kit/data` to `isaaclab`. Consistent with `kit/cache`/`kit/logs`, and it benignly persists Kit config across runs.

## Validation

Built the image (`nvcr.io/nvidian/isaac-sim:latest-release-6-0` base) and verified as the non-root runtime user (uid 1000):

| | `/isaac-sim/kit/data` | non-root write of `user.config.json` |
|---|---|---|
| Pre-fix (base image, inherited) | not writable | **Permission denied** |
| Post-fix (this PR) | owned by uid 1000 | **OK** |

`volume_mounts.py` now emits `/isaac-sim/kit/data`, and the running container no longer logs the `user.config.json` / `omni.datastore` / `DerivedDataCache` errors.
