### PR TITLE
Set RESOURCE_NAME in launcher wrappers

### DIFF
--- a/isaaclab.bat
+++ b/isaaclab.bat
@@ -26,6 +26,9 @@ if defined VIRTUAL_ENV (
 rem Add source/isaaclab to PYTHONPATH so we can import isaaclab.cli.
 set "PYTHONPATH=%ISAACLAB_PATH%\source\isaaclab;%PYTHONPATH%"
 
+rem Let Kit associate direct wrapper launches with the Isaac Sim desktop icon.
+if "%RESOURCE_NAME%"=="" set "RESOURCE_NAME=IsaacSim"
+
 rem If a local Isaac Sim binary is present, source its env setup so that
 rem PYTHONPATH/PATH/EXP_PATH are correct without depending on a conda
 rem activate.d hook (those don't fire under e.g. `conda run` on Windows).

--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -28,6 +28,9 @@ fi
 # Add source/isaaclab to PYTHONPATH so we can import isaaclab.cli.
 export PYTHONPATH="$ISAACLAB_PATH/source/isaaclab:$PYTHONPATH"
 
+# Let Kit associate direct wrapper launches with the Isaac Sim desktop icon.
+export RESOURCE_NAME="${RESOURCE_NAME:-IsaacSim}"
+
 # If a local Isaac Sim binary is present, source its env setup so that
 # PYTHONPATH/PATH/EXP_PATH are correct without depending on a conda
 # activate.d hook (those don't fire reliably under e.g. `conda run`).


### PR DESCRIPTION
## Summary
- default RESOURCE_NAME=IsaacSim in isaaclab.sh for direct wrapper launches
- mirror the default in isaaclab.bat while preserving caller-provided RESOURCE_NAME

## Validation
- Confirmed on Ubuntu 24.04 GNOME/X11 that launching with RESOURCE_NAME=IsaacSim changes the dock icon from the generic gear to the Isaac Sim icon.
- Ran bash -n isaaclab.sh.
- Ran git diff --check.
- Ran ./isaaclab.sh -h from the clean fix worktree.