### PR TITLE
Added support for normals in ovrtx and render correctness validation for normals for all renderers

### DIFF
--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -44,7 +44,7 @@ The renderer used by a camera is configured via the ``renderer_cfg`` field on
      - rgb, rgba, rgb_hdr, depth, normals, instance segmentation
    * - ``OVRTXRendererCfg``
      - No (+ ``isaaclab_ov``)
-     - rgb, rgba, rgb_hdr, depth, distances, semantic segmentation
+     - rgb, rgba, rgb_hdr, depth, distances, normals, semantic segmentation
 
 .. note::
 
@@ -239,7 +239,7 @@ is :class:`~isaaclab_ov.renderers.OVRTXRendererCfg`, and ``Newton Warp`` is
      - ✅
    * - ``normals``
      - ✅
-     - ❌
+     - ✅
      - ✅
    * - ``motion_vectors``
      - ✅

--- a/source/isaaclab_ov/changelog.d/normals-rendering-validation.rst
+++ b/source/isaaclab_ov/changelog.d/normals-rendering-validation.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added ``"normals"`` support to :class:`~isaaclab_ov.renderers.OVRTXRenderer`. The renderer now
+  declares :attr:`~isaaclab.renderers.RenderBufferKind.NORMALS` in
+  :meth:`~isaaclab_ov.renderers.OVRTXRenderer.supported_output_types` (3-channel ``float32``) and
+  extracts the ``NormalSD`` AOV from each rendered frame into the output buffer.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -246,6 +246,7 @@ class OVRTXRenderer(BaseRenderer):
             RenderBufferKind.DEPTH: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_IMAGE_PLANE: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_CAMERA: RenderBufferSpec(1, wp.float32),
+            RenderBufferKind.NORMALS: RenderBufferSpec(3, wp.float32),
         }
 
     @property
@@ -802,6 +803,22 @@ class OVRTXRenderer(BaseRenderer):
                     output_buffers,
                     "semantic_segmentation",
                     suffix="semantic",
+                )
+
+        if "NormalSD" in frame.render_vars and "normals" in output_buffers:
+            with frame.render_vars["NormalSD"].map(device=Device.CUDA) as mapping:
+                tiled_normals_data = wp.from_dlpack(mapping.tensor)
+                wp.launch(
+                    kernel=extract_all_rgb_float_tiles_kernel,
+                    dim=(render_data.num_envs, render_data.height, render_data.width),
+                    inputs=[
+                        tiled_normals_data,
+                        output_buffers["normals"],
+                        render_data.num_cols,
+                        render_data.width,
+                        render_data.height,
+                    ],
+                    device=self._device,
                 )
 
     def render(self, render_data: OVRTXRenderData) -> None:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -34,7 +34,7 @@ def get_render_var_config(data_types: list[str]) -> tuple[str, str, str]:
         return "/Render/Vars/albedo", "albedo", "DiffuseAlbedoSD"
     if use_semantic and not (use_rgb or use_albedo or use_normals):
         return "/Render/Vars/semantic", "semantic", "SemanticSegmentation"
-    if use_normals and not (use_rgb or use_albedo or use_semantic):
+    if use_normals and not (use_rgb or use_albedo or use_semantic or use_depth):
         return "/Render/Vars/NormalSD", "NormalSD", "NormalSD"
     if use_hdr and not use_rgb:
         return "/Render/Vars/HdrColor", "HdrColor", "HdrColor"

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -23,16 +23,19 @@ def get_render_var_config(data_types: list[str]) -> tuple[str, str, str]:
     )
     use_albedo = "albedo" in data_types
     use_semantic = "semantic_segmentation" in data_types
+    use_normals = "normals" in data_types
     use_rgb = any(dt in ["rgb", "rgba"] for dt in data_types)
     use_hdr = "rgb_hdr" in data_types
 
-    if use_depth and not (use_rgb or use_albedo or use_semantic):
+    if use_depth and not (use_rgb or use_albedo or use_semantic or use_normals):
         source = "DistanceToCameraSD" if use_distance_to_camera else "DistanceToImagePlaneSD"
         return "/Render/Vars/depth", "depth", source
-    if use_albedo and not (use_rgb or use_semantic):
+    if use_albedo and not (use_rgb or use_semantic or use_normals):
         return "/Render/Vars/albedo", "albedo", "DiffuseAlbedoSD"
-    if use_semantic and not (use_rgb or use_albedo):
+    if use_semantic and not (use_rgb or use_albedo or use_normals):
         return "/Render/Vars/semantic", "semantic", "SemanticSegmentation"
+    if use_normals and not (use_rgb or use_albedo or use_semantic):
+        return "/Render/Vars/NormalSD", "NormalSD", "NormalSD"
     if use_hdr and not use_rgb:
         return "/Render/Vars/HdrColor", "HdrColor", "HdrColor"
     return "/Render/Vars/LdrColor", "LdrColor", "LdrColor"

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -85,6 +85,7 @@ def test_ovrtx_supported_output_types_key_set():
         RenderBufferKind.DEPTH,
         RenderBufferKind.DISTANCE_TO_IMAGE_PLANE,
         RenderBufferKind.DISTANCE_TO_CAMERA,
