### PR TITLE
Kamino Reset Logic and Examples

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -71,6 +71,7 @@ Guidelines for modifications:
 * Chenyu Yang
 * Connor Smith
 * CY (Chien-Ying) Chen
+* David Cao-Mueller
 * David Leon
 * David Yang
 * Dhananjay Shendre

--- a/source/isaaclab/changelog.d/aserifi-kamino-core-hooks.minor.rst
+++ b/source/isaaclab/changelog.d/aserifi-kamino-core-hooks.minor.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed stale reset poses for maximal-coordinate solvers (e.g. Kamino) by refreshing
+  kinematics and derived buffers after in-step resets in
+  :meth:`~isaaclab.envs.ManagerBasedRLEnv.step` (no-op for other backends).

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -252,6 +252,13 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
 
             self._reset_idx(reset_env_ids)
 
+            # Refresh kinematics and derived buffers for the just-reset envs so the
+            # observations / terminations below reflect the reset pose. Maximal-coordinate
+            # solvers (e.g. Kamino) apply reset FK one step late; for others this is a no-op.
+            self.scene.write_data_to_sim()
+            self.sim.forward()
+            self.scene.update(dt=self.physics_dt)
+
             # if sensors are added to the scene, make sure we render to reflect changes in reset
             if self.render_enabled and is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -252,13 +252,6 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
 
             self._reset_idx(reset_env_ids)
 
-            # Refresh kinematics and derived buffers for the just-reset envs so the
-            # observations / terminations below reflect the reset pose. Maximal-coordinate
-            # solvers (e.g. Kamino) apply reset FK one step late; for others this is a no-op.
-            self.scene.write_data_to_sim()
-            self.sim.forward()
-            self.scene.update(dt=self.physics_dt)
-
             # if sensors are added to the scene, make sure we render to reflect changes in reset
             if self.render_enabled and is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):

--- a/source/isaaclab_newton/changelog.d/aserifi-newton-kamino-closed-loop.minor.rst
+++ b/source/isaaclab_newton/changelog.d/aserifi-newton-kamino-closed-loop.minor.rst
@@ -1,0 +1,11 @@
+Added
+^^^^^
+
+* Added ``max_contacts_per_world`` to :class:`~isaaclab_newton.physics.KaminoSolverCfg`
+  to bound per-world contact allocation for the Kamino solver.
+
+Fixed
+^^^^^
+
+* Fixed contact-sensor forces for the Kamino solver by routing contact aggregation
+  through a unified, solver-agnostic path shared with the MuJoCo-Warp backend.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -126,13 +126,13 @@ class ArticulationData(BaseArticulationData):
         """Run forward kinematics if joint state has changed since the last FK update.
 
         Newton's ``state.body_q`` (per-body world transforms) is updated by ``eval_fk``,
-        invoked here through ``SimulationManager.forward()``. After a manual joint or root
-        write that bypassed the sim step (``write_*_to_sim_*``), ``_fk_timestamp`` is set
-        to ``-1.0`` to force a refresh on the next read of any property that depends on
+        invoked here through the active manager's ``forward()``. After a manual joint or
+        root write that bypassed the sim step (``write_*_to_sim_*``), ``_fk_timestamp`` is
+        set to ``-1.0`` to force a refresh on the next read of any property that depends on
         body poses (``body_link_pose_w``, the Jacobian properties, ``mass_matrix``).
         """
         if self._fk_timestamp < self._sim_timestamp:
