### PR TITLE
Synchronize authored Newton particle state

### DIFF
--- a/source/isaaclab_contrib/changelog.d/newton-state-sync.rst
+++ b/source/isaaclab_contrib/changelog.d/newton-state-sync.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Synchronized authored rigid state with coupled Newton solvers and rebased
+  finite-difference history only for selected articulations.

--- a/source/isaaclab_contrib/changelog.d/particle-state-sync.rst
+++ b/source/isaaclab_contrib/changelog.d/particle-state-sync.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed task-authored deformable nodal-state writes to publish exact dirty
+  environments while keeping per-step kinematic targets on the control path.

--- a/source/isaaclab_contrib/isaaclab_contrib/deformable/_state_sync.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/deformable/_state_sync.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""State synchronization helpers for coupled Newton solvers."""
+
+import warp as wp
+from newton import Model, State
+
+
+@wp.kernel(enable_backward=False)
+def _rebase_rigid_body_history(
+    fk_mask: wp.array(dtype=wp.bool),
+    joint_articulation: wp.array(dtype=wp.int32),
+    joint_child: wp.array(dtype=wp.int32),
+    body_q: wp.array(dtype=wp.transformf),
+    body_qd: wp.array(dtype=wp.spatial_vectorf),
+    body_q_prev: wp.array(dtype=wp.transformf),
+    body_qd_prev: wp.array(dtype=wp.spatial_vectorf),
+):
+    """Copy current rigid state into history for authored articulations."""
+    joint = wp.tid()
+    articulation = joint_articulation[joint]
+    if articulation >= 0 and fk_mask[articulation]:
+        body = joint_child[joint]
+        body_q_prev[body] = body_q[body]
+        body_qd_prev[body] = body_qd[body]
+
+
+def rebase_rigid_body_history(model: Model, state: State, state_prev: State, fk_mask: wp.array) -> None:
+    """Rebase coupled finite-difference history after authored rigid state writes."""
+    if model.joint_count:
+        wp.launch(
+            _rebase_rigid_body_history,
+            dim=model.joint_count,
+            inputs=[
+                fk_mask,
+                model.joint_articulation,
+                model.joint_child,
+                state.body_q,
+                state.body_qd,
+            ],
+            outputs=[state_prev.body_q, state_prev.body_qd],
+            device=state.body_q.device,
+        )

--- a/source/isaaclab_contrib/isaaclab_contrib/deformable/coupled_featherstone_vbd_manager.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/deformable/coupled_featherstone_vbd_manager.py
@@ -19,6 +19,7 @@ from newton.solvers import SolverBase, SolverFeatherstone, SolverVBD
 
 from isaaclab.sim.utils.stage import get_current_stage
 
+from ._state_sync import rebase_rigid_body_history
 from .deformable_object import (
     add_deformable_entry_to_builder,
     clear_deformable_builder_hooks,
@@ -42,9 +43,15 @@ class NewtonCoupledFeatherstoneVBDManager(NewtonManager):
     Always uses Newton's :class:`CollisionPipeline` for contact handling.
     """
 
-    _rigid_solver: SolverFeatherstone
-    _soft_solver: SolverVBD
+    _rigid_solver: SolverFeatherstone | None = None
+    _soft_solver: SolverVBD | None = None
     _coupling_mode: str | None = None
+    _gravity_zero: wp.array | None = None
+    _gravity_saved: wp.array | None = None
+    _ke_saved: wp.array | None = None
+    _kd_saved: wp.array | None = None
+    _ke_zero: wp.array | None = None
+    _kd_zero: wp.array | None = None
 
     @classmethod
     def initialize(cls, sim_context: SimulationContext) -> None:
@@ -66,27 +73,23 @@ class NewtonCoupledFeatherstoneVBDManager(NewtonManager):
         super().initialize(sim_context)
 
     @classmethod
-    def step(cls) -> None:
-        """Step the physics simulation."""
-        from isaaclab.physics import PhysicsManager
-
-        sim = PhysicsManager._sim
-        if sim is None or not sim.is_playing():
-            return
-
-        # Notify solver of model changes
-        if cls._model_changes:
-            with wp.ScopedDevice(PhysicsManager._device):
-                for change in cls._model_changes:
-                    cls._rigid_solver.notify_model_changed(change)
-                    cls._soft_solver.notify_model_changed(change)
-                NewtonManager._model_changes = set()
-        super().step()
+    def _owned_solvers(cls) -> tuple[SolverBase, ...]:
+        """Return the initialized rigid and soft solvers."""
+        return tuple(solver for solver in (cls._rigid_solver, cls._soft_solver) if solver is not None)
 
     @classmethod
     def _solver_specific_clear(cls):
         """Clear VBD-specific state."""
         clear_deformable_builder_hooks()
+        cls._rigid_solver = None
+        cls._soft_solver = None
+        cls._coupling_mode = None
+        cls._gravity_zero = None
+        cls._gravity_saved = None
+        cls._ke_saved = None
+        cls._kd_saved = None
+        cls._ke_zero = None
+        cls._kd_zero = None
 
     @classmethod
     def _get_deformable_ignore_paths(cls) -> list[str]:
@@ -107,6 +110,17 @@ class NewtonCoupledFeatherstoneVBDManager(NewtonManager):
             paths.append(entry.sim_mesh_prim_path)
             paths.append(entry.vis_mesh_prim_path)
         return paths
+
+    @classmethod
+    def _synchronize_solver_state(
+        cls,
+        solver: SolverBase,
+        world_reset_mask: wp.array,
+        fk_mask: wp.array,
+    ) -> None:
+        """Rebase coupled rigid history after authored pose or velocity writes."""
+        if solver is cls._rigid_solver:
+            rebase_rigid_body_history(cls._model, cls._state_0, cls._state_1, fk_mask)
 
     @classmethod
     def start_simulation(cls) -> None:
@@ -280,7 +294,8 @@ class NewtonCoupledFeatherstoneVBDManager(NewtonManager):
         kwargs = {k: v for k, v in solver_cfg.soft_solver_cfg.to_dict().items() if k in valid}
         cls._soft_solver = SolverVBD(model, **kwargs)
 
-        # Dummy solver for the newtonmanager
+        # Keep the base lifecycle's required primary slot as a placeholder.
+        # _owned_solvers() exposes the real solvers for model/state work.
         NewtonManager._solver = SolverBase(model)
 
         NewtonManager._use_single_state = False

--- a/source/isaaclab_contrib/isaaclab_contrib/deformable/coupled_mjwarp_vbd_manager.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/deformable/coupled_mjwarp_vbd_manager.py
@@ -19,6 +19,7 @@ from newton.solvers import SolverBase, SolverMuJoCo, SolverVBD
 
 from isaaclab.sim.utils.stage import get_current_stage
 
+from ._state_sync import rebase_rigid_body_history
 from .deformable_object import (
     add_deformable_entry_to_builder,
     clear_deformable_builder_hooks,
@@ -42,8 +43,8 @@ class NewtonCoupledMJWarpVBDManager(NewtonManager):
     Always uses Newton's :class:`CollisionPipeline` for contact handling.
     """
 
-    _rigid_solver: SolverMuJoCo
-    _soft_solver: SolverVBD
+    _rigid_solver: SolverMuJoCo | None = None
+    _soft_solver: SolverVBD | None = None
     _coupling_mode: str | None = None
 
     @classmethod
@@ -66,27 +67,17 @@ class NewtonCoupledMJWarpVBDManager(NewtonManager):
         super().initialize(sim_context)
 
     @classmethod
-    def step(cls) -> None:
-        """Step the physics simulation."""
-        from isaaclab.physics import PhysicsManager
-
-        sim = PhysicsManager._sim
-        if sim is None or not sim.is_playing():
-            return
-
-        # Notify solver of model changes
-        if cls._model_changes:
-            with wp.ScopedDevice(PhysicsManager._device):
-                for change in cls._model_changes:
-                    cls._rigid_solver.notify_model_changed(change)
-                    cls._soft_solver.notify_model_changed(change)
-                NewtonManager._model_changes = set()
-        super().step()
+    def _owned_solvers(cls) -> tuple[SolverBase, ...]:
+        """Return the initialized rigid and soft solvers."""
+        return tuple(solver for solver in (cls._rigid_solver, cls._soft_solver) if solver is not None)
 
     @classmethod
     def _solver_specific_clear(cls):
         """Clear VBD-specific state."""
         clear_deformable_builder_hooks()
+        cls._rigid_solver = None
+        cls._soft_solver = None
+        cls._coupling_mode = None
 
     @classmethod
     def _get_deformable_ignore_paths(cls) -> list[str]:
@@ -272,6 +263,9 @@ class NewtonCoupledMJWarpVBDManager(NewtonManager):
         """
         cls._coupling_mode = solver_cfg.coupling_mode
 
+        if solver_cfg.rigid_solver_cfg.use_mujoco_cpu and model.world_count > 1:
+            raise ValueError("CPU MuJoCo supports only one Newton world. Use MJWarp or run a single world.")
+
         valid = set(inspect.signature(SolverMuJoCo.__init__).parameters) - {"self", "model"}
         kwargs = {k: v for k, v in solver_cfg.rigid_solver_cfg.to_dict().items() if k in valid}
         cls._rigid_solver = SolverMuJoCo(model, **kwargs)
@@ -280,11 +274,41 @@ class NewtonCoupledMJWarpVBDManager(NewtonManager):
         kwargs = {k: v for k, v in solver_cfg.soft_solver_cfg.to_dict().items() if k in valid}
         cls._soft_solver = SolverVBD(model, **kwargs)
 
-        # Dummy solver for the newtonmanager
+        # Keep the base lifecycle's required primary slot as a placeholder.
+        # _owned_solvers() exposes the real solvers for model/state work.
         NewtonManager._solver = SolverBase(model)
 
         NewtonManager._use_single_state = False
         NewtonManager._needs_collision_pipeline = True
+
+    @classmethod
+    def _state_write_graph_safe(cls) -> bool:
+        """CPU MuJoCo performs host transfers and cannot enter a CUDA graph."""
+        return cls._rigid_solver is None or not cls._rigid_solver.use_mujoco_cpu
+
+    @classmethod
+    def _supports_cuda_graph_capture(cls) -> bool:
+        """Require a fully device-side MuJoCo step with fixed per-step state handoff."""
+        return (
+            cls._rigid_solver is not None
+            and not cls._rigid_solver.use_mujoco_cpu
+            and cls._rigid_solver.update_data_interval <= 1
+        )
+
+    @classmethod
+    def _synchronize_solver_state(
+        cls,
+        solver: SolverBase,
+        world_reset_mask: wp.array,
+        fk_mask: wp.array,
+    ) -> None:
+        """Push authored state into the coupled MuJoCo solver when needed."""
+        if solver is cls._rigid_solver:
+            rebase_rigid_body_history(cls._model, cls._state_0, cls._state_1, fk_mask)
+            if cls._rigid_solver.update_data_interval != 1:
+                data = cls._rigid_solver.mj_data if cls._rigid_solver.use_mujoco_cpu else cls._rigid_solver.mjw_data
+                if data is not None:
+                    cls._rigid_solver._update_mjc_data(data, cls._model, cls._state_0)
 
     @classmethod
     def _step_solver(

--- a/source/isaaclab_contrib/isaaclab_contrib/deformable/deformable_object.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/deformable/deformable_object.py
@@ -392,6 +392,10 @@ class DeformableObject(BaseDeformableObject):
                 ],
                 device=self.device,
             )
+        self._invalidate_nodal_state_cache()
+        # Kinematic targets are applied as controls every step, not authored
+        # reset state, but rendering still needs to observe their device writes.
+        SimulationManager._mark_particles_dirty()
 
     def update(self, dt: float):
         self._data.update(dt)
@@ -437,6 +441,7 @@ class DeformableObject(BaseDeformableObject):
             )
 
         self._invalidate_nodal_pos_cache()
+        SimulationManager.invalidate_particles(env_ids=env_ids)
 
     def write_nodal_velocity_to_sim_index(
         self,
@@ -475,6 +480,7 @@ class DeformableObject(BaseDeformableObject):
             )
 
         self._invalidate_nodal_vel_cache()
+        SimulationManager.invalidate_particles(env_ids=env_ids)
 
     def write_nodal_kinematic_target_to_sim_index(
         self,
@@ -551,6 +557,7 @@ class DeformableObject(BaseDeformableObject):
             )
 
         self._invalidate_nodal_state_cache()
+        SimulationManager.invalidate_particles(env_mask=env_mask)
 
     def write_nodal_pos_to_sim_mask(
         self,
@@ -582,6 +589,7 @@ class DeformableObject(BaseDeformableObject):
             )
 
         self._invalidate_nodal_pos_cache()
+        SimulationManager.invalidate_particles(env_mask=env_mask)
 
     def write_nodal_velocity_to_sim_mask(
         self,
@@ -613,6 +621,7 @@ class DeformableObject(BaseDeformableObject):
             )
 
         self._invalidate_nodal_vel_cache()
