### PR TITLE
Enable OVPhysX shape-material test via OvPhysxView

### DIFF
--- a/source/isaaclab_ovphysx/changelog.d/antoiner-feat-ovphysx_shape_materials.minor.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-feat-ovphysx_shape_materials.minor.rst
@@ -1,0 +1,9 @@
+Added
+^^^^^
+
+* Added :data:`~isaaclab_ovphysx.tensor_types.SHAPE_FRICTION_AND_RESTITUTION` and
+  :data:`~isaaclab_ovphysx.tensor_types.RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION` aliases for
+  the per-collision-shape material tensor types (static friction, dynamic friction,
+  restitution) exposed by the ovphysx wheel. Read and write them through
+  :class:`~isaaclab_ovphysx.sim.views.OvPhysxView`, e.g.
+  ``root_view.get_attribute(tensor_types.SHAPE_FRICTION_AND_RESTITUTION)``.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/tensor_types.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/tensor_types.py
@@ -253,6 +253,27 @@ except AttributeError:
     pass
 
 """
+Shape material properties (friction / restitution) — new in ovphysx 0.4.13+.
+Guarded so this module stays import-safe against older wheels that lack them.
+"""
+
+try:
+    SHAPE_FRICTION_AND_RESTITUTION = _TT.ARTICULATION_SHAPE_FRICTION_AND_RESTITUTION
+    """Per-collision-shape material of each articulation instance — read/write, GPU.
+    Shape ``(N, S, 3)``: ``[0]`` static friction, ``[1]`` dynamic friction, ``[2]``
+    restitution (all dimensionless)."""
+except AttributeError:
+    pass
+
+try:
+    RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION = _TT.RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION
+    """Per-collision-shape material of each rigid body — read/write, GPU. Shape
+    ``(N, S, 3)``: ``[0]`` static friction, ``[1]`` dynamic friction, ``[2]`` restitution
+    (all dimensionless)."""
+except AttributeError:
+    pass
+
+"""
 Dynamics tensors (GPU)
 """
 

--- a/source/isaaclab_ovphysx/test/assets/test_articulation.py
+++ b/source/isaaclab_ovphysx/test/assets/test_articulation.py
@@ -94,14 +94,6 @@ _OMNI_PHYSX_SCHEMAS_GAP_REASON = (
     "docs/superpowers/specs/2026-04-28-ovphysx-wheel-gaps-for-marco.md."
 )
 
