### PR TITLE
Cache PhysX articulation COM offsets

### DIFF
--- a/source/isaaclab/changelog.d/physx-com-cache.skip
+++ b/source/isaaclab/changelog.d/physx-com-cache.skip
@@ -1,0 +1,1 @@
+Tests only; user-facing fragments live in the backend packages.

--- a/source/isaaclab/test/assets/test_articulation_iface.py
+++ b/source/isaaclab/test/assets/test_articulation_iface.py
@@ -1097,6 +1097,133 @@ class TestArticulationDataBodyState:
             name="body_com_pose_b",
         )
 
+    @pytest.mark.skipif("physx" not in BACKENDS, reason="PhysX backend unavailable")
+    def test_physx_body_com_pose_b_is_cached_across_sim_timestamps(self):
+        art, view = get_articulation("physx", num_instances=2, num_joints=3, num_bodies=4, device="cpu")
+
+        num_get_coms_calls = 0
+        get_coms = view.get_coms
+
+        def counted_get_coms():
+            nonlocal num_get_coms_calls
+            num_get_coms_calls += 1
+            return get_coms()
+
+        view.get_coms = counted_get_coms
+
+        art.data.update(dt=0.01)
+        art.data.body_com_pose_b
+        assert num_get_coms_calls == 1
+
+        art.data.update(dt=0.01)
+        art.data.body_com_pose_b
+        assert num_get_coms_calls == 1
+
+    @pytest.mark.skipif("physx" not in BACKENDS, reason="PhysX backend unavailable")
+    def test_physx_set_coms_index_updates_body_com_pose_b_cache(self):
+        art, view = get_articulation("physx", num_instances=2, num_joints=3, num_bodies=4, device="cpu")
+
+        num_get_coms_calls = 0
+        get_coms = view.get_coms
+
+        def counted_get_coms():
+            nonlocal num_get_coms_calls
+            num_get_coms_calls += 1
+            return get_coms()
+
+        view.get_coms = counted_get_coms
+
+        coms = wp.zeros((art.num_instances, art.num_bodies), dtype=wp.transformf, device="cpu")
+        art.set_coms_index(coms=coms, full_data=True)
+        art.data.body_com_pose_b
+
+        assert num_get_coms_calls == 0
+
+    @pytest.mark.skipif("physx" not in BACKENDS, reason="PhysX backend unavailable")
+    def test_physx_joint_position_write_preserves_body_com_pose_b_cache(self):
+        art, view = get_articulation("physx", num_instances=2, num_joints=3, num_bodies=4, device="cpu")
+
+        num_get_coms_calls = 0
+        get_coms = view.get_coms
+
+        def counted_get_coms():
+            nonlocal num_get_coms_calls
+            num_get_coms_calls += 1
+            return get_coms()
+
+        view.get_coms = counted_get_coms
+
+        art.data.update(dt=0.01)
+        art.data.body_com_pose_b
+        assert num_get_coms_calls == 1
+
+        joint_pos = torch.zeros((art.num_instances, art.num_joints), device="cpu")
+        art.write_joint_position_to_sim_index(position=joint_pos, full_data=True)
+        art.data.body_com_pose_b
+
+        assert num_get_coms_calls == 1
+
+    @pytest.mark.skipif("physx" not in BACKENDS, reason="PhysX backend unavailable")
+    def test_physx_partial_set_coms_index_initializes_cold_body_com_pose_b_cache(self):
+        art, view = get_articulation("physx", num_instances=2, num_joints=3, num_bodies=4, device="cpu")
+        initial_coms = view.get_coms().numpy().copy()
+
+        num_get_coms_calls = 0
+        get_coms = view.get_coms
+
+        def counted_get_coms():
+            nonlocal num_get_coms_calls
+            num_get_coms_calls += 1
+            return get_coms()
+
+        view.get_coms = counted_get_coms
+
+        coms = wp.zeros((1, 1), dtype=wp.transformf, device="cpu")
+        art.set_coms_index(
+            coms=coms,
+            env_ids=wp.array([0], dtype=wp.int32, device="cpu"),
+            body_ids=wp.array([0], dtype=wp.int32, device="cpu"),
+        )
+        body_com_pose_b = art.data.body_com_pose_b.torch
+
+        assert num_get_coms_calls == 1
+        torch.testing.assert_close(body_com_pose_b[1, 1], torch.from_numpy(initial_coms[1, 1]))
+
+    @pytest.mark.skipif("physx" not in BACKENDS, reason="PhysX backend unavailable")
+    def test_physx_set_coms_index_invalidates_body_com_pose_b_dependents(self):
+        art, _ = get_articulation("physx", num_instances=2, num_joints=3, num_bodies=4, device="cpu")
+
+        art.data.update(dt=0.01)
+        dependent_buffers = [
+            ("root_com_pose_w", art.data._root_com_pose_w),
+            ("root_com_vel_w", art.data._root_com_vel_w),
+            ("root_link_vel_w", art.data._root_link_vel_w),
+            ("body_com_pose_w", art.data._body_com_pose_w),
+            ("body_com_vel_w", art.data._body_com_vel_w),
+            ("body_link_vel_w", art.data._body_link_vel_w),
+            ("root_link_lin_vel_b", art.data._root_link_lin_vel_b),
+            ("root_link_ang_vel_b", art.data._root_link_ang_vel_b),
+            ("root_com_lin_vel_b", art.data._root_com_lin_vel_b),
+            ("root_com_ang_vel_b", art.data._root_com_ang_vel_b),
+            ("root_state_w", art.data._root_state_w),
+            ("root_link_state_w", art.data._root_link_state_w),
+            ("root_com_state_w", art.data._root_com_state_w),
+            ("body_state_w", art.data._body_state_w),
+            ("body_link_state_w", art.data._body_link_state_w),
+            ("body_com_state_w", art.data._body_com_state_w),
+            ("body_com_jacobian_w", art.data._body_com_jacobian_w),
+            ("mass_matrix", art.data._mass_matrix),
+            ("gravity_compensation_forces", art.data._gravity_compensation_forces),
+        ]
+        for _, buffer in dependent_buffers:
+            buffer.timestamp = art.data._sim_timestamp
+
+        coms = wp.zeros((art.num_instances, art.num_bodies), dtype=wp.transformf, device="cpu")
+        art.set_coms_index(coms=coms, full_data=True)
+
+        for name, buffer in dependent_buffers:
+            assert buffer.timestamp < art.data._sim_timestamp, name
+
     @_backends
     @_default_dims
     @_default_devices

