### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Run Link Checker
       if: steps.check_docs.outputs.run_job == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
       with:
         # Check all markdown files and documentation
         # Excluded are known crawl blockers

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Run Link Checker
       if: steps.check_docs.outputs.run_job == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
       with:
         # Check all markdown files and documentation
         # Excluded are known crawl blockers

--- a/.github/workflows/daily-compatibility.yml
+++ b/.github/workflows/daily-compatibility.yml
@@ -229,7 +229,7 @@ jobs:
         compression-level: 9
 
     - name: Report Test Results
-      uses: dorny/test-reporter@v2.6.0
+      uses: dorny/test-reporter@3d76b34a4535afbd0600d347b09a6ee5deb3ed7f # v2.6.0
       if: always()
       with:
         name: IsaacLab Compatibility Test Results (${{ github.event_name }})

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -127,7 +127,7 @@ jobs:
         path: ./docs/_build
 
     - name: Deploy to gh-pages
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,4 +21,4 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -64,12 +64,12 @@ jobs:
         lfs: true
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       with:
         platforms: linux/arm64
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       with:
         platforms: linux/amd64,linux/arm64
         driver-opts: |

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -64,12 +64,12 @@ jobs:
         lfs: true
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       with:
         platforms: linux/arm64
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       with:
         platforms: linux/amd64,linux/arm64
         driver-opts: |


### PR DESCRIPTION
# Description

Pins the third-party GitHub Actions referenced in the CI workflows to
full-length commit SHAs, keeping the human-readable version as a trailing
comment. This follows GitHub's supply-chain hardening guidance, which
recommends pinning third-party actions to an immutable commit SHA rather
than a mutable tag.

Actions pinned (current tag -> SHA):
- `lycheeverse/lychee-action` v2 -> `8646ba30535128ac92d33dfc9133794bfdd9b411` (check-links.yml)
- `dorny/test-reporter` v2.6.0 -> `3d76b34a4535afbd0600d347b09a6ee5deb3ed7f` (daily-compatibility.yml)
- `peaceiris/actions-gh-pages` v4 -> `84c30a85c19949d7eee79c4ff27748b70285e453` (docs.yaml)
- `pre-commit/action` v3.0.0 -> `646c83fcd040023954eafda54b4db0192ce70507` (pre-commit.yaml)
- `docker/setup-qemu-action` v3 -> `c7c53464625b32c7a7e944ae62b3e17d2b600130` (publish-images.yaml)
- `docker/setup-buildx-action` v3 -> `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` (publish-images.yaml)

No functional change; first-party `actions/*` are left as-is.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (N/A — CI-only change, no package touched)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
