### PR TITLE
[IsaacLab CI] Cache docker images

### DIFF
--- a/.github/actions/ecr-build-push-pull/README.md
+++ b/.github/actions/ecr-build-push-pull/README.md
@@ -1,7 +1,8 @@
 # ecr-build-push-pull
 
 Builds a Docker image and pushes it to ECR, or pulls it if the tag already exists.
-ECR is also used as the BuildKit layer cache.
+ECR is also used as the BuildKit layer cache. A dependency hash lets source-only
+changes reuse an existing image while the test action mounts the current checkout.
 
 ## Usage
 
@@ -22,3 +23,66 @@ ECR is also used as the BuildKit layer cache.
 2. `ECR_CACHE_URL` environment variable on the runner
 3. SSM parameter `/github-runner/<instance-id>/ecr-cache-url`
 4. If none resolve, ECR is skipped and the image is built locally
+
+## Cache behavior
+
+The action checks increasingly broad caches before building anything:
+
+1. **Exact commit image:** The CI image tag includes the tested commit. If the
+   corresponding ECR manifest exists, the action pulls and retags that image
+   locally. No build runs.
+2. **Dependency image:** If there is no exact image, the action calculates a
+   dependency hash from:
+
+   - the selected Dockerfile;
+   - `isaaclab.sh` and `environment.yml`;
+   - Isaac Lab CLI installation code;
+   - repository package manifests such as `pyproject.toml`, `setup.py`,
+     `extension.toml`, requirement files, and `uv.lock`; and
+   - the resolved digest of the Isaac Sim base image.
+
+   Regular Python source files are deliberately excluded. A source-only change
+   therefore resolves to the same `deps-<hash>` image. On a hit, the action
+   creates the commit-specific ECR tag from that existing manifest without
+   downloading or rebuilding its layers. Package tests then mount the current
+   checkout at `/workspace/isaaclab`, so they execute the changed source rather
+   than the source stored in the cached image.
+3. **BuildKit layer cache:** On a dependency-cache miss, the action builds a new
+   image using the registry cache named by `cache-tag`. Unchanged Docker layers
+   are downloaded from ECR instead of being rebuilt. The completed image is
+   pushed under both its commit-specific tag and its `deps-<hash>` tag for later
+   runs.
+4. **Local fallback:** If no ECR URL can be resolved, the action builds locally.
+   The resulting image can be reused only on that runner and is not available to
+   other runners or future machines.
+
+The `cache-result` output identifies the selected path:
+
+- `exact-hit`: reused the commit-specific image;
+- `dependency-hit`: reused an image with matching environment dependencies;
+- `remote-miss`: built and published a new ECR image; or
+- `local-build`: built locally because ECR was unavailable.
+
+## Reproducing a test environment
+
+After authenticating to ECR, copy `Source revision SHA` and `Image` from the CI job
+summary:
+
+```bash
+SOURCE_REVISION_SHA=<source-revision-sha>
+IMAGE=<ecr-image>@sha256:<digest>
+WORKTREE=/tmp/isaaclab-repro
+
+git fetch origin "$SOURCE_REVISION_SHA"
+git worktree add --detach "$WORKTREE" "$SOURCE_REVISION_SHA"
+docker pull "$IMAGE"
+docker run --rm -it --gpus all \
+  -v "$WORKTREE:/workspace/isaaclab" \
+  -w /workspace/isaaclab \
+  "$IMAGE" \
+  ./isaaclab.sh -p -m pytest tools -v
+git worktree remove "$WORKTREE"
+```
+
+The image provides the dependencies; the mounted revision provides the exact
+source tested by CI.

--- a/.github/actions/ecr-build-push-pull/README.md
+++ b/.github/actions/ecr-build-push-pull/README.md
@@ -63,7 +63,7 @@ The `cache-result` output identifies the selected path:
 - `remote-miss`: built and published a new ECR image; or
 - `local-build`: built locally because ECR was unavailable.
 
