### PR TITLE
Fix PhysxManager crash from stale omni.physx interface cache

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -131,6 +131,7 @@ Guidelines for modifications:
 * Michael Gussert
 * Michael Lin
 * Michael Noseworthy
+* Michal Hapala
 * Miguel Alonso Jr
 * Mihir Kulkarni
 * Mingxue Gu

--- a/source/isaaclab_physx/changelog.d/physx-iface-cache.rst
+++ b/source/isaaclab_physx/changelog.d/physx-iface-cache.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed a crash in :class:`~isaaclab_physx.physics.PhysxManager` when ``omni.physx`` is reloaded during a session.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -247,8 +247,6 @@ class PhysxManager(PhysicsManager):
 
     _timeline: ClassVar[omni.timeline.ITimeline] = omni.timeline.get_timeline_interface()
     _event_bus: ClassVar[carb.eventdispatcher.IEventDispatcher] = carb.eventdispatcher.get_eventdispatcher()
-    _physx: ClassVar[omni.physx.IPhysx] = omni.physx.get_physx_interface()
-    _physx_sim: ClassVar[omni.physx.IPhysxSimulation] = omni.physx.get_physx_simulation_interface()
     _scene_data_backend: ClassVar[PhysxSceneDataBackend | None] = None
 
     _view: ClassVar[omni.physics.tensors.SimulationView | None] = None
@@ -351,8 +349,9 @@ class PhysxManager(PhysicsManager):
             omni.kit.app.get_app().shutdown()
             return
 
-        cls._physx_sim.simulate(sim.cfg.dt, 0.0)
-        cls._physx_sim.fetch_results()
+        physx_sim = omni.physx.get_physx_simulation_interface()
+        physx_sim.simulate(sim.cfg.dt, 0.0)
+        physx_sim.fetch_results()
         device = PhysicsManager._device
         if "cuda" in device:
             torch.cuda.set_device(device)
@@ -415,10 +414,9 @@ class PhysxManager(PhysicsManager):
         """Clean up physics resources."""
         # Detach PhysX from the stage FIRST to prevent shape/actor cleanup errors
         # This disconnects PhysX from USD before any deletion events are fired
-        if cls._physx_sim is not None:
-            cls._physx_sim.detach_stage()
-            # Pump the app to flush pending PhysX cleanup operations
-            omni.kit.app.get_app().update()
+        omni.physx.get_physx_simulation_interface().detach_stage()
+        # Pump the app to flush pending PhysX cleanup operations
+        omni.kit.app.get_app().update()
 
         # Now invalidate views (they're already disconnected from PhysX)
         cls._invalidate_views()
@@ -526,9 +524,13 @@ class PhysxManager(PhysicsManager):
         ):
             return cls._event_bus.observe_event(event_name=event.value, order=order, on_event=callback)
         elif event == IsaacEvents.POST_PHYSICS_STEP:
-            return cls._physx.subscribe_physics_on_step_events(guarded(callback), pre_step=False, order=order)
+            return omni.physx.get_physx_interface().subscribe_physics_on_step_events(
+                guarded(callback), pre_step=False, order=order
+            )
         elif event == IsaacEvents.PRE_PHYSICS_STEP:
-            return cls._physx.subscribe_physics_on_step_events(guarded(callback), pre_step=True, order=order)
+            return omni.physx.get_physx_interface().subscribe_physics_on_step_events(
+                guarded(callback), pre_step=True, order=order
+            )
         elif event == IsaacEvents.TIMELINE_STOP:
             return cls._timeline.get_timeline_event_stream().create_subscription_to_pop_by_type(
                 int(omni.timeline.TimelineEventType.STOP), callback, order=order, name=name
@@ -754,19 +756,22 @@ class PhysxManager(PhysicsManager):
 
         is_gpu = "cuda" in PhysicsManager.get_device()
 
+        physx = omni.physx.get_physx_interface()
+        physx_sim = omni.physx.get_physx_simulation_interface()
+
         # Attach stage to PhysX BEFORE loading/starting - only needed for GPU pipeline.
         # For CPU, the old SimulationManager never called attach_stage() explicitly.
         # Calling attach_stage() + force_load_physics_from_usd() together causes a
         # double-initialization that corrupts the CPU broadphase (MBP) collision setup,
         # causing objects to fall through surfaces non-deterministically.
         if is_gpu:
-            cls._physx_sim.attach_stage(stage_id)
+            physx_sim.attach_stage(stage_id)
 
         # warmup physx
-        cls._physx.force_load_physics_from_usd()
-        cls._physx.start_simulation()
-        cls._physx.update_simulation(cls.get_physics_dt(), 0.0)
-        cls._physx_sim.fetch_results()
+        physx.force_load_physics_from_usd()
+        physx.start_simulation()
+        physx.update_simulation(cls.get_physics_dt(), 0.0)
+        physx_sim.fetch_results()
         cls._event_bus.dispatch_event(IsaacEvents.PHYSICS_WARMUP.value, payload={})
         cls._warmup_needed = False
 
@@ -783,7 +788,7 @@ class PhysxManager(PhysicsManager):
             cls._view_warp.set_subspace_roots("/")
 
         # Final update after view creation
-        cls._physx.update_simulation(cls.get_physics_dt(), 0.0)
+        omni.physx.get_physx_interface().update_simulation(cls.get_physics_dt(), 0.0)
         cls._view_created = True
         cls._scene_data_backend.simulation_view = cls._view
 

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -414,9 +414,10 @@ class PhysxManager(PhysicsManager):
         """Clean up physics resources."""
         # Detach PhysX from the stage FIRST to prevent shape/actor cleanup errors
         # This disconnects PhysX from USD before any deletion events are fired
-        omni.physx.get_physx_simulation_interface().detach_stage()
-        # Pump the app to flush pending PhysX cleanup operations
-        omni.kit.app.get_app().update()
+        if physx_sim := omni.physx.get_physx_simulation_interface():
+            physx_sim.detach_stage()
+            # Pump the app to flush pending PhysX cleanup operations
+            omni.kit.app.get_app().update()
 
         # Now invalidate views (they're already disconnected from PhysX)
         cls._invalidate_views()
@@ -788,7 +789,7 @@ class PhysxManager(PhysicsManager):
             cls._view_warp.set_subspace_roots("/")
 
         # Final update after view creation
-        omni.physx.get_physx_interface().update_simulation(cls.get_physics_dt(), 0.0)
+        physx.update_simulation(cls.get_physics_dt(), 0.0)
         cls._view_created = True
         cls._scene_data_backend.simulation_view = cls._view
 

--- a/source/isaaclab_physx/test/assets/test_rigid_object.py
+++ b/source/isaaclab_physx/test/assets/test_rigid_object.py
@@ -1273,25 +1273,23 @@ def test_warmup_attach_stage_not_called_for_cpu():
     complexity (multiple dynamic actors on a mesh collider), making it unreliable as a
     unit test assertion.
     """
-    from unittest.mock import MagicMock
+    from unittest.mock import MagicMock, patch
 
-    from isaaclab_physx.physics import PhysxManager
+    import omni.physx
 
     with build_simulation_context(device="cpu", add_ground_plane=True, dt=0.01, auto_add_lighting=True) as sim:
         sim._app_control_on_stop_handle = None
         generate_cubes_scene(num_cubes=1, height=1.0, device="cpu")
 
+        # PhysxManager no longer caches the simulation interface; it resolves it on each use
+        # via ``omni.physx.get_physx_simulation_interface()`` (the accessor memoizes it).
         # IPhysxSimulation is a C++ binding whose attributes are read-only, so we cannot
-        # assign to _physx_sim.attach_stage directly.  Instead, replace the class-level
-        # reference with a MagicMock that wraps the real object so all other calls still
-        # work, then restore it in the finally block.
-        original_physx_sim = PhysxManager._physx_sim
-        spy = MagicMock(wraps=original_physx_sim)
-        PhysxManager._physx_sim = spy
-        try:
+        # assign to ``attach_stage`` directly.  Instead, patch the accessor to return a
+        # MagicMock that wraps the real interface so all other calls still work, and spy on
+        # ``attach_stage``.
+        spy = MagicMock(wraps=omni.physx.get_physx_simulation_interface())
+        with patch("omni.physx.get_physx_simulation_interface", return_value=spy):
             sim.reset()
-        finally:
-            PhysxManager._physx_sim = original_physx_sim
 
         assert spy.attach_stage.call_count == 0, (
             f"attach_stage() was called {spy.attach_stage.call_count} time(s) during CPU warmup. "


### PR DESCRIPTION
# Description

`PhysxManager` cached the `omni.physx` `IPhysx` / `IPhysxSimulation` interfaces as class
variables acquired at **module-import time** and reused them for the whole process lifetime.

The `omni.physx` accessors (`get_physx_interface()` / `get_physx_simulation_interface()`)
already memoize the acquired interface for the process, so this was a redundant *second*
cache — and a stale one. If the `omni.physx` plugin is (re)loaded any time after this module
is imported, the cached pointers dangle. The next `_warmup_and_create_views()` then calls
`attach_stage()` on the freed interface and the indirect call faults under Windows Control
Flow Guard (`EXCEPTION_ACCESS_VIOLATION` in `_guard_dispatch_icall_nop`).

This was hit on a Blackwell GPU CI box running IsaacLab tasks back-to-back (`attach_stage`
is only invoked on the GPU pipeline, consistent with the crash).

**Fix:** drop the `_physx` / `_physx_sim` class variables and resolve the interfaces on each
use via `omni.physx.get_physx_interface()` / `omni.physx.get_physx_simulation_interface()`,
letting the single, correct `omni.physx` cache own the lifetime. The existing
`test_warmup_attach_stage_not_called_for_cpu` regression tests are updated to patch the
accessor instead of the removed class variable.

Fixes NVBugs 6289174.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<sub>Note: the reload-induced dangling-interface crash only reproduces under runtime
extension toggling (an unsupported flow on a specific GPU box), so a deterministic unit test
isn't feasible; the existing CPU `attach_stage` regression tests were updated to the new
accessor path instead.</sub>
