### PR TITLE
Fixes attribute reordering in configclass with partial type annotations

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,6 +44,7 @@ Guidelines for modifications:
 
 ## Contributors
 
+* Advait Jayant
 * Agon Serifi
 * Alessandro Assirelli
 * Alex Omar

--- a/source/isaaclab/changelog.d/0xadvait-fix-configclass-ordering.rst
+++ b/source/isaaclab/changelog.d/0xadvait-fix-configclass-ordering.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.utils.configclass.configclass` reordering class attributes when type
+  annotations are provided on only some of them. Annotated attributes no longer jump ahead of
+  non-annotated ones, so the resulting field order now matches the declaration order. This
+  is important for configuration classes where the attribute order is meaningful, such as
+  :class:`~isaaclab.scene.InteractiveSceneCfg`.

--- a/source/isaaclab/isaaclab/utils/configclass.py
+++ b/source/isaaclab/isaaclab/utils/configclass.py
@@ -283,20 +283,25 @@ def _add_annotation_types(cls):
             continue
         # get base class annotations
         ann = base.__dict__.get("__annotations__", {})
-        # directly add all annotations from base class
-        hints.update(ann)
         # iterate over base class members
         # Note: Do not change this to dir(base) since it orders the members alphabetically.
         #   This is not desirable since the order of the members is important in some cases.
+        # Note: We add annotated members while iterating over the class members (instead of
+        #   bulk-adding all annotations beforehand) to preserve the declaration order when
+        #   only some members have type annotations. Otherwise, annotated members would jump
+        #   ahead of non-annotated ones in the resulting field order.
         for key in base.__dict__:
             # get class member
             value = getattr(base, key)
             # skip members
             if _skippable_class_member(key, value, hints):
                 continue
+            # add type annotations for members that have explicit type annotations
+            if key in ann:
+                hints[key] = ann[key]
             # add type annotations for members that don't have explicit type annotations
             # for these, we deduce the type from the default value
-            if not isinstance(value, type):
+            elif not isinstance(value, type):
                 if key not in hints:
                     # check if var type is not MISSING
                     # we cannot deduce type from MISSING!
@@ -312,6 +317,10 @@ def _add_annotation_types(cls):
                 #   the name of the type matches the name of the variable.
                 # since Python 3.10, type hints are stored as strings
                 hints[key] = f"type[{value.__name__}]"
+        # add remaining annotations that do not have a corresponding class member (e.g. annotation-only
+        # declarations) or whose member was skipped above. For keys already present in the hints,
+        # this only refreshes the type and keeps their original position.
+        hints.update(ann)
 
     # Note: Do not change this line. `cls.__dict__.get("__annotations__", {})` is different from
     #   `cls.__annotations__` because of inheritance.

--- a/source/isaaclab/test/utils/test_configclass.py
+++ b/source/isaaclab/test/utils/test_configclass.py
@@ -175,6 +175,27 @@ class InheritedNonTypeAnnotationOrderingDemoCfg(NonTypeAnnotationOrderingDemoCfg
     pass
 
 
+@configclass
+class MixedAnnotationOrderingDemoCfg:
+    """Config class with type annotations on only some attributes."""
+
+    plane = RobotDefaultStateCfg()
+    robot = RobotDefaultStateCfg()
+    peg: RobotDefaultStateCfg = RobotDefaultStateCfg()
+    hole: RobotDefaultStateCfg = RobotDefaultStateCfg()
+    camera = RobotDefaultStateCfg()
+    light = RobotDefaultStateCfg()
+
+
+@configclass
+class InheritedMixedAnnotationOrderingDemoCfg(MixedAnnotationOrderingDemoCfg):
+    """Inherited config class with type annotations on only some attributes."""
+
+    table = RobotDefaultStateCfg()
+    sensor: RobotDefaultStateCfg = RobotDefaultStateCfg()
+    marker = RobotDefaultStateCfg()
+
+
 """
 Dummy configuration: Inheritance
 """
@@ -818,6 +839,26 @@ def test_configclass_type_ordering():
     assert list(cfg_1.__dict__.keys()) == list(cfg_2.__dict__.keys())
     assert list(cfg_3.__dict__.keys()) == list(cfg_2.__dict__.keys())
     assert list(cfg_1.__dict__.keys()) == list(cfg_3.__dict__.keys())
+
+
+def test_configclass_mixed_type_annotations_ordering():
+    """Checks that declaration order is preserved when only some attributes have type annotations.
+
+    Reference: https://github.com/isaac-sim/IsaacLab/issues/1949
+    """
+    cfg = MixedAnnotationOrderingDemoCfg()
+    expected_order = ["plane", "robot", "peg", "hole", "camera", "light"]
+
+    # check ordering of attributes and dictionary conversion
+    assert list(cfg.__dict__.keys()) == expected_order
+    assert list(cfg.to_dict().keys()) == expected_order
+
+    # check ordering with inheritance: parent fields first, then child fields in declaration order
+    cfg_inherited = InheritedMixedAnnotationOrderingDemoCfg()
+    expected_inherited_order = expected_order + ["table", "sensor", "marker"]
+
+    assert list(cfg_inherited.__dict__.keys()) == expected_inherited_order
+    assert list(cfg_inherited.to_dict().keys()) == expected_inherited_order
 
 
 def test_functions_config():


### PR DESCRIPTION
# Description

When type annotations are provided on only some attributes of a `configclass`, the resulting field order does not follow the declaration order: all annotated attributes jump ahead of the non-annotated ones. This breaks the documented guarantee that attribute order is preserved, which matters in particular for `InteractiveSceneCfg`, where the attribute order determines the scene entity creation order.

```python
@configclass
class SceneCfg(InteractiveSceneCfg):
    plane = AssetBaseCfg(...)
    robot = ArticulationCfg(...)
    peg: ArticulationCfg = ArticulationCfg(...)
    hole: ArticulationCfg = ArticulationCfg(...)
    camera = TiledCameraCfg(...)
    light = AssetBaseCfg(...)