--- a/source/isaaclab_ovphysx/changelog.d/physx-com-cache.rst
+++ b/source/isaaclab_ovphysx/changelog.d/physx-com-cache.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed repeated OVPhysX articulation body-frame center-of-mass pose reads by caching them as model
+  properties and invalidating dependent buffers when center-of-mass offsets are updated.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
@@ -2181,9 +2181,8 @@ class Articulation(BaseArticulation):
             outputs=[self._data._body_com_pose_b.data],
             device=self._device,
         )
-        # Invalidate derived buffers that depend on body_com_pose_b.
-        self.data._root_com_pose_w.timestamp = -1.0
-        self.data._body_com_pose_w.timestamp = -1.0
+        self._data._body_com_pose_b.timestamp = self._data._sim_timestamp
+        self._data._reset_body_com_pose_b_dependents()
         cpu_env_ids = self._get_cpu_env_ids(env_ids)
         wp.copy(self.data._cpu_body_coms, self._data._body_com_pose_b.data)
         binding = self._get_binding(TT.BODY_COM_POSE)
@@ -2227,9 +2226,8 @@ class Articulation(BaseArticulation):
             outputs=[self._data._body_com_pose_b.data],
             device=self._device,
         )
-        # Invalidate derived buffers that depend on body_com_pose_b.
-        self.data._root_com_pose_w.timestamp = -1.0
-        self.data._body_com_pose_w.timestamp = -1.0
+        self._data._body_com_pose_b.timestamp = self._data._sim_timestamp
+        self._data._reset_body_com_pose_b_dependents()
         wp.copy(self.data._cpu_body_coms, self._data._body_com_pose_b.data)
         binding = self._get_binding(TT.BODY_COM_POSE)
         binding.write(self.data._cpu_body_coms, mask=self._get_cpu_env_mask(env_mask_wp))

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation_data.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation_data.py
@@ -248,6 +248,29 @@ class ArticulationData(BaseArticulationData):
         # Force a kinematic refresh on the next FK-dependent read.
         self._fk_timestamp = -1.0
 
