### PR TITLE
Declare pyglet for Newton GL features

### DIFF
--- a/docs/source/overview/core-concepts/visualization.rst
+++ b/docs/source/overview/core-concepts/visualization.rst
@@ -646,6 +646,18 @@ The visualizer will still function correctly but may experience reduced performa
 CPU copy operations instead of direct GPU memory sharing.
 
 
+**Newton Visualizer OpenGL Context Failures**
+
+The Newton visualizer is an OpenGL window. If pyglet reports that
+``glCreateShader`` is not exported or that OpenGL 2.0 is required, the Python
+process did not receive a usable OpenGL 2.0+ context from the active Windows or
+Linux display session. This usually means the process is running in a
+non-interactive/service session, through a remote desktop path without GPU
+OpenGL acceleration, or with a software/basic OpenGL provider instead of the
+NVIDIA driver. Run from a GPU-backed interactive display session, or omit
+``--visualizer newton`` for headless inference.
+
+
 **Newton Visualizer on Spark with Conda**
 
 When running the Newton visualizer on Spark inside a conda environment, conda-installed X11 libraries

--- a/source/isaaclab/changelog.d/zhengyuz-newton-pyglet-install-message.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-newton-pyglet-install-message.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Updated the ``newton`` extra installation message to list the Newton GL
+  viewer's ``pyglet`` dependency.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -652,7 +652,9 @@ def _install_extra_feature(feature_name: str, selector: str = "") -> None:
     elif feature_name == "newton":
         if selector:
             print_warning(f"'newton' does not support selectors (got '{selector}'). Installing all newton extras.")
-        print_info("Installing newton extras (newton[sim], PyOpenGL-accelerate, imgui-bundle, typing-extensions)...")
+        print_info(
+            "Installing newton extras (newton[sim], pyglet, PyOpenGL-accelerate, imgui-bundle, typing-extensions)..."
+        )
         run_command(pip_cmd + ["install", "--editable", f"{source_dir}/isaaclab_newton[all]"])
         run_command(pip_cmd + ["install", "--editable", f"{source_dir}/isaaclab_physx[newton]"])
         run_command(pip_cmd + ["install", "--editable", f"{source_dir}/isaaclab_visualizers[newton]"])

--- a/source/isaaclab_newton/changelog.d/zhengyuz-newton-gl-pyglet-dependency.rst
+++ b/source/isaaclab_newton/changelog.d/zhengyuz-newton-gl-pyglet-dependency.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Added an explicit ``pyglet>=2.1.6,<3`` dependency for Newton GL video
+  recording support.

--- a/source/isaaclab_newton/pyproject.toml
+++ b/source/isaaclab_newton/pyproject.toml
@@ -26,6 +26,7 @@ Repository = "https://github.com/isaac-sim/IsaacLab"
 all = [
     "prettytable>=3.3.0",
     "PyOpenGL-accelerate>=3.1.0",
+    "pyglet>=2.1.6,<3",
     "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
 ]
 

--- a/source/isaaclab_visualizers/changelog.d/zhengyuz-newton-pyglet-dependency.rst
+++ b/source/isaaclab_visualizers/changelog.d/zhengyuz-newton-pyglet-dependency.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Added an explicit ``pyglet>=2.1.6,<3`` dependency for the Newton visualizer
+  extra so the OpenGL viewer does not rely on ambient transitive installs.

--- a/source/isaaclab_visualizers/pyproject.toml
+++ b/source/isaaclab_visualizers/pyproject.toml
@@ -31,6 +31,7 @@ newton = [
     "warp-lang",
     "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
     "PyOpenGL-accelerate",
+    "pyglet>=2.1.6,<3",
     "imgui-bundle>=1.92.5",
     "typing-extensions>=4.15.0",
 ]
@@ -47,6 +48,7 @@ all = [
     "imgui-bundle>=1.92.5",
     "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
     "PyOpenGL-accelerate",
+    "pyglet>=2.1.6,<3",
     # Match rerun-sdk's supported Arrow stack and avoid resolver drift across environments.
     "pyarrow==22.0.0",
     "rerun-sdk>=0.29.0",


### PR DESCRIPTION
## Summary
- Add explicit `pyglet>=2.1.6,<3` dependencies for Newton GL visualizer/video extras.
- Update the `newton` extra install message to include pyglet.
- Document the `glCreateShader` failure mode as an OpenGL-context/session problem rather than a task or Newton physics failure.

## Root cause
Newton ViewerGL requires pyglet/OpenGL, but Isaac Lab's Newton GL packages did not declare pyglet directly. Separately, the reported Windows stack means pyglet obtained an OpenGL context that does not expose OpenGL 2.0 shader functions; an RTX PRO 6000 driver should expose that, so the process is not receiving the NVIDIA OpenGL context in that automation/display session.

## Testing
- `pre-commit run --files docs/source/overview/core-concepts/visualization.rst source/isaaclab/isaaclab/cli/commands/install.py source/isaaclab_newton/pyproject.toml source/isaaclab_visualizers/pyproject.toml source/isaaclab/changelog.d/zhengyuz-newton-pyglet-install-message.rst source/isaaclab_newton/changelog.d/zhengyuz-newton-gl-pyglet-dependency.rst source/isaaclab_visualizers/changelog.d/zhengyuz-newton-pyglet-dependency.rst`
- `python3 tools/changelog/cli.py check develop`
- `git diff --check`
