### PR TITLE
Fix beta2 docs deploy selection

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -75,6 +75,8 @@ jobs:
           --exclude 'user@'
           --exclude 'helm\.ngc\.nvidia\.com'
           --exclude 'slurm\.schedmd\.com'
+          --exclude '^https://unitree\.com/h1$'
+          --exclude '^https://bostondynamics\.com/reinforcement-learning-researcher-kit/?$'
           --max-retries 3
           --retry-wait-time 5
           --timeout 30

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -103,11 +103,11 @@ jobs:
       working-directory: ./docs
       env:
         # "deploy" branches build the full set of versions so every page
-        # has a complete version dropdown: main, develop, tags >= v2.0.0
-        # (including pre-release suffixes like -beta or -rc1). v1.x tags and
-        # release/ branches are excluded.
-        SMV_BRANCH_WHITELIST: '^(main|develop)$'
-        SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+(-[A-Za-z0-9.]+)?$'
+        # has a complete version dropdown: main, develop, release/3.0.0-beta2,
+        # and stable tags >= v2.0.0. Other release branches and prerelease tags
+        # are excluded.
+        SMV_BRANCH_WHITELIST: '^(main|develop|release/3\.0\.0-beta2)$'
+        SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+$'
       run: |
         git fetch --prune --unshallow --tags
         git checkout --detach HEAD

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -106,7 +106,7 @@ jobs:
         # has a complete version dropdown: main, develop, release/3.0.0-beta2,
         # and stable tags >= v2.0.0. Other release branches and prerelease tags
         # are excluded.
-        SMV_BRANCH_WHITELIST: '^(main|develop|release/[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?)$'
+        SMV_BRANCH_WHITELIST: '^(main|develop|release/3\.0\.0-beta2)$'
         SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+$'
       run: |
         git fetch --prune --unshallow --tags

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -106,7 +106,7 @@ jobs:
         # has a complete version dropdown: main, develop, release/3.0.0-beta2,
         # and stable tags >= v2.0.0. Other release branches and prerelease tags
         # are excluded.
-        SMV_BRANCH_WHITELIST: '^(main|develop|release/3\.0\.0-beta2)$'
+        SMV_BRANCH_WHITELIST: '^(main|develop|release/[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?)$'
         SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+$'
       run: |
         git fetch --prune --unshallow --tags

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,5 +14,6 @@ sphinx-multiversion==0.2.4
 numpy
 matplotlib
 warp-lang
+lazy_loader>=0.4
 # learning
 gymnasium


### PR DESCRIPTION
## Summary
- include release/3.0.0-beta2 in the multi-version docs deploy branch whitelist
- exclude prerelease tags from the deploy build so the broken v3.0.0-beta tag does not block beta2 publication
- add lazy_loader to docs requirements to match package imports used by newer docs

## Context
Manual Docs workflow run 27398053912 failed while building the v3.0.0-beta tag before deploy, so release/3.0.0-beta2 docs were not published.

## Testing
- python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/docs.yaml")); print("yaml ok")'
- git diff --check