-## Reproducing a test environment
+## Opening a tested image
 
 After authenticating to ECR, copy `Source revision SHA` and `Image` from the CI job
 summary:
@@ -76,13 +76,16 @@ WORKTREE=/tmp/isaaclab-repro
 git fetch origin "$SOURCE_REVISION_SHA"
 git worktree add --detach "$WORKTREE" "$SOURCE_REVISION_SHA"
 docker pull "$IMAGE"
+# Restore _isaac_sim hidden by the worktree mount.
 docker run --rm -it --gpus all \
+  --entrypoint bash \
   -v "$WORKTREE:/workspace/isaaclab" \
   -w /workspace/isaaclab \
   "$IMAGE" \
-  ./isaaclab.sh -p -m pytest tools -v
+  -c 'ln -sfn /isaac-sim _isaac_sim && exec bash'
+rm "$WORKTREE/_isaac_sim"
 git worktree remove "$WORKTREE"
 ```
 
 The image provides the dependencies; the mounted revision provides the exact
-source tested by CI.
+source tested by CI. Run the relevant test commands from the interactive shell.

--- a/.github/actions/ecr-build-push-pull/action.yml
+++ b/.github/actions/ecr-build-push-pull/action.yml
@@ -37,6 +37,16 @@ inputs:
     description: Tag used for the ECR layer cache image (e.g. "cache-base", "cache-curobo").
     required: false
     default: 'cache'
+outputs:
+  cache-result:
+    description: 'Cache outcome: exact-hit, dependency-hit, remote-miss, or local-build.'
+    value: ${{ steps.image-metadata.outputs.cache-result }}
+  image-reference:
+    description: 'Immutable remote image reference, or the local image ID when ECR is unavailable.'
+    value: ${{ steps.image-metadata.outputs.image-reference }}
+  source-revision-sha:
+    description: 'Git commit SHA whose source is mounted when tests run.'
+    value: ${{ steps.image-metadata.outputs.source-revision-sha }}
 runs:
   using: composite
   steps:
@@ -310,7 +320,50 @@ runs:
         docker tag "${{ inputs.image-tag }}" "${DEPS_ECR_IMAGE}"
         docker push "${DEPS_ECR_IMAGE}"
 
-    ##### 9: Cleanup docker config #####
+    ##### 9: Record immutable image metadata #####
+
+    - name: Record image metadata
+      id: image-metadata
+      shell: bash
+      run: |
+        if [ "${{ steps.pull-exact.outputs.hit }}" = "true" ]; then
+          CACHE_RESULT=exact-hit
+        elif [ "${{ steps.deps-cache.outputs.deps-cache-hit }}" = "true" ]; then
+          CACHE_RESULT=dependency-hit
+        elif [ "${{ steps.resolve-ecr.outputs.available }}" = "true" ]; then
+          CACHE_RESULT=remote-miss
+        else
+          CACHE_RESULT=local-build
+        fi
+
+        if [ "${{ steps.resolve-ecr.outputs.available }}" = "true" ]; then
+          DIGEST=$(docker buildx imagetools inspect "${ECR_IMAGE}" \
+            --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"' || true)
+          if [ -n "$DIGEST" ]; then
+            IMAGE_REFERENCE="${ECR_IMAGE%:*}@${DIGEST}"
+          else
+            echo "::warning::Could not resolve an immutable digest for ${ECR_IMAGE}"
+            IMAGE_REFERENCE="${ECR_IMAGE}"
+          fi
+        else
+          IMAGE_REFERENCE=$(docker image inspect "${{ inputs.image-tag }}" --format '{{.Id}}')
+        fi
+
+        echo "cache-result=${CACHE_RESULT}" >> "$GITHUB_OUTPUT"
+        echo "image-reference=${IMAGE_REFERENCE}" >> "$GITHUB_OUTPUT"
+        echo "source-revision-sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "## Docker image cache"
+          echo ""
+          echo "| | Value |"
+          echo "|---|---|"
+          echo "| Result | \`${CACHE_RESULT}\` |"
+          echo "| Image | \`${IMAGE_REFERENCE}\` |"
+          echo "| Source revision SHA | \`${GITHUB_SHA}\` |"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    ##### 10: Cleanup docker config #####
 
     - name: Cleanup docker config
       if: always()

--- a/.github/actions/ecr-build-push-pull/action.yml
+++ b/.github/actions/ecr-build-push-pull/action.yml
@@ -330,10 +330,7 @@ runs:
       id: image-metadata
       shell: bash
       run: |
-        # On pull_request events GitHub checks out the synthetic merge commit
-        # (refs/pull/N/merge). HEAD^2 is the PR branch tip — a fetchable ref
-        # that other developers can reproduce.  Falls back to HEAD on push events.
-        SOURCE_REVISION_SHA=$(git log --format=%H -n 1 HEAD^2 2>/dev/null || git rev-parse HEAD)
+        SOURCE_REVISION_SHA=$(git rev-parse HEAD)
 
         if [ "${{ steps.pull-exact.outputs.hit }}" = "true" ]; then
           CACHE_RESULT=exact-hit

--- a/.github/actions/ecr-build-push-pull/action.yml
+++ b/.github/actions/ecr-build-push-pull/action.yml
@@ -325,6 +325,8 @@ runs:
     - name: Record image metadata
       id: image-metadata
       shell: bash
+      env:
+        SOURCE_REVISION_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
         if [ "${{ steps.pull-exact.outputs.hit }}" = "true" ]; then
           CACHE_RESULT=exact-hit
@@ -351,7 +353,7 @@ runs:
 
         echo "cache-result=${CACHE_RESULT}" >> "$GITHUB_OUTPUT"
         echo "image-reference=${IMAGE_REFERENCE}" >> "$GITHUB_OUTPUT"
-        echo "source-revision-sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+        echo "source-revision-sha=${SOURCE_REVISION_SHA}" >> "$GITHUB_OUTPUT"
 
         {
           echo "## Docker image cache"
@@ -360,7 +362,7 @@ runs:
           echo "|---|---|"
           echo "| Result | \`${CACHE_RESULT}\` |"
           echo "| Image | \`${IMAGE_REFERENCE}\` |"
-          echo "| Source revision SHA | \`${GITHUB_SHA}\` |"
+          echo "| Source revision SHA | \`${SOURCE_REVISION_SHA}\` |"
         } >> "$GITHUB_STEP_SUMMARY"
 
     ##### 10: Cleanup docker config #####

--- a/.github/actions/ecr-build-push-pull/action.yml
+++ b/.github/actions/ecr-build-push-pull/action.yml
@@ -330,7 +330,10 @@ runs:
       id: image-metadata
       shell: bash
       run: |
-        SOURCE_REVISION_SHA=$(git rev-parse HEAD)
+        # On pull_request events GitHub checks out the synthetic merge commit
+        # (refs/pull/N/merge). HEAD^2 is the PR branch tip — a fetchable ref
+        # that other developers can reproduce.  Falls back to HEAD on push events.
+        SOURCE_REVISION_SHA=$(git log --format=%H -n 1 HEAD^2 2>/dev/null || git rev-parse HEAD)
 
         if [ "${{ steps.pull-exact.outputs.hit }}" = "true" ]; then
           CACHE_RESULT=exact-hit

--- a/.github/actions/ecr-build-push-pull/action.yml
+++ b/.github/actions/ecr-build-push-pull/action.yml
@@ -243,11 +243,15 @@ runs:
         # not the actual layers, so this completes in seconds.
         if docker manifest inspect "${DEPS_ECR_IMAGE}" >/dev/null 2>&1; then
           echo "🟢 Deps cache HIT!!! Image exists in ECR: ${DEPS_ECR_IMAGE}"
-          # Create a commit-tagged alias pointing to the same manifest (registry-side,
-          # no layer download). Test jobs will pull this tag normally.
+          # Create a commit-tagged alias pointing to the same manifest, then pull it
+          # locally for downstream test jobs.
           echo "🔵 Tagging as commit image ${ECR_IMAGE}..."
           docker buildx imagetools create -t "${ECR_IMAGE}" "${DEPS_ECR_IMAGE}"
           echo "🟢 Tagged ${ECR_IMAGE} >> ${DEPS_ECR_IMAGE}"
+          echo "🔵 Pulling ${ECR_IMAGE} from ECR..."
+          docker pull "${ECR_IMAGE}"
+          docker tag "${ECR_IMAGE}" "${{ inputs.image-tag }}"
+          echo "🟢 Image pulled and tagged as ${{ inputs.image-tag }}"
           echo "deps-cache-hit=true" >> "$GITHUB_OUTPUT"
         else
           echo "🟠 Deps cache MISS 😿😿😿 (${DEPS_HASH}). Will build now. 🐢🐢🐢"

--- a/.github/actions/ecr-build-push-pull/action.yml
+++ b/.github/actions/ecr-build-push-pull/action.yml
@@ -329,9 +329,9 @@ runs:
     - name: Record image metadata
       id: image-metadata
       shell: bash
-      env:
-        SOURCE_REVISION_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
+        SOURCE_REVISION_SHA=$(git rev-parse HEAD)
+
         if [ "${{ steps.pull-exact.outputs.hit }}" = "true" ]; then
           CACHE_RESULT=exact-hit
         elif [ "${{ steps.deps-cache.outputs.deps-cache-hit }}" = "true" ]; then

--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -147,7 +147,7 @@ runs:
         echo "🔵 Docker Image Pulled in ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Report reproduction command
-      if: steps.image.outputs.cache-result != 'local-build'
+      if: success() && steps.image.outputs.cache-result != 'local-build'
       shell: bash
       env:
         IMAGE_REFERENCE: ${{ steps.image.outputs.image-reference }}

--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -152,8 +152,25 @@ runs:
       env:
         IMAGE_REFERENCE: ${{ steps.image.outputs.image-reference }}
         SOURCE_REVISION_SHA: ${{ steps.image.outputs.source-revision-sha }}
+        FILTER_PATTERN: ${{ inputs.filter-pattern }}
+        EXCLUDE_PATTERN: ${{ inputs.exclude-pattern }}
+        SHARD_INDEX: ${{ inputs.shard-index }}
+        SHARD_COUNT: ${{ inputs.shard-count }}
+        CUROBO_ONLY: ${{ inputs.curobo-only }}
+        QUARANTINED_ONLY: ${{ inputs.quarantined-only }}
+        INCLUDE_FILES: ${{ inputs.include-files }}
+        PYTEST_OPTIONS: ${{ inputs.pytest-options }}
       run: |
         WORKTREE="/tmp/isaaclab-${SOURCE_REVISION_SHA:0:12}"
+        DOCKER_ENV_FLAGS=""
+        [ -n "${FILTER_PATTERN}" ]         && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_FILTER_PATTERN='${FILTER_PATTERN}'"
+        [ -n "${EXCLUDE_PATTERN}" ]        && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_EXCLUDE_PATTERN='${EXCLUDE_PATTERN}'"
+        [ -n "${SHARD_INDEX}" ]            && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_SHARD_INDEX=${SHARD_INDEX} -e TEST_SHARD_COUNT=${SHARD_COUNT}"
+        [ "${CUROBO_ONLY}" = "true" ]      && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_CUROBO_ONLY=true"
+        [ "${QUARANTINED_ONLY}" = "true" ] && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_QUARANTINED_ONLY=true"
+        [ -n "${INCLUDE_FILES}" ]          && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_INCLUDE_FILES='${INCLUDE_FILES}'"
+        PYTEST_EXTRA=""
+        [ -n "${PYTEST_OPTIONS}" ]         && PYTEST_EXTRA=" ${PYTEST_OPTIONS}"
         {
           echo "### Reproduce this test environment"
           echo ""
@@ -161,7 +178,7 @@ runs:
           echo "git fetch origin ${SOURCE_REVISION_SHA}"
           echo "git worktree add --detach ${WORKTREE} ${SOURCE_REVISION_SHA}"
           echo "docker pull '${IMAGE_REFERENCE}'"
-          echo "docker run --rm -it --gpus all -v ${WORKTREE}:/workspace/isaaclab -w /workspace/isaaclab '${IMAGE_REFERENCE}' ./isaaclab.sh -p -m pytest tools -v"
+          echo "docker run --rm -it --gpus all${DOCKER_ENV_FLAGS} -v ${WORKTREE}:/workspace/isaaclab -w /workspace/isaaclab '${IMAGE_REFERENCE}' ./isaaclab.sh -p -m pytest tools -v${PYTEST_EXTRA}"
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -124,6 +124,7 @@ runs:
       run: echo "time=$(date +%s)" >> "$GITHUB_OUTPUT"
 
     - name: Pull image from ECR
+      id: image
       uses: ./.github/actions/ecr-build-push-pull
       with:
         image-tag: ${{ inputs.image-tag }}
@@ -144,6 +145,25 @@ runs:
         elapsed=$(( $(date +%s) - start_time ))
         printf "🔵 Image pull took %dm %ds\n" $((elapsed/60)) $((elapsed%60))
         echo "🔵 Docker Image Pulled in ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Report reproduction command
+      if: steps.image.outputs.cache-result != 'local-build'
+      shell: bash
+      env:
+        IMAGE_REFERENCE: ${{ steps.image.outputs.image-reference }}
+        SOURCE_REVISION_SHA: ${{ steps.image.outputs.source-revision-sha }}
+      run: |
+        WORKTREE="/tmp/isaaclab-${SOURCE_REVISION_SHA:0:12}"
+        {
+          echo "### Reproduce this test environment"
+          echo ""
+          echo '```bash'
+          echo "git fetch origin ${SOURCE_REVISION_SHA}"
+          echo "git worktree add --detach ${WORKTREE} ${SOURCE_REVISION_SHA}"
+          echo "docker pull '${IMAGE_REFERENCE}'"
+          echo "docker run --rm -it --gpus all -v ${WORKTREE}:/workspace/isaaclab -w /workspace/isaaclab '${IMAGE_REFERENCE}' ./isaaclab.sh -p -m pytest tools -v"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Run Tests
       uses: ./.github/actions/run-tests