+        RenderBufferKind.NORMALS,
     }
     assert specs[RenderBufferKind.RGBA] == RenderBufferSpec(4, wp.uint8)
     assert specs[RenderBufferKind.RGB_HDR] == RenderBufferSpec(3, wp.float32)

--- a/source/isaaclab_tasks/changelog.d/normals-rendering-validation.rst
+++ b/source/isaaclab_tasks/changelog.d/normals-rendering-validation.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added ``"normals"`` to the rendering correctness validation suite. The ``normals`` data type
+  (float32 surface normal vectors in ``[-1, 1]``) is now included in
+  :data:`~rendering_test_utils._DEFAULT_SENSOR_DATA_TYPES` for all RTX-based renderer
+  combinations and as an explicit parameter for the Newton Warp renderer.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/dexsuite_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/dexsuite_env_cfg.py
@@ -470,7 +470,7 @@ class DexsuiteReorientEnvCfg(ManagerBasedEnvCfg):
     def validate_config(self):
         """Check for invalid preset combinations after resolution."""
 
-        warp_supported = {"rgb", "depth", "distance_to_image_plane"}
+        warp_supported = {"rgb", "depth", "distance_to_image_plane", "normals"}
         for cam_attr in ("base_camera", "wrist_camera"):
             cam = getattr(self.scene, cam_attr, None)
             if cam is None:

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_camera_env_cfg.py
@@ -124,7 +124,7 @@ class ShadowHandCameraEnvCfg(ShadowHandEnvCfg):
     def validate_config(self):
         """Check renderer/data-type and feature-extractor compatibility."""
         renderer_type = getattr(self.tiled_camera.renderer_cfg, "renderer_type", None)
-        warp_supported = {"rgb", "depth"}
+        warp_supported = {"rgb", "depth", "normals"}
         if renderer_type == "newton_warp":
             unsupported = set(self.tiled_camera.data_types) - warp_supported
             if unsupported:

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:516de455bbf77ceafc5c8496e5f7ec6e154ac9efb7c3b51ae3d3a144165be69b
+size 764

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-newton_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e933536d04c93bc9df198a4ac3fcfa8ff4edc25d7c0ee67f23eaaa9aadb91f59
+size 766

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-ovrtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-ovrtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:516de455bbf77ceafc5c8496e5f7ec6e154ac9efb7c3b51ae3d3a144165be69b
+size 764

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e933536d04c93bc9df198a4ac3fcfa8ff4edc25d7c0ee67f23eaaa9aadb91f59
+size 766

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:516de455bbf77ceafc5c8496e5f7ec6e154ac9efb7c3b51ae3d3a144165be69b
+size 764

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:516de455bbf77ceafc5c8496e5f7ec6e154ac9efb7c3b51ae3d3a144165be69b
+size 764

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-newton_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e933536d04c93bc9df198a4ac3fcfa8ff4edc25d7c0ee67f23eaaa9aadb91f59
+size 766

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-isaacsim_rtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-isaacsim_rtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33cce7fdc53de5e4629ef9a45dc0ce850afeb3fcc0ed10ac2005442641ec5b6f
+size 1941

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4627d5925011dae9021c1b455030903c1e6145f41ca7cc5d3a720affdd6bfd48
+size 1966

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-ovrtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-ovrtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33cce7fdc53de5e4629ef9a45dc0ce850afeb3fcc0ed10ac2005442641ec5b6f
+size 1941

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-isaacsim_rtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-isaacsim_rtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d68551c1e2c1deca570da094a0515e700b3a5dcddd324807b228862a09d592e
+size 1940

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-newton_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1af0e88caf3f25cff399dcab1f8f95a09e2f4890062c5666ca22c009978c16f
+size 1956

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-isaacsim_rtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-isaacsim_rtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:011b53a7a713c00dc5e1892285aa4785defe99b2bcbaa7e551dc05b9abe974de
+size 1752

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-newton_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3ba7f28c411e39f3094100c03fdd168f48115be28dd882c81a3d193eba50d60
+size 1754

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-ovrtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-ovrtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:011b53a7a713c00dc5e1892285aa4785defe99b2bcbaa7e551dc05b9abe974de
+size 1752

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-isaacsim_rtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-isaacsim_rtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3009f0ef2b7e67bdeeeaef56d1b8bb800bd3159f3782d1c588f227137238f3e3
+size 1754

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-newton_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cf94b13ed7c4246be2b09767d1be41338446bb0e016cdb0ee4534e6275b0e87
+size 1759

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-isaacsim_rtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-isaacsim_rtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d891d4c2e8388e95d7e9afd659e14a35965b2357579b08bfdb965be36f4fd38
+size 10359

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-newton_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5c94c8085d0f8bbb74418447230b334f5426d5c1400ef3364157d4286dd66b3
+size 10029

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-ovrtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-ovrtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7792ca32acace98625517017dddad0be21ce30d8373bd7f438f32638649180c2
+size 10434

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-isaacsim_rtx_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-isaacsim_rtx_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4e3743174a4c4bcde9d56b7bf3696fe15e6d5401b846a6c910967b4768bc69a
+size 9152

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-newton_renderer-normals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dfc994325bd54c110328a5e79c09eee5cfea3aa2d27ae8e1fd980dcc48b4e2d
+size 9150

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -85,6 +85,7 @@ _DEFAULT_SENSOR_DATA_TYPES = (
     "depth",
     "distance_to_camera",
     "distance_to_image_plane",
+    "normals",
 )
 
 
