### PR TITLE
Clarifies Factory vs FORGE action-space control semantics

### DIFF
--- a/source/isaaclab_tasks/changelog.d/0xadvait-clarify-forge-ctrl-semantics.rst
+++ b/source/isaaclab_tasks/changelog.d/0xadvait-clarify-forge-ctrl-semantics.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Clarified the documentation of the action-space semantics in the Factory and FORGE control
+  configurations. In the Factory environments, the action thresholds scale per-step end-effector
+  displacements and the action bounds clip the target relative to the fixed asset, while in the
+  FORGE environments the action bounds map actions onto the operational volume around the fixed
+  asset and the randomized action thresholds clip the per-step motion, following the FORGE paper.

--- a/source/isaaclab_tasks/changelog.d/0xadvait-clarify-forge-ctrl-semantics.rst
+++ b/source/isaaclab_tasks/changelog.d/0xadvait-clarify-forge-ctrl-semantics.rst
@@ -1,8 +1,0 @@
-Changed
-^^^^^^^
-
-* Clarified the documentation of the action-space semantics in the Factory and FORGE control
-  configurations. In the Factory environments, the action thresholds scale per-step end-effector
-  displacements and the action bounds clip the target relative to the fixed asset, while in the
-  FORGE environments the action bounds map actions onto the operational volume around the fixed
-  asset and the randomized action thresholds clip the per-step motion, following the FORGE paper.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/factory_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/factory_env_cfg.py
@@ -50,6 +50,18 @@ class ObsRandCfg:
 
 @configclass
 class CtrlCfg:
+    """Controller and action-space configuration for the Factory environments.
+
+    In the Factory environments, policy actions are interpreted as displacements relative to the
+    current end-effector pose: ``pos_action_threshold`` [m] and ``rot_action_threshold`` [rad] scale
+    the normalized policy action to a per-step target displacement, while ``pos_action_bounds`` [m]
+    clips the resulting position target relative to the fixed asset to bound the workspace.
+
+    The FORGE environments reuse this configuration with a different action space (absolute targets
+    relative to the fixed asset), in which these parameters play different roles. See ``ForgeCtrlCfg``
+    in ``isaaclab_tasks/contrib/forge/forge_env_cfg.py``.
+    """
+
     ema_factor = 0.2
 
     pos_action_bounds = [0.05, 0.05, 0.05]

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/factory_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/factory_env_cfg.py
@@ -58,8 +58,8 @@ class CtrlCfg:
     clips the resulting position target relative to the fixed asset to bound the workspace.
 
     The FORGE environments reuse this configuration with a different action space (absolute targets
-    relative to the fixed asset), in which these parameters play different roles. See ``ForgeCtrlCfg``
-    in ``isaaclab_tasks/contrib/forge/forge_env_cfg.py``.
+    relative to the fixed asset), in which these parameters play different roles. See
+    :class:`~isaaclab_tasks.contrib.forge.forge_env_cfg.ForgeCtrlCfg`.
     """
 
     ema_factor = 0.2

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env.py
@@ -158,10 +158,11 @@ class ForgeEnv(FactoryEnv):
 
         * ``pos_action_bounds`` and ``rot_action_bounds`` map the normalized policy action onto the
           operational volume around the fixed asset.
-        * ``pos_threshold`` and ``rot_threshold`` clip the per-step motion of the target relative to the
-          current end-effector pose. They correspond to the action scale (lambda) in the FORGE paper,
-          which is randomized per episode as part of the dynamics randomization scheme and exposed to
-          the critic as privileged state.
+        * ``pos_action_threshold`` and ``rot_action_threshold`` clip the per-step motion of the target
+          relative to the current end-effector pose. They are applied through the per-environment
+          ``pos_threshold`` and ``rot_threshold`` tensors and correspond to the action scale (lambda)
+          in the FORGE paper, which is randomized per episode as part of the dynamics randomization
+          scheme and exposed to the critic as privileged state.
 
         Reference: Noseworthy et al., "FORGE: Force-Guided Exploration for Robust Contact-Rich
         Manipulation under Uncertainty", Sec. III-B, Eq. 6. https://arxiv.org/abs/2408.04587

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env.py
@@ -150,23 +150,15 @@ class ForgeEnv(FactoryEnv):
         return {"policy": obs_tensors, "critic": state_tensors}
 
     def _apply_action(self):
-        """FORGE actions are defined as targets relative to the fixed asset.
+        """Apply absolute FORGE pose targets relative to the fixed asset.
 
-        Unlike the Factory environments, where actions are interpreted as displacements relative to the
-        current end-effector pose, FORGE actions encode absolute pose targets relative to the fixed asset.
-        As a result, the control parameters play different roles in the two environment families:
-
-        * ``pos_action_bounds`` and ``rot_action_bounds`` map the normalized policy action onto the
-          operational volume around the fixed asset.
-        * ``pos_action_threshold`` and ``rot_action_threshold`` clip the per-step motion of the target
-          relative to the current end-effector pose. They are applied through the per-environment
-          ``pos_threshold`` and ``rot_threshold`` tensors and correspond to the action scale (lambda)
-          in the FORGE paper, which is randomized per episode as part of the dynamics randomization
-          scheme and exposed to the critic as privileged state.
-
-        Reference: Noseworthy et al., "FORGE: Force-Guided Exploration for Robust Contact-Rich
-        Manipulation under Uncertainty", Sec. III-B, Eq. 6. https://arxiv.org/abs/2408.04587
+        ``pos_action_bounds`` [m] maps translational actions onto the workspace and
+        ``rot_action_bounds`` [rad] maps rotational actions onto their allowable target range.
+        ``pos_action_threshold`` [m] and ``rot_action_threshold`` [rad] then clip per-step
+        target motion relative to the current end-effector pose. See :class:`ForgeCtrlCfg` for
+        the randomized action-scale semantics.
         """
