### PR TITLE
Kit Visualizer: Don't author omni:scenePartition attribute onto viewport camera when visualizing all envs 

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/kit-visualizer-dont-author-scenePartition-attribute-if-all-env-visible.rst
+++ b/source/isaaclab_visualizers/changelog.d/kit-visualizer-dont-author-scenePartition-attribute-if-all-env-visible.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_visualizers.kit.KitVisualizer` to not author the ``omni:scenePartition``
+  attribute onto the viewport camera when all environments are visible. Previously, the attribute
+  was authored with the value "env_0", causing only environment 0 to be visualized.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -516,6 +516,15 @@ class KitVisualizer(BaseVisualizer):
         """
         if num_envs <= 0 or self._controlled_camera_path is None:
             return
+
+        if self._resolved_visible_env_ids is None:
+            # If _resolved_visible_env_ids is None, all envs should be visible - so do not author
+            # this attribute on the viewport camera.
+            # There is a bug where if the camera doesn't have a omni:scenePartition attribute, then
+            # IsaacSim RTX will not render any of the partitioned prims
+            # (prims that possess the primvars:omni:scenePartition)
+            return
+
         env_id = self._resolved_visible_env_ids[0] if self._resolved_visible_env_ids else 0
         camera_prim = usd_stage.GetPrimAtPath(self._controlled_camera_path)
         if not camera_prim.IsValid() or not camera_prim.IsA(UsdGeom.Camera):


### PR DESCRIPTION
# Description

Previously, the value "env_0" was authored onto the Perspective Camera when using the kit visualizer.  E.g.
```bash
./isaaclab.sh train --rl_library rsl_rl \
    --task Isaac-Lift-KukaAllegro-Camera \
    presets=newton_mjwarp,isaacsim_rtx_renderer,rgb64,single_camera \
    --seed 42 \
    --num_envs 4 \
    --max_iterations 100 \
    --visualizer kit
```

This caused only the first environment to be made visible, per scenePartition behavior:
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/8a347f9a-d96d-4da8-a368-5a549fdce0ee" />

In the case where we want to visualize all envs (`_resolved_visible_env_ids is None`) - we should not be authoring the `omni:scenePartition` attribute at all.

The reason this is a draft PR is that there is a bug in IsaacSim RTX renderer where if a camera does not have the `omni:scenePartition` attribute, none of the partitioned prims are visible to the viewport (below I've removed the attribute):
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/3a8e981d-d072-43b0-bea1-41477c67e272" />


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