@@ -121,6 +122,12 @@ PHYSICS_RENDERER_AOV_COMBINATIONS = [
         "depth",
         id="physx-newton_warp-depth",
     ),
+    pytest.param(
+        "physx",
+        "newton_renderer",
+        "normals",
+        id="physx-newton_warp-normals",
+    ),
 ]
 
 KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS = [
@@ -139,6 +146,12 @@ KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS = [
         "depth",
         id="ovphysx-newton_warp-depth",
     ),
+    pytest.param(
+        "ovphysx",
+        "newton_renderer",
+        "normals",
+        id="ovphysx-newton_warp-normals",
+    ),
     # newton + newton_renderer (warp)
     pytest.param(
         "newton",
@@ -151,6 +164,12 @@ KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS = [
         "newton_renderer",
         "depth",
         id="newton-newton_warp-depth",
+    ),
+    pytest.param(
+        "newton",
+        "newton_renderer",
+        "normals",
+        id="newton-newton_warp-normals",
     ),
 ]
 
@@ -229,6 +248,8 @@ def _normalize_tensor(tensor: torch.Tensor, data_type: str) -> torch.Tensor:
             normalized = normalized / max_val
     elif data_type in {"albedo"}:
         normalized = normalized[..., :3] / 255.0
+    elif data_type in {"normals"}:
+        normalized = (normalized + 1.0) * 0.5
     else:
         normalized = normalized / 255.0
 
@@ -550,7 +571,7 @@ def validate_camera_outputs(
         tensor = output if isinstance(output, torch.Tensor) else output.torch
         condition = torch.logical_or(torch.isinf(tensor), torch.isnan(tensor))
         corrected = torch.where(condition, torch.zeros_like(tensor), tensor)
-        max_val = corrected.max()
+        max_val = corrected.abs().max()
         if max_val <= 0:
             failed_data_types[data_type] = f"Camera output '{data_type}' has no non-zero pixels."
             continue
@@ -636,6 +657,7 @@ def rendering_test_shadow_hand(
     class _ShadowHandTiledCameraTestCfg(ShadowHandTiledCameraCfg):
         distance_to_camera = _ShadowHandBaseTiledCameraCfg(data_types=["distance_to_camera"])
         distance_to_image_plane = _ShadowHandBaseTiledCameraCfg(data_types=["distance_to_image_plane"])
+        normals = _ShadowHandBaseTiledCameraCfg(data_types=["normals"])
 
     @configclass
     class _ShadowHandCameraTestEnvCfg(ShadowHandCameraEnvCfg):
@@ -695,6 +717,7 @@ def rendering_test_cartpole(
         distance_to_image_plane = CartpoleTiledCameraCfg.BaseCartpoleTiledCameraCfg(
             data_types=["distance_to_image_plane"]
         )
+        normals = CartpoleTiledCameraCfg.BaseCartpoleTiledCameraCfg(data_types=["normals"])
 
     @configclass
     class _CartpoleCameraTestEnvCfg(CartpoleCameraEnvCfg):
@@ -703,6 +726,9 @@ def rendering_test_cartpole(
         )
         distance_to_image_plane = CartpoleCameraEnvCfg.BaseCartpoleCameraEnvCfg(
             observation_space=[1, 100, 100], tiled_camera=_CartpoleTiledCameraTestCfg()
+        )
+        normals = CartpoleCameraEnvCfg.BaseCartpoleCameraEnvCfg(
+            observation_space=[3, 100, 100], tiled_camera=_CartpoleTiledCameraTestCfg()
         )
 
     env_cfg = _CartpoleCameraTestEnvCfg()
@@ -777,6 +803,9 @@ def rendering_test_dexsuite_kuka(
         distance_to_image_plane256 = BASE_CAMERA_CFG.replace(
             data_types=["distance_to_image_plane"], width=256, height=256
         )
+        normals64 = BASE_CAMERA_CFG.replace(data_types=["normals"], width=64, height=64)
+        normals128 = BASE_CAMERA_CFG.replace(data_types=["normals"], width=128, height=128)
+        normals256 = BASE_CAMERA_CFG.replace(data_types=["normals"], width=256, height=256)
 
     @configclass
     class _DexsuiteSingleCameraTestSceneCfg(SingleCameraSceneCfg):


### PR DESCRIPTION
# Description

- Added support for the "normals" data type in the ovrtx renderer integration
- Added render correctness test coverage for "normals" across applicable physics/renderer combinations

## Screenshots

See new golden images

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [] I have added my name to the `CONTRIBUTORS.md` or my name already exists there