### PR TITLE
Added instance_segmentation_fast & instance_id_segmentation_fast support to OVRTX renderer integration

### DIFF
--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -255,7 +255,7 @@ is :class:`~isaaclab_ov.renderers.OVRTXRendererCfg`, and ``Newton Warp`` is
      - ✅
    * - ``instance_id_segmentation_fast``
      - ✅
-     - ❌
+     - ✅
      - ❌
 
 RGB and RGBA

--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -251,7 +251,7 @@ is :class:`~isaaclab_ov.renderers.OVRTXRendererCfg`, and ``Newton Warp`` is
      - ❌
    * - ``instance_segmentation_fast``
      - ✅
-     - ❌
+     - ✅
      - ✅
    * - ``instance_id_segmentation_fast``
      - ✅

--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -35,16 +35,12 @@ The renderer used by a camera is configured via the ``renderer_cfg`` field on
 
    * - ``renderer_cfg``
      - Requires Isaac Sim?
-     - Supported data types
    * - ``IsaacRtxRendererCfg`` *(default)*
      - Yes
-     - All annotators (rgb, rgba, depth, distances, normals, motion vectors, semantic/instance segmentation)
    * - ``NewtonWarpRendererCfg``
      - No (kit-less)
-     - rgb, rgba, rgb_hdr, depth, normals, instance segmentation
    * - ``OVRTXRendererCfg``
      - No (+ ``isaaclab_ov``)
-     - rgb, rgba, rgb_hdr, depth, distances, normals, semantic segmentation
 
 .. note::
 
