### PR TITLE
WIP: Adding support to our OVRTX renderer integration for outputting idToLabels/idToSemantics in the segmentation annotators

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovrtx-id-to-labels-and-semantics.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-id-to-labels-and-semantics.rst
@@ -1,0 +1,8 @@
+Added
+^^^^^
+
+* Added ``idToLabels``/``idToSemantics`` info dict support to the OVRTX renderer for the
+  ``semantic_segmentation``, ``instance_segmentation_fast``, and ``instance_id_segmentation_fast``
+  data types, via :mod:`isaaclab_ov.renderers.annotator_utils`, which decodes OVRTX's
+  renderer-internal ``SemanticIdMap``, ``StableIdMap``, ``StableIdSemanticIdMap``, and
+  ``InstanceMap`` AOVs.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/annotator_utils.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Decode OVRTX's renderer-internal id/label AOVs into annotator ``info`` dicts.
+
+OVRTX does not run omni.replicator's OGN annotator graph, so the ``idToLabels``/
+``idToSemantics`` dicts that graph produces CPU-side for ``semantic_segmentation``,
+``instance_segmentation_fast``, and ``instance_id_segmentation_fast`` have to be
+reconstructed here from OVRTX's raw render vars:
+
+* ``SemanticIdMap``            -- ``{semantic_id: label}``.
+* ``StableIdMap``              -- ``{stable_id: prim_path}``, keyed on the full
+  128-bit stable id, not just its first 32-bit word.
+* ``StableIdSemanticIdMap``    -- ``{stable_id: semantic_id}`` entries, stored in
+  the same order as the compacted per-frame ids used by
+  ``NonStableInstanceSegmentation`` (see :func:`resolve_instance_segmentation_labels`).
+* ``InstanceMap``              -- for each renderer instance id used by
+  ``InstanceSegmentationSD``, its position in ``StableIdSemanticIdMap`` (see
+  :func:`resolve_instance_id_segmentation_labels`).
+
+The ``instance_segmentation_fast`` join mirrors
+``OgnInstanceSegmentationPostRender::computeCuda`` (``omni.replicator.nv``)
+exactly, verified against its source. The ``instance_id_segmentation_fast`` join
+(via ``InstanceMap``/``InstanceSegmentationSD``) was reverse-engineered
+empirically -- no OGN source for the corresponding post-render node was
+available -- by cross-referencing co-located pixels against the
+source-verified ``instance_segmentation_fast`` join, across render passes with
+different renderer-assigned id orderings.
+
+These render vars are not part of ovrtx's documented/supported output table --
+they are internal renderer AOVs that happen to use the same RenderVar/sourceName
+mechanism as the supported ones. Treat their binary layout as unstable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# A 128-bit stable id, stored as four little-endian uint32 words. Only the
+# first word is unique enough for casual inspection, but the full tuple must
+# be used as a dict key -- two different stable ids can share their first word.
+StableId = tuple[int, int, int, int]
+
+_INSTANCE_MAP_SENTINEL = 0xFFFFFFFF
+"""``InstanceMap`` entry value marking a renderer instance id with no semantic instance (e.g. UNLABELLED)."""
+
+_BACKGROUND_ID = 0
+_UNLABELLED_ID = 1
+
+# Shared binary layout for SemanticIdMap (id -> label) and StableIdMap
+# (id -> prim path): a packed array of {id[4], label_length, label_offset}
+# entries (128-bit id as four uint32 words), followed by a string table,
+# followed by a trailing 4-byte entry count.
+_ID_STRING_ENTRY_DTYPE = np.dtype(
+    [("id", "<u4", (4,)), ("label_length", "<u4"), ("label_offset", "<u4")]
+)
+
+# StableIdSemanticIdMap entries are fixed-size 32-byte {stable_id[4], semantic_id[4]}
+# records with no trailing count or string table -- the entry count is simply
+# buffer_size / 32.
+_STABLE_ID_SEMANTIC_ID_ENTRY_DTYPE = np.dtype(
+    [("stable_id", "<u4", (4,)), ("semantic_id", "<u4", (4,))]
+)
+
+
+def clean_label(label: str) -> str:
+    """Match ``OgnInstanceSegmentationPostRender::cleanLabel``.
+
+    Drops semicolons and the whitespace immediately following ``:``/``,``, then
+    trims trailing whitespace, matching the label formatting
+    ``instance_segmentation_fast`` applies before it lands in ``idToSemantics``.
+
+    Args:
+        label: Raw semantic label string, as decoded from ``SemanticIdMap``.
+
+    Returns:
+        The cleaned label.
+    """
+    result = []
+    skip_whitespace = False
+    for c in label:
+        if c == ";":
+            continue
+        if skip_whitespace:
+            if c in (" ", "\t"):
+                continue
+            skip_whitespace = False
+        if c in (":", ","):
+            result.append(c)
+            skip_whitespace = True
+            continue
+        result.append(c)
+    return "".join(result).rstrip(" \t\r\n")
+
+
+def decode_id_string_entries(tensor: np.ndarray) -> list[tuple[StableId, str]]:
+    """Decode a ``SemanticIdMap``/``StableIdMap`` payload into ``[(id, label), ...]``.
+
+    Order-preserving: entry position in the returned list matches its position
+    in the underlying buffer, which :func:`resolve_instance_segmentation_labels`
+    and :func:`resolve_instance_id_segmentation_labels` index into directly.
+
+    Args:
+        tensor: Raw ``SemanticIdMap``/``StableIdMap`` render var, mapped to host memory.
+
+    Returns:
+        A list of ``(id, label)`` pairs in buffer order.
+    """
+    data = np.ascontiguousarray(tensor).view(np.uint8).reshape(-1)
+    if data.size < 4:
+        return []
+
+    num_entries = int.from_bytes(data[-4:].tobytes(), byteorder="little")
+    if num_entries <= 0:
+        return []
+    entries_size = num_entries * _ID_STRING_ENTRY_DTYPE.itemsize
+    if entries_size > data.size - 4:
+        return []
+
+    entries = data[:entries_size].view(_ID_STRING_ENTRY_DTYPE).reshape(num_entries)
+    result: list[tuple[StableId, str]] = []
+    for entry in entries:
+        entry_id = tuple(int(w) for w in entry["id"])
+        label_offset = int(entry["label_offset"])
+        label_length = int(entry["label_length"])
+        label_end = label_offset + label_length
+        if label_end > data.size:
+            continue
+        label = data[label_offset:label_end].tobytes().decode("utf-8", "replace")
+        result.append((entry_id, label.rstrip("\x00").rstrip()))
+    return result
+
+
+def decode_id_string_map(tensor: np.ndarray) -> dict[int, str]:
+    """Decode a ``SemanticIdMap``/``StableIdMap`` payload into ``{id[0]: label}``.
+
+    Args:
+        tensor: Raw ``SemanticIdMap``/``StableIdMap`` render var, mapped to host memory.
+
+    Returns:
+        A dict keyed on each entry's first 32-bit id word. Sufficient for
+        ``SemanticIdMap`` (semantic ids fit in 32 bits), but collapses distinct
+        ``StableIdMap`` entries that happen to share their first word -- use
+        :func:`decode_id_string_entries` there instead.
+    """
+    return {entry_id[0]: label for entry_id, label in decode_id_string_entries(tensor)}
+
+
+def decode_stable_id_semantic_id_entries(tensor: np.ndarray) -> list[tuple[StableId, int]]:
+    """Decode a ``StableIdSemanticIdMap`` payload into ``[(stable_id, semantic_id), ...]``.
+
+    Order-preserving, see :func:`decode_id_string_entries`.
+
+    Args:
+        tensor: Raw ``StableIdSemanticIdMap`` render var, mapped to host memory.
+
+    Returns:
+        A list of ``(stable_id, semantic_id)`` pairs in buffer order.
+    """
+    data = np.ascontiguousarray(tensor).view(np.uint8).reshape(-1)
+    itemsize = _STABLE_ID_SEMANTIC_ID_ENTRY_DTYPE.itemsize
+    num_entries = data.size // itemsize
+    if num_entries <= 0:
+        return []
+
+    entries = data[: num_entries * itemsize].view(_STABLE_ID_SEMANTIC_ID_ENTRY_DTYPE)
+    return [(tuple(int(w) for w in e["stable_id"]), int(e["semantic_id"][0])) for e in entries]
+
+
+def decode_instance_map(tensor: np.ndarray) -> list[int]:
+    """Decode an ``InstanceMap`` payload into a flat list of ``StableIdSemanticIdMap`` positions.
+
+    ``InstanceMap`` is a flat ``uint32`` array with no header or trailing count:
+    entry ``i`` gives the position in ``StableIdSemanticIdMap`` for renderer
+    instance id ``i + 1`` as used by ``InstanceSegmentationSD`` (id ``0`` is
+    always BACKGROUND and never indexes into it). A value of
+    :data:`_INSTANCE_MAP_SENTINEL` marks an id with no semantic instance (e.g.
+    the reserved UNLABELLED id ``1``).
+
+    Args:
+        tensor: Raw ``InstanceMap`` render var, mapped to host memory.
+
+    Returns:
+        The flat list of ``uint32`` entries, indexed by ``renderer_instance_id - 1``.
+    """
+    data = np.ascontiguousarray(tensor).view(np.uint8).reshape(-1)
+    if data.size % 4 != 0:
+        return []
+    return data.view(np.uint32).tolist()
+
+
+def resolve_semantic_segmentation_labels(semantic_id_map_tensor: np.ndarray) -> dict[int, str]:
+    """Build ``idToLabels`` for ``semantic_segmentation`` from ``SemanticIdMap``.
+
+    ``SemanticSegmentation`` pixel values are semantic ids directly (no
+    positional indirection): ``SemanticIdMap``'s ``id`` field already equals
+    the pixel value it labels.
+
+    Args:
+        semantic_id_map_tensor: Raw ``SemanticIdMap`` render var, mapped to host memory.
+
+    Returns:
+        ``{semantic_id: label}``, including the reserved ``0: "BACKGROUND"`` and
+        ``1: "UNLABELLED"`` entries.
+    """
+    id_to_labels = {_BACKGROUND_ID: "BACKGROUND", _UNLABELLED_ID: "UNLABELLED"}
+    for semantic_id, label in decode_id_string_entries(semantic_id_map_tensor):
+        id_to_labels[semantic_id[0]] = clean_label(label)
+    return id_to_labels
+
+
+def resolve_instance_segmentation_labels(
+    pixel_ids: set[int],
+    stable_id_semantic_id_map_tensor: np.ndarray,
+    semantic_id_map_tensor: np.ndarray,
+    stable_id_map_tensor: np.ndarray,
+) -> tuple[dict[int, str], dict[int, str]]:
+    """Build ``idToLabels``/``idToSemantics`` for ``instance_segmentation_fast``.
+
+    Replicates ``OgnInstanceSegmentationPostRender::computeCuda``
+    (``omni.replicator.nv``): for each ``NonStableInstanceSegmentation`` pixel
+    value ``v >= 2``, ``v - 2`` is a direct index (not a value match) into
+    ``StableIdSemanticIdMap``; that entry's ``semantic_id - 2`` is, in turn, a
+    direct index into ``SemanticIdMap``. Only the final ``stable_id -> prim_path``
+    step is a real hashed lookup, keyed on the full 128-bit stable id.
+
+    Args:
+        pixel_ids: Unique pixel values observed in ``NonStableInstanceSegmentation``.
+        stable_id_semantic_id_map_tensor: Raw ``StableIdSemanticIdMap`` render var, mapped to host memory.
+        semantic_id_map_tensor: Raw ``SemanticIdMap`` render var, mapped to host memory.
+        stable_id_map_tensor: Raw ``StableIdMap`` render var, mapped to host memory.
+
+    Returns:
+        A ``(id_to_labels, id_to_semantics)`` tuple, each covering exactly the
+        ids present in ``pixel_ids`` plus the reserved ``0``/``1`` entries.
+    """
+    stable_id_semantic_id_entries = decode_stable_id_semantic_id_entries(stable_id_semantic_id_map_tensor)
+    semantic_id_entries = decode_id_string_entries(semantic_id_map_tensor)
+    stable_id_to_prim_path = dict(decode_id_string_entries(stable_id_map_tensor))
+
+    id_to_labels = {_BACKGROUND_ID: "BACKGROUND", _UNLABELLED_ID: "UNLABELLED"}
+    id_to_semantics = {_BACKGROUND_ID: "class:BACKGROUND", _UNLABELLED_ID: "class:UNLABELLED"}
+
+    for pixel_id in pixel_ids:
+        if pixel_id < 2:
+            continue
+
+        stable_id_semantic_idx = pixel_id - 2
+        if stable_id_semantic_idx >= len(stable_id_semantic_id_entries):
+            continue
+        stable_id, semantic_id = stable_id_semantic_id_entries[stable_id_semantic_idx]
+
+        semantic_idx = semantic_id - 2
+        if semantic_id < 2 or semantic_idx >= len(semantic_id_entries):
+            continue
+        _, raw_label = semantic_id_entries[semantic_idx]
+
+        id_to_labels[pixel_id] = stable_id_to_prim_path.get(stable_id, "UNLABELLED")
+        id_to_semantics[pixel_id] = clean_label(raw_label)
+
+    return id_to_labels, id_to_semantics
+
+
+def resolve_instance_id_segmentation_labels(
+    pixel_ids: set[int],
+    instance_map_tensor: np.ndarray,
+    stable_id_semantic_id_map_tensor: np.ndarray,
+    stable_id_map_tensor: np.ndarray,
+) -> dict[int, str]:
+    """Build ``idToLabels`` for ``instance_id_segmentation_fast``.
+
+    For each ``InstanceSegmentationSD`` pixel value ``v >= 2``,
+    ``InstanceMap[v - 1]`` gives the position of that instance in
+    ``StableIdSemanticIdMap`` (see :func:`decode_instance_map`); the entry's
+    stable id is then looked up in ``StableIdMap`` (hashed on the full 128-bit
+    id) to get the prim path.
+
+    Args:
+        pixel_ids: Unique pixel values observed in ``InstanceSegmentationSD``.
+        instance_map_tensor: Raw ``InstanceMap`` render var, mapped to host memory.
+        stable_id_semantic_id_map_tensor: Raw ``StableIdSemanticIdMap`` render var, mapped to host memory.
+        stable_id_map_tensor: Raw ``StableIdMap`` render var, mapped to host memory.
+
+    Returns:
+        ``{instance_id: prim_path}``, covering exactly the ids present in
+        ``pixel_ids`` plus the reserved ``0``/``1`` entries.
+    """
+    instance_map = decode_instance_map(instance_map_tensor)
+    stable_id_semantic_id_entries = decode_stable_id_semantic_id_entries(stable_id_semantic_id_map_tensor)
+    stable_id_to_prim_path = dict(decode_id_string_entries(stable_id_map_tensor))
+
+    id_to_labels = {_BACKGROUND_ID: "BACKGROUND", _UNLABELLED_ID: "UNLABELLED"}
+
+    for pixel_id in pixel_ids:
+        if pixel_id < 2:
+            continue
+
+        instance_map_idx = pixel_id - 1
+        if instance_map_idx >= len(instance_map):
+            continue
+        stable_id_semantic_idx = instance_map[instance_map_idx]
+        if stable_id_semantic_idx == _INSTANCE_MAP_SENTINEL:
+            id_to_labels[pixel_id] = "UNLABELLED"
+            continue
+        if stable_id_semantic_idx >= len(stable_id_semantic_id_entries):
+            continue
+
+        stable_id, _ = stable_id_semantic_id_entries[stable_id_semantic_idx]
+        id_to_labels[pixel_id] = stable_id_to_prim_path.get(stable_id, "UNLABELLED")
+
+    return id_to_labels

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -15,6 +15,11 @@ How it fits together
 - **ovrtx_renderer_kernels.py**: Warp GPU kernels for OVRTX rendering pipeline.
 
 - **ovrtx_usd.py**: USD helpers for OVRTX: render var config, camera injection, etc.
