### PR TITLE
Guard callback destructors during Python shutdown

### DIFF
--- a/source/isaaclab/changelog.d/fix-callback-owner-shutdown-del.rst
+++ b/source/isaaclab/changelog.d/fix-callback-owner-shutdown-del.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Guarded asset and sensor destructors against Python interpreter shutdown so
+  callback cleanup does not touch lazy imports after import machinery is torn down.

--- a/source/isaaclab/isaaclab/assets/asset_base.py
+++ b/source/isaaclab/isaaclab/assets/asset_base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import inspect
 import re
+import sys
 import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -112,10 +113,11 @@ class AssetBase(ABC):
         # set initial state of debug visualization
         self.set_debug_vis(self.cfg.debug_vis)
 
-    def __del__(self):
+    def __del__(self, _sys=sys):
         """Unsubscribe from the callbacks."""
         # clear events handles
-        self._clear_callbacks()
+        if not _sys.is_finalizing() and _sys.meta_path is not None:
+            self._clear_callbacks()
 
     """
     Properties

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import inspect
 import logging
 import re
+import sys
 import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -77,10 +78,11 @@ class SensorBase(ABC):
         # set initial state of debug visualization
         self.set_debug_vis(self.cfg.debug_vis)
 
-    def __del__(self):
+    def __del__(self, _sys=sys):
         """Unsubscribe from the callbacks."""
         # clear physics events handles
-        self._clear_callbacks()
+        if not _sys.is_finalizing() and _sys.meta_path is not None:
+            self._clear_callbacks()
 
     """
     Properties

--- a/source/isaaclab/test/assets/test_asset_base.py
+++ b/source/isaaclab/test/assets/test_asset_base.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from isaaclab.assets import AssetBase
+
+
+class _TestAsset(AssetBase):
+    @property
+    def num_instances(self):
+        return 0
+
+    @property
+    def data(self):
+        return None
+
+    def reset(self, env_ids=None):
+        pass
+
+    def write_data_to_sim(self):
+        pass
+
+    def update(self, dt):
+        pass
+
+    def _initialize_impl(self):
+        pass
+
+
+def test_asset_base_destructor_clears_before_shutdown(monkeypatch):
+    """Asset destructors should still clean up during normal runtime."""
+
+    cleared = False
+
+    def clear_callbacks(_self):
+        nonlocal cleared
+        cleared = True
+
+    asset = object.__new__(_TestAsset)
+    monkeypatch.setattr(_TestAsset, "_clear_callbacks", clear_callbacks)
+
+    asset.__del__()
+
+    assert cleared
+
+
+def test_asset_base_destructor_skips_clear_after_import_shutdown(monkeypatch):
+    """Asset destructors should not import modules after import machinery is torn down."""
+
+    def clear_callbacks(_self):
+        raise ImportError("sys.meta_path is None, Python is likely shutting down")
+
+    asset = object.__new__(_TestAsset)
+    monkeypatch.setattr(_TestAsset, "_clear_callbacks", clear_callbacks)
+    monkeypatch.setattr("sys.meta_path", None)
+
+    asset.__del__()

