### PR TITLE
Gate Isaac RTX per-env scene partitioning behind environment variable

### DIFF
--- a/source/isaaclab/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
+++ b/source/isaaclab/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added :func:`~isaaclab.utils.renderers.isaac_rtx_per_env_scene_partition_enabled` to
+  query whether per-environment Isaac RTX scene partitioning is enabled. Set
+  ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` to enable authoring of
+  ``primvars:omni:scenePartition`` and ``omni:scenePartition`` on the USD stage.

--- a/source/isaaclab/isaaclab/utils/renderers.py
+++ b/source/isaaclab/isaaclab/utils/renderers.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Renderer-related utility helpers."""
+
+import os
+
+
+def isaac_rtx_per_env_scene_partition_enabled() -> bool:
+    """Return whether per-environment RTX scene partitioning is enabled.
+
+    Partitioning is opt-in: set ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1``
+    to enable authoring of ``primvars:omni:scenePartition`` and ``omni:scenePartition``
+    on the USD stage.
+    """
+    return os.environ.get("ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION", "0") == "1"

--- a/source/isaaclab_physx/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
+++ b/source/isaaclab_physx/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed :meth:`~isaaclab_physx.renderers.IsaacRtxRenderer.prepare_stage` to skip authoring
+  ``primvars:omni:scenePartition`` and ``omni:scenePartition`` by default. Set the environment
+  variable ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` (to any value, including empty)
+  to re-enable per-environment scene partitioning for Isaac RTX rendering.

--- a/source/isaaclab_physx/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
+++ b/source/isaaclab_physx/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
@@ -3,5 +3,5 @@ Changed
 
 * Changed :meth:`~isaaclab_physx.renderers.IsaacRtxRenderer.prepare_stage` to skip authoring
   ``primvars:omni:scenePartition`` and ``omni:scenePartition`` by default. Set the environment
-  variable ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` (to any value, including empty)
-  to re-enable per-environment scene partitioning for Isaac RTX rendering.
+  variable ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` to re-enable
+  per-environment scene partitioning for Isaac RTX rendering.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import logging
 import math
-import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -23,6 +22,7 @@ from pxr import Sdf, Usd, UsdGeom
 from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
 from isaaclab.renderers.camera_render_spec import CameraRenderSpec
+from isaaclab.utils.renderers import isaac_rtx_per_env_scene_partition_enabled
 from isaaclab.utils.version import get_isaac_sim_version
 from isaaclab.utils.warp.kernels import reshape_tiled_image
 from isaaclab.utils.warp.warp_math import clamp_depth_to_inf_wp, replace_inf_depth_wp
@@ -52,16 +52,6 @@ def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
     if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
         raise exc
     raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc
-
-
-def isaac_rtx_per_env_scene_partition_enabled() -> bool:
-    """Return whether per-environment RTX scene partitioning is enabled.
-
-    Partitioning is opt-in: set
-    ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` to enable authoring of
-    ``primvars:omni:scenePartition`` and ``omni:scenePartition`` on the USD stage.
-    """
-    return os.environ.get("ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION", "0") == "1"
 
 
 # RTX simple-shading constants.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -57,12 +57,11 @@ def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
 def isaac_rtx_per_env_scene_partition_enabled() -> bool:
     """Return whether per-environment RTX scene partitioning is enabled.
 
-    Partitioning is opt-in: the presence of the
-    ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` environment variable (regardless
-    of its value) enables authoring of ``primvars:omni:scenePartition`` and
-    ``omni:scenePartition`` on the USD stage.
+    Partitioning is opt-in: set
+    ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` to enable authoring of
+    ``primvars:omni:scenePartition`` and ``omni:scenePartition`` on the USD stage.
     """
-    return "ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION" in os.environ
+    return os.environ.get("ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION", "0") == "1"
 
 
 # RTX simple-shading constants.
