### PR TITLE
Add explicit FrameTransformer prim-path regex API

### DIFF
--- a/docs/source/overview/core-concepts/sensors/frame_transformer.rst
+++ b/docs/source/overview/core-concepts/sensors/frame_transformer.rst
@@ -15,7 +15,12 @@ Frame Transformer
 
 One of the most common operations that needs to be performed within a physics simulation is the frame transformation: rewriting a vector or quaternion in the basis of an arbitrary euclidean coordinate system. There are many ways to accomplish this within Isaac and USD, but these methods can be cumbersome to implement within Isaac Lab's GPU based simulation and cloned environments. To mitigate this problem, we have designed the Frame Transformer Sensor, that tracks and calculate the relative frame transformations for rigid bodies of interest to the scene.
 
-The sensory is minimally defined by a source frame and a list of target frames.  These definitions take the form of a prim path (for the source) and list of regex capable prim paths the rigid bodies to be tracked (for the targets).
+The sensor is minimally defined by a source frame and a list of target frames.
+Use ``prim_path_regex`` for new configurations. It filters only the prims directly
+matched by the prim-path expression: ``/Robot/pelvis`` stops at the pelvis, while
+``/Robot/.*`` can select rigid bodies at the next path level below ``/Robot``.
+The deprecated ``prim_path`` field remains available for compatibility and
+recursively searches below each matched prim.
 
 .. literalinclude:: ../../../../../scripts/demos/sensors/frame_transformer_sensor.py
     :language: python

--- a/scripts/demos/sensors/frame_transformer_sensor.py
+++ b/scripts/demos/sensors/frame_transformer_sensor.py
@@ -67,23 +67,23 @@ class FrameTransformerSensorSceneCfg(InteractiveSceneCfg):
     )
 
     specific_transforms = FrameTransformerCfg(
-        prim_path="{ENV_REGEX_NS}/Robot/base",
+        prim_path_regex="{ENV_REGEX_NS}/Robot/base",
         target_frames=[
-            FrameTransformerCfg.FrameCfg(prim_path="{ENV_REGEX_NS}/Robot/LF_FOOT"),
-            FrameTransformerCfg.FrameCfg(prim_path="{ENV_REGEX_NS}/Robot/RF_FOOT"),
+            FrameTransformerCfg.FrameCfg(prim_path_regex="{ENV_REGEX_NS}/Robot/LF_FOOT"),
+            FrameTransformerCfg.FrameCfg(prim_path_regex="{ENV_REGEX_NS}/Robot/RF_FOOT"),
         ],
         debug_vis=True,
     )
 
     cube_transform = FrameTransformerCfg(
-        prim_path="{ENV_REGEX_NS}/Robot/base",
-        target_frames=[FrameTransformerCfg.FrameCfg(prim_path="{ENV_REGEX_NS}/Cube")],
+        prim_path_regex="{ENV_REGEX_NS}/Robot/base",
+        target_frames=[FrameTransformerCfg.FrameCfg(prim_path_regex="{ENV_REGEX_NS}/Cube")],
         debug_vis=False,
     )
 
     robot_transforms = FrameTransformerCfg(
-        prim_path="{ENV_REGEX_NS}/Robot/base",
-        target_frames=[FrameTransformerCfg.FrameCfg(prim_path="{ENV_REGEX_NS}/Robot/.*")],
+        prim_path_regex="{ENV_REGEX_NS}/Robot/base",
+        target_frames=[FrameTransformerCfg.FrameCfg(prim_path_regex="{ENV_REGEX_NS}/Robot/.*")],
         debug_vis=False,
     )
 

