### PR TITLE
Forward all CLI args to AppLauncher in scripts that ignored them

### DIFF
--- a/scripts/environments/state_machine/lift_cube_sm.py
+++ b/scripts/environments/state_machine/lift_cube_sm.py
@@ -33,7 +33,7 @@ AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
 
 # launch omniverse app
-app_launcher = AppLauncher(headless=args_cli.headless)
+app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
 """Rest everything else."""

--- a/scripts/environments/state_machine/lift_teddy_bear.py
+++ b/scripts/environments/state_machine/lift_teddy_bear.py
@@ -30,7 +30,7 @@ AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
 
 # launch omniverse app
-app_launcher = AppLauncher(headless=args_cli.headless)
+app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
 # disable metrics assembler due to scene graph instancing

--- a/scripts/environments/state_machine/open_cabinet_sm.py
+++ b/scripts/environments/state_machine/open_cabinet_sm.py
@@ -33,7 +33,7 @@ AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
 
 # launch omniverse app
-app_launcher = AppLauncher(headless=args_cli.headless)
+app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
 """Rest everything else."""

--- a/scripts/tutorials/04_sensors/run_frame_transformer.py
+++ b/scripts/tutorials/04_sensors/run_frame_transformer.py
@@ -27,7 +27,7 @@ AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
 
 # launch omniverse app
-app_launcher = AppLauncher(headless=args_cli.headless)
+app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
 """Rest everything follows."""


### PR DESCRIPTION
# Description

Several scripts add and parse the full set of app-launcher CLI arguments via `AppLauncher.add_app_launcher_args(parser)` and `parser.parse_args()`, but then construct the launcher with only:

```python
app_launcher = AppLauncher(headless=args_cli.headless)
```

This drops every other parsed app-launcher argument (e.g. `--viz`, `--livestream`, `--enable_cameras`, `--device`), so those flags silently have no effect. For example, running `lift_cube_sm.py` with `--viz kit` never opens the Kit visualizer because the argument is not forwarded.

This PR changes them to the standard usage `AppLauncher(args_cli)` already used in ~90 other scripts across the repository, so all parsed arguments are respected.

Affected scripts:
- `scripts/environments/state_machine/lift_cube_sm.py`
- `scripts/environments/state_machine/lift_teddy_bear.py`
- `scripts/environments/state_machine/open_cabinet_sm.py`
- `scripts/tutorials/04_sensors/run_frame_transformer.py`

Fixes #5572

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
