### PR TITLE
Tune Flexiv gear ROS inference env for SysID PhysX

### DIFF
--- a/input/actuator_models/__init__.py
+++ b/input/actuator_models/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Actuator model config loaders used by deployment tasks."""
+
+from pathlib import Path
+
+_ACTUATOR_MODELS_DIR = Path(__file__).resolve().parent
+_IMPLICIT_ACTUATOR_FIELDS = (
+    "effort_limit_sim",
+    "velocity_limit_sim",
+    "stiffness",
+    "damping",
+    "armature",
+    "friction",
+    "dynamic_friction",
+    "viscous_friction",
+)
+
+
+def load_implicit_actuator_cfg(yaml_file: str, joint_names_expr: list[str]):
+    """Load an Isaac Lab ``ImplicitActuatorCfg`` from an actuator-parameter YAML."""
+    from isaaclab.actuators import ImplicitActuatorCfg
+    from isaaclab.utils.io import load_yaml
+
+    yaml_path = Path(yaml_file)
+    if not yaml_path.is_absolute():
+        yaml_path = _ACTUATOR_MODELS_DIR / yaml_path
+
+    params = load_yaml(str(yaml_path))
+    actuator_kwargs = {field: params[field] for field in _IMPLICIT_ACTUATOR_FIELDS if field in params}
+    return ImplicitActuatorCfg(joint_names_expr=joint_names_expr, **actuator_kwargs)

--- a/input/actuator_models/flexiv/manual/flexiv_pd_only_gravityoff_high_cmdlimits_tuned_physx.yaml
+++ b/input/actuator_models/flexiv/manual/flexiv_pd_only_gravityoff_high_cmdlimits_tuned_physx.yaml
@@ -1,0 +1,62 @@
+_generated_by: scripts/sysid/run_sysid.py
+_source_best_params_yaml: /home/horde/IsaacLab/output/sysid/flexiv/pd_only_gravityoff_high_cmdlimits_seed_default_steps_pm10_physx_n64_g20/best_params.yaml
+_source_gains_yaml: /home/horde/IsaacLab/input/manual_pd/flexiv_pd_only_gravityoff_high_cmdlimits_tuned_physx.yaml
+_base_actuator_yaml: flexiv/rizon4s_grav_usd_default_implicit.yaml
+
+effort_limit_sim:
+  joint1: 123.0
+  joint2: 123.0
+  joint3: 64.0
+  joint4: 64.0
+  joint5: 39.0
+  joint6: 39.0
+  joint7: 39.0
+
+velocity_limit_sim:
+  joint1: 2.094
+  joint2: 2.094
+  joint3: 2.443
+  joint4: 2.443
+  joint5: 4.887
+  joint6: 4.887
+  joint7: 4.887
+
+stiffness:
+  joint1: 6051.500977
+  joint2: 3004.328857
+  joint3: 7032.64209
+  joint4: 4346.786133
+  joint5: 6829.847656
+  joint6: 3769.23291
+  joint7: 6181.429199
+
+damping:
+  joint1: 121.620995
+  joint2: 220.929214
+  joint3: 162.582214
+  joint4: 186.334442
+  joint5: 199.962311
+  joint6: 118.462029
+  joint7: 152.861771
+
+armature:
+  joint1: 0.0
+  joint2: 0.0
+  joint3: 0.0
+  joint4: 0.0
+  joint5: 0.0
+  joint6: 0.0
+  joint7: 0.0
+
+friction:
+  joint1: 0.0
+  joint2: 0.0
+  joint3: 0.0
+  joint4: 0.0
+  joint5: 0.0
+  joint6: 0.0
+  joint7: 0.0
+
+motor_lag_ms: 20.0
+command_velocity_limit: 2.0
+command_acceleration_limit: 3.0

--- a/input/actuator_models/flexiv/manual/flexiv_pd_only_gravityoff_high_cmdlimits_tuned_physx.yaml
+++ b/input/actuator_models/flexiv/manual/flexiv_pd_only_gravityoff_high_cmdlimits_tuned_physx.yaml
@@ -1,7 +1,10 @@
-_generated_by: scripts/sysid/run_sysid.py
+_generated_by: real_vs_sim_sysid_rmse/full_dataset_sysid/scripts/flexiv_full_dataset_sysid_tune.py
 _source_best_params_yaml: /home/horde/IsaacLab/output/sysid/flexiv/pd_only_gravityoff_high_cmdlimits_seed_default_steps_pm10_physx_n64_g20/best_params.yaml
 _source_gains_yaml: /home/horde/IsaacLab/input/manual_pd/flexiv_pd_only_gravityoff_high_cmdlimits_tuned_physx.yaml
 _base_actuator_yaml: flexiv/rizon4s_grav_usd_default_implicit.yaml
+_source_dataset:
+  - /home/ashwin/git_cloned/IsaacLab_osmo/input/sysid_data/flexiv_workspace_xlarge_base01_zero/output
+  - /home/ashwin/git_cloned/IsaacLab_osmo/input/sysid_data/flexiv_workspace_xlarge_base02_joint4_90deg/output
 
 effort_limit_sim:
   joint1: 123.0
@@ -22,40 +25,40 @@ velocity_limit_sim:
   joint7: 4.887
 
 stiffness:
-  joint1: 6051.500977
-  joint2: 3004.328857
-  joint3: 7032.64209
-  joint4: 4346.786133
-  joint5: 6829.847656
-  joint6: 3769.23291
-  joint7: 6181.429199
+  joint1: 2444.644779860334
+  joint2: 2454.6088134535826
+  joint3: 4273.368452557374
+  joint4: 2423.6797438613694
+  joint5: 6664.534638550969
+  joint6: 2476.4182575483555
+  joint7: 7750.655168285934
 
 damping:
-  joint1: 121.620995
-  joint2: 220.929214
-  joint3: 162.582214
-  joint4: 186.334442
-  joint5: 199.962311
-  joint6: 118.462029
-  joint7: 152.861771
+  joint1: 84.53152821762647
+  joint2: 270.1514569287321
+  joint3: 192.11542410547165
+  joint4: 185.80477160067872
+  joint5: 348.9429103302826
+  joint6: 137.1076685992307
+  joint7: 155.4299494964395
 
 armature:
-  joint1: 0.0
+  joint1: 0.016031804623087037
   joint2: 0.0
-  joint3: 0.0
+  joint3: 0.09079310995247876
   joint4: 0.0
-  joint5: 0.0
-  joint6: 0.0
+  joint5: 0.03506234030793366
+  joint6: 0.028407284483869172
   joint7: 0.0
 
 friction:
-  joint1: 0.0
-  joint2: 0.0
+  joint1: 0.4469057501336581
+  joint2: 0.0028027430277378224
   joint3: 0.0
-  joint4: 0.0
-  joint5: 0.0
-  joint6: 0.0
-  joint7: 0.0
+  joint4: 0.023950665402821605
+  joint5: 0.19162425676108663
+  joint6: 0.3486314724253511
+  joint7: 0.07779038751031743
 
 motor_lag_ms: 20.0
 command_velocity_limit: 2.0

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/rizon_4s/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/rizon_4s/joint_pos_env_cfg.py
@@ -150,6 +150,17 @@ class EventCfg:
         params={"gear_types": ["gear_small", "gear_medium", "gear_large"]},
     )
 
+    gear_insertion_pose_error_metric = EventTerm(
+        func=gear_assembly_events.log_gear_insertion_pose_error_metrics,
+        mode="interval",
+        interval_range_s=(0.0, 0.0),
+        is_global_time=True,
+        params={
+            "asset_cfg": SceneEntityCfg("factory_gear_base"),
+            "pose_error_thresholds": (0.001, 0.003, 0.005),
+        },
+    )
+
     reset_all = EventTerm(func=mdp.reset_scene_to_default, mode="reset")
 
     randomize_gears_and_base_pose = EventTerm(

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/rizon_4s/ros_inference_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/rizon_4s/ros_inference_env_cfg.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import math
+import sys
+from pathlib import Path
 
 import torch
 
@@ -11,12 +13,70 @@ from isaaclab.assets import RigidObjectCfg
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.utils.configclass import configclass
 
+from isaaclab_tasks.contrib.deploy.mdp.delayed_joint_actions_cfg import ShapedDelayedRelativeJointPositionActionCfg
+
 from .joint_pos_env_cfg import Rizon4sGearAssemblyEnvCfg
+
+ISAACLAB_ROOT = Path(__file__).resolve().parents[8]
+FLEXIV_ARM_JOINT_NAMES = ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint7"]
+FLEXIV_ACTION_LATENCY_MS = 20.0
+FLEXIV_PHYSX_SYSID_ACTUATOR_YAML = "flexiv/manual/flexiv_pd_only_gravityoff_high_cmdlimits_tuned_physx.yaml"
+FLEXIV_PHYSX_SYSID_ACTUATOR_YAML_PATH = f"input/actuator_models/{FLEXIV_PHYSX_SYSID_ACTUATOR_YAML}"
+FLEXIV_DEPLOYMENT_PHYSICS_FREQ_HZ = 200.0
+FLEXIV_DEPLOYMENT_DECIMATION = 4
+FLEXIV_DEPLOYMENT_CONTROL_FREQ_HZ = FLEXIV_DEPLOYMENT_PHYSICS_FREQ_HZ / FLEXIV_DEPLOYMENT_DECIMATION
+FLEXIV_ROBOT_COLLECTION_COMMAND_VELOCITY_LIMIT = 2.0
+FLEXIV_ROBOT_COLLECTION_COMMAND_ACCELERATION_LIMIT = 3.0
+FLEXIV_GRAV_ROS_INFERENCE_SETUP = {
+    "robot_usd": "rizon4s_with_grav.usd",
+    "gravity_compensation": "robot_rigid_bodies_disable_gravity_true",
+    "rigid_body": {
+        "disable_gravity": True,
+        "max_depenetration_velocity": 5.0,
+        "linear_damping": 0.0,
+        "angular_damping": 0.0,
+        "max_linear_velocity": 1000.0,
+        "max_angular_velocity": 3666.0,
+        "enable_gyroscopic_forces": True,
+        "solver_position_iteration_count": 4,
+        "solver_velocity_iteration_count": 1,
+        "max_contact_impulse": 1e32,
+    },
+    "articulation": {
+        "enabled_self_collisions": False,
+        "solver_position_iteration_count": 4,
+        "solver_velocity_iteration_count": 1,
+    },
+    "collision": {"contact_offset": 0.005, "rest_offset": 0.0},
+    "arm_actuator_yaml": FLEXIV_PHYSX_SYSID_ACTUATOR_YAML_PATH,
+    "action_latency_ms": FLEXIV_ACTION_LATENCY_MS,
+}
 
 
 def constant_obs(env, value: tuple) -> torch.Tensor:
     """Observation function that returns a fixed tensor every step."""
     return torch.tensor([value], device=env.device, dtype=torch.float32).expand(env.num_envs, -1)
+
+
+def _load_implicit_actuator_cfg(actuator_yaml: str):
+    if str(ISAACLAB_ROOT) not in sys.path:
+        sys.path.append(str(ISAACLAB_ROOT))
+    from input.actuator_models import load_implicit_actuator_cfg
+
+    return load_implicit_actuator_cfg(actuator_yaml, FLEXIV_ARM_JOINT_NAMES)
+
+
+def _replace_arm_actuator(robot_cfg, actuator_yaml: str) -> None:
+    """Install a single tuned arm actuator while preserving gripper actuators."""
+    gripper_actuators = {
+        actuator_name: actuator_cfg
+        for actuator_name, actuator_cfg in robot_cfg.actuators.items()
+        if actuator_name.startswith("gripper")
+    }
+    robot_cfg.actuators = {
+        "arm": _load_implicit_actuator_cfg(actuator_yaml),
+        **gripper_actuators,
+    }
 
 
 @configclass
@@ -53,6 +113,43 @@ class Rizon4sGearAssemblyROSInferenceEnvCfg(Rizon4sGearAssemblyEnvCfg):
 
         # Dynamically generate action_scale_joint_space based on action_space
         self.action_scale_joint_space = [self.joint_action_scale] * self.action_space
+
+        _replace_arm_actuator(self.scene.robot, FLEXIV_PHYSX_SYSID_ACTUATOR_YAML)
+        self.decimation = FLEXIV_DEPLOYMENT_DECIMATION
+        self.sim.dt = 1.0 / FLEXIV_DEPLOYMENT_PHYSICS_FREQ_HZ
+        self.sim.render_interval = self.decimation
+        self.flexiv_tuned_actuator_yaml = FLEXIV_PHYSX_SYSID_ACTUATOR_YAML_PATH
+        self.flexiv_action_latency_ms = FLEXIV_ACTION_LATENCY_MS
+        self.sim_to_real_tuned_config = dict(FLEXIV_GRAV_ROS_INFERENCE_SETUP)
+        self.sim_to_real_tuned_config.update(
+            {
+                "active_env": "IsaacContrib-Deploy-GearAssembly-Rizon4s-Grav-ROS-Inference",
+                "controller": "ShapedDelayedRelativeJointPositionActionCfg",
+                "arm_actuator_yaml": FLEXIV_PHYSX_SYSID_ACTUATOR_YAML_PATH,
+                "sysid_source": (
+                    "output/sysid/flexiv/"
+                    "pd_only_gravityoff_high_cmdlimits_seed_default_steps_pm10_physx_n64_g20/best_params.yaml"
+                ),
+                "physics_freq_hz": FLEXIV_DEPLOYMENT_PHYSICS_FREQ_HZ,
+                "decimation": FLEXIV_DEPLOYMENT_DECIMATION,
+                "control_freq_hz": FLEXIV_DEPLOYMENT_CONTROL_FREQ_HZ,
+                "command_velocity_limit_rad_s": FLEXIV_ROBOT_COLLECTION_COMMAND_VELOCITY_LIMIT,
+                "command_acceleration_limit_rad_s2": FLEXIV_ROBOT_COLLECTION_COMMAND_ACCELERATION_LIMIT,
+                "sysid_notes": (
+                    "PhysX PD-only step-response SysID plus command shaping matched to "
+                    "the 50 Hz Flexiv deployment command loop."
+                ),
+            }
+        )
+        self.actions.arm_action = ShapedDelayedRelativeJointPositionActionCfg(
+            asset_name="robot",
+            joint_names=FLEXIV_ARM_JOINT_NAMES,
+            scale=self.joint_action_scale,
+            use_zero_offset=True,
+            latency_s=FLEXIV_ACTION_LATENCY_MS / 1000.0,
+            command_velocity_limit=FLEXIV_ROBOT_COLLECTION_COMMAND_VELOCITY_LIMIT,
+            command_acceleration_limit=FLEXIV_ROBOT_COLLECTION_COMMAND_ACCELERATION_LIMIT,
+        )
 
         # Override robot initial pose for ROS inference (fixed pose, no randomization)
         # Joint positions and pos are inherited from parent, only override rotation to be deterministic

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/gear_assembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/gear_assembly_env_cfg.py
@@ -238,6 +238,17 @@ class EventCfg:
         },
     )
 
+    gear_insertion_pose_error_metric = EventTerm(
+        func=mdp.log_gear_insertion_pose_error_metrics,
+        mode="interval",
+        interval_range_s=(0.0, 0.0),
+        is_global_time=True,
+        params={
+            "asset_cfg": SceneEntityCfg("factory_gear_base"),
+            "pose_error_thresholds": (0.001, 0.003, 0.005),
+        },
+    )
+
 
 @configclass
 class RewardsCfg:

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/__init__.pyi
@@ -19,6 +19,7 @@ __all__ = [
     "keypoint_entity_error_exp",
     "keypoint_ee_grasp_error",
     "keypoint_ee_grasp_error_exp",
+    "log_gear_insertion_pose_error_metrics",
     "reset_when_gear_dropped",
     "reset_when_gear_orientation_exceeds_threshold",
     "DelayedRelativeJointPositionAction",
@@ -33,7 +34,12 @@ from .delayed_joint_actions import (
     ShapedDelayedRelativeJointPositionAction,
     ShapedDelayedRelativeJointPositionActionCfg,
 )
-from .events import randomize_gear_type, randomize_gears_and_base_pose, set_robot_to_grasp_pose
+from .events import (
+    log_gear_insertion_pose_error_metrics,
+    randomize_gear_type,
+    randomize_gears_and_base_pose,
+    set_robot_to_grasp_pose,
+)
 from .noise_models import ResetSampledConstantNoiseModel, ResetSampledConstantNoiseModelCfg
 from .observations import gear_pos_w, gear_quat_w, gear_shaft_pos_w, gear_shaft_quat_w
 from .rewards import (

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/__init__.pyi
@@ -21,8 +21,18 @@ __all__ = [
     "keypoint_ee_grasp_error_exp",
     "reset_when_gear_dropped",
     "reset_when_gear_orientation_exceeds_threshold",
+    "DelayedRelativeJointPositionAction",
+    "DelayedRelativeJointPositionActionCfg",
+    "ShapedDelayedRelativeJointPositionAction",
+    "ShapedDelayedRelativeJointPositionActionCfg",
 ]
 
+from .delayed_joint_actions import (
+    DelayedRelativeJointPositionAction,
+    DelayedRelativeJointPositionActionCfg,
+    ShapedDelayedRelativeJointPositionAction,
+    ShapedDelayedRelativeJointPositionActionCfg,
+)
 from .events import randomize_gear_type, randomize_gears_and_base_pose, set_robot_to_grasp_pose
 from .noise_models import ResetSampledConstantNoiseModel, ResetSampledConstantNoiseModelCfg
 from .observations import gear_pos_w, gear_quat_w, gear_shaft_pos_w, gear_shaft_quat_w

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/delayed_joint_actions.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/delayed_joint_actions.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2025-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import torch
+
+from isaaclab.envs.mdp.actions.joint_actions import RelativeJointPositionAction
+from isaaclab.utils import DelayBuffer
+from isaaclab_tasks.contrib.deploy.mdp.delayed_joint_actions_cfg import (
+    DelayedRelativeJointPositionActionCfg,
+    ShapedDelayedRelativeJointPositionActionCfg,
+)
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv
+
+
+class DelayedRelativeJointPositionAction(RelativeJointPositionAction):
+    """Relative joint-position action that applies a delayed absolute joint target."""
+
+    cfg: DelayedRelativeJointPositionActionCfg
+
+    def __init__(self, cfg: DelayedRelativeJointPositionActionCfg, env: ManagerBasedEnv):
+        super().__init__(cfg, env)
+
+        if self.cfg.latency_s < 0.0:
+            raise ValueError("latency_s must be non-negative")
+        if self.cfg.latency_steps is not None and self.cfg.latency_steps < 0:
+            raise ValueError("latency_steps must be non-negative")
+
+        # PhysX calls apply_actions() once per physics step. Newton graph mode may
+        # fold decimation internally, in which case apply_actions() runs once per env step.
+        apply_dt = env.step_dt if getattr(env, "_physics_handles_decimation", False) else env.physics_dt
+        if self.cfg.latency_steps is None:
+            self._delay_steps = 0 if self.cfg.latency_s == 0.0 else max(1, round(self.cfg.latency_s / apply_dt))
+        else:
+            self._delay_steps = int(self.cfg.latency_steps)
+        self._effective_latency_s = self._delay_steps * apply_dt
+
+        current_target = self._asset.data.joint_pos.torch[:, self._joint_ids].clone()
+        self._latest_target = current_target.clone()
+        self._delayed_target = current_target.clone()
+        self._target_delay_buffer = self._make_target_delay_buffer(current_target)
+
+    def process_actions(self, actions: torch.Tensor):
+        super().process_actions(actions)
+        current_joint_pos = self._asset.data.joint_pos.torch[:, self._joint_ids]
+        self._latest_target = current_joint_pos + self.processed_actions
+
+    def apply_actions(self):
+        self._delayed_target = self._compute_delayed_target(self._latest_target)
+        self._asset.set_joint_position_target_index(target=self._delayed_target, joint_ids=self._joint_ids)
+
+    def reset(self, env_ids: Sequence[int] | None = None) -> None:
+        super().reset(env_ids)
+        reset_ids = slice(None) if env_ids is None else env_ids
+        current_target = self._asset.data.joint_pos.torch[:, self._joint_ids]
+        self._latest_target[reset_ids] = current_target[reset_ids]
+        self._delayed_target[reset_ids] = current_target[reset_ids]
+        if self._target_delay_buffer is not None:
+            selected_target = current_target[reset_ids]
+            self._reset_target_delay_buffer(reset_ids, selected_target)
+
+    def _make_target_delay_buffer(self, initial_target: torch.Tensor) -> DelayBuffer | None:
+        if self._delay_steps <= 0:
+            return None
+
+        target_delay_buffer = DelayBuffer(self._delay_steps, self.num_envs, device=self.device)
+        target_delay_buffer.set_time_lag(self._delay_steps)
+        target_delay_buffer.compute(initial_target)
+        return target_delay_buffer
+
+    def _compute_delayed_target(self, target: torch.Tensor) -> torch.Tensor:
+        if self._target_delay_buffer is None:
+            return target
+        return self._target_delay_buffer.compute(target)
+
+    def _reset_target_delay_buffer(self, reset_ids: Sequence[int] | slice, selected_target: torch.Tensor) -> None:
+        if selected_target.ndim == 1:
+            selected_target = selected_target.unsqueeze(0)
+
+        self._target_delay_buffer.reset(reset_ids)
+        circular_buffer = self._target_delay_buffer._circular_buffer
+        if circular_buffer._buffer is not None:
+            # DelayBuffer.reset() clears reset rows; restore the reset joint pose so
+            # newly-reset envs hold that target for the configured command latency.
+            circular_buffer._buffer[:, reset_ids] = selected_target
+            circular_buffer._num_pushes[reset_ids] = 1
+            circular_buffer._need_reset = True
+
+
+class ShapedDelayedRelativeJointPositionAction(DelayedRelativeJointPositionAction):
+    """Delayed relative joint-position action with command-side velocity and acceleration limits."""
+
+    cfg: ShapedDelayedRelativeJointPositionActionCfg
+
+    def __init__(self, cfg: ShapedDelayedRelativeJointPositionActionCfg, env: ManagerBasedEnv):
+        super().__init__(cfg, env)
+
+        if self.cfg.command_velocity_limit < 0.0:
+            raise ValueError("command_velocity_limit must be non-negative")
+        if self.cfg.command_acceleration_limit < 0.0:
+            raise ValueError("command_acceleration_limit must be non-negative")
+
+        # Command shaping models the external robot command loop, so it advances
+        # once per env/control step. PhysX still receives the latest shaped target
+        # on every physics substep through apply_actions().
+        control_dt = env.step_dt
+        if self.cfg.latency_steps is None:
+            self._delay_steps = 0 if self.cfg.latency_s == 0.0 else max(1, round(self.cfg.latency_s / control_dt))
+        else:
+            self._delay_steps = int(self.cfg.latency_steps)
+        self._effective_latency_s = self._delay_steps * control_dt
+
+        current_target = self._asset.data.joint_pos.torch[:, self._joint_ids].clone()
+        self._latest_target = current_target.clone()
+        self._delayed_target = current_target.clone()
+        self._target_delay_buffer = self._make_target_delay_buffer(current_target)
+
+        self._shape_dt = control_dt
+        self._shaped_target = self._delayed_target.clone()
+        self._shaped_velocity = torch.zeros_like(self._shaped_target)
+
+    def process_actions(self, actions: torch.Tensor):
+        RelativeJointPositionAction.process_actions(self, actions)
+        current_joint_pos = self._asset.data.joint_pos.torch[:, self._joint_ids]
+        self._latest_target = current_joint_pos + self.processed_actions
+
+        delayed_target = self._compute_delayed_target(self._latest_target)
+        self._delayed_target = delayed_target
+        self._shaped_target, self._shaped_velocity = self._shape_position_target(
+            delayed_target,
+            self._shaped_target,
+            self._shaped_velocity,
+        )
+
+    def apply_actions(self):
+        self._asset.set_joint_position_target_index(target=self._shaped_target, joint_ids=self._joint_ids)
+
+    def reset(self, env_ids: Sequence[int] | None = None) -> None:
+        super().reset(env_ids)
+        reset_ids = slice(None) if env_ids is None else env_ids
+        current_target = self._asset.data.joint_pos.torch[:, self._joint_ids]
+        self._shaped_target[reset_ids] = current_target[reset_ids]
+        self._shaped_velocity[reset_ids] = 0.0
+
+    def _shape_position_target(
+        self,
+        desired_target: torch.Tensor,
+        shaped_target: torch.Tensor,
+        shaped_velocity: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.cfg.command_velocity_limit == 0.0 and self.cfg.command_acceleration_limit == 0.0:
+            return desired_target, shaped_velocity
+
+        target_velocity = (desired_target - shaped_target) / self._shape_dt
+        if self.cfg.command_velocity_limit > 0.0:
+            target_velocity = torch.clamp(
+                target_velocity,
+                min=-self.cfg.command_velocity_limit,
+                max=self.cfg.command_velocity_limit,
+            )
+
+        if self.cfg.command_acceleration_limit > 0.0:
+            max_delta_velocity = self.cfg.command_acceleration_limit * self._shape_dt
+            target_velocity = shaped_velocity + torch.clamp(
+                target_velocity - shaped_velocity,
+                min=-max_delta_velocity,
+                max=max_delta_velocity,
+            )
+
+        next_target = shaped_target + target_velocity * self._shape_dt
+        crossed = ((desired_target - shaped_target) * (desired_target - next_target)) < 0.0
+        if crossed.any():
+            next_target = torch.where(crossed, desired_target, next_target)
+            target_velocity = torch.where(crossed, torch.zeros_like(target_velocity), target_velocity)
+
+        return next_target, target_velocity

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/delayed_joint_actions_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/delayed_joint_actions_cfg.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from isaaclab.envs.mdp.actions.actions_cfg import RelativeJointPositionActionCfg
+from isaaclab.utils.configclass import configclass
+
+_ACTIONS_MODULE = "isaaclab_tasks.contrib.deploy.mdp.delayed_joint_actions"
+
+
+@configclass
+class DelayedRelativeJointPositionActionCfg(RelativeJointPositionActionCfg):
+    """Configuration for delayed relative joint-position actions."""
+
+    class_type: type | str = f"{_ACTIONS_MODULE}:DelayedRelativeJointPositionAction"
+
+    latency_s: float = 0.02
+    """Command latency in seconds. Defaults to one 50 Hz collection sample, 20 ms."""
+
+    latency_steps: int | None = None
+    """Optional explicit delay in action-application steps. Overrides latency_s when set."""
+
+
+@configclass
+class ShapedDelayedRelativeJointPositionActionCfg(DelayedRelativeJointPositionActionCfg):
+    """Configuration for delayed relative joint-position actions with command shaping."""
+
+    class_type: type | str = f"{_ACTIONS_MODULE}:ShapedDelayedRelativeJointPositionAction"
+
+    command_velocity_limit: float = 0.2
+    """Maximum command-target slew velocity in rad/s. Set to zero to disable."""
+
+    command_acceleration_limit: float = 0.5
+    """Maximum command-target slew acceleration in rad/s^2. Set to zero to disable."""

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/events.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/mdp/events.py
@@ -98,6 +98,71 @@ class randomize_gear_type(ManagerTermBase):
         return self._current_gear_type_indices
 
 
+def log_gear_insertion_pose_error_metrics(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor | None,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("factory_gear_base"),
+    pose_error_thresholds: tuple[float, ...] = (0.001, 0.003, 0.005),
+) -> None:
+    """Log insertion pose-error metrics for the active gear against the gear base.
+
+    The Factory gear assets are authored such that an inserted gear has the same
+    root position as the gear base. This metric intentionally logs only to
+    ``env.extras["log"]`` and does not contribute to the reward.
+    """
+    if not hasattr(env, "_gear_type_manager"):
+        raise RuntimeError(
+            "Gear type manager not initialized. Ensure randomize_gear_type event is configured "
+            "before logging gear insertion metrics."
+        )
+
+    if env_ids is None:
+        env_ids = torch.arange(env.num_envs, device=env.device)
+
+    base_asset = env.scene[asset_cfg.name]
+    gear_assets = {
+        "gear_small": env.scene["factory_gear_small"],
+        "gear_medium": env.scene["factory_gear_medium"],
+        "gear_large": env.scene["factory_gear_large"],
+    }
+
+    gear_type_indices = env._gear_type_manager.get_all_gear_type_indices()[env_ids]
+    all_gear_pos = torch.stack(
+        [
+            gear_assets["gear_small"].data.root_pos_w.torch[env_ids],
+            gear_assets["gear_medium"].data.root_pos_w.torch[env_ids],
+            gear_assets["gear_large"].data.root_pos_w.torch[env_ids],
+        ],
+        dim=1,
+    )
+    gear_pos = all_gear_pos[torch.arange(len(env_ids), device=env.device), gear_type_indices]
+    base_pos = base_asset.data.root_pos_w.torch[env_ids]
+
+    pos_error = gear_pos - base_pos
+    xy_error = torch.linalg.norm(pos_error[:, :2], dim=-1)
+    z_error = pos_error[:, 2]
+    pose_error = torch.maximum(xy_error, torch.abs(z_error))
+    distance_error = torch.linalg.norm(pos_error, dim=-1)
+    if not hasattr(env, "extras"):
+        env.extras = {}
+    if "log" not in env.extras:
+        env.extras["log"] = {}
+
+    for threshold in pose_error_thresholds:
+        threshold_mm = int(round(threshold * 1000.0))
+        success = pose_error <= threshold
+        env.extras["log"][f"gear_success/pose_error_success_rate_{threshold_mm}mm"] = (
+            success.float().mean().item()
+        )
+    env.extras["log"]["gear_success/pose_error_mean_m"] = pose_error.mean().item()
+    env.extras["log"]["gear_success/pose_error_min_m"] = pose_error.min().item()
+    env.extras["log"]["gear_success/xy_error_mean_m"] = xy_error.mean().item()
+    env.extras["log"]["gear_success/xy_error_min_m"] = xy_error.min().item()
+    env.extras["log"]["gear_success/z_error_mean_m"] = z_error.mean().item()
+    env.extras["log"]["gear_success/abs_z_error_min_m"] = torch.abs(z_error).min().item()
+    env.extras["log"]["gear_success/distance_error_min_m"] = distance_error.min().item()
+
+
 class set_robot_to_grasp_pose(ManagerTermBase):
     """Set robot to grasp pose using IK with pre-cached tensors.
 


