### PR TITLE
Avoid standalone USD with Isaac Sim

### DIFF
--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -31,6 +31,8 @@ pip extras include:
      - What it installs
    * - ``isaacsim``
      - Isaac Sim (``isaacsim[all,extscache]==6.0.0.1``) from `pypi.nvidia.com <https://pypi.nvidia.com>`_
+   * - ``usd``
+     - ``usd-exchange`` for kit-less USD workflows. Do not combine with ``isaacsim``.
    * - ``all``
      - RL frameworks (SB3, SKRL, RSL-RL). Combine with ``isaacsim`` for a full install.
 

--- a/source/isaaclab/changelog.d/conditional-standalone-usd.rst
+++ b/source/isaaclab/changelog.d/conditional-standalone-usd.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed standalone USD packages colliding with Isaac Sim. Install
+  ``isaaclab[usd]`` for kit-less USD workflows instead of combining it with ``isaacsim``.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -581,13 +581,20 @@ def split_install_items(install_type: str) -> list[str]:
     return parts
 
 
-def _install_isaaclab_submodules(isaaclab_submodules: list[str]) -> None:
+def _should_install_standalone_usd(install_isaacsim: bool) -> bool:
+    """Return whether a kit-less install needs the standalone USD provider."""
+    return not install_isaacsim and extract_isaacsim_path(required=False) is None
+
+
+def _install_isaaclab_submodules(isaaclab_submodules: list[str], install_standalone_usd: bool = False) -> None:
     """Install Isaac Lab submodules from the source directory as editable packages.
 
     Args:
         isaaclab_submodules: Ordered list of source directory names to install
             (e.g. ``["isaaclab", "isaaclab_assets", ...]``). ``isaaclab`` must
             appear first so downstream packages resolve against the local copy.
+        install_standalone_usd: Whether to install the root ``isaaclab`` package
+            with its standalone USD extra.
     """
     python_exe = extract_python_exe()
     source_dir = ISAACLAB_ROOT / "source"
@@ -603,7 +610,8 @@ def _install_isaaclab_submodules(isaaclab_submodules: list[str]) -> None:
             print_warning(f"Submodule directory not found or missing pyproject.toml: {item}")
             continue
         print_info(f"Installing submodule: {pkg_name}")
