### PR TITLE
Add ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS to control GPU transforms for…

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovrtx-read-gpu-transforms-env.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-read-gpu-transforms-env.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added the ``ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS`` environment variable to control whether
+  :class:`~isaaclab_ov.renderers.OVRTXRenderer` enables OVRTX GPU transform reads.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -93,6 +93,7 @@ _PPISP_IMPORT_ERROR_MESSAGE = (
     "Install Isaac Lab with the 'all' extra (`pip install isaaclab[all]`) or install the "
     "isaaclab-ppisp extension from the Isaac Lab source checkout."
 )
+_READ_GPU_TRANSFORMS_ENV = "ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS"
 
 
 def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
@@ -101,6 +102,16 @@ def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
     if exc.name != "isaaclab_ppisp" and not (exc.name and exc.name.startswith("isaaclab_ppisp.")):
         raise exc
     raise ModuleNotFoundError(_PPISP_IMPORT_ERROR_MESSAGE, name="isaaclab_ppisp") from exc
+
+
+def _read_gpu_transforms_enabled() -> bool:
+    """Return whether OVRTX should read GPU transforms from its internal transform cache."""
+    value = os.environ.get(_READ_GPU_TRANSFORMS_ENV, "1").strip()
+    if value not in {"0", "1"}:
+        raise ValueError(
+            f"Invalid value for environment variable `{_READ_GPU_TRANSFORMS_ENV}`: {value}. Expected 0 or 1."
+        )
+    return value == "1"
 
 
 def _resolve_rtx_minimal_mode(data_types: list[str]) -> int | None:
@@ -272,7 +283,7 @@ class OVRTXRenderer(BaseRenderer):
         OVRTX_CONFIG = RendererConfig(
             log_file_path=self.cfg.log_file_path,
             log_level=self.cfg.log_level,
-            read_gpu_transforms=True,
+            read_gpu_transforms=_read_gpu_transforms_enabled(),
             keep_system_alive=True,
         )
         self._renderer = Renderer(OVRTX_CONFIG)

--- a/source/isaaclab_tasks/changelog.d/ovrtx-read-gpu-transforms-correctness.skip
+++ b/source/isaaclab_tasks/changelog.d/ovrtx-read-gpu-transforms-correctness.skip
@@ -1,0 +1,1 @@
+Skipped changelog entry for kitless rendering-correctness test configuration changes.

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -432,12 +432,13 @@ def make_require_ovlibs_install_fixture():
     """
 
     @pytest.fixture(autouse=True)
-    def _require_ovlibs_install(request):
+    def _require_ovlibs_install(request, monkeypatch: pytest.MonkeyPatch):
         callspec = getattr(request.node, "callspec", None)
         if callspec is None:
             return
 
         if callspec.params.get("renderer") == "ovrtx_renderer":
+            monkeypatch.setenv("ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS", "0")
             try:
                 import ovrtx
 


### PR DESCRIPTION

# Description

Add ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS environment variable to control GPU transform reads during CI/CD testing for ovrtx-0.3. 

This is a temporary workaround to mitigate flaky CI/CD rendering correctness jobs. 

Once the upstream issues with GPU transform reads are resolved, this flag should be set back to 1.



## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
