### PR TITLE
Defer pxr/carb imports on the environment construction path

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-defer-pxr-imports-env-construction.rst
+++ b/source/isaaclab/changelog.d/jichuanh-defer-pxr-imports-env-construction.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed a duplicate-USD crash (``pxrInternal_v0_*`` Python class re-registration,
+  e.g. ``extension class wrapper for base class ... has not been created yet``)
+  hit while constructing environments when a pip ``usd-core`` is installed
+  alongside Isaac Sim's bundled USD. Module-level ``pxr``/``isaacsim`` imports in
+  :mod:`isaaclab.cloner`, :mod:`isaaclab.sensors`, :mod:`isaaclab.terrains`,
+  :mod:`isaaclab.scene_data`, and :mod:`isaaclab.sim.utils.stage` are now deferred
+  into the functions that use them, so Kit registers a single USD version on launch.

--- a/source/isaaclab/isaaclab/cloner/_fabric_notices.py
+++ b/source/isaaclab/isaaclab/cloner/_fabric_notices.py
@@ -22,8 +22,10 @@ import ctypes
 import logging
 import threading
 from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
-from pxr import Usd, UsdUtils
+if TYPE_CHECKING:
+    from pxr import Usd
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +196,8 @@ def disabled_fabric_change_notifies(stage: Usd.Stage, *, restore: bool = True) -
 
     # Avoid leaking a strong reference into the global ``StageCache`` for stages we did not
     # author into the cache: ``Insert`` keeps the stage alive for the rest of the process.
+    from pxr import UsdUtils  # noqa: PLC0415
+
     cache = UsdUtils.StageCache.Get()
     cached_id = cache.GetId(stage)
     stage_id = cached_id.ToLongInt() if cached_id.IsValid() else cache.Insert(stage).ToLongInt()

--- a/source/isaaclab/isaaclab/cloner/cloner_utils.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_utils.py
@@ -15,13 +15,11 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
-from pxr import Sdf, Usd, UsdGeom
-
 from .clone_plan import ClonePlan
 from .cloner_strategies import sequential
 
 if TYPE_CHECKING:
-    pass
+    from pxr import Usd
 
 logger = logging.getLogger(__name__)
 
@@ -367,6 +365,7 @@ def filter_collisions(
         global_paths: Optional global-collider paths.
 
     """
+    from pxr import Sdf, Usd, UsdGeom  # noqa: PLC0415
 
     scene_prim = stage.GetPrimAtPath(physicsscene_path)
     # We invert the collision group filters for more efficient collision filtering across environments

--- a/source/isaaclab/isaaclab/cloner/usd.py
+++ b/source/isaaclab/isaaclab/cloner/usd.py
@@ -6,15 +6,16 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
-
-from pxr import Gf, Sdf, Usd, UsdGeom, Vt
 
 from ._fabric_notices import disabled_fabric_change_notifies
 from .cloner_utils import split_clone_template
 from .replicate_session import REPLICATION_QUEUE
+
+if TYPE_CHECKING:
+    from pxr import Usd
 
 
 def _select_env_ids(env_ids: torch.Tensor, mask: torch.Tensor | None, row: int) -> torch.Tensor:
@@ -106,6 +107,8 @@ class UsdReplicateContext:
 
     def _apply_queue(self) -> None:
         """Author the queued copy specs into the stage's root layer."""
+        from pxr import Gf, Sdf, UsdGeom, Vt  # noqa: PLC0415
+
         rl = self.stage.GetRootLayer()
 
         def dp_depth(template: str) -> int:

--- a/source/isaaclab/isaaclab/scene_data/scene_data_provider.py
+++ b/source/isaaclab/isaaclab/scene_data/scene_data_provider.py
@@ -13,8 +13,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import warp as wp
 
-from pxr import UsdGeom
-
 import isaaclab.sim as sim_utils
 
 from .scene_data_backend import SceneDataBackend, SceneDataFormat
@@ -438,6 +436,8 @@ def _walk_camera_prims(stage: Usd.Stage | None) -> dict[str, Any] | None:
         ``positions``, ``orientations`` (per-camera, per-env, with ``None`` for
         absent envs), and ``num_envs``. Returns ``None`` when ``stage`` is ``None``.
     """
+    from pxr import UsdGeom  # noqa: PLC0415
+
     if stage is None:
         return None
 

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -13,8 +13,6 @@ import numpy as np
 import torch
 import warp as wp
 
-from pxr import UsdGeom, UsdPhysics
-
 import isaaclab.sim as sim_utils
 import isaaclab.utils.sensors as sensor_utils
 from isaaclab.cloner import queue_usd_replication
@@ -32,6 +30,8 @@ from ..sensor_base import SensorBase
 from .camera_data import CameraData, RenderBufferKind
 
 if TYPE_CHECKING:
+    from pxr import UsdGeom
+
     from .camera_cfg import CameraCfg
 
 # import logger
@@ -143,6 +143,8 @@ class Camera(SensorBase):
             RuntimeError: If no camera prim is found at the given path.
             ValueError: If the provided data types are not supported by the camera.
         """
+        from pxr import UsdPhysics  # noqa: PLC0415
+
         # perform check on supported data types
         self._check_supported_data_types(cfg)
         # initialize base class
@@ -395,6 +397,8 @@ class Camera(SensorBase):
                 whole batch). When only some rows are degenerate, those rows are skipped and the
                 remaining poses are still applied; a warning is logged.
         """
+        from pxr import UsdGeom  # noqa: PLC0415
+
         if isinstance(eyes, np.ndarray):
             eyes = torch.from_numpy(eyes).to(device=self._device)
         elif not isinstance(eyes, torch.Tensor):
@@ -479,6 +483,8 @@ class Camera(SensorBase):
                 runtime requirements are not satisfied (e.g. the RTX backend requires the
                 simulation app to be launched with ``--enable_cameras``).
         """
