### PR TITLE
Propagate Newton shape colors before cloning

### DIFF
--- a/source/isaaclab/changelog.d/new-replace-newton-builder-colors.rst
+++ b/source/isaaclab/changelog.d/new-replace-newton-builder-colors.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added :func:`~isaaclab.sim.utils.newton_model_utils.replace_newton_builder_shape_colors` to
+  propagate USD material and ``displayColor`` values into a Newton ``ModelBuilder``'s shape colors
+  before clone replication, so cloned environments inherit correct colors without a separate
+  post-finalize pass.

--- a/source/isaaclab/isaaclab/sim/utils/newton_model_utils.py
+++ b/source/isaaclab/isaaclab/sim/utils/newton_model_utils.py
@@ -13,8 +13,6 @@ to be deprecated and removed.
 from __future__ import annotations
 
 import logging
-import os
-import warnings
 from typing import Any
 
 import numpy as np
@@ -22,7 +20,7 @@ import warp as wp
 
 from pxr import Usd, UsdGeom, UsdShade
 
-__all__ = ["replace_newton_shape_colors"]
+__all__ = ["replace_newton_builder_shape_colors"]
 
 logger = logging.getLogger(__name__)
 
@@ -36,39 +34,15 @@ _OMNIPBR_DEFAULTS: dict[str, tuple[float, float, float]] = {
 _UNBOUND_DEFAULT_FALLBACK_GRAY = (0.18, 0.18, 0.18)
 
 
-@wp.func
-def _linear_channel_to_srgb_warp(c: float) -> float:
-    """Per-channel sRGB OETF on device: linear ``[0, 1]`` to sRGB-encoded ``[0, 1]``."""
+def _linear_channel_to_srgb(c: float) -> float:
+    """Per-channel sRGB OETF on host: linear ``[0, 1]`` to sRGB-encoded ``[0, 1]``."""
     if c <= 0.0:
         return 0.0
     if c <= 0.0031308:
         return 12.92 * c
     if c >= 1.0:
         return 1.0
-    return 1.055 * wp.pow(c, 1.0 / 2.4) - 0.055
-
-
-@wp.func
-def _linear_rgb_to_srgb_warp(linear_rgb: wp.vec3) -> wp.vec3:
-    """Apply sRGB OETF per channel: linear RGB ``[0, 1]`` to sRGB-encoded ``[0, 1]``."""
-    return wp.vec3(
-        _linear_channel_to_srgb_warp(linear_rgb[0]),
-        _linear_channel_to_srgb_warp(linear_rgb[1]),
-        _linear_channel_to_srgb_warp(linear_rgb[2]),
-    )
-
-
-@wp.kernel
-def _scatter_shape_color_rows_kernel(
-    shape_colors: wp.array(dtype=wp.vec3),  # type: ignore
-    row_indices: wp.array(dtype=wp.int32),  # type: ignore
-    row_colors: wp.array(dtype=wp.vec3),  # type: ignore
-):
-    """Write per-row sRGB colors into ``shape_colors``."""
-    tid = wp.tid()
-    index = row_indices[tid]
-    color = row_colors[tid]
-    shape_colors[index] = _linear_rgb_to_srgb_warp(color)
+    return 1.055 * (c ** (1.0 / 2.4)) - 0.055
 
 
 def _canonical_prim_lookup_key(prim: Usd.Prim) -> str:
@@ -231,122 +205,32 @@ def _resolve_shape_color(
     return material_color
 
 
-def replace_newton_shape_colors(model: Any, stage: Usd.Stage | None = None) -> int:
-    """Align Newton visualization colors with the USD stage.
+def replace_newton_builder_shape_colors(builder: Any, stage: Usd.Stage) -> int:
+    """Align a Newton ``ModelBuilder``'s source shape colors before clone replication."""
 
-    Newton assigns a per-shape palette to ``shape_color``. This overwrites those rows so rendering matches authored USD
-    data where supported:
-
-    - **No bound material**: use authored ``primvars:displayColor`` (treated as linear RGB), or a neutral 18% linear
-      gray if ``displayColor`` is not authored; linear values are encoded to sRGB in the scatter kernel.
-    - **OmniPBR**: use ``diffuse_color_constant`` times ``diffuse_tint`` (linear RGB, with MDL defaults when inputs are
-      not authored), encoded to sRGB in the scatter kernel.
-    - **Other materials**: leave the existing Newton color for that shape.
-    - **Guide purpose** prims (``UsdGeom.Tokens.guide``): leave unchanged so guide visualization stays on the palette.
-
-    Args:
-        model: Object with ``shape_label`` (``list`` of USD prim paths) and ``shape_color`` (``wp.array`` of
-            ``wp.vec3``), typically a finalized Newton model.
-        stage: USD stage to read from. If ``None``, uses :func:`~isaaclab.sim.utils.stage.get_current_stage`.
-
-    Returns:
-        Number of shapes that had their colors replaced.
-
-    Note:
-        Set ``ISAACLAB_REPLACE_NEWTON_SHAPE_COLORS`` to ``0``, ``false``, ``off``, or ``no`` to skip this pass
-        entirely (returns ``0``).
-
-        This pass exists only while Isaac Lab and Isaac Sim content still relies on NVIDIA-specific MDL and OmniPBR
-        materials; after migration to neutral USD materials that Newton can consume directly, this path is expected to
-        be deprecated and removed.
-
-        Wall time for USD resolution and the GPU scatter is measured with :class:`~isaaclab.utils.timer.Timer`, which
-        may print a timing summary when the timer is enabled.
-    """
-    env_val = os.getenv("ISAACLAB_REPLACE_NEWTON_SHAPE_COLORS")
-    if env_val is not None and env_val.strip().lower() in ["false", "0", "off", "no"]:
-        logger.debug("Newton shape color replacement is disabled")
-        return 0
-
-    warnings.warn(
-        "Newton shape color replacement is enabled; this workaround will be deprecated in a future release.",
-        FutureWarning,
-        stacklevel=2,
-    )
-
-    # Use duck typing to avoid introducing hard dependencies on newton.
-    shape_labels = getattr(model, "shape_label", None)
-    shape_colors = getattr(model, "shape_color", None)
-
-    if not isinstance(shape_labels, list):
-        logger.debug("shape_label must be a list, got %s", type(shape_labels))
-        return 0
-
-    if not isinstance(shape_colors, wp.array):
-        logger.debug("shape_color must be a Warp array, got %s", type(shape_colors))
-        return 0
-
-    num_shapes = len(shape_labels)
-    if num_shapes == 0:
-        logger.debug("Found empty list of shape labels")
-        return 0
-
-    if num_shapes != len(shape_colors):
-        logger.debug("Mismatching length of shape_labels and shape_colors: %d != %d", num_shapes, len(shape_colors))
-        return 0
+    shape_labels = builder.shape_label
+    shape_colors = builder.shape_color
+    if len(shape_labels) != len(shape_colors):
+        raise ValueError(
+            f"Mismatching length of shape_label and shape_color: {len(shape_labels)} != {len(shape_colors)}"
+        )
 
     from isaaclab.utils.timer import Timer
 
-    num_color_updates = 0
-
-    with Timer(f"[INFO]: Time taken for replace_newton_shape_colors for {num_shapes} shapes", enable=False):
-        if stage is None:
-            from .stage import get_current_stage
-
-            stage = get_current_stage()
-
-        shape_keys: list[str] = []
-
-        for label in shape_labels:
-            prim = stage.GetPrimAtPath(label)
-            shape_keys.append(_canonical_prim_lookup_key(prim) if prim.IsValid() else label)
-
-        # shape_keys must stay the same length as shape labels, to guarantee the correctness of
-        # shape indices that will be used in the scatter kernel.
-        assert num_shapes == len(shape_keys)
-
-        resolved_color_cache: dict[str, tuple[float, float, float] | None] = {}
+    with Timer(
+        f"[INFO]: Time taken for replace_newton_builder_shape_colors for {len(shape_labels)} shapes", enable=False
+    ):
+        num_color_updates = 0
         material_color_cache: dict[str, tuple[float, float, float] | None] = {}
-
-        unique_keys = dict.fromkeys(shape_keys)
-        for key in unique_keys:
-            color = _resolve_shape_color(stage, key, material_color_cache)
-            resolved_color_cache[key] = color
-
-        # Prepare the indices and colors for the scatter kernel:
-        # - Indices point to the slots in the shape_colors array that should be updated
-        # - Colors are the new values to write into the slots
-        indices_np = np.empty(num_shapes, dtype=np.int32)
-        colors_np = np.empty((num_shapes, 3), dtype=np.float32)
-
-        for i, shape_key in enumerate(shape_keys):
-            if rgb := resolved_color_cache.get(shape_key):
-                indices_np[num_color_updates] = i
-                colors_np[num_color_updates] = rgb
+        for i, label in enumerate(shape_labels):
+            rgb = _resolve_shape_color(stage, label, material_color_cache)
+            if rgb is not None:
+                shape_colors[i] = wp.vec3(
+                    _linear_channel_to_srgb(rgb[0]),
+                    _linear_channel_to_srgb(rgb[1]),
+                    _linear_channel_to_srgb(rgb[2]),
+                )
                 num_color_updates += 1
 
-        # If there are any color updates, launch the scatter kernel to update the shape_colors array.
-        if num_color_updates != 0:
-            indices_wp = wp.from_numpy(indices_np[:num_color_updates], dtype=wp.int32, device=shape_colors.device)
-            colors_wp = wp.from_numpy(colors_np[:num_color_updates], dtype=wp.vec3, device=shape_colors.device)
-
-            wp.launch(
-                kernel=_scatter_shape_color_rows_kernel,
-                dim=num_color_updates,
-                inputs=[shape_colors, indices_wp, colors_wp],
-                device=shape_colors.device,
-            )
-
-        logger.debug("Replaced colors for %d / %d shapes", num_color_updates, num_shapes)
-
-    return num_color_updates
+        logger.debug("Replaced builder colors for %d / %d shapes", num_color_updates, len(shape_labels))
+        return num_color_updates

--- a/source/isaaclab/isaaclab/sim/utils/newton_model_utils.py
+++ b/source/isaaclab/isaaclab/sim/utils/newton_model_utils.py
@@ -13,6 +13,7 @@ to be deprecated and removed.
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Any
 
 import numpy as np
@@ -177,7 +178,7 @@ def _resolve_shape_color(
     """Resolve replacement linear RGB for one prim path (sRGB encoding is applied in the scatter kernel).
 
     Returns:
-        Linear RGB to pass to :func:`_scatter_shape_color_rows_kernel`, or ``None`` to leave the row unchanged.
+        Linear RGB to pass, or ``None`` to leave the row unchanged.
     """
     shape_prim = stage.GetPrimAtPath(prim_path)
     if not shape_prim.IsValid():
@@ -206,10 +207,46 @@ def _resolve_shape_color(
 
 
 def replace_newton_builder_shape_colors(builder: Any, stage: Usd.Stage) -> int:
-    """Align a Newton ``ModelBuilder``'s source shape colors before clone replication."""
+    """Align a Newton ``ModelBuilder``'s shape colors with the USD stage before clone replication.
 
-    shape_labels = builder.shape_label
-    shape_colors = builder.shape_color
+    Overwrites entries in ``builder.shape_color`` so that colors match the authored USD data:
+
+    - **No bound material**: use authored ``primvars:displayColor`` (treated as linear RGB), or a
+      neutral 18% linear gray if ``displayColor`` is not authored.
+    - **OmniPBR**: use ``diffuse_color_constant`` × ``diffuse_tint`` (linear RGB, with MDL defaults
+      when inputs are not authored).
+    - **Other materials**: leave the existing Newton color for that shape unchanged.
+    - **Guide purpose** prims (``UsdGeom.Tokens.guide``): leave unchanged so guide visualization
+      stays on the Newton palette.
+
+    Linear RGB values are encoded to sRGB before being written into ``builder.shape_color``.
+
+    Args:
+        builder: Object with ``shape_label`` (``list`` of USD prim paths) and ``shape_color``
+            (``list`` of ``wp.vec3``), typically a Newton ``ModelBuilder`` before finalization.
+        stage: USD stage to read material and primvar data from.
+
+    Returns:
+        Number of shapes that had their colors replaced.
+    """
+    warnings.warn(
+        "Newton shape color replacement is enabled; this workaround will be deprecated in a future release.",
+        FutureWarning,
+        stacklevel=2,
+    )
+
+    # Use duck typing to avoid introducing hard dependencies on newton.
+    shape_labels = getattr(builder, "shape_label", None)
+    shape_colors = getattr(builder, "shape_color", None)
+
+    if not isinstance(shape_labels, list):
+        logger.debug("shape_label must be a list, got %s", type(shape_labels))
+        return 0
+
+    if not isinstance(shape_colors, list):
+        logger.debug("shape_color must be a list, got %s", type(shape_colors))
+        return 0
+
     if len(shape_labels) != len(shape_colors):
         raise ValueError(
             f"Mismatching length of shape_label and shape_color: {len(shape_labels)} != {len(shape_colors)}"

--- a/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
+++ b/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
@@ -100,7 +100,6 @@ def test_ensure_visualization_model_builds_from_stage_when_backend_is_physx(monk
     monkeypatch.setattr(nm.PhysicsManager, "_sim", None, raising=False)
     _set_sim_context(monkeypatch, nm)
     monkeypatch.setattr(nm.PhysicsManager, "_device", "cpu", raising=False)
-    monkeypatch.setattr(nm, "replace_newton_shape_colors", lambda model, *a, **kw: 0)
 
     finalize_calls: list[str] = []
 
@@ -155,7 +154,6 @@ def test_ensure_visualization_model_populates_num_envs_when_backend_is_physx(mon
     monkeypatch.setattr(nm.PhysicsManager, "_sim", None, raising=False)
     _set_sim_context(monkeypatch, nm)
     monkeypatch.setattr(nm.PhysicsManager, "_device", "cpu", raising=False)
-    monkeypatch.setattr(nm, "replace_newton_shape_colors", lambda model, *a, **kw: 0)
 
     class _FakeBuilder:
         body_count = 3

--- a/source/isaaclab/test/sim/test_newton_model_utils.py
+++ b/source/isaaclab/test/sim/test_newton_model_utils.py
@@ -9,12 +9,9 @@
 
 from __future__ import annotations
 
-import warnings
 from types import SimpleNamespace
 
-import numpy as np
 import pytest
-import torch
 import warp as wp
 
 from pxr import Gf, Sdf, Usd, UsdGeom, UsdShade
@@ -24,19 +21,8 @@ from isaaclab.sim.utils.newton_model_utils import (
     _UNBOUND_DEFAULT_FALLBACK_GRAY,
     _get_omnipbr_albedo,
     _resolve_shape_color,
-    _scatter_shape_color_rows_kernel,
-    replace_newton_shape_colors,
+    replace_newton_builder_shape_colors,
 )
-
-_WARNING_MESSAGE = "Newton shape color replacement is enabled; this workaround will be deprecated in a future release."
-
-
-def _replace_newton_shape_colors_wrapper(model: object, stage: Usd.Stage | None = None) -> int:
-    """Call :func:`replace_newton_shape_colors` with :class:`FutureWarning` suppressed in test reports."""
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message=_WARNING_MESSAGE, category=FutureWarning)
-        return replace_newton_shape_colors(model, stage)
-
 
 _OMNIPBR_ALBEDO_INPUT_CASES = [
     pytest.param((0.2, 0.4, 0.6), (0.5, 0.25, 2.0), id="both_authored"),
@@ -149,43 +135,6 @@ def _reference_linear_to_srgb(rgb: tuple[float, float, float]) -> tuple[float, f
     return (linear_to_srgb(r), linear_to_srgb(g), linear_to_srgb(b))
 
 
-def _run_scatter_shape_color_rows_kernel(
-    linear_colors: list[tuple[float, float, float]],
-    device: str,
-) -> torch.Tensor:
-    """Launch :func:`_scatter_shape_color_rows_kernel` on ``device``."""
-    num_colors = len(linear_colors)
-    row_indices = list(range(num_colors))
-
-    shape_colors = wp.zeros(num_colors, dtype=wp.vec3, device=device)
-    idx_wp = wp.array(row_indices, dtype=wp.int32, device=device)
-    colors_np = np.asarray(linear_colors, dtype=np.float32).reshape(num_colors, 3)
-    row_colors = wp.from_numpy(colors_np, dtype=wp.vec3, device=device)
-    wp.launch(
-        _scatter_shape_color_rows_kernel,
-        dim=num_colors,
-        inputs=[shape_colors, idx_wp, row_colors],
-        device=device,
-    )
-    return wp.to_torch(shape_colors)
-
-
-@pytest.mark.parametrize(
-    "linear_rgb",
-    [
-        pytest.param((0.002, 0.0, 0.21404114048), id="low_linear_zero_pow"),
-        pytest.param((-0.25, 1.75, 0.5), id="oob_clamps_pow"),
-    ],
-)
-@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_scatter_shape_color_rows_kernel(device: str, linear_rgb: tuple[float, float, float]):
-    """Packed RGB per case; the two parametrized cases jointly cover every ``_linear_channel_to_srgb_warp`` branch."""
-    after = _run_scatter_shape_color_rows_kernel([linear_rgb], device=device)
-    exp = _reference_linear_to_srgb(linear_rgb)
-    for ch in range(3):
-        assert after[0, ch].item() == pytest.approx(exp[ch], rel=1e-5)
-
-
 @pytest.mark.parametrize(("diffuse_color_constant", "diffuse_tint"), _OMNIPBR_ALBEDO_INPUT_CASES)
 def test_get_omnipbr_albedo(
     diffuse_color_constant: tuple[float, float, float] | None,
@@ -276,63 +225,19 @@ def test_resolve_shape_color_neutral_material_binding():
     assert _resolve_shape_color(stage, mesh_path, {}) is None
 
 
-def test_replace_newton_shape_colors_warning():
-    """A :exc:`FutureWarning` is expected by default."""
-    model = SimpleNamespace(shape_label=None, shape_color=None)
-
-    with pytest.warns(FutureWarning, match=_WARNING_MESSAGE):
-        replace_newton_shape_colors(model)
-
-
-@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_replace_newton_shape_colors_env_var_switch(monkeypatch: pytest.MonkeyPatch, device: str):
-    """Setting ``ISAACLAB_REPLACE_NEWTON_SHAPE_COLORS`` to ``0`` disables the workaround."""
-    monkeypatch.setenv("ISAACLAB_REPLACE_NEWTON_SHAPE_COLORS", "0")
-
-    # Set up a stage that has a prim with display color primvar and no material binding. If the workaround was enabled,
-    # the prim's color in the model would be synced with the display color primvar.
-    stage = Usd.Stage.CreateInMemory()
-    mesh = UsdGeom.Mesh.Define(stage, "/World/A")
-    assert mesh.GetPrim().IsValid()
-    pv = UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
-        "displayColor", Sdf.ValueTypeNames.Color3fArray, UsdGeom.Tokens.constant, 1
-    )
-    pv.Set([Gf.Vec3f(0.2, 0.4, 0.6)])
-
-    shape_color = wp.zeros(1, dtype=wp.vec3, device=device)
-    before = wp.to_torch(shape_color).clone()
-    model = SimpleNamespace(shape_label=["/World/A"], shape_color=shape_color)
-
-    # The workaround is disabled, so the shape color is expected to be unchanged
-    with warnings.catch_warnings(record=True) as recorded:
-        warnings.simplefilter("always")
-        num_colors_updated = replace_newton_shape_colors(model, stage)
-
-    assert num_colors_updated == 0
-    assert torch.allclose(wp.to_torch(shape_color), before)
-
-    # No FutureWarning is expected
-    assert not any(issubclass(w.category, FutureWarning) for w in recorded)
-
-
-@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_replace_newton_shape_colors_invalid_prim(device: str):
-    """Invalid prim path leaves ``shape_color`` unchanged."""
+def test_replace_newton_builder_shape_colors_invalid_prim():
+    """Invalid prim path leaves ``shape_color`` entry unchanged."""
     stage = Usd.Stage.CreateInMemory()
 
-    shape_color = wp.array([(0.1, 0.2, 0.3)], dtype=wp.vec3, device=device)
-    before = wp.to_torch(shape_color).clone()
+    initial = (0.1, 0.2, 0.3)
+    builder = SimpleNamespace(shape_label=["/World/Missing"], shape_color=[wp.vec3(*initial)])
 
-    model = SimpleNamespace(shape_label=["/World/Missing"], shape_color=shape_color)
-
-    count = _replace_newton_shape_colors_wrapper(model, stage)
-    assert count == 0
-    assert torch.allclose(wp.to_torch(shape_color), before)
+    assert replace_newton_builder_shape_colors(builder, stage) == 0
+    assert tuple(builder.shape_color[0]) == pytest.approx(initial)
 
 
-@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_replace_newton_shape_colors_guide_purpose(device: str):
-    """Guide-purpose mesh leaves ``shape_color`` unchanged."""
+def test_replace_newton_builder_shape_colors_guide_purpose():
+    """Guide-purpose mesh leaves ``shape_color`` entry unchanged."""
     stage = Usd.Stage.CreateInMemory()
     mesh = UsdGeom.Mesh.Define(stage, "/World/GuideMesh")
     assert mesh.GetPrim().IsValid()
@@ -340,17 +245,14 @@ def test_replace_newton_shape_colors_guide_purpose(device: str):
     assert purpose_attr.IsValid()
     purpose_attr.Set(UsdGeom.Tokens.guide)
 
-    shape_color = wp.array([(0.1, 0.2, 0.3)], dtype=wp.vec3, device=device)
-    before = wp.to_torch(shape_color).clone()
-    model = SimpleNamespace(shape_label=["/World/GuideMesh"], shape_color=shape_color)
+    initial = (0.1, 0.2, 0.3)
+    builder = SimpleNamespace(shape_label=["/World/GuideMesh"], shape_color=[wp.vec3(*initial)])
 
-    count = _replace_newton_shape_colors_wrapper(model, stage)
-    assert count == 0
-    assert torch.allclose(wp.to_torch(shape_color), before)
+    assert replace_newton_builder_shape_colors(builder, stage) == 0
+    assert tuple(builder.shape_color[0]) == pytest.approx(initial)
 
 
-@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_replace_newton_shape_colors_no_material_binding(device: str):
+def test_replace_newton_builder_shape_colors_no_material_binding():
     """No material: ``displayColor`` or unbound gray as linear RGB, then sRGB OETF into ``shape_color``."""
     stage = Usd.Stage.CreateInMemory()
 
@@ -365,61 +267,45 @@ def test_replace_newton_shape_colors_no_material_binding(device: str):
     # Mesh B has no material binding and no display color primvar.
     UsdGeom.Mesh.Define(stage, "/World/B")
 
-    shape_labels = ["/World/A", "/World/B"]
-    num_shapes = len(shape_labels)
-    shape_colors = wp.zeros(num_shapes, dtype=wp.vec3, device=device)
-    model = SimpleNamespace(shape_label=shape_labels, shape_color=shape_colors)
+    builder = SimpleNamespace(
+        shape_label=["/World/A", "/World/B"],
+        shape_color=[wp.vec3(0.0, 0.0, 0.0), wp.vec3(0.0, 0.0, 0.0)],
+    )
 
-    num_colors_updated = _replace_newton_shape_colors_wrapper(model, stage)
-    assert num_colors_updated == 2
-
-    after = wp.to_torch(shape_colors)
-    exp_a = _reference_linear_to_srgb(color_a)
-    exp_b = _reference_linear_to_srgb(_UNBOUND_DEFAULT_FALLBACK_GRAY)
-    expected = torch.tensor([exp_a, exp_b], dtype=after.dtype, device=after.device)
-    torch.testing.assert_close(after, expected, rtol=1e-5, atol=1e-5)
+    assert replace_newton_builder_shape_colors(builder, stage) == 2
+    assert tuple(builder.shape_color[0]) == pytest.approx(_reference_linear_to_srgb(color_a), rel=1e-5)
+    assert tuple(builder.shape_color[1]) == pytest.approx(
+        _reference_linear_to_srgb(_UNBOUND_DEFAULT_FALLBACK_GRAY), rel=1e-5
+    )
 
 
 @pytest.mark.parametrize(("diffuse_color_constant", "diffuse_tint"), _OMNIPBR_ALBEDO_INPUT_CASES)
-@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_replace_newton_shape_colors_omnipbr_binding(
-    device: str,
+def test_replace_newton_builder_shape_colors_omnipbr_binding(
     diffuse_color_constant: tuple[float, float, float] | None,
     diffuse_tint: tuple[float, float, float] | None,
 ):
     """Bound OmniPBR: diffuse × tint then sRGB OETF."""
     stage, _shader, mesh_path = _make_mesh_bound_to_omnipbr_test_material(diffuse_color_constant, diffuse_tint)
 
-    shape_color = wp.zeros(1, dtype=wp.vec3, device=device)
-    model = SimpleNamespace(shape_label=[mesh_path], shape_color=shape_color)
+    builder = SimpleNamespace(shape_label=[mesh_path], shape_color=[wp.vec3(0.0, 0.0, 0.0)])
 
-    assert _replace_newton_shape_colors_wrapper(model, stage) == 1
-
+    assert replace_newton_builder_shape_colors(builder, stage) == 1
     exp = _reference_linear_to_srgb(_expected_omnipbr_linear_albedo(diffuse_color_constant, diffuse_tint))
-    after = wp.to_torch(shape_color)[0]
-    torch.testing.assert_close(
-        after,
-        torch.tensor(exp, dtype=after.dtype, device=after.device),
-        rtol=1e-5,
-        atol=1e-5,
-    )
+    assert tuple(builder.shape_color[0]) == pytest.approx(exp, rel=1e-5)
 
 
-@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_replace_newton_shape_colors_neutral_material(device: str):
-    """Bound ``UsdPreviewSurface`` material leaves ``shape_color`` unchanged."""
+def test_replace_newton_builder_shape_colors_neutral_material():
+    """Bound ``UsdPreviewSurface`` material leaves ``shape_color`` entry unchanged."""
     stage, mesh_path = _make_preview_surface_bound_mesh_stage()
 
-    shape_color = wp.array([(0.1, 0.2, 0.3)], dtype=wp.vec3, device=device)
-    before = wp.to_torch(shape_color).clone()
-    model = SimpleNamespace(shape_label=[mesh_path], shape_color=shape_color)
+    initial = (0.1, 0.2, 0.3)
+    builder = SimpleNamespace(shape_label=[mesh_path], shape_color=[wp.vec3(*initial)])
 
-    assert _replace_newton_shape_colors_wrapper(model, stage) == 0
-    assert torch.allclose(wp.to_torch(shape_color), before)
+    assert replace_newton_builder_shape_colors(builder, stage) == 0
+    assert tuple(builder.shape_color[0]) == pytest.approx(initial)
 
 
-@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_replace_newton_shape_colors_respects_binding_strength(device: str):
+def test_replace_newton_builder_shape_colors_respects_binding_strength():
     """Parent stronger-than-descendants binding overrides direct child binding."""
     # Scene graph (``ComputeBoundMaterial`` on the mesh yields ParentMat / green, not ChildMat / red):
     #
@@ -455,24 +341,15 @@ def test_replace_newton_shape_colors_respects_binding_strength(device: str):
     UsdShade.MaterialBindingAPI.Apply(mesh_prim)
     UsdShade.MaterialBindingAPI(mesh_prim).Bind(child_mat)
 
-    shape_color = wp.zeros(1, dtype=wp.vec3, device=device)
-    model = SimpleNamespace(shape_label=["/World/Parent/Mesh"], shape_color=shape_color)
-    assert _replace_newton_shape_colors_wrapper(model, stage) == 1
+    builder = SimpleNamespace(shape_label=["/World/Parent/Mesh"], shape_color=[wp.vec3(0.0, 0.0, 0.0)])
+    assert replace_newton_builder_shape_colors(builder, stage) == 1
 
     # Expected color is green which is inherited from the parent xform prim
-    exp = (0.0, 1.0, 0.0)
-    after = wp.to_torch(shape_color)[0]
-    torch.testing.assert_close(
-        after,
-        torch.tensor(exp, dtype=after.dtype, device=after.device),
-        rtol=1e-5,
-        atol=1e-5,
-    )
+    assert tuple(builder.shape_color[0]) == pytest.approx((0.0, 1.0, 0.0))
 
 
-@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_replace_newton_shape_colors_instanced(device: str):
-    """Instance-proxy labels deduplicate via canonical prototype paths in the per-key cache."""
+def test_replace_newton_builder_shape_colors_instanced():
+    """Instance-proxy shape labels resolve colors from their prototype via displayColor."""
     stage = Usd.Stage.CreateInMemory()
 
     prototype = UsdGeom.Xform.Define(stage, "/World/Prototype")
@@ -502,15 +379,51 @@ def test_replace_newton_shape_colors_instanced(device: str):
         assert inst_proxy.IsValid(), f"Proxy path {proxy_path} is not valid"
         assert inst_proxy.IsInstanceProxy(), f"Proxy path {proxy_path} is not an instance proxy"
 
-    # Create the dummy model
-    shape_color = wp.zeros(2, dtype=wp.vec3, device=device)
-    model = SimpleNamespace(
+    builder = SimpleNamespace(
         shape_label=proxy_paths,
-        shape_color=shape_color,
+        shape_color=[wp.vec3(0.0, 0.0, 0.0), wp.vec3(0.0, 0.0, 0.0)],
     )
-    assert _replace_newton_shape_colors_wrapper(model, stage) == 2
+    assert replace_newton_builder_shape_colors(builder, stage) == 2
 
-    after = wp.to_torch(shape_color)
     exp = _reference_linear_to_srgb((0.1, 0.2, 0.3))
-    expected = torch.tensor([exp, exp], dtype=after.dtype, device=after.device)
-    torch.testing.assert_close(after, expected, rtol=1e-5, atol=1e-5)
+    assert tuple(builder.shape_color[0]) == pytest.approx(exp, rel=1e-5)
+    assert tuple(builder.shape_color[1]) == pytest.approx(exp, rel=1e-5)
+
+
+def test_replace_newton_builder_shape_colors_updates_source_builder():
+    """Source builders are colorized once before clone replication copies colors forward."""
+    stage = Usd.Stage.CreateInMemory()
+    mesh = UsdGeom.Mesh.Define(stage, "/World/envs/env_0/Robot/Mesh")
+    color = (0.2, 0.4, 0.6)
+    primvar = UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
+        "displayColor", Sdf.ValueTypeNames.Color3fArray, UsdGeom.Tokens.constant, 1
+    )
+    primvar.Set([Gf.Vec3f(*color)])
+
+    builder = SimpleNamespace(
+        shape_label=["/World/envs/env_0/Robot/Mesh", "/World/envs/env_1/Robot/Mesh"],
+        shape_color=[wp.vec3(0.0, 0.0, 0.0), wp.vec3(0.0, 0.0, 0.0)],
+    )
+
+    assert replace_newton_builder_shape_colors(builder, stage) == 1
+    assert tuple(builder.shape_color[0]) == pytest.approx(_reference_linear_to_srgb(color))
+    assert tuple(builder.shape_color[1]) == pytest.approx((0.0, 0.0, 0.0))
+
+
+def test_replace_newton_builder_shape_colors_skips_missing_prim_labels():
+    """Labels with no matching USD prim leave the corresponding ``shape_color`` entry unchanged."""
+    stage = Usd.Stage.CreateInMemory()
+    mesh = UsdGeom.Mesh.Define(stage, "/World/envs/env_0/Robot/Mesh")
+    primvar = UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
+        "displayColor", Sdf.ValueTypeNames.Color3fArray, UsdGeom.Tokens.constant, 1
+    )
+    primvar.Set([Gf.Vec3f(0.2, 0.4, 0.6)])
+
+    initial = (0.1, 0.2, 0.3)
+    builder = SimpleNamespace(
+        shape_label=["/World/envs/env_1/Robot/Mesh"],
+        shape_color=[wp.vec3(*initial)],
+    )
+
+    assert replace_newton_builder_shape_colors(builder, stage) == 0
+    assert tuple(builder.shape_color[0]) == pytest.approx(initial)

--- a/source/isaaclab/test/sim/test_newton_model_utils.py
+++ b/source/isaaclab/test/sim/test_newton_model_utils.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import warnings
 from types import SimpleNamespace
 
 import pytest
@@ -23,6 +24,16 @@ from isaaclab.sim.utils.newton_model_utils import (
     _resolve_shape_color,
     replace_newton_builder_shape_colors,
 )
+
+_WARNING_MESSAGE = "Newton shape color replacement is enabled; this workaround will be deprecated in a future release."
+
+
+def _replace_newton_builder_shape_colors_wrapper(builder: object, stage: Usd.Stage) -> int:
+    """Call :func:`replace_newton_builder_shape_colors` with :class:`FutureWarning` suppressed in test reports."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=_WARNING_MESSAGE, category=FutureWarning)
+        return replace_newton_builder_shape_colors(builder, stage)
+
 
 _OMNIPBR_ALBEDO_INPUT_CASES = [
     pytest.param((0.2, 0.4, 0.6), (0.5, 0.25, 2.0), id="both_authored"),
@@ -225,6 +236,14 @@ def test_resolve_shape_color_neutral_material_binding():
     assert _resolve_shape_color(stage, mesh_path, {}) is None
 
 
+def test_replace_newton_builder_shape_colors_warning():
+    """A :exc:`FutureWarning` is expected by default."""
+    builder = SimpleNamespace(shape_label=None, shape_color=None)
+
+    with pytest.warns(FutureWarning, match=_WARNING_MESSAGE):
+        replace_newton_builder_shape_colors(builder, stage=Usd.Stage.CreateInMemory())
+
+
 def test_replace_newton_builder_shape_colors_invalid_prim():
     """Invalid prim path leaves ``shape_color`` entry unchanged."""
     stage = Usd.Stage.CreateInMemory()
@@ -232,7 +251,7 @@ def test_replace_newton_builder_shape_colors_invalid_prim():
     initial = (0.1, 0.2, 0.3)
     builder = SimpleNamespace(shape_label=["/World/Missing"], shape_color=[wp.vec3(*initial)])
 
-    assert replace_newton_builder_shape_colors(builder, stage) == 0
+    assert _replace_newton_builder_shape_colors_wrapper(builder, stage) == 0
     assert tuple(builder.shape_color[0]) == pytest.approx(initial)
 
 
@@ -248,7 +267,7 @@ def test_replace_newton_builder_shape_colors_guide_purpose():
     initial = (0.1, 0.2, 0.3)
     builder = SimpleNamespace(shape_label=["/World/GuideMesh"], shape_color=[wp.vec3(*initial)])
 
-    assert replace_newton_builder_shape_colors(builder, stage) == 0
+    assert _replace_newton_builder_shape_colors_wrapper(builder, stage) == 0
     assert tuple(builder.shape_color[0]) == pytest.approx(initial)
 
 
@@ -272,7 +291,7 @@ def test_replace_newton_builder_shape_colors_no_material_binding():
         shape_color=[wp.vec3(0.0, 0.0, 0.0), wp.vec3(0.0, 0.0, 0.0)],
     )
 
-    assert replace_newton_builder_shape_colors(builder, stage) == 2
+    assert _replace_newton_builder_shape_colors_wrapper(builder, stage) == 2
     assert tuple(builder.shape_color[0]) == pytest.approx(_reference_linear_to_srgb(color_a), rel=1e-5)
     assert tuple(builder.shape_color[1]) == pytest.approx(
         _reference_linear_to_srgb(_UNBOUND_DEFAULT_FALLBACK_GRAY), rel=1e-5
@@ -289,7 +308,7 @@ def test_replace_newton_builder_shape_colors_omnipbr_binding(
 
     builder = SimpleNamespace(shape_label=[mesh_path], shape_color=[wp.vec3(0.0, 0.0, 0.0)])
 
-    assert replace_newton_builder_shape_colors(builder, stage) == 1
+    assert _replace_newton_builder_shape_colors_wrapper(builder, stage) == 1
     exp = _reference_linear_to_srgb(_expected_omnipbr_linear_albedo(diffuse_color_constant, diffuse_tint))
     assert tuple(builder.shape_color[0]) == pytest.approx(exp, rel=1e-5)
 
@@ -301,7 +320,7 @@ def test_replace_newton_builder_shape_colors_neutral_material():
     initial = (0.1, 0.2, 0.3)
     builder = SimpleNamespace(shape_label=[mesh_path], shape_color=[wp.vec3(*initial)])
 
-    assert replace_newton_builder_shape_colors(builder, stage) == 0
+    assert _replace_newton_builder_shape_colors_wrapper(builder, stage) == 0
     assert tuple(builder.shape_color[0]) == pytest.approx(initial)
 
 
@@ -342,7 +361,7 @@ def test_replace_newton_builder_shape_colors_respects_binding_strength():
     UsdShade.MaterialBindingAPI(mesh_prim).Bind(child_mat)
 
     builder = SimpleNamespace(shape_label=["/World/Parent/Mesh"], shape_color=[wp.vec3(0.0, 0.0, 0.0)])
-    assert replace_newton_builder_shape_colors(builder, stage) == 1
+    assert _replace_newton_builder_shape_colors_wrapper(builder, stage) == 1
 
     # Expected color is green which is inherited from the parent xform prim
     assert tuple(builder.shape_color[0]) == pytest.approx((0.0, 1.0, 0.0))
@@ -383,7 +402,7 @@ def test_replace_newton_builder_shape_colors_instanced():
         shape_label=proxy_paths,
         shape_color=[wp.vec3(0.0, 0.0, 0.0), wp.vec3(0.0, 0.0, 0.0)],
     )
-    assert replace_newton_builder_shape_colors(builder, stage) == 2
+    assert _replace_newton_builder_shape_colors_wrapper(builder, stage) == 2
 
     exp = _reference_linear_to_srgb((0.1, 0.2, 0.3))
     assert tuple(builder.shape_color[0]) == pytest.approx(exp, rel=1e-5)
@@ -405,7 +424,7 @@ def test_replace_newton_builder_shape_colors_updates_source_builder():
         shape_color=[wp.vec3(0.0, 0.0, 0.0), wp.vec3(0.0, 0.0, 0.0)],
     )
 
-    assert replace_newton_builder_shape_colors(builder, stage) == 1
+    assert _replace_newton_builder_shape_colors_wrapper(builder, stage) == 1
     assert tuple(builder.shape_color[0]) == pytest.approx(_reference_linear_to_srgb(color))
     assert tuple(builder.shape_color[1]) == pytest.approx((0.0, 0.0, 0.0))
 
@@ -425,5 +444,5 @@ def test_replace_newton_builder_shape_colors_skips_missing_prim_labels():
         shape_color=[wp.vec3(*initial)],
     )
 
-    assert replace_newton_builder_shape_colors(builder, stage) == 0
+    assert _replace_newton_builder_shape_colors_wrapper(builder, stage) == 0
     assert tuple(builder.shape_color[0]) == pytest.approx(initial)

--- a/source/isaaclab_newton/changelog.d/new-replace-newton-builder-colors.rst
+++ b/source/isaaclab_newton/changelog.d/new-replace-newton-builder-colors.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Moved Newton shape color propagation from post-finalize (on the model) to pre-clone (on the
+  builder) in :class:`~isaaclab_newton.physics.NewtonManager` and the cloner utilities. Colors are
+  now set via :func:`~isaaclab.sim.utils.newton_model_utils.replace_newton_builder_shape_colors`
+  before ``ModelBuilder`` replication, so all cloned environments automatically inherit the correct
+  USD material colors without an extra GPU scatter pass after finalization.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -15,6 +15,7 @@ from newton import ModelBuilder, solvers
 from pxr import Usd
 
 from isaaclab.cloner.cloner_utils import replace_path_prefix
+from isaaclab.sim.utils.newton_model_utils import replace_newton_builder_shape_colors
 
 
 def build_source_builders(
@@ -41,6 +42,7 @@ def build_source_builders(
         )
         if simplify_meshes:
             builder.approximate_meshes("convex_hull", keep_visual_shapes=True)
+        replace_newton_builder_shape_colors(builder, stage)
         builders[source] = builder
     return builders
 

--- a/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
@@ -17,6 +17,7 @@ from pxr import Usd
 
 from isaaclab.cloner.replicate_session import REPLICATION_QUEUE
 from isaaclab.physics import PhysicsManager
+from isaaclab.sim.utils.newton_model_utils import replace_newton_builder_shape_colors
 
 from isaaclab_newton.cloner.newton_clone_utils import (
     build_source_builders,
@@ -65,6 +66,7 @@ def _build_newton_builder_from_mapping(
         ignore_paths=["/World/envs", *sources],
         schema_resolvers=schema_resolvers,
     )
+    replace_newton_builder_shape_colors(builder, stage)
 
     # Deformable prim paths are handled by per_world_builder_hooks, not add_usd.
     # Resolve the regex prim_path patterns to concrete env_0 paths so add_usd

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -41,7 +41,7 @@ from pxr import UsdGeom
 from isaaclab.physics import CallbackHandle, PhysicsEvent, PhysicsManager
 from isaaclab.scene_data import SceneDataBackend, SceneDataFormat, SceneDataProvider
 from isaaclab.sim import SimulationContext
-from isaaclab.sim.utils.newton_model_utils import replace_newton_shape_colors
+from isaaclab.sim.utils.newton_model_utils import replace_newton_builder_shape_colors
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.utils import checked_apply
 from isaaclab.utils.string import resolve_matching_names
@@ -1114,8 +1114,6 @@ class NewtonManager(PhysicsManager):
             cls._model.set_gravity(cls._gravity_vector)
             cls._model.num_envs = cls._num_envs
 
-            replace_newton_shape_colors(cls._model)
-
         if cls._pending_extended_contact_attributes:
             cls._model.request_contact_attributes(*cls._pending_extended_contact_attributes)
             NewtonManager._pending_extended_contact_attributes = set()
@@ -1235,6 +1233,7 @@ class NewtonManager(PhysicsManager):
         if not env_paths:
             # No env Xforms — flat loading
             builder.add_usd(stage, schema_resolvers=schema_resolvers)
+            replace_newton_builder_shape_colors(builder, stage)
             NewtonManager._world_xforms = [wp.transform()]
             for hook in cls._per_world_builder_hooks:
                 hook(builder, 0, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0])
@@ -1242,10 +1241,12 @@ class NewtonManager(PhysicsManager):
             # Load everything except the env subtrees (ground plane, lights, etc.)
             ignore_paths = [path for _, path in env_paths]
             builder.add_usd(stage, ignore_paths=ignore_paths, schema_resolvers=schema_resolvers)
+            replace_newton_builder_shape_colors(builder, stage)
 
             _, proto_path = env_paths[0]
             source_builders = {proto_path: cls.create_builder(up_axis=up_axis)}
             source_builders[proto_path].add_usd(stage, root_path=proto_path, schema_resolvers=schema_resolvers)
+            replace_newton_builder_shape_colors(source_builders[proto_path], stage)
             cls._cl_protos = source_builders
 
             global_site_indices, source_site_indices, env_root_sites = cls._cl_inject_sites(builder, source_builders)
@@ -1824,7 +1825,6 @@ class NewtonManager(PhysicsManager):
             NewtonManager._model = builder.finalize(device=device)
             NewtonManager._state_0 = cls._model.state()
             cls._model.num_envs = cls._num_envs
-            replace_newton_shape_colors(cls._model)
 
         except Exception:
             logger.exception(

--- a/source/isaaclab_tasks/changelog.d/new-replace-newton-builder-colors.rst
+++ b/source/isaaclab_tasks/changelog.d/new-replace-newton-builder-colors.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Updated golden images for the ``dexsuite_kuka_hetero`` Newton renderer tests (RGB and RGBA) to
+  reflect corrected shape colors now that USD material colors are propagated before clone
+  replication.

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgb.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgb.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d863373adfefafa48fe4ab726e6115be1d96c589df1fa40d2cddee52e776377
-size 2576
+oid sha256:ffb6f5de5bfb0f28574db7f81a971dac8473f4946ab4c145519115028f1122eb
+size 1798

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgb.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgb.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffb6f5de5bfb0f28574db7f81a971dac8473f4946ab4c145519115028f1122eb
-size 1798
+oid sha256:831c5d56af0a1c224802d96175802b62daa729d990972e900bc5a13ff64e97ef
+size 1704

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgba.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgba.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58b30f938cbeb857a0c2ba6db9f64f96ae367236aad7f8f52ed54057e1e5a60a
-size 2833
+oid sha256:e2ae52d92e984b81bd2cee4876a1f5534e4b591c355ed2a51ebbaaa125950dc0
+size 2625

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgba.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-rgba.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4821fbdd2ea9341f42d00697678e12bd6ad019107f7e640bee9569974102a6e0
-size 3483
+oid sha256:58b30f938cbeb857a0c2ba6db9f64f96ae367236aad7f8f52ed54057e1e5a60a
+size 2833


### PR DESCRIPTION
# Description

This PR integrates @ooctipus's proposed fix for newton shape color replacement to occur pre-clone.  Original PR: https://github.com/rilei-nvidia/IsaacLab/pull/1  

Replace the post-finalize `replace_newton_shape_colors` pass on the Newton model with `replace_newton_builder_shape_colors`, applied to each ModelBuilder before clone replication. This ensures all cloned environments automatically inherit the correct USD material and displayColor values.  This not only improves performance but also addresses the regression that @huidongc discovered last week where only env_0 (the clone source) had the right color for the robot arm, and the other cloned envs got the fallback colors

- Add replace_newton_builder_shape_colors to newton_model_utils.  
- Removed replace_newton_shape_colors and any un-used functionality
- Call it in NewtonManager (flat, env, and proto-source builders),
  newton_clone_utils, and replicate
- Update tests to exercise the new replace_newton_builder_shape_colors
- Update dexsuite_kuka_hetero golden images for correctness 

# Validation

Validated for correctness in the Newton visualizer with (all robot arms should have the same color):
```bash
./isaaclab.sh train --rl_library rsl_rl \
    --task Isaac-Lift-KukaAllegro-Camera \
    presets=newton_mjwarp,newton_renderer,rgb64,single_camera \
    --seed 42 \
    --num_envs 4 \
    --max_iterations 2 \
    --visualizer newton
```
<img width="1917" height="1159" alt="image" src="https://github.com/user-attachments/assets/fabf9ef4-60f6-4e29-a11a-e266e77d7f61" />


Rendering test golden images for the dexsuite_kuka_hetero kitless suite have also been updated to reflect fix to the regression
```bash
./isaaclab.sh -p -m pytest -v -rA source/isaaclab_tasks/test/core/test_rendering_dexsuite_kuka_hetero_kitless.py::test_rendering_dexsuite_kuka_hetero_kitless[newton-newton_warp-rgb]
```
<img width="742" height="1046" alt="image" src="https://github.com/user-attachments/assets/6e357b06-5cf2-458f-886b-4b283952c94f" />


# Performance

Testing on a AMD Ryzen Threadripper PRO 7965WX 24-Cores (48) @ 5.36 GHz

For testing the performance impact I used the benchmark script:
```bash
./isaaclab.sh -p scripts/benchmarks/benchmark_non_rl.py \
    --task Isaac-Lift-KukaAllegro-Camera \
    presets=newton_mjwarp,ovrtx_renderer,rgb64,single_camera \
    --seed 42 \
    --num_envs "8000" \
    --benchmark_backend json \
    --output_path "hdc/benchmarks/20260611/heterogeneous_8000"
```

The time of replace_newton_shape_colors has been moved to calls to the new replace_newton_builder_shape_colors pre-clone:
| # Env | replace_newton_shape_colors (Before) | replace_newton_builder_shape_colors (After) |
| ------ | ----- | ----- |
| 4000 | 2 s | 0.0045~ s|  
| 8000 | 4 s | 0.0045~ s|  

With @ooctipus's change the time for shape color propagation is not only "free" now, but constant to increasing # of environments. 

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there