-            SimulationManager.forward()
+            (SimulationManager._active_cls or SimulationManager).forward()
             self._fk_timestamp = self._sim_timestamp
 
     def _reset_pose(

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -1029,6 +1029,8 @@ class ArticulationData(BaseArticulationData):
         Shape is (num_instances, num_joints), dtype = wp.float32. In torch this resolves to
         (num_instances, num_joints).
         """
+        if (SimulationManager._active_cls or SimulationManager)._reset_passive_joints:
+            self._ensure_fk_fresh()
         return self._joint_pos_ta
 
     @property
@@ -1038,6 +1040,8 @@ class ArticulationData(BaseArticulationData):
         Shape is (num_instances, num_joints), dtype = wp.float32. In torch this resolves to
         (num_instances, num_joints).
         """
+        if (SimulationManager._active_cls or SimulationManager)._reset_passive_joints:
+            self._ensure_fk_fresh()
         return self._joint_vel_ta
 
     @property

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -938,7 +938,7 @@ class ArticulationData(BaseArticulationData):
         Newton implementation: applies the COM→origin shift kernel to
         :attr:`body_com_jacobian_w` (Newton's ``eval_jacobian`` is COM-referenced).
         """
-        # ``body_link_pose_w`` accessor triggers ``SimulationManager.forward()`` if FK is
+        # ``body_link_pose_w`` accessor triggers the active manager's ``forward()`` if FK is
         # stale (after a manual joint / root write that bypassed the sim step). Reading the
         # property here — not ``_sim_bind_body_link_pose_w`` directly — keeps the shift
         # kernel from using stale link rotations during reset / IK-warm-start paths.

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object_data.py
@@ -129,14 +129,14 @@ class RigidObjectData(BaseRigidObjectData):
         """Run forward kinematics if the root state has changed since the last FK update.
 
         Newton's ``state.body_q`` (per-body world transforms) is updated by ``eval_fk``,
-        invoked here through ``SimulationManager.forward()``. After a manual root write
+        invoked here through the active manager's ``forward()``. After a manual root write
         that bypassed the sim step (``write_*_to_sim_*``), ``_fk_timestamp`` is set to
         ``-1.0`` to force a refresh on the next read of any property that depends on
         body poses (``body_link_pose_w``, ``body_com_pose_w`` and the composite body
         state buffers).
         """
         if self._fk_timestamp < self._sim_timestamp:
-            SimulationManager.forward()
+            (SimulationManager._active_cls or SimulationManager).forward()
             self._fk_timestamp = self._sim_timestamp
 
     def _reset_pose(

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -121,14 +121,14 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
         """Run forward kinematics if the root state has changed since the last FK update.
 
         Newton's ``state.body_q`` (per-body world transforms) is updated by ``eval_fk``,
-        invoked here through ``SimulationManager.forward()``. After a manual root write
+        invoked here through the active manager's ``forward()``. After a manual root write
         that bypassed the sim step (``write_*_to_sim_*``), ``_fk_timestamp`` is set to
         ``-1.0`` to force a refresh on the next read of any property that depends on
         body poses (``body_link_pose_w``, ``body_com_pose_w`` and the composite body
         state buffers).
         """
         if self._fk_timestamp < self._sim_timestamp:
-            SimulationManager.forward()
+            (SimulationManager._active_cls or SimulationManager).forward()
             self._fk_timestamp = self._sim_timestamp
 
     def _reset_pose(

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -32,6 +32,7 @@ def build_source_builders(
     for source in sources:
         builder = create_builder()
         solvers.SolverMuJoCo.register_custom_attributes(builder)
+        solvers.SolverKamino.register_custom_attributes(builder)
         builder.add_usd(
             stage,
             root_path=source,

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 import warp as wp
-from newton import Model, eval_fk
+from newton import JointType, Model, eval_fk
 from newton.solvers import SolverKamino
 
 from isaaclab.physics import PhysicsManager
@@ -32,21 +32,147 @@ class NewtonKaminoManager(NewtonManager):
 
     @classmethod
     def _forward_kamino(cls, world_mask: wp.array | None = None) -> None:
-        """Kamino-specific forward kinematics via ``solver.reset()``.
+        """Reset Kamino solver state to match the current joint configuration.
 
-        Kamino's ``joint_q`` / ``joint_u`` include coordinates for **all** joints
-        (including free joints), so we pass Newton's full state arrays directly.
+        Two reset paths are selected at solver-construction time via
+        :attr:`KaminoSolverCfg.use_fk_solver`:
+
+        * ``use_fk_solver=True`` (default): ``solver.reset(joint_q=..., joint_u=...,
+          base_q=..., base_u=...)`` runs Kamino's Gauss-Newton FK so ``body_q`` is
+          consistent with the written ``joint_q`` (needed for non-trivial joint reset
+          targets on closed-loop assets).
+        * ``use_fk_solver=False``: ``solver.reset(base_q=..., base_u=...)`` routes to
+          ``_reset_to_base_state`` -- bodies are placed by transforming the model's
+          reference body poses by ``base_q`` with **no FK solver**. This is the fast
+          path for tasks that pin every joint coord to ``0`` (the assembled
+          closed-loop-valid configuration) and sidesteps an FK-solver buffer overflow
+          at high ``num_envs``. It is only correct when the written ``joint_q`` equals
+          the model default (all zeros).
 
         Args:
             world_mask: Per-world mask indicating which worlds to reset.
                 Shape ``(num_worlds,)``, dtype ``wp.bool``. If None, resets all worlds.
         """
-        cls._solver.reset(
-            cls._state_0,
-            joint_q=cls._state_0.joint_q,
-            joint_u=cls._state_0.joint_qd,
-            world_mask=world_mask,
-        )
+        _model = cls._model
+        _nw = max(int(getattr(_model, "world_count", 0) or 0), 1)
+        _first_joint_is_free = _model.joint_count > 0 and int(_model.joint_type.numpy()[0]) == int(JointType.FREE)
+
+        _base_q = None
+        _base_u = None
+        if _first_joint_is_free:
+            _coord_count = int(getattr(_model, "joint_coord_count", _model.joint_count))
+            _dof_count = int(getattr(_model, "joint_dof_count", _model.joint_count))
+            if _nw > 0 and _coord_count % _nw == 0 and _dof_count % _nw == 0:
+                _coords_per_world = _coord_count // _nw
+                _dofs_per_world = _dof_count // _nw
+                if _coords_per_world >= 7 and _dofs_per_world >= 6:
+                    _jq = wp.to_torch(cls._state_0.joint_q).reshape(_nw, _coords_per_world)
+                    _ju = wp.to_torch(cls._state_0.joint_qd).reshape(_nw, _dofs_per_world)
+                    _base_q = wp.from_torch(_jq[:, :7].contiguous(), dtype=wp.transformf)
+                    _base_u = wp.from_torch(_ju[:, :6].contiguous(), dtype=wp.spatial_vectorf)
+        else:
+            _body_count = int(getattr(_model, "body_count", 0) or 0)
+            if _body_count > 0 and _nw > 0 and _body_count % _nw == 0:
+                _bodies_per_world = _body_count // _nw
+                if _model.joint_count > 0:
+                    _joints_per_world = _model.joint_count // _nw if _nw > 0 else _model.joint_count
+                    _joint_child_np = _model.joint_child.numpy()[: max(_joints_per_world, 0)]
+                    _per_world_children = {int(c) for c in _joint_child_np if int(c) >= 0}
+                else:
+                    _per_world_children = set()
+                if 0 not in _per_world_children:
+                    _bq = wp.to_torch(cls._state_0.body_q).reshape(_nw, _bodies_per_world, 7)
+                    _bu = wp.to_torch(cls._state_0.body_qd).reshape(_nw, _bodies_per_world, 6)
+                    _base_q = wp.from_torch(_bq[:, 0, :].contiguous(), dtype=wp.transformf)
+                    _base_u = wp.from_torch(_bu[:, 0, :].contiguous(), dtype=wp.spatial_vectorf)
+
+        _use_fk = bool(getattr(getattr(cls._solver, "_config", None), "use_fk_solver", True))
+        if _use_fk:
+            cls._solver.reset(
+                state=cls._state_0,
+                world_mask=world_mask,
+                joint_q=cls._state_0.joint_q,
+                joint_u=cls._state_0.joint_qd,
+                base_q=_base_q,
+                base_u=_base_u,
+            )
+        elif _base_q is not None:
+            # No-FK reset honoring the per-world target base pose: ``base_q`` routes Kamino to
+            # ``_reset_to_base_state``, which rigidly transforms the assembled reference
+            # configuration (valid at ``joint_q == 0``) so each world keeps its origin offset
+            # and the closed-loop constraints stay satisfied. ``base_u`` (zero on reset) zeroes
+            # all body velocities.
+            cls._solver.reset(
+                state=cls._state_0,
+                world_mask=world_mask,
+                base_q=_base_q,
+                base_u=_base_u,
+            )
+        else:
+            # Fallback when the base body could not be identified: restore the assembled
+            # model-default state (consistent, but ignores the per-world target pose).
+            cls._solver.reset(
+                state=cls._state_0,
+                world_mask=world_mask,
+            )
+
+        # Snap ``joint_q_prev`` to the reset joint coords for the reset worlds: the no-FK
+        # reset leaves it stale, so the Moreau integrator would otherwise emit a spurious
+        # ``(q_new - q_prev)/dt`` velocity on the first post-reset step. The mask keeps
+        # other worlds' history intact.
+        _jqp = getattr(cls._state_0, "joint_q_prev", None)
+        if _jqp is not None and world_mask is not None:
+            _jq_t = wp.to_torch(cls._state_0.joint_q)
+            _jqp_t = wp.to_torch(_jqp)
+            _mask = wp.to_torch(world_mask).bool()
+            _nw_m = _mask.shape[0]
+            if _nw_m > 0 and _jq_t.shape[0] % _nw_m == 0:
+                _c = _jq_t.shape[0] // _nw_m
+                _jqp_t.view(_nw_m, _c)[_mask] = _jq_t.view(_nw_m, _c)[_mask]
+
+        # Overwrite body_q via Newton's eval_fk for a consistent frame convention. For
+        # closed-loop assets the fk mask is zero-length, so this is a no-op and body poses
+        # come from the base-state reset above.
+        eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, cls._fk_reset_mask)
+
+        # Sync state_1 to match state_0 so both states are consistent for the dual-state
+        # stepping scheme.
+        if cls._state_1 is not None and cls._state_1 is not cls._state_0:
+            for attr in ("joint_q", "joint_qd", "body_q", "body_qd"):
+                _src = getattr(cls._state_0, attr, None)
+                _dst = getattr(cls._state_1, attr, None)
+                if _src is not None and _dst is not None:
+                    wp.copy(_dst, _src)
+            for attr in ("joint_q_prev", "joint_lambdas"):
+                _src = getattr(cls._state_0, attr, None)
+                _dst = getattr(cls._state_1, attr, None)
+                if _src is not None and (
+                    _dst is None or _dst.shape != _src.shape or _dst.dtype != _src.dtype or _dst.device != _src.device
+                ):
+                    setattr(cls._state_1, attr, wp.clone(_src))
+                elif _src is not None and _dst is not None:
+                    wp.copy(_dst, _src)
+
+    @classmethod
+    def forward(cls) -> None:
+        """Update kinematics without stepping physics.
+
+        For Kamino, consume any pending reset flagged by :meth:`invalidate_fk` so the
+        explicit-reset path (``env.reset()`` -> ``sim.forward()``) makes ``body_q``
+        consistent with the reset ``joint_q`` before observations are read. Falls back
+        to a full ``eval_fk`` when no reset is pending.
+        """
+        if cls._kamino_needs_reset:
+            cls._forward_kamino(world_mask=cls._world_reset_mask)
+            # Clear the flag on the BASE class: assigning through ``cls`` would shadow the
+            # base attribute and make every later ``invalidate_fk`` go unobserved.
+            NewtonManager._kamino_needs_reset = False
+            if cls._world_reset_mask is not None:
+                cls._world_reset_mask.zero_()
+            if cls._fk_reset_mask is not None:
+                cls._fk_reset_mask.zero_()
+            return
+        eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, None)
 
     @classmethod
     def step(cls) -> None:
@@ -55,12 +181,12 @@ class NewtonKaminoManager(NewtonManager):
         if sim is None or not sim.is_playing():
             return
 
-        # Kamino: run solver.reset() with the accumulated world mask to reinitialise
-        # internal state (warm-start containers, constraint multipliers) for reset worlds.
-        # Note: runs every step. solver.reset() with an all-False world_mask is a no-op
-        # (kernels check mask per-world and skip). The cost of a no-op launch is negligible
-        # compared to the complexity of maintaining a separate boolean guard.
-        cls._forward_kamino(world_mask=cls._world_reset_mask)
+        # Run solver.reset() only when invalidate_fk() flagged a pending reset: it rewrites
+        # joint_q_prev and re-snaps body_q, so it must not run on no-reset steps.
+        if cls._kamino_needs_reset:
+            cls._forward_kamino(world_mask=cls._world_reset_mask)
+            # Clear on the BASE class (see ``forward`` for the shadowing rationale).
+            NewtonManager._kamino_needs_reset = False
 
         # Notify solver of model changes
         if cls._model_changes:
@@ -119,7 +245,20 @@ class NewtonKaminoManager(NewtonManager):
         Sets :attr:`NewtonManager._needs_collision_pipeline` to ``True`` only
         when ``use_collision_detector=False`` (Kamino's internal detector
         handles contacts otherwise).