@@ -194,8 +193,8 @@ class IsaacRtxRenderer(BaseRenderer):
     def prepare_stage(self, stage: Usd.Stage, num_envs: int) -> None:
         """Author per-env ``omni:scenePartition`` attributes for RTX cull-by-env rendering.
 
-        Authoring is only performed when the environment variable
-        ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` is set (to any value).
+        Authoring is only performed when
+        ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` is set.
         When the variable is absent the method is a no-op and no ``primvars:omni:scenePartition``
         or ``omni:scenePartition`` attributes are written to the stage.
 
@@ -211,7 +210,7 @@ class IsaacRtxRenderer(BaseRenderer):
 
         logger.debug(
             "Per-environment RTX scene partitioning is enabled"
-            " (ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION)."
+            " (ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1)."
             " Authoring primvars:omni:scenePartition on %d env(s).",
             num_envs,
         )

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -51,6 +52,17 @@ def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
     if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
         raise exc
     raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc
+
+
+def isaac_rtx_per_env_scene_partition_enabled() -> bool:
+    """Return whether per-environment RTX scene partitioning is enabled.
+
+    Partitioning is opt-in: the presence of the
+    ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` environment variable (regardless
+    of its value) enables authoring of ``primvars:omni:scenePartition`` and
+    ``omni:scenePartition`` on the USD stage.
+    """
+    return "ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION" in os.environ
 
 
 # RTX simple-shading constants.
@@ -182,12 +194,28 @@ class IsaacRtxRenderer(BaseRenderer):
     def prepare_stage(self, stage: Usd.Stage, num_envs: int) -> None:
         """Author per-env ``omni:scenePartition`` attributes for RTX cull-by-env rendering.
 
-        For each ``/World/envs/env_{i}`` root, writes the inheriting primvar
+        Authoring is only performed when the environment variable
+        ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` is set (to any value).
+        When the variable is absent the method is a no-op and no ``primvars:omni:scenePartition``
+        or ``omni:scenePartition`` attributes are written to the stage.
+
+        When enabled, for each ``/World/envs/env_{i}`` root, writes the inheriting primvar
         ``primvars:omni:scenePartition`` (token ``env_{i}``) on the root and the matching
         non-primvar ``omni:scenePartition`` token on every :class:`UsdGeom.Camera` descendant.
         RTX honors primvar inheritance, so the env-root primvar propagates to all descendant
         geometry and isolates each env's render tile.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.prepare_stage`."""
+
+        if not isaac_rtx_per_env_scene_partition_enabled():
+            return
+
+        logger.debug(
+            "Per-environment RTX scene partitioning is enabled"
+            " (ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION)."
+            " Authoring primvars:omni:scenePartition on %d env(s).",
+            num_envs,
+        )
+
         root_layer = stage.GetRootLayer()
         token_type = Sdf.ValueTypeNames.Token
         with Sdf.ChangeBlock():

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_scene_partitioning.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_scene_partitioning.py
@@ -17,6 +17,12 @@ first articulation scene the app builds. The CI harness launches every
 ``isaacsim_ci`` test file in its own app, so keeping these tests isolated here gives them
 a clean renderer and exercises the real single-scene use case.
 
