### PR TITLE
docs: fix Isaac Lab container pull tag to 3.0.0-beta2

### DIFF
--- a/docs/source/deployment/docker.rst
+++ b/docs/source/deployment/docker.rst
@@ -322,7 +322,7 @@ To pull the minimal Isaac Lab container, run:
 
 .. code:: bash
 
-  docker pull nvcr.io/nvidia/isaac-lab:3.0.0.beta2
+  docker pull nvcr.io/nvidia/isaac-lab:3.0.0-beta2
 
 .. attention::
 
@@ -353,7 +353,7 @@ To run the Isaac Lab container with an interactive bash session, run:
      -v ~/docker/isaac-sim/logs:/root/.nvidia-omniverse/logs:rw \
      -v ~/docker/isaac-sim/data:/root/.local/share/ov/data:rw \
      -v ~/docker/isaac-sim/documents:/root/Documents:rw \
-     nvcr.io/nvidia/isaac-lab:3.0.0.beta2
+     nvcr.io/nvidia/isaac-lab:3.0.0-beta2
 
 To enable rendering through X11 forwarding, run:
 
@@ -372,7 +372,7 @@ To enable rendering through X11 forwarding, run:
      -v ~/docker/isaac-sim/logs:/root/.nvidia-omniverse/logs:rw \
      -v ~/docker/isaac-sim/data:/root/.local/share/ov/data:rw \
      -v ~/docker/isaac-sim/documents:/root/Documents:rw \
-     nvcr.io/nvidia/isaac-lab:3.0.0.beta2
+     nvcr.io/nvidia/isaac-lab:3.0.0-beta2
 
 To run an example within the container, run:
 


### PR DESCRIPTION
# Description

Fixes the Isaac Lab container pull tag in the Docker deployment docs.

`docs/source/deployment/docker.rst` referenced
`nvcr.io/nvidia/isaac-lab:3.0.0.beta2` (dot), but the published NGC container
tag uses a hyphen: `nvcr.io/nvidia/isaac-lab:3.0.0-beta2` (matching the
`3.0.0-beta1` convention). The dotted tag does not exist, so the documented
`docker pull` / `docker run` commands would fail. The same file already refers
to "3.0.0-beta2 and later" (hyphen) in prose, so this also removes an internal
inconsistency.

Fixes # (issue)

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (N/A — docs-only change)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
