### PR TITLE
Add FeatherPGS Newton solver support

### DIFF
--- a/docs/source/api/lab_newton/isaaclab_newton.physics.rst
+++ b/docs/source/api/lab_newton/isaaclab_newton.physics.rst
@@ -13,6 +13,7 @@
     MJWarpSolverCfg
     XPBDSolverCfg
     FeatherstoneSolverCfg
+    FeatherPGSSolverCfg
     KaminoSolverCfg
     MPMSolverCfg
     NewtonCollisionPipelineCfg
@@ -21,6 +22,7 @@
     NewtonMJWarpManager
     NewtonXPBDManager
     NewtonFeatherstoneManager
+    NewtonFeatherPGSManager
     NewtonKaminoManager
     NewtonMPMManager
 
@@ -58,6 +60,11 @@ Physics Configuration
   :exclude-members: __init__
 
 .. autoclass:: FeatherstoneSolverCfg
+  :members:
+  :show-inheritance:
+  :exclude-members: __init__
+
+.. autoclass:: FeatherPGSSolverCfg
   :members:
   :show-inheritance:
   :exclude-members: __init__
@@ -101,6 +108,11 @@ Solver Managers
   :show-inheritance:
 
 .. autoclass:: NewtonFeatherstoneManager
+  :members:
+  :inherited-members:
+  :show-inheritance:
+
+.. autoclass:: NewtonFeatherPGSManager
   :members:
   :inherited-members:
   :show-inheritance:

--- a/docs/source/overview/core-concepts/physical-backends/newton/feather-pgs-solver.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/feather-pgs-solver.rst
@@ -1,0 +1,96 @@
+FeatherPGS Solver
+=================
+
+FeatherPGS is an experimental Newton solver for articulated rigid-body systems.
+It evaluates reduced-coordinate dynamics and resolves contact and enabled joint
+constraints with projected Gauss-Seidel (PGS) iterations. Isaac Lab exposes it
+through :class:`~isaaclab_newton.physics.FeatherPGSSolverCfg` and
+:class:`~isaaclab_newton.physics.NewtonFeatherPGSManager`.
+
+FeatherPGS uses Newton's :class:`CollisionPipeline`. Configure contact
+generation with
+:class:`~isaaclab_newton.physics.NewtonCollisionPipelineCfg`, as with the
+Featherstone and XPBD Newton managers.
+
+Configuration
+-------------
+
+Select FeatherPGS by assigning its solver configuration to
+:attr:`~isaaclab_newton.physics.NewtonCfg.solver_cfg`:
+
+.. code-block:: python
+
+    from isaaclab.sim import SimulationCfg
+    from isaaclab_newton.physics import (
+        FeatherPGSSolverCfg,
+        NewtonCfg,
+        NewtonCollisionPipelineCfg,
+    )
+
+    solver_cfg = FeatherPGSSolverCfg(
+        enable_joint_limits=True,
+        pgs_iterations=8,
+        pgs_mode="split",
+        dense_max_constraints=64,
+        mf_max_constraints=512,
+        pgs_beta=0.05,
+        pgs_cfm=1.0e-6,
+    )
+    newton_cfg = NewtonCfg(
+        solver_cfg=solver_cfg,
+        collision_cfg=NewtonCollisionPipelineCfg(),
+        num_substeps=1,
+    )
+    sim_cfg = SimulationCfg(dt=1.0 / 200.0, physics=newton_cfg)
+
+The important accuracy and runtime controls are:
+
+* :attr:`~isaaclab_newton.physics.FeatherPGSSolverCfg.pgs_iterations`:
+  increases constraint-solve work and usually improves constraint fidelity.
+* :attr:`~isaaclab_newton.physics.NewtonCfg.num_substeps`: repeats collision,
+  integration, and the solve at a shorter effective time step.
+* :attr:`~isaaclab_newton.physics.FeatherPGSSolverCfg.pgs_mode`: selects the
+  dense, split, or matrix-free constraint layout.
+* :attr:`~isaaclab_newton.physics.FeatherPGSSolverCfg.dense_max_constraints`
+  and
+  :attr:`~isaaclab_newton.physics.FeatherPGSSolverCfg.mf_max_constraints`:
+  preallocate per-world constraint capacity. Undersizing either capacity can
+  omit constraints; oversizing it consumes memory and can reduce throughput.
+* :attr:`~isaaclab_newton.physics.FeatherPGSSolverCfg.pgs_beta` and
+  :attr:`~isaaclab_newton.physics.FeatherPGSSolverCfg.pgs_cfm`: control
+  position correction and solver regularization.
+
+Solve Layouts
+-------------
+
+The three :attr:`~isaaclab_newton.physics.FeatherPGSSolverCfg.pgs_mode`
+values trade memory, kernel work, and feature support:
+
+* ``"dense"`` constructs a full Delassus matrix for all constraints.
+* ``"split"`` uses the dense path for articulated contacts and a
+  matrix-free path for free rigid bodies.
+* ``"matrix_free"`` avoids the full Delassus matrix and recomputes the
+  articulated response during PGS iterations.
+
+The automatic kernel selectors use
+:attr:`~isaaclab_newton.physics.FeatherPGSSolverCfg.small_dof_threshold` to
+choose between loop and tiled implementations. Set
+:attr:`~isaaclab_newton.physics.FeatherPGSSolverCfg.nvtx` to ``True`` to
+emit solver-stage ranges when profiling.
+
+Current Limitations
+-------------------
+
+FeatherPGS support is experimental and is not selected by an Isaac Lab task
+preset yet. Task configurations should opt in explicitly and validate their
+time step, actuator, contact-capacity, and iteration settings.
+
+The current Newton implementation also has these restrictions:
+
+* Floating-base systems require an explicit free joint connecting the root body
+  to the world.
+* Joint velocity-limit constraints require ``pgs_mode="matrix_free"``.
+* Friction modes other than ``"current"`` require
+  ``pgs_mode="matrix_free"``.
+* Joint limits are incompatible with the ``"tiled_contact"`` and
+  ``"streaming"`` dense PGS kernels.

--- a/docs/source/overview/core-concepts/physical-backends/newton/feather-pgs-solver.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/feather-pgs-solver.rst
@@ -81,9 +81,15 @@ emit solver-stage ranges when profiling.
 Current Limitations
 -------------------
 
-FeatherPGS support is experimental and is not selected by an Isaac Lab task
-preset yet. Task configurations should opt in explicitly and validate their
-time step, actuator, contact-capacity, and iteration settings.
+FeatherPGS support is experimental. Tasks with a validated FeatherPGS
+configuration expose the ``feather_pgs`` preset, which selects the task-specific
+time step, actuator, contact-capacity, and iteration settings:
+
+.. code-block:: bash
+
+    ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Velocity-Flat-G1 presets=feather_pgs
+
+Tasks that do not declare this preset have not been validated with FeatherPGS.
 
 The current Newton implementation also has these restrictions:
 

--- a/docs/source/overview/core-concepts/physical-backends/newton/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/index.rst
@@ -23,6 +23,8 @@ handling different types of physics simulation. The Isaac Lab integration ships
 the following solver pages:
 
 * :doc:`mjwarp-solver` — the primary, validated solver path.
+* :doc:`feather-pgs-solver` — experimental reduced-coordinate dynamics with
+  projected Gauss-Seidel constraints.
 * :doc:`kamino-solver` — beta support on selected classic tasks.
 * :doc:`using-vbd-solver` — experimental VBD solver for cloth and soft bodies,
   available through :mod:`isaaclab_contrib.deformable` and the MJWarp + VBD or
@@ -48,6 +50,7 @@ new backend, see :doc:`../../multi_backend_architecture`.
   installation
   supported-features
   mjwarp-solver
+  feather-pgs-solver
   kamino-solver
   using-vbd-solver
   newton-manager-abstraction

--- a/docs/source/overview/core-concepts/physical-backends/solver-comparison.rst
+++ b/docs/source/overview/core-concepts/physical-backends/solver-comparison.rst
@@ -18,9 +18,12 @@ The solvers covered are:
 * **Newton Kamino** — beta P-ADMM :doc:`Newton solver <newton/kamino-solver>`,
   configured by :class:`~isaaclab_newton.physics.KaminoSolverCfg`.
 
-Newton additionally ships ``FeatherstoneSolverCfg`` and ``XPBDSolverCfg``;
-neither is wired into an Isaac Lab task at the time of writing and they
-are omitted from this comparison.
+Newton additionally ships
+:class:`~isaaclab_newton.physics.FeatherPGSSolverCfg`,
+``FeatherstoneSolverCfg``, and ``XPBDSolverCfg``. These experimental
+paths are not wired into an Isaac Lab task at the time of writing and are
+omitted from this comparison. See :doc:`newton/feather-pgs-solver` for the
+FeatherPGS configuration and current limitations.
 
 
 Friction Model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,10 @@ explicit = true
 [tool.uv]
 index-strategy = "unsafe-best-match"
 prerelease = "allow"
-override-dependencies = ["numpy>=2"]
+override-dependencies = [
+    "newton[sim] @ git+https://github.com/dylanturpin/newton-collab.git@3674b45e00cbe7b1e0d0b8f613af087298dcc110",
+    "numpy>=2",
+]
 python-preference = "only-managed"
 package = false
 

