### PR TITLE
[CI] Add pinned OVPhysX wheelhouse path for develop

### DIFF
--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -69,6 +69,14 @@ inputs:
     description: 'Space-separated pip packages to install inside the Docker container before pytest starts'
     default: ''
     required: false
+  wheelhouse-resource:
+    description: 'Optional NGC resource containing wheelhouse/ and manifest.json for offline pip installs'
+    default: ''
+    required: false
+  wheelhouse-packages:
+    description: 'Space-separated packages to install from the wheelhouse with pip --no-index'
+    default: ''
+    required: false
   container-name:
     description: 'Docker container name prefix (run-id is appended automatically)'
     required: true
@@ -133,6 +141,130 @@ runs:
         printf "🔵 Image pull took %dm %ds\n" $((elapsed/60)) $((elapsed%60))
         echo "🔵 Docker Image Pulled in ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
 
+    - name: Restore NGC CLI cache
+      if: inputs.wheelhouse-resource != '' && env.NGC_API_KEY != ''
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/ngc-cli-cache/ngccli_linux.zip
+        key: ngc-cli-${{ runner.os }}-${{ runner.arch }}-4.20.0-5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b
+
+    - name: Extract ovphysx wheelhouse
+      id: extract-wheelhouse
+      if: inputs.wheelhouse-resource != ''
+      shell: bash
+      env:
+        WHEELHOUSE_RESOURCE: ${{ inputs.wheelhouse-resource }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${NGC_API_KEY:-}" ]; then
+          echo "::error::wheelhouse-resource is set but NGC_API_KEY is unavailable; cannot download configured wheelhouse resource"
+          exit 1
+        fi
+
+        NGC_CLI_VERSION="4.20.0"
+        NGC_CLI_SHA256="5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b"
+        NGC_CLI_URL="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VERSION}/files/ngccli_linux.zip"
+
+        wheelhouse_root="$(mktemp -d "${RUNNER_TEMP:-/tmp}/ovphysx-wheelhouse.XXXXXX")"
+        download_root="$(mktemp -d "${RUNNER_TEMP:-/tmp}/ovphysx-wheelhouse-download.XXXXXX")"
+        ngc_home="$(mktemp -d "${RUNNER_TEMP:-/tmp}/ovphysx-ngc-home.XXXXXX")"
+        ngc_unpack_dir=""
+        preserve_wheelhouse_root=false
+        cleanup() {
+          if [ "$preserve_wheelhouse_root" != "true" ]; then
+            rm -rf "$wheelhouse_root"
+          fi
+          rm -rf "$download_root" "$ngc_home"
+          if [ -n "$ngc_unpack_dir" ]; then
+            rm -rf "$ngc_unpack_dir"
+          fi
+        }
+        trap cleanup EXIT
+
+        if ! command -v ngc >/dev/null 2>&1; then
+          cache_dir="${RUNNER_TEMP:-/tmp}/ngc-cli-cache"
+          ngc_zip="${cache_dir}/ngccli_linux.zip"
+          mkdir -p "$cache_dir"
+          if [ ! -f "$ngc_zip" ]; then
+            echo "Downloading NGC CLI ${NGC_CLI_VERSION}"
+            curl -fsSL -o "$ngc_zip" "$NGC_CLI_URL"
+          fi
+          echo "${NGC_CLI_SHA256}  ${ngc_zip}" | sha256sum -c -
+          ngc_unpack_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/ngc-cli.XXXXXX")"
+          unzip -q "$ngc_zip" -d "$ngc_unpack_dir"
+          export PATH="${ngc_unpack_dir}/ngc-cli:${PATH}"
+        fi
+
+        export NGC_CLI_API_KEY="$NGC_API_KEY"
+        export NGC_CLI_ORG=nvidian
+        export NGC_CLI_TEAM=omniverse
+        export NGC_CLI_HOME="$ngc_home"
+
+        ngc --version
+        echo "Downloading wheelhouse resource: $WHEELHOUSE_RESOURCE"
+        ngc registry resource download-version "$WHEELHOUSE_RESOURCE" --dest "$download_root"
+
+        mapfile -t manifests < <(find "$download_root" -type f -name manifest.json)
+        if [ "${#manifests[@]}" -ne 1 ]; then
+          echo "::error::expected exactly one manifest.json in downloaded wheelhouse resource, found ${#manifests[@]}"
+          printf '%s\n' "${manifests[@]}"
+          exit 1
+        fi
+
+        payload_dir="$(dirname "${manifests[0]}")"
+        if [ ! -d "${payload_dir}/wheelhouse" ]; then
+          echo "::error::downloaded wheelhouse resource is missing wheelhouse/ next to manifest.json"
+          exit 1
+        fi
+
+        mkdir -p "$wheelhouse_root/wheelhouse"
+        cp "${payload_dir}/manifest.json" "$wheelhouse_root/manifest.json"
+        cp "${payload_dir}/wheelhouse/"*.whl "$wheelhouse_root/wheelhouse/"
+
+        python3 - <<'PY' "$wheelhouse_root/manifest.json" "$wheelhouse_root/wheelhouse"
+        import hashlib
+        import json
+        import pathlib
+        import sys
+
+        manifest_path = pathlib.Path(sys.argv[1])
+        wheelhouse_dir = pathlib.Path(sys.argv[2])
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+        expected = {
+            "artifact": "ovphysx-wheelhouse",
+            "platform": "manylinux_2_35_x86_64",
+        }
+        for key, value in expected.items():
+            actual = manifest.get(key)
+            if actual != value:
+                raise SystemExit(f"manifest {key!r} mismatch: expected {value!r}, got {actual!r}")
+
+        wheels = manifest.get("wheels")
+        if not isinstance(wheels, list) or not wheels:
+            raise SystemExit("manifest has no wheels list")
+
+        for wheel in wheels:
+            filename = wheel.get("file")
+            expected_sha = wheel.get("sha256")
+            if not filename or not expected_sha:
+                raise SystemExit(f"invalid wheel manifest entry: {wheel!r}")
+            wheel_path = wheelhouse_dir / filename
+            if not wheel_path.is_file():
+                raise SystemExit(f"manifest wheel is missing from wheelhouse: {filename}")
+            actual_sha = hashlib.sha256(wheel_path.read_bytes()).hexdigest()
+            if actual_sha != expected_sha:
+                raise SystemExit(f"sha256 mismatch for {filename}: expected {expected_sha}, got {actual_sha}")
+
+        print(f"Validated {len(wheels)} wheelhouse wheels from {manifest_path}")
+        PY
+
+        echo "Wheelhouse contents:"
+        ls -l "$wheelhouse_root/wheelhouse"
+        preserve_wheelhouse_root=true
+        echo "wheelhouse_host_dir=$wheelhouse_root" >> "$GITHUB_OUTPUT"
+
     - name: Run Tests
       uses: ./.github/actions/run-tests
       with:
@@ -150,6 +282,8 @@ runs:
         include-files: ${{ inputs.include-files }}
         volume-mount-source: ${{ github.workspace }}
         extra-pip-packages: ${{ inputs.extra-pip-packages }}
+        wheelhouse-host-dir: ${{ steps.extract-wheelhouse.outputs.wheelhouse_host_dir }}
+        wheelhouse-packages: ${{ inputs.wheelhouse-packages }}
 
     - name: Check Test Results
       if: always()
@@ -164,6 +298,11 @@ runs:
           echo "No test results file found. This might indicate test execution failed."
           exit 1
         fi
+
+    - name: Cleanup wheelhouse artifacts
+      if: always() && steps.extract-wheelhouse.outputs.wheelhouse_host_dir != ''
+      shell: bash
+      run: rm -rf "${{ steps.extract-wheelhouse.outputs.wheelhouse_host_dir }}"
 
     - name: Kill container on cancellation
       if: cancelled()

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -69,6 +69,14 @@ inputs:
     description: 'Space-separated pip packages to install inside the Docker container before pytest starts'
     default: ''
     required: false
+  wheelhouse-host-dir:
+    description: 'Host directory containing wheelhouse/ and manifest.json for offline pip installs'
+    default: ''
+    required: false
+  wheelhouse-packages:
+    description: 'Space-separated packages to install from /tmp/ovphysx-wheelhouse with pip --no-index'
+    default: ''
+    required: false
 
 runs:
   using: composite
@@ -93,6 +101,8 @@ runs:
           local shard_count="${13}"
           local volume_mount_source="${14}"
           local extra_pip_packages="${15}"
+          local wheelhouse_host_dir="${16}"
+          local wheelhouse_packages="${17}"
           local logs_pid=""
           local wait_pid=""
           local docker_wait_file="/tmp/.docker_exit_${container_name}"
@@ -117,6 +127,12 @@ runs:
           fi
           if [ -n "$extra_pip_packages" ]; then
             echo "With extra pip packages: $extra_pip_packages"
+          fi
+          if [ -n "$wheelhouse_host_dir" ]; then
+            echo "With wheelhouse host directory: $wheelhouse_host_dir"
+          fi
+          if [ -n "$wheelhouse_packages" ]; then
+            echo "With wheelhouse packages: $wheelhouse_packages"
           fi
           if [ -n "$filter_pattern" ]; then
             echo "With filter pattern: $filter_pattern"
@@ -252,6 +268,31 @@ runs:
             echo "🔵 Running volume-mounted container as host uid:gid ${host_uid}:${host_gid} (${host_user})"
           fi
 
+          if [ -n "$wheelhouse_host_dir" ]; then
+            if [ -z "$wheelhouse_packages" ]; then
+              echo "::error::wheelhouse-host-dir was provided but wheelhouse-packages is empty"
+              return 1
+            fi
+            if [ ! -d "${wheelhouse_host_dir}/wheelhouse" ]; then
+              echo "::error::wheelhouse directory not found: ${wheelhouse_host_dir}/wheelhouse"
+              return 1
+            fi
+            if [ ! -f "${wheelhouse_host_dir}/manifest.json" ]; then
+              echo "::error::wheelhouse manifest not found: ${wheelhouse_host_dir}/manifest.json"
+              return 1
+            fi
+
+            export TEST_WHEELHOUSE_PACKAGES="$wheelhouse_packages"
+            docker_volume_args="$docker_volume_args \
+              -v ${wheelhouse_host_dir}/wheelhouse:/tmp/ovphysx-wheelhouse:ro \
+              -v ${wheelhouse_host_dir}/manifest.json:/tmp/ovphysx-wheelhouse-manifest.json:ro"
+            docker_env_vars="$docker_env_vars \
+              -e TEST_WHEELHOUSE_PATH=/tmp/ovphysx-wheelhouse \
+              -e TEST_WHEELHOUSE_MANIFEST=/tmp/ovphysx-wheelhouse-manifest.json \
+              -e TEST_WHEELHOUSE_PACKAGES"
+            echo "Mounting wheelhouse at /tmp/ovphysx-wheelhouse"
+          fi
+
           echo "Docker environment variables: '$docker_env_vars'"
 
           # Run tests in a detached container and follow logs.  Running detached
@@ -284,6 +325,26 @@ runs:
               # fall back to slow repeated retries.
               unset HUB__ARGS__DETECT_ONLY
               ./isaaclab.sh -p -m pip install pytest pytest-mock junitparser flatdict flaky \"coverage>=7.6.1\"
+              if [ -n \"\${TEST_WHEELHOUSE_PACKAGES:-}\" ]; then
+                if [ ! -d \"\${TEST_WHEELHOUSE_PATH:-}\" ]; then
+                  echo \"Wheelhouse path is missing: \${TEST_WHEELHOUSE_PATH:-}\"
+                  exit 1
+                fi
+                if [ ! -f \"\${TEST_WHEELHOUSE_MANIFEST:-}\" ]; then
+                  echo \"Wheelhouse manifest is missing: \${TEST_WHEELHOUSE_MANIFEST:-}\"
+                  exit 1
+                fi
+
+                echo \"Installing wheelhouse packages offline: \${TEST_WHEELHOUSE_PACKAGES}\"
+                ./isaaclab.sh -p -m pip uninstall -y \${TEST_WHEELHOUSE_PACKAGES} || true
+                PIP_NO_INDEX=1 ./isaaclab.sh -p -m pip install --no-index --find-links=\"\${TEST_WHEELHOUSE_PATH}\" --upgrade --force-reinstall \${TEST_WHEELHOUSE_PACKAGES}
+
+                case \" \${TEST_WHEELHOUSE_PACKAGES} \" in
+                  *\" ovphysx \"*)
+                    ./isaaclab.sh -p -c \"import importlib.metadata,json,os,pathlib; from packaging.version import Version; manifest=json.loads(pathlib.Path(os.environ['TEST_WHEELHOUSE_MANIFEST']).read_text(encoding='utf-8')); expected=manifest.get('ovphysx_version'); actual=importlib.metadata.version('ovphysx'); print(f'Resolved ovphysx package version: {actual}'); print(f'Wheelhouse manifest ovphysx version: {expected}'); import ovphysx; runtime=getattr(ovphysx, '__version__', actual); print(f'Imported ovphysx runtime version: {runtime}'); raise SystemExit(0 if Version(actual) == Version(expected) and Version(runtime) == Version(expected) else f'ovphysx version mismatch: installed {actual}, import {runtime}, manifest {expected}')\"
+                    ;;
+                esac
+              fi
               if [ -n \"\${TEST_EXTRA_PIP_PACKAGES:-}\" ]; then
                 echo \"Installing extra pip packages: \${TEST_EXTRA_PIP_PACKAGES}\"
                 ./isaaclab.sh -p -m pip install \${TEST_EXTRA_PIP_PACKAGES}
@@ -392,7 +453,7 @@ runs:
         }
 
         # Call the function with provided parameters
-        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "${{ inputs.pytest-options }}" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}"
+        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "${{ inputs.pytest-options }}" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.wheelhouse-host-dir }}" "${{ inputs.wheelhouse-packages }}"
 
     - name: Kill container on cancellation
       if: cancelled()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -181,6 +181,7 @@ jobs:
       isaacsim_image_name: ${{ steps.load.outputs.isaacsim_image_name }}
       isaacsim_image_tag: ${{ steps.load.outputs.isaacsim_image_tag }}
       isaaclab_image_name: ${{ steps.load.outputs.isaaclab_image_name }}
+      ovphysx_wheelhouse_resource: ${{ steps.load.outputs.ovphysx_wheelhouse_resource }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -194,6 +195,7 @@ jobs:
         echo "isaacsim_image_name=$(yq -r .isaacsim_image_name "$f")" >> "$GITHUB_OUTPUT"
         echo "isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$f")" >> "$GITHUB_OUTPUT"
         echo "isaaclab_image_name=$(yq -r .isaaclab_image_name "$f")" >> "$GITHUB_OUTPUT"
+        echo "ovphysx_wheelhouse_resource=$(yq -r .ovphysx_wheelhouse_resource "$f")" >> "$GITHUB_OUTPUT"
 
   #region build jobs
   build:
@@ -532,6 +534,8 @@ jobs:
     timeout-minutes: 180
     needs: [build, config]
     if: needs.build.result == 'success'
+    env:
+      USE_OVPHYSX_WHEELHOUSE: ${{ needs.config.outputs.ovphysx_wheelhouse_resource != '' && ((github.event_name == 'pull_request' && github.base_ref == 'develop') || (github.event_name != 'pull_request' && github.ref_name == 'develop')) }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -543,7 +547,9 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_ov"
-        extra-pip-packages: "ovrtx ovphysx"
+        extra-pip-packages: ${{ (env.USE_OVPHYSX_WHEELHOUSE == 'true' && env.NGC_API_KEY != '') && 'ovrtx' || 'ovrtx ovphysx' }}
+        wheelhouse-resource: ${{ (env.USE_OVPHYSX_WHEELHOUSE == 'true' && env.NGC_API_KEY != '') && needs.config.outputs.ovphysx_wheelhouse_resource || '' }}
+        wheelhouse-packages: ${{ (env.USE_OVPHYSX_WHEELHOUSE == 'true' && env.NGC_API_KEY != '') && 'ovphysx' || '' }}
         container-name: isaac-lab-ov-test
 
     # Folded from the former standalone verify-base-non-root job: reuses the

--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -8,3 +8,4 @@
 isaacsim_image_name: nvcr.io/nvidian/isaac-sim
 isaacsim_image_tag: latest-develop
 isaaclab_image_name: nvcr.io/nvidian/isaac-lab
+ovphysx_wheelhouse_resource: "nvidian/omniverse/ovphysx-wheelhouse:trunk-gc0b66f0c679b"


### PR DESCRIPTION
## Summary

- add a pinned OVPhysX wheelhouse image to the shared CI config
- install `ovphysx` from that wheelhouse in the existing `isaaclab_ov` Docker test job for develop-targeted runs
- keep main/release-targeted runs on the normal public package install path
- validate the copied wheelhouse manifest and wheel hashes before installing with `pip --no-index`

## Why

This lets IsaacLab `develop` test against a specific OVPhysX development wheel before the corresponding public PyPI release is available, while preserving the public-package path for release branches.

## Validation

- Parsed changed workflow/action YAML files with PyYAML
- Ran a static CI-contract check for the pinned image, develop switch, PyPI fallback, manifest validation, and offline install path
- Ran `git diff --check origin/develop...HEAD`
- Scanned the diff and PR text for unintended local provenance strings

`actionlint` is not installed in my local environment, so I could not run it before opening this draft PR.