--- a/scripts/tutorials/04_sensors/run_frame_transformer.py
+++ b/scripts/tutorials/04_sensors/run_frame_transformer.py
@@ -67,11 +67,11 @@ def define_sensor() -> FrameTransformer:
 
     # Example using .* to get full body + LF_FOOT
     frame_transformer_cfg = FrameTransformerCfg(
-        prim_path=f"{ROBOT_PRIM_PATH_EXPR}/base",
+        prim_path_regex=f"{ROBOT_PRIM_PATH_EXPR}/base",
         target_frames=[
-            FrameTransformerCfg.FrameCfg(prim_path=f"{ROBOT_PRIM_PATH_EXPR}/.*"),
+            FrameTransformerCfg.FrameCfg(prim_path_regex=f"{ROBOT_PRIM_PATH_EXPR}/.*"),
             FrameTransformerCfg.FrameCfg(
-                prim_path=f"{ROBOT_PRIM_PATH_EXPR}/LF_SHANK",
+                prim_path_regex=f"{ROBOT_PRIM_PATH_EXPR}/LF_SHANK",
                 name="LF_FOOT_USER",
                 offset=OffsetCfg(pos=tuple(pos_offset.tolist()), rot=tuple(rot_offset[0].tolist())),
             ),

--- a/source/isaaclab/changelog.d/frame-transformer-prim-path-regex.minor.rst
+++ b/source/isaaclab/changelog.d/frame-transformer-prim-path-regex.minor.rst
@@ -1,0 +1,13 @@
+Added
+^^^^^
+
+* Added ``prim_path_regex`` to frame-transformer source and target configurations
+  for matching only the prims selected by the path expression.
+* Added normalized regex parsing to
+  :func:`~isaaclab.sim.resolve_matching_prims_from_source`.
+
+Deprecated
+^^^^^^^^^^
+
+* Deprecated frame-transformer ``prim_path`` fields. Existing configurations keep
+  their recursive descendant lookup behavior.

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -224,7 +224,8 @@ class InteractiveScene:
                 asset_cfg.rigid_objects.values() if isinstance(asset_cfg, RigidObjectCollectionCfg) else [asset_cfg]
             )
             for child in children:
-                if hasattr(child, "prim_path"):
+                # FrameTransformer paths are resolved when its source and targets are constructed.
+                if hasattr(child, "prim_path") and not isinstance(child, FrameTransformerCfg):
                     child.prim_path = child.prim_path.format(ENV_REGEX_NS=self.cloner_cfg.clone_regex)
                     if hasattr(child, "spawn") and child.spawn is not None and self.env_ns in child.prim_path:
                         clone_asset_names.append(asset_name)
@@ -796,7 +797,12 @@ class InteractiveScene:
 
         for asset_name, asset_cfg in ordered_items:
             # resolve prim_path with env regex
-            if hasattr(asset_cfg, "prim_path"):
+            if isinstance(asset_cfg, FrameTransformerCfg):
+                source_path_field = "prim_path_regex" if asset_cfg.prim_path_regex is not None else "prim_path"
+                source_path = getattr(asset_cfg, source_path_field)
+                if source_path is not None:
+                    setattr(asset_cfg, source_path_field, source_path.replace("{ENV_REGEX_NS}", env_regex_ns))
+            elif hasattr(asset_cfg, "prim_path"):
                 asset_cfg.prim_path = asset_cfg.prim_path.format(ENV_REGEX_NS=self.env_regex_ns)
             # set spawn_path on spawner if cloning is needed
             if hasattr(asset_cfg, "spawn") and asset_cfg.spawn is not None:
@@ -852,7 +858,16 @@ class InteractiveScene:
                 if isinstance(asset_cfg, FrameTransformerCfg):
                     updated_target_frames = []
                     for target_frame in asset_cfg.target_frames:
-                        target_frame.prim_path = target_frame.prim_path.format(ENV_REGEX_NS=self.env_regex_ns)
+                        target_path_field = (
+                            "prim_path_regex" if target_frame.prim_path_regex is not None else "prim_path"
+                        )
+                        target_path = getattr(target_frame, target_path_field)
+                        if target_path is not None:
+                            setattr(
+                                target_frame,
+                                target_path_field,
+                                target_path.replace("{ENV_REGEX_NS}", env_regex_ns),
+                            )
                         updated_target_frames.append(target_frame)
                     asset_cfg.target_frames = updated_target_frames
                 elif isinstance(asset_cfg, ContactSensorCfg):

--- a/source/isaaclab/isaaclab/sensors/frame_transformer/base_frame_transformer.py
+++ b/source/isaaclab/isaaclab/sensors/frame_transformer/base_frame_transformer.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -57,6 +58,42 @@ class BaseFrameTransformer(SensorBase):
         """
         # initialize base class
         super().__init__(cfg)
+
+        self._source_prim_path = self._select_prim_path(self.cfg.prim_path, self.cfg.prim_path_regex)
+        self._target_prim_paths = [
+            self._select_prim_path(frame.prim_path, frame.prim_path_regex) for frame in self.cfg.target_frames
+        ]
+        self._source_prim_path_expr = (
+            f"(?:{self.cfg.prim_path_regex})"
+            if self.cfg.prim_path_regex is not None
+            else f"(?:{self._source_prim_path})(?:/.*)?"
+        )
+        self._target_prim_path_exprs = [
+            f"(?:{frame.prim_path_regex})" if frame.prim_path_regex is not None else f"(?:{path})(?:/.*)?"
+            for frame, path in zip(self.cfg.target_frames, self._target_prim_paths)
+        ]
+
+        if self.cfg.prim_path is not None or any(frame.prim_path is not None for frame in self.cfg.target_frames):
+            warnings.warn(
+                "FrameTransformerCfg.prim_path is deprecated; use prim_path_regex for explicit matching.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
+        # SensorBase still routes lifecycle events through ``cfg.prim_path``. Keep that
+        # internal routing path populated without changing the public user configuration.
+        self.cfg.prim_path = self._source_prim_path
+
+    @staticmethod
+    def _select_prim_path(prim_path: str | None, prim_path_regex: str | None) -> str:
+        """Select the configured path while rejecting ambiguous or empty inputs."""
+        if prim_path is not None:
+            if prim_path_regex is not None:
+                raise ValueError("Define exactly one of 'prim_path' or 'prim_path_regex'.")
+            return prim_path
+        if prim_path_regex is None:
+            raise ValueError("Define exactly one of 'prim_path' or 'prim_path_regex'.")
+        return prim_path_regex
 
     """
     Properties

--- a/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/frame_transformer/frame_transformer_cfg.py
@@ -35,15 +35,23 @@ class FrameTransformerCfg(SensorBaseCfg):
     class FrameCfg:
         """Information specific to a coordinate frame."""
 
-        prim_path: str = MISSING
+        prim_path: str | None = None
         """The prim path corresponding to a rigid body.
 
-        This can be a regex pattern to match multiple prims. For example, "/Robot/.*"
-        will match all prims under "/Robot".
+        .. deprecated::
+            Use :attr:`prim_path_regex` instead. For backwards compatibility, this path
+            recursively searches its descendants for rigid bodies.
+        """
 
-        This means that if the source :attr:`FrameTransformerCfg.prim_path` is "/Robot/base",
-        and the target :attr:`FrameTransformerCfg.FrameCfg.prim_path` is "/Robot/.*", then
-        the frame transformer will track the poses of all the prims under "/Robot",
+        prim_path_regex: str | None = None
+        """The prim path regex corresponding to a rigid body.
+
+        Only prims directly matched by the expression are selected. For example,
+        ``/Robot/.*`` matches rigid-body children of ``/Robot``.
+
+        This means that if the source :attr:`FrameTransformerCfg.prim_path_regex` is "/Robot/base",
+        and the target :attr:`FrameTransformerCfg.FrameCfg.prim_path_regex` is "/Robot/.*", then
+        the frame transformer will track the poses of matching rigid-body children under "/Robot",
         including "/Robot/base" (even though this will result in an identity pose w.r.t.
         the source frame).
         """
@@ -59,8 +67,19 @@ class FrameTransformerCfg(SensorBaseCfg):
 
     class_type: type[FrameTransformer] | str = "{DIR}.frame_transformer:FrameTransformer"
 
-    prim_path: str = MISSING
-    """The prim path of the body to transform from (source frame)."""
+    prim_path: str | None = None
+    """The prim path of the body to transform from (source frame).
+
+    .. deprecated::
+        Use :attr:`prim_path_regex` instead. For backwards compatibility, this path
+        recursively searches its descendants for a rigid body.
+    """
+
+    prim_path_regex: str | None = None
+    """The prim path regex of the body to transform from (source frame).
+
+    Only a rigid body directly matched by the expression is selected.
+    """
 
     source_frame_offset: OffsetCfg = OffsetCfg()
     """The pose offset from the source prim frame."""

--- a/source/isaaclab/isaaclab/sim/utils/queries.py
+++ b/source/isaaclab/isaaclab/sim/utils/queries.py
@@ -20,6 +20,8 @@ from .stage import get_current_stage
 if TYPE_CHECKING:
     from pxr import Sdf, Usd, UsdPhysics  # noqa: F401
 
+    from isaaclab.cloner import ClonePlan
+
 # import logger
 logger = logging.getLogger(__name__)
 
@@ -389,6 +391,128 @@ def find_matching_prims(prim_path_regex: str, stage: Usd.Stage | None = None) ->
     return output_prims
 
 
+def _resolve_clone_plan_prim_path_regex_from_source(
+    pattern: re.Pattern,
+    plan: ClonePlan,
+    predicate: Callable[[Usd.Prim], bool] | None,
+    traverse_instance_prims: bool,
+) -> tuple[list[tuple[Usd.Prim, str]], bool]:
+    """Filter prims projected from the clone plan's first source environment."""
+    num_envs = int(plan.clone_mask.shape[1])
+    if num_envs == 0:
+        return [], False
+
+    env_ids = list(range(num_envs)) if plan.env_ids is None else [int(env_id) for env_id in plan.env_ids.tolist()]
+    if len(env_ids) != num_envs:
+        raise ValueError(f"Clone plan has {num_envs} columns but {len(env_ids)} environment ids.")
+
+    stage = get_current_stage()
+    clone_plan_matched = False
+    matches: dict[tuple[str, str], tuple[Usd.Prim, list[int]]] = {}
+    # Source prims come only from the rows that populate the first environment. Project them into
+    # every concrete destination so the full regex remains independent of clone routing syntax.
+    for source_root, destination_template, clone_mask in zip(plan.sources, plan.destinations, plan.clone_mask):
+        if not clone_mask[0].item():
+            continue
+        source_root = source_root.rstrip("/") or "/"
+        if not stage.GetPrimAtPath(source_root).IsValid():
+            continue
+
+        for prim in get_all_matching_child_prims(
+            source_root, lambda _: True, traverse_instance_prims=traverse_instance_prims
+        ):
+            prim_path = prim.GetPath().pathString
+            suffix = prim_path if source_root == "/" else prim_path[len(source_root) :]
+            matching_envs: list[int] = []
+            matching_path = None
+            for column, env_id in enumerate(env_ids):
+                destination_root = destination_template.format(env_id).rstrip("/") or "/"
+                destination_path = suffix if destination_root == "/" else destination_root + suffix
+                if pattern.fullmatch(destination_path) is not None:
+                    matching_envs.append(column)
+                    if matching_path is None:
+                        matching_path = destination_path
+
+            if matching_path is None:
+                continue
+
+            clone_plan_matched = True
+            # Resolve ownership from one concrete path. This preserves the clone plan's nearest-owner
+            # rule even when a nested owner's source does not contain this prim.
+            resolved = cloner.query.path_to_source(plan, matching_path)
+            if resolved is None:
+                continue
+            _, owner_glob, owner_suffix = resolved
+            if destination_template.replace("{}", "*") == owner_glob:
+                matches.setdefault((destination_template, owner_suffix), (prim, matching_envs))
+
+    results: list[tuple[Usd.Prim, str]] = []
+    for (destination_template, suffix), (prim, matching_envs) in matches.items():
+        if len(matching_envs) != num_envs:
+            raise NotImplementedError(
+                f"Path regex matched only environments {sorted(matching_envs)} of {num_envs} at "
+                f"'{destination_template.replace('{}', '*') + suffix}'."
+            )
+        if predicate is not None and not predicate(prim):
+            continue
+        destination_glob = destination_template.replace("{}", "*").rstrip("/") or "/"
+        results.append((prim, destination_glob + suffix))
+
+    return results, clone_plan_matched
+
+
+def _resolve_authored_prim_path_regex_from_source(
+    pattern: re.Pattern,
+    predicate: Callable[[Usd.Prim], bool] | None,
+    env_regex_ns: str,
+    traverse_instance_prims: bool,
+) -> list[tuple[Usd.Prim, str]]:
+    """Filter prims below the first authored source instance."""
+    first = get_first_matching_child_prim(
+        "/",
+        lambda prim: prim.GetPath().pathString != "/" and pattern.fullmatch(prim.GetPath().pathString) is not None,
+        traverse_instance_prims=traverse_instance_prims,
+    )
+    if first is None:
+        return []
+
+    env_prims = find_matching_prims(env_regex_ns)
+    env_paths = [prim.GetPath().pathString.rstrip("/") for prim in env_prims]
+    first_path = first.GetPath().pathString
+    env_source_root = next(
+        (env_path for env_path in env_paths if first_path == env_path or first_path.startswith(env_path + "/")),
+        None,
+    )
+    if env_source_root is not None:
+        source_root = env_source_root
+        destination_root = env_regex_ns.rstrip("/")
+    else:
+        source_root = "/"
+        destination_root = "/"
+
+    matches = get_all_matching_child_prims(
+        source_root,
+        lambda prim: prim.GetPath().pathString != "/" and pattern.fullmatch(prim.GetPath().pathString) is not None,
+        traverse_instance_prims=traverse_instance_prims,
+    )
+    if source_root == "/":
+        return [
+            (prim, prim.GetPath().pathString)
+            for prim in matches
+            if not any(
+                prim.GetPath().pathString == env_path or prim.GetPath().pathString.startswith(env_path + "/")
+                for env_path in env_paths
+            )
+            and (predicate is None or predicate(prim))
+        ]
+
+    return [
+        (prim, destination_root + prim.GetPath().pathString[len(source_root) :])
+        for prim in matches
+        if predicate is None or predicate(prim)
+    ]
+
+
 def resolve_matching_prims_from_source(
     path_expr: str,
     predicate: Callable[[Usd.Prim], bool] | None = None,
@@ -403,8 +527,10 @@ def resolve_matching_prims_from_source(
     keeps the multi-instance pattern that callers can pass to simulation views.
 
     Args:
-        path_expr: Prim path expression to resolve. It may contain regex wildcards.
-        predicate: Optional descendant filter; returned expressions include the matching descendant suffix.
+        path_expr: Prim path expression to resolve. It may contain regex wildcards. A normalized expression
+            wrapped in ``(?:...)`` is full-matched within the selected source instance. Unwrapped expressions
+            retain the legacy descendant-filter behavior.
+        predicate: Optional prim filter applied after normalized regex matching.
         expected_num_matches: Optional exact result count.
         env_regex_ns: Namespace pattern that marks one instance root when no clone plan applies.
         raise_if_no_matches: Whether to raise if no prim matches ``path_expr``. Defaults to True.
@@ -417,54 +543,75 @@ def resolve_matching_prims_from_source(
     Raises:
         RuntimeError: If no prim matches ``path_expr`` and ``raise_if_no_matches`` is True.
     """
-    plan = SimulationContext.instance().get_clone_plan()
-    resolved = cloner.query.path_to_source(plan, path_expr) if plan is not None else None
-    if resolved is not None:
-        source_path, dest_glob, asset_suffix = resolved
-        walk_root = source_path + asset_suffix
-        results = [
-            (prim, dest_glob + prim.GetPath().pathString[len(source_path) :]) for prim in find_matching_prims(walk_root)
-        ]
-    else:
-        # No clone plan, or ``path_expr`` is not owned by any plan row. Resolve from the stage
-        # in two phases (mirroring the clone-plan branch above): (1) locate ONE instance root to
-        # search from, (2) collect the bodies of interest within just that instance and map each
-        # back to the multi-instance pattern. Phase 1 stops at the first match and phase 2 walks
-        # under a concrete instance prefix, so only a single instance subtree is traversed.
-        segments = path_expr.strip("/").split("/")
-        ns_segments = env_regex_ns.strip("/").split("/")
-        # Instance ("env") boundary. Assume the standard namespace ``env_regex_ns`` and put the
-        # boundary at its depth when ``path_expr`` sits under it -- literal ns segments must
-        # match, wildcard ns segments (e.g. ``env_.*``) accept any segment. Otherwise fall back
-        # to the first regex segment of ``path_expr`` (treat the first ``.*`` as the env id),
-        # covering ad-hoc roots like ``/World/Table_.*/Object``. A layout the fallback would
-        # mis-split (e.g. multiple wildcard levels) must pass ``env_regex_ns``.
-        under_ns = len(segments) >= len(ns_segments) and all(
-            ns_seg == seg or not ns_seg.isidentifier() for ns_seg, seg in zip(ns_segments, segments)
+    normalized_regex = path_expr.startswith("(?:")
+    sim = SimulationContext.instance()
+    plan = sim.get_clone_plan() if sim is not None else None
+    if normalized_regex:
+        descendant_suffix = ")(?:/.*)?"
+        if path_expr.endswith(descendant_suffix):
+            routing_expr = path_expr[3 : -len(descendant_suffix)]
+            routing_expr = _normalize_legacy_wildcard_pattern(routing_expr)
+            pattern = re.compile(f"(?:{routing_expr})(?:/.*)?")
+        else:
+            pattern = re.compile(path_expr)
+        results, clone_plan_match = (
+            _resolve_clone_plan_prim_path_regex_from_source(pattern, plan, predicate, traverse_instance_prims)
+            if plan is not None
+            else ([], False)
         )
-        if under_ns:
-            instance_seg = len(ns_segments) - 1
-        else:
-            instance_seg = next((i for i, seg in enumerate(segments) if not seg.isidentifier()), None)
-        first = find_first_matching_prim(path_expr)
-        if first is None:
-            results = []
-        elif instance_seg is None:
-            # Fully concrete path: a single instance, mapped to itself.
-            results = [(first, first.GetPath().pathString)]
-        else:
-            instance_expr = "/" + "/".join(segments[: instance_seg + 1])
-            match_segments = first.GetPath().pathString.strip("/").split("/")
-            instance_root = "/" + "/".join(match_segments[: instance_seg + 1])
-            trailing = segments[instance_seg + 1 :]
-            walk_root = instance_root + ("/" + "/".join(trailing) if trailing else "")
+        if not clone_plan_match:
+            results = _resolve_authored_prim_path_regex_from_source(
+                pattern, predicate, env_regex_ns, traverse_instance_prims
+            )
+    else:
+        resolved = cloner.query.path_to_source(plan, path_expr) if plan is not None else None
+        if resolved is not None:
+            source_path, dest_glob, asset_suffix = resolved
+            walk_root = source_path + asset_suffix
             results = [
-                (prim, instance_expr + prim.GetPath().pathString[len(instance_root) :])
+                (prim, dest_glob + prim.GetPath().pathString[len(source_path) :])
                 for prim in find_matching_prims(walk_root)
-                if prim.GetPath().pathString == instance_root
-                or prim.GetPath().pathString.startswith(instance_root + "/")
             ]
-    if predicate is not None:
+        else:
+            # No clone plan, or ``path_expr`` is not owned by any plan row. Resolve from the stage
+            # in two phases (mirroring the clone-plan branch above): (1) locate ONE instance root to
+            # search from, (2) collect the bodies of interest within just that instance and map each
+            # back to the multi-instance pattern. Phase 1 stops at the first match and phase 2 walks
+            # under a concrete instance prefix, so only a single instance subtree is traversed.
+            segments = path_expr.strip("/").split("/")
+            ns_segments = env_regex_ns.strip("/").split("/")
+            # Instance ("env") boundary. Assume the standard namespace ``env_regex_ns`` and put the
+            # boundary at its depth when ``path_expr`` sits under it -- literal ns segments must
+            # match, wildcard ns segments (e.g. ``env_.*``) accept any segment. Otherwise fall back
+            # to the first regex segment of ``path_expr`` (treat the first ``.*`` as the env id),
+            # covering ad-hoc roots like ``/World/Table_.*/Object``. A layout the fallback would
+            # mis-split (e.g. multiple wildcard levels) must pass ``env_regex_ns``.
+            under_ns = len(segments) >= len(ns_segments) and all(
+                ns_seg == seg or not ns_seg.isidentifier() for ns_seg, seg in zip(ns_segments, segments)
+            )
+            if under_ns:
+                instance_seg = len(ns_segments) - 1
+            else:
+                instance_seg = next((i for i, seg in enumerate(segments) if not seg.isidentifier()), None)
+            first = find_first_matching_prim(path_expr)
+            if first is None:
+                results = []
+            elif instance_seg is None:
+                # Fully concrete path: a single instance, mapped to itself.
+                results = [(first, first.GetPath().pathString)]
+            else:
+                instance_expr = "/" + "/".join(segments[: instance_seg + 1])
+                match_segments = first.GetPath().pathString.strip("/").split("/")
+                instance_root = "/" + "/".join(match_segments[: instance_seg + 1])
+                trailing = segments[instance_seg + 1 :]
+                walk_root = instance_root + ("/" + "/".join(trailing) if trailing else "")
+                results = [
+                    (prim, instance_expr + prim.GetPath().pathString[len(instance_root) :])
+                    for prim in find_matching_prims(walk_root)
+                    if prim.GetPath().pathString == instance_root
+                    or prim.GetPath().pathString.startswith(instance_root + "/")
+                ]
+    if predicate is not None and not normalized_regex:
         results = [
             (child, dest + child.GetPath().pathString[len(source.GetPath().pathString) :])
             for source, dest in results

--- a/source/isaaclab/test/sensors/test_frame_transformer_cfg.py
+++ b/source/isaaclab/test/sensors/test_frame_transformer_cfg.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True).app
+
+"""Everything else follows."""
+
+import pytest
+
+from isaaclab.sensors.frame_transformer.base_frame_transformer import BaseFrameTransformer
+
+
+@pytest.mark.parametrize(
+    ("prim_path", "prim_path_regex", "expected"),
+    [
+        ("/Robot", None, "/Robot"),
+        (None, "/Robot/pelvis", "/Robot/pelvis"),
+    ],
+)
+def test_select_prim_path(prim_path, prim_path_regex, expected):
+    assert BaseFrameTransformer._select_prim_path(prim_path, prim_path_regex) == expected
+
+
+@pytest.mark.parametrize(
+    ("prim_path", "prim_path_regex"),
+    [
+        (None, None),
+        ("/Robot", "/Robot"),
+    ],
+)
+def test_select_prim_path_rejects_both_or_neither(prim_path, prim_path_regex):
+    with pytest.raises(ValueError, match="exactly one"):
+        BaseFrameTransformer._select_prim_path(prim_path, prim_path_regex)

--- a/source/isaaclab/test/sim/test_utils_queries.py
+++ b/source/isaaclab/test/sim/test_utils_queries.py
@@ -14,10 +14,13 @@ simulation_app = AppLauncher(headless=True, enable_cameras=True).app
 """Rest everything follows."""
 
 import pytest
+import torch
 
 from pxr import UsdPhysics
 
 import isaaclab.sim as sim_utils
+import isaaclab.sim.utils.queries as query_utils
+from isaaclab.cloner import ClonePlan
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 pytestmark = pytest.mark.integration
@@ -95,6 +98,456 @@ def test_matches_path_expr_prefix():
     assert sim_utils.matches_path_expr_prefix(path_expr, "/World/envs/env_0/Robot")
     assert not sim_utils.matches_path_expr_prefix(path_expr, "/World/envs/env_0/Object")
     assert not sim_utils.matches_path_expr_prefix(path_expr, "/World/envs/env_0/Robot/base")
+
+
+def test_resolve_matching_prims_from_normalized_regex(monkeypatch):
+    """A normalized regex controls direct versus descendant predicate matching."""
+
+    class _NoClonePlanContext:
+        def get_clone_plan(self):
+            return None
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _NoClonePlanContext())
+
+    stage = sim_utils.get_current_stage()
+    pelvis_path = "/World/envs/env_0/Robot/pelvis"
+    child_path = f"{pelvis_path}/child"
+    sim_utils.create_prim(pelvis_path, "Xform")
+    sim_utils.create_prim(child_path, "Xform")
+    UsdPhysics.RigidBodyAPI.Apply(stage.GetPrimAtPath(pelvis_path))
+    UsdPhysics.RigidBodyAPI.Apply(stage.GetPrimAtPath(child_path))
+
+    direct_predicate_paths = []
+
+    def direct_has_rigid_body_api(prim):
+        direct_predicate_paths.append(prim.GetPath().pathString)
+        return bool(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+
+    recursive_predicate_paths = []
+
+    def recursive_has_rigid_body_api(prim):
+        recursive_predicate_paths.append(prim.GetPath().pathString)
+        return bool(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+
+    path_expr = "/World/envs/env_.*/Robot/pelvis"
+    direct = sim_utils.resolve_matching_prims_from_source(f"(?:{path_expr})", direct_has_rigid_body_api)
+    recursive = sim_utils.resolve_matching_prims_from_source(f"(?:{path_expr})(?:/.*)?", recursive_has_rigid_body_api)
+
+    assert [prim.GetPath().pathString for prim, _ in direct] == [pelvis_path]
+    assert [prim.GetPath().pathString for prim, _ in recursive] == [pelvis_path, child_path]
+    assert direct_predicate_paths == [pelvis_path]
+    assert recursive_predicate_paths == [pelvis_path, child_path]
+
+
+def test_resolve_matching_prims_preserves_authored_regex(monkeypatch):
+    """Python quantifiers and slash-containing character classes remain unchanged."""
+
+    class _NoClonePlanContext:
+        def get_clone_plan(self):
+            return None
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _NoClonePlanContext())
+
+    matching_path = "/World/envs/env_0/Robot/link_12"
+    nonmatching_path = "/World/envs/env_0/Robot/link_1tail"
+    sim_utils.create_prim(matching_path, "Xform")
+    sim_utils.create_prim(nonmatching_path, "Xform")
+
+    predicate_paths = []
+
+    def record_match(prim):
+        predicate_paths.append(prim.GetPath().pathString)
+        return True
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/World/envs/env_.*/Robot/link_[0-9]*)", record_match)
+
+    assert [prim.GetPath().pathString for prim, _ in matches] == [matching_path]
+    assert predicate_paths == [matching_path]
+
+
+def test_resolve_matching_prims_uses_global_source_domain(monkeypatch):
+    """A global regex filters all matches below the global source root."""
+
+    class _NoClonePlanContext:
+        def get_clone_plan(self):
+            return None
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _NoClonePlanContext())
+
+    first_path = "/World/Table_0/Object"
+    second_path = "/World/Table_1/Object"
+    sim_utils.create_prim(first_path, "Xform")
+    sim_utils.create_prim(second_path, "Xform")
+
+    predicate_paths = []
+
+    def record_match(prim):
+        predicate_paths.append(prim.GetPath().pathString)
+        return True
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/World/Table_.*/Object)", predicate=record_match)
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (first_path, first_path),
+        (second_path, second_path),
+    ]
+    assert predicate_paths == [first_path, second_path]
+
+
+def test_resolve_matching_prims_preserves_global_character_class(monkeypatch):
+    """Slashes inside an authored character class are not treated as path separators."""
+
+    class _NoClonePlanContext:
+        def get_clone_plan(self):
+            return None
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _NoClonePlanContext())
+
+    left_path = "/World/Robot/left"
+    right_path = "/World/Robot/right"
+    nested_path = f"{left_path}/nested"
+    sim_utils.create_prim(left_path, "Xform")
+    sim_utils.create_prim(right_path, "Xform")
+    sim_utils.create_prim(nested_path, "Xform")
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/World/Robot/[^/]+)")
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (left_path, left_path),
+        (right_path, right_path),
+    ]
+
+
+def test_resolve_matching_prims_excludes_pseudo_root(monkeypatch):
+    """A root-wide regex starts from the first real global prim."""
+
+    class _NoClonePlanContext:
+        def get_clone_plan(self):
+            return None
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _NoClonePlanContext())
+
+    world_path = "/World"
+    robot_path = f"{world_path}/Robot"
+    sim_utils.create_prim(robot_path, "Xform")
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/.*)")
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (world_path, world_path),
+        (robot_path, robot_path),
+    ]
+
+
+def test_resolve_matching_prims_normalizes_legacy_wildcard(monkeypatch):
+    """A deprecated path keeps its legacy bare-wildcard behavior."""
+
+    class _NoClonePlanContext:
+        def get_clone_plan(self):
+            return None
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _NoClonePlanContext())
+
+    object_path = "/World/Table_0/Object"
+    child_path = f"{object_path}/child"
+    sim_utils.create_prim(object_path, "Xform")
+    sim_utils.create_prim(child_path, "Xform")
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/World/Table_*/Object)(?:/.*)?")
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (object_path, object_path),
+        (child_path, child_path),
+    ]
+
+
+def test_resolve_matching_prims_from_clone_plan_regex(monkeypatch):
+    """A destination regex resolves against source-only clone-plan prims."""
+    source_path = "/World/prototypes/Robot"
+    body_path = f"{source_path}/base"
+    sim_utils.create_prim(body_path, "Xform")
+    plan = ClonePlan(
+        sources=(source_path,),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/World/envs/env_.*/Robot/base)")
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (body_path, "/World/envs/env_*/Robot/base")
+    ]
+
+
+def test_resolve_matching_prims_routes_grouped_clone_regex(monkeypatch):
+    """Clone routing is based on projected matches rather than regex text."""
+    source_path = "/World/prototypes/Robot"
+    body_path = f"{source_path}/base"
+    sim_utils.create_prim(body_path, "Xform")
+    plan = ClonePlan(
+        sources=(source_path,),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/World/envs/env_.*/(?:Robot)/base)")
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (body_path, "/World/envs/env_*/Robot/base")
+    ]
+
+
+def test_resolve_matching_prims_uses_clone_plan_source_only(monkeypatch):
+    """Authored clone destinations are not scanned after selecting the plan source."""
+    source_path = "/World/envs/env_0/Robot"
+    body_path = f"{source_path}/base"
+    other_body_path = "/World/envs/env_1/Robot/base"
+    sim_utils.create_prim(body_path, "Xform")
+    sim_utils.create_prim(other_body_path, "Xform")
+    plan = ClonePlan(
+        sources=(source_path,),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    predicate_paths = []
+
+    def record_match(prim):
+        predicate_paths.append(prim.GetPath().pathString)
+        return True
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/World/envs/env_.*/Robot/base)", predicate=record_match)
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (body_path, "/World/envs/env_*/Robot/base")
+    ]
+    assert predicate_paths == [body_path]
+
+
+def test_resolve_matching_prims_rejects_partial_clone_plan_regex(monkeypatch):
+    """A destination regex cannot silently broaden partial clone-plan coverage."""
+    source_path = "/World/prototypes/Robot"
+    sim_utils.create_prim(f"{source_path}/base", "Xform")
+    plan = ClonePlan(
+        sources=(source_path,),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.tensor([[True, False]]),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    with pytest.raises(NotImplementedError, match="partial-env heterogeneous coverage"):
+        sim_utils.resolve_matching_prims_from_source(r"(?:/World/envs/env_.*/Robot/base)")
+
+
+def test_resolve_matching_prims_rejects_regex_for_only_later_clone(monkeypatch):
+    """A later-environment match remains owned by the first clone source."""
+    source_path = "/World/prototypes/Robot"
+    sim_utils.create_prim(f"{source_path}/base", "Xform")
+    sim_utils.create_prim("/World/envs/env_1/Robot/base", "Xform")
+    plan = ClonePlan(
+        sources=(source_path,),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    with pytest.raises(NotImplementedError, match="matched only environments"):
+        sim_utils.resolve_matching_prims_from_source(r"(?:/World/envs/env_1/Robot/base)")
+
+
+def test_resolve_matching_prims_uses_first_authored_source_only(monkeypatch):
+    """An equivalent environment regex is evaluated only below its first source."""
+
+    class _NoClonePlanContext:
+        def get_clone_plan(self):
+            return None
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _NoClonePlanContext())
+
+    env_0_path = "/World/envs/env_0/Robot/base"
+    env_1_path = "/World/envs/env_1/Robot/base"
+    sim_utils.create_prim(env_0_path, "Xform")
+    sim_utils.create_prim(env_1_path, "Xform")
+
+    predicate_paths = []
+
+    def record_match(prim):
+        predicate_paths.append(prim.GetPath().pathString)
+        return True
+
+    matches = sim_utils.resolve_matching_prims_from_source(
+        r"(?:/World/envs/env_[0-9]+/Robot/base)", predicate=record_match
+    )
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (env_0_path, "/World/envs/env_.*/Robot/base")
+    ]
+    assert predicate_paths == [env_0_path]
+
+
+def test_resolve_matching_prims_uses_clone_plan_environment_ids(monkeypatch):
+    """Clone-mask columns map through the plan's target environment ids."""
+    source_path = "/World/prototypes/Robot"
+    body_path = f"{source_path}/base"
+    sim_utils.create_prim(body_path, "Xform")
+    plan = ClonePlan(
+        sources=(source_path,),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+        env_ids=torch.tensor([3, 7]),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/World/envs/env_(3|7)/Robot/base)")
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (body_path, "/World/envs/env_*/Robot/base")
+    ]
+
+
+def test_resolve_matching_prims_prefers_nearest_clone_owner(monkeypatch):
+    """A nested clone destination owns its subtree over a parent destination."""
+    scene_source = "/World/prototypes/Scene"
+    robot_source = "/World/prototypes/Robot"
+    parent_body_path = f"{scene_source}/Robot/base"
+    child_body_path = f"{robot_source}/base"
+    sim_utils.create_prim(parent_body_path, "Xform")
+    sim_utils.create_prim(child_body_path, "Xform")
+    plan = ClonePlan(
+        sources=(scene_source, robot_source),
+        destinations=("/World/envs/env_{}", "/World/envs/env_{}/Robot"),
+        clone_mask=torch.ones((2, 2), dtype=torch.bool),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    matches = sim_utils.resolve_matching_prims_from_source(r"(?:/World/envs/env_.*/Robot/base)")
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (child_body_path, "/World/envs/env_*/Robot/base")
+    ]
+
+
+def test_resolve_matching_prims_does_not_fall_back_to_parent_clone_owner(monkeypatch):
+    """A nested destination owns its subtree even when its source lacks the matching prim."""
+    scene_source = "/World/prototypes/Scene"
+    robot_source = "/World/prototypes/Robot"
+    sim_utils.create_prim(f"{scene_source}/Robot/base", "Xform")
+    sim_utils.create_prim(robot_source, "Xform")
+    plan = ClonePlan(
+        sources=(scene_source, robot_source),
+        destinations=("/World/envs/env_{}", "/World/envs/env_{}/Robot"),
+        clone_mask=torch.ones((2, 2), dtype=torch.bool),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    with pytest.raises(RuntimeError, match="No prim found"):
+        sim_utils.resolve_matching_prims_from_source(r"(?:/World/envs/env_.*/Robot/base)")
+
+
+def test_resolve_matching_prims_uses_first_clone_variant_only(monkeypatch):
+    """The predicate is evaluated on the selected source variant only."""
+    first_source = "/World/prototypes/RobotA"
+    second_source = "/World/prototypes/RobotB"
+    first_body_path = f"{first_source}/base"
+    second_body_path = f"{second_source}/base"
+    sim_utils.create_prim(first_body_path, "Xform")
+    sim_utils.create_prim(second_body_path, "Xform")
+    UsdPhysics.RigidBodyAPI.Apply(sim_utils.get_current_stage().GetPrimAtPath(first_body_path))
+    plan = ClonePlan(
+        sources=(first_source, second_source),
+        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Robot"),
+        clone_mask=torch.tensor([[True, False], [False, True]]),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    predicate_paths = []
+
+    def has_rigid_body_api(prim):
+        predicate_paths.append(prim.GetPath().pathString)
+        return bool(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+
+    matches = sim_utils.resolve_matching_prims_from_source(
+        r"(?:/World/envs/env_.*/Robot/base)", predicate=has_rigid_body_api
+    )
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [
+        (first_body_path, "/World/envs/env_*/Robot/base")
+    ]
+    assert predicate_paths == [first_body_path]
+
+
+def test_resolve_matching_global_prim_under_env_parent(monkeypatch):
+    """A clone plan does not hide a global prim below the environment parent."""
+
+    source_path = "/World/prototypes/Robot"
+    sim_utils.create_prim(f"{source_path}/base", "Xform")
+    plan = ClonePlan(
+        sources=(source_path,),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+    )
+
+    class _ClonePlanContext:
+        def get_clone_plan(self):
+            return plan
+
+    monkeypatch.setattr(query_utils.SimulationContext, "instance", lambda: _ClonePlanContext())
+
+    sim_utils.create_prim("/World/envs/env_0/Robot/base", "Xform")
+    global_path = "/World/envs/shared/Marker"
+    sim_utils.create_prim(global_path, "Xform")
+
+    matches = sim_utils.resolve_matching_prims_from_source(f"(?:{global_path})")
+
+    assert [(prim.GetPath().pathString, destination) for prim, destination in matches] == [(global_path, global_path)]
 
 
 def test_get_all_matching_child_prims():

--- a/source/isaaclab_newton/changelog.d/frame-transformer-prim-path-regex.minor.rst
+++ b/source/isaaclab_newton/changelog.d/frame-transformer-prim-path-regex.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added direct ``prim_path_regex`` matching to the Newton frame transformer while
+  preserving recursive descendant lookup for legacy ``prim_path``
+  configurations.

--- a/source/isaaclab_newton/isaaclab_newton/sensors/frame_transformer/frame_transformer.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/frame_transformer/frame_transformer.py
@@ -62,35 +62,42 @@ class FrameTransformer(BaseFrameTransformer):
         self._stride: int = 0
 
         self._sensor_index: int | None = None
-        self._source_frame_body_name: str = cfg.prim_path.rsplit("/", 1)[-1]
+        self._source_body_pattern = self._source_prim_path_expr
+        # Replaced with the resolved body name once Newton materializes the registered sites.
+        self._source_frame_body_name = self._source_prim_path.rsplit("/", 1)[-1]
 
         # Register world-origin reference site
         self._world_origin_label = NewtonManager.cl_register_site(None, wp.transform())
 
         # Register source site
         source_offset = wp.transform(cfg.source_frame_offset.pos, cfg.source_frame_offset.rot)
-        self._source_label = NewtonManager.cl_register_site(cfg.prim_path, source_offset)
+        self._source_label = NewtonManager.cl_register_site(self._source_body_pattern, source_offset)
 
         # Register target sites
         self._target_labels: list[str] = []
+        self._target_body_patterns: list[str] = []
         self._target_frame_body_names: list[str] = []
         self._num_targets: int = 0
 
-        for target_frame in cfg.target_frames:
+        for target_frame, target_prim_path, target_body_pattern in zip(
+            cfg.target_frames, self._target_prim_paths, self._target_prim_path_exprs
+        ):
             target_offset = wp.transform(target_frame.offset.pos, target_frame.offset.rot)
-            label = NewtonManager.cl_register_site(target_frame.prim_path, target_offset)
+            label = NewtonManager.cl_register_site(target_body_pattern, target_offset)
 
             self._target_labels.append(label)
-            body_name = target_frame.prim_path.rsplit("/", 1)[-1]
+            self._target_body_patterns.append(target_body_pattern)
+            body_name = target_prim_path.rsplit("/", 1)[-1]
             self._target_frame_body_names.append(target_frame.name or body_name)
             self._num_targets += 1
 
         # Set target frame names for base class find_bodies() and data container
-        self._target_frame_names = [t.name or t.prim_path.rsplit("/", 1)[-1] for t in cfg.target_frames]
+        self._target_frame_names = self._target_frame_body_names.copy()
         self._data._target_frame_names = self._target_frame_names
 
         logger.info(
-            f"FrameTransformer '{cfg.prim_path}': source='{self._source_frame_body_name}', "
+            f"FrameTransformer '{self._source_prim_path}': "
+            f"source='{self._source_frame_body_name}', "
             f"{self._num_targets} target(s) registered"
         )
 
@@ -130,24 +137,26 @@ class FrameTransformer(BaseFrameTransformer):
         world_origin_idx, _ = site_map[self._world_origin_label]
         source_indices, target_per_world = self._validate_site_map(
             self._source_label,
-            self.cfg.prim_path,
+            self._source_prim_path,
             self._target_labels,
-            [t.prim_path for t in self.cfg.target_frames],
+            self._target_prim_paths,
             site_map,
             num_envs,
         )
 
         # Expand targets and build sensor index lists
+        shape_labels = NewtonManager._builder.shape_label
         expanded_names, target_indices_per_target, shapes_list, references_list = self._build_sensor_index_lists(
             source_indices,
             target_per_world,
-            self._target_frame_body_names,
-            NewtonManager._builder.shape_label,
+            [target_frame.name for target_frame in self.cfg.target_frames],
+            shape_labels,
             world_origin_idx,
             num_envs,
         )
 
         # Update instance state with expanded values
+        self._source_frame_body_name = shape_labels[source_indices[0]].rsplit("/", 2)[-2]
         self._num_targets = len(target_indices_per_target)
         self._target_frame_names = expanded_names
         self._target_frame_body_names = expanded_names
@@ -249,7 +258,7 @@ class FrameTransformer(BaseFrameTransformer):
     def _build_sensor_index_lists(
         source_indices: list[int],
         target_per_world: list[list[list[int]]],
-        target_frame_body_names: list[str],
+        target_frame_names: list[str | None],
         shape_labels: list[str],
         world_origin_idx: int,
         num_envs: int,
@@ -260,7 +269,7 @@ class FrameTransformer(BaseFrameTransformer):
             source_indices: Per-env source site indices, length ``num_envs``.
             target_per_world: Per-target-config, per-world, per-body site indices.
                 Shape: ``[num_target_cfgs][num_envs][n_bodies_per_env]``.
-            target_frame_body_names: Config-level name for each target config entry.
+            target_frame_names: Optional user-provided name for each target config entry.
             shape_labels: ``builder.shape_label`` — maps shape index to its label string.
                 Site labels have the form ``"{body_name}/{site_label}"``; the body name
                 is extracted for wildcard expansion.
@@ -281,13 +290,13 @@ class FrameTransformer(BaseFrameTransformer):
             for k in range(n_bodies):
                 per_env = [per_world[env_idx][k] for env_idx in range(num_envs)]
                 target_indices_per_target.append(per_env)
-                # For wildcards (n_bodies > 1), derive the bare body name from the
-                # site label ("{body_path}/{site_label}") using env 0.
-                if n_bodies > 1:
+                # Preserve an explicit name for a single target. Otherwise derive the
+                # resolved body name from the site label ("{body_path}/{site_label}").
+                if n_bodies == 1 and target_frame_names[tgt_idx] is not None:
+                    expanded_names.append(target_frame_names[tgt_idx])
+                else:
                     site_idx = per_world[0][k]
                     expanded_names.append(shape_labels[site_idx].rsplit("/", 2)[-2])
-                else:
-                    expanded_names.append(target_frame_body_names[tgt_idx])
 
         num_targets = len(target_indices_per_target)
         shapes_list: list[int] = []
@@ -307,7 +316,7 @@ class FrameTransformer(BaseFrameTransformer):
     def _update_buffers_impl(self, env_mask: wp.array):
         """Copies transforms from Newton sensor into owned buffers."""
         if self._newton_transforms is None:
-            raise RuntimeError(f"FrameTransformer '{self.cfg.prim_path}': sensor is not initialized")
+            raise RuntimeError(f"FrameTransformer '{self._source_prim_path}': sensor is not initialized")
         wp.launch(
             copy_from_newton_kernel,
             dim=(self._num_envs, 1 + self._num_targets),
@@ -345,10 +354,10 @@ class FrameTransformer(BaseFrameTransformer):
         self._world_origin_label = NewtonManager.cl_register_site(None, wp.transform())
 
         source_offset = wp.transform(self.cfg.source_frame_offset.pos, self.cfg.source_frame_offset.rot)
-        self._source_label = NewtonManager.cl_register_site(self.cfg.prim_path, source_offset)
+        self._source_label = NewtonManager.cl_register_site(self._source_body_pattern, source_offset)
 
         self._target_labels = []
-        for target_frame in self.cfg.target_frames:
+        for target_frame, target_body_pattern in zip(self.cfg.target_frames, self._target_body_patterns):
             target_offset = wp.transform(target_frame.offset.pos, target_frame.offset.rot)
-            label = NewtonManager.cl_register_site(target_frame.prim_path, target_offset)
+            label = NewtonManager.cl_register_site(target_body_pattern, target_offset)
             self._target_labels.append(label)

--- a/source/isaaclab_newton/test/sensors/test_frame_transformer.py
+++ b/source/isaaclab_newton/test/sensors/test_frame_transformer.py
@@ -97,6 +97,24 @@ def sim():
     # Cleanup is handled by build_simulation_context
 
 
+@pytest.mark.isaacsim_ci
+def test_frame_transformer_resolves_source_from_unique_descendant(sim):
+    """A legacy container source path uses its single rigid-body descendant."""
+    scene_cfg = MySceneCfg(num_envs=2, env_spacing=2.0, lazy_sensor_update=False)
+    scene_cfg.cube.prim_path = "{ENV_REGEX_NS}/Group/cube"
+    scene_cfg.frame_transformer = FrameTransformerCfg(
+        prim_path="{ENV_REGEX_NS}/Group",
+        target_frames=[FrameTransformerCfg.FrameCfg(prim_path_regex="{ENV_REGEX_NS}/Group/cube")],
+    )
+    scene = InteractiveScene(scene_cfg)
+
+    sim.reset()
+
+    sensor = scene.sensors["frame_transformer"]
+    assert sensor._source_frame_body_name == "cube"
+    assert sensor.data.target_frame_names == ["cube"]
+
+
 def test_frame_transformer_feet_wrt_base(sim):
     """Test feet transformations w.r.t. base source frame.
 
@@ -532,10 +550,10 @@ def test_frame_transformer_all_bodies(sim):
     # Spawn things into stage
     scene_cfg = MySceneCfg(num_envs=2, env_spacing=5.0, lazy_sensor_update=False)
     scene_cfg.frame_transformer = FrameTransformerCfg(
-        prim_path="{ENV_REGEX_NS}/Robot/base",
+        prim_path_regex="{ENV_REGEX_NS}/Robot/base",
         target_frames=[
             FrameTransformerCfg.FrameCfg(
-                prim_path="{ENV_REGEX_NS}/Robot/.*",
+                prim_path_regex="{ENV_REGEX_NS}/Robot/.*",
             ),
         ],
     )
@@ -544,7 +562,9 @@ def test_frame_transformer_all_bodies(sim):
     # Play the simulator
     sim.reset()
 
-    target_frame_names = scene.sensors["frame_transformer"].data.target_frame_names
+    frame_transformer = scene.sensors["frame_transformer"]
+    assert frame_transformer._source_frame_body_name == "base"
+    target_frame_names = frame_transformer.data.target_frame_names
     articulation_body_names = scene.articulations["robot"].data.body_names
 
     reordering_indices = [target_frame_names.index(name) for name in articulation_body_names]

--- a/source/isaaclab_ovphysx/changelog.d/frame-transformer-prim-path-regex.minor.rst
+++ b/source/isaaclab_ovphysx/changelog.d/frame-transformer-prim-path-regex.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added direct ``prim_path_regex`` matching to the OV PhysX frame transformer
+  while preserving recursive descendant lookup for legacy ``prim_path``
+  configurations.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sensors/frame_transformer/frame_transformer.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sensors/frame_transformer/frame_transformer.py
@@ -165,24 +165,26 @@ class FrameTransformer(BaseFrameTransformer):
         # the prim, check that it has the appropriate rigid body API in a single loop.
         # First element is None because user can't specify source frame name
         frames = [None] + [target_frame.name for target_frame in self.cfg.target_frames]
-        frame_prim_paths = [self.cfg.prim_path] + [target_frame.prim_path for target_frame in self.cfg.target_frames]
+        frame_prim_path_exprs = [self._source_prim_path_expr] + self._target_prim_path_exprs
         # First element is None because source frame offset is handled separately
         frame_offsets = [None] + [target_frame.offset for target_frame in self.cfg.target_frames]
         frame_types = ["source"] + ["target"] * len(self.cfg.target_frames)
-        for frame, prim_path, offset, frame_type in zip(frames, frame_prim_paths, frame_offsets, frame_types):
-            # Resolve source-side env prims and destination expressions. This keeps discovery plan-aware when
-            # the active clone plan has physics clones without authored USD prims for every environment.
-            def has_rigid_body_api(prim) -> bool:
-                return bool(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        resolved_source_body_name = self._get_relative_body_path(self.cfg.prim_path)
 
+        def has_rigid_body_api(prim) -> bool:
+            return bool(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+
+        for frame, path_expr, offset, frame_type in zip(frames, frame_prim_path_exprs, frame_offsets, frame_types):
             matches = resolve_matching_prims_from_source(
-                prim_path, predicate=has_rigid_body_api, raise_if_no_matches=False
+                path_expr, predicate=has_rigid_body_api, raise_if_no_matches=False
             )
             if not matches:
                 raise ValueError(
-                    f"Failed to create frame transformer for frame '{frame}' with path '{prim_path}'."
+                    f"Failed to create frame transformer for frame '{frame}' with path '{path_expr}'."
                     " No matching rigid-body prims were found."
                 )
+            if frame_type == "source":
+                resolved_source_body_name = self._get_relative_body_path(matches[0][1])
             for prim, matching_prim_path in matches:
                 # Get the name of the body: use relative prim path for unique identification
                 body_name = self._get_relative_body_path(matching_prim_path)
@@ -296,8 +298,8 @@ class FrameTransformer(BaseFrameTransformer):
         # -- target frames: use relative prim path for unique identification
         self._target_frame_body_names = [self._get_relative_body_path(prim_path) for prim_path in sorted_prim_paths]
 
-        # -- source frame: use relative prim path for unique identification
-        self._source_frame_body_name = self._get_relative_body_path(self.cfg.prim_path)
+        # -- source frame: use the resolved rigid-body path, which may be below a configured container path
+        self._source_frame_body_name = resolved_source_body_name
         source_frame_index = self._target_frame_body_names.index(self._source_frame_body_name)
 
         # Only remove source frame from tracked bodies if it is not also a target frame

--- a/source/isaaclab_ovphysx/test/sensors/test_frame_transformer.py
+++ b/source/isaaclab_ovphysx/test/sensors/test_frame_transformer.py
@@ -629,6 +629,25 @@ def test_frame_transformer_offset_frames(device):
             torch.testing.assert_close(cube_quat_bottom, cube_quat_w_gt)
 
 
+def test_frame_transformer_resolves_source_from_unique_descendant():
+    """A legacy container source path uses its single rigid-body descendant."""
+    with _ovphysx_sim_context(device="cpu") as sim:
+        sim._app_control_on_stop_handle = None
+        scene_cfg = _SceneCfg(num_envs=2, env_spacing=2.0, lazy_sensor_update=False)
+        scene_cfg.cube.prim_path = "{ENV_REGEX_NS}/Group/cube"
+        scene_cfg.frame_transformer = FrameTransformerCfg(
+            prim_path="{ENV_REGEX_NS}/Group",
+            target_frames=[FrameTransformerCfg.FrameCfg(prim_path_regex="{ENV_REGEX_NS}/Group/cube")],
+        )
+        scene = InteractiveScene(scene_cfg)
+
+        sim.reset()
+
+        sensor = scene.sensors["frame_transformer"]
+        assert sensor._source_frame_body_name.endswith("/Group/cube")
+        assert sensor.data.target_frame_names == ["cube"]
+
+
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 def test_frame_transformer_all_bodies(device):
     """Test transformation of all bodies w.r.t. base source frame.
@@ -642,10 +661,10 @@ def test_frame_transformer_all_bodies(device):
         # Spawn things into stage
         scene_cfg = _SceneCfg(num_envs=2, env_spacing=5.0, lazy_sensor_update=False)
         scene_cfg.frame_transformer = FrameTransformerCfg(
-            prim_path="{ENV_REGEX_NS}/Robot/base",
+            prim_path_regex="{ENV_REGEX_NS}/Robot/base",
             target_frames=[
                 FrameTransformerCfg.FrameCfg(
-                    prim_path="{ENV_REGEX_NS}/Robot/.*",
+                    prim_path_regex="{ENV_REGEX_NS}/Robot/.*",
                 ),
             ],
         )

--- a/source/isaaclab_physx/changelog.d/frame-transformer-prim-path-regex.minor.rst
+++ b/source/isaaclab_physx/changelog.d/frame-transformer-prim-path-regex.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added direct ``prim_path_regex`` matching to the PhysX frame transformer while
+  preserving recursive descendant lookup for legacy ``prim_path``
+  configurations.

--- a/source/isaaclab_physx/isaaclab_physx/sensors/frame_transformer/frame_transformer.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/frame_transformer/frame_transformer.py
@@ -180,23 +180,26 @@ class FrameTransformer(BaseFrameTransformer):
         # the prim, check that it has the appropriate rigid body API in a single loop.
         # First element is None because user can't specify source frame name
         frames = [None] + [target_frame.name for target_frame in self.cfg.target_frames]
-        frame_prim_paths = [self.cfg.prim_path] + [target_frame.prim_path for target_frame in self.cfg.target_frames]
+        frame_prim_path_exprs = [self._source_prim_path_expr] + self._target_prim_path_exprs
         # First element is None because source frame offset is handled separately
         frame_offsets = [None] + [target_frame.offset for target_frame in self.cfg.target_frames]
         frame_types = ["source"] + ["target"] * len(self.cfg.target_frames)
-        for frame, prim_path, offset, frame_type in zip(frames, frame_prim_paths, frame_offsets, frame_types):
-            # Resolve the source-side env prims (filtered to rigid bodies) and their destination
-            # expressions. Plan-aware: with an active ``ClonePlan``, only env-0 representatives
-            # are walked and dest expressions are rebuilt against the plan's destination glob.
-            def has_rigid_body_api(prim) -> bool:
-                return bool(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        resolved_source_body_name = self._get_relative_body_path(self.cfg.prim_path)
 
-            matches = resolve_matching_prims_from_source(prim_path, has_rigid_body_api, raise_if_no_matches=False)
+        def has_rigid_body_api(prim) -> bool:
+            return bool(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+
+        for frame, path_expr, offset, frame_type in zip(frames, frame_prim_path_exprs, frame_offsets, frame_types):
+            matches = resolve_matching_prims_from_source(
+                path_expr, predicate=has_rigid_body_api, raise_if_no_matches=False
+            )
             if not matches:
                 raise ValueError(
-                    f"Failed to create frame transformer for frame '{frame}' with path '{prim_path}'."
+                    f"Failed to create frame transformer for frame '{frame}' with path '{path_expr}'."
                     " No matching rigid-body prims were found."
                 )
+            if frame_type == "source":
+                resolved_source_body_name = self._get_relative_body_path(matches[0][1])
             for prim, matching_prim_path in matches:
                 # Get the name of the body: use relative prim path for unique identification
                 body_name = self._get_relative_body_path(matching_prim_path)
@@ -298,8 +301,8 @@ class FrameTransformer(BaseFrameTransformer):
         # -- target frames: use relative prim path for unique identification
         self._target_frame_body_names = [self._get_relative_body_path(prim_path) for prim_path in sorted_prim_paths]
 
-        # -- source frame: use relative prim path for unique identification
-        self._source_frame_body_name = self._get_relative_body_path(self.cfg.prim_path)
+        # -- source frame: use the resolved rigid-body path, which may be below a configured container path
+        self._source_frame_body_name = resolved_source_body_name
         source_frame_index = self._target_frame_body_names.index(self._source_frame_body_name)
 
         # Only remove source frame from tracked bodies if it is not also a target frame

--- a/source/isaaclab_physx/test/sensors/test_frame_transformer.py
+++ b/source/isaaclab_physx/test/sensors/test_frame_transformer.py
@@ -90,6 +90,37 @@ def sim(request):
     # Cleanup is handled by build_simulation_context
 
 
+@pytest.mark.isaacsim_ci
+def test_frame_transformer_resolves_source_from_unique_descendant(sim):
+    """A legacy container source path uses its single rigid-body descendant."""
+
+    @configclass
+    class SingleRigidSceneCfg(InteractiveSceneCfg):
+        terrain = TerrainImporterCfg(prim_path="/World/ground", terrain_type="plane")
+        cube = RigidObjectCfg(
+            prim_path="{ENV_REGEX_NS}/Group/cube",
+            spawn=sim_utils.CuboidCfg(
+                size=(0.2, 0.2, 0.2),
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(),
+                mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            ),
+            init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
+        )
+        frame_transformer = FrameTransformerCfg(
+            prim_path="{ENV_REGEX_NS}/Group",
+            target_frames=[FrameTransformerCfg.FrameCfg(prim_path_regex="{ENV_REGEX_NS}/Group/cube")],
+        )
+
+    scene = InteractiveScene(SingleRigidSceneCfg(num_envs=2, env_spacing=2.0, lazy_sensor_update=False))
+    sim.reset()
+
+    sensor = scene.sensors["frame_transformer"]
+    assert sensor._source_frame_body_name.endswith("/Group/cube")
+    assert sensor.data.target_frame_names == ["cube"]
+
+
+
+
 @pytest.mark.parametrize(
     "sim",
     [
@@ -529,10 +560,10 @@ def test_frame_transformer_all_bodies(sim):
     # Spawn things into stage
     scene_cfg = MySceneCfg(num_envs=2, env_spacing=5.0, lazy_sensor_update=False)
     scene_cfg.frame_transformer = FrameTransformerCfg(
-        prim_path="{ENV_REGEX_NS}/Robot/base",
+        prim_path_regex="{ENV_REGEX_NS}/Robot/base",
         target_frames=[
             FrameTransformerCfg.FrameCfg(
-                prim_path="{ENV_REGEX_NS}/Robot/.*",
+                prim_path_regex="{ENV_REGEX_NS}/Robot/.*",
             ),
         ],
     )


### PR DESCRIPTION
## Summary
- add mutually exclusive `prim_path` / `prim_path_regex` fields for FrameTransformer source and target frames
- normalize explicit regexes as `(?:<regex>)`
- normalize deprecated `prim_path` values as `(?:<path>)(?:/.*)?`
- parse that normalized expression inside `resolve_matching_prims_from_source`
- keep PhysX and OV PhysX on one resolver call; Newton consumes the same final expression

## Matching semantics
- `prim_path_regex="/World/.../Robot/pelvis"`: filter only the directly matched pelvis prim
- `prim_path_regex="/World/.../Robot/.*"`: filter prims selected by that expression
- `prim_path="/World/.../Robot"` (deprecated): preserve recursive descendant lookup
- specifying both public fields, or neither, raises when the sensor is constructed

Existing unwrapped callers of `resolve_matching_prims_from_source` retain their previous recursive predicate behavior.

## Validation
- path selection guard: 4 passed
- normalized resolver tests: 7 passed
- PhysX FrameTransformer suite: 11 passed
- Newton FrameTransformer suite: 11 passed
- OV PhysX module reaches its expected capability-gated skip
- changed-file pre-commit: passed
- changelog fragment check: passed