+Per-env scene partitioning is gated behind the
+``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` environment variable and is off
+by default. Tests that verify partitioning is *active* use the ``enable_scene_partition``
+fixture, which sets the variable for the duration of the test and restores the previous
+state afterwards.
+
 Launch Isaac Sim Simulator first.
 """
 
@@ -32,6 +38,7 @@ import os
 import pytest
 import torch
 import warp as wp
+from isaaclab_physx.renderers.isaac_rtx_renderer import IsaacRtxRenderer, IsaacRtxRendererCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
@@ -42,9 +49,42 @@ from isaaclab.utils.configclass import configclass
 
 from isaaclab_assets.robots.kuka_allegro import KUKA_ALLEGRO_CFG
 
+_PARTITION_ENABLED_FN = "isaaclab_physx.renderers.isaac_rtx_renderer.isaac_rtx_per_env_scene_partition_enabled"
+
+
+@pytest.fixture()
+def enable_scene_partition(monkeypatch):
+    """Patch :func:`isaac_rtx_per_env_scene_partition_enabled` to return ``True`` for one test."""
+    monkeypatch.setattr(_PARTITION_ENABLED_FN, lambda: True)
+
 
 @pytest.mark.isaacsim_ci
-def test_partitioning_isolates_rigid_object():
+def test_partitioning_disabled_by_default(monkeypatch):
+    """``primvars:omni:scenePartition`` must NOT be authored when partitioning is disabled.
+
+    The feature is off by default; this test confirms that :meth:`IsaacRtxRenderer.prepare_stage`
+    is a no-op when :func:`isaac_rtx_per_env_scene_partition_enabled` returns ``False``.
+    """
+    from pxr import Usd
+
+    monkeypatch.setattr(_PARTITION_ENABLED_FN, lambda: False)
+
+    stage = Usd.Stage.CreateInMemory()
+    world = stage.DefinePrim("/World", "Xform")  # noqa: F841
+    env0 = stage.DefinePrim("/World/envs/env_0", "Xform")  # noqa: F841
+
+    renderer = object.__new__(IsaacRtxRenderer)
+    renderer.cfg = IsaacRtxRendererCfg()
+    renderer.prepare_stage(stage, num_envs=1)
+
+    prim = stage.GetPrimAtPath("/World/envs/env_0")
+    assert not prim.HasAttribute("primvars:omni:scenePartition"), (
+        "primvars:omni:scenePartition must not be authored when partitioning is disabled."
+    )
+
+
+@pytest.mark.isaacsim_ci
+def test_partitioning_isolates_rigid_object(enable_scene_partition):
     """Per-env :class:`~isaaclab.assets.RigidObject` instances at unique world positions render
     as visibly different per-env tiles when RTX honors ``primvars:omni:scenePartition``."""
 
@@ -111,7 +151,7 @@ def test_partitioning_isolates_rigid_object():
 
 
 @pytest.mark.isaacsim_ci
-def test_partitioning_isolates_articulation():
+def test_partitioning_isolates_articulation(enable_scene_partition):
     """Per-env :class:`~isaaclab.assets.Articulation` instances driven to wildly different joint
     poses render as visibly different per-env tiles when RTX honors top-level scene partitions."""
 

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_scene_partitioning.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_scene_partitioning.py
@@ -49,25 +49,25 @@ from isaaclab.utils.configclass import configclass
 
 from isaaclab_assets.robots.kuka_allegro import KUKA_ALLEGRO_CFG
 
-_PARTITION_ENABLED_FN = "isaaclab_physx.renderers.isaac_rtx_renderer.isaac_rtx_per_env_scene_partition_enabled"
+_ENV_VAR = "ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION"
 
 
 @pytest.fixture()
 def enable_scene_partition(monkeypatch):
-    """Patch :func:`isaac_rtx_per_env_scene_partition_enabled` to return ``True`` for one test."""
-    monkeypatch.setattr(_PARTITION_ENABLED_FN, lambda: True)
+    """Set ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` for the duration of one test."""
+    monkeypatch.setenv(_ENV_VAR, "1")
 
 
 @pytest.mark.isaacsim_ci
 def test_partitioning_disabled_by_default(monkeypatch):
-    """``primvars:omni:scenePartition`` must NOT be authored when partitioning is disabled.
+    """``primvars:omni:scenePartition`` must NOT be authored when the env var is absent.
 
     The feature is off by default; this test confirms that :meth:`IsaacRtxRenderer.prepare_stage`
-    is a no-op when :func:`isaac_rtx_per_env_scene_partition_enabled` returns ``False``.
+    is a no-op without ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1``.
     """
     from pxr import Usd
 
-    monkeypatch.setattr(_PARTITION_ENABLED_FN, lambda: False)
+    monkeypatch.delenv(_ENV_VAR, raising=False)
 
     stage = Usd.Stage.CreateInMemory()
     world = stage.DefinePrim("/World", "Xform")  # noqa: F841

--- a/source/isaaclab_tasks/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
+++ b/source/isaaclab_tasks/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added ``enable_scene_partition`` pytest fixture and enabled Isaac RTX per-environment scene
+  partitioning in rendering correctness tests for cartpole and registered camera tasks as a
+  temporary workaround.

--- a/source/isaaclab_tasks/test/conftest.py
+++ b/source/isaaclab_tasks/test/conftest.py
@@ -13,4 +13,12 @@ that live at the test-suite root.
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.fixture()
+def enable_scene_partition(monkeypatch):
+    """Set ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` for the duration of one test."""
+    monkeypatch.setenv("ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION", "1")

