### PR TITLE
[BUG] Fix Isaac Sim 6.0 streaming crash from prebundle torch shadowing

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-fix-sim6-prebundle-torch-streaming.rst
+++ b/source/isaaclab/changelog.d/jichuanh-fix-sim6-prebundle-torch-streaming.rst
@@ -1,0 +1,13 @@
+Fixed
+^^^^^
+
+* Fixed a crash (``undefined symbol: ncclDevCommCreate``) when launching the Isaac Sim
+  streaming app (e.g. ``isaac-sim.streaming.sh`` / ``runheadless.sh``) from an Isaac Lab
+  install against Isaac Sim 6.0. Isaac Sim's deprecated ``omni.isaac.ml_archive`` prebundle
+  ships its own PyTorch and NCCL while Isaac Lab installs a different pinned PyTorch; on
+  launch paths that do not import Isaac Lab (which otherwise deprioritizes the prebundle on
+  ``sys.path``), the two NCCL copies collide and the prebundled torch binds to the wrong
+  one. The install step that repoints the prebundle to the active environment now uses
+  overlayfs-safe filesystem operations, so it works inside the Docker image build (where it
+  previously failed silently with ``EXDEV`` / ``EINVAL``) and fails loudly if a shadowing
+  copy remains.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -701,6 +701,24 @@ regardless of import path order.
 """
 
 
+def _force_remove(path: Path) -> None:
+    """Recursively remove a file, directory, or symlink. A missing path is a no-op.
+
+    Uses absolute-path :func:`os.unlink` / :func:`os.rmdir` rather than the
+    ``dir_fd``-relative operations :func:`shutil.rmtree` performs internally. On
+    an overlayfs *lower* layer (e.g. inside a Docker image build) the ``dir_fd``
+    variant raises ``EINVAL``, whereas the plain ``unlink(2)`` / ``rmdir(2)``
+    syscalls create the proper whiteout. This makes prebundle neutralization
+    behave identically on a normal filesystem and on an overlayfs lower layer.
+    """
+    if path.is_symlink() or path.is_file():
+        os.unlink(path)
+    elif path.is_dir():
+        for child in path.iterdir():
+            _force_remove(child)
+        os.rmdir(path)
+
+
 def _repoint_prebundle_packages() -> None:
     """Replace prebundled packages in Isaac Sim with symlinks to the active environment.
 
@@ -780,16 +798,15 @@ def _repoint_prebundle_packages() -> None:
                 continue
 
             try:
-                if prebundled.is_symlink():
-                    if prebundled.resolve() == venv_pkg.resolve():
-                        continue
-                    prebundled.unlink()
-                else:
-                    backup = prebundle_dir / f"{pkg_name}.bak"
-                    if backup.exists() or backup.is_symlink():
-                        shutil.rmtree(backup) if backup.is_dir() else backup.unlink()
-                    prebundled.rename(backup)
-
+                # Already repointed to the right place — nothing to do.
+                if prebundled.is_symlink() and prebundled.resolve() == venv_pkg.resolve():
+                    continue
+                # Replace the prebundled copy (a stale symlink or a real directory)
+                # with a symlink to the active environment. We remove rather than
+                # rename-to-``.bak``: the env copy is the symlink target, so the
+                # prebundle content is redundant, and renaming a directory on an
+                # overlayfs lower layer (Docker image build) fails with ``EXDEV``.
+                _force_remove(prebundled)
                 if use_symlinks:
                     prebundled.symlink_to(venv_pkg)
                 else:
@@ -805,6 +822,24 @@ def _repoint_prebundle_packages() -> None:
         )
     else:
         print_debug("All prebundled packages already up-to-date — nothing to repoint.")