+
+- **annotator_utils.py**: Decodes OVRTX's renderer-internal id/label AOVs (``SemanticIdMap``,
+  ``StableIdMap``, ``StableIdSemanticIdMap``, ``InstanceMap``) into the ``idToLabels``/
+  ``idToSemantics`` info dicts for ``semantic_segmentation``, ``instance_segmentation_fast``,
+  and ``instance_id_segmentation_fast``.
 """
 
 from __future__ import annotations
@@ -57,6 +62,11 @@ from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.warp.warp_math import convert_camera_frame_orientation_convention_wp
 
+from .annotator_utils import (
+    resolve_instance_id_segmentation_labels,
+    resolve_instance_segmentation_labels,
+    resolve_semantic_segmentation_labels,
+)
 from .ovrtx_renderer_cfg import OVRTXRendererCfg
 from .ovrtx_renderer_kernels import (
     create_camera_transforms_kernel,
@@ -217,6 +227,9 @@ class OVRTXRenderData:
         self.num_cols = math.ceil(math.sqrt(self.num_envs))
         self.num_rows = math.ceil(self.num_envs / self.num_cols)
         self.warp_buffers: dict[str, wp.array] = {}
+        # idToLabels/idToSemantics info dicts for segmentation data types, populated
+        # each render() and copied into CameraData.info by read_output().
+        self.renderer_info: dict[str, dict] = {}
         # Post-render PPISP pipeline composed when ``spec.cfg.isp_cfg`` is set.
         # ``isp_cfg`` is already fully normalized by ``prepare_cameras`` by the time it reaches here.
         self.ppisp_pipeline: PpispPipeline | None = None
@@ -645,15 +658,17 @@ class OVRTXRenderer(BaseRenderer):
         render_data: OVRTXRenderData,
         camera_data: CameraData,
     ) -> None:
-        """No-op: outputs already live in the caller's torch storage.
+        """Copy segmentation info dicts collected during :meth:`render` into ``camera_data.info``.
 
-        :meth:`set_outputs` wraps each ``camera_data.output`` tensor as a
-        zero-copy warp array stored in ``render_data.warp_buffers``, and
-        :meth:`render` writes the rendered tiles directly into those warp
-        arrays. There is therefore nothing to copy here.
+        Pixel data already lives in the caller's torch storage: :meth:`set_outputs`
+        wraps each ``camera_data.output`` tensor as a zero-copy warp array stored in
+        ``render_data.warp_buffers``, and :meth:`render` writes the rendered tiles
+        directly into those warp arrays.
 
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.read_output`.
         """
