### PR TITLE
Preserve LEAPP metadata for manual deploy inputs

### DIFF
--- a/source/isaaclab/isaaclab/utils/leapp/__init__.pyi
+++ b/source/isaaclab/isaaclab/utils/leapp/__init__.pyi
@@ -23,6 +23,8 @@ __all__ = [
     "build_state_connection",
     "build_write_connection",
     "joint_names_resolver",
+    "leapp_input_tensor",
+    "leapp_real_env",
     "leapp_tensor_semantics",
     "patch_env_for_export",
     "resolve_leapp_element_names",
@@ -54,6 +56,7 @@ from .leapp_semantics import (
     target_frame_quat_resolver,
     target_frame_xyz_resolver,
 )
+from .manual_inputs import leapp_input_tensor, leapp_real_env
 from .utils import (
     build_command_connection,
     build_state_connection,

--- a/source/isaaclab/isaaclab/utils/leapp/manual_inputs.py
+++ b/source/isaaclab/isaaclab/utils/leapp/manual_inputs.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Helpers for manually exposing computed tensors as LEAPP inputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+class _ManualTensorView:
+    """Small adapter matching the ``data.<property>.torch`` access pattern."""
+
+    def __init__(self, tensor: torch.Tensor):
+        self._tensor = tensor
+
+    @property
+    def torch(self) -> torch.Tensor:
+        return self._tensor
+
+
+def _cache_manual_data_proxy(data_proxy: Any, real_data: Any, property_name: str, tensor: torch.Tensor) -> None:
+    """Cache a manual input tensor on a LEAPP data proxy."""
+    manual_cache = object.__getattribute__(data_proxy, "_manual_cache")
+    manual_cache[(id(real_data), property_name)] = _ManualTensorView(tensor)
+
+
+def leapp_real_env(env: Any) -> Any:
+    """Return the wrapped real environment when LEAPP passes an export proxy."""
+    if type(env).__name__ == "_EnvProxy":
+        return object.__getattribute__(env, "_real_env")
+    return env
+
+
+def leapp_input_tensor(
+    env: Any,
+    name: str,
+    tensor: torch.Tensor,
+    *,
+    kind: Any | None = None,
+    element_names: list[str] | list[list[str]] | None = None,
+    connection: str | dict[str, str] | None = None,
+    cache: tuple[str, str] | None = None,
+) -> torch.Tensor:
+    """Expose a tensor as a LEAPP input during export and return it unchanged otherwise.
+
+    Args:
+        env: Environment passed into the observation term.
+        name: LEAPP input tensor name.
+        tensor: Tensor to expose.
+        kind: Optional LEAPP input kind used by deployment tooling.
+        element_names: Optional element names for tensor dimensions.
+        connection: Optional Isaac Lab connection string or metadata dict.
+        cache: Optional ``(entity_name, property_name)`` tuple. When provided,
+            the annotated tensor is cached as that LEAPP scene-data property read.
+
+    Returns:
+        The annotated tensor during LEAPP export, otherwise ``tensor`` unchanged.
+    """
+    if type(env).__name__ != "_EnvProxy":
+        return tensor
+
+    from leapp import annotate
+    from leapp.utils.tensor_description import TensorSemantics
+
+    extra = None
+    if isinstance(connection, str):
+        extra = {"isaaclab_connection": connection}
+    elif connection is not None:
+        extra = connection
+
+    if kind is None and element_names is None and extra is None:
+        annotated = annotate.input_tensors(env.unwrapped.spec.id, {name: tensor})
+    else:
+        semantics = TensorSemantics(
+            name=name,
+            ref=tensor,
+            kind=kind,
+            element_names=element_names,
+            extra=extra,
+        )
+        annotated = annotate.input_tensors(env.unwrapped.spec.id, semantics)
+
+    if cache is not None:
+        entity_name, property_name = cache
+        real_env = leapp_real_env(env)
+        real_data = real_env.scene[entity_name].data
+        scene_proxy = object.__getattribute__(env, "_scene_proxy")
+        proxy_cache = object.__getattribute__(scene_proxy, "_cache")
+        tensor_view = _ManualTensorView(annotated)
+        proxy_cache[(id(real_data), property_name)] = tensor_view
+
+        proxied_entities = object.__getattribute__(scene_proxy, "_proxied")
+        entity_proxy = proxied_entities.get(entity_name)
+        if entity_proxy is not None:
+            data_proxy = object.__getattribute__(entity_proxy, "_data_proxy")
+            _cache_manual_data_proxy(data_proxy, real_data, property_name, annotated)
+
+        action_manager = getattr(real_env, "action_manager", None)
+        if action_manager is not None:
+            for action_term in action_manager._terms.values():
+                asset_proxy = getattr(action_term, "_asset", None)
+                if type(asset_proxy).__name__ != "_ArticulationWriteProxy":
+                    continue
+                if object.__getattribute__(asset_proxy, "_entity_name") != entity_name:
+                    continue
+                data_proxy = object.__getattribute__(asset_proxy, "_data_proxy")
+                _cache_manual_data_proxy(data_proxy, real_data, property_name, annotated)
+
+    return annotated

--- a/source/isaaclab/isaaclab/utils/leapp/proxy.py
+++ b/source/isaaclab/isaaclab/utils/leapp/proxy.py
@@ -148,6 +148,7 @@ class _DataProxy:
         object.__setattr__(self, "_task_name", task_name)
         object.__setattr__(self, "_property_resolution_cache", property_resolution_cache)
         object.__setattr__(self, "_cache", cache)
+        object.__setattr__(self, "_manual_cache", {})
         object.__setattr__(self, "_input_name_resolver", input_name_resolver)
 
     def __getattr__(self, name):
@@ -161,6 +162,9 @@ class _DataProxy:
 
         cache = object.__getattribute__(self, "_cache")
         cache_key = (id(real_data), name)
+        manual_cache = object.__getattribute__(self, "_manual_cache")
+        if cache_key in manual_cache:
+            return manual_cache[cache_key]
         if cache_key in cache:
             return cache[cache_key]
 

--- a/source/isaaclab_rl/test/export/test_leapp_proxy.py
+++ b/source/isaaclab_rl/test/export/test_leapp_proxy.py
@@ -14,6 +14,7 @@ pytest.importorskip("leapp")
 from isaaclab.envs import mdp
 from isaaclab.test.mock_interfaces.assets.mock_articulation import MockArticulationData
 from isaaclab.utils import math as math_utils
+from isaaclab.utils.leapp import leapp_input_tensor
 from isaaclab.utils.leapp import utils as leapp_utils
 from isaaclab.utils.leapp.export_annotator import ExportPatcher
 from isaaclab.utils.leapp.leapp_semantics import InputKindEnum
@@ -43,6 +44,9 @@ def _capture_leapp_inputs(monkeypatch: pytest.MonkeyPatch) -> list:
 
     def _record_input_tensor(task_name, semantics):
         annotated_inputs.append((task_name, semantics))
+        if isinstance(semantics, dict):
+            assert len(semantics) == 1
+            return next(iter(semantics.values()))
         return semantics.ref
 
     monkeypatch.setattr(leapp_utils.annotate, "input_tensors", _record_input_tensor)
@@ -102,3 +106,39 @@ def test_projected_gravity_observation_exports_root_quat_w_input(monkeypatch: py
     assert semantics.name == "robot_root_quat_w"
     assert semantics.kind == InputKindEnum.BODY_ROTATION
     assert semantics.extra == {"isaaclab_connection": "state:robot:root_quat_w"}
+
+
+def test_manual_input_tensor_alias_survives_trace_cache_clear(monkeypatch: pytest.MonkeyPatch):
+    """Test manual inputs can satisfy later proxy reads after the trace cache is cleared."""
+    annotated_inputs = _capture_leapp_inputs(monkeypatch)
+    data = MockArticulationData(num_instances=1, num_joints=7, num_bodies=0, device="cpu")
+    joint_pos = torch.arange(7, dtype=torch.float32).reshape(1, 7)
+    data.set_joint_pos(joint_pos)
+    scene = _TestScene({"robot": SimpleNamespace(data=data)})
+    env = SimpleNamespace(scene=scene, unwrapped=SimpleNamespace(spec=SimpleNamespace(id="Task-v0")))
+    cache = {}
+    proxy_env = _EnvProxy(env, "Task-v0", {}, cache)
+    proxy_env.scene["robot"]
+
+    selected_joint_pos = data.joint_pos.torch[:, :7]
+    annotated_joint_pos = leapp_input_tensor(
+        proxy_env,
+        "robot_joint_pos",
+        selected_joint_pos,
+        kind=InputKindEnum.JOINT_POSITION,
+        element_names=["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint7"],
+        connection="state:robot:joint_pos",
+        cache=("robot", "joint_pos"),
+    )
+    cache.clear()
+
+    action_side_joint_pos = proxy_env.scene["robot"].data.joint_pos.torch[:, list(range(7))]
+
+    assert torch.allclose(action_side_joint_pos, annotated_joint_pos)
+    assert len(annotated_inputs) == 1
+    semantics = annotated_inputs[0][1]
+    assert semantics.name == "robot_joint_pos"
+    assert semantics.ref is selected_joint_pos
+    assert semantics.kind == InputKindEnum.JOINT_POSITION
+    assert semantics.element_names == [["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint7"]]
+    assert semantics.extra == {"isaaclab_connection": "state:robot:joint_pos"}

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/__init__.pyi
@@ -13,6 +13,8 @@ __all__ = [
     "gear_quat_w",
     "gear_shaft_pos_w",
     "gear_shaft_quat_w",
+    "joint_pos",
+    "joint_vel",
     "keypoint_command_error",
     "keypoint_command_error_exp",
     "keypoint_entity_error",
@@ -25,7 +27,7 @@ __all__ = [
 
 from .events import randomize_gear_type, randomize_gears_and_base_pose, set_robot_to_grasp_pose
 from .noise_models import ResetSampledConstantNoiseModel, ResetSampledConstantNoiseModelCfg
-from .observations import gear_pos_w, gear_quat_w, gear_shaft_pos_w, gear_shaft_quat_w
+from .observations import gear_pos_w, gear_quat_w, gear_shaft_pos_w, gear_shaft_quat_w, joint_pos, joint_vel
 from .rewards import (
     keypoint_command_error,
     keypoint_command_error_exp,

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/observations.py
@@ -12,6 +12,13 @@ from typing import TYPE_CHECKING
 import torch
 
 from isaaclab.managers import ManagerTermBase, ObservationTermCfg, SceneEntityCfg
+from isaaclab.utils.leapp import (
+    QUAT_XYZW_ELEMENT_NAMES,
+    XYZ_ELEMENT_NAMES,
+    InputKindEnum,
+    leapp_input_tensor,
+    leapp_real_env,
+)
 from isaaclab.utils.math import combine_frame_transforms
 
 if TYPE_CHECKING:
@@ -19,6 +26,58 @@ if TYPE_CHECKING:
     from isaaclab.envs import ManagerBasedRLEnv
 
     from .events import randomize_gear_type
+
+
+def _selected_joint_names(asset, joint_ids) -> list[str] | None:
+    """Return joint names selected by the observation config."""
+    joint_names = getattr(asset, "joint_names", None)
+    if joint_names is None:
+        return None
+    if joint_ids is None or joint_ids == slice(None):
+        return list(joint_names)
+    if isinstance(joint_ids, slice):
+        return list(joint_names[joint_ids])
+    if hasattr(joint_ids, "tolist"):
+        joint_ids = joint_ids.tolist()
+    return [joint_names[int(joint_id)] for joint_id in joint_ids]
+
+
+# These wrappers intentionally shadow the generic Isaac Lab joint observations
+# for the deploy gear-assembly MDP. The generic terms read
+# ``asset.data.joint_pos/vel.torch`` before slicing by ``asset_cfg.joint_ids``,
+# so LEAPP sees and exports the full articulation tensor. Here we create the
+# sliced arm-joint tensor first and annotate that tensor as the LEAPP input.
+def joint_pos(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    """Joint positions for the configured joints, exposed as the LEAPP input boundary."""
+    real_env = leapp_real_env(env)
+    asset = real_env.scene[asset_cfg.name]
+    selected_joint_pos = asset.data.joint_pos.torch[:, asset_cfg.joint_ids]
+    joint_names = _selected_joint_names(asset, asset_cfg.joint_ids)
+    return leapp_input_tensor(
+        env,
+        f"{asset_cfg.name}_joint_pos",
+        selected_joint_pos,
+        kind=InputKindEnum.JOINT_POSITION,
+        element_names=joint_names,
+        connection=f"state:{asset_cfg.name}:joint_pos",
+        cache=(asset_cfg.name, "joint_pos"),
+    )
+
+
+def joint_vel(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    """Joint velocities for the configured joints, exposed as the LEAPP input boundary."""
+    real_env = leapp_real_env(env)
+    asset = real_env.scene[asset_cfg.name]
+    selected_joint_vel = asset.data.joint_vel.torch[:, asset_cfg.joint_ids]
+    joint_names = _selected_joint_names(asset, asset_cfg.joint_ids)
+    return leapp_input_tensor(
+        env,
+        f"{asset_cfg.name}_joint_vel",
+        selected_joint_vel,
+        kind=InputKindEnum.JOINT_VELOCITY,
+        element_names=joint_names,
+        connection=f"state:{asset_cfg.name}:joint_vel",
+    )
 
 
 class gear_shaft_pos_w(ManagerTermBase):
@@ -116,19 +175,22 @@ class gear_shaft_pos_w(ManagerTermBase):
         Returns:
             Gear shaft position tensor of shape (num_envs, 3)
         """
+        real_env = leapp_real_env(env)
+
         # Check if gear type manager exists
         # During initialization (shape checking), the manager may not exist yet
-        if not hasattr(env, "_gear_type_manager"):
+        if not hasattr(real_env, "_gear_type_manager"):
             # Return default shape during initialization
-            return torch.zeros(env.num_envs, 3, device=env.device)
+            return torch.zeros(real_env.num_envs, 3, device=real_env.device)
 
-        gear_type_manager: randomize_gear_type = env._gear_type_manager
+        gear_type_manager: randomize_gear_type = real_env._gear_type_manager
         # Get gear type indices directly as tensor (no Python loops!)
         gear_type_indices = gear_type_manager.get_all_gear_type_indices()
 
         # Get base gear position and orientation
-        base_pos = self.asset.data.root_pos_w.torch
-        base_quat = self.asset.data.root_quat_w.torch
+        asset = real_env.scene[self.asset_cfg.name]
+        base_pos = asset.data.root_pos_w.torch
+        base_quat = asset.data.root_quat_w.torch
 
         # Update offsets using vectorized indexing
         self.offsets_buffer = self.gear_offsets_stacked[gear_type_indices]
@@ -136,7 +198,15 @@ class gear_shaft_pos_w(ManagerTermBase):
         # Transform offsets
         shaft_pos, _ = combine_frame_transforms(base_pos, base_quat, self.offsets_buffer, self.identity_quat)
 
-        return shaft_pos - env.scene.env_origins
+        shaft_pos = shaft_pos - real_env.scene.env_origins
+        return leapp_input_tensor(
+            env,
+            "gear_shaft_pos",
+            shaft_pos,
+            kind=InputKindEnum.BODY_POSITION,
+            element_names=XYZ_ELEMENT_NAMES,
+            connection="observation:policy:gear_shaft_pos",
+        )
 
 
 class gear_shaft_quat_w(ManagerTermBase):
@@ -180,8 +250,19 @@ class gear_shaft_quat_w(ManagerTermBase):
         Returns:
             Gear shaft orientation tensor of shape (num_envs, 4)
         """
-        # Get base quaternion
-        base_quat = self.asset.data.root_quat_w.torch
+        # Get the raw shaft/base quaternion. During LEAPP export, read it from
+        # the real env and annotate it before canonicalization so the ONNX graph
+        # owns the ``qw >= 0`` sign convention.
+        real_env = leapp_real_env(env)
+        base_quat = real_env.scene[self.asset_cfg.name].data.root_quat_w.torch
+        base_quat = leapp_input_tensor(
+            env,
+            "gear_shaft_quat",
+            base_quat,
+            kind=InputKindEnum.BODY_ROTATION,
+            element_names=QUAT_XYZW_ELEMENT_NAMES,
+            connection="observation:policy:gear_shaft_quat",
+        )
 
         # Ensure w component is positive (q and -q represent the same rotation)
         # Pick one canonical form to reduce observation variation seen by the policy


### PR DESCRIPTION
# Description

This PR adds a metadata-preserving manual LEAPP input path for deploy observation tensors.

Some deploy workflows need to expose a higher-level observation tensor as the LEAPP input boundary instead of tracing every simulator-side dependency used to compute that observation. For the gear assembly ROS inference task, the deploy runtime provides arm joint state and shaft pose inputs directly, while the Isaac Lab environment may compute those values from simulator-only state during training/export.

The new `leapp_input_tensor(...)` helper is a no-op outside LEAPP export, but during export it can annotate a computed tensor as a LEAPP input with `kind`, `element_names`, and `isaaclab_connection` metadata. This keeps exported YAML compatible with Isaac ROS Deploy input routing, which selects converters using the input `kind`.

This PR also updates the gear assembly deploy observations so the exported policy inputs are:

- `robot_joint_pos`: 7 arm joints, `state/joint/position`
- `robot_joint_vel`: 7 arm joints, `state/joint/velocity`
- `gear_shaft_pos`: `state/body/position`
- `gear_shaft_quat`: `state/body/rotation`

The action output remains arm-only and keeps its existing `target/joint/position` metadata.

No new dependencies are required.

Fixes # <!-- issue number, if available -->

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Screenshots

Not applicable.

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there