### PR TITLE
Fix Newton renderer simulation context ownership

### DIFF
--- a/source/isaaclab/changelog.d/fix-physx-newton-renderer-sim-binding.rst
+++ b/source/isaaclab/changelog.d/fix-physx-newton-renderer-sim-binding.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.physics.PhysicsManager` shutdown so inactive manager classes do not clear the active simulation context binding.

--- a/source/isaaclab/isaaclab/physics/physics_manager.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager.py
@@ -312,14 +312,15 @@ class PhysicsManager(ABC):
         Subclasses should call super().close() after backend-specific cleanup.
         """
         sim = PhysicsManager._sim
-        if sim is None or sim.physics_manager is not cls:
-            return
+        is_active_manager = sim is not None and sim.physics_manager is cls
+        if is_active_manager:
+            cls.dispatch_event(PhysicsEvent.STOP)  # notify listeners before cleanup
 
-        cls.dispatch_event(PhysicsEvent.STOP)  # notify listeners before cleanup
         cls.clear_callbacks()
-        PhysicsManager._sim = None
-        PhysicsManager._cfg = None
-        PhysicsManager._sim_time = 0.0
+        if is_active_manager:
+            PhysicsManager._sim = None
+            PhysicsManager._cfg = None
+            PhysicsManager._sim_time = 0.0
 
     @classmethod
     def get_physics_dt(cls) -> float:

--- a/source/isaaclab/isaaclab/physics/physics_manager.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager.py
@@ -311,9 +311,12 @@ class PhysicsManager(ABC):
 
         Subclasses should call super().close() after backend-specific cleanup.
         """
+        sim = PhysicsManager._sim
+        if sim is None or sim.physics_manager is not cls:
+            return
+
         cls.dispatch_event(PhysicsEvent.STOP)  # notify listeners before cleanup
         cls.clear_callbacks()
-        # Reset on PhysicsManager explicitly (matches initialize())
         PhysicsManager._sim = None
         PhysicsManager._cfg = None
         PhysicsManager._sim_time = 0.0

--- a/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
+++ b/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
@@ -69,7 +69,9 @@ def test_physics_manager_close_only_clears_active_manager_binding(monkeypatch):
     monkeypatch.setattr(PhysicsManager, "_cfg", "active-cfg", raising=False)
     monkeypatch.setattr(PhysicsManager, "_sim_time", 1.25, raising=False)
 
+    monkeypatch.setattr(PhysicsManager, "_callbacks", {1: (None, lambda _: None, 0, "stale", None)}, raising=False)
     _InactiveManager.close()
+    assert PhysicsManager._callbacks == {}
     assert (PhysicsManager._sim, PhysicsManager._cfg, PhysicsManager._sim_time) == (active_sim, "active-cfg", 1.25)
 
     _ActiveManager.close()

--- a/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
+++ b/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
@@ -40,6 +40,42 @@ def _make_env_stage(num_envs: int = 1):
     return stage
 
 
+def _set_sim_context(monkeypatch, nm, clone_plan=None, scene_data_provider=None):
+    clone_plan = clone_plan if clone_plan is not None else SimpleNamespace()
+    scene_data_provider = scene_data_provider if scene_data_provider is not None else SimpleNamespace()
+    sim = SimpleNamespace(
+        get_clone_plan=lambda: clone_plan,
+        get_scene_data_provider=lambda: scene_data_provider,
+    )
+    monkeypatch.setattr(nm.SimulationContext, "instance", classmethod(lambda cls: sim))
+    return sim
+
+
+def test_physics_manager_close_only_clears_active_manager_binding(monkeypatch):
+    """Only the active physics manager can clear shared SimulationContext state."""
+    from isaaclab.physics import PhysicsManager
+
+    class _ActiveManager(PhysicsManager):
+        _callbacks = {}
+
+    class _InactiveManager(PhysicsManager):
+        pass
+
+    _ActiveManager.close()
+    assert PhysicsManager._sim is None
+
+    active_sim = SimpleNamespace(physics_manager=_ActiveManager)
+    monkeypatch.setattr(PhysicsManager, "_sim", active_sim, raising=False)
+    monkeypatch.setattr(PhysicsManager, "_cfg", "active-cfg", raising=False)
+    monkeypatch.setattr(PhysicsManager, "_sim_time", 1.25, raising=False)
+
+    _InactiveManager.close()
+    assert (PhysicsManager._sim, PhysicsManager._cfg, PhysicsManager._sim_time) == (active_sim, "active-cfg", 1.25)
+
+    _ActiveManager.close()
+    assert (PhysicsManager._sim, PhysicsManager._cfg, PhysicsManager._sim_time) == (None, None, 0.0)
+
+
 def test_ensure_visualization_model_noop_when_backend_is_newton(monkeypatch):
     """When sim backend is Newton, the manager keeps its own model/state untouched."""
     from isaaclab_newton.physics import NewtonManager
@@ -59,7 +95,8 @@ def test_ensure_visualization_model_builds_from_stage_when_backend_is_physx(monk
     _reset_newton_manager_state()
     monkeypatch.setattr(NewtonManager, "_backend_is_newton", classmethod(lambda cls, scene_data_provider=None: False))
     monkeypatch.setattr(nm, "get_current_stage", lambda *args, **kwargs: _make_env_stage())
-    monkeypatch.setattr(nm.PhysicsManager, "_sim", SimpleNamespace(get_clone_plan=lambda: SimpleNamespace()))
+    monkeypatch.setattr(nm.PhysicsManager, "_sim", None, raising=False)
+    _set_sim_context(monkeypatch, nm)
     monkeypatch.setattr(nm.PhysicsManager, "_device", "cpu", raising=False)
     monkeypatch.setattr(nm, "replace_newton_shape_colors", lambda model, *a, **kw: 0)
 
@@ -89,7 +126,8 @@ def test_ensure_visualization_model_empty_builder_logs_and_skips(monkeypatch, ca
     _reset_newton_manager_state()
     monkeypatch.setattr(NewtonManager, "_backend_is_newton", classmethod(lambda cls, scene_data_provider=None: False))
     monkeypatch.setattr(nm, "get_current_stage", lambda *args, **kwargs: _make_env_stage())
-    monkeypatch.setattr(nm.PhysicsManager, "_sim", SimpleNamespace(get_clone_plan=lambda: SimpleNamespace()))
+    monkeypatch.setattr(nm.PhysicsManager, "_sim", None, raising=False)
+    _set_sim_context(monkeypatch, nm)
 
     class _EmptyBuilder:
         body_count = 0
@@ -112,7 +150,8 @@ def test_ensure_visualization_model_populates_num_envs_when_backend_is_physx(mon
     _reset_newton_manager_state()
     monkeypatch.setattr(NewtonManager, "_backend_is_newton", classmethod(lambda cls, scene_data_provider=None: False))
     monkeypatch.setattr(nm, "get_current_stage", lambda *args, **kwargs: _make_env_stage(num_envs=4))
-    monkeypatch.setattr(nm.PhysicsManager, "_sim", SimpleNamespace(get_clone_plan=lambda: SimpleNamespace()))
+    monkeypatch.setattr(nm.PhysicsManager, "_sim", None, raising=False)
+    _set_sim_context(monkeypatch, nm)
     monkeypatch.setattr(nm.PhysicsManager, "_device", "cpu", raising=False)
     monkeypatch.setattr(nm, "replace_newton_shape_colors", lambda model, *a, **kw: 0)
 

--- a/source/isaaclab_newton/changelog.d/fix-physx-newton-renderer-sim-binding.rst
+++ b/source/isaaclab_newton/changelog.d/fix-physx-newton-renderer-sim-binding.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Newton renderer shadow-model initialization to read clone plans from the active :class:`~isaaclab.sim.SimulationContext`.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -40,6 +40,7 @@ from pxr import UsdGeom
 
 from isaaclab.physics import CallbackHandle, PhysicsEvent, PhysicsManager
 from isaaclab.scene_data import SceneDataBackend, SceneDataFormat, SceneDataProvider
+from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils.newton_model_utils import replace_newton_shape_colors
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.utils import checked_apply
@@ -53,8 +54,6 @@ from .newton_manager_cfg import NewtonCfg, NewtonShapeCfg
 
 if TYPE_CHECKING:
     from pxr import Usd
-
-    from isaaclab.sim.simulation_context import SimulationContext
 
     from isaaclab_newton.actuators import NewtonActuatorAdapter
 
@@ -1806,9 +1805,9 @@ class NewtonManager(PhysicsManager):
             return
 
         NewtonManager._num_envs = len(env_paths)
-        builder = build_visualization_builder_from_stage_envs(
-            stage, env_paths, PhysicsManager._sim.get_clone_plan(), up_axis=up_axis
-        )
+        sim = SimulationContext.instance()
+        assert sim is not None
+        builder = build_visualization_builder_from_stage_envs(stage, env_paths, sim.get_clone_plan(), up_axis=up_axis)
 
         if builder.body_count == 0:
             logger.error(
@@ -1837,17 +1836,8 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def get_scene_data_provider(cls) -> SceneDataProvider:
-        """Return the active scene data provider, or None if unavailable.
-
-        Prefers ``PhysicsManager._sim`` when set; otherwise falls back to
-        ``SimulationContext.instance()``.
-        """
-        sim = PhysicsManager._sim
-        if sim is None:
-            from isaaclab.sim import SimulationContext
-
-            sim = SimulationContext.instance()
-
+        """Return the active scene data provider."""
+        sim = SimulationContext.instance()
         assert sim is not None
         return sim.get_scene_data_provider()
 


### PR DESCRIPTION
## Summary
- read Newton shadow-model clone plans from the active SimulationContext instead of PhysicsManager._sim
- keep PhysicsManager.close() from clearing shared lifecycle state when a non-active manager class is closing
- add regression coverage for PhysX + Newton renderer initialization with PhysicsManager._sim unset

## Validation
- PYTHONPATH="$PWD/source/isaaclab:$PWD/source/isaaclab_newton:$PWD/source/isaaclab_physx:$PWD/source/isaaclab_assets:$PWD/source/isaaclab_tasks:$PWD/source/isaaclab_mimic:$PWD/source/isaaclab_rl:$PWD/source/isaaclab_visualizers" ../develop/.venv/bin/python -m pytest source/isaaclab/test/sim/test_newton_manager_visualization_state.py
- pre-commit run --files source/isaaclab/isaaclab/physics/physics_manager.py source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py source/isaaclab/test/sim/test_newton_manager_visualization_state.py source/isaaclab/changelog.d/fix-physx-newton-renderer-sim-binding.rst source/isaaclab_newton/changelog.d/fix-physx-newton-renderer-sim-binding.rst
- python3 tools/changelog/cli.py check changelog-check-develop (temporary local origin/changelog-check-develop ref pointed at upstream/develop)