+
         if self.last_update_timestamp < self._robot._data._sim_timestamp:
             self._compute_intermediate_values(dt=self.physics_dt)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env.py
@@ -150,7 +150,22 @@ class ForgeEnv(FactoryEnv):
         return {"policy": obs_tensors, "critic": state_tensors}
 
     def _apply_action(self):
-        """FORGE actions are defined as targets relative to the fixed asset."""
+        """FORGE actions are defined as targets relative to the fixed asset.
+
+        Unlike the Factory environments, where actions are interpreted as displacements relative to the
+        current end-effector pose, FORGE actions encode absolute pose targets relative to the fixed asset.
+        As a result, the control parameters play different roles in the two environment families:
+
+        * ``pos_action_bounds`` and ``rot_action_bounds`` map the normalized policy action onto the
+          operational volume around the fixed asset.
+        * ``pos_threshold`` and ``rot_threshold`` clip the per-step motion of the target relative to the
+          current end-effector pose. They correspond to the action scale (lambda) in the FORGE paper,
+          which is randomized per episode as part of the dynamics randomization scheme and exposed to
+          the critic as privileged state.
+
+        Reference: Noseworthy et al., "FORGE: Force-Guided Exploration for Robust Contact-Rich
+        Manipulation under Uncertainty", Sec. III-B, Eq. 6. https://arxiv.org/abs/2408.04587
+        """
         if self.last_update_timestamp < self._robot._data._sim_timestamp:
             self._compute_intermediate_values(dt=self.physics_dt)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env_cfg.py