@@ -505,6 +501,11 @@ An ``info`` dictionary is available via ``tiled_camera.data.info['instance_segme
 
 - If ``colorize_instance_segmentation=True``: shape ``(B, H, W, 4)``, type ``torch.uint8``.
 - If ``colorize_instance_segmentation=False``: shape ``(B, H, W, 1)``, type ``torch.int32``.
+
+Pixels belonging to prims with no assigned semantic label are rendered black
+(RGBA ``(0, 0, 0, 255)``) when ``colorize_instance_segmentation=True``. When
+``colorize_instance_segmentation=False``, those pixels instead carry the raw
+UNLABELLED instance ID (``1``) rather than a color value.
 
 The ``idToLabels`` dict maps color to USD prim path. The ``idToSemantics`` dict maps color to
 semantic label.

--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -31,7 +31,7 @@ The renderer used by a camera is configured via the ``renderer_cfg`` field on
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 30 40
+   :widths: 30 30
 
    * - ``renderer_cfg``
      - Requires Isaac Sim?

--- a/source/isaaclab_ov/changelog.d/ovrtx-instance-segmentation-fast.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-instance-segmentation-fast.rst
@@ -1,10 +1,13 @@
 Added
 ^^^^^
 
-* Added :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.colorize_instance_segmentation` config field
+* Added :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.colorize_instance_segmentation` and
+  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.colorize_instance_id_segmentation` config fields
   to :class:`~isaaclab_ov.renderers.OVRTXRendererCfg`.
-* Added support for ``instance_segmentation_fast`` data type in the OVRTX renderer via the
-  ``NonStableInstanceSegmentation`` AOV. When
-  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.colorize_instance_segmentation` is ``True``
-  (default), instance IDs are colorized and returned as ``uint8`` RGBA; when ``False``, raw
-  ``uint32`` instance IDs are returned.
+* Added support for the ``instance_segmentation_fast`` and ``instance_id_segmentation_fast``
+  data types in the OVRTX renderer, via the ``NonStableInstanceSegmentation`` and
+  ``InstanceSegmentationSD`` AOVs respectively. When the corresponding
+  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.colorize_instance_segmentation` /
+  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.colorize_instance_id_segmentation` flag is
+  ``True`` (default), instance IDs are colorized and returned as ``uint8`` RGBA; when ``False``,
+  raw ``uint32`` instance IDs are returned.

--- a/source/isaaclab_ov/changelog.d/ovrtx-instance-segmentation-fast.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-instance-segmentation-fast.rst
@@ -1,0 +1,10 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.colorize_instance_segmentation` config field
+  to :class:`~isaaclab_ov.renderers.OVRTXRendererCfg`.
+* Added support for ``instance_segmentation_fast`` data type in the OVRTX renderer via the
+  ``NonStableInstanceSegmentation`` AOV. When
+  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.colorize_instance_segmentation` is ``True``
+  (default), instance IDs are colorized and returned as ``uint8`` RGBA; when ``False``, raw
+  ``uint32`` instance IDs are returned.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -287,7 +287,6 @@ class OVRTXRenderer(BaseRenderer):
         self._initialized_scene = False
         self._exported_usd_string: str | None = None
         self._camera_rel_path: str | None = None
-        self._output_semantic_color_buffer: wp.array | None = None
         self._output_id_color_buffers: dict[str, wp.array] = {}
         self._clone_plan: ClonePlan | None = None
 
@@ -690,9 +689,9 @@ class OVRTXRenderer(BaseRenderer):
     ) -> None:
         """Extract a uint32 ID-segmentation render var into ``output_buffers[buffer_key]``.
 
-        Shared by ``instance_segmentation_fast`` (``NonStableInstanceSegmentation``) and
-        ``instance_id_segmentation_fast`` (``InstanceSegmentationSD``), which only differ in
-        the source render var, the destination buffer, and whether to colorize.
+        Shared by ``semantic_segmentation`` (``SemanticSegmentation``), ``instance_segmentation_fast``
+        (``NonStableInstanceSegmentation``), and ``instance_id_segmentation_fast`` (``InstanceSegmentationSD``),
+        which only differ in the source render var, the destination buffer, and whether to colorize.
 
         Args:
             render_data: OVRTX render data for the current frame.
@@ -874,32 +873,16 @@ class OVRTXRenderer(BaseRenderer):
                 tiled_hdr_data = self._prepare_ppisp_hdr_source(render_data, tiled_hdr_data, output_buffers)
                 self._extract_hdr_color_tiles(render_data, tiled_hdr_data, output_buffers)
 
-        if "SemanticSegmentation" in frame.render_vars and "semantic_segmentation" in output_buffers:
-            with frame.render_vars["SemanticSegmentation"].map(device=Device.CUDA) as mapping:
-                tiled_semantic_data = wp.from_dlpack(mapping.tensor)
-
-                if tiled_semantic_data.dtype == wp.uint32:
-                    self._output_semantic_color_buffer = self._generate_random_colors_from_ids(
-                        tiled_semantic_data, self._output_semantic_color_buffer
-                    )
-                    semantic_colors = self._output_semantic_color_buffer
-
-                    semantic_torch = wp.to_torch(semantic_colors)
-                    semantic_uint8 = semantic_torch.view(torch.uint8)
-
-                    if semantic_torch.dim() == 2:
-                        h, w = semantic_torch.shape
-                        semantic_uint8 = semantic_uint8.reshape(h, w, 4)
-
-                    tiled_semantic_data = wp.from_torch(semantic_uint8, dtype=wp.uint8)
-
-                self._extract_rgba_tiles(
-                    render_data,
-                    tiled_semantic_data,
-                    output_buffers,
-                    "semantic_segmentation",
-                    suffix="semantic",
-                )
+        # Semantic segmentation is always colorized: unlike instance (id) segmentation, there is no
+        # raw-uint32 output mode exposed for it (see OVRTXRenderer.supported_output_types).
+        self._process_id_segmentation_render_var(
+            render_data,
+            frame,
+            output_buffers,
+            "SemanticSegmentation",
+            "semantic_segmentation",
+            True,
+        )
 
         self._process_id_segmentation_render_var(
             render_data,
@@ -991,6 +974,5 @@ class OVRTXRenderer(BaseRenderer):
             self._renderer = None
 
         self._render_product_paths.clear()
-        self._output_semantic_color_buffer = None
         self._output_id_color_buffers.clear()
         self._initialized_scene = False

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -249,6 +249,11 @@ class OVRTXRenderer(BaseRenderer):
         instance_seg_spec = (
             RenderBufferSpec(4, wp.uint8) if self.cfg.colorize_instance_segmentation else RenderBufferSpec(1, wp.uint32)
         )
+        instance_id_seg_spec = (
+            RenderBufferSpec(4, wp.uint8)
+            if self.cfg.colorize_instance_id_segmentation
+            else RenderBufferSpec(1, wp.uint32)
+        )
         return {
             RenderBufferKind.RGBA: RenderBufferSpec(4, wp.uint8),
             RenderBufferKind.RGB: RenderBufferSpec(3, wp.uint8),
@@ -259,6 +264,7 @@ class OVRTXRenderer(BaseRenderer):
             RenderBufferKind.SIMPLE_SHADING_FULL_MDL: RenderBufferSpec(3, wp.uint8),
             RenderBufferKind.SEMANTIC_SEGMENTATION: RenderBufferSpec(4, wp.uint8),
             RenderBufferKind.INSTANCE_SEGMENTATION_FAST: instance_seg_spec,
+            RenderBufferKind.INSTANCE_ID_SEGMENTATION_FAST: instance_id_seg_spec,
             RenderBufferKind.DEPTH: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_IMAGE_PLANE: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_CAMERA: RenderBufferSpec(1, wp.float32),
@@ -282,7 +288,7 @@ class OVRTXRenderer(BaseRenderer):
         self._exported_usd_string: str | None = None
         self._camera_rel_path: str | None = None
         self._output_semantic_color_buffer: wp.array | None = None
-        self._output_instance_color_buffer: wp.array | None = None
+        self._output_id_color_buffers: dict[str, wp.array] = {}
         self._clone_plan: ClonePlan | None = None
 
         logger.info("Creating OVRTX renderer...")
@@ -673,6 +679,69 @@ class OVRTXRenderer(BaseRenderer):
         )
         return output_colors
 
+    def _process_id_segmentation_render_var(
+        self,
+        render_data: OVRTXRenderData,
+        frame,
+        output_buffers: dict,
+        render_var_name: str,
+        buffer_key: str,
+        colorize: bool,
+    ) -> None:
+        """Extract a uint32 ID-segmentation render var into ``output_buffers[buffer_key]``.
+
+        Shared by ``instance_segmentation_fast`` (``NonStableInstanceSegmentation``) and
+        ``instance_id_segmentation_fast`` (``InstanceSegmentationSD``), which only differ in
+        the source render var, the destination buffer, and whether to colorize.
+
+        Args:
+            render_data: OVRTX render data for the current frame.
+            frame: OVRTX frame holding the mapped render vars.
+            output_buffers: Destination warp buffers, keyed by data type.
+            render_var_name: Name of the OVRTX render var to read.
+            buffer_key: Data type key into ``output_buffers``.
+            colorize: If True, IDs are mapped to RGBA colors; otherwise raw uint32 IDs are copied.
+        """
+        if render_var_name not in frame.render_vars or buffer_key not in output_buffers:
+            return
+
+        with frame.render_vars[render_var_name].map(device=Device.CUDA) as mapping:
+            tiled_data = wp.from_dlpack(mapping.tensor)
+            if tiled_data.dtype != wp.uint32:
+                return
+
+            if colorize:
+                color_buffer = self._generate_random_colors_from_ids(
+                    tiled_data, self._output_id_color_buffers.get(buffer_key)
+                )
+                self._output_id_color_buffers[buffer_key] = color_buffer
+
+                colors_torch = wp.to_torch(color_buffer)
+                colors_uint8 = colors_torch.view(torch.uint8)
+                if colors_torch.dim() == 2:
+                    h, w = colors_torch.shape
+                    colors_uint8 = colors_uint8.reshape(h, w, 4)
+                tiled_data = wp.from_torch(colors_uint8, dtype=wp.uint8)
+                self._extract_rgba_tiles(render_data, tiled_data, output_buffers, buffer_key)
+            else:
+                # Non-colorized: ensure (TH, TW, 1) shape for the uint32 extraction kernel.
+                data_torch = wp.to_torch(tiled_data)
+                if data_torch.dim() == 2:
+                    data_torch = data_torch.unsqueeze(-1)
+                tiled_data = wp.from_torch(data_torch, dtype=wp.uint32)
+                wp.launch(
+                    kernel=extract_all_uint32_tiles_kernel,
+                    dim=(render_data.num_envs, render_data.height, render_data.width),
+                    inputs=[
+                        tiled_data,
+                        output_buffers[buffer_key],
+                        render_data.num_cols,
+                        render_data.width,
+                        render_data.height,
+                    ],
+                    device=self._device,
+                )
+
     def _extract_rgba_tiles(
         self,
         render_data: OVRTXRenderData,
@@ -832,46 +901,23 @@ class OVRTXRenderer(BaseRenderer):
                     suffix="semantic",
                 )
 
-        if "NonStableInstanceSegmentation" in frame.render_vars and "instance_segmentation_fast" in output_buffers:
-            with frame.render_vars["NonStableInstanceSegmentation"].map(device=Device.CUDA) as mapping:
-                tiled_instance_data = wp.from_dlpack(mapping.tensor)
+        self._process_id_segmentation_render_var(
+            render_data,
+            frame,
+            output_buffers,
+            "NonStableInstanceSegmentation",
+            "instance_segmentation_fast",
+            self.cfg.colorize_instance_segmentation,
+        )
 
-                if tiled_instance_data.dtype == wp.uint32:
-                    if self.cfg.colorize_instance_segmentation:
-                        self._output_instance_color_buffer = self._generate_random_colors_from_ids(
-                            tiled_instance_data, self._output_instance_color_buffer
-                        )
-                        instance_colors = self._output_instance_color_buffer
-                        instance_torch = wp.to_torch(instance_colors)
-                        instance_uint8 = instance_torch.view(torch.uint8)
-                        if instance_torch.dim() == 2:
-                            h, w = instance_torch.shape
-                            instance_uint8 = instance_uint8.reshape(h, w, 4)
-                        tiled_instance_data = wp.from_torch(instance_uint8, dtype=wp.uint8)
-                        self._extract_rgba_tiles(
-                            render_data,
-                            tiled_instance_data,
-                            output_buffers,
-                            "instance_segmentation_fast",
-                        )
-                    else:
-                        # Non-colorized: ensure (TH, TW, 1) shape for the uint32 extraction kernel.
-                        instance_torch = wp.to_torch(tiled_instance_data)
-                        if instance_torch.dim() == 2:
-                            instance_torch = instance_torch.unsqueeze(-1)
-                        tiled_instance_data = wp.from_torch(instance_torch, dtype=wp.uint32)
-                        wp.launch(
-                            kernel=extract_all_uint32_tiles_kernel,
-                            dim=(render_data.num_envs, render_data.height, render_data.width),
-                            inputs=[
-                                tiled_instance_data,
-                                output_buffers["instance_segmentation_fast"],
-                                render_data.num_cols,
-                                render_data.width,
-                                render_data.height,
-                            ],
-                            device=self._device,
-                        )
+        self._process_id_segmentation_render_var(
+            render_data,
+            frame,
+            output_buffers,
+            "InstanceSegmentationSD",
+            "instance_id_segmentation_fast",
+            self.cfg.colorize_instance_id_segmentation,
+        )
 
         if "NormalSD" in frame.render_vars and "normals" in output_buffers:
             with frame.render_vars["NormalSD"].map(device=Device.CUDA) as mapping:
@@ -946,5 +992,5 @@ class OVRTXRenderer(BaseRenderer):
 
         self._render_product_paths.clear()
         self._output_semantic_color_buffer = None
-        self._output_instance_color_buffer = None
+        self._output_id_color_buffers.clear()
         self._initialized_scene = False

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -64,6 +64,7 @@ from .ovrtx_renderer_kernels import (
     extract_all_rgb_float_tiles_kernel,
     extract_all_rgb_half_tiles_kernel,
     extract_all_rgba_tiles_kernel,
+    extract_all_uint32_tiles_kernel,
     generate_random_colors_from_ids_kernel,
     sync_newton_transforms_kernel,
 )
@@ -245,6 +246,9 @@ class OVRTXRenderer(BaseRenderer):
     def supported_output_types(self) -> dict[RenderBufferKind, RenderBufferSpec]:
         """Publish the per-output layout this OVRTX backend writes.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.supported_output_types`."""
+        instance_seg_spec = (
+            RenderBufferSpec(4, wp.uint8) if self.cfg.colorize_instance_segmentation else RenderBufferSpec(1, wp.uint32)
+        )
         return {
             RenderBufferKind.RGBA: RenderBufferSpec(4, wp.uint8),
             RenderBufferKind.RGB: RenderBufferSpec(3, wp.uint8),
@@ -254,6 +258,7 @@ class OVRTXRenderer(BaseRenderer):
             RenderBufferKind.SIMPLE_SHADING_DIFFUSE_MDL: RenderBufferSpec(3, wp.uint8),
             RenderBufferKind.SIMPLE_SHADING_FULL_MDL: RenderBufferSpec(3, wp.uint8),
             RenderBufferKind.SEMANTIC_SEGMENTATION: RenderBufferSpec(4, wp.uint8),
+            RenderBufferKind.INSTANCE_SEGMENTATION_FAST: instance_seg_spec,
             RenderBufferKind.DEPTH: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_IMAGE_PLANE: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_CAMERA: RenderBufferSpec(1, wp.float32),
@@ -277,6 +282,7 @@ class OVRTXRenderer(BaseRenderer):
         self._exported_usd_string: str | None = None
         self._camera_rel_path: str | None = None
         self._output_semantic_color_buffer: wp.array | None = None
+        self._output_instance_color_buffer: wp.array | None = None
         self._clone_plan: ClonePlan | None = None
 
         logger.info("Creating OVRTX renderer...")
@@ -644,12 +650,20 @@ class OVRTXRenderer(BaseRenderer):
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.read_output`.
         """
 
-    def _generate_random_colors_from_ids(self, input_ids: wp.array) -> wp.array:
-        """Generate pseudo-random colors from semantic IDs."""
-        if self._output_semantic_color_buffer is None or self._output_semantic_color_buffer.shape != input_ids.shape:
-            self._output_semantic_color_buffer = wp.zeros(shape=input_ids.shape, dtype=wp.uint32, device=self._device)
+    def _generate_random_colors_from_ids(self, input_ids: wp.array, output_colors: wp.array | None) -> wp.array:
+        """Generate pseudo-random RGBA colors from uint32 IDs into a reusable output buffer.
 