--- a/source/isaaclab_tasks/test/core/test_rendering_cartpole.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_cartpole.py
@@ -32,6 +32,6 @@ _attach_comparison_properties_fixture = make_attach_comparison_properties_fixtur
 
 
 @pytest.mark.parametrize("physics_backend,renderer,data_type", PHYSICS_RENDERER_AOV_COMBINATIONS)
-def test_rendering_cartpole(physics_backend, renderer, data_type):
+def test_rendering_cartpole(physics_backend, renderer, data_type, enable_scene_partition):
     """Test cartpole environment rendering correctness."""
     rendering_test_cartpole(physics_backend, renderer, data_type, _COMPARISON_SCORES)

--- a/source/isaaclab_tasks/test/core/test_rendering_registered_tasks.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_registered_tasks.py
@@ -86,7 +86,7 @@ _RENDER_CORRECTNESS_TASK_IDS = [
 
 
 @pytest.mark.parametrize("task_id, presets, env_name", _RENDER_CORRECTNESS_TASK_IDS)
-def test_rendering_registered_tasks(task_id: str, presets: str | None, env_name: str):
+def test_rendering_registered_tasks(task_id: str, presets: str | None, env_name: str, enable_scene_partition):
     """Test registered tasks rendering correctness."""
     env = None
 

--- a/source/isaaclab_visualizers/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
+++ b/source/isaaclab_visualizers/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
@@ -1,7 +1,7 @@
 Changed
 ^^^^^^^
 
-* Changed :meth:`~isaaclab_visualizers.kit.KitVisualizer._apply_viewport_camera_scene_partition` to
-  skip tagging the viewport camera with an ``omni:scenePartition`` token by default. Set the
-  environment variable ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` to re-enable
-  per-environment scene partitioning for the Kit viewport camera.
+* Changed :class:`~isaaclab_visualizers.kit.KitVisualizer` to skip authoring the
+  ``omni:scenePartition`` attribute on the viewport camera by default. Set
+  ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` to re-enable per-environment
+  scene partitioning for the Kit viewport camera.

--- a/source/isaaclab_visualizers/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
+++ b/source/isaaclab_visualizers/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
@@ -3,5 +3,5 @@ Changed
 
 * Changed :meth:`~isaaclab_visualizers.kit.KitVisualizer._apply_viewport_camera_scene_partition` to
   skip tagging the viewport camera with an ``omni:scenePartition`` token by default. Set the
-  environment variable ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` (to any value,
-  including empty) to re-enable per-environment scene partitioning for the Kit viewport camera.
+  environment variable ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` to re-enable
+  per-environment scene partitioning for the Kit viewport camera.

--- a/source/isaaclab_visualizers/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
+++ b/source/isaaclab_visualizers/changelog.d/isaac-rtx-per-env-scene-partition-env-var.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed :meth:`~isaaclab_visualizers.kit.KitVisualizer._apply_viewport_camera_scene_partition` to
+  skip tagging the viewport camera with an ``omni:scenePartition`` token by default. Set the
+  environment variable ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` (to any value,
+  including empty) to re-enable per-environment scene partitioning for the Kit viewport camera.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -523,6 +523,9 @@ class KitVisualizer(BaseVisualizer):
         if not isaac_rtx_per_env_scene_partition_enabled():
             return
 
+        if num_envs <= 0 or self._controlled_camera_path is None:
+            return
+
         logger.debug(
             "[KitVisualizer] Per-environment Isaac RTX scene partitioning is enabled"
             " (ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1)."
@@ -530,8 +533,6 @@ class KitVisualizer(BaseVisualizer):
             self._controlled_camera_path,
         )
 
-        if num_envs <= 0 or self._controlled_camera_path is None:
-            return
         env_id = self._resolved_visible_env_ids[0] if self._resolved_visible_env_ids else 0
         camera_prim = usd_stage.GetPrimAtPath(self._controlled_camera_path)
         if not camera_prim.IsValid() or not camera_prim.IsA(UsdGeom.Camera):

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -514,8 +514,8 @@ class KitVisualizer(BaseVisualizer):
         ``/World/envs`` and are created by Kit, so they do not inherit the env-root
         primvar authored by :class:`~isaaclab.scene.InteractiveScene`.
 
-        This method is a no-op when ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION``
-        is not set, matching the opt-in behaviour of
+        This method is a no-op unless ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1``,
+        matching the opt-in behaviour of
         :meth:`~isaaclab_physx.renderers.IsaacRtxRenderer.prepare_stage`.
         """
         from isaaclab_physx.renderers.isaac_rtx_renderer import isaac_rtx_per_env_scene_partition_enabled
@@ -525,7 +525,7 @@ class KitVisualizer(BaseVisualizer):
 
         logger.debug(
             "[KitVisualizer] Per-environment Isaac RTX scene partitioning is enabled"
-            " (ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION)."
+            " (ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1)."
             " Authoring omni:scenePartition attribute onto viewport camera '%s'.",
             self._controlled_camera_path,
         )

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -513,7 +513,23 @@ class KitVisualizer(BaseVisualizer):
         ``omni:scenePartition`` token. Interactive viewport cameras live outside
         ``/World/envs`` and are created by Kit, so they do not inherit the env-root
         primvar authored by :class:`~isaaclab.scene.InteractiveScene`.
+
+        This method is a no-op when ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION``
+        is not set, matching the opt-in behaviour of
+        :meth:`~isaaclab_physx.renderers.IsaacRtxRenderer.prepare_stage`.
         """
+        from isaaclab_physx.renderers.isaac_rtx_renderer import isaac_rtx_per_env_scene_partition_enabled
+
+        if not isaac_rtx_per_env_scene_partition_enabled():
+            return
+
+        logger.debug(
+            "[KitVisualizer] Per-environment Isaac RTX scene partitioning is enabled"
+            " (ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION)."
+            " Authoring omni:scenePartition attribute onto viewport camera '%s'.",
+            self._controlled_camera_path,
+        )
+
         if num_envs <= 0 or self._controlled_camera_path is None:
             return
         env_id = self._resolved_visible_env_ids[0] if self._resolved_visible_env_ids else 0

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -30,6 +30,7 @@ from isaaclab.envs.utils.camera_view import (
     resolve_tiled_env_indices,
 )
 from isaaclab.utils.math import create_rotation_matrix_from_view, quat_from_matrix
+from isaaclab.utils.renderers import isaac_rtx_per_env_scene_partition_enabled
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
 
 from isaaclab_visualizers.newton_adapter import resolve_visible_env_indices
@@ -518,7 +519,6 @@ class KitVisualizer(BaseVisualizer):
         matching the opt-in behaviour of
         :meth:`~isaaclab_physx.renderers.IsaacRtxRenderer.prepare_stage`.
         """
-        from isaaclab_physx.renderers.isaac_rtx_renderer import isaac_rtx_per_env_scene_partition_enabled
 
         if not isaac_rtx_per_env_scene_partition_enabled():
             return


### PR DESCRIPTION
# Description

Add ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION environment variable to opt in to authoring primvars:omni:scenePartition and omni:scenePartition on the USD stage. Previously this was always on; now it is off by default.  This is to address an OOM in one of our IsaacSim RTX benchmark suites related to primvar inheritance of the scene partition attributes while the root cause/fix is under investigation.

## Testing

We have a separate issue which only visualizes env_0 in kit when scene partitioning is enabled...  so I tested with:
```bash
./isaaclab.sh train --rl_library rsl_rl \
    --task Isaac-Lift-KukaAllegro-Camera \
    presets=newton_mjwarp,isaacsim_rtx_renderer,rgb64,single_camera \
    --seed 42 \
    --num_envs 4 \
    --max_iterations 1000 \
    --visualizer kit
```
... and it shows all the envs - checked all the env Xforms and camera and they don't have the scenePartition attribute/primvars:
<img width="3813" height="2072" alt="image" src="https://github.com/user-attachments/assets/ea22b566-db95-498b-aa5d-445c1c2b0c8b" />

Conversely, tested with the environment variable enabled:
```bash
ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1 ./isaaclab.sh train --rl_library rsl_rl \
    --task Isaac-Lift-KukaAllegro-Camera \
    presets=newton_mjwarp,isaacsim_rtx_renderer,rgb64,single_camera \
    --seed 42 \
    --num_envs 4 \
    --max_iterations 1000 \
    --visualizer kit
```

And we get the old behavior of only env_0 showing.

@fatimaanes keen to hear if this helps mitigate the benchmark OOM you are seeing.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
