### PR TITLE
Handle unavailable Newton OpenGL viewer

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/zhengyuz-newton-gl-fallback.rst
+++ b/source/isaaclab_visualizers/changelog.d/zhengyuz-newton-gl-fallback.rst
@@ -1,0 +1,5 @@
+Fixed
+-----
+
+* Allowed the Newton visualizer to keep simulation/inference running without an
+  interactive OpenGL window when pyglet cannot create a usable OpenGL context.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -38,6 +38,21 @@ from .newton_visualizer_cfg import NewtonVisualizerCfg
 
 logger = logging.getLogger(__name__)
 
+_OPENGL_CONTEXT_ERROR_NAMES = {
+    "ContextException",
+    "MissingFunctionException",
+    "NoSuchConfigException",
+    "NoSuchDisplayException",
+}
+
+_OPENGL_CONTEXT_ERROR_TOKENS = (
+    "Cannot connect to",
+    "Could not create GL context",
+    "No GL context",
+    "OpenGL",
+    "glCreateShader",
+)
+
 CONTACT_ARROW_PATH = "/contacts"
 """Viewer path used for native and synthesized contact arrows."""
 
@@ -49,6 +64,28 @@ CONTACT_ARROW_LENGTH = 0.1
 
 if TYPE_CHECKING:
     from isaaclab.scene_data import SceneDataProvider