+        for output_name, info in render_data.renderer_info.items():
+            camera_data.info[output_name] = info
 
     def _generate_random_colors_from_ids(self, input_ids: wp.array, output_colors: wp.array | None) -> wp.array:
         """Generate pseudo-random RGBA colors from uint32 IDs into a reusable output buffer.
@@ -677,6 +692,70 @@ class OVRTXRenderer(BaseRenderer):
             device=self._device,
         )
         return output_colors
+
+    def _map_render_var_cpu(self, frame, name: str) -> np.ndarray | None:
+        """Map render var ``name`` to CPU memory and copy it out as NumPy, or ``None`` if absent."""
+        if name not in frame.render_vars:
+            return None
+        with frame.render_vars[name].map(device=Device.CPU) as mapping:
+            return np.from_dlpack(mapping.tensor).copy()
+
+    def _update_segmentation_info(
+        self,
+        render_data: OVRTXRenderData,
+        frame,
+        buffer_key: str,
+        tiled_data: wp.array,
+    ) -> None:
+        """Populate ``render_data.renderer_info[buffer_key]`` with ``idToLabels``/``idToSemantics``.
+
+        Decodes OVRTX's renderer-internal id/label maps via
+        :mod:`isaaclab_ov.renderers.annotator_utils`. No-ops when the required
+        render vars were not authored on the render product (e.g. because
+        :func:`isaaclab_ov.renderers.ovrtx_usd.get_render_var_configs` was not
+        asked for this data type).
+
+        Args:
+            render_data: OVRTX render data for the current frame.
+            frame: OVRTX frame holding the mapped render vars.
+            buffer_key: Data type key, one of ``"semantic_segmentation"``,
+                ``"instance_segmentation_fast"``, ``"instance_id_segmentation_fast"``.
+            tiled_data: Raw (pre-colorize) uint32 tiled render var, used to find the
+                unique pixel ids on screen for the instance (id) segmentation joins.
+        """
+        if buffer_key == "semantic_segmentation":
+            semantic_id_map = self._map_render_var_cpu(frame, "SemanticIdMap")
+            if semantic_id_map is not None:
+                render_data.renderer_info[buffer_key] = {
+                    "idToLabels": resolve_semantic_segmentation_labels(semantic_id_map)
+                }
+            return
+
+        if buffer_key not in ("instance_segmentation_fast", "instance_id_segmentation_fast"):
+            return
+
+        stable_id_map = self._map_render_var_cpu(frame, "StableIdMap")
+        stable_id_semantic_id_map = self._map_render_var_cpu(frame, "StableIdSemanticIdMap")
+        if stable_id_map is None or stable_id_semantic_id_map is None:
+            return
+        pixel_ids = {int(v) for v in torch.unique(wp.to_torch(tiled_data)).tolist()}
+
+        if buffer_key == "instance_segmentation_fast":
+            semantic_id_map = self._map_render_var_cpu(frame, "SemanticIdMap")
+            if semantic_id_map is None:
+                return
+            id_to_labels, id_to_semantics = resolve_instance_segmentation_labels(
+                pixel_ids, stable_id_semantic_id_map, semantic_id_map, stable_id_map
+            )
+            render_data.renderer_info[buffer_key] = {"idToLabels": id_to_labels, "idToSemantics": id_to_semantics}
+        else:
+            instance_map = self._map_render_var_cpu(frame, "InstanceMap")
+            if instance_map is None:
+                return
+            id_to_labels = resolve_instance_id_segmentation_labels(
+                pixel_ids, instance_map, stable_id_semantic_id_map, stable_id_map
+            )
+            render_data.renderer_info[buffer_key] = {"idToLabels": id_to_labels}
 
     def _process_id_segmentation_render_var(
         self,
@@ -709,6 +788,8 @@ class OVRTXRenderer(BaseRenderer):
             if tiled_data.dtype != wp.uint32:
                 return
 
+            self._update_segmentation_info(render_data, frame, buffer_key, tiled_data)
+
             if colorize:
                 color_buffer = self._generate_random_colors_from_ids(
                     tiled_data, self._output_id_color_buffers.get(buffer_key)
@@ -724,9 +805,14 @@ class OVRTXRenderer(BaseRenderer):
                 self._extract_rgba_tiles(render_data, tiled_data, output_buffers, buffer_key)
             else:
                 # Non-colorized: ensure (TH, TW, 1) shape for the uint32 extraction kernel.
+                # Warp's torch interop does not support the torch.uint32 dtype directly
+                # (see warp._src.torch.dtype_from_torch), so bit-reinterpret through the
+                # compatible torch.int32 view before wrapping back up as wp.uint32.
                 data_torch = wp.to_torch(tiled_data)
                 if data_torch.dim() == 2:
                     data_torch = data_torch.unsqueeze(-1)
+                if data_torch.dtype == torch.uint32:
+                    data_torch = data_torch.view(torch.int32)
                 tiled_data = wp.from_torch(data_torch, dtype=wp.uint32)
                 wp.launch(
                     kernel=extract_all_uint32_tiles_kernel,

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -66,13 +66,35 @@ def get_render_var_configs(data_types: list[str]) -> list[tuple[str, str, str]]:
     plus ``HdrColor`` when both ``"rgb"`` (or ``"rgba"``) and ``"rgb_hdr"`` are
     in ``data_types`` so PPISP can consume the HDR AOV alongside the LDR
     destination on the same render product. Other multi-AOV combinations are
-    not supported.
+    not supported, except for the renderer-internal id/label maps below.
+
+    ``semantic_segmentation``, ``instance_segmentation_fast``, and
+    ``instance_id_segmentation_fast`` additionally pull in the renderer-internal
+    maps :mod:`isaaclab_ov.renderers.annotator_utils` decodes into the
+    ``idToLabels``/``idToSemantics`` info dicts for those data types.
     """
     data_types = data_types if data_types else ["rgb"]
     render_vars: list[tuple[str, str, str]] = [get_render_var_config(data_types)]
