### PR TITLE
Fix Newton marker world rendering

### DIFF
--- a/docs/source/overview/core-concepts/visualization.rst
+++ b/docs/source/overview/core-concepts/visualization.rst
@@ -163,6 +163,22 @@ There are 3 fields exposed in the ``VisualizerCfg`` for selecting environments f
 
 Also, there is a CLI arg ``--max_visible_envs`` that overrides ``VisualizerCfg.max_visible_envs`` for the run.
 
+Newton environments can share simulated coordinates, for example when ``scene.env_spacing=0``.
+Use :attr:`~isaaclab_visualizers.newton.NewtonVisualizerCfg.world_spacing` to arrange selected
+worlds visually without changing their simulated poses:
+
+.. code-block:: python
+
+
+    from isaaclab_visualizers.newton import NewtonVisualizerCfg
+    NewtonVisualizerCfg(
+        visible_env_indices=[0, 1, 2, 3],
+        world_spacing=(2.0, 2.0, 0.0),
+    )
+
+Dense environment-major :class:`~isaaclab.markers.VisualizationMarkers` batches follow the same
+selection and visual offsets. This includes point-cloud and task-geometry markers.
+
 .. _visualization-common-modes:
 
 .. list-table:: Common modes

--- a/source/isaaclab/test/markers/test_visualization_markers.py
+++ b/source/isaaclab/test/markers/test_visualization_markers.py
@@ -19,6 +19,7 @@ import isaaclab_visualizers.viser.viser_visualizer as viser_visualizer
 import numpy as np
 import pytest
 import torch
+import warp as wp
 from isaaclab_visualizers.kit.kit_visualizer import KitVisualizer
 from isaaclab_visualizers.kit.kit_visualizer_cfg import KitVisualizerCfg
 from isaaclab_visualizers.newton.newton_visualizer_cfg import NewtonVisualizerCfg
@@ -498,8 +499,22 @@ class _FakeNewtonMarkerMesh:
     uvs = np.zeros((0, 2), dtype=np.float32)
 
 
+_NEWTON_MARKER_SPECS = {
+    "arrow": newton_markers._NewtonMarkerSpec(
+        renderer="mesh",
+        mesh_type="box",
+        mesh_params={"size": (1.0, 1.0, 1.0)},
+        color=(1.0, 1.0, 1.0),
+        texture=np.zeros((2, 2, 3), dtype=np.uint8),
+    ),
+    "sphere": newton_markers._NewtonMarkerSpec(renderer="mesh", mesh_type="sphere", mesh_params={"radius": 1.0}),
+    "frame": newton_markers._NewtonMarkerSpec(renderer="frame"),
+}
+
+
 class _FakeNewtonMarkerViewer:
-    def __init__(self):
+    def __init__(self, world_offsets):
+        self.world_offsets = world_offsets
         self.meshes = []
         self.instances = []
         self.lines = []