--- a/source/isaaclab/test/sensors/test_sensor_base.py
+++ b/source/isaaclab/test/sensors/test_sensor_base.py
@@ -3,228 +3,48 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Launch Isaac Sim Simulator first."""
+from __future__ import annotations
 
-from isaaclab.app import AppLauncher
-
-# launch omniverse app
-app_launcher = AppLauncher(headless=True)
-simulation_app = app_launcher.app
+from isaaclab.sensors import SensorBase
 
 
-"""Rest everything follows."""
-
-from collections.abc import Sequence
-from dataclasses import dataclass
-
-import pytest
-import torch
-import warp as wp
-
-import isaaclab.sim as sim_utils
-from isaaclab.sensors import SensorBase, SensorBaseCfg
-from isaaclab.utils.configclass import configclass
-
-
-@dataclass
-class DummyData:
-    count: torch.Tensor = None
-
-
-class DummySensor(SensorBase):
-    def __init__(self, cfg):
-        super().__init__(cfg)
-        self._data = DummyData()
-
-    def _initialize_impl(self):
-        super()._initialize_impl()
-        self._data.count = torch.zeros((self._num_envs), dtype=torch.int, device=self.device)
-
+class _TestSensor(SensorBase):
     @property
     def data(self):
-        # update sensors if needed
-        self._update_outdated_buffers()
-        # return the data (where `_data` is the data for the sensor)
-        return self._data
+        return None
 
-    def _update_buffers_impl(self, env_mask: wp.array | None = None):
-        env_ids = wp.to_torch(env_mask).nonzero(as_tuple=False).squeeze(-1)
-        if len(env_ids) == 0:
-            return
-        self._data.count[env_ids] += 1
+    def _initialize_impl(self):
+        pass
 
-    def reset(self, env_ids: Sequence[int] | None = None, env_mask: wp.array | None = None):
-        super().reset(env_ids=env_ids, env_mask=env_mask)
-        # Resolve sensor ids
-        if env_ids is None and env_mask is not None:
-            env_ids = wp.to_torch(env_mask).nonzero(as_tuple=False).squeeze(-1)
-        elif env_ids is None:
-            env_ids = slice(None)
-        self._data.count[env_ids] = 0
+    def _update_buffers_impl(self, env_mask):
+        pass
 
 
-@configclass
-class DummySensorCfg(SensorBaseCfg):
-    class_type = DummySensor
+def test_sensor_base_destructor_clears_before_shutdown(monkeypatch):
+    """Sensor destructors should still clean up during normal runtime."""
 
-    prim_path = "/World/envs/env_.*/Cube/dummy_sensor"
+    cleared = False
 
+    def clear_callbacks(_self):
+        nonlocal cleared
+        cleared = True
 
-def _populate_scene():
-    """"""
+    sensor = object.__new__(_TestSensor)
+    monkeypatch.setattr(_TestSensor, "_clear_callbacks", clear_callbacks)
 
-    # Ground-plane
-    cfg = sim_utils.GroundPlaneCfg()
-    cfg.func("/World/defaultGroundPlane", cfg)
-    # Lights
-    cfg = sim_utils.SphereLightCfg()
-    cfg.func("/World/Light/GreySphere", cfg, translation=(4.5, 3.5, 10.0))
-    cfg.func("/World/Light/WhiteSphere", cfg, translation=(-4.5, 3.5, 10.0))
+    sensor.__del__()
 
-    # create prims
-    for i in range(5):
-        _ = sim_utils.create_prim(
-            f"/World/envs/env_{i:02d}/Cube",
-            "Cube",
-            translation=(i * 1.0, 0.0, 0.0),
-            scale=(0.25, 0.25, 0.25),
-        )
+    assert cleared
 
 
-@pytest.fixture
-def create_dummy_sensor(request, device):
-    # Create a new stage
-    sim_utils.create_new_stage()
+def test_sensor_base_destructor_skips_clear_after_import_shutdown(monkeypatch):
+    """Sensor destructors should not import modules after import machinery is torn down."""
 
-    # Simulation time-step
-    dt = 0.01
-    # Load kit helper
-    sim_cfg = sim_utils.SimulationCfg(device=device, dt=dt)
-    sim = sim_utils.SimulationContext(sim_cfg)
+    def clear_callbacks(_self):
+        raise ImportError("sys.meta_path is None, Python is likely shutting down")
 
-    # create sensor
-    _populate_scene()
+    sensor = object.__new__(_TestSensor)
+    monkeypatch.setattr(_TestSensor, "_clear_callbacks", clear_callbacks)
+    monkeypatch.setattr("sys.meta_path", None)
 
-    sensor_cfg = DummySensorCfg()
-
-    sim_utils.update_stage()
-
-    yield sensor_cfg, sim, dt
-
-    # stop simulation and clean up
-    sim.stop()
-    sim.clear_instance()
-
-
-@pytest.mark.parametrize("device", ("cpu", "cuda"))
-def test_sensor_init(create_dummy_sensor, device):
-    """Test that the sensor initializes, steps without update, and forces update."""
-
-    sensor_cfg, sim, dt = create_dummy_sensor
-    sensor = DummySensor(cfg=sensor_cfg)
-
-    # Play sim
-    sim.step()
-
-    sim.reset()
-
-    assert sensor.is_initialized
-    assert int(sensor.num_instances) == 5
-
-    # test that the data is not updated
-    for i in range(10):
-        sim.step()
-        sensor.update(dt=dt, force_recompute=True)
-        expected_value = i + 1
-        torch.testing.assert_close(
-            sensor.data.count,
-            torch.tensor(expected_value, device=device, dtype=torch.int32).repeat(sensor.num_instances),
-        )
-    assert sensor.data.count.shape[0] == 5
-
-    # test that the data is not updated if sensor.data is not accessed
-    for _ in range(5):
-        sim.step()
-        sensor.update(dt=dt, force_recompute=False)
-        torch.testing.assert_close(
-            sensor._data.count,
-            torch.tensor(expected_value, device=device, dtype=torch.int32).repeat(sensor.num_instances),
-        )
-
-
-@pytest.mark.parametrize("device", ("cpu", "cuda"))
-def test_sensor_update_rate(create_dummy_sensor, device):
-    """Test that the update_rate configuration parameter works by checking the value of the data is old for an update
-    period of 2.
-    """
-    sensor_cfg, sim, dt = create_dummy_sensor
-    sensor_cfg.update_period = 2 * dt
-    sensor = DummySensor(cfg=sensor_cfg)
-
-    # Play sim
-    sim.step()
-
-    sim.reset()
-
-    assert sensor.is_initialized
-    assert int(sensor.num_instances) == 5
-    expected_value = 1
-    for i in range(10):
-        sim.step()
-        sensor.update(dt=dt, force_recompute=True)
-        # count should he half of the number of steps
-        torch.testing.assert_close(
-            sensor.data.count,
-            torch.tensor(expected_value, device=device, dtype=torch.int32).repeat(sensor.num_instances),
-        )
-        expected_value += i % 2
-
-
-@pytest.mark.parametrize("device", ("cpu", "cuda"))
-def test_sensor_reset(create_dummy_sensor, device):
-    """Test that sensor can be reset for all or partial env ids."""
-    sensor_cfg, sim, dt = create_dummy_sensor
-    sensor = DummySensor(cfg=sensor_cfg)
-
-    # Play sim
-    sim.step()
-    sim.reset()
-
-    assert sensor.is_initialized
-    assert int(sensor.num_instances) == 5
-    for i in range(5):
-        sim.step()
-        sensor.update(dt=dt)
-        # count should he half of the number of steps
-        torch.testing.assert_close(
-            sensor.data.count,
-            torch.tensor(i + 1, device=device, dtype=torch.int32).repeat(sensor.num_instances),
-        )
-
-    sensor.reset()
-
-    for j in range(5):
-        sim.step()
-        sensor.update(dt=dt)
-        # count should he half of the number of steps
-        torch.testing.assert_close(
-            sensor.data.count,
-            torch.tensor(j + 1, device=device, dtype=torch.int32).repeat(sensor.num_instances),
-        )
-
-    reset_ids = [2, 4]
-    cont_ids = [0, 1, 3]
-    sensor.reset(env_ids=reset_ids)
-
-    for k in range(5):
-        sim.step()
-        sensor.update(dt=dt)
-        # count should he half of the number of steps
-        torch.testing.assert_close(
-            sensor.data.count[reset_ids],
-            torch.tensor(k + 1, device=device, dtype=torch.int32).repeat(len(reset_ids)),
-        )
-        torch.testing.assert_close(
-            sensor.data.count[cont_ids],
-            torch.tensor(k + 6, device=device, dtype=torch.int32).repeat(len(cont_ids)),
-        )
+    sensor.__del__()

--- a/source/isaaclab/test/sensors/test_sensor_base_integration.py
+++ b/source/isaaclab/test/sensors/test_sensor_base_integration.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+# launch omniverse app
+app_launcher = AppLauncher(headless=True)
+simulation_app = app_launcher.app
+
+
+"""Rest everything follows."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import pytest
+import torch
+import warp as wp
+
+import isaaclab.sim as sim_utils
+from isaaclab.sensors import SensorBase, SensorBaseCfg
+from isaaclab.utils.configclass import configclass
+
+
+@dataclass
+class DummyData:
+    count: torch.Tensor = None
+
+
+class DummySensor(SensorBase):
+    def __init__(self, cfg):
+        super().__init__(cfg)
+        self._data = DummyData()
+
+    def _initialize_impl(self):
+        super()._initialize_impl()
+        self._data.count = torch.zeros((self._num_envs), dtype=torch.int, device=self.device)
+
+    @property
+    def data(self):
+        # update sensors if needed
+        self._update_outdated_buffers()
+        # return the data (where `_data` is the data for the sensor)
+        return self._data
+
+    def _update_buffers_impl(self, env_mask: wp.array | None = None):
+        env_ids = wp.to_torch(env_mask).nonzero(as_tuple=False).squeeze(-1)
+        if len(env_ids) == 0:
+            return
+        self._data.count[env_ids] += 1
+
+    def reset(self, env_ids: Sequence[int] | None = None, env_mask: wp.array | None = None):
+        super().reset(env_ids=env_ids, env_mask=env_mask)
+        # Resolve sensor ids
+        if env_ids is None and env_mask is not None:
+            env_ids = wp.to_torch(env_mask).nonzero(as_tuple=False).squeeze(-1)
+        elif env_ids is None:
+            env_ids = slice(None)
+        self._data.count[env_ids] = 0
+
+
+@configclass
+class DummySensorCfg(SensorBaseCfg):
+    class_type = DummySensor
+
+    prim_path = "/World/envs/env_.*/Cube/dummy_sensor"
+
+
+def _populate_scene():
+    """"""
+
+    # Ground-plane
+    cfg = sim_utils.GroundPlaneCfg()
+    cfg.func("/World/defaultGroundPlane", cfg)
+    # Lights
+    cfg = sim_utils.SphereLightCfg()
+    cfg.func("/World/Light/GreySphere", cfg, translation=(4.5, 3.5, 10.0))
+    cfg.func("/World/Light/WhiteSphere", cfg, translation=(-4.5, 3.5, 10.0))
+
+    # create prims
+    for i in range(5):
+        _ = sim_utils.create_prim(
+            f"/World/envs/env_{i:02d}/Cube",
+            "Cube",
+            translation=(i * 1.0, 0.0, 0.0),
+            scale=(0.25, 0.25, 0.25),
+        )
+
+
+@pytest.fixture
+def create_dummy_sensor(request, device):
+    # Create a new stage
+    sim_utils.create_new_stage()
+
+    # Simulation time-step
+    dt = 0.01
+    # Load kit helper
+    sim_cfg = sim_utils.SimulationCfg(device=device, dt=dt)
+    sim = sim_utils.SimulationContext(sim_cfg)
+
+    # create sensor
+    _populate_scene()
+
+    sensor_cfg = DummySensorCfg()
+
+    sim_utils.update_stage()
+
+    yield sensor_cfg, sim, dt
+
+    # stop simulation and clean up
+    sim.stop()
+    sim.clear_instance()
+
+
+@pytest.mark.parametrize("device", ("cpu", "cuda"))
+def test_sensor_init(create_dummy_sensor, device):
+    """Test that the sensor initializes, steps without update, and forces update."""
+
+    sensor_cfg, sim, dt = create_dummy_sensor
+    sensor = DummySensor(cfg=sensor_cfg)
+
+    # Play sim
+    sim.step()
+
+    sim.reset()
+
+    assert sensor.is_initialized
+    assert int(sensor.num_instances) == 5
+
+    # test that the data is not updated
+    for i in range(10):
+        sim.step()
+        sensor.update(dt=dt, force_recompute=True)
+        expected_value = i + 1
+        torch.testing.assert_close(
+            sensor.data.count,
+            torch.tensor(expected_value, device=device, dtype=torch.int32).repeat(sensor.num_instances),
+        )
+    assert sensor.data.count.shape[0] == 5
+
+    # test that the data is not updated if sensor.data is not accessed
+    for _ in range(5):
+        sim.step()
+        sensor.update(dt=dt, force_recompute=False)
+        torch.testing.assert_close(
+            sensor._data.count,
+            torch.tensor(expected_value, device=device, dtype=torch.int32).repeat(sensor.num_instances),
+        )
+
+
+@pytest.mark.parametrize("device", ("cpu", "cuda"))
+def test_sensor_update_rate(create_dummy_sensor, device):
+    """Test that the update_rate configuration parameter works by checking the value of the data is old for an update
+    period of 2.
+    """
+    sensor_cfg, sim, dt = create_dummy_sensor
+    sensor_cfg.update_period = 2 * dt
+    sensor = DummySensor(cfg=sensor_cfg)
+
+    # Play sim
+    sim.step()
+
+    sim.reset()
+
+    assert sensor.is_initialized
+    assert int(sensor.num_instances) == 5
+    expected_value = 1
+    for i in range(10):
+        sim.step()
+        sensor.update(dt=dt, force_recompute=True)
+        # count should he half of the number of steps
+        torch.testing.assert_close(
+            sensor.data.count,
+            torch.tensor(expected_value, device=device, dtype=torch.int32).repeat(sensor.num_instances),
+        )
+        expected_value += i % 2
+
+
+@pytest.mark.parametrize("device", ("cpu", "cuda"))
+def test_sensor_reset(create_dummy_sensor, device):
+    """Test that sensor can be reset for all or partial env ids."""
+    sensor_cfg, sim, dt = create_dummy_sensor
+    sensor = DummySensor(cfg=sensor_cfg)
+
+    # Play sim
+    sim.step()
+    sim.reset()
+
+    assert sensor.is_initialized
+    assert int(sensor.num_instances) == 5
+    for i in range(5):
+        sim.step()
+        sensor.update(dt=dt)
+        # count should he half of the number of steps
+        torch.testing.assert_close(
+            sensor.data.count,
+            torch.tensor(i + 1, device=device, dtype=torch.int32).repeat(sensor.num_instances),
+        )
+
+    sensor.reset()
+
+    for j in range(5):
+        sim.step()
+        sensor.update(dt=dt)
+        # count should he half of the number of steps
+        torch.testing.assert_close(
+            sensor.data.count,
+            torch.tensor(j + 1, device=device, dtype=torch.int32).repeat(sensor.num_instances),
+        )
+
+    reset_ids = [2, 4]
+    cont_ids = [0, 1, 3]
+    sensor.reset(env_ids=reset_ids)
+
+    for k in range(5):
+        sim.step()
+        sensor.update(dt=dt)
+        # count should he half of the number of steps
+        torch.testing.assert_close(
+            sensor.data.count[reset_ids],
+            torch.tensor(k + 1, device=device, dtype=torch.int32).repeat(len(reset_ids)),
+        )
+        torch.testing.assert_close(
+            sensor.data.count[cont_ids],
+            torch.tensor(k + 6, device=device, dtype=torch.int32).repeat(len(cont_ids)),
+        )