-        output_colors = self._output_semantic_color_buffer
+        Args:
+            input_ids: 3-D uint32 Warp array of shape (H, W, 1).
+            output_colors: Existing color buffer to reuse, or None to allocate a new one.
+
+        Returns:
+            Color buffer containing the generated colors.
+        """
+
+        # Lazily allocate, and re-allocate if the shape changes.
+        if output_colors is None or output_colors.shape != input_ids.shape:
+            output_colors = wp.zeros(shape=input_ids.shape, dtype=wp.uint32, device=self._device)
 
         wp.launch(
             kernel=generate_random_colors_from_ids_kernel,
@@ -657,7 +671,6 @@ class OVRTXRenderer(BaseRenderer):
             inputs=[input_ids, output_colors],
             device=self._device,
         )
-
         return output_colors
 
     def _extract_rgba_tiles(
@@ -797,7 +810,10 @@ class OVRTXRenderer(BaseRenderer):
                 tiled_semantic_data = wp.from_dlpack(mapping.tensor)
 
                 if tiled_semantic_data.dtype == wp.uint32:
-                    semantic_colors = self._generate_random_colors_from_ids(tiled_semantic_data)
+                    self._output_semantic_color_buffer = self._generate_random_colors_from_ids(
+                        tiled_semantic_data, self._output_semantic_color_buffer
+                    )
+                    semantic_colors = self._output_semantic_color_buffer
 
                     semantic_torch = wp.to_torch(semantic_colors)
                     semantic_uint8 = semantic_torch.view(torch.uint8)
@@ -815,6 +831,47 @@ class OVRTXRenderer(BaseRenderer):
                     "semantic_segmentation",
                     suffix="semantic",
                 )
+
+        if "NonStableInstanceSegmentation" in frame.render_vars and "instance_segmentation_fast" in output_buffers:
+            with frame.render_vars["NonStableInstanceSegmentation"].map(device=Device.CUDA) as mapping:
+                tiled_instance_data = wp.from_dlpack(mapping.tensor)
+
+                if tiled_instance_data.dtype == wp.uint32:
+                    if self.cfg.colorize_instance_segmentation:
+                        self._output_instance_color_buffer = self._generate_random_colors_from_ids(
+                            tiled_instance_data, self._output_instance_color_buffer
+                        )
+                        instance_colors = self._output_instance_color_buffer
+                        instance_torch = wp.to_torch(instance_colors)
+                        instance_uint8 = instance_torch.view(torch.uint8)
+                        if instance_torch.dim() == 2:
+                            h, w = instance_torch.shape
+                            instance_uint8 = instance_uint8.reshape(h, w, 4)
+                        tiled_instance_data = wp.from_torch(instance_uint8, dtype=wp.uint8)
+                        self._extract_rgba_tiles(
+                            render_data,
+                            tiled_instance_data,
+                            output_buffers,
+                            "instance_segmentation_fast",
+                        )
+                    else:
+                        # Non-colorized: ensure (TH, TW, 1) shape for the uint32 extraction kernel.
+                        instance_torch = wp.to_torch(tiled_instance_data)
+                        if instance_torch.dim() == 2:
+                            instance_torch = instance_torch.unsqueeze(-1)
+                        tiled_instance_data = wp.from_torch(instance_torch, dtype=wp.uint32)
+                        wp.launch(
+                            kernel=extract_all_uint32_tiles_kernel,
+                            dim=(render_data.num_envs, render_data.height, render_data.width),
+                            inputs=[
+                                tiled_instance_data,
+                                output_buffers["instance_segmentation_fast"],
+                                render_data.num_cols,
+                                render_data.width,
+                                render_data.height,
+                            ],
+                            device=self._device,
+                        )
 
         if "NormalSD" in frame.render_vars and "normals" in output_buffers:
             with frame.render_vars["NormalSD"].map(device=Device.CUDA) as mapping:
@@ -889,4 +946,5 @@ class OVRTXRenderer(BaseRenderer):
 
         self._render_product_paths.clear()
         self._output_semantic_color_buffer = None
+        self._output_instance_color_buffer = None
         self._initialized_scene = False

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
@@ -46,3 +46,10 @@ class OVRTXRendererCfg(RendererCfg):
     If True, instance IDs are mapped to RGBA colors and returned as a ``uint8`` 4-channel array.
     If False, raw instance IDs are returned as a ``uint32`` 1-channel array.
     """
