### PR TITLE
Enable OVPhysX rigid-object-collection material test via OvPhysxView

### DIFF
--- a/source/isaaclab_ovphysx/changelog.d/antoiner-feat-ovphysx_rigidobjectcollection_materials.skip
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-feat-ovphysx_rigidobjectcollection_materials.skip
@@ -1,0 +1,3 @@
+Test-only: enable the rigid-object-collection shape-material test against the
+new ovphysx material binding. The public ``RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION``
+alias it relies on is documented by the sibling material PRs (#6239 / #6240).

--- a/source/isaaclab_ovphysx/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/test/assets/test_rigid_object_collection.py
@@ -32,6 +32,7 @@ import warp as wp
 # CI jobs that need OVPhysX coverage install it explicitly.
 pytest.importorskip("ovphysx.types", reason="ovphysx wheel not installed")
 
+from isaaclab_ovphysx import tensor_types as TT  # noqa: E402
 from isaaclab_ovphysx.assets import RigidObjectCollection  # noqa: E402
 from isaaclab_ovphysx.physics import OvPhysxCfg  # noqa: E402
 
@@ -98,20 +99,6 @@ def _ovphysx_sim_context(device: str, **kwargs):
     gravity = (0.0, 0.0, -9.81) if gravity_enabled else (0.0, 0.0, 0.0)
     sim_cfg = SimulationCfg(physics=OvPhysxCfg(), device=device, dt=dt, gravity=gravity)
     return build_simulation_context(device=device, sim_cfg=sim_cfg, **kwargs)
-
-
-# ---------------------------------------------------------------------------
-# Material-property gap (xfail reason shared by the test below)
-# ---------------------------------------------------------------------------
-
-_MATERIAL_GAP_REASON = (
-    "Requires RIGID_BODY_MATERIAL TensorType (or a view-helper) on the ovphysx "
-    "wheel side.  RigidObjectCollection.root_view is an OvPhysxView over fused "
-    "per-tensor-type bindings on OVPhysX, so root_view.get_material_properties() / "
-    "set_material_properties() "
-    "are not available.  See "
-    "docs/superpowers/specs/2026-04-28-ovphysx-wheel-gaps-for-marco.md."
-)
 
 
 def generate_cubes_scene(
@@ -766,13 +753,45 @@ def test_reset_object_collection(num_envs, num_cubes, device):
                 assert torch.count_nonzero(object_collection._permanent_wrench_composer.composed_torque.torch) == 0
 
 
-@pytest.mark.xfail(reason=_MATERIAL_GAP_REASON, strict=False)
 @pytest.mark.parametrize("num_envs", [1, 3])
 @pytest.mark.parametrize("num_cubes", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_set_material_properties(num_envs, num_cubes, device):
-    """Test getting and setting material properties of rigid object."""
-    raise NotImplementedError(_MATERIAL_GAP_REASON)
+    """Test getting and setting per-shape material properties of a rigid object collection.
+
+    OVPhysX exposes per-collision-shape material as the
+    ``rigid_body_shape_friction_and_restitution`` tensor binding, addressed through the
+    fused :class:`~isaaclab_ovphysx.sim.views.OvPhysxView`. The binding is body-major flat,
+    so data ``[num_envs, num_cubes, 3]`` is mapped to/from the view layout with
+    :meth:`~isaaclab_ovphysx.assets.RigidObjectCollection.reshape_data_to_view_3d` and its
+    inverse. (The PhysX backend uses ``root_view.get/set_material_properties``.)
+    """
+    with _ovphysx_sim_context(device=device, add_ground_plane=True, auto_add_lighting=True) as sim:
+        object_collection, _ = generate_cubes_scene(num_envs=num_envs, num_cubes=num_cubes, device=device)
+
+        # Play sim
+        sim.reset()
+
+        # Random material per object: (static_friction, dynamic_friction, restitution), on the sim device.
+        static_friction = torch.empty(num_envs, num_cubes, 1, device=device).uniform_(0.4, 0.8)
+        dynamic_friction = torch.empty(num_envs, num_cubes, 1, device=device).uniform_(0.4, 0.8)
+        restitution = torch.empty(num_envs, num_cubes, 1, device=device).uniform_(0.0, 0.2)
+        materials = torch.cat([static_friction, dynamic_friction, restitution], dim=-1)  # [num_envs, num_cubes, 3]
+
+        # Map data -> body-major view layout, write through the view.
+        view_materials = object_collection.reshape_data_to_view_3d(wp.from_torch(materials, dtype=wp.float32), 3)
+        object_collection.root_view.set_attribute(TT.RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION, view_materials)
+
+        # Simulate physics
+        sim.step()
+        object_collection.update(sim.cfg.dt)
+
+        # Read back and map view -> data layout (inverse of reshape_data_to_view_3d), then verify.
+        view_check = wp.to_torch(
+            object_collection.root_view.get_attribute(TT.RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION)
+        )
+        materials_check = view_check.reshape(num_cubes, num_envs, 3).transpose(0, 1).contiguous()
+        torch.testing.assert_close(materials_check, materials)
 
 
 @pytest.mark.parametrize("num_envs", [1, 3])


### PR DESCRIPTION
> **Stacked on #6227** (OVPhysX `RigidObjectCollection` → `OvPhysxView`), which is stacked on #6224 (`OvPhysxView`). Review/merge those first. Sibling of #6239 (articulation) and #6240 (rigid object).

## What

The ovphysx wheel now exposes per-collision-shape rigid-body material as the `RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION` tensor type. This closes the gap that kept the collection's `test_set_material_properties` `xfail`ed (it was an empty `NotImplementedError` stub written against the PhysX-only `root_view.get/set_material_properties()` API).

- Add the `tensor_types` alias `RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION`, guarded with `try/except AttributeError` (shared with the sibling material PRs; documented there).
- Implement `test_set_material_properties`, mirroring the PhysX backend but reading/writing the material through `OvPhysxView.get_attribute` / `set_attribute`. The collection's fused binding is body-major flat, so data `[num_envs, num_cubes, 3]` is mapped to/from the view layout with `reshape_data_to_view_3d` and its inverse.

## Verification

OVPhysX runs the PhysX solver. The material round-trip passes on both `cpu` and `cuda:0` for `num_envs` 1/3 × `num_cubes` 1/2.

The changelog fragment is a `.skip` because the only user-facing addition (the alias) is documented by the sibling material PRs; this PR is test enablement.