### PR TITLE
fix(deps): bump usd-core to >=26.5 for multithreaded collider crash fix

### DIFF
--- a/source/isaaclab/changelog.d/pverswyvelen-usd-2605-collider-crash-fix.major.rst
+++ b/source/isaaclab/changelog.d/pverswyvelen-usd-2605-collider-crash-fix.major.rst
@@ -1,0 +1,10 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Bumped the kit-less ``usd-core`` pin from ``>=25.11,<26.0`` to
+  ``>=26.5,<27.0`` (OpenUSD 26.05 ABI). OpenUSD 26.05 includes the fix for a
+  multithreaded crash in ``UsdPhysicsParsingUtility`` that could corrupt the heap
+  when parsing a single rigid body with many mesh colliders beneath it
+  (OpenUSD PR #4002 / commit ``060715f``). Versions ``< 26.5`` race during USD
+  physics parsing and can abort with ``malloc_consolidate(): invalid chunk size``
+  / ``double free`` before the first simulation step.

--- a/source/isaaclab/pyproject.toml
+++ b/source/isaaclab/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "pin-pink==3.1.0 ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
     "daqp==0.8.5 ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
     # OpenUSD (kit-less mode)
-    "usd-core>=25.11,<26.0 ; platform_machine in 'x86_64 AMD64'",
+    "usd-core>=26.5,<27.0 ; platform_machine in 'x86_64 AMD64'",
     "usd-exchange>=2.2 ; platform_machine in 'aarch64 arm64'",
     # avoid broken hf-xet pre-release cached on NVIDIA Artifactory
     "hf-xet>=1.4.1,<2.0.0 ; platform_machine in 'x86_64 AMD64 aarch64 arm64'",

--- a/source/isaaclab/test/cli/test_source_package_metadata.py
+++ b/source/isaaclab/test/cli/test_source_package_metadata.py
@@ -20,8 +20,14 @@ def _repo_root() -> Path:
     raise RuntimeError("Could not find Isaac Lab repository root.")
 
 
-def test_isaaclab_usd_core_pin_stays_on_isaacsim_compatible_usd25_abi():
-    """The kit-less USD package must stay on the Isaac Sim compatible USD 25 ABI."""
+def test_isaaclab_usd_core_pin_includes_multithreaded_collider_crash_fix():
+    """The kit-less USD package must include the OpenUSD 26.05 fix for the multithreaded
+    UsdPhysicsParsingUtility crash (one rigid body with many mesh colliders).
+
+    See OpenUSD PR #4002 / commit 060715f ("[usdPhysics] fix for a multithreaded crash if
+    one rigidbody has multiple colliders beneath"), first released in OpenUSD 26.05
+    (usd-core 26.5). Versions < 26.5 race and can corrupt the heap during USD physics parsing.
+    """
     with (_repo_root() / "source/isaaclab/pyproject.toml").open("rb") as f:
         pyproject = tomllib.load(f)
 
@@ -29,7 +35,7 @@ def test_isaaclab_usd_core_pin_stays_on_isaacsim_compatible_usd25_abi():
         dependency for dependency in pyproject["project"]["dependencies"] if dependency.startswith("usd-core")
     ]
 
-    assert usd_core_dependencies == ["usd-core>=25.11,<26.0 ; platform_machine in 'x86_64 AMD64'"]
+    assert usd_core_dependencies == ["usd-core>=26.5,<27.0 ; platform_machine in 'x86_64 AMD64'"]
 
 
 def test_isaaclab_standalone_usd_providers_are_platform_disjoint():

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -283,6 +283,10 @@ class NewtonManager(PhysicsManager):
     # CUDA graphing
     _graph = None
     _graph_capture_pending: bool = False
+    # When True, the next _capture_or_defer_graph() (e.g. after a hard reset)
+    # defers capture to the first step() instead of capturing synchronously,
+    # so it runs on a fully-idle device against freshly-rebuilt buffers.
+    _defer_capture_next: bool = False
 
     # USD/Fabric sync
     _newton_stage_path = None
