### PR TITLE
Fix typos and a broken image link in the documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -117,6 +117,7 @@ Guidelines for modifications:
 * Kaixi Bao
 * Kourosh Darvish
 * Kousheek Chakraborty
+* Lin He
 * Kris Wilson
 * Krishna Lakhi
 * Lionel Gulich

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -117,9 +117,9 @@ Guidelines for modifications:
 * Kaixi Bao
 * Kourosh Darvish
 * Kousheek Chakraborty
-* Lin He
 * Kris Wilson
 * Krishna Lakhi
+* Lin He
 * Lionel Gulich
 * Lorenz Wellhausen
 * Lotus Li

--- a/docs/source/how-to/import_new_asset.rst
+++ b/docs/source/how-to/import_new_asset.rst
@@ -44,7 +44,7 @@ is then passed to the :class:`~sim.converters.UrdfConverter` class.
    See the :doc:`/source/migration/migrating_to_isaaclab_3-0` for a full list of breaking changes.
 
 The URDF importer has various configuration parameters that can be set to control the behavior of the importer.
-The default values for the importer's configuration parameters are specified are in the :class:`~sim.converters.UrdfConverterCfg` class, and they are listed below. We made a few commonly modified settings to be available as command-line arguments when calling the ``convert_urdf.py``, and they are marked with ``*`` in the list. For a comprehensive list of the configuration parameters, please check the the documentation at `URDF importer`_.
+The default values for the importer's configuration parameters are specified in the :class:`~sim.converters.UrdfConverterCfg` class, and they are listed below. We made a few commonly modified settings to be available as command-line arguments when calling the ``convert_urdf.py``, and they are marked with ``*`` in the list. For a comprehensive list of the configuration parameters, please check the documentation at `URDF importer`_.
 
 Articulation and joint structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -219,7 +219,7 @@ The default values for the importer's configuration parameters are specified in 
 :class:`~sim.converters.MjcfConverterCfg` class. The configuration parameters are listed below.
 We made a few commonly modified settings to be available as command-line arguments when calling the
 ``convert_mjcf.py``, and they are marked with ``*`` in the list. For a comprehensive list of the configuration
-parameters, please check the the documentation at `MJCF importer`_.
+parameters, please check the documentation at `MJCF importer`_.
 
 .. note::
    The MJCF importer was rewritten in Isaac Sim 5.0 to use the ``mujoco-usd-converter`` library.

--- a/docs/source/overview/core-concepts/sensors/imu.rst
+++ b/docs/source/overview/core-concepts/sensors/imu.rst
@@ -29,7 +29,7 @@ Here we have explicitly removed the bias from one of the sensors, and we can see
 
 Notice that the right front foot explicitly has a bias of (0,0,0).  In the visualization, you should see that the arrow indicating the acceleration from the right IMU rapidly changes over time, while the arrow visualizing the left IMU points constantly along the vertical axis.
 
-Retrieving values form the sensor is done in the usual way
+Retrieving values from the sensor is done in the usual way
 
 .. code-block:: python
 
@@ -56,7 +56,7 @@ Retrieving values form the sensor is done in the usual way
       print("Received linear acceleration: ", scene["imu_RF"].data.lin_acc_b)
       print("Received angular acceleration: ", scene["imu_RF"].data.ang_acc_b)
 
-The oscillations in the values reported by the sensor are a direct result of of how the sensor calculates the acceleration, which is through a finite difference approximation between adjacent ground truth velocity values as reported by the sim.  We can see this in the reported result (pay attention to the **linear acceleration**) because the acceleration from the right foot is small, but explicitly zero.
+The oscillations in the values reported by the sensor are a direct result of how the sensor calculates the acceleration, which is through a finite difference approximation between adjacent ground truth velocity values as reported by the sim.  We can see this in the reported result (pay attention to the **linear acceleration**) because the acceleration from the right foot is small, but explicitly zero.
 
 .. code-block:: bash
 

--- a/docs/source/overview/core-concepts/task_workflows.rst
+++ b/docs/source/overview/core-concepts/task_workflows.rst
@@ -43,7 +43,7 @@ Manager-based environments promote modular implementations of tasks by decomposi
 When developing new training environments, it is often beneficial to break the environment into independent components.  This can be highly effective for collaboration, as it lets individual developers focus on different aspects of the environment, while allowing those disparate efforts to be joined back together into a single runnable task. For example, you may have multiple robots with differing sensoriums, requiring different observation managers to process those sensory data into a form that's useful for downstream components.  You might have multiple members on the team with different ideas about what the reward should be to achieve your goals, and by having each one develop their own reward manager, you can swap and test as you see fit. The modular nature of the manager workflow is essential for more complex projects!
 
 For reinforcement learning, much of this has been done for you already! In most cases, it will be enough to write your environment to inherit from
-:class:`envs.ManagerBasedRLEnv` and and your configuration from :class:`envs.ManagerBasedRLEnvCfg`.
+:class:`envs.ManagerBasedRLEnv` and your configuration from :class:`envs.ManagerBasedRLEnvCfg`.
 
 .. dropdown:: Example for defining the reward function for the Cartpole task using the manager-style
     :icon: plus

--- a/docs/source/tutorials/04_sensors/add_sensors_on_robot.rst
+++ b/docs/source/tutorials/04_sensors/add_sensors_on_robot.rst
@@ -183,7 +183,7 @@ Additionally, you can switch the viewport to the camera view to see the RGB imag
 camera sensor. Please check `here <https://youtu.be/htPbcKkNMPs?feature=shared>`_ for more information
 on how to switch the viewport to the camera view.
 
-.. figure:: ../../_static/tutorials/tutorial_add_sensors. jpg
+.. figure:: ../../_static/tutorials/tutorial_add_sensors.jpg
     :align: center
     :figwidth: 100%
     :alt: result of add_sensors_on_robot.py

--- a/docs/source/tutorials/05_controllers/run_osc.rst
+++ b/docs/source/tutorials/05_controllers/run_osc.rst
@@ -52,7 +52,7 @@ the arguments to the :class:`~controllers.OperationalSpaceControllerCfg` should 
 in mind.
 
 For the motion control, the task space targets could be given as absolute (i.e., defined w.r.t. the robot base,
-``target_types: "pose_abs"``) or relative the the end-effector's current pose (i.e., ``target_types: "pose_rel"``).
+``target_types: "pose_abs"``) or relative to the end-effector's current pose (i.e., ``target_types: "pose_rel"``).
 For the force control, the task space targets could be given as absolute (i.e., defined w.r.t. the robot base,
 ``target_types: "force_abs"``). If it is desired to apply pose and force control simultaneously, the ``target_types``
 should be a list such as ``["pose_abs", "wrench_abs"]`` or ``["pose_rel", "wrench_abs"]``.


### PR DESCRIPTION
# Description

Retargeted this documentation-only cleanup to `develop`. The former Quickstart typo is no longer applicable because that page was rewritten on `develop`.

- Fixes duplicate-word and wording typos in the asset-import, IMU, task-workflow, and OSC-controller documentation.
- Fixes the `add_sensors_on_robot` figure path so the existing image renders.
- Adds Lin He to `CONTRIBUTORS.md`.

## Type of change

- Documentation update

## Validation

- `./isaaclab.sh -f`
- `git diff --check`