### PR TITLE
Run OV test jobs on fork PRs without the OVPhysX wheelhouse

### DIFF
--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -41,6 +41,12 @@ inputs:
       skipped. Combines with filter-pattern (include + exclude).
     default: ''
     required: false
+  test-k-expr:
+    description: >-
+      Global pytest -k expression applied inside every per-file pytest run
+      spawned by tools/conftest.py (combined with device-split selectors).
+    default: ''
+    required: false
   shard-index:
     description: 'Zero-based shard index'
     default: ''
@@ -286,6 +292,7 @@ runs:
         pytest-options: ${{ inputs.pytest-options }}
         filter-pattern: ${{ inputs.filter-pattern }}
         exclude-pattern: ${{ inputs.exclude-pattern }}
+        test-k-expr: ${{ inputs.test-k-expr }}
         shard-index: ${{ inputs.shard-index }}
         shard-count: ${{ inputs.shard-count }}
         curobo-only: ${{ inputs.curobo-only }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -94,6 +94,11 @@ runs:
   steps:
     - name: Run Tests in Docker Container
       shell: bash
+      env:
+        # Passed via env instead of inline ${{ }} interpolation: pytest options may
+        # contain spaces and quotes (e.g. -k "not ovphysx"), which would word-split
+        # the run_tests positional arguments if substituted textually.
+        PYTEST_OPTIONS: ${{ inputs.pytest-options }}
       run: |
         # Function to run tests in Docker container
         run_tests() {
@@ -491,7 +496,7 @@ runs:
         }
 
         # Call the function with provided parameters
-        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "${{ inputs.pytest-options }}" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.test-node-ids-file }}" "${{ inputs.test-node-ids-key }}" "${{ inputs.wheelhouse-host-dir }}" "${{ inputs.wheelhouse-packages }}"
+        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "$PYTEST_OPTIONS" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.test-node-ids-file }}" "${{ inputs.test-node-ids-key }}" "${{ inputs.wheelhouse-host-dir }}" "${{ inputs.wheelhouse-packages }}"
 
     - name: Kill container on cancellation
       if: cancelled()

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -41,6 +41,14 @@ inputs:
       excluded. Combines with filter-pattern (include + exclude).
     default: ''
     required: false
+  test-k-expr:
+    description: >-
+      Global pytest -k expression applied inside every per-file pytest run
+      spawned by tools/conftest.py (combined with device-split selectors).
+      Unlike pytest-options, this reaches the individual test processes, so it
+      can deselect parametrized cases (e.g. "not ovphysx").
+    default: ''
+    required: false
   curobo-only:
     description: 'Run only cuRobo and SkillGen tests (requires the cuRobo Docker image)'
     default: 'false'
@@ -99,6 +107,7 @@ runs:
         # contain spaces and quotes (e.g. -k "not ovphysx"), which would word-split
         # the run_tests positional arguments if substituted textually.
         PYTEST_OPTIONS: ${{ inputs.pytest-options }}
+        TEST_K_EXPR_INPUT: ${{ inputs.test-k-expr }}
       run: |
         # Function to run tests in Docker container
         run_tests() {
@@ -121,6 +130,7 @@ runs:
           local test_node_ids_key="${17}"
           local wheelhouse_host_dir="${18}"
           local wheelhouse_packages="${19}"
+          local test_k_expr="${20}"
           local logs_pid=""
           local wait_pid=""
           local docker_wait_file="/tmp/.docker_exit_${container_name}"
@@ -261,6 +271,12 @@ runs:
           if [ -n "$extra_pip_packages" ]; then
             export TEST_EXTRA_PIP_PACKAGES="$extra_pip_packages"
             docker_env_vars="$docker_env_vars -e TEST_EXTRA_PIP_PACKAGES"
+          fi
+
+          if [ -n "$test_k_expr" ]; then
+            export TEST_K_EXPR="$test_k_expr"
+            docker_env_vars="$docker_env_vars -e TEST_K_EXPR"
+            echo "Setting per-file pytest -k expression: $test_k_expr"
           fi
 
           # Volume mount for deps-cache-hit mode: bind-mount the checked-out
@@ -496,7 +512,7 @@ runs:
         }
 
         # Call the function with provided parameters