+        SimulationManager.invalidate_particles(env_mask=env_mask)
 
     def write_nodal_kinematic_target_to_sim_mask(
         self,

--- a/source/isaaclab_contrib/test/deformable/test_coupled_manager_state_sync.py
+++ b/source/isaaclab_contrib/test/deformable/test_coupled_manager_state_sync.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for coupled Newton manager solver ownership and state synchronization."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import warp as wp
+from isaaclab_newton.physics import NewtonCfg, NewtonManager
+
+from isaaclab.physics import PhysicsManager
+
+from isaaclab_contrib.deformable import (
+    CoupledFeatherstoneVBDSolverCfg,
+    CoupledMJWarpVBDSolverCfg,
+)
+from isaaclab_contrib.deformable import coupled_featherstone_vbd_manager as featherstone_module
+from isaaclab_contrib.deformable import coupled_mjwarp_vbd_manager as mjwarp_module
+from isaaclab_contrib.deformable._state_sync import rebase_rigid_body_history
+from isaaclab_contrib.deformable.coupled_featherstone_vbd_manager import NewtonCoupledFeatherstoneVBDManager
+from isaaclab_contrib.deformable.coupled_mjwarp_vbd_manager import NewtonCoupledMJWarpVBDManager
+
+
+class _SolverRecorder:
+    """Minimal solver that records model notifications."""
+
+    def __init__(self, model=None, **kwargs) -> None:
+        self.model = model
+        self.update_data_interval = 1
+        self.use_mujoco_cpu = False
+        self.notifications: list[int] = []
+
+    def notify_model_changed(self, flags: int) -> None:
+        self.notifications.append(flags)
+
+
+@pytest.mark.parametrize(
+    "manager",
+    [NewtonCoupledMJWarpVBDManager, NewtonCoupledFeatherstoneVBDManager],
+)
+def test_coupled_state_sync_fans_out_to_both_real_solvers(monkeypatch, manager):
+    """The placeholder/primary slot never swallows coupled notifications or state sync."""
+    rigid = _SolverRecorder()
+    soft = _SolverRecorder()
+    state = object()
+    world_mask = object()
+    module = mjwarp_module if manager is NewtonCoupledMJWarpVBDManager else featherstone_module
+    monkeypatch.setattr(module, "rebase_rigid_body_history", lambda model, current, previous, fk_mask: None)
+    monkeypatch.setattr(manager, "_rigid_solver", rigid, raising=False)
+    monkeypatch.setattr(manager, "_soft_solver", soft, raising=False)
+    monkeypatch.setattr(manager, "_state_0", state, raising=False)
+    monkeypatch.setattr(manager, "_state_1", object(), raising=False)
+    monkeypatch.setattr(manager, "_model", object(), raising=False)
+    monkeypatch.setattr(manager, "_eval_fk_impl", classmethod(lambda cls, worlds, articulations: None))
+    monkeypatch.setattr(NewtonManager, "_model_changes", {1, 4}, raising=False)
+    monkeypatch.setattr(PhysicsManager, "_cfg", NewtonCfg(), raising=False)
+    monkeypatch.setattr(PhysicsManager, "_device", "cpu", raising=False)
+
+    manager._notify_solver_model_changes()
+    manager._apply_state_writes(world_mask, object())
+
+    assert sorted(rigid.notifications) == [1, 4]
+    assert sorted(soft.notifications) == [1, 4]
+
+
+def test_coupled_history_rebases_only_worlds_with_rigid_writes():
+    """A reset teleport cannot become finite-difference velocity on the next substep."""
+    model = SimpleNamespace(
+        joint_count=2,
+        joint_articulation=wp.array([0, 1], dtype=wp.int32, device="cpu"),
+        joint_child=wp.array([0, 1], dtype=wp.int32, device="cpu"),
+    )
+    state = SimpleNamespace(
+        body_q=wp.array(
+            [(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0), (2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)],
+            dtype=wp.transformf,
+            device="cpu",
+        ),
+        body_qd=wp.array(
+            [(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), (6.0, 5.0, 4.0, 3.0, 2.0, 1.0)],
+            dtype=wp.spatial_vectorf,
+            device="cpu",
+        ),
+    )
+    state_prev = SimpleNamespace(
+        body_q=wp.array(
+            [(-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0), (-2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)],
+            dtype=wp.transformf,
+            device="cpu",
+        ),
+        body_qd=wp.zeros(2, dtype=wp.spatial_vectorf, device="cpu"),
+    )
+    fk_mask = wp.array([False, True], dtype=wp.bool, device="cpu")
+
+    rebase_rigid_body_history(model, state, state_prev, fk_mask)
+
+    assert state_prev.body_q.numpy()[:, 0].tolist() == [-1.0, 2.0]
+    assert state_prev.body_qd.numpy().tolist() == [[0.0] * 6, [6.0, 5.0, 4.0, 3.0, 2.0, 1.0]]
+
+
+def test_coupled_history_rebases_global_free_body():
+    """Global rigid bodies are selected by articulation rather than world ownership."""
+    model = SimpleNamespace(
+        joint_count=1,
+        joint_articulation=wp.array([0], dtype=wp.int32, device="cpu"),
+        joint_child=wp.array([0], dtype=wp.int32, device="cpu"),
+    )
+    state = SimpleNamespace(
+        body_q=wp.array([(3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)], dtype=wp.transformf, device="cpu"),
+        body_qd=wp.array([(1.0, 2.0, 3.0, 4.0, 5.0, 6.0)], dtype=wp.spatial_vectorf, device="cpu"),
+    )
+    state_prev = SimpleNamespace(
+        body_q=wp.array([(-3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)], dtype=wp.transformf, device="cpu"),
+        body_qd=wp.zeros(1, dtype=wp.spatial_vectorf, device="cpu"),
+    )
+
+    rebase_rigid_body_history(model, state, state_prev, wp.array([True], dtype=wp.bool, device="cpu"))
+
+    assert state_prev.body_q.numpy()[0, 0] == 3.0
+    assert state_prev.body_qd.numpy()[0].tolist() == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+@pytest.mark.parametrize(
+    ("manager", "module", "cfg"),
+    [
+        (
+            NewtonCoupledMJWarpVBDManager,
+            mjwarp_module,
+            CoupledMJWarpVBDSolverCfg(coupling_mode="one_way"),
+        ),
+        (
+            NewtonCoupledFeatherstoneVBDManager,
+            featherstone_module,
+            CoupledFeatherstoneVBDSolverCfg(coupling_mode="one_way"),
+        ),
+    ],
+)
+def test_coupled_build_keeps_contact_placeholder_out_of_owned_solvers(monkeypatch, manager, module, cfg):
+    """Contact plumbing keeps its placeholder while state work reaches real solvers."""
+    rigid_name = "SolverMuJoCo" if manager is NewtonCoupledMJWarpVBDManager else "SolverFeatherstone"
+    monkeypatch.setattr(module, rigid_name, _SolverRecorder)
+    monkeypatch.setattr(module, "SolverVBD", _SolverRecorder)
+    monkeypatch.setattr(module, "SolverBase", _SolverRecorder)
+    monkeypatch.setattr(PhysicsManager, "_cfg", NewtonCfg(), raising=False)
+    monkeypatch.setattr(NewtonManager, "_solver", None, raising=False)
+
+    manager._build_solver(SimpleNamespace(world_count=1), cfg)
+
+    assert NewtonManager._solver is not manager._rigid_solver
+    assert NewtonManager._solver not in manager._owned_solvers()
+    assert manager._owned_solvers() == (manager._rigid_solver, manager._soft_solver)
+
+
+def test_coupled_featherstone_clear_releases_kinematic_buffers(monkeypatch):
+    """Full teardown releases every coupled Featherstone device-buffer reference."""
+    sentinel = object()
+    monkeypatch.setattr(featherstone_module, "clear_deformable_builder_hooks", lambda: None)
+    for name in ("_gravity_zero", "_gravity_saved", "_ke_saved", "_kd_saved", "_ke_zero", "_kd_zero"):
+        monkeypatch.setattr(NewtonCoupledFeatherstoneVBDManager, name, sentinel, raising=False)
+
+    NewtonCoupledFeatherstoneVBDManager._solver_specific_clear()
+
+    for name in ("_gravity_zero", "_gravity_saved", "_ke_saved", "_kd_saved", "_ke_zero", "_kd_zero"):
+        assert getattr(NewtonCoupledFeatherstoneVBDManager, name) is None
+
+
+@pytest.mark.parametrize(
+    ("use_mujoco_cpu", "update_data_interval", "expected"),
+    [(True, 1, False), (False, 2, False), (False, 1, True), (False, 0, True)],
+)
+def test_coupled_mujoco_main_graph_requires_device_per_step_handoff(
+    monkeypatch, use_mujoco_cpu, update_data_interval, expected
+):
+    """Coupled MuJoCo preserves Python cadence by staying eager when required."""
+    solver = SimpleNamespace(use_mujoco_cpu=use_mujoco_cpu, update_data_interval=update_data_interval)
+    monkeypatch.setattr(NewtonCoupledMJWarpVBDManager, "_rigid_solver", solver, raising=False)
+
+    assert NewtonCoupledMJWarpVBDManager._supports_cuda_graph_capture() is expected

--- a/source/isaaclab_contrib/test/deformable/test_deformable_particle_state.py
+++ b/source/isaaclab_contrib/test/deformable/test_deformable_particle_state.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for task-authored contrib deformable particle state."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from isaaclab_newton.physics import NewtonManager
+
+from isaaclab_contrib.deformable import deformable_object as deformable_object_module
+from isaaclab_contrib.deformable.deformable_object import DeformableObject
+
+
+class _DeformableObjectUnderTest(DeformableObject):
+    """Deformable object with teardown disabled for lightweight method tests."""
+
+    def __del__(self) -> None:
+        pass
+
+
+def _make_deformable(monkeypatch) -> DeformableObject:
+    asset = object.__new__(_DeformableObjectUnderTest)
+    asset._device = "cpu"
+    asset._num_instances = 3
+    asset._particles_per_body = 1
+    asset._particle_offsets = object()
+    asset._ALL_INDICES = object()
+    asset._ALL_ENV_MASK = object()
+    asset._data = SimpleNamespace(
+        _nodal_pos_w=SimpleNamespace(timestamp=1.0),
+        _nodal_vel_w=SimpleNamespace(timestamp=1.0),
+        _nodal_state_w=SimpleNamespace(timestamp=1.0),
+        _root_pos_w=SimpleNamespace(timestamp=1.0),
+        _root_vel_w=SimpleNamespace(timestamp=1.0),
+    )
+    state = SimpleNamespace(particle_q=object(), particle_qd=object())
+    monkeypatch.setattr(asset, "_iter_particle_states", lambda: iter((state,)))
+    monkeypatch.setattr(asset, "assert_shape_and_dtype", lambda *args, **kwargs: None)
+    monkeypatch.setattr(deformable_object_module.wp, "launch", lambda *args, **kwargs: None)
+    return asset
+
+
+@pytest.mark.parametrize(
+    ("method_name", "selector_name"),
+    [
+        ("write_nodal_pos_to_sim_index", "env_ids"),
+        ("write_nodal_velocity_to_sim_index", "env_ids"),
+        ("write_nodal_state_to_sim_mask", "env_mask"),
+        ("write_nodal_pos_to_sim_mask", "env_mask"),
+        ("write_nodal_velocity_to_sim_mask", "env_mask"),
+    ],
+)
+def test_deformable_writers_publish_the_resolved_selection(monkeypatch, method_name, selector_name):
+    """Every concrete deformable state writer publishes its resolved selector."""
+    asset = _make_deformable(monkeypatch)
+    caller_selection = object()
+    resolved_selection = SimpleNamespace(shape=(3,))
+    calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(asset, "_resolve_env_ids", lambda value: resolved_selection)
+    monkeypatch.setattr(asset, "_resolve_mask", lambda value, full_mask: resolved_selection)
+    monkeypatch.setattr(
+        NewtonManager,
+        "invalidate_particles",
+        classmethod(lambda cls, **kwargs: calls.append(kwargs)),
+    )
+
+    getattr(asset, method_name)(object(), **{selector_name: caller_selection})
+
+    assert calls == [{selector_name: resolved_selection}]
+
+
+def test_kinematic_control_dirties_caches_and_render_without_publishing_reset_state(monkeypatch):
+    """Per-step kinematic controls cannot trigger the authored-state reset policy."""
+    asset = _make_deformable(monkeypatch)
+    asset._data.nodal_kinematic_target = SimpleNamespace(warp=object())
+    asset._default_particle_inv_mass = object()
+    asset._default_particle_flags = object()
+    model = SimpleNamespace(particle_inv_mass=object(), particle_flags=object())
+    events: list[str] = []
+
+    monkeypatch.setattr(NewtonManager, "get_model", classmethod(lambda cls: model))
+    monkeypatch.setattr(NewtonManager, "_mark_particles_dirty", classmethod(lambda cls: events.append("render")))
+    monkeypatch.setattr(
+        NewtonManager,
+        "invalidate_particles",
+        classmethod(lambda cls, **kwargs: events.append("authored")),
+    )
+    monkeypatch.setattr(asset, "_invalidate_nodal_state_cache", lambda: events.append("cache"))
+
+    asset.write_data_to_sim()
+
+    assert events == ["cache", "render"]

--- a/source/isaaclab_newton/changelog.d/particle-state-sync.rst
+++ b/source/isaaclab_newton/changelog.d/particle-state-sync.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed task-authored MPM particle-state writes to publish the exact dirty
+  environments and keep particle rendering current after CUDA graph replay.

--- a/source/isaaclab_newton/changelog.d/solver-reset.minor.rst
+++ b/source/isaaclab_newton/changelog.d/solver-reset.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_newton.physics.NewtonCfg.solver_reset` to clear
+  solver-owned state after task-authored environment writes. The option is
+  disabled by default and preserves authored positions and velocities.

--- a/source/isaaclab_newton/changelog.d/state-boundaries.rst
+++ b/source/isaaclab_newton/changelog.d/state-boundaries.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Ensured rigid state writes are published even when asset cache invalidation
+  is skipped, and direct body-state readers flush pending synchronization.

--- a/source/isaaclab_newton/changelog.d/state-pipeline.rst
+++ b/source/isaaclab_newton/changelog.d/state-pipeline.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Unified task-authored rigid-state reconciliation so forward kinematics and
+  solver-specific state are synchronized before the next step or coherent read.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -518,8 +518,7 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of the pose related properties.
-        if not skip_forward:
-            self.data._reset_pose(env_ids=env_ids)
+        self.data._reset_pose(env_ids=env_ids, invalidate_cache=not skip_forward)
 
     def write_root_link_pose_to_sim_mask(
         self,
@@ -565,8 +564,7 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of the pose related properties.
-        if not skip_forward:
-            self.data._reset_pose(env_mask=env_mask)
+        self.data._reset_pose(env_mask=env_mask, invalidate_cache=not skip_forward)
 
     def write_root_com_pose_to_sim_index(
         self,
@@ -619,8 +617,7 @@ class Articulation(BaseArticulation):
         )
         # Let the data class handle the invalidation of the pose related properties.
         # The com pose was just written, so it must not be invalidated.
-        if not skip_forward:
-            self.data._reset_pose(env_ids=env_ids, from_link=False)
+        self.data._reset_pose(env_ids=env_ids, from_link=False, invalidate_cache=not skip_forward)
 
     def write_root_com_pose_to_sim_mask(
         self,
@@ -669,8 +666,7 @@ class Articulation(BaseArticulation):
         )
         # Let the data class handle the invalidation of the pose related properties.
         # The com pose was just written, so it must not be invalidated.
-        if not skip_forward:
-            self.data._reset_pose(env_mask=env_mask, from_link=False)
+        self.data._reset_pose(env_mask=env_mask, from_link=False, invalidate_cache=not skip_forward)
 
     def write_root_velocity_to_sim_index(
         self,
@@ -789,8 +785,7 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of the velocity related properties.
-        if not skip_forward:
-            self.data._reset_velocity(env_ids=env_ids)
+        self.data._reset_velocity(env_ids=env_ids, invalidate_cache=not skip_forward)
 
     def write_root_com_velocity_to_sim_mask(
         self,
@@ -840,8 +835,7 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of the velocity related properties.
-        if not skip_forward:
-            self.data._reset_velocity(env_mask=env_mask)
+        self.data._reset_velocity(env_mask=env_mask, invalidate_cache=not skip_forward)
 
     def write_root_link_velocity_to_sim_index(
         self,
@@ -898,8 +892,7 @@ class Articulation(BaseArticulation):
         )
         # Let the data class handle the invalidation of the velocity related properties.
         # The link velocity was just written, so it must not be invalidated.
-        if not skip_forward:
-            self.data._reset_velocity(env_ids=env_ids, from_com=False)
+        self.data._reset_velocity(env_ids=env_ids, from_com=False, invalidate_cache=not skip_forward)
 
     def write_root_link_velocity_to_sim_mask(
         self,
@@ -953,8 +946,7 @@ class Articulation(BaseArticulation):
         )
         # Let the data class handle the invalidation of the velocity related properties.
         # The link velocity was just written, so it must not be invalidated.
-        if not skip_forward:
-            self.data._reset_velocity(env_mask=env_mask, from_com=False)
+        self.data._reset_velocity(env_mask=env_mask, from_com=False, invalidate_cache=not skip_forward)
 
     def write_joint_state_to_sim_index(
         self,
@@ -1007,9 +999,8 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of the pose and velocity related properties.
-        if not skip_forward:
-            self.data._reset_pose(env_ids=env_ids)
-            self.data._reset_velocity(env_ids=env_ids)
+        self.data._reset_pose(env_ids=env_ids, invalidate_cache=not skip_forward)
+        self.data._reset_velocity(env_ids=env_ids, invalidate_cache=not skip_forward)
 
     def write_joint_state_to_sim_mask(
         self,
@@ -1062,9 +1053,8 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of the pose and velocity related properties.
-        if not skip_forward:
-            self.data._reset_pose(env_mask=env_mask)
-            self.data._reset_velocity(env_mask=env_mask)
+        self.data._reset_pose(env_mask=env_mask, invalidate_cache=not skip_forward)
+        self.data._reset_velocity(env_mask=env_mask, invalidate_cache=not skip_forward)
 
     def write_joint_position_to_sim_index(
         self,
@@ -1112,9 +1102,8 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of pose- and velocity-dependent properties.
-        if not skip_forward:
-            self.data._reset_pose(env_ids=env_ids)
-            self.data._reset_velocity(env_ids=env_ids)
+        self.data._reset_pose(env_ids=env_ids, invalidate_cache=not skip_forward)
+        self.data._reset_velocity(env_ids=env_ids, invalidate_cache=not skip_forward)
 
     def write_joint_position_to_sim_mask(
         self,
@@ -1160,9 +1149,8 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of pose- and velocity-dependent properties.
-        if not skip_forward:
-            self.data._reset_pose(env_mask=env_mask)
-            self.data._reset_velocity(env_mask=env_mask)
+        self.data._reset_pose(env_mask=env_mask, invalidate_cache=not skip_forward)
+        self.data._reset_velocity(env_mask=env_mask, invalidate_cache=not skip_forward)
 
     def write_joint_velocity_to_sim_index(
         self,
@@ -1212,8 +1200,7 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of the velocity related properties.
-        if not skip_forward:
-            self.data._reset_velocity(env_ids=env_ids)
+        self.data._reset_velocity(env_ids=env_ids, invalidate_cache=not skip_forward)
 
     def write_joint_velocity_to_sim_mask(
         self,
@@ -1261,8 +1248,7 @@ class Articulation(BaseArticulation):
             device=self.device,
         )
         # Let the data class handle the invalidation of the velocity related properties.
-        if not skip_forward:
-            self.data._reset_velocity(env_mask=env_mask)
+        self.data._reset_velocity(env_mask=env_mask, invalidate_cache=not skip_forward)
 
     """
     Operations - Simulation Parameters Writers.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -137,7 +137,12 @@ class ArticulationData(BaseArticulationData):
             self._fk_timestamp = self._sim_timestamp
 
     def _reset_pose(
-        self, from_link: bool = True, *, env_ids: wp.array | None = None, env_mask: wp.array | None = None
+        self,
+        from_link: bool = True,
+        *,
+        env_ids: wp.array | None = None,
+        env_mask: wp.array | None = None,
+        invalidate_cache: bool = True,
     ) -> None:
         """Reset the pose of the articulation.
 
@@ -149,32 +154,37 @@ class ArticulationData(BaseArticulationData):
             from_link: Set ``True`` when the root link pose was written so the derived root
                 center-of-mass pose (:attr:`root_com_pose_w`) is also invalidated; set ``False`` when
                 the center-of-mass pose was written directly so it is not clobbered. Defaults to True.
+            invalidate_cache: Whether to invalidate derived asset data. Solver synchronization is
+                published regardless. Defaults to True.
         """
-        # Invalidate the derived root com pose only when it was not the quantity just written.
-        reset_timestamps(
-            [
-                self._root_com_pose_w if from_link else None,
-                self._body_com_pose_w,
-                # root states
-                self._root_state_w,
-                self._root_link_state_w,
-                self._root_com_state_w,
-                # body com states
-                self._body_state_w,
-                self._body_link_state_w,
-                self._body_com_state_w,
-            ]
-        )
-        # NOTE: _fk_timestamp and invalidate_fk serve two distinct roles. _fk_timestamp is on the
-        # data side and forces a refresh on the next outdated read. invalidate_fk is on the
-        # simulation-manager side and lets the solver know state changed before its next step.
-        self._fk_timestamp = -1.0
+        if invalidate_cache:
+            # Invalidate the derived root com pose only when it was not the quantity just written.
+            reset_timestamps(
+                [
+                    self._root_com_pose_w if from_link else None,
+                    self._body_com_pose_w,
+                    # root states
+                    self._root_state_w,
+                    self._root_link_state_w,
+                    self._root_com_state_w,
+                    # body com states
+                    self._body_state_w,
+                    self._body_link_state_w,
+                    self._body_com_state_w,
+                ]
+            )
+            self._fk_timestamp = -1.0
         SimulationManager.invalidate_fk(
             env_mask=env_mask, env_ids=env_ids, articulation_ids=self._root_view.articulation_ids
         )
 
     def _reset_velocity(
-        self, from_com: bool = True, *, env_ids: wp.array | None = None, env_mask: wp.array | None = None
+        self,
+        from_com: bool = True,
+        *,
+        env_ids: wp.array | None = None,
+        env_mask: wp.array | None = None,
+        invalidate_cache: bool = True,
     ) -> None:
         """Reset the velocity of the articulation.
 
@@ -186,26 +196,26 @@ class ArticulationData(BaseArticulationData):
             from_com: Set ``True`` when the root center-of-mass velocity was written so the derived root
                 link velocity (:attr:`root_link_vel_w`) is also invalidated; set ``False`` when the link
                 velocity was written directly so it is not clobbered. Defaults to True.
+            invalidate_cache: Whether to invalidate derived asset data. Solver synchronization is
+                published regardless. Defaults to True.
         """
-        # Invalidate the derived root link velocity only when it was not the quantity just written.
-        reset_timestamps(
-            [
-                self._root_link_vel_w if from_com else None,
-                self._body_link_vel_w,
-                # root states
-                self._root_state_w,
-                self._root_link_state_w,
-                self._root_com_state_w,
-                # body com states
-                self._body_state_w,
-                self._body_link_state_w,
-                self._body_com_state_w,
-            ]
-        )
-        # NOTE: _fk_timestamp and invalidate_fk serve two distinct roles. _fk_timestamp is on the
-        # data side and forces a refresh on the next outdated read. invalidate_fk is on the
-        # simulation-manager side and lets the solver know state changed before its next step.
-        self._fk_timestamp = -1.0
+        if invalidate_cache:
+            # Invalidate the derived root link velocity only when it was not the quantity just written.
+            reset_timestamps(
+                [
+                    self._root_link_vel_w if from_com else None,
+                    self._body_link_vel_w,
+                    # root states
+                    self._root_state_w,
+                    self._root_link_state_w,
+                    self._root_com_state_w,
+                    # body com states
+                    self._body_state_w,
+                    self._body_link_state_w,
+                    self._body_com_state_w,
+                ]
+            )
+            self._fk_timestamp = -1.0
         SimulationManager.invalidate_fk(
             env_mask=env_mask, env_ids=env_ids, articulation_ids=self._root_view.articulation_ids
         )

--- a/source/isaaclab_newton/isaaclab_newton/assets/mpm_object/mpm_object.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/mpm_object/mpm_object.py
@@ -148,7 +148,7 @@ class MPMObject(BaseDeformableObject):
         env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
         full_data: bool = False,
     ) -> None:
-        self._scatter_to_sim_index(
+        env_ids = self._scatter_to_sim_index(
             nodal_state,
             env_ids,
             full_data,
@@ -157,7 +157,7 @@ class MPMObject(BaseDeformableObject):
             ("particle_q", "particle_qd"),
             "nodal_state",
         )
-        self._invalidate_caches(pos=True, vel=True)
+        self._invalidate_caches(pos=True, vel=True, env_ids=env_ids)
 
     def write_nodal_pos_to_sim_index(
         self,
@@ -165,10 +165,10 @@ class MPMObject(BaseDeformableObject):
         env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
         full_data: bool = False,
     ) -> None:
-        self._scatter_to_sim_index(
+        env_ids = self._scatter_to_sim_index(
             nodal_pos, env_ids, full_data, wp.vec3f, scatter_particles_vec3f_index, ("particle_q",), "nodal_pos"
         )
-        self._invalidate_caches(pos=True)
+        self._invalidate_caches(pos=True, env_ids=env_ids)
 
     def write_nodal_velocity_to_sim_index(
         self,
@@ -176,10 +176,10 @@ class MPMObject(BaseDeformableObject):
         env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
         full_data: bool = False,
     ) -> None:
-        self._scatter_to_sim_index(
+        env_ids = self._scatter_to_sim_index(
             nodal_vel, env_ids, full_data, wp.vec3f, scatter_particles_vec3f_index, ("particle_qd",), "nodal_vel"
         )
-        self._invalidate_caches(vel=True)
+        self._invalidate_caches(vel=True, env_ids=env_ids)
 
     def write_nodal_kinematic_target_to_sim_index(
         self,
@@ -194,7 +194,7 @@ class MPMObject(BaseDeformableObject):
         nodal_state: torch.Tensor | wp.array | ProxyArray,
         env_mask: wp.array | torch.Tensor | None = None,
     ) -> None:
-        self._scatter_to_sim_mask(
+        env_mask = self._scatter_to_sim_mask(
             nodal_state,
             env_mask,
             vec6f,
@@ -202,27 +202,27 @@ class MPMObject(BaseDeformableObject):
             ("particle_q", "particle_qd"),
             "nodal_state",
         )
-        self._invalidate_caches(pos=True, vel=True)
+        self._invalidate_caches(pos=True, vel=True, env_mask=env_mask)
 
     def write_nodal_pos_to_sim_mask(
         self,
         nodal_pos: torch.Tensor | wp.array | ProxyArray,
         env_mask: wp.array | torch.Tensor | None = None,
     ) -> None:
-        self._scatter_to_sim_mask(
+        env_mask = self._scatter_to_sim_mask(
             nodal_pos, env_mask, wp.vec3f, scatter_particles_vec3f_mask, ("particle_q",), "nodal_pos"
         )
-        self._invalidate_caches(pos=True)
+        self._invalidate_caches(pos=True, env_mask=env_mask)
 
     def write_nodal_velocity_to_sim_mask(
         self,
         nodal_vel: torch.Tensor | wp.array | ProxyArray,
         env_mask: wp.array | torch.Tensor | None = None,
     ) -> None:
-        self._scatter_to_sim_mask(
+        env_mask = self._scatter_to_sim_mask(
             nodal_vel, env_mask, wp.vec3f, scatter_particles_vec3f_mask, ("particle_qd",), "nodal_vel"
         )
-        self._invalidate_caches(vel=True)
+        self._invalidate_caches(vel=True, env_mask=env_mask)
 
     def write_nodal_kinematic_target_to_sim_mask(
         self,
@@ -238,7 +238,7 @@ class MPMObject(BaseDeformableObject):
     write_particle_pos_to_sim_mask = write_nodal_pos_to_sim_mask
     write_particle_velocity_to_sim_mask = write_nodal_velocity_to_sim_mask
 
-    def _scatter_to_sim_index(self, data, env_ids, full_data: bool, dtype, kernel, targets, name: str) -> None:
+    def _scatter_to_sim_index(self, data, env_ids, full_data: bool, dtype, kernel, targets, name: str) -> wp.array:
         """Scatter per-environment particle data into the Newton state arrays in ``targets``."""
         env_ids = self._resolve_env_ids(env_ids)
         num_rows = self.num_instances if full_data else env_ids.shape[0]
@@ -251,8 +251,9 @@ class MPMObject(BaseDeformableObject):
                 outputs=[getattr(state, target) for target in targets],
                 device=self.device,
             )
+        return env_ids
 
-    def _scatter_to_sim_mask(self, data, env_mask, dtype, kernel, targets, name: str) -> None:
+    def _scatter_to_sim_mask(self, data, env_mask, dtype, kernel, targets, name: str) -> wp.array:
         """Scatter masked per-environment particle data into the Newton state arrays in ``targets``."""
         env_mask = self._resolve_mask(env_mask)
         data = self._as_warp(data, dtype, (env_mask.shape[0], self._particles_per_object), name)
@@ -264,6 +265,7 @@ class MPMObject(BaseDeformableObject):
                 outputs=[getattr(state, target) for target in targets],
                 device=self.device,
             )
+        return env_mask
 
     def _as_warp(self, data, dtype, shape: tuple[int, int], name: str) -> wp.array:
         """Validate user data and return it as a Warp array of ``dtype``."""
@@ -401,8 +403,15 @@ class MPMObject(BaseDeformableObject):
         if state_1 is not None and state_1 is not state_0:
             yield state_1
 
-    def _invalidate_caches(self, pos: bool = False, vel: bool = False) -> None:
-        """Invalidate gathered data buffers after a particle write and flag the render sync."""
+    def _invalidate_caches(
+        self,
+        pos: bool = False,
+        vel: bool = False,
+        *,
+        env_ids: wp.array | None = None,
+        env_mask: wp.array | None = None,
+    ) -> None:
+        """Invalidate gathered data and publish the selected particle-state write."""
         if pos:
             self._data._particle_pos_w.timestamp = -1.0
             self._data._root_pos_w.timestamp = -1.0
@@ -410,7 +419,7 @@ class MPMObject(BaseDeformableObject):
             self._data._particle_vel_w.timestamp = -1.0
             self._data._root_vel_w.timestamp = -1.0
         self._data._particle_state_w.timestamp = -1.0
-        SimulationManager._mark_particles_dirty()
+        SimulationManager.invalidate_particles(env_ids=env_ids, env_mask=env_mask)
 
     def _set_debug_vis_impl(self, debug_vis: bool):
         raise NotImplementedError("Debug visualization is not implemented for MPMObject.")

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
@@ -367,8 +367,7 @@ class RigidObject(BaseRigidObject):
             device=self.device,
         )
         # Let the data class handle the invalidation of pose-dependent properties.
-        if not skip_forward:
-            self.data._reset_pose(env_ids=env_ids)
+        self.data._reset_pose(env_ids=env_ids, invalidate_cache=not skip_forward)
 
     def write_root_link_pose_to_sim_mask(
         self,
@@ -415,8 +414,7 @@ class RigidObject(BaseRigidObject):
             device=self.device,
         )
         # Let the data class handle the invalidation of pose-dependent properties.
-        if not skip_forward:
-            self.data._reset_pose(env_mask=env_mask)
+        self.data._reset_pose(env_mask=env_mask, invalidate_cache=not skip_forward)
 
     def write_root_com_pose_to_sim_index(
         self,
@@ -469,8 +467,7 @@ class RigidObject(BaseRigidObject):
         )
         # Let the data class handle the invalidation of pose-dependent properties.
         # The com pose was just written, so it must not be invalidated.
-        if not skip_forward:
-            self.data._reset_pose(env_ids=env_ids, from_link=False)
+        self.data._reset_pose(env_ids=env_ids, from_link=False, invalidate_cache=not skip_forward)
 
     def write_root_com_pose_to_sim_mask(
         self,
@@ -520,8 +517,7 @@ class RigidObject(BaseRigidObject):
         )
         # Let the data class handle the invalidation of pose-dependent properties.
         # The com pose was just written, so it must not be invalidated.
-        if not skip_forward:
-            self.data._reset_pose(env_mask=env_mask, from_link=False)
+        self.data._reset_pose(env_mask=env_mask, from_link=False, invalidate_cache=not skip_forward)
 
     def write_root_com_velocity_to_sim_index(
         self,
@@ -574,8 +570,7 @@ class RigidObject(BaseRigidObject):
             device=self.device,
         )
         # Let the data class handle the invalidation of velocity-dependent properties.
-        if not skip_forward:
-            self.data._reset_velocity(env_ids=env_ids)
+        self.data._reset_velocity(env_ids=env_ids, invalidate_cache=not skip_forward)
 
     def write_root_com_velocity_to_sim_mask(
         self,
@@ -626,8 +621,7 @@ class RigidObject(BaseRigidObject):
             device=self.device,
         )
         # Let the data class handle the invalidation of velocity-dependent properties.
-        if not skip_forward:
-            self.data._reset_velocity(env_mask=env_mask)
+        self.data._reset_velocity(env_mask=env_mask, invalidate_cache=not skip_forward)
 
     def write_root_link_velocity_to_sim_index(
         self,
@@ -685,8 +679,7 @@ class RigidObject(BaseRigidObject):
         )
         # Let the data class handle the invalidation of velocity-dependent properties.
         # The link velocity was just written, so it must not be invalidated.
-        if not skip_forward:
-            self.data._reset_velocity(env_ids=env_ids, from_com=False)
+        self.data._reset_velocity(env_ids=env_ids, from_com=False, invalidate_cache=not skip_forward)
 
     def write_root_link_velocity_to_sim_mask(
         self,
@@ -741,8 +734,7 @@ class RigidObject(BaseRigidObject):
         )
         # Let the data class handle the invalidation of velocity-dependent properties.
         # The link velocity was just written, so it must not be invalidated.
-        if not skip_forward:
-            self.data._reset_velocity(env_mask=env_mask, from_com=False)
+        self.data._reset_velocity(env_mask=env_mask, from_com=False, invalidate_cache=not skip_forward)
 
     """
     Operations - Setters.

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object_data.py
@@ -145,6 +145,7 @@ class RigidObjectData(BaseRigidObjectData):
         *,
         env_ids: wp.array | torch.Tensor | None = None,
         env_mask: wp.array | None = None,
+        invalidate_cache: bool = True,
     ) -> None:
         """Reset pose-dependent cached rigid object properties.
 
@@ -154,24 +155,32 @@ class RigidObjectData(BaseRigidObjectData):
             from_link: Set ``True`` when the root link pose was written so the derived root
                 center-of-mass pose (:attr:`root_com_pose_w`) is also invalidated; set ``False`` when
                 the center-of-mass pose was written directly so it is not clobbered. Defaults to True.
+            invalidate_cache: Whether to invalidate derived asset data. Solver synchronization is
+                published regardless. Defaults to True.
         """
-        # Invalidate the derived root com pose only when it was not the quantity just written.
-        reset_timestamps(
-            [
-                self._root_com_pose_w if from_link else None,
-                # root states
-                self._root_state_w,
-                self._root_link_state_w,
-                self._root_com_state_w,
-            ]
-        )
-        self._fk_timestamp = -1.0
+        if invalidate_cache:
+            # Invalidate the derived root com pose only when it was not the quantity just written.
+            reset_timestamps(
+                [
+                    self._root_com_pose_w if from_link else None,
+                    # root states
+                    self._root_state_w,
+                    self._root_link_state_w,
+                    self._root_com_state_w,
+                ]
+            )
+            self._fk_timestamp = -1.0
         SimulationManager.invalidate_fk(
             env_mask=env_mask, env_ids=env_ids, articulation_ids=self._root_view.articulation_ids
         )
 
     def _reset_velocity(
-        self, from_com: bool = True, *, env_ids: wp.array | torch.Tensor | None = None, env_mask: wp.array | None = None
+        self,
+        from_com: bool = True,
+        *,
+        env_ids: wp.array | torch.Tensor | None = None,
+        env_mask: wp.array | None = None,
+        invalidate_cache: bool = True,
     ) -> None:
         """Reset velocity-dependent cached rigid object properties.
 
@@ -181,19 +190,22 @@ class RigidObjectData(BaseRigidObjectData):
             from_com: Set ``True`` when the root center-of-mass velocity was written so the derived root
                 link velocity (:attr:`root_link_vel_w`) is also invalidated; set ``False`` when the link
                 velocity was written directly so it is not clobbered. Defaults to True.
+            invalidate_cache: Whether to invalidate derived asset data. Solver synchronization is
+                published regardless. Defaults to True.
         """
-        # Invalidate the derived root link velocity only when it was not the quantity just written.
-        reset_timestamps(
-            [
-                self._root_link_vel_w if from_com else None,
-                self._body_link_vel_w,
-                # root states
-                self._root_state_w,
-                self._root_link_state_w,
-                self._root_com_state_w,
-            ]
-        )
-        self._fk_timestamp = -1.0
+        if invalidate_cache:
+            # Invalidate the derived root link velocity only when it was not the quantity just written.
+            reset_timestamps(
+                [
+                    self._root_link_vel_w if from_com else None,
+                    self._body_link_vel_w,
+                    # root states
+                    self._root_state_w,
+                    self._root_link_state_w,
+                    self._root_com_state_w,
+                ]
+            )
+            self._fk_timestamp = -1.0
         SimulationManager.invalidate_fk(
             env_mask=env_mask, env_ids=env_ids, articulation_ids=self._root_view.articulation_ids
         )

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
@@ -457,8 +457,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             device=self.device,
         )
         # Invalidate dependent timestamps
-        if not skip_forward:
-            self.data._reset_pose(env_ids=env_ids)
+        self.data._reset_pose(env_ids=env_ids, body_ids=body_ids, invalidate_cache=not skip_forward)
 
     def write_body_link_pose_to_sim_mask(
         self,
@@ -557,8 +556,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             device=self.device,
         )
         # Invalidate dependent timestamps. The com poses were just written, so they must not be invalidated.
-        if not skip_forward:
-            self.data._reset_pose(env_ids=env_ids, from_link=False)
+        self.data._reset_pose(env_ids=env_ids, body_ids=body_ids, from_link=False, invalidate_cache=not skip_forward)
 
     def write_body_com_pose_to_sim_mask(
         self,
@@ -664,8 +662,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             device=self.device,
         )
         # Invalidate dependent timestamps
-        if not skip_forward:
-            self.data._reset_velocity(env_ids=env_ids)
+        self.data._reset_velocity(env_ids=env_ids, body_ids=body_ids, invalidate_cache=not skip_forward)
 
     def write_body_com_velocity_to_sim_mask(
         self,
@@ -781,8 +778,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             device=self.device,
         )
         # Invalidate dependent timestamps.
-        if not skip_forward:
-            self.data._reset_velocity(env_ids=env_ids, from_com=False)
+        self.data._reset_velocity(env_ids=env_ids, body_ids=body_ids, from_com=False, invalidate_cache=not skip_forward)
 
     def write_body_link_velocity_to_sim_mask(
         self,

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -137,29 +137,38 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
         *,
         env_ids: wp.array | None = None,
         env_mask: wp.array | None = None,
+        body_ids: wp.array | None = None,
+        invalidate_cache: bool = True,
     ) -> None:
         """Reset pose-dependent cached rigid object collection properties.
 
         Args:
             env_ids: Environment indices. If None, then all indices are used.
             env_mask: Environment mask. If None, then all instances are updated. Shape is (num_instances,).
+            body_ids: Body columns modified by the write. If None, then all bodies are updated.
             from_link: Set ``True`` when the body link poses were written so the derived body
                 center-of-mass poses (:attr:`body_com_pose_w`) are also invalidated; set ``False`` when
                 the center-of-mass poses were written directly so they are not clobbered. Defaults to True.
+            invalidate_cache: Whether to invalidate derived asset data. Solver synchronization is
+                published regardless. Defaults to True.
         """
-        # Invalidate the derived body com poses only when they were not the quantity just written.
-        reset_timestamps(
-            [
-                self._body_com_pose_w if from_link else None,
-                # body com states
-                self._body_state_w,
-                self._body_link_state_w,
-                self._body_com_state_w,
-            ]
-        )
-        self._fk_timestamp = -1.0
+        if invalidate_cache:
+            # Invalidate the derived body com poses only when they were not the quantity just written.
+            reset_timestamps(
+                [
+                    self._body_com_pose_w if from_link else None,
+                    # body com states
+                    self._body_state_w,
+                    self._body_link_state_w,
+                    self._body_com_state_w,
+                ]
+            )
+            self._fk_timestamp = -1.0
         SimulationManager.invalidate_fk(
-            env_mask=env_mask, env_ids=env_ids, articulation_ids=self._root_view.articulation_ids
+            env_mask=env_mask,
+            env_ids=env_ids,
+            articulation_ids=self._root_view.articulation_ids,
+            articulation_selection=body_ids,
         )
 
     def _reset_velocity(
@@ -168,29 +177,38 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
         *,
         env_ids: wp.array | None = None,
         env_mask: wp.array | None = None,
+        body_ids: wp.array | None = None,
+        invalidate_cache: bool = True,
     ) -> None:
         """Reset velocity-dependent cached rigid object collection properties.
 
         Args:
             env_ids: Environment indices. If None, then all indices are used.
             env_mask: Environment mask. If None, then all instances are updated. Shape is (num_instances,).
+            body_ids: Body columns modified by the write. If None, then all bodies are updated.
             from_com: Set ``True`` when the body center-of-mass velocities were written so the derived body
                 link velocities (:attr:`body_link_vel_w`) are also invalidated; set ``False`` when the link
                 velocities were written directly so they are not clobbered. Defaults to True.
+            invalidate_cache: Whether to invalidate derived asset data. Solver synchronization is
+                published regardless. Defaults to True.
         """
-        # Invalidate the derived body link velocities only when they were not the quantity just written.
-        reset_timestamps(
-            [
-                self._body_link_vel_w if from_com else None,
-                # body com states
-                self._body_state_w,
-                self._body_link_state_w,
-                self._body_com_state_w,
-            ]
-        )
-        self._fk_timestamp = -1.0
+        if invalidate_cache:
+            # Invalidate the derived body link velocities only when they were not the quantity just written.
+            reset_timestamps(
+                [
+                    self._body_link_vel_w if from_com else None,
+                    # body com states
+                    self._body_state_w,
+                    self._body_link_state_w,
+                    self._body_com_state_w,
+                ]
+            )
+            self._fk_timestamp = -1.0
         SimulationManager.invalidate_fk(
-            env_mask=env_mask, env_ids=env_ids, articulation_ids=self._root_view.articulation_ids
+            env_mask=env_mask,
+            env_ids=env_ids,
+            articulation_ids=self._root_view.articulation_ids,
+            articulation_selection=body_ids,
         )
 
     """

--- a/source/isaaclab_newton/isaaclab_newton/physics/_authored_state_transaction.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/_authored_state_transaction.py
@@ -28,9 +28,9 @@ def _mark_from_mask(
 ):
     """Accumulate selected worlds and their articulations."""
     world = wp.tid()
-    if env_mask[world]:
+    count = articulation_selection.shape[0] if use_selection else articulation_ids.shape[1]
+    if env_mask[world] and count > 0:
         world_mask[world] = True
-        count = articulation_selection.shape[0] if use_selection else articulation_ids.shape[1]
         for index in range(count):
             column = articulation_selection[index] if use_selection else index
             fk_mask[articulation_ids[world, column]] = True
@@ -49,13 +49,14 @@ def _mark_from_ids(
 ):
     """Accumulate sparse world indices and their articulations."""
     index = wp.tid()
-    world = env_ids[index]
-    world_mask[world] = True
     count = articulation_selection.shape[0] if use_selection else articulation_ids.shape[1]
-    for selection_index in range(count):
-        column = articulation_selection[selection_index] if use_selection else selection_index
-        fk_mask[articulation_ids[world, column]] = True
-    wp.atomic_max(pending, 0, 1)
+    if count > 0:
+        world = env_ids[index]
+        world_mask[world] = True
+        for selection_index in range(count):
+            column = articulation_selection[selection_index] if use_selection else selection_index
+            fk_mask[articulation_ids[world, column]] = True
+        wp.atomic_max(pending, 0, 1)
 
 
 class _CaptureState(Enum):

--- a/source/isaaclab_newton/isaaclab_newton/physics/_authored_state_transaction.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/_authored_state_transaction.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Device-backed transaction for task-authored Newton state writes."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from enum import Enum, auto
+
+import warp as wp
+
+logger = logging.getLogger(__name__)
+
+
+@wp.kernel(enable_backward=False)
+def _mark_from_mask(
+    env_mask: wp.array(dtype=wp.bool),
+    articulation_ids: wp.array2d(dtype=int),
+    articulation_selection: wp.array(dtype=int),
+    use_selection: int,
+    world_mask: wp.array(dtype=wp.bool),
+    fk_mask: wp.array(dtype=wp.bool),
+    pending: wp.array(dtype=wp.int32),
+):
+    """Accumulate selected worlds and their articulations."""
+    world = wp.tid()
+    if env_mask[world]:
+        world_mask[world] = True
+        count = articulation_selection.shape[0] if use_selection else articulation_ids.shape[1]
+        for index in range(count):
+            column = articulation_selection[index] if use_selection else index
+            fk_mask[articulation_ids[world, column]] = True
+        wp.atomic_max(pending, 0, 1)
+
+
+@wp.kernel(enable_backward=False)
+def _mark_from_ids(
+    env_ids: wp.array(dtype=int),
+    articulation_ids: wp.array2d(dtype=int),
+    articulation_selection: wp.array(dtype=int),
+    use_selection: int,
+    world_mask: wp.array(dtype=wp.bool),
+    fk_mask: wp.array(dtype=wp.bool),
+    pending: wp.array(dtype=wp.int32),
+):
+    """Accumulate sparse world indices and their articulations."""
+    index = wp.tid()
+    world = env_ids[index]
+    world_mask[world] = True
+    count = articulation_selection.shape[0] if use_selection else articulation_ids.shape[1]
+    for selection_index in range(count):
+        column = articulation_selection[selection_index] if use_selection else selection_index
+        fk_mask[articulation_ids[world, column]] = True
+    wp.atomic_max(pending, 0, 1)
+
+
+class _CaptureState(Enum):
+    """Conditional-graph lifecycle."""
+
+    DISABLED = auto()
+    DEFERRED = auto()
+    READY = auto()
+
+
+class AuthoredStateTransaction:
+    """Coalesce authored state writes and reconcile them at coherent boundaries.
+
+    The device scalar is authoritative so marking kernels remain valid when
+    replayed from an outer CUDA graph. The bound ``apply`` callback receives the
+    accumulated world and articulation masks and is responsible for FK and
+    solver-specific synchronization.
+    """
+
+    RENDER_TRANSFORMS = 1
+
+    def __init__(
+        self,
+        world_count: int,
+        articulation_count: int,
+        device,
+        apply: Callable[[wp.array, wp.array], None],
+    ) -> None:
+        self._device = wp.get_device(device)
+        self._apply = apply
+        self._world_mask = wp.zeros(world_count, dtype=wp.bool, device=self._device)
+        self._fk_mask = wp.zeros(articulation_count, dtype=wp.bool, device=self._device)
+        self._empty_selection = wp.empty(0, dtype=wp.int32, device=self._device)
+        self._pending = wp.zeros(1, dtype=wp.int32, device=self._device)
+        self._graph = None
+        self._graph_safe = False
+        self._capture_state = _CaptureState.DISABLED
+        self._writes_may_replay = False
+        self._host_pending = False
+        self._replay_render_domains = 0
+
+    @property
+    def world_mask(self) -> wp.array:
+        """Accumulated per-world mask, exposed for private tests and policies."""
+        return self._world_mask
+
+    @property
+    def fk_mask(self) -> wp.array:
+        """Accumulated per-articulation FK mask, exposed for private tests."""
+        return self._fk_mask
+
+    @property
+    def needs_capture(self) -> bool:
+        """Whether a deferred conditional graph still needs capturing."""
+        return self._capture_state is _CaptureState.DEFERRED
+
+    @property
+    def writes_may_replay(self) -> bool:
+        """Whether any mark operation was recorded into a CUDA graph."""
+        return self._writes_may_replay
+
+    @property
+    def replay_render_domains(self) -> int:
+        """Render domains whose host dirty markers may replay only on device."""
+        return self._replay_render_domains
+
+    def note_render_write(self, domain: int) -> None:
+        """Remember render invalidation recorded while a CUDA stream is capturing."""
+        if self._device.is_cuda and self._device.stream.is_capturing:
+            self._replay_render_domains |= domain
+
+    def mark_rigid(
+        self,
+        *,
+        env_mask: wp.array | None = None,
+        env_ids: wp.array | None = None,
+        articulation_ids: wp.array | None = None,
+        articulation_selection: wp.array | None = None,
+    ) -> None:
+        """Accumulate rigid worlds and articulations modified by an asset write."""
+        self._host_pending = True
+        if self._device.is_cuda and self._device.stream.is_capturing:
+            self._writes_may_replay = True
+
+        # Preserve the pre-transaction conservative fallback: without view
+        # topology, a rigid write cannot safely map a world selection to
+        # articulations, so reconcile the whole model.
+        if articulation_ids is None:
+            self._world_mask.fill_(True)
+            self._fk_mask.fill_(True)
+            self._pending.fill_(1)
+            return
+
+        if articulation_ids is not None and env_mask is not None:
+            selection = self._empty_selection if articulation_selection is None else articulation_selection
+            wp.launch(
+                _mark_from_mask,
+                dim=articulation_ids.shape[0],
+                inputs=[env_mask, articulation_ids, selection, int(articulation_selection is not None)],
+                outputs=[self._world_mask, self._fk_mask, self._pending],
+                device=self._device,
+            )
+        elif articulation_ids is not None and env_ids is not None:
+            selection = self._empty_selection if articulation_selection is None else articulation_selection
+            wp.launch(
+                _mark_from_ids,
+                dim=env_ids.shape[0],
+                inputs=[env_ids, articulation_ids, selection, int(articulation_selection is not None)],
+                outputs=[self._world_mask, self._fk_mask, self._pending],
+                device=self._device,
+            )
+        else:
+            # No selection means every world and articulation.
+            self._world_mask.fill_(True)
+            self._fk_mask.fill_(True)
+            self._pending.fill_(1)
+
+    def configure_capture(self, graph_safe: bool, defer: bool = False, enabled: bool = True) -> None:
+        """Configure the reusable conditional graph for the active backend."""
+        self._graph = None
+        self._graph_safe = graph_safe
+        self._capture_state = _CaptureState.DISABLED
+
+        if not enabled or not graph_safe or not self._device.is_cuda:
+            return
+        if not wp.is_conditional_graph_supported():
+            logger.warning(
+                "CUDA conditional graph nodes are unavailable; authored-state synchronization will use "
+                "a synchronous condition readback outside graph capture."
+            )
+            return
+        if defer:
+            self._capture_state = _CaptureState.DEFERRED
+            return
+
+        with wp.ScopedCapture(device=self._device) as capture:
+            self._capture_condition()
+        self._graph = capture.graph
+        self._capture_state = _CaptureState.READY
+
+    def capture_deferred(
+        self,
+        capture_fn: Callable[[Callable[[], None]], object | None],
+    ) -> None:
+        """Capture a deferred conditional through an RTX-safe capture function."""
+        if not self.needs_capture:
+            return
+
+        graph = capture_fn(self._capture_condition)
+        if graph is None:
+            self._capture_state = _CaptureState.DISABLED
+            logger.warning("Authored-state graph capture failed; using eager conditional execution.")
+            return
+
+        self._graph = graph
+        self._capture_state = _CaptureState.READY
+
+    def flush(self) -> None:
+        """Apply and consume pending writes, preserving outer-capture replay."""
+        capturing = self._device.is_cuda and self._device.stream.is_capturing
+
+        if self._capture_state is _CaptureState.READY and not capturing:
+            wp.capture_launch(self._graph)
+            self._host_pending = False
+            return
+
+        if capturing:
+            if not self._graph_safe:
+                raise RuntimeError(
+                    "Authored-state synchronization for this Newton backend is not CUDA-graph-safe. "
+                    "Run the synchronization boundary outside graph capture."
+                )
+            if not wp.is_conditional_graph_supported():
+                raise RuntimeError(
+                    "Replaying authored-state writes inside a CUDA graph requires CUDA conditional graph nodes."
+                )
+
+        # For eager writers, the host call is an exact clean/dirty hint and
+        # avoids synchronizing a CUDA condition at every clean boundary. Once
+        # a writer itself was captured, only the device scalar is authoritative.
+        if not capturing and not self._host_pending and not self._writes_may_replay:
+            return
+
+        # Without an active capture, capture_if directly evaluates the CPU
+        # condition or performs the documented CUDA readback fallback.
+        wp.capture_if(self._pending, self._consume)
+        self._host_pending = False
+
+    def _capture_condition(self) -> None:
+        """Insert the device-side transaction branch into the active capture."""
+        wp.capture_if(self._pending, self._consume)
+
+    def _consume(self) -> None:
+        """Apply the transaction and clear it only after successful dispatch."""
+        self._apply(self._world_mask, self._fk_mask)
+        self._world_mask.zero_()
+        self._fk_mask.zero_()
+        self._pending.zero_()

--- a/source/isaaclab_newton/isaaclab_newton/physics/_authored_state_transaction.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/_authored_state_transaction.py
@@ -59,6 +59,31 @@ def _mark_from_ids(
         wp.atomic_max(pending, 0, 1)
 
 
+@wp.kernel(enable_backward=False)
+def _mark_worlds_from_mask(
+    env_mask: wp.array(dtype=wp.bool),
+    world_mask: wp.array(dtype=wp.bool),
+    pending: wp.array(dtype=wp.int32),
+):
+    """Accumulate selected worlds without requesting articulation FK."""
+    world = wp.tid()
+    if env_mask[world]:
+        world_mask[world] = True
+        wp.atomic_max(pending, 0, 1)
+
+
+@wp.kernel(enable_backward=False)
+def _mark_worlds_from_ids(
+    env_ids: wp.array(dtype=int),
+    world_mask: wp.array(dtype=wp.bool),
+    pending: wp.array(dtype=wp.int32),
+):
+    """Accumulate sparse world indices without requesting articulation FK."""
+    world = env_ids[wp.tid()]
+    world_mask[world] = True
+    wp.atomic_max(pending, 0, 1)
+
+
 class _CaptureState(Enum):
     """Conditional-graph lifecycle."""
 
@@ -77,6 +102,7 @@ class AuthoredStateTransaction:
     """
 
     RENDER_TRANSFORMS = 1
+    RENDER_PARTICLES = 2
 
     def __init__(
         self,
@@ -137,9 +163,7 @@ class AuthoredStateTransaction:
         articulation_selection: wp.array | None = None,
     ) -> None:
         """Accumulate rigid worlds and articulations modified by an asset write."""
-        self._host_pending = True
-        if self._device.is_cuda and self._device.stream.is_capturing:
-            self._writes_may_replay = True
+        self._begin_mark()
 
         # Preserve the pre-transaction conservative fallback: without view
         # topology, a rigid write cannot safely map a world selection to
@@ -150,7 +174,7 @@ class AuthoredStateTransaction:
             self._pending.fill_(1)
             return
 
-        if articulation_ids is not None and env_mask is not None:
+        if env_mask is not None:
             selection = self._empty_selection if articulation_selection is None else articulation_selection
             wp.launch(
                 _mark_from_mask,
@@ -159,7 +183,7 @@ class AuthoredStateTransaction:
                 outputs=[self._world_mask, self._fk_mask, self._pending],
                 device=self._device,
             )
-        elif articulation_ids is not None and env_ids is not None:
+        elif env_ids is not None:
             selection = self._empty_selection if articulation_selection is None else articulation_selection
             wp.launch(
                 _mark_from_ids,
@@ -173,6 +197,41 @@ class AuthoredStateTransaction:
             self._world_mask.fill_(True)
             self._fk_mask.fill_(True)
             self._pending.fill_(1)
+
+    def mark_particles(
+        self,
+        *,
+        env_mask: wp.array | None = None,
+        env_ids: wp.array | None = None,
+    ) -> None:
+        """Accumulate particle worlds without requesting articulation FK."""
+        self._begin_mark()
+
+        if env_mask is not None:
+            wp.launch(
+                _mark_worlds_from_mask,
+                dim=env_mask.shape[0],
+                inputs=[env_mask],
+                outputs=[self._world_mask, self._pending],
+                device=self._device,
+            )
+        elif env_ids is not None:
+            wp.launch(
+                _mark_worlds_from_ids,
+                dim=env_ids.shape[0],
+                inputs=[env_ids],
+                outputs=[self._world_mask, self._pending],
+                device=self._device,
+            )
+        else:
+            self._world_mask.fill_(True)
+            self._pending.fill_(1)
+
+    def _begin_mark(self) -> None:
+        """Record host and graph-replay state shared by every authored write."""
+        self._host_pending = True
+        if self._device.is_cuda and self._device.stream.is_capturing:
+            self._writes_may_replay = True
 
     def configure_capture(self, graph_safe: bool, defer: bool = False, enabled: bool = True) -> None:
         """Configure the reusable conditional graph for the active backend."""

--- a/source/isaaclab_newton/isaaclab_newton/physics/_cuda_graph.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/_cuda_graph.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""RTX-compatible CUDA graph capture helpers."""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import logging
+from collections.abc import Callable
+
+import warp as wp
+
+logger = logging.getLogger(__name__)
+
+# Relaxed capture lets RTX continue work on CUDA's legacy stream.
+try:
+    _cudart = ctypes.CDLL("libcudart.so.12")
+except OSError:
+    try:
+        _cudart = ctypes.CDLL("libcudart.so")
+    except OSError:
+        _cudart = None
+
+
+def capture_relaxed_graph(device: str, operation: Callable[[], None], *, warmup: bool = True):
+    """Capture ``operation`` on an RTX-safe non-blocking CUDA stream.
+
+    CUDA capture starts in relaxed mode before Warp registers the stream as an
+    external capture. This avoids synchronization with RTX's legacy-stream
+    work while allowing nested Warp conditional nodes. The returned Warp graph
+    is patched with the raw graph handle because external capture does not yet
+    expose that handle through Warp's public API.
+    """
+    if _cudart is None:
+        logger.warning("libcudart not available; cannot use relaxed graph capture")
+        return None
+
+    if warmup:
+        with wp.ScopedDevice(device):
+            operation()
+        wp.synchronize_stream(wp.get_stream(device))
+
+    raw_handle = ctypes.c_void_p()
+    ret = _cudart.cudaStreamCreateWithFlags(ctypes.byref(raw_handle), ctypes.c_uint(0x01))
+    if ret != 0:
+        logger.warning("cudaStreamCreateWithFlags(NonBlocking) failed (code %d)", ret)
+        return None
+    fresh_handle = raw_handle.value
+    fresh_stream = wp.Stream(device, cuda_stream=fresh_handle, owner=False)
+
+    ret = _cudart.cudaStreamBeginCapture(ctypes.c_void_p(fresh_handle), ctypes.c_int(2))
+    if ret != 0:
+        _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
+        logger.warning("cudaStreamBeginCapture(relaxed) failed (code %d)", ret)
+        return None
+
+    try:
+        wp.capture_begin(stream=fresh_stream, external=True)
+    except Exception as exc:
+        raw_graph = ctypes.c_void_p()
+        _cudart.cudaStreamEndCapture(ctypes.c_void_p(fresh_handle), ctypes.byref(raw_graph))
+        if raw_graph.value:
+            _cudart.cudaGraphDestroy(raw_graph)
+        _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
+        logger.warning("wp.capture_begin(external=True) failed: %s", exc)
+        return None
+
+    error = None
+    with wp.ScopedStream(fresh_stream, sync_enter=False):
+        try:
+            operation()
+        except Exception as exc:
+            error = exc
+
+    if error is None:
+        try:
+            graph = wp.capture_end(stream=fresh_stream)
+        except Exception as exc:
+            error = exc
+            graph = None
+    else:
+        with contextlib.suppress(Exception):
+            wp.capture_end(stream=fresh_stream)
+        graph = None
+
+    raw_graph = ctypes.c_void_p()
+    end_ret = _cudart.cudaStreamEndCapture(ctypes.c_void_p(fresh_handle), ctypes.byref(raw_graph))
+    _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
+
+    if error is not None:
+        if raw_graph.value:
+            _cudart.cudaGraphDestroy(raw_graph)
+        logger.warning("Newton graph capture aborted: %s", error)
+        return None
+    if end_ret != 0 or not raw_graph.value:
+        logger.warning("cudaStreamEndCapture failed (code %d)", end_ret)
+        return None
+
+    graph.graph = raw_graph
+    graph.graph_exec = None
+    return graph

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 import warp as wp
-from newton import Model, eval_fk
+from newton import Model, ModelBuilder, eval_fk
 from newton.solvers import SolverKamino
 
 from isaaclab.physics import PhysicsManager
@@ -56,6 +56,11 @@ class NewtonKaminoManager(NewtonManager):
 
     # Annotate the concrete solver type.
     _solver: SolverKamino
+
+    @classmethod
+    def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
+        """Register Kamino state/config attributes before model finalization."""
+        SolverKamino.register_custom_attributes(builder)
 
     @classmethod
     def _get_kamino_solver_cfg(cls) -> KaminoSolverCfg:
@@ -108,12 +113,10 @@ class NewtonKaminoManager(NewtonManager):
         when ``use_collision_detector=False`` (Kamino's internal detector
         handles contacts otherwise).
 
-        Sets :attr:`NewtonManager._needs_fk_before_step` because Kamino treats body state as
-        authoritative: reset worlds (written via joint coordinates) must be reconciled before each
-        step. The shared :attr:`NewtonManager._world_reset_mask` and
-        :attr:`NewtonManager._fk_reset_mask` restrict that pre-step reconcile and
-        :meth:`NewtonManager.forward` to reset worlds, so non-reset worlds keep their live,
-        authoritative body state through Kamino's :meth:`_eval_fk_impl` overwrite.
+        Kamino treats body state as authoritative, so task-authored joint state
+        is reconciled through its mandatory reset before any step or coherent
+        read boundary. The shared masks restrict that transaction to dirty
+        worlds, preserving live body state elsewhere.
 
         Raises:
             RuntimeError: If the model has more than one articulation per environment. The Kamino
@@ -144,4 +147,3 @@ class NewtonKaminoManager(NewtonManager):
         NewtonManager._solver = SolverKamino(model, solver_cfg.to_solver_config())
         NewtonManager._use_single_state = False
         NewtonManager._needs_collision_pipeline = not solver_cfg.use_collision_detector
-        NewtonManager._needs_fk_before_step = True

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -106,6 +106,11 @@ class NewtonKaminoManager(NewtonManager):
             )
 
     @classmethod
+    def _reset_solver_state(cls, solver: SolverKamino, world_reset_mask: wp.array) -> None:
+        """Skip the generic optional reset already performed by Kamino synchronization."""
+        pass
+
+    @classmethod
     def _build_solver(cls, model: Model, solver_cfg: KaminoSolverCfg) -> None:
         """Construct :class:`SolverKamino` and populate the base-class slots.
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
@@ -11,6 +11,7 @@ import inspect
 import logging
 
 import numpy as np
+import warp as wp
 from newton import Contacts, Model
 from newton.solvers import SolverMuJoCo
 
@@ -41,6 +42,10 @@ class NewtonMJWarpManager(NewtonManager):
         :attr:`NewtonManager._needs_collision_pipeline` to
         ``True`` only when ``use_mujoco_contacts=False``.
         """
+        cfg = PhysicsManager._cfg
+        if solver_cfg.use_mujoco_cpu and model.world_count > 1:
+            raise ValueError("CPU MuJoCo supports only one Newton world. Use MJWarp or run a single world.")
+
         ignored = {"class_type", "solver_type", "ls_parallel"}
         valid = set(inspect.signature(SolverMuJoCo.__init__).parameters) - {"self", "model"} - ignored
         kwargs = {k: v for k, v in solver_cfg.to_dict().items() if k in valid}
@@ -48,7 +53,6 @@ class NewtonMJWarpManager(NewtonManager):
         NewtonManager._use_single_state = True
         NewtonManager._needs_collision_pipeline = not solver_cfg.use_mujoco_contacts
 
-        cfg = PhysicsManager._cfg
         # Cross-config validation that needs both halves.
         if solver_cfg.use_mujoco_contacts and cfg.collision_cfg is not None:
             raise ValueError(
@@ -56,6 +60,33 @@ class NewtonMJWarpManager(NewtonManager):
                 "solver_cfg.use_mujoco_contacts=True. Either set "
                 "use_mujoco_contacts=False or remove collision_cfg."
             )
+
+    @classmethod
+    def _state_write_graph_safe(cls) -> bool:
+        """CPU MuJoCo performs host transfers and cannot enter a CUDA graph."""
+        return not cls._solver.use_mujoco_cpu
+
+    @classmethod
+    def _supports_cuda_graph_capture(cls) -> bool:
+        """Require a fully device-side MuJoCo step with fixed per-step state handoff."""
+        return not cls._solver.use_mujoco_cpu and cls._solver.update_data_interval <= 1
+
+    @classmethod
+    def _synchronize_solver_state(
+        cls,
+        solver: SolverMuJoCo,
+        world_reset_mask: wp.array,
+        fk_mask: wp.array,
+    ) -> None:
+        """Push authored coordinates into MuJoCo when per-step updates are sparse."""
+        # With the default interval, the next step always copies Newton state
+        # into qpos/qvel. Sparse or disabled updates need an immediate handoff;
+        # SolverMuJoCo currently exposes that operation only through its
+        # internal state-conversion helper.
+        if solver.update_data_interval != 1:
+            data = solver.mj_data if solver.use_mujoco_cpu else solver.mjw_data
+            if data is not None:
+                solver._update_mjc_data(data, cls._model, cls._state_0)
 
     @classmethod
     def _initialize_contacts(cls) -> None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/mpm_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/mpm_manager.py
@@ -107,7 +107,6 @@ class NewtonMPMManager(NewtonManager):
         )
         NewtonManager._use_single_state = True
         NewtonManager._needs_collision_pipeline = False
-        NewtonManager._needs_fk_before_step = True
         cls._project_outside_colliders = solver_cfg.project_outside_colliders
 
     @classmethod

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -7,8 +7,6 @@
 
 from __future__ import annotations
 
-import contextlib
-import ctypes
 import logging
 import re
 from abc import abstractmethod
@@ -18,23 +16,12 @@ from typing import TYPE_CHECKING
 
 import torch
 import warp as wp
-
-# Load CUDA runtime for relaxed-mode graph capture (RTX-compatible).
-# cudaStreamCaptureModeRelaxed (2) allows the RTX compositor's background
-# CUDA stream to keep running during capture without invalidating it.
-try:
-    _cudart = ctypes.CDLL("libcudart.so.12")
-except OSError:
-    try:
-        _cudart = ctypes.CDLL("libcudart.so")
-    except OSError:
-        _cudart = None
 from newton import Axis, CollisionPipeline, Contacts, Control, Model, ModelBuilder, State, eval_fk
 from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 from newton.sensors import SensorContact as NewtonContactSensor
 from newton.sensors import SensorFrameTransform
 from newton.sensors import SensorIMU as NewtonSensorIMU
-from newton.solvers import SolverBase, SolverKamino, SolverNotifyFlags
+from newton.solvers import SolverBase, SolverNotifyFlags
 
 from pxr import UsdGeom
 
@@ -50,6 +37,8 @@ from isaaclab.utils.timer import Timer
 from isaaclab_newton.cloner.newton_clone_utils import replicate_builder_mapping
 from isaaclab_newton.physics.visualization_builder import build_visualization_builder_from_stage_envs
 
+from ._authored_state_transaction import AuthoredStateTransaction
+from ._cuda_graph import capture_relaxed_graph
 from .newton_manager_cfg import NewtonCfg, NewtonShapeCfg
 
 if TYPE_CHECKING:
@@ -124,34 +113,6 @@ class _ParticleVisualPrim:
     frames_since_sync: int
 
 
-@wp.kernel(enable_backward=False)
-def _or_reset_masks_from_mask(
-    env_mask: wp.array(dtype=wp.bool),
-    articulation_ids: wp.array2d(dtype=int),
-    world_mask: wp.array(dtype=wp.bool),
-    fk_mask: wp.array(dtype=wp.bool),
-):
-    """OR env_mask into world_mask and set corresponding articulation bits in fk_mask."""
-    world, arti = wp.tid()
-    if env_mask[world]:
-        world_mask[world] = True
-        fk_mask[articulation_ids[world, arti]] = True
-
-
-@wp.kernel(enable_backward=False)
-def _scatter_reset_masks_from_ids(
-    env_ids: wp.array(dtype=int),
-    articulation_ids: wp.array2d(dtype=int),
-    world_mask: wp.array(dtype=wp.bool),
-    fk_mask: wp.array(dtype=wp.bool),
-):
-    """Scatter-set world_mask and fk_mask from sparse env_ids."""
-    i, arti = wp.tid()
-    world = env_ids[i]
-    world_mask[world] = True
-    fk_mask[articulation_ids[world, arti]] = True
-
-
 class NewtonSceneDataBackend(SceneDataBackend):
     """Scene data backend that reads rigid body transforms from Newton's simulation state.
 
@@ -186,20 +147,11 @@ class NewtonSceneDataBackend(SceneDataBackend):
         return NewtonManager.get_model()
 
     @property
-    def state(self) -> Model:
+    def state(self) -> State:
+        # SceneDataProvider is a public transform-read boundary. Keep body_q
+        # coherent even when no asset property getter triggered lazy FK first.
+        NewtonManager.forward()
         return NewtonManager.get_state_0()
-
-
-def _eval_fk_unbound(world_reset_mask: wp.array | None, fk_mask: wp.array | None) -> None:
-    """Default :attr:`NewtonManager._eval_fk` value before a solver is initialized.
-
-    Raises so a stray ``forward()`` / ``step()`` before ``initialize_solver()`` fails loudly
-    instead of silently running a wrong (or no) FK.
-    """
-    raise RuntimeError(
-        "FK hook is not bound. NewtonManager.initialize_solver() must run "
-        "(via reset()) before forward()/step() can run forward kinematics."
-    )
 
 
 class NewtonManager(PhysicsManager):
@@ -257,7 +209,6 @@ class NewtonManager(PhysicsManager):
     # Collision and contacts
     _contacts: Contacts | None = None
     _needs_collision_pipeline: bool = False
-    _needs_fk_before_step: bool = False
     _collision_pipeline = None
     _collision_cfg: NewtonCollisionPipelineCfg | None = None
     _newton_contact_sensors: dict = {}  # Maps sensor_key to NewtonContactSensor
@@ -267,11 +218,8 @@ class NewtonManager(PhysicsManager):
     _pending_extended_contact_attributes: set[str] = set()
     _report_contacts: bool = False
 
-    # Per-world reset masks (allocated in start_simulation, consumed in step/forward).
-    _world_reset_mask: wp.array | None = None  # (num_envs,) wp.bool — for SolverKamino.reset(world_mask=...)
-    _fk_reset_mask: wp.array | None = None  # (articulation_count,) wp.bool — for eval_fk(mask=...)
-    # Solver-specialized FK delegate. Bound in initialize_solver() to the active subclass's choice of FK implementation.
-    _eval_fk: Callable[[wp.array | None, wp.array | None], None] = _eval_fk_unbound
+    # Task-authored positions and velocities, coalesced until the next coherent boundary.
+    _state_writes: AuthoredStateTransaction | None = None
 
     # Newton actuator adapter (owns actuators and double-buffered states)
     _adapter: NewtonActuatorAdapter | None = None
@@ -300,7 +248,7 @@ class NewtonManager(PhysicsManager):
     _cubric_adapter: int | None = None
     _cubric_bound_fabric_id: int | None = None
 
-    # Model changes (callbacks use unified system from PhysicsManager)
+    # Pending Newton ModelFlags, retained as a set for coupled-manager compatibility.
     _model_changes: set[int] = set()
 
     # Scene data backend
@@ -395,29 +343,78 @@ class NewtonManager(PhysicsManager):
         eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, fk_mask)
 
     @classmethod
-    def forward(cls) -> None:
-        """Update articulation kinematics without stepping physics.
+    def _resolve_active_manager(cls) -> type[NewtonManager]:
+        """Resolve the concrete manager when data-layer code calls the base class.
 
-        Update body poses from joint coordinates via the solver-specialized FK delegate
-        (:attr:`_eval_fk`, bound to the active subclass's :meth:`_eval_fk_impl` in
-        :meth:`initialize_solver`). Only the articulations flagged dirty in
-        :attr:`_fk_reset_mask` and :attr:`_world_reset_mask` (see :meth:`invalidate_fk`) are
-        updated. The masks are consumed (zeroed) afterwards so the next :meth:`step` does not
-        redundantly re-solve them.
-
-        The delegate (rather than a direct ``cls._eval_fk_impl`` call) is required because the
-        data layer invokes ``NewtonManager.forward()`` on the base class, where ``cls`` is the
-        base ``NewtonManager``; the bound delegate dispatches to the concrete subclass override.
+        Asset data imports :class:`NewtonManager` directly, while solver policy
+        lives on its concrete subclass. The simulation context already owns that
+        selected manager, so use it instead of maintaining a second bound
+        dispatch delegate.
         """
-        cls._eval_fk(cls._world_reset_mask, cls._fk_reset_mask)
-        if cls._fk_reset_mask is not None:
-            cls._fk_reset_mask.zero_()
-        if cls._world_reset_mask is not None:
-            cls._world_reset_mask.zero_()
+        if cls is not NewtonManager:
+            return cls
+        sim = PhysicsManager._sim
+        return getattr(sim, "physics_manager", cls) if sim is not None else cls
+
+    @classmethod
+    def _owned_solvers(cls) -> tuple[SolverBase, ...]:
+        """Return solvers that receive model and authored-state updates."""
+        return () if cls._solver is None else (cls._solver,)
+
+    @classmethod
+    def _apply_state_writes(
+        cls,
+        world_reset_mask: wp.array,
+        fk_mask: wp.array,
+    ) -> None:
+        """Reconcile task-authored state with derived and solver-specific state.
+
+        Subclasses with a solver-specific state representation may override
+        this as one atomic policy. The default updates derived body state first,
+        then pushes it into every owned solver's private representation.
+        """
+        cls._eval_fk_impl(world_reset_mask, fk_mask)
+
+        for solver in cls._owned_solvers():
+            cls._synchronize_solver_state(solver, world_reset_mask, fk_mask)
+
+    @classmethod
+    def _synchronize_solver_state(
+        cls,
+        solver: SolverBase,
+        world_reset_mask: wp.array,
+        fk_mask: wp.array,
+    ) -> None:
+        """Push authored state into a solver-specific representation when needed."""
+        pass
+
+    @classmethod
+    def _state_write_graph_safe(cls) -> bool:
+        """Return whether authored-state reconciliation can be CUDA-captured."""
+        return True
+
+    @classmethod
+    def _flush_pending_changes(cls) -> None:
+        """Apply pending authored state before a coherent boundary."""
+        if NewtonManager._state_writes is not None:
+            NewtonManager._state_writes.flush()
+
+    @classmethod
+    def forward(cls) -> None:
+        """Flush authored state and update articulation kinematics without stepping."""
+        manager = cls._resolve_active_manager()
+        manager._flush_pending_changes()
 
     @classmethod
     def pre_render(cls) -> None:
-        """Flush deferred Fabric writes before cameras/visualizers read the scene."""
+        """Make authored state coherent, then flush it to cameras and visualizers."""
+        cls._flush_pending_changes()
+        # Captured writers replay only device work. Re-arm the affected render
+        # domains because external graph launch/destruction is invisible here.
+        transaction = NewtonManager._state_writes
+        if transaction is not None:
+            if transaction.replay_render_domains & transaction.RENDER_TRANSFORMS:
+                NewtonManager._transforms_dirty = True
         cls.sync_transforms_to_usd()
         cls.sync_particles_to_usd()
 
@@ -604,6 +601,8 @@ class NewtonManager(PhysicsManager):
         which runs at render cadence via :meth:`pre_render`.
         """
         NewtonManager._transforms_dirty = True
+        if NewtonManager._state_writes is not None:
+            NewtonManager._state_writes.note_render_write(AuthoredStateTransaction.RENDER_TRANSFORMS)
 
     @classmethod
     def _mark_particles_dirty(cls) -> None:
@@ -677,43 +676,34 @@ class NewtonManager(PhysicsManager):
         if sim is None or not sim.is_playing():
             return
 
-        # Notify solver of model changes
-        if cls._model_changes:
-            with wp.ScopedDevice(PhysicsManager._device):
-                for change in cls._model_changes:
-                    cls._solver.notify_model_changed(change)
-                NewtonManager._model_changes = set()
-
-        # Lazy CUDA graph capture
         cfg = PhysicsManager._cfg
         device = PhysicsManager._device
+
+        # Model-property notifications remain step-owned for compatibility
+        # with existing coupled managers, which fan them out to sub-solvers
+        # before delegating here.
+        cls._notify_solver_model_changes()
+
+        # RTX-active initialization defers this tiny conditional graph to the
+        # first safe inter-frame window, just like the simulation graph below.
+        transaction = NewtonManager._state_writes
+        if transaction is not None and transaction.needs_capture and device is not None and "cuda" in device:
+            transaction.capture_deferred(
+                lambda capture: cls._capture_relaxed_graph(device, capture_fn=capture, warmup=False)
+            )
+
+        # Reconcile authored state before graph warmup/capture, collision
+        # detection, or solver stepping can consume it.
+        cls._flush_pending_changes()
+
+        # Lazy CUDA graph capture
         if cls._graph_capture_pending and cfg is not None and cfg.use_cuda_graph and "cuda" in device:  # type: ignore[union-attr]
             NewtonManager._graph_capture_pending = False
             NewtonManager._graph = cls._capture_relaxed_graph(device)
             if cls._graph is not None:
-                # Kamino: StateKamino.from_newton() lazily allocates body_f_total,
-                # joint_q_prev, and joint_lambdas via wp.clone/wp.zeros during the
-                # first step() inside graph capture. Replay once to pin those
-                # memory-pool addresses before any eager solver.reset() call.
-                if isinstance(cls._solver, SolverKamino):
-                    wp.capture_launch(cls._graph)
                 logger.info("Newton CUDA graph captured (deferred relaxed mode, RTX-compatible)")
             else:
                 logger.warning("Newton deferred CUDA graph capture failed; using eager execution")
-
-        # Ensure body_q is up-to-date before solvers read rigid transforms.
-        # After env resets or kinematic root writes, joint_q is written but
-        # body_q is stale until FK runs. Collision-based solvers need this for
-        # broadphase/narrowphase; collider-based solvers such as MPM need it
-        # for their internal collider queries. Maximal-coordinate solvers
-        # that treat body state as the main state (e.g. Kamino) require FK before step.
-        # Only runs FK for dirtied articulations via the accumulated mask.
-        if cls._needs_collision_pipeline or cls._needs_fk_before_step:
-            cls._eval_fk(cls._world_reset_mask, cls._fk_reset_mask)
-
-        # Zero both masks after consumption
-        NewtonManager._world_reset_mask.zero_()
-        NewtonManager._fk_reset_mask.zero_()
 
         physics_dt = cls._solver_dt * cls._num_substeps
         use_graph = cfg is not None and cfg.use_cuda_graph and cls._graph is not None and "cuda" in device  # type: ignore[union-attr]
@@ -805,8 +795,6 @@ class NewtonManager(PhysicsManager):
         NewtonManager._control = None
         NewtonManager._contacts = None
         NewtonManager._needs_collision_pipeline = False
-        NewtonManager._needs_fk_before_step = False
-        NewtonManager._eval_fk = _eval_fk_unbound
         NewtonManager._collision_pipeline = None
         NewtonManager._collision_cfg = None
         NewtonManager._newton_contact_sensors = {}
@@ -821,9 +809,7 @@ class NewtonManager(PhysicsManager):
         # a CUDA graph (see :meth:`_is_all_graphable`).
         NewtonManager._use_newton_actuators_active = False
         NewtonManager._decimation = 1
-        # Per-world reset masks
-        NewtonManager._world_reset_mask = None
-        NewtonManager._fk_reset_mask = None
+        NewtonManager._state_writes = None
         NewtonManager._graph = None
         NewtonManager._graph_capture_pending = False
         NewtonManager._newton_stage_path = None
@@ -1080,9 +1066,22 @@ class NewtonManager(PhysicsManager):
         cls._cl_pending_sites.clear()
 
     @classmethod
-    def add_model_change(cls, change: SolverNotifyFlags) -> None:
-        """Register a model change to notify the solver."""
-        cls._model_changes.add(change)
+    def add_model_change(cls, change: SolverNotifyFlags | int) -> None:
+        """Register a model change for the next synchronization boundary."""
+        NewtonManager._model_changes.add(int(change))
+
+    @classmethod
+    def _notify_solver_model_changes(cls) -> None:
+        """Notify every owned solver of pending model changes."""
+        if cls._model_changes:
+            solvers = cls._owned_solvers()
+            if not solvers:
+                return
+            with wp.ScopedDevice(PhysicsManager._device):
+                for solver in solvers:
+                    for change in cls._model_changes:
+                        solver.notify_model_changed(change)
+            NewtonManager._model_changes = set()
 
     @classmethod
     def invalidate_fk(
@@ -1090,12 +1089,13 @@ class NewtonManager(PhysicsManager):
         env_mask: wp.array | None = None,
         env_ids: wp.array | None = None,
         articulation_ids: wp.array | None = None,
+        articulation_selection: wp.array | None = None,
     ) -> None:
-        """Mark environments as needing FK recomputation and solver reset.
+        """Mark environments whose authored state needs solver synchronization.
 
         Called by asset write methods that modify joint coordinates or root
-        transforms. The masks are consumed in :meth:`step` before physics
-        stepping.
+        transforms. The masks are consumed together by :meth:`forward`,
+        :meth:`step`, or a coherent visualization boundary.
 
         Args:
             env_mask: Boolean mask of dirtied environments. Shape ``(num_envs,)``.
@@ -1105,32 +1105,16 @@ class NewtonManager(PhysicsManager):
             articulation_ids: Mapping from ``(world, arti)`` to model articulation
                 index. Shape ``(world_count, count_per_world)``. Obtained from
                 ``ArticulationView.articulation_ids``.
+            articulation_selection: Optional columns of ``articulation_ids`` modified by the write.
         """
         cls._mark_transforms_dirty()
-
-        if cls._world_reset_mask is None or cls._fk_reset_mask is None:
-            return
-
-        if articulation_ids is not None and env_mask is not None:
-            wp.launch(
-                _or_reset_masks_from_mask,
-                dim=articulation_ids.shape,
-                inputs=[env_mask, articulation_ids],
-                outputs=[NewtonManager._world_reset_mask, NewtonManager._fk_reset_mask],
-                device=PhysicsManager._device,
+        if NewtonManager._state_writes is not None:
+            NewtonManager._state_writes.mark_rigid(
+                env_mask=env_mask,
+                env_ids=env_ids,
+                articulation_ids=articulation_ids,
+                articulation_selection=articulation_selection,
             )
-        elif articulation_ids is not None and env_ids is not None:
-            wp.launch(
-                _scatter_reset_masks_from_ids,
-                dim=(env_ids.shape[0], articulation_ids.shape[1]),
-                inputs=[env_ids, articulation_ids],
-                outputs=[NewtonManager._world_reset_mask, NewtonManager._fk_reset_mask],
-                device=PhysicsManager._device,
-            )
-        else:
-            # Fallback: no topology info — mark everything dirty
-            NewtonManager._world_reset_mask.fill_(True)
-            NewtonManager._fk_reset_mask.fill_(True)
 
     @classmethod
     def start_simulation(cls) -> None:
@@ -1185,9 +1169,12 @@ class NewtonManager(PhysicsManager):
         NewtonManager._adapter = None
         NewtonManager._use_newton_actuators_active = False
 
-        # Allocate per-world reset masks (used by all solvers for masked FK, and by Kamino for masked reset).
-        NewtonManager._world_reset_mask = wp.zeros(cls._model.world_count, dtype=wp.bool, device=device)
-        NewtonManager._fk_reset_mask = wp.zeros(cls._model.articulation_count, dtype=wp.bool, device=device)
+        NewtonManager._state_writes = AuthoredStateTransaction(
+            cls._model.world_count,
+            cls._model.articulation_count,
+            device,
+            cls._apply_state_writes,
+        )
 
         logger.info("Dispatching PHYSICS_READY callbacks")
         cls.dispatch_event(PhysicsEvent.PHYSICS_READY)
@@ -1458,16 +1445,16 @@ class NewtonManager(PhysicsManager):
                 )
             cls._initialize_contacts()
 
-        # Bind the solver-specialized FK delegate to the active subclass's _eval_fk_impl so
-        # that forward()/step() dispatch correctly even when forward() is invoked through the
-        # base class (the data layer imports NewtonManager directly). ``cls`` is the concrete
-        # subclass here, since initialize_solver is reached via sim.physics_manager.reset().
-        NewtonManager._eval_fk = cls._eval_fk_impl
-
         # Establish the initial kinematically-consistent body state through the
-        # solver-specialized FK delegate, now that the solver and the delegate both exist.
+        # concrete manager hook, now that the solver exists.
         # Runs before graph capture below so the capture warmup sees a valid body_q.
-        cls._eval_fk(None, None)
+        cls._eval_fk_impl(None, None)
+        if NewtonManager._state_writes is not None:
+            NewtonManager._state_writes.configure_capture(
+                graph_safe=cls._state_write_graph_safe(),
+                defer=cls._usdrt_stage is not None,
+                enabled=cfg.use_cuda_graph,
+            )
 
         if cls._usdrt_stage is not None:
             cls._setup_cubric_bindings()
@@ -1540,13 +1527,6 @@ class NewtonManager(PhysicsManager):
                         simulate()
                     NewtonManager._graph = capture.graph
                     logger.info("Newton CUDA graph captured (standard Warp mode)")
-
-                    # Kamino: StateKamino.from_newton() lazily allocates body_f_total,
-                    # joint_q_prev, and joint_lambdas via wp.clone/wp.zeros during the
-                    # first step() inside graph capture. Replay once to pin those
-                    # memory-pool addresses before any eager solver.reset() call.
-                    if isinstance(cls._solver, SolverKamino):
-                        wp.capture_launch(cls._graph)
                 else:
                     # RTX is active during initialization — cudaImportExternalMemory and other
                     # non-capturable RTX ops run on background CUDA streams right now.
@@ -1564,126 +1544,18 @@ class NewtonManager(PhysicsManager):
         return True
 
     @classmethod
-    def _capture_relaxed_graph(cls, device: str):
-        """Capture Newton physics (only) as a CUDA graph, RTX-compatible.
-
-        Uses a hybrid approach to work around two conflicting requirements:
-
-        1. RTX background threads use CUDA's legacy stream (stream 0) for async operations
-           like ``cudaImportExternalMemory``.  A standard ``wp.ScopedCapture()`` uses
-           ``cudaStreamCaptureModeThreadLocal`` on Warp's default stream (a blocking stream).
-           A blocking stream synchronises implicitly with legacy stream 0, so RTX ops inside
-           the capture window fail with error 906.
-
-        2. ``mujoco_warp`` calls ``wp.capture_while`` inside ``solver.solve()``.
-           ``wp.capture_while`` checks ``device.captures`` (populated by ``wp.capture_begin``)
-           to decide whether to insert a conditional graph node (graph-capture path) or to run
-           eagerly with ``wp.synchronize_stream`` (non-capture path).  Without an entry in
-           ``device.captures``, it synchronises the capturing stream — which raises "Cannot
-           synchronize stream while graph capture is active".
-
-        Solution:
-
-        - Create a **non-blocking** stream (``cudaStreamNonBlocking = 0x01``): no implicit sync
-          with legacy stream 0, so RTX background threads are unaffected (avoids error 906).
-        - Start the capture externally via ``cudaStreamBeginCapture`` with
-          ``cudaStreamCaptureModeRelaxed`` so no other CUDA activity is disrupted.
-        - Call ``wp.capture_begin(external=True, stream=fresh_stream)``:
-          this registers the capture in Warp's ``device.captures`` *without* calling
-          ``cudaStreamBeginCapture`` (already done) and *without* changing device-wide memory
-          pool attributes (avoids error 900 in RTX's ``cudaMallocAsync``).
-        - Run the simulate function inside ``ScopedStream(fresh_stream)``:
-          kernels dispatch to ``fresh_stream`` and are captured; ``wp.capture_while`` finds the
-          active capture and inserts a conditional graph node instead of synchronising.
-        - Call ``wp.capture_end(stream=fresh_stream)`` to finalise the Warp-level capture.
-        - Call ``cudaStreamEndCapture`` to close the CUDA stream capture and get the graph.
-
-        Warmup run pre-allocates all solver scratch buffers so no ``cudaMalloc`` occurs during
-        capture.  ``sync_transforms_to_usd`` (which calls ``wp.synchronize_device``) is
-        excluded from the capture and runs eagerly in ``step()`` after ``wp.capture_launch``.
-
-        Returns a ``wp.Graph`` on success, or ``None`` on failure.
-        """
-        if _cudart is None:
-            logger.warning("libcudart not available; cannot use relaxed graph capture")
-            return None
-
-        # Warmup: pre-allocate all solver scratch buffers so the capture window has
-        # no new cudaMalloc calls (which are forbidden inside graph capture).
-        simulate = cls._simulate_full if cls._is_all_graphable() else cls._simulate_physics_only
-        with wp.ScopedDevice(device):
-            simulate()
-        wp.synchronize_stream(wp.get_stream(device))
-
-        # Create a non-blocking stream (cudaStreamNonBlocking = 0x01).
-        raw_handle = ctypes.c_void_p()
-        ret = _cudart.cudaStreamCreateWithFlags(ctypes.byref(raw_handle), ctypes.c_uint(0x01))
-        if ret != 0:
-            logger.warning("cudaStreamCreateWithFlags(NonBlocking) failed (code %d)", ret)
-            return None
-        fresh_handle = raw_handle.value
-        fresh_stream = wp.Stream(device, cuda_stream=fresh_handle, owner=False)
-
-        # Start capture in relaxed mode BEFORE entering ScopedStream.
-        ret = _cudart.cudaStreamBeginCapture(ctypes.c_void_p(fresh_handle), ctypes.c_int(2))
-        if ret != 0:
-            _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
-            logger.warning("cudaStreamBeginCapture(relaxed) failed (code %d)", ret)
-            return None
-
-        try:
-            wp.capture_begin(stream=fresh_stream, external=True)
-        except Exception as exc:
-            raw_graph = ctypes.c_void_p()
-            _cudart.cudaStreamEndCapture(ctypes.c_void_p(fresh_handle), ctypes.byref(raw_graph))
-            if raw_graph.value:
-                _cudart.cudaGraphDestroy(raw_graph)
-            _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
-            logger.warning("wp.capture_begin(external=True) failed: %s", exc)
-            return None
-
-        err_during_capture = None
-        with wp.ScopedStream(fresh_stream, sync_enter=False):
-            try:
-                simulate()
-            except Exception as exc:
-                err_during_capture = exc
-
-        if err_during_capture is None:
-            try:
-                graph = wp.capture_end(stream=fresh_stream)
-            except Exception as exc:
-                err_during_capture = exc
-                graph = None
-        else:
-            with contextlib.suppress(Exception):
-                wp.capture_end(stream=fresh_stream)
-            graph = None
-
-        raw_graph = ctypes.c_void_p()
-        end_ret = _cudart.cudaStreamEndCapture(ctypes.c_void_p(fresh_handle), ctypes.byref(raw_graph))
-        _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
-
-        if err_during_capture is not None:
-            if raw_graph.value:
-                _cudart.cudaGraphDestroy(raw_graph)
-            logger.warning("Newton graph capture aborted during simulate: %s", err_during_capture)
-            return None
-
-        if end_ret != 0 or not raw_graph.value:
-            logger.warning("cudaStreamEndCapture failed (code %d)", end_ret)
-            return None
-
-        # Patch the Warp Graph object with the raw CUDA graph handle obtained
-        # from our external cudaStreamEndCapture.  wp.capture_end(external=True)
-        # returns a Graph with a stale handle; we overwrite it so that
-        # wp.capture_launch() replays the correct graph.
-        # NOTE: This relies on Warp internals (Graph.graph / Graph.graph_exec).
-        # Setting graph_exec = None triggers lazy cudaGraphInstantiate on
-        # the next capture_launch.  Replace with public API when available.
-        graph.graph = raw_graph
-        graph.graph_exec = None
-        return graph
+    def _capture_relaxed_graph(
+        cls,
+        device: str,
+        capture_fn: Callable[[], None] | None = None,
+        *,
+        warmup: bool = True,
+    ):
+        """Capture physics or a supplied operation through the RTX-safe helper."""
+        operation = capture_fn
+        if operation is None:
+            operation = cls._simulate_full if cls._is_all_graphable() else cls._simulate_physics_only
+        return capture_relaxed_graph(device, operation, warmup=warmup)
 
     # ------------------------------------------------------------------
     # Building blocks — used by _simulate_full / _simulate_physics_only
@@ -1790,7 +1662,7 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def get_state_0(cls) -> State:
-        """Get the current state."""
+        """Get the current raw state without flushing authored writes."""
         cls._ensure_visualization_model()
         return cls._state_0
 
@@ -1803,9 +1675,10 @@ class NewtonManager(PhysicsManager):
         refreshes the shadow ``_state_0.body_q`` from the live PhysX scene via
         :meth:`update_visualization_state` before returning, so callers never
         observe stale transforms. Under the Newton sim backend
-        :meth:`update_visualization_state` is a no-op and this is equivalent to
-        :meth:`get_state_0`.
+        pending authored state is synchronized before the live state is returned.
         """
+        if cls._backend_is_newton(scene_data_provider):
+            cls.forward()
         cls.update_visualization_state(scene_data_provider)
         return cls.get_state_0()
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -425,6 +425,8 @@ class NewtonManager(PhysicsManager):
         if transaction is not None:
             if transaction.replay_render_domains & transaction.RENDER_TRANSFORMS:
                 NewtonManager._transforms_dirty = True
+            if transaction.replay_render_domains & transaction.RENDER_PARTICLES:
+                NewtonManager._particles_dirty = True
         cls.sync_transforms_to_usd()
         cls.sync_particles_to_usd()
 
@@ -622,6 +624,8 @@ class NewtonManager(PhysicsManager):
         which runs at render cadence via :meth:`pre_render`.
         """
         NewtonManager._particles_dirty = True
+        if NewtonManager._state_writes is not None:
+            NewtonManager._state_writes.note_render_write(AuthoredStateTransaction.RENDER_PARTICLES)
 
     @classmethod
     def _mark_state_dirty(cls) -> None:
@@ -1120,6 +1124,21 @@ class NewtonManager(PhysicsManager):
                 articulation_ids=articulation_ids,
                 articulation_selection=articulation_selection,
             )
+
+    @classmethod
+    def invalidate_particles(
+        cls,
+        env_mask: wp.array | None = None,
+        env_ids: wp.array | None = None,
+    ) -> None:
+        """Mark worlds whose task-authored particle state changed.
+
+        Particle writes share the solver transaction and dirty-world mask with
+        rigid writes, but they do not request articulation forward kinematics.
+        """
+        cls._mark_particles_dirty()
+        if NewtonManager._state_writes is not None:
+            NewtonManager._state_writes.mark_particles(env_mask=env_mask, env_ids=env_ids)
 
     @classmethod
     def start_simulation(cls) -> None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -358,7 +358,7 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def _owned_solvers(cls) -> tuple[SolverBase, ...]:
-        """Return solvers that receive model and authored-state updates."""
+        """Return solvers that receive model, authored-state, and reset updates."""
         return () if cls._solver is None else (cls._solver,)
 
     @classmethod
@@ -371,12 +371,16 @@ class NewtonManager(PhysicsManager):
 
         Subclasses with a solver-specific state representation may override
         this as one atomic policy. The default updates derived body state first,
-        then pushes it into every owned solver's private representation.
+        pushes it into every owned solver's private representation, then
+        optionally clears solver-owned state without changing authored values.
         """
         cls._eval_fk_impl(world_reset_mask, fk_mask)
 
+        cfg = PhysicsManager._cfg
         for solver in cls._owned_solvers():
             cls._synchronize_solver_state(solver, world_reset_mask, fk_mask)
+            if cfg is not None and cfg.solver_reset:
+                cls._reset_solver_state(solver, world_reset_mask)
 
     @classmethod
     def _synchronize_solver_state(
@@ -389,13 +393,19 @@ class NewtonManager(PhysicsManager):
         pass
 
     @classmethod
+    def _reset_solver_state(cls, solver: SolverBase, world_reset_mask: wp.array) -> None:
+        """Clear one solver's derived state without changing authored state."""
+        solver.reset(cls._state_0, world_mask=world_reset_mask, flags=0)
+
+    @classmethod
     def _state_write_graph_safe(cls) -> bool:
         """Return whether authored-state reconciliation can be CUDA-captured."""
         return True
 
     @classmethod
     def _flush_pending_changes(cls) -> None:
-        """Apply pending authored state before a coherent boundary."""
+        """Apply pending model and authored-state changes before a coherent boundary."""
+        cls._notify_solver_model_changes()
         if NewtonManager._state_writes is not None:
             NewtonManager._state_writes.flush()
 
@@ -678,11 +688,6 @@ class NewtonManager(PhysicsManager):
 
         cfg = PhysicsManager._cfg
         device = PhysicsManager._device
-
-        # Model-property notifications remain step-owned for compatibility
-        # with existing coupled managers, which fan them out to sub-solvers
-        # before delegating here.
-        cls._notify_solver_model_changes()
 
         # RTX-active initialization defers this tiny conditional graph to the
         # first safe inter-frame window, just like the simulation graph below.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
@@ -97,6 +97,15 @@ class NewtonCfg(PhysicsCfg):
     Users normally do not set this directly.
     """
 
+    solver_reset: bool = False
+    """Whether to clear solver-owned state after task-authored environment writes.
+
+    This cross-cutting behavior is opt-in. Isaac Lab passes ``flags=0`` so
+    task-authored positions and velocities remain unchanged. Kamino's mandatory
+    state synchronization is independent of this option, and solvers that
+    inherit Newton's no-op reset hook are unaffected.
+    """
+
     num_substeps: int = 1
     """Number of substeps to use for the solver."""
 
@@ -155,6 +164,9 @@ class NewtonCfg(PhysicsCfg):
     """
 
     def __post_init__(self):
+        if not isinstance(self.solver_reset, bool):
+            raise TypeError("NewtonCfg.solver_reset must be a bool.")
+
         # NewtonCfg.class_type is auto-derived from solver_cfg.class_type.
         # Refuse a user-set value: setting both is ambiguous and was
         # previously silently overwritten.

--- a/source/isaaclab_newton/isaaclab_newton/sensors/joint_wrench/joint_wrench_sensor.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/joint_wrench/joint_wrench_sensor.py
@@ -186,6 +186,7 @@ class JointWrenchSensor(BaseJointWrenchSensor):
                 f"Joint wrench sensor '{self.cfg.prim_path}': not initialized."
                 " Access sensor data only after sim.reset() has been called."
             )
+        NewtonManager.forward()
         wp.launch(
             joint_wrench_to_incoming_joint_frame_kernel,
             dim=(self._num_envs, self._num_joints),

--- a/source/isaaclab_newton/isaaclab_newton/sensors/pva/pva.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/pva/pva.py
@@ -166,6 +166,7 @@ class Pva(BasePva):
                 f"Pva '{self.cfg.prim_path}': sensor not initialized. "
                 "Access sensor data only after sim.reset() has been called."
             )
+        NewtonManager.forward()
         state = NewtonManager._state_0
 
         wp.launch(

--- a/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/ray_caster.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/ray_caster.py
@@ -287,6 +287,7 @@ class _NewtonRayCasterMixin:
         quat_buf: wp.array,
     ) -> None:
         """Launch the Newton site pose kernel into caller-provided buffers."""
+        NewtonManager.forward()
         model = NewtonManager._model
         state = NewtonManager._state_0
         if model is None or state is None:

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -424,6 +424,7 @@ class NewtonSiteFrameView(BaseFrameView):
 
     def get_world_poses(self, indices: wp.array | None = None) -> tuple[ProxyArray, ProxyArray]:
         """Get world-space positions and orientations."""
+        NewtonManager.forward()
         state = NewtonManager.get_state_0()
         site_indices = self._site_indices if indices is None else indices
         n = self.count if indices is None else len(indices)
@@ -451,6 +452,7 @@ class NewtonSiteFrameView(BaseFrameView):
         if positions is None and orientations is None:
             return
 
+        NewtonManager.forward()
         state = NewtonManager.get_state_0()
         if positions is None or orientations is None:
             cur_pos_ta, cur_quat_ta = self.get_world_poses(indices)

--- a/source/isaaclab_newton/test/assets/test_rigid_object.py
+++ b/source/isaaclab_newton/test/assets/test_rigid_object.py
@@ -1331,13 +1331,13 @@ def test_body_link_pose_w_fresh_after_root_pose_write(device, writer):
     (Newton ``body_q``) is stale until forward kinematics is re-evaluated. The getter must call
     :meth:`SimulationManager.forward` so the returned tensor matches the written pose. Without the fix,
     the getter returns the pre-write value. The write must also dirty the simulator-side
-    ``_fk_reset_mask`` so collision queries (which read ``body_q`` directly, not via the property)
+    the authored-state FK mask so collision queries (which read ``body_q`` directly, not via the property)
     re-run FK before the next step.
     """
 
     def _fk_reset_mask_dirty() -> bool:
-        assert SimulationManager._fk_reset_mask is not None
-        return bool(wp.to_torch(SimulationManager._fk_reset_mask).any().item())
+        assert SimulationManager._state_writes is not None
+        return bool(wp.to_torch(SimulationManager._state_writes.fk_mask).any().item())
 
     num_cubes = 2
     with _newton_sim_context(device, gravity_enabled=False, auto_add_lighting=True) as sim:

--- a/source/isaaclab_newton/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab_newton/test/assets/test_rigid_object_collection.py
@@ -942,14 +942,14 @@ def test_body_pose_write_marks_fk_reset_mask(device, writer):
     buffer, so the property read is not what becomes stale — the simulator's internal ``body_q`` used by
     collision detection is. The write methods must therefore call :meth:`SimulationManager.invalidate_fk`
     so downstream consumers re-run forward kinematics before the next step. Without the fix,
-    ``_fk_reset_mask`` remains unset after an explicit pose write. The buffer-aliasing invariant is
+    the authored-state FK mask remains unset after an explicit pose write. The buffer-aliasing invariant is
     also pinned: a refactor that decouples ``_sim_bind_body_link_pose_w`` from the write target would
     silently make the property stale, so we check the post-write pose matches the written value.
     """
 
     def _fk_reset_mask_dirty() -> bool:
-        assert SimulationManager._fk_reset_mask is not None
-        return bool(wp.to_torch(SimulationManager._fk_reset_mask).any().item())
+        assert SimulationManager._state_writes is not None
+        return bool(wp.to_torch(SimulationManager._state_writes.fk_mask).any().item())
 
     num_envs = 2
     num_cubes = 2

--- a/source/isaaclab_newton/test/physics/test_newton_particle_state.py
+++ b/source/isaaclab_newton/test/physics/test_newton_particle_state.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for task-authored Newton particle-state synchronization."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import warp as wp
+from isaaclab_newton.assets.mpm_object import mpm_object as mpm_object_module
+from isaaclab_newton.assets.mpm_object.mpm_object import MPMObject
+from isaaclab_newton.physics import NewtonCfg, NewtonManager
+from isaaclab_newton.physics._authored_state_transaction import AuthoredStateTransaction
+
+from isaaclab.physics import PhysicsManager
+
+
+class _MPMObjectUnderTest(MPMObject):
+    """MPM object with teardown disabled for lightweight method tests."""
+
+    def __del__(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize(
+    ("selector_name", "selector", "expected_worlds"),
+    [
+        ("env_ids", [2, 0], [True, False, True]),
+        ("env_mask", [False, True, False], [False, True, False]),
+    ],
+)
+def test_particle_invalidation_marks_exact_worlds_without_fk(monkeypatch, selector_name, selector, expected_worlds):
+    """Particle writes select solver-transaction worlds without selecting rigid articulations."""
+    transaction = AuthoredStateTransaction(3, 2, "cpu", lambda worlds, articulations: None)
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+    monkeypatch.setattr(NewtonManager, "_particles_dirty", False, raising=False)
+
+    if selector_name == "env_ids":
+        value = wp.array(selector, dtype=wp.int32, device="cpu")
+    else:
+        value = wp.array(selector, dtype=wp.bool, device="cpu")
+    NewtonManager.invalidate_particles(**{selector_name: value})
+
+    assert transaction.world_mask.numpy().tolist() == expected_worlds
+    assert transaction.fk_mask.numpy().tolist() == [False, False]
+    assert transaction._pending.numpy().tolist() == [1]
+    assert NewtonManager._particles_dirty is True
+
+
+@pytest.mark.parametrize("selector_name", ["env_ids", "env_mask"])
+def test_empty_particle_selection_does_not_publish_state_work(monkeypatch, selector_name):
+    """Present-but-empty particle selections remain no-ops rather than selecting every world."""
+    calls: list[str] = []
+    transaction = AuthoredStateTransaction(3, 2, "cpu", lambda worlds, articulations: calls.append("apply"))
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    if selector_name == "env_ids":
+        value = wp.empty(0, dtype=wp.int32, device="cpu")
+    else:
+        value = wp.zeros(3, dtype=wp.bool, device="cpu")
+    NewtonManager.invalidate_particles(**{selector_name: value})
+    transaction.flush()
+
+    assert calls == []
+    assert transaction.world_mask.numpy().tolist() == [False, False, False]
+    assert transaction.fk_mask.numpy().tolist() == [False, False]
+    assert transaction._pending.numpy().tolist() == [0]
+
+
+def test_particle_and_rigid_writes_coalesce_before_owned_solver_resets(monkeypatch):
+    """One transaction preserves both selection domains before reset fan-out."""
+
+    class _ResetRecorder:
+        def __init__(self) -> None:
+            self.calls: list[tuple[object, list[bool], int]] = []
+
+        def reset(self, state, *, world_mask, flags):
+            self.calls.append((state, world_mask.numpy().tolist(), flags))
+
+    first = _ResetRecorder()
+    second = _ResetRecorder()
+    state = object()
+    observed_fk: list[list[bool]] = []
+    monkeypatch.setattr(PhysicsManager, "_cfg", NewtonCfg(solver_reset=True), raising=False)
+    monkeypatch.setattr(NewtonManager, "_state_0", state, raising=False)
+    monkeypatch.setattr(NewtonManager, "_model_changes", set(), raising=False)
+    monkeypatch.setattr(NewtonManager, "_owned_solvers", classmethod(lambda cls: (first, second)))
+    monkeypatch.setattr(
+        NewtonManager,
+        "_eval_fk_impl",
+        classmethod(lambda cls, worlds, articulations: observed_fk.append(articulations.numpy().tolist())),
+    )
+    monkeypatch.setattr(
+        NewtonManager,
+        "_synchronize_solver_state",
+        classmethod(lambda cls, solver, worlds, articulations: None),
+    )
+
+    transaction = AuthoredStateTransaction(3, 3, "cpu", NewtonManager._apply_state_writes)
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+    particle_ids = wp.array([2], dtype=wp.int32, device="cpu")
+    rigid_mask = wp.array([False, True, False], dtype=wp.bool, device="cpu")
+    articulation_ids = wp.array([[0], [1], [2]], dtype=wp.int32, device="cpu")
+
+    NewtonManager.invalidate_particles(env_ids=particle_ids)
+    NewtonManager.invalidate_fk(env_mask=rigid_mask, articulation_ids=articulation_ids)
+    NewtonManager._flush_pending_changes()
+
+    assert observed_fk == [[False, True, False]]
+    expected_reset = [(state, [False, True, True], 0)]
+    assert first.calls == expected_reset
+    assert second.calls == expected_reset
+
+
+@pytest.mark.skipif(not wp.get_cuda_device_count(), reason="CUDA is unavailable")
+def test_captured_particle_writer_rearms_only_particle_rendering(monkeypatch):
+    """Particle writes replayed from a CUDA graph remain visible at every render boundary."""
+    device = "cuda:0"
+    env_mask = wp.zeros(1, dtype=wp.bool, device=device)
+    transaction = AuthoredStateTransaction(1, 0, device, lambda worlds, articulations: None)
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    with wp.ScopedCapture(device=device) as capture:
+        NewtonManager.invalidate_particles(env_mask=env_mask)
+
+    assert transaction.replay_render_domains == transaction.RENDER_PARTICLES
+
+    observed: list[tuple[bool, bool]] = []
+
+    def sync_particles(cls):
+        observed.append((NewtonManager._transforms_dirty, NewtonManager._particles_dirty))
+        NewtonManager._particles_dirty = False
+
+    monkeypatch.setattr(NewtonManager, "_flush_pending_changes", classmethod(lambda cls: None))
+    monkeypatch.setattr(NewtonManager, "sync_transforms_to_usd", classmethod(lambda cls: None))
+    monkeypatch.setattr(NewtonManager, "sync_particles_to_usd", classmethod(sync_particles))
+    monkeypatch.setattr(NewtonManager, "_transforms_dirty", False, raising=False)
+    monkeypatch.setattr(NewtonManager, "_particles_dirty", False, raising=False)
+
+    env_mask.fill_(True)
+    for _ in range(2):
+        wp.capture_launch(capture.graph)
+        wp.synchronize_device(device)
+        NewtonManager.pre_render()
+
+    assert observed == [(False, True), (False, True)]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "selector_name"),
+    [
+        ("write_nodal_state_to_sim_index", "env_ids"),
+        ("write_nodal_pos_to_sim_index", "env_ids"),
+        ("write_nodal_velocity_to_sim_index", "env_ids"),
+        ("write_nodal_state_to_sim_mask", "env_mask"),
+        ("write_nodal_pos_to_sim_mask", "env_mask"),
+        ("write_nodal_velocity_to_sim_mask", "env_mask"),
+    ],
+)
+def test_mpm_writers_publish_the_resolved_selection(monkeypatch, method_name, selector_name):
+    """Every MPM state writer publishes the selector used by its scatter kernel."""
+    asset = object.__new__(_MPMObjectUnderTest)
+    asset._device = "cpu"
+    asset._num_instances = 3
+    asset._particles_per_object = 1
+    asset._particle_offsets = object()
+    asset._data = SimpleNamespace(
+        _particle_pos_w=SimpleNamespace(timestamp=1.0),
+        _particle_vel_w=SimpleNamespace(timestamp=1.0),
+        _particle_state_w=SimpleNamespace(timestamp=1.0),
+        _root_pos_w=SimpleNamespace(timestamp=1.0),
+        _root_vel_w=SimpleNamespace(timestamp=1.0),
+    )
+    caller_selection = object()
+    resolved_selection = SimpleNamespace(shape=(3,))
+    calls: list[dict[str, object]] = []
+    state = SimpleNamespace(particle_q=object(), particle_qd=object())
+
+    monkeypatch.setattr(asset, "_resolve_env_ids", lambda value: resolved_selection)
+    monkeypatch.setattr(asset, "_resolve_mask", lambda value: resolved_selection)
+    monkeypatch.setattr(asset, "_as_warp", lambda *args, **kwargs: object())
+    monkeypatch.setattr(asset, "_iter_particle_states", lambda: iter((state,)))
+    monkeypatch.setattr(mpm_object_module.wp, "launch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        NewtonManager,
+        "invalidate_particles",
+        classmethod(lambda cls, **kwargs: calls.append(kwargs)),
+    )
+
+    getattr(asset, method_name)(object(), **{selector_name: caller_selection})
+
+    expected = {"env_ids": None, "env_mask": None}
+    expected[selector_name] = resolved_selection
+    assert calls == [expected]

--- a/source/isaaclab_newton/test/physics/test_newton_solver_reset.py
+++ b/source/isaaclab_newton/test/physics/test_newton_solver_reset.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for opt-in clearing of solver-owned state after authored writes."""
+
+from __future__ import annotations
+
+import pytest
+from isaaclab_newton.physics import KaminoSolverCfg, NewtonCfg, NewtonKaminoManager, NewtonManager
+from isaaclab_newton.physics import kamino_manager as kamino_manager_module
+
+from isaaclab.physics import PhysicsManager
+
+
+class _SolverRecorder:
+    """Minimal solver that records model notifications and reset calls."""
+
+    def __init__(self, name: str, events: list[str]) -> None:
+        self.name = name
+        self.events = events
+        self.resets: list[tuple[object, object, int]] = []
+
+    def notify_model_changed(self, change: int) -> None:
+        self.events.append(f"notify:{self.name}:{change}")
+
+    def reset(self, state: object, *, world_mask: object, flags: int) -> None:
+        self.resets.append((state, world_mask, flags))
+        self.events.append(f"reset:{self.name}")
+
+
+class _Transaction:
+    """Tiny transaction boundary that delegates to the manager policy."""
+
+    def __init__(self, events: list[str], world_mask: object, fk_mask: object) -> None:
+        self.events = events
+        self.world_mask = world_mask
+        self.fk_mask = fk_mask
+
+    def flush(self) -> None:
+        self.events.append("transaction")
+        NewtonManager._apply_state_writes(self.world_mask, self.fk_mask)
+
+
+def test_newton_cfg_solver_reset_is_strictly_opt_in():
+    """The direct Newton configuration field defaults to disabled."""
+    assert NewtonCfg().solver_reset is False
+    assert NewtonCfg(solver_reset=True).solver_reset is True
+
+
+@pytest.mark.parametrize("value", [None, 1])
+def test_newton_cfg_rejects_non_boolean_solver_reset(value):
+    """Invalid reset policy fails before solver initialization."""
+    with pytest.raises(TypeError, match="solver_reset must be a bool"):
+        NewtonCfg(solver_reset=value)
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_flush_orders_optional_reset_after_required_sync(monkeypatch, enabled):
+    """Every owned solver sees model and authored state before optional clearing."""
+    events: list[str] = []
+    first = _SolverRecorder("first", events)
+    second = _SolverRecorder("second", events)
+    state = object()
+    world_mask = object()
+    fk_mask = object()
+
+    monkeypatch.setattr(PhysicsManager, "_cfg", NewtonCfg(solver_reset=enabled), raising=False)
+    monkeypatch.setattr(PhysicsManager, "_device", "cpu", raising=False)
+    monkeypatch.setattr(NewtonManager, "_state_0", state, raising=False)
+    monkeypatch.setattr(NewtonManager, "_model_changes", {4}, raising=False)
+    monkeypatch.setattr(NewtonManager, "_state_writes", _Transaction(events, world_mask, fk_mask), raising=False)
+    monkeypatch.setattr(NewtonManager, "_owned_solvers", classmethod(lambda cls: (first, second)))
+    monkeypatch.setattr(
+        NewtonManager,
+        "_eval_fk_impl",
+        classmethod(lambda cls, worlds, articulations: events.append("fk")),
+    )
+    monkeypatch.setattr(
+        NewtonManager,
+        "_synchronize_solver_state",
+        classmethod(lambda cls, solver, worlds, articulations: events.append(f"sync:{solver.name}")),
+    )
+
+    NewtonManager._flush_pending_changes()
+
+    expected = ["notify:first:4", "notify:second:4", "transaction", "fk", "sync:first"]
+    if enabled:
+        expected.append("reset:first")
+    expected.append("sync:second")
+    if enabled:
+        expected.append("reset:second")
+    assert events == expected
+    assert NewtonManager._model_changes == set()
+
+    for solver in (first, second):
+        if enabled:
+            assert solver.resets == [(state, world_mask, 0)]
+        else:
+            assert solver.resets == []
+
+
+def test_kamino_mandatory_sync_is_not_reset_twice(monkeypatch):
+    """Enabling the policy does not duplicate Kamino's required reset operation."""
+
+    class _KaminoResetRecorder:
+        class ResetConfig:
+            @staticmethod
+            def from_joints():
+                return "from_joints"
+
+            @staticmethod
+            def preserve():
+                return "preserve"
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[object, object, object, object]] = []
+
+        def reset(self, state, *, world_mask, flags=None, config=None):
+            self.calls.append((state, world_mask, flags, config))
+
+    solver = _KaminoResetRecorder()
+    state = object()
+    world_mask = object()
+    monkeypatch.setattr(
+        PhysicsManager,
+        "_cfg",
+        NewtonCfg(solver_cfg=KaminoSolverCfg(use_fk_solver=True), solver_reset=True),
+        raising=False,
+    )
+    monkeypatch.setattr(kamino_manager_module, "SolverKamino", _KaminoResetRecorder)
+    monkeypatch.setattr(NewtonKaminoManager, "_solver", solver, raising=False)
+    monkeypatch.setattr(NewtonKaminoManager, "_state_0", state, raising=False)
+
+    NewtonKaminoManager._apply_state_writes(world_mask, object())
+
+    assert solver.calls == [(state, world_mask, None, "from_joints")]

--- a/source/isaaclab_newton/test/physics/test_newton_state_boundaries.py
+++ b/source/isaaclab_newton/test/physics/test_newton_state_boundaries.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for asset-write and direct-read Newton state boundaries."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import warp as wp
+from isaaclab_newton.assets.articulation.articulation_data import ArticulationData
+from isaaclab_newton.assets.rigid_object.rigid_object_data import RigidObjectData
+from isaaclab_newton.assets.rigid_object_collection.rigid_object_collection_data import RigidObjectCollectionData
+from isaaclab_newton.physics import NewtonManager
+from isaaclab_newton.physics._authored_state_transaction import AuthoredStateTransaction
+from isaaclab_newton.sensors.joint_wrench import joint_wrench_sensor as joint_wrench_module
+from isaaclab_newton.sensors.joint_wrench.joint_wrench_sensor import JointWrenchSensor
+
+
+@pytest.mark.parametrize("data_type", [ArticulationData, RigidObjectData, RigidObjectCollectionData])
+@pytest.mark.parametrize("reset_method", ["_reset_pose", "_reset_velocity"])
+def test_skip_cache_invalidation_still_publishes_state_write(monkeypatch, data_type, reset_method):
+    """skip_forward may preserve asset caches but cannot hide authored state from the solver."""
+    articulation_ids = object()
+    env_ids = object()
+    calls: list[dict] = []
+    data = object.__new__(data_type)
+    data._root_view = SimpleNamespace(articulation_ids=articulation_ids)
+    data._fk_timestamp = 17.0
+    monkeypatch.setattr(
+        NewtonManager,
+        "invalidate_fk",
+        classmethod(lambda cls, **kwargs: calls.append(kwargs)),
+    )
+
+    getattr(data, reset_method)(env_ids=env_ids, invalidate_cache=False)
+
+    assert data._fk_timestamp == 17.0
+    expected = {"env_mask": None, "env_ids": env_ids, "articulation_ids": articulation_ids}
+    if data_type is RigidObjectCollectionData:
+        expected["articulation_selection"] = None
+    assert calls == [expected]
+
+
+@pytest.mark.parametrize("reset_method", ["_reset_pose", "_reset_velocity"])
+def test_collection_publishes_selected_articulation_columns(monkeypatch, reset_method):
+    """Partial collection writes preserve their body-column selection."""
+    articulation_ids = object()
+    body_ids = object()
+    calls: list[dict] = []
+    data = object.__new__(RigidObjectCollectionData)
+    data._root_view = SimpleNamespace(articulation_ids=articulation_ids)
+    monkeypatch.setattr(
+        NewtonManager,
+        "invalidate_fk",
+        classmethod(lambda cls, **kwargs: calls.append(kwargs)),
+    )
+
+    getattr(data, reset_method)(body_ids=body_ids, invalidate_cache=False)
+
+    assert calls == [
+        {
+            "env_mask": None,
+            "env_ids": None,
+            "articulation_ids": articulation_ids,
+            "articulation_selection": body_ids,
+        }
+    ]
+
+
+def test_empty_collection_selection_does_not_publish_work(monkeypatch):
+    """A no-op collection write does not trigger backend synchronization."""
+    transaction = AuthoredStateTransaction(1, 1, "cpu", lambda worlds, articulations: None)
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+    NewtonManager.invalidate_fk(
+        env_ids=wp.array([0], dtype=wp.int32, device="cpu"),
+        articulation_ids=wp.array([[0]], dtype=wp.int32, device="cpu"),
+        articulation_selection=wp.empty(0, dtype=wp.int32, device="cpu"),
+    )
+
+    assert transaction.world_mask.numpy().tolist() == [False]
+    assert transaction._pending.numpy().tolist() == [0]
+
+
+def test_joint_wrench_read_flushes_pending_state(monkeypatch):
+    """Direct body-state sensors establish the same coherent read boundary as asset data."""
+    events: list[str] = []
+    sensor = object.__new__(JointWrenchSensor)
+    sensor._sim_bind_body_parent_f = object()
+    sensor._sim_bind_body_q = object()
+    sensor._sim_bind_body_com = object()
+    sensor._sim_bind_joint_X_c = object()
+    sensor._joint_child = object()
+    sensor._num_envs = 1
+    sensor._num_joints = 1
+    sensor._timestamp = object()
+    sensor._device = "cpu"
+    sensor._data = SimpleNamespace(_force=object(), _torque=object())
+    sensor._initialize_handle = None
+    sensor._invalidate_initialize_handle = None
+    sensor._prim_deletion_handle = None
+    monkeypatch.setattr(NewtonManager, "forward", classmethod(lambda cls: events.append("forward")))
+    monkeypatch.setattr(joint_wrench_module.wp, "launch", lambda *args, **kwargs: events.append("launch"))
+
+    sensor._update_buffers_impl(object())
+
+    assert events == ["forward", "launch"]

--- a/source/isaaclab_newton/test/physics/test_newton_state_pipeline.py
+++ b/source/isaaclab_newton/test/physics/test_newton_state_pipeline.py
@@ -128,8 +128,8 @@ def test_invalidate_fk_preserves_selected_articulation_columns(monkeypatch):
     assert transaction.fk_mask.numpy().tolist() == [False, False, True, False]
 
 
-def test_invalidate_fk_marks_world_without_articulations(monkeypatch):
-    """Rigid-only worlds still request solver-owned state clearing."""
+def test_empty_articulation_selection_is_noop(monkeypatch):
+    """An empty view selection cannot publish work for an unchanged world."""
     transaction = AuthoredStateTransaction(1, 0, "cpu", lambda worlds, articulations: None)
     env_mask = wp.array([True], dtype=wp.bool, device="cpu")
     articulation_ids = wp.empty((1, 0), dtype=wp.int32, device="cpu")
@@ -137,8 +137,8 @@ def test_invalidate_fk_marks_world_without_articulations(monkeypatch):
 
     NewtonManager.invalidate_fk(env_mask=env_mask, articulation_ids=articulation_ids)
 
-    assert transaction.world_mask.numpy().tolist() == [True]
-    assert transaction._pending.numpy().tolist() == [1]
+    assert transaction.world_mask.numpy().tolist() == [False]
+    assert transaction._pending.numpy().tolist() == [0]
 
 
 def test_invalidate_fk_without_topology_conservatively_marks_all_articulations(monkeypatch):

--- a/source/isaaclab_newton/test/physics/test_newton_state_pipeline.py
+++ b/source/isaaclab_newton/test/physics/test_newton_state_pipeline.py
@@ -1,0 +1,624 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for consuming task-authored Newton state as one transaction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import warp as wp
+from isaaclab_newton.physics import (
+    KaminoSolverCfg,
+    MJWarpSolverCfg,
+    NewtonCfg,
+    NewtonKaminoManager,
+    NewtonManager,
+    NewtonMJWarpManager,
+)
+from isaaclab_newton.physics import kamino_manager as kamino_manager_module
+from isaaclab_newton.physics import mjwarp_manager as mjwarp_manager_module
+from isaaclab_newton.physics import newton_manager as newton_manager_module
+from isaaclab_newton.physics._authored_state_transaction import AuthoredStateTransaction
+
+from isaaclab.physics import PhysicsManager
+
+
+class _SolverRecorder:
+    """Minimal solver that records synchronization calls."""
+
+    def __init__(self, events: list[str] | None = None) -> None:
+        self.events = [] if events is None else events
+        self.notifications: list[int] = []
+
+    def notify_model_changed(self, flags: int) -> None:
+        self.notifications.append(flags)
+        self.events.append(f"notify:{flags}")
+
+
+@wp.kernel
+def _increment_counter(counter: wp.array(dtype=wp.int32)):
+    wp.atomic_add(counter, 0, 1)
+
+
+def test_apply_state_writes_reconciles_derived_and_solver_state(monkeypatch):
+    """Every transaction updates FK before backend-specific state handoff."""
+    events: list[str] = []
+    solver = _SolverRecorder(events)
+    monkeypatch.setattr(NewtonManager, "_solver", solver, raising=False)
+    monkeypatch.setattr(
+        NewtonManager,
+        "_eval_fk_impl",
+        classmethod(lambda cls, worlds, articulations: events.append("fk")),
+    )
+    monkeypatch.setattr(
+        NewtonManager,
+        "_synchronize_solver_state",
+        classmethod(lambda cls, owned_solver, worlds, articulations: events.append("sync")),
+    )
+
+    NewtonManager._apply_state_writes(object(), object())
+
+    assert events == ["fk", "sync"]
+
+
+def test_model_changes_are_delivered_to_every_owned_solver(monkeypatch):
+    """Pending flags reach every owned solver without changing their representation."""
+    first = _SolverRecorder()
+    second = _SolverRecorder()
+    monkeypatch.setattr(NewtonManager, "_model_changes", set(), raising=False)
+    monkeypatch.setattr(
+        NewtonManager,
+        "_owned_solvers",
+        classmethod(lambda cls: (first, second)),
+    )
+    monkeypatch.setattr(PhysicsManager, "_device", "cpu", raising=False)
+
+    NewtonManager.add_model_change(1)
+    NewtonManager.add_model_change(4)
+    NewtonManager._notify_solver_model_changes()
+
+    assert sorted(first.notifications) == [1, 4]
+    assert sorted(second.notifications) == [1, 4]
+    assert NewtonManager._model_changes == set()
+
+
+def test_model_changes_wait_until_a_solver_exists(monkeypatch):
+    """Pre-initialization notifications are retained for the first real solver."""
+    monkeypatch.setattr(NewtonManager, "_model_changes", {3}, raising=False)
+    monkeypatch.setattr(NewtonManager, "_owned_solvers", classmethod(lambda cls: ()))
+
+    NewtonManager._notify_solver_model_changes()
+
+    assert NewtonManager._model_changes == {3}
+
+
+def test_invalidate_fk_sets_masks_and_device_transaction_gate(monkeypatch):
+    """The same kernel launch records both dirty topology and pending work."""
+    transaction = AuthoredStateTransaction(2, 2, "cpu", lambda worlds, articulations: None)
+    env_mask = wp.array([False, True], dtype=wp.bool, device="cpu")
+    articulation_ids = wp.array([[0], [1]], dtype=wp.int32, device="cpu")
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    NewtonManager.invalidate_fk(env_mask=env_mask, articulation_ids=articulation_ids)
+
+    assert transaction.world_mask.numpy().tolist() == [False, True]
+    assert transaction.fk_mask.numpy().tolist() == [False, True]
+    assert transaction._pending.numpy().tolist() == [1]
+
+
+def test_invalidate_fk_preserves_selected_articulation_columns(monkeypatch):
+    """Partial collection writes do not dirty history for untouched objects."""
+    transaction = AuthoredStateTransaction(2, 4, "cpu", lambda worlds, articulations: None)
+    env_ids = wp.array([1], dtype=wp.int32, device="cpu")
+    articulation_ids = wp.array([[0, 1], [2, 3]], dtype=wp.int32, device="cpu")
+    articulation_selection = wp.array([0], dtype=wp.int32, device="cpu")
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    NewtonManager.invalidate_fk(
+        env_ids=env_ids,
+        articulation_ids=articulation_ids,
+        articulation_selection=articulation_selection,
+    )
+
+    assert transaction.world_mask.numpy().tolist() == [False, True]
+    assert transaction.fk_mask.numpy().tolist() == [False, False, True, False]
+
+
+def test_invalidate_fk_marks_world_without_articulations(monkeypatch):
+    """Rigid-only worlds still request solver-owned state clearing."""
+    transaction = AuthoredStateTransaction(1, 0, "cpu", lambda worlds, articulations: None)
+    env_mask = wp.array([True], dtype=wp.bool, device="cpu")
+    articulation_ids = wp.empty((1, 0), dtype=wp.int32, device="cpu")
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    NewtonManager.invalidate_fk(env_mask=env_mask, articulation_ids=articulation_ids)
+
+    assert transaction.world_mask.numpy().tolist() == [True]
+    assert transaction._pending.numpy().tolist() == [1]
+
+
+def test_invalidate_fk_without_topology_conservatively_marks_all_articulations(monkeypatch):
+    """Topology-free rigid invalidation preserves the conservative FK fallback."""
+    transaction = AuthoredStateTransaction(2, 3, "cpu", lambda worlds, articulations: None)
+    env_mask = wp.array([False, True], dtype=wp.bool, device="cpu")
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    NewtonManager.invalidate_fk(env_mask=env_mask)
+
+    assert transaction.world_mask.numpy().tolist() == [True, True]
+    assert transaction.fk_mask.numpy().tolist() == [True, True, True]
+    assert transaction._pending.numpy().tolist() == [1]
+
+
+@pytest.mark.skipif(
+    not wp.get_cuda_device_count() or not wp.is_conditional_graph_supported(),
+    reason="CUDA conditional graphs are unavailable",
+)
+def test_captured_state_writer_replays_one_device_gated_transaction(monkeypatch):
+    """Replayed reset writers do not depend on a capture-time Python flag."""
+    device = "cuda:0"
+    env_mask = wp.zeros(1, dtype=wp.bool, device=device)
+    articulation_ids = wp.array([[0]], dtype=wp.int32, device=device)
+    counter = wp.zeros(1, dtype=wp.int32, device=device)
+    monkeypatch.setattr(NewtonManager, "_model_changes", set(), raising=False)
+
+    def apply(worlds, articulations):
+        wp.launch(_increment_counter, 1, inputs=[counter], device=device)
+
+    transaction = AuthoredStateTransaction(1, 1, device, apply)
+    transaction.configure_capture(graph_safe=True, defer=True)
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    with wp.ScopedCapture(device=device) as capture:
+        NewtonManager.invalidate_fk(env_mask=env_mask, articulation_ids=articulation_ids)
+        NewtonManager._flush_pending_changes()
+
+    assert transaction.writes_may_replay
+    observed_dirty: list[bool] = []
+
+    def sync_transforms(cls):
+        observed_dirty.append(NewtonManager._transforms_dirty)
+        NewtonManager._transforms_dirty = False
+
+    monkeypatch.setattr(NewtonManager, "_flush_pending_changes", classmethod(lambda cls: None))
+    monkeypatch.setattr(NewtonManager, "sync_transforms_to_usd", classmethod(sync_transforms))
+    monkeypatch.setattr(NewtonManager, "sync_particles_to_usd", classmethod(lambda cls: None))
+    monkeypatch.setattr(NewtonManager, "_transforms_dirty", False, raising=False)
+
+    env_mask.fill_(True)
+    wp.capture_launch(capture.graph)
+    wp.synchronize_device(device)
+    NewtonManager.pre_render()
+
+    wp.capture_launch(capture.graph)
+    wp.synchronize_device(device)
+    NewtonManager.pre_render()
+
+    assert counter.numpy().tolist() == [2]
+    assert observed_dirty == [True, True]
+
+
+@pytest.mark.skipif(
+    not wp.get_cuda_device_count() or not wp.is_conditional_graph_supported(),
+    reason="CUDA conditional graphs are unavailable",
+)
+def test_clean_boundary_captured_before_writer_graph_still_consumes_replay():
+    """Boundary capture always records the conditional, even before any writer is captured."""
+    device = "cuda:0"
+    env_mask = wp.array([True], dtype=wp.bool, device=device)
+    articulation_ids = wp.array([[0]], dtype=wp.int32, device=device)
+    counter = wp.zeros(1, dtype=wp.int32, device=device)
+
+    def apply(worlds, articulations):
+        wp.launch(_increment_counter, 1, inputs=[counter], device=device)
+
+    transaction = AuthoredStateTransaction(1, 1, device, apply)
+    transaction.configure_capture(graph_safe=True, enabled=False)
+
+    with wp.ScopedCapture(device=device) as boundary_capture:
+        transaction.flush()
+    with wp.ScopedCapture(device=device) as writer_capture:
+        transaction.mark_rigid(env_mask=env_mask, articulation_ids=articulation_ids)
+
+    transaction._world_mask.zero_()
+    transaction._fk_mask.zero_()
+    transaction._pending.zero_()
+    transaction._host_pending = False
+
+    wp.capture_launch(writer_capture.graph)
+    wp.capture_launch(boundary_capture.graph)
+    wp.synchronize_device(device)
+
+    assert counter.numpy().tolist() == [1]
+
+
+@pytest.mark.skipif(not wp.get_cuda_device_count(), reason="CUDA is unavailable")
+def test_captured_step_rearms_transform_render_domain(monkeypatch):
+    """A replayed physics step cannot lose host-only transform dirtiness."""
+    device = "cuda:0"
+    counter = wp.zeros(1, dtype=wp.int32, device=device)
+    transaction = AuthoredStateTransaction(1, 0, device, lambda worlds, articulations: None)
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    with wp.ScopedCapture(device=device) as capture:
+        wp.launch(_increment_counter, 1, inputs=[counter], device=device)
+        NewtonManager._mark_transforms_dirty()
+
+    observed_dirty: list[bool] = []
+
+    def sync_transforms(cls):
+        observed_dirty.append(NewtonManager._transforms_dirty)
+        NewtonManager._transforms_dirty = False
+
+    monkeypatch.setattr(NewtonManager, "_flush_pending_changes", classmethod(lambda cls: None))
+    monkeypatch.setattr(NewtonManager, "sync_transforms_to_usd", classmethod(sync_transforms))
+    monkeypatch.setattr(NewtonManager, "sync_particles_to_usd", classmethod(lambda cls: None))
+    monkeypatch.setattr(NewtonManager, "_transforms_dirty", False, raising=False)
+
+    for _ in range(2):
+        wp.capture_launch(capture.graph)
+        wp.synchronize_device(device)
+        NewtonManager.pre_render()
+
+    assert counter.numpy().tolist() == [2]
+    assert observed_dirty == [True, True]
+
+
+def test_graph_unsafe_state_handoff_is_rejected_during_outer_capture():
+    """A backend that performs host transfers cannot enter an outer CUDA graph."""
+    transaction = AuthoredStateTransaction(1, 1, "cpu", lambda worlds, articulations: None)
+    transaction.configure_capture(graph_safe=False)
+    transaction._device = SimpleNamespace(is_cuda=True, stream=SimpleNamespace(is_capturing=True))
+
+    with pytest.raises(RuntimeError, match="not CUDA-graph-safe"):
+        transaction.flush()
+
+
+def test_outer_capture_requires_cuda_conditional_nodes(monkeypatch):
+    """Unsupported conditional capture fails explicitly instead of during callback work."""
+    transaction = AuthoredStateTransaction(1, 1, "cpu", lambda worlds, articulations: None)
+    transaction.configure_capture(graph_safe=True)
+    transaction._device = SimpleNamespace(is_cuda=True, stream=SimpleNamespace(is_capturing=True))
+    monkeypatch.setattr(wp, "is_conditional_graph_supported", lambda: False)
+
+    with pytest.raises(RuntimeError, match="requires CUDA conditional graph nodes"):
+        transaction.flush()
+
+
+def test_flush_applies_and_consumes_state_transaction(monkeypatch):
+    """A flush clears masks only after state reconciliation succeeds."""
+    events: list[str] = []
+    transaction = AuthoredStateTransaction(1, 1, "cpu", lambda worlds, articulations: events.append("apply"))
+    transaction.mark_rigid()
+
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    NewtonManager._flush_pending_changes()
+
+    assert events == ["apply"]
+    assert transaction.world_mask.numpy().tolist() == [False]
+    assert transaction.fk_mask.numpy().tolist() == [False]
+    assert transaction._pending.numpy().tolist() == [0]
+
+
+def test_clean_second_flush_skips_state_transaction(monkeypatch):
+    """A consumed transaction does not repeat reset work at later boundaries."""
+    calls: list[str] = []
+    transaction = AuthoredStateTransaction(1, 1, "cpu", lambda worlds, articulations: calls.append("consume"))
+    transaction.mark_rigid()
+    monkeypatch.setattr(NewtonManager, "_model_changes", set(), raising=False)
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    NewtonManager._flush_pending_changes()
+    NewtonManager._flush_pending_changes()
+
+    assert calls == ["consume"]
+
+
+def test_flush_retains_masks_when_state_sync_fails(monkeypatch):
+    """A failed reconciliation leaves device masks available for diagnosis/retry."""
+
+    def fail(worlds, articulations):
+        raise RuntimeError("state sync failed")
+
+    transaction = AuthoredStateTransaction(1, 1, "cpu", fail)
+    transaction.mark_rigid(articulation_ids=wp.array([[0]], dtype=wp.int32, device="cpu"))
+    monkeypatch.setattr(NewtonManager, "_model_changes", set(), raising=False)
+    monkeypatch.setattr(NewtonManager, "_state_writes", transaction, raising=False)
+
+    with pytest.raises(RuntimeError, match="state sync failed"):
+        NewtonManager._flush_pending_changes()
+
+    assert transaction.world_mask.numpy().tolist() == [True]
+    assert transaction.fk_mask.numpy().tolist() == [True]
+    assert transaction._pending.numpy().tolist() == [1]
+
+
+def test_forward_resolves_concrete_manager(monkeypatch):
+    """Data-layer calls through NewtonManager still reach solver-specific policy."""
+    calls: list[str] = []
+
+    class _ActiveManager:
+        @classmethod
+        def _flush_pending_changes(cls) -> None:
+            calls.append("flush")
+
+    monkeypatch.setattr(
+        PhysicsManager,
+        "_sim",
+        SimpleNamespace(physics_manager=_ActiveManager),
+        raising=False,
+    )
+
+    NewtonManager.forward()
+
+    assert calls == ["flush"]
+
+
+def test_step_flushes_before_deferred_graph_warmup(monkeypatch):
+    """No graph warmup may advance state before authored writes are coherent."""
+    events: list[str] = []
+
+    def capture(cls, device):
+        events.append("capture")
+        raise RuntimeError("stop after ordering check")
+
+    monkeypatch.setattr(PhysicsManager, "_sim", SimpleNamespace(is_playing=lambda: True), raising=False)
+    monkeypatch.setattr(
+        PhysicsManager,
+        "_cfg",
+        NewtonCfg(use_cuda_graph=True),
+        raising=False,
+    )
+    monkeypatch.setattr(PhysicsManager, "_device", "cuda:0", raising=False)
+    monkeypatch.setattr(NewtonManager, "_graph_capture_pending", True, raising=False)
+    monkeypatch.setattr(
+        NewtonManager,
+        "_flush_pending_changes",
+        classmethod(lambda cls: events.append("flush")),
+    )
+    monkeypatch.setattr(NewtonManager, "_capture_relaxed_graph", classmethod(capture))
+
+    with pytest.raises(RuntimeError, match="ordering check"):
+        NewtonManager.step()
+
+    assert events == ["flush", "capture"]
+
+
+def test_step_captures_deferred_state_graph_before_flush(monkeypatch):
+    """RTX uses one safe relaxed window before consuming the first transaction."""
+    events: list[str] = []
+
+    class _DeferredTransaction:
+        needs_capture = True
+
+        def capture_deferred(self, capture_fn):
+            capture_fn(lambda: None)
+
+    def capture(cls, device, capture_fn=None, *, warmup=True):
+        if capture_fn is not None:
+            events.append(f"state_capture:{warmup}")
+            return object()
+        events.append("physics_capture")
+        raise RuntimeError("stop after ordering check")
+
+    monkeypatch.setattr(PhysicsManager, "_sim", SimpleNamespace(is_playing=lambda: True), raising=False)
+    monkeypatch.setattr(PhysicsManager, "_cfg", NewtonCfg(use_cuda_graph=True), raising=False)
+    monkeypatch.setattr(PhysicsManager, "_device", "cuda:0", raising=False)
+    monkeypatch.setattr(NewtonManager, "_state_writes", _DeferredTransaction(), raising=False)
+    monkeypatch.setattr(NewtonManager, "_graph_capture_pending", True, raising=False)
+    monkeypatch.setattr(
+        NewtonManager,
+        "_flush_pending_changes",
+        classmethod(lambda cls: events.append("flush")),
+    )
+    monkeypatch.setattr(NewtonManager, "_capture_relaxed_graph", classmethod(capture))
+
+    with pytest.raises(RuntimeError, match="ordering check"):
+        NewtonManager.step()
+
+    assert events == ["state_capture:False", "flush", "physics_capture"]
+
+
+def test_pre_render_flushes_before_fabric_sync(monkeypatch):
+    """Fabric cannot consume stale body transforms after an authored write."""
+    events: list[str] = []
+    monkeypatch.setattr(
+        NewtonManager,
+        "_flush_pending_changes",
+        classmethod(lambda cls: events.append("flush")),
+    )
+    monkeypatch.setattr(
+        NewtonManager,
+        "sync_transforms_to_usd",
+        classmethod(lambda cls: events.append("transforms")),
+    )
+    monkeypatch.setattr(
+        NewtonManager,
+        "sync_particles_to_usd",
+        classmethod(lambda cls: events.append("particles")),
+    )
+
+    NewtonManager.pre_render()
+
+    assert events == ["flush", "transforms", "particles"]
+
+
+def test_get_state_flushes_newton_backend(monkeypatch):
+    """Direct renderer/visualizer state access receives coherent Newton state."""
+    events: list[str] = []
+    state = object()
+    monkeypatch.setattr(
+        NewtonManager,
+        "_backend_is_newton",
+        classmethod(lambda cls, provider=None: True),
+    )
+    monkeypatch.setattr(NewtonManager, "forward", classmethod(lambda cls: events.append("forward")))
+    monkeypatch.setattr(
+        NewtonManager,
+        "update_visualization_state",
+        classmethod(lambda cls, provider=None: events.append("visualization")),
+    )
+    monkeypatch.setattr(NewtonManager, "get_state_0", classmethod(lambda cls: state))
+
+    assert NewtonManager.get_state() is state
+    assert events == ["forward", "visualization"]
+
+
+def test_scene_data_backend_state_flushes_before_transform_read(monkeypatch):
+    """SceneDataProvider's direct state boundary cannot expose stale body_q."""
+    events: list[str] = []
+    state = object()
+    backend = newton_manager_module.NewtonSceneDataBackend()
+    monkeypatch.setattr(NewtonManager, "forward", classmethod(lambda cls: events.append("forward")))
+    monkeypatch.setattr(NewtonManager, "get_state_0", classmethod(lambda cls: state))
+
+    assert backend.state is state
+    assert events == ["forward"]
+
+
+def test_kamino_registers_state_buffers_before_finalize(monkeypatch):
+    """Kamino state arrays are model-owned rather than allocated during capture."""
+    monkeypatch.setattr(
+        PhysicsManager,
+        "_cfg",
+        NewtonCfg(solver_cfg=KaminoSolverCfg()),
+        raising=False,
+    )
+
+    builder = NewtonKaminoManager.create_builder()
+
+    assert builder.has_custom_attribute("body_f_total")
+    assert builder.has_custom_attribute("joint_q_prev")
+    assert builder.has_custom_attribute("joint_lambdas")
+
+    # Registration is intentionally unconditional and idempotent so a custom
+    # builder cannot leave the three state buffers only partially declared.
+    NewtonKaminoManager._register_builder_attributes(builder)
+
+
+def test_kamino_state_write_uses_one_mandatory_reset(monkeypatch):
+    """Kamino reconciles authored joint state exactly once."""
+
+    class _KaminoResetRecorder:
+        class ResetConfig:
+            @staticmethod
+            def from_joints():
+                return "from_joints"
+
+            @staticmethod
+            def preserve():
+                return "preserve"
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[object, object, object, object]] = []
+
+        def reset(self, state, *, world_mask, flags=None, config=None):
+            self.calls.append((state, world_mask, flags, config))
+
+    solver = _KaminoResetRecorder()
+    state = object()
+    world_mask = object()
+    monkeypatch.setattr(
+        PhysicsManager,
+        "_cfg",
+        NewtonCfg(solver_cfg=KaminoSolverCfg(use_fk_solver=True)),
+        raising=False,
+    )
+    monkeypatch.setattr(kamino_manager_module, "SolverKamino", _KaminoResetRecorder)
+    monkeypatch.setattr(NewtonKaminoManager, "_solver", solver, raising=False)
+    monkeypatch.setattr(NewtonKaminoManager, "_state_0", state, raising=False)
+
+    NewtonKaminoManager._apply_state_writes(world_mask, object())
+
+    assert solver.calls == [(state, world_mask, None, "from_joints")]
+
+
+def test_cpu_mujoco_rejects_multiworld(monkeypatch):
+    """The CPU MuJoCo backend itself is limited to one Newton world."""
+    cfg = NewtonCfg(solver_cfg=MJWarpSolverCfg(use_mujoco_cpu=True))
+    monkeypatch.setattr(PhysicsManager, "_cfg", cfg, raising=False)
+
+    with pytest.raises(ValueError, match="supports only one Newton world"):
+        NewtonMJWarpManager._build_solver(SimpleNamespace(world_count=2), cfg.solver_cfg)
+
+
+def test_cpu_mujoco_allows_single_world(monkeypatch):
+    """CPU MuJoCo accepts its supported single-world topology."""
+
+    class _CpuMuJoCo:
+        def __init__(self, model, **kwargs):
+            self.model = model
+            self.use_mujoco_cpu = True
+
+    cfg = NewtonCfg(solver_cfg=MJWarpSolverCfg(use_mujoco_cpu=True))
+    monkeypatch.setattr(PhysicsManager, "_cfg", cfg, raising=False)
+    monkeypatch.setattr(mjwarp_manager_module, "SolverMuJoCo", _CpuMuJoCo)
+
+    NewtonMJWarpManager._build_solver(SimpleNamespace(world_count=1), cfg.solver_cfg)
+
+    assert isinstance(NewtonManager._solver, _CpuMuJoCo)
+
+
+@pytest.mark.parametrize(
+    ("use_mujoco_cpu", "update_data_interval", "expected"),
+    [(True, 1, False), (False, 2, False), (False, 1, True), (False, 0, True)],
+)
+def test_mujoco_main_graph_requires_device_per_step_handoff(
+    monkeypatch, use_mujoco_cpu, update_data_interval, expected
+):
+    """Host execution and Python sparse cadence stay outside the main CUDA graph."""
+    solver = SimpleNamespace(use_mujoco_cpu=use_mujoco_cpu, update_data_interval=update_data_interval)
+    monkeypatch.setattr(NewtonMJWarpManager, "_solver", solver, raising=False)
+
+    assert NewtonMJWarpManager._supports_cuda_graph_capture() is expected
+
+
+def test_mujoco_sparse_update_interval_receives_authored_state(monkeypatch):
+    """Sparse MuJoCo cadence still receives task-authored state immediately."""
+
+    class _MuJoCoRecorder:
+        use_mujoco_cpu = False
+        update_data_interval = 2
+        mj_data = None
+        mjw_data = object()
+
+        def __init__(self):
+            self.events: list[tuple] = []
+
+        def reset(self, state, *, world_mask, flags):
+            self.events.append(("reset", state, world_mask, flags))
+
+        def _update_mjc_data(self, data, model, state):
+            self.events.append(("sync", data, model, state))
+
+    solver = _MuJoCoRecorder()
+    state = object()
+    model = object()
+    mask = object()
+    monkeypatch.setattr(
+        PhysicsManager,
+        "_cfg",
+        NewtonCfg(solver_cfg=MJWarpSolverCfg()),
+        raising=False,
+    )
+    monkeypatch.setattr(NewtonMJWarpManager, "_solver", solver, raising=False)
+    monkeypatch.setattr(NewtonMJWarpManager, "_state_0", state, raising=False)
+    monkeypatch.setattr(NewtonMJWarpManager, "_model", model, raising=False)
+    monkeypatch.setattr(
+        NewtonMJWarpManager,
+        "_eval_fk_impl",
+        classmethod(lambda cls, worlds, articulations: solver.events.append(("fk", worlds, articulations))),
+    )
+
+    fk_mask = object()
+    NewtonMJWarpManager._apply_state_writes(mask, fk_mask)
+
+    assert solver.events == [
+        ("fk", mask, fk_mask),
+        ("sync", solver.mjw_data, model, state),
+    ]


### PR DESCRIPTION
## Summary

- add a world-only particle path to the shared authored-state transaction, preserving exact mask/index selection without requesting rigid forward kinematics
- publish every explicit MPM and contrib deformable state, position, and velocity write through that path
- re-arm particle rendering when device writes replay from a CUDA graph
- keep per-step deformable kinematic-target application on the control path, where it refreshes caches and rendering without creating optional-reset work

Current MPM and VBD reset hooks remain Newton no-ops; this PR does not claim to clear their deformation or warm-start history. It provides the correct selected worlds to owned solver hooks when they have meaningful reset behavior.

## Dependencies

- Depends on #6350, #6351, #6352, and #6349.
- GitHub shows the cumulative stack here until those PRs land. This PR's final commit is confined to particle transaction/rendering behavior, MPM/deformable writers, focused tests, and two package changelogs.

## Testing

- Exact pinned Newton dependency: 75 state-pipeline, boundary, coupled-state, reset-policy, and particle-state tests passed.
- Existing MPM object integration suite: 8 passed against the exact pin using process-local logging symbols expected by that pin's newer Warp API; no compatibility workaround is included in source.
- Targeted pre-commit checks passed for all eight files.
- Compile and diff checks passed.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added changelog fragments for every touched package
- [x] I have added my name to `CONTRIBUTORS.md` or my name already exists there
