### PR TITLE
Removes force_orphan from docs deploy on main

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -140,4 +140,3 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build
         keep_files: false
-        force_orphan: true


### PR DESCRIPTION
# Description

The nightly docs deploy on `main` fails at the `Deploy to gh-pages` step because `force_orphan: true` makes `peaceiris/actions-gh-pages` publish an orphan branch with `git push --force`, which the repo's "Block force pushes" branch rule rejects (`GH013`).

This removes `force_orphan: true` so the action uses a normal fast-forward push, matching the deploys that currently succeed. This is the same fix @kellyguo11 already applied to `develop` in #5853, which never landed on `main`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there