-        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "$PYTEST_OPTIONS" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.test-node-ids-file }}" "${{ inputs.test-node-ids-key }}" "${{ inputs.wheelhouse-host-dir }}" "${{ inputs.wheelhouse-packages }}"
+        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "$PYTEST_OPTIONS" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.test-node-ids-file }}" "${{ inputs.test-node-ids-key }}" "${{ inputs.wheelhouse-host-dir }}" "${{ inputs.wheelhouse-packages }}" "$TEST_K_EXPR_INPUT"
 
     - name: Kill container on cancellation
       if: cancelled()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -795,7 +795,7 @@ jobs:
         # ovphysx-backed test params require ovphysx >= 0.5.1, which is only available
         # from the NGC wheelhouse; untrusted runs (fork PRs) fall back to the public pip
         # index and keep the newton/ovrtx kitless rendering coverage.
-        pytest-options: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && '' || '-k "not ovphysx"' }}
+        test-k-expr: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && '' || 'not ovphysx' }}
         extra-pip-packages: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && 'ovrtx' || 'ovrtx ovphysx' }}
         wheelhouse-resource: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && needs.config.outputs.ovphysx_wheelhouse_resource || '' }}
         wheelhouse-packages: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && 'ovphysx' || '' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -778,14 +778,7 @@ jobs:
     timeout-minutes: 120
     continue-on-error: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     needs: [build, config]
-    # The kitless matrix is predominantly ovphysx-backed and requires ovphysx >= 0.5.1
-    # (NGC wheelhouse only), so this job cannot run meaningfully on fork PRs until the
-    # wheel is published to the public pip index.
-    if: >-
-      needs.build.result == 'success' &&
-      (needs.config.outputs.ovphysx_wheelhouse_resource == '' ||
-       (github.event_name == 'pull_request' && github.base_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) ||
-       (github.event_name != 'pull_request' && github.ref_name == 'develop'))
+    if: needs.build.result == 'success'
     env:
       USE_OVPHYSX_WHEELHOUSE: ${{ needs.config.outputs.ovphysx_wheelhouse_resource != '' && ((github.event_name == 'pull_request' && github.base_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name != 'pull_request' && github.ref_name == 'develop')) }}
     steps:
@@ -799,6 +792,10 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_tasks"
+        # ovphysx-backed test params require ovphysx >= 0.5.1, which is only available
+        # from the NGC wheelhouse; untrusted runs (fork PRs) fall back to the public pip
+        # index and keep the newton/ovrtx kitless rendering coverage.
+        pytest-options: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && '' || '-k "not ovphysx"' }}
         extra-pip-packages: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && 'ovrtx' || 'ovrtx ovphysx' }}
         wheelhouse-resource: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && needs.config.outputs.ovphysx_wheelhouse_resource || '' }}
         wheelhouse-packages: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && 'ovphysx' || '' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -596,10 +596,7 @@ jobs:
     needs: [build, config]
     if: >-
       github.event_name != 'push' &&
-      needs.build.result == 'success' &&
-      (needs.config.outputs.ovphysx_wheelhouse_resource == '' ||
-       (github.event_name == 'pull_request' && github.base_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) ||
-       (github.event_name != 'pull_request' && github.ref_name == 'develop'))
+      needs.build.result == 'success'
     env:
       USE_OVPHYSX_WHEELHOUSE: ${{ needs.config.outputs.ovphysx_wheelhouse_resource != '' && ((github.event_name == 'pull_request' && github.base_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name != 'pull_request' && github.ref_name == 'develop')) }}
     steps:
@@ -777,11 +774,7 @@ jobs:
     timeout-minutes: 120
     continue-on-error: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     needs: [build, config]
-    if: >-
-      needs.build.result == 'success' &&
-      (needs.config.outputs.ovphysx_wheelhouse_resource == '' ||
-       (github.event_name == 'pull_request' && github.base_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) ||
-       (github.event_name != 'pull_request' && github.ref_name == 'develop'))
+    if: needs.build.result == 'success'
     env:
       USE_OVPHYSX_WHEELHOUSE: ${{ needs.config.outputs.ovphysx_wheelhouse_resource != '' && ((github.event_name == 'pull_request' && github.base_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name != 'pull_request' && github.ref_name == 'develop')) }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -610,6 +610,10 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_ov"
+        # isaaclab_ovphysx requires ovphysx >= 0.5.1, which is only available from the
+        # NGC wheelhouse; untrusted runs (fork PRs) fall back to the public pip index
+        # and keep only the ovrtx-based isaaclab_ov coverage.
+        exclude-pattern: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && '' || 'isaaclab_ovphysx' }}
         extra-pip-packages: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && 'ovrtx' || 'ovrtx ovphysx' }}
         wheelhouse-resource: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && needs.config.outputs.ovphysx_wheelhouse_resource || '' }}
         wheelhouse-packages: ${{ env.USE_OVPHYSX_WHEELHOUSE == 'true' && 'ovphysx' || '' }}
