### PR TITLE
OMPE-96097: Fix reset-mode color randomization crash on PhysX

### DIFF
--- a/source/isaaclab/changelog.d/jmart-dr-reset.rst
+++ b/source/isaaclab/changelog.d/jmart-dr-reset.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed a crash where :class:`~isaaclab.envs.mdp.randomize_visual_color` used in ``reset`` mode
+  raised ``AttributeError: 'NoneType' object has no attribute 'link_count'`` during environment
+  startup on the PhysX backend. The randomizer authored USD (``SetInstanceable`` and material
+  binding) on the articulation root prim, which invalidated the PhysX articulation view so that
+  the subsequent at-play body-name resolution dereferenced a ``None`` metatype. It now scopes to
+  descendant visual prims, mirroring :class:`~isaaclab.envs.mdp.randomize_visual_texture_material`.

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -2492,9 +2492,34 @@ class randomize_visual_color(ManagerTermBase):
         asset = env.scene[asset_cfg.name]
 
         # create the affected prim path
-        if not mesh_name.startswith("/"):
-            mesh_name = "/" + mesh_name
-        mesh_prim_path = f"{asset.cfg.prim_path}{mesh_name}"
+        # note: Never match the articulation root prim. Authoring on the root (the SetInstanceable
+        #   and material binding below) invalidates the PhysX articulation view, crashing a later
+        #   at-play body-name resolution (root_view.shared_metatype becomes None). So we scope to
+        #   descendant visual prims, mirroring randomize_visual_texture_material.
+        if mesh_name:
+            # explicit mesh override
+            if not mesh_name.startswith("/"):
+                mesh_name = "/" + mesh_name
+            mesh_prim_path = f"{asset.cfg.prim_path}{mesh_name}"
+        else:
+            # default: the configured bodies' visual meshes
+            body_names = asset_cfg.body_names
+            if isinstance(body_names, str):
+                body_names_regex = body_names
+            elif isinstance(body_names, list):
+                body_names_regex = "|".join(body_names)
+            else:
+                body_names_regex = ".*"
+            pattern_with_visuals = f"{asset.cfg.prim_path}/{body_names_regex}/visuals"
+            if sim_utils.find_matching_prim_paths(pattern_with_visuals):
+                mesh_prim_path = pattern_with_visuals
+            else:
+                # fall back to any descendant if the asset has no ".../visuals" layout
+                mesh_prim_path = f"{asset.cfg.prim_path}/.*"
+                logging.info(
+                    f"Pattern '{pattern_with_visuals}' found no prims. Falling back to '{mesh_prim_path}'"
+                    " for color randomization."
+                )
         # TODO: Need to make it work for multiple meshes.
 
         # extract the replicator version

--- a/source/isaaclab/test/envs/test_color_randomization.py
+++ b/source/isaaclab/test/envs/test_color_randomization.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 """
-This script tests the functionality of texture randomization applied to the cartpole scene.
+This script tests the functionality of color randomization applied to the cartpole scene.
 """
 
 """Launch Isaac Sim Simulator first."""
@@ -66,12 +66,11 @@ class ObservationsCfg:
 class EventCfg:
     """Configuration for events."""
 
-    # on prestartup apply a new set of textures
-    # note from @mayank: Changed from 'reset' to 'prestartup' to make test pass.
-    #   The error happens otherwise on Kit thread which is not the main thread.
-    cart_texture_randomizer = EventTerm(
+    # Color randomization terms; the mode is overridden per parametrization in
+    # :func:`test_color_randomization` (both "prestartup" and "reset" are exercised).
+    cart_color_randomizer = EventTerm(
         func=mdp.randomize_visual_color,
-        mode="prestartup",
+        mode="reset",
         params={
             "asset_cfg": SceneEntityCfg("robot", body_names=["cart"]),
             "colors": {"r": (0.0, 1.0), "g": (0.0, 1.0), "b": (0.0, 1.0)},
@@ -79,8 +78,7 @@ class EventCfg:
         },
     )
 
-    # on reset apply a new set of textures
-    pole_texture_randomizer = EventTerm(
+    pole_color_randomizer = EventTerm(
         func=mdp.randomize_visual_color,
         mode="reset",
         params={
@@ -135,8 +133,15 @@ class CartpoleEnvCfg(ManagerBasedEnvCfg):
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
-def test_color_randomization(device):
-    """Test color randomization for cartpole environment."""
+@pytest.mark.parametrize("mode", ["prestartup", "reset"])
+def test_color_randomization(mode, device):
+    """Test color randomization for the cartpole environment in both event modes.
+
+    The randomizer is exercised in both ``prestartup`` and ``reset`` modes. The ``reset`` case is a
+    regression guard: reset-mode color randomization on the articulation used to invalidate the
+    PhysX articulation view and crash environment construction with an
+    ``AttributeError: 'NoneType' object has no attribute 'link_count'``.
+    """
     # skip test if stage in memory is not supported
     if get_isaac_sim_version().major < 5:
         pytest.skip("Color randomization test hangs in this version of Isaac Sim")
@@ -150,6 +155,9 @@ def test_color_randomization(device):
         env_cfg.scene.num_envs = 16
         env_cfg.scene.replicate_physics = False
         env_cfg.sim.device = device
+        # exercise the parametrized event mode for both color terms
+        env_cfg.events.cart_color_randomizer.mode = mode
+        env_cfg.events.pole_color_randomizer.mode = mode
 
         # Setup base environment
         env = ManagerBasedEnv(cfg=env_cfg)


### PR DESCRIPTION
# Description

`randomize_visual_color` authored USD (SetInstanceable + material binding) on the articulation root prim, which invalidated the PhysX articulation view; the at-play body-name resolution then hit a `None` metatype and raised "AttributeError: 'NoneType' object has no attribute 'link_count'".

Scope the prim match to the configured bodies' `/visuals` prims (mirroring `randomize_visual_texture_material`) so the root is never re-composed, and parametrize `test_color_randomization` over prestartup/reset as a guard.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there