### PR TITLE
[Fix] Allow Warp environments to launch with the Kit visualizer (cherry-pick of #6111)

### DIFF
--- a/source/isaaclab_experimental/changelog.d/fix-warp-env-visualizer-setting.rst
+++ b/source/isaaclab_experimental/changelog.d/fix-warp-env-visualizer-setting.rst
@@ -1,0 +1,12 @@
+Fixed
+^^^^^
+
+* Fixed a crash (``AttributeError: 'dict' object has no attribute 'split'``) when
+  launching the experimental Warp environments
+  (:class:`~isaaclab_experimental.envs.ManagerBasedRLEnvWarp`,
+  :class:`~isaaclab_experimental.envs.DirectRLEnvWarp`) with a Kit visualizer
+  requested (e.g. ``--visualizer kit``). The environments now resolve the active
+  visualizer through :meth:`~isaaclab.sim.SimulationContext.has_active_visualizers`
+  and the :attr:`~isaaclab.sim.SimulationContext.is_rendering` property, matching the
+  stable environments, instead of parsing the ``/isaaclab/visualizer`` settings node
+  (which is a dictionary) as a string.

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
@@ -214,7 +214,7 @@ class DirectRLEnvWarp(DirectRLEnv):
         # extend UI elements
         # we need to do this here after all the managers are initialized
         # this is because they dictate the sensors and commands right now
-        if bool(self.sim.settings.get("/isaaclab/visualizer")) and self.cfg.ui_window_class_type is not None:
+        if self.sim.has_gui and self.cfg.ui_window_class_type is not None:
             self._window = self.cfg.ui_window_class_type(self, window_name="IsaacLab")
         else:
             # if no window, then we don't need to store the window
@@ -417,9 +417,8 @@ class DirectRLEnvWarp(DirectRLEnv):
             )  # Creates a tensor and discards it. Not graphable unless training loop reuses the same pointer.
 
         # check if we need to do rendering within the physics loop
-        # note: checked here once to avoid multiple checks within the loop
-        _has_rtx = hasattr(self.sim, "has_rtx_sensors") and self.sim.has_rtx_sensors()
-        is_rendering = bool(self.sim.settings.get("/isaaclab/visualizer")) or _has_rtx
+        # note: uses cached property to avoid settings lookup every step
+        is_rendering = self.sim.is_rendering
 
         # perform physics stepping
         with Timer(name="physics_loop", msg="Physics loop took:", enable=DEBUG_TIMERS):

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
@@ -417,7 +417,7 @@ class DirectRLEnvWarp(DirectRLEnv):
             )  # Creates a tensor and discards it. Not graphable unless training loop reuses the same pointer.
 
         # check if we need to do rendering within the physics loop
-        # note: uses cached property to avoid settings lookup every step
+        # note: hoisted out of the decimation loop; is_rendering does live settings lookups
         is_rendering = self.sim.is_rendering
 
         # perform physics stepping

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
@@ -164,8 +164,7 @@ class ManagerBasedEnvWarp:
         # non-rendering modes.
         # Initialize when a Kit viewport exists. ViewportCameraController uses omni.kit (renderer camera);
         # skip in kitless Newton-only runs (e.g. --viz rerun) where no Kit app is running.
-        has_visualizers = self.sim.has_active_visualizers()
-        if (self.sim.has_gui or has_visualizers) and has_kit():
+        if (self.sim.has_gui or self.sim.has_active_visualizers()) and has_kit():
             self.viewport_camera_controller = ViewportCameraController(self, self.cfg.viewer)
         else:
             self.viewport_camera_controller = None
@@ -539,7 +538,7 @@ class ManagerBasedEnvWarp:
         self.recorder_manager.record_pre_step()
 
         # check if we need to do rendering within the physics loop
-        # note: uses cached property to avoid settings lookup every step
+        # note: hoisted out of the decimation loop; is_rendering does live settings lookups
         is_rendering = self.sim.is_rendering
 
         # perform physics stepping

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
@@ -35,6 +35,7 @@ from isaaclab.sim.utils import use_stage
 from isaaclab.ui.widgets import ManagerLiveVisualizer
 from isaaclab.utils.seed import configure_seed
 from isaaclab.utils.timer import Timer
+from isaaclab.utils.version import has_kit
 
 from isaaclab_experimental.envs.interactive_scene_warp import InteractiveSceneWarp as InteractiveScene
 from isaaclab_experimental.utils.manager_call_switch import ManagerCallMode, ManagerCallSwitch
@@ -161,9 +162,10 @@ class ManagerBasedEnvWarp:
         # viewport is not available in other rendering modes so the function will throw a warning
         # FIXME: This needs to be fixed in the future when we unify the UI functionalities even for
         # non-rendering modes.
-        viz_str = self.sim.get_setting("/isaaclab/visualizer") or ""
-        available_visualizers = [v.strip() for v in viz_str.split(",") if v.strip()]
-        if "kit" in available_visualizers and bool(viz_str):
+        # Initialize when a Kit viewport exists. ViewportCameraController uses omni.kit (renderer camera);
+        # skip in kitless Newton-only runs (e.g. --viz rerun) where no Kit app is running.
+        has_visualizers = self.sim.has_active_visualizers()
+        if (self.sim.has_gui or has_visualizers) and has_kit():
             self.viewport_camera_controller = ViewportCameraController(self, self.cfg.viewer)
         else:
             self.viewport_camera_controller = None
@@ -537,10 +539,8 @@ class ManagerBasedEnvWarp:
         self.recorder_manager.record_pre_step()
 
         # check if we need to do rendering within the physics loop
-        # note: checked here once to avoid multiple checks within the loop
-        is_rendering = bool(self.sim.settings.get("/isaaclab/visualizer")) or self.sim.settings.get(
-            "/isaaclab/render/rtx_sensors"
-        )
+        # note: uses cached property to avoid settings lookup every step
+        is_rendering = self.sim.is_rendering
 
         # perform physics stepping
         for _ in range(self.cfg.decimation):


### PR DESCRIPTION
## Summary

Cherry-pick of #6111 onto `release/3.0.0-beta2`.

Fixes a crash when launching the experimental Warp environments with a Kit visualizer (`--visualizer kit`): `AttributeError: 'dict' object has no attribute 'split'` at environment construction. Reported by QA across ~10 manager-based Warp tasks (velocity/reach, e.g. `Isaac-Velocity-Flat-Unitree-Go2-Warp-Play-v0`).

## Root cause

The Warp environments read the **parent** settings node `/isaaclab/visualizer`, which carb returns as a **dict** of the `{types, explicit, disable_all, max_visible_envs}` subtree that `AppLauncher` writes — then call `.split(",")` on it. The stable environments never do this: they read `/isaaclab/visualizer/types` via `SimulationContext.has_active_visualizers()` and the `is_rendering` property, which also guard against non-string values.

## Fix

Align the Warp environments with the stable ones:

- `manager_based_env_warp.py`: viewport setup → `has_active_visualizers()` + `has_kit()`; in-loop `is_rendering` → `self.sim.is_rendering`.
- `direct_rl_env_warp.py`: UI-window gate → `self.sim.has_gui`; in-loop `is_rendering` → `self.sim.is_rendering`.

See #6111 for full discussion and validation.