+
+        Applies :attr:`KaminoSolverCfg.max_contacts_per_world`, when set, by overriding
+        ``model.rigid_contact_max`` before solver construction. This bounds GPU memory
+        for contact-rich multi-env training that would otherwise over-allocate from
+        ``geoms.world_minimum_contacts``.
         """
+        if solver_cfg.max_contacts_per_world is not None:
+            model.rigid_contact_max = int(solver_cfg.max_contacts_per_world) * model.world_count
+            logger.info(
+                "[KAMINO] Capping rigid_contact_max to %d (%d/world * %d worlds)",
+                model.rigid_contact_max,
+                solver_cfg.max_contacts_per_world,
+                model.world_count,
+            )
         NewtonManager._solver = SolverKamino(model, solver_cfg.to_solver_config())
         NewtonManager._use_single_state = False
         NewtonManager._needs_collision_pipeline = not solver_cfg.use_collision_detector

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 import warp as wp
-from newton import Model, eval_fk
+from newton import JointType, Model, eval_fk
 from newton.solvers import SolverKamino
 
 from isaaclab.physics import PhysicsManager
@@ -37,10 +37,12 @@ class NewtonKaminoManager(NewtonManager):
         Kamino's ``joint_q`` / ``joint_u`` include coordinates for **all** joints
         (including free joints), so we pass Newton's full state arrays directly.
 
-        The first joint per world is assumed to be a free (floating-base) joint, so
-        ``base_q`` / ``base_u`` are always reconstructed from the first 7 coords / 6 dofs
-        of ``joint_q`` / ``joint_qd``. After the solver reset, a full ``eval_fk`` (mask
-        ``None``) overwrites ``body_q`` for a consistent frame convention.
+        For floating-base models the first joint per world is a free joint and
+        ``base_q`` / ``base_u`` are reconstructed from the first 7 coords / 6 dofs
+        of ``joint_q`` / ``joint_qd``. Fixed-base models (e.g. Cartpole) omit
+        ``base_q`` / ``base_u`` and reset through ``joint_q`` / ``joint_u`` only.
+        After the solver reset, a full ``eval_fk`` (mask ``None``) overwrites
+        ``body_q`` for a consistent frame convention.
 
         Consumes the pending reset state: zeroes the world / FK reset masks and clears
         :attr:`_reset_pending` so that callers (:meth:`forward`, :meth:`step`) do not
@@ -59,8 +61,13 @@ class NewtonKaminoManager(NewtonManager):
         _dofs_per_world = _dof_count // _nw
         _jq = wp.to_torch(cls._state_0.joint_q).reshape(_nw, _coords_per_world)
         _ju = wp.to_torch(cls._state_0.joint_qd).reshape(_nw, _dofs_per_world)
-        _base_q = wp.from_torch(_jq[:, :7].contiguous(), dtype=wp.transformf)
-        _base_u = wp.from_torch(_ju[:, :6].contiguous(), dtype=wp.spatial_vectorf)
+        _has_free_base = _coords_per_world >= 7 and int(_model.joint_type.numpy()[0]) == int(JointType.FREE)
+        if _has_free_base:
+            _base_q = wp.from_torch(_jq[:, :7].contiguous(), dtype=wp.transformf)
+            _base_u = wp.from_torch(_ju[:, :6].contiguous(), dtype=wp.spatial_vectorf)
+        else:
+            _base_q = None
+            _base_u = None
 
         cls._solver.reset(
             state=cls._state_0,
@@ -73,6 +80,7 @@ class NewtonKaminoManager(NewtonManager):
 
         # Overwrite body_q via Newton's full eval_fk for a consistent frame convention.
         eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, None)
+        cls._update_sensors(None)
         NewtonManager._world_reset_mask.zero_()
         NewtonManager._fk_reset_mask.zero_()
         NewtonManager._reset_pending = False

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 import warp as wp
-from newton import JointType, Model, eval_fk
+from newton import Model, eval_fk
 from newton.solvers import SolverKamino
 
 from isaaclab.physics import PhysicsManager
@@ -32,22 +32,19 @@ class NewtonKaminoManager(NewtonManager):
 
     @classmethod
     def _forward_kamino(cls, world_mask: wp.array | None = None) -> None:
-        """Reset Kamino solver state to match the current joint configuration.
+        """Kamino-specific forward kinematics via ``solver.reset()``.
 
-        Two reset paths are selected at solver-construction time via
-        :attr:`KaminoSolverCfg.use_fk_solver`:
+        Kamino's ``joint_q`` / ``joint_u`` include coordinates for **all** joints
+        (including free joints), so we pass Newton's full state arrays directly.
 
-        * ``use_fk_solver=True`` (default): ``solver.reset(joint_q=..., joint_u=...,
-          base_q=..., base_u=...)`` runs Kamino's Gauss-Newton FK so ``body_q`` is
-          consistent with the written ``joint_q`` (needed for non-trivial joint reset
-          targets on closed-loop assets).
-        * ``use_fk_solver=False``: ``solver.reset(base_q=..., base_u=...)`` routes to
-          ``_reset_to_base_state`` -- bodies are placed by transforming the model's
-          reference body poses by ``base_q`` with **no FK solver**. This is the fast
-          path for tasks that pin every joint coord to ``0`` (the assembled
-          closed-loop-valid configuration) and sidesteps an FK-solver buffer overflow
-          at high ``num_envs``. It is only correct when the written ``joint_q`` equals
-          the model default (all zeros).
+        The first joint per world is assumed to be a free (floating-base) joint, so
+        ``base_q`` / ``base_u`` are always reconstructed from the first 7 coords / 6 dofs
+        of ``joint_q`` / ``joint_qd``. After the solver reset, a full ``eval_fk`` (mask
+        ``None``) overwrites ``body_q`` for a consistent frame convention.
+
+        Consumes the pending reset state: zeroes the world / FK reset masks and clears
+        :attr:`_reset_pending` so that callers (:meth:`forward`, :meth:`step`) do not
+        redo the work.
 
         Args:
             world_mask: Per-world mask indicating which worlds to reset.
@@ -55,124 +52,48 @@ class NewtonKaminoManager(NewtonManager):
         """
         _model = cls._model
         _nw = max(int(getattr(_model, "world_count", 0) or 0), 1)
-        _first_joint_is_free = _model.joint_count > 0 and int(_model.joint_type.numpy()[0]) == int(JointType.FREE)
 
-        _base_q = None
-        _base_u = None
-        if _first_joint_is_free:
-            _coord_count = int(getattr(_model, "joint_coord_count", _model.joint_count))
-            _dof_count = int(getattr(_model, "joint_dof_count", _model.joint_count))
-            if _nw > 0 and _coord_count % _nw == 0 and _dof_count % _nw == 0:
-                _coords_per_world = _coord_count // _nw
-                _dofs_per_world = _dof_count // _nw
-                if _coords_per_world >= 7 and _dofs_per_world >= 6:
-                    _jq = wp.to_torch(cls._state_0.joint_q).reshape(_nw, _coords_per_world)
-                    _ju = wp.to_torch(cls._state_0.joint_qd).reshape(_nw, _dofs_per_world)
-                    _base_q = wp.from_torch(_jq[:, :7].contiguous(), dtype=wp.transformf)
-                    _base_u = wp.from_torch(_ju[:, :6].contiguous(), dtype=wp.spatial_vectorf)
-        else:
-            _body_count = int(getattr(_model, "body_count", 0) or 0)
-            if _body_count > 0 and _nw > 0 and _body_count % _nw == 0:
-                _bodies_per_world = _body_count // _nw
-                if _model.joint_count > 0:
-                    _joints_per_world = _model.joint_count // _nw if _nw > 0 else _model.joint_count
-                    _joint_child_np = _model.joint_child.numpy()[: max(_joints_per_world, 0)]
-                    _per_world_children = {int(c) for c in _joint_child_np if int(c) >= 0}
-                else:
-                    _per_world_children = set()
-                if 0 not in _per_world_children:
-                    _bq = wp.to_torch(cls._state_0.body_q).reshape(_nw, _bodies_per_world, 7)
-                    _bu = wp.to_torch(cls._state_0.body_qd).reshape(_nw, _bodies_per_world, 6)
-                    _base_q = wp.from_torch(_bq[:, 0, :].contiguous(), dtype=wp.transformf)
-                    _base_u = wp.from_torch(_bu[:, 0, :].contiguous(), dtype=wp.spatial_vectorf)
+        _coord_count = int(getattr(_model, "joint_coord_count", _model.joint_count))
+        _dof_count = int(getattr(_model, "joint_dof_count", _model.joint_count))
+        _coords_per_world = _coord_count // _nw
+        _dofs_per_world = _dof_count // _nw
+        _jq = wp.to_torch(cls._state_0.joint_q).reshape(_nw, _coords_per_world)
+        _ju = wp.to_torch(cls._state_0.joint_qd).reshape(_nw, _dofs_per_world)
+        _base_q = wp.from_torch(_jq[:, :7].contiguous(), dtype=wp.transformf)
+        _base_u = wp.from_torch(_ju[:, :6].contiguous(), dtype=wp.spatial_vectorf)
 