+    def _reset_body_com_pose_b_dependents(self) -> None:
+        """Reset cached properties derived from body-frame center-of-mass offsets."""
+        reset_timestamps(
+            [
+                self._root_com_pose_w,
+                self._root_com_vel_w,
+                self._root_link_vel_w,
+                self._body_com_pose_w,
+                self._body_com_vel_w,
+                self._body_link_vel_w,
+                self._root_link_lin_vel_b,
+                self._root_link_ang_vel_b,
+                self._root_com_lin_vel_b,
+                self._root_com_ang_vel_b,
+                self._root_state_w_buf,
+                self._root_link_state_w_buf,
+                self._root_com_state_w_buf,
+                self._body_state_w_buf,
+                self._body_link_state_w_buf,
+                self._body_com_state_w_buf,
+            ]
+        )
+
     """
     Names.
     """
@@ -977,7 +1000,8 @@ class ArticulationData(BaseArticulationData):
         This quantity is the pose of the center of mass frame of the rigid body relative to the body's link frame.
         The orientation is provided in (x, y, z, w) format.
         """
-        self._read_transform_binding(TT.BODY_COM_POSE, self._body_com_pose_b)
+        if self._body_com_pose_b.timestamp < 0.0:
+            self._read_transform_binding(TT.BODY_COM_POSE, self._body_com_pose_b)
         if self._body_com_pose_b_ta is None:
             self._body_com_pose_b_ta = ProxyArray(self._body_com_pose_b.data)
         return self._body_com_pose_b_ta

--- a/source/isaaclab_ovphysx/test/assets/test_articulation.py
+++ b/source/isaaclab_ovphysx/test/assets/test_articulation.py
@@ -1978,6 +1978,51 @@ def test_write_root_state(sim, num_articulations, device, with_offset, state_loc
             torch.testing.assert_close(rand_state[..., 7:], articulation.data.root_link_vel_w.torch)
 
 
+@pytest.mark.parametrize("device", ["cpu"])
+def test_body_com_pose_b_cache_and_set_coms_invalidation(sim, device):
+    """Body-frame COM offsets stay cached and invalidate derived buffers after writes."""
+    sim._app_control_on_stop_handle = None
+    articulation_cfg = generate_articulation_cfg(articulation_type="single_joint_implicit")
+    articulation, _ = generate_articulation(articulation_cfg, 2, device=device)
+
+    sim.reset()
+    articulation.update(sim.cfg.dt)
+
+    articulation.data.body_com_pose_b
+    first_timestamp = articulation.data._body_com_pose_b.timestamp
+    articulation.update(sim.cfg.dt)
+    articulation.data.body_com_pose_b
+    assert articulation.data._body_com_pose_b.timestamp == first_timestamp
+
+    dependent_buffers = [
+        ("root_com_pose_w", articulation.data._root_com_pose_w),
+        ("root_com_vel_w", articulation.data._root_com_vel_w),
+        ("root_link_vel_w", articulation.data._root_link_vel_w),
+        ("body_com_pose_w", articulation.data._body_com_pose_w),
+        ("body_com_vel_w", articulation.data._body_com_vel_w),
+        ("body_link_vel_w", articulation.data._body_link_vel_w),
+        ("root_link_lin_vel_b", articulation.data._root_link_lin_vel_b),
+        ("root_link_ang_vel_b", articulation.data._root_link_ang_vel_b),
+        ("root_com_lin_vel_b", articulation.data._root_com_lin_vel_b),
+        ("root_com_ang_vel_b", articulation.data._root_com_ang_vel_b),
+        ("root_state_w", articulation.data._root_state_w_buf),
+        ("root_link_state_w", articulation.data._root_link_state_w_buf),
+        ("root_com_state_w", articulation.data._root_com_state_w_buf),
+        ("body_state_w", articulation.data._body_state_w_buf),
+        ("body_link_state_w", articulation.data._body_link_state_w_buf),
+        ("body_com_state_w", articulation.data._body_com_state_w_buf),
+    ]
+    for _, buffer in dependent_buffers:
+        buffer.timestamp = articulation.data._sim_timestamp
+
+    coms = wp.zeros((articulation.num_instances, articulation.num_bodies), dtype=wp.transformf, device=device)
+    articulation.set_coms_index(coms=coms)
+
+    assert articulation.data._body_com_pose_b.timestamp == articulation.data._sim_timestamp
+    for name, buffer in dependent_buffers:
+        assert buffer.timestamp < articulation.data._sim_timestamp, name
+
+
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_setting_articulation_root_prim_path(sim, device):
     """Test that the articulation root prim path can be set explicitly."""

--- a/source/isaaclab_physx/changelog.d/physx-com-cache.rst
+++ b/source/isaaclab_physx/changelog.d/physx-com-cache.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed repeated PhysX articulation body-frame center-of-mass pose reads by caching them as model
+  properties and invalidating dependent buffers when center-of-mass offsets are updated.

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -2357,6 +2357,11 @@ class Articulation(BaseArticulation):
             self.assert_shape_and_dtype(coms, (self.num_instances, self.num_bodies), wp.transformf, "coms")
         else:
             self.assert_shape_and_dtype(coms, (env_ids.shape[0], body_ids.shape[0]), wp.transformf, "coms")
+        if self.data._body_com_pose_b.timestamp < 0.0 and (
+            env_ids.shape[0] != self.num_instances or body_ids.shape[0] != self.num_bodies
+        ):
+            # Partial writes need the current model-property cache as a base for untouched entries.
+            self.data.body_com_pose_b
         # Warp kernels can ingest torch tensors directly, so we don't need to convert to warp arrays here.
         wp.launch(
             shared_kernels.write_body_com_pose_to_buffer,
@@ -2372,6 +2377,8 @@ class Articulation(BaseArticulation):
             ],
             device=self.device,
         )
+        self.data._body_com_pose_b.timestamp = self.data._sim_timestamp
+        self.data._reset_body_com_pose_b_dependents()
         # Set into simulation, note that when updating "model" properties with PhysX we need to do it on CPU.
         # Convert from wp.transformf to flat (N, M, 7) array for PhysX
         cpu_env_ids = self._get_cpu_env_ids(env_ids)

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation_data.py
@@ -196,6 +196,32 @@ class ArticulationData(BaseArticulationData):
         )
         self._fk_timestamp = -1.0
 
+    def _reset_body_com_pose_b_dependents(self) -> None:
+        """Reset cached properties derived from body-frame center-of-mass offsets."""
+        reset_timestamps(
+            [
+                self._root_com_pose_w,
+                self._root_com_vel_w,
+                self._root_link_vel_w,
+                self._body_com_pose_w,
+                self._body_com_vel_w,
+                self._body_link_vel_w,
+                self._root_link_lin_vel_b,
+                self._root_link_ang_vel_b,
+                self._root_com_lin_vel_b,
+                self._root_com_ang_vel_b,
+                self._root_state_w,
+                self._root_link_state_w,
+                self._root_com_state_w,
+                self._body_state_w,
+                self._body_link_state_w,
+                self._body_com_state_w,
+                self._body_com_jacobian_w,
+                self._mass_matrix,
+                self._gravity_compensation_forces,
+            ]
+        )
+
     """
     Names.
     """
@@ -914,8 +940,8 @@ class ArticulationData(BaseArticulationData):
         This quantity is the pose of the center of mass frame of the rigid body relative to the body's link frame.
         The orientation is provided in (x, y, z, w) format.
         """