--- a/source/isaaclab_newton/changelog.d/add-feather-pgs.rst
+++ b/source/isaaclab_newton/changelog.d/add-feather-pgs.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab_newton.physics.FeatherPGSSolverCfg` and
+  :class:`~isaaclab_newton.physics.NewtonFeatherPGSManager` for Newton's
+  reduced-coordinate FeatherPGS solver.

--- a/source/isaaclab_newton/isaaclab_newton/physics/__init__.pyi
+++ b/source/isaaclab_newton/isaaclab_newton/physics/__init__.pyi
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 __all__ = [
+    "NewtonFeatherPGSManager",
+    "FeatherPGSSolverCfg",
     "NewtonFeatherstoneManager",
     "FeatherstoneSolverCfg",
     "HydroelasticSDFCfg",
@@ -22,6 +24,8 @@ __all__ = [
     "XPBDSolverCfg",
 ]
 
+from .feather_pgs_manager import NewtonFeatherPGSManager
+from .feather_pgs_manager_cfg import FeatherPGSSolverCfg
 from .featherstone_manager import NewtonFeatherstoneManager
 from .featherstone_manager_cfg import FeatherstoneSolverCfg
 from .kamino_manager import NewtonKaminoManager

--- a/source/isaaclab_newton/isaaclab_newton/physics/feather_pgs_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/feather_pgs_manager.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""FeatherPGS Newton manager."""
+
+from __future__ import annotations
+
+from newton import Model
+
+try:
+    from newton.solvers import SolverFeatherPGS
+except ImportError:
+    from newton._src.solvers import SolverFeatherPGS
+
+from .feather_pgs_manager_cfg import FeatherPGSSolverCfg
+from .newton_manager import NewtonManager
+
+
+class NewtonFeatherPGSManager(NewtonManager):
+    """:class:`NewtonManager` specialization for the FeatherPGS solver.
+
+    FeatherPGS uses Newton's :class:`CollisionPipeline` for contact handling and
+    steps with separate input/output states.
+    """
+
+    @classmethod
+    def _build_solver(cls, model: Model, solver_cfg: FeatherPGSSolverCfg) -> None:
+        """Construct :class:`SolverFeatherPGS` and populate the base-class slots."""
+        ignored = {"class_type", "solver_type"}
+        kwargs = {key: value for key, value in solver_cfg.to_dict().items() if key not in ignored}
+        NewtonManager._solver = SolverFeatherPGS(model, **kwargs)
+        NewtonManager._use_single_state = False
+        NewtonManager._needs_collision_pipeline = True

--- a/source/isaaclab_newton/isaaclab_newton/physics/feather_pgs_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/feather_pgs_manager_cfg.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Configuration for the Newton FeatherPGS physics manager."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from isaaclab.utils.configclass import configclass
+
+from .newton_manager_cfg import NewtonSolverCfg
+
+if TYPE_CHECKING:
+    from isaaclab_newton.physics import NewtonManager
+
+
+@configclass
+class FeatherPGSSolverCfg(NewtonSolverCfg):
+    """Configuration for Newton's reduced-coordinate FeatherPGS solver.
+
+    FeatherPGS evaluates articulated-body dynamics in generalized coordinates
+    and resolves contacts and enabled joint constraints with projected
+    Gauss-Seidel iterations. It always uses Newton's collision pipeline.
+    """
+
+    class_type: type[NewtonManager] | str = "{DIR}.feather_pgs_manager:NewtonFeatherPGSManager"
+    """Manager class for the FeatherPGS solver."""
+
+    solver_type: str = "feather_pgs"
+    """Solver type metadata."""
+
+    angular_damping: float = 0.05
+    """Angular velocity damping rate [s^-1]."""
+
+    update_mass_matrix_interval: int = 1
+    """Number of simulation steps between mass-matrix updates."""
+
+    friction_smoothing: float = 1.0
+    """Huber delta for normalizing tangential contact velocity [m/s]."""
+
+    enable_contact_friction: bool = True
+    """Whether to resolve Coulomb friction in the PGS solve."""
+
+    enable_joint_limits: bool = False
+    """Whether to enforce joint position limits as unilateral constraints."""
+
+    enable_joint_velocity_limits: bool = False
+    """Whether to enforce per-DOF joint velocity limits.
+
+    This option currently requires :attr:`pgs_mode` to be ``"matrix_free"``.
+    """
+
+    pgs_iterations: int = 12
+    """Number of projected Gauss-Seidel iterations per solver step."""
+
+    pgs_beta: float = 0.2
+    """Dimensionless error-reduction factor for position correction."""
+
+    pgs_cfm: float = 1.0e-6
+    """Regularization added to Newton's impulse-space Delassus diagonal.
+
+    The solver-space units depend on the generalized coordinate represented by
+    each constraint row.
+    """
+
+    dense_contact_compliance: float = 0.0
+    """Normal compliance for dense articulated contact rows [m/N]."""
+
+    pgs_omega: float = 1.0
+    """Dimensionless successive over-relaxation factor."""
+
+    dense_max_constraints: int = 32
+    """Maximum dense articulated-contact rows stored per world."""
+
+    pgs_warmstart: bool = False
+    """Whether to initialize persistent contacts from the previous step's impulses."""
+
+    pgs_mode: Literal["dense", "split", "matrix_free"] = "split"
+    """Constraint solve layout.
+
+    ``"dense"`` builds the full Delassus matrix, ``"split"`` uses the dense
+    path for articulations and a matrix-free path for free rigid bodies, and
+    ``"matrix_free"`` avoids constructing the dense matrix.
+    """
+
+    friction_mode: Literal["current", "bisection", "bisection_desaxce", "coulomb_newton"] = "current"
+    """Coulomb friction strategy for matrix-free constraints.
+
+    Values other than ``"current"`` require :attr:`pgs_mode` to be
+    ``"matrix_free"``.
+    """
+
+    mf_max_constraints: int = 512
+    """Maximum matrix-free constraint rows stored per world."""
+
+    cholesky_kernel: Literal["tiled", "loop", "auto"] = "auto"
+    """Kernel used for Cholesky factorization."""
+
+    trisolve_kernel: Literal["tiled", "loop", "auto"] = "auto"
+    """Kernel used for triangular solves."""
+
+    hinv_jt_kernel: Literal["tiled", "par_row", "auto"] = "auto"
+    """Kernel used to compute the articulated response ``H^-1 J^T``."""
+
+    delassus_kernel: Literal["tiled", "par_row_col", "auto"] = "auto"
+    """Kernel used to accumulate the Delassus matrix."""
+
+    pgs_kernel: Literal["loop", "tiled_row", "tiled_contact", "streaming"] = "tiled_row"
+    """Kernel used for the dense projected Gauss-Seidel sweep."""
+
+    delassus_chunk_size: int | None = None
+    """Constraint-row chunk size for the streaming Delassus kernel.
+
+    A value of ``None`` lets Newton select the size automatically.
+    """
+
+    pgs_chunk_size: int | None = None
+    """Contact chunk size for the streaming PGS kernel.
+
+    A value of ``None`` uses Newton's default.
+    """
+
+    small_dof_threshold: int = 12
+    """DOF count above which automatic kernel selection chooses tiled kernels."""
+
+    use_parallel_streams: bool = True
+    """Whether to dispatch articulation-size groups on separate CUDA streams."""
+
+    double_buffer: bool = True
+    """Whether to double-buffer solver workspaces between steps."""
+
+    nvtx: bool = False
+    """Whether to emit NVTX ranges for solver stages."""
+
+    pgs_debug: bool = False
+    """Whether to collect PGS convergence diagnostics."""
+
+    effort_limit_mode: Literal["actuator"] = "actuator"
+    """Effort-limit policy.
+
+    FeatherPGS currently supports actuator-drive clamping only.
+    """

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import ctypes
+import inspect
 import logging
 import re
 from abc import abstractmethod
@@ -244,6 +245,7 @@ class NewtonManager(PhysicsManager):
     _builder: ModelBuilder = None
     _model: Model = None
     _solver: SolverBase | None = None
+    _solver_update_contacts_accepts_state: bool = True
     _use_single_state: bool | None = None
     """Use only one state for both input and output for solver stepping. Requires solver support."""
     _state_0: State = None
@@ -799,6 +801,7 @@ class NewtonManager(PhysicsManager):
         NewtonManager._builder = None
         NewtonManager._model = None
         NewtonManager._solver = None
+        NewtonManager._solver_update_contacts_accepts_state = True
         NewtonManager._use_single_state = None
         NewtonManager._state_0 = None
         NewtonManager._state_1 = None
@@ -1404,6 +1407,18 @@ class NewtonManager(PhysicsManager):
         """
         cls._solver.step(state_0, state_1, control, contacts, substep_dt)
 
+    @staticmethod
+    def _solver_accepts_update_contacts_state(solver: SolverBase) -> bool:
+        """Return whether solver.update_contacts accepts the simulation state argument."""
+        try:
+            parameters = list(inspect.signature(solver.update_contacts).parameters.values())
+        except (TypeError, ValueError):
+            return True
+
+        if any(parameter.kind == inspect.Parameter.VAR_POSITIONAL for parameter in parameters):
+            return True
+        return len(parameters) >= 2
+
     @classmethod
     def _solver_specific_clear(cls) -> None:
         """Solver-specific cleanup hook called from :meth:`clear`.
@@ -1456,6 +1471,9 @@ class NewtonManager(PhysicsManager):
                     "Subclasses of NewtonManager must populate NewtonManager._solver, "
                     "NewtonManager._use_single_state, and NewtonManager._needs_collision_pipeline."
                 )
+            NewtonManager._solver_update_contacts_accepts_state = cls._solver_accepts_update_contacts_state(
+                NewtonManager._solver
+            )
             cls._initialize_contacts()
 
         # Bind the solver-specialized FK delegate to the active subclass's _eval_fk_impl so
@@ -1727,7 +1745,10 @@ class NewtonManager(PhysicsManager):
                 sensor.update(cls._state_0)
         if cls._report_contacts:
             eval_contacts = contacts if contacts is not None else cls._contacts
-            cls._solver.update_contacts(eval_contacts, cls._state_0)
+            if cls._solver_update_contacts_accepts_state:
+                cls._solver.update_contacts(eval_contacts, cls._state_0)
+            else:
+                cls._solver.update_contacts(eval_contacts)
             for sensor in cls._newton_contact_sensors.values():
                 sensor.update(cls._state_0, eval_contacts)
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
@@ -124,7 +124,8 @@ class NewtonCfg(PhysicsCfg):
     - :class:`MJWarpSolverCfg` with ``use_mujoco_contacts=False``,
     - :class:`KaminoSolverCfg` with ``use_collision_detector=False``,
     - :class:`XPBDSolverCfg` (always),
-    - :class:`FeatherstoneSolverCfg` (always).
+    - :class:`FeatherstoneSolverCfg` (always),
+    - :class:`FeatherPGSSolverCfg` (always).
 
     :class:`~isaaclab_newton.physics.MPMSolverCfg` does not use this pipeline;
     implicit MPM treats rigid geometry as colliders internally.

--- a/source/isaaclab_newton/pyproject.toml
+++ b/source/isaaclab_newton/pyproject.toml
@@ -27,7 +27,7 @@ all = [
     "prettytable>=3.3.0",
     "PyOpenGL-accelerate>=3.1.0",
     "pyglet>=2.1.6,<3",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim] @ git+https://github.com/dylanturpin/newton-collab.git@3674b45e00cbe7b1e0d0b8f613af087298dcc110",
 ]
 
 [tool.setuptools]

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -13,6 +13,10 @@ Covers:
   manager.
 * Each leaf manager subclasses :class:`NewtonManager` and implements
   :meth:`_build_solver` (with the abstract base raising ``NotImplementedError``).
+* :class:`FeatherPGSSolverCfg` exposes exactly the arguments accepted by
+  Newton's ``SolverFeatherPGS`` constructor.
+* Contact reporting supports Newton solvers with and without a state argument
+  on ``update_contacts``.
 * The cross-config validation in :meth:`NewtonMJWarpManager._build_solver`
   rejects the ``MJWarp + use_mujoco_contacts=True + collision_cfg`` combination.
 * Manager name dispatch (used by :class:`InteractiveScene` and the various
@@ -25,18 +29,21 @@ Covers:
 
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 import warp as wp
 from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
     FeatherstoneSolverCfg,
     KaminoSolverCfg,
     MJWarpSolverCfg,
     MPMSolverCfg,
     NewtonCfg,
     NewtonCollisionPipelineCfg,
+    NewtonFeatherPGSManager,
     NewtonFeatherstoneManager,
     NewtonKaminoManager,
     NewtonManager,
@@ -48,6 +55,11 @@ from isaaclab_newton.physics import (
 )
 from isaaclab_newton.physics.mpm_manager import _make_solver_config
 from newton.solvers import SolverFeatherstone, SolverImplicitMPM, SolverKamino, SolverMuJoCo, SolverXPBD
+
+try:
+    from newton.solvers import SolverFeatherPGS
+except ImportError:
+    from newton._src.solvers import SolverFeatherPGS
 
 from isaaclab.sim import SimulationCfg, build_simulation_context
 
@@ -91,6 +103,14 @@ SOLVER_MATRIX = [
         id="featherstone",
     ),
     pytest.param(
+        lambda: FeatherPGSSolverCfg(),
+        NewtonFeatherPGSManager,
+        SolverFeatherPGS,
+        False,
+        True,
+        id="feather_pgs",
+    ),
+    pytest.param(
         lambda: KaminoSolverCfg(use_collision_detector=True),
         NewtonKaminoManager,
         SolverKamino,
@@ -115,6 +135,28 @@ SOLVER_MATRIX = [
         id="implicit_mpm",
     ),
 ]
+
+
+def test_feather_pgs_cfg_matches_newton_constructor():
+    """Every public FeatherPGS field is forwarded to Newton instead of silently ignored."""
+    cfg_fields = set(FeatherPGSSolverCfg().to_dict()) - {"class_type", "solver_type"}
+    constructor_fields = set(inspect.signature(SolverFeatherPGS.__init__).parameters) - {"self", "model"}
+    assert cfg_fields == constructor_fields
+
+
+def test_solver_update_contacts_signature_detection():
+    """Contact reporting supports both Newton's base and FeatherPGS signatures."""
+
+    class BaseSignature:
+        def update_contacts(self, _contacts, _state=None):
+            pass
+
+    class FeatherPGSSignature:
+        def update_contacts(self, _contacts):
+            pass
+
+    assert NewtonManager._solver_accepts_update_contacts_state(BaseSignature())
+    assert not NewtonManager._solver_accepts_update_contacts_state(FeatherPGSSignature())
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab_tasks/changelog.d/add-feather-pgs-task-presets.rst
+++ b/source/isaaclab_tasks/changelog.d/add-feather-pgs-task-presets.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added the ``feather_pgs`` physics preset to tasks validated with the Newton
+  FeatherPGS solver.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
@@ -9,7 +9,8 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from .rough_env_cfg import UnitreeA1RoughEnvCfg
 
@@ -28,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, angular_damping=0.1)
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
@@ -40,6 +42,9 @@ class UnitreeA1FlatEnvCfg(UnitreeA1RoughEnvCfg):
         # post init of parent
         super().__post_init__()
 
+        self.scene.robot.actuators["base_legs"].armature = preset(
+            default=self.scene.robot.actuators["base_legs"].armature, feather_pgs=0.1
+        )
         # override rewards
         self.rewards.flat_orientation_l2.weight = -2.5
         self.rewards.feet_air_time.weight = 0.25

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
@@ -3,13 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg, preset
 
 from .rough_env_cfg import UnitreeA1RoughEnvCfg
@@ -29,7 +35,26 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, angular_damping=0.1)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.1,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=8,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/rough_env_cfg.py
@@ -4,9 +4,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import (
+    LocomotionVelocityRoughEnvCfg,
+    RoughPhysicsCfg,
+    make_feather_pgs_physics_cfg,
+)
+from isaaclab_tasks.utils import preset
 
 ##
 # Pre-defined configs
@@ -15,12 +21,22 @@ from isaaclab_assets.robots.unitree import UNITREE_A1_CFG  # isort: skip
 
 
 @configclass
+class PhysicsCfg(RoughPhysicsCfg):
+    feather_pgs = make_feather_pgs_physics_cfg(
+        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.6
+    )
+
+
+@configclass
 class UnitreeA1RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
+
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
 
         self.scene.robot = UNITREE_A1_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+        self.scene.robot.actuators["base_legs"].armature = preset(default=0.0, feather_pgs=0.05)
         self.scene.height_scanner.prim_path = "{ENV_REGEX_NS}/Robot/trunk"
         # scale down the terrains because the robot is small
         self.scene.terrain.terrain_generator.sub_terrains["boxes"].grid_height_range = (0.025, 0.1)

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/rough_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
@@ -10,7 +11,6 @@ from isaaclab.utils.configclass import configclass
 from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RoughPhysicsCfg,
-    make_feather_pgs_physics_cfg,
 )
 from isaaclab_tasks.utils import preset
 
@@ -22,8 +22,25 @@ from isaaclab_assets.robots.unitree import UNITREE_A1_CFG  # isort: skip
 
 @configclass
 class PhysicsCfg(RoughPhysicsCfg):
-    feather_pgs = make_feather_pgs_physics_cfg(
-        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.6
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.6,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=16,
+            pgs_beta=0.02,
+            pgs_cfm=1.0e-5,
+            pgs_omega=0.8,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
@@ -9,6 +9,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import AnymalBRoughEnvCfg
@@ -27,6 +28,9 @@ class PhysicsCfg(PresetCfg):
         ),
         num_substeps=1,
         debug_mode=False,
+    )
+    feather_pgs = make_feather_pgs_physics_cfg(
+        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.5
     )
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
@@ -3,13 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import AnymalBRoughEnvCfg
@@ -29,8 +35,25 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    feather_pgs = make_feather_pgs_physics_cfg(
-        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.5
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.5,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=16,
+            pgs_beta=0.02,
+            pgs_cfm=1.0e-5,
+            pgs_omega=0.8,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/rough_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
@@ -10,7 +11,6 @@ from isaaclab.utils.configclass import configclass
 from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RoughPhysicsCfg,
-    make_feather_pgs_physics_cfg,
 )
 from isaaclab_tasks.utils import preset
 
@@ -22,8 +22,25 @@ from isaaclab_assets import ANYMAL_B_CFG  # isort: skip
 
 @configclass
 class PhysicsCfg(RoughPhysicsCfg):
-    feather_pgs = make_feather_pgs_physics_cfg(
-        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.5
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.5,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=16,
+            pgs_beta=0.02,
+            pgs_cfm=1.0e-5,
+            pgs_omega=0.8,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/rough_env_cfg.py
@@ -4,9 +4,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import (
+    LocomotionVelocityRoughEnvCfg,
+    RoughPhysicsCfg,
+    make_feather_pgs_physics_cfg,
+)
+from isaaclab_tasks.utils import preset
 
 ##
 # Pre-defined configs
@@ -15,12 +21,22 @@ from isaaclab_assets import ANYMAL_B_CFG  # isort: skip
 
 
 @configclass
+class PhysicsCfg(RoughPhysicsCfg):
+    feather_pgs = make_feather_pgs_physics_cfg(
+        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.5
+    )
+
+
+@configclass
 class AnymalBRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
+
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
         # switch robot to anymal-b
         self.scene.robot = ANYMAL_B_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+        self.scene.robot.actuators["legs"].armature = preset(default=0.0, feather_pgs=0.05)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
@@ -9,6 +9,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import AnymalCRoughEnvCfg
@@ -28,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, num_substeps=2, dense_max_constraints=32)
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
@@ -3,13 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import AnymalCRoughEnvCfg
@@ -29,7 +35,26 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, num_substeps=2, dense_max_constraints=32)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.05,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=8,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=32,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=2,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
@@ -10,7 +11,6 @@ from isaaclab.utils.configclass import configclass
 from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RoughPhysicsCfg,
-    make_feather_pgs_physics_cfg,
 )
 from isaaclab_tasks.utils import preset
 
@@ -22,7 +22,26 @@ from isaaclab_assets.robots.anymal import ANYMAL_C_CFG  # isort: skip
 
 @configclass
 class PhysicsCfg(RoughPhysicsCfg):
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=4, num_substeps=2)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.05,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=4,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=2,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
@@ -4,9 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import (
+    LocomotionVelocityRoughEnvCfg,
+    RoughPhysicsCfg,
+    make_feather_pgs_physics_cfg,
+)
 from isaaclab_tasks.utils import preset
 
 ##
@@ -16,13 +21,22 @@ from isaaclab_assets.robots.anymal import ANYMAL_C_CFG  # isort: skip
 
 
 @configclass
+class PhysicsCfg(RoughPhysicsCfg):
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=4, num_substeps=2)
+
+
+@configclass
 class AnymalCRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
+
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
         # switch robot to anymal-c
         self.scene.robot = ANYMAL_C_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.actuators["legs"].armature = preset(default=0.0, newton_mjwarp=0.01, physx=0.0)
+        self.scene.robot.actuators["legs"].armature = preset(
+            default=0.0, newton_mjwarp=0.01, feather_pgs=0.01, physx=0.0
+        )
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
@@ -3,13 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg, preset
 
 from .rough_env_cfg import UnitreeGo1RoughEnvCfg
@@ -30,7 +36,26 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, angular_damping=0.1)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.1,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=8,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
@@ -9,7 +9,8 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from .rough_env_cfg import UnitreeGo1RoughEnvCfg
 
@@ -29,6 +30,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, angular_damping=0.1)
 
 
 @configclass
@@ -39,6 +41,9 @@ class UnitreeGo1FlatEnvCfg(UnitreeGo1RoughEnvCfg):
         # post init of parent
         super().__post_init__()
 
+        self.scene.robot.actuators["base_legs"].armature = preset(
+            default=self.scene.robot.actuators["base_legs"].armature, feather_pgs=0.2
+        )
         # override rewards
         self.rewards.flat_orientation_l2.weight = -2.5
         self.rewards.feet_air_time.weight = 0.25

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/rough_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
@@ -10,7 +11,6 @@ from isaaclab.utils.configclass import configclass
 from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RoughPhysicsCfg,
-    make_feather_pgs_physics_cfg,
 )
 from isaaclab_tasks.utils import preset
 
@@ -22,8 +22,25 @@ from isaaclab_assets.robots.unitree import UNITREE_GO1_CFG  # isort: skip
 
 @configclass
 class PhysicsCfg(RoughPhysicsCfg):
-    feather_pgs = make_feather_pgs_physics_cfg(
-        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.6
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.6,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=16,
+            pgs_beta=0.02,
+            pgs_cfm=1.0e-5,
+            pgs_omega=0.8,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/rough_env_cfg.py
@@ -4,9 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import (
+    LocomotionVelocityRoughEnvCfg,
+    RoughPhysicsCfg,
+    make_feather_pgs_physics_cfg,
+)
 from isaaclab_tasks.utils import preset
 
 ##
@@ -16,13 +21,22 @@ from isaaclab_assets.robots.unitree import UNITREE_GO1_CFG  # isort: skip
 
 
 @configclass
+class PhysicsCfg(RoughPhysicsCfg):
+    feather_pgs = make_feather_pgs_physics_cfg(
+        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.6
+    )
+
+
+@configclass
 class UnitreeGo1RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
+
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
 
         self.scene.robot = UNITREE_GO1_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.actuators["base_legs"].armature = preset(default=0.0, newton_mjwarp=0.02)
+        self.scene.robot.actuators["base_legs"].armature = preset(default=0.0, newton_mjwarp=0.02, feather_pgs=0.1)
         self.scene.height_scanner.prim_path = "{ENV_REGEX_NS}/Robot/trunk"
         # scale down the terrains because the robot is small
         self.scene.terrain.terrain_generator.sub_terrains["boxes"].grid_height_range = (0.025, 0.1)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
@@ -6,7 +6,7 @@
 
 from dataclasses import MISSING
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -26,7 +26,7 @@ from isaaclab.sim import SimulationCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from . import mdp
 
@@ -78,6 +78,25 @@ class CabinetSimCfg(PresetCfg):
         render_interval=1,
         physics=NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=1),
     )
+    feather_pgs: SimulationCfg = SimulationCfg(
+        dt=1 / 60,
+        render_interval=1,
+        physics=NewtonCfg(
+            solver_cfg=FeatherPGSSolverCfg(
+                angular_damping=0.2,
+                enable_joint_limits=True,
+                pgs_iterations=32,
+                pgs_beta=0.02,
+                pgs_cfm=1.0e-5,
+                pgs_omega=1.0,
+                dense_max_constraints=64,
+                mf_max_constraints=512,
+            ),
+            num_substeps=1,
+            debug_mode=False,
+            use_cuda_graph=False,
+        ),
+    )
 
 
 ##
@@ -119,7 +138,7 @@ class CabinetSceneCfg(InteractiveSceneCfg):
                 joint_names_expr=["drawer_top_joint", "drawer_bottom_joint"],
                 effort_limit_sim=87.0,
                 stiffness=10.0,
-                damping=1.0,
+                damping=preset(default=1.0, feather_pgs=3.0),
             ),
             "doors": ImplicitActuatorCfg(
                 joint_names_expr=["door_left_joint", "door_right_joint"],
@@ -262,10 +281,35 @@ class _CabinetNewtonEventCfg:
 
 
 @configclass
+class _CabinetFeatherPGSEventCfg(_CabinetNewtonEventCfg):
+    robot_body_inertia = EventTerm(
+        func=mdp.randomize_rigid_body_inertia,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "inertia_distribution_params": (0.02, 0.02),
+            "operation": "add",
+            "diagonal_only": True,
+        },
+    )
+    cabinet_body_inertia = EventTerm(
+        func=mdp.randomize_rigid_body_inertia,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("cabinet"),
+            "inertia_distribution_params": (0.05, 0.05),
+            "operation": "add",
+            "diagonal_only": True,
+        },
+    )
+
+
+@configclass
 class CabinetEventCfg(PresetCfg):
     default: EventCfg = EventCfg()
     physx: EventCfg = EventCfg()
     newton_mjwarp: _CabinetNewtonEventCfg = _CabinetNewtonEventCfg()
+    feather_pgs: _CabinetFeatherPGSEventCfg = _CabinetFeatherPGSEventCfg()
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import math
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
@@ -37,6 +37,19 @@ class CartpolePhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
         use_cuda_graph=True,
+    )
+    feather_pgs: NewtonCfg = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            enable_joint_limits=True,
+            pgs_iterations=4,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            dense_max_constraints=8,
+            mf_max_constraints=64,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
     )
     newton_kamino: NewtonCfg = NewtonCfg(
         solver_cfg=KaminoSolverCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
@@ -5,7 +5,7 @@
 
 import math
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
@@ -47,6 +47,19 @@ class CartpolePhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
         use_cuda_graph=True,
+    )
+    feather_pgs: NewtonCfg = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            enable_joint_limits=True,
+            pgs_iterations=4,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            dense_max_constraints=8,
+            mf_max_constraints=64,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
     )
     newton_kamino: NewtonCfg = NewtonCfg(
         solver_cfg=KaminoSolverCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
@@ -36,6 +36,19 @@ class AntPhysicsCfg(PresetCfg):
         ),
         num_substeps=1,
         debug_mode=False,
+    )
+    feather_pgs: NewtonCfg = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            enable_joint_limits=True,
+            pgs_iterations=8,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            dense_max_constraints=64,
+            mf_max_constraints=512,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
     )
     newton_kamino: NewtonCfg = NewtonCfg(
         solver_cfg=KaminoSolverCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -43,6 +43,19 @@ class AntPhysicsCfg(PresetCfg):
         ),
         num_substeps=1,
         debug_mode=False,
+    )
+    feather_pgs: NewtonCfg = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            enable_joint_limits=True,
+            pgs_iterations=8,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            dense_max_constraints=64,
+            mf_max_constraints=512,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
     )
     newton_kamino: NewtonCfg = NewtonCfg(
         solver_cfg=KaminoSolverCfg(
@@ -155,6 +168,7 @@ class AntObservationsCfg(PresetCfg):
     default: ObservationsCfg = ObservationsCfg()
     physx: ObservationsCfg = ObservationsCfg()
     newton_mjwarp: ObservationsCfg = ObservationsCfg()
+    feather_pgs: ObservationsCfg = newton_mjwarp
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
@@ -5,19 +5,22 @@
 
 from __future__ import annotations
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
+import isaaclab.envs.mdp as mdp
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg
 from isaaclab.envs import DirectRLEnvCfg
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import SceneEntityCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from isaaclab_assets import HUMANOID_CFG
 
@@ -38,7 +41,52 @@ class HumanoidPhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
+    feather_pgs: NewtonCfg = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=5.0,
+            enable_joint_limits=True,
+            pgs_iterations=24,
+            pgs_beta=0.002,
+            pgs_cfm=1.0e-4,
+            pgs_omega=0.5,
+            dense_max_constraints=64,
+            mf_max_constraints=512,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+    )
     ovphysx: OvPhysxCfg = OvPhysxCfg()
+
+
+@configclass
+class FeatherPGSEventCfg:
+    robot_body_mass = EventTerm(
+        func=mdp.randomize_rigid_body_mass,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "mass_distribution_params": (2.0, 2.0),
+            "operation": "abs",
+            "recompute_inertia": False,
+        },
+    )
+    robot_body_inertia = EventTerm(
+        func=mdp.randomize_rigid_body_inertia,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "inertia_distribution_params": (2.0, 2.0),
+            "operation": "add",
+            "diagonal_only": True,
+        },
+    )
+
+
+@configclass
+class HumanoidDirectEventCfg(PresetCfg):
+    default = None
+    feather_pgs = FeatherPGSEventCfg()
 
 
 @configclass
@@ -52,6 +100,7 @@ class HumanoidEnvCfg(DirectRLEnvCfg):
     action_space = 21
     observation_space = 75
     state_space = 0
+    events: HumanoidDirectEventCfg = HumanoidDirectEventCfg()
 
     # simulation
     sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=HumanoidPhysicsCfg())
@@ -76,6 +125,7 @@ class HumanoidEnvCfg(DirectRLEnvCfg):
 
     # robot
     robot: ArticulationCfg = HUMANOID_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+    robot.actuators["body"].armature = preset(default=robot.actuators["body"].armature, feather_pgs=0.2)
 
     physx_joint_gears: list[float] = [
         67.5000,  # lower_waist

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
@@ -21,7 +21,7 @@ from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils.configclass import configclass
 
 import isaaclab_tasks.core.locomotion.mdp as mdp
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from isaaclab_assets.robots.humanoid import HUMANOID_CFG  # isort:skip
 
@@ -41,6 +41,21 @@ class HumanoidPhysicsCfg(PresetCfg):
         ),
         num_substeps=2,
         debug_mode=False,
+    )
+    feather_pgs: NewtonCfg = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=5.0,
+            enable_joint_limits=True,
+            pgs_iterations=24,
+            pgs_beta=0.002,
+            pgs_cfm=1.0e-4,
+            pgs_omega=0.5,
+            dense_max_constraints=64,
+            mf_max_constraints=512,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
     )
 
 
@@ -64,6 +79,7 @@ class HumanoidSceneCfg(InteractiveSceneCfg):
 
     # robot
     robot = HUMANOID_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    robot.actuators["body"].armature = preset(default=robot.actuators["body"].armature, feather_pgs=0.2)
 
     # sensors
     joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
@@ -138,6 +154,7 @@ class HumanoidObservationsCfg(PresetCfg):
     default: ObservationsCfg = ObservationsCfg()
     physx: ObservationsCfg = ObservationsCfg()
     newton_mjwarp: ObservationsCfg = ObservationsCfg()
+    feather_pgs: ObservationsCfg = newton_mjwarp
 
 
 @configclass
@@ -158,6 +175,36 @@ class EventCfg:
             "velocity_range": (-0.1, 0.1),
         },
     )
+
+
+@configclass
+class FeatherPGSEventCfg(EventCfg):
+    robot_body_mass = EventTerm(
+        func=mdp.randomize_rigid_body_mass,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "mass_distribution_params": (2.0, 2.0),
+            "operation": "abs",
+            "recompute_inertia": False,
+        },
+    )
+    robot_body_inertia = EventTerm(
+        func=mdp.randomize_rigid_body_inertia,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "inertia_distribution_params": (2.0, 2.0),
+            "operation": "add",
+            "diagonal_only": True,
+        },
+    )
+
+
+@configclass
+class HumanoidEventCfg(PresetCfg):
+    default = EventCfg()
+    feather_pgs = FeatherPGSEventCfg()
 
 
 @configclass
@@ -237,7 +284,7 @@ class HumanoidEnvCfg(ManagerBasedRLEnvCfg):
     # MDP settings
     rewards: RewardsCfg = RewardsCfg()
     terminations: TerminationsCfg = TerminationsCfg()
-    events: EventCfg = EventCfg()
+    events: HumanoidEventCfg = HumanoidEventCfg()
 
     def __post_init__(self):
         """Post initialization."""

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
@@ -5,7 +5,7 @@
 
 from dataclasses import MISSING
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
@@ -47,6 +47,19 @@ class ReachPhysicsCfg(PresetCfg):
         solver_cfg=KaminoSolverCfg(max_contacts_per_world=32),
         num_substeps=2,
     )
+    feather_pgs: NewtonCfg = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            enable_joint_limits=True,
+            pgs_iterations=8,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            dense_max_constraints=32,
+            mf_max_constraints=256,
+        ),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+    )
 
     default = physx
 
@@ -79,6 +92,7 @@ class TableCfg(PresetCfg):
         actuators={},
         articulation_root_prim_path="",
     )
+    feather_pgs = newton_mjwarp
 
     newton_kamino = newton_mjwarp
     default = physx

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
@@ -18,7 +18,7 @@ from isaaclab.sim.spawners.materials.physics_materials_cfg import RigidBodyMater
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from isaaclab_assets.robots.allegro import ALLEGRO_HAND_CFG
 
@@ -57,6 +57,7 @@ class ObjectCfg(PresetCfg):
         actuators={},
         articulation_root_prim_path="",
     )
+    feather_pgs = newton_mjwarp
     ovphysx = RigidObjectCfg(
         prim_path="/World/envs/env_.*/object",
         spawn=sim_utils.UsdFileCfg(
@@ -99,6 +100,21 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            enable_joint_limits=True,
+            enable_joint_velocity_limits=True,
+            pgs_iterations=16,
+            pgs_beta=0.02,
+            pgs_cfm=1.0e-5,
+            dense_max_constraints=64,
+            pgs_mode="matrix_free",
+            mf_max_constraints=512,
+        ),
+        num_substeps=12,
+        debug_mode=False,
+        use_cuda_graph=False,
+    )
     ovphysx = OvPhysxCfg()
     default = physx
 
@@ -106,7 +122,7 @@ class PhysicsCfg(PresetCfg):
 @configclass
 class AllegroHandEnvCfg(DirectRLEnvCfg):
     # env
-    decimation = 4
+    decimation = preset(default=4, feather_pgs=2)
     episode_length_s = 10.0
     action_space = 16
     observation_space = 124  # (full)
@@ -125,6 +141,7 @@ class AllegroHandEnvCfg(DirectRLEnvCfg):
     )
     # robot
     robot_cfg: ArticulationCfg = ALLEGRO_HAND_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+    robot_cfg.actuators["fingers"].armature = preset(default=None, feather_pgs=0.1)
 
     actuated_joint_names = [
         "index_joint_0",

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import FeatherPGSSolverCfg, KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
@@ -21,7 +21,7 @@ from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
 from isaaclab.utils.noise import GaussianNoiseCfg, NoiseModelWithAdditiveBiasCfg
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from isaaclab_assets.robots.shadow_hand import SHADOW_HAND_CFG
 
@@ -85,6 +85,26 @@ class NewtonEventCfg:
             "distribution": "log_uniform",
         },
     )
+
+
+@configclass
+class FeatherPGSEventCfg:
+    object_physics_inertia = EventTerm(
+        func=mdp.randomize_rigid_body_inertia,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("object"),
+            "inertia_distribution_params": (0.1, 0.1),
+            "operation": "add",
+            "diagonal_only": True,
+        },
+    )
+
+
+@configclass
+class ShadowHandDirectEventCfg(PresetCfg):
+    default = None
+    feather_pgs = FeatherPGSEventCfg()
 
 
 @configclass
@@ -207,6 +227,9 @@ class ShadowHandRobotCfg(PresetCfg):
         },
         soft_joint_pos_limit_factor=1.0,
     )
+    feather_pgs = newton_mjwarp.copy()
+    feather_pgs.actuators["fingers"].friction = 0.1
+    feather_pgs.actuators["fingers"].armature = 0.05
     default = physx
     newton_kamino = newton_mjwarp
 
@@ -247,6 +270,7 @@ class ObjectCfg(PresetCfg):
         actuators={},
         articulation_root_prim_path="",
     )
+    feather_pgs = newton_mjwarp
     default = physx
     newton_kamino = newton_mjwarp
 
@@ -265,6 +289,7 @@ class ShadowHandSceneCfg(PresetCfg):
     newton_mjwarp: InteractiveSceneCfg = InteractiveSceneCfg(
         num_envs=8192, env_spacing=0.75, replicate_physics=True, clone_in_fabric=False
     )
+    feather_pgs: InteractiveSceneCfg = newton_mjwarp
     default: InteractiveSceneCfg = physx
     newton_kamino = newton_mjwarp
 
@@ -290,6 +315,21 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            enable_joint_limits=True,
+            enable_joint_velocity_limits=True,
+            pgs_iterations=24,
+            pgs_beta=0.005,
+            pgs_cfm=5.0e-5,
+            pgs_omega=1.0,
+            pgs_mode="matrix_free",
+            mf_max_constraints=512,
+        ),
+        num_substeps=12,
+        debug_mode=False,
+        use_cuda_graph=False,
+    )
     default = physx
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=128), num_substeps=2)
 
@@ -314,6 +354,7 @@ class ShadowHandEnvCfg(DirectRLEnvCfg):
     )
     # robot
     robot_cfg: ShadowHandRobotCfg = ShadowHandRobotCfg()
+    events: ShadowHandDirectEventCfg = ShadowHandDirectEventCfg()
     actuated_joint_names = [
         "robot0_WRJ1",
         "robot0_WRJ0",
@@ -360,8 +401,8 @@ class ShadowHandEnvCfg(DirectRLEnvCfg):
     scene: ShadowHandSceneCfg = ShadowHandSceneCfg()
 
     # reset
-    reset_position_noise = 0.01  # range of position at reset
-    reset_dof_pos_noise = 0.2  # range of dof pos at reset
+    reset_position_noise = preset(default=0.01, feather_pgs=0.0)
+    reset_dof_pos_noise = preset(default=0.2, feather_pgs=0.0)
     reset_dof_vel_noise = 0.0  # range of dof vel at reset
     # reward scales
     dist_reward_scale = -10.0
@@ -377,7 +418,7 @@ class ShadowHandEnvCfg(DirectRLEnvCfg):
     success_count_threshold: int = 1
     """Minimum number of goals reached in an episode to count it as a successful episode."""
     av_factor = 0.1
-    act_moving_average = 1.0
+    act_moving_average = preset(default=1.0, feather_pgs=0.05)
     force_torque_obs_scale = 10.0
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/flat_env_cfg.py
@@ -3,14 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import AnymalDRoughEnvCfg
@@ -29,7 +34,26 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=4, angular_damping=0.1)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.1,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=4,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
     physx = default
     ovphysx = OvPhysxCfg()
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/flat_env_cfg.py
@@ -10,6 +10,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import AnymalDRoughEnvCfg
@@ -28,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=4, angular_damping=0.1)
     physx = default
     ovphysx = OvPhysxCfg()
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
@@ -10,7 +11,6 @@ from isaaclab.utils.configclass import configclass
 from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RoughPhysicsCfg,
-    make_feather_pgs_physics_cfg,
 )
 
 ##
@@ -21,7 +21,26 @@ from isaaclab_assets.robots.anymal import ANYMAL_D_CFG  # isort: skip
 
 @configclass
 class PhysicsCfg(RoughPhysicsCfg):
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=2, num_substeps=2)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.05,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=2,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=2,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
@@ -4,9 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import (
+    LocomotionVelocityRoughEnvCfg,
+    RoughPhysicsCfg,
+    make_feather_pgs_physics_cfg,
+)
 
 ##
 # Pre-defined configs
@@ -15,7 +20,14 @@ from isaaclab_assets.robots.anymal import ANYMAL_D_CFG  # isort: skip
 
 
 @configclass
+class PhysicsCfg(RoughPhysicsCfg):
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=2, num_substeps=2)
+
+
+@configclass
 class AnymalDRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
+
     def __post_init__(self):
         # post init of parent
         super().__post_init__()

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
@@ -3,13 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import CassieRoughEnvCfg
@@ -29,8 +35,25 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    feather_pgs = make_feather_pgs_physics_cfg(
-        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.2
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.2,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=16,
+            pgs_beta=0.02,
+            pgs_cfm=1.0e-5,
+            pgs_omega=0.8,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
@@ -9,6 +9,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import CassieRoughEnvCfg
@@ -27,6 +28,9 @@ class PhysicsCfg(PresetCfg):
         ),
         num_substeps=1,
         debug_mode=False,
+    )
+    feather_pgs = make_feather_pgs_physics_cfg(
+        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.2
     )
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
@@ -14,7 +15,6 @@ from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RewardsCfg,
     RoughPhysicsCfg,
-    make_feather_pgs_physics_cfg,
 )
 from isaaclab_tasks.utils import preset
 
@@ -26,8 +26,25 @@ from isaaclab_assets.robots.cassie import CASSIE_CFG  # isort: skip
 
 @configclass
 class PhysicsCfg(RoughPhysicsCfg):
-    feather_pgs = make_feather_pgs_physics_cfg(
-        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.2
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.2,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=16,
+            pgs_beta=0.02,
+            pgs_cfm=1.0e-5,
+            pgs_omega=0.8,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
@@ -6,12 +6,15 @@
 
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
 import isaaclab_tasks.core.velocity.mdp as mdp
 from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RewardsCfg,
+    RoughPhysicsCfg,
+    make_feather_pgs_physics_cfg,
 )
 from isaaclab_tasks.utils import preset
 
@@ -19,6 +22,13 @@ from isaaclab_tasks.utils import preset
 # Pre-defined configs
 ##
 from isaaclab_assets.robots.cassie import CASSIE_CFG  # isort: skip
+
+
+@configclass
+class PhysicsCfg(RoughPhysicsCfg):
+    feather_pgs = make_feather_pgs_physics_cfg(
+        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.2
+    )
 
 
 @configclass
@@ -55,6 +65,8 @@ class CassieRewardsCfg(RewardsCfg):
 class CassieRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
     """Cassie rough environment configuration."""
 
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
+
     rewards: CassieRewardsCfg = CassieRewardsCfg()
 
     def __post_init__(self):
@@ -66,7 +78,7 @@ class CassieRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
         # scene
         self.scene.robot = CASSIE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
         # Cassie Newton-only armature for biped stability on rough terrain; PhysX unchanged
-        self.scene.robot.actuators["legs"].armature = preset(default=0.0, newton_mjwarp=0.02)
+        self.scene.robot.actuators["legs"].armature = preset(default=0.0, newton_mjwarp=0.02, feather_pgs=0.05)
 
         self.scene.height_scanner.prim_path = "{ENV_REGEX_NS}/Robot/pelvis"
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
@@ -3,14 +3,20 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg, preset
 
 from .rough_env_cfg import G1RoughEnvCfg
@@ -33,7 +39,26 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=4, pgs_mode="matrix_free", update_mass_matrix_interval=2)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.05,
+            update_mass_matrix_interval=2,
+            enable_joint_limits=True,
+            pgs_iterations=4,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="matrix_free",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
@@ -10,9 +10,12 @@ from isaaclab.managers import SceneEntityCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from .rough_env_cfg import G1RoughEnvCfg
+
+from isaaclab_assets import G1_MINIMAL_CFG  # isort: skip
 
 
 @configclass
@@ -30,6 +33,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=4, pgs_mode="matrix_free", update_mass_matrix_interval=2)
 
 
 @configclass
@@ -39,6 +43,18 @@ class G1FlatEnvCfg(G1RoughEnvCfg):
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
+
+        self.decimation = preset(default=self.decimation, feather_pgs=2)
+        self.sim.dt = preset(default=self.sim.dt, feather_pgs=0.01)
+        self.sim.render_interval = preset(default=self.sim.render_interval, feather_pgs=2)
+        self.scene.contact_forces.update_period = preset(
+            default=self.scene.contact_forces.update_period, feather_pgs=0.01
+        )
+        for name, actuator in self.scene.robot.actuators.items():
+            actuator.armature = preset(
+                default=actuator.armature,
+                feather_pgs=G1_MINIMAL_CFG.actuators[name].armature,
+            )
 
         # change terrain to flat
         self.scene.terrain.terrain_type = "plane"

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/rough_env_cfg.py
@@ -6,18 +6,29 @@
 
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
 import isaaclab_tasks.core.velocity.mdp as mdp
 from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RewardsCfg,
+    RoughPhysicsCfg,
+    make_feather_pgs_physics_cfg,
 )
+from isaaclab_tasks.utils import preset
 
 ##
 # Pre-defined configs
 ##
 from isaaclab_assets import G1_MINIMAL_CFG  # isort: skip
+
+
+@configclass
+class PhysicsCfg(RoughPhysicsCfg):
+    feather_pgs = make_feather_pgs_physics_cfg(
+        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.5
+    )
 
 
 @configclass
@@ -106,6 +117,8 @@ class G1Rewards(RewardsCfg):
 
 @configclass
 class G1RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
+
     rewards: G1Rewards = G1Rewards()
 
     def __post_init__(self):
@@ -117,6 +130,8 @@ class G1RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
         self.commands.base_velocity.vel_yaw_success_threshold = 0.8
         # Scene
         self.scene.robot = G1_MINIMAL_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+        for actuator in self.scene.robot.actuators.values():
+            actuator.armature = preset(default=actuator.armature, feather_pgs=0.1)
         self.scene.height_scanner.prim_path = "{ENV_REGEX_NS}/Robot/torso_link"
 
         # G1 uses "torso_link" as base body — disable mass randomization for bipeds

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/rough_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
@@ -14,7 +15,6 @@ from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RewardsCfg,
     RoughPhysicsCfg,
-    make_feather_pgs_physics_cfg,
 )
 from isaaclab_tasks.utils import preset
 
@@ -26,8 +26,25 @@ from isaaclab_assets import G1_MINIMAL_CFG  # isort: skip
 
 @configclass
 class PhysicsCfg(RoughPhysicsCfg):
-    feather_pgs = make_feather_pgs_physics_cfg(
-        pgs_iterations=16, pgs_beta=0.02, pgs_cfm=1.0e-5, pgs_omega=0.8, angular_damping=0.5
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.5,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=16,
+            pgs_beta=0.02,
+            pgs_cfm=1.0e-5,
+            pgs_omega=0.8,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
@@ -3,13 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg, preset
 
 from .rough_env_cfg import UnitreeGo2RoughEnvCfg
@@ -29,7 +35,26 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, angular_damping=0.1)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.1,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=8,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
@@ -9,7 +9,8 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from .rough_env_cfg import UnitreeGo2RoughEnvCfg
 
@@ -28,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, angular_damping=0.1)
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 
@@ -40,6 +42,9 @@ class UnitreeGo2FlatEnvCfg(UnitreeGo2RoughEnvCfg):
         # post init of parent
         super().__post_init__()
 
+        self.scene.robot.actuators["base_legs"].armature = preset(
+            default=self.scene.robot.actuators["base_legs"].armature, feather_pgs=0.1
+        )
         # override rewards
         self.rewards.flat_orientation_l2.weight = -2.5
         self.rewards.feet_air_time.weight = 0.25

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
@@ -10,7 +11,6 @@ from isaaclab.utils.configclass import configclass
 from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RoughPhysicsCfg,
-    make_feather_pgs_physics_cfg,
 )
 from isaaclab_tasks.utils import preset
 
@@ -22,8 +22,25 @@ from isaaclab_assets.robots.unitree import UNITREE_GO2_CFG  # isort: skip
 
 @configclass
 class PhysicsCfg(RoughPhysicsCfg):
-    feather_pgs = make_feather_pgs_physics_cfg(
-        pgs_iterations=16, pgs_beta=0.01, pgs_cfm=2.0e-5, pgs_omega=0.8, angular_damping=1.2
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=1.2,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=16,
+            pgs_beta=0.01,
+            pgs_cfm=2.0e-5,
+            pgs_omega=0.8,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
@@ -4,9 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
+from isaaclab_tasks.core.velocity.velocity_env_cfg import (
+    LocomotionVelocityRoughEnvCfg,
+    RoughPhysicsCfg,
+    make_feather_pgs_physics_cfg,
+)
 from isaaclab_tasks.utils import preset
 
 ##
@@ -16,13 +21,22 @@ from isaaclab_assets.robots.unitree import UNITREE_GO2_CFG  # isort: skip
 
 
 @configclass
+class PhysicsCfg(RoughPhysicsCfg):
+    feather_pgs = make_feather_pgs_physics_cfg(
+        pgs_iterations=16, pgs_beta=0.01, pgs_cfm=2.0e-5, pgs_omega=0.8, angular_damping=1.2
+    )
+
+
+@configclass
 class UnitreeGo2RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
+
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
 
         self.scene.robot = UNITREE_GO2_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.actuators["base_legs"].armature = preset(default=0.0, newton_mjwarp=0.02)
+        self.scene.robot.actuators["base_legs"].armature = preset(default=0.0, newton_mjwarp=0.02, feather_pgs=0.05)
         self.scene.height_scanner.prim_path = "{ENV_REGEX_NS}/Robot/base"
         # scale down the terrains because the robot is small
         self.scene.terrain.terrain_generator.sub_terrains["boxes"].grid_height_range = (0.025, 0.1)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
@@ -3,13 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import H1RoughEnvCfg
@@ -29,7 +35,26 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, num_substeps=2)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.05,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=8,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=2,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
@@ -9,6 +9,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.core.velocity.velocity_env_cfg import make_feather_pgs_physics_cfg
 from isaaclab_tasks.utils import PresetCfg
 
 from .rough_env_cfg import H1RoughEnvCfg
@@ -28,6 +29,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8, num_substeps=2)
     physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/rough_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
@@ -14,7 +15,6 @@ from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RewardsCfg,
     RoughPhysicsCfg,
-    make_feather_pgs_physics_cfg,
 )
 
 ##
@@ -25,7 +25,26 @@ from isaaclab_assets import H1_MINIMAL_CFG  # isort: skip
 
 @configclass
 class PhysicsCfg(RoughPhysicsCfg):
-    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8)
+    feather_pgs = NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=0.05,
+            update_mass_matrix_interval=1,
+            enable_joint_limits=True,
+            pgs_iterations=8,
+            pgs_beta=0.05,
+            pgs_cfm=1.0e-6,
+            pgs_omega=1.0,
+            dense_max_constraints=64,
+            pgs_warmstart=False,
+            pgs_mode="split",
+            mf_max_constraints=512,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=1,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/rough_env_cfg.py
@@ -6,18 +6,26 @@
 
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
 import isaaclab_tasks.core.velocity.mdp as mdp
 from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RewardsCfg,
+    RoughPhysicsCfg,
+    make_feather_pgs_physics_cfg,
 )
 
 ##
 # Pre-defined configs
 ##
 from isaaclab_assets import H1_MINIMAL_CFG  # isort: skip
+
+
+@configclass
+class PhysicsCfg(RoughPhysicsCfg):
+    feather_pgs = make_feather_pgs_physics_cfg(pgs_iterations=8)
 
 
 @configclass
@@ -73,6 +81,8 @@ class H1Rewards(RewardsCfg):
 
 @configclass
 class H1RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
+    sim: SimulationCfg = SimulationCfg(physics=PhysicsCfg())
+
     rewards: H1Rewards = H1Rewards()
 
     def __post_init__(self):

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
@@ -5,8 +5,15 @@
 
 import math
 from dataclasses import MISSING
+from typing import Literal
 
-from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
+from isaaclab_newton.physics import (
+    FeatherPGSSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonCollisionPipelineCfg,
+    NewtonShapeCfg,
+)
 from isaaclab_newton.sensors import ContactSensorCfg as NewtonContactSensorCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_ovphysx.sensors import ContactSensorCfg as OvPhysXContactSensorCfg
@@ -71,6 +78,59 @@ class RoughPhysicsCfg(PresetCfg):
     ovphysx = OvPhysxCfg()
 
 
+def make_feather_pgs_physics_cfg(
+    *,
+    pgs_iterations: int,
+    num_substeps: int = 1,
+    pgs_mode: Literal["dense", "split", "matrix_free"] = "split",
+    pgs_beta: float = 0.05,
+    pgs_cfm: float = 1.0e-6,
+    pgs_omega: float = 1.0,
+    angular_damping: float = 0.05,
+    dense_max_constraints: int = 64,
+    mf_max_constraints: int = 512,
+    update_mass_matrix_interval: int = 1,
+) -> NewtonCfg:
+    """Create the shared FeatherPGS configuration for velocity tasks.
+
+    Args:
+        pgs_iterations: Number of projected Gauss-Seidel iterations per substep.
+        num_substeps: Number of solver substeps per simulation step.
+        pgs_mode: Constraint solve layout.
+        pgs_beta: Dimensionless position-error reduction factor.
+        pgs_cfm: Constraint-force regularization in solver-space units.
+        pgs_omega: Dimensionless successive over-relaxation factor.
+        angular_damping: Angular velocity damping rate [s^-1].
+        dense_max_constraints: Maximum dense constraint rows per world.
+        mf_max_constraints: Maximum matrix-free constraint rows per world.
+        update_mass_matrix_interval: Simulation steps between mass-matrix updates.
+
+    Returns:
+        A Newton physics configuration using FeatherPGS and the rough-terrain
+        collision settings validated by the velocity tasks.
+    """
+    return NewtonCfg(
+        solver_cfg=FeatherPGSSolverCfg(
+            angular_damping=angular_damping,
+            update_mass_matrix_interval=update_mass_matrix_interval,
+            enable_joint_limits=True,
+            pgs_iterations=pgs_iterations,
+            pgs_beta=pgs_beta,
+            pgs_cfm=pgs_cfm,
+            pgs_omega=pgs_omega,
+            dense_max_constraints=dense_max_constraints,
+            pgs_warmstart=False,
+            pgs_mode=pgs_mode,
+            mf_max_constraints=mf_max_constraints,
+        ),
+        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
+        num_substeps=num_substeps,
+        debug_mode=False,
+        use_cuda_graph=False,
+        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+    )
+
+
 ##
 # Scene definition
 ##
@@ -81,6 +141,7 @@ class VelocityEnvContactSensorCfg(PresetCfg):
     default = PhysXContactSensorCfg(prim_path="{ENV_REGEX_NS}/Robot/.*", history_length=3, track_air_time=True)
     newton_mjwarp = NewtonContactSensorCfg(prim_path="{ENV_REGEX_NS}/Robot/.*", history_length=3, track_air_time=True)
     newton_kamino = newton_mjwarp
+    feather_pgs = newton_mjwarp
     physx = default
     ovphysx = OvPhysXContactSensorCfg(prim_path="{ENV_REGEX_NS}/Robot/.*", history_length=3, track_air_time=True)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
@@ -5,10 +5,8 @@
 
 import math
 from dataclasses import MISSING
-from typing import Literal
 
 from isaaclab_newton.physics import (
-    FeatherPGSSolverCfg,
     MJWarpSolverCfg,
     NewtonCfg,
     NewtonCollisionPipelineCfg,
@@ -76,59 +74,6 @@ class RoughPhysicsCfg(PresetCfg):
     )
     physx = default
     ovphysx = OvPhysxCfg()
-
-
-def make_feather_pgs_physics_cfg(
-    *,
-    pgs_iterations: int,
-    num_substeps: int = 1,
-    pgs_mode: Literal["dense", "split", "matrix_free"] = "split",
-    pgs_beta: float = 0.05,
-    pgs_cfm: float = 1.0e-6,
-    pgs_omega: float = 1.0,
-    angular_damping: float = 0.05,
-    dense_max_constraints: int = 64,
-    mf_max_constraints: int = 512,
-    update_mass_matrix_interval: int = 1,
-) -> NewtonCfg:
-    """Create the shared FeatherPGS configuration for velocity tasks.
-
-    Args:
-        pgs_iterations: Number of projected Gauss-Seidel iterations per substep.
-        num_substeps: Number of solver substeps per simulation step.
-        pgs_mode: Constraint solve layout.
-        pgs_beta: Dimensionless position-error reduction factor.
-        pgs_cfm: Constraint-force regularization in solver-space units.
-        pgs_omega: Dimensionless successive over-relaxation factor.
-        angular_damping: Angular velocity damping rate [s^-1].
-        dense_max_constraints: Maximum dense constraint rows per world.
-        mf_max_constraints: Maximum matrix-free constraint rows per world.
-        update_mass_matrix_interval: Simulation steps between mass-matrix updates.
-
-    Returns:
-        A Newton physics configuration using FeatherPGS and the rough-terrain
-        collision settings validated by the velocity tasks.
-    """
-    return NewtonCfg(
-        solver_cfg=FeatherPGSSolverCfg(
-            angular_damping=angular_damping,
-            update_mass_matrix_interval=update_mass_matrix_interval,
-            enable_joint_limits=True,
-            pgs_iterations=pgs_iterations,
-            pgs_beta=pgs_beta,
-            pgs_cfm=pgs_cfm,
-            pgs_omega=pgs_omega,
-            dense_max_constraints=dense_max_constraints,
-            pgs_warmstart=False,
-            pgs_mode=pgs_mode,
-            mf_max_constraints=mf_max_constraints,
-        ),
-        collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
-        num_substeps=num_substeps,
-        debug_mode=False,
-        use_cuda_graph=False,
-        default_shape_cfg=NewtonShapeCfg(margin=0.01),
-    )
 
 
 ##

--- a/source/isaaclab_tasks/test/core/test_environments_feather_pgs.py
+++ b/source/isaaclab_tasks/test/core/test_environments_feather_pgs.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Launch Isaac Sim before importing task modules."""
+
+from isaaclab.app import AppLauncher
+
+app_launcher = AppLauncher(headless=True)
+simulation_app = app_launcher.app
+
+
+"""Run each dashboard-validated FeatherPGS task."""
+
+import pytest
+
+import isaaclab_tasks  # noqa: F401
+
+from env_test_utils import _run_environments  # isort: skip
+
+
+_TASKS = [
+    "Isaac-Reach-Franka",
+    "Isaac-Reach-UR10",
+    "Isaac-Cartpole",
+    "Isaac-Cartpole-Direct",
+    "Isaac-Ant",
+    "Isaac-Ant-Direct",
+    "Isaac-Reorient-Cube-Allegro-Direct",
+    "Isaac-Reorient-Cube-Shadow-Direct",
+    "IsaacContrib-Velocity-Flat-AnymalB",
+    "IsaacContrib-Velocity-Rough-AnymalB",
+    "IsaacContrib-Velocity-Flat-AnymalC",
+    "IsaacContrib-Velocity-Rough-AnymalC",
+    "Isaac-Velocity-Flat-AnymalD",
+    "Isaac-Velocity-Rough-AnymalD",
+    "IsaacContrib-Velocity-Flat-UnitreeA1",
+    "IsaacContrib-Velocity-Rough-UnitreeA1",
+    "IsaacContrib-Velocity-Flat-UnitreeGo1",
+    "IsaacContrib-Velocity-Rough-UnitreeGo1",
+    "Isaac-Velocity-Flat-UnitreeGo2",
+    "Isaac-Velocity-Rough-UnitreeGo2",
+    "Isaac-Velocity-Flat-Cassie",
+    "Isaac-Velocity-Rough-Cassie",
+    "Isaac-Velocity-Flat-G1",
+    "Isaac-Velocity-Rough-G1",
+    "Isaac-Velocity-Flat-H1",
+    "Isaac-Velocity-Rough-H1",
+    "Isaac-Humanoid",
+    "Isaac-Humanoid-Direct",
+    "Isaac-Open-Drawer-Franka",
+]
+
+
+@pytest.mark.parametrize("task_name", _TASKS)
+@pytest.mark.newton_ci
+def test_environments_feather_pgs(task_name: str) -> None:
+    _run_environments(
+        task_name,
+        "cuda",
+        2,
+        num_steps=2,
+        physics_preset_name="feather_pgs",
+        create_stage_in_memory=False,
+    )

--- a/source/isaaclab_tasks/test/core/test_feather_pgs_task_presets.py
+++ b/source/isaaclab_tasks/test/core/test_feather_pgs_task_presets.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for task-level FeatherPGS presets."""
+
+import pytest
+from isaaclab_newton.physics import FeatherPGSSolverCfg, NewtonCfg
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils.hydra import collect_presets, resolve_presets
+from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
+
+
+@pytest.mark.parametrize(
+    (
+        "task_name",
+        "num_substeps",
+        "pgs_iterations",
+        "pgs_mode",
+        "pgs_beta",
+        "pgs_cfm",
+        "dt",
+        "decimation",
+    ),
+    [
+        pytest.param("Isaac-Reach-Franka", 1, 8, "split", 0.05, 1.0e-6, 1 / 60, 2, id="reach-franka"),
+        pytest.param("Isaac-Reach-UR10", 1, 8, "split", 0.05, 1.0e-6, 1 / 60, 2, id="reach-ur10"),
+        pytest.param("Isaac-Cartpole", 1, 4, "split", 0.05, 1.0e-6, 1 / 120, 2, id="cartpole-manager"),
+        pytest.param("Isaac-Cartpole-Direct", 1, 4, "split", 0.05, 1.0e-6, 1 / 120, 2, id="cartpole-direct"),
+        pytest.param("Isaac-Ant", 1, 8, "split", 0.05, 1.0e-6, 1 / 120, 2, id="ant-manager"),
+        pytest.param("Isaac-Ant-Direct", 1, 8, "split", 0.05, 1.0e-6, 1 / 120, 2, id="ant-direct"),
+        pytest.param(
+            "Isaac-Reorient-Cube-Allegro-Direct",
+            12,
+            16,
+            "matrix_free",
+            0.02,
+            1.0e-5,
+            1 / 120,
+            2,
+            id="allegro-direct",
+        ),
+        pytest.param(
+            "Isaac-Reorient-Cube-Shadow-Direct",
+            12,
+            24,
+            "matrix_free",
+            0.005,
+            5.0e-5,
+            1 / 120,
+            2,
+            id="shadow-direct",
+        ),
+        pytest.param(
+            "IsaacContrib-Velocity-Flat-AnymalB",
+            1,
+            16,
+            "split",
+            0.02,
+            1.0e-5,
+            0.005,
+            4,
+            id="anymal-b-flat",
+        ),
+        pytest.param(
+            "IsaacContrib-Velocity-Rough-AnymalB",
+            1,
+            16,
+            "split",
+            0.02,
+            1.0e-5,
+            0.005,
+            4,
+            id="anymal-b-rough",
+        ),
+        pytest.param(
+            "IsaacContrib-Velocity-Flat-AnymalC",
+            2,
+            8,
+            "split",
+            0.05,
+            1.0e-6,
+            0.005,
+            4,
+            id="anymal-c-flat",
+        ),
+        pytest.param(
+            "IsaacContrib-Velocity-Rough-AnymalC",
+            2,
+            4,
+            "split",
+            0.05,
+            1.0e-6,
+            0.005,
+            4,
+            id="anymal-c-rough",
+        ),
+        pytest.param("Isaac-Velocity-Flat-AnymalD", 1, 4, "split", 0.05, 1.0e-6, 0.005, 4, id="anymal-d-flat"),
+        pytest.param(
+            "Isaac-Velocity-Rough-AnymalD",
+            2,
+            2,
+            "split",
+            0.05,
+            1.0e-6,
+            0.005,
+            4,
+            id="anymal-d-rough",
+        ),
+        pytest.param("IsaacContrib-Velocity-Flat-UnitreeA1", 1, 8, "split", 0.05, 1.0e-6, 0.005, 4, id="a1-flat"),
+        pytest.param(
+            "IsaacContrib-Velocity-Rough-UnitreeA1",
+            1,
+            16,
+            "split",
+            0.02,
+            1.0e-5,
+            0.005,
+            4,
+            id="a1-rough",
+        ),
+        pytest.param("IsaacContrib-Velocity-Flat-UnitreeGo1", 1, 8, "split", 0.05, 1.0e-6, 0.005, 4, id="go1-flat"),
+        pytest.param(
+            "IsaacContrib-Velocity-Rough-UnitreeGo1",
+            1,
+            16,
+            "split",
+            0.02,
+            1.0e-5,
+            0.005,
+            4,
+            id="go1-rough",
+        ),
+        pytest.param("Isaac-Velocity-Flat-UnitreeGo2", 1, 8, "split", 0.05, 1.0e-6, 0.005, 4, id="go2-flat"),
+        pytest.param(
+            "Isaac-Velocity-Rough-UnitreeGo2",
+            1,
+            16,
+            "split",
+            0.01,
+            2.0e-5,
+            0.005,
+            4,
+            id="go2-rough",
+        ),
+        pytest.param("Isaac-Velocity-Flat-Cassie", 1, 16, "split", 0.02, 1.0e-5, 0.005, 4, id="cassie-flat"),
+        pytest.param("Isaac-Velocity-Rough-Cassie", 1, 16, "split", 0.02, 1.0e-5, 0.005, 4, id="cassie-rough"),
+        pytest.param("Isaac-Velocity-Flat-G1", 1, 4, "matrix_free", 0.05, 1.0e-6, 0.01, 2, id="g1-flat"),
+        pytest.param("Isaac-Velocity-Rough-G1", 1, 16, "split", 0.02, 1.0e-5, 0.005, 4, id="g1-rough"),
+        pytest.param("Isaac-Velocity-Flat-H1", 2, 8, "split", 0.05, 1.0e-6, 0.005, 4, id="h1-flat"),
+        pytest.param("Isaac-Velocity-Rough-H1", 1, 8, "split", 0.05, 1.0e-6, 0.005, 4, id="h1-rough"),
+        pytest.param("Isaac-Humanoid", 1, 24, "split", 0.002, 1.0e-4, 1 / 120, 2, id="humanoid-manager"),
+        pytest.param("Isaac-Humanoid-Direct", 1, 24, "split", 0.002, 1.0e-4, 1 / 120, 2, id="humanoid-direct"),
+        pytest.param("Isaac-Open-Drawer-Franka", 1, 32, "split", 0.02, 1.0e-5, 1 / 60, 1, id="cabinet-franka"),
+    ],
+)
+def test_feather_pgs_task_preset_matches_validated_configuration(
+    task_name: str,
+    num_substeps: int,
+    pgs_iterations: int,
+    pgs_mode: str,
+    pgs_beta: float,
+    pgs_cfm: float,
+    dt: float,
+    decimation: int,
+) -> None:
+    raw_cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
+    cfg = resolve_presets(raw_cfg, {"feather_pgs"})
+
+    assert collect_presets(cfg) == {}
+    assert isinstance(cfg.sim.physics, NewtonCfg)
+    assert isinstance(cfg.sim.physics.solver_cfg, FeatherPGSSolverCfg)
+    assert cfg.sim.physics.num_substeps == num_substeps
+    assert cfg.sim.physics.solver_cfg.pgs_iterations == pgs_iterations
+    assert cfg.sim.physics.solver_cfg.pgs_mode == pgs_mode
+    assert cfg.sim.physics.solver_cfg.pgs_beta == pytest.approx(pgs_beta)
+    assert cfg.sim.physics.solver_cfg.pgs_cfm == pytest.approx(pgs_cfm)
+    assert cfg.sim.dt == pytest.approx(dt)
+    assert cfg.decimation == decimation
+
+
+@pytest.mark.parametrize("task_name", ["Isaac-Humanoid", "Isaac-Humanoid-Direct"])
+def test_feather_pgs_humanoid_preset_applies_stabilization(task_name: str) -> None:
+    cfg = resolve_presets(load_cfg_from_registry(task_name, "env_cfg_entry_point"), {"feather_pgs"})
+
+    robot = cfg.robot if hasattr(cfg, "robot") else cfg.scene.robot
+    assert robot.actuators["body"].armature == 0.2
+    assert cfg.events.robot_body_mass.params["mass_distribution_params"] == (2.0, 2.0)
+    assert cfg.events.robot_body_inertia.params["inertia_distribution_params"] == (2.0, 2.0)
+
+
+def test_feather_pgs_hand_and_cabinet_presets_apply_stabilization() -> None:
+    allegro = resolve_presets(
+        load_cfg_from_registry("Isaac-Reorient-Cube-Allegro-Direct", "env_cfg_entry_point"),
+        {"feather_pgs"},
+    )
+    shadow = resolve_presets(
+        load_cfg_from_registry("Isaac-Reorient-Cube-Shadow-Direct", "env_cfg_entry_point"),
+        {"feather_pgs"},
+    )
+    cabinet = resolve_presets(
+        load_cfg_from_registry("Isaac-Open-Drawer-Franka", "env_cfg_entry_point"),
+        {"feather_pgs"},
+    )
+
+    assert allegro.robot_cfg.actuators["fingers"].armature == 0.1
+    assert shadow.robot_cfg.actuators["fingers"].armature == 0.05
+    assert shadow.robot_cfg.actuators["fingers"].friction == 0.1
+    assert shadow.events.object_physics_inertia.params["inertia_distribution_params"] == (0.1, 0.1)
+    assert cabinet.scene.cabinet.actuators["drawers"].damping == 3.0
+    assert cabinet.events.robot_body_inertia.params["inertia_distribution_params"] == (0.02, 0.02)
+    assert cabinet.events.cabinet_body_inertia.params["inertia_distribution_params"] == (0.05, 0.05)

--- a/source/isaaclab_tasks/test/env_test_utils.py
+++ b/source/isaaclab_tasks/test/env_test_utils.py
@@ -19,7 +19,7 @@ from isaaclab.envs.utils.spaces import sample_space
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.version import get_isaac_sim_version
 
-from isaaclab_tasks.utils.hydra import apply_overrides, collect_presets
+from isaaclab_tasks.utils.hydra import resolve_presets
 from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry, parse_env_cfg
 
 # Map of task IDs to the reason for marking the corresponding parametrized
@@ -370,18 +370,14 @@ def _check_random_actions(
     get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
     env = None
     try:
-        # parse config
-        env_cfg = parse_env_cfg(task_name, device=device, num_envs=num_envs)
-        # apply physics preset override before creating the environment
-        if physics_preset_name is not None:
-            # parse_env_cfg already resolved PresetCfg wrappers to their default,
-            # so we load the raw config to retrieve preset alternatives.
+        if physics_preset_name is None:
+            env_cfg = parse_env_cfg(task_name, device=device, num_envs=num_envs)
+        else:
             raw_cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
-            presets = {"env": collect_presets(raw_cfg), "agent": {}}
-            hydra_cfg = {"env": env_cfg.to_dict(), "agent": None}
-            apply_overrides(env_cfg, None, hydra_cfg, [physics_preset_name], [], [], presets)
-            # Re-apply num_envs since apply_overrides may have replaced
-            # the scene config with the preset's default num_envs.
+            if isinstance(raw_cfg, dict):
+                raise RuntimeError(f"Configuration for the task: '{task_name}' is not a class.")
+            env_cfg = resolve_presets(raw_cfg, {physics_preset_name})
+            env_cfg.sim.device = device
             if num_envs is not None:
                 env_cfg.scene.num_envs = num_envs
         # set config args


### PR DESCRIPTION
## Summary

- integrate Newton's FeatherPGS solver through the existing Isaac Lab Newton manager and typed configuration interfaces
- add explicit, task-local `feather_pgs` presets for 29 task variants validated by the 16K training matrix
- document solver selection and limitations, and add configuration and runtime regression coverage

## Validation

- `32 passed` in `test_feather_pgs_task_presets.py` on 4g
- strict Sphinx documentation build completed successfully
- all pre-commit hooks passed for the changed files
- the 29-task GPU runtime matrix is included but was not rerun in this pass because the 4g GPUs were occupied by existing experiments

## Dependency note

This temporarily pins `newton[sim]` to Dylan Turpin's FeatherPGS branch at `3674b45e00cbe7b1e0d0b8f613af087298dcc110`. The pin can move to the official Newton branch once those changes land upstream.

Supersedes #6319 so ongoing development can use the upstream `fpgs_solver_dev` branch.
