### PR TITLE
Fix typos and an incorrect task ID in Newton physics docs

### DIFF
--- a/docs/source/experimental-features/newton-physics-integration/isaaclab_newton-beta-2.rst
+++ b/docs/source/experimental-features/newton-physics-integration/isaaclab_newton-beta-2.rst
@@ -8,7 +8,7 @@ set of abstract methods that all physics engines must implement. In turn this al
 This also allows us to ensure that Isaac Lab 3.0 Beta is backwards compatible with Isaac Lab 2.X. For engine specific calls, users could get the underlying view of
 the physics engine and call the engine specific APIs directly.
 
-However, as we are refactoring the code, we are also looking at ways to limit the overhead of Isaac Lab's. In an effort to minimize the overhead, we are moving
+However, as we are refactoring the code, we are also looking at ways to limit the overhead of Isaac Lab. In an effort to minimize the overhead, we are moving
 all our low level code away from torch, and instead will rely heavily on warp. This will allow us to write low level code that is more efficient, and also
 to take advantage of the cuda-graphing. However, this means that the ``data classes`` such as :class:`~isaaclab.assets.articulation.ArticulationData` or
 :class:`~isaaclab.sensors.ContactSensorData` will only return warp arrays. Users will hence have to call ``wp.to_torch`` to convert them to torch tensors if they desire.

--- a/docs/source/experimental-features/newton-physics-integration/sim-to-sim.rst
+++ b/docs/source/experimental-features/newton-physics-integration/sim-to-sim.rst
@@ -88,7 +88,7 @@ Here are examples for different robots:
 .. code-block:: bash
 
    ./isaaclab.sh -p scripts/sim2sim_transfer/rsl_rl_transfer.py \
-       --task=Isaac-Velocity-Flat-Go2-v0 \
+       --task=Isaac-Velocity-Flat-Unitree-Go2-v0 \
        --num_envs=32 \
        --checkpoint <PATH_TO_PHYSX_CHECKPOINT> \
        --policy_transfer_file scripts/sim2sim_transfer/config/physx_to_newton_go2.yaml \
@@ -143,7 +143,7 @@ Here are examples for different robots:
 .. code-block:: bash
 
    ./isaaclab.sh -p scripts/sim2sim_transfer/rsl_rl_transfer.py \
-       --task=Isaac-Velocity-Flat-Go2-v0 \
+       --task=Isaac-Velocity-Flat-Unitree-Go2-v0 \
        --num_envs=32 \
        --checkpoint <PATH_TO_NEWTON_CHECKPOINT> \
        --policy_transfer_file scripts/sim2sim_transfer/config/newton_to_physx_go2.yaml

--- a/docs/source/experimental-features/newton-physics-integration/training-environments.rst
+++ b/docs/source/experimental-features/newton-physics-integration/training-environments.rst
@@ -26,7 +26,7 @@ The currently supported tasks are as follows:
 * Isaac-Reach-UR10-v0
 * Isaac-Repose-Cube-Allegro-Direct-v0
 
-New experimental warp-based enviromnets:
+New experimental warp-based environments:
 
 * Isaac-Cartpole-Direct-Warp-v0
 * Isaac-Ant-Direct-Warp-v0

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -70,7 +70,7 @@ def hydra_task_config(task_name: str, agent_cfg_entry_point: str) -> Callable:
         agent_cfg_entry_point: The entry point key to resolve the agent's configuration file.
 
     Returns:
-        The decorated function with the envrionment's and agent's configurations updated from command line arguments.
+        The decorated function with the environment's and agent's configurations updated from command line arguments.
     """
 
     def decorator(func):


### PR DESCRIPTION
# Description

Small documentation fixes in the Newton physics integration docs (and one docstring):

- `sim-to-sim.rst`: the example command uses `--task=Isaac-Velocity-Flat-Go2-v0`, but the registered gym ID is `Isaac-Velocity-Flat-Unitree-Go2-v0` (see `.../velocity/config/go2/__init__.py`). As written the command fails with a task-not-found error. Fixed in both occurrences. The doc's G1/H1/Anymal-D commands already use the correct `Unitree-`/full IDs.
- `training-environments.rst`: typo `enviromnets` → `environments`.
- `isaaclab_newton-beta-2.rst`: dangling possessive `Isaac Lab's.` → `Isaac Lab.`.
- `isaaclab_tasks/utils/hydra.py`: docstring typo `envrionment's` → `environment's`.

Documentation-only changes; no functional code impact.

Fixes # (N/A — minor documentation fixes)

## Type of change

- Documentation update

## Screenshots

N/A (text-only documentation changes)

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
