### PR TITLE
Articulation Reordering Part 2/8: Core ordering foundation

### DIFF
--- a/docs/source/api/lab/isaaclab.assets.rst
+++ b/docs/source/api/lab/isaaclab.assets.rst
@@ -20,9 +20,22 @@
     DeformableObject
     DeformableObjectData
     DeformableObjectCfg
+    BaseArticulation
+    BaseArticulationData
     Articulation
     ArticulationData
     ArticulationCfg
+    ArticulationOrderingConvention
+    ArticulationNameMap
+
+  .. rubric:: Functions
+
+  .. autosummary::
+
+    apply_articulation_ordering_preset
+    build_articulation_name_map
+    parse_articulation_ordering_convention
+    get_articulation_name_ordering
 
 .. currentmodule:: isaaclab.assets
 
@@ -115,7 +128,18 @@ Articulation
     :inherited-members:
     :show-inheritance:
 
+.. autoclass:: BaseArticulation
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
 .. autoclass:: ArticulationData
+    :members:
+    :inherited-members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: BaseArticulationData
     :members:
     :inherited-members:
     :show-inheritance:
@@ -126,3 +150,20 @@ Articulation
     :inherited-members:
     :show-inheritance:
     :exclude-members: __init__, class_type
+
+Articulation Ordering
+---------------------
+
+.. autoclass:: ArticulationOrderingConvention
+    :members:
+
+.. autoclass:: ArticulationNameMap
+    :members:
+
+.. autofunction:: apply_articulation_ordering_preset
+
+.. autofunction:: build_articulation_name_map
+
+.. autofunction:: parse_articulation_ordering_convention
+
+.. autofunction:: get_articulation_name_ordering

--- a/docs/source/api/lab/isaaclab.assets.rst
+++ b/docs/source/api/lab/isaaclab.assets.rst
@@ -33,7 +33,6 @@
   .. autosummary::
 
     apply_articulation_ordering_preset
-    build_articulation_name_map
     parse_articulation_ordering_convention
     get_articulation_name_ordering
 
@@ -161,8 +160,6 @@ Articulation Ordering
     :members:
 
 .. autofunction:: apply_articulation_ordering_preset
-
-.. autofunction:: build_articulation_name_map
 
 .. autofunction:: parse_articulation_ordering_convention
 

--- a/source/isaaclab/changelog.d/articulation-ordering.major.rst
+++ b/source/isaaclab/changelog.d/articulation-ordering.major.rst
@@ -1,0 +1,22 @@
+Added
+^^^^^
+
+* Added articulation ordering utilities and optional :class:`~isaaclab.assets.ArticulationCfg`
+  fields for public joint/body ordering presets.
+* Added :meth:`~isaaclab.assets.Articulation.map_body_ids_to_backend` and
+  :meth:`~isaaclab.assets.Articulation.map_joint_ids_to_backend` to translate
+  public-order body/joint indices into backend view order for raw-view interop.
+* Added the ``__backend_native_orderings__`` class attribute on
+  :class:`~isaaclab.assets.BaseArticulation` so backends declare which symbolic
+  ordering conventions their native order satisfies, enabling the identity
+  fast path without editing the core resolvers.
+
+Changed
+^^^^^^^
+
+* Changed custom :class:`~isaaclab.assets.BaseArticulation` backends to expose
+  backend joint/body names and ordering maps. Existing backends continue to
+  work through deprecated fallbacks; override
+  :attr:`~isaaclab.assets.BaseArticulation.backend_joint_names` and
+  :attr:`~isaaclab.assets.BaseArticulation.backend_body_names` before these
+  properties become abstract in a future release.

--- a/source/isaaclab/isaaclab/assets/__init__.pyi
+++ b/source/isaaclab/isaaclab/assets/__init__.pyi
@@ -9,6 +9,12 @@ __all__ = [
     "Articulation",
     "ArticulationCfg",
     "ArticulationData",
+    "ArticulationOrderingConvention",
+    "ArticulationNameMap",
+    "apply_articulation_ordering_preset",
+    "build_articulation_name_map",
+    "parse_articulation_ordering_convention",
+    "get_articulation_name_ordering",
     "AssetBase",
     "AssetBaseCfg",
     "BaseRigidObject",
@@ -34,6 +40,12 @@ from .articulation import (
     Articulation,
     ArticulationCfg,
     ArticulationData,
+    ArticulationOrderingConvention,
+    ArticulationNameMap,
+    apply_articulation_ordering_preset,
+    build_articulation_name_map,
+    parse_articulation_ordering_convention,
+    get_articulation_name_ordering,
 )
 from .asset_base import AssetBase
 from .asset_base_cfg import AssetBaseCfg

--- a/source/isaaclab/isaaclab/assets/__init__.pyi
+++ b/source/isaaclab/isaaclab/assets/__init__.pyi
@@ -12,7 +12,6 @@ __all__ = [
     "ArticulationOrderingConvention",
     "ArticulationNameMap",
     "apply_articulation_ordering_preset",
-    "build_articulation_name_map",
     "parse_articulation_ordering_convention",
     "get_articulation_name_ordering",
     "AssetBase",
@@ -43,7 +42,6 @@ from .articulation import (
     ArticulationOrderingConvention,
     ArticulationNameMap,
     apply_articulation_ordering_preset,
-    build_articulation_name_map,
     parse_articulation_ordering_convention,
     get_articulation_name_ordering,
 )

--- a/source/isaaclab/isaaclab/assets/articulation/__init__.pyi
+++ b/source/isaaclab/isaaclab/assets/articulation/__init__.pyi
@@ -9,6 +9,12 @@ __all__ = [
     "Articulation",
     "ArticulationCfg",
     "ArticulationData",
+    "ArticulationOrderingConvention",
+    "ArticulationNameMap",
+    "apply_articulation_ordering_preset",
+    "build_articulation_name_map",
+    "parse_articulation_ordering_convention",
+    "get_articulation_name_ordering",
 ]
 
 from .base_articulation import BaseArticulation
@@ -16,3 +22,11 @@ from .base_articulation_data import BaseArticulationData
 from .articulation import Articulation
 from .articulation_cfg import ArticulationCfg
 from .articulation_data import ArticulationData
+from .ordering import (
+    ArticulationOrderingConvention,
+    ArticulationNameMap,
+    apply_articulation_ordering_preset,
+    build_articulation_name_map,
+    parse_articulation_ordering_convention,
+)
+from .ordering_resolvers import get_articulation_name_ordering

--- a/source/isaaclab/isaaclab/assets/articulation/__init__.pyi
+++ b/source/isaaclab/isaaclab/assets/articulation/__init__.pyi
@@ -12,7 +12,6 @@ __all__ = [
     "ArticulationOrderingConvention",
     "ArticulationNameMap",
     "apply_articulation_ordering_preset",
-    "build_articulation_name_map",
     "parse_articulation_ordering_convention",
     "get_articulation_name_ordering",
 ]
@@ -26,7 +25,6 @@ from .ordering import (
     ArticulationOrderingConvention,
     ArticulationNameMap,
     apply_articulation_ordering_preset,
-    build_articulation_name_map,
     parse_articulation_ordering_convention,
 )
 from .ordering_resolvers import get_articulation_name_ordering

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
@@ -69,12 +69,12 @@ class ArticulationCfg(AssetBaseCfg):
     The soft joint position limits are accessible through the :attr:`ArticulationData.soft_joint_pos_limits` attribute.
     """
 
-    joint_ordering: list[str] | tuple[str, ...] | str | ArticulationOrderingConvention | None = None
+    joint_ordering: tuple[str, ...] | str | ArticulationOrderingConvention | None = None
     """Public joint-name ordering convention or complete explicit permutation.
 
     Accepts ``"physx"``, ``"mjwarp"``, and ``"robot_schema"`` aliases, the
-    corresponding :class:`ArticulationOrderingConvention` members, or a list or
-    tuple containing every backend joint name exactly once.
+    corresponding :class:`ArticulationOrderingConvention` members, or a tuple
+    containing every backend joint name exactly once.
 
     ``None`` is the default: public joint order follows active backend solver-view
     order and no ordering map is installed. An order that resolves to backend
@@ -83,12 +83,12 @@ class ArticulationCfg(AssetBaseCfg):
     articulation initialization only, not each step.
     """
 
-    body_ordering: list[str] | tuple[str, ...] | str | ArticulationOrderingConvention | None = None
+    body_ordering: tuple[str, ...] | str | ArticulationOrderingConvention | None = None
     """Public body-name ordering convention or complete explicit permutation.
 
     Accepts ``"physx"``, ``"mjwarp"``, and ``"robot_schema"`` aliases, the
-    corresponding :class:`ArticulationOrderingConvention` members, or a list or
-    tuple containing every backend body name exactly once.
+    corresponding :class:`ArticulationOrderingConvention` members, or a tuple
+    containing every backend body name exactly once.
 
     ``None`` is the default: public body order follows active backend solver-view
     order and no ordering map is installed. An order that resolves to backend

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
@@ -69,12 +69,12 @@ class ArticulationCfg(AssetBaseCfg):
     The soft joint position limits are accessible through the :attr:`ArticulationData.soft_joint_pos_limits` attribute.
     """
 
-    joint_ordering: tuple[str, ...] | str | ArticulationOrderingConvention | None = None
+    joint_ordering: list[str] | tuple[str, ...] | str | ArticulationOrderingConvention | None = None
     """Public joint-name ordering convention or complete explicit permutation.
 
     Accepts ``"physx"``, ``"mjwarp"``, and ``"robot_schema"`` aliases, the
-    corresponding :class:`ArticulationOrderingConvention` members, or a tuple
-    containing every backend joint name exactly once.
+    corresponding :class:`ArticulationOrderingConvention` members, or a list or
+    tuple (normalized to a tuple at initialization) containing every backend joint name exactly once.
 
     ``None`` is the default: public joint order follows active backend solver-view
     order and no ordering map is installed. An order that resolves to backend
@@ -83,12 +83,12 @@ class ArticulationCfg(AssetBaseCfg):
     articulation initialization only, not each step.
     """
 
-    body_ordering: tuple[str, ...] | str | ArticulationOrderingConvention | None = None
+    body_ordering: list[str] | tuple[str, ...] | str | ArticulationOrderingConvention | None = None
     """Public body-name ordering convention or complete explicit permutation.
 
     Accepts ``"physx"``, ``"mjwarp"``, and ``"robot_schema"`` aliases, the
-    corresponding :class:`ArticulationOrderingConvention` members, or a tuple
-    containing every backend body name exactly once.
+    corresponding :class:`ArticulationOrderingConvention` members, or a list or
+    tuple (normalized to a tuple at initialization) containing every backend body name exactly once.
 
     ``None`` is the default: public body order follows active backend solver-view
     order and no ordering map is installed. An order that resolves to backend

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
@@ -77,9 +77,10 @@ class ArticulationCfg(AssetBaseCfg):
     tuple containing every backend joint name exactly once.
 
     ``None`` is the default: public joint order follows active backend solver-view
-    order and no ordering map is installed. An explicit order that matches backend
-    order installs a non-``None`` identity map. Symbolic resolution and map
-    construction occur during articulation initialization only, not each step.
+    order and no ordering map is installed. An order that resolves to backend
+    order is normalized to ``None`` as well, so an installed map always denotes
+    an actual permutation. Symbolic resolution and map construction occur during
+    articulation initialization only, not each step.
     """
 
     body_ordering: list[str] | tuple[str, ...] | str | ArticulationOrderingConvention | None = None
@@ -90,9 +91,10 @@ class ArticulationCfg(AssetBaseCfg):
     tuple containing every backend body name exactly once.
 
     ``None`` is the default: public body order follows active backend solver-view
-    order and no ordering map is installed. An explicit order that matches backend
-    order installs a non-``None`` identity map. Symbolic resolution and map
-    construction occur during articulation initialization only, not each step.
+    order and no ordering map is installed. An order that resolves to backend
+    order is normalized to ``None`` as well, so an installed map always denotes
+    an actual permutation. Symbolic resolution and map construction occur during
+    articulation initialization only, not each step.
 
     For fixed-base articulations, the backend root body must remain at public index
     zero; all remaining bodies may be permuted. Floating-base orders may relocate

--- a/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
+++ b/source/isaaclab/isaaclab/assets/articulation/articulation_cfg.py
@@ -12,6 +12,7 @@ from isaaclab.actuators import ActuatorBaseCfg
 from isaaclab.utils.configclass import configclass
 
 from ..asset_base_cfg import AssetBaseCfg
+from .ordering import ArticulationOrderingConvention
 
 if TYPE_CHECKING:
     from .articulation import Articulation
@@ -66,6 +67,36 @@ class ArticulationCfg(AssetBaseCfg):
     positions from violating the limits, such as for termination conditions.
 
     The soft joint position limits are accessible through the :attr:`ArticulationData.soft_joint_pos_limits` attribute.
+    """
+
+    joint_ordering: list[str] | tuple[str, ...] | str | ArticulationOrderingConvention | None = None
+    """Public joint-name ordering convention or complete explicit permutation.
+
+    Accepts ``"physx"``, ``"mjwarp"``, and ``"robot_schema"`` aliases, the
+    corresponding :class:`ArticulationOrderingConvention` members, or a list or
+    tuple containing every backend joint name exactly once.
+
+    ``None`` is the default: public joint order follows active backend solver-view
+    order and no ordering map is installed. An explicit order that matches backend
+    order installs a non-``None`` identity map. Symbolic resolution and map
+    construction occur during articulation initialization only, not each step.
+    """
+
+    body_ordering: list[str] | tuple[str, ...] | str | ArticulationOrderingConvention | None = None
+    """Public body-name ordering convention or complete explicit permutation.
+
+    Accepts ``"physx"``, ``"mjwarp"``, and ``"robot_schema"`` aliases, the
+    corresponding :class:`ArticulationOrderingConvention` members, or a list or
+    tuple containing every backend body name exactly once.
+
+    ``None`` is the default: public body order follows active backend solver-view
+    order and no ordering map is installed. An explicit order that matches backend
+    order installs a non-``None`` identity map. Symbolic resolution and map
+    construction occur during articulation initialization only, not each step.
+
+    For fixed-base articulations, the backend root body must remain at public index
+    zero; all remaining bodies may be permuted. Floating-base orders may relocate
+    the root body.
     """
 
     actuators: dict[str, ActuatorBaseCfg] = MISSING

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import logging
 import warnings
 from abc import abstractmethod
 from collections.abc import Sequence
@@ -29,6 +30,8 @@ if TYPE_CHECKING:
 
     from .articulation_cfg import ArticulationCfg
     from .base_articulation_data import BaseArticulationData
+
+logger = logging.getLogger(__name__)
 
 
 class BaseArticulation(AssetBase):
@@ -248,9 +251,10 @@ class BaseArticulation(AssetBase):
     def joint_ordering(self) -> ArticulationNameMap | None:
         """Bidirectional map between backend and public joint order.
 
-        The map is ``None`` for the default ``None`` configuration, a non-``None``
-        identity map when an explicit order resolves to backend order, and a
-        nonidentity map for any actual permutation.
+        The map is ``None`` whenever the public and backend orders coincide:
+        either no ordering is configured, or the configured ordering resolved
+        to the backend's native order. A non-``None`` map always denotes an
+        actual permutation.
         """
         return getattr(self.data, "joint_ordering", None)
 
@@ -258,9 +262,10 @@ class BaseArticulation(AssetBase):
     def body_ordering(self) -> ArticulationNameMap | None:
         """Bidirectional map between backend and public body order.
 
-        The map is ``None`` for the default ``None`` configuration, a non-``None``
-        identity map when an explicit order resolves to backend order, and a
-        nonidentity map for any actual permutation.
+        The map is ``None`` whenever the public and backend orders coincide:
+        either no ordering is configured, or the configured ordering resolved
+        to the backend's native order. A non-``None`` map always denotes an
+        actual permutation.
         """
         return getattr(self.data, "body_ordering", None)
 
@@ -273,9 +278,9 @@ class BaseArticulation(AssetBase):
         that pick joints with public indices (for example event terms) must
         convert those indices before addressing backend arrays.
 
-        When :attr:`joint_ordering` is ``None`` or an identity permutation, the
-        public and backend orders coincide and :paramref:`joint_ids` is returned
-        unchanged without any per-index lookup.
+        When :attr:`joint_ordering` is ``None`` the public and backend orders
+        coincide and :paramref:`joint_ids` is returned unchanged without any
+        per-index lookup.
 
         Args:
             joint_ids: Joint indices in public :attr:`joint_names` order.
@@ -285,7 +290,7 @@ class BaseArticulation(AssetBase):
             order, or :paramref:`joint_ids` unchanged when the orders coincide.
         """
         ordering = self.joint_ordering
-        if ordering is None or ordering.is_identity:
+        if ordering is None:
             return joint_ids
         return [ordering.user_to_backend_indices[joint_id] for joint_id in joint_ids]
 
@@ -298,9 +303,9 @@ class BaseArticulation(AssetBase):
         that pick bodies with public indices (for example event terms) must
         convert those indices before addressing backend arrays.
 
-        When :attr:`body_ordering` is ``None`` or an identity permutation, the
-        public and backend orders coincide and :paramref:`body_ids` is returned
-        unchanged without any per-index lookup.
+        When :attr:`body_ordering` is ``None`` the public and backend orders
+        coincide and :paramref:`body_ids` is returned unchanged without any
+        per-index lookup.
 
         Args:
             body_ids: Body indices in public :attr:`body_names` order.
@@ -310,7 +315,7 @@ class BaseArticulation(AssetBase):
             or :paramref:`body_ids` unchanged when the orders coincide.
         """
         ordering = self.body_ordering
-        if ordering is None or ordering.is_identity:
+        if ordering is None:
             return body_ids
         return [ordering.user_to_backend_indices[body_id] for body_id in body_ids]
 
@@ -330,7 +335,12 @@ class BaseArticulation(AssetBase):
         raise NotImplementedError()
 
     def _resolve_and_install_ordering_maps(self) -> None:
-        """Resolve configured articulation name orderings and store maps on :attr:`data`."""
+        """Resolve configured articulation name orderings and store maps on :attr:`data`.
+
+        Orderings that resolve to the backend's native order are normalized to
+        ``None`` here, so an installed map always denotes an actual permutation
+        and ``is not None`` checks alone decide whether reordering is active.
+        """
         had_ordering = self.data.joint_ordering is not None or self.data.body_ordering is not None
 
         if self.cfg.joint_ordering is None:
@@ -344,13 +354,21 @@ class BaseArticulation(AssetBase):
                 active_backend_name=self.__backend_name__,
                 articulation=self,
             )
-            self.data.joint_ordering = build_articulation_name_map(
+            joint_ordering = build_articulation_name_map(
                 kind="joint",
                 backend_names=self.backend_joint_names,
                 user_names=joint_user_names,
                 device=self.device,
             )
-            self.data.joint_names = list(self.data.joint_ordering.user_names)
+            if joint_ordering.is_identity:
+                logger.info(
+                    "Configured joint_ordering for '%s' resolves to the backend's native order; no reordering"
+                    " will be applied.",
+                    self.cfg.prim_path,
+                )
+                joint_ordering = None
+            self.data.joint_ordering = joint_ordering
+            self.data.joint_names = list(joint_user_names)
 
         if self.cfg.body_ordering is None:
             self.data.body_ordering = None
@@ -380,8 +398,15 @@ class BaseArticulation(AssetBase):
                         f"{requested_index}. Put '{root_body_name}' first; all remaining bodies may be reordered "
                         "freely."
                     )
+            if body_ordering.is_identity:
+                logger.info(
+                    "Configured body_ordering for '%s' resolves to the backend's native order; no reordering"
+                    " will be applied.",
+                    self.cfg.prim_path,
+                )
+                body_ordering = None
             self.data.body_ordering = body_ordering
-            self.data.body_names = list(body_ordering.user_names)
+            self.data.body_names = list(body_user_names)
 
         has_ordering = self.data.joint_ordering is not None or self.data.body_ordering is not None
         if had_ordering or has_ordering:

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -2435,12 +2435,13 @@ class BaseArticulation(AssetBase):
     def _joint_user_to_backend_map(self) -> wp.array:
         """Device public-to-backend joint map, or the identity map when no ordering is active.
 
-        The identity fallback reads the backend-allocated ``_ALL_JOINT_INDICES``
-        index buffer (the same backend-owned contract as
-        :attr:`_ordering_joint_staging_names`), so unconditional launch sites --
-        for example in-graph publish kernels that always gather -- get a valid map
-        either way. Conditional sites should read :attr:`data.joint_ordering`
-        directly and skip the launch when it is ``None``.
+        The identity fallback reads ``_ALL_JOINT_INDICES``, an index buffer that
+        backends allocate without a base-class default (a backend-owned contract,
+        like the staging attributes named by :attr:`_ordering_joint_staging_names`),
+        so unconditional launch sites -- for example in-graph publish kernels that
+        always gather -- get a valid map either way. Conditional sites should read
+        :attr:`~BaseArticulationData.joint_ordering` directly and skip the launch
+        when it is ``None``.
         """
         ordering = self.data.joint_ordering
         return ordering.user_to_backend if ordering is not None else self._ALL_JOINT_INDICES
@@ -2506,7 +2507,7 @@ class BaseArticulation(AssetBase):
 
         Avoid this modify-then-reorder helper on per-step hot paths: it costs a
         full extra kernel launch over the buffer. Prefer the fused
-        ``write_*_user_to_backend`` kernels from
+        ``write_*_user_to_backend`` write paths from
         :mod:`isaaclab.assets.articulation.ordering_kernels`, which write the
         public and backend buffers in a single launch. This helper exists for
         infrequent property writers where the extra launch is irrelevant.

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -220,7 +220,14 @@ class BaseArticulation(AssetBase):
         The inherited compatibility fallback emits :class:`DeprecationWarning`
         and returns :attr:`joint_names`. A subclass relying on that fallback
         therefore receives public order and cannot expose a distinct solver order.
+
+        Raises:
+            NotImplementedError: If the subclass overrides neither
+                :attr:`joint_names` nor this property, since the two inherited
+                fallbacks delegate to each other and cannot produce names.
         """
+        if type(self).joint_names is BaseArticulation.joint_names:
+            raise NotImplementedError(f"{type(self).__name__} must override joint_names or backend_joint_names.")
         warnings.warn(
             f"{type(self).__name__} must override backend_joint_names before it becomes abstract in a future release.",
             DeprecationWarning,
@@ -239,7 +246,14 @@ class BaseArticulation(AssetBase):
         The inherited compatibility fallback emits :class:`DeprecationWarning`
         and returns :attr:`body_names`. A subclass relying on that fallback
         therefore receives public order and cannot expose a distinct solver order.
+
+        Raises:
+            NotImplementedError: If the subclass overrides neither
+                :attr:`body_names` nor this property, since the two inherited
+                fallbacks delegate to each other and cannot produce names.
         """
+        if type(self).body_names is BaseArticulation.body_names:
+            raise NotImplementedError(f"{type(self).__name__} must override body_names or backend_body_names.")
         warnings.warn(
             f"{type(self).__name__} must override backend_body_names before it becomes abstract in a future release.",
             DeprecationWarning,
@@ -269,7 +283,7 @@ class BaseArticulation(AssetBase):
         """
         return self.data.body_ordering
 
-    def map_joint_ids_to_backend(self, joint_ids: Sequence[int]) -> Sequence[int]:
+    def map_joint_ids_to_backend(self, joint_ids: Sequence[int] | slice) -> Sequence[int] | slice:
         """Translate public joint indices to active-backend joint indices.
 
         Backend solver views expose joint metadata and joint-indexed arrays in
@@ -283,18 +297,22 @@ class BaseArticulation(AssetBase):
         per-index lookup.
 
         Args:
-            joint_ids: Joint indices in public :attr:`joint_names` order.
+            joint_ids: Joint indices in public :attr:`joint_names` order, or a
+                slice selecting them.
 
         Returns:
-            The same joint indices expressed in :attr:`backend_joint_names`
+            The selected joint indices expressed in :attr:`backend_joint_names`
             order, or :paramref:`joint_ids` unchanged when the orders coincide.
+            A slice is expanded to its backend indices under a permutation.
         """
         ordering = self.joint_ordering
         if ordering is None:
             return joint_ids
+        if isinstance(joint_ids, slice):
+            return list(ordering.user_to_backend_indices[joint_ids])
         return [ordering.user_to_backend_indices[joint_id] for joint_id in joint_ids]
 
-    def map_body_ids_to_backend(self, body_ids: Sequence[int]) -> Sequence[int]:
+    def map_body_ids_to_backend(self, body_ids: Sequence[int] | slice) -> Sequence[int] | slice:
         """Translate public body indices to active-backend body indices.
 
         Backend solver views expose body metadata and body-indexed arrays in
@@ -308,15 +326,19 @@ class BaseArticulation(AssetBase):
         per-index lookup.
 
         Args:
-            body_ids: Body indices in public :attr:`body_names` order.
+            body_ids: Body indices in public :attr:`body_names` order, or a
+                slice selecting them.
 
         Returns:
-            The same body indices expressed in :attr:`backend_body_names` order,
-            or :paramref:`body_ids` unchanged when the orders coincide.
+            The selected body indices expressed in :attr:`backend_body_names`
+            order, or :paramref:`body_ids` unchanged when the orders coincide.
+            A slice is expanded to its backend indices under a permutation.
         """
         ordering = self.body_ordering
         if ordering is None:
             return body_ids
+        if isinstance(body_ids, slice):
+            return list(ordering.user_to_backend_indices[body_ids])
         return [ordering.user_to_backend_indices[body_id] for body_id in body_ids]
 
     @property

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -11,20 +11,24 @@ from __future__ import annotations
 import warnings
 from abc import abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import torch
 import warp as wp
 
 from ...sim import SimulationContext
+from ...utils.buffers import TimestampedBufferWarp
 from ...utils.leapp.leapp_semantics import OutputKindEnum, joint_names_resolver, leapp_tensor_semantics
 from ..asset_base import AssetBase
+from . import ordering_kernels
+from .ordering import ArticulationNameMap, ArticulationOrderingConvention, build_articulation_name_map
+from .ordering_resolvers import _resolve_articulation_ordering_names
 
 if TYPE_CHECKING:
     from isaaclab.utils.wrench_composer import WrenchComposer
 
     from .articulation_cfg import ArticulationCfg
-    from .articulation_data import ArticulationData
+    from .base_articulation_data import BaseArticulationData
 
 
 class BaseArticulation(AssetBase):
@@ -71,6 +75,12 @@ class BaseArticulation(AssetBase):
         # update the articulation state, where dt is the simulation time step
         my_articulation.update(dt)
 
+    .. note::
+        Index-based writer selectors must contain unique environment, joint, and
+        body indices. Repeated selector entries issue concurrent writes to the
+        same simulation cell, so the winning value is undefined. Use a mask when
+        a selection may contain duplicates.
+
     .. _`USD ArticulationRootAPI`: https://openusd.org/dev/api/class_usd_physics_articulation_root_a_p_i.html
 
     """
@@ -80,6 +90,16 @@ class BaseArticulation(AssetBase):
 
     __backend_name__: str = "base"
     """The name of the backend for the articulation."""
+
+    __backend_native_orderings__: tuple[str, ...] = ()
+    """Symbolic convention names this backend's native order already satisfies.
+
+    A convention listed here takes the identity fast path in ordering
+    resolution: requesting it returns backend names without any cross-backend
+    discovery. The base default is empty; concrete backends declare the
+    :class:`ArticulationOrderingConvention` values (e.g. ``("physx",)``) their
+    solver-view order matches.
+    """
 
     actuators: dict
     """Dictionary of actuator instances for the articulation.
@@ -98,6 +118,13 @@ class BaseArticulation(AssetBase):
         super().__init__(cfg)
         sim_ctx = SimulationContext.instance()
         self._sim_cfg = sim_ctx.cfg if sim_ctx is not None else None
+        # Per-articulation cache of resolved cross-backend convention name orderings,
+        # populated lazily while ordering maps are resolved. A single resolution may
+        # query the same convention for both joints and bodies, so results are keyed
+        # by ``(convention, kind)``.
+        self._ordering_convention_name_cache: dict[
+            tuple[ArticulationOrderingConvention, Literal["joint", "body"]], tuple[str, ...]
+        ] = {}
 
     """
     Properties
@@ -105,7 +132,7 @@ class BaseArticulation(AssetBase):
 
     @property
     @abstractmethod
-    def data(self) -> ArticulationData:
+    def data(self) -> BaseArticulationData:
         raise NotImplementedError()
 
     @property
@@ -144,10 +171,16 @@ class BaseArticulation(AssetBase):
         raise NotImplementedError()
 
     @property
-    @abstractmethod
     def joint_names(self) -> list[str]:
-        """Ordered names of joints in articulation."""
-        raise NotImplementedError()
+        """Joint names in public API order.
+
+        The order follows :attr:`ArticulationCfg.joint_ordering` when configured
+        and otherwise matches :attr:`backend_joint_names`.
+        """
+        ordering = getattr(getattr(self, "data", None), "joint_ordering", None)
+        if ordering is not None:
+            return list(ordering.user_names)
+        return list(self.backend_joint_names)
 
     @property
     @abstractmethod
@@ -162,20 +195,197 @@ class BaseArticulation(AssetBase):
         raise NotImplementedError()
 
     @property
-    @abstractmethod
     def body_names(self) -> list[str]:
-        """Ordered names of bodies in articulation."""
-        raise NotImplementedError()
+        """Body names in public API order.
+
+        The order follows :attr:`ArticulationCfg.body_ordering` when configured
+        and otherwise matches :attr:`backend_body_names`.
+        """
+        ordering = getattr(getattr(self, "data", None), "body_ordering", None)
+        if ordering is not None:
+            return list(ordering.user_names)
+        return list(self.backend_body_names)
+
+    @property
+    def backend_joint_names(self) -> list[str]:
+        """Joint names in active backend solver-view order.
+
+        Concrete backends must override this property so its order matches
+        ``root_view`` metadata and joint-indexed solver arrays even when
+        :attr:`joint_names` uses another public order.
+
+        The inherited compatibility fallback emits :class:`DeprecationWarning`
+        and returns :attr:`joint_names`. A subclass relying on that fallback
+        therefore receives public order and cannot expose a distinct solver order.
+        """
+        warnings.warn(
+            f"{type(self).__name__} must override backend_joint_names before it becomes abstract in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.joint_names
+
+    @property
+    def backend_body_names(self) -> list[str]:
+        """Body names in active backend solver-view order.
+
+        Concrete backends must override this property so its order matches
+        ``root_view`` metadata and body-indexed solver arrays even when
+        :attr:`body_names` uses another public order.
+
+        The inherited compatibility fallback emits :class:`DeprecationWarning`
+        and returns :attr:`body_names`. A subclass relying on that fallback
+        therefore receives public order and cannot expose a distinct solver order.
+        """
+        warnings.warn(
+            f"{type(self).__name__} must override backend_body_names before it becomes abstract in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.body_names
+
+    @property
+    def joint_ordering(self) -> ArticulationNameMap | None:
+        """Bidirectional map between backend and public joint order.
+
+        The map is ``None`` for the default ``None`` configuration, a non-``None``
+        identity map when an explicit order resolves to backend order, and a
+        nonidentity map for any actual permutation.
+        """
+        return getattr(self.data, "joint_ordering", None)
+
+    @property
+    def body_ordering(self) -> ArticulationNameMap | None:
+        """Bidirectional map between backend and public body order.
+
+        The map is ``None`` for the default ``None`` configuration, a non-``None``
+        identity map when an explicit order resolves to backend order, and a
+        nonidentity map for any actual permutation.
+        """
+        return getattr(self.data, "body_ordering", None)
+
+    def map_joint_ids_to_backend(self, joint_ids: Sequence[int]) -> Sequence[int]:
+        """Translate public joint indices to active-backend joint indices.
+
+        Backend solver views expose joint metadata and joint-indexed arrays in
+        :attr:`backend_joint_names` order, which can differ from the public
+        :attr:`joint_names` order selected by :attr:`joint_ordering`. Consumers
+        that pick joints with public indices (for example event terms) must
+        convert those indices before addressing backend arrays.
+
+        When :attr:`joint_ordering` is ``None`` or an identity permutation, the
+        public and backend orders coincide and :paramref:`joint_ids` is returned
+        unchanged without any per-index lookup.
+
+        Args:
+            joint_ids: Joint indices in public :attr:`joint_names` order.
+
+        Returns:
+            The same joint indices expressed in :attr:`backend_joint_names`
+            order, or :paramref:`joint_ids` unchanged when the orders coincide.
+        """
+        ordering = self.joint_ordering
+        if ordering is None or ordering.is_identity:
+            return joint_ids
+        return [ordering.user_to_backend_indices[joint_id] for joint_id in joint_ids]
+
+    def map_body_ids_to_backend(self, body_ids: Sequence[int]) -> Sequence[int]:
+        """Translate public body indices to active-backend body indices.
+
+        Backend solver views expose body metadata and body-indexed arrays in
+        :attr:`backend_body_names` order, which can differ from the public
+        :attr:`body_names` order selected by :attr:`body_ordering`. Consumers
+        that pick bodies with public indices (for example event terms) must
+        convert those indices before addressing backend arrays.
+
+        When :attr:`body_ordering` is ``None`` or an identity permutation, the
+        public and backend orders coincide and :paramref:`body_ids` is returned
+        unchanged without any per-index lookup.
+
+        Args:
+            body_ids: Body indices in public :attr:`body_names` order.
+
+        Returns:
+            The same body indices expressed in :attr:`backend_body_names` order,
+            or :paramref:`body_ids` unchanged when the orders coincide.
+        """
+        ordering = self.body_ordering
+        if ordering is None or ordering.is_identity:
+            return body_ids
+        return [ordering.user_to_backend_indices[body_id] for body_id in body_ids]
 
     @property
     @abstractmethod
     def root_view(self):
-        """Root view for the asset.
+        """Root articulation view in active backend order.
+
+        Name metadata and joint- or body-indexed arrays exposed by this view always
+        use backend solver-view order, regardless of the configured public order.
+        Use :attr:`joint_ordering` or :attr:`body_ordering` when converting axes.
 
         .. note::
-            Use this view with caution. It requires handling of tensors in a specific way.
+            Use this view with caution. It requires handling backend tensors in
+            the backend-specific way.
         """
         raise NotImplementedError()
+
+    def _resolve_and_install_ordering_maps(self) -> None:
+        """Resolve configured articulation name orderings and store maps on :attr:`data`."""
+        had_ordering = self.data.joint_ordering is not None or self.data.body_ordering is not None
+
+        if self.cfg.joint_ordering is None:
+            self.data.joint_ordering = None
+            self.data.joint_names = list(self.backend_joint_names)
+        else:
+            joint_user_names = _resolve_articulation_ordering_names(
+                kind="joint",
+                backend_names=self.backend_joint_names,
+                ordering=self.cfg.joint_ordering,
+                active_backend_name=self.__backend_name__,
+                articulation=self,
+            )
+            self.data.joint_ordering = build_articulation_name_map(
+                kind="joint",
+                backend_names=self.backend_joint_names,
+                user_names=joint_user_names,
+                device=self.device,
+            )
+            self.data.joint_names = list(self.data.joint_ordering.user_names)
+
+        if self.cfg.body_ordering is None:
+            self.data.body_ordering = None
+            self.data.body_names = list(self.backend_body_names)
+        else:
+            backend_body_names = self.backend_body_names
+            body_user_names = _resolve_articulation_ordering_names(
+                kind="body",
+                backend_names=backend_body_names,
+                ordering=self.cfg.body_ordering,
+                active_backend_name=self.__backend_name__,
+                articulation=self,
+            )
+            body_ordering = build_articulation_name_map(
+                kind="body",
+                backend_names=backend_body_names,
+                user_names=body_user_names,
+                device=self.device,
+            )
+            if self.is_fixed_base and backend_body_names:
+                root_body_name = backend_body_names[0]
+                requested_index = body_ordering.backend_to_user_indices[0]
+                if requested_index != 0:
+                    raise ValueError(
+                        f"Invalid body_ordering for fixed-base articulation '{self.cfg.prim_path}': root body "
+                        f"'{root_body_name}' must remain at public index 0, but was requested at index "
+                        f"{requested_index}. Put '{root_body_name}' first; all remaining bodies may be reordered "
+                        "freely."
+                    )
+            self.data.body_ordering = body_ordering
+            self.data.body_names = list(body_ordering.user_names)
+
+        has_ordering = self.data.joint_ordering is not None or self.data.body_ordering is not None
+        if had_ordering or has_ordering:
+            self.data._apply_ordering_maps_after_resolve()
 
     @property
     def num_base_dofs(self) -> int:
@@ -2191,6 +2401,166 @@ class BaseArticulation(AssetBase):
     def _invalidate_initialize_callback(self, event) -> None:
         """Invalidates the scene elements."""
         super()._invalidate_initialize_callback(event)
+
+    """
+    Internal helpers -- Ordering.
+    """
+
+    _ordering_joint_staging_names: tuple[str, ...] = ()
+    """Backend-order joint-target staging attributes managed by :meth:`_ordering_configure_backend_staging`.
+
+    Each named attribute is a 2-D ``(num_instances, num_joints)`` ``wp.float32``
+    staging buffer, allocated while a nonidentity joint ordering is active and set
+    to ``None`` otherwise. Backends override this tuple to declare their staging;
+    the default empty tuple keeps identity-only backends at a no-op.
+    """
+
+    def _cache_ordering_maps(self) -> None:
+        """Cache backend/public ordering maps on the articulation instance.
+
+        Backends install ordering maps exactly once during initialization. There
+        is no public runtime re-ordering API, so re-invoking this method after the
+        maps are cached indicates a programming error and is rejected. A backend
+        that legitimately rebuilds its maps calls :meth:`_reset_and_cache_ordering_maps`
+        (which resets :attr:`_ordering_maps_cached` first), mirroring the single
+        initialization path.
+
+        The data container owns the canonical ordering flags; this method mirrors
+        them onto the asset as plain attributes so hot write paths read one value
+        without a per-step property hop, while the asset keeps its own device maps
+        (identity-order reads still need a valid ``_ALL_*_INDICES`` array).
+
+        Raises:
+            RuntimeError: If invoked again after the ordering maps were cached.
+        """
+        if getattr(self, "_ordering_maps_cached", False):
+            raise RuntimeError(
+                "Articulation ordering maps are cached exactly once during initialization; "
+                "re-ordering an already initialized articulation is not supported."
+            )
+
+        joint_ordering = self.data.joint_ordering
+        if joint_ordering is None:
+            self._joint_user_to_backend = self._ALL_JOINT_INDICES
+            self._joint_backend_to_user = self._ALL_JOINT_INDICES
+        else:
+            self._joint_user_to_backend = joint_ordering.user_to_backend
+            self._joint_backend_to_user = joint_ordering.backend_to_user
+        self._has_joint_ordering = self.data._has_joint_ordering
+
+        body_ordering = self.data.body_ordering
+        if body_ordering is None:
+            self._body_user_to_backend = self._ALL_BODY_INDICES
+            self._body_backend_to_user = self._ALL_BODY_INDICES
+        else:
+            self._body_user_to_backend = body_ordering.user_to_backend
+            self._body_backend_to_user = body_ordering.backend_to_user
+        self._has_body_ordering = self.data._has_body_ordering
+
+        self._ordering_configure_backend_staging()
+        self._ordering_maps_cached = True
+
+    def _reset_and_cache_ordering_maps(self) -> None:
+        """Reset the cache guard and (re)cache the articulation ordering maps.
+
+        Pairs the guard reset with :meth:`_cache_ordering_maps` so every backend
+        re-establishes its ordering maps through one structural entry point when it
+        (re)creates buffers, instead of resetting :attr:`_ordering_maps_cached`
+        ad hoc before each call.
+        """
+        self._ordering_maps_cached = False
+        self._cache_ordering_maps()
+
+    def _ordering_configure_backend_staging(self) -> None:
+        """Allocate or release backend-order joint-target staging after ordering maps change.
+
+        Iterates :attr:`_ordering_joint_staging_names`, allocating each declared
+        staging buffer while a nonidentity joint ordering is active and clearing it
+        to ``None`` otherwise. Backends that also stage body-indexed buffers extend
+        this via ``super()`` before handling their own body staging.
+        """
+        for backend_name in self._ordering_joint_staging_names:
+            if not hasattr(self, backend_name):
+                continue
+            if self._has_joint_ordering:
+                if getattr(self, backend_name) is None:
+                    setattr(
+                        self,
+                        backend_name,
+                        wp.zeros((self.num_instances, self.num_joints), dtype=wp.float32, device=self.device),
+                    )
+            else:
+                setattr(self, backend_name, None)
+
+    def _reorder_joint_buffer_to_backend(
+        self,
+        user_buffer: wp.array,
+        backend_buffer: wp.array | TimestampedBufferWarp | None,
+        *,
+        component_count: int | None = None,
+    ) -> wp.array:
+        """Return a backend-order view or copy of a public-order joint buffer.
+
+        When :paramref:`component_count` is ``None`` the buffer is treated as
+        two-dimensional (per joint); otherwise it is treated as three-dimensional
+        with that many trailing components per joint.
+
+        Args:
+            user_buffer: Public-order joint buffer to reorder.
+            backend_buffer: Backend-order staging destination, either a raw Warp
+                array or a :class:`~isaaclab.utils.buffers.TimestampedBufferWarp`.
+                Required when the articulation has a non-identity joint ordering.
+            component_count: Number of trailing components per joint for a
+                three-dimensional buffer, or ``None`` for a two-dimensional buffer.
+
+        Returns:
+            :paramref:`user_buffer` when the joint ordering is identity; otherwise
+            the backend-order staging array populated from :paramref:`user_buffer`.
+
+        Raises:
+            RuntimeError: If a non-identity joint ordering is active but no backend
+                staging buffer was provided.
+        """
+        if not self._has_joint_ordering:
+            return user_buffer
+        if backend_buffer is None:
+            detail = "backend staging" if component_count is None else "3-D backend staging"
+            raise RuntimeError(f"{self.__backend_name__} joint ordering requires {detail}.")
+        backend_data = backend_buffer.data if isinstance(backend_buffer, TimestampedBufferWarp) else backend_buffer
+        if component_count is None:
+            wp.launch(
+                ordering_kernels.reorder_2d_user_to_backend,
+                dim=(self.num_instances, self.num_joints),
+                inputs=[user_buffer, self._joint_backend_to_user],
+                outputs=[backend_data],
+                device=self.device,
+            )
+        else:
+            wp.launch(
+                ordering_kernels.reorder_3d_user_to_backend,
+                dim=(self.num_instances, self.num_joints, component_count),
+                inputs=[user_buffer, self._joint_backend_to_user],
+                outputs=[backend_data],
+                device=self.device,
+            )
+        return backend_data
+
+    def _get_backend_ordered_joint_buffer(
+        self,
+        user_buffer: wp.array,
+        backend_buffer: wp.array | TimestampedBufferWarp | None,
+    ) -> wp.array:
+        """Return a backend-order view or copy of a public-order joint buffer."""
+        return self._reorder_joint_buffer_to_backend(user_buffer, backend_buffer)
+
+    def _get_backend_ordered_joint_3d_buffer(
+        self,
+        user_buffer: wp.array,
+        backend_buffer: wp.array | TimestampedBufferWarp | None,
+        component_count: int,
+    ) -> wp.array:
+        """Return a backend-order view or copy of a public-order 3-D joint buffer."""
+        return self._reorder_joint_buffer_to_backend(user_buffer, backend_buffer, component_count=component_count)
 
     """
     Internal helpers -- Actuators.

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -178,11 +178,13 @@ class BaseArticulation(AssetBase):
         """Joint names in public API order.
 
         The order follows :attr:`ArticulationCfg.joint_ordering` when configured
-        and otherwise matches :attr:`backend_joint_names`.
+        and otherwise matches :attr:`backend_joint_names`. Once the articulation
+        installs its resolved names on :attr:`data`, those are returned directly;
+        before that, the property falls back to :attr:`backend_joint_names`.
         """
-        ordering = self.data.joint_ordering
-        if ordering is not None:
-            return list(self.data.joint_names)
+        names = self.data.joint_names
+        if names is not None:
+            return list(names)
         return list(self.backend_joint_names)
 
     @property
@@ -202,11 +204,13 @@ class BaseArticulation(AssetBase):
         """Body names in public API order.
 
         The order follows :attr:`ArticulationCfg.body_ordering` when configured
-        and otherwise matches :attr:`backend_body_names`.
+        and otherwise matches :attr:`backend_body_names`. Once the articulation
+        installs its resolved names on :attr:`data`, those are returned directly;
+        before that, the property falls back to :attr:`backend_body_names`.
         """
-        ordering = self.data.body_ordering
-        if ordering is not None:
-            return list(self.data.body_names)
+        names = self.data.body_names
+        if names is not None:
+            return list(names)
         return list(self.backend_body_names)
 
     @property
@@ -367,8 +371,6 @@ class BaseArticulation(AssetBase):
         permutation and ``is not None`` checks alone decide whether reordering is
         active.
         """
-        had_ordering = self.data.joint_ordering is not None or self.data.body_ordering is not None
-
         joint_names, joint_ordering = self._resolve_axis_ordering("joint")
         self.data.joint_names = joint_names
         self.data.joint_ordering = joint_ordering
@@ -387,9 +389,7 @@ class BaseArticulation(AssetBase):
         self.data.body_names = body_names
         self.data.body_ordering = body_ordering
 
-        has_ordering = self.data.joint_ordering is not None or self.data.body_ordering is not None
-        if had_ordering or has_ordering:
-            self.data._apply_ordering_maps_after_resolve()
+        self.data._apply_ordering_maps_after_resolve()
 
     def _resolve_axis_ordering(self, kind: Literal["joint", "body"]) -> tuple[list[str], ArticulationNameMap | None]:
         """Resolve one axis's public names and permutation from the configuration.
@@ -2514,7 +2514,7 @@ class BaseArticulation(AssetBase):
             else:
                 setattr(self, backend_name, None)
 
-    def _reorder_joint_buffer_to_backend(
+    def _get_backend_ordered_joint_buffer(
         self,
         user_buffer: wp.array,
         backend_buffer: wp.array | TimestampedBufferWarp | None,
@@ -2574,53 +2574,6 @@ class BaseArticulation(AssetBase):
                 device=self.device,
             )
         return backend_data
-
-    def _get_backend_ordered_joint_buffer(
-        self,
-        user_buffer: wp.array,
-        backend_buffer: wp.array | TimestampedBufferWarp | None,
-    ) -> wp.array:
-        """Return a backend-order view or copy of a public-order 2-D joint buffer.
-
-        Thin wrapper over :meth:`_reorder_joint_buffer_to_backend` for buffers
-        with one value per joint; see that method for the argument contract,
-        the identity fast path, and the hot-path guidance.
-
-        Args:
-            user_buffer: Public-order joint buffer to reorder.
-            backend_buffer: Backend-order staging destination. Required when a
-                non-identity joint ordering is active.
-
-        Returns:
-            :paramref:`user_buffer` under identity ordering; otherwise the
-            populated backend-order staging array.
-        """
-        return self._reorder_joint_buffer_to_backend(user_buffer, backend_buffer)
-
-    def _get_backend_ordered_joint_3d_buffer(
-        self,
-        user_buffer: wp.array,
-        backend_buffer: wp.array | TimestampedBufferWarp | None,
-        component_count: int,
-    ) -> wp.array:
-        """Return a backend-order view or copy of a public-order 3-D joint buffer.
-
-        Thin wrapper over :meth:`_reorder_joint_buffer_to_backend` for buffers
-        with :paramref:`component_count` trailing components per joint; see that
-        method for the argument contract, the identity fast path, and the
-        hot-path guidance.
-
-        Args:
-            user_buffer: Public-order joint buffer to reorder.
-            backend_buffer: Backend-order staging destination. Required when a
-                non-identity joint ordering is active.
-            component_count: Number of trailing components per joint.
-
-        Returns:
-            :paramref:`user_buffer` under identity ordering; otherwise the
-            populated backend-order staging array.
-        """
-        return self._reorder_joint_buffer_to_backend(user_buffer, backend_buffer, component_count=component_count)
 
     """
     Internal helpers -- Actuators.

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -182,7 +182,7 @@ class BaseArticulation(AssetBase):
         """
         ordering = self.data.joint_ordering
         if ordering is not None:
-            return list(ordering.user_names)
+            return list(self.data.joint_names)
         return list(self.backend_joint_names)
 
     @property
@@ -206,7 +206,7 @@ class BaseArticulation(AssetBase):
         """
         ordering = self.data.body_ordering
         if ordering is not None:
-            return list(ordering.user_names)
+            return list(self.data.body_names)
         return list(self.backend_body_names)
 
     @property
@@ -337,80 +337,72 @@ class BaseArticulation(AssetBase):
     def _resolve_and_install_ordering_maps(self) -> None:
         """Resolve configured articulation name orderings and store maps on :attr:`data`.
 
-        Orderings that resolve to the backend's native order are normalized to
-        ``None`` here, so an installed map always denotes an actual permutation
-        and ``is not None`` checks alone decide whether reordering is active.
+        This is the single install site for ordering state: the resolved maps live
+        only on :attr:`data` (:attr:`~BaseArticulationData.joint_ordering` and
+        :attr:`~BaseArticulationData.body_ordering`) and every read path checks
+        them there. Orderings that resolve to the backend's native order are
+        normalized to ``None``, so a non-``None`` map always denotes an actual
+        permutation and ``is not None`` checks alone decide whether reordering is
+        active.
         """
         had_ordering = self.data.joint_ordering is not None or self.data.body_ordering is not None
 
-        if self.cfg.joint_ordering is None:
-            self.data.joint_ordering = None
-            self.data.joint_names = list(self.backend_joint_names)
-        else:
-            joint_user_names = _resolve_articulation_ordering_names(
-                kind="joint",
-                backend_names=tuple(self.backend_joint_names),
-                ordering=self.cfg.joint_ordering,
-                active_backend_name=self.__backend_name__,
-                articulation=self,
-            )
-            joint_ordering = build_articulation_name_map(
-                kind="joint",
-                backend_names=tuple(self.backend_joint_names),
-                user_names=joint_user_names,
-                device=self.device,
-            )
-            if joint_ordering.is_identity:
-                logger.info(
-                    "Configured joint_ordering for '%s' resolves to the backend's native order; no reordering"
-                    " will be applied.",
-                    self.cfg.prim_path,
-                )
-                joint_ordering = None
-            self.data.joint_ordering = joint_ordering
-            self.data.joint_names = list(joint_user_names)
+        joint_names, joint_ordering = self._resolve_axis_ordering("joint")
+        self.data.joint_names = joint_names
+        self.data.joint_ordering = joint_ordering
 
-        if self.cfg.body_ordering is None:
-            self.data.body_ordering = None
-            self.data.body_names = list(self.backend_body_names)
-        else:
-            backend_body_names = tuple(self.backend_body_names)
-            body_user_names = _resolve_articulation_ordering_names(
-                kind="body",
-                backend_names=backend_body_names,
-                ordering=self.cfg.body_ordering,
-                active_backend_name=self.__backend_name__,
-                articulation=self,
-            )
-            body_ordering = build_articulation_name_map(
-                kind="body",
-                backend_names=backend_body_names,
-                user_names=body_user_names,
-                device=self.device,
-            )
-            if self.is_fixed_base and backend_body_names:
-                root_body_name = backend_body_names[0]
-                requested_index = body_ordering.backend_to_user_indices[0]
-                if requested_index != 0:
-                    raise ValueError(
-                        f"Invalid body_ordering for fixed-base articulation '{self.cfg.prim_path}': root body "
-                        f"'{root_body_name}' must remain at public index 0, but was requested at index "
-                        f"{requested_index}. Put '{root_body_name}' first; all remaining bodies may be reordered "
-                        "freely."
-                    )
-            if body_ordering.is_identity:
-                logger.info(
-                    "Configured body_ordering for '%s' resolves to the backend's native order; no reordering"
-                    " will be applied.",
-                    self.cfg.prim_path,
+        body_names, body_ordering = self._resolve_axis_ordering("body")
+        if body_ordering is not None and self.is_fixed_base:
+            root_body_name = self.backend_body_names[0]
+            requested_index = body_ordering.backend_to_user_indices[0]
+            if requested_index != 0:
+                raise ValueError(
+                    f"Invalid body_ordering for fixed-base articulation '{self.cfg.prim_path}': root body "
+                    f"'{root_body_name}' must remain at public index 0, but was requested at index "
+                    f"{requested_index}. Put '{root_body_name}' first; all remaining bodies may be reordered "
+                    "freely."
                 )
-                body_ordering = None
-            self.data.body_ordering = body_ordering
-            self.data.body_names = list(body_user_names)
+        self.data.body_names = body_names
+        self.data.body_ordering = body_ordering
 
         has_ordering = self.data.joint_ordering is not None or self.data.body_ordering is not None
         if had_ordering or has_ordering:
             self.data._apply_ordering_maps_after_resolve()
+
+    def _resolve_axis_ordering(self, kind: Literal["joint", "body"]) -> tuple[list[str], ArticulationNameMap | None]:
+        """Resolve one axis's public names and permutation from the configuration.
+
+        Args:
+            kind: Articulation element kind to resolve.
+
+        Returns:
+            The public names for the axis and its permutation map, where ``None``
+            means public order equals backend order (no ordering configured, or a
+            configured ordering that resolved to the backend's native order).
+        """
+        backend_names = tuple(self.backend_joint_names if kind == "joint" else self.backend_body_names)
+        cfg_ordering = self.cfg.joint_ordering if kind == "joint" else self.cfg.body_ordering
+        if cfg_ordering is None:
+            return list(backend_names), None
+
+        user_names = _resolve_articulation_ordering_names(
+            kind=kind,
+            backend_names=backend_names,
+            ordering=cfg_ordering,
+            active_backend_name=self.__backend_name__,
+            articulation=self,
+        )
+        ordering = build_articulation_name_map(
+            kind=kind, backend_names=backend_names, user_names=user_names, device=self.device
+        )
+        if ordering is None:
+            logger.info(
+                "Configured %s_ordering for '%s' resolves to the backend's native order; no reordering"
+                " will be applied.",
+                kind,
+                self.cfg.prim_path,
+            )
+        return list(user_names), ordering
 
     @property
     def num_base_dofs(self) -> int:
@@ -2440,61 +2432,43 @@ class BaseArticulation(AssetBase):
     the default empty tuple keeps identity-only backends at a no-op.
     """
 
-    def _cache_ordering_maps(self) -> None:
-        """Cache backend/public ordering maps on the articulation instance.
+    def _joint_user_to_backend_map(self) -> wp.array:
+        """Device public-to-backend joint map, or the identity map when no ordering is active.
 
-        Backends install ordering maps exactly once during initialization. There
-        is no public runtime re-ordering API, so re-invoking this method after the
-        maps are cached indicates a programming error and is rejected. A backend
-        that legitimately rebuilds its maps calls :meth:`_reset_and_cache_ordering_maps`
-        (which resets :attr:`_ordering_maps_cached` first), mirroring the single
-        initialization path.
-
-        The data container owns the canonical ordering flags; this method mirrors
-        them onto the asset as plain attributes so hot write paths read one value
-        without a per-step property hop, while the asset keeps its own device maps
-        (identity-order reads still need a valid ``_ALL_*_INDICES`` array).
-
-        Raises:
-            RuntimeError: If invoked again after the ordering maps were cached.
+        The identity fallback reads the backend-allocated ``_ALL_JOINT_INDICES``
+        index buffer (the same backend-owned contract as
+        :attr:`_ordering_joint_staging_names`), so unconditional launch sites --
+        for example in-graph publish kernels that always gather -- get a valid map
+        either way. Conditional sites should read :attr:`data.joint_ordering`
+        directly and skip the launch when it is ``None``.
         """
-        if getattr(self, "_ordering_maps_cached", False):
-            raise RuntimeError(
-                "Articulation ordering maps are cached exactly once during initialization; "
-                "re-ordering an already initialized articulation is not supported."
-            )
+        ordering = self.data.joint_ordering
+        return ordering.user_to_backend if ordering is not None else self._ALL_JOINT_INDICES
 
-        joint_ordering = self.data.joint_ordering
-        if joint_ordering is None:
-            self._joint_user_to_backend = self._ALL_JOINT_INDICES
-            self._joint_backend_to_user = self._ALL_JOINT_INDICES
-        else:
-            self._joint_user_to_backend = joint_ordering.user_to_backend
-            self._joint_backend_to_user = joint_ordering.backend_to_user
-        self._has_joint_ordering = self.data._has_joint_ordering
+    def _joint_backend_to_user_map(self) -> wp.array:
+        """Device backend-to-public joint map, or the identity map when no ordering is active.
 
-        body_ordering = self.data.body_ordering
-        if body_ordering is None:
-            self._body_user_to_backend = self._ALL_BODY_INDICES
-            self._body_backend_to_user = self._ALL_BODY_INDICES
-        else:
-            self._body_user_to_backend = body_ordering.user_to_backend
-            self._body_backend_to_user = body_ordering.backend_to_user
-        self._has_body_ordering = self.data._has_body_ordering
-
-        self._ordering_configure_backend_staging()
-        self._ordering_maps_cached = True
-
-    def _reset_and_cache_ordering_maps(self) -> None:
-        """Reset the cache guard and (re)cache the articulation ordering maps.
-
-        Pairs the guard reset with :meth:`_cache_ordering_maps` so every backend
-        re-establishes its ordering maps through one structural entry point when it
-        (re)creates buffers, instead of resetting :attr:`_ordering_maps_cached`
-        ad hoc before each call.
+        See :meth:`_joint_user_to_backend_map` for the identity-fallback contract.
         """
-        self._ordering_maps_cached = False
-        self._cache_ordering_maps()
+        ordering = self.data.joint_ordering
+        return ordering.backend_to_user if ordering is not None else self._ALL_JOINT_INDICES
+
+    def _body_user_to_backend_map(self) -> wp.array:
+        """Device public-to-backend body map, or the identity map when no ordering is active.
+
+        See :meth:`_joint_user_to_backend_map` for the identity-fallback contract;
+        the body fallback reads ``_ALL_BODY_INDICES``.
+        """
+        ordering = self.data.body_ordering
+        return ordering.user_to_backend if ordering is not None else self._ALL_BODY_INDICES
+
+    def _body_backend_to_user_map(self) -> wp.array:
+        """Device backend-to-public body map, or the identity map when no ordering is active.
+
+        See :meth:`_body_user_to_backend_map` for the identity-fallback contract.
+        """
+        ordering = self.data.body_ordering
+        return ordering.backend_to_user if ordering is not None else self._ALL_BODY_INDICES
 
     def _ordering_configure_backend_staging(self) -> None:
         """Allocate or release backend-order joint-target staging after ordering maps change.
@@ -2507,7 +2481,7 @@ class BaseArticulation(AssetBase):
         for backend_name in self._ordering_joint_staging_names:
             if not hasattr(self, backend_name):
                 continue
-            if self._has_joint_ordering:
+            if self.data.joint_ordering is not None:
                 if getattr(self, backend_name) is None:
                     setattr(
                         self,
@@ -2553,7 +2527,8 @@ class BaseArticulation(AssetBase):
             RuntimeError: If a non-identity joint ordering is active but no backend
                 staging buffer was provided.
         """
-        if not self._has_joint_ordering:
+        ordering = self.data.joint_ordering
+        if ordering is None:
             return user_buffer
         if backend_buffer is None:
             detail = "backend staging" if component_count is None else "3-D backend staging"
@@ -2563,7 +2538,7 @@ class BaseArticulation(AssetBase):
             wp.launch(
                 ordering_kernels.reorder_2d_user_to_backend,
                 dim=(self.num_instances, self.num_joints),
-                inputs=[user_buffer, self._joint_backend_to_user],
+                inputs=[user_buffer, ordering.backend_to_user],
                 outputs=[backend_data],
                 device=self.device,
             )
@@ -2571,7 +2546,7 @@ class BaseArticulation(AssetBase):
             wp.launch(
                 ordering_kernels.reorder_3d_user_to_backend,
                 dim=(self.num_instances, self.num_joints, component_count),
-                inputs=[user_buffer, self._joint_backend_to_user],
+                inputs=[user_buffer, ordering.backend_to_user],
                 outputs=[backend_data],
                 device=self.device,
             )

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -180,7 +180,7 @@ class BaseArticulation(AssetBase):
         The order follows :attr:`ArticulationCfg.joint_ordering` when configured
         and otherwise matches :attr:`backend_joint_names`.
         """
-        ordering = getattr(getattr(self, "data", None), "joint_ordering", None)
+        ordering = self.data.joint_ordering
         if ordering is not None:
             return list(ordering.user_names)
         return list(self.backend_joint_names)
@@ -204,7 +204,7 @@ class BaseArticulation(AssetBase):
         The order follows :attr:`ArticulationCfg.body_ordering` when configured
         and otherwise matches :attr:`backend_body_names`.
         """
-        ordering = getattr(getattr(self, "data", None), "body_ordering", None)
+        ordering = self.data.body_ordering
         if ordering is not None:
             return list(ordering.user_names)
         return list(self.backend_body_names)
@@ -256,7 +256,7 @@ class BaseArticulation(AssetBase):
         to the backend's native order. A non-``None`` map always denotes an
         actual permutation.
         """
-        return getattr(self.data, "joint_ordering", None)
+        return self.data.joint_ordering
 
     @property
     def body_ordering(self) -> ArticulationNameMap | None:
@@ -267,7 +267,7 @@ class BaseArticulation(AssetBase):
         to the backend's native order. A non-``None`` map always denotes an
         actual permutation.
         """
-        return getattr(self.data, "body_ordering", None)
+        return self.data.body_ordering
 
     def map_joint_ids_to_backend(self, joint_ids: Sequence[int]) -> Sequence[int]:
         """Translate public joint indices to active-backend joint indices.
@@ -2530,6 +2530,13 @@ class BaseArticulation(AssetBase):
         two-dimensional (per joint); otherwise it is treated as three-dimensional
         with that many trailing components per joint.
 
+        Avoid this modify-then-reorder helper on per-step hot paths: it costs a
+        full extra kernel launch over the buffer. Prefer the fused
+        ``write_*_user_to_backend`` kernels from
+        :mod:`isaaclab.assets.articulation.ordering_kernels`, which write the
+        public and backend buffers in a single launch. This helper exists for
+        infrequent property writers where the extra launch is irrelevant.
+
         Args:
             user_buffer: Public-order joint buffer to reorder.
             backend_buffer: Backend-order staging destination, either a raw Warp
@@ -2575,7 +2582,21 @@ class BaseArticulation(AssetBase):
         user_buffer: wp.array,
         backend_buffer: wp.array | TimestampedBufferWarp | None,
     ) -> wp.array:
-        """Return a backend-order view or copy of a public-order joint buffer."""
+        """Return a backend-order view or copy of a public-order 2-D joint buffer.
+
+        Thin wrapper over :meth:`_reorder_joint_buffer_to_backend` for buffers
+        with one value per joint; see that method for the argument contract,
+        the identity fast path, and the hot-path guidance.
+
+        Args:
+            user_buffer: Public-order joint buffer to reorder.
+            backend_buffer: Backend-order staging destination. Required when a
+                non-identity joint ordering is active.
+
+        Returns:
+            :paramref:`user_buffer` under identity ordering; otherwise the
+            populated backend-order staging array.
+        """
         return self._reorder_joint_buffer_to_backend(user_buffer, backend_buffer)
 
     def _get_backend_ordered_joint_3d_buffer(
@@ -2584,7 +2605,23 @@ class BaseArticulation(AssetBase):
         backend_buffer: wp.array | TimestampedBufferWarp | None,
         component_count: int,
     ) -> wp.array:
-        """Return a backend-order view or copy of a public-order 3-D joint buffer."""
+        """Return a backend-order view or copy of a public-order 3-D joint buffer.
+
+        Thin wrapper over :meth:`_reorder_joint_buffer_to_backend` for buffers
+        with :paramref:`component_count` trailing components per joint; see that
+        method for the argument contract, the identity fast path, and the
+        hot-path guidance.
+
+        Args:
+            user_buffer: Public-order joint buffer to reorder.
+            backend_buffer: Backend-order staging destination. Required when a
+                non-identity joint ordering is active.
+            component_count: Number of trailing components per joint.
+
+        Returns:
+            :paramref:`user_buffer` under identity ordering; otherwise the
+            populated backend-order staging array.
+        """
         return self._reorder_joint_buffer_to_backend(user_buffer, backend_buffer, component_count=component_count)
 
     """

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation.py
@@ -349,14 +349,14 @@ class BaseArticulation(AssetBase):
         else:
             joint_user_names = _resolve_articulation_ordering_names(
                 kind="joint",
-                backend_names=self.backend_joint_names,
+                backend_names=tuple(self.backend_joint_names),
                 ordering=self.cfg.joint_ordering,
                 active_backend_name=self.__backend_name__,
                 articulation=self,
             )
             joint_ordering = build_articulation_name_map(
                 kind="joint",
-                backend_names=self.backend_joint_names,
+                backend_names=tuple(self.backend_joint_names),
                 user_names=joint_user_names,
                 device=self.device,
             )
@@ -374,7 +374,7 @@ class BaseArticulation(AssetBase):
             self.data.body_ordering = None
             self.data.body_names = list(self.backend_body_names)
         else:
-            backend_body_names = self.backend_body_names
+            backend_body_names = tuple(self.backend_body_names)
             body_user_names = _resolve_articulation_ordering_names(
                 kind="body",
                 backend_names=backend_body_names,

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
@@ -118,28 +118,30 @@ class BaseArticulationData(ABC):
     joint_ordering: ArticulationNameMap | None = None
     """Bidirectional map between backend and public joint order.
 
-    This is ``None`` for default ordering, a non-``None`` identity map for an
-    explicit identity order, and a nonidentity map for an actual permutation.
+    This is ``None`` whenever public and backend orders coincide (default
+    ordering, or a configured ordering that resolved to backend order); a
+    non-``None`` map always denotes an actual permutation.
     """
 
     body_ordering: ArticulationNameMap | None = None
     """Bidirectional map between backend and public body order.
 
-    This is ``None`` for default ordering, a non-``None`` identity map for an
-    explicit identity order, and a nonidentity map for an actual permutation.
+    This is ``None`` whenever public and backend orders coincide (default
+    ordering, or a configured ordering that resolved to backend order); a
+    non-``None`` map always denotes an actual permutation.
     """
 
     _has_joint_ordering: bool = False
-    """Canonical flag for an active nonidentity joint ordering; set by :meth:`_install_ordering_flags`."""
+    """Canonical flag for an active joint ordering; set by :meth:`_install_ordering_flags`."""
 
     _has_body_ordering: bool = False
-    """Canonical flag for an active nonidentity body ordering; set by :meth:`_install_ordering_flags`."""
+    """Canonical flag for an active body ordering; set by :meth:`_install_ordering_flags`."""
 
     _joint_user_to_backend: wp.array | None = None
-    """Device joint public-to-backend permutation, or ``None`` under default or identity ordering."""
+    """Device joint public-to-backend permutation, or ``None`` when no ordering is active."""
 
     _body_user_to_backend: wp.array | None = None
-    """Device body public-to-backend permutation, or ``None`` under default or identity ordering."""
+    """Device body public-to-backend permutation, or ``None`` when no ordering is active."""
 
     fixed_tendon_names: list[str] | None = None
     """Fixed tendon names in active backend solver-view order."""
@@ -174,11 +176,13 @@ class BaseArticulationData(ABC):
         """
         had_joint_ordering = self._has_joint_ordering
         had_body_ordering = self._has_body_ordering
+        # Installed maps are normalized by the asset: identity orderings become
+        # ``None``, so presence alone decides whether reordering is active.
         joint_ordering = self.joint_ordering
-        self._has_joint_ordering = joint_ordering is not None and not joint_ordering.is_identity
+        self._has_joint_ordering = joint_ordering is not None
         self._joint_user_to_backend = joint_ordering.user_to_backend if self._has_joint_ordering else None
         body_ordering = self.body_ordering
-        self._has_body_ordering = body_ordering is not None and not body_ordering.is_identity
+        self._has_body_ordering = body_ordering is not None
         self._body_user_to_backend = body_ordering.user_to_backend if self._has_body_ordering else None
         return had_joint_ordering, had_body_ordering
 

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
@@ -147,21 +147,19 @@ class BaseArticulationData(ABC):
         paths require when the public order differs from backend order.
         """
 
-    def _make_jacobian_body_user_to_backend(self, body_ordering: ArticulationNameMap | None) -> wp.array:
+    def _make_jacobian_body_user_to_backend(self) -> wp.array:
         """Build the compact user-to-backend row map for Jacobian body axes.
 
-        Fixed-base articulations omit the root link's Jacobian rows, so a nonzero
-        :attr:`_jacobian_link_offset` drops backend row 0 and shifts the remaining
-        rows down by one.
-
-        Args:
-            body_ordering: Body ordering map, or ``None`` to build the row map in
-                backend body order.
+        The map follows the installed :attr:`body_ordering`, or backend body
+        order when no ordering is active. Fixed-base articulations omit the
+        root link's Jacobian rows, so a nonzero :attr:`_jacobian_link_offset`
+        drops backend row 0 and shifts the remaining rows down by one.
 
         Returns:
             One-dimensional ``wp.int32`` device array of backend Jacobian rows in
             public body order.
         """
+        body_ordering = self.body_ordering
         body_user_to_backend = (
             body_ordering.user_to_backend_indices if body_ordering is not None else range(self._num_bodies)
         )

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
@@ -131,18 +131,6 @@ class BaseArticulationData(ABC):
     non-``None`` map always denotes an actual permutation.
     """
 
-    _has_joint_ordering: bool = False
-    """Canonical flag for an active joint ordering; set by :meth:`_install_ordering_flags`."""
-
-    _has_body_ordering: bool = False
-    """Canonical flag for an active body ordering; set by :meth:`_install_ordering_flags`."""
-
-    _joint_user_to_backend: wp.array | None = None
-    """Device joint public-to-backend permutation, or ``None`` when no ordering is active."""
-
-    _body_user_to_backend: wp.array | None = None
-    """Device body public-to-backend permutation, or ``None`` when no ordering is active."""
-
     fixed_tendon_names: list[str] | None = None
     """Fixed tendon names in active backend solver-view order."""
 
@@ -158,33 +146,6 @@ class BaseArticulationData(ABC):
         override it to allocate or release the backend-order shadow buffers their read
         paths require when the public order differs from backend order.
         """
-
-    def _install_ordering_flags(self) -> tuple[bool, bool]:
-        """Record the canonical joint/body ordering flags and user-to-backend maps.
-
-        Reads the resolved :attr:`joint_ordering` / :attr:`body_ordering` maps and
-        stores, as the single source of truth for this data container, whether each
-        axis carries a nonidentity ordering (:attr:`_has_joint_ordering` /
-        :attr:`_has_body_ordering`) together with its device user-to-backend
-        permutation (``None`` under default or identity ordering). Backend
-        :meth:`_apply_ordering_maps_after_resolve` overrides call this first and then
-        reconfigure their backend-order staging using the returned previous flags.
-
-        Returns:
-            The ``(had_joint_ordering, had_body_ordering)`` flags from before this
-            call, so buffer reconfiguration can detect an ordering that was cleared.
-        """
-        had_joint_ordering = self._has_joint_ordering
-        had_body_ordering = self._has_body_ordering
-        # Installed maps are normalized by the asset: identity orderings become
-        # ``None``, so presence alone decides whether reordering is active.
-        joint_ordering = self.joint_ordering
-        self._has_joint_ordering = joint_ordering is not None
-        self._joint_user_to_backend = joint_ordering.user_to_backend if self._has_joint_ordering else None
-        body_ordering = self.body_ordering
-        self._has_body_ordering = body_ordering is not None
-        self._body_user_to_backend = body_ordering.user_to_backend if self._has_body_ordering else None
-        return had_joint_ordering, had_body_ordering
 
     def _make_jacobian_body_user_to_backend(self, body_ordering: ArticulationNameMap | None) -> wp.array:
         """Build the compact user-to-backend row map for Jacobian body axes.
@@ -231,7 +192,7 @@ class BaseArticulationData(ABC):
         """
         if self._body_com_pose_b.timestamp >= 0.0:
             return
-        if not self._has_body_ordering:
+        if self.body_ordering is None:
             self._fetch_body_com_pose_b_backend(self._body_com_pose_b)
             return
         backend_staging = self._body_com_pose_b_backend
@@ -241,7 +202,7 @@ class BaseArticulationData(ABC):
         wp.launch(
             ordering_kernels.reorder_2d_backend_to_user,
             dim=(self._num_instances, self._num_bodies),
-            inputs=[backend_staging.data, self._body_user_to_backend],
+            inputs=[backend_staging.data, self.body_ordering.user_to_backend],
             outputs=[self._body_com_pose_b.data],
             device=self.device,
         )
@@ -250,7 +211,7 @@ class BaseArticulationData(ABC):
     @property
     def _backend_body_com_pose_b(self) -> wp.array(dtype=wp.transformf, ndim=2):
         """Backend-order body COM pose buffer for root-only computations."""
-        if not self._has_body_ordering:
+        if self.body_ordering is None:
             self._ensure_body_com_pose_b_current()
             return self._body_com_pose_b.data
         backend_staging = self._body_com_pose_b_backend

--- a/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
+++ b/source/isaaclab/isaaclab/assets/articulation/base_articulation_data.py
@@ -3,8 +3,11 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import warnings
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import warp as wp
 
@@ -22,6 +25,13 @@ from isaaclab.utils.leapp import (
     leapp_tensor_semantics,
 )
 from isaaclab.utils.warp import ProxyArray
+
+from . import ordering_kernels
+
+if TYPE_CHECKING:
+    from isaaclab.utils.buffers import TimestampedBufferWarp
+
+    from .ordering import ArticulationNameMap
 
 
 class BaseArticulationData(ABC):
@@ -41,6 +51,9 @@ class BaseArticulationData(ABC):
     Depending on the settings, the two frames may not coincide with each other. In the robotics sense, the actor frame
     can be interpreted as the link frame.
     """
+
+    __backend_name__: str = "base"
+    """The name of the backend for the articulation data container."""
 
     def __init__(self, root_view, device: str):
         """Initializes the articulation data.
@@ -89,16 +102,158 @@ class BaseArticulationData(ABC):
     ##
 
     body_names: list[str] | None = None
-    """Body names in the order parsed by the simulation view."""
+    """Body names in public API order.
+
+    Configured order is used when present; otherwise this is active backend
+    solver-view order.
+    """
 
     joint_names: list[str] | None = None
-    """Joint names in the order parsed by the simulation view."""
+    """Joint names in public API order.
+
+    Configured order is used when present; otherwise this is active backend
+    solver-view order.
+    """
+
+    joint_ordering: ArticulationNameMap | None = None
+    """Bidirectional map between backend and public joint order.
+
+    This is ``None`` for default ordering, a non-``None`` identity map for an
+    explicit identity order, and a nonidentity map for an actual permutation.
+    """
+
+    body_ordering: ArticulationNameMap | None = None
+    """Bidirectional map between backend and public body order.
+
+    This is ``None`` for default ordering, a non-``None`` identity map for an
+    explicit identity order, and a nonidentity map for an actual permutation.
+    """
+
+    _has_joint_ordering: bool = False
+    """Canonical flag for an active nonidentity joint ordering; set by :meth:`_install_ordering_flags`."""
+
+    _has_body_ordering: bool = False
+    """Canonical flag for an active nonidentity body ordering; set by :meth:`_install_ordering_flags`."""
+
+    _joint_user_to_backend: wp.array | None = None
+    """Device joint public-to-backend permutation, or ``None`` under default or identity ordering."""
+
+    _body_user_to_backend: wp.array | None = None
+    """Device body public-to-backend permutation, or ``None`` under default or identity ordering."""
 
     fixed_tendon_names: list[str] | None = None
-    """Fixed tendon names in the order parsed by the simulation view."""
+    """Fixed tendon names in active backend solver-view order."""
 
     spatial_tendon_names: list[str] | None = None
-    """Spatial tendon names in the order parsed by the simulation view."""
+    """Spatial tendon names in active backend solver-view order."""
+
+    def _apply_ordering_maps_after_resolve(self) -> None:
+        """Configure backend-order staging after the articulation resolves ordering maps.
+
+        The owning articulation calls this once it has resolved and stored the joint
+        and body ordering maps (:attr:`joint_ordering` and :attr:`body_ordering`) on
+        this data container. The base implementation is a no-op; backend data classes
+        override it to allocate or release the backend-order shadow buffers their read
+        paths require when the public order differs from backend order.
+        """
+
+    def _install_ordering_flags(self) -> tuple[bool, bool]:
+        """Record the canonical joint/body ordering flags and user-to-backend maps.
+
+        Reads the resolved :attr:`joint_ordering` / :attr:`body_ordering` maps and
+        stores, as the single source of truth for this data container, whether each
+        axis carries a nonidentity ordering (:attr:`_has_joint_ordering` /
+        :attr:`_has_body_ordering`) together with its device user-to-backend
+        permutation (``None`` under default or identity ordering). Backend
+        :meth:`_apply_ordering_maps_after_resolve` overrides call this first and then
+        reconfigure their backend-order staging using the returned previous flags.
+
+        Returns:
+            The ``(had_joint_ordering, had_body_ordering)`` flags from before this
+            call, so buffer reconfiguration can detect an ordering that was cleared.
+        """
+        had_joint_ordering = self._has_joint_ordering
+        had_body_ordering = self._has_body_ordering
+        joint_ordering = self.joint_ordering
+        self._has_joint_ordering = joint_ordering is not None and not joint_ordering.is_identity
+        self._joint_user_to_backend = joint_ordering.user_to_backend if self._has_joint_ordering else None
+        body_ordering = self.body_ordering
+        self._has_body_ordering = body_ordering is not None and not body_ordering.is_identity
+        self._body_user_to_backend = body_ordering.user_to_backend if self._has_body_ordering else None
+        return had_joint_ordering, had_body_ordering
+
+    def _make_jacobian_body_user_to_backend(self, body_ordering: ArticulationNameMap | None) -> wp.array:
+        """Build the compact user-to-backend row map for Jacobian body axes.
+
+        Fixed-base articulations omit the root link's Jacobian rows, so a nonzero
+        :attr:`_jacobian_link_offset` drops backend row 0 and shifts the remaining
+        rows down by one.
+
+        Args:
+            body_ordering: Body ordering map, or ``None`` to build the row map in
+                backend body order.
+
+        Returns:
+            One-dimensional ``wp.int32`` device array of backend Jacobian rows in
+            public body order.
+        """
+        body_user_to_backend = (
+            body_ordering.user_to_backend_indices if body_ordering is not None else range(self._num_bodies)
+        )
+        if self._jacobian_link_offset == 0:
+            backend_rows = tuple(int(backend_id) for backend_id in body_user_to_backend)
+        else:
+            backend_rows = tuple(int(backend_id) - 1 for backend_id in body_user_to_backend if int(backend_id) != 0)
+        return wp.array(backend_rows, dtype=wp.int32, device=self.device)
+
+    def _fetch_body_com_pose_b_backend(self, buf: TimestampedBufferWarp) -> None:
+        """Read the current backend-order static body COM pose into ``buf`` when stale.
+
+        Backend hook for :meth:`_ensure_body_com_pose_b_current` and
+        :attr:`_backend_body_com_pose_b`. The base raises because only backends that
+        stage a static body COM pose implement the fetch.
+
+        Args:
+            buf: Timestamped buffer to refresh with the backend-order COM pose.
+        """
+        raise NotImplementedError
+
+    def _ensure_body_com_pose_b_current(self) -> None:
+        """Refresh the static body COM pose cache when explicitly invalidated.
+
+        Under body ordering the fetch fills the backend-order staging buffer and the
+        result is gathered into public order; otherwise it fills the public buffer
+        directly.
+        """
+        if self._body_com_pose_b.timestamp >= 0.0:
+            return
+        if not self._has_body_ordering:
+            self._fetch_body_com_pose_b_backend(self._body_com_pose_b)
+            return
+        backend_staging = self._body_com_pose_b_backend
+        if backend_staging is None:
+            raise RuntimeError(f"{self.__backend_name__} body COM ordering staging was not initialized.")
+        self._fetch_body_com_pose_b_backend(backend_staging)
+        wp.launch(
+            ordering_kernels.reorder_2d_backend_to_user,
+            dim=(self._num_instances, self._num_bodies),
+            inputs=[backend_staging.data, self._body_user_to_backend],
+            outputs=[self._body_com_pose_b.data],
+            device=self.device,
+        )
+        self._body_com_pose_b.timestamp = backend_staging.timestamp
+
+    @property
+    def _backend_body_com_pose_b(self) -> wp.array(dtype=wp.transformf, ndim=2):
+        """Backend-order body COM pose buffer for root-only computations."""
+        if not self._has_body_ordering:
+            self._ensure_body_com_pose_b_current()
+            return self._body_com_pose_b.data
+        backend_staging = self._body_com_pose_b_backend
+        if backend_staging is None:
+            raise RuntimeError(f"{self.__backend_name__} body COM ordering staging was not initialized.")
+        self._fetch_body_com_pose_b_backend(backend_staging)
+        return backend_staging.data
 
     ##
     # Defaults - Initial state.
@@ -720,6 +875,8 @@ class BaseArticulationData(ABC):
         Conventions:
             * Body axis: ``jacobi_body_idx == body_idx - 1`` for fixed-base (fixed-root
               row excluded); ``jacobi_body_idx == body_idx`` for floating-base.
+              With custom body ordering, fixed-base Jacobian rows follow user body
+              order with the fixed root omitted.
             * DoF axis: leading
               :attr:`~isaaclab.assets.BaseArticulation.num_base_dofs` floating-base
               columns (world-frame ``[lin_x, lin_y, lin_z, ang_x, ang_y, ang_z]``),

--- a/source/isaaclab/isaaclab/assets/articulation/ordering.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering.py
@@ -7,8 +7,10 @@
 
 This module owns the public ordering surface: the
 :class:`ArticulationOrderingConvention` enum, the frozen
-:class:`ArticulationNameMap` bidirectional descriptor, and the helpers that
-parse conventions and build validated maps between backend and public order.
+:class:`ArticulationNameMap` permutation type (built only by the module-level
+:func:`build_articulation_name_map` factory, never constructed directly), and
+the helpers that parse conventions and build validated maps between backend and
+public order.
 Discovering a convention's concrete names lives in
 :mod:`isaaclab.assets.articulation.ordering_resolvers`, and device-side axis
 conversion lives in :mod:`isaaclab.assets.articulation.ordering_kernels`.
@@ -17,7 +19,7 @@ conversion lives in :mod:`isaaclab.assets.articulation.ordering_kernels`.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import InitVar, dataclass
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
@@ -43,18 +45,6 @@ def _validate_articulation_names(names: list[str] | tuple[str, ...], *, paramete
     return tuple(names)
 
 
-def _validate_articulation_indices(indices: list[int] | tuple[int, ...], *, parameter_name: str) -> tuple[int, ...]:
-    """Return the indices as a tuple after a hard list-or-tuple-of-int check."""
-    if type(indices) not in (list, tuple):
-        raise TypeError(f"{parameter_name} must be a list or tuple of integers; got {type(indices).__name__}.")
-    for element_index, value in enumerate(indices):
-        if type(value) is not int:
-            raise TypeError(
-                f"{parameter_name} element {element_index} must be int; got {value!r} ({type(value).__name__})."
-            )
-    return tuple(indices)
-
-
 class ArticulationOrderingConvention(str, Enum):
     """Built-in non-default public articulation name-ordering conventions.
 
@@ -75,63 +65,25 @@ class ArticulationOrderingConvention(str, Enum):
 
 @dataclass(frozen=True)
 class ArticulationNameMap:
-    """Frozen bidirectional descriptor of backend and public articulation order.
+    """Frozen permutation between backend and public articulation order.
 
     ``user`` in the field names means the order exposed by the public API.
     ``user_to_backend`` maps a public index to its backend index, while
-    ``backend_to_user`` maps a backend index to its public index. The CPU tuples
-    and device arrays are complete inverse permutations.
+    ``backend_to_user`` maps a backend index to its public index. The CPU
+    tuples and device arrays are complete inverse permutations of the same
+    length; both device maps are one-dimensional ``wp.int32`` arrays on the
+    articulation's device. The frozen dataclass prevents field reassignment,
+    but the Warp arrays remain mutable objects and callers must treat both
+    device maps as read-only.
 
-    All name and index sequences have the same length. Each name sequence is
-    unique, both device maps are one-dimensional arrays with shape
-    ``(num_names,)`` and dtype ``wp.int32``, and the device maps share a Warp
-    device. Construction copies each device map to host and compares it with the
-    corresponding CPU tuple as part of validation. The frozen dataclass prevents
-    field reassignment, but the Warp arrays remain mutable objects and callers
-    must treat both device maps as read-only.
-
-    When an articulation constructs its maps, this validation occurs during
-    initialization. Hot read and write paths reuse the validated device maps and
-    do not synchronize them to the host.
-
-    Identity maps are legal values of this type: an explicit ordering equal to
-    backend order produces a map with :attr:`is_identity` set, and
-    :func:`build_articulation_name_map` always returns a map. Articulations,
-    however, normalize identity orderings away at install time — the
-    :attr:`~isaaclab.assets.Articulation.joint_ordering` and
+    Instances are built by the owning articulation during initialization via
+    :func:`build_articulation_name_map`; the class is not intended for direct
+    construction. Identity orderings are represented as ``None`` rather than a
+    map — the :attr:`~isaaclab.assets.Articulation.joint_ordering` and
     :attr:`~isaaclab.assets.Articulation.body_ordering` properties are ``None``
-    whenever public and backend orders coincide, and a non-``None`` map on an
-    asset always denotes an actual permutation.
-
-    Args:
-        kind: Mapped articulation element kind.
-        backend_names: Names in active backend solver-view order.
-        user_names: The same number of names in public API order.
-        user_to_backend_indices: CPU permutation from public to backend indices.
-        backend_to_user_indices: CPU inverse permutation from backend to public indices.
-        user_to_backend: Read-only device permutation from public to backend indices.
-        backend_to_user: Read-only device inverse permutation from backend to public indices.
-        is_identity: Whether names and both permutations are in identical order.
-        _prevalidated: Internal, init-only. :func:`build_articulation_name_map`
-            sets this to skip revalidating fields it already validated; direct
-            construction leaves it ``False`` and fully validates every field.
-
-    Raises:
-        TypeError: If either name field is not a sequence of strings, a CPU map
-            contains a non-integer value, either device map is not a Warp array,
-            or is_identity is not a built-in bool.
-        ValueError: If a field violates the length, uniqueness, permutation,
-            device, or identity invariants.
+    whenever public and backend orders coincide, so a non-``None`` map always
+    denotes an actual permutation.
     """
-
-    kind: Literal["joint", "body"]
-    """Mapped articulation element kind."""
-
-    backend_names: tuple[str, ...]
-    """Names in active backend solver-view order."""
-
-    user_names: tuple[str, ...]
-    """Names in public articulation API order."""
 
     user_to_backend_indices: tuple[int, ...]
     """One-dimensional CPU map from public index to backend index."""
@@ -144,98 +96,6 @@ class ArticulationNameMap:
 
     backend_to_user: wp.array(dtype=wp.int32)
     """Read-only backend-to-public device map, shape ``(num_names,)``, dtype ``wp.int32``."""
-
-    is_identity: bool
-    """Whether names and both index maps are identity permutations."""
-
-    _prevalidated: InitVar[bool] = False
-    """Set by :func:`build_articulation_name_map` to skip revalidating fields it already validated."""
-
-    def __post_init__(self, _prevalidated: bool) -> None:
-        """Validate CPU-side name-map invariants unless the builder pre-validated them.
-
-        :func:`build_articulation_name_map` establishes every invariant while
-        constructing the map, so it passes ``_prevalidated=True`` to skip the
-        redundant checks (including two device-to-host copies). Directly
-        constructed maps are always fully validated.
-        """
-        if not _prevalidated:
-            self._validate()
-
-    def _validate(self) -> None:
-        """Enforce exact field types and all CPU and device map invariants.
-
-        Fields are required to already hold the annotated types; nothing is
-        coerced or reassigned. Directly constructed maps must pass tuples.
-        """
-        if self.kind not in {"joint", "body"}:
-            raise ValueError(f"ArticulationNameMap kind must be 'joint' or 'body'. Got {self.kind!r}.")
-        if type(self.is_identity) is not bool:
-            raise TypeError(f"ArticulationNameMap is_identity must be bool; got {type(self.is_identity).__name__}.")
-
-        for field_name, value in (
-            ("backend_names", self.backend_names),
-            ("user_names", self.user_names),
-            ("user_to_backend_indices", self.user_to_backend_indices),
-            ("backend_to_user_indices", self.backend_to_user_indices),
-        ):
-            if type(value) is not tuple:
-                raise TypeError(f"ArticulationNameMap {field_name} must be a tuple; got {type(value).__name__}.")
-        _validate_articulation_names(self.backend_names, parameter_name="backend_names")
-        _validate_articulation_names(self.user_names, parameter_name="user_names")
-        _validate_articulation_indices(self.user_to_backend_indices, parameter_name="user_to_backend_indices")
-        _validate_articulation_indices(self.backend_to_user_indices, parameter_name="backend_to_user_indices")
-
-        num_names = len(self.backend_names)
-        if len(self.user_names) != num_names:
-            raise ValueError("ArticulationNameMap user_names and backend_names must have the same length.")
-        if len(self.user_to_backend_indices) != num_names or len(self.backend_to_user_indices) != num_names:
-            raise ValueError("ArticulationNameMap CPU index maps must match the number of names.")
-        if len(set(self.backend_names)) != num_names:
-            raise ValueError(f"Duplicate backend {self.kind} names are not supported: {self.backend_names}.")
-        if len(set(self.user_names)) != num_names:
-            raise ValueError(f"Duplicate user {self.kind} names are not supported: {self.user_names}.")
-
-        expected_indices = set(range(num_names))
-        user_to_backend = self.user_to_backend_indices
-        backend_to_user = self.backend_to_user_indices
-        if set(user_to_backend) != expected_indices:
-            raise ValueError("ArticulationNameMap user_to_backend_indices must be a complete permutation.")
-        if set(backend_to_user) != expected_indices:
-            raise ValueError("ArticulationNameMap backend_to_user_indices must be a complete permutation.")
-        for user_index, backend_index in enumerate(user_to_backend):
-            if backend_to_user[backend_index] != user_index:
-                raise ValueError("ArticulationNameMap CPU index maps must be inverse permutations.")
-            if self.user_names[user_index] != self.backend_names[backend_index]:
-                raise ValueError("ArticulationNameMap name and index mappings must agree.")
-
-        for map_name, device_map, cpu_map in (
-            ("user_to_backend", self.user_to_backend, user_to_backend),
-            ("backend_to_user", self.backend_to_user, backend_to_user),
-        ):
-            if not isinstance(device_map, wp.array):
-                raise TypeError(
-                    f"ArticulationNameMap {map_name} must be a Warp array; got {type(device_map).__name__}."
-                )
-            if device_map.dtype != wp.int32 or device_map.ndim != 1 or device_map.shape != (num_names,):
-                raise ValueError(
-                    f"ArticulationNameMap device {map_name} map must be a one-dimensional int32 array "
-                    f"with shape ({num_names},)."
-                )
-            if tuple(int(index) for index in device_map.numpy()) != cpu_map:
-                raise ValueError(f"ArticulationNameMap device {map_name} map must match {map_name}_indices.")
-
-        if self.user_to_backend.device != self.backend_to_user.device:
-            raise ValueError("ArticulationNameMap device index maps must be allocated on the same device.")
-
-        identity_indices = tuple(range(num_names))
-        expected_identity = (
-            self.user_names == self.backend_names
-            and user_to_backend == identity_indices
-            and backend_to_user == identity_indices
-        )
-        if self.is_identity != expected_identity:
-            raise ValueError("ArticulationNameMap is_identity is inconsistent with names and index maps.")
 
 
 def parse_articulation_ordering_convention(
@@ -311,30 +171,33 @@ def build_articulation_name_map(
     backend_names: Sequence[str],
     user_names: Sequence[str] | None,
     device: str,
-) -> ArticulationNameMap:
+) -> ArticulationNameMap | None:
     """Build a validated map between backend and public articulation order.
 
     Args:
-        kind: Mapped element kind, either ``"joint"`` or ``"body"``.
+        kind: Mapped element kind, either ``"joint"`` or ``"body"``; used in
+            error messages.
         backend_names: Names in active backend solver-view order.
-        user_names: Complete permutation in public API order. ``None`` uses
-            :paramref:`backend_names` and builds an explicit identity map.
+        user_names: Complete permutation in public API order, or ``None`` to
+            keep the backend order.
         device: Warp device on which both device index maps are allocated.
 
     Returns:
         An :class:`ArticulationNameMap` containing CPU index tuples and
-        one-dimensional ``wp.int32`` device maps on :paramref:`device`.
+        one-dimensional ``wp.int32`` device maps on :paramref:`device`, or
+        ``None`` when :paramref:`user_names` is ``None`` or already in backend
+        order (identity).
 
     Raises:
-        ValueError: If :paramref:`kind` is invalid, either name sequence has
-            duplicates, :paramref:`user_names` is not a complete permutation
-            of :paramref:`backend_names`, or a name-map invariant is violated.
-        TypeError: If either name input is not a sequence of strings.
+        ValueError: If either name sequence has duplicates or
+            :paramref:`user_names` is not a complete permutation of
+            :paramref:`backend_names`.
+        TypeError: If either name input is not a list or tuple of strings.
     """
     backend_names = _validate_articulation_names(backend_names, parameter_name="backend_names")
-    user_names = (
-        backend_names if user_names is None else _validate_articulation_names(user_names, parameter_name="user_names")
-    )
+    if user_names is None:
+        return None
+    user_names = _validate_articulation_names(user_names, parameter_name="user_names")
 
     if len(set(backend_names)) != len(backend_names):
         raise ValueError(f"Duplicate backend {kind} names are not supported: {backend_names}.")
@@ -350,20 +213,17 @@ def build_articulation_name_map(
             f"Requested {kind} names must be a complete permutation of backend names. Missing={missing}, extra={extra}."
         )
 
+    if user_names == backend_names:
+        return None
+
     backend_index_by_name = {name: index for index, name in enumerate(backend_names)}
     user_to_backend_np = np.asarray([backend_index_by_name[name] for name in user_names], dtype=np.int32)
     backend_to_user_np = np.empty_like(user_to_backend_np)
     backend_to_user_np[user_to_backend_np] = np.arange(len(user_names), dtype=np.int32)
-    is_identity = user_names == backend_names
 
     return ArticulationNameMap(
-        kind=kind,
-        backend_names=backend_names,
-        user_names=user_names,
         user_to_backend_indices=tuple(int(index) for index in user_to_backend_np),
         backend_to_user_indices=tuple(int(index) for index in backend_to_user_np),
         user_to_backend=wp.array(user_to_backend_np, dtype=wp.int32, device=device),
         backend_to_user=wp.array(backend_to_user_np, dtype=wp.int32, device=device),
-        is_identity=is_identity,
-        _prevalidated=True,
     )

--- a/source/isaaclab/isaaclab/assets/articulation/ordering.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering.py
@@ -104,9 +104,14 @@ class ArticulationNameMap:
     initialization. Hot read and write paths reuse the validated device maps and
     do not synchronize them to the host.
 
-    An explicit ordering equal to backend order still produces a map with
-    :attr:`is_identity` set. The default ``None`` ordering is represented by no
-    map on the articulation instead.
+    Identity maps are legal values of this type: an explicit ordering equal to
+    backend order produces a map with :attr:`is_identity` set, and
+    :func:`build_articulation_name_map` always returns a map. Articulations,
+    however, normalize identity orderings away at install time — the
+    :attr:`~isaaclab.assets.Articulation.joint_ordering` and
+    :attr:`~isaaclab.assets.Articulation.body_ordering` properties are ``None``
+    whenever public and backend orders coincide, and a non-``None`` map on an
+    asset always denotes an actual permutation.
 
     Args:
         kind: Mapped articulation element kind.

--- a/source/isaaclab/isaaclab/assets/articulation/ordering.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering.py
@@ -1,0 +1,372 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Public articulation ordering name-map type and its validation.
+
+This module owns the public ordering surface: the
+:class:`ArticulationOrderingConvention` enum, the frozen
+:class:`ArticulationNameMap` bidirectional descriptor, and the helpers that
+parse conventions and build validated maps between backend and public order.
+Discovering a convention's concrete names lives in
+:mod:`isaaclab.assets.articulation.ordering_resolvers`, and device-side axis
+conversion lives in :mod:`isaaclab.assets.articulation.ordering_kernels`.
+"""
+
+from __future__ import annotations
+
+import operator
+from collections.abc import Sequence
+from dataclasses import InitVar, dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import warp as wp
+
+if TYPE_CHECKING:
+    from .articulation_cfg import ArticulationCfg
+
+
+def _coerce_articulation_names(names: object, *, parameter_name: str) -> tuple[str, ...]:
+    """Return a validated articulation name sequence."""
+    if isinstance(names, str | bytes | bytearray):
+        raise TypeError(f"{parameter_name} must be a sequence of strings; got {type(names).__name__}.")
+    try:
+        name_tuple = tuple(names)
+    except TypeError as exc:
+        raise TypeError(f"{parameter_name} must be a sequence of strings; got {type(names).__name__}.") from exc
+    for index, name in enumerate(name_tuple):
+        if not isinstance(name, str):
+            raise TypeError(f"{parameter_name} element {index} must be str; got {name!r} ({type(name).__name__}).")
+    return name_tuple
+
+
+def _coerce_articulation_indices(indices: object, *, parameter_name: str) -> tuple[int, ...]:
+    """Return a validated integer index sequence."""
+    if isinstance(indices, str | bytes | bytearray):
+        raise TypeError(f"{parameter_name} must be a sequence of integers; got {type(indices).__name__}.")
+    try:
+        index_tuple = tuple(indices)
+    except TypeError as exc:
+        raise TypeError(f"{parameter_name} must be a sequence of integers; got {type(indices).__name__}.") from exc
+
+    normalized_indices = []
+    for element_index, value in enumerate(index_tuple):
+        if isinstance(value, bool):
+            raise TypeError(f"{parameter_name} element {element_index} must be an integer; got {value!r} (bool).")
+        try:
+            normalized_indices.append(operator.index(value))
+        except TypeError as exc:
+            raise TypeError(
+                f"{parameter_name} element {element_index} must be an integer; got {value!r} ({type(value).__name__})."
+            ) from exc
+    return tuple(normalized_indices)
+
+
+class ArticulationOrderingConvention(str, Enum):
+    """Built-in non-default public articulation name-ordering conventions.
+
+    Attributes:
+        PHYSX: Active PhysX or OVPhysX tensor-view order.
+        MJWARP: Newton or MJWarp articulation-view order.
+        ROBOT_SCHEMA: Authored target order of the ``isaac:physics:robotJoints``
+            and ``isaac:physics:robotLinks`` relationships.
+
+    ``None`` selects the active backend order by default and is not a member of
+    this enum.
+    """
+
+    PHYSX = "physx"
+    MJWARP = "mjwarp"
+    ROBOT_SCHEMA = "robot_schema"
+
+
+@dataclass(frozen=True)
+class ArticulationNameMap:
+    """Frozen bidirectional descriptor of backend and public articulation order.
+
+    ``user`` in the field names means the order exposed by the public API.
+    ``user_to_backend`` maps a public index to its backend index, while
+    ``backend_to_user`` maps a backend index to its public index. The CPU tuples
+    and device arrays are complete inverse permutations.
+
+    All name and index sequences have the same length. Each name sequence is
+    unique, both device maps are one-dimensional arrays with shape
+    ``(num_names,)`` and dtype ``wp.int32``, and the device maps share a Warp
+    device. Construction copies each device map to host and compares it with the
+    corresponding CPU tuple as part of validation. The frozen dataclass prevents
+    field reassignment, but the Warp arrays remain mutable objects and callers
+    must treat both device maps as read-only.
+
+    When an articulation constructs its maps, this validation occurs during
+    initialization. Hot read and write paths reuse the validated device maps and
+    do not synchronize them to the host.
+
+    An explicit ordering equal to backend order still produces a map with
+    :attr:`is_identity` set. The default ``None`` ordering is represented by no
+    map on the articulation instead.
+
+    Args:
+        kind: Mapped articulation element kind.
+        backend_names: Names in active backend solver-view order.
+        user_names: The same number of names in public API order.
+        user_to_backend_indices: CPU permutation from public to backend indices.
+        backend_to_user_indices: CPU inverse permutation from backend to public indices.
+        user_to_backend: Read-only device permutation from public to backend indices.
+        backend_to_user: Read-only device inverse permutation from backend to public indices.
+        is_identity: Whether names and both permutations are in identical order.
+        _prevalidated: Internal, init-only. :func:`build_articulation_name_map`
+            sets this to skip revalidating fields it already validated; direct
+            construction leaves it ``False`` and fully validates every field.
+
+    Raises:
+        TypeError: If either name field is not a sequence of strings, a CPU map
+            contains a non-integer value, either device map is not a Warp array,
+            or is_identity is not a built-in bool.
+        ValueError: If a field violates the length, uniqueness, permutation,
+            device, or identity invariants.
+    """
+
+    kind: Literal["joint", "body"]
+    """Mapped articulation element kind."""
+
+    backend_names: tuple[str, ...]
+    """Names in active backend solver-view order."""
+
+    user_names: tuple[str, ...]
+    """Names in public articulation API order."""
+
+    user_to_backend_indices: tuple[int, ...]
+    """One-dimensional CPU map from public index to backend index."""
+
+    backend_to_user_indices: tuple[int, ...]
+    """One-dimensional CPU map from backend index to public index."""
+
+    user_to_backend: wp.array(dtype=wp.int32)
+    """Read-only public-to-backend device map, shape ``(num_names,)``, dtype ``wp.int32``."""
+
+    backend_to_user: wp.array(dtype=wp.int32)
+    """Read-only backend-to-public device map, shape ``(num_names,)``, dtype ``wp.int32``."""
+
+    is_identity: bool
+    """Whether names and both index maps are identity permutations."""
+
+    _prevalidated: InitVar[bool] = False
+    """Set by :func:`build_articulation_name_map` to skip revalidating fields it already validated."""
+
+    def __post_init__(self, _prevalidated: bool) -> None:
+        """Validate CPU-side name-map invariants unless the builder pre-validated them.
+
+        :func:`build_articulation_name_map` establishes every invariant while
+        constructing the map, so it passes ``_prevalidated=True`` to skip the
+        redundant checks (including two device-to-host copies). Directly
+        constructed maps are always fully validated.
+        """
+        if not _prevalidated:
+            self._validate()
+
+    def _validate(self) -> None:
+        """Coerce name/index fields and enforce all CPU and device map invariants."""
+        if self.kind not in {"joint", "body"}:
+            raise ValueError(f"ArticulationNameMap kind must be 'joint' or 'body'. Got {self.kind!r}.")
+        if type(self.is_identity) is not bool:
+            raise TypeError(f"ArticulationNameMap is_identity must be bool; got {type(self.is_identity).__name__}.")
+
+        object.__setattr__(
+            self, "backend_names", _coerce_articulation_names(self.backend_names, parameter_name="backend_names")
+        )
+        object.__setattr__(self, "user_names", _coerce_articulation_names(self.user_names, parameter_name="user_names"))
+        object.__setattr__(
+            self,
+            "user_to_backend_indices",
+            _coerce_articulation_indices(self.user_to_backend_indices, parameter_name="user_to_backend_indices"),
+        )
+        object.__setattr__(
+            self,
+            "backend_to_user_indices",
+            _coerce_articulation_indices(self.backend_to_user_indices, parameter_name="backend_to_user_indices"),
+        )
+
+        num_names = len(self.backend_names)
+        if len(self.user_names) != num_names:
+            raise ValueError("ArticulationNameMap user_names and backend_names must have the same length.")
+        if len(self.user_to_backend_indices) != num_names or len(self.backend_to_user_indices) != num_names:
+            raise ValueError("ArticulationNameMap CPU index maps must match the number of names.")
+        if len(set(self.backend_names)) != num_names:
+            raise ValueError(f"Duplicate backend {self.kind} names are not supported: {self.backend_names}.")
+        if len(set(self.user_names)) != num_names:
+            raise ValueError(f"Duplicate user {self.kind} names are not supported: {self.user_names}.")
+
+        expected_indices = set(range(num_names))
+        user_to_backend = self.user_to_backend_indices
+        backend_to_user = self.backend_to_user_indices
+        if set(user_to_backend) != expected_indices:
+            raise ValueError("ArticulationNameMap user_to_backend_indices must be a complete permutation.")
+        if set(backend_to_user) != expected_indices:
+            raise ValueError("ArticulationNameMap backend_to_user_indices must be a complete permutation.")
+        for user_index, backend_index in enumerate(user_to_backend):
+            if backend_to_user[backend_index] != user_index:
+                raise ValueError("ArticulationNameMap CPU index maps must be inverse permutations.")
+            if self.user_names[user_index] != self.backend_names[backend_index]:
+                raise ValueError("ArticulationNameMap name and index mappings must agree.")
+
+        for map_name, device_map, cpu_map in (
+            ("user_to_backend", self.user_to_backend, user_to_backend),
+            ("backend_to_user", self.backend_to_user, backend_to_user),
+        ):
+            if not isinstance(device_map, wp.array):
+                raise TypeError(
+                    f"ArticulationNameMap {map_name} must be a Warp array; got {type(device_map).__name__}."
+                )
+            if device_map.dtype != wp.int32 or device_map.ndim != 1 or device_map.shape != (num_names,):
+                raise ValueError(
+                    f"ArticulationNameMap device {map_name} map must be a one-dimensional int32 array "
+                    f"with shape ({num_names},)."
+                )
+            if tuple(int(index) for index in device_map.numpy()) != cpu_map:
+                raise ValueError(f"ArticulationNameMap device {map_name} map must match {map_name}_indices.")
+
+        if self.user_to_backend.device != self.backend_to_user.device:
+            raise ValueError("ArticulationNameMap device index maps must be allocated on the same device.")
+
+        identity_indices = tuple(range(num_names))
+        expected_identity = (
+            self.user_names == self.backend_names
+            and user_to_backend == identity_indices
+            and backend_to_user == identity_indices
+        )
+        if self.is_identity != expected_identity:
+            raise ValueError("ArticulationNameMap is_identity is inconsistent with names and index maps.")
+
+
+def parse_articulation_ordering_convention(
+    ordering: str | ArticulationOrderingConvention | None,
+) -> ArticulationOrderingConvention | None:
+    """Parse a symbolic public articulation ordering convention.
+
+    Accepted aliases are ``"physx"``, ``"mjwarp"``, and
+    ``"robot_schema"``. String aliases are matched case-insensitively.
+    ``None`` keeps the active backend's default order and is not an enum member.
+
+    Args:
+        ordering: Convention alias, :class:`ArticulationOrderingConvention`
+            member, or ``None``.
+
+    Returns:
+        The matching :class:`ArticulationOrderingConvention` member, or
+        ``None`` when no non-default convention is requested.
+
+    Raises:
+        TypeError: If :paramref:`ordering` is not a supported type.
+        ValueError: If :paramref:`ordering` is an unsupported string alias.
+    """
+    if ordering is None:
+        return None
+    if isinstance(ordering, ArticulationOrderingConvention):
+        return ordering
+    if isinstance(ordering, str):
+        try:
+            return ArticulationOrderingConvention(ordering.lower())
+        except ValueError as exc:
+            valid_values = ", ".join(convention.value for convention in ArticulationOrderingConvention)
+            raise ValueError(
+                f"Unsupported articulation ordering convention '{ordering}'. Expected one of: {valid_values}."
+            ) from exc
+    raise TypeError(
+        "Articulation ordering convention must be a string, "
+        f"{ArticulationOrderingConvention.__name__}, or None. Got {type(ordering).__name__}."
+    )
+
+
+def apply_articulation_ordering_preset(
+    cfg: ArticulationCfg,
+    ordering: str | ArticulationOrderingConvention | None,
+) -> ArticulationCfg:
+    """Apply one public ordering preset to both joints and bodies.
+
+    Args:
+        cfg: Articulation configuration to copy when a preset is requested.
+        ordering: Convention alias, :class:`ArticulationOrderingConvention`
+            member, or ``None``.
+
+    Returns:
+        A copy of :paramref:`cfg` whose
+        :attr:`ArticulationCfg.joint_ordering` and
+        :attr:`ArticulationCfg.body_ordering` use the parsed convention.
+        When :paramref:`ordering` is ``None``, returns the original
+        :paramref:`cfg` object unchanged.
+
+    Raises:
+        TypeError: If :paramref:`ordering` is not a supported type.
+        ValueError: If :paramref:`ordering` is an unsupported string alias.
+    """
+    parsed_ordering = parse_articulation_ordering_convention(ordering)
+    if parsed_ordering is None:
+        return cfg
+    return cfg.replace(joint_ordering=parsed_ordering, body_ordering=parsed_ordering)
+
+
+def build_articulation_name_map(
+    *,
+    kind: Literal["joint", "body"],
+    backend_names: Sequence[str],
+    user_names: Sequence[str] | None,
+    device: str,
+) -> ArticulationNameMap:
+    """Build a validated map between backend and public articulation order.
+
+    Args:
+        kind: Mapped element kind, either ``"joint"`` or ``"body"``.
+        backend_names: Names in active backend solver-view order.
+        user_names: Complete permutation in public API order. ``None`` uses
+            :paramref:`backend_names` and builds an explicit identity map.
+        device: Warp device on which both device index maps are allocated.
+
+    Returns:
+        An :class:`ArticulationNameMap` containing CPU index tuples and
+        one-dimensional ``wp.int32`` device maps on :paramref:`device`.
+
+    Raises:
+        ValueError: If :paramref:`kind` is invalid, either name sequence has
+            duplicates, :paramref:`user_names` is not a complete permutation
+            of :paramref:`backend_names`, or a name-map invariant is violated.
+        TypeError: If either name input is not a sequence of strings.
+    """
+    backend_names = _coerce_articulation_names(backend_names, parameter_name="backend_names")
+    user_names = (
+        backend_names if user_names is None else _coerce_articulation_names(user_names, parameter_name="user_names")
+    )
+
+    if len(set(backend_names)) != len(backend_names):
+        raise ValueError(f"Duplicate backend {kind} names are not supported: {backend_names}.")
+    if len(set(user_names)) != len(user_names):
+        raise ValueError(f"Duplicate requested {kind} names are not supported: {user_names}.")
+
+    backend_name_set = set(backend_names)
+    user_name_set = set(user_names)
+    if user_name_set != backend_name_set:
+        missing = sorted(backend_name_set - user_name_set)
+        extra = sorted(user_name_set - backend_name_set)
+        raise ValueError(
+            f"Requested {kind} names must be a complete permutation of backend names. Missing={missing}, extra={extra}."
+        )
+
+    backend_index_by_name = {name: index for index, name in enumerate(backend_names)}
+    user_to_backend_np = np.asarray([backend_index_by_name[name] for name in user_names], dtype=np.int32)
+    backend_to_user_np = np.empty_like(user_to_backend_np)
+    backend_to_user_np[user_to_backend_np] = np.arange(len(user_names), dtype=np.int32)
+    is_identity = user_names == backend_names
+
+    return ArticulationNameMap(
+        kind=kind,
+        backend_names=backend_names,
+        user_names=user_names,
+        user_to_backend_indices=tuple(int(index) for index in user_to_backend_np),
+        backend_to_user_indices=tuple(int(index) for index in backend_to_user_np),
+        user_to_backend=wp.array(user_to_backend_np, dtype=wp.int32, device=device),
+        backend_to_user=wp.array(backend_to_user_np, dtype=wp.int32, device=device),
+        is_identity=is_identity,
+        _prevalidated=True,
+    )

--- a/source/isaaclab/isaaclab/assets/articulation/ordering.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering.py
@@ -28,26 +28,26 @@ if TYPE_CHECKING:
     from .articulation_cfg import ArticulationCfg
 
 
-def _validate_articulation_names(names: list[str] | tuple[str, ...], *, parameter_name: str) -> tuple[str, ...]:
-    """Return the names as a tuple after a hard list-or-tuple-of-str check."""
-    if type(names) not in (list, tuple):
-        raise TypeError(f"{parameter_name} must be a list or tuple of strings; got {type(names).__name__}.")
+def _validate_articulation_names(names: tuple[str, ...], *, parameter_name: str) -> tuple[str, ...]:
+    """Return the names unchanged after a hard tuple-of-str check."""
+    if type(names) is not tuple:
+        raise TypeError(f"{parameter_name} must be a tuple of strings; got {type(names).__name__}.")
     for index, name in enumerate(names):
         if type(name) is not str:
             raise TypeError(f"{parameter_name} element {index} must be str; got {name!r} ({type(name).__name__}).")
-    return tuple(names)
+    return names
 
 
-def _validate_articulation_indices(indices: list[int] | tuple[int, ...], *, parameter_name: str) -> tuple[int, ...]:
-    """Return the indices as a tuple after a hard list-or-tuple-of-int check."""
-    if type(indices) not in (list, tuple):
-        raise TypeError(f"{parameter_name} must be a list or tuple of integers; got {type(indices).__name__}.")
+def _validate_articulation_indices(indices: tuple[int, ...], *, parameter_name: str) -> tuple[int, ...]:
+    """Return the indices unchanged after a hard tuple-of-int check."""
+    if type(indices) is not tuple:
+        raise TypeError(f"{parameter_name} must be a tuple of integers; got {type(indices).__name__}.")
     for element_index, value in enumerate(indices):
         if type(value) is not int:
             raise TypeError(
                 f"{parameter_name} element {element_index} must be int; got {value!r} ({type(value).__name__})."
             )
-    return tuple(indices)
+    return indices
 
 
 class ArticulationOrderingConvention(str, Enum):
@@ -168,17 +168,10 @@ class ArticulationNameMap:
         if type(self.is_identity) is not bool:
             raise TypeError(f"ArticulationNameMap is_identity must be bool; got {type(self.is_identity).__name__}.")
 
-        for field_name, names in (("backend_names", self.backend_names), ("user_names", self.user_names)):
-            if type(names) is not tuple:
-                raise TypeError(f"ArticulationNameMap {field_name} must be a tuple; got {type(names).__name__}.")
-            _validate_articulation_names(names, parameter_name=field_name)
-        for field_name, indices in (
-            ("user_to_backend_indices", self.user_to_backend_indices),
-            ("backend_to_user_indices", self.backend_to_user_indices),
-        ):
-            if type(indices) is not tuple:
-                raise TypeError(f"ArticulationNameMap {field_name} must be a tuple; got {type(indices).__name__}.")
-            _validate_articulation_indices(indices, parameter_name=field_name)
+        _validate_articulation_names(self.backend_names, parameter_name="backend_names")
+        _validate_articulation_names(self.user_names, parameter_name="user_names")
+        _validate_articulation_indices(self.user_to_backend_indices, parameter_name="user_to_backend_indices")
+        _validate_articulation_indices(self.backend_to_user_indices, parameter_name="backend_to_user_indices")
 
         num_names = len(self.backend_names)
         if len(self.user_names) != num_names:

--- a/source/isaaclab/isaaclab/assets/articulation/ordering.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering.py
@@ -28,26 +28,31 @@ if TYPE_CHECKING:
     from .articulation_cfg import ArticulationCfg
 
 
-def _validate_articulation_names(names: tuple[str, ...], *, parameter_name: str) -> tuple[str, ...]:
-    """Return the names unchanged after a hard tuple-of-str check."""
-    if type(names) is not tuple:
-        raise TypeError(f"{parameter_name} must be a tuple of strings; got {type(names).__name__}.")
+def _validate_articulation_names(names: list[str] | tuple[str, ...], *, parameter_name: str) -> tuple[str, ...]:
+    """Return the names as a tuple after a hard list-or-tuple-of-str check.
+
+    Ingestion boundaries accept both plain sequence types because config
+    sources such as Hydra produce lists; the canonical stored form is always
+    a tuple.
+    """
+    if type(names) not in (list, tuple):
+        raise TypeError(f"{parameter_name} must be a list or tuple of strings; got {type(names).__name__}.")
     for index, name in enumerate(names):
         if type(name) is not str:
             raise TypeError(f"{parameter_name} element {index} must be str; got {name!r} ({type(name).__name__}).")
-    return names
+    return tuple(names)
 
 
-def _validate_articulation_indices(indices: tuple[int, ...], *, parameter_name: str) -> tuple[int, ...]:
-    """Return the indices unchanged after a hard tuple-of-int check."""
-    if type(indices) is not tuple:
-        raise TypeError(f"{parameter_name} must be a tuple of integers; got {type(indices).__name__}.")
+def _validate_articulation_indices(indices: list[int] | tuple[int, ...], *, parameter_name: str) -> tuple[int, ...]:
+    """Return the indices as a tuple after a hard list-or-tuple-of-int check."""
+    if type(indices) not in (list, tuple):
+        raise TypeError(f"{parameter_name} must be a list or tuple of integers; got {type(indices).__name__}.")
     for element_index, value in enumerate(indices):
         if type(value) is not int:
             raise TypeError(
                 f"{parameter_name} element {element_index} must be int; got {value!r} ({type(value).__name__})."
             )
-    return indices
+    return tuple(indices)
 
 
 class ArticulationOrderingConvention(str, Enum):
@@ -168,6 +173,14 @@ class ArticulationNameMap:
         if type(self.is_identity) is not bool:
             raise TypeError(f"ArticulationNameMap is_identity must be bool; got {type(self.is_identity).__name__}.")
 
+        for field_name, value in (
+            ("backend_names", self.backend_names),
+            ("user_names", self.user_names),
+            ("user_to_backend_indices", self.user_to_backend_indices),
+            ("backend_to_user_indices", self.backend_to_user_indices),
+        ):
+            if type(value) is not tuple:
+                raise TypeError(f"ArticulationNameMap {field_name} must be a tuple; got {type(value).__name__}.")
         _validate_articulation_names(self.backend_names, parameter_name="backend_names")
         _validate_articulation_names(self.user_names, parameter_name="user_names")
         _validate_articulation_indices(self.user_to_backend_indices, parameter_name="user_to_backend_indices")

--- a/source/isaaclab/isaaclab/assets/articulation/ordering.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering.py
@@ -16,7 +16,6 @@ conversion lives in :mod:`isaaclab.assets.articulation.ordering_kernels`.
 
 from __future__ import annotations
 
-import operator
 from collections.abc import Sequence
 from dataclasses import InitVar, dataclass
 from enum import Enum
@@ -29,40 +28,26 @@ if TYPE_CHECKING:
     from .articulation_cfg import ArticulationCfg
 
 
-def _coerce_articulation_names(names: object, *, parameter_name: str) -> tuple[str, ...]:
-    """Return a validated articulation name sequence."""
-    if isinstance(names, str | bytes | bytearray):
-        raise TypeError(f"{parameter_name} must be a sequence of strings; got {type(names).__name__}.")
-    try:
-        name_tuple = tuple(names)
-    except TypeError as exc:
-        raise TypeError(f"{parameter_name} must be a sequence of strings; got {type(names).__name__}.") from exc
-    for index, name in enumerate(name_tuple):
-        if not isinstance(name, str):
+def _validate_articulation_names(names: list[str] | tuple[str, ...], *, parameter_name: str) -> tuple[str, ...]:
+    """Return the names as a tuple after a hard list-or-tuple-of-str check."""
+    if type(names) not in (list, tuple):
+        raise TypeError(f"{parameter_name} must be a list or tuple of strings; got {type(names).__name__}.")
+    for index, name in enumerate(names):
+        if type(name) is not str:
             raise TypeError(f"{parameter_name} element {index} must be str; got {name!r} ({type(name).__name__}).")
-    return name_tuple
+    return tuple(names)
 
 
-def _coerce_articulation_indices(indices: object, *, parameter_name: str) -> tuple[int, ...]:
-    """Return a validated integer index sequence."""
-    if isinstance(indices, str | bytes | bytearray):
-        raise TypeError(f"{parameter_name} must be a sequence of integers; got {type(indices).__name__}.")
-    try:
-        index_tuple = tuple(indices)
-    except TypeError as exc:
-        raise TypeError(f"{parameter_name} must be a sequence of integers; got {type(indices).__name__}.") from exc
-
-    normalized_indices = []
-    for element_index, value in enumerate(index_tuple):
-        if isinstance(value, bool):
-            raise TypeError(f"{parameter_name} element {element_index} must be an integer; got {value!r} (bool).")
-        try:
-            normalized_indices.append(operator.index(value))
-        except TypeError as exc:
+def _validate_articulation_indices(indices: list[int] | tuple[int, ...], *, parameter_name: str) -> tuple[int, ...]:
+    """Return the indices as a tuple after a hard list-or-tuple-of-int check."""
+    if type(indices) not in (list, tuple):
+        raise TypeError(f"{parameter_name} must be a list or tuple of integers; got {type(indices).__name__}.")
+    for element_index, value in enumerate(indices):
+        if type(value) is not int:
             raise TypeError(
-                f"{parameter_name} element {element_index} must be an integer; got {value!r} ({type(value).__name__})."
-            ) from exc
-    return tuple(normalized_indices)
+                f"{parameter_name} element {element_index} must be int; got {value!r} ({type(value).__name__})."
+            )
+    return tuple(indices)
 
 
 class ArticulationOrderingConvention(str, Enum):
@@ -173,26 +158,27 @@ class ArticulationNameMap:
             self._validate()
 
     def _validate(self) -> None:
-        """Coerce name/index fields and enforce all CPU and device map invariants."""
+        """Enforce exact field types and all CPU and device map invariants.
+
+        Fields are required to already hold the annotated types; nothing is
+        coerced or reassigned. Directly constructed maps must pass tuples.
+        """
         if self.kind not in {"joint", "body"}:
             raise ValueError(f"ArticulationNameMap kind must be 'joint' or 'body'. Got {self.kind!r}.")
         if type(self.is_identity) is not bool:
             raise TypeError(f"ArticulationNameMap is_identity must be bool; got {type(self.is_identity).__name__}.")
 
-        object.__setattr__(
-            self, "backend_names", _coerce_articulation_names(self.backend_names, parameter_name="backend_names")
-        )
-        object.__setattr__(self, "user_names", _coerce_articulation_names(self.user_names, parameter_name="user_names"))
-        object.__setattr__(
-            self,
-            "user_to_backend_indices",
-            _coerce_articulation_indices(self.user_to_backend_indices, parameter_name="user_to_backend_indices"),
-        )
-        object.__setattr__(
-            self,
-            "backend_to_user_indices",
-            _coerce_articulation_indices(self.backend_to_user_indices, parameter_name="backend_to_user_indices"),
-        )
+        for field_name, names in (("backend_names", self.backend_names), ("user_names", self.user_names)):
+            if type(names) is not tuple:
+                raise TypeError(f"ArticulationNameMap {field_name} must be a tuple; got {type(names).__name__}.")
+            _validate_articulation_names(names, parameter_name=field_name)
+        for field_name, indices in (
+            ("user_to_backend_indices", self.user_to_backend_indices),
+            ("backend_to_user_indices", self.backend_to_user_indices),
+        ):
+            if type(indices) is not tuple:
+                raise TypeError(f"ArticulationNameMap {field_name} must be a tuple; got {type(indices).__name__}.")
+            _validate_articulation_indices(indices, parameter_name=field_name)
 
         num_names = len(self.backend_names)
         if len(self.user_names) != num_names:
@@ -339,9 +325,9 @@ def build_articulation_name_map(
             of :paramref:`backend_names`, or a name-map invariant is violated.
         TypeError: If either name input is not a sequence of strings.
     """
-    backend_names = _coerce_articulation_names(backend_names, parameter_name="backend_names")
+    backend_names = _validate_articulation_names(backend_names, parameter_name="backend_names")
     user_names = (
-        backend_names if user_names is None else _coerce_articulation_names(user_names, parameter_name="user_names")
+        backend_names if user_names is None else _validate_articulation_names(user_names, parameter_name="user_names")
     )
 
     if len(set(backend_names)) != len(backend_names):

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
@@ -692,10 +692,16 @@ def write_3d_user_to_backend_with_mask(
 
 
 # Concrete, dtype-suffixed overloads of the generic ``write_*`` kernels above.
-# They exist to give torch-tensor inputs (adapted through Warp) a concrete
-# dtype signature at launch time, and are the public entry points that the
-# backend packages launch by name (the ``_vec3``/``_transform``/``_float``
-# suffix names the input/output element dtype).
+# These exist because Warp cannot infer generic (``dtype=Any``) kernel
+# parameters from torch tensors: launching a generic kernel with a torch input
+# raises "Unable to infer the type of argument" even for an unambiguous
+# float32 tensor, while a concrete overload adapts the tensor to the declared
+# dtype, including trailing-dimension folding for vector and transform
+# element types. Kernels launched exclusively with Warp arrays need no
+# explicit overload (implicit instantiation handles them); every kernel whose
+# call sites accept ``torch.Tensor`` inputs does. The backend packages launch
+# these by name (the ``_vec3``/``_transform``/``_float`` suffix names the
+# input/output element dtype).
 write_2d_user_to_backend_with_indices_vec3 = wp.overload(
     write_2d_user_to_backend_with_indices,
     {
@@ -850,10 +856,12 @@ def write_float_user_to_backend_with_mask(
         backend_data[env_id, backend_id] = value
 
 
-# Concrete array overloads of the ``write_float_*`` kernels above. They give an
-# adapted torch-tensor (rather than scalar) input a concrete 2-D float dtype
-# signature at launch time, and are the public entry points that the backend
-# packages launch by name (the ``_array`` suffix marks the array input form).
+# Concrete array overloads of the ``write_float_*`` kernels above, for the
+# array (rather than scalar) input form. Same rationale as the block above:
+# their call sites accept torch tensors, which Warp cannot adapt to a generic
+# parameter, so the 2-D float32 signature must be declared explicitly. The
+# backend packages launch these by name (the ``_array`` suffix marks the
+# array input form).
 write_float_user_to_backend_with_indices_array = wp.overload(
     write_float_user_to_backend_with_indices, {"input_data": wp.array2d(dtype=wp.float32)}
 )

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
@@ -1,0 +1,862 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared Warp kernels for articulation ordering conversions.
+
+Visibility contract:
+    The elementwise ``reorder_2d_*``/``reorder_3d_*`` kernels listed in
+    ``__all__`` are public: they gather a single item axis between public and
+    backend order and can legitimately be launched on raw solver-view arrays for
+    advanced interop. Every other symbol in this module -- the fused joint-target
+    and body-wrench kernels, the Jacobian/mass-matrix/generalized-vector
+    specials, the ``write_*`` kernels, and their dtype-suffixed overloads -- is
+    an internal contract between isaaclab core and the backend packages. Those
+    symbols are not user API and may change without deprecation; the backend
+    packages launch them by name, so they stay non-underscored despite being
+    internal.
+
+Axis conventions and ownership:
+    Axis 0 is always the environment axis. An articulation item axis is
+    described as public or backend order at each argument. Direct joint and body
+    permutations are validated, read-only maps owned by ArticulationNameMap.
+    Derived Jacobian maps and identity/no-order ``_ALL_*_INDICES`` buffers are
+    articulation- or data-owned. These kernels treat every map as read-only.
+    Component, spatial, and floating-base DoF axes are preserved unless a kernel
+    explicitly states otherwise.
+
+    Index-based writers require unique environment and public-item selectors;
+    duplicate selectors issue concurrent writes with undefined winners.
+    Mask-based writers do not have that precondition. When has_ordering is
+    false, fused writers update only the public buffer and permit that public
+    buffer to alias the backend output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import warp as wp
+
+__all__ = [
+    "reorder_2d_backend_to_user",
+    "reorder_2d_user_to_backend",
+    "reorder_3d_backend_to_user",
+    "reorder_3d_user_to_backend",
+]
+
+
+@wp.kernel
+def reorder_2d_backend_to_user(
+    backend_data: wp.array2d(dtype=Any),
+    user_to_backend: wp.array(dtype=wp.int32),
+    user_data: wp.array2d(dtype=Any),
+) -> None:
+    """Gather a 2-D backend-order item axis into public order.
+
+    Args:
+        backend_data: Source array shaped [num_envs, num_items] in backend
+            order. Values retain the caller-defined units.
+        user_to_backend: Read-only map shaped [num_items] from each public item
+            index to its backend item index.
+        user_data: Destination array shaped [num_envs, num_items] in public
+            order, with the same units as backend_data. It must not alias
+            backend_data for a nonidentity permutation.
+    """
+    env_id, user_id = wp.tid()
+    backend_id = user_to_backend[user_id]
+    user_data[env_id, user_id] = backend_data[env_id, backend_id]
+
+
+@wp.kernel
+def reorder_2d_user_to_backend(
+    user_data: wp.array2d(dtype=Any),
+    backend_to_user: wp.array(dtype=wp.int32),
+    backend_data: wp.array2d(dtype=Any),
+) -> None:
+    """Gather a 2-D public-order item axis into backend order.
+
+    Args:
+        user_data: Source array shaped [num_envs, num_items] in public order.
+            Values retain the caller-defined units.
+        backend_to_user: Read-only map shaped [num_items] from each backend item
+            index to its public item index.
+        backend_data: Destination array shaped [num_envs, num_items] in backend
+            order, with the same units as user_data. It must not alias user_data
+            for a nonidentity permutation.
+    """
+    env_id, backend_id = wp.tid()
+    user_id = backend_to_user[backend_id]
+    backend_data[env_id, backend_id] = user_data[env_id, user_id]
+
+
+@wp.kernel
+def reorder_joint_targets_user_to_backend(
+    user_effort: wp.array2d(dtype=wp.float32),
+    user_pos_target: wp.array2d(dtype=wp.float32),
+    user_vel_target: wp.array2d(dtype=wp.float32),
+    backend_to_user: wp.array(dtype=wp.int32),
+    write_effort: bool,
+    write_pos_target: bool,
+    write_vel_target: bool,
+    write_joint_act: bool,
+    backend_effort: wp.array2d(dtype=wp.float32),
+    backend_pos_target: wp.array2d(dtype=wp.float32),
+    backend_vel_target: wp.array2d(dtype=wp.float32),
+    backend_joint_act: wp.array2d(dtype=wp.float32),
+) -> None:
+    """Gather the per-step joint write-path targets into backend order in one launch.
+
+    This fuses the several :func:`reorder_2d_user_to_backend` launches that a
+    single :meth:`write_data_to_sim` would otherwise issue. Each boolean flag is
+    fixed at launch (graph-capture safe) and selects whether one backend output
+    is written; the effort source is read once and can feed both the actuation
+    effort and the direct-drive ``joint_act`` output. A gated-off backend output
+    is never indexed and may alias any other argument.
+
+    Args:
+        user_effort: Actuation effort or applied torque
+            [N or N*m, depending on joint type], shaped [num_envs, num_joints]
+            in public joint order.
+        user_pos_target: Joint position targets [m or rad, depending on joint
+            type], shaped [num_envs, num_joints] in public joint order.
+        user_vel_target: Joint velocity targets [m/s or rad/s, depending on
+            joint type], shaped [num_envs, num_joints] in public joint order.
+        backend_to_user: Read-only map shaped [num_joints] from each backend
+            joint index to its public joint index.
+        write_effort: Whether to gather ``user_effort`` into ``backend_effort``.
+        write_pos_target: Whether to gather ``user_pos_target`` into
+            ``backend_pos_target``.
+        write_vel_target: Whether to gather ``user_vel_target`` into
+            ``backend_vel_target``.
+        write_joint_act: Whether to gather ``user_effort`` into
+            ``backend_joint_act`` from the same read as ``backend_effort``.
+        backend_effort: Effort destination
+            [N or N*m, depending on joint type] in backend joint order.
+        backend_pos_target: Position-target destination
+            [m or rad, depending on joint type] in backend joint order.
+        backend_vel_target: Velocity-target destination
+            [m/s or rad/s, depending on joint type] in backend joint order.
+        backend_joint_act: Direct-drive actuation destination
+            [N or N*m, depending on joint type] in backend joint order.
+    """
+    env_id, backend_id = wp.tid()
+    user_id = backend_to_user[backend_id]
+
+    if write_effort or write_joint_act:
+        effort = user_effort[env_id, user_id]
+        if write_effort:
+            backend_effort[env_id, backend_id] = effort
+        if write_joint_act:
+            backend_joint_act[env_id, backend_id] = effort
+
+    if write_pos_target:
+        backend_pos_target[env_id, backend_id] = user_pos_target[env_id, user_id]
+
+    if write_vel_target:
+        backend_vel_target[env_id, backend_id] = user_vel_target[env_id, user_id]
+
+
+@wp.kernel
+def reorder_body_wrench_user_to_backend(
+    user_force: wp.array2d(dtype=wp.vec3f),
+    user_torque: wp.array2d(dtype=wp.vec3f),
+    backend_to_user: wp.array(dtype=wp.int32),
+    backend_force: wp.array2d(dtype=wp.vec3f),
+    backend_torque: wp.array2d(dtype=wp.vec3f),
+) -> None:
+    """Gather public body wrenches into backend body order.
+
+    Args:
+        user_force: Body-frame forces [N], shaped [num_envs, num_bodies], in
+            public body order.
+        user_torque: Body-frame torques [N*m], shaped [num_envs, num_bodies],
+            in public body order.
+        backend_to_user: Read-only map shaped [num_bodies] from backend body
+            indices to public body indices.
+        backend_force: Force destination [N], shaped [num_envs, num_bodies], in
+            backend body order.
+        backend_torque: Torque destination [N*m], shaped
+            [num_envs, num_bodies], in backend body order. Source and
+            destination arrays must not alias for a nonidentity permutation.
+    """
+    env_id, backend_body_id = wp.tid()
+    user_body_id = backend_to_user[backend_body_id]
+    backend_force[env_id, backend_body_id] = user_force[env_id, user_body_id]
+    backend_torque[env_id, backend_body_id] = user_torque[env_id, user_body_id]
+
+
+@wp.kernel
+def reorder_3d_user_to_backend(
+    user_data: wp.array3d(dtype=Any),
+    backend_to_user: wp.array(dtype=wp.int32),
+    backend_data: wp.array3d(dtype=Any),
+) -> None:
+    """Gather a 3-D public item axis into backend order.
+
+    Args:
+        user_data: Source shaped [num_envs, num_items, num_components] in public
+            order. Values retain the caller-defined units.
+        backend_to_user: Read-only map shaped [num_items] from backend item
+            indices to public item indices.
+        backend_data: Destination with the same shape and units in backend
+            order. The component axis is preserved, and source and destination
+            must not alias for a nonidentity permutation.
+    """
+    env_id, backend_id, component_id = wp.tid()
+    user_id = backend_to_user[backend_id]
+    backend_data[env_id, backend_id, component_id] = user_data[env_id, user_id, component_id]
+
+
+@wp.kernel
+def reorder_3d_backend_to_user(
+    backend_data: wp.array3d(dtype=Any),
+    user_to_backend: wp.array(dtype=wp.int32),
+    user_data: wp.array3d(dtype=Any),
+) -> None:
+    """Gather a 3-D backend item axis into public order.
+
+    Args:
+        backend_data: Source shaped [num_envs, num_items, num_components] in
+            backend order. Values retain the caller-defined units.
+        user_to_backend: Read-only map shaped [num_items] from public item
+            indices to backend item indices.
+        user_data: Destination with the same shape and units in public order.
+            The component axis is preserved, and source and destination must
+            not alias for a nonidentity permutation.
+    """
+    env_id, user_id, component_id = wp.tid()
+    backend_id = user_to_backend[user_id]
+    user_data[env_id, user_id, component_id] = backend_data[env_id, backend_id, component_id]
+
+
+@wp.kernel
+def reorder_jacobian_backend_to_user(
+    backend_data: wp.array4d(dtype=wp.float32),
+    jacobian_body_user_to_backend: wp.array(dtype=wp.int32),
+    joint_user_to_backend: wp.array(dtype=wp.int32),
+    num_base_dofs: wp.int32,
+    has_body_ordering: bool,
+    has_joint_ordering: bool,
+    user_data: wp.array4d(dtype=wp.float32),
+) -> None:
+    """Gather Jacobian body rows and actuated-joint columns into public order.
+
+    Args:
+        backend_data: Geometric Jacobian shaped
+            [num_envs, num_jacobian_bodies, 6, num_dofs] in backend body and
+            joint order. Linear rows are [m/s per unit DoF velocity] and angular
+            rows are [rad/s per unit DoF velocity].
+        jacobian_body_user_to_backend: Read-only map from public Jacobian body
+            rows to backend rows. Any fixed-root omission is already encoded.
+        joint_user_to_backend: Read-only map from public actuated-joint columns
+            to backend actuated-joint columns.
+        num_base_dofs: Number of leading floating-base DoFs, either 0 or 6.
+        has_body_ordering: Whether to apply the body-row map.
+        has_joint_ordering: Whether to apply the joint-column map after the
+            leading base DoFs.
+        user_data: Destination with the same shape and units in public body and
+            joint order. Spatial rows and leading base-DoF columns are
+            preserved. It may alias backend_data only when both ordering flags
+            are false.
+    """
+    env_id, user_body_id, spatial_id, user_dof_id = wp.tid()
+    backend_body_id = user_body_id
+    if has_body_ordering:
+        backend_body_id = jacobian_body_user_to_backend[user_body_id]
+
+    backend_dof_id = user_dof_id
+    if has_joint_ordering and user_dof_id >= num_base_dofs:
+        backend_dof_id = num_base_dofs + joint_user_to_backend[user_dof_id - num_base_dofs]
+
+    user_data[env_id, user_body_id, spatial_id, user_dof_id] = backend_data[
+        env_id, backend_body_id, spatial_id, backend_dof_id
+    ]
+
+
+@wp.kernel
+def reorder_mass_matrix_backend_to_user(
+    backend_data: wp.array3d(dtype=wp.float32),
+    joint_user_to_backend: wp.array(dtype=wp.int32),
+    num_base_dofs: wp.int32,
+    has_joint_ordering: bool,
+    user_data: wp.array3d(dtype=wp.float32),
+) -> None:
+    """Gather both actuated-joint axes of a generalized mass matrix into public order.
+
+    Args:
+        backend_data: Generalized mass matrix [kg*m^2 or kg, per DoF type],
+            shaped [num_envs, num_dofs, num_dofs], in backend joint order.
+        joint_user_to_backend: Read-only map from public actuated-joint indices
+            to backend actuated-joint indices.
+        num_base_dofs: Number of leading floating-base DoFs, either 0 or 6.
+        has_joint_ordering: Whether to apply the map to rows and columns after
+            the leading base DoFs.
+        user_data: Destination with the same shape and units in public joint
+            order. Leading base-DoF rows and columns are preserved. It may alias
+            backend_data only when has_joint_ordering is false.
+    """
+    env_id, user_row_id, user_col_id = wp.tid()
+    backend_row_id = user_row_id
+    backend_col_id = user_col_id
+    if has_joint_ordering:
+        if user_row_id >= num_base_dofs:
+            backend_row_id = num_base_dofs + joint_user_to_backend[user_row_id - num_base_dofs]
+        if user_col_id >= num_base_dofs:
+            backend_col_id = num_base_dofs + joint_user_to_backend[user_col_id - num_base_dofs]
+
+    user_data[env_id, user_row_id, user_col_id] = backend_data[env_id, backend_row_id, backend_col_id]
+
+
+@wp.kernel
+def reorder_generalized_vector_backend_to_user(
+    backend_data: wp.array2d(dtype=wp.float32),
+    joint_user_to_backend: wp.array(dtype=wp.int32),
+    num_base_dofs: wp.int32,
+    has_joint_ordering: bool,
+    user_data: wp.array2d(dtype=wp.float32),
+) -> None:
+    """Gather an actuated-joint segment of a generalized force vector into public order.
+
+    Args:
+        backend_data: Generalized force [N or N*m, depending on DoF type],
+            shaped [num_envs, num_dofs], in backend joint order.
+        joint_user_to_backend: Read-only map from public actuated-joint indices
+            to backend actuated-joint indices.
+        num_base_dofs: Number of leading floating-base DoFs, either 0 or 6.
+        has_joint_ordering: Whether to apply the map after the leading base DoFs.
+        user_data: Destination with the same shape and units in public joint
+            order. Leading base-DoF entries are preserved. It may alias
+            backend_data only when has_joint_ordering is false.
+    """
+    env_id, user_dof_id = wp.tid()
+    backend_dof_id = user_dof_id
+    if has_joint_ordering and user_dof_id >= num_base_dofs:
+        backend_dof_id = num_base_dofs + joint_user_to_backend[user_dof_id - num_base_dofs]
+
+    user_data[env_id, user_dof_id] = backend_data[env_id, backend_dof_id]
+
+
+@wp.kernel
+def write_joint_vel_user_to_backend_with_indices(
+    in_data: wp.array2d(dtype=wp.float32),
+    env_ids: wp.array(dtype=wp.int32),
+    user_ids: wp.array(dtype=wp.int32),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    full_data: bool,
+    user_vel: wp.array2d(dtype=wp.float32),
+    user_prev_vel: wp.array2d(dtype=wp.float32),
+    user_acc: wp.array2d(dtype=wp.float32),
+    backend_vel: wp.array2d(dtype=wp.float32),
+) -> None:
+    """Write selected public joint velocities and reset their acceleration history.
+
+    The Cartesian-product selectors must each contain unique indices. Repeated
+    indices can issue concurrent writes to the same destination cell.
+
+    Args:
+        in_data: Joint velocities [m/s or rad/s, depending on joint type].
+            With full_data true, shape is [num_envs, num_joints] in public
+            order; otherwise it is [len(env_ids), len(user_ids)].
+        env_ids: Unique environment indices selected from [0, num_envs).
+        user_ids: Unique public joint indices selected from [0, num_joints).
+        user_to_backend: Read-only map from public to backend joint indices.
+        has_ordering: Whether to scatter velocity into backend_vel. When false,
+            backend_vel is not written and may alias user_vel.
+        full_data: Whether in_data uses full public indices instead of compact
+            selector-local indices.
+        user_vel: Public joint velocity destination [m/s or rad/s].
+        user_prev_vel: Public previous-velocity destination [m/s or rad/s].
+        user_acc: Public acceleration destination [m/s^2 or rad/s^2], set to
+            zero for selected cells.
+        backend_vel: Backend joint velocity destination [m/s or rad/s].
+    """
+    i, j = wp.tid()
+    env_id = env_ids[i]
+    user_id = user_ids[j]
+
+    if full_data:
+        value = in_data[env_id, user_id]
+    else:
+        value = in_data[i, j]
+
+    user_vel[env_id, user_id] = value
+    user_prev_vel[env_id, user_id] = value
+    user_acc[env_id, user_id] = 0.0
+    if has_ordering:
+        backend_id = user_to_backend[user_id]
+        backend_vel[env_id, backend_id] = value
+
+
+@wp.kernel
+def write_joint_state_user_to_backend_with_indices(
+    pos_data: wp.array2d(dtype=wp.float32),
+    vel_data: wp.array2d(dtype=wp.float32),
+    env_ids: wp.array(dtype=wp.int32),
+    user_ids: wp.array(dtype=wp.int32),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    full_data: bool,
+    user_pos: wp.array2d(dtype=wp.float32),
+    user_vel: wp.array2d(dtype=wp.float32),
+    user_prev_vel: wp.array2d(dtype=wp.float32),
+    user_acc: wp.array2d(dtype=wp.float32),
+    backend_pos: wp.array2d(dtype=wp.float32),
+    backend_vel: wp.array2d(dtype=wp.float32),
+) -> None:
+    """Write selected public joint state and reset its acceleration history.
+
+    The Cartesian-product selectors must each contain unique indices. Repeated
+    indices can issue concurrent writes to the same destination cell.
+
+    Args:
+        pos_data: Joint positions [m or rad, depending on joint type]. With
+            full_data true, shape is [num_envs, num_joints] in public order;
+            otherwise it is [len(env_ids), len(user_ids)].
+        vel_data: Joint velocities [m/s or rad/s, depending on joint type], with
+            the same full or compact shape interpretation as pos_data.
+        env_ids: Unique environment indices selected from [0, num_envs).
+        user_ids: Unique public joint indices selected from [0, num_joints).
+        user_to_backend: Read-only map from public to backend joint indices.
+        has_ordering: Whether to scatter state into backend_pos and backend_vel.
+            When false, backend outputs are not written and may alias the
+            corresponding public outputs.
+        full_data: Whether input arrays use full public indices instead of
+            compact selector-local indices.
+        user_pos: Public joint position destination [m or rad].
+        user_vel: Public joint velocity destination [m/s or rad/s].
+        user_prev_vel: Public previous-velocity destination [m/s or rad/s].
+        user_acc: Public acceleration destination [m/s^2 or rad/s^2], set to
+            zero for selected cells.
+        backend_pos: Backend joint position destination [m or rad].
+        backend_vel: Backend joint velocity destination [m/s or rad/s].
+    """
+    i, j = wp.tid()
+    env_id = env_ids[i]
+    user_id = user_ids[j]
+
+    if full_data:
+        position = pos_data[env_id, user_id]
+        velocity = vel_data[env_id, user_id]
+    else:
+        position = pos_data[i, j]
+        velocity = vel_data[i, j]
+
+    user_pos[env_id, user_id] = position
+    user_vel[env_id, user_id] = velocity
+    user_prev_vel[env_id, user_id] = velocity
+    user_acc[env_id, user_id] = 0.0
+    if has_ordering:
+        backend_id = user_to_backend[user_id]
+        backend_pos[env_id, backend_id] = position
+        backend_vel[env_id, backend_id] = velocity
+
+
+@wp.kernel
+def write_joint_vel_user_to_backend_with_mask(
+    in_data: wp.array2d(dtype=wp.float32),
+    env_mask: wp.array(dtype=wp.bool),
+    user_mask: wp.array(dtype=wp.bool),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    user_vel: wp.array2d(dtype=wp.float32),
+    user_prev_vel: wp.array2d(dtype=wp.float32),
+    user_acc: wp.array2d(dtype=wp.float32),
+    backend_vel: wp.array2d(dtype=wp.float32),
+) -> None:
+    """Write masked public joint velocities and reset their acceleration history.
+
+    Args:
+        in_data: Public joint velocities [m/s or rad/s, depending on joint
+            type], shaped [num_envs, num_joints].
+        env_mask: Environment-selection mask shaped [num_envs].
+        user_mask: Public-joint selection mask shaped [num_joints].
+        user_to_backend: Read-only map from public to backend joint indices.
+        has_ordering: Whether to scatter velocity into backend_vel. When false,
+            backend_vel is not written and may alias user_vel.
+        user_vel: Public joint velocity destination [m/s or rad/s].
+        user_prev_vel: Public previous-velocity destination [m/s or rad/s].
+        user_acc: Public acceleration destination [m/s^2 or rad/s^2], set to
+            zero for selected cells.
+        backend_vel: Backend joint velocity destination [m/s or rad/s].
+    """
+    env_id, user_id = wp.tid()
+    if not env_mask[env_id] or not user_mask[user_id]:
+        return
+
+    value = in_data[env_id, user_id]
+    user_vel[env_id, user_id] = value
+    user_prev_vel[env_id, user_id] = value
+    user_acc[env_id, user_id] = 0.0
+    if has_ordering:
+        backend_id = user_to_backend[user_id]
+        backend_vel[env_id, backend_id] = value
+
+
+@wp.kernel
+def write_joint_state_user_to_backend_with_mask(
+    pos_data: wp.array2d(dtype=wp.float32),
+    vel_data: wp.array2d(dtype=wp.float32),
+    env_mask: wp.array(dtype=wp.bool),
+    user_mask: wp.array(dtype=wp.bool),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    user_pos: wp.array2d(dtype=wp.float32),
+    user_vel: wp.array2d(dtype=wp.float32),
+    user_prev_vel: wp.array2d(dtype=wp.float32),
+    user_acc: wp.array2d(dtype=wp.float32),
+    backend_pos: wp.array2d(dtype=wp.float32),
+    backend_vel: wp.array2d(dtype=wp.float32),
+) -> None:
+    """Write masked public joint state and reset its acceleration history.
+
+    Args:
+        pos_data: Public joint positions [m or rad, depending on joint type],
+            shaped [num_envs, num_joints].
+        vel_data: Public joint velocities [m/s or rad/s, depending on joint
+            type], shaped [num_envs, num_joints].
+        env_mask: Environment-selection mask shaped [num_envs].
+        user_mask: Public-joint selection mask shaped [num_joints].
+        user_to_backend: Read-only map from public to backend joint indices.
+        has_ordering: Whether to scatter state into backend_pos and backend_vel.
+            When false, backend outputs are not written and may alias the
+            corresponding public outputs.
+        user_pos: Public joint position destination [m or rad].
+        user_vel: Public joint velocity destination [m/s or rad/s].
+        user_prev_vel: Public previous-velocity destination [m/s or rad/s].
+        user_acc: Public acceleration destination [m/s^2 or rad/s^2], set to
+            zero for selected cells.
+        backend_pos: Backend joint position destination [m or rad].
+        backend_vel: Backend joint velocity destination [m/s or rad/s].
+    """
+    env_id, user_id = wp.tid()
+    if not env_mask[env_id] or not user_mask[user_id]:
+        return
+
+    position = pos_data[env_id, user_id]
+    velocity = vel_data[env_id, user_id]
+    user_pos[env_id, user_id] = position
+    user_vel[env_id, user_id] = velocity
+    user_prev_vel[env_id, user_id] = velocity
+    user_acc[env_id, user_id] = 0.0
+    if has_ordering:
+        backend_id = user_to_backend[user_id]
+        backend_pos[env_id, backend_id] = position
+        backend_vel[env_id, backend_id] = velocity
+
+
+@wp.kernel
+def write_2d_user_to_backend_with_indices(
+    input_data: wp.array2d(dtype=Any),
+    env_ids: wp.array(dtype=wp.int32),
+    user_ids: wp.array(dtype=wp.int32),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    full_data: bool,
+    user_data: wp.array2d(dtype=Any),
+    backend_data: wp.array2d(dtype=Any),
+) -> None:
+    """Write selected structured values to public- and backend-order buffers.
+
+    Args:
+        input_data: Values in caller-defined units. With full_data true, shape
+            is [num_envs, num_items] in public order; otherwise it is
+            [len(env_ids), len(user_ids)].
+        env_ids: Unique selected environment indices.
+        user_ids: Unique selected public item indices.
+        user_to_backend: Read-only public-to-backend item map.
+        has_ordering: Whether to scatter values into backend_data. When false,
+            backend_data is not written and may alias user_data.
+        full_data: Whether input_data uses global public indices.
+        user_data: Public-order destination with the same dtype as input_data.
+        backend_data: Backend-order destination with the same dtype as input_data.
+    """
+    local_env_id, local_user_id = wp.tid()
+    env_id = env_ids[local_env_id]
+    user_id = user_ids[local_user_id]
+    if full_data:
+        value = input_data[env_id, user_id]
+    else:
+        value = input_data[local_env_id, local_user_id]
+
+    user_data[env_id, user_id] = value
+    if has_ordering:
+        backend_data[env_id, user_to_backend[user_id]] = value
+
+
+@wp.kernel
+def write_2d_user_to_backend_with_mask(
+    input_data: wp.array2d(dtype=Any),
+    env_mask: wp.array(dtype=wp.bool),
+    user_mask: wp.array(dtype=wp.bool),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    user_data: wp.array2d(dtype=Any),
+    backend_data: wp.array2d(dtype=Any),
+) -> None:
+    """Write masked structured values to public- and backend-order buffers.
+
+    Args:
+        input_data: Full public-order values shaped [num_envs, num_items] in
+            caller-defined units.
+        env_mask: Environment-selection mask.
+        user_mask: Public-item-selection mask.
+        user_to_backend: Read-only public-to-backend item map.
+        has_ordering: Whether to scatter values into backend_data. When false,
+            backend_data is not written and may alias user_data.
+        user_data: Public-order destination with the same dtype as input_data.
+        backend_data: Backend-order destination with the same dtype as input_data.
+    """
+    env_id, user_id = wp.tid()
+    if not env_mask[env_id] or not user_mask[user_id]:
+        return
+
+    value = input_data[env_id, user_id]
+    user_data[env_id, user_id] = value
+    if has_ordering:
+        backend_data[env_id, user_to_backend[user_id]] = value
+
+
+@wp.kernel
+def write_3d_user_to_backend_with_indices(
+    input_data: wp.array3d(dtype=Any),
+    env_ids: wp.array(dtype=wp.int32),
+    user_ids: wp.array(dtype=wp.int32),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    full_data: bool,
+    user_data: wp.array3d(dtype=Any),
+    backend_data: wp.array3d(dtype=Any),
+) -> None:
+    """Write selected component values to public- and backend-order buffers.
+
+    Args:
+        input_data: Values in caller-defined units. With full_data true, shape
+            is [num_envs, num_items, num_components] in public order;
+            otherwise it is [len(env_ids), len(user_ids), num_components].
+        env_ids: Unique selected environment indices.
+        user_ids: Unique selected public item indices.
+        user_to_backend: Read-only public-to-backend item map.
+        has_ordering: Whether to scatter values into backend_data. When false,
+            backend_data is not written and may alias user_data.
+        full_data: Whether input_data uses global public indices.
+        user_data: Public-order destination with the same dtype as input_data.
+        backend_data: Backend-order destination with the same dtype as input_data.
+    """
+    local_env_id, local_user_id, component_id = wp.tid()
+    env_id = env_ids[local_env_id]
+    user_id = user_ids[local_user_id]
+    if full_data:
+        value = input_data[env_id, user_id, component_id]
+    else:
+        value = input_data[local_env_id, local_user_id, component_id]
+
+    user_data[env_id, user_id, component_id] = value
+    if has_ordering:
+        backend_data[env_id, user_to_backend[user_id], component_id] = value
+
+
+@wp.kernel
+def write_3d_user_to_backend_with_mask(
+    input_data: wp.array3d(dtype=Any),
+    env_mask: wp.array(dtype=wp.bool),
+    user_mask: wp.array(dtype=wp.bool),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    user_data: wp.array3d(dtype=Any),
+    backend_data: wp.array3d(dtype=Any),
+) -> None:
+    """Write masked component values to public- and backend-order buffers.
+
+    Args:
+        input_data: Full public-order values shaped
+            [num_envs, num_items, num_components] in caller-defined units.
+        env_mask: Environment-selection mask.
+        user_mask: Public-item-selection mask.
+        user_to_backend: Read-only public-to-backend item map.
+        has_ordering: Whether to scatter values into backend_data. When false,
+            backend_data is not written and may alias user_data.
+        user_data: Public-order destination with the same dtype as input_data.
+        backend_data: Backend-order destination with the same dtype as input_data.
+    """
+    env_id, user_id, component_id = wp.tid()
+    if not env_mask[env_id] or not user_mask[user_id]:
+        return
+
+    value = input_data[env_id, user_id, component_id]
+    user_data[env_id, user_id, component_id] = value
+    if has_ordering:
+        backend_data[env_id, user_to_backend[user_id], component_id] = value
+
+
+# Concrete, dtype-suffixed overloads of the generic ``write_*`` kernels above.
+# They exist to give torch-tensor inputs (adapted through Warp) a concrete
+# dtype signature at launch time, and are the public entry points that the
+# backend packages launch by name (the ``_vec3``/``_transform``/``_float``
+# suffix names the input/output element dtype).
+write_2d_user_to_backend_with_indices_vec3 = wp.overload(
+    write_2d_user_to_backend_with_indices,
+    {
+        "input_data": wp.array2d(dtype=wp.vec3f),
+        "user_data": wp.array2d(dtype=wp.vec3f),
+        "backend_data": wp.array2d(dtype=wp.vec3f),
+    },
+)
+write_2d_user_to_backend_with_mask_vec3 = wp.overload(
+    write_2d_user_to_backend_with_mask,
+    {
+        "input_data": wp.array2d(dtype=wp.vec3f),
+        "user_data": wp.array2d(dtype=wp.vec3f),
+        "backend_data": wp.array2d(dtype=wp.vec3f),
+    },
+)
+write_2d_user_to_backend_with_indices_transform = wp.overload(
+    write_2d_user_to_backend_with_indices,
+    {
+        "input_data": wp.array2d(dtype=wp.transformf),
+        "user_data": wp.array2d(dtype=wp.transformf),
+        "backend_data": wp.array2d(dtype=wp.transformf),
+    },
+)
+write_2d_user_to_backend_with_mask_transform = wp.overload(
+    write_2d_user_to_backend_with_mask,
+    {
+        "input_data": wp.array2d(dtype=wp.transformf),
+        "user_data": wp.array2d(dtype=wp.transformf),
+        "backend_data": wp.array2d(dtype=wp.transformf),
+    },
+)
+write_3d_user_to_backend_with_indices_float = wp.overload(
+    write_3d_user_to_backend_with_indices,
+    {
+        "input_data": wp.array3d(dtype=wp.float32),
+        "user_data": wp.array3d(dtype=wp.float32),
+        "backend_data": wp.array3d(dtype=wp.float32),
+    },
+)
+write_3d_user_to_backend_with_mask_float = wp.overload(
+    write_3d_user_to_backend_with_mask,
+    {
+        "input_data": wp.array3d(dtype=wp.float32),
+        "user_data": wp.array3d(dtype=wp.float32),
+        "backend_data": wp.array3d(dtype=wp.float32),
+    },
+)
+
+
+@wp.func
+def _resolve_float_input(
+    input_data: wp.float32,
+    env_id: int,
+    user_id: int,
+    local_env_id: int,
+    local_user_id: int,
+    full_data: bool,
+) -> wp.float32:
+    """Return a scalar input unchanged."""
+    return input_data
+
+
+@wp.func
+def _resolve_float_input(
+    input_data: wp.array2d(dtype=wp.float32),
+    env_id: int,
+    user_id: int,
+    local_env_id: int,
+    local_user_id: int,
+    full_data: bool,
+) -> wp.float32:
+    """Read a 2-D input using full or selector-local indices."""
+    if full_data:
+        return input_data[env_id, user_id]
+    return input_data[local_env_id, local_user_id]
+
+
+@wp.kernel
+def write_float_user_to_backend_with_indices(
+    input_data: Any,
+    env_ids: wp.array(dtype=wp.int32),
+    user_ids: wp.array(dtype=wp.int32),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    full_data: bool,
+    user_data: wp.array2d(dtype=wp.float32),
+    backend_data: wp.array2d(dtype=wp.float32),
+) -> None:
+    """Write a scalar or selected 2-D public values to public and backend buffers.
+
+    The Cartesian-product selectors must each contain unique indices. Repeated
+    indices can issue concurrent writes to the same destination cell.
+
+    Args:
+        input_data: Scalar or 2-D values in caller-defined SI units. With full_data
+            true, 2-D input is shaped [num_envs, num_items] in public order;
+            otherwise it is shaped [len(env_ids), len(user_ids)].
+        env_ids: Unique environment indices selected from [0, num_envs).
+        user_ids: Unique public item indices selected from [0, num_items).
+        user_to_backend: Read-only map from public to backend item indices.
+        has_ordering: Whether to scatter values into backend_data. When false,
+            backend_data is not written and may alias user_data.
+        full_data: Whether 2-D input uses full public indices instead of compact
+            selector-local indices.
+        user_data: Public-order destination shaped [num_envs, num_items].
+        backend_data: Backend-order destination shaped [num_envs, num_items].
+    """
+    i, j = wp.tid()
+    env_id = env_ids[i]
+    user_id = user_ids[j]
+
+    value = _resolve_float_input(input_data, env_id, user_id, i, j, full_data)
+
+    user_data[env_id, user_id] = value
+    if has_ordering:
+        backend_id = user_to_backend[user_id]
+        backend_data[env_id, backend_id] = value
+
+
+@wp.kernel
+def write_float_user_to_backend_with_mask(
+    input_data: Any,
+    env_mask: wp.array(dtype=wp.bool),
+    user_mask: wp.array(dtype=wp.bool),
+    user_to_backend: wp.array(dtype=wp.int32),
+    has_ordering: bool,
+    user_data: wp.array2d(dtype=wp.float32),
+    backend_data: wp.array2d(dtype=wp.float32),
+) -> None:
+    """Write a scalar or masked 2-D public values to public and backend buffers.
+
+    Args:
+        input_data: Scalar or 2-D values in caller-defined SI units. A 2-D input is
+            shaped [num_envs, num_items] in public order.
+        env_mask: Environment-selection mask shaped [num_envs].
+        user_mask: Public-item selection mask shaped [num_items].
+        user_to_backend: Read-only map from public to backend item indices.
+        has_ordering: Whether to scatter values into backend_data. When false,
+            backend_data is not written and may alias user_data.
+        user_data: Public-order destination shaped [num_envs, num_items].
+        backend_data: Backend-order destination shaped [num_envs, num_items].
+    """
+    env_id, user_id = wp.tid()
+    if not env_mask[env_id] or not user_mask[user_id]:
+        return
+
+    value = _resolve_float_input(input_data, env_id, user_id, env_id, user_id, True)
+    user_data[env_id, user_id] = value
+    if has_ordering:
+        backend_id = user_to_backend[user_id]
+        backend_data[env_id, backend_id] = value
+
+
+# Concrete array overloads of the ``write_float_*`` kernels above. They give an
+# adapted torch-tensor (rather than scalar) input a concrete 2-D float dtype
+# signature at launch time, and are the public entry points that the backend
+# packages launch by name (the ``_array`` suffix marks the array input form).
+write_float_user_to_backend_with_indices_array = wp.overload(
+    write_float_user_to_backend_with_indices, {"input_data": wp.array2d(dtype=wp.float32)}
+)
+write_float_user_to_backend_with_mask_array = wp.overload(
+    write_float_user_to_backend_with_mask, {"input_data": wp.array2d(dtype=wp.float32)}
+)

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
@@ -40,6 +40,8 @@ from typing import Any
 import warp as wp
 
 __all__ = [
+    "gather_2d",
+    "gather_3d",
     "reorder_2d_backend_to_user",
     "reorder_2d_user_to_backend",
     "reorder_3d_backend_to_user",
@@ -48,47 +50,23 @@ __all__ = [
 
 
 @wp.kernel
-def reorder_2d_backend_to_user(
-    backend_data: wp.array2d(dtype=Any),
-    user_to_backend: wp.array(dtype=wp.int32),
-    user_data: wp.array2d(dtype=Any),
+def gather_2d(
+    src: wp.array2d(dtype=Any),
+    dst_to_src: wp.array(dtype=wp.int32),
+    dst: wp.array2d(dtype=Any),
 ) -> None:
-    """Gather a 2-D backend-order item axis into public order.
+    """Gather a 2-D item axis into destination order.
 
     Args:
-        backend_data: Source array shaped [num_envs, num_items] in backend
-            order. Values retain the caller-defined units.
-        user_to_backend: Read-only map shaped [num_items] from each public item
-            index to its backend item index.
-        user_data: Destination array shaped [num_envs, num_items] in public
-            order, with the same units as backend_data. It must not alias
-            backend_data for a nonidentity permutation.
+        src: Source array shaped [num_envs, num_items]. Values retain the
+            caller-defined units.
+        dst_to_src: Read-only map shaped [num_items] from each destination item
+            index to its source item index.
+        dst: Destination array shaped [num_envs, num_items], with the same
+            units as src. It must not alias src for a nonidentity permutation.
     """
-    env_id, user_id = wp.tid()
-    backend_id = user_to_backend[user_id]
-    user_data[env_id, user_id] = backend_data[env_id, backend_id]
-
-
-@wp.kernel
-def reorder_2d_user_to_backend(
-    user_data: wp.array2d(dtype=Any),
-    backend_to_user: wp.array(dtype=wp.int32),
-    backend_data: wp.array2d(dtype=Any),
-) -> None:
-    """Gather a 2-D public-order item axis into backend order.
-
-    Args:
-        user_data: Source array shaped [num_envs, num_items] in public order.
-            Values retain the caller-defined units.
-        backend_to_user: Read-only map shaped [num_items] from each backend item
-            index to its public item index.
-        backend_data: Destination array shaped [num_envs, num_items] in backend
-            order, with the same units as user_data. It must not alias user_data
-            for a nonidentity permutation.
-    """
-    env_id, backend_id = wp.tid()
-    user_id = backend_to_user[backend_id]
-    backend_data[env_id, backend_id] = user_data[env_id, user_id]
+    env_id, dst_id = wp.tid()
+    dst[env_id, dst_id] = src[env_id, dst_to_src[dst_id]]
 
 
 @wp.kernel
@@ -188,47 +166,36 @@ def reorder_body_wrench_user_to_backend(
 
 
 @wp.kernel
-def reorder_3d_user_to_backend(
-    user_data: wp.array3d(dtype=Any),
-    backend_to_user: wp.array(dtype=wp.int32),
-    backend_data: wp.array3d(dtype=Any),
+def gather_3d(
+    src: wp.array3d(dtype=Any),
+    dst_to_src: wp.array(dtype=wp.int32),
+    dst: wp.array3d(dtype=Any),
 ) -> None:
-    """Gather a 3-D public item axis into backend order.
+    """Gather a 3-D item axis into destination order, preserving components.
 
     Args:
-        user_data: Source shaped [num_envs, num_items, num_components] in public
-            order. Values retain the caller-defined units.
-        backend_to_user: Read-only map shaped [num_items] from backend item
-            indices to public item indices.
-        backend_data: Destination with the same shape and units in backend
-            order. The component axis is preserved, and source and destination
-            must not alias for a nonidentity permutation.
+        src: Source shaped [num_envs, num_items, num_components]. Values retain
+            the caller-defined units.
+        dst_to_src: Read-only map shaped [num_items] from each destination item
+            index to its source item index.
+        dst: Destination with the same shape and units. The component axis is
+            preserved; src and dst must not alias for a nonidentity permutation.
     """
-    env_id, backend_id, component_id = wp.tid()
-    user_id = backend_to_user[backend_id]
-    backend_data[env_id, backend_id, component_id] = user_data[env_id, user_id, component_id]
+    env_id, dst_id, component_id = wp.tid()
+    src_id = dst_to_src[dst_id]
+    dst[env_id, dst_id, component_id] = src[env_id, src_id, component_id]
 
 
-@wp.kernel
-def reorder_3d_backend_to_user(
-    backend_data: wp.array3d(dtype=Any),
-    user_to_backend: wp.array(dtype=wp.int32),
-    user_data: wp.array3d(dtype=Any),
-) -> None:
-    """Gather a 3-D backend item axis into public order.
-
-    Args:
-        backend_data: Source shaped [num_envs, num_items, num_components] in
-            backend order. Values retain the caller-defined units.
-        user_to_backend: Read-only map shaped [num_items] from public item
-            indices to backend item indices.
-        user_data: Destination with the same shape and units in public order.
-            The component axis is preserved, and source and destination must
-            not alias for a nonidentity permutation.
-    """
-    env_id, user_id, component_id = wp.tid()
-    backend_id = user_to_backend[user_id]
-    user_data[env_id, user_id, component_id] = backend_data[env_id, backend_id, component_id]
+# Directional aliases of the gather kernels. The alias name documents intent at
+# a launch site; the map argument follows from it by the dst_to_src contract:
+#   *_backend_to_user gathers backend-order data into public order
+#       -> pass the ordering's ``user_to_backend`` map (destination is the user axis);
+#   *_user_to_backend gathers public-order data into backend order
+#       -> pass the ordering's ``backend_to_user`` map (destination is the backend axis).
+reorder_2d_backend_to_user = gather_2d
+reorder_2d_user_to_backend = gather_2d
+reorder_3d_backend_to_user = gather_3d
+reorder_3d_user_to_backend = gather_3d
 
 
 @wp.kernel

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
@@ -841,25 +841,37 @@ def write_float_user_to_backend_with_indices(
 ) -> None:
     """Write a scalar or selected 2-D public values to public and backend buffers.
 
-    Launch wrapper over :func:`_write_float_user_to_backend_with_indices`.
-    ``input_data`` may be a Python scalar (passed through to the scalar
-    ``wp.func`` overload) or a 2-D float32 torch tensor / Warp array.
+    ``input_data`` may be a Python scalar, broadcast to the selected cells by
+    :func:`_write_scalar_user_to_backend_with_indices` (:paramref:`full_data`
+    is irrelevant for a scalar and ignored), or a 2-D float32 torch tensor /
+    Warp array, delegated to :func:`write_2d_user_to_backend_with_indices`.
     """
-    if not isinstance(input_data, (int, float)):
-        input_data = _as_warp_array(input_data, wp.float32)
-    wp.launch(
-        _write_float_user_to_backend_with_indices,
-        dim=(env_ids.shape[0], user_ids.shape[0]),
-        inputs=[
-            input_data,
-            env_ids,
-            user_ids,
-            user_to_backend,
-            has_ordering,
-            full_data,
-            _as_warp_array(user_data, wp.float32),
-            _as_warp_array(backend_data, wp.float32),
-        ],
+    if isinstance(input_data, (int, float)):
+        wp.launch(
+            _write_scalar_user_to_backend_with_indices,
+            dim=(env_ids.shape[0], user_ids.shape[0]),
+            inputs=[
+                float(input_data),
+                env_ids,
+                user_ids,
+                user_to_backend,
+                has_ordering,
+                _as_warp_array(user_data, wp.float32),
+                _as_warp_array(backend_data, wp.float32),
+            ],
+            device=device,
+        )
+        return
+    write_2d_user_to_backend_with_indices(
+        input_data,
+        env_ids,
+        user_ids,
+        user_to_backend,
+        has_ordering,
+        full_data,
+        user_data,
+        backend_data,
+        dtype=wp.float32,
         device=device,
     )
 
@@ -877,82 +889,62 @@ def write_float_user_to_backend_with_mask(
 ) -> None:
     """Write a scalar or masked 2-D public values to public and backend buffers.
 
-    Launch wrapper over :func:`_write_float_user_to_backend_with_mask`; see
-    :func:`write_float_user_to_backend_with_indices` for the input contract.
+    ``input_data`` may be a Python scalar, broadcast to the masked cells by
+    :func:`_write_scalar_user_to_backend_with_mask`, or a 2-D float32 torch
+    tensor / Warp array, delegated to
+    :func:`write_2d_user_to_backend_with_mask`.
     """
-    if not isinstance(input_data, (int, float)):
-        input_data = _as_warp_array(input_data, wp.float32)
-    wp.launch(
-        _write_float_user_to_backend_with_mask,
-        dim=(env_mask.shape[0], user_mask.shape[0]),
-        inputs=[
-            input_data,
-            env_mask,
-            user_mask,
-            user_to_backend,
-            has_ordering,
-            _as_warp_array(user_data, wp.float32),
-            _as_warp_array(backend_data, wp.float32),
-        ],
+    if isinstance(input_data, (int, float)):
+        wp.launch(
+            _write_scalar_user_to_backend_with_mask,
+            dim=(env_mask.shape[0], user_mask.shape[0]),
+            inputs=[
+                float(input_data),
+                env_mask,
+                user_mask,
+                user_to_backend,
+                has_ordering,
+                _as_warp_array(user_data, wp.float32),
+                _as_warp_array(backend_data, wp.float32),
+            ],
+            device=device,
+        )
+        return
+    write_2d_user_to_backend_with_mask(
+        input_data,
+        env_mask,
+        user_mask,
+        user_to_backend,
+        has_ordering,
+        user_data,
+        backend_data,
+        dtype=wp.float32,
         device=device,
     )
 
 
-@wp.func
-def _resolve_float_input(
-    input_data: wp.float32,
-    env_id: int,
-    user_id: int,
-    local_env_id: int,
-    local_user_id: int,
-    full_data: bool,
-) -> wp.float32:
-    """Return a scalar input unchanged."""
-    return input_data
-
-
-@wp.func
-def _resolve_float_input(
-    input_data: wp.array2d(dtype=wp.float32),
-    env_id: int,
-    user_id: int,
-    local_env_id: int,
-    local_user_id: int,
-    full_data: bool,
-) -> wp.float32:
-    """Read a 2-D input using full or selector-local indices."""
-    if full_data:
-        return input_data[env_id, user_id]
-    return input_data[local_env_id, local_user_id]
-
-
 @wp.kernel
-def _write_float_user_to_backend_with_indices(
-    input_data: Any,
+def _write_scalar_user_to_backend_with_indices(
+    input_value: wp.float32,
     env_ids: wp.array(dtype=wp.int32),
     user_ids: wp.array(dtype=wp.int32),
     user_to_backend: wp.array(dtype=wp.int32),
     has_ordering: bool,
-    full_data: bool,
     user_data: wp.array2d(dtype=wp.float32),
     backend_data: wp.array2d(dtype=wp.float32),
 ) -> None:
-    """Write a scalar or selected 2-D public values to public and backend buffers.
+    """Broadcast one scalar to selected public and backend buffer cells.
 
     The Cartesian-product selectors must each contain unique indices. Repeated
     indices can issue concurrent writes to the same destination cell.
 
     Args:
-        input_data: Scalar or 2-D values in caller-defined SI units. With full_data
-            true, 2-D input is shaped [num_envs, num_items] in public order;
-            otherwise it is shaped [len(env_ids), len(user_ids)].
+        input_value: Scalar value in caller-defined SI units.
         env_ids: Unique environment indices selected from [0, num_envs).
         user_ids: Unique public item indices selected from [0, num_items).
         user_to_backend: Read-only map from public to backend item indices.
-        has_ordering: Whether to scatter values into backend_data. When false,
-            backend_data is not written and may alias user_data.
-        full_data: Whether 2-D input uses full public indices instead of compact
-            selector-local indices.
+        has_ordering: Whether to scatter the value into backend_data. When
+            false, backend_data is not written and may alias user_data.
         user_data: Public-order destination shaped [num_envs, num_items].
         backend_data: Backend-order destination shaped [num_envs, num_items].
     """
@@ -960,17 +952,15 @@ def _write_float_user_to_backend_with_indices(
     env_id = env_ids[i]
     user_id = user_ids[j]
 
-    value = _resolve_float_input(input_data, env_id, user_id, i, j, full_data)
-
-    user_data[env_id, user_id] = value
+    user_data[env_id, user_id] = input_value
     if has_ordering:
         backend_id = user_to_backend[user_id]
-        backend_data[env_id, backend_id] = value
+        backend_data[env_id, backend_id] = input_value
 
 
 @wp.kernel
-def _write_float_user_to_backend_with_mask(
-    input_data: Any,
+def _write_scalar_user_to_backend_with_mask(
+    input_value: wp.float32,
     env_mask: wp.array(dtype=wp.bool),
     user_mask: wp.array(dtype=wp.bool),
     user_to_backend: wp.array(dtype=wp.int32),
@@ -978,16 +968,15 @@ def _write_float_user_to_backend_with_mask(
     user_data: wp.array2d(dtype=wp.float32),
     backend_data: wp.array2d(dtype=wp.float32),
 ) -> None:
-    """Write a scalar or masked 2-D public values to public and backend buffers.
+    """Broadcast one scalar to masked public and backend buffer cells.
 
     Args:
-        input_data: Scalar or 2-D values in caller-defined SI units. A 2-D input is
-            shaped [num_envs, num_items] in public order.
+        input_value: Scalar value in caller-defined SI units.
         env_mask: Environment-selection mask shaped [num_envs].
         user_mask: Public-item selection mask shaped [num_items].
         user_to_backend: Read-only map from public to backend item indices.
-        has_ordering: Whether to scatter values into backend_data. When false,
-            backend_data is not written and may alias user_data.
+        has_ordering: Whether to scatter the value into backend_data. When
+            false, backend_data is not written and may alias user_data.
         user_data: Public-order destination shaped [num_envs, num_items].
         backend_data: Backend-order destination shaped [num_envs, num_items].
     """
@@ -995,8 +984,7 @@ def _write_float_user_to_backend_with_mask(
     if not env_mask[env_id] or not user_mask[user_id]:
         return
 
-    value = _resolve_float_input(input_data, env_id, user_id, env_id, user_id, True)
-    user_data[env_id, user_id] = value
+    user_data[env_id, user_id] = input_value
     if has_ordering:
         backend_id = user_to_backend[user_id]
-        backend_data[env_id, backend_id] = value
+        backend_data[env_id, backend_id] = input_value

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
@@ -6,16 +6,16 @@
 """Shared Warp kernels for articulation ordering conversions.
 
 Visibility contract:
-    The elementwise ``reorder_2d_*``/``reorder_3d_*`` kernels listed in
-    ``__all__`` are public: they gather a single item axis between public and
-    backend order and can legitimately be launched on raw solver-view arrays for
-    advanced interop. Every other symbol in this module -- the fused joint-target
-    and body-wrench kernels, the Jacobian/mass-matrix/generalized-vector
-    specials, the ``write_*`` kernels, and their dtype-suffixed overloads -- is
-    an internal contract between isaaclab core and the backend packages. Those
-    symbols are not user API and may change without deprecation; the backend
-    packages launch them by name, so they stay non-underscored despite being
-    internal.
+    The ``gather_2d``/``gather_3d`` kernels and their directional
+    ``reorder_*`` aliases listed in ``__all__`` are public: they gather a
+    single item axis between public and backend order and can legitimately be
+    launched on raw solver-view arrays for advanced interop. The
+    ``write_*_user_to_backend_*`` Python launch wrappers and the fused
+    joint-target, body-wrench, joint-state, Jacobian, mass-matrix, and
+    generalized-vector kernels are an internal contract between isaaclab core
+    and the backend packages: not user API, may change without deprecation.
+    Underscore-prefixed kernels and helpers are module-private; backends go
+    through the wrappers.
 
 Axis conventions and ownership:
     Axis 0 is always the environment axis. An articulation item axis is
@@ -515,7 +515,7 @@ def write_joint_state_user_to_backend_with_mask(
 
 
 @wp.kernel
-def write_2d_user_to_backend_with_indices(
+def _write_2d_user_to_backend_with_indices(
     input_data: wp.array2d(dtype=Any),
     env_ids: wp.array(dtype=wp.int32),
     user_ids: wp.array(dtype=wp.int32),
@@ -554,7 +554,7 @@ def write_2d_user_to_backend_with_indices(
 
 
 @wp.kernel
-def write_2d_user_to_backend_with_mask(
+def _write_2d_user_to_backend_with_mask(
     input_data: wp.array2d(dtype=Any),
     env_mask: wp.array(dtype=wp.bool),
     user_mask: wp.array(dtype=wp.bool),
@@ -587,7 +587,7 @@ def write_2d_user_to_backend_with_mask(
 
 
 @wp.kernel
-def write_3d_user_to_backend_with_indices(
+def _write_3d_user_to_backend_with_indices(
     input_data: wp.array3d(dtype=Any),
     env_ids: wp.array(dtype=wp.int32),
     user_ids: wp.array(dtype=wp.int32),
@@ -626,7 +626,7 @@ def write_3d_user_to_backend_with_indices(
 
 
 @wp.kernel
-def write_3d_user_to_backend_with_mask(
+def _write_3d_user_to_backend_with_mask(
     input_data: wp.array3d(dtype=Any),
     env_mask: wp.array(dtype=wp.bool),
     user_mask: wp.array(dtype=wp.bool),
@@ -658,65 +658,244 @@ def write_3d_user_to_backend_with_mask(
         backend_data[env_id, user_to_backend[user_id], component_id] = value
 
 
-# Concrete, dtype-suffixed overloads of the generic ``write_*`` kernels above.
-# These exist because Warp cannot infer generic (``dtype=Any``) kernel
-# parameters from torch tensors: launching a generic kernel with a torch input
-# raises "Unable to infer the type of argument" even for an unambiguous
-# float32 tensor, while a concrete overload adapts the tensor to the declared
-# dtype, including trailing-dimension folding for vector and transform
-# element types. Kernels launched exclusively with Warp arrays need no
-# explicit overload (implicit instantiation handles them); every kernel whose
-# call sites accept ``torch.Tensor`` inputs does. The backend packages launch
-# these by name (the ``_vec3``/``_transform``/``_float`` suffix names the
-# input/output element dtype).
-write_2d_user_to_backend_with_indices_vec3 = wp.overload(
-    write_2d_user_to_backend_with_indices,
-    {
-        "input_data": wp.array2d(dtype=wp.vec3f),
-        "user_data": wp.array2d(dtype=wp.vec3f),
-        "backend_data": wp.array2d(dtype=wp.vec3f),
-    },
-)
-write_2d_user_to_backend_with_mask_vec3 = wp.overload(
-    write_2d_user_to_backend_with_mask,
-    {
-        "input_data": wp.array2d(dtype=wp.vec3f),
-        "user_data": wp.array2d(dtype=wp.vec3f),
-        "backend_data": wp.array2d(dtype=wp.vec3f),
-    },
-)
-write_2d_user_to_backend_with_indices_transform = wp.overload(
-    write_2d_user_to_backend_with_indices,
-    {
-        "input_data": wp.array2d(dtype=wp.transformf),
-        "user_data": wp.array2d(dtype=wp.transformf),
-        "backend_data": wp.array2d(dtype=wp.transformf),
-    },
-)
-write_2d_user_to_backend_with_mask_transform = wp.overload(
-    write_2d_user_to_backend_with_mask,
-    {
-        "input_data": wp.array2d(dtype=wp.transformf),
-        "user_data": wp.array2d(dtype=wp.transformf),
-        "backend_data": wp.array2d(dtype=wp.transformf),
-    },
-)
-write_3d_user_to_backend_with_indices_float = wp.overload(
-    write_3d_user_to_backend_with_indices,
-    {
-        "input_data": wp.array3d(dtype=wp.float32),
-        "user_data": wp.array3d(dtype=wp.float32),
-        "backend_data": wp.array3d(dtype=wp.float32),
-    },
-)
-write_3d_user_to_backend_with_mask_float = wp.overload(
-    write_3d_user_to_backend_with_mask,
-    {
-        "input_data": wp.array3d(dtype=wp.float32),
-        "user_data": wp.array3d(dtype=wp.float32),
-        "backend_data": wp.array3d(dtype=wp.float32),
-    },
-)
+def _as_warp_array(data, dtype) -> wp.array:
+    """Return ``data`` as a Warp array of ``dtype``, adapting torch tensors.
+
+    Warp cannot infer generic (``dtype=Any``) kernel parameters from torch
+    tensors, so the launch wrappers below adapt every torch input once, here,
+    including trailing-dimension folding for vector and transform dtypes.
+    Warp arrays pass through unchanged and must already carry ``dtype``.
+    """
+    if isinstance(data, wp.array):
+        return data
+    return wp.from_torch(data, dtype=dtype)
+
+
+def write_2d_user_to_backend_with_indices(
+    input_data,
+    env_ids,
+    user_ids,
+    user_to_backend,
+    has_ordering,
+    full_data,
+    user_data,
+    backend_data,
+    *,
+    dtype,
+    device,
+) -> None:
+    """Write selected structured values to public- and backend-order buffers.
+
+    Launch wrapper over the module-private generic kernel: adapts torch inputs
+    to :paramref:`dtype` and derives the launch dim from the selectors, so call
+    sites need no dtype-suffixed overload names. Argument contract matches
+    :func:`_write_2d_user_to_backend_with_indices`.
+
+    Args:
+        input_data: Values in caller-defined units, torch tensor or Warp array.
+            With full_data true, shape is [num_envs, num_items] in public order;
+            otherwise it is [len(env_ids), len(user_ids)].
+        env_ids: Unique selected environment indices, ``wp.int32``.
+        user_ids: Unique selected public item indices, ``wp.int32``.
+        user_to_backend: Read-only public-to-backend item map, ``wp.int32``.
+        has_ordering: Whether to scatter values into backend_data. When false,
+            backend_data is not written and may alias user_data.
+        full_data: Whether input_data uses global public indices.
+        user_data: Public-order destination with element type ``dtype``.
+        backend_data: Backend-order destination with element type ``dtype``.
+        dtype: Warp element dtype shared by the data arrays (e.g. ``wp.vec3f``,
+            ``wp.transformf``).
+        device: Warp launch device.
+    """
+    wp.launch(
+        _write_2d_user_to_backend_with_indices,
+        dim=(env_ids.shape[0], user_ids.shape[0]),
+        inputs=[
+            _as_warp_array(input_data, dtype),
+            env_ids,
+            user_ids,
+            user_to_backend,
+            has_ordering,
+            full_data,
+            _as_warp_array(user_data, dtype),
+            _as_warp_array(backend_data, dtype),
+        ],
+        device=device,
+    )
+
+
+def write_2d_user_to_backend_with_mask(
+    input_data,
+    env_mask,
+    user_mask,
+    user_to_backend,
+    has_ordering,
+    user_data,
+    backend_data,
+    *,
+    dtype,
+    device,
+) -> None:
+    """Write masked structured values to public- and backend-order buffers.
+
+    Launch wrapper over :func:`_write_2d_user_to_backend_with_mask`; see
+    :func:`write_2d_user_to_backend_with_indices` for the adaptation contract.
+    The launch dim is the full [num_envs, num_items] mask domain.
+    """
+    wp.launch(
+        _write_2d_user_to_backend_with_mask,
+        dim=(env_mask.shape[0], user_mask.shape[0]),
+        inputs=[
+            _as_warp_array(input_data, dtype),
+            env_mask,
+            user_mask,
+            user_to_backend,
+            has_ordering,
+            _as_warp_array(user_data, dtype),
+            _as_warp_array(backend_data, dtype),
+        ],
+        device=device,
+    )
+
+
+def write_3d_user_to_backend_with_indices(
+    input_data,
+    env_ids,
+    user_ids,
+    user_to_backend,
+    has_ordering,
+    full_data,
+    user_data,
+    backend_data,
+    *,
+    dtype,
+    device,
+) -> None:
+    """Write selected component values to public- and backend-order buffers.
+
+    Launch wrapper over :func:`_write_3d_user_to_backend_with_indices`; the
+    component count of the launch dim comes from the adapted destination.
+    """
+    user_array = _as_warp_array(user_data, dtype)
+    wp.launch(
+        _write_3d_user_to_backend_with_indices,
+        dim=(env_ids.shape[0], user_ids.shape[0], user_array.shape[2]),
+        inputs=[
+            _as_warp_array(input_data, dtype),
+            env_ids,
+            user_ids,
+            user_to_backend,
+            has_ordering,
+            full_data,
+            user_array,
+            _as_warp_array(backend_data, dtype),
+        ],
+        device=device,
+    )
+
+
+def write_3d_user_to_backend_with_mask(
+    input_data,
+    env_mask,
+    user_mask,
+    user_to_backend,
+    has_ordering,
+    user_data,
+    backend_data,
+    *,
+    dtype,
+    device,
+) -> None:
+    """Write masked component values to public- and backend-order buffers.
+
+    Launch wrapper over :func:`_write_3d_user_to_backend_with_mask`.
+    """
+    user_array = _as_warp_array(user_data, dtype)
+    wp.launch(
+        _write_3d_user_to_backend_with_mask,
+        dim=(env_mask.shape[0], user_mask.shape[0], user_array.shape[2]),
+        inputs=[
+            _as_warp_array(input_data, dtype),
+            env_mask,
+            user_mask,
+            user_to_backend,
+            has_ordering,
+            user_array,
+            _as_warp_array(backend_data, dtype),
+        ],
+        device=device,
+    )
+
+
+def write_float_user_to_backend_with_indices(
+    input_data,
+    env_ids,
+    user_ids,
+    user_to_backend,
+    has_ordering,
+    full_data,
+    user_data,
+    backend_data,
+    *,
+    device,
+) -> None:
+    """Write a scalar or selected 2-D public values to public and backend buffers.
+
+    Launch wrapper over :func:`_write_float_user_to_backend_with_indices`.
+    ``input_data`` may be a Python scalar (passed through to the scalar
+    ``wp.func`` overload) or a 2-D float32 torch tensor / Warp array.
+    """
+    if not isinstance(input_data, (int, float)):
+        input_data = _as_warp_array(input_data, wp.float32)
+    wp.launch(
+        _write_float_user_to_backend_with_indices,
+        dim=(env_ids.shape[0], user_ids.shape[0]),
+        inputs=[
+            input_data,
+            env_ids,
+            user_ids,
+            user_to_backend,
+            has_ordering,
+            full_data,
+            _as_warp_array(user_data, wp.float32),
+            _as_warp_array(backend_data, wp.float32),
+        ],
+        device=device,
+    )
+
+
+def write_float_user_to_backend_with_mask(
+    input_data,
+    env_mask,
+    user_mask,
+    user_to_backend,
+    has_ordering,
+    user_data,
+    backend_data,
+    *,
+    device,
+) -> None:
+    """Write a scalar or masked 2-D public values to public and backend buffers.
+
+    Launch wrapper over :func:`_write_float_user_to_backend_with_mask`; see
+    :func:`write_float_user_to_backend_with_indices` for the input contract.
+    """
+    if not isinstance(input_data, (int, float)):
+        input_data = _as_warp_array(input_data, wp.float32)
+    wp.launch(
+        _write_float_user_to_backend_with_mask,
+        dim=(env_mask.shape[0], user_mask.shape[0]),
+        inputs=[
+            input_data,
+            env_mask,
+            user_mask,
+            user_to_backend,
+            has_ordering,
+            _as_warp_array(user_data, wp.float32),
+            _as_warp_array(backend_data, wp.float32),
+        ],
+        device=device,
+    )
 
 
 @wp.func
@@ -748,7 +927,7 @@ def _resolve_float_input(
 
 
 @wp.kernel
-def write_float_user_to_backend_with_indices(
+def _write_float_user_to_backend_with_indices(
     input_data: Any,
     env_ids: wp.array(dtype=wp.int32),
     user_ids: wp.array(dtype=wp.int32),
@@ -790,7 +969,7 @@ def write_float_user_to_backend_with_indices(
 
 
 @wp.kernel
-def write_float_user_to_backend_with_mask(
+def _write_float_user_to_backend_with_mask(
     input_data: Any,
     env_mask: wp.array(dtype=wp.bool),
     user_mask: wp.array(dtype=wp.bool),
@@ -821,17 +1000,3 @@ def write_float_user_to_backend_with_mask(
     if has_ordering:
         backend_id = user_to_backend[user_id]
         backend_data[env_id, backend_id] = value
-
-
-# Concrete array overloads of the ``write_float_*`` kernels above, for the
-# array (rather than scalar) input form. Same rationale as the block above:
-# their call sites accept torch tensors, which Warp cannot adapt to a generic
-# parameter, so the 2-D float32 signature must be declared explicitly. The
-# backend packages launch these by name (the ``_array`` suffix marks the
-# array input form).
-write_float_user_to_backend_with_indices_array = wp.overload(
-    write_float_user_to_backend_with_indices, {"input_data": wp.array2d(dtype=wp.float32)}
-)
-write_float_user_to_backend_with_mask_array = wp.overload(
-    write_float_user_to_backend_with_mask, {"input_data": wp.array2d(dtype=wp.float32)}
-)

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_kernels.py
@@ -10,8 +10,8 @@ Visibility contract:
     ``reorder_*`` aliases listed in ``__all__`` are public: they gather a
     single item axis between public and backend order and can legitimately be
     launched on raw solver-view arrays for advanced interop. The
-    ``write_*_user_to_backend_*`` Python launch wrappers and the fused
-    joint-target, body-wrench, joint-state, Jacobian, mass-matrix, and
+    ``write_2d``/``write_3d``/``write_float`` Python launch wrappers and the
+    fused joint-target, body-wrench, joint-state, Jacobian, mass-matrix, and
     generalized-vector kernels are an internal contract between isaaclab core
     and the backend packages: not user API, may change without deprecation.
     Underscore-prefixed kernels and helpers are module-private; backends go

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
@@ -763,7 +763,7 @@ def _resolve_articulation_ordering_names(
     *,
     kind: Literal["joint", "body"],
     backend_names: tuple[str, ...],
-    ordering: tuple[str, ...] | str | ArticulationOrderingConvention | None,
+    ordering: list[str] | tuple[str, ...] | str | ArticulationOrderingConvention | None,
     active_backend_name: str,
     articulation: BaseArticulation | None = None,
 ) -> tuple[str, ...]:
@@ -814,11 +814,12 @@ def _resolve_articulation_ordering_names(
         convention = ordering
     elif isinstance(ordering, str):
         convention = parse_articulation_ordering_convention(ordering)
-    elif type(ordering) is tuple:
+    elif type(ordering) in (list, tuple):
         return _validate_articulation_names(ordering, parameter_name=f"{kind}_ordering")
     else:
         raise TypeError(
-            f"{kind}_ordering must be a name tuple, convention string/enum, or None; got {type(ordering).__name__}."
+            f"{kind}_ordering must be a name list or tuple, convention string/enum, or None;"
+            f" got {type(ordering).__name__}."
         )
 
     if convention is None or _backend_matches_ordering_convention(articulation, convention):

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
@@ -1,0 +1,835 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Resolution of symbolic articulation ordering conventions into concrete names.
+
+A public joint or body axis can request a symbolic convention
+(:class:`~isaaclab.assets.ArticulationOrderingConvention`) instead of an
+explicit name permutation. Resolution walks the following chain and stops at the
+first source that yields a complete backend-name permutation:
+
+#. Same-backend native fast path. When the active backend already exposes the
+   requested convention -- declared through
+   :attr:`~isaaclab.assets.BaseArticulation.__backend_native_orderings__` --
+   backend names are returned without any discovery.
+#. Per-articulation convention cache. A convention resolved earlier for the same
+   articulation is reused (keyed by convention and element kind).
+#. Authored robot-schema USD relationships. The ``robot_schema`` convention
+   reads the ``isaac:physics:robotJoints``/``isaac:physics:robotLinks``
+   relationships on the source asset, expanding nested robot targets.
+#. Temporary Newton USD ``ModelBuilder`` emulation. The ``physx`` and ``mjwarp``
+   conventions build a throwaway Newton view from the source USD, differing only
+   in joint traversal: breadth-first reproduces PhysX order and depth-first
+   reproduces MJWarp order. The depth-first emulation is coupled to
+   isaaclab_newton's ``NewtonManager``, which calls ``ModelBuilder.add_usd`` with
+   Newton's default ordering; if that call ever passes explicit ordering
+   arguments, the emulation constants here must be updated in lockstep or MJWarp
+   resolution silently diverges from the live backend.
+
+:mod:`isaaclab.assets.articulation.ordering` owns the public name-map type and
+its validation; this module owns discovery.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal
+
+from .ordering import ArticulationOrderingConvention, _coerce_articulation_names, parse_articulation_ordering_convention
+
+if TYPE_CHECKING:
+    from pxr import Sdf, Usd
+
+    from .base_articulation import BaseArticulation
+
+logger = logging.getLogger(__name__)
+
+
+def _backend_matches_ordering_convention(
+    articulation: BaseArticulation | None,
+    convention: ArticulationOrderingConvention,
+) -> bool:
+    """Return whether an articulation's backend natively exposes a convention's order.
+
+    A backend declares the conventions its native solver-view order already
+    satisfies through
+    :attr:`~isaaclab.assets.BaseArticulation.__backend_native_orderings__`, so
+    a fourth backend self-declares instead of being added to a hardcoded name
+    set here. A convention listed there takes the identity fast path: requesting
+    it returns backend names without cross-backend discovery. Returns ``False``
+    when no articulation is available to consult.
+    """
+    if articulation is None:
+        return False
+    return convention.value in getattr(articulation, "__backend_native_orderings__", ())
+
+
+def _coerce_name_sequence(names: object) -> tuple[str, ...] | None:
+    """Return names as a tuple when they look like an articulation name sequence."""
+    if names is None or isinstance(names, str | bytes | bytearray):
+        return None
+    try:
+        name_tuple = tuple(names)
+    except TypeError:
+        return None
+    if not all(isinstance(name, str) for name in name_tuple):
+        return None
+    return name_tuple
+
+
+def _validate_ordering_kind(kind: object) -> Literal["joint", "body"]:
+    """Return a supported articulation element kind."""
+    if kind == "joint" or kind == "body":
+        return kind
+    raise ValueError(f"kind must be 'joint' or 'body'; got {kind!r}.")
+
+
+def _get_backend_names(articulation: BaseArticulation, kind: Literal["joint", "body"]) -> tuple[str, ...]:
+    """Return active backend names from an articulation."""
+    attr_name = "backend_joint_names" if kind == "joint" else "backend_body_names"
+    names = _coerce_name_sequence(getattr(articulation, attr_name))
+    if names is None:
+        raise TypeError(f"Articulation {attr_name} must be a sequence of strings.")
+    return names
+
+
+def _get_cached_convention_names(
+    articulation: BaseArticulation,
+    convention: ArticulationOrderingConvention,
+    kind: Literal["joint", "body"],
+) -> tuple[str, ...] | None:
+    """Return cached convention names for an articulation, if present."""
+    return _coerce_name_sequence(articulation._ordering_convention_name_cache.get((convention, kind)))
+
+
+def _cache_convention_names(
+    articulation: BaseArticulation,
+    convention: ArticulationOrderingConvention,
+    names_by_kind: dict[Literal["joint", "body"], tuple[str, ...]],
+) -> None:
+    """Cache convention names on the articulation instance."""
+    cache = articulation._ordering_convention_name_cache
+    for kind, names in names_by_kind.items():
+        cache[(convention, kind)] = tuple(names)
+
+
+def _get_prim_path_string(prim: Usd.Prim) -> str:
+    """Return a USD prim's path string."""
+    return prim.GetPath().pathString
+
+
+_ROBOT_SCHEMA_RELATIONSHIP_NAMES: dict[Literal["joint", "body"], str] = {
+    "joint": "isaac:physics:robotJoints",
+    "body": "isaac:physics:robotLinks",
+}
+
+_ROBOT_SCHEMA_NAME_OVERRIDE_ATTRS: dict[Literal["joint", "body"], tuple[str, ...]] = {
+    "joint": ("isaac:NameOverride", "isaac:nameOverride"),
+    "body": ("isaac:nameOverride", "isaac:NameOverride"),
+}
+
+
+def _get_stage_prim_at_path(stage: Usd.Stage, path: Sdf.Path | str) -> Usd.Prim | None:
+    """Return the stage prim at a path, or ``None`` when the path resolves to no prim.
+
+    ``Usd.Stage.GetPrimAtPath`` returns an invalid prim (it never raises) for a path that is not
+    present on the stage, so an unresolvable relationship target surfaces here as ``None``.
+    """
+    prim = stage.GetPrimAtPath(path)
+    return prim if prim.IsValid() else None
+
+
+def _get_prim_authored_string(prim: Usd.Prim, attr_names: Sequence[str]) -> str | None:
+    """Return the first non-empty authored string among candidate attributes.
+
+    ``Usd.Prim.GetAttribute`` returns an invalid attribute (it never raises) for an unauthored
+    attribute, and ``Usd.Attribute.Get`` returns ``None`` for it.
+    """
+    for attr_name in attr_names:
+        value = prim.GetAttribute(attr_name).Get()
+        if value is None or value == "":
+            continue
+        return value if isinstance(value, str) else str(value)
+    return None
+
+
+def _get_prim_name(prim: Usd.Prim) -> str:
+    """Return a prim's name."""
+    return prim.GetName()
+
+
+def _get_robot_schema_target_name(prim: Usd.Prim, kind: Literal["joint", "body"]) -> str:
+    """Return the articulation name represented by a robot schema target prim."""
+    name_override = _get_prim_authored_string(prim, _ROBOT_SCHEMA_NAME_OVERRIDE_ATTRS[kind])
+    if name_override is not None:
+        return name_override
+    return _get_prim_name(prim)
+
+
+def _get_relationship_targets(prim: Usd.Prim, relationship_name: str) -> tuple[Sdf.Path, ...]:
+    """Return relationship target paths, empty when the relationship is unauthored.
+
+    ``Usd.Prim.GetRelationship`` returns an invalid relationship (it never raises) for an unauthored
+    relationship, and its ``GetTargets`` returns an empty list.
+    """
+    return tuple(prim.GetRelationship(relationship_name).GetTargets())
+
+
+def _collect_robot_schema_relationship_names(
+    robot_prim: Usd.Prim,
+    kind: Literal["joint", "body"],
+    visited_paths: set[str],
+    unresolved_targets: list[str] | None = None,
+) -> tuple[str, ...]:
+    """Collect names from robot schema relationships, expanding nested robot targets.
+
+    An authored relationship target that cannot be resolved on the stage (for
+    example a typo'd path) is logged and skipped rather than silently dropped,
+    since an unresolvable target otherwise degrades to a generic incomplete-
+    ordering failure with no indication of which target was at fault. A target
+    that resolves to a prim path already seen in :paramref:`visited_paths`
+    raises instead of being silently deduplicated, since an authored ordering
+    should never reference the same element twice.
+
+    Args:
+        robot_prim: Prim-like object whose robot schema relationship is read.
+        kind: Element kind, either joint or body.
+        visited_paths: Resolved target prim paths seen so far in this
+            expansion, used to detect duplicate targets.
+        unresolved_targets: Optional list collecting unresolvable target path
+            strings, for diagnostics when the caller reports a failure.
+
+    Returns:
+        Names collected from the relationship, in authored order.
+
+    Raises:
+        ValueError: If a relationship target resolves to a prim path already
+            present in :paramref:`visited_paths`.
+    """
+    relationship_name = _ROBOT_SCHEMA_RELATIONSHIP_NAMES[kind]
+    target_paths = _get_relationship_targets(robot_prim, relationship_name)
+    if not target_paths:
+        return ()
+
+    stage = robot_prim.GetStage()
+    robot_prim_path = _get_prim_path_string(robot_prim)
+    names: list[str] = []
+    for target_path in target_paths:
+        target_prim = _get_stage_prim_at_path(stage, target_path)
+        if target_prim is None:
+            target_path_string = str(target_path)
+            logger.warning(
+                "Ignoring unresolvable '%s' target '%s' authored on '%s'.",
+                relationship_name,
+                target_path_string,
+                robot_prim_path,
+            )
+            if unresolved_targets is not None:
+                unresolved_targets.append(target_path_string)
+            continue
+        target_prim_path = _get_prim_path_string(target_prim)
+        if target_prim_path in visited_paths:
+            raise ValueError(
+                f"Duplicate '{relationship_name}' target '{target_prim_path}' authored on '{robot_prim_path}'; "
+                "each articulation-schema target must appear exactly once."
+            )
+        visited_paths.add(target_prim_path)
+        if _get_relationship_targets(target_prim, relationship_name):
+            names.extend(
+                _collect_robot_schema_relationship_names(
+                    target_prim, kind, visited_paths, unresolved_targets=unresolved_targets
+                )
+            )
+        else:
+            names.append(_get_robot_schema_target_name(target_prim, kind))
+    return tuple(names)
+
+
+def _filter_complete_backend_name_order(
+    names: Sequence[str],
+    backend_names: Sequence[str],
+) -> tuple[str, ...] | None:
+    """Return names when they form a complete backend-name order, ignoring extras."""
+    backend_name_set = set(backend_names)
+    filtered_names: list[str] = []
+    seen_names: set[str] = set()
+    for name in names:
+        if name not in backend_name_set:
+            continue
+        if name in seen_names:
+            return None
+        filtered_names.append(name)
+        seen_names.add(name)
+    if seen_names != backend_name_set:
+        return None
+    return tuple(filtered_names)
+
+
+def _canonical_joint_dof_name(name: str) -> str:
+    """Return a backend-agnostic spelling for per-DoF joint names."""
+    return name.replace(":", "_")
+
+
+def _match_backend_joint_name_spellings(
+    names: Sequence[str],
+    backend_names: Sequence[str],
+) -> tuple[str, ...]:
+    """Return convention names rewritten with active-backend joint-name spellings."""
+    names = tuple(names)
+    backend_names = tuple(backend_names)
+    if set(names) == set(backend_names):
+        return names
+
+    backend_name_by_canonical: dict[str, str] = {}
+    for backend_name in backend_names:
+        canonical_name = _canonical_joint_dof_name(backend_name)
+        if canonical_name in backend_name_by_canonical:
+            return names
+        backend_name_by_canonical[canonical_name] = backend_name
+
+    matched_names: list[str] = []
+    seen_backend_names: set[str] = set()
+    for name in names:
+        backend_name = backend_name_by_canonical.get(_canonical_joint_dof_name(name))
+        if backend_name is None or backend_name in seen_backend_names:
+            return names
+        matched_names.append(backend_name)
+        seen_backend_names.add(backend_name)
+
+    if seen_backend_names != set(backend_names):
+        return names
+    return tuple(matched_names)
+
+
+def _match_backend_name_spellings(
+    *,
+    kind: Literal["joint", "body"],
+    names: Sequence[str],
+    backend_names: Sequence[str],
+) -> tuple[str, ...]:
+    """Return convention names rewritten with active-backend spellings when needed."""
+    if kind == "joint":
+        return _match_backend_joint_name_spellings(names, backend_names)
+    return tuple(names)
+
+
+def _get_complete_convention_names(
+    *,
+    kind: Literal["joint", "body"],
+    names: object,
+    backend_names: Sequence[str],
+) -> tuple[str, ...] | None:
+    """Return a convention candidate when it is a complete backend-name permutation."""
+    candidate_names = _coerce_name_sequence(names)
+    if candidate_names is None:
+        return None
+    candidate_names = _match_backend_name_spellings(
+        kind=kind,
+        names=candidate_names,
+        backend_names=backend_names,
+    )
+    backend_names = tuple(backend_names)
+    if len(candidate_names) != len(backend_names) or set(candidate_names) != set(backend_names):
+        return None
+    return candidate_names
+
+
+def _get_complete_convention_names_by_kind(
+    articulation: BaseArticulation,
+    names_by_kind: dict[Literal["joint", "body"], tuple[str, ...]],
+) -> dict[Literal["joint", "body"], tuple[str, ...]]:
+    """Return only complete convention-name candidates from a multi-kind provider."""
+    complete_names: dict[Literal["joint", "body"], tuple[str, ...]] = {}
+    for candidate_kind in ("joint", "body"):
+        backend_names = _get_backend_names(articulation, candidate_kind)
+        names = _get_complete_convention_names(
+            kind=candidate_kind,
+            names=names_by_kind.get(candidate_kind),
+            backend_names=backend_names,
+        )
+        if names is not None:
+            complete_names[candidate_kind] = names
+    return complete_names
+
+
+def _get_source_asset_prim(articulation: BaseArticulation) -> Usd.Prim | None:
+    """Return the source asset prim for an articulation config when available."""
+    prim_path = articulation.cfg.prim_path
+    from isaaclab.sim.utils.queries import resolve_matching_prims_from_source  # noqa: PLC0415
+
+    source_asset_matches = resolve_matching_prims_from_source(prim_path, expected_num_matches=1)
+    if not source_asset_matches:
+        return None
+    return source_asset_matches[0][0]
+
+
+def _get_robot_schema_candidate_prims(articulation: BaseArticulation) -> tuple[Usd.Prim, ...]:
+    """Return candidate prims that may author robot schema ordering relationships."""
+    source_asset_prim = _get_source_asset_prim(articulation)
+    if source_asset_prim is None:
+        return ()
+
+    candidate_prims = [source_asset_prim]
+    articulation_root_prim_path = articulation.cfg.articulation_root_prim_path
+    if articulation_root_prim_path is not None:
+        root_path = _get_prim_path_string(source_asset_prim) + articulation_root_prim_path
+        articulation_root_prim = _get_stage_prim_at_path(source_asset_prim.GetStage(), root_path)
+        if articulation_root_prim is not None:
+            candidate_prims.append(articulation_root_prim)
+    return tuple(candidate_prims)
+
+
+def _get_robot_schema_names(
+    articulation: BaseArticulation,
+    kind: Literal["joint", "body"],
+) -> tuple[tuple[str, ...] | None, str]:
+    """Return complete articulation names from Isaac Sim robot schema relationships.
+
+    Args:
+        articulation: Articulation whose source USD relationships are resolved.
+        kind: Element kind, either joint or body.
+
+    Returns:
+        A tuple of the resolved names, or ``None`` when no candidate prim
+        authored a complete backend-name permutation, and a short diagnostic
+        reason describing why resolution stopped (empty when names were
+        resolved).
+    """
+    backend_names = _get_backend_names(articulation, kind)
+    relationship_name = _ROBOT_SCHEMA_RELATIONSHIP_NAMES[kind]
+
+    candidate_prims = _get_robot_schema_candidate_prims(articulation)
+    if not candidate_prims:
+        return None, "robot_schema: source asset prim is unavailable"
+
+    unresolved_targets: list[str] = []
+    best_relationship_names: tuple[str, ...] = ()
+    for candidate_prim in candidate_prims:
+        relationship_names = _collect_robot_schema_relationship_names(
+            candidate_prim, kind, set(), unresolved_targets=unresolved_targets
+        )
+        if len(relationship_names) > len(best_relationship_names):
+            best_relationship_names = relationship_names
+        names = _filter_complete_backend_name_order(relationship_names, backend_names)
+        if names is not None:
+            return names, ""
+
+    if unresolved_targets:
+        return None, (
+            f"robot_schema: {len(unresolved_targets)} relationship target(s) unresolved: "
+            f"[{', '.join(unresolved_targets)}]"
+        )
+    if not best_relationship_names:
+        return None, f"robot_schema: no '{relationship_name}' relationship authored"
+    missing = sorted(set(backend_names) - set(best_relationship_names))
+    extra = sorted(set(best_relationship_names) - set(backend_names))
+    return None, f"robot_schema: incomplete permutation (missing={missing}, extra={extra})"
+
+
+def _get_names_from_newton_usd_builder(
+    articulation: BaseArticulation,
+    *,
+    joint_ordering: Literal["bfs", "dfs"],
+    bodies_follow_joint_ordering: bool,
+) -> dict[Literal["joint", "body"], tuple[str, ...]] | None:
+    """Build a lightweight Newton prototype view and return its articulation names."""
+    cfg = articulation.cfg
+    prim_path = cfg.prim_path
+
+    try:
+        from newton import JointType, ModelBuilder, solvers  # noqa: PLC0415
+        from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx  # noqa: PLC0415
+        from newton.selection import ArticulationView  # noqa: PLC0415
+
+        from pxr import UsdGeom, UsdPhysics  # noqa: PLC0415
+
+        from isaaclab.sim.utils.queries import resolve_matching_prims_from_source  # noqa: PLC0415
+        from isaaclab.sim.utils.stage import get_current_stage  # noqa: PLC0415
+    except ModuleNotFoundError as exc:
+        missing_module = exc.name or ""
+        if missing_module not in {"newton", "pxr"} and not missing_module.startswith(("newton.", "pxr.")):
+            raise
+        return None
+
+    stage = get_current_stage()
+    if stage is None:
+        return None
+
+    source_asset_matches = resolve_matching_prims_from_source(prim_path, expected_num_matches=1)
+    if not source_asset_matches:
+        return None
+    source_asset_path = _get_prim_path_string(source_asset_matches[0][0])
+
+    articulation_root_prim_path = cfg.articulation_root_prim_path
+    if articulation_root_prim_path is not None:
+        source_articulation_path = source_asset_path + articulation_root_prim_path
+    else:
+
+        def has_articulation_root_api(prim) -> bool:
+            return bool(prim.HasAPI(UsdPhysics.ArticulationRootAPI))
+
+        source_root_matches = resolve_matching_prims_from_source(
+            prim_path,
+            predicate=has_articulation_root_api,
+            expected_num_matches=1,
+        )
+        if not source_root_matches:
+            return None
+        source_articulation_path = _get_prim_path_string(source_root_matches[0][0])
+
+    builder = ModelBuilder(up_axis=UsdGeom.GetStageUpAxis(stage))
+    solvers.SolverMuJoCo.register_custom_attributes(builder)
+    builder.add_usd(
+        stage,
+        root_path=source_asset_path,
+        load_visual_shapes=False,
+        skip_mesh_approximation=True,
+        schema_resolvers=[SchemaResolverNewton(), SchemaResolverPhysx()],
+        joint_ordering=joint_ordering,
+        bodies_follow_joint_ordering=bodies_follow_joint_ordering,
+    )
+    model = builder.finalize(device="cpu")
+    view = ArticulationView(
+        model,
+        source_articulation_path,
+        verbose=False,
+        exclude_joint_types=[JointType.FREE, JointType.FIXED],
+    )
+    return {"joint": tuple(view.joint_dof_names), "body": tuple(view.link_names)}
+
+
+def _get_physx_names_from_newton_usd_builder(
+    articulation: BaseArticulation,
+) -> dict[Literal["joint", "body"], tuple[str, ...]] | None:
+    """Build a lightweight Newton prototype view with PhysX-style articulation names."""
+    # NOTE: "bfs" assumes Newton's breadth-first USD traversal reproduces
+    # PhysX's native articulation-view order. Unlike the MJWarp constants
+    # below, this is not coupled to isaaclab_newton's NewtonManager: a live
+    # PhysX/OVPhysX backend never goes through Newton's ModelBuilder.add_usd,
+    # so there is no analogous "active backend already matches these
+    # arguments" identity path to keep in sync.
+    return _get_names_from_newton_usd_builder(
+        articulation,
+        joint_ordering="bfs",
+        bodies_follow_joint_ordering=True,
+    )
+
+
+def _get_mjwarp_names_from_newton_usd_builder(
+    articulation: BaseArticulation,
+) -> dict[Literal["joint", "body"], tuple[str, ...]] | None:
+    """Build a lightweight Newton prototype view with MJWarp-style articulation names."""
+    # NOTE: "dfs" and bodies_follow_joint_ordering=True mirror the defaults of
+    # Newton's ModelBuilder.add_usd. isaaclab_newton's NewtonManager calls
+    # add_usd (see instantiate_builder_from_stage) without passing
+    # joint_ordering/bodies_follow_joint_ordering, so a live Newton backend's
+    # native order matches this emulation only because both sides currently
+    # rely on the same Newton library defaults. The "mjwarp" convention's
+    # same-backend identity path (active backend "newton") returns that live
+    # order directly, assuming it equals what these hardcoded constants would
+    # produce. If NewtonManager ever passes explicit ordering arguments to
+    # add_usd, these constants must be updated in lockstep or MJWarp
+    # resolution will silently diverge from the live backend.
+    return _get_names_from_newton_usd_builder(
+        articulation,
+        joint_ordering="dfs",
+        bodies_follow_joint_ordering=True,
+    )
+
+
+def _describe_incomplete_convention_names(
+    kind: Literal["joint", "body"],
+    names: Sequence[str] | None,
+    backend_names: Sequence[str],
+) -> str:
+    """Return a short reason a convention candidate is not a complete backend-name permutation."""
+    if names is None:
+        return f"no {kind} names were discovered"
+    missing = sorted(set(backend_names) - set(names))
+    extra = sorted(set(names) - set(backend_names))
+    return f"{kind} names are not a complete permutation (missing={missing}, extra={extra})"
+
+
+def _describe_newton_usd_builder_unavailability(articulation: BaseArticulation) -> str:
+    """Return a short reason the temporary Newton USD builder produced no articulation names.
+
+    Only re-derives the cheap early-exit checks (module availability, stage
+    availability, source-prim resolution); it never re-runs the Newton model
+    build. Never raises: an articulation missing the USD-backed contract
+    properties (for example in unit tests) falls back to a generic reason
+    instead of masking the caller's real failure.
+    """
+    cfg = getattr(articulation, "cfg", None)
+    prim_path = getattr(cfg, "prim_path", None)
+    if prim_path is None:
+        return "the Newton USD builder returned no articulation names"
+
+    try:
+        import newton  # noqa: F401, PLC0415
+
+        from pxr import UsdPhysics  # noqa: PLC0415
+
+        from isaaclab.sim.utils.queries import resolve_matching_prims_from_source  # noqa: PLC0415
+        from isaaclab.sim.utils.stage import get_current_stage  # noqa: PLC0415
+    except ModuleNotFoundError as exc:
+        return f"'{exc.name or 'unknown'}' module is not installed"
+
+    if get_current_stage() is None:
+        return "no current USD stage is available"
+
+    if not resolve_matching_prims_from_source(prim_path, expected_num_matches=1):
+        return f"source asset prim matching '{prim_path}' was not found"
+
+    articulation_root_prim_path = getattr(cfg, "articulation_root_prim_path", None)
+    if articulation_root_prim_path is None:
+
+        def has_articulation_root_api(prim) -> bool:
+            return bool(prim.HasAPI(UsdPhysics.ArticulationRootAPI))
+
+        if not resolve_matching_prims_from_source(
+            prim_path, predicate=has_articulation_root_api, expected_num_matches=1
+        ):
+            return "no prim with ArticulationRootAPI was found under the source asset"
+
+    return "the Newton USD builder returned no articulation names"
+
+
+def _resolve_articulation_convention_name_ordering(
+    *,
+    articulation: BaseArticulation,
+    convention: str | ArticulationOrderingConvention,
+    kind: Literal["joint", "body"],
+) -> tuple[str, ...]:
+    """Resolve a symbolic convention to names for the public articulation axis.
+
+    A convention matching the active backend returns backend names without
+    discovery. Cross-backend resolution uses a validated per-articulation cache,
+    authored robot-schema relationships for robot_schema, or a temporary Newton
+    USD view. PhysX discovery uses breadth-first joint ordering and MJWarp
+    discovery uses depth-first ordering. Builder results are cached only when
+    both joint and body names are complete permutations.
+
+    Args:
+        articulation: Articulation whose configured source asset is resolved.
+        convention: Convention alias or ArticulationOrderingConvention member.
+        kind: Element kind, either joint or body.
+
+    Returns:
+        Names to expose on the requested public joint or body axis.
+
+    Raises:
+        AttributeError: If required articulation contract properties are absent.
+        TypeError: If convention or discovered names are malformed.
+        ValueError: If kind or convention is invalid, a provider rejects source
+            metadata, or an authored robot-schema relationship targets the
+            same prim more than once.
+        NotImplementedError: If no supported source provides a complete ordering.
+            The message identifies the corresponding configuration field, the
+            explicit-name fallback, and a short reason the attempted
+            resolution strategy did not apply.
+    """
+    kind = _validate_ordering_kind(kind)
+    parsed_convention = parse_articulation_ordering_convention(convention)
+    if parsed_convention is None:
+        return _get_backend_names(articulation, kind)
+
+    active_backend_name = articulation.__backend_name__
+    if _backend_matches_ordering_convention(articulation, parsed_convention):
+        return _get_backend_names(articulation, kind)
+
+    backend_names = _get_backend_names(articulation, kind)
+    resolution_failures: list[str] = []
+
+    cached_names = _get_cached_convention_names(articulation, parsed_convention, kind)
+    cached_names = _get_complete_convention_names(
+        kind=kind,
+        names=cached_names,
+        backend_names=backend_names,
+    )
+    if cached_names is not None:
+        return cached_names
+
+    if parsed_convention is ArticulationOrderingConvention.ROBOT_SCHEMA:
+        raw_robot_schema_names, robot_schema_failure_reason = _get_robot_schema_names(articulation, kind)
+        robot_schema_names = _get_complete_convention_names(
+            kind=kind,
+            names=raw_robot_schema_names,
+            backend_names=backend_names,
+        )
+        if robot_schema_names is not None:
+            _cache_convention_names(articulation, parsed_convention, {kind: robot_schema_names})
+            return robot_schema_names
+        resolution_failures.append(robot_schema_failure_reason)
+
+    # PhysX and MJWarp both resolve through a temporary Newton USD build; they
+    # differ only in the provider function (breadth- vs depth-first joint
+    # ordering) and the failure-reason label.
+    newton_usd_builder_providers = {
+        ArticulationOrderingConvention.PHYSX: ("physx_usd_builder", _get_physx_names_from_newton_usd_builder),
+        ArticulationOrderingConvention.MJWARP: ("mjwarp_usd_builder", _get_mjwarp_names_from_newton_usd_builder),
+    }
+    builder_provider = newton_usd_builder_providers.get(parsed_convention)
+    if builder_provider is not None:
+        provider_label, provider = builder_provider
+        builder_names = provider(articulation)
+        if builder_names is not None:
+            complete_names = _get_complete_convention_names_by_kind(articulation, builder_names)
+            if len(complete_names) == 2:
+                _cache_convention_names(articulation, parsed_convention, complete_names)
+            if kind in complete_names:
+                return complete_names[kind]
+            reason = _describe_incomplete_convention_names(kind, builder_names.get(kind), backend_names)
+            resolution_failures.append(f"{provider_label}: {reason}")
+        else:
+            reason = _describe_newton_usd_builder_unavailability(articulation)
+            resolution_failures.append(f"{provider_label}: {reason}")
+
+    config_field = "joint_ordering" if kind == "joint" else "body_ordering"
+    attempted_resolutions = f" Attempted resolutions: {'; '.join(resolution_failures)}." if resolution_failures else ""
+    raise NotImplementedError(
+        f"Unable to resolve '{parsed_convention.value}' {kind} ordering for active backend "
+        f"'{active_backend_name}'. Ensure the source USD and required ordering dependencies are available, "
+        f"set env.scene.robot.{config_field} to an explicit {kind}-name permutation, or use None to keep "
+        f"active-backend order.{attempted_resolutions}"
+    )
+
+
+def get_articulation_name_ordering(
+    articulation: BaseArticulation,
+    convention: str | ArticulationOrderingConvention,
+    kind: Literal["joint", "body"],
+) -> tuple[str, ...]:
+    """Return articulation names in the order defined by a naming convention.
+
+    The supported conventions are:
+
+    * ``"physx"`` -- PhysX or OVPhysX articulation-view order. PhysX and OVPhysX
+      articulations return active-backend names without discovery; other backends
+      discover the order from a temporary Newton USD view using breadth-first
+      joint ordering.
+    * ``"mjwarp"`` -- Newton or MJWarp articulation-view order. Newton
+      articulations return active-backend names without discovery; other backends
+      discover the order from a temporary Newton USD view using depth-first joint
+      ordering.
+    * ``"robot_schema"`` -- authored robot-schema order. The source asset prim or
+      configured articulation-root prim must author ``isaac:physics:robotJoints``
+      for joints or ``isaac:physics:robotLinks`` for bodies. Nested robot targets
+      are expanded, name overrides are honored, unresolvable targets are logged
+      and skipped, and the remaining names must be a complete unique permutation
+      of active-backend names.
+
+    Cross-backend discovery through the temporary Newton USD view requires a
+    source USD readable by the optional Newton and PXR dependencies, and a
+    complete joint-and-body result is cached per articulation.
+
+    The result defines the public axis only; backend views remain in native order.
+
+    Args:
+        articulation: Articulation whose names are resolved.
+        convention: Convention alias (``"physx"``, ``"mjwarp"``, or
+            ``"robot_schema"``, matched case-insensitively) or
+            :class:`~isaaclab.assets.ArticulationOrderingConvention` member.
+        kind: Element kind, either joint or body.
+
+    Returns:
+        Names in the requested convention's order.
+
+    Raises:
+        TypeError: If backend or discovered names are malformed.
+        ValueError: If kind or convention is invalid, the builder or USD
+            resolution rejects the source metadata, or an authored robot-schema
+            relationship targets the same prim more than once.
+        NotImplementedError: If the source USD, builder dependencies, authored
+            relationships, or a complete name permutation is unavailable. The
+            message identifies the corresponding configuration field, the
+            explicit-name fallback, and a short reason resolution did not produce
+            a complete ordering.
+    """
+    return _resolve_articulation_convention_name_ordering(
+        articulation=articulation,
+        convention=convention,
+        kind=kind,
+    )
+
+
+def _resolve_articulation_ordering_names(
+    *,
+    kind: Literal["joint", "body"],
+    backend_names: Sequence[str],
+    ordering: Sequence[str] | str | ArticulationOrderingConvention | None,
+    active_backend_name: str,
+    articulation: BaseArticulation | None = None,
+) -> tuple[str, ...]:
+    """Resolve configured public articulation ordering to concrete names.
+
+    ``None`` and conventions matching :paramref:`active_backend_name` take an
+    identity fast path and return :paramref:`backend_names`. Explicit sequences
+    are type-checked here; complete-permutation validation is performed later by
+    :func:`build_articulation_name_map`.
+
+    Cross-backend conventions delegate to
+    :func:`_resolve_articulation_convention_name_ordering` and reuse its
+    per-articulation discovery cache. Joint names are normalized to active-backend
+    spelling when Newton multi-DoF separators differ.
+
+    The returned tuple defines public order. :paramref:`backend_names` and
+    solver-view arrays remain in backend order. Supported discovery failures may
+    end in :class:`NotImplementedError`; other provider or builder exceptions
+    propagate.
+
+    Args:
+        kind: Element kind, either ``"joint"`` or ``"body"``.
+        backend_names: Names in active backend solver-view order.
+        ordering: Explicit public name sequence, symbolic convention alias or
+            enum member, or ``None``.
+        active_backend_name: Name of the backend exposing
+            :paramref:`backend_names`.
+        articulation: Articulation used for cached cross-backend discovery when
+            a symbolic convention differs from the active backend.
+
+    Returns:
+        Concrete names for the public joint or body axis.
+
+    Raises:
+        AttributeError: If a provider or builder raises this error.
+        TypeError: If :paramref:`ordering` has an unsupported type, an explicit
+            sequence contains a non-string, or a provider raises an unhandled type error.
+        ValueError: If :paramref:`kind` is invalid, :paramref:`ordering` is an
+            unsupported alias, or a provider or builder rejects the source metadata.
+        NotImplementedError: If cross-backend ordering lacks an articulation, or
+            all supported convention metadata is absent or incomplete.
+    """
+    kind = _validate_ordering_kind(kind)
+    backend_names = _coerce_articulation_names(backend_names, parameter_name="backend_names")
+    if ordering is None:
+        return backend_names
+    if isinstance(ordering, ArticulationOrderingConvention):
+        convention = ordering
+    elif isinstance(ordering, str):
+        convention = parse_articulation_ordering_convention(ordering)
+    elif isinstance(ordering, Sequence) and not isinstance(ordering, bytes | bytearray):
+        return _coerce_articulation_names(ordering, parameter_name=f"{kind}_ordering")
+    else:
+        raise TypeError(
+            f"{kind}_ordering must be a name sequence, convention string/enum, or None; got {type(ordering).__name__}."
+        )
+
+    if convention is None or _backend_matches_ordering_convention(articulation, convention):
+        return backend_names
+    if articulation is not None:
+        convention_names = _resolve_articulation_convention_name_ordering(
+            articulation=articulation,
+            convention=convention,
+            kind=kind,
+        )
+        return _match_backend_name_spellings(kind=kind, names=convention_names, backend_names=backend_names)
+
+    config_field = "joint_ordering" if kind == "joint" else "body_ordering"
+    raise NotImplementedError(
+        f"Unable to resolve '{convention.value}' {kind} ordering for active backend '{active_backend_name}'. "
+        f"Set env.scene.robot.{config_field} to an explicit {kind}-name permutation, or supply an articulation "
+        "whose source USD can provide that convention."
+    )

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
@@ -118,13 +118,10 @@ _ROBOT_SCHEMA_RELATIONSHIP_NAMES: dict[Literal["joint", "body"], str] = {
     "body": "isaac:physics:robotLinks",
 }
 
-_ROBOT_SCHEMA_NAME_OVERRIDE_ATTR: str = "isaac:nameOverride"
-"""Name-override attribute defined by the Isaac Sim robot schema.
-
-``isaacsim.robot.schema`` defines exactly this lowerCamelCase spelling
-(``RobotSchema.usda``: ``string isaac:nameOverride``) for joint and body
-target prims alike; no other capitalization is recognized.
-"""
+_ROBOT_SCHEMA_NAME_OVERRIDE_ATTRS: dict[Literal["joint", "body"], tuple[str, ...]] = {
+    "joint": ("isaac:NameOverride", "isaac:nameOverride"),
+    "body": ("isaac:nameOverride", "isaac:NameOverride"),
+}
 
 
 def _get_stage_prim_at_path(stage: Usd.Stage, path: Sdf.Path | str) -> Usd.Prim | None:
@@ -156,9 +153,9 @@ def _get_prim_name(prim: Usd.Prim) -> str:
     return prim.GetName()
 
 
-def _get_robot_schema_target_name(prim: Usd.Prim) -> str:
+def _get_robot_schema_target_name(prim: Usd.Prim, kind: Literal["joint", "body"]) -> str:
     """Return the articulation name represented by a robot schema target prim."""
-    name_override = _get_prim_authored_string(prim, (_ROBOT_SCHEMA_NAME_OVERRIDE_ATTR,))
+    name_override = _get_prim_authored_string(prim, _ROBOT_SCHEMA_NAME_OVERRIDE_ATTRS[kind])
     if name_override is not None:
         return name_override
     return _get_prim_name(prim)
@@ -239,7 +236,7 @@ def _collect_robot_schema_relationship_names(
                 )
             )
         else:
-            names.append(_get_robot_schema_target_name(target_prim))
+            names.append(_get_robot_schema_target_name(target_prim, kind))
     return tuple(names)
 
 

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
@@ -762,8 +762,8 @@ def get_articulation_name_ordering(
 def _resolve_articulation_ordering_names(
     *,
     kind: Literal["joint", "body"],
-    backend_names: Sequence[str],
-    ordering: Sequence[str] | str | ArticulationOrderingConvention | None,
+    backend_names: tuple[str, ...],
+    ordering: tuple[str, ...] | str | ArticulationOrderingConvention | None,
     active_backend_name: str,
     articulation: BaseArticulation | None = None,
 ) -> tuple[str, ...]:
@@ -814,11 +814,11 @@ def _resolve_articulation_ordering_names(
         convention = ordering
     elif isinstance(ordering, str):
         convention = parse_articulation_ordering_convention(ordering)
-    elif isinstance(ordering, Sequence) and not isinstance(ordering, bytes | bytearray):
+    elif type(ordering) is tuple:
         return _validate_articulation_names(ordering, parameter_name=f"{kind}_ordering")
     else:
         raise TypeError(
-            f"{kind}_ordering must be a name sequence, convention string/enum, or None; got {type(ordering).__name__}."
+            f"{kind}_ordering must be a name tuple, convention string/enum, or None; got {type(ordering).__name__}."
         )
 
     if convention is None or _backend_matches_ordering_convention(articulation, convention):

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
@@ -38,7 +38,11 @@ import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
-from .ordering import ArticulationOrderingConvention, _coerce_articulation_names, parse_articulation_ordering_convention
+from .ordering import (
+    ArticulationOrderingConvention,
+    _validate_articulation_names,
+    parse_articulation_ordering_convention,
+)
 
 if TYPE_CHECKING:
     from pxr import Sdf, Usd
@@ -803,7 +807,7 @@ def _resolve_articulation_ordering_names(
             all supported convention metadata is absent or incomplete.
     """
     kind = _validate_ordering_kind(kind)
-    backend_names = _coerce_articulation_names(backend_names, parameter_name="backend_names")
+    backend_names = _validate_articulation_names(backend_names, parameter_name="backend_names")
     if ordering is None:
         return backend_names
     if isinstance(ordering, ArticulationOrderingConvention):
@@ -811,7 +815,7 @@ def _resolve_articulation_ordering_names(
     elif isinstance(ordering, str):
         convention = parse_articulation_ordering_convention(ordering)
     elif isinstance(ordering, Sequence) and not isinstance(ordering, bytes | bytearray):
-        return _coerce_articulation_names(ordering, parameter_name=f"{kind}_ordering")
+        return _validate_articulation_names(ordering, parameter_name=f"{kind}_ordering")
     else:
         raise TypeError(
             f"{kind}_ordering must be a name sequence, convention string/enum, or None; got {type(ordering).__name__}."

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
@@ -118,10 +118,13 @@ _ROBOT_SCHEMA_RELATIONSHIP_NAMES: dict[Literal["joint", "body"], str] = {
     "body": "isaac:physics:robotLinks",
 }
 
-_ROBOT_SCHEMA_NAME_OVERRIDE_ATTRS: dict[Literal["joint", "body"], tuple[str, ...]] = {
-    "joint": ("isaac:NameOverride", "isaac:nameOverride"),
-    "body": ("isaac:nameOverride", "isaac:NameOverride"),
-}
+_ROBOT_SCHEMA_NAME_OVERRIDE_ATTR: str = "isaac:nameOverride"
+"""Name-override attribute defined by the Isaac Sim robot schema.
+
+``isaacsim.robot.schema`` defines exactly this lowerCamelCase spelling
+(``RobotSchema.usda``: ``string isaac:nameOverride``) for joint and body
+target prims alike; no other capitalization is recognized.
+"""
 
 
 def _get_stage_prim_at_path(stage: Usd.Stage, path: Sdf.Path | str) -> Usd.Prim | None:
@@ -153,9 +156,9 @@ def _get_prim_name(prim: Usd.Prim) -> str:
     return prim.GetName()
 
 
-def _get_robot_schema_target_name(prim: Usd.Prim, kind: Literal["joint", "body"]) -> str:
+def _get_robot_schema_target_name(prim: Usd.Prim) -> str:
     """Return the articulation name represented by a robot schema target prim."""
-    name_override = _get_prim_authored_string(prim, _ROBOT_SCHEMA_NAME_OVERRIDE_ATTRS[kind])
+    name_override = _get_prim_authored_string(prim, (_ROBOT_SCHEMA_NAME_OVERRIDE_ATTR,))
     if name_override is not None:
         return name_override
     return _get_prim_name(prim)
@@ -236,7 +239,7 @@ def _collect_robot_schema_relationship_names(
                 )
             )
         else:
-            names.append(_get_robot_schema_target_name(target_prim, kind))
+            names.append(_get_robot_schema_target_name(target_prim))
     return tuple(names)
 
 

--- a/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
+++ b/source/isaaclab/isaaclab/assets/articulation/ordering_resolvers.py
@@ -71,19 +71,6 @@ def _backend_matches_ordering_convention(
     return convention.value in getattr(articulation, "__backend_native_orderings__", ())
 
 
-def _coerce_name_sequence(names: object) -> tuple[str, ...] | None:
-    """Return names as a tuple when they look like an articulation name sequence."""
-    if names is None or isinstance(names, str | bytes | bytearray):
-        return None
-    try:
-        name_tuple = tuple(names)
-    except TypeError:
-        return None
-    if not all(isinstance(name, str) for name in name_tuple):
-        return None
-    return name_tuple
-
-
 def _validate_ordering_kind(kind: object) -> Literal["joint", "body"]:
     """Return a supported articulation element kind."""
     if kind == "joint" or kind == "body":
@@ -94,10 +81,7 @@ def _validate_ordering_kind(kind: object) -> Literal["joint", "body"]:
 def _get_backend_names(articulation: BaseArticulation, kind: Literal["joint", "body"]) -> tuple[str, ...]:
     """Return active backend names from an articulation."""
     attr_name = "backend_joint_names" if kind == "joint" else "backend_body_names"
-    names = _coerce_name_sequence(getattr(articulation, attr_name))
-    if names is None:
-        raise TypeError(f"Articulation {attr_name} must be a sequence of strings.")
-    return names
+    return _validate_articulation_names(getattr(articulation, attr_name), parameter_name=f"Articulation {attr_name}")
 
 
 def _get_cached_convention_names(
@@ -105,8 +89,12 @@ def _get_cached_convention_names(
     convention: ArticulationOrderingConvention,
     kind: Literal["joint", "body"],
 ) -> tuple[str, ...] | None:
-    """Return cached convention names for an articulation, if present."""
-    return _coerce_name_sequence(articulation._ordering_convention_name_cache.get((convention, kind)))
+    """Return cached convention names for an articulation, if present.
+
+    The cache is written only by :func:`_cache_convention_names` with already
+    validated tuples, so entries are returned without re-validation.
+    """
+    return articulation._ordering_convention_name_cache.get((convention, kind))
 
 
 def _cache_convention_names(
@@ -323,13 +311,18 @@ def _match_backend_name_spellings(
 def _get_complete_convention_names(
     *,
     kind: Literal["joint", "body"],
-    names: object,
+    names: tuple[str, ...] | None,
     backend_names: Sequence[str],
 ) -> tuple[str, ...] | None:
-    """Return a convention candidate when it is a complete backend-name permutation."""
-    candidate_names = _coerce_name_sequence(names)
-    if candidate_names is None:
+    """Return a convention candidate when it is a complete backend-name permutation.
+
+    Providers contractually return validated name tuples or ``None``; a missing
+    candidate short-circuits to ``None`` so resolution falls through to the next
+    strategy.
+    """
+    if names is None:
         return None
+    candidate_names = names
     candidate_names = _match_backend_name_spellings(
         kind=kind,
         names=candidate_names,

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -684,7 +684,7 @@ def test_robot_schema_ordering_helper_reads_authored_relationships(monkeypatch: 
     # A name override renames the target prim, and a target absent from the backend names (tool_site)
     # must be dropped by the complete-permutation filter.
     stage.GetPrimAtPath(f"{robot_path}/joint_a_prim").CreateAttribute(
-        "isaac:NameOverride", Sdf.ValueTypeNames.String
+        "isaac:nameOverride", Sdf.ValueTypeNames.String
     ).Set("joint_a")
     stage.GetPrimAtPath(f"{robot_path}/base_prim").CreateAttribute("isaac:nameOverride", Sdf.ValueTypeNames.String).Set(
         "base"
@@ -724,6 +724,23 @@ def test_robot_schema_ordering_helper_reads_authored_relationships(monkeypatch: 
         active_backend_name=articulation.__backend_name__,
         articulation=articulation,
     ) == ("joint_b", "joint_a", "joint_c")
+
+
+def test_robot_schema_name_override_ignores_capitalized_spelling() -> None:
+    """Only the schema-defined ``isaac:nameOverride`` spelling is honored, for both kinds."""
+    stage = Usd.Stage.CreateInMemory()
+    robot_path = "/World/Robot"
+    joint_prim = stage.DefinePrim(f"{robot_path}/joint_a_prim", "Xform")
+    body_prim = stage.DefinePrim(f"{robot_path}/base_prim", "Xform")
+    # Capitalized spelling is not part of isaacsim.robot.schema: fall back to the prim name.
+    joint_prim.CreateAttribute("isaac:NameOverride", Sdf.ValueTypeNames.String).Set("joint_a")
+    body_prim.CreateAttribute("isaac:NameOverride", Sdf.ValueTypeNames.String).Set("base")
+    assert ordering_resolvers._get_robot_schema_target_name(joint_prim) == "joint_a_prim"
+    assert ordering_resolvers._get_robot_schema_target_name(body_prim) == "base_prim"
+
+    lower_joint = stage.DefinePrim(f"{robot_path}/j", "Xform")
+    lower_joint.CreateAttribute("isaac:nameOverride", Sdf.ValueTypeNames.String).Set("hip")
+    assert ordering_resolvers._get_robot_schema_target_name(lower_joint) == "hip"
 
 
 def test_robot_schema_ordering_helper_rejects_incomplete_relationships(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -539,31 +539,24 @@ def _author_robot_schema_relationship(prim: Usd.Prim, relationship_name: str, ta
     prim.CreateRelationship(relationship_name).SetTargets([Sdf.Path(path) for path in target_paths])
 
 
-def test_robot_schema_ordering_helper_reads_authored_relationships(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Resolve explicit robot schema ordering from authored USD relationship targets."""
+def test_robot_schema_ordering_helper_resolves_canonical_name_override_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolve joint ordering from authored relationships honoring the canonical ``isaac:NameOverride``."""
     stage = Usd.Stage.CreateInMemory()
     robot_path = "/World/envs/env_0/Robot"
     robot_prim = stage.DefinePrim(robot_path, "Xform")
-    for child in ("joint_a_prim", "joint_b", "joint_c", "base_prim", "tool_site", "thigh", "foot"):
+    for child in ("joint_a_prim", "joint_b", "joint_c"):
         stage.DefinePrim(f"{robot_path}/{child}", "Xform")
     _author_robot_schema_relationship(
         robot_prim,
         "isaac:physics:robotJoints",
         [f"{robot_path}/joint_b", f"{robot_path}/joint_a_prim", f"{robot_path}/joint_c"],
     )
-    _author_robot_schema_relationship(
-        robot_prim,
-        "isaac:physics:robotLinks",
-        [f"{robot_path}/base_prim", f"{robot_path}/tool_site", f"{robot_path}/thigh", f"{robot_path}/foot"],
-    )
-    # A name override renames the target prim, and a target absent from the backend names (tool_site)
-    # must be dropped by the complete-permutation filter.
+    # The canonical uppercase ``NameOverride`` renames the target prim to its backend joint name.
     stage.GetPrimAtPath(f"{robot_path}/joint_a_prim").CreateAttribute(
-        "isaac:nameOverride", Sdf.ValueTypeNames.String
+        "isaac:NameOverride", Sdf.ValueTypeNames.String
     ).Set("joint_a")
-    stage.GetPrimAtPath(f"{robot_path}/base_prim").CreateAttribute("isaac:nameOverride", Sdf.ValueTypeNames.String).Set(
-        "base"
-    )
 
     def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
         assert path_expr == "/World/envs/env_.*/Robot"
@@ -582,7 +575,7 @@ def test_robot_schema_ordering_helper_reads_authored_relationships(monkeypatch: 
 
         @property
         def backend_body_names(self) -> list[str]:
-            return ["base", "thigh", "foot"]
+            return []
 
     articulation = _Articulation()
 
@@ -591,7 +584,7 @@ def test_robot_schema_ordering_helper_reads_authored_relationships(monkeypatch: 
         "joint_a",
         "joint_c",
     )
-    assert get_articulation_name_ordering(articulation, "robot_schema", kind="body") == ("base", "thigh", "foot")
+    # The public resolver entry point routes through the same authored-relationship discovery.
     assert _resolve_articulation_ordering_names(
         kind="joint",
         backend_names=tuple(articulation.backend_joint_names),
@@ -601,21 +594,48 @@ def test_robot_schema_ordering_helper_reads_authored_relationships(monkeypatch: 
     ) == ("joint_b", "joint_a", "joint_c")
 
 
-def test_robot_schema_name_override_ignores_capitalized_spelling() -> None:
-    """Only the schema-defined ``isaac:nameOverride`` spelling is honored, for both kinds."""
+def test_robot_schema_ordering_helper_resolves_fallback_name_override_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolve body ordering via the fallback ``isaac:nameOverride`` spelling, dropping extra targets."""
     stage = Usd.Stage.CreateInMemory()
-    robot_path = "/World/Robot"
-    joint_prim = stage.DefinePrim(f"{robot_path}/joint_a_prim", "Xform")
-    body_prim = stage.DefinePrim(f"{robot_path}/base_prim", "Xform")
-    # Capitalized spelling is not part of isaacsim.robot.schema: fall back to the prim name.
-    joint_prim.CreateAttribute("isaac:NameOverride", Sdf.ValueTypeNames.String).Set("joint_a")
-    body_prim.CreateAttribute("isaac:NameOverride", Sdf.ValueTypeNames.String).Set("base")
-    assert ordering_resolvers._get_robot_schema_target_name(joint_prim) == "joint_a_prim"
-    assert ordering_resolvers._get_robot_schema_target_name(body_prim) == "base_prim"
+    robot_path = "/World/envs/env_0/Robot"
+    robot_prim = stage.DefinePrim(robot_path, "Xform")
+    for child in ("base_prim", "tool_site", "thigh", "foot"):
+        stage.DefinePrim(f"{robot_path}/{child}", "Xform")
+    _author_robot_schema_relationship(
+        robot_prim,
+        "isaac:physics:robotLinks",
+        [f"{robot_path}/base_prim", f"{robot_path}/tool_site", f"{robot_path}/thigh", f"{robot_path}/foot"],
+    )
+    # The fallback lowercase ``nameOverride`` renames the root target; tool_site is absent from the
+    # backend names and must be dropped by the complete-permutation filter.
+    stage.GetPrimAtPath(f"{robot_path}/base_prim").CreateAttribute(
+        "isaac:nameOverride", Sdf.ValueTypeNames.String
+    ).Set("base")
 
-    lower_joint = stage.DefinePrim(f"{robot_path}/j", "Xform")
-    lower_joint.CreateAttribute("isaac:nameOverride", Sdf.ValueTypeNames.String).Set("hip")
-    assert ordering_resolvers._get_robot_schema_target_name(lower_joint) == "hip"
+    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
+        assert path_expr == "/World/envs/env_.*/Robot"
+        return [(robot_prim, "/World/envs/env_.*/Robot")]
+
+    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
+
+    class _Articulation:
+        __backend_name__ = "newton"
+        _ordering_convention_name_cache: dict = {}
+        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
+
+        @property
+        def backend_joint_names(self) -> list[str]:
+            return []
+
+        @property
+        def backend_body_names(self) -> list[str]:
+            return ["base", "thigh", "foot"]
+
+    articulation = _Articulation()
+
+    assert get_articulation_name_ordering(articulation, "robot_schema", kind="body") == ("base", "thigh", "foot")
 
 
 def test_robot_schema_ordering_helper_rejects_incomplete_relationships(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -355,19 +355,23 @@ def test_articulation_name_map_direct_constructor_rejects_non_integer_indices(in
 
 
 @pytest.mark.parametrize("index_type", [int, np.int64])
-def test_articulation_name_map_direct_constructor_accepts_integral_indices(index_type) -> None:
-    """Accept Python and NumPy integral indices and normalize them to int."""
+def test_articulation_name_map_direct_constructor_requires_exact_int_indices(index_type) -> None:
+    """Accept built-in int indices and reject other integral types without coercion."""
     indices = tuple(index_type(index) for index in range(3))
 
-    name_map = _make_identity_articulation_name_map(
-        user_to_backend_indices=indices,
-        backend_to_user_indices=indices,
-    )
-
-    assert name_map.user_to_backend_indices == (0, 1, 2)
-    assert name_map.backend_to_user_indices == (0, 1, 2)
-    assert all(type(index) is int for index in name_map.user_to_backend_indices)
-    assert all(type(index) is int for index in name_map.backend_to_user_indices)
+    if index_type is int:
+        name_map = _make_identity_articulation_name_map(
+            user_to_backend_indices=indices,
+            backend_to_user_indices=indices,
+        )
+        assert name_map.user_to_backend_indices == (0, 1, 2)
+        assert name_map.backend_to_user_indices == (0, 1, 2)
+    else:
+        with pytest.raises(TypeError, match=r"user_to_backend_indices element 0 must be int"):
+            _make_identity_articulation_name_map(
+                user_to_backend_indices=indices,
+                backend_to_user_indices=indices,
+            )
 
 
 def test_articulation_name_map_direct_constructor_rejects_non_bool_identity() -> None:
@@ -382,7 +386,7 @@ def test_build_articulation_name_map_rejects_scalar_name_sequences() -> None:
     ``backend_names`` and ``user_names`` share one coercion helper, so one representative field and
     value pin the rule and the offending type.
     """
-    with pytest.raises(TypeError, match=r"backend_names must be a sequence of strings; got str"):
+    with pytest.raises(TypeError, match=r"backend_names must be a list or tuple of strings; got str"):
         build_articulation_name_map(
             kind="joint",
             backend_names="joint_0",
@@ -414,16 +418,15 @@ def test_resolve_articulation_ordering_names_accepts_explicit_sequence() -> None
     assert user_names == ("joint_2", "joint_0", "joint_1")
 
 
-def test_resolve_articulation_ordering_names_accepts_generic_sequence() -> None:
-    """Resolve explicit public ordering names from a generic sequence."""
-    user_names = _resolve_articulation_ordering_names(
-        kind="joint",
-        backend_names=("joint_0", "joint_1", "joint_2"),
-        ordering=UserList(["joint_2", "joint_0", "joint_1"]),
-        active_backend_name="physx",
-    )
-
-    assert user_names == ("joint_2", "joint_0", "joint_1")
+def test_resolve_articulation_ordering_names_rejects_generic_sequence() -> None:
+    """Reject explicit orderings that are not plain lists or tuples."""
+    with pytest.raises(TypeError, match=r"joint_ordering must be a list or tuple of strings; got UserList"):
+        _resolve_articulation_ordering_names(
+            kind="joint",
+            backend_names=("joint_0", "joint_1", "joint_2"),
+            ordering=UserList(["joint_2", "joint_0", "joint_1"]),
+            active_backend_name="physx",
+        )
 
 
 def test_resolve_articulation_ordering_names_reports_non_string_element() -> None:
@@ -432,7 +435,7 @@ def test_resolve_articulation_ordering_names_reports_non_string_element() -> Non
         _resolve_articulation_ordering_names(
             kind="joint",
             backend_names=("joint_0", "joint_1", "joint_2"),
-            ordering=UserList(["joint_1", 7]),
+            ordering=["joint_1", 7],
             active_backend_name="physx",
         )
 

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -10,13 +10,11 @@ from collections import UserList
 
 import numpy as np
 import pytest
-import warp as wp
 
 from pxr import Sdf, Usd
 
 import isaaclab.assets.articulation.ordering_resolvers as ordering_resolvers
 from isaaclab.assets.articulation.ordering import (
-    ArticulationNameMap,
     ArticulationOrderingConvention,
     apply_articulation_ordering_preset,
     build_articulation_name_map,
@@ -157,123 +155,6 @@ def test_apply_articulation_ordering_preset_sets_joint_and_body_ordering() -> No
     assert apply_articulation_ordering_preset(cfg, None) is cfg
 
 
-def test_articulation_name_map_direct_constructor_validates_maps() -> None:
-    """Reject inconsistent public name maps built without the factory."""
-    identity_map = wp.array((0, 1, 2), dtype=wp.int32, device="cpu")
-    reversed_map = wp.array((2, 1, 0), dtype=wp.int32, device="cpu")
-
-    with pytest.raises(ValueError, match="inverse"):
-        ArticulationNameMap(
-            kind="joint",
-            backend_names=("joint_0", "joint_1", "joint_2"),
-            user_names=("joint_2", "joint_1", "joint_0"),
-            user_to_backend_indices=(2, 1, 0),
-            backend_to_user_indices=(0, 1, 2),
-            user_to_backend=reversed_map,
-            backend_to_user=identity_map,
-            is_identity=False,
-        )
-
-
-def test_articulation_name_map_direct_constructor_validates_name_index_correspondence() -> None:
-    """Reject maps whose indices do not map each public name to the same backend name."""
-    identity_map = wp.array((0, 1, 2), dtype=wp.int32, device="cpu")
-
-    with pytest.raises(ValueError, match="name and index mappings must agree"):
-        ArticulationNameMap(
-            kind="joint",
-            backend_names=("joint_0", "joint_1", "joint_2"),
-            user_names=("joint_2", "joint_1", "joint_0"),
-            user_to_backend_indices=(0, 1, 2),
-            backend_to_user_indices=(0, 1, 2),
-            user_to_backend=identity_map,
-            backend_to_user=identity_map,
-            is_identity=False,
-        )
-
-
-def test_articulation_name_map_direct_constructor_validates_device_maps() -> None:
-    """Reject device maps that contradict the validated CPU permutations."""
-    identity_map = wp.array((0, 1, 2), dtype=wp.int32, device="cpu")
-    reversed_map = wp.array((2, 1, 0), dtype=wp.int32, device="cpu")
-
-    with pytest.raises(ValueError, match="device user_to_backend map must match user_to_backend_indices"):
-        ArticulationNameMap(
-            kind="joint",
-            backend_names=("joint_0", "joint_1", "joint_2"),
-            user_names=("joint_2", "joint_1", "joint_0"),
-            user_to_backend_indices=(2, 1, 0),
-            backend_to_user_indices=(2, 1, 0),
-            user_to_backend=identity_map,
-            backend_to_user=reversed_map,
-            is_identity=False,
-        )
-
-
-def _make_identity_articulation_name_map(**overrides) -> ArticulationNameMap:
-    """Construct an identity name map with selected direct-constructor overrides."""
-    identity_device_map = wp.array((0, 1, 2), dtype=wp.int32, device="cpu")
-    fields = {
-        "kind": "joint",
-        "backend_names": ("joint_0", "joint_1", "joint_2"),
-        "user_names": ("joint_0", "joint_1", "joint_2"),
-        "user_to_backend_indices": (0, 1, 2),
-        "backend_to_user_indices": (0, 1, 2),
-        "user_to_backend": identity_device_map,
-        "backend_to_user": identity_device_map,
-        "is_identity": True,
-    }
-    fields.update(overrides)
-    return ArticulationNameMap(**fields)
-
-
-def test_articulation_name_map_direct_constructor_rejects_non_warp_device_maps() -> None:
-    """Reject a device map that is not a Warp array before accessing its metadata.
-
-    Both device maps flow through one validation loop, so one representative field and value pin
-    the rule, its error type, and the offending type.
-    """
-    with pytest.raises(TypeError, match=r"user_to_backend must be a Warp array; got list"):
-        _make_identity_articulation_name_map(user_to_backend=[0, 1, 2])
-
-
-@pytest.mark.parametrize("invalid_value", [pytest.param(0.5, id="lossy_float"), pytest.param(True, id="bool")])
-def test_articulation_name_map_direct_constructor_rejects_non_integer_indices(invalid_value) -> None:
-    """Reject a lossy value and a bool in a CPU index permutation.
-
-    Both index permutations share one coercion helper, so one field covers the rule. ``bool`` is a
-    distinct guard because it would otherwise pass ``operator.index`` as 0/1.
-    """
-    with pytest.raises(TypeError, match=r"user_to_backend_indices element 0"):
-        _make_identity_articulation_name_map(user_to_backend_indices=(invalid_value, 1, 2))
-
-
-@pytest.mark.parametrize("index_type", [int, np.int64])
-def test_articulation_name_map_direct_constructor_requires_exact_int_indices(index_type) -> None:
-    """Accept built-in int indices and reject other integral types without coercion."""
-    indices = tuple(index_type(index) for index in range(3))
-
-    if index_type is int:
-        name_map = _make_identity_articulation_name_map(
-            user_to_backend_indices=indices,
-            backend_to_user_indices=indices,
-        )
-        assert name_map.user_to_backend_indices == (0, 1, 2)
-        assert name_map.backend_to_user_indices == (0, 1, 2)
-    else:
-        with pytest.raises(TypeError, match=r"user_to_backend_indices element 0 must be int"):
-            _make_identity_articulation_name_map(
-                user_to_backend_indices=indices,
-                backend_to_user_indices=indices,
-            )
-
-
-def test_articulation_name_map_direct_constructor_rejects_non_bool_identity() -> None:
-    """Require ``is_identity`` to be a built-in bool, rejecting a truthy int like ``1``."""
-    with pytest.raises(TypeError, match=r"is_identity must be bool; got int"):
-        _make_identity_articulation_name_map(is_identity=1)
-
-
 def test_build_articulation_name_map_rejects_scalar_name_sequences() -> None:
     """Reject a scalar string instead of splitting it into per-character names.
 
@@ -324,12 +205,6 @@ def test_resolve_articulation_ordering_names_accepts_list_and_tuple(sequence_typ
 
     assert user_names == ("joint_2", "joint_0", "joint_1")
     assert type(user_names) is tuple
-
-
-def test_articulation_name_map_direct_constructor_requires_tuple_fields() -> None:
-    """Keep the frozen map strict: directly constructed fields must be tuples, not lists."""
-    with pytest.raises(TypeError, match=r"ArticulationNameMap backend_names must be a tuple; got list"):
-        _make_identity_articulation_name_map(backend_names=["joint_0", "joint_1", "joint_2"])
 
 
 def test_resolve_articulation_ordering_names_rejects_generic_sequence() -> None:
@@ -1180,6 +1055,7 @@ def test_base_articulation_keeps_none_ordering_on_default_path() -> None:
         backend_body_names=["base", "foot"],
         device="cpu",
     )
+    articulation._resolve_axis_ordering = BaseArticulation._resolve_axis_ordering.__get__(articulation)
 
     BaseArticulation._resolve_and_install_ordering_maps(articulation)
 
@@ -1220,7 +1096,7 @@ def _make_ordering_resolution_articulation(
         body_names=None,
         _apply_ordering_maps_after_resolve=lambda: None,
     )
-    return types.SimpleNamespace(
+    articulation = types.SimpleNamespace(
         __backend_name__="mock",
         _ordering_convention_name_cache={},
         cfg=types.SimpleNamespace(
@@ -1234,6 +1110,8 @@ def _make_ordering_resolution_articulation(
         is_fixed_base=is_fixed_base,
         device="cpu",
     )
+    articulation._resolve_axis_ordering = BaseArticulation._resolve_axis_ordering.__get__(articulation)
+    return articulation
 
 
 def test_base_articulation_ordering_contract_preserves_legacy_subclasses() -> None:
@@ -1305,27 +1183,6 @@ def test_base_articulation_data_defines_optional_ordering_maps() -> None:
     assert hasattr(BaseArticulationData, "body_ordering")
 
 
-def test_build_articulation_name_map_uses_identity_device_maps() -> None:
-    """Build an identity articulation name map with identity device maps."""
-    name_map = build_articulation_name_map(
-        kind="joint",
-        backend_names=("hip", "knee", "ankle"),
-        user_names=None,
-        device="cpu",
-    )
-
-    assert name_map.kind == "joint"
-    assert name_map.backend_names == ("hip", "knee", "ankle")
-    assert name_map.user_names == ("hip", "knee", "ankle")
-    assert name_map.user_to_backend_indices == (0, 1, 2)
-    assert name_map.backend_to_user_indices == (0, 1, 2)
-    assert name_map.user_to_backend is not None
-    assert name_map.backend_to_user is not None
-    np.testing.assert_array_equal(name_map.user_to_backend.numpy(), np.asarray([0, 1, 2], dtype=np.int32))
-    np.testing.assert_array_equal(name_map.backend_to_user.numpy(), np.asarray([0, 1, 2], dtype=np.int32))
-    assert name_map.is_identity
-
-
 def test_build_articulation_name_map_builds_permutation_indices_and_device_maps() -> None:
     """Build CPU and device maps for an explicit user ordering permutation."""
     name_map = build_articulation_name_map(
@@ -1335,16 +1192,12 @@ def test_build_articulation_name_map_builds_permutation_indices_and_device_maps(
         device="cpu",
     )
 
-    assert name_map.kind == "body"
-    assert name_map.backend_names == ("base", "left_foot", "right_foot")
-    assert name_map.user_names == ("right_foot", "base", "left_foot")
     assert name_map.user_to_backend_indices == (2, 0, 1)
     assert name_map.backend_to_user_indices == (1, 2, 0)
     assert name_map.user_to_backend is not None
     assert name_map.backend_to_user is not None
     np.testing.assert_array_equal(name_map.user_to_backend.numpy(), np.asarray([2, 0, 1], dtype=np.int32))
     np.testing.assert_array_equal(name_map.backend_to_user.numpy(), np.asarray([1, 2, 0], dtype=np.int32))
-    assert not name_map.is_identity
 
 
 def test_build_articulation_name_map_rejects_duplicate_backend_names() -> None:
@@ -1378,3 +1231,35 @@ def test_build_articulation_name_map_rejects_incomplete_permutation() -> None:
             user_names=("hip", "wheel"),
             device="cpu",
         )
+
+
+def test_build_articulation_name_map_returns_none_for_identity() -> None:
+    """Identity orderings have no map object; None is the single identity state."""
+    backend_names = ("j_a", "j_b", "j_c")
+    assert (
+        build_articulation_name_map(kind="joint", backend_names=backend_names, user_names=backend_names, device="cpu")
+        is None
+    )
+    assert build_articulation_name_map(kind="joint", backend_names=backend_names, user_names=None, device="cpu") is None
+
+    permuted = build_articulation_name_map(
+        kind="joint", backend_names=backend_names, user_names=("j_c", "j_a", "j_b"), device="cpu"
+    )
+    assert permuted is not None
+    assert permuted.user_to_backend_indices == (2, 0, 1)
+    assert permuted.backend_to_user_indices == (1, 2, 0)
+    assert not hasattr(permuted, "is_identity")
+    assert not hasattr(permuted, "user_names")
+
+
+def test_ordering_state_lives_only_on_data() -> None:
+    """No mirrored ordering flags or maps exist on the asset or data classes."""
+    from isaaclab.assets.articulation.base_articulation import BaseArticulation
+    from isaaclab.assets.articulation.base_articulation_data import BaseArticulationData
+
+    for owner, names in (
+        (BaseArticulation, ("_cache_ordering_maps", "_reset_and_cache_ordering_maps")),
+        (BaseArticulationData, ("_install_ordering_flags", "_has_joint_ordering", "_has_body_ordering")),
+    ):
+        for name in names:
+            assert not hasattr(owner, name), f"{owner.__name__}.{name} should be deleted"

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -4,12 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging
-import subprocess
 import sys
-import textwrap
 import types
 from collections import UserList
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -18,17 +15,6 @@ import warp as wp
 from pxr import Sdf, Usd
 
 import isaaclab.assets.articulation.ordering_resolvers as ordering_resolvers
-
-_inserted_torch_stub = False
-try:
-    import torch  # noqa: F401
-except ModuleNotFoundError:
-    torch_stub = types.ModuleType("torch")
-    torch_stub.Tensor = type("Tensor", (), {})
-    if "torch" not in sys.modules:
-        sys.modules["torch"] = torch_stub
-        _inserted_torch_stub = True
-
 from isaaclab.assets.articulation.ordering import (
     ArticulationNameMap,
     ArticulationOrderingConvention,
@@ -82,9 +68,6 @@ from isaaclab.assets.articulation.articulation_cfg import ArticulationCfg
 from isaaclab.assets.articulation.base_articulation import BaseArticulation
 from isaaclab.assets.articulation.base_articulation_data import BaseArticulationData
 
-if _inserted_torch_stub and sys.modules.get("torch") is torch_stub:
-    sys.modules.pop("torch")
-
 if _inserted_sim_stub:
     sys.modules.pop("isaaclab.sim", None)
 if _inserted_sim_context_stub:
@@ -93,58 +76,6 @@ if _inserted_asset_base_stub:
     sys.modules.pop("isaaclab.assets.asset_base", None)
 if _inserted_sim_stub or _inserted_asset_base_stub:
     sys.modules.pop("isaaclab.assets.articulation.base_articulation", None)
-
-
-def test_ordering_module_torch_stub_is_scoped_to_imports() -> None:
-    """Remove only the temporary torch stub installed while importing base classes."""
-    script = textwrap.dedent(
-        """
-        import builtins
-        import runpy
-        import sys
-        import types
-
-        import numpy  # noqa: F401
-        import pytest  # noqa: F401
-        import warp  # noqa: F401
-        import isaaclab.assets.articulation.ordering_resolvers  # noqa: F401
-
-        mode = sys.argv[1]
-        module_path = sys.argv[2]
-        sentinel = None
-        if mode == "missing":
-            sys.modules.pop("torch", None)
-            real_import = builtins.__import__
-            block_torch_import = [True]
-
-            def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
-                if name == "torch" and block_torch_import[0]:
-                    block_torch_import[0] = False
-                    raise ModuleNotFoundError("No module named torch", name="torch")
-                return real_import(name, globals, locals, fromlist, level)
-
-            builtins.__import__ = guarded_import
-        else:
-            sentinel = types.ModuleType("torch")
-            sentinel.Tensor = type("Tensor", (), {})
-            sys.modules["torch"] = sentinel
-
-        runpy.run_path(module_path)
-
-        if mode == "missing" and "torch" in sys.modules:
-            raise SystemExit("temporary torch stub leaked from the ordering test module")
-        if mode == "preexisting" and sys.modules.get("torch") is not sentinel:
-            raise SystemExit("pre-existing torch module was replaced or removed")
-        """
-    )
-
-    for mode in ("preexisting", "missing"):
-        result = subprocess.run(
-            [sys.executable, "-c", script, mode, str(Path(__file__))],
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_parse_articulation_ordering_convention_accepts_none_strings_and_enum() -> None:
@@ -198,43 +129,6 @@ def test_ordering_resolvers_reject_invalid_kind(entrypoint: str) -> None:
             get_articulation_name_ordering(articulation, "mjwarp", kind="dof")  # type: ignore[arg-type]
         else:
             get_articulation_name_ordering(articulation, "robot_schema", kind="dof")  # type: ignore[arg-type]
-
-
-def test_assets_package_reexports_public_ordering_symbols() -> None:
-    """Expose every documented ordering symbol from the public assets package."""
-    from isaaclab import assets
-
-    expected_exports = {
-        "ArticulationOrderingConvention": ArticulationOrderingConvention,
-        "ArticulationNameMap": ArticulationNameMap,
-        "apply_articulation_ordering_preset": apply_articulation_ordering_preset,
-        "build_articulation_name_map": build_articulation_name_map,
-        "parse_articulation_ordering_convention": parse_articulation_ordering_convention,
-        "get_articulation_name_ordering": get_articulation_name_ordering,
-    }
-    for name, expected_export in expected_exports.items():
-        assert getattr(assets, name, None) is expected_export, name
-    assert not hasattr(assets, "resolve_articulation_ordering_names")
-    assert not hasattr(assets, "resolve_articulation_convention_name_ordering")
-
-
-def test_assets_api_page_defines_ordering_symbols() -> None:
-    """Publish exact ordering directives; the preceding test covers re-exports."""
-    repo_root = Path(__file__).resolve().parents[4]
-    api_page = (repo_root / "docs/source/api/lab/isaaclab.assets.rst").read_text(encoding="utf-8")
-    actual_directives = {line.strip() for line in api_page.splitlines() if line.strip().startswith(".. ")}
-
-    expected_directives = {
-        ".. currentmodule:: isaaclab.assets",
-        ".. autoclass:: ArticulationOrderingConvention",
-        ".. autoclass:: ArticulationNameMap",
-        ".. autofunction:: apply_articulation_ordering_preset",
-        ".. autofunction:: build_articulation_name_map",
-        ".. autofunction:: parse_articulation_ordering_convention",
-        ".. autofunction:: get_articulation_name_ordering",
-    }
-    missing_directives = expected_directives - actual_directives
-    assert not missing_directives, f"Missing exact RST directives: {sorted(missing_directives)}"
 
 
 def test_articulation_cfg_accepts_optional_ordering_fields() -> None:

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -386,7 +386,7 @@ def test_build_articulation_name_map_rejects_scalar_name_sequences() -> None:
     ``backend_names`` and ``user_names`` share one coercion helper, so one representative field and
     value pin the rule and the offending type.
     """
-    with pytest.raises(TypeError, match=r"backend_names must be a tuple of strings; got str"):
+    with pytest.raises(TypeError, match=r"backend_names must be a list or tuple of strings; got str"):
         build_articulation_name_map(
             kind="joint",
             backend_names="joint_0",
@@ -418,9 +418,31 @@ def test_resolve_articulation_ordering_names_accepts_explicit_sequence() -> None
     assert user_names == ("joint_2", "joint_0", "joint_1")
 
 
+@pytest.mark.parametrize("sequence_type", [list, tuple])
+def test_resolve_articulation_ordering_names_accepts_list_and_tuple(sequence_type) -> None:
+    """Resolve explicit orderings from both plain sequence forms, normalized to a tuple."""
+    user_names = _resolve_articulation_ordering_names(
+        kind="joint",
+        backend_names=("joint_0", "joint_1", "joint_2"),
+        ordering=sequence_type(["joint_2", "joint_0", "joint_1"]),
+        active_backend_name="physx",
+    )
+
+    assert user_names == ("joint_2", "joint_0", "joint_1")
+    assert type(user_names) is tuple
+
+
+def test_articulation_name_map_direct_constructor_requires_tuple_fields() -> None:
+    """Keep the frozen map strict: directly constructed fields must be tuples, not lists."""
+    with pytest.raises(TypeError, match=r"ArticulationNameMap backend_names must be a tuple; got list"):
+        _make_identity_articulation_name_map(backend_names=["joint_0", "joint_1", "joint_2"])
+
+
 def test_resolve_articulation_ordering_names_rejects_generic_sequence() -> None:
-    """Reject explicit orderings that are not plain name tuples."""
-    with pytest.raises(TypeError, match=r"joint_ordering must be a name tuple, convention string/enum, or None"):
+    """Reject explicit orderings that are not plain lists or tuples."""
+    with pytest.raises(
+        TypeError, match=r"joint_ordering must be a name list or tuple, convention string/enum, or None"
+    ):
         _resolve_articulation_ordering_names(
             kind="joint",
             backend_names=("joint_0", "joint_1", "joint_2"),
@@ -446,7 +468,6 @@ def test_resolve_articulation_ordering_names_reports_non_string_element() -> Non
     ("ordering", "type_name"),
     [
         (7, "int"),
-        (["joint_0", "joint_1", "joint_2"], "list"),
         (b"", "bytes"),
         (b"joint_0", "bytes"),
         (bytearray(), "bytearray"),
@@ -464,7 +485,7 @@ def test_resolve_articulation_ordering_names_reports_unsupported_type(ordering, 
         )
 
     assert str(exc_info.value) == (
-        f"joint_ordering must be a name tuple, convention string/enum, or None; got {type_name}."
+        f"joint_ordering must be a name list or tuple, convention string/enum, or None; got {type_name}."
     )
 
 

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -94,12 +94,14 @@ def test_parse_articulation_ordering_convention_rejects_unknown_string() -> None
         parse_articulation_ordering_convention("backend")
 
 
-@pytest.mark.parametrize(
-    "entrypoint",
-    ["resolve_names", "resolve_convention", "physx", "mjwarp", "robot_schema"],
-)
+@pytest.mark.parametrize("entrypoint", ["resolve_names", "resolve_convention", "get_ordering"])
 def test_ordering_resolvers_reject_invalid_kind(entrypoint: str) -> None:
-    """Reject misspelled element kinds at every resolver entry point."""
+    """Reject a misspelled element kind at each distinct resolver validation site.
+
+    ``get_articulation_name_ordering`` validates ``kind`` before parsing the convention, so its
+    ``physx``/``mjwarp``/``robot_schema`` aliases all reach one guard; a single public call covers
+    them.
+    """
 
     class _Articulation:
         __backend_name__ = "physx"
@@ -121,12 +123,8 @@ def test_ordering_resolvers_reject_invalid_kind(entrypoint: str) -> None:
                 convention="physx",
                 kind="dof",  # type: ignore[arg-type]
             )
-        elif entrypoint == "physx":
-            get_articulation_name_ordering(articulation, "physx", kind="dof")  # type: ignore[arg-type]
-        elif entrypoint == "mjwarp":
-            get_articulation_name_ordering(articulation, "mjwarp", kind="dof")  # type: ignore[arg-type]
         else:
-            get_articulation_name_ordering(articulation, "robot_schema", kind="dof")  # type: ignore[arg-type]
+            get_articulation_name_ordering(articulation, "physx", kind="dof")  # type: ignore[arg-type]
 
 
 def test_articulation_cfg_accepts_optional_ordering_fields() -> None:
@@ -181,18 +179,6 @@ def test_build_articulation_name_map_reports_non_string_name_element() -> None:
         )
 
 
-def test_resolve_articulation_ordering_names_accepts_explicit_sequence() -> None:
-    """Resolve explicit public ordering names from config."""
-    user_names = _resolve_articulation_ordering_names(
-        kind="joint",
-        backend_names=("joint_0", "joint_1", "joint_2"),
-        ordering=("joint_2", "joint_0", "joint_1"),
-        active_backend_name="physx",
-    )
-
-    assert user_names == ("joint_2", "joint_0", "joint_1")
-
-
 @pytest.mark.parametrize("sequence_type", [list, tuple])
 def test_resolve_articulation_ordering_names_accepts_list_and_tuple(sequence_type) -> None:
     """Resolve explicit orderings from both plain sequence forms, normalized to a tuple."""
@@ -236,15 +222,16 @@ def test_resolve_articulation_ordering_names_reports_non_string_element() -> Non
 @pytest.mark.parametrize(
     ("ordering", "type_name"),
     [
-        (7, "int"),
-        (b"", "bytes"),
-        (b"joint_0", "bytes"),
-        (bytearray(), "bytearray"),
-        (bytearray(b"joint_0"), "bytearray"),
+        pytest.param(7, "int", id="scalar-int"),
+        pytest.param(b"joint_0", "bytes", id="bytes-like"),
     ],
 )
 def test_resolve_articulation_ordering_names_reports_unsupported_type(ordering, type_name: str) -> None:
-    """Report accepted resolver inputs for unsupported scalar orderings."""
+    """Report the offending type for unsupported scalar orderings.
+
+    All unsupported scalars hit one ``else`` branch, so a plain scalar and a bytes-like value -- which
+    must not be silently iterated into per-character names -- pin the rule and its error message.
+    """
     with pytest.raises(TypeError) as exc_info:
         _resolve_articulation_ordering_names(
             kind="joint",
@@ -534,50 +521,70 @@ def _install_source_asset_resolver(monkeypatch: pytest.MonkeyPatch, resolve_matc
     monkeypatch.setitem(sys.modules, "isaaclab.sim.utils.queries", queries_mod)
 
 
+_ROBOT_SCHEMA_PRIM_PATH = "/World/envs/env_0/Robot"
+_ROBOT_SCHEMA_SOURCE_EXPR = "/World/envs/env_.*/Robot"
+
+
 def _author_robot_schema_relationship(prim: Usd.Prim, relationship_name: str, target_paths: list[str]) -> None:
     """Author a robot-schema relationship on a real prim with the given target prim paths."""
     prim.CreateRelationship(relationship_name).SetTargets([Sdf.Path(path) for path in target_paths])
+
+
+def _author_robot_schema_stage(child_names: tuple[str, ...]) -> tuple[Usd.Stage, Usd.Prim]:
+    """Create an in-memory stage with a robot prim and the named leaf child prims."""
+    stage = Usd.Stage.CreateInMemory()
+    robot_prim = stage.DefinePrim(_ROBOT_SCHEMA_PRIM_PATH, "Xform")
+    for child in child_names:
+        stage.DefinePrim(f"{_ROBOT_SCHEMA_PRIM_PATH}/{child}", "Xform")
+    return stage, robot_prim
+
+
+def _install_robot_schema_source_asset(monkeypatch: pytest.MonkeyPatch, robot_prim: Usd.Prim) -> None:
+    """Route source-asset resolution to a single authored robot prim for robot-schema discovery."""
+
+    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
+        assert path_expr == _ROBOT_SCHEMA_SOURCE_EXPR
+        return [(robot_prim, _ROBOT_SCHEMA_SOURCE_EXPR)]
+
+    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
+
+
+def _make_robot_schema_articulation(
+    *,
+    backend_joint_names: tuple[str, ...] | None = None,
+    backend_body_names: tuple[str, ...] | None = None,
+) -> types.SimpleNamespace:
+    """Build an articulation surface that resolves robot-schema ordering from an in-memory stage."""
+    return types.SimpleNamespace(
+        __backend_name__="newton",
+        _ordering_convention_name_cache={},
+        cfg=types.SimpleNamespace(prim_path=_ROBOT_SCHEMA_SOURCE_EXPR, articulation_root_prim_path=None),
+        backend_joint_names=list(backend_joint_names) if backend_joint_names is not None else [],
+        backend_body_names=list(backend_body_names) if backend_body_names is not None else [],
+    )
 
 
 def test_robot_schema_ordering_helper_resolves_canonical_name_override_spelling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Resolve joint ordering from authored relationships honoring the canonical ``isaac:NameOverride``."""
-    stage = Usd.Stage.CreateInMemory()
-    robot_path = "/World/envs/env_0/Robot"
-    robot_prim = stage.DefinePrim(robot_path, "Xform")
-    for child in ("joint_a_prim", "joint_b", "joint_c"):
-        stage.DefinePrim(f"{robot_path}/{child}", "Xform")
+    stage, robot_prim = _author_robot_schema_stage(("joint_a_prim", "joint_b", "joint_c"))
     _author_robot_schema_relationship(
         robot_prim,
         "isaac:physics:robotJoints",
-        [f"{robot_path}/joint_b", f"{robot_path}/joint_a_prim", f"{robot_path}/joint_c"],
+        [
+            f"{_ROBOT_SCHEMA_PRIM_PATH}/joint_b",
+            f"{_ROBOT_SCHEMA_PRIM_PATH}/joint_a_prim",
+            f"{_ROBOT_SCHEMA_PRIM_PATH}/joint_c",
+        ],
     )
     # The canonical uppercase ``NameOverride`` renames the target prim to its backend joint name.
-    stage.GetPrimAtPath(f"{robot_path}/joint_a_prim").CreateAttribute(
+    stage.GetPrimAtPath(f"{_ROBOT_SCHEMA_PRIM_PATH}/joint_a_prim").CreateAttribute(
         "isaac:NameOverride", Sdf.ValueTypeNames.String
     ).Set("joint_a")
+    _install_robot_schema_source_asset(monkeypatch, robot_prim)
 
-    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
-        assert path_expr == "/World/envs/env_.*/Robot"
-        return [(robot_prim, "/World/envs/env_.*/Robot")]
-
-    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
-
-    class _Articulation:
-        __backend_name__ = "newton"
-        _ordering_convention_name_cache: dict = {}
-        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
-
-        @property
-        def backend_joint_names(self) -> list[str]:
-            return ["joint_a", "joint_b", "joint_c"]
-
-        @property
-        def backend_body_names(self) -> list[str]:
-            return []
-
-    articulation = _Articulation()
+    articulation = _make_robot_schema_articulation(backend_joint_names=("joint_a", "joint_b", "joint_c"))
 
     assert get_articulation_name_ordering(articulation, "robot_schema", kind="joint") == (
         "joint_b",
@@ -598,75 +605,43 @@ def test_robot_schema_ordering_helper_resolves_fallback_name_override_spelling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Resolve body ordering via the fallback ``isaac:nameOverride`` spelling, dropping extra targets."""
-    stage = Usd.Stage.CreateInMemory()
-    robot_path = "/World/envs/env_0/Robot"
-    robot_prim = stage.DefinePrim(robot_path, "Xform")
-    for child in ("base_prim", "tool_site", "thigh", "foot"):
-        stage.DefinePrim(f"{robot_path}/{child}", "Xform")
+    stage, robot_prim = _author_robot_schema_stage(("base_prim", "tool_site", "thigh", "foot"))
     _author_robot_schema_relationship(
         robot_prim,
         "isaac:physics:robotLinks",
-        [f"{robot_path}/base_prim", f"{robot_path}/tool_site", f"{robot_path}/thigh", f"{robot_path}/foot"],
+        [
+            f"{_ROBOT_SCHEMA_PRIM_PATH}/base_prim",
+            f"{_ROBOT_SCHEMA_PRIM_PATH}/tool_site",
+            f"{_ROBOT_SCHEMA_PRIM_PATH}/thigh",
+            f"{_ROBOT_SCHEMA_PRIM_PATH}/foot",
+        ],
     )
     # The fallback lowercase ``nameOverride`` renames the root target; tool_site is absent from the
     # backend names and must be dropped by the complete-permutation filter.
-    stage.GetPrimAtPath(f"{robot_path}/base_prim").CreateAttribute(
+    stage.GetPrimAtPath(f"{_ROBOT_SCHEMA_PRIM_PATH}/base_prim").CreateAttribute(
         "isaac:nameOverride", Sdf.ValueTypeNames.String
     ).Set("base")
+    _install_robot_schema_source_asset(monkeypatch, robot_prim)
 
-    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
-        assert path_expr == "/World/envs/env_.*/Robot"
-        return [(robot_prim, "/World/envs/env_.*/Robot")]
-
-    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
-
-    class _Articulation:
-        __backend_name__ = "newton"
-        _ordering_convention_name_cache: dict = {}
-        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
-
-        @property
-        def backend_joint_names(self) -> list[str]:
-            return []
-
-        @property
-        def backend_body_names(self) -> list[str]:
-            return ["base", "thigh", "foot"]
-
-    articulation = _Articulation()
+    articulation = _make_robot_schema_articulation(backend_body_names=("base", "thigh", "foot"))
 
     assert get_articulation_name_ordering(articulation, "robot_schema", kind="body") == ("base", "thigh", "foot")
 
 
 def test_robot_schema_ordering_helper_rejects_incomplete_relationships(monkeypatch: pytest.MonkeyPatch) -> None:
     """Reject robot schema relationships that are not complete backend-name permutations."""
-    stage = Usd.Stage.CreateInMemory()
-    robot_path = "/World/envs/env_0/Robot"
-    robot_prim = stage.DefinePrim(robot_path, "Xform")
-    for child in ("joint_a", "joint_b"):
-        stage.DefinePrim(f"{robot_path}/{child}", "Xform")
+    stage, robot_prim = _author_robot_schema_stage(("joint_a", "joint_b"))
     _author_robot_schema_relationship(
         robot_prim,
         "isaac:physics:robotJoints",
-        [f"{robot_path}/joint_b", f"{robot_path}/joint_a"],
+        [f"{_ROBOT_SCHEMA_PRIM_PATH}/joint_b", f"{_ROBOT_SCHEMA_PRIM_PATH}/joint_a"],
     )
+    _install_robot_schema_source_asset(monkeypatch, robot_prim)
 
-    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
-        return [(robot_prim, "/World/envs/env_.*/Robot")]
-
-    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
-
-    class _Articulation:
-        __backend_name__ = "newton"
-        _ordering_convention_name_cache: dict = {}
-        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
-
-        @property
-        def backend_joint_names(self) -> list[str]:
-            return ["joint_a", "joint_b", "joint_c"]
+    articulation = _make_robot_schema_articulation(backend_joint_names=("joint_a", "joint_b", "joint_c"))
 
     with pytest.raises(NotImplementedError) as exc_info:
-        get_articulation_name_ordering(_Articulation(), "robot_schema", kind="joint")
+        get_articulation_name_ordering(articulation, "robot_schema", kind="joint")
 
     message = str(exc_info.value)
     assert "Unable to resolve 'robot_schema' joint ordering" in message
@@ -677,40 +652,25 @@ def test_robot_schema_ordering_helper_reports_unresolvable_relationship_target(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Name the unresolvable target in both the warning log and the terminal failure message."""
-    stage = Usd.Stage.CreateInMemory()
-    robot_path = "/World/envs/env_0/Robot"
-    robot_prim = stage.DefinePrim(robot_path, "Xform")
-    stage.DefinePrim(f"{robot_path}/joint_a", "Xform")
+    stage, robot_prim = _author_robot_schema_stage(("joint_a",))
     # joint_typo is authored as a relationship target but never defined on the stage, so USD resolves
     # it to an invalid prim.
-    unresolved_target_path = f"{robot_path}/joint_typo"
+    unresolved_target_path = f"{_ROBOT_SCHEMA_PRIM_PATH}/joint_typo"
     _author_robot_schema_relationship(
         robot_prim,
         "isaac:physics:robotJoints",
-        [f"{robot_path}/joint_a", unresolved_target_path],
+        [f"{_ROBOT_SCHEMA_PRIM_PATH}/joint_a", unresolved_target_path],
     )
+    _install_robot_schema_source_asset(monkeypatch, robot_prim)
 
-    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
-        return [(robot_prim, "/World/envs/env_.*/Robot")]
-
-    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
-
-    class _Articulation:
-        __backend_name__ = "newton"
-        _ordering_convention_name_cache: dict = {}
-        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
-
-        @property
-        def backend_joint_names(self) -> list[str]:
-            # A second backend joint name that the single resolvable target cannot cover, so
-            # resolution falls through to the terminal failure instead of an incomplete-but-silent
-            # success.
-            return ["joint_a", "joint_b"]
+    # A second backend joint name that the single resolvable target cannot cover, so resolution falls
+    # through to the terminal failure instead of an incomplete-but-silent success.
+    articulation = _make_robot_schema_articulation(backend_joint_names=("joint_a", "joint_b"))
 
     caplog.set_level(logging.WARNING, logger="isaaclab.assets.articulation.ordering_resolvers")
 
     with pytest.raises(NotImplementedError) as exc_info:
-        get_articulation_name_ordering(_Articulation(), "robot_schema", kind="joint")
+        get_articulation_name_ordering(articulation, "robot_schema", kind="joint")
 
     message = str(exc_info.value)
     assert unresolved_target_path in message
@@ -726,37 +686,24 @@ def test_robot_schema_ordering_helper_rejects_duplicate_relationship_targets(
     stage can express is the same leaf prim reached through two distinct nested robot-schema
     relationships. That nested case is exactly what the resolver must reject rather than dedupe.
     """
-    stage = Usd.Stage.CreateInMemory()
-    robot_path = "/World/envs/env_0/Robot"
-    robot_prim = stage.DefinePrim(robot_path, "Xform")
-    sub_a_prim = stage.DefinePrim(f"{robot_path}/sub_a", "Xform")
-    sub_b_prim = stage.DefinePrim(f"{robot_path}/sub_b", "Xform")
-    duplicated_target_path = f"{robot_path}/joint_a"
+    stage, robot_prim = _author_robot_schema_stage(("sub_a", "sub_b"))
+    sub_a_prim = stage.GetPrimAtPath(f"{_ROBOT_SCHEMA_PRIM_PATH}/sub_a")
+    sub_b_prim = stage.GetPrimAtPath(f"{_ROBOT_SCHEMA_PRIM_PATH}/sub_b")
+    duplicated_target_path = f"{_ROBOT_SCHEMA_PRIM_PATH}/joint_a"
     stage.DefinePrim(duplicated_target_path, "Xform")
     _author_robot_schema_relationship(
         robot_prim,
         "isaac:physics:robotJoints",
-        [f"{robot_path}/sub_a", f"{robot_path}/sub_b"],
+        [f"{_ROBOT_SCHEMA_PRIM_PATH}/sub_a", f"{_ROBOT_SCHEMA_PRIM_PATH}/sub_b"],
     )
     _author_robot_schema_relationship(sub_a_prim, "isaac:physics:robotJoints", [duplicated_target_path])
     _author_robot_schema_relationship(sub_b_prim, "isaac:physics:robotJoints", [duplicated_target_path])
+    _install_robot_schema_source_asset(monkeypatch, robot_prim)
 
-    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
-        return [(robot_prim, "/World/envs/env_.*/Robot")]
-
-    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
-
-    class _Articulation:
-        __backend_name__ = "newton"
-        _ordering_convention_name_cache: dict = {}
-        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
-
-        @property
-        def backend_joint_names(self) -> list[str]:
-            return ["joint_a", "joint_b"]
+    articulation = _make_robot_schema_articulation(backend_joint_names=("joint_a", "joint_b"))
 
     with pytest.raises(ValueError, match=f"Duplicate .* target '{duplicated_target_path}'"):
-        get_articulation_name_ordering(_Articulation(), "robot_schema", kind="joint")
+        get_articulation_name_ordering(articulation, "robot_schema", kind="joint")
 
 
 def _install_newton_usd_builder_mocks(monkeypatch: pytest.MonkeyPatch, stage: Usd.Stage, calls: dict, view_names: dict):
@@ -1378,3 +1325,60 @@ def test_ordering_state_lives_only_on_data() -> None:
     ):
         for name in names:
             assert not hasattr(owner, name), f"{owner.__name__}.{name} should be deleted"
+
+
+_NONIDENTITY_ORDERING = types.SimpleNamespace(
+    user_to_backend_indices=(0, 2, 1),
+    backend_to_user_indices=(0, 2, 1),
+    is_identity=False,
+)
+
+
+class _MapBodyIdsSurface:
+    """Minimal surface exercising the real body-id translation method."""
+
+    map_body_ids_to_backend = BaseArticulation.map_body_ids_to_backend
+
+    def __init__(self, body_ordering):
+        self.body_ordering = body_ordering
+
+
+class _MapJointIdsSurface:
+    """Minimal surface exercising the real joint-id translation method."""
+
+    map_joint_ids_to_backend = BaseArticulation.map_joint_ids_to_backend
+
+    def __init__(self, joint_ordering):
+        self.joint_ordering = joint_ordering
+
+
+def test_map_body_ids_to_backend_returns_input_unchanged_for_default_ordering() -> None:
+    """A ``None`` body ordering returns the input object unchanged.
+
+    ``None`` covers identity-configured orderings too: assets normalize
+    identity maps away at install time, so this is the only fast-path state.
+    """
+    asset = _MapBodyIdsSurface(None)
+    body_ids = [2, 0, 1]
+    assert asset.map_body_ids_to_backend(body_ids) is body_ids
+
+
+def test_map_body_ids_to_backend_permutes_ids_for_nonidentity_ordering() -> None:
+    """A nonidentity body ordering gathers public IDs into backend order."""
+    asset = _MapBodyIdsSurface(_NONIDENTITY_ORDERING)
+    # user_to_backend_indices == (0, 2, 1): public 1 -> backend 2, public 2 -> backend 1
+    assert asset.map_body_ids_to_backend([1, 2]) == [2, 1]
+
+
+def test_map_joint_ids_to_backend_returns_input_unchanged_for_default_ordering() -> None:
+    """A ``None`` (default) joint ordering returns the input object unchanged."""
+    asset = _MapJointIdsSurface(None)
+    joint_ids = [2, 0, 1]
+    assert asset.map_joint_ids_to_backend(joint_ids) is joint_ids
+
+
+def test_map_joint_ids_to_backend_permutes_ids_for_nonidentity_ordering() -> None:
+    """A nonidentity joint ordering gathers public IDs into backend order."""
+    asset = _MapJointIdsSurface(_NONIDENTITY_ORDERING)
+    # user_to_backend_indices == (0, 2, 1): public 1 -> backend 2, public 2 -> backend 1
+    assert asset.map_joint_ids_to_backend([1, 2]) == [2, 1]

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -1063,7 +1063,9 @@ def test_base_articulation_keeps_none_ordering_on_default_path() -> None:
     assert data.body_ordering is None
     assert data.joint_names == ["hip", "knee"]
     assert data.body_names == ["base", "foot"]
-    assert apply_calls == []
+    # The install site always lets the data container reconcile its staging;
+    # backend hooks are no-ops when no ordering is or was active.
+    assert apply_calls == ["called"]
 
 
 class _LegacyArticulation(BaseArticulation):
@@ -1140,7 +1142,9 @@ def test_base_articulation_ordering_contract_preserves_legacy_subclasses() -> No
 def test_backend_name_fallbacks_reject_missing_overrides() -> None:
     """Raise instead of recursing when a backend overrides neither name property of an axis."""
     articulation = object.__new__(_IncompleteArticulation)
-    articulation._data = types.SimpleNamespace(joint_ordering=None, body_ordering=None)
+    articulation._data = types.SimpleNamespace(
+        joint_ordering=None, body_ordering=None, joint_names=None, body_names=None
+    )
 
     with pytest.raises(NotImplementedError, match="joint_names"):
         _ = articulation.backend_joint_names
@@ -1159,13 +1163,14 @@ def _make_map_ids_articulation(*, permuted: bool) -> _LegacyArticulation:
     articulation._joint_names = ["j_b", "j_c", "j_a"]
     articulation._body_names = ["link", "foot", "base"]
     if permuted:
-        # 3-cycle: user_to_backend == (1, 2, 0) differs from backend_to_user == (2, 0, 1),
-        # so a direction-swapped implementation cannot pass.
+        # Opposite 3-cycles per axis: joint user_to_backend == (1, 2, 0) differs from its
+        # backend_to_user == (2, 0, 1) and from the body maps (u2b == (2, 0, 1)), so neither
+        # a direction-swapped nor an axis-swapped implementation can pass.
         joint_ordering = build_articulation_name_map(
             kind="joint", backend_names=("j_a", "j_b", "j_c"), user_names=("j_b", "j_c", "j_a"), device="cpu"
         )
         body_ordering = build_articulation_name_map(
-            kind="body", backend_names=("base", "link", "foot"), user_names=("link", "foot", "base"), device="cpu"
+            kind="body", backend_names=("base", "link", "foot"), user_names=("foot", "base", "link"), device="cpu"
         )
     else:
         joint_ordering = None
@@ -1180,8 +1185,8 @@ def test_map_ids_to_backend_applies_three_cycle_permutation() -> None:
 
     assert articulation.map_joint_ids_to_backend([0, 1, 2]) == [1, 2, 0]
     assert articulation.map_joint_ids_to_backend([2, 0]) == [0, 1]
-    assert articulation.map_body_ids_to_backend([0, 1, 2]) == [1, 2, 0]
-    assert articulation.map_body_ids_to_backend([1]) == [2]
+    assert articulation.map_body_ids_to_backend([0, 1, 2]) == [2, 0, 1]
+    assert articulation.map_body_ids_to_backend([1]) == [0]
 
 
 def test_map_ids_to_backend_handles_slice_selectors() -> None:
@@ -1189,13 +1194,34 @@ def test_map_ids_to_backend_handles_slice_selectors() -> None:
     permuted = _make_map_ids_articulation(permuted=True)
     assert permuted.map_joint_ids_to_backend(slice(None)) == [1, 2, 0]
     assert permuted.map_joint_ids_to_backend(slice(1, 3)) == [2, 0]
-    assert permuted.map_body_ids_to_backend(slice(None)) == [1, 2, 0]
-    assert permuted.map_body_ids_to_backend(slice(0, 3, 2)) == [1, 0]
+    assert permuted.map_body_ids_to_backend(slice(None)) == [2, 0, 1]
+    assert permuted.map_body_ids_to_backend(slice(0, 3, 2)) == [2, 1]
 
     identity = _make_map_ids_articulation(permuted=False)
     all_items = slice(None)
     assert identity.map_joint_ids_to_backend(all_items) is all_items
     assert identity.map_body_ids_to_backend(all_items) is all_items
+
+
+def test_ordering_map_helpers_pick_axis_direction_and_identity_fallback() -> None:
+    """Return the exact map object per axis and direction, or the backend identity buffer."""
+    permuted = _make_map_ids_articulation(permuted=True)
+    joint_ordering = permuted._data.joint_ordering
+    body_ordering = permuted._data.body_ordering
+    assert permuted._joint_user_to_backend_map() is joint_ordering.user_to_backend
+    assert permuted._joint_backend_to_user_map() is joint_ordering.backend_to_user
+    assert permuted._body_user_to_backend_map() is body_ordering.user_to_backend
+    assert permuted._body_backend_to_user_map() is body_ordering.backend_to_user
+
+    identity = _make_map_ids_articulation(permuted=False)
+    joint_identity_map = object()
+    body_identity_map = object()
+    identity._ALL_JOINT_INDICES = joint_identity_map
+    identity._ALL_BODY_INDICES = body_identity_map
+    assert identity._joint_user_to_backend_map() is joint_identity_map
+    assert identity._joint_backend_to_user_map() is joint_identity_map
+    assert identity._body_user_to_backend_map() is body_identity_map
+    assert identity._body_backend_to_user_map() is body_identity_map
 
 
 @pytest.mark.parametrize("ordering", [("foot", "base"), ArticulationOrderingConvention.MJWARP])

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -386,7 +386,7 @@ def test_build_articulation_name_map_rejects_scalar_name_sequences() -> None:
     ``backend_names`` and ``user_names`` share one coercion helper, so one representative field and
     value pin the rule and the offending type.
     """
-    with pytest.raises(TypeError, match=r"backend_names must be a list or tuple of strings; got str"):
+    with pytest.raises(TypeError, match=r"backend_names must be a tuple of strings; got str"):
         build_articulation_name_map(
             kind="joint",
             backend_names="joint_0",
@@ -419,8 +419,8 @@ def test_resolve_articulation_ordering_names_accepts_explicit_sequence() -> None
 
 
 def test_resolve_articulation_ordering_names_rejects_generic_sequence() -> None:
-    """Reject explicit orderings that are not plain lists or tuples."""
-    with pytest.raises(TypeError, match=r"joint_ordering must be a list or tuple of strings; got UserList"):
+    """Reject explicit orderings that are not plain name tuples."""
+    with pytest.raises(TypeError, match=r"joint_ordering must be a name tuple, convention string/enum, or None"):
         _resolve_articulation_ordering_names(
             kind="joint",
             backend_names=("joint_0", "joint_1", "joint_2"),
@@ -435,7 +435,7 @@ def test_resolve_articulation_ordering_names_reports_non_string_element() -> Non
         _resolve_articulation_ordering_names(
             kind="joint",
             backend_names=("joint_0", "joint_1", "joint_2"),
-            ordering=["joint_1", 7],
+            ordering=("joint_1", 7),
             active_backend_name="physx",
         )
 
@@ -446,6 +446,7 @@ def test_resolve_articulation_ordering_names_reports_non_string_element() -> Non
     ("ordering", "type_name"),
     [
         (7, "int"),
+        (["joint_0", "joint_1", "joint_2"], "list"),
         (b"", "bytes"),
         (b"joint_0", "bytes"),
         (bytearray(), "bytearray"),
@@ -463,7 +464,7 @@ def test_resolve_articulation_ordering_names_reports_unsupported_type(ordering, 
         )
 
     assert str(exc_info.value) == (
-        f"joint_ordering must be a name sequence, convention string/enum, or None; got {type_name}."
+        f"joint_ordering must be a name tuple, convention string/enum, or None; got {type_name}."
     )
 
 
@@ -803,7 +804,7 @@ def test_robot_schema_ordering_helper_reads_authored_relationships(monkeypatch: 
     assert get_articulation_name_ordering(articulation, "robot_schema", kind="body") == ("base", "thigh", "foot")
     assert _resolve_articulation_ordering_names(
         kind="joint",
-        backend_names=articulation.backend_joint_names,
+        backend_names=tuple(articulation.backend_joint_names),
         ordering="robot_schema",
         active_backend_name=articulation.__backend_name__,
         articulation=articulation,

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -1347,6 +1347,22 @@ def test_floating_base_body_ordering_accepts_root_relocation() -> None:
     assert articulation.data.body_names == ["foot", "base"]
 
 
+def test_explicit_backend_order_normalizes_to_none() -> None:
+    """Normalize orderings that resolve to backend order to ``None`` instead of identity maps."""
+    articulation = _make_ordering_resolution_articulation(
+        body_ordering=("base", "foot"),
+        is_fixed_base=True,
+    )
+    articulation.cfg.joint_ordering = ("joint",)
+
+    BaseArticulation._resolve_and_install_ordering_maps(articulation)
+
+    assert articulation.data.joint_ordering is None
+    assert articulation.data.body_ordering is None
+    assert articulation.data.joint_names == ["joint"]
+    assert articulation.data.body_names == ["base", "foot"]
+
+
 def test_base_articulation_data_defines_optional_ordering_maps() -> None:
     """Expose optional ordering maps on articulation data containers."""
     assert hasattr(BaseArticulationData, "joint_ordering")

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -1,0 +1,1428 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import subprocess
+import sys
+import textwrap
+import types
+from collections import UserList
+from pathlib import Path
+
+import numpy as np
+import pytest
+import warp as wp
+
+from pxr import Sdf, Usd
+
+import isaaclab.assets.articulation.ordering_resolvers as ordering_resolvers
+
+_inserted_torch_stub = False
+try:
+    import torch  # noqa: F401
+except ModuleNotFoundError:
+    torch_stub = types.ModuleType("torch")
+    torch_stub.Tensor = type("Tensor", (), {})
+    if "torch" not in sys.modules:
+        sys.modules["torch"] = torch_stub
+        _inserted_torch_stub = True
+
+from isaaclab.assets.articulation.ordering import (
+    ArticulationNameMap,
+    ArticulationOrderingConvention,
+    apply_articulation_ordering_preset,
+    build_articulation_name_map,
+    parse_articulation_ordering_convention,
+)
+from isaaclab.assets.articulation.ordering_resolvers import (
+    _resolve_articulation_convention_name_ordering,
+    _resolve_articulation_ordering_names,
+    get_articulation_name_ordering,
+)
+
+sim_stub = types.ModuleType("isaaclab.sim")
+
+
+class _SimulationContext:
+    @staticmethod
+    def instance():
+        return None
+
+
+class _SpawnerCfg:
+    pass
+
+
+sim_stub.SimulationContext = _SimulationContext
+sim_stub.SpawnerCfg = _SpawnerCfg
+simulation_context_stub = types.ModuleType("isaaclab.sim.simulation_context")
+simulation_context_stub.SimulationContext = _SimulationContext
+_inserted_sim_stub = "isaaclab.sim" not in sys.modules
+_inserted_sim_context_stub = "isaaclab.sim.simulation_context" not in sys.modules
+sys.modules.setdefault("isaaclab.sim", sim_stub)
+sys.modules.setdefault("isaaclab.sim.simulation_context", simulation_context_stub)
+
+
+asset_base_stub = types.ModuleType("isaaclab.assets.asset_base")
+
+
+class _AssetBase:
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+
+asset_base_stub.AssetBase = _AssetBase
+_inserted_asset_base_stub = "isaaclab.assets.asset_base" not in sys.modules
+sys.modules.setdefault("isaaclab.assets.asset_base", asset_base_stub)
+
+
+from isaaclab.assets.articulation.articulation_cfg import ArticulationCfg
+from isaaclab.assets.articulation.base_articulation import BaseArticulation
+from isaaclab.assets.articulation.base_articulation_data import BaseArticulationData
+
+if _inserted_torch_stub and sys.modules.get("torch") is torch_stub:
+    sys.modules.pop("torch")
+
+if _inserted_sim_stub:
+    sys.modules.pop("isaaclab.sim", None)
+if _inserted_sim_context_stub:
+    sys.modules.pop("isaaclab.sim.simulation_context", None)
+if _inserted_asset_base_stub:
+    sys.modules.pop("isaaclab.assets.asset_base", None)
+if _inserted_sim_stub or _inserted_asset_base_stub:
+    sys.modules.pop("isaaclab.assets.articulation.base_articulation", None)
+
+
+def test_ordering_module_torch_stub_is_scoped_to_imports() -> None:
+    """Remove only the temporary torch stub installed while importing base classes."""
+    script = textwrap.dedent(
+        """
+        import builtins
+        import runpy
+        import sys
+        import types
+
+        import numpy  # noqa: F401
+        import pytest  # noqa: F401
+        import warp  # noqa: F401
+        import isaaclab.assets.articulation.ordering_resolvers  # noqa: F401
+
+        mode = sys.argv[1]
+        module_path = sys.argv[2]
+        sentinel = None
+        if mode == "missing":
+            sys.modules.pop("torch", None)
+            real_import = builtins.__import__
+            block_torch_import = [True]
+
+            def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+                if name == "torch" and block_torch_import[0]:
+                    block_torch_import[0] = False
+                    raise ModuleNotFoundError("No module named torch", name="torch")
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = guarded_import
+        else:
+            sentinel = types.ModuleType("torch")
+            sentinel.Tensor = type("Tensor", (), {})
+            sys.modules["torch"] = sentinel
+
+        runpy.run_path(module_path)
+
+        if mode == "missing" and "torch" in sys.modules:
+            raise SystemExit("temporary torch stub leaked from the ordering test module")
+        if mode == "preexisting" and sys.modules.get("torch") is not sentinel:
+            raise SystemExit("pre-existing torch module was replaced or removed")
+        """
+    )
+
+    for mode in ("preexisting", "missing"):
+        result = subprocess.run(
+            [sys.executable, "-c", script, mode, str(Path(__file__))],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_parse_articulation_ordering_convention_accepts_none_strings_and_enum() -> None:
+    """Parse supported articulation ordering convention inputs."""
+    assert parse_articulation_ordering_convention(None) is None
+    assert parse_articulation_ordering_convention("physx") is ArticulationOrderingConvention.PHYSX
+    assert parse_articulation_ordering_convention("mjwarp") is ArticulationOrderingConvention.MJWARP
+    assert parse_articulation_ordering_convention("robot_schema") is ArticulationOrderingConvention.ROBOT_SCHEMA
+    assert (
+        parse_articulation_ordering_convention(ArticulationOrderingConvention.PHYSX)
+        is ArticulationOrderingConvention.PHYSX
+    )
+
+
+def test_parse_articulation_ordering_convention_rejects_unknown_string() -> None:
+    """Reject unknown symbolic articulation ordering conventions."""
+    with pytest.raises(ValueError, match="Unsupported articulation ordering convention"):
+        parse_articulation_ordering_convention("backend")
+
+
+@pytest.mark.parametrize(
+    "entrypoint",
+    ["resolve_names", "resolve_convention", "physx", "mjwarp", "robot_schema"],
+)
+def test_ordering_resolvers_reject_invalid_kind(entrypoint: str) -> None:
+    """Reject misspelled element kinds at every resolver entry point."""
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        backend_joint_names = ("joint",)
+        backend_body_names = ("body",)
+
+    articulation = _Articulation()
+    with pytest.raises(ValueError, match="kind must be 'joint' or 'body'; got 'dof'"):
+        if entrypoint == "resolve_names":
+            _resolve_articulation_ordering_names(
+                kind="dof",  # type: ignore[arg-type]
+                backend_names=("joint",),
+                ordering=None,
+                active_backend_name="physx",
+            )
+        elif entrypoint == "resolve_convention":
+            _resolve_articulation_convention_name_ordering(
+                articulation=articulation,
+                convention="physx",
+                kind="dof",  # type: ignore[arg-type]
+            )
+        elif entrypoint == "physx":
+            get_articulation_name_ordering(articulation, "physx", kind="dof")  # type: ignore[arg-type]
+        elif entrypoint == "mjwarp":
+            get_articulation_name_ordering(articulation, "mjwarp", kind="dof")  # type: ignore[arg-type]
+        else:
+            get_articulation_name_ordering(articulation, "robot_schema", kind="dof")  # type: ignore[arg-type]
+
+
+def test_assets_package_reexports_public_ordering_symbols() -> None:
+    """Expose every documented ordering symbol from the public assets package."""
+    from isaaclab import assets
+
+    expected_exports = {
+        "ArticulationOrderingConvention": ArticulationOrderingConvention,
+        "ArticulationNameMap": ArticulationNameMap,
+        "apply_articulation_ordering_preset": apply_articulation_ordering_preset,
+        "build_articulation_name_map": build_articulation_name_map,
+        "parse_articulation_ordering_convention": parse_articulation_ordering_convention,
+        "get_articulation_name_ordering": get_articulation_name_ordering,
+    }
+    for name, expected_export in expected_exports.items():
+        assert getattr(assets, name, None) is expected_export, name
+    assert not hasattr(assets, "resolve_articulation_ordering_names")
+    assert not hasattr(assets, "resolve_articulation_convention_name_ordering")
+
+
+def test_assets_api_page_defines_ordering_symbols() -> None:
+    """Publish exact ordering directives; the preceding test covers re-exports."""
+    repo_root = Path(__file__).resolve().parents[4]
+    api_page = (repo_root / "docs/source/api/lab/isaaclab.assets.rst").read_text(encoding="utf-8")
+    actual_directives = {line.strip() for line in api_page.splitlines() if line.strip().startswith(".. ")}
+
+    expected_directives = {
+        ".. currentmodule:: isaaclab.assets",
+        ".. autoclass:: ArticulationOrderingConvention",
+        ".. autoclass:: ArticulationNameMap",
+        ".. autofunction:: apply_articulation_ordering_preset",
+        ".. autofunction:: build_articulation_name_map",
+        ".. autofunction:: parse_articulation_ordering_convention",
+        ".. autofunction:: get_articulation_name_ordering",
+    }
+    missing_directives = expected_directives - actual_directives
+    assert not missing_directives, f"Missing exact RST directives: {sorted(missing_directives)}"
+
+
+def test_articulation_cfg_accepts_optional_ordering_fields() -> None:
+    """Configure explicit or symbolic public articulation ordering."""
+    explicit_joint_order = ("shoulder", "elbow", "wrist")
+    cfg = ArticulationCfg(
+        prim_path="/World/Robot",
+        actuators={},
+        joint_ordering=explicit_joint_order,
+        body_ordering="mjwarp",
+    )
+
+    assert cfg.joint_ordering == explicit_joint_order
+    assert cfg.body_ordering == "mjwarp"
+
+
+def test_apply_articulation_ordering_preset_sets_joint_and_body_ordering() -> None:
+    """Apply one ergonomic ordering preset to both joints and bodies."""
+    cfg = ArticulationCfg(prim_path="/World/Robot", actuators={})
+
+    ordered_cfg = apply_articulation_ordering_preset(cfg, "physx")
+
+    assert ordered_cfg is not cfg
+    assert ordered_cfg.joint_ordering is ArticulationOrderingConvention.PHYSX
+    assert ordered_cfg.body_ordering is ArticulationOrderingConvention.PHYSX
+    assert apply_articulation_ordering_preset(cfg, None) is cfg
+
+
+def test_articulation_name_map_direct_constructor_validates_maps() -> None:
+    """Reject inconsistent public name maps built without the factory."""
+    identity_map = wp.array((0, 1, 2), dtype=wp.int32, device="cpu")
+    reversed_map = wp.array((2, 1, 0), dtype=wp.int32, device="cpu")
+
+    with pytest.raises(ValueError, match="inverse"):
+        ArticulationNameMap(
+            kind="joint",
+            backend_names=("joint_0", "joint_1", "joint_2"),
+            user_names=("joint_2", "joint_1", "joint_0"),
+            user_to_backend_indices=(2, 1, 0),
+            backend_to_user_indices=(0, 1, 2),
+            user_to_backend=reversed_map,
+            backend_to_user=identity_map,
+            is_identity=False,
+        )
+
+
+def test_articulation_name_map_direct_constructor_validates_name_index_correspondence() -> None:
+    """Reject maps whose indices do not map each public name to the same backend name."""
+    identity_map = wp.array((0, 1, 2), dtype=wp.int32, device="cpu")
+
+    with pytest.raises(ValueError, match="name and index mappings must agree"):
+        ArticulationNameMap(
+            kind="joint",
+            backend_names=("joint_0", "joint_1", "joint_2"),
+            user_names=("joint_2", "joint_1", "joint_0"),
+            user_to_backend_indices=(0, 1, 2),
+            backend_to_user_indices=(0, 1, 2),
+            user_to_backend=identity_map,
+            backend_to_user=identity_map,
+            is_identity=False,
+        )
+
+
+def test_articulation_name_map_direct_constructor_validates_device_maps() -> None:
+    """Reject device maps that contradict the validated CPU permutations."""
+    identity_map = wp.array((0, 1, 2), dtype=wp.int32, device="cpu")
+    reversed_map = wp.array((2, 1, 0), dtype=wp.int32, device="cpu")
+
+    with pytest.raises(ValueError, match="device user_to_backend map must match user_to_backend_indices"):
+        ArticulationNameMap(
+            kind="joint",
+            backend_names=("joint_0", "joint_1", "joint_2"),
+            user_names=("joint_2", "joint_1", "joint_0"),
+            user_to_backend_indices=(2, 1, 0),
+            backend_to_user_indices=(2, 1, 0),
+            user_to_backend=identity_map,
+            backend_to_user=reversed_map,
+            is_identity=False,
+        )
+
+
+def _make_identity_articulation_name_map(**overrides) -> ArticulationNameMap:
+    """Construct an identity name map with selected direct-constructor overrides."""
+    identity_device_map = wp.array((0, 1, 2), dtype=wp.int32, device="cpu")
+    fields = {
+        "kind": "joint",
+        "backend_names": ("joint_0", "joint_1", "joint_2"),
+        "user_names": ("joint_0", "joint_1", "joint_2"),
+        "user_to_backend_indices": (0, 1, 2),
+        "backend_to_user_indices": (0, 1, 2),
+        "user_to_backend": identity_device_map,
+        "backend_to_user": identity_device_map,
+        "is_identity": True,
+    }
+    fields.update(overrides)
+    return ArticulationNameMap(**fields)
+
+
+def test_articulation_name_map_direct_constructor_rejects_non_warp_device_maps() -> None:
+    """Reject a device map that is not a Warp array before accessing its metadata.
+
+    Both device maps flow through one validation loop, so one representative field and value pin
+    the rule, its error type, and the offending type.
+    """
+    with pytest.raises(TypeError, match=r"user_to_backend must be a Warp array; got list"):
+        _make_identity_articulation_name_map(user_to_backend=[0, 1, 2])
+
+
+@pytest.mark.parametrize("invalid_value", [pytest.param(0.5, id="lossy_float"), pytest.param(True, id="bool")])
+def test_articulation_name_map_direct_constructor_rejects_non_integer_indices(invalid_value) -> None:
+    """Reject a lossy value and a bool in a CPU index permutation.
+
+    Both index permutations share one coercion helper, so one field covers the rule. ``bool`` is a
+    distinct guard because it would otherwise pass ``operator.index`` as 0/1.
+    """
+    with pytest.raises(TypeError, match=r"user_to_backend_indices element 0"):
+        _make_identity_articulation_name_map(user_to_backend_indices=(invalid_value, 1, 2))
+
+
+@pytest.mark.parametrize("index_type", [int, np.int64])
+def test_articulation_name_map_direct_constructor_accepts_integral_indices(index_type) -> None:
+    """Accept Python and NumPy integral indices and normalize them to int."""
+    indices = tuple(index_type(index) for index in range(3))
+
+    name_map = _make_identity_articulation_name_map(
+        user_to_backend_indices=indices,
+        backend_to_user_indices=indices,
+    )
+
+    assert name_map.user_to_backend_indices == (0, 1, 2)
+    assert name_map.backend_to_user_indices == (0, 1, 2)
+    assert all(type(index) is int for index in name_map.user_to_backend_indices)
+    assert all(type(index) is int for index in name_map.backend_to_user_indices)
+
+
+def test_articulation_name_map_direct_constructor_rejects_non_bool_identity() -> None:
+    """Require ``is_identity`` to be a built-in bool, rejecting a truthy int like ``1``."""
+    with pytest.raises(TypeError, match=r"is_identity must be bool; got int"):
+        _make_identity_articulation_name_map(is_identity=1)
+
+
+def test_build_articulation_name_map_rejects_scalar_name_sequences() -> None:
+    """Reject a scalar string instead of splitting it into per-character names.
+
+    ``backend_names`` and ``user_names`` share one coercion helper, so one representative field and
+    value pin the rule and the offending type.
+    """
+    with pytest.raises(TypeError, match=r"backend_names must be a sequence of strings; got str"):
+        build_articulation_name_map(
+            kind="joint",
+            backend_names="joint_0",
+            user_names=("joint_0",),
+            device="cpu",
+        )
+
+
+def test_build_articulation_name_map_reports_non_string_name_element() -> None:
+    """Identify malformed elements in public map-construction inputs."""
+    with pytest.raises(TypeError, match=r"^backend_names element 1 must be str; got 7 \(int\)\.$"):
+        build_articulation_name_map(
+            kind="joint",
+            backend_names=("joint_0", 7),
+            user_names=("joint_0", "joint_1"),
+            device="cpu",
+        )
+
+
+def test_resolve_articulation_ordering_names_accepts_explicit_sequence() -> None:
+    """Resolve explicit public ordering names from config."""
+    user_names = _resolve_articulation_ordering_names(
+        kind="joint",
+        backend_names=("joint_0", "joint_1", "joint_2"),
+        ordering=("joint_2", "joint_0", "joint_1"),
+        active_backend_name="physx",
+    )
+
+    assert user_names == ("joint_2", "joint_0", "joint_1")
+
+
+def test_resolve_articulation_ordering_names_accepts_generic_sequence() -> None:
+    """Resolve explicit public ordering names from a generic sequence."""
+    user_names = _resolve_articulation_ordering_names(
+        kind="joint",
+        backend_names=("joint_0", "joint_1", "joint_2"),
+        ordering=UserList(["joint_2", "joint_0", "joint_1"]),
+        active_backend_name="physx",
+    )
+
+    assert user_names == ("joint_2", "joint_0", "joint_1")
+
+
+def test_resolve_articulation_ordering_names_reports_non_string_element() -> None:
+    """Report the location and type of invalid explicit ordering elements."""
+    with pytest.raises(TypeError) as exc_info:
+        _resolve_articulation_ordering_names(
+            kind="joint",
+            backend_names=("joint_0", "joint_1", "joint_2"),
+            ordering=UserList(["joint_1", 7]),
+            active_backend_name="physx",
+        )
+
+    assert str(exc_info.value) == "joint_ordering element 1 must be str; got 7 (int)."
+
+
+@pytest.mark.parametrize(
+    ("ordering", "type_name"),
+    [
+        (7, "int"),
+        (b"", "bytes"),
+        (b"joint_0", "bytes"),
+        (bytearray(), "bytearray"),
+        (bytearray(b"joint_0"), "bytearray"),
+    ],
+)
+def test_resolve_articulation_ordering_names_reports_unsupported_type(ordering, type_name: str) -> None:
+    """Report accepted resolver inputs for unsupported scalar orderings."""
+    with pytest.raises(TypeError) as exc_info:
+        _resolve_articulation_ordering_names(
+            kind="joint",
+            backend_names=("joint_0", "joint_1", "joint_2"),
+            ordering=ordering,
+            active_backend_name="physx",
+        )
+
+    assert str(exc_info.value) == (
+        f"joint_ordering must be a name sequence, convention string/enum, or None; got {type_name}."
+    )
+
+
+def test_resolve_articulation_ordering_names_keeps_matching_backend_preset_identity() -> None:
+    """Resolve same-backend symbolic presets without requiring traversal helpers."""
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        __backend_native_orderings__ = ("physx",)
+
+    user_names = _resolve_articulation_ordering_names(
+        kind="body",
+        backend_names=("base", "left_foot", "right_foot"),
+        ordering=ArticulationOrderingConvention.PHYSX,
+        active_backend_name="physx",
+        articulation=_Articulation(),
+    )
+
+    assert user_names == ("base", "left_foot", "right_foot")
+
+
+@pytest.mark.parametrize("backend_name", ["physx", "ovphysx"])
+def test_physx_ordering_helper_uses_same_backend_identity_without_discovery(
+    monkeypatch: pytest.MonkeyPatch, backend_name: str
+) -> None:
+    """Return PhysX and OVPhysX backend names without metadata discovery."""
+
+    class _Articulation:
+        __backend_name__ = backend_name
+        __backend_native_orderings__ = ("physx",)
+        backend_joint_names = ("shoulder", "elbow", "wrist")
+        backend_body_names = ("base", "arm", "hand")
+
+    monkeypatch.setattr(
+        ordering_resolvers,
+        "_get_physx_names_from_newton_usd_builder",
+        lambda _: pytest.fail("same-backend resolution must not invoke the USD builder"),
+    )
+
+    articulation = _Articulation()
+    assert get_articulation_name_ordering(articulation, "physx", kind="joint") == articulation.backend_joint_names
+    assert get_articulation_name_ordering(articulation, "physx", kind="body") == articulation.backend_body_names
+
+
+def test_mjwarp_ordering_helper_uses_newton_identity_without_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return Newton backend names without metadata discovery."""
+
+    class _Articulation:
+        __backend_name__ = "newton"
+        __backend_native_orderings__ = ("mjwarp",)
+        backend_joint_names = ("knee", "hip", "ankle")
+        backend_body_names = ("base", "thigh", "foot")
+
+    monkeypatch.setattr(
+        ordering_resolvers,
+        "_get_mjwarp_names_from_newton_usd_builder",
+        lambda _: pytest.fail("same-backend resolution must not invoke the USD builder"),
+    )
+
+    articulation = _Articulation()
+    assert get_articulation_name_ordering(articulation, "mjwarp", kind="joint") == articulation.backend_joint_names
+    assert get_articulation_name_ordering(articulation, "mjwarp", kind="body") == articulation.backend_body_names
+
+
+def test_backend_native_orderings_declaration_drives_identity_fast_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A backend self-declares the conventions its native order satisfies.
+
+    The resolver keys the same-backend identity fast path off
+    ``__backend_native_orderings__`` rather than a hardcoded backend-name set,
+    so a fourth backend opts into a convention purely by declaring it.
+    """
+
+    class _Articulation:
+        __backend_name__ = "fourth_backend"
+        __backend_native_orderings__ = ("physx",)
+        _ordering_convention_name_cache: dict = {}
+        backend_joint_names = ("shoulder", "elbow")
+        backend_body_names = ("base", "arm")
+
+    monkeypatch.setattr(
+        ordering_resolvers,
+        "_get_physx_names_from_newton_usd_builder",
+        lambda _: pytest.fail("a declared native convention must not invoke the USD builder"),
+    )
+
+    articulation = _Articulation()
+    assert get_articulation_name_ordering(articulation, "physx", kind="joint") == articulation.backend_joint_names
+    assert get_articulation_name_ordering(articulation, "physx", kind="body") == articulation.backend_body_names
+
+
+def test_undeclared_convention_bypasses_identity_fast_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A convention absent from ``__backend_native_orderings__`` falls through to discovery."""
+
+    class _Articulation:
+        __backend_name__ = "fourth_backend"
+        __backend_native_orderings__ = ("physx",)
+        _ordering_convention_name_cache: dict = {}
+        backend_joint_names = ("shoulder", "elbow")
+        backend_body_names = ("base", "arm")
+
+    monkeypatch.setattr(ordering_resolvers, "_get_mjwarp_names_from_newton_usd_builder", lambda _: None)
+
+    with pytest.raises(NotImplementedError, match="Unable to resolve 'mjwarp'"):
+        get_articulation_name_ordering(_Articulation(), "mjwarp", kind="joint")
+
+
+@pytest.mark.parametrize(
+    ("kind", "config_field"),
+    [
+        ("joint", "joint_ordering"),
+        ("body", "body_ordering"),
+    ],
+)
+def test_mjwarp_ordering_helper_reports_actionable_cross_backend_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+    config_field: str,
+) -> None:
+    """Explain how to recover when MJWarp ordering discovery is unavailable."""
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        _ordering_convention_name_cache: dict = {}
+        backend_joint_names = ("hip", "knee")
+        backend_body_names = ("base", "foot")
+
+    monkeypatch.setattr(ordering_resolvers, "_get_mjwarp_names_from_newton_usd_builder", lambda _: None)
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        get_articulation_name_ordering(_Articulation(), "mjwarp", kind=kind)  # type: ignore[arg-type]
+
+    message = str(exc_info.value)
+    assert f"Unable to resolve 'mjwarp' {kind} ordering" in message
+    assert "active backend 'physx'" in message
+    assert f"env.scene.robot.{config_field}" in message
+    assert f"explicit {kind}-name permutation" in message
+    assert "mjwarp_usd_builder: the Newton USD builder returned no articulation names" in message
+
+
+def test_mjwarp_ordering_helper_reports_incomplete_usd_builder_names_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Name the missing/extra backend names when the temporary builder view is incomplete."""
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        _ordering_convention_name_cache: dict = {}
+        backend_joint_names = ("hip", "knee")
+        backend_body_names = ("base", "foot")
+
+    monkeypatch.setattr(
+        ordering_resolvers,
+        "_get_mjwarp_names_from_newton_usd_builder",
+        lambda _: {"joint": ("hip",), "body": ("base", "foot")},
+    )
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        get_articulation_name_ordering(_Articulation(), "mjwarp", kind="joint")
+
+    message = str(exc_info.value)
+    assert "mjwarp_usd_builder: joint names are not a complete permutation" in message
+    assert "missing=['knee']" in message
+    assert "extra=[]" in message
+
+
+def test_mjwarp_ordering_helper_surfaces_specific_usd_builder_unavailability_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forward the specific unavailability reason instead of a generic one when known."""
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        _ordering_convention_name_cache: dict = {}
+        backend_joint_names = ("hip", "knee")
+        backend_body_names = ("base", "foot")
+
+    monkeypatch.setattr(ordering_resolvers, "_get_mjwarp_names_from_newton_usd_builder", lambda _: None)
+    monkeypatch.setattr(
+        ordering_resolvers,
+        "_describe_newton_usd_builder_unavailability",
+        lambda _: "no current USD stage is available",
+    )
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        get_articulation_name_ordering(_Articulation(), "mjwarp", kind="joint")
+
+    assert "mjwarp_usd_builder: no current USD stage is available" in str(exc_info.value)
+
+
+def test_describe_newton_usd_builder_unavailability_falls_back_without_cfg() -> None:
+    """Return a generic reason instead of raising when the articulation has no cfg."""
+
+    class _Articulation:
+        pass
+
+    reason = ordering_resolvers._describe_newton_usd_builder_unavailability(_Articulation())
+
+    assert reason == "the Newton USD builder returned no articulation names"
+
+
+def test_describe_newton_usd_builder_unavailability_reports_missing_stage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Identify a missing current USD stage as the reason resolution could not proceed."""
+
+    class _UsdPhysics:
+        class ArticulationRootAPI:
+            pass
+
+    pxr_mod = types.ModuleType("pxr")
+    pxr_mod.UsdPhysics = _UsdPhysics
+    stage_mod = types.ModuleType("isaaclab.sim.utils.stage")
+    stage_mod.get_current_stage = lambda: None
+    queries_mod = types.ModuleType("isaaclab.sim.utils.queries")
+    queries_mod.resolve_matching_prims_from_source = lambda *args, **kwargs: pytest.fail(
+        "must not resolve prims when the stage is unavailable"
+    )
+    sim_utils_mod = types.ModuleType("isaaclab.sim.utils")
+    monkeypatch.setattr(sim_stub, "__path__", [], raising=False)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim", sim_stub)
+    monkeypatch.setitem(sys.modules, "pxr", pxr_mod)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.utils", sim_utils_mod)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.utils.stage", stage_mod)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.utils.queries", queries_mod)
+
+    class _Articulation:
+        cfg = types.SimpleNamespace(prim_path="/World/Robot", articulation_root_prim_path=None)
+
+    reason = ordering_resolvers._describe_newton_usd_builder_unavailability(_Articulation())
+
+    assert reason == "no current USD stage is available"
+
+
+def test_describe_newton_usd_builder_unavailability_reports_missing_source_asset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Identify a missing source asset prim as the reason resolution could not proceed."""
+
+    class _UsdPhysics:
+        class ArticulationRootAPI:
+            pass
+
+    class _Stage:
+        pass
+
+    pxr_mod = types.ModuleType("pxr")
+    pxr_mod.UsdPhysics = _UsdPhysics
+    stage_mod = types.ModuleType("isaaclab.sim.utils.stage")
+    stage_mod.get_current_stage = lambda: _Stage()
+    queries_mod = types.ModuleType("isaaclab.sim.utils.queries")
+    queries_mod.resolve_matching_prims_from_source = lambda *args, **kwargs: []
+    sim_utils_mod = types.ModuleType("isaaclab.sim.utils")
+    monkeypatch.setattr(sim_stub, "__path__", [], raising=False)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim", sim_stub)
+    monkeypatch.setitem(sys.modules, "pxr", pxr_mod)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.utils", sim_utils_mod)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.utils.stage", stage_mod)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.utils.queries", queries_mod)
+
+    class _Articulation:
+        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
+
+    reason = ordering_resolvers._describe_newton_usd_builder_unavailability(_Articulation())
+
+    assert reason == "source asset prim matching '/World/envs/env_.*/Robot' was not found"
+
+
+def _install_source_asset_resolver(monkeypatch: pytest.MonkeyPatch, resolve_matching_prims_from_source) -> None:
+    """Route ``resolve_matching_prims_from_source`` through a stubbed ``isaaclab.sim.utils.queries``.
+
+    The resolver imports the source-prim query lazily from ``isaaclab.sim.utils.queries``; the sim
+    package is otherwise unavailable in this unit-test env, so we install a minimal module tree that
+    exposes only the query the resolver calls.
+    """
+    queries_mod = types.ModuleType("isaaclab.sim.utils.queries")
+    queries_mod.resolve_matching_prims_from_source = resolve_matching_prims_from_source
+    sim_utils_mod = types.ModuleType("isaaclab.sim.utils")
+    monkeypatch.setattr(sim_stub, "__path__", [], raising=False)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim", sim_stub)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.utils", sim_utils_mod)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.utils.queries", queries_mod)
+
+
+def _author_robot_schema_relationship(prim: Usd.Prim, relationship_name: str, target_paths: list[str]) -> None:
+    """Author a robot-schema relationship on a real prim with the given target prim paths."""
+    prim.CreateRelationship(relationship_name).SetTargets([Sdf.Path(path) for path in target_paths])
+
+
+def test_robot_schema_ordering_helper_reads_authored_relationships(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve explicit robot schema ordering from authored USD relationship targets."""
+    stage = Usd.Stage.CreateInMemory()
+    robot_path = "/World/envs/env_0/Robot"
+    robot_prim = stage.DefinePrim(robot_path, "Xform")
+    for child in ("joint_a_prim", "joint_b", "joint_c", "base_prim", "tool_site", "thigh", "foot"):
+        stage.DefinePrim(f"{robot_path}/{child}", "Xform")
+    _author_robot_schema_relationship(
+        robot_prim,
+        "isaac:physics:robotJoints",
+        [f"{robot_path}/joint_b", f"{robot_path}/joint_a_prim", f"{robot_path}/joint_c"],
+    )
+    _author_robot_schema_relationship(
+        robot_prim,
+        "isaac:physics:robotLinks",
+        [f"{robot_path}/base_prim", f"{robot_path}/tool_site", f"{robot_path}/thigh", f"{robot_path}/foot"],
+    )
+    # A name override renames the target prim, and a target absent from the backend names (tool_site)
+    # must be dropped by the complete-permutation filter.
+    stage.GetPrimAtPath(f"{robot_path}/joint_a_prim").CreateAttribute(
+        "isaac:NameOverride", Sdf.ValueTypeNames.String
+    ).Set("joint_a")
+    stage.GetPrimAtPath(f"{robot_path}/base_prim").CreateAttribute("isaac:nameOverride", Sdf.ValueTypeNames.String).Set(
+        "base"
+    )
+
+    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
+        assert path_expr == "/World/envs/env_.*/Robot"
+        return [(robot_prim, "/World/envs/env_.*/Robot")]
+
+    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
+
+    class _Articulation:
+        __backend_name__ = "newton"
+        _ordering_convention_name_cache: dict = {}
+        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
+
+        @property
+        def backend_joint_names(self) -> list[str]:
+            return ["joint_a", "joint_b", "joint_c"]
+
+        @property
+        def backend_body_names(self) -> list[str]:
+            return ["base", "thigh", "foot"]
+
+    articulation = _Articulation()
+
+    assert get_articulation_name_ordering(articulation, "robot_schema", kind="joint") == (
+        "joint_b",
+        "joint_a",
+        "joint_c",
+    )
+    assert get_articulation_name_ordering(articulation, "robot_schema", kind="body") == ("base", "thigh", "foot")
+    assert _resolve_articulation_ordering_names(
+        kind="joint",
+        backend_names=articulation.backend_joint_names,
+        ordering="robot_schema",
+        active_backend_name=articulation.__backend_name__,
+        articulation=articulation,
+    ) == ("joint_b", "joint_a", "joint_c")
+
+
+def test_robot_schema_ordering_helper_rejects_incomplete_relationships(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject robot schema relationships that are not complete backend-name permutations."""
+    stage = Usd.Stage.CreateInMemory()
+    robot_path = "/World/envs/env_0/Robot"
+    robot_prim = stage.DefinePrim(robot_path, "Xform")
+    for child in ("joint_a", "joint_b"):
+        stage.DefinePrim(f"{robot_path}/{child}", "Xform")
+    _author_robot_schema_relationship(
+        robot_prim,
+        "isaac:physics:robotJoints",
+        [f"{robot_path}/joint_b", f"{robot_path}/joint_a"],
+    )
+
+    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
+        return [(robot_prim, "/World/envs/env_.*/Robot")]
+
+    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
+
+    class _Articulation:
+        __backend_name__ = "newton"
+        _ordering_convention_name_cache: dict = {}
+        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
+
+        @property
+        def backend_joint_names(self) -> list[str]:
+            return ["joint_a", "joint_b", "joint_c"]
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        get_articulation_name_ordering(_Articulation(), "robot_schema", kind="joint")
+
+    message = str(exc_info.value)
+    assert "Unable to resolve 'robot_schema' joint ordering" in message
+    assert "robot_schema: incomplete permutation (missing=['joint_c'], extra=[])" in message
+
+
+def test_robot_schema_ordering_helper_reports_unresolvable_relationship_target(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Name the unresolvable target in both the warning log and the terminal failure message."""
+    stage = Usd.Stage.CreateInMemory()
+    robot_path = "/World/envs/env_0/Robot"
+    robot_prim = stage.DefinePrim(robot_path, "Xform")
+    stage.DefinePrim(f"{robot_path}/joint_a", "Xform")
+    # joint_typo is authored as a relationship target but never defined on the stage, so USD resolves
+    # it to an invalid prim.
+    unresolved_target_path = f"{robot_path}/joint_typo"
+    _author_robot_schema_relationship(
+        robot_prim,
+        "isaac:physics:robotJoints",
+        [f"{robot_path}/joint_a", unresolved_target_path],
+    )
+
+    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
+        return [(robot_prim, "/World/envs/env_.*/Robot")]
+
+    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
+
+    class _Articulation:
+        __backend_name__ = "newton"
+        _ordering_convention_name_cache: dict = {}
+        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
+
+        @property
+        def backend_joint_names(self) -> list[str]:
+            # A second backend joint name that the single resolvable target cannot cover, so
+            # resolution falls through to the terminal failure instead of an incomplete-but-silent
+            # success.
+            return ["joint_a", "joint_b"]
+
+    caplog.set_level(logging.WARNING, logger="isaaclab.assets.articulation.ordering_resolvers")
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        get_articulation_name_ordering(_Articulation(), "robot_schema", kind="joint")
+
+    message = str(exc_info.value)
+    assert unresolved_target_path in message
+    assert any(unresolved_target_path in record.message for record in caplog.records)
+
+
+def test_robot_schema_ordering_helper_rejects_duplicate_relationship_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raise instead of silently deduplicating a target reached twice through nested robots.
+
+    USD collapses a relationship that lists the same target path twice, so the duplicate a real
+    stage can express is the same leaf prim reached through two distinct nested robot-schema
+    relationships. That nested case is exactly what the resolver must reject rather than dedupe.
+    """
+    stage = Usd.Stage.CreateInMemory()
+    robot_path = "/World/envs/env_0/Robot"
+    robot_prim = stage.DefinePrim(robot_path, "Xform")
+    sub_a_prim = stage.DefinePrim(f"{robot_path}/sub_a", "Xform")
+    sub_b_prim = stage.DefinePrim(f"{robot_path}/sub_b", "Xform")
+    duplicated_target_path = f"{robot_path}/joint_a"
+    stage.DefinePrim(duplicated_target_path, "Xform")
+    _author_robot_schema_relationship(
+        robot_prim,
+        "isaac:physics:robotJoints",
+        [f"{robot_path}/sub_a", f"{robot_path}/sub_b"],
+    )
+    _author_robot_schema_relationship(sub_a_prim, "isaac:physics:robotJoints", [duplicated_target_path])
+    _author_robot_schema_relationship(sub_b_prim, "isaac:physics:robotJoints", [duplicated_target_path])
+
+    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
+        return [(robot_prim, "/World/envs/env_.*/Robot")]
+
+    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
+
+    class _Articulation:
+        __backend_name__ = "newton"
+        _ordering_convention_name_cache: dict = {}
+        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
+
+        @property
+        def backend_joint_names(self) -> list[str]:
+            return ["joint_a", "joint_b"]
+
+    with pytest.raises(ValueError, match=f"Duplicate .* target '{duplicated_target_path}'"):
+        get_articulation_name_ordering(_Articulation(), "robot_schema", kind="joint")
+
+
+def _install_newton_usd_builder_mocks(monkeypatch: pytest.MonkeyPatch, stage: Usd.Stage, calls: dict, view_names: dict):
+    """Install mocked Newton modules and a current-stage provider around a real in-memory stage.
+
+    Only the optional Newton dependency (unavailable in this unit-test env) is mocked; ``pxr`` stays
+    real so the resolver reads real prims and a real stage. Returns nothing; records builder activity
+    into :paramref:`calls` and serves :paramref:`view_names` from the mocked articulation view.
+    """
+
+    class _JointType:
+        FREE = 0
+        FIXED = 1
+
+    class _SolverMuJoCo:
+        @staticmethod
+        def register_custom_attributes(builder) -> None:
+            calls["registered"] += 1
+
+    class _ModelBuilder:
+        def __init__(self, up_axis):
+            self.up_axis = up_axis
+
+        def add_usd(self, stage, **kwargs):
+            calls["add_usd"].append(kwargs)
+
+        def finalize(self, **kwargs):
+            calls["finalize"].append(kwargs)
+            return object()
+
+    class _ArticulationView:
+        def __init__(self, model, pattern, **kwargs):
+            calls["views"].append((pattern, kwargs))
+            self.joint_dof_names = list(view_names["joint"])
+            self.link_names = list(view_names["body"])
+
+    newton_mod = types.ModuleType("newton")
+    newton_mod.JointType = _JointType
+    newton_mod.ModelBuilder = _ModelBuilder
+    newton_mod.solvers = types.SimpleNamespace(SolverMuJoCo=_SolverMuJoCo)
+    selection_mod = types.ModuleType("newton.selection")
+    selection_mod.ArticulationView = _ArticulationView
+    schemas_mod = types.ModuleType("newton._src.usd.schemas")
+    schemas_mod.SchemaResolverNewton = lambda: "newton_schema"
+    schemas_mod.SchemaResolverPhysx = lambda: "physx_schema"
+    stage_mod = types.ModuleType("isaaclab.sim.utils.stage")
+    stage_mod.get_current_stage = lambda: stage
+    monkeypatch.setitem(sys.modules, "newton", newton_mod)
+    monkeypatch.setitem(sys.modules, "newton.selection", selection_mod)
+    monkeypatch.setitem(sys.modules, "newton._src.usd.schemas", schemas_mod)
+    monkeypatch.setitem(sys.modules, "isaaclab.sim.utils.stage", stage_mod)
+
+
+def test_mjwarp_ordering_helper_builds_newton_view_from_usd_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve MJWarp ordering from Newton's USD builder path when no Newton root view exists."""
+    calls = {"add_usd": [], "finalize": [], "views": [], "registered": 0}
+
+    stage = Usd.Stage.CreateInMemory()
+    robot_prim = stage.DefinePrim("/World/envs/env_0/Robot", "Xform")
+    root_prim = stage.DefinePrim("/World/envs/env_0/Robot/base", "Xform")
+
+    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
+        assert path_expr == "/World/envs/env_.*/Robot"
+        if predicate is None:
+            return [(robot_prim, "/World/envs/env_.*/Robot")]
+        return [(root_prim, "/World/envs/env_.*/Robot/base")]
+
+    _install_newton_usd_builder_mocks(
+        monkeypatch,
+        stage,
+        calls,
+        {"joint": ["knee", "hip", "ankle"], "body": ["base", "thigh", "foot"]},
+    )
+    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        _ordering_convention_name_cache: dict = {}
+        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
+
+        @property
+        def backend_joint_names(self) -> list[str]:
+            return ["hip", "knee", "ankle"]
+
+        @property
+        def backend_body_names(self) -> list[str]:
+            return ["foot", "base", "thigh"]
+
+    articulation = _Articulation()
+
+    assert get_articulation_name_ordering(articulation, "mjwarp", kind="joint") == ("knee", "hip", "ankle")
+    assert get_articulation_name_ordering(articulation, "mjwarp", kind="body") == ("base", "thigh", "foot")
+    assert calls["registered"] == 1
+    assert len(calls["add_usd"]) == 1
+    assert calls["add_usd"][0]["root_path"] == "/World/envs/env_0/Robot"
+    assert calls["add_usd"][0]["joint_ordering"] == "dfs"
+    assert calls["views"] == [("/World/envs/env_0/Robot/base", {"verbose": False, "exclude_joint_types": [0, 1]})]
+
+
+def test_physx_ordering_helper_builds_bfs_newton_view_from_usd_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve PhysX ordering from Newton's BFS USD builder path when no PhysX root view exists."""
+    calls = {"add_usd": [], "finalize": [], "views": [], "registered": 0}
+
+    stage = Usd.Stage.CreateInMemory()
+    robot_prim = stage.DefinePrim("/World/envs/env_0/Robot", "Xform")
+    root_prim = stage.DefinePrim("/World/envs/env_0/Robot/base", "Xform")
+
+    def _resolve_matching_prims_from_source(path_expr, predicate=None, expected_num_matches=None):
+        assert path_expr == "/World/envs/env_.*/Robot"
+        if predicate is None:
+            return [(robot_prim, "/World/envs/env_.*/Robot")]
+        return [(root_prim, "/World/envs/env_.*/Robot/base")]
+
+    _install_newton_usd_builder_mocks(
+        monkeypatch,
+        stage,
+        calls,
+        {
+            "joint": ["hip", "shoulder", "knee", "elbow"],
+            "body": ["base", "upper_arm", "forearm", "hand"],
+        },
+    )
+    _install_source_asset_resolver(monkeypatch, _resolve_matching_prims_from_source)
+
+    class _Articulation:
+        __backend_name__ = "newton"
+        _ordering_convention_name_cache: dict = {}
+        cfg = types.SimpleNamespace(prim_path="/World/envs/env_.*/Robot", articulation_root_prim_path=None)
+
+        @property
+        def backend_joint_names(self) -> list[str]:
+            return ["hip", "knee", "shoulder", "elbow"]
+
+        @property
+        def backend_body_names(self) -> list[str]:
+            return ["base", "upper_arm", "hand", "forearm"]
+
+    articulation = _Articulation()
+
+    assert get_articulation_name_ordering(articulation, "physx", kind="joint") == (
+        "hip",
+        "shoulder",
+        "knee",
+        "elbow",
+    )
+    assert get_articulation_name_ordering(articulation, "physx", kind="body") == (
+        "base",
+        "upper_arm",
+        "forearm",
+        "hand",
+    )
+    assert calls["registered"] == 1
+    assert len(calls["add_usd"]) == 1
+    assert calls["add_usd"][0]["root_path"] == "/World/envs/env_0/Robot"
+    assert calls["add_usd"][0]["joint_ordering"] == "bfs"
+    assert calls["add_usd"][0]["bodies_follow_joint_ordering"] is True
+    assert calls["views"] == [("/World/envs/env_0/Robot/base", {"verbose": False, "exclude_joint_types": [0, 1]})]
+
+
+def test_symbolic_cross_backend_resolver_uses_newton_builder_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve a cross-backend symbolic preset through the Newton USD builder."""
+    calls = []
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        _ordering_convention_name_cache: dict = {}
+        backend_joint_names = ("hip", "knee", "ankle")
+        backend_body_names = ("foot", "base", "thigh")
+
+    articulation = _Articulation()
+
+    def _build_names(candidate):
+        calls.append(candidate)
+        return {
+            "joint": ("knee", "hip", "ankle"),
+            "body": ("base", "thigh", "foot"),
+        }
+
+    monkeypatch.setattr(ordering_resolvers, "_get_mjwarp_names_from_newton_usd_builder", _build_names)
+
+    user_names = _resolve_articulation_ordering_names(
+        kind="joint",
+        backend_names=articulation.backend_joint_names,
+        ordering=ArticulationOrderingConvention.MJWARP,
+        active_backend_name=articulation.__backend_name__,
+        articulation=articulation,
+    )
+
+    assert user_names == ("knee", "hip", "ankle")
+    assert calls == [articulation]
+
+
+def test_symbolic_resolver_skips_incomplete_cached_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Continue to the Newton USD builder when cached names are incomplete."""
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        backend_joint_names = ("joint_0", "joint_1")
+        backend_body_names = ("body_0", "body_1")
+        _ordering_convention_name_cache = {
+            (ArticulationOrderingConvention.MJWARP, "joint"): ("joint_0",),
+        }
+
+    monkeypatch.setattr(
+        ordering_resolvers,
+        "_get_mjwarp_names_from_newton_usd_builder",
+        lambda _: {
+            "joint": ("joint_1", "joint_0"),
+            "body": ("body_1", "body_0"),
+        },
+    )
+
+    assert get_articulation_name_ordering(_Articulation(), "mjwarp", kind="joint") == ("joint_1", "joint_0")
+
+
+def test_symbolic_resolver_does_not_cache_incomplete_builder_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cache a builder result only when both joint and body orders are complete."""
+    calls = []
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        _ordering_convention_name_cache: dict = {}
+        backend_joint_names = ("joint_0", "joint_1")
+        backend_body_names = ("body_0", "body_1")
+
+    articulation = _Articulation()
+    builder_names = {
+        "joint": ("joint_0",),
+        "body": ("body_1", "body_0"),
+    }
+
+    def _build_names(candidate):
+        calls.append(candidate)
+        return builder_names
+
+    monkeypatch.setattr(ordering_resolvers, "_get_mjwarp_names_from_newton_usd_builder", _build_names)
+
+    with pytest.raises(NotImplementedError, match="Unable to resolve 'mjwarp' joint ordering"):
+        get_articulation_name_ordering(articulation, "mjwarp", kind="joint")
+    assert articulation._ordering_convention_name_cache == {}
+
+    builder_names["joint"] = ("joint_1", "joint_0")
+    assert get_articulation_name_ordering(articulation, "mjwarp", kind="joint") == ("joint_1", "joint_0")
+    assert get_articulation_name_ordering(articulation, "mjwarp", kind="body") == ("body_1", "body_0")
+    assert calls == [articulation, articulation]
+
+
+def test_symbolic_cross_backend_resolver_normalizes_newton_multi_dof_joint_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Normalize Newton multi-DoF spelling only when each match is unique."""
+
+    class _Articulation:
+        __backend_name__ = "physx"
+        _ordering_convention_name_cache: dict = {}
+        backend_joint_names = ("hinge", "ball_rot_z", "ball_rot_x", "ball_rot_y")
+        backend_body_names = ("base",)
+
+    articulation = _Articulation()
+    monkeypatch.setattr(
+        ordering_resolvers,
+        "_get_mjwarp_names_from_newton_usd_builder",
+        lambda _: {
+            "joint": ("ball:rot_x", "ball:rot_y", "ball:rot_z", "hinge"),
+            "body": ("base",),
+        },
+    )
+
+    user_names = _resolve_articulation_ordering_names(
+        kind="joint",
+        backend_names=articulation.backend_joint_names,
+        ordering=ArticulationOrderingConvention.MJWARP,
+        active_backend_name=articulation.__backend_name__,
+        articulation=articulation,
+    )
+
+    assert user_names == ("ball_rot_x", "ball_rot_y", "ball_rot_z", "hinge")
+    name_map = build_articulation_name_map(
+        kind="joint",
+        backend_names=articulation.backend_joint_names,
+        user_names=user_names,
+        device="cpu",
+    )
+    assert name_map.user_to_backend_indices == (2, 3, 1, 0)
+
+
+def test_multi_dof_name_normalization_keeps_ambiguous_spellings() -> None:
+    """Do not rewrite separator variants when canonical backend names collide."""
+    convention_names = ("ball:rot_x", "ball_rot:x")
+    backend_names = ("ball_rot_x", "ball:rot_x")
+
+    assert ordering_resolvers._match_backend_joint_name_spellings(convention_names, backend_names) == convention_names
+
+
+def test_base_articulation_data_property_uses_base_data_contract() -> None:
+    """Annotate the abstract property with the type implemented by every backend."""
+    return_annotation = BaseArticulation.data.fget.__annotations__["return"]
+    assert return_annotation == "BaseArticulationData"
+
+
+def test_base_articulation_keeps_none_ordering_on_default_path() -> None:
+    """Keep the default public ordering path free of ordering maps."""
+    apply_calls = []
+    data = types.SimpleNamespace(
+        joint_ordering=None,
+        body_ordering=None,
+        joint_names=None,
+        body_names=None,
+        _apply_ordering_maps_after_resolve=lambda: apply_calls.append("called"),
+    )
+    articulation = types.SimpleNamespace(
+        __backend_name__="mock",
+        cfg=types.SimpleNamespace(joint_ordering=None, body_ordering=None),
+        data=data,
+        backend_joint_names=["hip", "knee"],
+        backend_body_names=["base", "foot"],
+        device="cpu",
+    )
+
+    BaseArticulation._resolve_and_install_ordering_maps(articulation)
+
+    assert data.joint_ordering is None
+    assert data.body_ordering is None
+    assert data.joint_names == ["hip", "knee"]
+    assert data.body_names == ["base", "foot"]
+    assert apply_calls == []
+
+
+class _LegacyArticulation(BaseArticulation):
+    """Old-style backend that predates the ordering introspection properties."""
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def joint_names(self) -> list[str]:
+        return self._joint_names
+
+    @property
+    def body_names(self) -> list[str]:
+        return self._body_names
+
+
+def _make_ordering_resolution_articulation(
+    *,
+    body_ordering,
+    backend_body_names: tuple[str, ...] = ("base", "foot"),
+    is_fixed_base: bool,
+):
+    """Create a minimal articulation-shaped object for base ordering resolution."""
+    data = types.SimpleNamespace(
+        joint_ordering=None,
+        body_ordering=None,
+        joint_names=None,
+        body_names=None,
+        _apply_ordering_maps_after_resolve=lambda: None,
+    )
+    return types.SimpleNamespace(
+        __backend_name__="mock",
+        _ordering_convention_name_cache={},
+        cfg=types.SimpleNamespace(
+            prim_path="/World/Robot",
+            joint_ordering=None,
+            body_ordering=body_ordering,
+        ),
+        data=data,
+        backend_joint_names=["joint"],
+        backend_body_names=list(backend_body_names),
+        is_fixed_base=is_fixed_base,
+        device="cpu",
+    )
+
+
+def test_base_articulation_ordering_contract_preserves_legacy_subclasses() -> None:
+    """Keep third-party backends instantiable while ordering properties are deprecated fallbacks."""
+    articulation = object.__new__(_LegacyArticulation)
+    articulation._joint_names = ["hip", "knee"]
+    articulation._body_names = ["base", "foot"]
+    articulation._data = types.SimpleNamespace(joint_ordering=None, body_ordering=None)
+
+    with pytest.warns(DeprecationWarning, match="override backend_joint_names"):
+        assert articulation.backend_joint_names == ["hip", "knee"]
+    with pytest.warns(DeprecationWarning, match="override backend_body_names"):
+        assert articulation.backend_body_names == ["base", "foot"]
+    assert articulation.joint_ordering is None
+    assert articulation.body_ordering is None
+
+
+@pytest.mark.parametrize("ordering", [("foot", "base"), ArticulationOrderingConvention.MJWARP])
+def test_fixed_base_body_ordering_rejects_root_relocation(ordering, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject explicit and symbolic fixed-base orders that move the root from public index zero."""
+    monkeypatch.setattr(
+        ordering_resolvers,
+        "_get_mjwarp_names_from_newton_usd_builder",
+        lambda _: {"joint": ("joint",), "body": ("foot", "base")},
+    )
+    articulation = _make_ordering_resolution_articulation(body_ordering=ordering, is_fixed_base=True)
+
+    with pytest.raises(ValueError) as exc_info:
+        BaseArticulation._resolve_and_install_ordering_maps(articulation)
+
+    assert str(exc_info.value) == (
+        "Invalid body_ordering for fixed-base articulation '/World/Robot': root body 'base' must remain at public "
+        "index 0, but was requested at index 1. Put 'base' first; all remaining bodies may be reordered freely."
+    )
+    assert articulation.data.body_ordering is None
+
+
+def test_floating_base_body_ordering_accepts_root_relocation() -> None:
+    """Allow a complete body permutation to move the root for floating-base articulations."""
+    articulation = _make_ordering_resolution_articulation(
+        body_ordering=("foot", "base"),
+        is_fixed_base=False,
+    )
+
+    BaseArticulation._resolve_and_install_ordering_maps(articulation)
+
+    assert articulation.data.body_names == ["foot", "base"]
+
+
+def test_base_articulation_data_defines_optional_ordering_maps() -> None:
+    """Expose optional ordering maps on articulation data containers."""
+    assert hasattr(BaseArticulationData, "joint_ordering")
+    assert hasattr(BaseArticulationData, "body_ordering")
+
+
+def test_build_articulation_name_map_uses_identity_device_maps() -> None:
+    """Build an identity articulation name map with identity device maps."""
+    name_map = build_articulation_name_map(
+        kind="joint",
+        backend_names=("hip", "knee", "ankle"),
+        user_names=None,
+        device="cpu",
+    )
+
+    assert name_map.kind == "joint"
+    assert name_map.backend_names == ("hip", "knee", "ankle")
+    assert name_map.user_names == ("hip", "knee", "ankle")
+    assert name_map.user_to_backend_indices == (0, 1, 2)
+    assert name_map.backend_to_user_indices == (0, 1, 2)
+    assert name_map.user_to_backend is not None
+    assert name_map.backend_to_user is not None
+    np.testing.assert_array_equal(name_map.user_to_backend.numpy(), np.asarray([0, 1, 2], dtype=np.int32))
+    np.testing.assert_array_equal(name_map.backend_to_user.numpy(), np.asarray([0, 1, 2], dtype=np.int32))
+    assert name_map.is_identity
+
+
+def test_build_articulation_name_map_builds_permutation_indices_and_device_maps() -> None:
+    """Build CPU and device maps for an explicit user ordering permutation."""
+    name_map = build_articulation_name_map(
+        kind="body",
+        backend_names=("base", "left_foot", "right_foot"),
+        user_names=("right_foot", "base", "left_foot"),
+        device="cpu",
+    )
+
+    assert name_map.kind == "body"
+    assert name_map.backend_names == ("base", "left_foot", "right_foot")
+    assert name_map.user_names == ("right_foot", "base", "left_foot")
+    assert name_map.user_to_backend_indices == (2, 0, 1)
+    assert name_map.backend_to_user_indices == (1, 2, 0)
+    assert name_map.user_to_backend is not None
+    assert name_map.backend_to_user is not None
+    np.testing.assert_array_equal(name_map.user_to_backend.numpy(), np.asarray([2, 0, 1], dtype=np.int32))
+    np.testing.assert_array_equal(name_map.backend_to_user.numpy(), np.asarray([1, 2, 0], dtype=np.int32))
+    assert not name_map.is_identity
+
+
+def test_build_articulation_name_map_rejects_duplicate_backend_names() -> None:
+    """Reject backend names that cannot be mapped unambiguously."""
+    with pytest.raises(ValueError, match="Duplicate backend joint names"):
+        build_articulation_name_map(
+            kind="joint",
+            backend_names=("hip", "hip"),
+            user_names=("hip", "knee"),
+            device="cpu",
+        )
+
+
+def test_build_articulation_name_map_rejects_duplicate_requested_names() -> None:
+    """Reject requested user names that cannot be mapped unambiguously."""
+    with pytest.raises(ValueError, match="Duplicate requested body names"):
+        build_articulation_name_map(
+            kind="body",
+            backend_names=("base", "foot"),
+            user_names=("base", "base"),
+            device="cpu",
+        )
+
+
+def test_build_articulation_name_map_rejects_incomplete_permutation() -> None:
+    """Reject requested names that are not a complete backend-name permutation."""
+    with pytest.raises(ValueError, match=r"Missing=\['knee'\], extra=\['wheel'\]"):
+        build_articulation_name_map(
+            kind="joint",
+            backend_names=("hip", "knee"),
+            user_names=("hip", "wheel"),
+            device="cpu",
+        )

--- a/source/isaaclab/test/assets/test_articulation_ordering.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering.py
@@ -1082,6 +1082,14 @@ class _LegacyArticulation(BaseArticulation):
         return self._body_names
 
 
+class _IncompleteArticulation(BaseArticulation):
+    """Backend overriding neither the public nor the backend name properties."""
+
+    @property
+    def data(self):
+        return self._data
+
+
 def _make_ordering_resolution_articulation(
     *,
     body_ordering,
@@ -1127,6 +1135,67 @@ def test_base_articulation_ordering_contract_preserves_legacy_subclasses() -> No
         assert articulation.backend_body_names == ["base", "foot"]
     assert articulation.joint_ordering is None
     assert articulation.body_ordering is None
+
+
+def test_backend_name_fallbacks_reject_missing_overrides() -> None:
+    """Raise instead of recursing when a backend overrides neither name property of an axis."""
+    articulation = object.__new__(_IncompleteArticulation)
+    articulation._data = types.SimpleNamespace(joint_ordering=None, body_ordering=None)
+
+    with pytest.raises(NotImplementedError, match="joint_names"):
+        _ = articulation.backend_joint_names
+    with pytest.raises(NotImplementedError, match="body_names"):
+        _ = articulation.backend_body_names
+    # The public properties funnel into the same fallbacks and must fail identically.
+    with pytest.raises(NotImplementedError, match="joint_names"):
+        _ = articulation.joint_names
+    with pytest.raises(NotImplementedError, match="body_names"):
+        _ = articulation.body_names
+
+
+def _make_map_ids_articulation(*, permuted: bool) -> _LegacyArticulation:
+    """Create a name-mapping articulation with a 3-cycle joint/body permutation or identity maps."""
+    articulation = object.__new__(_LegacyArticulation)
+    articulation._joint_names = ["j_b", "j_c", "j_a"]
+    articulation._body_names = ["link", "foot", "base"]
+    if permuted:
+        # 3-cycle: user_to_backend == (1, 2, 0) differs from backend_to_user == (2, 0, 1),
+        # so a direction-swapped implementation cannot pass.
+        joint_ordering = build_articulation_name_map(
+            kind="joint", backend_names=("j_a", "j_b", "j_c"), user_names=("j_b", "j_c", "j_a"), device="cpu"
+        )
+        body_ordering = build_articulation_name_map(
+            kind="body", backend_names=("base", "link", "foot"), user_names=("link", "foot", "base"), device="cpu"
+        )
+    else:
+        joint_ordering = None
+        body_ordering = None
+    articulation._data = types.SimpleNamespace(joint_ordering=joint_ordering, body_ordering=body_ordering)
+    return articulation
+
+
+def test_map_ids_to_backend_applies_three_cycle_permutation() -> None:
+    """Translate public indices through the exact user-to-backend direction of a 3-cycle."""
+    articulation = _make_map_ids_articulation(permuted=True)
+
+    assert articulation.map_joint_ids_to_backend([0, 1, 2]) == [1, 2, 0]
+    assert articulation.map_joint_ids_to_backend([2, 0]) == [0, 1]
+    assert articulation.map_body_ids_to_backend([0, 1, 2]) == [1, 2, 0]
+    assert articulation.map_body_ids_to_backend([1]) == [2]
+
+
+def test_map_ids_to_backend_handles_slice_selectors() -> None:
+    """Accept slice selectors on both the identity and the permutation paths."""
+    permuted = _make_map_ids_articulation(permuted=True)
+    assert permuted.map_joint_ids_to_backend(slice(None)) == [1, 2, 0]
+    assert permuted.map_joint_ids_to_backend(slice(1, 3)) == [2, 0]
+    assert permuted.map_body_ids_to_backend(slice(None)) == [1, 2, 0]
+    assert permuted.map_body_ids_to_backend(slice(0, 3, 2)) == [1, 0]
+
+    identity = _make_map_ids_articulation(permuted=False)
+    all_items = slice(None)
+    assert identity.map_joint_ids_to_backend(all_items) is all_items
+    assert identity.map_body_ids_to_backend(all_items) is all_items
 
 
 @pytest.mark.parametrize("ordering", [("foot", "base"), ArticulationOrderingConvention.MJWARP])

--- a/source/isaaclab/test/assets/test_articulation_ordering_kernels.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering_kernels.py
@@ -551,3 +551,13 @@ def test_write_3d_user_to_backend_updates_component_buffers(selection: str) -> N
     expected_backend[0, [1, 0]] = input_data_np[0, [0, 2]]
     np.testing.assert_allclose(user_data.numpy(), expected_user)
     np.testing.assert_allclose(backend_data.numpy(), expected_backend)
+
+
+def test_directional_reorder_names_alias_the_gather_kernels() -> None:
+    """The four direction names are aliases: one kernel body per rank."""
+    from isaaclab.assets.articulation import ordering_kernels as k
+
+    assert k.reorder_2d_backend_to_user is k.gather_2d
+    assert k.reorder_2d_user_to_backend is k.gather_2d
+    assert k.reorder_3d_backend_to_user is k.gather_3d
+    assert k.reorder_3d_user_to_backend is k.gather_3d

--- a/source/isaaclab/test/assets/test_articulation_ordering_kernels.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering_kernels.py
@@ -1,0 +1,553 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for shared articulation ordering Warp kernels."""
+
+import numpy as np
+import pytest
+import warp as wp
+
+from isaaclab.assets.articulation.ordering_kernels import (
+    reorder_2d_backend_to_user,
+    reorder_2d_user_to_backend,
+    reorder_3d_backend_to_user,
+    reorder_joint_targets_user_to_backend,
+    write_2d_user_to_backend_with_indices,
+    write_2d_user_to_backend_with_mask,
+    write_3d_user_to_backend_with_indices,
+    write_3d_user_to_backend_with_mask,
+    write_float_user_to_backend_with_indices,
+    write_float_user_to_backend_with_mask,
+    write_joint_state_user_to_backend_with_indices,
+    write_joint_state_user_to_backend_with_mask,
+    write_joint_vel_user_to_backend_with_indices,
+    write_joint_vel_user_to_backend_with_mask,
+)
+
+
+def test_reorder_2d_backend_to_user_gathers_user_axis() -> None:
+    """Reorder a 2-D backend buffer into public user order."""
+    backend_data = wp.array(
+        np.asarray(
+            [
+                [10.0, 11.0, 12.0],
+                [20.0, 21.0, 22.0],
+            ],
+            dtype=np.float32,
+        ),
+        dtype=wp.float32,
+        device="cpu",
+    )
+    user_to_backend = wp.array(np.asarray([2, 0, 1], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_data = wp.zeros_like(backend_data)
+
+    wp.launch(
+        reorder_2d_backend_to_user,
+        dim=user_data.shape,
+        inputs=[backend_data, user_to_backend],
+        outputs=[user_data],
+        device="cpu",
+    )
+
+    expected = np.asarray([[12.0, 10.0, 11.0], [22.0, 20.0, 21.0]], dtype=np.float32)
+    np.testing.assert_allclose(user_data.numpy(), expected)
+
+
+def test_reorder_2d_user_to_backend_scatters_backend_axis() -> None:
+    """Reorder a 2-D public user buffer into backend order."""
+    user_data = wp.array(
+        np.asarray(
+            [
+                [12.0, 10.0, 11.0],
+                [22.0, 20.0, 21.0],
+            ],
+            dtype=np.float32,
+        ),
+        dtype=wp.float32,
+        device="cpu",
+    )
+    backend_to_user = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    backend_data = wp.zeros_like(user_data)
+
+    wp.launch(
+        reorder_2d_user_to_backend,
+        dim=backend_data.shape,
+        inputs=[user_data, backend_to_user],
+        outputs=[backend_data],
+        device="cpu",
+    )
+
+    expected = np.asarray([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]], dtype=np.float32)
+    np.testing.assert_allclose(backend_data.numpy(), expected)
+
+
+def test_reorder_3d_backend_to_user_gathers_user_axis() -> None:
+    """Reorder a 3-D backend buffer whose second axis is the public user axis."""
+    backend_data_np = np.asarray(
+        [
+            [[100.0, 101.0], [110.0, 111.0], [120.0, 121.0]],
+            [[200.0, 201.0], [210.0, 211.0], [220.0, 221.0]],
+        ],
+        dtype=np.float32,
+    )
+    backend_data = wp.array(backend_data_np, dtype=wp.float32, device="cpu")
+    user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_data = wp.zeros_like(backend_data)
+
+    wp.launch(
+        reorder_3d_backend_to_user,
+        dim=user_data.shape,
+        inputs=[backend_data, user_to_backend],
+        outputs=[user_data],
+        device="cpu",
+    )
+
+    np.testing.assert_allclose(user_data.numpy(), backend_data_np[:, [1, 2, 0], :])
+
+
+@pytest.mark.parametrize(
+    "combo, write_effort, write_pos, write_vel, write_act",
+    [
+        ("effort_only", True, False, False, False),
+        ("all_targets", True, True, True, False),
+        ("newton_four", True, True, True, True),
+    ],
+)
+def test_reorder_joint_targets_user_to_backend_writes_only_flagged_outputs(
+    combo: str,
+    write_effort: bool,
+    write_pos: bool,
+    write_vel: bool,
+    write_act: bool,
+) -> None:
+    """Fuse the write-path target reorders, honoring per-output flags over a non-trivial permutation."""
+    user_effort_np = np.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
+    user_pos_np = user_effort_np + 10.0
+    user_vel_np = user_effort_np + 20.0
+    # Non-identity permutation: backend joint i draws from public joint backend_to_user[i].
+    backend_to_user_np = np.asarray([2, 0, 1], dtype=np.int32)
+
+    user_effort = wp.array(user_effort_np, dtype=wp.float32, device="cpu")
+    user_pos = wp.array(user_pos_np, dtype=wp.float32, device="cpu")
+    user_vel = wp.array(user_vel_np, dtype=wp.float32, device="cpu")
+    backend_to_user = wp.array(backend_to_user_np, dtype=wp.int32, device="cpu")
+
+    # Distinct sentinels so gated-off outputs are provably untouched.
+    effort_sentinel = np.full_like(user_effort_np, -1.0)
+    pos_sentinel = np.full_like(user_effort_np, -2.0)
+    vel_sentinel = np.full_like(user_effort_np, -3.0)
+    act_sentinel = np.full_like(user_effort_np, -4.0)
+    backend_effort = wp.array(effort_sentinel, dtype=wp.float32, device="cpu")
+    backend_pos = wp.array(pos_sentinel, dtype=wp.float32, device="cpu")
+    backend_vel = wp.array(vel_sentinel, dtype=wp.float32, device="cpu")
+    backend_act = wp.array(act_sentinel, dtype=wp.float32, device="cpu")
+
+    wp.launch(
+        reorder_joint_targets_user_to_backend,
+        dim=(user_effort_np.shape[0], user_effort_np.shape[1]),
+        inputs=[user_effort, user_pos, user_vel, backend_to_user, write_effort, write_pos, write_vel, write_act],
+        outputs=[backend_effort, backend_pos, backend_vel, backend_act],
+        device="cpu",
+    )
+
+    expected_effort = user_effort_np[:, backend_to_user_np] if write_effort else effort_sentinel
+    expected_pos = user_pos_np[:, backend_to_user_np] if write_pos else pos_sentinel
+    expected_vel = user_vel_np[:, backend_to_user_np] if write_vel else vel_sentinel
+    expected_act = user_effort_np[:, backend_to_user_np] if write_act else act_sentinel
+    np.testing.assert_array_equal(backend_effort.numpy(), expected_effort)
+    np.testing.assert_array_equal(backend_pos.numpy(), expected_pos)
+    np.testing.assert_array_equal(backend_vel.numpy(), expected_vel)
+    np.testing.assert_array_equal(backend_act.numpy(), expected_act)
+
+
+@pytest.mark.parametrize("selection", ["indices", "mask"])
+@pytest.mark.parametrize("writer", ["scalar", "float", "velocity", "state"])
+def test_fused_identity_writer_supports_aliased_outputs(selection: str, writer: str) -> None:
+    """Preserve identity-order writes when public and backend outputs alias."""
+    user_to_backend = wp.array(np.asarray([0, 1, 2], dtype=np.int32), dtype=wp.int32, device="cpu")
+    env_ids = wp.array(np.asarray([0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_ids = wp.array(np.asarray([1], dtype=np.int32), dtype=wp.int32, device="cpu")
+    env_mask = wp.array(np.asarray([True, False]), dtype=wp.bool, device="cpu")
+    user_mask = wp.array(np.asarray([False, True, False]), dtype=wp.bool, device="cpu")
+    initial = np.asarray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
+    input_data = wp.array(
+        np.asarray([[101.0, 102.0, 103.0], [104.0, 105.0, 106.0]], dtype=np.float32),
+        dtype=wp.float32,
+        device="cpu",
+    )
+
+    def expected_with_selected_value(source: np.ndarray, value: float) -> np.ndarray:
+        expected = source.copy()
+        expected[0, 1] = value
+        return expected
+
+    if writer == "scalar":
+        data = wp.array(initial, dtype=wp.float32, device="cpu")
+        if selection == "indices":
+            wp.launch(
+                write_float_user_to_backend_with_indices,
+                dim=(env_ids.shape[0], user_ids.shape[0]),
+                inputs=[42.0, env_ids, user_ids, user_to_backend, False, False],
+                outputs=[data, data],
+                device="cpu",
+            )
+        else:
+            wp.launch(
+                write_float_user_to_backend_with_mask,
+                dim=data.shape,
+                inputs=[42.0, env_mask, user_mask, user_to_backend, False],
+                outputs=[data, data],
+                device="cpu",
+            )
+        np.testing.assert_allclose(data.numpy(), expected_with_selected_value(initial, 42.0))
+        return
+
+    if writer == "float":
+        data = wp.array(initial, dtype=wp.float32, device="cpu")
+        if selection == "indices":
+            wp.launch(
+                write_float_user_to_backend_with_indices,
+                dim=(env_ids.shape[0], user_ids.shape[0]),
+                inputs=[input_data, env_ids, user_ids, user_to_backend, False, True],
+                outputs=[data, data],
+                device="cpu",
+            )
+        else:
+            wp.launch(
+                write_float_user_to_backend_with_mask,
+                dim=data.shape,
+                inputs=[input_data, env_mask, user_mask, user_to_backend, False],
+                outputs=[data, data],
+                device="cpu",
+            )
+        np.testing.assert_allclose(data.numpy(), expected_with_selected_value(initial, 102.0))
+        return
+
+    initial_velocity = initial + 10.0
+    initial_previous_velocity = initial + 20.0
+    initial_acceleration = initial + 30.0
+    velocity = wp.array(initial_velocity, dtype=wp.float32, device="cpu")
+    previous_velocity = wp.array(initial_previous_velocity, dtype=wp.float32, device="cpu")
+    acceleration = wp.array(initial_acceleration, dtype=wp.float32, device="cpu")
+
+    if writer == "velocity":
+        if selection == "indices":
+            wp.launch(
+                write_joint_vel_user_to_backend_with_indices,
+                dim=(env_ids.shape[0], user_ids.shape[0]),
+                inputs=[input_data, env_ids, user_ids, user_to_backend, False, True],
+                outputs=[velocity, previous_velocity, acceleration, velocity],
+                device="cpu",
+            )
+        else:
+            wp.launch(
+                write_joint_vel_user_to_backend_with_mask,
+                dim=velocity.shape,
+                inputs=[input_data, env_mask, user_mask, user_to_backend, False],
+                outputs=[velocity, previous_velocity, acceleration, velocity],
+                device="cpu",
+            )
+        np.testing.assert_allclose(velocity.numpy(), expected_with_selected_value(initial_velocity, 102.0))
+        np.testing.assert_allclose(
+            previous_velocity.numpy(), expected_with_selected_value(initial_previous_velocity, 102.0)
+        )
+        np.testing.assert_allclose(acceleration.numpy(), expected_with_selected_value(initial_acceleration, 0.0))
+        return
+
+    position_data = wp.array(
+        np.asarray([[201.0, 202.0, 203.0], [204.0, 205.0, 206.0]], dtype=np.float32),
+        dtype=wp.float32,
+        device="cpu",
+    )
+    velocity_data = wp.array(
+        np.asarray([[301.0, 302.0, 303.0], [304.0, 305.0, 306.0]], dtype=np.float32),
+        dtype=wp.float32,
+        device="cpu",
+    )
+    initial_position = initial + 40.0
+    position = wp.array(initial_position, dtype=wp.float32, device="cpu")
+    if selection == "indices":
+        wp.launch(
+            write_joint_state_user_to_backend_with_indices,
+            dim=(env_ids.shape[0], user_ids.shape[0]),
+            inputs=[position_data, velocity_data, env_ids, user_ids, user_to_backend, False, True],
+            outputs=[position, velocity, previous_velocity, acceleration, position, velocity],
+            device="cpu",
+        )
+    else:
+        wp.launch(
+            write_joint_state_user_to_backend_with_mask,
+            dim=position.shape,
+            inputs=[position_data, velocity_data, env_mask, user_mask, user_to_backend, False],
+            outputs=[position, velocity, previous_velocity, acceleration, position, velocity],
+            device="cpu",
+        )
+    np.testing.assert_allclose(position.numpy(), expected_with_selected_value(initial_position, 202.0))
+    np.testing.assert_allclose(velocity.numpy(), expected_with_selected_value(initial_velocity, 302.0))
+    np.testing.assert_allclose(
+        previous_velocity.numpy(), expected_with_selected_value(initial_previous_velocity, 302.0)
+    )
+    np.testing.assert_allclose(acceleration.numpy(), expected_with_selected_value(initial_acceleration, 0.0))
+
+
+def test_write_float_scalar_user_to_backend_with_indices_updates_user_and_backend_buffers() -> None:
+    """Fuse indexed scalar writes into user and backend-order buffers."""
+    env_ids = wp.array(np.asarray([0, 2], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_ids = wp.array(np.asarray([2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_data = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
+    backend_data = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
+
+    wp.launch(
+        write_float_user_to_backend_with_indices,
+        dim=(env_ids.shape[0], user_ids.shape[0]),
+        inputs=[4.5, env_ids, user_ids, user_to_backend, True, False],
+        outputs=[user_data, backend_data],
+        device="cpu",
+    )
+
+    expected_user = np.asarray([[4.5, 0.0, 4.5], [0.0, 0.0, 0.0], [4.5, 0.0, 4.5]], dtype=np.float32)
+    expected_backend = np.asarray([[4.5, 4.5, 0.0], [0.0, 0.0, 0.0], [4.5, 4.5, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(user_data.numpy(), expected_user)
+    np.testing.assert_allclose(backend_data.numpy(), expected_backend)
+
+
+def test_write_float_scalar_user_to_backend_with_mask_updates_selected_entries() -> None:
+    """Fuse masked scalar writes into user and backend-order buffers."""
+    env_mask = wp.array(np.asarray([True, False], dtype=bool), dtype=wp.bool, device="cpu")
+    user_mask = wp.array(np.asarray([False, True, True], dtype=bool), dtype=wp.bool, device="cpu")
+    user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_data = wp.zeros((2, 3), dtype=wp.float32, device="cpu")
+    backend_data = wp.zeros((2, 3), dtype=wp.float32, device="cpu")
+
+    wp.launch(
+        write_float_user_to_backend_with_mask,
+        dim=user_data.shape,
+        inputs=[7.25, env_mask, user_mask, user_to_backend, True],
+        outputs=[user_data, backend_data],
+        device="cpu",
+    )
+
+    expected_user = np.asarray([[0.0, 7.25, 7.25], [0.0, 0.0, 0.0]], dtype=np.float32)
+    expected_backend = np.asarray([[7.25, 0.0, 7.25], [0.0, 0.0, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(user_data.numpy(), expected_user)
+    np.testing.assert_allclose(backend_data.numpy(), expected_backend)
+
+
+def test_write_float_array_user_to_backend_with_indices_updates_user_and_backend_buffers() -> None:
+    """Fuse partial user-order writes into user and backend-order buffers."""
+    input_data = wp.array(
+        np.asarray(
+            [
+                [10.0, 11.0],
+                [20.0, 21.0],
+            ],
+            dtype=np.float32,
+        ),
+        dtype=wp.float32,
+        device="cpu",
+    )
+    env_ids = wp.array(np.asarray([0, 2], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_ids = wp.array(np.asarray([2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_data = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
+    backend_data = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
+
+    wp.launch(
+        write_float_user_to_backend_with_indices,
+        dim=input_data.shape,
+        inputs=[input_data, env_ids, user_ids, user_to_backend, True, False],
+        outputs=[user_data, backend_data],
+        device="cpu",
+    )
+
+    expected_user = np.asarray([[11.0, 0.0, 10.0], [0.0, 0.0, 0.0], [21.0, 0.0, 20.0]], dtype=np.float32)
+    expected_backend = np.asarray([[10.0, 11.0, 0.0], [0.0, 0.0, 0.0], [20.0, 21.0, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(user_data.numpy(), expected_user)
+    np.testing.assert_allclose(backend_data.numpy(), expected_backend)
+
+
+def test_write_float_array_user_to_backend_with_mask_updates_selected_entries() -> None:
+    """Fuse masked user-order writes into user and backend-order buffers."""
+    input_data = wp.array(
+        np.asarray(
+            [
+                [10.0, 11.0, 12.0],
+                [20.0, 21.0, 22.0],
+            ],
+            dtype=np.float32,
+        ),
+        dtype=wp.float32,
+        device="cpu",
+    )
+    env_mask = wp.array(np.asarray([True, False], dtype=bool), dtype=wp.bool, device="cpu")
+    user_mask = wp.array(np.asarray([False, True, True], dtype=bool), dtype=wp.bool, device="cpu")
+    user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_data = wp.zeros_like(input_data)
+    backend_data = wp.zeros_like(input_data)
+
+    wp.launch(
+        write_float_user_to_backend_with_mask,
+        dim=input_data.shape,
+        inputs=[input_data, env_mask, user_mask, user_to_backend, True],
+        outputs=[user_data, backend_data],
+        device="cpu",
+    )
+
+    expected_user = np.asarray([[0.0, 11.0, 12.0], [0.0, 0.0, 0.0]], dtype=np.float32)
+    expected_backend = np.asarray([[12.0, 0.0, 11.0], [0.0, 0.0, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(user_data.numpy(), expected_user)
+    np.testing.assert_allclose(backend_data.numpy(), expected_backend)
+
+
+def test_write_joint_state_user_to_backend_with_indices_updates_history_and_backend_buffers() -> None:
+    """Fuse indexed joint state writes into user cache, history, and backend buffers."""
+    position = wp.array(np.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32), dtype=wp.float32, device="cpu")
+    velocity = wp.array(np.asarray([[5.0, 6.0], [7.0, 8.0]], dtype=np.float32), dtype=wp.float32, device="cpu")
+    env_ids = wp.array(np.asarray([0, 2], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_ids = wp.array(np.asarray([2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_pos = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
+    user_vel = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
+    user_prev_vel = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
+    user_acc = wp.ones((3, 3), dtype=wp.float32, device="cpu")
+    backend_pos = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
+    backend_vel = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
+
+    wp.launch(
+        write_joint_state_user_to_backend_with_indices,
+        dim=position.shape,
+        inputs=[position, velocity, env_ids, user_ids, user_to_backend, True, False],
+        outputs=[user_pos, user_vel, user_prev_vel, user_acc, backend_pos, backend_vel],
+        device="cpu",
+    )
+
+    expected_user_pos = np.asarray([[2.0, 0.0, 1.0], [0.0, 0.0, 0.0], [4.0, 0.0, 3.0]], dtype=np.float32)
+    expected_user_vel = np.asarray([[6.0, 0.0, 5.0], [0.0, 0.0, 0.0], [8.0, 0.0, 7.0]], dtype=np.float32)
+    expected_backend_pos = np.asarray([[1.0, 2.0, 0.0], [0.0, 0.0, 0.0], [3.0, 4.0, 0.0]], dtype=np.float32)
+    expected_backend_vel = np.asarray([[5.0, 6.0, 0.0], [0.0, 0.0, 0.0], [7.0, 8.0, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(user_pos.numpy(), expected_user_pos)
+    np.testing.assert_allclose(user_vel.numpy(), expected_user_vel)
+    np.testing.assert_allclose(user_prev_vel.numpy(), expected_user_vel)
+    np.testing.assert_allclose(backend_pos.numpy(), expected_backend_pos)
+    np.testing.assert_allclose(backend_vel.numpy(), expected_backend_vel)
+    np.testing.assert_allclose(user_acc.numpy()[[0, 2]][:, [0, 2]], np.zeros((2, 2), dtype=np.float32))
+
+
+def test_write_joint_vel_user_to_backend_with_mask_updates_selected_entries() -> None:
+    """Fuse masked joint velocity writes into user cache, history, and backend buffers."""
+    velocity = wp.array(
+        np.asarray([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]], dtype=np.float32),
+        dtype=wp.float32,
+        device="cpu",
+    )
+    env_mask = wp.array(np.asarray([True, False], dtype=bool), dtype=wp.bool, device="cpu")
+    user_mask = wp.array(np.asarray([False, True, True], dtype=bool), dtype=wp.bool, device="cpu")
+    user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_vel = wp.zeros_like(velocity)
+    user_prev_vel = wp.zeros_like(velocity)
+    user_acc = wp.ones_like(velocity)
+    backend_vel = wp.zeros_like(velocity)
+
+    wp.launch(
+        write_joint_vel_user_to_backend_with_mask,
+        dim=velocity.shape,
+        inputs=[velocity, env_mask, user_mask, user_to_backend, True],
+        outputs=[user_vel, user_prev_vel, user_acc, backend_vel],
+        device="cpu",
+    )
+
+    expected_user = np.asarray([[0.0, 11.0, 12.0], [0.0, 0.0, 0.0]], dtype=np.float32)
+    expected_backend = np.asarray([[12.0, 0.0, 11.0], [0.0, 0.0, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(user_vel.numpy(), expected_user)
+    np.testing.assert_allclose(user_prev_vel.numpy(), expected_user)
+    np.testing.assert_allclose(backend_vel.numpy(), expected_backend)
+    np.testing.assert_allclose(user_acc.numpy()[0, 1:], np.zeros((2,), dtype=np.float32))
+
+
+@pytest.mark.parametrize("selection", ["indices", "mask"])
+def test_write_2d_user_to_backend_updates_structured_buffers(selection: str) -> None:
+    """Fuse selected structured writes into public and backend-order buffers."""
+    kernel = write_2d_user_to_backend_with_indices if selection == "indices" else write_2d_user_to_backend_with_mask
+
+    input_data_np = np.asarray(
+        [
+            [[10.0, 11.0, 12.0], [20.0, 21.0, 22.0], [30.0, 31.0, 32.0]],
+            [[40.0, 41.0, 42.0], [50.0, 51.0, 52.0], [60.0, 61.0, 62.0]],
+        ],
+        dtype=np.float32,
+    )
+    input_data = wp.array(input_data_np, dtype=wp.vec3f, device="cpu")
+    user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_data = wp.zeros_like(input_data)
+    backend_data = wp.zeros_like(input_data)
+
+    if selection == "indices":
+        env_ids = wp.array(np.asarray([0], dtype=np.int32), dtype=wp.int32, device="cpu")
+        user_ids = wp.array(np.asarray([0, 2], dtype=np.int32), dtype=wp.int32, device="cpu")
+        wp.launch(
+            kernel,
+            dim=(env_ids.shape[0], user_ids.shape[0]),
+            inputs=[input_data, env_ids, user_ids, user_to_backend, True, True],
+            outputs=[user_data, backend_data],
+            device="cpu",
+        )
+    else:
+        env_mask = wp.array(np.asarray([True, False]), dtype=wp.bool, device="cpu")
+        user_mask = wp.array(np.asarray([True, False, True]), dtype=wp.bool, device="cpu")
+        wp.launch(
+            kernel,
+            dim=input_data.shape,
+            inputs=[input_data, env_mask, user_mask, user_to_backend, True],
+            outputs=[user_data, backend_data],
+            device="cpu",
+        )
+
+    expected_user = np.zeros_like(input_data_np)
+    expected_user[0, [0, 2]] = input_data_np[0, [0, 2]]
+    expected_backend = np.zeros_like(input_data_np)
+    expected_backend[0, [1, 0]] = input_data_np[0, [0, 2]]
+    np.testing.assert_allclose(user_data.numpy(), expected_user)
+    np.testing.assert_allclose(backend_data.numpy(), expected_backend)
+
+
+@pytest.mark.parametrize("selection", ["indices", "mask"])
+def test_write_3d_user_to_backend_updates_component_buffers(selection: str) -> None:
+    """Fuse selected component-array writes into public and backend-order buffers."""
+    kernel = write_3d_user_to_backend_with_indices if selection == "indices" else write_3d_user_to_backend_with_mask
+
+    input_data_np = np.arange(2 * 3 * 4, dtype=np.float32).reshape(2, 3, 4) + 1.0
+    input_data = wp.array(input_data_np, dtype=wp.float32, device="cpu")
+    user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
+    user_data = wp.zeros_like(input_data)
+    backend_data = wp.zeros_like(input_data)
+
+    if selection == "indices":
+        env_ids = wp.array(np.asarray([0], dtype=np.int32), dtype=wp.int32, device="cpu")
+        user_ids = wp.array(np.asarray([0, 2], dtype=np.int32), dtype=wp.int32, device="cpu")
+        wp.launch(
+            kernel,
+            dim=(env_ids.shape[0], user_ids.shape[0], input_data.shape[2]),
+            inputs=[input_data, env_ids, user_ids, user_to_backend, True, True],
+            outputs=[user_data, backend_data],
+            device="cpu",
+        )
+    else:
+        env_mask = wp.array(np.asarray([True, False]), dtype=wp.bool, device="cpu")
+        user_mask = wp.array(np.asarray([True, False, True]), dtype=wp.bool, device="cpu")
+        wp.launch(
+            kernel,
+            dim=input_data.shape,
+            inputs=[input_data, env_mask, user_mask, user_to_backend, True],
+            outputs=[user_data, backend_data],
+            device="cpu",
+        )
+
+    expected_user = np.zeros_like(input_data_np)
+    expected_user[0, [0, 2]] = input_data_np[0, [0, 2]]
+    expected_backend = np.zeros_like(input_data_np)
+    expected_backend[0, [1, 0]] = input_data_np[0, [0, 2]]
+    np.testing.assert_allclose(user_data.numpy(), expected_user)
+    np.testing.assert_allclose(backend_data.numpy(), expected_backend)

--- a/source/isaaclab/test/assets/test_articulation_ordering_kernels.py
+++ b/source/isaaclab/test/assets/test_articulation_ordering_kernels.py
@@ -186,20 +186,12 @@ def test_fused_identity_writer_supports_aliased_outputs(selection: str, writer: 
     if writer == "scalar":
         data = wp.array(initial, dtype=wp.float32, device="cpu")
         if selection == "indices":
-            wp.launch(
-                write_float_user_to_backend_with_indices,
-                dim=(env_ids.shape[0], user_ids.shape[0]),
-                inputs=[42.0, env_ids, user_ids, user_to_backend, False, False],
-                outputs=[data, data],
-                device="cpu",
+            write_float_user_to_backend_with_indices(
+                42.0, env_ids, user_ids, user_to_backend, False, False, data, data, device="cpu"
             )
         else:
-            wp.launch(
-                write_float_user_to_backend_with_mask,
-                dim=data.shape,
-                inputs=[42.0, env_mask, user_mask, user_to_backend, False],
-                outputs=[data, data],
-                device="cpu",
+            write_float_user_to_backend_with_mask(
+                42.0, env_mask, user_mask, user_to_backend, False, data, data, device="cpu"
             )
         np.testing.assert_allclose(data.numpy(), expected_with_selected_value(initial, 42.0))
         return
@@ -207,20 +199,12 @@ def test_fused_identity_writer_supports_aliased_outputs(selection: str, writer: 
     if writer == "float":
         data = wp.array(initial, dtype=wp.float32, device="cpu")
         if selection == "indices":
-            wp.launch(
-                write_float_user_to_backend_with_indices,
-                dim=(env_ids.shape[0], user_ids.shape[0]),
-                inputs=[input_data, env_ids, user_ids, user_to_backend, False, True],
-                outputs=[data, data],
-                device="cpu",
+            write_float_user_to_backend_with_indices(
+                input_data, env_ids, user_ids, user_to_backend, False, True, data, data, device="cpu"
             )
         else:
-            wp.launch(
-                write_float_user_to_backend_with_mask,
-                dim=data.shape,
-                inputs=[input_data, env_mask, user_mask, user_to_backend, False],
-                outputs=[data, data],
-                device="cpu",
+            write_float_user_to_backend_with_mask(
+                input_data, env_mask, user_mask, user_to_backend, False, data, data, device="cpu"
             )
         np.testing.assert_allclose(data.numpy(), expected_with_selected_value(initial, 102.0))
         return
@@ -300,12 +284,8 @@ def test_write_float_scalar_user_to_backend_with_indices_updates_user_and_backen
     user_data = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
     backend_data = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
 
-    wp.launch(
-        write_float_user_to_backend_with_indices,
-        dim=(env_ids.shape[0], user_ids.shape[0]),
-        inputs=[4.5, env_ids, user_ids, user_to_backend, True, False],
-        outputs=[user_data, backend_data],
-        device="cpu",
+    write_float_user_to_backend_with_indices(
+        4.5, env_ids, user_ids, user_to_backend, True, False, user_data, backend_data, device="cpu"
     )
 
     expected_user = np.asarray([[4.5, 0.0, 4.5], [0.0, 0.0, 0.0], [4.5, 0.0, 4.5]], dtype=np.float32)
@@ -322,12 +302,8 @@ def test_write_float_scalar_user_to_backend_with_mask_updates_selected_entries()
     user_data = wp.zeros((2, 3), dtype=wp.float32, device="cpu")
     backend_data = wp.zeros((2, 3), dtype=wp.float32, device="cpu")
 
-    wp.launch(
-        write_float_user_to_backend_with_mask,
-        dim=user_data.shape,
-        inputs=[7.25, env_mask, user_mask, user_to_backend, True],
-        outputs=[user_data, backend_data],
-        device="cpu",
+    write_float_user_to_backend_with_mask(
+        7.25, env_mask, user_mask, user_to_backend, True, user_data, backend_data, device="cpu"
     )
 
     expected_user = np.asarray([[0.0, 7.25, 7.25], [0.0, 0.0, 0.0]], dtype=np.float32)
@@ -355,12 +331,8 @@ def test_write_float_array_user_to_backend_with_indices_updates_user_and_backend
     user_data = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
     backend_data = wp.zeros((3, 3), dtype=wp.float32, device="cpu")
 
-    wp.launch(
-        write_float_user_to_backend_with_indices,
-        dim=input_data.shape,
-        inputs=[input_data, env_ids, user_ids, user_to_backend, True, False],
-        outputs=[user_data, backend_data],
-        device="cpu",
+    write_float_user_to_backend_with_indices(
+        input_data, env_ids, user_ids, user_to_backend, True, False, user_data, backend_data, device="cpu"
     )
 
     expected_user = np.asarray([[11.0, 0.0, 10.0], [0.0, 0.0, 0.0], [21.0, 0.0, 20.0]], dtype=np.float32)
@@ -388,12 +360,8 @@ def test_write_float_array_user_to_backend_with_mask_updates_selected_entries() 
     user_data = wp.zeros_like(input_data)
     backend_data = wp.zeros_like(input_data)
 
-    wp.launch(
-        write_float_user_to_backend_with_mask,
-        dim=input_data.shape,
-        inputs=[input_data, env_mask, user_mask, user_to_backend, True],
-        outputs=[user_data, backend_data],
-        device="cpu",
+    write_float_user_to_backend_with_mask(
+        input_data, env_mask, user_mask, user_to_backend, True, user_data, backend_data, device="cpu"
     )
 
     expected_user = np.asarray([[0.0, 11.0, 12.0], [0.0, 0.0, 0.0]], dtype=np.float32)
@@ -470,8 +438,6 @@ def test_write_joint_vel_user_to_backend_with_mask_updates_selected_entries() ->
 @pytest.mark.parametrize("selection", ["indices", "mask"])
 def test_write_2d_user_to_backend_updates_structured_buffers(selection: str) -> None:
     """Fuse selected structured writes into public and backend-order buffers."""
-    kernel = write_2d_user_to_backend_with_indices if selection == "indices" else write_2d_user_to_backend_with_mask
-
     input_data_np = np.asarray(
         [
             [[10.0, 11.0, 12.0], [20.0, 21.0, 22.0], [30.0, 31.0, 32.0]],
@@ -487,21 +453,30 @@ def test_write_2d_user_to_backend_updates_structured_buffers(selection: str) -> 
     if selection == "indices":
         env_ids = wp.array(np.asarray([0], dtype=np.int32), dtype=wp.int32, device="cpu")
         user_ids = wp.array(np.asarray([0, 2], dtype=np.int32), dtype=wp.int32, device="cpu")
-        wp.launch(
-            kernel,
-            dim=(env_ids.shape[0], user_ids.shape[0]),
-            inputs=[input_data, env_ids, user_ids, user_to_backend, True, True],
-            outputs=[user_data, backend_data],
+        write_2d_user_to_backend_with_indices(
+            input_data,
+            env_ids,
+            user_ids,
+            user_to_backend,
+            True,
+            True,
+            user_data,
+            backend_data,
+            dtype=wp.vec3f,
             device="cpu",
         )
     else:
         env_mask = wp.array(np.asarray([True, False]), dtype=wp.bool, device="cpu")
         user_mask = wp.array(np.asarray([True, False, True]), dtype=wp.bool, device="cpu")
-        wp.launch(
-            kernel,
-            dim=input_data.shape,
-            inputs=[input_data, env_mask, user_mask, user_to_backend, True],
-            outputs=[user_data, backend_data],
+        write_2d_user_to_backend_with_mask(
+            input_data,
+            env_mask,
+            user_mask,
+            user_to_backend,
+            True,
+            user_data,
+            backend_data,
+            dtype=wp.vec3f,
             device="cpu",
         )
 
@@ -516,8 +491,6 @@ def test_write_2d_user_to_backend_updates_structured_buffers(selection: str) -> 
 @pytest.mark.parametrize("selection", ["indices", "mask"])
 def test_write_3d_user_to_backend_updates_component_buffers(selection: str) -> None:
     """Fuse selected component-array writes into public and backend-order buffers."""
-    kernel = write_3d_user_to_backend_with_indices if selection == "indices" else write_3d_user_to_backend_with_mask
-
     input_data_np = np.arange(2 * 3 * 4, dtype=np.float32).reshape(2, 3, 4) + 1.0
     input_data = wp.array(input_data_np, dtype=wp.float32, device="cpu")
     user_to_backend = wp.array(np.asarray([1, 2, 0], dtype=np.int32), dtype=wp.int32, device="cpu")
@@ -527,21 +500,30 @@ def test_write_3d_user_to_backend_updates_component_buffers(selection: str) -> N
     if selection == "indices":
         env_ids = wp.array(np.asarray([0], dtype=np.int32), dtype=wp.int32, device="cpu")
         user_ids = wp.array(np.asarray([0, 2], dtype=np.int32), dtype=wp.int32, device="cpu")
-        wp.launch(
-            kernel,
-            dim=(env_ids.shape[0], user_ids.shape[0], input_data.shape[2]),
-            inputs=[input_data, env_ids, user_ids, user_to_backend, True, True],
-            outputs=[user_data, backend_data],
+        write_3d_user_to_backend_with_indices(
+            input_data,
+            env_ids,
+            user_ids,
+            user_to_backend,
+            True,
+            True,
+            user_data,
+            backend_data,
+            dtype=wp.float32,
             device="cpu",
         )
     else:
         env_mask = wp.array(np.asarray([True, False]), dtype=wp.bool, device="cpu")
         user_mask = wp.array(np.asarray([True, False, True]), dtype=wp.bool, device="cpu")
-        wp.launch(
-            kernel,
-            dim=input_data.shape,
-            inputs=[input_data, env_mask, user_mask, user_to_backend, True],
-            outputs=[user_data, backend_data],
+        write_3d_user_to_backend_with_mask(
+            input_data,
+            env_mask,
+            user_mask,
+            user_to_backend,
+            True,
+            user_data,
+            backend_data,
+            dtype=wp.float32,
             device="cpu",
         )
 
@@ -561,3 +543,54 @@ def test_directional_reorder_names_alias_the_gather_kernels() -> None:
     assert k.reorder_2d_user_to_backend is k.gather_2d
     assert k.reorder_3d_backend_to_user is k.gather_3d
     assert k.reorder_3d_user_to_backend is k.gather_3d
+
+
+def test_write_2d_wrapper_adapts_torch_vec3_inputs() -> None:
+    """The launch wrapper accepts torch tensors and folds trailing vec3 dims."""
+    import torch
+
+    from isaaclab.assets.articulation import ordering_kernels as k
+
+    num_envs, num_items = 2, 3
+    input_data = torch.arange(num_envs * num_items * 3, dtype=torch.float32, device="cpu").reshape(
+        num_envs, num_items, 3
+    )
+    user_data = torch.zeros_like(input_data)
+    backend_data = torch.zeros_like(input_data)
+    env_ids = wp.array([0, 1], dtype=wp.int32, device="cpu")
+    user_ids = wp.array([0, 1, 2], dtype=wp.int32, device="cpu")
+    user_to_backend = wp.array([2, 0, 1], dtype=wp.int32, device="cpu")
+
+    k.write_2d_user_to_backend_with_indices(
+        input_data,
+        env_ids,
+        user_ids,
+        user_to_backend,
+        True,
+        True,
+        user_data,
+        backend_data,
+        dtype=wp.vec3f,
+        device="cpu",
+    )
+    assert torch.equal(user_data, input_data)
+    assert torch.equal(backend_data[:, [2, 0, 1], :], input_data)
+
+
+def test_write_float_wrapper_accepts_scalar_input() -> None:
+    """The float wrapper passes Python scalars straight to the scalar overload."""
+    import torch
+
+    from isaaclab.assets.articulation import ordering_kernels as k
+
+    user_data = torch.zeros((2, 3), dtype=torch.float32, device="cpu")
+    backend_data = torch.zeros((2, 3), dtype=torch.float32, device="cpu")
+    env_ids = wp.array([0, 1], dtype=wp.int32, device="cpu")
+    user_ids = wp.array([1], dtype=wp.int32, device="cpu")
+    user_to_backend = wp.array([2, 0, 1], dtype=wp.int32, device="cpu")
+
+    k.write_float_user_to_backend_with_indices(
+        7.5, env_ids, user_ids, user_to_backend, True, False, user_data, backend_data, device="cpu"
+    )
+    assert user_data[0, 1].item() == 7.5 and user_data[1, 1].item() == 7.5
+    assert backend_data[0, 0].item() == 7.5  # user index 1 -> backend index 0


### PR DESCRIPTION
# Description

Introduces the public joint/body ordering machinery in `isaaclab` core: the `ArticulationNameMap` type and builder, the ordering preset helper, the Warp reorder kernels with an explicit visibility contract, the symbolic convention resolvers (`physx`, `mjwarp`, `robot_schema`), the `ArticulationCfg.joint_ordering`/`body_ordering` fields, the `BaseArticulation`/`BaseArticulationData` plumbing that backends wire into, and the API reference entries.

**Transitional semantics:** no backend consumes the machinery yet, so configuring an ordering in this intermediate state is a silent no-op until Parts 3/4/6 land. This is called out in the cfg field docstrings and resolves quickly as the stack merges.

Part 2/8 of the series splitting #6248 into independently reviewable units. #6248 remains open, untouched, as the reference implementation; this stack was cut from its final tree after a `develop` sync (Kamino Core, Newton bump, OVPhysX 0.5.1).

## Stack

- Part 1/8: #6334 — Extract rigid object interface test utilities
- **Part 2/8 (this PR)**: #6335 — Core ordering foundation
- Part 3/8: #6336 — Newton backend
- Part 4/8: #6337 — PhysX backend
- Part 5/8: #6338 — Extract articulation interface test utilities
- Part 6/8: #6339 — OVPhysX backend
- Part 7/8: #6340 — Cross-backend ordering interface tests
- Part 8/8: #6341 — Events, consumers, and documentation

> [!NOTE]
> All parts target `develop`, so until the preceding parts merge this PR's diff includes them. The true delta of this part is [this compare](https://github.com/AntoineRichard/IsaacLab/compare/antoiner%2Farticulation-reordering-p1...antoiner%2Farticulation-reordering-p2).

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name exists in `CONTRIBUTORS.md`

## Test Plan

- [x] `./isaaclab.sh -p -m pytest source/isaaclab/test/assets/test_articulation_ordering.py` -> 67 passed
- [x] `./isaaclab.sh -p -m pytest source/isaaclab/test/assets/test_articulation_ordering_kernels.py` -> 24 passed
- [x] `./isaaclab.sh -f` -> all hooks pass