### PR TITLE
Fix newton shape color resolution when skipping USD cloning

### DIFF
--- a/source/isaaclab/changelog.d/fix-newton-clone-plan-color-resolve.rst
+++ b/source/isaaclab/changelog.d/fix-newton-clone-plan-color-resolve.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.sim.utils.newton_model_utils.replace_newton_shape_colors` incorrectly
+  keeping Newton's random palette colors for environments 1–N when USD cloning is skipped
+  Shape labels for non-source environments now resolve to the clone-plan source prim so
+  the correct USD material color is applied to all environments.

--- a/source/isaaclab/isaaclab/sim/utils/newton_model_utils.py
+++ b/source/isaaclab/isaaclab/sim/utils/newton_model_utils.py
@@ -15,12 +15,18 @@ from __future__ import annotations
 import logging
 import os
 import warnings
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import warp as wp
 
 from pxr import Usd, UsdGeom, UsdShade
+
+from isaaclab.sim import SimulationContext
+
+if TYPE_CHECKING:
+    from isaaclab.cloner import ClonePlan
+
 
 __all__ = ["replace_newton_shape_colors"]
 
@@ -195,12 +201,139 @@ def _get_primvar_display_color(shape_prim: Usd.Prim) -> tuple[float, float, floa
     return _coerce_color(primvar.Get())
 
 
+def _build_clone_source_map(missing_keys: set[str], clone_plan: ClonePlan) -> dict[str, str]:
+    """Map missing destination prim paths to their clone-plan source prim paths in one pass.
+
+    In the Newton headless path USD cloning is skipped, so only the source env (env_0) has
+    real USD prims.  Shape labels for all other envs point to paths that don't exist in the
+    stage.  This function resolves them back to the source prim that was cloned into each env
+    so the correct material color can be read from an existing prim.
+
+    Example:
+        Given a clone plan with source ``/World/envs/env_0/Robot`` cloned into envs 0-3, and
+        missing keys for envs 1-3::
+
+            missing_keys = {
+                "/World/envs/env_1/Robot/Mesh",
+                "/World/envs/env_2/Robot/Mesh",
+                "/World/envs/env_3/Robot/Mesh",
+            }
+
+        The function returns::
+
+            {
+                "/World/envs/env_1/Robot/Mesh": "/World/envs/env_0/Robot/Mesh",
+                "/World/envs/env_2/Robot/Mesh": "/World/envs/env_0/Robot/Mesh",
+                "/World/envs/env_3/Robot/Mesh": "/World/envs/env_0/Robot/Mesh",
+            }
+
+        In a heterogeneous scene where ``RobotA`` populates envs 0 and 2, and ``RobotB``
+        populates envs 1 and 3, env_2 maps to ``RobotA``'s source and env_3 to ``RobotB``'s::
+
+            {
+                "/World/envs/env_2/Robot/Mesh": "/World/envs/env_0/RobotA/Mesh",
+                "/World/envs/env_3/Robot/Mesh": "/World/envs/env_1/RobotB/Mesh",
+            }
+
+    Instead of querying the clone plan once per missing key (which scans all rows and applies a
+    compiled regex per call via :func:`~isaaclab.cloner.cloner_utils.iter_clone_plan_matches`),
+    this function iterates the clone-plan rows once and matches all missing keys against each source
+    using simple string prefix and digit checks.  The total cost is O(R × K_miss) with a low
+    constant factor, where R is the number of clone-plan rows and K_miss = ``len(missing_keys)``.
+
+    Rows are processed in decreasing order of instantiated template length so that more-specific
+    (deeper) templates take priority, matching
+    :func:`~isaaclab.cloner.cloner_utils.iter_clone_plan_matches` semantics.
+
+    Args:
+        missing_keys: Destination prim paths absent from the USD stage.
+        clone_plan: Active clone plan.
+
+    Returns:
+        Dict mapping each resolvable missing path to its clone-source prim path.
+    """
+    from dataclasses import dataclass
+
+    @dataclass
+    class _Source:
+        root: str
+        template_prefix: str  # template prefix before the "{}" env-slot
+        template_suffix: str  # template suffix after the "{}" env-slot
+        env_ids: frozenset[int]
+
+        def instantiated_length(self) -> int:
+            """Length of the template when formatted with the smallest env id."""
+            return len(self.template_prefix) + len(str(min(self.env_ids))) + len(self.template_suffix)
+
+    result: dict[str, str] = {}
+    if not missing_keys:
+        return result
+
+    # Pre-process rows: strip trailing slashes, split the template at the env-slot placeholder,
+    # and collect the populated env ids as a frozenset for O(1) membership checks.
+    sources: list[_Source] = []
+    for row_idx, (root, dest_template) in enumerate(zip(clone_plan.sources, clone_plan.destinations)):
+        if "{}" not in dest_template:
+            continue
+        env_ids: frozenset[int] = frozenset(
+            int(j) for j in clone_plan.clone_mask[row_idx].nonzero(as_tuple=False).flatten().tolist()
+        )
+        if not env_ids:
+            continue
+        template_prefix, template_suffix = dest_template.rstrip("/").split("{}", 1)
+        sources.append(
+            _Source(
+                root=root.rstrip("/"), template_prefix=template_prefix, template_suffix=template_suffix, env_ids=env_ids
+            )
+        )
+
+    # Sort by instantiated template length descending, matching iter_clone_plan_matches semantics.
+    sources.sort(key=lambda r: r.instantiated_length(), reverse=True)
+
+    # Match each destination prim path against one of the sources.
+    remaining_dest = set(missing_keys)
+    for source in sources:
+        if not remaining_dest:
+            break
+        resolved: set[str] = set()
+        for prim_path in remaining_dest:
+            # Reject paths that don't start with this source's template prefix.
+            if not prim_path.startswith(source.template_prefix):
+                continue
+
+            # Extract the env-slot token: the path segment immediately after the prefix.
+            rest = prim_path[len(source.template_prefix) :]
+            slash = rest.find("/")
+            slot_str = rest[:slash] if slash >= 0 else rest
+
+            # Reject if the slot is not a digit or doesn't belong to this source's env ids.
+            if not slot_str.isdigit() or int(slot_str) not in source.env_ids:
+                continue
+
+            # Reject if the template_suffix-slot portion of the path doesn't match the template suffix.
+            after_slot = rest[len(slot_str) :]
+            if not after_slot.startswith(source.template_suffix):
+                continue
+
+            # Everything after the instantiated template root is the asset suffix;
+            # prepend the source root to form the source prim path.
+            result[prim_path] = source.root + after_slot[len(source.template_suffix) :]
+            resolved.add(prim_path)
+
+        remaining_dest -= resolved
+
+    return result
+
+
 def _resolve_shape_color(
     stage: Usd.Stage,
     prim_path: str,
     material_color_cache: dict[str, tuple[float, float, float] | None],
 ) -> tuple[float, float, float] | None:
     """Resolve replacement linear RGB for one prim path (sRGB encoding is applied in the scatter kernel).
+
+    The caller is responsible for remapping missing destination prim paths to their clone-source
+    equivalents before calling this function (see :func:`_build_clone_source_map`).
 
     Returns:
         Linear RGB to pass to :func:`_scatter_shape_color_rows_kernel`, or ``None`` to leave the row unchanged.
@@ -305,23 +438,39 @@ def replace_newton_shape_colors(model: Any, stage: Usd.Stage | None = None) -> i
 
             stage = get_current_stage()
 
-        shape_keys: list[str] = []
+        sim = SimulationContext.instance()
+        clone_plan = sim.get_clone_plan() if sim is not None else None
 
+        # Collect canonical lookup keys, tracking which labels had no prim in the stage.
+        # Missing labels are kept verbatim so _build_clone_source_map can map them back to
+        # their clone-source equivalents (Newton headless path skips USD cloning for env_1-N).
+        shape_keys: list[str] = []
+        missing_key_set: set[str] = set()
         for label in shape_labels:
             prim = stage.GetPrimAtPath(label)
-            shape_keys.append(_canonical_prim_lookup_key(prim) if prim.IsValid() else label)
+            if prim.IsValid():
+                shape_keys.append(_canonical_prim_lookup_key(prim))
+            else:
+                shape_keys.append(label)
+                missing_key_set.add(label)
 
         # shape_keys must stay the same length as shape labels, to guarantee the correctness of
         # shape indices that will be used in the scatter kernel.
         assert num_shapes == len(shape_keys)
+
+        # Pre-build the dest -> source map for all missing keys in one clone-plan pass instead of
+        # calling iter_clone_plan_matches once per key (which applies a regex per call).
+        clone_source_map = (
+            _build_clone_source_map(missing_key_set, clone_plan) if missing_key_set and clone_plan else {}
+        )
 
         resolved_color_cache: dict[str, tuple[float, float, float] | None] = {}
         material_color_cache: dict[str, tuple[float, float, float] | None] = {}
 
         unique_keys = dict.fromkeys(shape_keys)
         for key in unique_keys:
-            color = _resolve_shape_color(stage, key, material_color_cache)
-            resolved_color_cache[key] = color
+            lookup = clone_source_map.get(key, key)
+            resolved_color_cache[key] = _resolve_shape_color(stage, lookup, material_color_cache)
 
         # Prepare the indices and colors for the scatter kernel:
         # - Indices point to the slots in the shape_colors array that should be updated

--- a/source/isaaclab/test/sim/test_newton_model_utils.py
+++ b/source/isaaclab/test/sim/test_newton_model_utils.py
@@ -19,9 +19,11 @@ import warp as wp
 
 from pxr import Gf, Sdf, Usd, UsdGeom, UsdShade
 
+from isaaclab.cloner import ClonePlan
 from isaaclab.sim.utils.newton_model_utils import (
     _OMNIPBR_DEFAULTS,
     _UNBOUND_DEFAULT_FALLBACK_GRAY,
+    _build_clone_source_map,
     _get_omnipbr_albedo,
     _resolve_shape_color,
     _scatter_shape_color_rows_kernel,
@@ -514,3 +516,60 @@ def test_replace_newton_shape_colors_instanced(device: str):
     exp = _reference_linear_to_srgb((0.1, 0.2, 0.3))
     expected = torch.tensor([exp, exp], dtype=after.dtype, device=after.device)
     torch.testing.assert_close(after, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_build_clone_source_map_homogeneous():
+    """Missing dest paths are mapped to the clone source in a homogeneous scene.
+
+    Simulates the Newton headless path (USD cloning skipped): only the env_0 source
+    prim exists; envs 1-3 labels are missing and must resolve back to env_0's source.
+    """
+    clone_plan = ClonePlan(
+        sources=("/World/envs/env_0/Robot",),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.ones((1, 4), dtype=torch.bool),
+    )
+
+    missing = {f"/World/envs/env_{i}/Robot/Mesh" for i in range(1, 4)}
+    result = _build_clone_source_map(missing, clone_plan)
+
+    assert result == {key: "/World/envs/env_0/Robot/Mesh" for key in missing}
+
+
+def test_build_clone_source_map_heterogeneous():
+    """Each missing dest path resolves to the correct variant source in a heterogeneous scene.
+
+    Two robot variants share the same destination template but populate disjoint env
+    subsets: RobotA → envs 0,2; RobotB → envs 1,3.  env_2 must map to RobotA's
+    source and env_3 to RobotB's source, not always to the first row's source.
+    """
+    mask = torch.zeros((2, 4), dtype=torch.bool)
+    mask[0, [0, 2]] = True  # RobotA populates envs 0 and 2
+    mask[1, [1, 3]] = True  # RobotB populates envs 1 and 3
+    clone_plan = ClonePlan(
+        sources=("/World/envs/env_0/RobotA", "/World/envs/env_1/RobotB"),
+        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Robot"),
+        clone_mask=mask,
+    )
+
+    missing = {
+        "/World/envs/env_2/Robot/Mesh",  # env_2 → RobotA (row 0 owns env_ids {0, 2})
+        "/World/envs/env_3/Robot/Mesh",  # env_3 → RobotB (row 1 owns env_ids {1, 3})
+    }
+    result = _build_clone_source_map(missing, clone_plan)
+
+    assert result["/World/envs/env_2/Robot/Mesh"] == "/World/envs/env_0/RobotA/Mesh"
+    assert result["/World/envs/env_3/Robot/Mesh"] == "/World/envs/env_1/RobotB/Mesh"
+
+
+def test_build_clone_source_map_no_match():
+    """Paths not owned by any clone-plan row are absent from the result."""
+    clone_plan = ClonePlan(
+        sources=("/World/envs/env_0/Robot",),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.ones((1, 4), dtype=torch.bool),
+    )
+
+    # "Sensor" sub-tree is not under the "Robot" template, so no match.
+    result = _build_clone_source_map({"/World/envs/env_2/Sensor/Mesh"}, clone_plan)
+    assert result == {}

--- a/source/isaaclab_tasks/changelog.d/fix-newton-clone-plan-color-resolve.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-newton-clone-plan-color-resolve.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Updated golden test images for the ``dexsuite_kuka_hetero`` Newton + Warp renderer
+  tests (``newton-newton_renderer-rgb`` and ``newton-newton_renderer-rgba``) to reflect
+  correct per-environment colors after fixing shape color resolution when USD cloning is
+  skipped.

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgb.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgb.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f0f0d8bb9390f45824ab3338ed37eb0787ac70f6550c967bc2905148545fd58
-size 2541
+oid sha256:ffb6f5de5bfb0f28574db7f81a971dac8473f4946ab4c145519115028f1122eb
+size 1798

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgba.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgba.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8825ffcbfe8434a7874f1062d8b58b0be6cacaeebb20e48c5c58d4d68e163056
-size 3480
+oid sha256:58b30f938cbeb857a0c2ba6db9f64f96ae367236aad7f8f52ed54057e1e5a60a
+size 2833


### PR DESCRIPTION
# Description

Fix newton shape color resolution when skipping USD cloning

Commit e9fe73c skipped USD cloning in pure newton path. As a side effect, shape labels for non-clone-source envs point to USD prims that no longer exist, causing replace_newton_shape_colors to silently fallback to Newton's random palette colors.

This fix updates _resolve_shape_color to use the iter_clone_plan_matches and resolve the source prim for cloned destination prims.

## Screenshots

Please attach before and after screenshots of the change if applicable.

| Before | After |
| ------ | ----- |
| <img width="134" height="134" alt="image" src="https://github.com/user-attachments/assets/f9dd0d0a-dd4f-4c5f-90db-0333d3e896db" /> | <img width="134" height="134" alt="image" src="https://github.com/user-attachments/assets/9758051b-f496-4b8c-a68d-4d69cc91c3df" /> |

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there