+
+
+def _is_opengl_context_error(exc: BaseException) -> bool:
+    """Return whether *exc* looks like a pyglet/OpenGL context availability error."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        exc_type = type(current)
+        module = exc_type.__module__
+        name = exc_type.__name__
+        message = str(current)
+
+        if module.startswith("pyglet.") and name in _OPENGL_CONTEXT_ERROR_NAMES:
+            return True
+        if module.startswith("pyglet.") and any(token in message for token in _OPENGL_CONTEXT_ERROR_TOKENS):
+            return True
+        if "glCreateShader" in message and "OpenGL" in message:
+            return True
+
+        current = current.__cause__ or current.__context__
+    return False
 
 
 class NewtonViewerGL(ViewerGL):
@@ -492,13 +529,25 @@ class NewtonVisualizer(BaseVisualizer):
 
             pyglet.options["headless"] = True
 
-        self._viewer = NewtonViewerGL(
-            width=self.cfg.window_width,
-            height=self.cfg.window_height,
-            headless=runtime_headless,
-            metadata=metadata,
-            update_frequency=self.cfg.update_frequency,
-        )
+        try:
+            self._viewer = NewtonViewerGL(
+                width=self.cfg.window_width,
+                height=self.cfg.window_height,
+                headless=runtime_headless,
+                metadata=metadata,
+                update_frequency=self.cfg.update_frequency,
+            )
+        except Exception as exc:
+            if not _is_opengl_context_error(exc):
+                raise
+            self._viewer = None
+            self._headless_no_viewer = True
+            logger.warning(
+                "[NewtonVisualizer] Newton OpenGL viewer is unavailable (%s: %s). "
+                "Continuing without an interactive Newton viewer.",
+                type(exc).__name__,
+                exc,
+            )
 
         if self._viewer is not None:
             self._viewer.set_model(self._model)
@@ -553,7 +602,8 @@ class NewtonVisualizer(BaseVisualizer):
                 ("tiled_cam_view", self.cfg.tiled_cam_view),
                 ("tiled_cam_num", self.cfg.tiled_cam_num),
                 ("num_visualized_envs", num_visualized_envs),
-                ("headless", self.cfg.headless),
+                ("headless", runtime_headless),
+                ("viewer", "disabled" if self._headless_no_viewer else "opengl"),
                 ("show_particles", self.cfg.show_particles),
                 ("particle_color", self.cfg.particle_color),
             ],
@@ -760,6 +810,12 @@ class NewtonVisualizer(BaseVisualizer):
     def _setup_camera_sensor_view(self, num_envs: int) -> None:
         """Resolve or create the camera sensor used by non-interactive image views."""
         if not self._uses_camera_sensor_view():
+            return
+        if self._headless_no_viewer and self._viewer is None:
+            logger.warning(
+                "[NewtonVisualizer] Tiled camera view requested, but the Newton OpenGL viewer is unavailable. "
+                "Skipping tiled camera setup."
+            )
             return
         env_ids = resolve_tiled_env_indices(
             num_envs,

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import isaaclab_visualizers.newton.newton_visualizer as newton_visualizer
 import numpy as np
+import pytest
 import torch
 import warp as wp
 from isaaclab_visualizers.newton import NewtonVisualizer, NewtonVisualizerCfg
@@ -109,6 +111,67 @@ def test_newton_visualizer_cfg_exposes_particle_options():
 
     assert cfg.show_particles is True
     assert cfg.particle_color == (0.1, 0.2, 0.3)
+
+
+class _PygletMissingFunctionException(RuntimeError):
+    pass
+
+
+_PygletMissingFunctionException.__module__ = "pyglet.gl.lib"
+
+
+class _FakeSceneDataProvider:
+    num_envs = 1
+
+
+def _patch_newton_manager(monkeypatch):
+    from isaaclab_newton.physics import NewtonManager
+
+    monkeypatch.setattr(NewtonManager, "get_model", staticmethod(lambda: None))
+    monkeypatch.setattr(NewtonManager, "get_state", staticmethod(lambda *_args, **_kwargs: None))
+
+
+def test_newton_visualizer_identifies_pyglet_missing_gl_function():
+    exc = RuntimeError("viewer failed")
+    exc.__cause__ = _PygletMissingFunctionException(
+        "glCreateShader is not exported by the available OpenGL driver. OpenGL 2.0 is required."
+    )
+
+    assert newton_visualizer._is_opengl_context_error(exc)
+
+
+def test_newton_visualizer_falls_back_when_opengl_viewer_is_unavailable(monkeypatch, caplog):
+    _patch_newton_manager(monkeypatch)
+
+    def _raise_missing_gl(*_args, **_kwargs):
+        raise _PygletMissingFunctionException(
+            "glCreateShader is not exported by the available OpenGL driver. OpenGL 2.0 is required."
+        )
+
+    monkeypatch.setattr(newton_visualizer, "NewtonViewerGL", _raise_missing_gl)
+    visualizer = NewtonVisualizer(NewtonVisualizerCfg())
+
+    with caplog.at_level("WARNING"):
+        visualizer.initialize(_FakeSceneDataProvider())
+
+    assert visualizer.is_initialized
+    assert visualizer._viewer is None
+    assert visualizer._headless_no_viewer is True
+    assert visualizer.is_running()
+    assert "Continuing without an interactive Newton viewer" in caplog.text
+
+
+def test_newton_visualizer_reraises_non_opengl_viewer_errors(monkeypatch):
+    _patch_newton_manager(monkeypatch)
+
+    def _raise_construction_bug(*_args, **_kwargs):
+        raise RuntimeError("construction bug")
+
+    monkeypatch.setattr(newton_visualizer, "NewtonViewerGL", _raise_construction_bug)
+    visualizer = NewtonVisualizer(NewtonVisualizerCfg())
+
+    with pytest.raises(RuntimeError, match="construction bug"):
+        visualizer.initialize(_FakeSceneDataProvider())
 
 
 def test_newton_visualizer_set_camera_view_updates_cfg_without_viewer():


### PR DESCRIPTION
## Summary
- Detect pyglet/OpenGL context availability failures during Newton ViewerGL creation
- Keep Newton visualizer initialized in no-viewer mode so inference continues when no usable OpenGL context exists
- Add focused coverage for the Windows glCreateShader failure shape and non-OpenGL error propagation

## Testing
- pre-commit run --files source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py source/isaaclab_visualizers/test/test_newton_adapter.py source/isaaclab_visualizers/changelog.d/zhengyuz-newton-gl-fallback.rst
- python3 tools/changelog/cli.py check develop
- git diff --check
- python3 -m py_compile source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py source/isaaclab_visualizers/test/test_newton_adapter.py

Note: focused pytest collection cannot run in this local system Python because lazy_loader is not installed.