### PR TITLE
Removes rlgames from pypi wheel to prepare for release

### DIFF
--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -32,7 +32,7 @@ pip extras include:
    * - ``isaacsim``
      - Isaac Sim (``isaacsim[all,extscache]==6.0.0.1``) from `pypi.nvidia.com <https://pypi.nvidia.com>`_
    * - ``all``
-     - RL frameworks (SB3, SKRL, RL-Games, RSL-RL). Combine with ``isaacsim`` for a full install.
+     - RL frameworks (SB3, SKRL, RSL-RL). Combine with ``isaacsim`` for a full install.
 
 Install with ``isaaclab[isaacsim,all]`` for the full workflow.
 
@@ -49,6 +49,15 @@ Install with ``isaaclab[isaacsim,all]`` for the full workflow.
       .. code-block:: bash
 
          pip install "isaaclab[isaacsim,all]" --extra-index-url https://pypi.nvidia.com --pre
+
+.. note::
+
+   ``rl_games`` is not included in the Isaac Lab pip wheel extras. If your workflow requires
+   ``rl_games``, install it manually from the Isaac Lab-compatible branch:
+
+   .. code-block:: bash
+
+      pip install "rl-games @ git+https://github.com/isaac-sim/rl_games.git@python3.11" gym standard-distutils
 
 Installing dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -202,8 +202,6 @@ Added
   ``CUDA_VISIBLE_DEVICES`` selects a subset of a node's GPUs, including the
   ``NCCL_P2P_DISABLE=1`` workaround and an explanation of why it is not needed when all GPUs
   are visible.
-* Added the ``rl-games`` optional dependency to the ``isaaclab`` wheel and
-  included it in the wheel's ``all`` extra.
 
 Changed
 ^^^^^^^

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -99,12 +99,6 @@ pyproject.optional-dependencies.all = [
     # RL libraries
     { "sb3" = ["stable-baselines3>=2.6", "tqdm", "rich"] },
     { "skrl" = ["skrl>=2.1.0"] },
-    # Do not pin aiohttp here: isaacsim-kernel==6.0.0.0 pins aiohttp==3.12.14.
-    { "rl-games" = [
-        "rl-games @ git+https://github.com/isaac-sim/rl_games.git@python3.11",
-        "gym",
-        "standard-distutils",
-    ] },
     { "rsl-rl" = ["rsl-rl-lib==5.0.1", "onnxscript>=0.5"] },
     { "rsl_rl" = ["rsl-rl-lib==5.0.1", "onnxscript>=0.5"] },
     # ================================================================================
@@ -120,9 +114,6 @@ pyproject.optional-dependencies.all = [
         "tqdm",
         "rich",
         "skrl>=2.1.0",
-        "rl-games @ git+https://github.com/isaac-sim/rl_games.git@python3.11",
-        "gym",
-        "standard-distutils",
         "rsl-rl-lib==5.0.1",
         "onnxscript>=0.5",
     ] },


### PR DESCRIPTION
# Description

Removes rlgames from pypi as public pypi does not allow using git links directly.
Adds back note in docs with command to install rlgames if needed.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
