### PR TITLE
Fixes Rlinf config path

### DIFF
--- a/scripts/reinforcement_learning/rlinf/play_rlinf.py
+++ b/scripts/reinforcement_learning/rlinf/play_rlinf.py
@@ -57,8 +57,8 @@ args_cli = parser.parse_args()
 # Resolve config path and name from CLI args
 if not args_cli.config_name:
     parser.error("--config_name is required (e.g. --config_name isaaclab_ppo_gr00t_assemble_trocar)")
-config_dir = args_cli.config_path or str(SCRIPT_DIR)
 config_name = args_cli.config_name
+config_dir = cli_args.resolve_config_dir(config_name, args_cli.config_path)
 os.environ["RLINF_CONFIG_FILE"] = str(Path(config_dir) / f"{config_name}.yaml")
 
 # Add config dir to PYTHONPATH so that Ray rollout workers can resolve

--- a/scripts/reinforcement_learning/rlinf/train_rlinf.py
+++ b/scripts/reinforcement_learning/rlinf/train_rlinf.py
@@ -70,8 +70,8 @@ def run(argv: list[str]) -> None:
         _list_tasks()
         return
 
-    config_dir = args_cli.config_path or str(RLINF_DIR)
     config_name = args_cli.config_name
+    config_dir = CLI_ARGS.resolve_config_dir(config_name, args_cli.config_path)
     os.environ["RLINF_CONFIG_FILE"] = str(Path(config_dir) / f"{config_name}.yaml")
 
     if config_dir not in os.environ.get("PYTHONPATH", ""):


### PR DESCRIPTION
# Description

Fixes path of RLinf config yaml file caused by missing path resolver.

## Type of change

- Bug fix (non-breaking change which fixes an issue)



## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
