### PR TITLE
Optimize local-only wrench composition

### DIFF
--- a/source/isaaclab/isaaclab/utils/wrench_composer.py
+++ b/source/isaaclab/isaaclab/utils/wrench_composer.py
@@ -66,6 +66,7 @@ class WrenchComposer:
         self._asset = asset
         self._active = False
         self._dirty = False
+        self._uses_global_frame = False
         if hasattr(self._asset.data, "body_com_pos_w"):
             self._get_com_pos_fn = lambda a=self._asset: a.data.body_com_pos_w.warp
         else:
@@ -112,8 +113,9 @@ class WrenchComposer:
         require scanning the buffers, defeating the purpose of a cheap guard.
 
         This means the flag may remain ``True`` even if all buffers are zero after partial resets.
-        This is by design: the cost of an unnecessary compose + apply on zero data is negligible
-        compared to scanning the buffers every frame.
+        This is by design: checking whether all environments are zero would require scanning the
+        buffers every frame. Local-frame wrenches cache their composed output to avoid pose reads
+        when the inputs have not changed.
         """
         return self._active
 
@@ -263,8 +265,7 @@ class WrenchComposer:
             )
             return
 
-        self._active = True
-        self._dirty = True
+        self._invalidate_composed_wrench(is_global)
 
         wp.launch(
             add_forces_to_dual_buffers_index,
@@ -326,8 +327,7 @@ class WrenchComposer:
         # Clear input buffers for the targeted environments before writing
         self.reset(env_ids=env_ids)
 
-        self._active = True
-        self._dirty = True
+        self._invalidate_composed_wrench(is_global)
 
         wp.launch(
             set_forces_to_dual_buffers_index,
@@ -386,8 +386,7 @@ class WrenchComposer:
             )
             return
 
-        self._active = True
-        self._dirty = True
+        self._invalidate_composed_wrench(is_global)
 
         wp.launch(
             add_forces_to_dual_buffers_mask,
@@ -451,8 +450,7 @@ class WrenchComposer:
         # Clear input buffers for the masked environments before writing
         self.reset(env_mask=env_mask)
 
-        self._active = True
-        self._dirty = True
+        self._invalidate_composed_wrench(is_global)
 
         wp.launch(
             set_forces_to_dual_buffers_mask,
@@ -493,6 +491,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._uses_global_frame = self._uses_global_frame or other._uses_global_frame
 
         wp.launch(
             add_raw_wrench_buffers,
@@ -521,9 +520,15 @@ class WrenchComposer:
 
         The dirty flag is cleared after composition.
         """
+        if not self._uses_global_frame:
+            if self._dirty:
+                wp.copy(self._out_force_b, self._local_force_b)
+                wp.copy(self._out_torque_b, self._local_torque_b)
+                self._dirty = False
+            return
+
         com_pos_w = self._get_com_pos_fn()
         link_quat_w = self._get_link_quat_fn()