-_MATERIAL_GAP_REASON = (
-    "Requires a ``RIGID_BODY_MATERIAL`` TensorType (or a view-helper) on the "
-    "ovphysx wheel side.  ``Articulation.root_view`` is an ``OvPhysxView`` over "
-    "the per-tensor-type bindings on OVPhysX, so ``root_view.get_material_properties()`` / "
-    "``set_material_properties()`` / ``max_shapes`` are not available.  See "
-    "docs/superpowers/specs/2026-04-28-ovphysx-wheel-gaps-for-marco.md."
-)
-
 
 def _read_binding_to_torch(articulation: Articulation, tensor_type: int, device: str | torch.device) -> torch.Tensor:
     """Read an OVPhysX attribute into a torch tensor on *device*.
@@ -2326,9 +2318,19 @@ def test_write_joint_frictions_to_sim(sim, num_articulations, device, add_ground
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("articulation_type", ["panda"])
-@pytest.mark.xfail(reason=_MATERIAL_GAP_REASON, strict=False)
 def test_set_material_properties(sim, num_articulations, device, add_ground_plane, articulation_type):
-    """Test getting and setting material properties (friction/restitution) of articulation shapes."""
+    """Test getting and setting per-shape material properties (friction/restitution).
+
+    OVPhysX exposes per-collision-shape material as the
+    ``articulation_shape_friction_and_restitution`` tensor binding (shape ``[N, S, 3]`` =
+    static friction, dynamic friction, restitution), addressed through the
+    :class:`~isaaclab_ovphysx.sim.views.OvPhysxView`. The binding is device-resident, so the
+    buffer lives on the simulation device. (The PhysX backend instead uses a dedicated
+    ``root_view.get_material_properties`` / ``set_material_properties`` view API.)
+    """
+    if not hasattr(TT, "SHAPE_FRICTION_AND_RESTITUTION"):
+        pytest.skip("ovphysx wheel does not expose the shape material tensor type")
+
     articulation_cfg = generate_articulation_cfg(articulation_type=articulation_type)
     articulation, _ = generate_articulation(
         articulation_cfg=articulation_cfg, num_articulations=num_articulations, device=device
@@ -2337,28 +2339,21 @@ def test_set_material_properties(sim, num_articulations, device, add_ground_plan
     # Play the simulator
     sim.reset()
 
-    # Get number of shapes from the articulation
-    max_shapes = articulation.root_view.max_shapes
+    view = articulation.root_view
+    # Number of collision shapes per articulation, from the material binding's shape [N, S, 3].
+    num_shapes = view.binding_for(TT.SHAPE_FRICTION_AND_RESTITUTION).shape[1]
 
-    # Generate random material properties: (static_friction, dynamic_friction, restitution)
-    materials = torch.empty(num_articulations, max_shapes, 3, device="cpu").uniform_(0.0, 1.0)
-    # Ensure dynamic friction <= static friction
-    materials[..., 1] = torch.min(materials[..., 0], materials[..., 1])
+    # Random material per shape: (static_friction, dynamic_friction, restitution), on the sim device.
+    materials = torch.empty(num_articulations, num_shapes, 3, device=device).uniform_(0.0, 1.0)
+    materials[..., 1] = torch.min(materials[..., 0], materials[..., 1])  # dynamic <= static
 
-    # Set material properties via the PhysX view-level API
-    env_ids = torch.arange(num_articulations, dtype=torch.int32)
-    articulation.root_view.set_material_properties(
-        wp.from_torch(materials, dtype=wp.float32), wp.from_torch(env_ids, dtype=wp.int32)
-    )
-
-    # Simulate physics
+    # Set material properties through the view, then simulate.
+    view.set_attribute(TT.SHAPE_FRICTION_AND_RESTITUTION, wp.from_torch(materials, dtype=wp.float32))
     sim.step()
     articulation.update(sim.cfg.dt)
 
-    # Get material properties from simulation
-    materials_check = wp.to_torch(articulation.root_view.get_material_properties())
-
-    # Check if material properties are set correctly
+    # Read back from the simulation and verify the round-trip.
+    materials_check = wp.to_torch(view.get_attribute(TT.SHAPE_FRICTION_AND_RESTITUTION))
     torch.testing.assert_close(materials_check, materials)
 
 


### PR DESCRIPTION
> **Stacked on #6225** (OVPhysX `Articulation` → `OvPhysxView`), which is stacked on #6224 (`OvPhysxView`). Review/merge those first — the diff here collapses to a single commit once they land.

## What

The ovphysx wheel now exposes per-collision-shape material as the `ARTICULATION_SHAPE_FRICTION_AND_RESTITUTION` / `RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION` tensor types. This closes the gap that kept `test_set_material_properties` `xfail`ed: the test had been written against the PhysX-only `root_view.get_material_properties()` / `set_material_properties()` / `max_shapes` view API, which `OvPhysxView` does not provide.

- Add `tensor_types` aliases `SHAPE_FRICTION_AND_RESTITUTION` and `RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION`, guarded with `try/except AttributeError` so the module stays import-safe against older wheels.
- Rewrite `test_set_material_properties` to read/write the material through `OvPhysxView.get_attribute` / `set_attribute` on the new tensor type. The per-articulation shape count is derived from the binding shape `[N, S, 3]` (`[static_friction, dynamic_friction, restitution]`); the test skips on wheels that lack the type. The now-unused `_MATERIAL_GAP_REASON` is removed.

## Verification

The material binding is device-resident (it follows the simulation device). The `set → step → read` round-trip passes on both `cpu` and `cuda:0` for `num_articulations` 1 and 2.