-        _use_fk = bool(getattr(getattr(cls._solver, "_config", None), "use_fk_solver", True))
-        if _use_fk:
-            cls._solver.reset(
-                state=cls._state_0,
-                world_mask=world_mask,
-                joint_q=cls._state_0.joint_q,
-                joint_u=cls._state_0.joint_qd,
-                base_q=_base_q,
-                base_u=_base_u,
-            )
-        elif _base_q is not None:
-            # No-FK reset honoring the per-world target base pose: ``base_q`` routes Kamino to
-            # ``_reset_to_base_state``, which rigidly transforms the assembled reference
-            # configuration (valid at ``joint_q == 0``) so each world keeps its origin offset
-            # and the closed-loop constraints stay satisfied. ``base_u`` (zero on reset) zeroes
-            # all body velocities.
-            cls._solver.reset(
-                state=cls._state_0,
-                world_mask=world_mask,
-                base_q=_base_q,
-                base_u=_base_u,
-            )
-        else:
-            # Fallback when the base body could not be identified: restore the assembled
-            # model-default state (consistent, but ignores the per-world target pose).
-            cls._solver.reset(
-                state=cls._state_0,
-                world_mask=world_mask,
-            )
+        cls._solver.reset(
+            state=cls._state_0,
+            world_mask=world_mask,
+            joint_q=cls._state_0.joint_q,
+            joint_u=cls._state_0.joint_qd,
+            base_q=_base_q,
+            base_u=_base_u,
+        )
 
-        # Snap ``joint_q_prev`` to the reset joint coords for the reset worlds: the no-FK
-        # reset leaves it stale, so the Moreau integrator would otherwise emit a spurious
-        # ``(q_new - q_prev)/dt`` velocity on the first post-reset step. The mask keeps
-        # other worlds' history intact.
-        _jqp = getattr(cls._state_0, "joint_q_prev", None)
-        if _jqp is not None and world_mask is not None:
-            _jq_t = wp.to_torch(cls._state_0.joint_q)
-            _jqp_t = wp.to_torch(_jqp)
-            _mask = wp.to_torch(world_mask).bool()
-            _nw_m = _mask.shape[0]
-            if _nw_m > 0 and _jq_t.shape[0] % _nw_m == 0:
-                _c = _jq_t.shape[0] // _nw_m
-                _jqp_t.view(_nw_m, _c)[_mask] = _jq_t.view(_nw_m, _c)[_mask]
-
-        # Overwrite body_q via Newton's eval_fk for a consistent frame convention. For
-        # closed-loop assets the fk mask is zero-length, so this is a no-op and body poses
-        # come from the base-state reset above.
-        eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, cls._fk_reset_mask)
-
-        # Sync state_1 to match state_0 so both states are consistent for the dual-state
-        # stepping scheme.
-        if cls._state_1 is not None and cls._state_1 is not cls._state_0:
-            for attr in ("joint_q", "joint_qd", "body_q", "body_qd"):
-                _src = getattr(cls._state_0, attr, None)
-                _dst = getattr(cls._state_1, attr, None)
-                if _src is not None and _dst is not None:
-                    wp.copy(_dst, _src)
-            for attr in ("joint_q_prev", "joint_lambdas"):
-                _src = getattr(cls._state_0, attr, None)
-                _dst = getattr(cls._state_1, attr, None)
-                if _src is not None and (
-                    _dst is None or _dst.shape != _src.shape or _dst.dtype != _src.dtype or _dst.device != _src.device
-                ):
-                    setattr(cls._state_1, attr, wp.clone(_src))
-                elif _src is not None and _dst is not None:
-                    wp.copy(_dst, _src)
+        # Overwrite body_q via Newton's full eval_fk for a consistent frame convention.
+        eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, None)
+        NewtonManager._world_reset_mask.zero_()
+        NewtonManager._fk_reset_mask.zero_()
+        NewtonManager._reset_pending = False
 
     @classmethod
     def forward(cls) -> None:
         """Update kinematics without stepping physics.
 
-        For Kamino, consume any pending reset flagged by :meth:`invalidate_fk` so the
-        explicit-reset path (``env.reset()`` -> ``sim.forward()``) makes ``body_q``
-        consistent with the reset ``joint_q`` before observations are read. Falls back
-        to a full ``eval_fk`` when no reset is pending.
+        Runs the Kamino solver reset over the accumulated world mask so ``body_q`` is
+        consistent with the written ``joint_q`` before observations / rendering read it
+        (the explicit-reset path ``env.reset()`` -> ``sim.forward()``, and the lazy
+        read path via ``ArticulationData._ensure_fk_fresh``).
+
+        Gated on :attr:`_reset_pending`: with no pending reset the solver reset and FK
+        would be a no-op, so the launch is skipped entirely. :meth:`_forward_kamino`
+        consumes the masks and clears the flag so a following :meth:`step` does not
+        redo the work.
         """
-        if cls._kamino_needs_reset:
-            cls._forward_kamino(world_mask=cls._world_reset_mask)
-            # Clear the flag on the BASE class: assigning through ``cls`` would shadow the
-            # base attribute and make every later ``invalidate_fk`` go unobserved.
-            NewtonManager._kamino_needs_reset = False
-            if cls._world_reset_mask is not None:
-                cls._world_reset_mask.zero_()
-            if cls._fk_reset_mask is not None:
-                cls._fk_reset_mask.zero_()
+        if not cls._reset_pending:
             return
-        eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, None)
+        cls._forward_kamino(world_mask=cls._world_reset_mask)
 
     @classmethod
     def step(cls) -> None:
@@ -181,12 +102,8 @@ class NewtonKaminoManager(NewtonManager):
         if sim is None or not sim.is_playing():
             return
 
-        # Run solver.reset() only when invalidate_fk() flagged a pending reset: it rewrites
-        # joint_q_prev and re-snaps body_q, so it must not run on no-reset steps.
-        if cls._kamino_needs_reset:
+        if cls._reset_pending:
             cls._forward_kamino(world_mask=cls._world_reset_mask)
-            # Clear on the BASE class (see ``forward`` for the shadowing rationale).
-            NewtonManager._kamino_needs_reset = False
 
         # Notify solver of model changes
         if cls._model_changes:
@@ -212,17 +129,6 @@ class NewtonKaminoManager(NewtonManager):
                 logger.info("Newton CUDA graph captured (deferred relaxed mode, RTX-compatible)")
             else:
                 logger.warning("Newton deferred CUDA graph capture failed; using eager execution")
-
-        # Ensure body_q is up-to-date before collision detection.
-        # After env resets, joint_q is written but body_q (used by
-        # broadphase/narrowphase) is stale until FK runs.
-        # Only runs FK for dirtied articulations via the accumulated mask.
-        if cls._needs_collision_pipeline:
-            eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, cls._fk_reset_mask)
-
-        # Zero both masks after consumption
-        NewtonManager._world_reset_mask.zero_()
-        NewtonManager._fk_reset_mask.zero_()
 
         # Step simulation (graphed or not; _graph is None when capture is disabled or failed)
         if cfg is not None and cfg.use_cuda_graph and cls._graph is not None and "cuda" in device:  # type: ignore[union-attr]

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -168,6 +168,7 @@ class NewtonKaminoManager(NewtonManager):
         NewtonManager._solver = SolverKamino(model, solver_cfg.to_solver_config())
         NewtonManager._use_single_state = False
         NewtonManager._needs_collision_pipeline = not solver_cfg.use_collision_detector