+
+    colorize_instance_id_segmentation: bool = True
+    """Whether to colorize instance ID segmentation output. Defaults to True.
+
+    If True, instance IDs are mapped to RGBA colors and returned as a ``uint8`` 4-channel array.
+    If False, raw instance IDs are returned as a ``uint32`` 1-channel array.
+    """

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
@@ -39,3 +39,10 @@ class OVRTXRendererCfg(RendererCfg):
 
     log_file_path: str = os.path.join(tempfile.gettempdir(), "ovrtx_renderer.log")
     """Path for OVRTX log file. Defaults to ``<system temp>/ovrtx_renderer.log``."""
+
+    colorize_instance_segmentation: bool = True
+    """Whether to colorize instance segmentation output. Defaults to True.
+
+    If True, instance IDs are mapped to RGBA colors and returned as a ``uint8`` 4-channel array.
+    If False, raw instance IDs are returned as a ``uint32`` 1-channel array.
+    """

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
@@ -295,6 +295,23 @@ def random_color_from_id(input_id: wp.uint32) -> wp.uint32:
 
 
 @wp.kernel
+def extract_all_uint32_tiles_kernel(
+    tiled_buffer: wp.array(dtype=wp.uint32, ndim=3),  # type: ignore  (TH, TW, 1)
+    output_buffer: wp.array(dtype=wp.uint32, ndim=4),  # type: ignore  (num_envs, H, W, 1)
+    num_cols: int,
+    tile_width: int,
+    tile_height: int,
+):
+    """Extract all single-channel uint32 tiles (e.g. raw instance segmentation IDs)."""
+    env_idx, y, x = wp.tid()
+    tile_x = env_idx % num_cols
+    tile_y = env_idx // num_cols
+    src_x = tile_x * tile_width + x
+    src_y = tile_y * tile_height + y
+    output_buffer[env_idx, y, x, 0] = tiled_buffer[src_y, src_x, 0]
+
+
+@wp.kernel
 def generate_random_colors_from_ids_kernel(
     input_ids: wp.array(dtype=wp.uint32, ndim=3),  # type: ignore
     output_colors: wp.array(dtype=wp.uint32, ndim=3),  # type: ignore

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -23,18 +23,25 @@ def get_render_var_config(data_types: list[str]) -> tuple[str, str, str]:
     )
     use_albedo = "albedo" in data_types
     use_semantic = "semantic_segmentation" in data_types
+    use_instance_seg = "instance_segmentation_fast" in data_types
     use_normals = "normals" in data_types
     use_rgb = any(dt in ["rgb", "rgba"] for dt in data_types)
     use_hdr = "rgb_hdr" in data_types
 