### PR DESCRIPTION
# Description

This PR updates the existing Flexiv Rizon4s gear assembly ROS-inference environment to use a SysID-tuned PhysX command/actuator model.

Summary:
- Adds command-side joint target velocity and acceleration limiting to better match the deployed Flexiv command path.
- Adds one-step command latency using Isaac Lab `DelayBuffer`.
- Adds tuned Flexiv implicit actuator parameters from real robot command-response SysID.
- Updates the existing Rizon4s ROS-inference gear assembly env to use:
  - 200 Hz physics timestep
  - existing decimation of 4, giving a 50 Hz effective control rate
  - 20 ms action latency
  - 2.0 rad/s command target velocity limit
  - 3.0 rad/s² command target acceleration limit
  - SysID-tuned PhysX implicit actuator stiffness/damping values

Motivation:
We collected real Flexiv Rizon4s command-response data using NRT joint impedance at 50 Hz. The previous simulation response was much faster/different from the real robot. This change preserves the existing decimation while moving physics to 200 Hz, giving a 50 Hz effective control rate, and adds tuned PhysX actuator gains plus command-side velocity/acceleration limiting and latency to better match deployment command-response behavior.

Validation:
Real-vs-sim step-response replay showed a large reduction in joint-position RMSE after tuning:
- PM2 step response: ~81% mean RMSE reduction
- PM5 step response: ~88% mean RMSE reduction
- PM10 step response: ~90% mean RMSE reduction

Dependencies:
None beyond existing Isaac Lab dependencies.

Fixes # N/A

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

Attach the PM5 step-response plot if useful.

The plot compares:
- black: commanded joint step
- blue: real robot response
- red: default/original sim response
- green: SysID-tuned sim response

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there