+        NewtonManager._reset_passive_joints = True
 
     @classmethod
     def _capture_or_defer_cuda_graph(cls) -> None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -30,6 +30,29 @@ class NewtonKaminoManager(NewtonManager):
     Kamino's internal collision detector handles contact generation.
     """
 
+    # Host-side flag mirroring the shared reset masks. Set by :meth:`invalidate_fk`
+    # whenever joint / root state is written, cleared once the masks are consumed
+    # by :meth:`forward` or :meth:`step`. Kamino-specific: it gates the eager
+    # ``solver.reset()`` so a host-side check avoids a GPU -> CPU mask readback.
+    _reset_pending: bool = False
+
+    @classmethod
+    def invalidate_fk(
+        cls,
+        env_mask: wp.array | None = None,
+        env_ids: wp.array | None = None,
+        articulation_ids: wp.array | None = None,
+    ) -> None:
+        """Accumulate the reset masks and mark a Kamino reset as pending.
+
+        Delegates the mask accumulation to :meth:`NewtonManager.invalidate_fk`,
+        then records that the next :meth:`forward` / :meth:`step` must run the
+        Kamino solver reset once. See :attr:`_reset_pending`.
+        """
+        super().invalidate_fk(env_mask=env_mask, env_ids=env_ids, articulation_ids=articulation_ids)
+        if cls._world_reset_mask is not None and cls._fk_reset_mask is not None:
+            NewtonKaminoManager._reset_pending = True
+
     @classmethod
     def _forward_kamino(cls, world_mask: wp.array | None = None) -> None:
         """Kamino-specific forward kinematics via ``solver.reset()``.
@@ -83,7 +106,7 @@ class NewtonKaminoManager(NewtonManager):
         cls._update_sensors(None)
         NewtonManager._world_reset_mask.zero_()
         NewtonManager._fk_reset_mask.zero_()
-        NewtonManager._reset_pending = False
+        NewtonKaminoManager._reset_pending = False
 
     @classmethod
     def forward(cls) -> None:
@@ -177,6 +200,7 @@ class NewtonKaminoManager(NewtonManager):
         NewtonManager._use_single_state = False
         NewtonManager._needs_collision_pipeline = not solver_cfg.use_collision_detector
         NewtonManager._reset_passive_joints = True
+        NewtonKaminoManager._reset_pending = False
 
     @classmethod
     def _capture_or_defer_cuda_graph(cls) -> None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
@@ -145,6 +145,16 @@ class KaminoSolverCfg(NewtonSolverCfg):
     Only used when :attr:`use_collision_detector` is ``True``. If ``None``, Newton's default is used.
     """
 
+    max_contacts_per_world: int | None = None
+    """Cap the per-world contact pre-allocation handed to Kamino.
+
+    When ``None``, Kamino falls back to ``geoms.world_minimum_contacts`` derived from the
+    collision pipeline, which over-allocates dramatically for contact-rich assets. Set this
+    to bound GPU memory for multi-env training of contact-heavy tasks (e.g. legged
+    locomotion or manipulation). The total ``model.rigid_contact_max`` is computed as
+    ``max_contacts_per_world * model.world_count`` before solver construction.
+    """
+
     dynamics_preconditioning: bool = True
     """Whether to use preconditioning in the constrained dynamics solver.
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -257,6 +257,9 @@ class NewtonManager(PhysicsManager):
     # Per-world reset masks (allocated in start_simulation, consumed in step)
     _world_reset_mask: wp.array | None = None  # (num_envs,) wp.bool — for SolverKamino.reset(world_mask=...)
     _fk_reset_mask: wp.array | None = None  # (articulation_count,) wp.bool — for eval_fk(mask=...)
+    # Set by ``invalidate_fk`` and consumed by ``NewtonKaminoManager.step`` / ``forward``
+    # so the Kamino solver reset only runs on steps where a reset actually occurred.
+    _kamino_needs_reset: bool = False
 
     # Newton actuator adapter (owns actuators and double-buffered states)
     _adapter: NewtonActuatorAdapter | None = None
@@ -776,6 +779,7 @@ class NewtonManager(PhysicsManager):
         # Per-world reset masks
         NewtonManager._world_reset_mask = None
         NewtonManager._fk_reset_mask = None
+        NewtonManager._kamino_needs_reset = False
         NewtonManager._graph = None
         NewtonManager._graph_capture_pending = False
         NewtonManager._newton_stage_path = None
@@ -1063,6 +1067,9 @@ class NewtonManager(PhysicsManager):
         if cls._world_reset_mask is None or cls._fk_reset_mask is None:
             return
 
+        # Flag a pending Kamino solver reset; consumed by NewtonKaminoManager.
+        NewtonManager._kamino_needs_reset = True
+
         if articulation_ids is not None and env_mask is not None:
             wp.launch(
                 _or_reset_masks_from_mask,
@@ -1114,8 +1121,12 @@ class NewtonManager(PhysicsManager):
             cls._builder.request_state_attributes(*cls._pending_extended_state_attributes)
             NewtonManager._pending_extended_state_attributes = set()
         cls._prepare_builder_for_finalize(cls._builder)
+        # Kamino works in maximal coordinates, so joints need not form a strict tree;
+        # skip the tree-joint validation for Kamino only.
+        _solver_cfg = getattr(PhysicsManager._cfg, "solver_cfg", None)
+        _skip_joint_validation = getattr(_solver_cfg, "solver_type", "") == "kamino"
         with Timer(name="newton_finalize_builder", msg="Finalize builder took:"):
-            NewtonManager._model = cls._builder.finalize(device=device)
+            NewtonManager._model = cls._builder.finalize(device=device, skip_validation_joints=_skip_joint_validation)
             cls._model.set_gravity(cls._gravity_vector)
             cls._model.num_envs = cls._num_envs
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -261,11 +261,6 @@ class NewtonManager(PhysicsManager):
     _world_reset_mask: wp.array | None = None  # (num_envs,) wp.bool — for SolverKamino.reset(world_mask=...)
     _fk_reset_mask: wp.array | None = None  # (articulation_count,) wp.bool — for eval_fk(mask=...)
 
-    # Host-side flag mirroring the reset masks. Set by :meth:`invalidate_fk`
-    # whenever joint / root state is written, cleared once the masks are consumed
-    # by :meth:`forward` or :meth:`step`.
-    _reset_pending: bool = False
-
     # Concrete manager subclass that is actually driving the simulation (e.g.
     # ``NewtonKaminoManager``). Recorded in :meth:`initialize` because the base
     # class is referenced as a bare literal in data containers; lazy FK refresh
@@ -680,10 +675,9 @@ class NewtonManager(PhysicsManager):
         if cls._needs_collision_pipeline or cls._needs_fk_before_step:
             eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, cls._fk_reset_mask)
 