-    if use_depth and not (use_rgb or use_albedo or use_semantic or use_normals):
+    if use_depth and not (use_rgb or use_albedo or use_semantic or use_instance_seg or use_normals):
         source = "DistanceToCameraSD" if use_distance_to_camera else "DistanceToImagePlaneSD"
         return "/Render/Vars/depth", "depth", source
-    if use_albedo and not (use_rgb or use_semantic or use_normals):
+    if use_albedo and not (use_rgb or use_semantic or use_instance_seg or use_normals):
         return "/Render/Vars/albedo", "albedo", "DiffuseAlbedoSD"
     if use_semantic and not (use_rgb or use_albedo or use_normals):
         return "/Render/Vars/semantic", "semantic", "SemanticSegmentation"
-    if use_normals and not (use_rgb or use_albedo or use_semantic or use_depth):
+    if use_instance_seg and not (use_rgb or use_albedo or use_semantic or use_normals or use_depth or use_hdr):
+        return (
+            "/Render/Vars/NonStableInstanceSegmentation",
+            "NonStableInstanceSegmentation",
+            "NonStableInstanceSegmentation",
+        )
+    if use_normals and not (use_rgb or use_albedo or use_semantic or use_instance_seg or use_depth):
         return "/Render/Vars/NormalSD", "NormalSD", "NormalSD"
     if use_hdr and not use_rgb:
         return "/Render/Vars/HdrColor", "HdrColor", "HdrColor"

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -24,24 +24,35 @@ def get_render_var_config(data_types: list[str]) -> tuple[str, str, str]:
     use_albedo = "albedo" in data_types
     use_semantic = "semantic_segmentation" in data_types
     use_instance_seg = "instance_segmentation_fast" in data_types
+    use_instance_id_seg = "instance_id_segmentation_fast" in data_types
     use_normals = "normals" in data_types
     use_rgb = any(dt in ["rgb", "rgba"] for dt in data_types)
     use_hdr = "rgb_hdr" in data_types
 
-    if use_depth and not (use_rgb or use_albedo or use_semantic or use_instance_seg or use_normals):
+    if use_depth and not (
+        use_rgb or use_albedo or use_semantic or use_instance_seg or use_instance_id_seg or use_normals
+    ):
         source = "DistanceToCameraSD" if use_distance_to_camera else "DistanceToImagePlaneSD"
         return "/Render/Vars/depth", "depth", source
-    if use_albedo and not (use_rgb or use_semantic or use_instance_seg or use_normals):
+    if use_albedo and not (use_rgb or use_semantic or use_instance_seg or use_instance_id_seg or use_normals):
         return "/Render/Vars/albedo", "albedo", "DiffuseAlbedoSD"
     if use_semantic and not (use_rgb or use_albedo or use_normals):
         return "/Render/Vars/semantic", "semantic", "SemanticSegmentation"
-    if use_instance_seg and not (use_rgb or use_albedo or use_semantic or use_normals or use_depth or use_hdr):
+    if use_instance_seg and not (
+        use_rgb or use_albedo or use_semantic or use_instance_id_seg or use_normals or use_depth or use_hdr
+    ):
         return (
             "/Render/Vars/NonStableInstanceSegmentation",
             "NonStableInstanceSegmentation",
             "NonStableInstanceSegmentation",
         )
-    if use_normals and not (use_rgb or use_albedo or use_semantic or use_instance_seg or use_depth):
+    if use_instance_id_seg and not (
+        use_rgb or use_albedo or use_semantic or use_instance_seg or use_normals or use_depth or use_hdr
+    ):
+        return "/Render/Vars/InstanceSegmentationSD", "InstanceSegmentationSD", "InstanceSegmentationSD"
+    if use_normals and not (
+        use_rgb or use_albedo or use_semantic or use_instance_seg or use_instance_id_seg or use_depth
+    ):
         return "/Render/Vars/NormalSD", "NormalSD", "NormalSD"
     if use_hdr and not use_rgb:
         return "/Render/Vars/HdrColor", "HdrColor", "HdrColor"

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -83,6 +83,7 @@ def test_ovrtx_supported_output_types_key_set():
         RenderBufferKind.SIMPLE_SHADING_FULL_MDL,
         RenderBufferKind.SEMANTIC_SEGMENTATION,
         RenderBufferKind.INSTANCE_SEGMENTATION_FAST,
+        RenderBufferKind.INSTANCE_ID_SEGMENTATION_FAST,
         RenderBufferKind.DEPTH,
         RenderBufferKind.DISTANCE_TO_IMAGE_PLANE,
         RenderBufferKind.DISTANCE_TO_CAMERA,

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -82,6 +82,7 @@ def test_ovrtx_supported_output_types_key_set():
         RenderBufferKind.SIMPLE_SHADING_DIFFUSE_MDL,
         RenderBufferKind.SIMPLE_SHADING_FULL_MDL,
         RenderBufferKind.SEMANTIC_SEGMENTATION,
+        RenderBufferKind.INSTANCE_SEGMENTATION_FAST,
         RenderBufferKind.DEPTH,
         RenderBufferKind.DISTANCE_TO_IMAGE_PLANE,
         RenderBufferKind.DISTANCE_TO_CAMERA,

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -81,6 +81,15 @@ def test_ovrtx_rgb_hdr_uses_hdr_color_render_var():
     assert get_render_var_config(["rgb_hdr"]) == ("/Render/Vars/HdrColor", "HdrColor", "HdrColor")
 
 