+
+    # Fail loud: a real (non-symlink) prebundled ``torch`` left behind shadows the
+    # pip-installed torch on launch paths that do not import ``isaaclab`` (e.g.
+    # ``isaac-sim.streaming.sh``), pulling a mismatched NCCL and crashing with
+    # ``undefined symbol: ncclDevCommCreate``. Never let that state ship silently.
+    # Only relevant when symlinking (Linux); the Windows branch deliberately copies the
+    # env package into the prebundle, which is a real directory by design.
+    if use_symlinks and (site_packages / "torch").exists():
+        shadowing = [
+            prebundle_dir / "torch"
+            for prebundle_dir in prebundle_dirs
+            if (prebundle_dir / "torch").is_dir() and not (prebundle_dir / "torch").is_symlink()
+        ]
+        if shadowing:
+            raise RuntimeError(
+                "Failed to neutralize prebundled torch under Isaac Sim; the following would shadow the "
+                "pip-installed torch and crash non-isaaclab launches:\n  " + "\n  ".join(str(p) for p in shadowing)
+            )
 
 
 def command_install(install_type: str = "all") -> None:

--- a/source/isaaclab/test/cli/test_install.py
+++ b/source/isaaclab/test/cli/test_install.py
@@ -222,3 +222,36 @@ class TestDeterminePythonVersion:
         ):
             result = determine_python_version()
             assert result == "3.11"
+
+
+# ---------------------------------------------------------------------------
+# Prebundled-torch shadowing invariant (regression: nvbugs 6343978)
+# ---------------------------------------------------------------------------
+
+
+def test_no_shadowing_prebundled_torch_in_isaac_sim():
+    """A prebundled torch must not shadow the pip-installed torch.
+
+    Regression test for nvbugs 6343978: Isaac Sim 6.0 ships a prebundled PyTorch under
+    the deprecated ``omni.isaac.ml_archive`` extension whose ``libtorch_cuda.so``
+    requires an NCCL symbol the co-bundled NCCL does not export. Launch paths that do
+    not import :mod:`isaaclab` (e.g. ``isaac-sim.streaming.sh`` / ``runheadless.sh``)
+    bypass the ``sys.path`` deprioritization and import this broken copy, crashing with
+    ``undefined symbol: ncclDevCommCreate``. After install/build, every
+    ``pip_prebundle/torch`` under Isaac Sim must therefore be either removed or a
+    symlink into the active environment, never a real shadowing directory.
+    """
+    isaacsim_path = extract_isaacsim_path(required=False)
+    if isaacsim_path is None or not isaacsim_path.exists():
+        pytest.skip("Isaac Sim installation not found; skipping prebundle-shadow invariant check")
+
+    shadowing = [
+        prebundled_torch
+        for prebundled_torch in isaacsim_path.rglob("pip_prebundle/torch")
+        if prebundled_torch.is_dir() and not prebundled_torch.is_symlink()
+    ]
+    assert not shadowing, (
+        "Found prebundled torch directories that shadow the pip-installed torch (nvbugs 6343978). "
+        "They must be removed at image build time or repointed to the active environment:\n  "
+        + "\n  ".join(str(p) for p in shadowing)
+    )

--- a/source/isaaclab/test/cli/test_install_commands.py
+++ b/source/isaaclab/test/cli/test_install_commands.py
@@ -643,7 +643,7 @@ class TestRePointPrebundlePackages:
         symlink = prebundle / "torch"
         assert symlink.is_symlink(), "torch should be a symlink after repoint"
         assert symlink.resolve() == (site_pkgs / "torch").resolve()