-        # Zero both masks after consumption and clear the pending flag.
+        # Zero both masks after consumption
         NewtonManager._world_reset_mask.zero_()
         NewtonManager._fk_reset_mask.zero_()
-        NewtonManager._reset_pending = False
 
         physics_dt = cls._solver_dt * cls._num_substeps
         use_graph = cfg is not None and cfg.use_cuda_graph and cls._graph is not None and "cuda" in device  # type: ignore[union-attr]
@@ -794,7 +788,6 @@ class NewtonManager(PhysicsManager):
         # Per-world reset masks
         NewtonManager._world_reset_mask = None
         NewtonManager._fk_reset_mask = None
-        NewtonManager._reset_pending = False
         NewtonManager._active_cls = None
         NewtonManager._graph = None
         NewtonManager._graph_capture_pending = False
@@ -1066,8 +1059,8 @@ class NewtonManager(PhysicsManager):
         """Mark environments as needing FK recomputation and solver reset.
 
         Called by asset write methods that modify joint coordinates or root
-        transforms. The masks are consumed in :meth:`forward` or :meth:`step`
-        (whichever runs first), gated by the :attr:`_reset_pending` flag set here.
+        transforms. The masks are consumed in :meth:`step` before physics
+        stepping.
 
         Args:
             env_mask: Boolean mask of dirtied environments. Shape ``(num_envs,)``.
@@ -1082,9 +1075,6 @@ class NewtonManager(PhysicsManager):
 
         if cls._world_reset_mask is None or cls._fk_reset_mask is None:
             return
-
-        # Mark a reset as pending so the next forward()/step() runs FK once.
-        NewtonManager._reset_pending = True
 
         if articulation_ids is not None and env_mask is not None:
             wp.launch(

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -234,6 +234,9 @@ class NewtonManager(PhysicsManager):
     _solver: SolverBase | None = None
     _use_single_state: bool | None = None
     """Use only one state for both input and output for solver stepping. Requires solver support."""
+    _reset_passive_joints: bool = False
+    """Whether joint writes set only actuated joints, so passive joints must be resolved by a
+    solver reset (``forward()``) before joint state is consistent on read (e.g. Kamino)."""
     _state_0: State = None
     _state_1: State = None
     _control: Control = None
@@ -767,6 +770,7 @@ class NewtonManager(PhysicsManager):
         NewtonManager._model = None
         NewtonManager._solver = None
         NewtonManager._use_single_state = None
+        NewtonManager._reset_passive_joints = False
         NewtonManager._state_0 = None
         NewtonManager._state_1 = None
         NewtonManager._control = None

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -257,9 +257,17 @@ class NewtonManager(PhysicsManager):
     # Per-world reset masks (allocated in start_simulation, consumed in step)
     _world_reset_mask: wp.array | None = None  # (num_envs,) wp.bool — for SolverKamino.reset(world_mask=...)
     _fk_reset_mask: wp.array | None = None  # (articulation_count,) wp.bool — for eval_fk(mask=...)
-    # Set by ``invalidate_fk`` and consumed by ``NewtonKaminoManager.step`` / ``forward``
-    # so the Kamino solver reset only runs on steps where a reset actually occurred.
-    _kamino_needs_reset: bool = False
+
+    # Host-side flag mirroring the reset masks. Set by :meth:`invalidate_fk`
+    # whenever joint / root state is written, cleared once the masks are consumed
+    # by :meth:`forward` or :meth:`step`.
+    _reset_pending: bool = False
+
+    # Concrete manager subclass that is actually driving the simulation (e.g.
+    # ``NewtonKaminoManager``). Recorded in :meth:`initialize` because the base
+    # class is referenced as a bare literal in data containers; lazy FK refresh
+    # must dispatch through this to reach the active backend's ``forward()``.
+    _active_cls: type[NewtonManager] | None = None
 
     # Newton actuator adapter (owns actuators and double-buffered states)
     _adapter: NewtonActuatorAdapter | None = None
@@ -334,6 +342,8 @@ class NewtonManager(PhysicsManager):
             sim_context: Parent simulation context.
         """
         super().initialize(sim_context)
+
+        NewtonManager._active_cls = cls
 
         # Newton-specific setup: get gravity from SimulationCfg (not physics manager cfg)
         sim = PhysicsManager._sim
@@ -667,9 +677,10 @@ class NewtonManager(PhysicsManager):
         if cls._needs_collision_pipeline or cls._needs_fk_before_step:
             eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, cls._fk_reset_mask)
 
-        # Zero both masks after consumption
+        # Zero both masks after consumption and clear the pending flag.
         NewtonManager._world_reset_mask.zero_()
         NewtonManager._fk_reset_mask.zero_()
+        NewtonManager._reset_pending = False
 
         physics_dt = cls._solver_dt * cls._num_substeps
         use_graph = cfg is not None and cfg.use_cuda_graph and cls._graph is not None and "cuda" in device  # type: ignore[union-attr]
@@ -779,7 +790,8 @@ class NewtonManager(PhysicsManager):
         # Per-world reset masks
         NewtonManager._world_reset_mask = None
         NewtonManager._fk_reset_mask = None
-        NewtonManager._kamino_needs_reset = False
+        NewtonManager._reset_pending = False
+        NewtonManager._active_cls = None
         NewtonManager._graph = None
         NewtonManager._graph_capture_pending = False
         NewtonManager._newton_stage_path = None
@@ -1050,8 +1062,8 @@ class NewtonManager(PhysicsManager):
         """Mark environments as needing FK recomputation and solver reset.
 
         Called by asset write methods that modify joint coordinates or root
-        transforms. The masks are consumed in :meth:`step` before physics
-        stepping.
+        transforms. The masks are consumed in :meth:`forward` or :meth:`step`
+        (whichever runs first), gated by the :attr:`_reset_pending` flag set here.
 
         Args:
             env_mask: Boolean mask of dirtied environments. Shape ``(num_envs,)``.
@@ -1067,8 +1079,8 @@ class NewtonManager(PhysicsManager):
         if cls._world_reset_mask is None or cls._fk_reset_mask is None:
             return
 
-        # Flag a pending Kamino solver reset; consumed by NewtonKaminoManager.
-        NewtonManager._kamino_needs_reset = True
+        # Mark a reset as pending so the next forward()/step() runs FK once.
+        NewtonManager._reset_pending = True
 
         if articulation_ids is not None and env_mask is not None:
             wp.launch(
@@ -1121,8 +1133,7 @@ class NewtonManager(PhysicsManager):
             cls._builder.request_state_attributes(*cls._pending_extended_state_attributes)
             NewtonManager._pending_extended_state_attributes = set()
         cls._prepare_builder_for_finalize(cls._builder)
-        # Kamino works in maximal coordinates, so joints need not form a strict tree;
-        # skip the tree-joint validation for Kamino only.
+        # Kamino works in maximal coordinates, so skip the tree-joint validation for Kamino only.
         _solver_cfg = getattr(PhysicsManager._cfg, "solver_cfg", None)
         _skip_joint_validation = getattr(_solver_cfg, "solver_type", "") == "kamino"
         with Timer(name="newton_finalize_builder", msg="Finalize builder took:"):

--- a/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor.py
@@ -401,7 +401,10 @@ class ContactSensor(BaseContactSensor):
         Args:
             env_mask: Mask of the environments to update. None: update all environments.
         """