-        if self._body_com_pose_b.timestamp < self._sim_timestamp:
-            # set the buffer data and timestamp
+        if self._body_com_pose_b.timestamp < 0.0:
+            # Body-frame CoM offsets are model properties; cache them until an explicit CoM write updates them.
             self._body_com_pose_b.data.assign(self._root_view.get_coms().view(wp.transformf))
             self._body_com_pose_b.timestamp = self._sim_timestamp
 

--- a/source/isaaclab_physx/test/assets/test_articulation.py
+++ b/source/isaaclab_physx/test/assets/test_articulation.py
@@ -1753,8 +1753,9 @@ def test_body_root_state(sim, num_articulations, device, with_offset):
     link_offset = [1.0, 0.0, 0.0]  # the offset from CenterPivot to Arm frames
     new_com = torch.tensor(offset, device=device).repeat(num_articulations, 1, 1)
     com[:, arm_idx, :3] = new_com.squeeze(-2)
-    articulation.root_view.set_coms(
-        wp.from_torch(com.cpu(), dtype=wp.float32), wp.from_torch(env_idx.cpu(), dtype=wp.int32)
+    articulation.set_coms_index(
+        coms=wp.from_torch(com.to(device).contiguous(), dtype=wp.transformf),
+        env_ids=wp.from_torch(env_idx, dtype=wp.int32),
     )
 
     # check they are set
@@ -1869,8 +1870,9 @@ def test_write_root_state(sim, num_articulations, device, with_offset, state_loc
     com = wp.to_torch(articulation.root_view.get_coms())
     new_com = offset
     com[:, 0, :3] = new_com.squeeze(-2)
-    articulation.root_view.set_coms(
-        wp.from_torch(com.cpu(), dtype=wp.float32), wp.from_torch(env_idx.cpu(), dtype=wp.int32)
+    articulation.set_coms_index(
+        coms=wp.from_torch(com.to(device).contiguous(), dtype=wp.transformf),
+        env_ids=wp.from_torch(env_idx, dtype=wp.int32),
     )
 
     # check they are set


### PR DESCRIPTION
## Summary
- cache PhysX body-frame COM offsets as model properties instead of re-reading them every sim timestamp
- invalidate all PhysX COM-offset-dependent cached buffers after set_coms_index writes
- apply the same model-property cache policy and dependent invalidation to OVPhysX articulation COM offsets
- add PhysX and OVPhysX regression tests for timestamp reuse, setter cache updates, joint writes, partial writes, and dependent invalidation
- add changelog fragments for the touched packages

This intentionally keeps the scope to the cached-property fix; it does not include PR #6260's local-only composition fast path.

## Profiling
- G1 PhysX, 4096 env quick profile before the dependent-invalidation follow-up: compose_to_body_frame dropped from ~7.25 ms to ~0.24 ms
- after the cache fix, normal step time was 69.20 ms vs 68.76 ms with compose skipped in the same quick profile
- full-run wall timings were noisy on the laptop/GPU, likely thermal throttling, but no longer showed the pre-fix COM-read cliff

## Test Plan
- python3 tools/changelog/cli.py check develop
- pre-commit run --from-ref origin/develop --to-ref HEAD
- git diff --check origin/develop...HEAD
- ./isaaclab.sh -p -m py_compile source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation_data.py source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation_data.py source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py source/isaaclab/test/assets/test_articulation_iface.py source/isaaclab_ovphysx/test/assets/test_articulation.py
- ./isaaclab.sh -p -m pytest source/isaaclab/test/assets/test_articulation_iface.py -k 'physx_set_coms_index_invalidates_body_com_pose_b_dependents or physx_body_com_pose_b_is_cached_across_sim_timestamps or physx_set_coms_index_updates_body_com_pose_b_cache or physx_joint_position_write_preserves_body_com_pose_b_cache or physx_partial_set_coms_index_initializes_cold_body_com_pose_b_cache' -q
- ./isaaclab.sh -p -m pytest source/isaaclab_ovphysx/test/assets/test_articulation.py -k 'body_com_pose_b_cache_and_set_coms_invalidation' -q
