### PR TITLE
[Docker] Make kit/data writable by the non-root user (cherry-pick of #6122)

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -14,6 +14,9 @@ x-default-isaac-lab-volumes: &default-isaac-lab-volumes
     source: isaac-cache-kit
     target: ${DOCKER_ISAACSIM_ROOT_PATH}/kit/cache
   - type: volume
+    source: isaac-data-kit
+    target: ${DOCKER_ISAACSIM_ROOT_PATH}/kit/data
+  - type: volume
     source: isaac-cache-ov
     target: ${DOCKER_USER_HOME}/.cache/ov
   - type: volume
@@ -138,6 +141,7 @@ services:
 volumes:
   # isaac-sim
   isaac-cache-kit:
+  isaac-data-kit:
   isaac-cache-ov:
   isaac-cache-pip:
   isaac-cache-gl:


### PR DESCRIPTION
Cherry-pick of #6122 to `release/3.0.0-beta2` for nvbug 6288406.

Makes `/isaac-sim/kit/data` writable by the non-root `isaaclab` user by declaring it as a named volume, so the Kit kernel can write `user.config.json` (the residual that #6082/#6095 did not cover — `kit/data` was never a declared volume). Routes through the existing `volume_mounts.py` + build-time `chown`; `docker-compose.yaml` is the single source of truth.

Clean cherry-pick (release already has the #6095 volume-prep mechanism). Validated on develop in #6122: on a clean rebuild, `/isaac-sim/kit/data` is owned by uid 1000 and `user.config.json` writes succeed (pre-fix: `Permission denied`).
