### PR TITLE
Allow for automatic switching between ovrtx and isaac sim RTX docs

### DIFF
--- a/docs/source/setup/quickstart_details.rst
+++ b/docs/source/setup/quickstart_details.rst
@@ -84,16 +84,46 @@ Available Presets
 - ``isaacsim_rtx_renderer`` — Isaac Sim RTX (default with Isaac Sim)
 - ``newton_renderer`` — Newton Warp renderer
 - ``ovrtx_renderer`` — OV RTX renderer (kit-less)
-- ``rtx`` — automatic RTX renderer selection
+- ``rtx`` — Automatic RTX renderer selection
+
+Automatic RTX selection is available only when the camera exposes the renderer
+choices with :class:`~isaaclab_tasks.utils.presets.MultiBackendRendererCfg`:
+
+.. code-block:: python
+
+   from isaaclab.sensors import CameraCfg
+   from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
+
+   camera = CameraCfg(
+       # Other camera settings...
+       renderer_cfg=MultiBackendRendererCfg(),
+   )
+
+Then use ``renderer=rtx`` to select the RTX implementation required by the runtime:
+
+.. list-table::
+   :widths: 55 45
+   :header-rows: 1
+
+   * - Runtime
+     - Resolved renderer
+   * - Requires Isaac Sim/Kit, such as ``physics=physx``, ``--visualizer kit``,
+       livestreaming, or another Kit camera
+     - :class:`~isaaclab_physx.renderers.IsaacRtxRendererCfg`
+   * - Fully kit-less, such as ``physics=newton_mjwarp`` or ``physics=ovphysx``
+       without a Kit visualizer or camera
+     - :class:`~isaaclab_ov.renderers.OVRTXRendererCfg`
+
+For example, ``physics=newton_mjwarp renderer=rtx`` selects OVRTX for a
+fully kit-less run, but selects Isaac Sim RTX when combined with
+``--visualizer kit``.
+
+A camera configured directly with ``renderer_cfg=IsaacRtxRendererCfg()`` does
+not participate in automatic selection and is not overridden by
+``renderer=rtx`` because it does not use the multi-backend renderer configuration.
 
 **Domain presets** (``presets=NAME[,NAME,...]``) are task-specific — run
 ``--task=<name> --help`` to list them.
-
-Use ``renderer=rtx`` for automatic RTX selection on tasks that expose the
-multi-backend renderer selector. The selection follows the runtime: it uses
-Isaac Sim RTX when the run needs Isaac Sim/Kit, such as ``physics=physx`` or
-``--visualizer kit``, and uses OVRTX when the run is fully kit-less. For example,
-``physics=ovphysx renderer=rtx`` selects OVRTX;
 
 Common combinations:
 


### PR DESCRIPTION
# Description

Update auto rtx docs to be more concise

Fixes # (OMPE-92354)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

- Documentation update


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
