### PR TITLE
Initialize visualizers before timeline play on reset

### DIFF
--- a/source/isaaclab/changelog.d/zhengyuz-sim-reset-visualizer-before-play.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-sim-reset-visualizer-before-play.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed SimulationContext reset ordering so initial visualizers are created before the timeline play event pump can invalidate freshly created PhysX tensor views.

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -724,11 +724,11 @@ class SimulationContext:
         self.physics_manager.reset(soft)
         for viz in self._visualizers:
             viz.reset(soft)
+        if not self._visualizers:
+            # Initialize visualizers after PhysX sim views are ready, but before play() pumps timeline events.
+            self.initialize_visualizers()
         # Start the timeline so the play button is pressed
         self.physics_manager.play()
-        if not self._visualizers:
-            # Initialize visualizers after PhysX sim view is ready.
-            self.initialize_visualizers()
         self._is_playing = True
         self._is_stopped = False
 

--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -194,6 +194,35 @@ def test_update_visualizers_handles_training_pause_loop():
     assert viz.step_calls == [0.0, 0.2]
 
 
+def test_reset_initializes_visualizers_before_playing_timeline():
+    """Initial visualizers must see the PhysX views created by reset before play() pumps timeline events."""
+    events: list[str] = []
+    ctx = object.__new__(SimulationContext)
+    ctx._visualizers = []
+
+    class _PhysicsManager:
+        @staticmethod
+        def reset(soft=False):
+            events.append(f"reset:{soft}")
+
+        @staticmethod
+        def play():
+            events.append("play")
+
+    def _initialize_visualizers():
+        events.append("initialize_visualizers")
+        ctx._visualizers = [_FakeVisualizer()]
+
+    ctx.physics_manager = _PhysicsManager()
+    ctx.initialize_visualizers = _initialize_visualizers
+
+    ctx.reset()
+
+    assert events == ["reset:False", "initialize_visualizers", "play"]
+    assert ctx.is_playing()
+    assert not ctx.is_stopped()
+
+
 class _DummyViserSceneDataProvider:
     @property
     def num_envs(self) -> int:


### PR DESCRIPTION
## Summary
- Initializes first-time visualizers after `physics_manager.reset()` has created PhysX tensor views, but before `physics_manager.play()` pumps Kit timeline events.
- Prevents Newton visualizer initialization from seeing a PhysX scene-data backend whose tensor view was invalidated by a STOP event processed during the play event pump.
- Adds a focused unit test that locks the reset ordering to `reset -> initialize_visualizers -> play` for first-time visualizers.

## Root cause
The reported command selects the Newton visualizer, but not Newton physics, so the failing path is PhysX simulation feeding the Newton visualizer through the scene-data provider.

`PhysxManager.reset()` creates the PhysX tensor simulation view and stores it in the scene-data backend. `SimulationContext.reset()` then called `physics_manager.play()` before creating visualizers. `PhysxManager.play()` calls `omni.kit.app.get_app().update()`, which can process timeline events. On the failing Windows/Kit path, a STOP event is processed there, and `PhysxManager._on_stop()` invalidates the freshly created tensor views. The Newton visualizer is then initialized after that invalidation and asks scene data for `transform_paths`, which reaches `RigidBodyView.prim_paths` on an invalid PhysX view and crashes with `NoneType.prim_paths`.

The correct fix is to initialize visualizers before the play event pump, not to make scene-data consumers tolerate already-invalid views.

## Validation
- `python3 -m py_compile source/isaaclab/isaaclab/sim/simulation_context.py source/isaaclab/test/sim/test_simulation_context_visualizers.py`
- `python3 tools/changelog/cli.py check develop`
- `git diff --cached --check`
- `pre-commit run --files source/isaaclab/isaaclab/sim/simulation_context.py source/isaaclab/test/sim/test_simulation_context_visualizers.py source/isaaclab/changelog.d/zhengyuz-sim-reset-visualizer-before-play.rst`

Focused pytest was attempted locally, but this shell lacks runtime deps (`lazy_loader`) needed to import the visualizer test module.