### PR TITLE
Fixes nlopt docker build for arm

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -101,10 +101,25 @@ RUN touch /bin/nvidia-smi && \
     mkdir -p /var/run/nvidia-persistenced && \
     touch /var/run/nvidia-persistenced/socket
 
-# installing Isaac Lab dependencies
-# use pip caching to avoid reinstalling large packages
+# On arm64, temporarily install swig for the nlopt source build, keep it
+# through the Isaac Lab dependency install, then purge it before the layer ends.
+# This lets ./isaaclab.sh --install see nlopt as already satisfied without
+# leaving swig in the final container filesystem.
 RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
-    ${ISAACLAB_PATH}/isaaclab.sh --install
+    if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends swig && \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel numpy && \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
+    fi && \
+    ${ISAACLAB_PATH}/isaaclab.sh --install && \
+    if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -c "import nlopt" && \
+        apt-get purge -y --auto-remove swig && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* && \
+        if command -v swig >/dev/null 2>&1; then exit 1; fi; \
+    fi
 
 # HACK: Remove install of quadprog dependency
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -101,18 +101,6 @@ RUN touch /bin/nvidia-smi && \
     mkdir -p /var/run/nvidia-persistenced && \
     touch /var/run/nvidia-persistenced/socket
 
-# On arm64, pre-install nlopt 2.6.2 (transitively pinned by isaacteleop[retargeters]).
-# There is no aarch64 wheel for this version, and pip's isolated build env hides the
-# system numpy from nlopt's cmake-based build, so we install it manually with
-# --no-build-isolation. setuptools+wheel+numpy must be importable in the host Python
-# for that mode (PEP 517 backend lookup). The subsequent isaaclab.sh --install then
-# sees nlopt as already satisfied and skips the from-source rebuild that would fail.
-RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
-    if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
-        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel numpy && \
-        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
-    fi
-
 # installing Isaac Lab dependencies
 # use pip caching to avoid reinstalling large packages
 RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -149,10 +149,25 @@ RUN rm -rf ${ISAACSIM_ROOT_PATH}/kit/python/lib/python3.12/site-packages/pip* &&
     ${ISAACLAB_PATH}/_isaac_sim/kit/python/bin/python3 get-pip.py && \
     rm get-pip.py
 
-# installing Isaac Lab dependencies
-# use pip caching to avoid reinstalling large packages
+# On arm64, temporarily install swig for the nlopt source build, keep it
+# through the Isaac Lab dependency install, then purge it before the layer ends.
+# This lets ./isaaclab.sh --install see nlopt as already satisfied without
+# leaving swig in the final container filesystem.
 RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
-    ${ISAACLAB_PATH}/isaaclab.sh --install
+    if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends swig && \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel numpy && \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
+    fi && \
+    ${ISAACLAB_PATH}/isaaclab.sh --install && \
+    if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        ${ISAACLAB_PATH}/isaaclab.sh -p -c "import nlopt" && \
+        apt-get purge -y --auto-remove swig && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* && \
+        if command -v swig >/dev/null 2>&1; then exit 1; fi; \
+    fi
 
 # HACK: Uninstall quadprog as it causes issues with some reinforcement learning frameworks
 RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip uninstall -y quadprog

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -149,18 +149,6 @@ RUN rm -rf ${ISAACSIM_ROOT_PATH}/kit/python/lib/python3.12/site-packages/pip* &&
     ${ISAACLAB_PATH}/_isaac_sim/kit/python/bin/python3 get-pip.py && \
     rm get-pip.py
 
-# On arm64, pre-install nlopt 2.6.2 (transitively pinned by isaacteleop[retargeters]).
-# There is no aarch64 wheel for this version, and pip's isolated build env hides the
-# system numpy from nlopt's cmake-based build, so we install it manually with
-# --no-build-isolation. setuptools+wheel+numpy must be importable in the host Python
-# for that mode (PEP 517 backend lookup). The subsequent isaaclab.sh --install then
-# sees nlopt as already satisfied and skips the from-source rebuild that would fail.
-RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \
-    if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
-        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install setuptools wheel numpy && \
-        ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-build-isolation nlopt==2.6.2; \
-    fi
-
 # installing Isaac Lab dependencies
 # use pip caching to avoid reinstalling large packages
 RUN --mount=type=cache,target=${DOCKER_USER_HOME}/.cache/pip \

