### PR TITLE
[IsaacLab CI]  Smoke test marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ markers = [
     "device_split: re-invoke this file once per device (CPU and GPU) in CI due to process-global device locks (e.g., ovphysx<=0.3.7 gap G5)",
     "windows_ci: mark test to run on Windows platforms in CI",
     "arm_ci: mark test to run on ARM platforms in CI (e.g. NVIDIA DGX Spark)",
-    "smoke: mark test as a quick smoke test for targeted selection via -m smoke",
+    "smoke: tests for core installation, task, and RL functionality",
 ]
 
 # Add pypi.nvidia.com so that `uv pip install isaaclab[isaacsim]` works without --extra-index-url.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ markers = [
     "device_split: re-invoke this file once per device (CPU and GPU) in CI due to process-global device locks (e.g., ovphysx<=0.3.7 gap G5)",
     "windows_ci: mark test to run on Windows platforms in CI",
     "arm_ci: mark test to run on ARM platforms in CI (e.g. NVIDIA DGX Spark)",
+    "smoke: mark test as a quick smoke test for targeted selection via -m smoke",
 ]
 
 # Add pypi.nvidia.com so that `uv pip install isaaclab[isaacsim]` works without --extra-index-url.

--- a/source/isaaclab/changelog.d/mataylor-smoke-test-marker.skip
+++ b/source/isaaclab/changelog.d/mataylor-smoke-test-marker.skip
@@ -1,0 +1,3 @@
+Test-only: add a ``smoke`` pytest marker and register it, then tag the
+install-CI smoke tests with it so quick installation smoke checks can be
+selected as a group.

--- a/source/isaaclab/test/install_ci/cli/test_cli_install_in_globalenv_smoke.py
+++ b/source/isaaclab/test/install_ci/cli/test_cli_install_in_globalenv_smoke.py
@@ -19,6 +19,7 @@ import pytest
 from utils import run_cmd
 
 
+@pytest.mark.smoke
 class Test_Cli_Install_In_Globalenv_Smoke:
     """./isaaclab.sh -i with no uv/conda env active (system Python)."""
 

--- a/source/isaaclab/test/install_ci/cli/test_cli_install_in_uvenv_smoke.py
+++ b/source/isaaclab/test/install_ci/cli/test_cli_install_in_uvenv_smoke.py
@@ -33,6 +33,7 @@ def _skip_if_isaacsim_unavailable() -> None:
             pytest.skip("isaacsim is not importable and _isaac_sim link not found, skipping")
 
 
+@pytest.mark.smoke
 class Test_Cli_Install_In_Uvenv_Smoke(UV_Mixin):
     """./isaaclab.sh -u/-i smoke checks plus optional submodule (mimic) and feature (newton) installs."""
 

--- a/source/isaaclab/test/install_ci/conftest.py
+++ b/source/isaaclab/test/install_ci/conftest.py
@@ -100,7 +100,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    config.addinivalue_line("markers", "smoke: quick installation, task, and RL smoke tests")
+    config.addinivalue_line("markers", "smoke: light weight tests for core installation, task, and RL functionality")
     config.addinivalue_line("markers", "bug: bug-regression tests (use bug id as argument)")
     config.addinivalue_line("markers", "gpu: tests that require a GPU")
     config.addinivalue_line("markers", "docker: tests that only run inside Docker")

--- a/source/isaaclab/test/install_ci/conftest.py
+++ b/source/isaaclab/test/install_ci/conftest.py
@@ -100,6 +100,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "smoke: quick installation, task, and RL smoke tests")
     config.addinivalue_line("markers", "bug: bug-regression tests (use bug id as argument)")
     config.addinivalue_line("markers", "gpu: tests that require a GPU")
     config.addinivalue_line("markers", "docker: tests that only run inside Docker")

--- a/source/isaaclab/test/install_ci/conftest.py
+++ b/source/isaaclab/test/install_ci/conftest.py
@@ -100,7 +100,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    config.addinivalue_line("markers", "smoke: light weight tests for core installation, task, and RL functionality")
+    config.addinivalue_line("markers", "smoke: tests for core installation, task, and RL functionality")
     config.addinivalue_line("markers", "bug: bug-regression tests (use bug id as argument)")
     config.addinivalue_line("markers", "gpu: tests that require a GPU")
     config.addinivalue_line("markers", "docker: tests that only run inside Docker")