-        run_command(pip_cmd + ["install", "--editable", str(item)])
+        install_target = f"{item}[usd]" if pkg_name == "isaaclab" and install_standalone_usd else str(item)
+        run_command(pip_cmd + ["install", "--editable", install_target])
         _upgrade_extension_pip_dependencies(
             python_exe,
             pip_cmd,
@@ -1048,11 +1056,13 @@ def command_install(install_type: str = "all") -> None:
         if install_isaacsim:
             _install_isaacsim()
 
+        install_standalone_usd = _should_install_standalone_usd(install_isaacsim)
+
         # Install pytorch (version based on arch).
         _ensure_cuda_torch()
 
         # Install all submodules (core set + any explicitly requested optional ones).
-        _install_isaaclab_submodules(submodules_to_install)
+        _install_isaaclab_submodules(submodules_to_install, install_standalone_usd=install_standalone_usd)
 
         # Install requested optional submodule dependency extras.
         if optional_submodule_extra_dependencies:

--- a/source/isaaclab/pyproject.toml
+++ b/source/isaaclab/pyproject.toml
@@ -53,9 +53,6 @@ dependencies = [
     "pin ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
     "pin-pink==3.1.0 ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
     "daqp==0.8.5 ; platform_system == 'Linux' and platform_machine in 'x86_64 AMD64 aarch64 arm64'",
-    # OpenUSD (kit-less mode)
-    "usd-core>=25.11,<26.0 ; platform_machine in 'x86_64 AMD64'",
-    "usd-exchange>=2.2 ; platform_machine in 'x86_64 AMD64 aarch64 arm64'",
     # avoid broken hf-xet pre-release cached on NVIDIA Artifactory
     "hf-xet>=1.4.1,<2.0.0 ; platform_machine in 'x86_64 AMD64 aarch64 arm64'",
 ]
@@ -82,6 +79,7 @@ test = [
     "coverage>=7.6.1",
 ]
 isaacsim = ["isaacsim[all,extscache]>=6.0.0"]
+usd = ["usd-exchange>=2.2"]
 all = [
     "isaacsim[all,extscache]>=6.0.0",
     "isaaclab_assets",

--- a/source/isaaclab/test/cli/test_install_commands.py
+++ b/source/isaaclab/test/cli/test_install_commands.py
@@ -943,3 +943,41 @@ class TestRePointPrebundlePackages:
 
         assert (prebundle / pkg_name).is_symlink(), f"{pkg_name} should be repointed"
         assert (prebundle / pkg_name).resolve() == (site_pkgs / pkg_name).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Standalone USD selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("install_isaacsim", "isaacsim_path", "expected"),
+    [
+        (False, None, True),
+        (False, Path("/tmp/isaacsim"), False),
+        (True, None, False),
+    ],
+)
+def test_selects_standalone_usd_only_without_isaacsim(install_isaacsim, isaacsim_path, expected):
+    """Standalone USD is selected only when Isaac Sim is absent and not requested."""
+    with mock.patch("isaaclab.cli.commands.install.extract_isaacsim_path", return_value=isaacsim_path):
+        assert install_cmd._should_install_standalone_usd(install_isaacsim) is expected
+
+
+def test_installs_usd_extra_only_for_isaaclab_root_submodule(tmp_path):
+    """The standalone USD extra is applied only to the root Isaac Lab package."""
+    source_dir = tmp_path / "source" / "isaaclab"
+    source_dir.mkdir(parents=True)
+    (source_dir / "pyproject.toml").touch()
+
+    python_exe = str(tmp_path / "python")
+    pip_cmd = [python_exe, "-m", "pip"]
+    with (
+        mock.patch("isaaclab.cli.commands.install.ISAACLAB_ROOT", tmp_path),
+        mock.patch("isaaclab.cli.commands.install.extract_python_exe", return_value=python_exe),
+        mock.patch("isaaclab.cli.commands.install.get_pip_command", return_value=pip_cmd),
+        mock.patch("isaaclab.cli.commands.install.run_command") as mock_run,
+    ):
+        install_cmd._install_isaaclab_submodules(["isaaclab"], install_standalone_usd=True)
+
+    mock_run.assert_called_once_with(pip_cmd + ["install", "--editable", f"{source_dir}[usd]"])

--- a/source/isaaclab/test/cli/test_source_package_metadata.py
+++ b/source/isaaclab/test/cli/test_source_package_metadata.py
@@ -20,13 +20,16 @@ def _repo_root() -> Path:
     raise RuntimeError("Could not find Isaac Lab repository root.")
 
 
-def test_isaaclab_usd_core_pin_stays_on_isaacsim_compatible_usd25_abi():
-    """The kit-less USD package must stay on the Isaac Sim compatible USD 25 ABI."""
+def test_isaaclab_standalone_usd_is_an_opt_in_extra():
+    """Standalone USD must not be installed with the Isaac Sim extra."""
     with (_repo_root() / "source/isaaclab/pyproject.toml").open("rb") as f:
         pyproject = tomllib.load(f)
 
-    usd_core_dependencies = [
-        dependency for dependency in pyproject["project"]["dependencies"] if dependency.startswith("usd-core")
+    standalone_usd_dependencies = [
+        dependency
+        for dependency in pyproject["project"]["dependencies"]
+        if dependency.startswith(("usd-core", "usd-exchange"))
     ]
 
-    assert usd_core_dependencies == ["usd-core>=25.11,<26.0 ; platform_machine in 'x86_64 AMD64'"]
+    assert standalone_usd_dependencies == []
+    assert pyproject["project"]["optional-dependencies"]["usd"] == ["usd-exchange>=2.2"]

--- a/source/isaaclab/test/cli/test_wheel_builder_metadata.py
+++ b/source/isaaclab/test/cli/test_wheel_builder_metadata.py
@@ -112,3 +112,14 @@ def test_wheel_builder_warp_pin_matches_core_package():
 
     assert wheel_core_pin == expected_pin
     assert wheel_newton_pin == expected_pin
+
+
+def test_wheel_builder_standalone_usd_is_an_opt_in_extra():
+    """The bundled wheel must not install a standalone USD provider with Isaac Sim."""
+    dependencies_by_extra = _wheel_builder_dependencies_by_extra()
+
+    assert dependencies_by_extra["usd"] == ["usd-exchange>=2.2"]
+    for extra_name in ("all", "isaacsim"):
+        assert not any(
+            dependency.startswith(("usd-core", "usd-exchange")) for dependency in dependencies_by_extra[extra_name]
+        )

--- a/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_imports_isaaclab.py
+++ b/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_imports_isaaclab.py
@@ -7,7 +7,7 @@
 Setup:
     - (wheel supplied by runner: tools/run_install_ci.py --build-wheel or --wheel <path>)
     - ./isaaclab.sh -u
-    - uv pip install <wheel>
+    - uv pip install <wheel>[usd]
 Tests:
     - python -c "import isaaclab" -> verify isaaclab importable
     - python -c "from isaaclab import __version__; print(__version__)" -> verify version matches wheel
@@ -42,8 +42,8 @@ class Test_Uv_Pip_Install_Isaaclab_Imports_Isaaclab(UV_Mixin):
         cls.python = self.python
         cls.cli_script = self.cli_script
 
-        result = self.run_in_uv_env(["uv", "pip", "install", cls._wheel], cwd=isaaclab_root, timeout=900)
-        assert result.returncode == 0, f"uv pip install {cls._wheel} failed:\n{result.stdout}\n{result.stderr}"
+        result = self.run_in_uv_env(["uv", "pip", "install", f"{cls._wheel}[usd]"], cwd=isaaclab_root, timeout=900)
+        assert result.returncode == 0, f"uv pip install {cls._wheel}[usd] failed:\n{result.stdout}\n{result.stderr}"
 
         yield
 
@@ -71,3 +71,14 @@ class Test_Uv_Pip_Install_Isaaclab_Imports_Isaaclab(UV_Mixin):
         assert imported_version == expected_version, (
             f"isaaclab.__version__ mismatch: expected {expected_version}, got {imported_version}"
         )
+
+    @pytest.mark.docker
+    @pytest.mark.uv
+    @pytest.mark.slow
+    @pytest.mark.timeout(900)
+    def test_install_usd_makes_usd_exchange_available_without_usd_core(self):
+        """``[usd]`` installs only the standalone USD provider."""
+        result = self.run_in_uv_env(["uv", "pip", "list"])
+        installed_distributions = result.stdout.lower()
+        assert result.returncode == 0, f"uv pip list failed:\n{result.stdout}\n{result.stderr}"
+        assert "usd-exchange" in installed_distributions

--- a/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_isaacsim_imports_simulation_context.py
+++ b/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_isaacsim_imports_simulation_context.py
@@ -119,3 +119,14 @@ class Test_Uv_Pip_Install_Isaaclab_Isaacsim_Imports_Simulation_Context(UV_Mixin)
             env=aarch64_isaacsim_env(),
         )
         assert result.returncode == 0, f"import isaaclab.sim failed:\n{result.stdout}\n{result.stderr}"
+
+    @pytest.mark.docker
+    @pytest.mark.uv
+    @pytest.mark.slow
+    @pytest.mark.timeout(1800)
+    def test_install_isaacsim_omits_standalone_usd_providers(self):
+        """``[isaacsim]`` uses Isaac Sim's USD provider exclusively."""
+        result = self.run_in_uv_env(["uv", "pip", "list"])
+        installed_distributions = result.stdout.lower()
+        assert result.returncode == 0, f"uv pip list failed:\n{result.stdout}\n{result.stderr}"
+        assert "usd-exchange" not in installed_distributions

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -82,6 +82,8 @@ pyproject.dependencies.all = [
 ]
 pyproject.optional-dependencies.all = [
     # Isaac Sim
+    # OpenUSD (kit-less mode)
+    { "usd" = ["usd-exchange>=2.2"] },
     { "isaacsim" = ["isaacsim[all,extscache]==6.0.0.1"] },
     # ================================================================================
     # https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab_newton/setup.py


### PR DESCRIPTION
## Summary
- Move the kit-less USD provider to an explicit usd extra and remove usd-core.
- Select the extra only when ./isaaclab.sh -i neither finds nor installs Isaac Sim.
- Cover source and wheel resolution paths so Isaac Sim installs contain no standalone USD provider.

## Test plan
- [x] Focused metadata and installer tests: 63 passed.
- [x] ./isaaclab.sh -f
- [ ] x86 install jobs pass five reruns.
- [ ] ARM install jobs pass five reruns.