-        # Copy data from Newton into owned buffers (respecting env_mask)
+        # Copy data from Newton into owned buffers (respecting env_mask). This single path
+        # works for every solver backend: the Newton :class:`~newton.sensors.SensorContact`
+        # accumulates per-contact forces from ``Contacts.force``, which the MuJoCo-Warp and
+        # Kamino solvers both populate in their ``update_contacts`` conversions.
         # Launch with 3D for coalescing: dim=(num_envs, num_sensors, max(num_filter_objects, 1))
         wp.launch(
             copy_from_newton_kernel,

--- a/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor.py
@@ -401,10 +401,7 @@ class ContactSensor(BaseContactSensor):
         Args:
             env_mask: Mask of the environments to update. None: update all environments.
         """
-        # Copy data from Newton into owned buffers (respecting env_mask). This single path
-        # works for every solver backend: the Newton :class:`~newton.sensors.SensorContact`
-        # accumulates per-contact forces from ``Contacts.force``, which the MuJoCo-Warp and
-        # Kamino solvers both populate in their ``update_contacts`` conversions.
+        # Copy data from Newton into owned buffers (respecting env_mask)
         # Launch with 3D for coalescing: dim=(num_envs, num_sensors, max(num_filter_objects, 1))
         wp.launch(
             copy_from_newton_kernel,

--- a/source/isaaclab_tasks/changelog.d/aserifi-kamino-task-presets.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/aserifi-kamino-task-presets.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added ``newton_kamino`` physics presets to the velocity, reach, cabinet, shadow-hand,
+  and humanoid task configurations, enabling those tasks to run on the Kamino solver.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -28,6 +28,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
@@ -6,7 +6,7 @@
 
 from dataclasses import MISSING
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -72,6 +72,11 @@ class CabinetSimCfg(PresetCfg):
             num_substeps=1,
             debug_mode=False,
         ),
+    )
+    newton_kamino: SimulationCfg = SimulationCfg(
+        dt=1 / 600,
+        render_interval=1,
+        physics=NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=1),
     )
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
@@ -38,6 +38,7 @@ class HumanoidPhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
+    newton_kamino: NewtonCfg = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
     ovphysx: OvPhysxCfg = OvPhysxCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -42,6 +42,7 @@ class HumanoidPhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
+    newton_kamino: NewtonCfg = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 ##

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
@@ -5,7 +5,7 @@
 
 from dataclasses import MISSING
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
@@ -43,6 +43,10 @@ class ReachPhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    newton_kamino: NewtonCfg = NewtonCfg(
+        solver_cfg=KaminoSolverCfg(max_contacts_per_world=32),
+        num_substeps=2,
+    )
 
     default = physx
 
@@ -65,7 +69,7 @@ class TableCfg(PresetCfg):
     newton_mjwarp: ArticulationCfg = ArticulationCfg(
         prim_path="/World/envs/env_.*/Table",
         init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.5, 0.15, -0.5), rot=(0, 0, 0.707, 0.707), joint_pos={}, joint_vel={}
+            pos=(0.5, 0, -0.5), rot=(0, 0, 0.707, 0.707), joint_pos={}, joint_vel={}
         ),
         spawn=sim_utils.CuboidCfg(
             size=(0.9, 1.3, 1.00),
@@ -76,6 +80,7 @@ class TableCfg(PresetCfg):
         articulation_root_prim_path="",
     )
 
+    newton_kamino = newton_mjwarp
     default = physx
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
@@ -80,7 +80,7 @@ class TableCfg(PresetCfg):
         articulation_root_prim_path="",
     )
 
-    newton_kamino = newton_mjwarp
+    newton_kamino: ArticulationCfg = newton_mjwarp
     default = physx
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
@@ -135,6 +135,7 @@ class ShadowHandEventCfg(PresetCfg):
     physx = PhysxEventCfg()
     newton_mjwarp = NewtonEventCfg()
     default = physx
+    newton_kamino = newton_mjwarp
 
 
 @configclass
@@ -207,6 +208,7 @@ class ShadowHandRobotCfg(PresetCfg):
         soft_joint_pos_limit_factor=1.0,
     )
     default = physx
+    newton_kamino = newton_mjwarp
 
 
 @configclass
@@ -246,6 +248,7 @@ class ObjectCfg(PresetCfg):
         articulation_root_prim_path="",
     )
     default = physx
+    newton_kamino = newton_mjwarp
 
 
 @configclass
@@ -263,6 +266,7 @@ class ShadowHandSceneCfg(PresetCfg):
         num_envs=8192, env_spacing=0.75, replicate_physics=True, clone_in_fabric=False
     )
     default: InteractiveSceneCfg = physx
+    newton_kamino = newton_mjwarp
 
 
 @configclass
@@ -287,6 +291,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     default = physx
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
@@ -266,7 +266,7 @@ class ShadowHandSceneCfg(PresetCfg):
         num_envs=8192, env_spacing=0.75, replicate_physics=True, clone_in_fabric=False
     )
     default: InteractiveSceneCfg = physx
-    newton_kamino = newton_mjwarp
+    newton_kamino: InteractiveSceneCfg = newton_mjwarp
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.managers import SceneEntityCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
@@ -29,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
@@ -3,7 +3,13 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
+from isaaclab_newton.physics import (
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -43,6 +49,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
         default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(), num_substeps=2)
 
 
 ##
@@ -223,6 +230,7 @@ class SpotEventCfg(PresetCfg):
     default = SpotPhysxEventCfg()
     newton_mjwarp = SpotNewtonEventCfg()
     physx = default
+    newton_kamino = newton_mjwarp
 
 
 @configclass


### PR DESCRIPTION
# Description

* Add logic to run the Kamino reset function once (it ensures every read that requires data from fk triggers fk, or if we do not read data, it does so at step)
* Add simulation presets for Kamino
* Fixes small issues

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