--- a/source/isaaclab/changelog.d/fix-arm-docker-install.rst
+++ b/source/isaaclab/changelog.d/fix-arm-docker-install.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Linux ARM Docker installation by removing the unnecessary
+  ``nlopt==2.6.2`` source-build preinstall.

--- a/source/isaaclab/changelog.d/fix-arm-docker-install.rst
+++ b/source/isaaclab/changelog.d/fix-arm-docker-install.rst
@@ -1,5 +1,6 @@
 Fixed
 ^^^^^
 
-* Fixed Linux ARM Docker installation by removing the unnecessary
-  ``nlopt==2.6.2`` source-build preinstall.
+* Fixed Linux ARM Docker installation by keeping ``swig`` available while
+  building ``nlopt==2.6.2`` and installing Isaac Lab dependencies, then
+  removing ``swig`` before the image layer completes.

--- a/source/isaaclab/changelog.d/fix-arm-docker-install.rst
+++ b/source/isaaclab/changelog.d/fix-arm-docker-install.rst
@@ -1,6 +1,6 @@
 Fixed
 ^^^^^
 
-* Fixed Linux ARM Docker installation by keeping ``swig`` available while
-  building ``nlopt==2.6.2`` and installing Isaac Lab dependencies, then
-  removing ``swig`` before the image layer completes.
+* Fixed Linux ARM installation by pre-installing ``nlopt==2.6.2`` before
+  Isaac Lab dependencies are resolved, and by keeping ``swig`` available in
+  Docker only until dependency installation completes.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -79,15 +79,6 @@ def _install_system_deps() -> None:
             ]
             run_command(["sudo"] + cmd if os.geteuid() != 0 else cmd)
 
-        # nlopt has no aarch64 manylinux wheel for the version pinned by
-        # isaacteleop[retargeters]. The installer pre-installs nlopt below to
-        # avoid the CMake source-build fallback that would require SWIG.
-        if not shutil.which("swig"):
-            print_info(
-                "swig is missing; continuing because nlopt is pre-installed on ARM before optional "
-                "dependencies are resolved. Pre-install swig manually only if you need to build nlopt from source."
-            )
-
         # imgui-bundle has no aarch64 manylinux wheel, so pip falls back to a
         # CMake source build that needs GL/X11 dev headers (via glfw).
         # Mirrors the apt step in docker/Dockerfile.base.
@@ -145,25 +136,6 @@ sys.exit(0)
         text=True,
     )
     return result.returncode == 1
-
-
-def _maybe_preinstall_arm_nlopt(pip_cmd: list[str]) -> None:
-    """Pre-install ``nlopt==2.6.2`` on ARM Linux to skip the source-build fallback.
-
-    There is no aarch64 manylinux wheel for the ``nlopt 2.6.2`` version pinned
-    by ``isaacteleop[retargeters]``, so pip falls back to a CMake source build
-    that hides the host-Python ``numpy`` from its isolated build env. Mirror
-    the docker/Dockerfile.base arm64 step: install ``setuptools wheel numpy``
-    in the host Python first, then ``--no-build-isolation`` install nlopt so
-    later submodule installs see it as already satisfied.
-    """
-    if is_windows() or not is_arm():
-        return
-    print_info("Pre-installing nlopt==2.6.2 on ARM (no-build-isolation)...")
-    print_info("  step 1/2: ensure setuptools/wheel/numpy are importable for the no-build-isolation backend")
-    run_command(pip_cmd + ["install", "setuptools", "wheel", "numpy"])
-    print_info("  step 2/2: install nlopt==2.6.2 with --no-build-isolation")
-    run_command(pip_cmd + ["install", "--no-build-isolation", "nlopt==2.6.2"])
 
 
 def _maybe_uninstall_prebundled_torch(
@@ -944,9 +916,6 @@ def command_install(install_type: str = "all") -> None:
 
         # Pin setuptools to avoid issues with pkg_resources removal in 82.0.0.
         run_command(pip_cmd + ["install", "setuptools<82.0.0"])
-
-        # On ARM Linux pre-install nlopt to dodge its from-source build fallback.
-        _maybe_preinstall_arm_nlopt(pip_cmd)
 
         # Drop pip-installed torch if Isaac Sim's deprecated ML prebundle would shadow it.
         _maybe_uninstall_prebundled_torch(python_exe, pip_cmd, using_uv, probe_env=probe_env)

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -79,6 +79,15 @@ def _install_system_deps() -> None:
             ]
             run_command(["sudo"] + cmd if os.geteuid() != 0 else cmd)
 