+    seen_names = {render_vars[0][1]}
+
+    def _add(name: str) -> None:
+        if name in seen_names:
+            return
+        seen_names.add(name)
+        render_vars.append((f"/Render/Vars/{name}", name, name))
+
     use_rgb = any(dt in ["rgb", "rgba"] for dt in data_types)
     if use_rgb and "rgb_hdr" in data_types:
-        render_vars.append(("/Render/Vars/HdrColor", "HdrColor", "HdrColor"))
+        _add("HdrColor")
+
+    if "semantic_segmentation" in data_types or "instance_segmentation_fast" in data_types:
+        _add("SemanticIdMap")
+    if "instance_segmentation_fast" in data_types or "instance_id_segmentation_fast" in data_types:
+        _add("StableIdMap")
+        _add("StableIdSemanticIdMap")
+    if "instance_id_segmentation_fast" in data_types:
+        _add("InstanceMap")
+
     return render_vars
 
 

--- a/source/isaaclab_ov/test/test_annotator_utils.py
+++ b/source/isaaclab_ov/test/test_annotator_utils.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for OVRTX annotator id/label decoding, using synthetic render var buffers.
+
+These construct the raw byte layouts by hand (no GPU/ovrtx runtime required) to
+pin down the binary formats documented in ``annotator_utils.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+
+_REQUIRED_MODULES = ("isaaclab_ov",)
+_MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
+
+pytestmark = [
+    pytest.mark.isaacsim_ci,
+    pytest.mark.skipif(
+        bool(_MISSING_MODULES),
+        reason=f"requires optional modules: {', '.join(_MISSING_MODULES)}",
+    ),
+]
+
+if not _MISSING_MODULES:
+    from isaaclab_ov.renderers.annotator_utils import (  # noqa: E402
+        clean_label,
+        decode_id_string_entries,
+        decode_id_string_map,
+        decode_instance_map,
+        decode_stable_id_semantic_id_entries,
+        resolve_instance_id_segmentation_labels,
+        resolve_instance_segmentation_labels,
+        resolve_semantic_segmentation_labels,
+    )
+else:
+    clean_label = None
+    decode_id_string_entries = None
+    decode_id_string_map = None
+    decode_instance_map = None
+    decode_stable_id_semantic_id_entries = None
+    resolve_instance_id_segmentation_labels = None
+    resolve_instance_segmentation_labels = None
+    resolve_semantic_segmentation_labels = None
+
+
+def _build_id_string_buffer(entries: list[tuple[tuple[int, int, int, int], str]]) -> np.ndarray:
+    """Build a raw ``SemanticIdMap``/``StableIdMap`` buffer from ``(id, label)`` entries."""
+    entry_dtype = np.dtype([("id", "<u4", (4,)), ("label_length", "<u4"), ("label_offset", "<u4")])
+    header_size = len(entries) * entry_dtype.itemsize
+
+    labels_bytes = b""
+    header = np.zeros(len(entries), dtype=entry_dtype)
+    for i, (entry_id, label) in enumerate(entries):
+        label_bytes = label.encode("utf-8")
+        header[i]["id"] = entry_id
+        header[i]["label_length"] = len(label_bytes)
+        header[i]["label_offset"] = header_size + len(labels_bytes)
+        labels_bytes += label_bytes
+
+    trailing_count = np.array([len(entries)], dtype="<u4")
+    return np.frombuffer(header.tobytes() + labels_bytes + trailing_count.tobytes(), dtype=np.uint8)
+
+
+def _build_stable_id_semantic_id_buffer(entries: list[tuple[tuple[int, int, int, int], int]]) -> np.ndarray:
+    """Build a raw ``StableIdSemanticIdMap`` buffer from ``(stable_id, semantic_id)`` entries."""
+    entry_dtype = np.dtype([("stable_id", "<u4", (4,)), ("semantic_id", "<u4", (4,))])
+    array = np.zeros(len(entries), dtype=entry_dtype)
+    for i, (stable_id, semantic_id) in enumerate(entries):
+        array[i]["stable_id"] = stable_id
+        array[i]["semantic_id"][0] = semantic_id
+    return np.frombuffer(array.tobytes(), dtype=np.uint8)
+
+
+def _build_instance_map_buffer(values: list[int]) -> np.ndarray:
+    """Build a raw ``InstanceMap`` buffer: a flat ``uint32`` array, no header/trailing count."""
+    return np.array(values, dtype="<u4").view(np.uint8)
+
+
+def _sid(word0: int) -> tuple[int, int, int, int]:
+    """Build a stable-id-shaped tuple, distinguishable by its first word only."""
+    return (word0, 0, 0, 0)
+
+
+class Test_CleanLabel:
+    def test_strips_semicolons_and_post_delimiter_whitespace(self):
+        assert clean_label("instance: cone_01; class: cone;") == "instance:cone_01 class:cone"
+
+    def test_leaves_plain_label_unchanged(self):
+        assert clean_label("class:cube") == "class:cube"
+
+
+class Test_DecodeIdStringEntries:
+    def test_round_trips_multiple_entries(self):
+        buffer = _build_id_string_buffer([(_sid(2), "class:cube"), (_sid(3), "class:sphere")])
+        entries = decode_id_string_entries(buffer)
+        assert entries == [(_sid(2), "class:cube"), (_sid(3), "class:sphere")]
+
+    def test_empty_buffer_returns_empty_list(self):
+        assert decode_id_string_entries(np.zeros(0, dtype=np.uint8)) == []
+
+    def test_decode_id_string_map_keys_on_first_word(self):
+        buffer = _build_id_string_buffer([(_sid(2), "class:cube"), (_sid(3), "class:sphere")])
+        assert decode_id_string_map(buffer) == {2: "class:cube", 3: "class:sphere"}
+
+
+class Test_DecodeStableIdSemanticIdEntries:
+    def test_round_trips_multiple_entries(self):
+        buffer = _build_stable_id_semantic_id_buffer([(_sid(1000), 2), (_sid(2000), 3)])
+        assert decode_stable_id_semantic_id_entries(buffer) == [(_sid(1000), 2), (_sid(2000), 3)]
+
+    def test_empty_buffer_returns_empty_list(self):
+        assert decode_stable_id_semantic_id_entries(np.zeros(0, dtype=np.uint8)) == []
+
+
+class Test_DecodeInstanceMap:
+    def test_returns_flat_uint32_list(self):
+        buffer = _build_instance_map_buffer([0xFFFFFFFF, 0, 2, 1])
+        assert decode_instance_map(buffer) == [0xFFFFFFFF, 0, 2, 1]
+
+    def test_odd_byte_count_returns_empty_list(self):
+        assert decode_instance_map(np.zeros(3, dtype=np.uint8)) == []
+
+
+class Test_ResolveSemanticSegmentationLabels:
+    def test_includes_reserved_and_decoded_ids(self):
+        semantic_id_map = _build_id_string_buffer([(_sid(2), "class:cube"), (_sid(3), "class: sphere;")])
+        id_to_labels = resolve_semantic_segmentation_labels(semantic_id_map)
+        assert id_to_labels == {0: "BACKGROUND", 1: "UNLABELLED", 2: "class:cube", 3: "class:sphere"}
+
+
+class Test_ResolveInstanceSegmentationLabels:
+    def test_join_matches_ogn_instance_segmentation_post_render(self):
+        # Two instances: pixel 2 -> StableIdSemanticIdMap[0] -> semantic id 2 -> SemanticIdMap[0]="class:cube".
+        # pixel 3 -> StableIdSemanticIdMap[1] -> semantic id 3 -> SemanticIdMap[1]="class:sphere".
+        stable_id_semantic_id_map = _build_stable_id_semantic_id_buffer([(_sid(1000), 2), (_sid(2000), 3)])
+        semantic_id_map = _build_id_string_buffer([(_sid(2), "class:cube"), (_sid(3), "class: sphere;")])
+        stable_id_map = _build_id_string_buffer([(_sid(1000), "/World/Cube"), (_sid(2000), "/World/Sphere")])
+
+        id_to_labels, id_to_semantics = resolve_instance_segmentation_labels(
+            {0, 1, 2, 3}, stable_id_semantic_id_map, semantic_id_map, stable_id_map
+        )
+
+        assert id_to_labels == {0: "BACKGROUND", 1: "UNLABELLED", 2: "/World/Cube", 3: "/World/Sphere"}
+        assert id_to_semantics == {0: "class:BACKGROUND", 1: "class:UNLABELLED", 2: "class:cube", 3: "class:sphere"}
+
+    def test_unmatched_stable_id_falls_back_to_unlabelled(self):
+        # StableIdSemanticIdMap references a stable id absent from StableIdMap
+        # (e.g. a second instance sharing another's semantic label, per the
+        # real scene's "two prims, one class label" case).
+        stable_id_semantic_id_map = _build_stable_id_semantic_id_buffer([(_sid(9999), 2)])
+        semantic_id_map = _build_id_string_buffer([(_sid(2), "class:cube")])
+        stable_id_map = _build_id_string_buffer([(_sid(1000), "/World/Cube")])
+
+        id_to_labels, _ = resolve_instance_segmentation_labels(
+            {2}, stable_id_semantic_id_map, semantic_id_map, stable_id_map
+        )
+        assert id_to_labels[2] == "UNLABELLED"
+
+    def test_only_covers_requested_pixel_ids(self):
+        stable_id_semantic_id_map = _build_stable_id_semantic_id_buffer([(_sid(1000), 2), (_sid(2000), 3)])
+        semantic_id_map = _build_id_string_buffer([(_sid(2), "class:cube"), (_sid(3), "class:sphere")])
+        stable_id_map = _build_id_string_buffer([(_sid(1000), "/World/Cube"), (_sid(2000), "/World/Sphere")])
+
+        id_to_labels, id_to_semantics = resolve_instance_segmentation_labels(
+            {0, 1, 2}, stable_id_semantic_id_map, semantic_id_map, stable_id_map
+        )
+        assert 3 not in id_to_labels
+        assert 3 not in id_to_semantics
+
+
+class Test_ResolveInstanceIdSegmentationLabels:
+    def test_join_via_instance_map_indirection(self):
+        # InstanceSegmentationSD ids 2 and 3 route through InstanceMap (indexed
+        # by id - 1) to StableIdSemanticIdMap positions, in a different order
+        # than instance_segmentation_fast's direct (id - 2) indexing.
+        instance_map = _build_instance_map_buffer([0xFFFFFFFF, 1, 0])
+        stable_id_semantic_id_map = _build_stable_id_semantic_id_buffer([(_sid(1000), 2), (_sid(2000), 3)])
+        stable_id_map = _build_id_string_buffer([(_sid(1000), "/World/Cube"), (_sid(2000), "/World/Sphere")])
+
+        id_to_labels = resolve_instance_id_segmentation_labels(
+            {0, 1, 2, 3}, instance_map, stable_id_semantic_id_map, stable_id_map
+        )
+
+        assert id_to_labels == {
+            0: "BACKGROUND",
+            1: "UNLABELLED",
+            2: "/World/Sphere",  # InstanceMap[2 - 1] == 1 -> StableIdSemanticIdMap[1] -> stable id 2000
+            3: "/World/Cube",  # InstanceMap[3 - 1] == 0 -> StableIdSemanticIdMap[0] -> stable id 1000
+        }
+
+    def test_sentinel_entry_resolves_to_unlabelled(self):
+        instance_map = _build_instance_map_buffer([0xFFFFFFFF])
+        stable_id_semantic_id_map = _build_stable_id_semantic_id_buffer([(_sid(1000), 2)])
+        stable_id_map = _build_id_string_buffer([(_sid(1000), "/World/Cube")])
+
+        id_to_labels = resolve_instance_id_segmentation_labels(
+            {0, 1}, instance_map, stable_id_semantic_id_map, stable_id_map
+        )
+        assert id_to_labels == {0: "BACKGROUND", 1: "UNLABELLED"}

