### PR TITLE
Document schema fragment framework in API reference

### DIFF
--- a/docs/source/api/lab/isaaclab.sim.schemas.rst
+++ b/docs/source/api/lab/isaaclab.sim.schemas.rst
@@ -23,6 +23,29 @@ isaaclab.sim.schemas
     FixedTendonPropertiesCfg
     DeformableBodyPropertiesBaseCfg
 
+  .. rubric:: Schema fragments
+
+  Single-namespace "fragment" classes. Each fragment authors the attributes of exactly one
+  USD namespace, and a spawner slot accepts a *list* of fragments, so a single prim can compose
+  properties from several backends at once (e.g. ``UsdPhysics`` + PhysX + Newton). :class:`SchemaFragment`
+  is the common base; the per-family marker bases type their spawner slots; and the ``UsdPhysics*Cfg``
+  fragments carry the solver-common ``physics:*`` attributes. Backend-specific fragments live in
+  :mod:`isaaclab_physx.sim.schemas` / :mod:`isaaclab_newton.sim.schemas`. See
+  :doc:`/source/overview/core-concepts/schema_cfgs` for the design.
+
+  .. autosummary::
+
+    SchemaFragment
+    RigidBodyFragment
+    CollisionFragment
+    MassFragment
+    MeshCollisionFragment
+    FixedTendonFragment
+    SpatialTendonFragment
+    UsdPhysicsRigidBodyCfg
+    UsdPhysicsCollisionCfg
+    UsdPhysicsMeshCollisionCfg
+
   .. rubric:: Mesh collision approximations (USD-only, no PhysX schema)
 
   .. autosummary::
@@ -34,6 +57,14 @@ isaaclab.sim.schemas
 
   .. autosummary::
 
+    apply_namespaced
+    apply_rigid_body_properties
+    apply_collision_properties
+    apply_mass_properties
+    apply_mesh_collision
+    apply_mesh_collision_properties
+    apply_fixed_tendon_properties
+    apply_spatial_tendon_properties
     define_articulation_root_properties
     modify_articulation_root_properties
     define_rigid_body_properties
@@ -49,6 +80,60 @@ isaaclab.sim.schemas
     modify_fixed_tendon_properties
     define_deformable_body_properties
     modify_deformable_body_properties
+
+Schema fragments
+----------------
+
+.. autoclass:: SchemaFragment
+    :members:
+    :exclude-members: __init__
+
+.. autoclass:: RigidBodyFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: CollisionFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: MassFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: MeshCollisionFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: FixedTendonFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: SpatialTendonFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: UsdPhysicsRigidBodyCfg
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: UsdPhysicsCollisionCfg
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: UsdPhysicsMeshCollisionCfg
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autofunction:: apply_namespaced
 
 Articulation Root
 -----------------
@@ -73,6 +158,7 @@ Rigid Body
     :members:
     :exclude-members: __init__
 
+.. autofunction:: apply_rigid_body_properties
 .. autofunction:: define_rigid_body_properties
 .. autofunction:: modify_rigid_body_properties
 .. autofunction:: activate_contact_sensors
@@ -89,6 +175,7 @@ Collision
     :members:
     :exclude-members: __init__
 
+.. autofunction:: apply_collision_properties
 .. autofunction:: define_collision_properties
 .. autofunction:: modify_collision_properties
 
@@ -106,6 +193,7 @@ Mass
     :members:
     :exclude-members: __init__
 
+.. autofunction:: apply_mass_properties
 .. autofunction:: define_mass_properties
 .. autofunction:: modify_mass_properties
 
@@ -140,6 +228,8 @@ Mesh Collision
     :show-inheritance:
     :exclude-members: __init__
 
+.. autofunction:: apply_mesh_collision
+.. autofunction:: apply_mesh_collision_properties
 .. autofunction:: define_mesh_collision_properties
 .. autofunction:: modify_mesh_collision_properties
 
@@ -151,6 +241,8 @@ For Newton hull-vertex limit, see
 Tendon
 ------
 
+.. autofunction:: apply_fixed_tendon_properties
+.. autofunction:: apply_spatial_tendon_properties
 .. autofunction:: modify_fixed_tendon_properties
 .. autofunction:: modify_spatial_tendon_properties
 

--- a/source/isaaclab/changelog.d/vidurv-schema-frag-docs.skip
+++ b/source/isaaclab/changelog.d/vidurv-schema-frag-docs.skip
@@ -1,0 +1,4 @@
+Docs: documented the schema "fragment" framework in the ``isaaclab.sim.schemas`` API
+reference -- the single-namespace fragment classes (``SchemaFragment``, the per-family
+marker bases, and the ``UsdPhysics*Cfg`` fragments) and the family writers
+(``apply_namespaced`` and the ``apply_*_properties`` functions).


### PR DESCRIPTION
## Description

The schema-cfg "fragment" refactor introduced a new public API in `isaaclab.sim.schemas` — single-namespace fragment classes and family writers — but the rendered API reference still listed only the legacy `define_*`/`modify_*` writers and `*PropertiesCfg` classes. This documents the fragment API that is already merged into `develop`.

Added to `docs/source/api/lab/isaaclab.sim.schemas.rst`:

- **Schema fragments** rubric + detail section: `SchemaFragment`, the per-family marker bases (`RigidBodyFragment`, `CollisionFragment`, `MassFragment`, `MeshCollisionFragment`, `FixedTendonFragment`, `SpatialTendonFragment`), and the solver-common `UsdPhysics*Cfg` fragments (`UsdPhysicsRigidBodyCfg`, `UsdPhysicsCollisionCfg`, `UsdPhysicsMeshCollisionCfg`).
- The family writers: `apply_namespaced`, `apply_rigid_body_properties`, `apply_collision_properties`, `apply_mass_properties`, `apply_mesh_collision`, `apply_mesh_collision_properties`, `apply_fixed_tendon_properties`, `apply_spatial_tendon_properties` — wired into their respective sections.

Scope is the API reference only; the narrative concept page (`schema_cfgs.rst`) rewrite is deliberately out of scope. Articulation-root and joint-drive fragment symbols are documented in their own PRs (#6272, #6273), since those symbols are not yet in `develop`.

## Type of change

- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have added a changelog fragment (docs-only `.skip`)
- [ ] I have updated the changelog accordingly (handled by CI)