-
         wp.launch(
             compose_wrench_to_body_frame,
             dim=(self.num_envs, self.num_bodies),
@@ -570,6 +575,7 @@ class WrenchComposer:
             self._out_torque_b.zero_()
             self._active = False
             self._dirty = False
+            self._uses_global_frame = False
         elif env_mask is not None:
             wp.launch(
                 reset_wrench_composer_mask,
@@ -662,6 +668,13 @@ class WrenchComposer:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _invalidate_composed_wrench(self, is_global: bool):
+        """Invalidate cached body-frame outputs after input-buffer writes."""
+        self._active = True
+        self._dirty = True
+        if is_global:
+            self._uses_global_frame = True
 
     def _resolve_env_ids(self, env_ids: wp.array | torch.Tensor | list | slice | None) -> wp.array:
         """Resolve environment IDs to a warp int32 array.

--- a/source/isaaclab/test/utils/test_wrench_composer.py
+++ b/source/isaaclab/test/utils/test_wrench_composer.py
@@ -1443,6 +1443,79 @@ def test_lazy_composition_tracks_dirty_flag(device: str):
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_local_only_composition_does_not_query_pose(device: str):
+    """Local-frame wrenches are already in body frame and do not require pose reads."""
+    num_envs, num_bodies = 4, 3
+    rng = np.random.default_rng(seed=72)
+
+    mock_asset = create_mock_asset(num_envs, num_bodies, device)
+    composer = WrenchComposer(mock_asset)
+
+    def fail_com_pos():
+        raise AssertionError("body CoM position should not be queried for local-frame wrenches")
+
+    def fail_link_quat():
+        raise AssertionError("body link orientation should not be queried for local-frame wrenches")
+
+    composer._get_com_pos_fn = fail_com_pos
+    composer._get_link_quat_fn = fail_link_quat
+
+    forces_np = rng.uniform(-10.0, 10.0, (num_envs, num_bodies, 3)).astype(np.float32)
+    torques_np = rng.uniform(-5.0, 5.0, (num_envs, num_bodies, 3)).astype(np.float32)
+    composer.add_forces_and_torques_index(
+        forces=wp.from_numpy(forces_np, dtype=wp.vec3f, device=device),
+        torques=wp.from_numpy(torques_np, dtype=wp.vec3f, device=device),
+    )
+
+    composer.compose_to_body_frame()
+    np.testing.assert_allclose(composer.out_force_b.warp.numpy(), forces_np, atol=1e-4, rtol=1e-5)
+    np.testing.assert_allclose(composer.out_torque_b.warp.numpy(), torques_np, atol=1e-4, rtol=1e-5)
+
+    # A second compose without writes should be a no-op for local-frame inputs.
+    composer.compose_to_body_frame()
+    np.testing.assert_allclose(composer.out_force_b.warp.numpy(), forces_np, atol=1e-4, rtol=1e-5)
+    np.testing.assert_allclose(composer.out_torque_b.warp.numpy(), torques_np, atol=1e-4, rtol=1e-5)
+
+
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_global_positioned_composition_queries_pose_each_call(device: str):
+    """Global forces with positions remain pose-dependent even when input buffers are clean."""
+    num_envs, num_bodies = 2, 2
+    rng = np.random.default_rng(seed=73)
+
+    mock_asset = create_mock_asset(num_envs, num_bodies, device)
+    composer = WrenchComposer(mock_asset)
+
+    call_counts = {"com_pos": 0, "link_quat": 0}
+    get_com_pos_fn = composer._get_com_pos_fn
+    get_link_quat_fn = composer._get_link_quat_fn
+
+    def counted_com_pos():
+        call_counts["com_pos"] += 1
+        return get_com_pos_fn()
+
+    def counted_link_quat():
+        call_counts["link_quat"] += 1
+        return get_link_quat_fn()
+
+    composer._get_com_pos_fn = counted_com_pos
+    composer._get_link_quat_fn = counted_link_quat
+
+    forces_np = rng.uniform(-10.0, 10.0, (num_envs, num_bodies, 3)).astype(np.float32)
+    positions_np = rng.uniform(-1.0, 1.0, (num_envs, num_bodies, 3)).astype(np.float32)
+    composer.add_forces_and_torques_index(
+        forces=wp.from_numpy(forces_np, dtype=wp.vec3f, device=device),
+        positions=wp.from_numpy(positions_np, dtype=wp.vec3f, device=device),
+        is_global=True,
+    )
+
+    composer.compose_to_body_frame()
+    composer.compose_to_body_frame()
+
+    assert call_counts == {"com_pos": 2, "link_quat": 2}
+
+
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_compose_is_idempotent(device: str):
     """Calling compose_to_body_frame twice without intervening writes produces the same result."""
     rng = np.random.default_rng(seed=456)


### PR DESCRIPTION
## Summary
- Track whether a WrenchComposer has ever received world-frame inputs since its last full reset.
- Fast-path local-only composition by copying local force/torque buffers into the body-frame outputs only when dirty.
- Preserve per-call pose refresh for world-frame positioned forces, which remain pose-dependent.

## Tests
- ./isaaclab.sh -p -m pytest source/isaaclab/test/utils/test_wrench_composer.py -k "local_only_composition_does_not_query_pose or global_positioned_composition_queries_pose_each_call or lazy_composition_tracks_dirty_flag or compose_is_idempotent" -q
- ./isaaclab.sh -p -m pytest source/isaaclab/test/utils/test_wrench_composer.py -q
- ./isaaclab.sh -p -m py_compile source/isaaclab/isaaclab/utils/wrench_composer.py source/isaaclab/test/utils/test_wrench_composer.py
- git diff --check

Ruff was not run because the local IsaacLab venv does not have the ruff module installed.