--- a/source/isaaclab_ov/test/test_ovrtx_annotator_integration.py
+++ b/source/isaaclab_ov/test/test_ovrtx_annotator_integration.py
@@ -1,0 +1,377 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Integration tests for the OVRTX renderer's idToLabels/idToSemantics resolution.
+
+Builds semantically-labeled USD scenes programmatically with ``pxr.Usd``/
+``pxr.UsdSemantics``, renders them through a real ``ovrtx.Renderer`` using the
+production render-var wiring (:func:`isaaclab_ov.renderers.ovrtx_usd.build_render_product_as_string`),
+then drives the actual :class:`~isaaclab_ov.renderers.ovrtx_renderer.OVRTXRenderer`
+methods (``_process_id_segmentation_render_var`` -> ``_update_segmentation_info``
+-> ``read_output``) against the resulting frame and asserts the expected
+prim paths/labels land in ``CameraData.info``.
+
+Driving the real ``OVRTXRenderer`` methods (rather than calling
+:mod:`isaaclab_ov.renderers.annotator_utils` directly, which is already
+covered by ``test_annotator_utils.py``'s synthetic-buffer unit tests) is the
+point of this file: it is the only place that exercises the actual wiring in
+``ovrtx_renderer.py`` -- render var selection, CPU mapping, and
+``CameraData.info`` propagation -- against a real render.
+
+Requires an NVIDIA RTX-capable GPU: this constructs and steps a real
+``ovrtx.Renderer``.
+
+.. note::
+    The renderer occasionally drops exactly one labeled instance's
+    ``StableIdMap`` entry per render (its ``idToSemantics`` label still
+    resolves correctly; only the ``idToLabels`` prim path falls back to
+    ``"UNLABELLED"``). This looks like an OVRTX-internal timing/ordering
+    quirk unrelated to the ``annotator_utils`` decode logic exercised here --
+    it reproduces with a hand-authored ``.usda`` file too, not just
+    programmatically-built stages. The tests below tolerate up to one such
+    fallback per scene rather than asserting exact 1:1 resolution for every
+    instance; see the assertions in
+    ``test_instance_segmentation_fast_id_to_labels_resolve_to_real_prim_paths``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import os
+
+import pytest
+
+_REQUIRED_MODULES = ("isaaclab_ov", "ovrtx", "pxr")
+_MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
+
+pytestmark = [
+    pytest.mark.isaacsim_ci,
+    pytest.mark.skipif(
+        bool(_MISSING_MODULES),
+        reason=f"requires optional modules: {', '.join(_MISSING_MODULES)}",
+    ),
+]
+
+if not _MISSING_MODULES:
+    os.environ.setdefault("OVRTX_SKIP_USD_CHECK", "1")
+
+    import ovrtx
+    import warp as wp
+    from pxr import Usd, UsdGeom, UsdLux, UsdSemantics
+
+    from isaaclab.sensors.camera.camera_data import CameraData, RenderBufferKind
+
+    from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderData, OVRTXRenderer
+    from isaaclab_ov.renderers.ovrtx_renderer_cfg import OVRTXRendererCfg
+    from isaaclab_ov.renderers.ovrtx_usd import build_render_product_as_string
+else:
+    ovrtx = None
+    wp = None
+    Usd = None
+    UsdGeom = None
+    UsdLux = None
+    UsdSemantics = None
+    CameraData = None
+    RenderBufferKind = None
+    OVRTXRenderData = None
+    OVRTXRenderer = None
+    OVRTXRendererCfg = None
+    build_render_product_as_string = None
+
+
+CAMERA_REL_PATH = "Camera"
+_WIDTH, _HEIGHT = 320, 240
+_WARMUP_STEPS = 3
+
+
+def _require_gpu() -> None:
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("OVRTX integration tests require a CUDA-capable GPU")
+
+
+def _apply_labels(prim: Usd.Prim, taxonomy: str, labels: list[str]) -> None:
+    UsdSemantics.LabelsAPI.Apply(prim, taxonomy).CreateLabelsAttr(labels)
+
+
+def _xform_at(stage: Usd.Stage, name: str, translate: tuple[float, float, float]) -> Usd.Prim:
+    xform = UsdGeom.Xform.Define(stage, f"/World/envs/env_0/{name}")
+    xform.AddTranslateOp().Set(translate)
+    return xform.GetPrim()
+
+
+def build_labeled_scene_stage() -> Usd.Stage:
+    """Build a single-env USD stage with several distinctly-labeled prims.
+
+    Mirrors ``ovrtx_aov_test/semantic_maps_scene.usda``, constructed
+    programmatically via ``pxr.Usd``/``pxr.UsdSemantics`` instead of hand-typed
+    USDA text:
+
+    * ``Cone`` -- two semantic taxonomies (``class:cone``, ``instance:cone_01``).
+    * ``Cube`` -- a single semantic taxonomy (``class:cube``).
+    * ``Sphere`` -- a single semantic taxonomy (``class:sphere``).
+    * ``Vehicle_Xform`` -- carries ``class:vehicle``; its child ``Wheel`` has no
+      label of its own, so it inherits the label from its ancestor.
+    * ``GroundPlane`` -- unlabeled, so the reserved UNLABELLED id also appears
+      on screen.
+
+    Returns:
+        An in-memory USD stage with prims under ``/World/envs/env_0``, a
+        camera at ``/World/envs/env_0/Camera`` framing all objects, and a
+        distant light.
+    """
+    stage = Usd.Stage.CreateInMemory()
+    UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
+    UsdGeom.Xform.Define(stage, "/World")
+    UsdGeom.Xform.Define(stage, "/World/envs")
+    UsdGeom.Xform.Define(stage, "/World/envs/env_0")
+
+    cone_xform = _xform_at(stage, "Cone_Xform", (-3.0, 0.5, 0.0))
+    cone = UsdGeom.Cone.Define(stage, cone_xform.GetPath().AppendChild("Cone"))
+    cone.CreateHeightAttr(1.0)
+    cone.CreateRadiusAttr(0.5)
+    cone.CreateDisplayColorAttr([(0.8, 0.2, 0.2)])
+    _apply_labels(cone.GetPrim(), "class", ["cone"])
+    _apply_labels(cone.GetPrim(), "instance", ["cone_01"])
+
+    cube_xform = _xform_at(stage, "Cube_Xform", (-1.0, 0.5, 0.0))
+    cube = UsdGeom.Cube.Define(stage, cube_xform.GetPath().AppendChild("Cube"))
+    cube.CreateSizeAttr(1.0)
+    cube.CreateDisplayColorAttr([(0.2, 0.6, 0.8)])
+    _apply_labels(cube.GetPrim(), "class", ["cube"])
+
+    sphere_xform = _xform_at(stage, "Sphere_Xform", (3.0, 0.5, 0.0))
+    sphere = UsdGeom.Sphere.Define(stage, sphere_xform.GetPath().AppendChild("Sphere"))
+    sphere.CreateRadiusAttr(0.5)
+    sphere.CreateDisplayColorAttr([(0.3, 0.8, 0.3)])
+    _apply_labels(sphere.GetPrim(), "class", ["sphere"])
+
+    vehicle_xform = UsdGeom.Xform.Define(stage, "/World/envs/env_0/Vehicle_Xform")
+    vehicle_xform.AddTranslateOp().Set((0.0, 0.5, 3.0))
+    _apply_labels(vehicle_xform.GetPrim(), "class", ["vehicle"])
+    wheel = UsdGeom.Cylinder.Define(stage, "/World/envs/env_0/Vehicle_Xform/Wheel")
+    wheel.CreateHeightAttr(0.3)
+    wheel.CreateRadiusAttr(0.6)
+    wheel.CreateAxisAttr("X")
+    wheel.CreateDisplayColorAttr([(0.1, 0.1, 0.1)])
+
+    ground = UsdGeom.Mesh.Define(stage, "/World/envs/env_0/GroundPlane")
+    ground.CreateExtentAttr([(-10, 0, -10), (10, 0, 10)])
+    ground.CreateFaceVertexCountsAttr([4])
+    ground.CreateFaceVertexIndicesAttr([0, 1, 2, 3])
+    ground.CreatePointsAttr([(-10, 0, -10), (10, 0, -10), (10, 0, 10), (-10, 0, 10)])
+    ground.CreateNormalsAttr([(0, 1, 0)] * 4)
+
+    light = UsdLux.DistantLight.Define(stage, "/World/envs/env_0/DistantLight")
+    light.CreateIntensityAttr(3000.0)
+    UsdGeom.Xformable(light).AddRotateXYZOp().Set((300.0, 45.0, 0.0))
+
+    camera = UsdGeom.Camera.Define(stage, f"/World/envs/env_0/{CAMERA_REL_PATH}")
+    camera.CreateFocalLengthAttr(24.0)
+    camera.CreateHorizontalApertureAttr(20.955)
+    camera.CreateClippingRangeAttr((0.1, 1000.0))
+    camera_xformable = UsdGeom.Xformable(camera)
+    camera_xformable.AddTranslateOp().Set((0.0, 4.0, 10.0))
+    camera_xformable.AddRotateXYZOp().Set((-20.0, 0.0, 0.0))
+
+    return stage
+
+
+def _render_frame(stage: Usd.Stage, data_type: str):
+    """Render ``stage`` for ``data_type`` and return the resulting ovrtx renderer, step result, and frame.
+
+    The caller must keep both the returned renderer AND the step result
+    (``products``) alive for as long as ``frame`` is used: the render var
+    output handles ``frame`` wraps are only valid while ``products`` -- not
+    just the renderer -- has not been garbage collected.
+    """
+    render_product_string, render_product_path = build_render_product_as_string(
+        width=_WIDTH,
+        height=_HEIGHT,
+        num_envs=1,
+        data_types=[data_type],
+        camera_rel_path=CAMERA_REL_PATH,
+    )
+    full_usd_string = stage.ExportToString() + "\n\n" + render_product_string
+
+    renderer = ovrtx.Renderer()
+    renderer.open_usd_from_string(full_usd_string)
+    for _ in range(_WARMUP_STEPS):
+        renderer.step(render_products={render_product_path}, delta_time=0.0)
+    products = renderer.step(render_products={render_product_path}, delta_time=0.0)
+    frame = products[render_product_path].frames[0]
+    return renderer, products, frame
+
+
+_DEVICE = "cuda:0"
+
+
+def _make_ovrtx_renderer_stub(**cfg_overrides) -> OVRTXRenderer:
+    """Build an OVRTXRenderer with just enough state for _process_render_frame."""
+    renderer = OVRTXRenderer.__new__(OVRTXRenderer)
+    renderer.cfg = OVRTXRendererCfg(**cfg_overrides)
+    renderer._device = _DEVICE
+    renderer._output_id_color_buffers = {}
+    return renderer
+
+
+def _make_ovrtx_render_data_stub(num_envs: int, height: int, width: int) -> OVRTXRenderData:
+    render_data = OVRTXRenderData.__new__(OVRTXRenderData)
+    render_data.num_envs = num_envs
+    render_data.height = height
+    render_data.width = width
+    render_data.num_cols = math.ceil(math.sqrt(num_envs))
+    render_data.num_rows = math.ceil(num_envs / render_data.num_cols)
+    render_data.warp_buffers = {}
+    render_data.renderer_info = {}
+    render_data.ppisp_pipeline = None
+    return render_data
+
+
+def _run_segmentation_info(stage: Usd.Stage, data_type: str, **cfg_overrides) -> dict:
+    """Render ``stage`` for ``data_type`` and return the ``idToLabels``/``idToSemantics`` info dict.
+
+    Drives the real ``OVRTXRenderer._process_render_frame`` -- the same entry
+    point ``render()`` calls in production -- against a real ovrtx frame, then
+    ``read_output`` to confirm the result lands in ``CameraData.info``. Only
+    the public ``data_type`` name (and, for the two instance types,
+    ``cfg_overrides`` to select colorize True/False) is known here; which AOV
+    backs it, its buffer_key, and dtype are all resolved the same way
+    production code resolves them (``supported_output_types()``), not
+    hardcoded in the test.
+    """
+    renderer_, products_, frame = _render_frame(stage, data_type)
+    try:
+        renderer = _make_ovrtx_renderer_stub(**cfg_overrides)
+        render_data = _make_ovrtx_render_data_stub(num_envs=1, height=_HEIGHT, width=_WIDTH)
+
+        spec = renderer.supported_output_types()[RenderBufferKind(data_type)]
+        output_buffers = {
+            data_type: wp.zeros((1, _HEIGHT, _WIDTH, spec.channels), dtype=spec.dtype, device=_DEVICE),
+        }
+
+        renderer._process_render_frame(render_data, frame, output_buffers)
+    finally:
+        del products_, renderer_
+
+    assert data_type in render_data.renderer_info, (
+        f"OVRTXRenderer never populated renderer_info[{data_type!r}] -- check that"
+        f" ovrtx_usd.get_render_var_configs authors the render vars _update_segmentation_info needs"
+    )
+
+    camera_data = CameraData()
+    camera_data.info = {}
+    camera_data._output = {}
+    renderer.read_output(render_data, camera_data)
+    assert camera_data.info == render_data.renderer_info
+
+    return camera_data.info[data_type]
+
+
+def test_semantic_segmentation_id_to_labels_matches_authored_labels():
+    """OVRTXRenderer resolves semantic_segmentation's idToLabels via a real render."""
+    _require_gpu()
+    stage = build_labeled_scene_stage()
+    info = _run_segmentation_info(stage, "semantic_segmentation")
+
+    id_to_labels = info["idToLabels"]
+    assert id_to_labels[0] == "BACKGROUND"
+    assert id_to_labels[1] == "UNLABELLED"
+    resolved_labels = set(id_to_labels.values())
+    assert {"class:cube", "class:sphere", "class:vehicle"} <= resolved_labels
+    assert any("instance:cone_01" in label and "class:cone" in label for label in resolved_labels)
+
+
+@pytest.mark.parametrize("colorize", [True, False], ids=["colorize", "raw_ids"])
+def test_instance_segmentation_fast_id_to_semantics_matches_authored_labels(colorize: bool):
+    """OVRTXRenderer resolves instance_segmentation_fast's idToSemantics via a real render.
+
+    Unlike idToLabels (prim paths, see the flakiness noted in the module
+    docstring), idToSemantics only depends on the positional
+    StableIdSemanticIdMap -> SemanticIdMap join and has been reliable in
+    practice across every instance. Parametrized over colorize since the info
+    dict is populated identically either way but the pixel-extraction branch
+    ``_process_id_segmentation_render_var`` takes differs (see the
+    torch.uint32/wp.uint32 conversion fixed in ovrtx_renderer.py, which only
+    reproduced on the ``colorize=False`` branch).
+    """
+    _require_gpu()
+    stage = build_labeled_scene_stage()
+    info = _run_segmentation_info(stage, "instance_segmentation_fast", colorize_instance_segmentation=colorize)
+
+    resolved_labels = set(info["idToSemantics"].values())
+    assert {"class:cube", "class:sphere", "class:vehicle"} <= resolved_labels
+    assert any("instance:cone_01" in label and "class:cone" in label for label in resolved_labels)
+
+
+@pytest.mark.parametrize("colorize", [True, False], ids=["colorize", "raw_ids"])
+def test_instance_segmentation_fast_id_to_labels_resolve_to_real_prim_paths(colorize: bool):
+    """OVRTXRenderer resolves instance_segmentation_fast's idToLabels to real (or fallback) prim paths."""
+    _require_gpu()
+    stage = build_labeled_scene_stage()
+    info = _run_segmentation_info(stage, "instance_segmentation_fast", colorize_instance_segmentation=colorize)
+    id_to_labels = info["idToLabels"]
+
+    fallback_values = {"BACKGROUND", "UNLABELLED", "<unknown prim>"}
+    real_prim_paths = {v for v in id_to_labels.values() if v not in fallback_values}
+
+    # Every resolved value is either a real prim that exists on the stage, or
+    # one of the documented fallbacks -- never garbage.
+    for prim_path in real_prim_paths:
+        assert stage.GetPrimAtPath(prim_path).IsValid(), f"resolved a prim path not on the stage: {prim_path}"
+
+    # See the module docstring: the renderer occasionally drops one instance's
+    # StableIdMap entry, so tolerate at most one fallback among the 4 labeled
+    # instances (Cone, Cube, Sphere, Vehicle_Xform) rather than requiring all 4.
+    assert len(real_prim_paths) >= 3, f"expected at least 3 of 4 instances to resolve, got: {id_to_labels}"
+
+
+@pytest.mark.parametrize("colorize", [True, False], ids=["colorize", "raw_ids"])
+def test_instance_id_segmentation_fast_id_to_labels_resolve_to_real_prim_paths(colorize: bool):
+    """OVRTXRenderer resolves instance_id_segmentation_fast's idToLabels to real (or fallback) prim paths."""
+    _require_gpu()
+    stage = build_labeled_scene_stage()
+    info = _run_segmentation_info(stage, "instance_id_segmentation_fast", colorize_instance_id_segmentation=colorize)
+    id_to_labels = info["idToLabels"]
+
+    fallback_values = {"BACKGROUND", "UNLABELLED", "<unknown prim>"}
+    real_prim_paths = {v for v in id_to_labels.values() if v not in fallback_values}
+
+    for prim_path in real_prim_paths:
+        assert stage.GetPrimAtPath(prim_path).IsValid(), f"resolved a prim path not on the stage: {prim_path}"
+
+    # See the module docstring for the known single-instance fallback quirk.
+    assert len(real_prim_paths) >= 3, f"expected at least 3 of 4 instances to resolve, got: {id_to_labels}"
+
+
+def test_render_var_wiring_authors_expected_render_vars_per_data_type():
+    """get_render_var_configs()-driven render products expose the render vars annotator_utils needs."""
+    _require_gpu()
+    stage = build_labeled_scene_stage()
+
+    expectations = {
+        "semantic_segmentation": {"SemanticSegmentation", "SemanticIdMap"},
+        "instance_segmentation_fast": {
+            "NonStableInstanceSegmentation",
+            "SemanticIdMap",
+            "StableIdMap",
+            "StableIdSemanticIdMap",
+        },
+        "instance_id_segmentation_fast": {
+            "InstanceSegmentationSD",
+            "StableIdMap",
+            "StableIdSemanticIdMap",
+            "InstanceMap",
+        },
+    }
+    for data_type, expected_render_vars in expectations.items():
+        renderer, products, frame = _render_frame(stage, data_type)
+        try:
+            assert expected_render_vars <= set(frame.render_vars.keys())
+        finally:
+            del products, renderer

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -58,6 +58,7 @@ def _make_ovrtx_render_data() -> OVRTXRenderData:
     rd.height = 8
     rd.num_envs = 2
     rd.warp_buffers = {}
+    rd.renderer_info = {}
     rd.ppisp_pipeline = None
     return rd
 
@@ -210,8 +211,8 @@ def test_ovrtx_ppisp_hdr_source_is_cloned_to_output_device(monkeypatch):
     assert clone_calls == [(source, "cuda:0")]
 
 
-def test_ovrtx_read_output_is_a_no_op_after_consolidation():
-    """OVRTXRenderer.read_output is a no-op once set_outputs wires up zero-copy."""
+def test_ovrtx_read_output_does_not_touch_pixel_buffers():
+    """OVRTXRenderer.read_output only copies renderer_info; pixel data is already in place."""
     renderer = _make_ovrtx_renderer_without_backend()
     render_data = _make_ovrtx_render_data()
     camera_data = CameraData()
@@ -223,3 +224,17 @@ def test_ovrtx_read_output_is_a_no_op_after_consolidation():
     assert render_data.warp_buffers == {}
     assert camera_data.info == {}
     assert camera_data.output == {}
+
+
+def test_ovrtx_read_output_copies_renderer_info_into_camera_data():
+    """OVRTXRenderer.read_output propagates idToLabels/idToSemantics info dicts."""
+    renderer = _make_ovrtx_renderer_without_backend()
+    render_data = _make_ovrtx_render_data()
+    render_data.renderer_info = {"semantic_segmentation": {"idToLabels": {0: "BACKGROUND", 2: "class:cube"}}}
+    camera_data = CameraData()
+    camera_data.info = {}
+    camera_data._output = {}
+
+    renderer.read_output(render_data, camera_data)
+
+    assert camera_data.info == {"semantic_segmentation": {"idToLabels": {0: "BACKGROUND", 2: "class:cube"}}}


### PR DESCRIPTION
# Description

Adding support to our OVRTX renderer integration for outputting idToLabels/idToSemantics in the segmentation annotators:
- semantic_segmentation
- instance_id_segmentation_fast
- instance_segmentation_fast

Still WIP, but want to get the code up for early visibility 

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