--- a/source/isaaclab/test/install_ci/misc/test_wheel_builder_smoke.py
+++ b/source/isaaclab/test/install_ci/misc/test_wheel_builder_smoke.py
@@ -33,6 +33,7 @@ import pytest
 from utils import UV_Mixin, run_cmd
 
 
+@pytest.mark.smoke
 class Test_Wheel_Builder_Smoke(UV_Mixin):
     """Test building the isaaclab wheel and installing it in a uv environment."""
 

--- a/source/isaaclab/test/install_ci/pytest.ini
+++ b/source/isaaclab/test/install_ci/pytest.ini
@@ -6,6 +6,7 @@ python_files =
     *_test.py
     *_tests.py
 markers =
+    smoke: quick installation, task, and RL smoke tests
     bug: regression tests (bug id as argument)
     gpu: tests that require a GPU
     docker: tests that ONLY run inside Docker

--- a/source/isaaclab/test/install_ci/pytest.ini
+++ b/source/isaaclab/test/install_ci/pytest.ini
@@ -6,7 +6,7 @@ python_files =
     *_test.py
     *_tests.py
 markers =
-    smoke: quick installation, task, and RL smoke tests
+    smoke: light weight tests for core installation, task, and RL functionality
     bug: regression tests (bug id as argument)
     gpu: tests that require a GPU
     docker: tests that ONLY run inside Docker

--- a/source/isaaclab/test/install_ci/pytest.ini
+++ b/source/isaaclab/test/install_ci/pytest.ini
@@ -6,7 +6,7 @@ python_files =
     *_test.py
     *_tests.py
 markers =
-    smoke: light weight tests for core installation, task, and RL functionality
+    smoke: tests for core installation, task, and RL functionality
     bug: regression tests (bug id as argument)
     gpu: tests that require a GPU
     docker: tests that ONLY run inside Docker

--- a/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_isaacsim_trains_cartpole.py
+++ b/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_isaacsim_trains_cartpole.py
@@ -58,6 +58,7 @@ class Test_Uv_Pip_Install_Isaaclab_All_Isaacsim_Trains_Cartpole(UV_Mixin):
             pytest.skip("uv is not available")
 
     @pytest.mark.docker
+    @pytest.mark.smoke
     @pytest.mark.uv
     @pytest.mark.slow
     @pytest.mark.gpu

--- a/source/isaaclab_contrib/changelog.d/mataylor-smoke-test-marker.skip
+++ b/source/isaaclab_contrib/changelog.d/mataylor-smoke-test-marker.skip
@@ -1,0 +1,2 @@
+Test-only: tag the rigid/deformable coupling smoke test with the shared
+``smoke`` pytest marker.

--- a/source/isaaclab_contrib/test/deformable/test_rigid_deformable_coupling.py
+++ b/source/isaaclab_contrib/test/deformable/test_rigid_deformable_coupling.py
@@ -219,6 +219,7 @@ def generate_lateral_rigid_and_deformable_cubes(
     return rigid_cube, deformable_cube
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize(
     "sim",
     [("featherstone", "kinematic")],

--- a/source/isaaclab_tasks/changelog.d/mataylor-smoke-test-marker.skip
+++ b/source/isaaclab_tasks/changelog.d/mataylor-smoke-test-marker.skip
@@ -1,0 +1,2 @@
+Test-only: tag the contrib environments smoke test with the shared ``smoke``
+pytest marker.

--- a/source/isaaclab_tasks/test/contrib/test_contrib_environments_smoke.py
+++ b/source/isaaclab_tasks/test/contrib/test_contrib_environments_smoke.py
@@ -37,6 +37,7 @@ import isaaclab_tasks  # noqa: F401
 from env_test_utils import _run_environments, setup_environment  # isort: skip
 
 
+@pytest.mark.smoke
 @pytest.mark.parametrize("num_envs, device", [(2, "cuda")])
 @pytest.mark.parametrize(
     "task_name",


### PR DESCRIPTION
# Description

Adds the smoke test marker for annotating smoke tests which should always be run in the pipeline

- Register a shared `smoke` pytest marker in the install-CI `pytest.ini` and `conftest.py`.
- Tag existing installation, contrib-environment, and rigid/deformable coupling smoke tests with `@pytest.mark.smoke`.
- Lets core installation, task, and RL smoke functionality checks be selected as a group via `-m smoke`.

Tests named with `_smoke` have been marked:

Other tests can be marked respectively if they should be classified as smoke.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