# before this fix:
# ['peg', 'hole', 'plane', 'robot', 'camera', 'light']
# with this fix:
# ['plane', 'robot', 'peg', 'hole', 'camera', 'light']
```

**Root cause**: `_add_annotation_types` bulk-adds each base class's `__annotations__` into the type-hints dictionary *before* iterating over the class members (`hints.update(ann)` prior to the `base.__dict__` walk), so annotated fields are always inserted first.

**Fix**: build the hints dictionary in a single pass over `base.__dict__` (which preserves declaration order), picking up the explicit annotation when one exists and deducing the type from the default value otherwise. A trailing `hints.update(ann)` keeps the previous behavior for corner cases (annotation-only declarations, re-annotated inherited members, members skipped by `_skippable_class_member`) — for keys already present it only refreshes the type and keeps the position.

The semantics are otherwise unchanged: cross-base ordering (parent fields first, overrides keep the parent position), `MISSING` handling, `ClassVar` handling, and nested-class handling all behave as before.

**Verification**

- New regression test `test_configclass_mixed_type_annotations_ordering` (mirrors the issue repro, plus an inheritance case). It fails before the fix and passes after.
- Full `test_configclass.py` suite passes (44 tests).
- The complete `source/isaaclab/test/utils/` suite was run on CPU before and after the change with byte-identical results (the only failing tests are CUDA-/Nucleus-dependent and fail identically on both sides).
- An AST scan over `source/` found 81 configclasses whose field order changes with this fix (i.e., classes currently affected by the silent reordering), of which ~15 are `InteractiveSceneCfg` subclasses. For these, entity creation order now matches the declaration order, which is what the documentation promises (e.g., terrain/ground declared first now actually spawns first). Managers and scene entities are referenced by name, so no name-based lookups are affected.

Fixes #1949
Related to #1743 (the same hoisting also affected `None`-typed members before it was special-cased)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