@@ -29,8 +29,9 @@ class ForgeCtrlCfg(CtrlCfg):
     """Controller and action-space configuration for the FORGE environments.
 
     In the FORGE environments, policy actions encode absolute pose targets relative to the fixed
-    asset: ``pos_action_bounds`` [m] and ``rot_action_bounds`` [rad] map the normalized policy action
-    onto the operational volume around the fixed asset, while ``pos_action_threshold`` [m] and
+    asset: ``pos_action_bounds`` [m] maps the translational action onto the operational volume, while
+    ``rot_action_bounds`` [rad] maps the rotational action onto its allowable target range.
+    Meanwhile, ``pos_action_threshold`` [m] and
     ``rot_action_threshold`` [rad] clip the per-step motion of the target relative to the current
     end-effector pose. This differs from the Factory environments, where actions are displacements
     relative to the current end-effector pose and the same parameters play the opposite roles.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/forge_env_cfg.py
@@ -26,6 +26,25 @@ STATE_DIM_CFG.update({"force_threshold": 1, "ft_force": 3})
 
 @configclass
 class ForgeCtrlCfg(CtrlCfg):
+    """Controller and action-space configuration for the FORGE environments.
+
+    In the FORGE environments, policy actions encode absolute pose targets relative to the fixed
+    asset: ``pos_action_bounds`` [m] and ``rot_action_bounds`` [rad] map the normalized policy action
+    onto the operational volume around the fixed asset, while ``pos_action_threshold`` [m] and
+    ``rot_action_threshold`` [rad] clip the per-step motion of the target relative to the current
+    end-effector pose. This differs from the Factory environments, where actions are displacements
+    relative to the current end-effector pose and the same parameters play the opposite roles.
+
+    The per-step clips correspond to the action scale (lambda) in the FORGE paper (Sec. III-B, Eq. 6).
+    They are randomized per episode via ``pos_threshold_noise_level`` and ``rot_threshold_noise_level``
+    as part of the dynamics randomization scheme and are exposed to the critic as privileged state.
+    With the default values, the randomized position action scale spans [1.6, 2.5] cm, matching the
+    randomization parameters in Appendix A of the paper.
+
+    Reference: Noseworthy et al., "FORGE: Force-Guided Exploration for Robust Contact-Rich
+    Manipulation under Uncertainty". https://arxiv.org/abs/2408.04587
+    """
+
     ema_factor_range = [0.025, 0.1]
     default_task_prop_gains = [565.0, 565.0, 565.0, 28.0, 28.0, 28.0]
     task_prop_gains_noise_level = [0.41, 0.41, 0.41, 0.41, 0.41, 0.41]


### PR DESCRIPTION
# Description

The Factory and FORGE environments share the `CtrlCfg` fields `pos_action_bounds` / `rot_action_bounds` and `pos_action_threshold` / `rot_action_threshold`, but apply them in *opposite roles*, because the two families use different action spaces:

| | Factory (`factory_env.py`) | FORGE (`forge_env.py`) |
|---|---|---|
| Action meaning | displacement relative to current EE pose | absolute target relative to fixed asset |
| `pos_action_threshold` | **scales** the normalized action to a per-step displacement | **clips** the per-step motion of the target w.r.t. the current EE pose |
| `pos_action_bounds` | **clips** the target relative to the fixed asset (workspace bound) | **scales** the normalized action onto the operational volume around the fixed asset |

Read side by side, this looks like the two variables were accidentally swapped in `ForgeEnv` (see #5424). The FORGE implementation is, however, faithful to the FORGE paper:

- The paper defines the action as a relative pose applied to the fixed part's pose to obtain an absolute target, which "is clipped by an action scale, λ, to ensure that the target is not too far from the EE's current pose" (Sec. III-B, Eq. 6), and states "we allow targets to be up to 5cm away in all directions" (the operational volume, i.e. `pos_action_bounds = 0.05`).
- λ is listed in the paper's dynamics randomization table (Appendix A) as "Action Scale: λ ∈ [1.6, 2.5] cm". With the implementation's noise scheme (`x * m` or `x / m` with `m = 1 + U(0,1) · noise_level`), `pos_action_threshold = 0.02` and `pos_threshold_noise_level = 0.25` give exactly `0.02 × [1/1.25, 1.25] = [1.6, 2.5] cm`. The same check works for the controller gains: `565 × [1/1.41, 1.41] ≈ [400, 800]`, matching the paper's "Controller Gains [400, 800]".
- Since FORGE actions are positions (not displacements), the per-step motion limit can only be realized as a clip on the delta to the current EE pose — a multiplicative scale on the action cannot play that role in this action space.

Because this keeps being read as a bug, this PR documents both semantics where a reader would look for them: a class docstring on `CtrlCfg` (Factory semantics), a class docstring on `ForgeCtrlCfg` (FORGE semantics, the λ correspondence and the randomization ranges), and an expanded `ForgeEnv._apply_action` docstring with the paper reference.

Documentation-only change; no behavior is modified.

Related to #5424 (a detailed analysis is posted on the issue).

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
