### PR TITLE
Consolidate OVRTX tile-extraction kernels

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovrtx-consolidate-tile-extraction-kernels.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-consolidate-tile-extraction-kernels.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Consolidated the OVRTX tile-extraction Warp kernels into a single generic
+  :func:`~isaaclab_ov.renderers.ovrtx_renderer_kernels.extract_all_tiles_kernel`.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -60,11 +60,7 @@ from isaaclab.utils.warp.warp_math import convert_camera_frame_orientation_conve
 from .ovrtx_renderer_cfg import OVRTXRendererCfg
 from .ovrtx_renderer_kernels import (
     create_camera_transforms_kernel,
-    extract_all_depth_tiles_kernel,
-    extract_all_rgb_float_tiles_kernel,
-    extract_all_rgb_half_tiles_kernel,
-    extract_all_rgba_tiles_kernel,
-    extract_all_uint32_tiles_kernel,
+    extract_all_tiles_kernel,
     generate_random_colors_from_ids_kernel,
     sync_newton_transforms_kernel,
 )
@@ -729,7 +725,7 @@ class OVRTXRenderer(BaseRenderer):
                     data_torch = data_torch.unsqueeze(-1)
                 tiled_data = wp.from_torch(data_torch, dtype=wp.uint32)
                 wp.launch(
-                    kernel=extract_all_uint32_tiles_kernel,
+                    kernel=extract_all_tiles_kernel,
                     dim=(render_data.num_envs, render_data.height, render_data.width),
                     inputs=[
                         tiled_data,
@@ -756,7 +752,7 @@ class OVRTXRenderer(BaseRenderer):
             raise ValueError(f"Expected RGB (3 channels) or RGBA (4 channels), got {num_channels}")
 
         wp.launch(
-            kernel=extract_all_rgba_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(render_data.num_envs, render_data.height, render_data.width),
             inputs=[
                 tiled_data,
@@ -764,7 +760,6 @@ class OVRTXRenderer(BaseRenderer):
                 render_data.num_cols,
                 render_data.width,
                 render_data.height,
-                num_channels,
             ],
             device=self._device,
         )
@@ -776,7 +771,7 @@ class OVRTXRenderer(BaseRenderer):
         for depth_type in ["depth", "distance_to_image_plane", "distance_to_camera"]:
             if depth_type in output_buffers:
                 wp.launch(
-                    kernel=extract_all_depth_tiles_kernel,
+                    kernel=extract_all_tiles_kernel,
                     dim=(render_data.num_envs, render_data.height, render_data.width),
                     inputs=[
                         tiled_depth_data,
@@ -794,14 +789,10 @@ class OVRTXRenderer(BaseRenderer):
         """Extract per-env HdrColor tiles into output_buffers."""
         if "rgb_hdr" not in output_buffers:
             return
-        if tiled_data.dtype == wp.float16:
-            kernel = extract_all_rgb_half_tiles_kernel
-        elif tiled_data.dtype == wp.float32:
-            kernel = extract_all_rgb_float_tiles_kernel
-        else:
+        if tiled_data.dtype not in (wp.float16, wp.float32):
             raise TypeError(f"Unsupported OVRTX HdrColor dtype: {tiled_data.dtype}.")
         wp.launch(
-            kernel=kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(render_data.num_envs, render_data.height, render_data.width),
             inputs=[
                 tiled_data,
@@ -906,7 +897,7 @@ class OVRTXRenderer(BaseRenderer):
             with frame.render_vars["NormalSD"].map(device=Device.CUDA) as mapping:
                 tiled_normals_data = wp.from_dlpack(mapping.tensor)
                 wp.launch(
-                    kernel=extract_all_rgb_float_tiles_kernel,
+                    kernel=extract_all_tiles_kernel,
                     dim=(render_data.num_envs, render_data.height, render_data.width),
                     inputs=[
                         tiled_normals_data,

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -724,18 +724,47 @@ class OVRTXRenderer(BaseRenderer):
                 if data_torch.dim() == 2:
                     data_torch = data_torch.unsqueeze(-1)
                 tiled_data = wp.from_torch(data_torch, dtype=wp.uint32)
-                wp.launch(
-                    kernel=extract_all_tiles_kernel,
-                    dim=(render_data.num_envs, render_data.height, render_data.width),
-                    inputs=[
-                        tiled_data,
-                        output_buffers[buffer_key],
-                        render_data.num_cols,
-                        render_data.width,
-                        render_data.height,
-                    ],
-                    device=self._device,
-                )
+                self._launch_extract_all_tiles(render_data, tiled_data, output_buffers[buffer_key])
+
+    def _launch_extract_all_tiles(
+        self, render_data: OVRTXRenderData, tiled_buffer: wp.array, output_buffer: wp.array
+    ) -> None:
+        """Launch ``extract_all_tiles_kernel`` for one tiled/output buffer pair.
+
+        This is the only place that should launch ``extract_all_tiles_kernel``: it validates that
+        ``output_buffer`` cannot read past the end of ``tiled_buffer`` (the kernel derives its per-thread
+        channel loop bound from ``output_buffer``'s last dimension) before every launch, so callers cannot
+        accidentally skip the check.
+
+        Args:
+            render_data: OVRTX render data for the current frame.
+            tiled_buffer: 3D array of shape (H, W, C) holding all tiles packed into one buffer.
+            output_buffer: 4D array of shape (num_envs, H, W, C) to receive the per-env tiles, with C no
+                greater than ``tiled_buffer``'s channel count.
+
+        Raises:
+            ValueError: If ``output_buffer``'s channel count exceeds ``tiled_buffer``'s.
+        """
+        tiled_channels = tiled_buffer.shape[-1]
+        output_channels = output_buffer.shape[-1]
+        if output_channels > tiled_channels:
+            raise ValueError(
+                f"Output buffer has {output_channels} channels but the tiled buffer only has {tiled_channels};"
+                " extract_all_tiles_kernel would read out of bounds."
+            )
+
+        wp.launch(
+            kernel=extract_all_tiles_kernel,
+            dim=(render_data.num_envs, render_data.height, render_data.width),
+            inputs=[
+                tiled_buffer,
+                output_buffer,
+                render_data.num_cols,
+                render_data.width,
+                render_data.height,
+            ],
+            device=self._device,
+        )
 
     def _extract_rgba_tiles(
         self,
@@ -751,18 +780,7 @@ class OVRTXRenderer(BaseRenderer):
         if num_channels not in (3, 4):
             raise ValueError(f"Expected RGB (3 channels) or RGBA (4 channels), got {num_channels}")
 
-        wp.launch(
-            kernel=extract_all_tiles_kernel,
-            dim=(render_data.num_envs, render_data.height, render_data.width),
-            inputs=[
-                tiled_data,
-                output_buffer,
-                render_data.num_cols,
-                render_data.width,
-                render_data.height,
-            ],
-            device=self._device,
-        )
+        self._launch_extract_all_tiles(render_data, tiled_data, output_buffer)
 
     def _extract_depth_tiles(
         self, render_data: OVRTXRenderData, tiled_depth_data: wp.array, output_buffers: dict
@@ -770,18 +788,7 @@ class OVRTXRenderer(BaseRenderer):
         """Extract per-env depth tiles into output_buffers (single kernel launch)."""
         for depth_type in ["depth", "distance_to_image_plane", "distance_to_camera"]:
             if depth_type in output_buffers:
-                wp.launch(
-                    kernel=extract_all_tiles_kernel,
-                    dim=(render_data.num_envs, render_data.height, render_data.width),
-                    inputs=[
-                        tiled_depth_data,
-                        output_buffers[depth_type],
-                        render_data.num_cols,
-                        render_data.width,
-                        render_data.height,
-                    ],
-                    device=self._device,
-                )
+                self._launch_extract_all_tiles(render_data, tiled_depth_data, output_buffers[depth_type])
 
     def _extract_hdr_color_tiles(
         self, render_data: OVRTXRenderData, tiled_data: wp.array, output_buffers: dict
@@ -791,18 +798,7 @@ class OVRTXRenderer(BaseRenderer):
             return
         if tiled_data.dtype not in (wp.float16, wp.float32):
             raise TypeError(f"Unsupported OVRTX HdrColor dtype: {tiled_data.dtype}.")
-        wp.launch(
-            kernel=extract_all_tiles_kernel,
-            dim=(render_data.num_envs, render_data.height, render_data.width),
-            inputs=[
-                tiled_data,
-                output_buffers["rgb_hdr"],
-                render_data.num_cols,
-                render_data.width,
-                render_data.height,
-            ],
-            device=self._device,
-        )
+        self._launch_extract_all_tiles(render_data, tiled_data, output_buffers["rgb_hdr"])
 
     def _prepare_ppisp_hdr_source(
         self, render_data: OVRTXRenderData, tiled_data: wp.array, output_buffers: dict
@@ -896,18 +892,7 @@ class OVRTXRenderer(BaseRenderer):
         if "NormalSD" in frame.render_vars and "normals" in output_buffers:
             with frame.render_vars["NormalSD"].map(device=Device.CUDA) as mapping:
                 tiled_normals_data = wp.from_dlpack(mapping.tensor)
-                wp.launch(
-                    kernel=extract_all_tiles_kernel,
-                    dim=(render_data.num_envs, render_data.height, render_data.width),
-                    inputs=[
-                        tiled_normals_data,
-                        output_buffers["normals"],
-                        render_data.num_cols,
-                        render_data.width,
-                        render_data.height,
-                    ],
-                    device=self._device,
-                )
+                self._launch_extract_all_tiles(render_data, tiled_normals_data, output_buffers["normals"])
 
     def render(self, render_data: OVRTXRenderData) -> None:
         """Render the scene into the provided RenderData."""

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
@@ -89,9 +89,17 @@ def extract_all_tiles_kernel(
     same kernel body serves every tile-extraction case; see the :func:`warp.overload` registrations below for
     the concrete dtype pairs this is compiled for.
 
+    Precondition:
+        ``output_buffer``'s channel count (last dimension) must not exceed ``tiled_buffer``'s (the per-thread
+        channel loop below indexes ``tiled_buffer`` up to that bound). In this package, always launch this
+        kernel through ``OVRTXRenderer._launch_extract_all_tiles``, which validates this before every launch
+        instead of relying on each call site to remember to check. Passing a wider output buffer than the
+        tiled input reads out of bounds on the GPU.
+
     Args:
         tiled_buffer: 3D array of shape (H, W, C) holding all tiles packed into one buffer.
-        output_buffer: 4D array of shape (num_envs, H, W, C) to receive the per-env tiles.
+        output_buffer: 4D array of shape (num_envs, H, W, C) to receive the per-env tiles, with C no greater
+            than ``tiled_buffer``'s channel count.
         num_cols: number of columns in the tiled buffer.
         tile_width: width of each tile.
         tile_height: height of each tile.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
@@ -5,6 +5,8 @@
 
 """Warp kernels for OVRTX rendering pipeline."""
 
+from typing import Any
+
 import warp as wp
 
 
@@ -72,92 +74,24 @@ def extract_tile_from_tiled_buffer_kernel(
 
 
 @wp.kernel
-def extract_all_rgba_tiles_kernel(
-    tiled_buffer: wp.array(dtype=wp.uint8, ndim=3),  # type: ignore
-    output_buffer: wp.array(dtype=wp.uint8, ndim=4),  # type: ignore
+def extract_all_tiles_kernel(
+    tiled_buffer: wp.array(dtype=Any, ndim=3),  # type: ignore
+    output_buffer: wp.array(dtype=Any, ndim=4),  # type: ignore
     num_cols: int,
     tile_width: int,
     tile_height: int,
-    num_channels: int,
 ):
-    """Extract ALL RGBA or RGB tiles from a tiled buffer in a single kernel launch.
+    """Extract ALL tiles from a tiled buffer into per-env tiles in a single kernel launch.
+
+    Generic over the tile channel layout (RGB, RGBA, or single-channel depth) and dtype (e.g. uint8 color,
+    float32 depth/HDR color, or float16 HDR color widened to float32 on output). The channel count is taken
+    from ``output_buffer`` rather than passed explicitly, and each element is cast to the output dtype, so the
+    same kernel body serves every tile-extraction case; see the :func:`warp.overload` registrations below for
+    the concrete dtype pairs this is compiled for.
 
     Args:
-        tiled_buffer: 3D uint8 array of shape (H, W, 4) for RGBA or (H, W, 3) for RGB.
-        output_buffer: 4D uint8 array of shape (num_envs, H, W, 4) for RGBA or (num_envs, H, W, 3) for RGB.
-        num_cols: number of columns in the tiled buffer.
-        tile_width: width of each tile.
-        tile_height: height of each tile.
-        num_channels: number of channels in the output buffer. Use 3 for RGB or 4 for RGBA.
-            If a value other than 3 or 4 is given, it will be treated as 3 (RGB).
-    """
-    env_idx, y, x = wp.tid()
-    tile_x = env_idx % num_cols
-    tile_y = env_idx // num_cols
-    src_x = tile_x * tile_width + x
-    src_y = tile_y * tile_height + y
-
-    # RGB
-    output_buffer[env_idx, y, x, 0] = tiled_buffer[src_y, src_x, 0]
-    output_buffer[env_idx, y, x, 1] = tiled_buffer[src_y, src_x, 1]
-    output_buffer[env_idx, y, x, 2] = tiled_buffer[src_y, src_x, 2]
-
-    # Alpha (if it is RGBA)
-    if num_channels == 4:
-        output_buffer[env_idx, y, x, 3] = tiled_buffer[src_y, src_x, 3]
-
-
-@wp.kernel
-def extract_all_rgb_float_tiles_kernel(
-    tiled_buffer: wp.array(dtype=wp.float32, ndim=3),  # type: ignore
-    output_buffer: wp.array(dtype=wp.float32, ndim=4),  # type: ignore  (num_envs, H, W, 3)
-    num_cols: int,
-    tile_width: int,
-    tile_height: int,
-):
-    """Extract ALL RGB float tiles from a tiled buffer in a single kernel launch."""
-    env_idx, y, x = wp.tid()
-    tile_x = env_idx % num_cols
-    tile_y = env_idx // num_cols
-    src_x = tile_x * tile_width + x
-    src_y = tile_y * tile_height + y
-    output_buffer[env_idx, y, x, 0] = tiled_buffer[src_y, src_x, 0]
-    output_buffer[env_idx, y, x, 1] = tiled_buffer[src_y, src_x, 1]
-    output_buffer[env_idx, y, x, 2] = tiled_buffer[src_y, src_x, 2]
-
-
-@wp.kernel
-def extract_all_rgb_half_tiles_kernel(
-    tiled_buffer: wp.array(dtype=wp.float16, ndim=3),  # type: ignore
-    output_buffer: wp.array(dtype=wp.float32, ndim=4),  # type: ignore  (num_envs, H, W, 3)
-    num_cols: int,
-    tile_width: int,
-    tile_height: int,
-):
-    """Extract ALL RGB half tiles into float32 output in a single kernel launch."""
-    env_idx, y, x = wp.tid()
-    tile_x = env_idx % num_cols
-    tile_y = env_idx // num_cols
-    src_x = tile_x * tile_width + x
-    src_y = tile_y * tile_height + y
-    output_buffer[env_idx, y, x, 0] = wp.float32(tiled_buffer[src_y, src_x, 0])
-    output_buffer[env_idx, y, x, 1] = wp.float32(tiled_buffer[src_y, src_x, 1])
-    output_buffer[env_idx, y, x, 2] = wp.float32(tiled_buffer[src_y, src_x, 2])
-
-
-@wp.kernel
-def extract_all_depth_tiles_kernel(
-    tiled_buffer: wp.array(dtype=wp.float32, ndim=3),  # type: ignore
-    output_buffer: wp.array(dtype=wp.float32, ndim=4),  # type: ignore
-    num_cols: int,
-    tile_width: int,
-    tile_height: int,
-):
-    """Extract all depth tiles from a tiled buffer in a single kernel launch.
-
-    Args:
-        tiled_buffer: 3D float32 array of shape (H, W, 1) for depth.
-        output_buffer: 4D float32 array of shape (num_envs, H, W, 1) for depth.
+        tiled_buffer: 3D array of shape (H, W, C) holding all tiles packed into one buffer.
+        output_buffer: 4D array of shape (num_envs, H, W, C) to receive the per-env tiles.
         num_cols: number of columns in the tiled buffer.
         tile_width: width of each tile.
         tile_height: height of each tile.
@@ -167,7 +101,30 @@ def extract_all_depth_tiles_kernel(
     tile_y = env_idx // num_cols
     src_x = tile_x * tile_width + x
     src_y = tile_y * tile_height + y
-    output_buffer[env_idx, y, x, 0] = tiled_buffer[src_y, src_x, 0]
+    for channel in range(output_buffer.shape[3]):
+        output_buffer[env_idx, y, x, channel] = output_buffer.dtype(tiled_buffer[src_y, src_x, channel])
+
+
+# uint8 color tiles (e.g. RGB/RGBA, semantic segmentation).
+wp.overload(
+    extract_all_tiles_kernel,
+    [wp.array(dtype=wp.uint8, ndim=3), wp.array(dtype=wp.uint8, ndim=4), int, int, int],
+)
+# float32 tiles (e.g. depth, normals, HDR color).
+wp.overload(
+    extract_all_tiles_kernel,
+    [wp.array(dtype=wp.float32, ndim=3), wp.array(dtype=wp.float32, ndim=4), int, int, int],
+)
+# float16 tiles (e.g. HDR color), widened to a float32 output buffer.
+wp.overload(
+    extract_all_tiles_kernel,
+    [wp.array(dtype=wp.float16, ndim=3), wp.array(dtype=wp.float32, ndim=4), int, int, int],
+)
+# uint32 tiles (e.g. raw instance segmentation IDs).
+wp.overload(
+    extract_all_tiles_kernel,
+    [wp.array(dtype=wp.uint32, ndim=3), wp.array(dtype=wp.uint32, ndim=4), int, int, int],
+)
 
 
 @wp.kernel
@@ -292,23 +249,6 @@ def random_color_from_id(input_id: wp.uint32) -> wp.uint32:
         | (wp.uint32(ai) << wp.uint32(24))
     )
     return color
-
-
-@wp.kernel
-def extract_all_uint32_tiles_kernel(
-    tiled_buffer: wp.array(dtype=wp.uint32, ndim=3),  # type: ignore  (TH, TW, 1)
-    output_buffer: wp.array(dtype=wp.uint32, ndim=4),  # type: ignore  (num_envs, H, W, 1)
-    num_cols: int,
-    tile_width: int,
-    tile_height: int,
-):
-    """Extract all single-channel uint32 tiles (e.g. raw instance segmentation IDs)."""
-    env_idx, y, x = wp.tid()
-    tile_x = env_idx % num_cols
-    tile_y = env_idx // num_cols
-    src_x = tile_x * tile_width + x
-    src_y = tile_y * tile_height + y
-    output_buffer[env_idx, y, x, 0] = tiled_buffer[src_y, src_x, 0]
 
 
 @wp.kernel

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -210,6 +210,39 @@ def test_ovrtx_ppisp_hdr_source_is_cloned_to_output_device(monkeypatch):
     assert clone_calls == [(source, "cuda:0")]
 
 
+class _FakeArray:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+def test_launch_extract_all_tiles_rejects_wider_output_channels():
+    """An output wider than the tiled input would read out of bounds, so it must raise before launching."""
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._device = "cpu"
+    render_data = _make_ovrtx_render_data()
+
+    with pytest.raises(ValueError, match="out of bounds"):
+        renderer._launch_extract_all_tiles(render_data, _FakeArray((8, 16, 3)), _FakeArray((2, 8, 16, 4)))
+
+
+def test_launch_extract_all_tiles_launches_kernel_when_channels_are_compatible(monkeypatch):
+    """Equal or narrower output channel counts pass validation and reach the kernel launch."""
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._device = "cpu"
+    render_data = _make_ovrtx_render_data()
+    render_data.num_cols = 2
+
+    launch_calls = []
+    monkeypatch.setattr(wp, "launch", lambda **kwargs: launch_calls.append(kwargs))
+
+    tiled_buffer = _FakeArray((8, 16, 4))
+    output_buffer = _FakeArray((2, 8, 16, 3))
+    renderer._launch_extract_all_tiles(render_data, tiled_buffer, output_buffer)
+
+    assert len(launch_calls) == 1
+    assert launch_calls[0]["inputs"][:2] == [tiled_buffer, output_buffer]
+
+
 def test_ovrtx_read_output_is_a_no_op_after_consolidation():
     """OVRTXRenderer.read_output is a no-op once set_outputs wires up zero-copy."""
     renderer = _make_ovrtx_renderer_without_backend()

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
@@ -90,6 +90,26 @@ def _reference_extract_all_depth_tiles(
     return out
 
 
+def _reference_extract_all_uint32_tiles(
+    tiled_np: np.ndarray,
+    num_envs: int,
+    num_cols: int,
+    tile_width: int,
+    tile_height: int,
+) -> np.ndarray:
+    """NumPy reference for the uint32 (e.g. raw instance segmentation ID) case of ``extract_all_tiles_kernel``."""
+    out = np.zeros((num_envs, tile_height, tile_width, 1), dtype=np.uint32)
+    for env_idx in range(num_envs):
+        tile_x = env_idx % num_cols
+        tile_y = env_idx // num_cols
+        for y in range(tile_height):
+            for x in range(tile_width):
+                src_y = tile_y * tile_height + y
+                src_x = tile_x * tile_width + x
+                out[env_idx, y, x, 0] = tiled_np[src_y, src_x, 0]
+    return out
+
+
 def _reference_extract_all_rgba_tiles(
     tiled_np: np.ndarray,
     num_envs: int,
@@ -216,6 +236,84 @@ class TestExtractAllDepthTilesKernel:
 
         expected = _reference_extract_all_depth_tiles(tiled_np, num_envs, num_cols, tile_width, tile_height)
         np.testing.assert_allclose(output_wp.numpy(), expected, rtol=1e-6, atol=1e-6)
+
+
+class TestExtractAllUint32TilesKernel:
+    """Tests for the uint32 (e.g. raw instance segmentation ID) case of ``extract_all_tiles_kernel``."""
+
+    def test_two_by_two_tile_grid(self):
+        num_cols = 2
+        num_envs = 4
+        tile_width = 2
+        tile_height = 3
+        tiled_h = (num_envs // num_cols) * tile_height
+        tiled_w = num_cols * tile_width
+        rng = np.random.default_rng(98765)
+        tiled_np = rng.integers(0, 2**31, size=(tiled_h, tiled_w, 1), dtype=np.uint32)
+
+        tiled_wp = wp.array(tiled_np, dtype=wp.uint32, ndim=3, device=DEVICE)
+        output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 1), dtype=wp.uint32, device=DEVICE)
+
+        wp.launch(
+            kernel=extract_all_tiles_kernel,
+            dim=(num_envs, tile_height, tile_width),
+            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
+            device=DEVICE,
+        )
+        wp.synchronize()
+
+        expected = _reference_extract_all_uint32_tiles(tiled_np, num_envs, num_cols, tile_width, tile_height)
+        np.testing.assert_array_equal(output_wp.numpy(), expected)
+
+    def test_single_tile(self):
+        num_cols = 1
+        num_envs = 1
+        tile_width = 4
+        tile_height = 4
+        tiled_np = np.arange(tile_height * tile_width, dtype=np.uint32).reshape(tile_height, tile_width, 1)
+
+        tiled_wp = wp.array(tiled_np, dtype=wp.uint32, ndim=3, device=DEVICE)
+        output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 1), dtype=wp.uint32, device=DEVICE)
+
+        wp.launch(
+            kernel=extract_all_tiles_kernel,
+            dim=(num_envs, tile_height, tile_width),
+            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
+            device=DEVICE,
+        )
+        wp.synchronize()
+
+        expected = _reference_extract_all_uint32_tiles(tiled_np, num_envs, num_cols, tile_width, tile_height)
+        np.testing.assert_array_equal(output_wp.numpy(), expected)
+
+    @pytest.mark.parametrize(
+        ("num_cols", "num_envs", "tile_width", "tile_height"),
+        [
+            (3, 6, 2, 2),
+            (1, 3, 5, 1),
+            (4, 8, 1, 1),
+        ],
+    )
+    def test_various_layouts(self, num_cols, num_envs, tile_width, tile_height):
+        num_rows = (num_envs + num_cols - 1) // num_cols
+        tiled_h = num_rows * tile_height
+        tiled_w = num_cols * tile_width
+        rng = np.random.default_rng(13579)
+        tiled_np = rng.integers(0, 2**31, size=(tiled_h, tiled_w, 1), dtype=np.uint32)
+
+        tiled_wp = wp.array(tiled_np, dtype=wp.uint32, ndim=3, device=DEVICE)
+        output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 1), dtype=wp.uint32, device=DEVICE)
+
+        wp.launch(
+            kernel=extract_all_tiles_kernel,
+            dim=(num_envs, tile_height, tile_width),
+            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
+            device=DEVICE,
+        )
+        wp.synchronize()
+
+        expected = _reference_extract_all_uint32_tiles(tiled_np, num_envs, num_cols, tile_width, tile_height)
+        np.testing.assert_array_equal(output_wp.numpy(), expected)
 
 
 class TestExtractAllRgbaTilesKernel:

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
@@ -11,10 +11,7 @@ import numpy as np
 import pytest
 import warp as wp
 from isaaclab_ov.renderers.ovrtx_renderer_kernels import (
-    extract_all_depth_tiles_kernel,
-    extract_all_rgb_float_tiles_kernel,
-    extract_all_rgb_half_tiles_kernel,
-    extract_all_rgba_tiles_kernel,
+    extract_all_tiles_kernel,
     generate_random_colors_from_ids_kernel,
 )
 
@@ -142,7 +139,7 @@ def _reference_extract_all_rgb_float_tiles(
 
 
 class TestExtractAllDepthTilesKernel:
-    """Tests for ``extract_all_depth_tiles_kernel``."""
+    """Tests for the depth case of ``extract_all_tiles_kernel``."""
 
     def test_two_by_two_tile_grid(self):
         num_cols = 2
@@ -160,7 +157,7 @@ class TestExtractAllDepthTilesKernel:
         output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 1), dtype=wp.float32, device=DEVICE)
 
         wp.launch(
-            kernel=extract_all_depth_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(num_envs, tile_height, tile_width),
             inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
             device=DEVICE,
@@ -181,7 +178,7 @@ class TestExtractAllDepthTilesKernel:
         output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 1), dtype=wp.float32, device=DEVICE)
 
         wp.launch(
-            kernel=extract_all_depth_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(num_envs, tile_height, tile_width),
             inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
             device=DEVICE,
@@ -210,7 +207,7 @@ class TestExtractAllDepthTilesKernel:
         output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 1), dtype=wp.float32, device=DEVICE)
 
         wp.launch(
-            kernel=extract_all_depth_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(num_envs, tile_height, tile_width),
             inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
             device=DEVICE,
@@ -222,7 +219,7 @@ class TestExtractAllDepthTilesKernel:
 
 
 class TestExtractAllRgbaTilesKernel:
-    """Tests for ``extract_all_rgba_tiles_kernel``."""
+    """Tests for the RGB/RGBA case of ``extract_all_tiles_kernel``."""
 
     def test_two_by_two_tile_grid_rgba(self):
         num_cols = 2
@@ -244,9 +241,9 @@ class TestExtractAllRgbaTilesKernel:
         output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, num_channels), dtype=wp.uint8, device=DEVICE)
 
         wp.launch(
-            kernel=extract_all_rgba_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(num_envs, tile_height, tile_width),
-            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height, num_channels],
+            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
             device=DEVICE,
         )
         wp.synchronize()
@@ -268,9 +265,9 @@ class TestExtractAllRgbaTilesKernel:
         output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, num_channels), dtype=wp.uint8, device=DEVICE)
 
         wp.launch(
-            kernel=extract_all_rgba_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(num_envs, tile_height, tile_width),
-            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height, num_channels],
+            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
             device=DEVICE,
         )
         wp.synchronize()
@@ -280,8 +277,8 @@ class TestExtractAllRgbaTilesKernel:
         )
         np.testing.assert_array_equal(output_wp.numpy(), expected)
 
-    def test_num_channels_not_four_skips_alpha(self):
-        """Values other than 4 use the RGB-only path (same as RGB tiled input)."""
+    def test_three_channel_output_skips_alpha(self):
+        """A 3-channel output buffer only copies RGB, even if the tiled input has an alpha channel."""
         num_cols = 1
         num_envs = 1
         tile_width = 2
@@ -298,14 +295,14 @@ class TestExtractAllRgbaTilesKernel:
         output_wp = wp.zeros(shape=(1, 2, 2, 3), dtype=wp.uint8, device=DEVICE)
 
         wp.launch(
-            kernel=extract_all_rgba_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(1, tile_height, tile_width),
-            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height, 2],
+            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
             device=DEVICE,
         )
         wp.synchronize()
 
-        expected = _reference_extract_all_rgba_tiles(tiled_np, num_envs, num_cols, tile_width, tile_height, 2)
+        expected = _reference_extract_all_rgba_tiles(tiled_np, num_envs, num_cols, tile_width, tile_height, 3)
         np.testing.assert_array_equal(output_wp.numpy(), expected)
 
     @pytest.mark.parametrize(
@@ -333,9 +330,9 @@ class TestExtractAllRgbaTilesKernel:
         )
 
         wp.launch(
-            kernel=extract_all_rgba_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(num_envs, tile_height, tile_width),
-            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height, num_channels],
+            inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
             device=DEVICE,
         )
         wp.synchronize()
@@ -347,7 +344,7 @@ class TestExtractAllRgbaTilesKernel:
 
 
 class TestExtractAllRgbFloatTilesKernel:
-    """Tests for ``extract_all_rgb_float_tiles_kernel`` used by OVRTX HdrColor."""
+    """Tests for the HdrColor (float32/float16) case of ``extract_all_tiles_kernel``."""
 
     def test_two_by_two_tile_grid(self):
         num_cols = 2
@@ -367,7 +364,7 @@ class TestExtractAllRgbFloatTilesKernel:
         output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 3), dtype=wp.float32, device=DEVICE)
 
         wp.launch(
-            kernel=extract_all_rgb_float_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(num_envs, tile_height, tile_width),
             inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
             device=DEVICE,
@@ -395,7 +392,7 @@ class TestExtractAllRgbFloatTilesKernel:
         output_wp = wp.zeros(shape=(num_envs, tile_height, tile_width, 3), dtype=wp.float32, device=DEVICE)
 
         wp.launch(
-            kernel=extract_all_rgb_half_tiles_kernel,
+            kernel=extract_all_tiles_kernel,
             dim=(num_envs, tile_height, tile_width),
             inputs=[tiled_wp, output_wp, num_cols, tile_width, tile_height],
             device=DEVICE,


### PR DESCRIPTION
# Description

Originally flagged on https://github.com/isaac-sim/IsaacLab/pull/6312/changes and https://github.com/isaac-sim/IsaacLab/pull/6317/changes

extract_all_rgba_tiles_kernel, extract_all_rgb_float_tiles_kernel, extract_all_rgb_half_tiles_kernel, and extract_all_depth_tiles_kernel, and extract_all_uint32_tiles_kernel were near-identical copies differing only in dtype and channel count. Replace them with a single generic extract_all_tiles_kernel, using Warp's Any dtype plus wp.overload to compile the concrete uint8, float32, and float16-to-float32 variants, and array.dtype() to cast each element to the output type.

Channel count is now read from output_buffer.shape[3] instead of being passed as an explicit num_channels argument, so callers no longer need to branch on dtype to pick a kernel.
## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Refactor / Quality of life

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