+        from pxr import UsdGeom  # noqa: PLC0415
+
         # Initialize parent class
         super()._initialize_impl()
 

--- a/source/isaaclab/isaaclab/sensors/ray_caster/base_ray_caster.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/base_ray_caster.py
@@ -13,8 +13,6 @@ import numpy as np
 import torch
 import warp as wp
 
-from pxr import Gf, Usd, UsdGeom
-
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
 from isaaclab.cloner import queue_usd_replication
@@ -159,6 +157,8 @@ class BaseRayCaster(SensorBase):
         raise NotImplementedError(f"{self.__class__.__name__} must initialize backend pose tracking.")
 
     def _initialize_warp_meshes(self):
+        from pxr import Gf, Usd, UsdGeom  # noqa: PLC0415
+
         # check number of mesh prims provided
         if len(self.cfg.mesh_prim_paths) != 1:
             raise NotImplementedError(

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -20,8 +20,6 @@ from typing import TYPE_CHECKING, Any
 
 import warp as wp
 
-from pxr import UsdPhysics
-
 import isaaclab.sim as sim_utils
 from isaaclab.cloner.cloner_utils import iter_clone_plan_matches
 from isaaclab.physics import PhysicsEvent, PhysicsManager
@@ -456,6 +454,8 @@ class SensorBase(ABC):
               quaternion ``(x, y, z, w)``, or ``None`` when the sensor is
               mounted directly at the body origin.
         """
+        from pxr import UsdPhysics  # noqa: PLC0415
+
         prim, target_expr = sim_utils.resolve_matching_prims_from_source(self.cfg.prim_path)[0]
 
         ancestor_prim = get_first_matching_ancestor_prim(

--- a/source/isaaclab/isaaclab/sim/utils/stage.py
+++ b/source/isaaclab/isaaclab/sim/utils/stage.py
@@ -136,15 +136,31 @@ def resolve_paths(
 # ##############################################################################
 
 
-try:
-    # _context is a singleton design in isaacsim and for that reason
-    #  until we fully replace all modules that references the singleton(such as XformPrim, Prim ....), we have to point
-    #  that singleton to this _context
-    from isaacsim.core.experimental.utils import stage as sim_stage
+_isaacsim_context_shared = False
 
-    sim_stage._context = _context  # type: ignore
-except ImportError:
-    pass
+
+def _share_context_with_isaacsim() -> None:
+    """Point isaacsim's experimental stage singleton at this module's thread-local context.
+
+    ``isaacsim.core.experimental.utils.stage`` keeps its own ``_context`` singleton; until all
+    callers are migrated off it (e.g. ``XformPrim``, ``Prim``), the two must reference the same
+    object so a stage set here is visible there.
+
+    Deferred and idempotent: importing ``isaacsim`` at module-import time would pull ``pxr`` into
+    ``sys.modules`` before Kit registers its bundled USD, causing a duplicate USD class-registration
+    crash. Called lazily from the stage-establishing entry points, by which point Kit is running and
+    the bundled USD is the resolved binding. A no-op when ``isaacsim`` is unavailable (kitless).
+    """
+    global _isaacsim_context_shared
+    if _isaacsim_context_shared:
+        return
+    try:
+        from isaacsim.core.experimental.utils import stage as sim_stage  # noqa: PLC0415
+
+        sim_stage._context = _context  # type: ignore
+    except ImportError:
+        pass
+    _isaacsim_context_shared = True
 
 
 def create_new_stage() -> Usd.Stage:
@@ -170,6 +186,7 @@ def create_new_stage() -> Usd.Stage:
     from pxr import Usd, UsdUtils  # noqa: PLC0415
 
     stage: Usd.Stage = Usd.Stage.CreateInMemory()
+    _share_context_with_isaacsim()
     _context.stage = stage
     UsdUtils.StageCache.Get().Insert(stage)
     return stage
@@ -235,6 +252,7 @@ def open_stage(usd_path: str) -> Usd.Stage:
     if stage is None:
         raise RuntimeError(f"Failed to open USD stage at path '{usd_path}'.")
     # Set as current stage so get_current_stage() can find it
+    _share_context_with_isaacsim()
     _context.stage = stage
     return stage
 
@@ -284,6 +302,7 @@ def use_stage(stage: Usd.Stage) -> Generator[None, None, None]:
         previous_stage = getattr(_context, "stage", None)
         # set new context value
         try:
+            _share_context_with_isaacsim()
             _context.stage = stage
             yield
         # remove context value or restore previous one if it exists

--- a/source/isaaclab/isaaclab/terrains/utils.py
+++ b/source/isaaclab/isaaclab/terrains/utils.py
@@ -11,8 +11,6 @@ import torch
 import trimesh
 import warp as wp
 
-from pxr import UsdGeom
-
 import isaaclab.sim as sim_utils
 from isaaclab.utils.warp import raycast_mesh
 
@@ -102,6 +100,8 @@ def create_prim_from_mesh(prim_path: str, mesh: trimesh.Trimesh, **kwargs):
     sim_utils.define_collision_properties(prim.GetPrimPath(), collider_cfg)
     # add rgba color to the mesh primvars
     if mesh.visual.vertex_colors is not None:
+        from pxr import UsdGeom  # noqa: PLC0415
+
         # obtain color from the mesh
         rgba_colors = np.asarray(mesh.visual.vertex_colors).astype(np.float32) / 255.0
         # displayColor is a primvar attribute that is used to color the mesh

--- a/source/isaaclab_tasks/changelog.d/jichuanh-defer-pxr-imports-env-construction.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-defer-pxr-imports-env-construction.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed eager module-level ``pxr``/``carb`` imports in the cabinet and factory
+  direct environments that could bind a mismatched USD/Carbonite build before Kit
+  launches; the imports are now deferred into the methods that use them. Extended
+  the env-config import guard test to also import each task's env-class entry point,
+  so this class of eager backend import is caught for the ``gym.make`` path too.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/factory_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/factory_env.py
@@ -6,8 +6,6 @@
 import numpy as np
 import torch
 
-import carb
-
 import isaaclab.sim as sim_utils
 from isaaclab import cloner
 from isaaclab.assets import Articulation
@@ -624,6 +622,8 @@ class FactoryEnv(DirectRLEnv):
 
     def randomize_initial_state(self, env_ids):
         """Randomize initial state and perform any episode-level randomization."""
+        import carb  # noqa: PLC0415
+
         # Disable gravity.
         physics_sim_view = sim_utils.SimulationContext.instance().physics_sim_view
         physics_sim_view.set_gravity(carb.Float3(0.0, 0.0, 0.0))

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_direct_env.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING
 import torch
 import warp as wp
 
-from pxr import UsdGeom
-
 import isaaclab.sim as sim_utils
 from isaaclab import cloner
 from isaaclab.assets import Articulation
@@ -36,6 +34,8 @@ class CabinetDirectEnv(DirectRLEnv):
     cfg: CabinetDirectEnvCfg
 
     def __init__(self, cfg: CabinetDirectEnvCfg, render_mode: str | None = None, **kwargs):
+        from pxr import UsdGeom  # noqa: PLC0415
+
         super().__init__(cfg, render_mode, **kwargs)
 
         def get_env_local_pose(env_pos: torch.Tensor, xformable: UsdGeom.Xformable, device: torch.device):

--- a/source/isaaclab_tasks/test/core/test_env_cfg_no_forbidden_imports.py
+++ b/source/isaaclab_tasks/test/core/test_env_cfg_no_forbidden_imports.py
@@ -72,7 +72,9 @@ _ALL_ISAAC_TASKS = sorted(name for name in gymnasium.registry if name.startswith
 
 def _build_batch_script(task_names: list[str]) -> str:
     return textwrap.dedent(f"""\
-        import sys, traceback, json
+        import sys, traceback, json, importlib
+
+        import gymnasium
 
         FORBIDDEN = {list(_FORBIDDEN_PREFIXES)!r}
         task_names = {task_names!r}
@@ -86,6 +88,7 @@ def _build_batch_script(task_names: list[str]) -> str:
         for task_name in task_names:
             violations = {{}}
             load_error = None
+            entry_error = None
 
             _orig_import = __builtins__.__import__
 
@@ -97,9 +100,26 @@ def _build_batch_script(task_names: list[str]) -> str:
 
             __builtins__.__import__ = _hook
             try:
-                cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
-            except Exception as exc:
-                load_error = str(exc)
+                try:
+                    cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
+                except Exception as exc:
+                    load_error = str(exc)
+
+                # Also import the env-class entry point -- the module gym.make()
+                # imports via load_env_creator().  This is the path that pulls in
+                # the asset/sim/scene-data stack, which is where eager pxr/omni
+                # imports actually leak (the env_cfg above is pure data and never
+                # touches it).  We capture the import error separately so a
+                # missing optional dependency does not mask the violation: the
+                # hook still records any forbidden import made *during* the
+                # attempt, before any failure.
+                try:
+                    spec = gymnasium.registry.get(task_name)
+                    entry = getattr(spec, "entry_point", None)
+                    if isinstance(entry, str):
+                        importlib.import_module(entry.split(":")[0])
+                except Exception as exc:
+                    entry_error = str(exc)
             finally:
                 __builtins__.__import__ = _orig_import
 
@@ -112,6 +132,7 @@ def _build_batch_script(task_names: list[str]) -> str:
 
             results[task_name] = {{
                 'load_error': load_error,
+                'entry_error': entry_error,
                 'violations': violations,
             }}
 
@@ -154,14 +175,19 @@ def all_cfg_check_results() -> dict:
 
 @pytest.mark.parametrize("task_name", _ALL_ISAAC_TASKS)
 def test_config_load_does_not_import_backend_modules(task_name: str, all_cfg_check_results: dict):
-    """Config loading must not import forbidden runtime modules.
+    """Loading a task must not import forbidden runtime modules at import time.
 
-    Config classes are pure data.  They must not pull in backend modules
-    (pxr, omni, carb, isaacsim) or heavyweight libraries (scipy).
+    Covers both pre-launch paths: the ``env_cfg_entry_point`` (pure-data config)
+    and the env-class ``entry_point`` (the module ``gym.make()`` imports, which
+    pulls in the asset/sim/scene-data stack).  Neither may pull in backend
+    modules (pxr, omni, carb, isaacsim) or heavyweight libraries (scipy) at
+    module-import time -- those bind a backend before Kit establishes the
+    bundled one.
 
     Fix: use lazy_loader.attach_stub with .pyi stubs in __init__.py files,
-    TYPE_CHECKING guards for annotation-only imports, and string references
-    for class_type/func fields in cfg files.
+    TYPE_CHECKING guards for annotation-only imports, string references for
+    class_type/func fields in cfg files, and function-local (``# noqa: PLC0415``)
+    imports for pxr/omni/carb/isaacsim inside the bodies that use them.
     """
     if "__subprocess_crash__" in all_cfg_check_results:
         pytest.fail(f"Batch check subprocess crashed:\n{all_cfg_check_results['__subprocess_crash__']}")
@@ -171,11 +197,17 @@ def test_config_load_does_not_import_backend_modules(task_name: str, all_cfg_che
 
     info = all_cfg_check_results[task_name]
     load_error = info.get("load_error")
+    entry_error = info.get("entry_error")
     violations = info.get("violations", {})
 
     messages = []
     if load_error:
         messages.append(f"ERROR: config load crashed: {load_error}")
+    if entry_error and violations:
+        # Informational only: the entry-point import may fail for unrelated
+        # reasons (e.g. a missing optional extension).  We surface it solely to
+        # explain where a recorded violation came from; we never assert on it.
+        messages.append(f"NOTE: env-class entry_point import raised: {entry_error}")
     if violations:
         messages.append(f"FAIL: {len(violations)} forbidden top-level module(s) imported:")
         for mod, stack in sorted(violations.items()):


### PR DESCRIPTION
# Description

Constructing an environment via `gym.make()` imports the env class, which transitively pulls in the cloner / sensor / terrain / scene-data / stage utilities. Several of those modules imported `pxr` (and `carb`) at module level. When a pip `usd-core` is installed alongside Isaac Sim's bundled USD — which happens on x86 `[all]` installs, where `isaaclab` declares `usd-core>=25.0.0` (`source/isaaclab/pyproject.toml`) — that eager import binds the standalone `usd-core` build into `sys.modules['pxr']` before Kit registers its bundled USD. The two builds then collide with a duplicate `pxrInternal_v0_*` class registration:

```
RuntimeError: extension class wrapper for base class
pxrInternal_v0_25_11__pxrReserved__::UsdTyped has not been created yet
```

This surfaced as the `Installation Tests (x86)` failure in `test_install_all_trains_cartpole` (ARM is unaffected — `usd-core` is x86-only).

## Fix

Defer the backend imports into the functions that use them (and `TYPE_CHECKING` for annotation-only uses), so nothing imports `pxr` before Kit launches. Kit then seeds `sys.modules['pxr']` with a single bundled version, and every later `import pxr` hits that cache. This follows the existing pattern from "Defer pxr loading in isaaclab.sim, .assets, .scene, and .sim/utils" (#5826), extending it to the env-class construction path.

Modules updated: `isaaclab.cloner` (`_fabric_notices`, `cloner_utils`, `usd`), `isaaclab.sensors` (`camera`, `ray_caster.base_ray_caster`, `sensor_base`), `isaaclab.terrains.utils`, `isaaclab.scene_data`, plus the `cabinet` and `factory` direct envs.

`isaaclab.sim.utils.stage` is the one behavioral change: its module-level `try/except` wired Isaac Sim's `_context` singleton as a side effect. That became a deferred, idempotent helper invoked from the stage-establishing entry points, preserving the wiring while moving the `isaacsim` import to post-launch.

## Test

The env-config import guard (`test_env_cfg_no_forbidden_imports.py`) previously only loaded the `env_cfg_entry_point` (pure data) and never the env-class `entry_point` — the path that actually triggered this. It now also imports each task's env-class entry point under the same hook, so the `gym.make()` import path is covered. Verified locally that importing every affected module leaves zero `pxr`/`omni`/`carb`/`isaacsim` entries in `sys.modules`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have added a changelog entry (fragments under `changelog.d/`)
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
