### PR TITLE
[3.0.0-beta2] Fix PhysX scene data invalid tensor views

### DIFF
--- a/source/isaaclab_physx/changelog.d/zhengyuz-physx-scene-data-invalid-view.rst
+++ b/source/isaaclab_physx/changelog.d/zhengyuz-physx-scene-data-invalid-view.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed PhysX scene-data rigid-body view handling so Newton visualizers do not crash when a cached PhysX tensor view has been invalidated.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -170,6 +170,11 @@ class PhysxSceneDataBackend(SceneDataBackend):
         self._simulation_view = simulation_view
         self._rigid_body_view = None
 
+    @staticmethod
+    def _is_valid_tensor_view(view: Any | None) -> bool:
+        """Return whether a PhysX tensor view still has a live backend."""
+        return view is not None and getattr(view, "_backend", None) is not None
+
     def get_rigid_body_view(self) -> omni.physics.tensors.RigidBodyView | None:
         """Lazily create a rigid body view covering all rigid bodies in the scene.
 
@@ -179,9 +184,12 @@ class PhysxSceneDataBackend(SceneDataBackend):
         the wildcard to the non-rigid prim.
         """
         if self._rigid_body_view is not None:
-            return self._rigid_body_view
+            if self._is_valid_tensor_view(self._rigid_body_view):
+                return self._rigid_body_view
+            self._rigid_body_view = None
 
-        if self._simulation_view is None:
+        if not self._is_valid_tensor_view(self._simulation_view):
+            self._simulation_view = None
             return None
 
         stage: Usd.Stage = omni.usd.get_context().get_stage()
@@ -212,7 +220,11 @@ class PhysxSceneDataBackend(SceneDataBackend):
         if not body_paths:
             return None
 
-        self._rigid_body_view = self._simulation_view.create_rigid_body_view(body_paths)
+        rigid_body_view = self._simulation_view.create_rigid_body_view(body_paths)
+        if not self._is_valid_tensor_view(rigid_body_view):
+            return None
+
+        self._rigid_body_view = rigid_body_view
         return self._rigid_body_view
 
     @property
@@ -797,6 +809,8 @@ class PhysxManager(PhysicsManager):
         for view in (cls._view, cls._view_warp):
             if view:
                 view.invalidate()
+        if cls._scene_data_backend is not None:
+            cls._scene_data_backend.simulation_view = None
         cls._view = None
         cls._view_warp = None
         cls._view_created = False

