### PR TITLE
Fix NoneType crash in Newton visualization model build when no ClonePlan is published

### DIFF
--- a/source/isaaclab_newton/changelog.d/fix-newton-viz-clone-plan-none-guard.rst
+++ b/source/isaaclab_newton/changelog.d/fix-newton-viz-clone-plan-none-guard.rst
@@ -1,0 +1,12 @@
+Fixed
+^^^^^
+
+* Fixed ``AttributeError: 'NoneType' object has no attribute 'get_clone_plan'``
+  in :meth:`NewtonManager._ensure_visualization_model` on the PhysX backend
+  (regression from #6119). The renderer's ``PHYSICS_READY`` callback can fire
+  before ``PhysicsManager.initialize()`` sets ``_sim``, and
+  :meth:`SimulationContext.get_clone_plan` may also legitimately return ``None``
+  for scenes that have not yet replicated. ``build_visualization_builder_from_stage_envs``
+  now accepts ``clone_plan=None`` and falls back to the env_0 prototype-replicate
+  path that pre-existed PR #6119, restoring the ``physx,newton_renderer,*``
+  benchmark presets in omniperf-benchmark.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1806,8 +1806,17 @@ class NewtonManager(PhysicsManager):
             return
 
         NewtonManager._num_envs = len(env_paths)
+        # ``PhysicsManager._sim`` can be unset during early renderer initialization
+        # on the PhysX backend (the renderer's PHYSICS_READY callback can fire
+        # before ``PhysicsManager.initialize()`` has set ``_sim``).
+        # ``SimulationContext.get_clone_plan()`` may also legitimately return
+        # ``None`` for scenes that have not yet replicated. In either case
+        # ``build_visualization_builder_from_stage_envs`` falls back to the
+        # env_0 prototype-replicate path.
+        sim_ctx = PhysicsManager._sim
+        clone_plan = sim_ctx.get_clone_plan() if sim_ctx is not None else None
         builder = build_visualization_builder_from_stage_envs(
-            stage, env_paths, PhysicsManager._sim.get_clone_plan(), up_axis=up_axis
+            stage, env_paths, clone_plan, up_axis=up_axis
         )
 
         if builder.body_count == 0:

--- a/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
@@ -9,10 +9,11 @@ from collections.abc import Sequence
 from typing import Any
 
 import torch
-from newton import ModelBuilder
+import warp as wp
+from newton import Axis, ModelBuilder
 from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 
-from pxr import Usd
+from pxr import Usd, UsdGeom
 
 from isaaclab.sim.utils.transforms import resolve_prim_pose
 
@@ -26,11 +27,23 @@ from isaaclab_newton.cloner.newton_clone_utils import (
 def build_visualization_builder_from_stage_envs(
     stage: Usd.Stage,
     env_paths: Sequence[tuple[int, str]],
-    clone_plan: Any,
+    clone_plan: Any | None,
     *,
     up_axis: str = "Z",
 ) -> ModelBuilder:
-    """Build the Newton shadow visualization builder from cloned USD environments."""
+    """Build the Newton shadow visualization builder from cloned USD environments.
+
+    When ``clone_plan`` is ``None`` (no published ClonePlan -- common on the
+    PhysX backend during early renderer initialization, or for scenes that do
+    not publish a plan), falls back to an env_0 prototype-replicate path so the
+    PhysX-backed visualizer still gets a populated Newton ``Model``. The
+    ClonePlan-aware path produces a more accurate model for heterogeneous
+    environments; this fallback covers the homogeneous-env case that pre-existed
+    PR #6119.
+    """
+    if clone_plan is None:
+        return _build_from_env_0_prototype(stage, env_paths, up_axis=up_axis)
+
     env_path_by_id = dict(env_paths)
 
     sources = tuple(clone_plan.sources)
@@ -53,4 +66,95 @@ def build_visualization_builder_from_stage_envs(
     )
     replicate_builder_mapping(builder, sources, mapping, positions, quaternions, source_builders)
     rename_builder_labels(builder, sources, destinations, env_ids, mapping)
+    return builder
+
+
+def _build_from_env_0_prototype(
+    stage: Usd.Stage,
+    env_paths: Sequence[tuple[int, str]],
+    *,
+    up_axis: str = "Z",
+) -> ModelBuilder:
+    """Pre-#6119 fallback: build the visualization model from env_0 as a prototype.
+
+    Used when no ``ClonePlan`` is published (e.g. early in the PhysX-backend
+    lifecycle, or for scenes that do not publish a plan). Walks the
+    ``/World/envs/env_<id>`` convention, builds ``env_0`` as a prototype, then
+    replicates it across every env via :meth:`ModelBuilder.add_builder` with the
+    correct relative transform. Label arrays are rewritten so each replicated
+    world references its own env prim path (otherwise the PhysX ->
+    ``state.body_q`` sync resolves every match to world 0 and worlds 1..N never
+    receive fresh poses).
+    """
+    up_axis_enum = Axis.from_string(up_axis) if isinstance(up_axis, str) else up_axis
+    schema_resolvers = [SchemaResolverNewton(), SchemaResolverPhysx()]
+
+    builder = ModelBuilder(up_axis=up_axis_enum)
+
+    if not env_paths:
+        # No ``/World/envs/env_<id>`` prims -- ingest the whole stage as a single world.
+        builder.add_usd(stage, schema_resolvers=schema_resolvers)
+        return builder
+
+    # Ingest stage-level (non-env) geometry first so visualization sees ground
+    # planes, ceilings, fixed props, etc.
+    builder.add_usd(
+        stage,
+        ignore_paths=[r"/World/envs($|/.*)"],
+        schema_resolvers=schema_resolvers,
+    )
+
+    sorted_envs = sorted(env_paths, key=lambda x: x[0])
+    proto_env_path = sorted_envs[0][1]
+    proto = ModelBuilder(up_axis=up_axis_enum)
+    proto.add_usd(
+        stage,
+        root_path=proto_env_path,
+        schema_resolvers=schema_resolvers,
+    )
+
+    xform_cache = UsdGeom.XformCache()
+
+    label_attrs = ("body_label", "articulation_label", "joint_label", "shape_label")
+    label_starts = {attr: len(getattr(builder, attr)) for attr in label_attrs}
+
+    proto_world_gf = xform_cache.GetLocalToWorldTransform(stage.GetPrimAtPath(proto_env_path))
+    proto_translation = proto_world_gf.ExtractTranslation()
+    proto_rotation = proto_world_gf.ExtractRotationQuat()
+    proto_world_tf = wp.transform(
+        (proto_translation[0], proto_translation[1], proto_translation[2]),
+        (
+            proto_rotation.GetImaginary()[0],
+            proto_rotation.GetImaginary()[1],
+            proto_rotation.GetImaginary()[2],
+            proto_rotation.GetReal(),
+        ),
+    )
+    proto_world_tf_inv = wp.transform_inverse(proto_world_tf)
+
+    for _, env_path in sorted_envs:
+        world_xform = xform_cache.GetLocalToWorldTransform(stage.GetPrimAtPath(env_path))
+        translation = world_xform.ExtractTranslation()
+        rotation = world_xform.ExtractRotationQuat()
+        env_world_tf = wp.transform(
+            (translation[0], translation[1], translation[2]),
+            (
+                rotation.GetImaginary()[0],
+                rotation.GetImaginary()[1],
+                rotation.GetImaginary()[2],
+                rotation.GetReal(),
+            ),
+        )
+        relative_tf = wp.transform_multiply(env_world_tf, proto_world_tf_inv)
+        builder.begin_world()
+        builder.add_builder(proto, xform=relative_tf)
+        if env_path != proto_env_path:
+            for attr in label_attrs:
+                labels = getattr(builder, attr)
+                for i in range(label_starts[attr], len(labels)):
+                    labels[i] = labels[i].replace(proto_env_path, env_path, 1)
+        for attr in label_attrs:
+            label_starts[attr] = len(getattr(builder, attr))
+        builder.end_world()
+
     return builder


### PR DESCRIPTION
# Description

Regression fix for PR #6119.

PR #6119 introduced an unguarded `PhysicsManager._sim.get_clone_plan()` call
in `NewtonManager._ensure_visualization_model()` (the PhysX-backend shadow-
model path). `PhysicsManager._sim` is `None` at the point this code runs
(the renderer's `PHYSICS_READY` callback path), and
`SimulationContext.get_clone_plan()` itself may return `None` for scenes
that have not yet replicated. The result is an immediate
`AttributeError: 'NoneType' object has no attribute 'get_clone_plan'` on
every `physx,newton_renderer,*` invocation — the very configuration this
code path exists to support.

## Reproduction

```
./isaaclab.sh -p scripts/benchmarks/benchmark_rsl_rl.py \
  --task=Isaac-Lift-KukaAllegro-Camera \
  --headless --enable_cameras --max_iterations 10 --num_envs=256 \
  presets=cube,duo_camera,physx,newton_renderer,rgb64
```

Crashes immediately at `_init_sim()` with:
```
File ".../newton_manager.py", line 1810, in _ensure_visualization_model
    stage, env_paths, PhysicsManager._sim.get_clone_plan(), up_axis=up_axis
AttributeError: 'NoneType' object has no attribute 'get_clone_plan'
```

## Changes

- Guards the `_sim` deref at the call site, passing `clone_plan=None` when
  the simulation context is not yet set.
- Updates `build_visualization_builder_from_stage_envs` to accept
  `clone_plan=None` and fall back to an env_0 prototype-replicate path that
  restores the pre-#6119 visualization behavior for homogeneous environments
  (faithful inline of the pre-#6119 `_build_visualization_model_from_stage`
  method that ran in production from late May through Jun 11).
- Adds a changelog fragment under `isaaclab_newton/changelog.d/`.

## Impact

Restores the `physx,newton_renderer,*` benchmark presets in omniperf's
`ISAAC_LAB_SINGLE_GPU_GTL_PRESET_PHYSX_WARP_*` group, which has been 100%
failing since #6119 merged on Jun 12. DB telemetry: 13/13 KPIs on Jun 11 →
0/386 KPIs Jun 13–15.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the `pre-commit` checks
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/`
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

Related: #6119