+        # nlopt has no aarch64 manylinux wheel for the version pinned by
+        # isaacteleop[retargeters]. The installer pre-installs nlopt below to
+        # avoid the CMake source-build fallback that would require SWIG.
+        if not shutil.which("swig"):
+            print_info(
+                "swig is missing; continuing because nlopt is pre-installed on ARM before optional "
+                "dependencies are resolved. Pre-install swig manually only if you need to build nlopt from source."
+            )
+
         # imgui-bundle has no aarch64 manylinux wheel, so pip falls back to a
         # CMake source build that needs GL/X11 dev headers (via glfw).
         # Mirrors the apt step in docker/Dockerfile.base.
@@ -158,6 +167,41 @@ def _maybe_uninstall_prebundled_torch(
         pip_cmd + ["uninstall"] + uninstall_flags + ["torch", "torchvision", "torchaudio"],
         check=False,
     )
+
+
+def _maybe_preinstall_arm_nlopt(python_exe: str, pip_cmd: list[str]) -> None:
+    """Pre-install ``nlopt==2.6.2`` on ARM Linux to skip the source-build fallback.
+
+    There is no aarch64 manylinux wheel for the ``nlopt 2.6.2`` version pinned
+    by ``isaacteleop[retargeters]``, so pip falls back to a CMake source build
+    that hides the host-Python ``numpy`` from its isolated build env. Mirror
+    the docker/Dockerfile.base arm64 step: install ``setuptools wheel numpy``
+    in the host Python first, then ``--no-build-isolation`` install nlopt so
+    later submodule installs see it as already satisfied.
+    """
+    if is_windows() or not is_arm():
+        return
+
+    probe_result = run_command(
+        [
+            python_exe,
+            "-c",
+            "import importlib.metadata as metadata; import nlopt; "
+            "raise SystemExit(0 if metadata.version('nlopt') == '2.6.2' else 1)",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if probe_result.returncode == 0:
+        print_info("nlopt==2.6.2 is already installed on ARM.")
+        return
+
+    print_info("Pre-installing nlopt==2.6.2 on ARM (no-build-isolation)...")
+    print_info("  step 1/2: ensure setuptools/wheel/numpy are importable for the no-build-isolation backend")
+    run_command(pip_cmd + ["install", "setuptools", "wheel", "numpy"])
+    print_info("  step 2/2: install nlopt==2.6.2 with --no-build-isolation")
+    run_command(pip_cmd + ["install", "--no-build-isolation", "nlopt==2.6.2"])
 
 
 # Dependency stack required by isaaclab.controllers.pink_ik. Pinocchio is installed
@@ -916,6 +960,9 @@ def command_install(install_type: str = "all") -> None:
 
         # Pin setuptools to avoid issues with pkg_resources removal in 82.0.0.
         run_command(pip_cmd + ["install", "setuptools<82.0.0"])
+
+        # On ARM Linux pre-install nlopt to dodge its from-source build fallback.
+        _maybe_preinstall_arm_nlopt(python_exe, pip_cmd)
 
         # Drop pip-installed torch if Isaac Sim's deprecated ML prebundle would shadow it.
         _maybe_uninstall_prebundled_torch(python_exe, pip_cmd, using_uv, probe_env=probe_env)


### PR DESCRIPTION
# Description

Previous PR that attempted to keep swig at the docker layer level to avoid GPL dependencies broke the post-merge docker publish job on arm. This PR keeps swig for the full installation process before pruning it from the image.