--- a/source/isaaclab_physx/test/sim/test_physx_scene_data_backend.py
+++ b/source/isaaclab_physx/test/sim/test_physx_scene_data_backend.py
@@ -27,9 +27,11 @@ def test_scene_data_rigid_body_view_skips_joint_prims_with_rigid_body_api(monkey
     captured_paths = []
 
     class _SimulationView:
+        _backend = object()
+
         def create_rigid_body_view(self, body_paths):
             captured_paths.extend(body_paths)
-            return SimpleNamespace(prim_paths=body_paths)
+            return SimpleNamespace(_backend=object(), prim_paths=body_paths)
 
     monkeypatch.setattr(
         physx_manager.omni.usd,
@@ -42,3 +44,96 @@ def test_scene_data_rigid_body_view_skips_joint_prims_with_rigid_body_api(monkey
     backend.get_rigid_body_view()
 
     assert captured_paths == ["/World/envs/env_*/Robot/robot0_forearm"]
+
+
+def test_scene_data_backend_discards_invalid_cached_rigid_body_view():
+    """Cached PhysX rigid-body views can be invalidated by timeline lifecycle events."""
+    from isaaclab_physx.physics.physx_manager import PhysxSceneDataBackend
+
+    backend = PhysxSceneDataBackend()
+    backend._rigid_body_view = SimpleNamespace(_backend=None)
+
+    assert backend.get_rigid_body_view() is None
+    assert backend.transform_paths == []
+    assert backend._rigid_body_view is None
+
+
+def test_scene_data_backend_discards_invalid_simulation_view():
+    """Invalid PhysX simulation views should not be reused to create rigid-body views."""
+    from isaaclab_physx.physics.physx_manager import PhysxSceneDataBackend
+
+    class _InvalidSimulationView:
+        _backend = None
+
+        def create_rigid_body_view(self, body_paths):
+            raise AssertionError("invalid simulation view must not be used")
+
+    backend = PhysxSceneDataBackend()
+    backend.simulation_view = _InvalidSimulationView()
+
+    assert backend.get_rigid_body_view() is None
+    assert backend.transform_paths == []
+    assert backend.simulation_view is None
+
+
+def test_scene_data_backend_discards_invalid_created_rigid_body_view(monkeypatch):
+    """PhysX may return an invalid rigid-body view when its simulation view is stale."""
+    from isaaclab_physx.physics import physx_manager
+    from isaaclab_physx.physics.physx_manager import PhysxSceneDataBackend
+
+    from pxr import Usd, UsdGeom, UsdPhysics
+
+    stage = Usd.Stage.CreateInMemory()
+    body_prim = UsdGeom.Xform.Define(stage, "/World/envs/env_0/Robot/torso").GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(body_prim)
+
+    class _SimulationView:
+        _backend = object()
+
+        def create_rigid_body_view(self, body_paths):
+            return SimpleNamespace(_backend=None)
+
+    monkeypatch.setattr(
+        physx_manager.omni.usd,
+        "get_context",
+        lambda: SimpleNamespace(get_stage=lambda: stage),
+    )
+
+    backend = PhysxSceneDataBackend()
+    backend.simulation_view = _SimulationView()
+
+    assert backend.transform_paths == []
+    assert backend._rigid_body_view is None
+
+
+def test_invalidate_views_clears_scene_data_backend_simulation_view(monkeypatch):
+    """PhysxManager invalidation must also clear the scene-data backend view cache."""
+    from isaaclab_physx.physics.physx_manager import PhysxManager, PhysxSceneDataBackend
+
+    class _View:
+        _backend = object()
+
+        def __init__(self):
+            self.invalidated = False
+
+        def invalidate(self):
+            self.invalidated = True
+
+    view = _View()
+    view_warp = _View()
+    backend = PhysxSceneDataBackend()
+    backend.simulation_view = view
+
+    monkeypatch.setattr(PhysxManager, "_view", view)
+    monkeypatch.setattr(PhysxManager, "_view_warp", view_warp)
+    monkeypatch.setattr(PhysxManager, "_view_created", True)
+    monkeypatch.setattr(PhysxManager, "_scene_data_backend", backend)
+
+    PhysxManager._invalidate_views()
+
+    assert view.invalidated
+    assert view_warp.invalidated
+    assert backend.simulation_view is None
+    assert PhysxManager._view is None
+    assert PhysxManager._view_warp is None
+    assert not PhysxManager._view_created


### PR DESCRIPTION
## Summary
- Fixes PhysX scene-data backend handling of invalidated tensor simulation and rigid-body views.
- Clears the scene-data backend when PhysxManager invalidates simulation views.
- Prevents Newton visualizer initialization from crashing on `NoneType.prim_paths` when a PhysX tensor view has already been invalidated.
- Adds focused regression tests for invalid cached views, invalid simulation views, invalid created rigid-body views, and manager invalidation.

## Notes
The reported command uses the PhysX simulation backend with the Newton visualizer, despite the report mentioning `newton_mjwarp`. That path is supported through the PhysX scene-data provider and should not crash.

## Validation
- `python3 -m py_compile source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py source/isaaclab_physx/test/sim/test_physx_scene_data_backend.py`
- `python3 tools/changelog/cli.py check release/3.0.0-beta2`
- `git diff --check`
- `pre-commit run --files source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py source/isaaclab_physx/test/sim/test_physx_scene_data_backend.py source/isaaclab_physx/changelog.d/zhengyuz-physx-scene-data-invalid-view.rst`
- `python3 -m pytest source/isaaclab_physx/test/sim/test_physx_scene_data_backend.py -q` skipped locally because this shell does not have Omni/USD bindings installed.