@@ -552,36 +567,31 @@ def _make_newton_marker_for_render(
     marker.count = translations.shape[0]
     marker._registered_meshes = set()
     marker._warned_unsupported = set()
+    marker._marker_specs = {name: _NEWTON_MARKER_SPECS[name] for name in marker_names}
     return marker
 
 
-def _patch_newton_marker_render_deps(monkeypatch: pytest.MonkeyPatch) -> None:
-    specs = {
-        "arrow": newton_markers._NewtonMarkerSpec(
-            renderer="mesh",
-            mesh_type="box",
-            mesh_params={"size": (1.0, 1.0, 1.0)},
-            color=(1.0, 1.0, 1.0),
-            texture=np.zeros((2, 2, 3), dtype=np.uint8),
-        ),
-        "sphere": newton_markers._NewtonMarkerSpec(renderer="mesh", mesh_type="sphere", mesh_params={"radius": 1.0}),
-        "frame": newton_markers._NewtonMarkerSpec(renderer="frame"),
-    }
+def _patch_newton_marker_render_deps(
+    monkeypatch: pytest.MonkeyPatch, world_offsets: np.ndarray | None = None, world_offsets_device: str = "cpu"
+):
+    if world_offsets is None:
+        world_offsets = np.zeros((4, 3), dtype=np.float32)
+    warp_world_offsets = wp.array(world_offsets, dtype=wp.vec3, device=world_offsets_device)
 
     monkeypatch.setattr(newton_markers, "_create_mesh", lambda cfg: _FakeNewtonMarkerMesh())
     monkeypatch.setattr(newton_markers.wp, "array", lambda value, dtype=None: value)
-    monkeypatch.setattr(newton_markers, "_resolve_newton_marker_cfg", lambda name, marker_cfg, cfg: specs[name])
+    return warp_world_offsets
 
 
 def test_newton_marker_render_filters_visible_envs(monkeypatch: pytest.MonkeyPatch):
-    _patch_newton_marker_render_deps(monkeypatch)
+    world_offsets = _patch_newton_marker_render_deps(monkeypatch)
     translations = torch.arange(8, dtype=torch.float32).unsqueeze(1).repeat(1, 3)
     marker = _make_newton_marker_for_render(
         marker_names=["arrow"],
         translations=translations,
         marker_indices=torch.zeros(8, dtype=torch.int32),
     )
-    viewer = _FakeNewtonMarkerViewer()
+    viewer = _FakeNewtonMarkerViewer(world_offsets)
 
     marker.render(viewer, visible_env_ids=[1, 3], num_envs=4)
 
@@ -590,47 +600,68 @@ def test_newton_marker_render_filters_visible_envs(monkeypatch: pytest.MonkeyPat
     assert viewer.instances[0]["xforms"][:, 0].tolist() == [2.0, 3.0, 6.0, 7.0]
 
 
-def test_newton_marker_render_applies_visible_world_offsets(monkeypatch: pytest.MonkeyPatch):
-    _patch_newton_marker_render_deps(monkeypatch)
+@pytest.mark.parametrize(
+    ("visible_env_ids", "expected"),
+    [
+        ([1, 3], [12.0, 13.0, 36.0, 37.0]),
+        (None, [0.0, 1.0, 12.0, 13.0, 24.0, 25.0, 36.0, 37.0]),
+    ],
+)
+def test_newton_marker_render_applies_world_offsets(
+    monkeypatch: pytest.MonkeyPatch, visible_env_ids: list[int] | None, expected: list[float]
+):
+    world_offsets_device = "cuda:0" if wp.is_cuda_available() else "cpu"
+    world_offsets = _patch_newton_marker_render_deps(
+        monkeypatch,
+        np.array(
+            [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [20.0, 0.0, 0.0], [30.0, 0.0, 0.0]],
+            dtype=np.float32,
+        ),
+        world_offsets_device=world_offsets_device,
+    )
     translations = torch.arange(8, dtype=torch.float32).unsqueeze(1).repeat(1, 3)
     marker = _make_newton_marker_for_render(
         marker_names=["arrow"],
         translations=translations,
         marker_indices=torch.zeros(8, dtype=torch.int32),
     )
-    viewer = _FakeNewtonMarkerViewer()
-    viewer.world_offsets = torch.tensor([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [20.0, 0.0, 0.0], [30.0, 0.0, 0.0]])
+    viewer = _FakeNewtonMarkerViewer(world_offsets)
+
+    marker.render(viewer, visible_env_ids=visible_env_ids, num_envs=4)
+
+    assert viewer.instances[0]["xforms"][:, 0].tolist() == expected
+
+
+def test_newton_marker_render_keeps_global_batch_unmodified(monkeypatch: pytest.MonkeyPatch):
+    world_offsets = _patch_newton_marker_render_deps(
+        monkeypatch,
+        np.array(
+            [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [20.0, 0.0, 0.0], [30.0, 0.0, 0.0]],
+            dtype=np.float32,
+        ),
+    )
+    translations = torch.arange(3, dtype=torch.float32).unsqueeze(1).repeat(1, 3)
+    marker = _make_newton_marker_for_render(
+        marker_names=["arrow"],
+        translations=translations,
+        marker_indices=torch.zeros(3, dtype=torch.int32),
+    )
+    viewer = _FakeNewtonMarkerViewer(world_offsets)
 
     marker.render(viewer, visible_env_ids=[1, 3], num_envs=4)
 
-    assert viewer.instances[0]["xforms"][:, 0].tolist() == [12.0, 13.0, 36.0, 37.0]
-
-
-def test_newton_marker_render_applies_world_offsets_when_all_envs_visible(monkeypatch: pytest.MonkeyPatch):
-    _patch_newton_marker_render_deps(monkeypatch)
-    translations = torch.arange(8, dtype=torch.float32).unsqueeze(1).repeat(1, 3)
-    marker = _make_newton_marker_for_render(
-        marker_names=["arrow"],
-        translations=translations,
-        marker_indices=torch.zeros(8, dtype=torch.int32),
-    )
-    viewer = _FakeNewtonMarkerViewer()
-    viewer.world_offsets = torch.tensor([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [20.0, 0.0, 0.0], [30.0, 0.0, 0.0]])
-
-    marker.render(viewer, visible_env_ids=None, num_envs=4)
-
-    assert viewer.instances[0]["xforms"][:, 0].tolist() == [0.0, 1.0, 12.0, 13.0, 24.0, 25.0, 36.0, 37.0]
+    assert viewer.instances[0]["xforms"][:, 0].tolist() == [0.0, 1.0, 2.0]
 
 
 def test_newton_marker_render_routes_instances_by_prototype(monkeypatch: pytest.MonkeyPatch):
-    _patch_newton_marker_render_deps(monkeypatch)
+    world_offsets = _patch_newton_marker_render_deps(monkeypatch)
     translations = torch.arange(4, dtype=torch.float32).unsqueeze(1).repeat(1, 3)
     marker = _make_newton_marker_for_render(
         marker_names=["arrow", "sphere"],
         translations=translations,
         marker_indices=torch.tensor([0, 1, 0, 1], dtype=torch.int32),
     )
-    viewer = _FakeNewtonMarkerViewer()
+    viewer = _FakeNewtonMarkerViewer(world_offsets)
 
     marker.render(viewer, visible_env_ids=None, num_envs=4)
 
@@ -645,13 +676,13 @@ def test_newton_marker_render_routes_instances_by_prototype(monkeypatch: pytest.
 
 
 def test_newton_marker_render_hides_unselected_prototypes(monkeypatch: pytest.MonkeyPatch):
-    _patch_newton_marker_render_deps(monkeypatch)
+    world_offsets = _patch_newton_marker_render_deps(monkeypatch)
     marker = _make_newton_marker_for_render(
         marker_names=["arrow", "sphere", "frame"],
         translations=torch.zeros((3, 3), dtype=torch.float32),
         marker_indices=torch.zeros(3, dtype=torch.int32),
     )
-    viewer = _FakeNewtonMarkerViewer()
+    viewer = _FakeNewtonMarkerViewer(world_offsets)
 
     marker.render(viewer, visible_env_ids=None, num_envs=3)
 

--- a/source/isaaclab/test/markers/test_visualization_markers.py
+++ b/source/isaaclab/test/markers/test_visualization_markers.py
@@ -587,7 +587,39 @@ def test_newton_marker_render_filters_visible_envs(monkeypatch: pytest.MonkeyPat
 
     assert len(viewer.instances) == 1
     assert viewer.instances[0]["hidden"] is False
-    assert viewer.instances[0]["xforms"][:, 0].tolist() == [1.0, 3.0, 5.0, 7.0]
+    assert viewer.instances[0]["xforms"][:, 0].tolist() == [2.0, 3.0, 6.0, 7.0]
+
+
+def test_newton_marker_render_applies_visible_world_offsets(monkeypatch: pytest.MonkeyPatch):
+    _patch_newton_marker_render_deps(monkeypatch)
+    translations = torch.arange(8, dtype=torch.float32).unsqueeze(1).repeat(1, 3)
+    marker = _make_newton_marker_for_render(
+        marker_names=["arrow"],
+        translations=translations,
+        marker_indices=torch.zeros(8, dtype=torch.int32),
+    )
+    viewer = _FakeNewtonMarkerViewer()
+    viewer.world_offsets = torch.tensor([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [20.0, 0.0, 0.0], [30.0, 0.0, 0.0]])
+
+    marker.render(viewer, visible_env_ids=[1, 3], num_envs=4)
+
+    assert viewer.instances[0]["xforms"][:, 0].tolist() == [12.0, 13.0, 36.0, 37.0]
+
+
+def test_newton_marker_render_applies_world_offsets_when_all_envs_visible(monkeypatch: pytest.MonkeyPatch):
+    _patch_newton_marker_render_deps(monkeypatch)
+    translations = torch.arange(8, dtype=torch.float32).unsqueeze(1).repeat(1, 3)
+    marker = _make_newton_marker_for_render(
+        marker_names=["arrow"],
+        translations=translations,
+        marker_indices=torch.zeros(8, dtype=torch.int32),
+    )
+    viewer = _FakeNewtonMarkerViewer()
+    viewer.world_offsets = torch.tensor([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [20.0, 0.0, 0.0], [30.0, 0.0, 0.0]])
+
+    marker.render(viewer, visible_env_ids=None, num_envs=4)
+
+    assert viewer.instances[0]["xforms"][:, 0].tolist() == [0.0, 1.0, 12.0, 13.0, 24.0, 25.0, 36.0, 37.0]
 
 
 def test_newton_marker_render_routes_instances_by_prototype(monkeypatch: pytest.MonkeyPatch):

--- a/source/isaaclab/test/markers/test_visualization_markers.py
+++ b/source/isaaclab/test/markers/test_visualization_markers.py
@@ -583,6 +583,24 @@ def _patch_newton_marker_render_deps(
     return warp_world_offsets
 
 
+def test_newton_marker_partial_update_preserves_prototype_indices():
+    marker = _make_newton_marker_for_render(
+        marker_names=["arrow", "sphere"],
+        translations=torch.zeros((4, 3), dtype=torch.float32),
+        marker_indices=torch.tensor([0, 1, 0, 1], dtype=torch.int32),
+    )
+    expected_indices = marker.marker_indices
+
+    marker.visualize(
+        translations=torch.ones((4, 3), dtype=torch.float32),
+        orientations=None,
+        scales=None,
+        marker_indices=None,
+    )
+
+    assert marker.marker_indices is expected_indices
+
+
 def test_newton_marker_render_filters_visible_envs(monkeypatch: pytest.MonkeyPatch):
     world_offsets = _patch_newton_marker_render_deps(monkeypatch)
     translations = torch.arange(8, dtype=torch.float32).unsqueeze(1).repeat(1, 3)
@@ -630,6 +648,105 @@ def test_newton_marker_render_applies_world_offsets(
     marker.render(viewer, visible_env_ids=visible_env_ids, num_envs=4)
 
     assert viewer.instances[0]["xforms"][:, 0].tolist() == expected
+
+
+def test_newton_marker_render_preserves_reordered_env_state(monkeypatch: pytest.MonkeyPatch):
+    offsets = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [100.0, 200.0, 300.0],
+            [200.0, 400.0, 600.0],
+            [300.0, 600.0, 900.0],
+        ],
+        dtype=np.float32,
+    )
+    world_offsets = _patch_newton_marker_render_deps(monkeypatch, offsets)
+    translations = torch.arange(24, dtype=torch.float32).reshape(3, 8).T
+    orientations = torch.arange(32, dtype=torch.float32).reshape(4, 8).T
+    scales = torch.arange(1, 25, dtype=torch.float32).reshape(3, 8).T
+    marker = _make_newton_marker_for_render(
+        marker_names=["arrow"],
+        translations=translations,
+        marker_indices=torch.zeros(8, dtype=torch.int32),
+    )
+    marker.orientations = orientations
+    marker.scales = scales
+    source_state = (
+        marker.translations,
+        marker.orientations,
+        marker.scales,
+        marker.marker_indices,
+    )
+    source_values = tuple(value.clone() for value in source_state)
+    viewer = _FakeNewtonMarkerViewer(world_offsets)
+
+    selections = (
+        ([3, 1], torch.tensor([6, 7, 2, 3])),
+        ([1, 3], torch.tensor([2, 3, 6, 7])),
+    )
+
+    monkeypatch.setattr(
+        newton_markers.torch,
+        "arange",
+        lambda *args, **kwargs: pytest.fail("render should not construct environment index tensors"),
+    )
+
+    for visible_env_ids, expected_indices in selections:
+        selected_offsets = torch.from_numpy(offsets[np.repeat(visible_env_ids, 2)])
+        expected_positions = translations[expected_indices] + selected_offsets
+        expected_xforms = torch.cat((expected_positions, orientations[expected_indices]), dim=1)
+        expected_scales = scales[expected_indices]
+        marker.render(viewer, visible_env_ids=visible_env_ids, num_envs=4)
+        call = viewer.instances[-1]
+        assert call["hidden"] is False
+        np.testing.assert_allclose(call["xforms"], expected_xforms.numpy(), rtol=0.0, atol=0.0)
+        np.testing.assert_allclose(call["scales"], expected_scales.numpy(), rtol=0.0, atol=0.0)
+
+    current_state = (
+        marker.translations,
+        marker.orientations,
+        marker.scales,
+        marker.marker_indices,
+    )
+    for current, source, expected in zip(current_state, source_state, source_values):
+        assert current is source
+        assert torch.equal(current, expected)
+    assert len(viewer.instances) == 2
+
+
+def test_newton_marker_render_hides_empty_env_selection(monkeypatch: pytest.MonkeyPatch):
+    world_offsets = _patch_newton_marker_render_deps(monkeypatch)
+    marker = _make_newton_marker_for_render(
+        marker_names=["arrow"],
+        translations=torch.zeros((8, 3), dtype=torch.float32),
+    )
+    viewer = _FakeNewtonMarkerViewer(world_offsets)
+
+    marker.render(viewer, visible_env_ids=[], num_envs=4)
+
+    assert len(viewer.instances) == 1
+    assert viewer.instances[0]["hidden"] is True
+
+
+def test_newton_marker_render_defaults_to_first_prototype(monkeypatch: pytest.MonkeyPatch):
+    world_offsets = _patch_newton_marker_render_deps(monkeypatch)
+    marker = _make_newton_marker_for_render(
+        marker_names=["arrow", "sphere"],
+        translations=torch.zeros((4, 3), dtype=torch.float32),
+    )
+    marker.orientations = None
+    marker.scales = None
+    viewer = _FakeNewtonMarkerViewer(world_offsets)
+
+    marker.render(viewer, visible_env_ids=None, num_envs=4)
+
+    visible_instances = [call for call in viewer.instances if not call["hidden"]]
+    assert len(visible_instances) == 1
+    assert visible_instances[0]["batch_name"] == "/Visuals/marker::test/arrow"
+    assert visible_instances[0]["xforms"][:, 3:].tolist() == [[0.0, 0.0, 0.0, 1.0]] * 4
+    assert visible_instances[0]["scales"].tolist() == [[1.0, 1.0, 1.0]] * 4
+    hidden_batches = [call["batch_name"] for call in viewer.instances if call["hidden"]]
+    assert hidden_batches == ["/Visuals/marker::test/sphere"]
 
 
 def test_newton_marker_render_keeps_global_batch_unmodified(monkeypatch: pytest.MonkeyPatch):

--- a/source/isaaclab_visualizers/changelog.d/newton-world-spacing.minor.rst
+++ b/source/isaaclab_visualizers/changelog.d/newton-world-spacing.minor.rst
@@ -3,8 +3,6 @@ Added
 
 * Added :attr:`~isaaclab_visualizers.newton.NewtonVisualizerCfg.world_spacing`
   to visually separate Newton worlds without changing their simulated poses.
-* Added :meth:`~isaaclab_visualizers.newton.NewtonVisualizer.render_markers`
-  to render active Isaac Lab marker groups into another Newton viewer.
 
 Fixed
 ^^^^^

--- a/source/isaaclab_visualizers/changelog.d/newton-world-spacing.minor.rst
+++ b/source/isaaclab_visualizers/changelog.d/newton-world-spacing.minor.rst
@@ -1,0 +1,13 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_visualizers.newton.NewtonVisualizerCfg.world_spacing`
+  to visually separate Newton worlds without changing their simulated poses.
+* Added :meth:`~isaaclab_visualizers.newton.NewtonVisualizer.render_markers`
+  to render active Isaac Lab marker groups into another Newton viewer.
+
+Fixed
+^^^^^
+
+* Fixed Newton marker filtering for environment-major marker arrays and aligned marker
+  overlays with visual world spacing.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualization_markers.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualization_markers.py
@@ -15,6 +15,7 @@ import numpy as np
 import torch
 import warp as wp
 from newton import Axis, Mesh
+from newton.viewer import ViewerBase
 
 import isaaclab.sim as sim_utils
 from isaaclab.markers.visualization_markers_cfg import VisualizationMarkersCfg
@@ -49,7 +50,7 @@ class _MeshData:
     uvs: np.ndarray
 
 
-def render_newton_visualization_markers(viewer, visible_env_ids: list[int] | None, num_envs: int) -> None:
+def render_newton_visualization_markers(viewer: ViewerBase, visible_env_ids: list[int] | None, num_envs: int) -> None:
     """Render all active Newton visualization marker groups into a Newton-family viewer."""
     sim = sim_utils.SimulationContext.instance()
     if sim is None:
@@ -74,6 +75,9 @@ class NewtonVisualizationMarkers:
         self.count = len(cfg.markers)
         self._registered_meshes: set[tuple[int, str]] = set()
         self._warned_unsupported: set[str] = set()
+        self._marker_specs: dict[str, _NewtonMarkerSpec] = {
+            name: _infer_newton_marker_cfg(marker_cfg) for name, marker_cfg in cfg.markers.items()
+        }
 
         sim = sim_utils.SimulationContext.instance()
         if sim is not None:
@@ -123,33 +127,66 @@ class NewtonVisualizationMarkers:
         elif self.count != 0:
             self.marker_indices = torch.zeros(self.count, dtype=torch.int32, device=self.infer_device())
 
-    def render(self, viewer, visible_env_ids: list[int] | None, num_envs: int) -> None:
-        """Render marker state to a Newton viewer."""
-        state = _filter_marker_state(self, visible_env_ids=visible_env_ids, num_envs=num_envs)
-        if state["count"] == 0:
-            for name, marker_cfg in self.cfg.markers.items():
-                self._hide_batch(viewer, name, _resolve_newton_marker_cfg(name, marker_cfg, self.cfg))
+    def render(self, viewer: ViewerBase, visible_env_ids: list[int] | None, num_envs: int) -> None:
+        """Render marker state to a Newton viewer.
+
+        Marker batches divisible by ``num_envs`` are interpreted as dense environment-major arrays
+        with shape ``(num_envs, markers_per_env, ...)``. Other batches are rendered as global markers.
+        """
+        translations = self.translations
+        orientations = self.orientations
+        scales = self.scales
+        marker_indices = self.marker_indices
+        count = self.count
+
+        if count > 0 and num_envs > 0 and count % num_envs == 0:
+            markers_per_env = count // num_envs
+            device = self.infer_device()
+            env_ids = (
+                torch.arange(num_envs, dtype=torch.long, device=device)
+                if visible_env_ids is None
+                else torch.tensor(visible_env_ids, dtype=torch.long, device=device)
+            )
+            if visible_env_ids is not None:
+                index = (
+                    env_ids.unsqueeze(1) * markers_per_env
+                    + torch.arange(markers_per_env, dtype=torch.long, device=device).unsqueeze(0)
+                ).flatten()
+                if translations is not None:
+                    translations = translations.index_select(0, index)
+                if orientations is not None:
+                    orientations = orientations.index_select(0, index)
+                if scales is not None:
+                    scales = scales.index_select(0, index)
+                if marker_indices is not None:
+                    marker_indices = marker_indices.index_select(0, index)
+                count = index.numel()
+            if translations is not None:
+                offsets = wp.to_torch(viewer.world_offsets)
+                offset_env_ids = env_ids.to(device=offsets.device)
+                selected_offsets = offsets.index_select(0, offset_env_ids)
+                selected_offsets = selected_offsets.to(device=translations.device, dtype=translations.dtype)
+                translations = translations + selected_offsets.repeat_interleave(markers_per_env, dim=0)
+
+        if count == 0:
+            for name, newton_cfg in self._marker_specs.items():
+                self._hide_batch(viewer, name, newton_cfg)
             return
 
-        translations = state["translations"]
         if translations is None:
             return
-        translations = _apply_marker_world_offsets(viewer, translations, state["world_indices"], num_envs)
-        orientations = state["orientations"]
         if orientations is None:
-            orientations = torch.tensor([[0.0, 0.0, 0.0, 1.0]], device=translations.device).repeat(state["count"], 1)
-        scales = state["scales"]
+            orientations = torch.tensor([[0.0, 0.0, 0.0, 1.0]], device=translations.device).repeat(count, 1)
         if scales is None:
-            scales = torch.ones((state["count"], 3), dtype=torch.float32, device=translations.device)
-        marker_indices = state["marker_indices"]
+            scales = torch.ones((count, 3), dtype=torch.float32, device=translations.device)
         if marker_indices is None:
-            marker_indices = torch.zeros(state["count"], dtype=torch.int64, device=translations.device)
+            marker_indices = torch.zeros(count, dtype=torch.int64, device=translations.device)
 
         for proto_index, (name, marker_cfg) in enumerate(self.cfg.markers.items()):
-            newton_cfg = _resolve_newton_marker_cfg(name, marker_cfg, self.cfg)
+            newton_cfg = self._marker_specs[name]
             batch_name = f"{self.group_id}/{name}"
             selected = marker_indices == proto_index
-            if not state["visible"] or int(selected.sum().item()) == 0:
+            if not self.visible or int(selected.sum().item()) == 0:
                 self._hide_batch(viewer, name, newton_cfg)
                 continue
 
@@ -205,7 +242,7 @@ class NewtonVisualizationMarkers:
                     hidden=False,
                 )
 
-    def _hide_batch(self, viewer, name: str, newton_cfg: _NewtonMarkerSpec) -> None:
+    def _hide_batch(self, viewer: ViewerBase, name: str, newton_cfg: _NewtonMarkerSpec) -> None:
         batch_name = f"{self.group_id}/{name}"
         if newton_cfg.renderer == "mesh" and newton_cfg.mesh_type is not None:
             mesh_name = f"{self.group_id}/meshes/{name}"
@@ -214,7 +251,7 @@ class NewtonVisualizationMarkers:
         elif newton_cfg.renderer == "frame":
             viewer.log_lines(batch_name, None, None, None, hidden=True)
 
-    def _ensure_mesh_registered(self, viewer, mesh_name: str, newton_cfg: _NewtonMarkerSpec) -> None:
+    def _ensure_mesh_registered(self, viewer: ViewerBase, mesh_name: str, newton_cfg: _NewtonMarkerSpec) -> None:
         # The marker backend is shared by all Newton-family visualizers. Mesh
         # registration is viewer-local, so the same marker mesh must be logged
         # once per viewer (for example, once for Rerun and once for Viser).
@@ -232,11 +269,6 @@ class NewtonVisualizationMarkers:
             hidden=True,
         )
         self._registered_meshes.add(registered_key)
-
-
-def _resolve_newton_marker_cfg(name: str, marker_cfg: object, cfg: VisualizationMarkersCfg) -> _NewtonMarkerSpec:
-    del name, cfg
-    return _infer_newton_marker_cfg(marker_cfg)
 
 
 def _infer_newton_marker_cfg(marker_cfg: object) -> _NewtonMarkerSpec:
@@ -407,93 +439,6 @@ def _create_textured_box_mesh(size: tuple[float, float, float]) -> _MeshData:
         normals=np.zeros((0, 3), dtype=np.float32),
         uvs=uvs,
     )
-
-
-def _filter_marker_state(
-    marker: NewtonVisualizationMarkers,
-    visible_env_ids: list[int] | None,
-    num_envs: int,
-) -> dict[str, Any]:
-    """Filter an environment-major marker batch and retain each marker's owning world."""
-    if visible_env_ids is None or marker.count == 0 or num_envs <= 0 or marker.count % num_envs != 0:
-        return {
-            "visible": marker.visible,
-            "translations": marker.translations,
-            "orientations": marker.orientations,
-            "scales": marker.scales,
-            "marker_indices": marker.marker_indices,
-            "count": marker.count,
-            "world_indices": None,
-        }
-
-    keep: list[int] = []
-    world_ids: list[int] = []
-    repeat_count = marker.count // num_envs
-    for env_id in dict.fromkeys(visible_env_ids):
-        if env_id < 0 or env_id >= num_envs:
-            continue
-        start = env_id * repeat_count
-        for idx in range(start, start + repeat_count):
-            keep.append(idx)
-            world_ids.append(env_id)
-    world_indices = torch.tensor(world_ids, dtype=torch.long, device=marker.infer_device())
-
-    if keep == list(range(marker.count)):
-        return {
-            "visible": marker.visible,
-            "translations": marker.translations,
-            "orientations": marker.orientations,
-            "scales": marker.scales,
-            "marker_indices": marker.marker_indices,
-            "count": marker.count,
-            "world_indices": world_indices,
-        }
-
-    index = torch.tensor(keep, dtype=torch.long, device=marker.infer_device())
-    return {
-        "visible": marker.visible,
-        "translations": marker.translations.index_select(0, index) if marker.translations is not None else None,
-        "orientations": marker.orientations.index_select(0, index) if marker.orientations is not None else None,
-        "scales": marker.scales.index_select(0, index) if marker.scales is not None else None,
-        "marker_indices": marker.marker_indices.index_select(0, index) if marker.marker_indices is not None else None,
-        "count": len(keep),
-        "world_indices": world_indices,
-    }
-
-
-def _apply_marker_world_offsets(
-    viewer, translations: torch.Tensor, world_indices: torch.Tensor | None, num_envs: int
-) -> torch.Tensor:
-    """Apply a Newton viewer's visual world offsets to env-owned markers."""
-    spacing = getattr(viewer, "_user_spacing", None)
-    if spacing is not None and all(float(spacing[axis]) == 0.0 for axis in range(3)):
-        return translations
-
-    world_offsets = getattr(viewer, "world_offsets", None)
-    if world_offsets is None:
-        return translations
-
-    if isinstance(world_offsets, torch.Tensor):
-        offsets = world_offsets
-    elif isinstance(world_offsets, np.ndarray):
-        offsets = torch.as_tensor(world_offsets)
-    else:
-        try:
-            offsets = wp.to_torch(world_offsets)
-        except (AttributeError, RuntimeError, TypeError):
-            return translations
-    if offsets.ndim != 2 or offsets.shape[1] != 3:
-        return translations
-
-    if world_indices is None:
-        if num_envs <= 0 or translations.shape[0] % num_envs != 0:
-            return translations
-        repeat_count = translations.shape[0] // num_envs
-        world_indices = torch.arange(num_envs, device=translations.device).repeat_interleave(repeat_count)
-
-    indices = world_indices.to(device=offsets.device)
-    selected_offsets = offsets.index_select(0, indices).to(device=translations.device, dtype=translations.dtype)
-    return translations + selected_offsets
 
 
 def _extract_scale_hint(marker_cfg: object) -> tuple[float, float, float]:

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualization_markers.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualization_markers.py
@@ -124,8 +124,6 @@ class NewtonVisualizationMarkers:
         if marker_indices is not None:
             self.marker_indices = marker_indices.detach().to(dtype=torch.int32)
             self.count = marker_indices.shape[0]
-        elif self.count != 0:
-            self.marker_indices = torch.zeros(self.count, dtype=torch.int32, device=self.infer_device())
 
     def render(self, viewer: ViewerBase, visible_env_ids: list[int] | None, num_envs: int) -> None:
         """Render marker state to a Newton viewer.
@@ -139,34 +137,27 @@ class NewtonVisualizationMarkers:
         marker_indices = self.marker_indices
         count = self.count
 
+        if not self.visible:
+            for name, newton_cfg in self._marker_specs.items():
+                self._hide_batch(viewer, name, newton_cfg)
+            return
+
         if count > 0 and num_envs > 0 and count % num_envs == 0:
             markers_per_env = count // num_envs
-            device = self.infer_device()
-            env_ids = (
-                torch.arange(num_envs, dtype=torch.long, device=device)
-                if visible_env_ids is None
-                else torch.tensor(visible_env_ids, dtype=torch.long, device=device)
-            )
-            if visible_env_ids is not None:
-                index = (
-                    env_ids.unsqueeze(1) * markers_per_env
-                    + torch.arange(markers_per_env, dtype=torch.long, device=device).unsqueeze(0)
-                ).flatten()
-                if translations is not None:
-                    translations = translations.index_select(0, index)
-                if orientations is not None:
-                    orientations = orientations.index_select(0, index)
-                if scales is not None:
-                    scales = scales.index_select(0, index)
-                if marker_indices is not None:
-                    marker_indices = marker_indices.index_select(0, index)
-                count = index.numel()
+            env_selection = slice(num_envs) if visible_env_ids is None else visible_env_ids
+            selected_env_count = num_envs if visible_env_ids is None else len(visible_env_ids)
             if translations is not None:
-                offsets = wp.to_torch(viewer.world_offsets)
-                offset_env_ids = env_ids.to(device=offsets.device)
-                selected_offsets = offsets.index_select(0, offset_env_ids)
-                selected_offsets = selected_offsets.to(device=translations.device, dtype=translations.dtype)
-                translations = translations + selected_offsets.repeat_interleave(markers_per_env, dim=0)
+                translations = translations.reshape(num_envs, markers_per_env, 3)[env_selection]
+            if orientations is not None:
+                orientations = orientations.reshape(num_envs, markers_per_env, 4)[env_selection].flatten(0, 1)
+            if scales is not None:
+                scales = scales.reshape(num_envs, markers_per_env, 3)[env_selection].flatten(0, 1)
+            if marker_indices is not None:
+                marker_indices = marker_indices.reshape(num_envs, markers_per_env)[env_selection].flatten(0, 1)
+            count = selected_env_count * markers_per_env
+            if translations is not None:
+                offsets = wp.to_torch(viewer.world_offsets)[env_selection].to(translations)
+                translations = (translations + offsets[:, None, :]).flatten(0, 1)
 
         if count == 0:
             for name, newton_cfg in self._marker_specs.items():
@@ -175,20 +166,20 @@ class NewtonVisualizationMarkers:
 
         if translations is None:
             return
-        if orientations is None:
-            orientations = torch.tensor([[0.0, 0.0, 0.0, 1.0]], device=translations.device).repeat(count, 1)
-        if scales is None:
-            scales = torch.ones((count, 3), dtype=torch.float32, device=translations.device)
-        if marker_indices is None:
-            marker_indices = torch.zeros(count, dtype=torch.int64, device=translations.device)
 
         for proto_index, (name, marker_cfg) in enumerate(self.cfg.markers.items()):
             newton_cfg = self._marker_specs[name]
             batch_name = f"{self.group_id}/{name}"
-            selected = marker_indices == proto_index
-            if not self.visible or int(selected.sum().item()) == 0:
-                self._hide_batch(viewer, name, newton_cfg)
-                continue
+            if marker_indices is None:
+                if proto_index != 0:
+                    self._hide_batch(viewer, name, newton_cfg)
+                    continue
+                selected = slice(None)
+            else:
+                selected = marker_indices == proto_index
+                if not torch.any(selected):
+                    self._hide_batch(viewer, name, newton_cfg)
+                    continue
 
             if newton_cfg.renderer == "none":
                 unsupported_key = f"{self.group_id}:{name}"
@@ -202,24 +193,28 @@ class NewtonVisualizationMarkers:
                 continue
 
             selected_translations = translations[selected]
-            selected_orientations = orientations[selected]
+            selected_count = selected_translations.shape[0]
+            if orientations is None:
+                selected_orientations = selected_translations.new_tensor((0.0, 0.0, 0.0, 1.0)).expand(
+                    selected_count, -1
+                )
+            else:
+                selected_orientations = orientations[selected]
             default_scale = newton_cfg.scale or _extract_scale_hint(marker_cfg)
-            selected_scales = scales[selected] * torch.tensor(
-                default_scale, dtype=torch.float32, device=scales.device
-            ).unsqueeze(0)
+            default_scale_tensor = selected_translations.new_tensor(default_scale)
+            if scales is None:
+                selected_scales = default_scale_tensor.expand(selected_count, -1)
+            else:
+                selected_scales = scales[selected] * default_scale_tensor
 
             if newton_cfg.renderer == "mesh":
                 mesh_name = f"{self.group_id}/meshes/{name}"
                 self._ensure_mesh_registered(viewer, mesh_name, newton_cfg)
                 color = newton_cfg.color or _extract_color(marker_cfg)
-                colors = torch.tensor(color, dtype=torch.float32, device=scales.device).repeat(
-                    selected_scales.shape[0], 1
-                )
-                materials = torch.zeros((selected_scales.shape[0], 4), dtype=torch.float32, device=scales.device)
-                if newton_cfg.texture is not None:
-                    # ViewerGL gates texture sampling with material.w. Rerun and
-                    # Viser ignore this flag but consume the mesh texture.
-                    materials[:, 3] = 1.0
+                colors = selected_translations.new_tensor(color).expand(selected_count, -1)
+                # ViewerGL gates texture sampling with material.w. Rerun and Viser ignore this flag.
+                texture_flag = float(newton_cfg.texture is not None)
+                materials = selected_translations.new_tensor((0.0, 0.0, 0.0, texture_flag)).expand(selected_count, -1)
                 xforms = torch.cat((selected_translations, selected_orientations), dim=1).detach().cpu().numpy()
                 viewer.log_instances(
                     batch_name,

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualization_markers.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualization_markers.py
@@ -134,6 +134,7 @@ class NewtonVisualizationMarkers:
         translations = state["translations"]
         if translations is None:
             return
+        translations = _apply_marker_world_offsets(viewer, translations, state["world_indices"], num_envs)
         orientations = state["orientations"]
         if orientations is None:
             orientations = torch.tensor([[0.0, 0.0, 0.0, 1.0]], device=translations.device).repeat(state["count"], 1)
@@ -413,6 +414,7 @@ def _filter_marker_state(
     visible_env_ids: list[int] | None,
     num_envs: int,
 ) -> dict[str, Any]:
+    """Filter an environment-major marker batch and retain each marker's owning world."""
     if visible_env_ids is None or marker.count == 0 or num_envs <= 0 or marker.count % num_envs != 0:
         return {
             "visible": marker.visible,
@@ -421,18 +423,22 @@ def _filter_marker_state(
             "scales": marker.scales,
             "marker_indices": marker.marker_indices,
             "count": marker.count,
+            "world_indices": None,
         }
 
     keep: list[int] = []
+    world_ids: list[int] = []
     repeat_count = marker.count // num_envs
-    for block_idx in range(repeat_count):
-        base = block_idx * num_envs
-        for env_id in visible_env_ids:
-            idx = base + env_id
-            if idx < marker.count:
-                keep.append(idx)
+    for env_id in dict.fromkeys(visible_env_ids):
+        if env_id < 0 or env_id >= num_envs:
+            continue
+        start = env_id * repeat_count
+        for idx in range(start, start + repeat_count):
+            keep.append(idx)
+            world_ids.append(env_id)
+    world_indices = torch.tensor(world_ids, dtype=torch.long, device=marker.infer_device())
 
-    if len(keep) == marker.count:
+    if keep == list(range(marker.count)):
         return {
             "visible": marker.visible,
             "translations": marker.translations,
@@ -440,6 +446,7 @@ def _filter_marker_state(
             "scales": marker.scales,
             "marker_indices": marker.marker_indices,
             "count": marker.count,
+            "world_indices": world_indices,
         }
 
     index = torch.tensor(keep, dtype=torch.long, device=marker.infer_device())
@@ -450,7 +457,43 @@ def _filter_marker_state(
         "scales": marker.scales.index_select(0, index) if marker.scales is not None else None,
         "marker_indices": marker.marker_indices.index_select(0, index) if marker.marker_indices is not None else None,
         "count": len(keep),
+        "world_indices": world_indices,
     }
+
+
+def _apply_marker_world_offsets(
+    viewer, translations: torch.Tensor, world_indices: torch.Tensor | None, num_envs: int
+) -> torch.Tensor:
+    """Apply a Newton viewer's visual world offsets to env-owned markers."""
+    spacing = getattr(viewer, "_user_spacing", None)
+    if spacing is not None and all(float(spacing[axis]) == 0.0 for axis in range(3)):
+        return translations
+
+    world_offsets = getattr(viewer, "world_offsets", None)
+    if world_offsets is None:
+        return translations
+
+    if isinstance(world_offsets, torch.Tensor):
+        offsets = world_offsets
+    elif isinstance(world_offsets, np.ndarray):
+        offsets = torch.as_tensor(world_offsets)
+    else:
+        try:
+            offsets = wp.to_torch(world_offsets)
+        except (AttributeError, RuntimeError, TypeError):
+            return translations
+    if offsets.ndim != 2 or offsets.shape[1] != 3:
+        return translations
+
+    if world_indices is None:
+        if num_envs <= 0 or translations.shape[0] % num_envs != 0:
+            return translations
+        repeat_count = translations.shape[0] // num_envs
+        world_indices = torch.arange(num_envs, device=translations.device).repeat_interleave(repeat_count)
+
+    indices = world_indices.to(device=offsets.device)
+    selected_offsets = offsets.index_select(0, indices).to(device=translations.device, dtype=translations.dtype)
+    return translations + selected_offsets
 
 
 def _extract_scale_hint(marker_cfg: object) -> tuple[float, float, float]:

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -32,7 +32,7 @@ from isaaclab.envs.utils.camera_view import (
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
 
 from isaaclab_visualizers.newton.newton_visualization_markers import render_newton_visualization_markers
-from isaaclab_visualizers.newton_adapter import apply_viewer_visible_worlds, resolve_visible_env_indices
+from isaaclab_visualizers.newton_adapter import resolve_visible_env_indices
 
 from .newton_visualizer_cfg import NewtonVisualizerCfg
 
@@ -477,6 +477,7 @@ class NewtonVisualizer(BaseVisualizer):
         num_envs = scene_data_provider.num_envs
         metadata = {"num_envs": num_envs}
         self._env_ids = self._compute_visualized_env_ids()
+        self._resolved_visible_env_ids = resolve_visible_env_indices(self._env_ids, self.cfg.max_visible_envs, num_envs)
         self._model = NewtonManager.get_model()
         self._state = NewtonManager.get_state(self._scene_data_provider)
 
@@ -502,12 +503,7 @@ class NewtonVisualizer(BaseVisualizer):
 
         if self._viewer is not None:
             self._viewer.set_model(self._model)
-            apply_viewer_visible_worlds(
-                self._viewer,
-                env_ids=self._env_ids,
-                max_visible_envs=self.cfg.max_visible_envs,
-                num_envs=num_envs,
-            )
+            self._viewer.set_visible_worlds(self._resolved_visible_env_ids)
             self._viewer.set_world_offsets(self.cfg.world_spacing)
             self._apply_camera_focal_length()
             initial_pose = self._resolve_initial_camera_pose()
@@ -535,7 +531,6 @@ class NewtonVisualizer(BaseVisualizer):
             self._viewer.renderer.sky_lower = self._viewer._coerce_color3(self.cfg.sky_lower_color)
             self._viewer.renderer._light_color = self._viewer._coerce_color3(self.cfg.light_color)
 
-        self._resolved_visible_env_ids = resolve_visible_env_indices(self._env_ids, self.cfg.max_visible_envs, num_envs)
         self._setup_camera_sensor_view(num_envs)
         num_visualized_envs = (
             len(self._resolved_visible_env_ids) if self._resolved_visible_env_ids is not None else num_envs
@@ -599,7 +594,10 @@ class NewtonVisualizer(BaseVisualizer):
                             self._viewer.log_contacts(contacts, self._state)
                         else:
                             self._log_scene_contact_sensor_arrows(num_envs)
-                        self.render_markers(self._viewer, num_envs=num_envs)
+                        if self.cfg.enable_markers:
+                            render_newton_visualization_markers(
+                                self._viewer, self._resolved_visible_env_ids, num_envs=num_envs
+                            )
                         self._log_camera_sensor_image()
                 finally:
                     self._viewer.end_frame()
@@ -849,22 +847,6 @@ class NewtonVisualizer(BaseVisualizer):
         self.cfg.eye = eye_t
         self.cfg.lookat = target_t
         self._apply_camera_pose((eye_t, target_t))
-
-    def render_markers(self, viewer: ViewerGL, num_envs: int | None = None) -> None:
-        """Render active Isaac Lab marker groups into a Newton viewer.
-
-        Args:
-            viewer: Newton viewer that receives the marker overlays.
-            num_envs: Total number of simulation environments. If ``None``, the count is
-                queried from the active Newton manager.
-        """
-        if not self.cfg.enable_markers:
-            return
-        if num_envs is None:
-            from isaaclab_newton.physics import NewtonManager
-
-            num_envs = NewtonManager.get_num_envs()
-        render_newton_visualization_markers(viewer, self._resolved_visible_env_ids, num_envs=num_envs)
 
     def supports_markers(self) -> bool:
         """Newton OpenGL viewer supports Isaac Lab markers through viewer-side meshes and lines."""

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -508,7 +508,7 @@ class NewtonVisualizer(BaseVisualizer):
                 max_visible_envs=self.cfg.max_visible_envs,
                 num_envs=num_envs,
             )
-            self._viewer.set_world_offsets((0.0, 0.0, 0.0))
+            self._viewer.set_world_offsets(self.cfg.world_spacing)
             self._apply_camera_focal_length()
             initial_pose = self._resolve_initial_camera_pose()
             self._apply_camera_pose(initial_pose)
@@ -599,10 +599,7 @@ class NewtonVisualizer(BaseVisualizer):
                             self._viewer.log_contacts(contacts, self._state)
                         else:
                             self._log_scene_contact_sensor_arrows(num_envs)
-                        if self.cfg.enable_markers:
-                            render_newton_visualization_markers(
-                                self._viewer, self._resolved_visible_env_ids, num_envs=num_envs
-                            )
+                        self.render_markers(self._viewer, num_envs=num_envs)
                         self._log_camera_sensor_image()
                 finally:
                     self._viewer.end_frame()
@@ -852,6 +849,22 @@ class NewtonVisualizer(BaseVisualizer):
         self.cfg.eye = eye_t
         self.cfg.lookat = target_t
         self._apply_camera_pose((eye_t, target_t))
+
+    def render_markers(self, viewer: ViewerGL, num_envs: int | None = None) -> None:
+        """Render active Isaac Lab marker groups into a Newton viewer.
+
+        Args:
+            viewer: Newton viewer that receives the marker overlays.
+            num_envs: Total number of simulation environments. If ``None``, the count is
+                queried from the active Newton manager.
+        """
+        if not self.cfg.enable_markers:
+            return
+        if num_envs is None:
+            from isaaclab_newton.physics import NewtonManager
+
+            num_envs = NewtonManager.get_num_envs()
+        render_newton_visualization_markers(viewer, self._resolved_visible_env_ids, num_envs=num_envs)
 
     def supports_markers(self) -> bool:
         """Newton OpenGL viewer supports Isaac Lab markers through viewer-side meshes and lines."""

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer_cfg.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer_cfg.py
@@ -28,6 +28,12 @@ class NewtonVisualizerCfg(VisualizerCfg):
     update_frequency: int = 1
     """Visualizer update frequency (updates every N frames)."""
 
+    world_spacing: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    """Visual spacing between simulation worlds along each axis [m].
+
+    Non-zero axes arrange visible worlds in a compact grid without changing their simulated poses.
+    """
+
     show_joints: bool = False
     """Show joint visualization."""
 

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton_adapter.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton_adapter.py
@@ -64,14 +64,14 @@ def resolve_visible_env_indices(
     * Cap-only path (``env_ids`` is ``None``): contiguous ``0 .. min(cap, num_envs) - 1`` when ``max_visible_envs``
       is set; otherwise ``None`` (viewer shows all worlds). (Random cap-only selection is applied earlier by
       turning it into explicit ``env_ids``.)
-    * Explicit path (``env_ids`` is a list): if ``max_visible_envs`` is set, keep only the first *cap* indices
-      (truncate from the end); if ``None``, use the full list.
+    * Explicit path (``env_ids`` is a list): remove duplicate indices while preserving order, then keep only the
+      first *cap* indices when ``max_visible_envs`` is set.
 
     Returns:
         Selected indices, or ``None`` when all environments should be visible (cap-only, no limit).
     """
     if env_ids is not None:
-        out = list(env_ids)
+        out = list(dict.fromkeys(env_ids))
         if max_visible_envs is not None:
             out = out[: max(0, int(max_visible_envs))]
         return out

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -70,6 +70,10 @@ def test_resolve_visible_env_indices_truncates_explicit_list():
     assert resolve_visible_env_indices([1, 3], 1, 10) == [1]
 
 
+def test_resolve_visible_env_indices_deduplicates_before_truncating():
+    assert resolve_visible_env_indices([1, 1, 3, 5], 2, 10) == [1, 3]
+
+
 def test_resolve_visible_env_indices_explicit_full_list_when_no_cap():
     assert resolve_visible_env_indices([1, 3], None, 10) == [1, 3]
 
@@ -105,32 +109,16 @@ def test_apply_viewer_visible_worlds_delegates_to_resolved():
 
 
 def test_newton_visualizer_cfg_exposes_particle_options():
-    cfg = NewtonVisualizerCfg(show_particles=True, particle_color=(0.1, 0.2, 0.3), world_spacing=(2.0, 2.0, 0.0))
+    cfg = NewtonVisualizerCfg(show_particles=True, particle_color=(0.1, 0.2, 0.3))
 
     assert cfg.show_particles is True
     assert cfg.particle_color == (0.1, 0.2, 0.3)
+
+
+def test_newton_visualizer_cfg_exposes_world_spacing():
+    cfg = NewtonVisualizerCfg(world_spacing=(2.0, 2.0, 0.0))
+
     assert cfg.world_spacing == (2.0, 2.0, 0.0)
-
-
-def test_newton_visualizer_render_markers_delegates_to_marker_backend(monkeypatch):
-    from isaaclab_newton.physics import NewtonManager
-    from isaaclab_visualizers.newton import newton_visualizer as newton_visualizer_module
-
-    calls = []
-    viewer = object()
-    visualizer = NewtonVisualizer(NewtonVisualizerCfg(enable_markers=True))
-    visualizer._resolved_visible_env_ids = [1, 3]
-
-    monkeypatch.setattr(NewtonManager, "get_num_envs", lambda: 4)
-    monkeypatch.setattr(
-        newton_visualizer_module,
-        "render_newton_visualization_markers",
-        lambda target, visible_env_ids, num_envs: calls.append((target, visible_env_ids, num_envs)),
-    )
-
-    visualizer.render_markers(viewer)
-
-    assert calls == [(viewer, [1, 3], 4)]
 
 
 def test_newton_visualizer_set_camera_view_updates_cfg_without_viewer():

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -105,10 +105,32 @@ def test_apply_viewer_visible_worlds_delegates_to_resolved():
 
 
 def test_newton_visualizer_cfg_exposes_particle_options():
-    cfg = NewtonVisualizerCfg(show_particles=True, particle_color=(0.1, 0.2, 0.3))
+    cfg = NewtonVisualizerCfg(show_particles=True, particle_color=(0.1, 0.2, 0.3), world_spacing=(2.0, 2.0, 0.0))
 
     assert cfg.show_particles is True
     assert cfg.particle_color == (0.1, 0.2, 0.3)
+    assert cfg.world_spacing == (2.0, 2.0, 0.0)
+
+
+def test_newton_visualizer_render_markers_delegates_to_marker_backend(monkeypatch):
+    from isaaclab_newton.physics import NewtonManager
+    from isaaclab_visualizers.newton import newton_visualizer as newton_visualizer_module
+
+    calls = []
+    viewer = object()
+    visualizer = NewtonVisualizer(NewtonVisualizerCfg(enable_markers=True))
+    visualizer._resolved_visible_env_ids = [1, 3]
+
+    monkeypatch.setattr(NewtonManager, "get_num_envs", lambda: 4)
+    monkeypatch.setattr(
+        newton_visualizer_module,
+        "render_newton_visualization_markers",
+        lambda target, visible_env_ids, num_envs: calls.append((target, visible_env_ids, num_envs)),
+    )
+
+    visualizer.render_markers(viewer)
+
+    assert calls == [(viewer, [1, 3], 4)]
 
 
 def test_newton_visualizer_set_camera_view_updates_cfg_without_viewer():


### PR DESCRIPTION
## Summary

- add `NewtonVisualizerCfg.world_spacing` for visual-only separation of co-located simulation worlds
- render dense environment-major marker batches using the same selected worlds and offsets as model geometry
- select marker state along its environment axis and broadcast offsets without flattened gather or repeated-offset tensors
- cache marker prototype conversion and keep filtering/offset application in one typed render path
- resolve and deduplicate visible environment IDs once, then pass the exact selection to the Newton viewer
- document partial Newton visualization and its dense environment-major marker convention

Non-divisible marker batches remain global and are neither filtered nor offset.

## Testing

- `22 passed`: `source/isaaclab_visualizers/test/test_newton_adapter.py`
- `10 passed`: scoped Newton marker render and partial-update tests
- CPU marker state with CUDA viewer offsets: selected worlds produced `[12, 13, 36, 37]`
- all-world offset smoke: `[0, 1, 12, 13, 24, 25, 36, 37]`
- non-divisible global marker smoke remained `[0, 1, 2]`
- fail-before-fix verification: old filtering produced `[1, 3, 5, 7]` instead of `[12, 13, 36, 37]`; the old allocation path also invoked the forbidden `torch.arange` regression guard
- dynamic reordered selections `[3, 1]` and `[1, 3]` preserve transform, scale, and source tensor state
- `./isaaclab.sh -d` passed with warnings treated as errors
- scoped pre-commit passed, including the LFS hook
- repository-wide pre-commit passed with only the known unrelated golden-image LFS hook skipped
- changelog fragment check passed