+def test_ovrtx_instance_segmentation_fast_uses_non_stable_instance_segmentation_render_var():
+    """Requesting instance_segmentation_fast from OVRTX selects the NonStableInstanceSegmentation render variable."""
+    assert get_render_var_config(["instance_segmentation_fast"]) == (
+        "/Render/Vars/NonStableInstanceSegmentation",
+        "NonStableInstanceSegmentation",
+        "NonStableInstanceSegmentation",
+    )
+
+
 def test_ovrtx_instance_id_segmentation_fast_uses_instance_segmentation_sd_render_var():
     """Requesting instance_id_segmentation_fast from OVRTX selects the InstanceSegmentationSD render variable."""
     assert get_render_var_config(["instance_id_segmentation_fast"]) == (

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -81,6 +81,15 @@ def test_ovrtx_rgb_hdr_uses_hdr_color_render_var():
     assert get_render_var_config(["rgb_hdr"]) == ("/Render/Vars/HdrColor", "HdrColor", "HdrColor")
 
 
+def test_ovrtx_instance_id_segmentation_fast_uses_instance_segmentation_sd_render_var():
+    """Requesting instance_id_segmentation_fast from OVRTX selects the InstanceSegmentationSD render variable."""
+    assert get_render_var_config(["instance_id_segmentation_fast"]) == (
+        "/Render/Vars/InstanceSegmentationSD",
+        "InstanceSegmentationSD",
+        "InstanceSegmentationSD",
+    )
+
+
 def test_ovrtx_rgb_and_rgb_hdr_author_both_render_vars():
     """Requesting LDR RGB and RGB_HDR keeps both OVRTX render variables."""
     render_var_configs = get_render_var_configs(["rgb", "rgb_hdr"])

--- a/source/isaaclab_tasks/changelog.d/ovrtx-instance-segmentation-fast.rst
+++ b/source/isaaclab_tasks/changelog.d/ovrtx-instance-segmentation-fast.rst
@@ -1,0 +1,9 @@
+Added
+^^^^^
+
+* Added ``instance_segmentation_fast`` rendering test presets to the rendering test utilities
+  for Cartpole, ShadowHand, and Dexsuite environments, covering both the OVRTX and Isaac RTX
+  renderers. Because instance IDs are non-stable across runs, golden images are saved with full
+  RGBA colors but comparison is restricted to the alpha channel only, which encodes the instance
+  mask shape reliably. SSIM is also disabled for this data type; only the per-pixel L2 gate
+  is used to decide pass/fail.

--- a/source/isaaclab_tasks/changelog.d/ovrtx-instance-segmentation-fast.rst
+++ b/source/isaaclab_tasks/changelog.d/ovrtx-instance-segmentation-fast.rst
@@ -1,9 +1,9 @@
 Added
 ^^^^^
 
-* Added ``instance_segmentation_fast`` rendering test presets to the rendering test utilities
-  for Cartpole, ShadowHand, and Dexsuite environments, covering both the OVRTX and Isaac RTX
-  renderers. Because instance IDs are non-stable across runs, golden images are saved with full
-  RGBA colors but comparison is restricted to the alpha channel only, which encodes the instance
-  mask shape reliably. SSIM is also disabled for this data type; only the per-pixel L2 gate
-  is used to decide pass/fail.
+* Added ``instance_segmentation_fast`` and ``instance_id_segmentation_fast`` rendering test
+  presets to the rendering test utilities for Cartpole, ShadowHand, and Dexsuite environments,
+  covering both the OVRTX and Isaac RTX renderers. Because instance IDs are non-stable across
+  runs, golden images are saved with full RGBA colors but comparison is restricted to the alpha
+  channel only, which encodes the instance mask shape reliably. SSIM is also disabled for these
+  data types; only the per-pixel L2 gate is used to decide pass/fail.

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ea5b5e7f937b293152960d668cae542e379c7d3512be63f83ed9dca17de635e
+size 615

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-isaacsim_rtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1834b5dacf9b54375a6e4dc29cab777af63baf3db62ab3519a8f918d86dc980
+size 501

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45a4f2dc3c72e0c1472a66c096f106fca193ec18921ad86635f8ef862980a419
+size 596

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-ovrtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-ovrtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5753345a44259432586b1449ac669149faae6839f286c2dbd51d7c10fc4906fe
+size 502

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df0dacf8a21ac62bfbd9d4c43354a108283d99eb26d7c661156dded7f9216718
+size 593

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5753345a44259432586b1449ac669149faae6839f286c2dbd51d7c10fc4906fe
+size 502

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f38e6af9aaa8e80ab22ee5cc4139685941c4aa26e2a355e98f67cf54f1f0bdd8
+size 600

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:448cf080979ce371de5d8ffb61de6615b906dbe852aa82c018d45467e59016ec
+size 501

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f0bdb1f222020492308ba02bb1c2328a313abc2431aa6e475cbf667b25c1aea
+size 1268

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-isaacsim_rtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-isaacsim_rtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7681c231ab2c75ee863b70f61a252480cb42d2214ef2d4397f0aa418d95aa82a
+size 703

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e71bcee0ed23c5eb3f243b626560c34f40f9b7d7aec8a3a7fcaa39452512d5a7
+size 1258

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-ovrtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-ovrtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7681c231ab2c75ee863b70f61a252480cb42d2214ef2d4397f0aa418d95aa82a
+size 703

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:faf7bd52ff523f811df1324c51383491020f053108b365954b7f079f3d26154a
+size 1260

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-isaacsim_rtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-isaacsim_rtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7681c231ab2c75ee863b70f61a252480cb42d2214ef2d4397f0aa418d95aa82a
+size 703

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:692702c1fdc7180b17ce49ee8c690ff2bd54e0f70d4145477987dc76533cd4af
+size 1280

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-isaacsim_rtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-isaacsim_rtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b8729d722d1780272b24f0804e517ea024ec2b93f4a0fa3e26c82f222f5c9eb
+size 700

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50ebc2502eca0cab618f5e28238724cf7e921d105c4d777889a95dff32b04b9b
+size 1285

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-ovrtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-ovrtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b8729d722d1780272b24f0804e517ea024ec2b93f4a0fa3e26c82f222f5c9eb
+size 700

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82f83c645e08169008c3e8620a93d82963aa17de990c30f9fd460b6f99e91c54
+size 1280

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-isaacsim_rtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-isaacsim_rtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b8729d722d1780272b24f0804e517ea024ec2b93f4a0fa3e26c82f222f5c9eb
+size 700

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7d509b2433290260065056f37d597d889882e0249f4bd1c2a73848bb767b4ac
+size 3813

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-isaacsim_rtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-isaacsim_rtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d01750545fb0798db0461a97bb65e1a27e4933fa4d9ee3c48272181459bb7ae
+size 1480

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07e2bec85c84cbf9884176ac07d37dfead6f8f7a72217095f2bd3a1a1e4bdd5d
+size 3768

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-ovrtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-ovrtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27961cd19e5a0490581141ff00959c964082ce540373978ca7dccc81a83ce407
+size 1482

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-isaacsim_rtx_renderer-instance_id_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3c55c9d15098d60d99701732470aa7a14de07896bd1772a2d3d06d74b67ea77
+size 3556

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-isaacsim_rtx_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-isaacsim_rtx_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19ccb59003bec3d086580d0842606403d6b6095d38f1ba8688872ffdff695867
+size 1522

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -641,6 +641,9 @@ def validate_camera_outputs(
             "img_golden_path": None,
         }
 
+        # We want to keep the record in the test artifact so that we can have a chance to see whether
+        # test cases that appear successful is a false positive or not, e.g. image diff threshold is set
+        # 8%, if the result image is 7% different from the golden, it is considered a pass
         if diff_pct > 0:
             prefix = f"{test_name}-{physics_backend}-{renderer}-{data_type}"
             entry["img_result_path"] = _save_comparison_image(result_image, f"{prefix}-actual.png")

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -59,7 +59,12 @@ _SSIM_THRESHOLD_BY_ENV_NAME = {
 # outputs where the per-pixel value distribution is highly non-uniform after normalisation (e.g. depth, where we
 # divide by the max value so tiny absolute differences near the far plane dominate windowed variance). For these
 # data types we still compute SSIM for reporting, but only the per-pixel L2 gate is used to decide pass/fail.
-_SSIM_DISABLED_DATA_TYPES: set[str] = {"depth", "distance_to_camera", "distance_to_image_plane"}
+_SSIM_DISABLED_DATA_TYPES: set[str] = {
+    "depth",
+    "distance_to_camera",
+    "distance_to_image_plane",
+    "instance_segmentation_fast",
+}
 
 # Directory for comparison images saved during the test session.
 # Located under the pytest output root so it gets copied alongside test reports.
@@ -86,6 +91,7 @@ _DEFAULT_SENSOR_DATA_TYPES = (
     "distance_to_camera",
     "distance_to_image_plane",
     "normals",
+    "instance_segmentation_fast",
 )
 
 
@@ -594,10 +600,24 @@ def validate_camera_outputs(
             failed_data_types[data_type] = f"Error opening golden image: {error}"
             continue
 
+        # Instance seg colors are non-stable across runs (NonStableInstanceSegmentation IDs vary).
+        # Compare only the alpha channel (instance mask shape) by zeroing RGB on both images.
+        result_image_for_comparison = result_image
+        golden_image_for_comparison = golden_image
+        if data_type == "instance_segmentation_fast":
+
+            def _alpha_only(img: Image.Image) -> Image.Image:
+                r, g, b, a = img.split()
+                zero = r.point(lambda _: 0)
+                return Image.merge("RGBA", (zero, zero, zero, a))
+
+            result_image_for_comparison = _alpha_only(result_image)
+            golden_image_for_comparison = _alpha_only(golden_image)
+
         check_ssim = data_type not in _SSIM_DISABLED_DATA_TYPES
         succeeded, error_message, diff_pct, ssim_score = _compare_images(
-            result_image,
-            golden_image,
+            result_image_for_comparison,
+            golden_image_for_comparison,
             max_different_pixels_percentage,
             check_ssim=check_ssim,
             ssim_threshold=ssim_threshold,
@@ -618,7 +638,7 @@ def validate_camera_outputs(
             "img_golden_path": None,
         }
 
-        if diff_pct > 0:
+        if not succeeded:
             prefix = f"{test_name}-{physics_backend}-{renderer}-{data_type}"
             entry["img_result_path"] = _save_comparison_image(result_image, f"{prefix}-actual.png")
             entry["img_golden_path"] = _save_comparison_image(golden_image, f"{prefix}-golden.png")
@@ -659,6 +679,7 @@ def rendering_test_shadow_hand(
         distance_to_camera = _ShadowHandBaseTiledCameraCfg(data_types=["distance_to_camera"])
         distance_to_image_plane = _ShadowHandBaseTiledCameraCfg(data_types=["distance_to_image_plane"])
         normals = _ShadowHandBaseTiledCameraCfg(data_types=["normals"])
+        instance_segmentation_fast = _ShadowHandBaseTiledCameraCfg(data_types=["instance_segmentation_fast"])
 
     @configclass
     class _ShadowHandCameraTestEnvCfg(ShadowHandCameraEnvCfg):
@@ -712,6 +733,8 @@ def rendering_test_cartpole(
     from isaaclab_tasks.core.cartpole.cartpole_direct_camera_env import CartpoleCameraEnv
     from isaaclab_tasks.core.cartpole.cartpole_direct_camera_env_cfg import CartpoleCameraEnvCfg, CartpoleTiledCameraCfg
 
+    from isaaclab_assets.robots.cartpole import CARTPOLE_CFG
+
     @configclass
     class _CartpoleTiledCameraTestCfg(CartpoleTiledCameraCfg):
         distance_to_camera = CartpoleTiledCameraCfg.BaseCartpoleTiledCameraCfg(data_types=["distance_to_camera"])
@@ -719,17 +742,30 @@ def rendering_test_cartpole(
             data_types=["distance_to_image_plane"]
         )
         normals = CartpoleTiledCameraCfg.BaseCartpoleTiledCameraCfg(data_types=["normals"])
+        instance_segmentation_fast = CartpoleTiledCameraCfg.BaseCartpoleTiledCameraCfg(
+            data_types=["instance_segmentation_fast"]
+        )
+
+    @configclass
+    class _BaseCartpoleCameraEnvTestCfg(CartpoleCameraEnvCfg.BaseCartpoleCameraEnvCfg):
+        robot_cfg = CARTPOLE_CFG.replace(
+            prim_path="/World/envs/env_.*/Robot",
+            spawn=CARTPOLE_CFG.spawn.replace(semantic_tags=[("class", "cartpole")]),
+        )
 
     @configclass
     class _CartpoleCameraTestEnvCfg(CartpoleCameraEnvCfg):
-        distance_to_camera = CartpoleCameraEnvCfg.BaseCartpoleCameraEnvCfg(
+        distance_to_camera = _BaseCartpoleCameraEnvTestCfg(
             observation_space=[1, 100, 100], tiled_camera=_CartpoleTiledCameraTestCfg()
         )
-        distance_to_image_plane = CartpoleCameraEnvCfg.BaseCartpoleCameraEnvCfg(
+        distance_to_image_plane = _BaseCartpoleCameraEnvTestCfg(
             observation_space=[1, 100, 100], tiled_camera=_CartpoleTiledCameraTestCfg()
         )
-        normals = CartpoleCameraEnvCfg.BaseCartpoleCameraEnvCfg(
+        normals = _BaseCartpoleCameraEnvTestCfg(
             observation_space=[3, 100, 100], tiled_camera=_CartpoleTiledCameraTestCfg()
+        )
+        instance_segmentation_fast = _BaseCartpoleCameraEnvTestCfg(
+            observation_space=[4, 100, 100], tiled_camera=_CartpoleTiledCameraTestCfg()
         )
 
     env_cfg = _CartpoleCameraTestEnvCfg()
@@ -807,6 +843,15 @@ def rendering_test_dexsuite_kuka(
         normals64 = BASE_CAMERA_CFG.replace(data_types=["normals"], width=64, height=64)
         normals128 = BASE_CAMERA_CFG.replace(data_types=["normals"], width=128, height=128)
         normals256 = BASE_CAMERA_CFG.replace(data_types=["normals"], width=256, height=256)
+        instance_segmentation_fast64 = BASE_CAMERA_CFG.replace(
+            data_types=["instance_segmentation_fast"], width=64, height=64
+        )
+        instance_segmentation_fast128 = BASE_CAMERA_CFG.replace(
+            data_types=["instance_segmentation_fast"], width=128, height=128
+        )
+        instance_segmentation_fast256 = BASE_CAMERA_CFG.replace(
+            data_types=["instance_segmentation_fast"], width=256, height=256
+        )
 
     @configclass
     class _DexsuiteSingleCameraTestSceneCfg(SingleCameraSceneCfg):

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -64,6 +64,7 @@ _SSIM_DISABLED_DATA_TYPES: set[str] = {
     "distance_to_camera",
     "distance_to_image_plane",
     "instance_segmentation_fast",
+    "instance_id_segmentation_fast",
 }
 
 # Directory for comparison images saved during the test session.
@@ -92,6 +93,7 @@ _DEFAULT_SENSOR_DATA_TYPES = (
     "distance_to_image_plane",
     "normals",
     "instance_segmentation_fast",
+    "instance_id_segmentation_fast",
 )
 
 
@@ -600,11 +602,12 @@ def validate_camera_outputs(
             failed_data_types[data_type] = f"Error opening golden image: {error}"
             continue
 
-        # Instance seg colors are non-stable across runs (NonStableInstanceSegmentation IDs vary).
-        # Compare only the alpha channel (instance mask shape) by zeroing RGB on both images.
+        # Instance seg colors are non-stable across runs (NonStableInstanceSegmentation /
+        # InstanceSegmentationSD IDs vary). Compare only the alpha channel (instance mask shape)
+        # by zeroing RGB on both images.
         result_image_for_comparison = result_image
         golden_image_for_comparison = golden_image
-        if data_type == "instance_segmentation_fast":
+        if data_type in {"instance_segmentation_fast", "instance_id_segmentation_fast"}:
 
             def _alpha_only(img: Image.Image) -> Image.Image:
                 r, g, b, a = img.split()
@@ -680,6 +683,7 @@ def rendering_test_shadow_hand(
         distance_to_image_plane = _ShadowHandBaseTiledCameraCfg(data_types=["distance_to_image_plane"])
         normals = _ShadowHandBaseTiledCameraCfg(data_types=["normals"])
         instance_segmentation_fast = _ShadowHandBaseTiledCameraCfg(data_types=["instance_segmentation_fast"])
+        instance_id_segmentation_fast = _ShadowHandBaseTiledCameraCfg(data_types=["instance_id_segmentation_fast"])
 
     @configclass
     class _ShadowHandCameraTestEnvCfg(ShadowHandCameraEnvCfg):
@@ -745,6 +749,9 @@ def rendering_test_cartpole(
         instance_segmentation_fast = CartpoleTiledCameraCfg.BaseCartpoleTiledCameraCfg(
             data_types=["instance_segmentation_fast"]
         )
+        instance_id_segmentation_fast = CartpoleTiledCameraCfg.BaseCartpoleTiledCameraCfg(
+            data_types=["instance_id_segmentation_fast"]
+        )
 
     @configclass
     class _BaseCartpoleCameraEnvTestCfg(CartpoleCameraEnvCfg.BaseCartpoleCameraEnvCfg):
@@ -765,6 +772,9 @@ def rendering_test_cartpole(
             observation_space=[3, 100, 100], tiled_camera=_CartpoleTiledCameraTestCfg()
         )
         instance_segmentation_fast = _BaseCartpoleCameraEnvTestCfg(
+            observation_space=[4, 100, 100], tiled_camera=_CartpoleTiledCameraTestCfg()
+        )
+        instance_id_segmentation_fast = _BaseCartpoleCameraEnvTestCfg(
             observation_space=[4, 100, 100], tiled_camera=_CartpoleTiledCameraTestCfg()
         )
 
@@ -851,6 +861,15 @@ def rendering_test_dexsuite_kuka(
         )
         instance_segmentation_fast256 = BASE_CAMERA_CFG.replace(
             data_types=["instance_segmentation_fast"], width=256, height=256
+        )
+        instance_id_segmentation_fast64 = BASE_CAMERA_CFG.replace(
+            data_types=["instance_id_segmentation_fast"], width=64, height=64
+        )
+        instance_id_segmentation_fast128 = BASE_CAMERA_CFG.replace(
+            data_types=["instance_id_segmentation_fast"], width=128, height=128
+        )
+        instance_id_segmentation_fast256 = BASE_CAMERA_CFG.replace(
+            data_types=["instance_id_segmentation_fast"], width=256, height=256
         )
 
     @configclass

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -641,7 +641,7 @@ def validate_camera_outputs(
             "img_golden_path": None,
         }
 
-        if not succeeded:
+        if diff_pct > 0:
             prefix = f"{test_name}-{physics_backend}-{renderer}-{data_type}"
             entry["img_result_path"] = _save_comparison_image(result_image, f"{prefix}-actual.png")
             entry["img_golden_path"] = _save_comparison_image(golden_image, f"{prefix}-golden.png")


### PR DESCRIPTION
# Description

Added instance_segmentation_fast & instance_id_segmentation_fast support to OVRTX renderer integration to match IsaacSim RTX integration.

Additionally, added render correctness tests for instance_segmentation_fast across ovrtx & isaacsim RTX renderers.
- Only the colorized output is tested at this moment.  We will add tests for the non-colorized in a follow up PR
- Because these data types are based on an RTX AOVs which produces IDs which are not stable across runs (hence the `_fast`), we only compare the alpha mask of the colorized output against the golden image's.  
- I extended the test cartpole cfg in our rendering_test_utils.py with semantic tags to further test this data type, as shadow hand is currently the only other task that natively has objects with semantic tags.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

See the images in changes

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