@@ -774,7 +778,14 @@ jobs:
     timeout-minutes: 120
     continue-on-error: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     needs: [build, config]
-    if: needs.build.result == 'success'
+    # The kitless matrix is predominantly ovphysx-backed and requires ovphysx >= 0.5.1
+    # (NGC wheelhouse only), so this job cannot run meaningfully on fork PRs until the
+    # wheel is published to the public pip index.
+    if: >-
+      needs.build.result == 'success' &&
+      (needs.config.outputs.ovphysx_wheelhouse_resource == '' ||
+       (github.event_name == 'pull_request' && github.base_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) ||
+       (github.event_name != 'pull_request' && github.ref_name == 'develop'))
     env:
       USE_OVPHYSX_WHEELHOUSE: ${{ needs.config.outputs.ovphysx_wheelhouse_resource != '' && ((github.event_name == 'pull_request' && github.base_ref == 'develop' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name != 'pull_request' && github.ref_name == 'develop')) }}
     steps:

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -738,6 +738,9 @@ def run_individual_tests(test_files, workspace_root, isaacsim_ci, test_node_ids_
     xml_reports = []
     cold_cache_applied = False
     test_node_ids_by_file = test_node_ids_by_file or {}
+    global_k_expr = os.environ.get("TEST_K_EXPR", "").strip() or None
+    if global_k_expr is not None:
+        print(f"Applying global pytest -k expression to every test file: '{global_k_expr}'")
 
     for test_file in test_files:
         print(f"\n\n🚀 Running {test_file} independently...\n")
@@ -786,6 +789,8 @@ def run_individual_tests(test_files, workspace_root, isaacsim_ci, test_node_ids_
 
         merged_status: dict | None = None
         for suffix, k_expr in passes:
+            if global_k_expr is not None:
+                k_expr = f"({k_expr}) and ({global_k_expr})" if k_expr else global_k_expr
             report, status, was_failure = _run_one_pass(ctx, k_expr=k_expr, suffix=suffix)
             if report is not None:
                 xml_reports.append(report)


### PR DESCRIPTION
# Description

Since #6314 landed, `test-isaaclab-ov` and `test-rendering-correctness-kitless` are silently skipped on every fork PR: the job-level `if:` conditions require a same-repository PR (or `develop`) whenever `ovphysx_wheelhouse_resource` is configured — which it now always is. Fork contributors and team members working from forks have had zero OVRTX / kitless rendering CI coverage since then, with no visible signal (the jobs just show "skipped").

The NGC trust boundary is correct (the wheelhouse download needs `NGC_API_KEY`, which fork PRs cannot access), and this PR keeps it intact — the `USE_OVPHYSX_WHEELHOUSE` env var from #6314 already resolves trust per run, and the NGC download step is gated on `wheelhouse-resource != ''`, so it never executes without credentials.

This PR's own CI (it is a fork PR, and PR runs use the merge-commit workflow, so it exercises its own fix) established exactly which coverage is recoverable on the public pip stack:

- **All `isaaclab_ov` (ovrtx) tests pass** with pip-index `ovrtx` + `ovphysx` — 0 failures.
- **All 562 `isaaclab_ovphysx` test failures are one error**: `AttributeError: type object 'PhysX' has no attribute 'set_cpu_mode'` — `ovphysx_manager` now requires ovphysx ≥ 0.5.1, which only exists in the NGC wheelhouse; the newest public wheel is 0.4.13.

ovrtx does not depend on ovphysx, so the fallback separates them at the finest granularity each job allows:

- `test-isaaclab-ov` **runs on fork PRs** via the pip fallback with `exclude-pattern: isaaclab_ovphysx` (file-level — the two packages live in separate test trees; the shared `filter-pattern: "isaaclab_ov"` only bundles them by prefix match).
- `test-rendering-correctness-kitless` **runs on fork PRs** with a new `test-k-expr` input that reaches the per-file pytest subprocesses spawned by `tools/conftest.py` (param-level: `not ovphysx` — the golden-image files parametrize physics backends inside each file, so fork runs keep the `newton + ovrtx` combinations and deselect only the ovphysx-backed params).
- Trusted runs (same-repo PRs to `develop`, post-merge `develop`) are byte-for-byte unchanged.

Once ovphysx ≥ 0.5.1 is published to the public pip index, the exclude and the `-k` deselect can both be dropped and fork PRs regain full parity.

cc @AntoineRichard — #6314's description says "Do not merge; this PR exists only for CI validation", so flagging in case the fork-PR skip wasn't meant to reach `develop` in this form at all.

Fixes the coverage gap observed on #6308, where the OVRTX-variant jobs skip on every attempt.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there