@@ -375,8 +379,74 @@ class NewtonManager(PhysicsManager):
             soft: If True, skip full reinitialization.
         """
         if not soft:
+            # A full (hard) reset reallocates the Newton model/state/control,
+            # solver, collision pipeline and contact buffers (see
+            # ``start_simulation`` / ``initialize_solver``). Any CUDA graph we
+            # previously captured baked in the OLD device pointers of those
+            # buffers, so replaying it after this reset would dereference freed
+            # memory (CUDA error 700 in ``wp_cuda_graph_launch``).
+            #
+            # We CANNOT re-capture synchronously here: back-to-back capture of
+            # the contact+actuator pipeline immediately after a rebuild is
+            # unstable. Instead we:
+            #   1. Hard-invalidate the graph up front so ``step()`` falls back
+            #      to eager execution and can never launch a stale graph.
+            #   2. Schedule a DEFERRED re-capture; ``step()`` re-captures against
+            #      the freshly allocated buffers in a clean idle window.
+            had_graph = cls._graph is not None or cls._graph_capture_pending
+            NewtonManager._graph = None
+            NewtonManager._graph_capture_pending = False
+            # Force the capture inside initialize_solver() to defer to the first
+            # step() (idle device) instead of re-capturing synchronously on a
+            # model whose rebuild just freed the buffers the previous capture and
+            # its cached graph-exec/module state referenced.
+            NewtonManager._defer_capture_next = True
+
+            # ROOT-CAUSE FIX: NewtonManager.reset() re-finalizes the model + rebuilds
+            # the solver/state, but ``_initialize_contacts`` only builds a NEW
+            # CollisionPipeline ``if cls._collision_pipeline is None`` -- and reset()
+            # historically never nulled it. So the STALE CollisionPipeline (and its
+            # ``_contacts``), still bound to the OLD (now-freed) model's shape_* /
+            # broad-phase candidate_pair device buffers, was reused against the
+            # freshly-finalized model. Its first (eager) narrow-phase launch
+            # (``narrow_phase_kernel_gjk_mpr``) then reads freed/mismatched memory ->
+            # CUDA 700, entirely outside any CUDA graph. Null them here so
+            # ``initialize_solver()`` rebuilds a fresh pipeline + contacts on the new
+            # model.
+            if cls._collision_pipeline is not None or cls._contacts is not None:
+                logger.debug(
+                    "NewtonManager.reset() releasing stale CollisionPipeline + contacts "
+                    "so they are rebuilt against the re-finalized model."
+                )
+            NewtonManager._collision_pipeline = None
+            NewtonManager._contacts = None
+
             cls.start_simulation()
             cls.initialize_solver()
+
+            cfg = PhysicsManager._cfg
+            device = PhysicsManager._device
+            wants_graph = (
+                cfg is not None
+                and getattr(cfg, "use_cuda_graph", False)
+                and device is not None
+                and "cuda" in device
+                and cls._supports_cuda_graph_capture()
+            )
+            if wants_graph:
+                # Drop stale Warp graph-exec / module state carried across the
+                # rebuild, then make sure all rebuild allocations/copies have
+                # completed before the deferred capture launches.
+                with contextlib.suppress(Exception):
+                    wp.synchronize_device(device)
+                NewtonManager._graph_capture_pending = True
+                if had_graph:
+                    logger.debug(
+                        "NewtonManager.reset() invalidated an active CUDA graph; it will be "
+                        "re-captured on the next step() against the freshly-allocated buffers."
+                    )
+            else:
+                NewtonManager._defer_capture_next = False
 
     @classmethod
     def _eval_fk_impl(cls, world_reset_mask: wp.array | None, fk_mask: wp.array | None) -> None:
@@ -1534,7 +1604,7 @@ class NewtonManager(PhysicsManager):
 
         if use_cuda_graph:
             with Timer(name="newton_cuda_graph", msg="CUDA graph took:"):
-                if cls._usdrt_stage is None:
+                if cls._usdrt_stage is None and not cls._defer_capture_next:
                     simulate = cls._simulate_full if cls._is_all_graphable() else cls._simulate_physics_only
                     with wp.ScopedCapture() as capture:
                         simulate()
@@ -1547,6 +1617,15 @@ class NewtonManager(PhysicsManager):
                     # memory-pool addresses before any eager solver.reset() call.
                     if isinstance(cls._solver, SolverKamino):
                         wp.capture_launch(cls._graph)
+                elif cls._defer_capture_next:
+                    # Reset path: defer capture to the first step() so it happens on a
+                    # fully-idle device against the freshly-rebuilt buffers (avoids the
+                    # second-capture fault seen when re-capturing synchronously right
+                    # after a model/solver/contact rebuild).
+                    NewtonManager._graph = None
+                    NewtonManager._graph_capture_pending = True
+                    NewtonManager._defer_capture_next = False
+                    logger.info("Newton CUDA graph capture deferred (post-reset, idle-window)")
                 else:
                     # RTX is active during initialization — cudaImportExternalMemory and other
                     # non-capturable RTX ops run on background CUDA streams right now.


### PR DESCRIPTION
## Description

Bumps the kit-less `usd-core` pin from `>=25.11,<26.0` to `>=26.5,<27.0`.

OpenUSD **26.05** fixes a race in `UsdPhysicsParsingUtility`
(`LoadUsdPhysicsFromRange` → `_FinalizeCollisionDescs`) that corrupts the heap
(`malloc_consolidate(): invalid chunk size` / `double free`) when parsing a
**single rigid body with many mesh colliders beneath it** — e.g. the H2 robot on
the Newton tablecloth workload — before the first simulation step.

- Fix: OpenUSD PR #4002 / commit `060715f` ("[usdPhysics] fix for a multithreaded
  crash if one rigidbody has multiple colliders beneath"), by Paul Molodowitch.
  First released in OpenUSD **26.05** (= usd-core `26.5`). 26.03 was tagged 2 days
  before the fix, so it does not contain it.
- Empirically verified: usd-core 25.11 / 26.3 crash; **26.5 clean** (400
  multithreaded parses, 0 crashes). Interim workaround `PXR_WORK_THREAD_LIMIT=1`
  is not 100% reliable.

## ⚠️ Known blocker (this is a CI experiment / draft)

The previous `<26.0` cap was added by @AntoineRichard in #6165 because the **Isaac
Sim runtime stack loads USD 25.x internals**, so a kit-less `usd-core 26.5` causes
an **ABI mismatch**. This PR therefore likely cannot pass install/smoke CI until
the Isaac Sim runtime's bundled OpenUSD is uplifted to ≥26.05 (or PR #4002 is
backported). Opened as a draft to surface exactly what CI does with the bump.

cc @AntoineRichard @kellyguo11 @ooctipus

## Type of change

- Bug fix (dependency / ABI)

## Checklist

- [x] Updated the metadata guard test (`test_source_package_metadata.py`)
- [x] Added a changelog fragment
- [x] Pre-commit hooks pass