### PR TITLE
Change hugging face links

### DIFF
--- a/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
+++ b/docs/source/policy_deployment/03_compass_with_NuRec/compass_navigation_policy_with_NuRec.rst
@@ -19,7 +19,7 @@ training scenes and real operating environments and improve zero-shot transfer. 
 to evaluate policies in reconstructed simulation scenes that better reflect target deployment spaces.
 
 Some sample assets compatible with COMPASS training are available in the
-`PhysicalAI-Robotics-NuRec dataset on Hugging Face <https://huggingface.co/datasets/nvidia/PhysicalAI-Robotics-NuRec/tree/v0.2>`_.
+`PhysicalAI-Robotics-NuRec dataset on Hugging Face <https://huggingface.co/datasets/nvidia/PhysicalAI-Robotics-NuRec>`_.
 
 Real2Sim Assets
 ~~~~~~~~~~~~~~~
@@ -36,7 +36,6 @@ scenes produced with this workflow; two examples are shown below.
 
    * - .. figure:: https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/nurec_real2sim_galileo.gif
           :alt: Galileo Real2Sim NuRec asset
-          :target: https://huggingface.co/datasets/nvidia/PhysicalAI-Robotics-NuRec/tree/v0.2/nova_carter-galileo
           :class: nurec-gif-cover
           :align: center
 
@@ -46,7 +45,6 @@ scenes produced with this workflow; two examples are shown below.
           | Sensor Rig: 4 x `Stereo Camera <https://leopardimaging.com/wp-content/uploads/2024/07/LI-AR0234CS-STEREO-GMSL2-30_Datasheet_V1.8.pdf>`_
      - .. figure:: https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/nurec_real2sim_living_room.gif
           :alt: Living Room Real2Sim NuRec asset
-          :target: https://huggingface.co/datasets/nvidia/PhysicalAI-Robotics-NuRec/tree/v0.2/hand_hold-endeavor-livingroom
           :class: nurec-gif-cover
           :align: center
 
@@ -68,7 +66,6 @@ assets available in Isaac Sim.
 
    * - .. figure:: https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/xgrid_wormhole_with_sim_objects.gif
           :alt: Wormhole XGRIDS reconstruction
-          :target: https://huggingface.co/datasets/nvidia/PhysicalAI-Robotics-NuRec/tree/v0.2/xgrid-wormhole
           :class: nurec-gif-cover
           :align: center
 


### PR DESCRIPTION
## Description

Adds animated GIF previews of NuRec assets and COMPASS training clips to the COMPASS NuRec documentation page. GIFs are hosted on the NVIDIA CDN (`download.isaacsim.omniverse.nvidia.com/isaaclab/images/`) and displayed in a two-column grid layout.

**Changes:**
- Replace plain bullet lists with `list-table` figure grids showing asset and training GIFs
- Add `nurec-gif-*` CSS rules for grid layout, 16:9 aspect ratio, and cover/contain cropping
- Add HuggingFace dataset links for each NuRec asset (Galileo, Living Room, Wormhole)
- Add Stereo Camera datasheet links (Leopard Imaging) for Galileo and Living Room entries
- Add XGRIDS PortalCam link for Wormhole entry

## Type of change

- Documentation update

## Screenshots

| Section | Preview |
| ------- | ------- |
| NuRec Assets | _(two-column GIF grid: Galileo + Living Room)_ |
| XGRIDS Assets | _(single-column GIF: Wormhole)_ |
| Training Examples | _(two-column GIF grid: G1 in Galileo + Carter in Wormhole)_ |

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with ./isaaclab.sh --format
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's config/extension.toml file
- [ ] I have added my name to the CONTRIBUTORS.md or my name already exists there