### PR TITLE
Fix MARL adapter destructor state

### DIFF
--- a/source/isaaclab/changelog.d/fix-marl-adapter-del.rst
+++ b/source/isaaclab/changelog.d/fix-marl-adapter-del.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Prevented MARL adapter wrappers from raising destructor tracebacks when destroyed by setting their environment lifecycle state explicitly.

--- a/source/isaaclab/isaaclab/envs/utils/marl.py
+++ b/source/isaaclab/isaaclab/envs/utils/marl.py
@@ -48,6 +48,7 @@ def multi_agent_to_single_agent(env: DirectMARLEnv, state_as_observation: bool =
     class Env(DirectRLEnv):
         def __init__(self, env: DirectMARLEnv) -> None:
             self.env: DirectMARLEnv = env.unwrapped
+            self._is_closed = False
 
             # check if it is possible to use the multi-agent environment state as single-agent observation
             self._state_as_observation = state_as_observation
@@ -133,7 +134,9 @@ def multi_agent_to_single_agent(env: DirectMARLEnv, state_as_observation: bool =
             return self.env.render(recompute)
 
         def close(self) -> None:
-            self.env.close()
+            if not self._is_closed:
+                self.env.close()
+                self._is_closed = True
 
     return Env(env)
 
@@ -168,6 +171,7 @@ def multi_agent_with_one_agent(env: DirectMARLEnv, state_as_observation: bool = 
     class Env(DirectMARLEnv):
         def __init__(self, env: DirectMARLEnv) -> None:
             self.env: DirectMARLEnv = env.unwrapped
+            self._is_closed = False
 
             # check if it is possible to use the multi-agent environment state as agent observation
             self._state_as_observation = state_as_observation
@@ -272,6 +276,8 @@ def multi_agent_with_one_agent(env: DirectMARLEnv, state_as_observation: bool = 
             self.env.render(recompute)
 
         def close(self) -> None:
-            self.env.close()
+            if not self._is_closed:
+                self.env.close()
+                self._is_closed = True
 
     return Env(env)

--- a/source/isaaclab/test/envs/test_env_destructors.py
+++ b/source/isaaclab/test/envs/test_env_destructors.py
@@ -5,9 +5,36 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import gymnasium as gym
 import pytest
 
 from isaaclab.envs import DirectMARLEnv, DirectRLEnv, ManagerBasedEnv
+from isaaclab.envs.utils.marl import multi_agent_to_single_agent, multi_agent_with_one_agent
+
+
+class _FakeMultiAgentEnv:
+    possible_agents = ["agent_0", "agent_1"]
+    observation_spaces = {
+        "agent_0": gym.spaces.Box(low=-1.0, high=1.0, shape=(3,)),
+        "agent_1": gym.spaces.Box(low=-1.0, high=1.0, shape=(4,)),
+    }
+    action_spaces = {
+        "agent_0": gym.spaces.Box(low=-1.0, high=1.0, shape=(1,)),
+        "agent_1": gym.spaces.Box(low=-1.0, high=1.0, shape=(2,)),
+    }
+    render_mode = None
+
+    def __init__(self):
+        self.unwrapped = self
+        self.cfg = SimpleNamespace(state_space=1)
+        self.sim = object()
+        self.scene = SimpleNamespace(num_envs=2)
+        self.closed_count = 0
+
+    def close(self):
+        self.closed_count += 1
 
 
 @pytest.mark.parametrize("env_cls", [DirectRLEnv, DirectMARLEnv, ManagerBasedEnv])
@@ -56,3 +83,17 @@ def test_env_destructor_skips_close_after_import_shutdown(env_cls, monkeypatch):
     monkeypatch.setattr("sys.meta_path", None)
 
     env.__del__()
+
+
+@pytest.mark.parametrize("converter", [multi_agent_to_single_agent, multi_agent_with_one_agent])
+def test_marl_adapter_destructor_closes_wrapped_env_once(converter):
+    """MARL adapters inherit env destructors without running base env __init__."""
+
+    env = _FakeMultiAgentEnv()
+    converted_env = converter(env)
+
+    converted_env.__del__()
+    converted_env.__del__()
+
+    assert converted_env._is_closed
+    assert env.closed_count == 1


### PR DESCRIPTION
## Summary
- beta2 companion for #6174
- initialize lifecycle state in MARL adapter wrappers that subclass DirectRLEnv/DirectMARLEnv without running the base constructor
- make adapter close idempotent so inherited destructors can clean up without AttributeError
- add regression coverage for both MARL adapter destructor paths

## Testing
- git diff --check
- python3 -m py_compile source/isaaclab/isaaclab/envs/utils/marl.py source/isaaclab/test/envs/test_env_destructors.py
- python3 tools/changelog/cli.py check release/3.0.0-beta2

Not run locally: focused pytest, because this worktree launcher uses /usr/bin/python3.12 without gymnasium installed.