### PR DESCRIPTION
## Summary
- Guard `AssetBase.__del__` and `SensorBase.__del__` against Python interpreter shutdown after `sys.meta_path` is cleared.
- Add lightweight base-class tests in `test/assets/test_asset_base.py` and `test/sensors/test_sensor_base.py` covering normal cleanup and shutdown-time skip behavior.
- Move the existing simulator-backed sensor base tests to `test/sensors/test_sensor_base_integration.py` so the unit/integration boundary is explicit.
- Add a changelog fragment.

## Verification
- `env_isaaclab/bin/python -m pytest source/isaaclab/test/assets/test_asset_base.py source/isaaclab/test/sensors/test_sensor_base.py source/isaaclab/test/envs/test_env_destructors.py -q`
  - 13 passed
- `env_isaaclab/bin/python -m pytest source/isaaclab/test/sensors/test_sensor_base_integration.py -q`
  - 6 passed
- Full repro in a clean `/tmp` env with Isaac Sim 6.0.0.1, EULA accepted:
  - `./isaaclab.sh -p -u scripts/reinforcement_learning/rl_games/train.py --task Isaac-Repose-Cube-Shadow-OpenAI-LSTM-Direct-v0 --headless --max_iterations 5 presets=newton_mjwarp`
  - Exit code 0
  - Completed 5/5 epochs and saved checkpoint
  - Full log scan found no `Exception ignored`, `sys.meta_path`, `Traceback`, `ImportError`, `SensorBase.__del__`, or `DirectRLEnv.__del__` matches.

## Notes
PR #6049 already guards env destructors. This follow-up covers the callback-owner path from the newer report: `SensorBase.__del__ -> _clear_callbacks() -> isaaclab.sim.SimulationContext` lazy import during interpreter shutdown.
