### PR TITLE
Bump newton version pin to ``79e95bf5571d70a0a46c8eaedc80644531d27368``

### DIFF
--- a/source/isaaclab/changelog.d/bump-newton-pin.rst
+++ b/source/isaaclab/changelog.d/bump-newton-pin.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed the wheel-builder ``newton[sim]`` dependency pin to use Newton commit
+  ``79e95bf5571d70a0a46c8eaedc80644531d27368``, including the
+  RenderContext triangle-mesh construction fix from `newton-physics/newton#3199
+  <https://github.com/newton-physics/newton/pull/3199>`_.

--- a/source/isaaclab_newton/changelog.d/bump-newton-pin.rst
+++ b/source/isaaclab_newton/changelog.d/bump-newton-pin.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed the ``newton[sim]`` dependency pin to use Newton commit
+  ``79e95bf5571d70a0a46c8eaedc80644531d27368``, including the
+  RenderContext triangle-mesh construction fix from `newton-physics/newton#3199
+  <https://github.com/newton-physics/newton/pull/3199>`_.

--- a/source/isaaclab_newton/pyproject.toml
+++ b/source/isaaclab_newton/pyproject.toml
@@ -27,7 +27,7 @@ all = [
     "prettytable>=3.3.0",
     "PyOpenGL-accelerate>=3.1.0",
     "pyglet>=2.1.6,<3",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@79e95bf5571d70a0a46c8eaedc80644531d27368",
 ]
 
 [tool.setuptools]

--- a/source/isaaclab_physx/changelog.d/bump-newton-pin.rst
+++ b/source/isaaclab_physx/changelog.d/bump-newton-pin.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed the optional ``newton[sim]`` dependency pin to use Newton commit
+  ``79e95bf5571d70a0a46c8eaedc80644531d27368``, including the
+  RenderContext triangle-mesh construction fix from `newton-physics/newton#3199
+  <https://github.com/newton-physics/newton/pull/3199>`_.

--- a/source/isaaclab_physx/pyproject.toml
+++ b/source/isaaclab_physx/pyproject.toml
@@ -24,7 +24,7 @@ Repository = "https://github.com/isaac-sim/IsaacLab"
 
 [project.optional-dependencies]
 newton = [
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@79e95bf5571d70a0a46c8eaedc80644531d27368",
 ]
 
 [tool.setuptools]

--- a/source/isaaclab_visualizers/changelog.d/bump-newton-pin.rst
+++ b/source/isaaclab_visualizers/changelog.d/bump-newton-pin.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed the visualizer extras' ``newton[sim]`` dependency pin to use Newton
+  commit ``79e95bf5571d70a0a46c8eaedc80644531d27368``, including the
+  RenderContext triangle-mesh construction fix from `newton-physics/newton#3199
+  <https://github.com/newton-physics/newton/pull/3199>`_.

--- a/source/isaaclab_visualizers/pyproject.toml
+++ b/source/isaaclab_visualizers/pyproject.toml
@@ -29,24 +29,24 @@ Repository = "https://github.com/isaac-sim/IsaacLab"
 kit = []
 newton = [
     "warp-lang",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@79e95bf5571d70a0a46c8eaedc80644531d27368",
     "PyOpenGL-accelerate",
     "pyglet>=2.1.6,<3",
     "imgui-bundle>=1.92.5",
     "typing-extensions>=4.15.0",
 ]
 rerun = [
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@79e95bf5571d70a0a46c8eaedc80644531d27368",
     "rerun-sdk>=0.29.0",
     "pyarrow==22.0.0",
 ]
 viser = [
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@79e95bf5571d70a0a46c8eaedc80644531d27368",
     "viser>=1.0.16",
 ]
 all = [
     "imgui-bundle>=1.92.5",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@79e95bf5571d70a0a46c8eaedc80644531d27368",
     "PyOpenGL-accelerate",
     "pyglet>=2.1.6,<3",
     # Match rerun-sdk's supported Arrow stack and avoid resolver drift across environments.

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -88,7 +88,7 @@ pyproject.optional-dependencies.all = [
     # ================================================================================
     { "newton" = [
         "warp-lang==1.14.0",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@811968bfb7cc7ff4e37b9260a2ba56930a3e605e",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@79e95bf5571d70a0a46c8eaedc80644531d27368",
         "PyOpenGL-accelerate==3.1.10"
     ] },
     # ================================================================================


### PR DESCRIPTION
# Description

Fixed the `newton[sim]` dependency pin to use Newton commit `79e95bf5571d70a0a46c8eaedc80644531d27368`, including the `RenderContext` triangle-mesh construction fix from [newton-physics/newton#3199](https://github.com/newton-physics/newton/pull/3199).


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