--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -155,13 +155,14 @@ runs:
       run: |
         WORKTREE="/tmp/isaaclab-${SOURCE_REVISION_SHA:0:12}"
         {
-          echo "### Reproduce this test environment"
+          echo "### Open the tested image"
           echo ""
           echo '```bash'
           echo "git fetch origin ${SOURCE_REVISION_SHA}"
           echo "git worktree add --detach ${WORKTREE} ${SOURCE_REVISION_SHA}"
           echo "docker pull '${IMAGE_REFERENCE}'"
-          echo "docker run --rm -it --gpus all -v ${WORKTREE}:/workspace/isaaclab -w /workspace/isaaclab '${IMAGE_REFERENCE}' bash"
+          echo "# Restore _isaac_sim hidden by the worktree mount."
+          echo "docker run --rm -it --gpus all --entrypoint bash -v ${WORKTREE}:/workspace/isaaclab -w /workspace/isaaclab '${IMAGE_REFERENCE}' -c 'ln -sfn /isaac-sim _isaac_sim && exec bash'"
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -152,25 +152,8 @@ runs:
       env:
         IMAGE_REFERENCE: ${{ steps.image.outputs.image-reference }}
         SOURCE_REVISION_SHA: ${{ steps.image.outputs.source-revision-sha }}
-        FILTER_PATTERN: ${{ inputs.filter-pattern }}
-        EXCLUDE_PATTERN: ${{ inputs.exclude-pattern }}
-        SHARD_INDEX: ${{ inputs.shard-index }}
-        SHARD_COUNT: ${{ inputs.shard-count }}
-        CUROBO_ONLY: ${{ inputs.curobo-only }}
-        QUARANTINED_ONLY: ${{ inputs.quarantined-only }}
-        INCLUDE_FILES: ${{ inputs.include-files }}
-        PYTEST_OPTIONS: ${{ inputs.pytest-options }}
       run: |
         WORKTREE="/tmp/isaaclab-${SOURCE_REVISION_SHA:0:12}"
-        DOCKER_ENV_FLAGS=""
-        [ -n "${FILTER_PATTERN}" ]         && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_FILTER_PATTERN='${FILTER_PATTERN}'"
-        [ -n "${EXCLUDE_PATTERN}" ]        && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_EXCLUDE_PATTERN='${EXCLUDE_PATTERN}'"
-        [ -n "${SHARD_INDEX}" ]            && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_SHARD_INDEX=${SHARD_INDEX} -e TEST_SHARD_COUNT=${SHARD_COUNT}"
-        [ "${CUROBO_ONLY}" = "true" ]      && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_CUROBO_ONLY=true"
-        [ "${QUARANTINED_ONLY}" = "true" ] && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_QUARANTINED_ONLY=true"
-        [ -n "${INCLUDE_FILES}" ]          && DOCKER_ENV_FLAGS="${DOCKER_ENV_FLAGS} -e TEST_INCLUDE_FILES='${INCLUDE_FILES}'"
-        PYTEST_EXTRA=""
-        [ -n "${PYTEST_OPTIONS}" ]         && PYTEST_EXTRA=" ${PYTEST_OPTIONS}"
         {
           echo "### Reproduce this test environment"
           echo ""
@@ -178,7 +161,7 @@ runs:
           echo "git fetch origin ${SOURCE_REVISION_SHA}"
           echo "git worktree add --detach ${WORKTREE} ${SOURCE_REVISION_SHA}"
           echo "docker pull '${IMAGE_REFERENCE}'"
-          echo "docker run --rm -it --gpus all${DOCKER_ENV_FLAGS} -v ${WORKTREE}:/workspace/isaaclab -w /workspace/isaaclab '${IMAGE_REFERENCE}' ./isaaclab.sh -p -m pytest tools -v${PYTEST_EXTRA}"
+          echo "docker run --rm -it --gpus all -v ${WORKTREE}:/workspace/isaaclab -w /workspace/isaaclab '${IMAGE_REFERENCE}' bash"
           echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
# Description

CI currently rebuilds Docker images for each pull request, including Python-only changes that do not modify the container environment. These builds add significant latency and consume self-hosted runner resources before affected tests can begin.
Add persistent Docker image caching so CI can reuse an image when its environment-defining inputs have not changed.

Proposed behavior:

Calculate a cache key from Dockerfiles, dependency manifests, installation scripts, base-image identity, and relevant CI configuration.
Pull and reuse an existing cached image when the key matches.
Rebuild and publish the image when the key changes or no cached image exists.
Continue mounting or checking out the current PR source so reused images test the latest code.
Fall back safely to a local build when the cache is unavailable.

This should save ~1.5 hours of blocking work that gets done on each PR


- Reuse the exact commit image if present.
- Otherwise calculate a dependency hash.
- Reuse deps-<hash> when Dockerfiles, manifests, install scripts, and the Isaac Sim base image are unchanged.
- Mount the current PR source over that cached image.
- Build from scratch only on a cache miss or when ECR is unavailable.



Fixes # ([OMPE-99393](https://jirasw.nvidia.com/browse/OMPE-99393))


## Type of change

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
