### PR TITLE
Bump h5py version to >=3.16.0

### DIFF
--- a/source/isaaclab_mimic/changelog.d/peterd-bump-h5py.rst
+++ b/source/isaaclab_mimic/changelog.d/peterd-bump-h5py.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+* Bumped the ``h5py`` requirement from a pinned ``==3.15.1`` to ``>=3.16.0``.

--- a/source/isaaclab_mimic/setup.py
+++ b/source/isaaclab_mimic/setup.py
@@ -22,7 +22,7 @@ INSTALL_REQUIRES = [
     # jupyter notebook
     "ipywidgets==8.1.5",
     # data collection
-    "h5py==3.15.1",
+    "h5py>=3.16.0",
 ]
 
 # robomimic has no Windows/macOS wheels; only add it on Linux

--- a/source/isaaclab_rl/changelog.d/peterd-bump-h5py.rst
+++ b/source/isaaclab_rl/changelog.d/peterd-bump-h5py.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+* Bumped the ``h5py`` requirement from a pinned ``==3.15.1`` to ``>=3.16.0``.

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -26,7 +26,7 @@ INSTALL_REQUIRES = [
     # configuration management
     "hydra-core",
     # data collection
-    "h5py==3.15.1",
+    "h5py>=3.16.0",
     # basic logger
     "tensorboard",
     # video recording


### PR DESCRIPTION
# Description

Bumps h5py dep version to >=3.16.0 to be in line with Isaac Sim 6.0 GA which requires 3.16.x

Fixes #6213

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