-        assert (prebundle / "torch.bak").is_dir(), "Original torch should be backed up"
+        assert not (prebundle / "torch.bak").exists(), "repoint replaces in place — no .bak (env copy is the target)"
 
     def test_local_build_skips_nvidia_when_cudnn_absent_kit_python(self, tmp_path):
         """Local build + kit Python: site-packages/nvidia has only 'srl' (no cudnn) → nvidia NOT repointed.
@@ -717,23 +717,20 @@ class TestRePointPrebundlePackages:
 
         assert (prebundle / "torch").resolve() == (site_pkgs / "torch").resolve(), "Stale symlink must be updated"
 
-    def test_removes_old_backup_before_renaming(self, tmp_path):
-        """A pre-existing .bak directory is removed before the current package is backed up."""
+    def test_raises_when_prebundled_torch_not_neutralized(self, tmp_path):
+        """Fail loud: a real prebundled torch surviving repoint would shadow the pip torch
+        on launch paths that do not import isaaclab (nvbugs 6343978), so repoint raises
+        instead of silently leaving the broken state in place."""
         isaacsim_path, prebundle = self._sim_with_prebundle(tmp_path / "sim", ["torch"])
         site_pkgs = _make_site_packages(tmp_path / "env", ["torch"])
         py = str(tmp_path / "env" / "bin" / "python")
 
-        # Simulate leftover backup from a previous partial install.
-        old_backup = prebundle / "torch.bak"
-        old_backup.mkdir()
-        (old_backup / "stale_file.py").touch()
-
+        # Simulate the removal not taking effect (e.g. an unhandled filesystem quirk): the
+        # prebundled torch stays a real directory rather than becoming a symlink.
         with self._patch(isaacsim_path, site_pkgs, py):
-            _repoint_prebundle_packages()
-
-        assert (prebundle / "torch").is_symlink(), "torch must be repointed"
-        # The old backup was replaced by the fresh backup.
-        assert (prebundle / "torch.bak").is_dir()
+            with mock.patch("isaaclab.cli.commands.install._force_remove"):
+                with pytest.raises(RuntimeError, match="neutralize"):
+                    _repoint_prebundle_packages()
 
     # ---- pip-installed isaacsim (path found via import probe) ----------------
 


### PR DESCRIPTION
## Summary

Fixes a crash (nvbugs 6343978) when launching the Isaac Sim streaming app
(`isaac-sim.streaming.sh` / `runheadless.sh`) from an Isaac Lab install against Isaac Sim 6.0:

```
[Error] [isaacsim.core.deprecation_manager.api] Import error:
.../omni.isaac.ml_archive/pip_prebundle/torch/lib/libtorch_cuda.so:
undefined symbol: ncclDevCommCreate
```

## Root cause (corrected after investigation)

Not a broken Isaac Sim package — a **cross-stack NCCL collision**:

- Isaac Sim 6.0's deprecated `omni.isaac.ml_archive` prebundle ships a *self-consistent*
  torch + NCCL (torch 2.11 + nccl 2.28.9, which **does** export `ncclDevCommCreate`).
- Isaac Lab installs its own pinned torch (2.10) + nccl (2.27.5) into site-packages.
- torch's Python-side CUDA preload resolves `libnccl.so.2` by `sys.path`/namespace order
  (`RTLD_GLOBAL`), *before* `libtorch_cuda.so`'s RPATH. On launch paths that **don't import
  `isaaclab`** (the streaming app — `isaaclab/__init__.py` deprioritizes the prebundle only on
  import), the older pip nccl 2.27.5 loads, the prebundle torch 2.11 binds to it, and
  `ncclDevCommCreate` is missing → crash. LD_DEBUG confirms the pip nccl wins the load.

`_repoint_prebundle_packages()` already exists to prevent this (it symlinks the prebundle to
the active env, collapsing to one stack), but it **silently no-op'd inside the Docker image
build**: the prebundle is on an overlayfs lower layer where `os.rename`→`.bak` raises `EXDEV`
and `shutil.rmtree` raises `EINVAL` (its `dir_fd` walk), both swallowed as warnings. It works
on the host (single filesystem), which is why only the Docker image was affected.

## Fix

Make `_repoint_prebundle_packages()` overlayfs-safe via a single uniform path:

- Replace rename-to-`.bak` + `shutil.rmtree` with `_force_remove` (plain-path
  `os.unlink`/`os.rmdir`, which create the proper overlayfs whiteout) + symlink. No `.bak`
  (the env copy is the symlink target), no subprocess, no fallback.
- Add a fail-loud post-check: raise if a real prebundle `torch` still shadows the pip torch,
  so the broken state can't ship silently again.

This collapses the two torch/nccl stacks into one on every launch path, host and Docker.

## Validation (x86 RTX A6000, exact `isaac-lab` container)

- Before: streaming crashes at ~19s with `undefined symbol: ncclDevCommCreate`.
- After (repoint runs at build): prebundle torch → symlink to env 2.10; streaming boots to
  `Isaac Sim Full Streaming Version: 6.0.0-rc.47`, 0 `ncclDevCommCreate`.

## Tests

- `test_no_shadowing_prebundled_torch_in_isaac_sim` (filesystem invariant): RED on the
  un-fixed image (real prebundle torch), GREEN on the fixed image / host (symlink).
- Updated `_repoint_prebundle_packages` unit tests: no `.bak`; new fail-loud test.

Fixes nvbugs 6343978.
