### PR TITLE
Add opt-in Newton solver reset

### DIFF
--- a/source/isaaclab_newton/changelog.d/solver-reset.minor.rst
+++ b/source/isaaclab_newton/changelog.d/solver-reset.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_newton.physics.NewtonCfg.solver_reset` for opt-in clearing of Newton
+  solver-owned state after task-authored joint or root writes while preserving the authored state.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -34,7 +34,7 @@ from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 from newton.sensors import SensorContact as NewtonContactSensor
 from newton.sensors import SensorFrameTransform
 from newton.sensors import SensorIMU as NewtonSensorIMU
-from newton.solvers import SolverBase, SolverKamino, SolverNotifyFlags
+from newton.solvers import SolverBase, SolverKamino, SolverMuJoCo, SolverNotifyFlags
 
 from pxr import UsdGeom
 
@@ -402,14 +402,27 @@ class NewtonManager(PhysicsManager):
         (:attr:`_eval_fk`, bound to the active subclass's :meth:`_eval_fk_impl` in
         :meth:`initialize_solver`). Only the articulations flagged dirty in
         :attr:`_fk_reset_mask` and :attr:`_world_reset_mask` (see :meth:`invalidate_fk`) are
-        updated. The masks are consumed (zeroed) afterwards so the next :meth:`step` does not
-        redundantly re-solve them.
+        updated. When :attr:`~isaaclab_newton.physics.NewtonCfg.solver_reset` is enabled,
+        solver-owned state is also cleared for the selected worlds without changing authored
+        positions or velocities. The masks are consumed (zeroed) afterwards so the next
+        :meth:`step` does not redundantly process them.
 
         The delegate (rather than a direct ``cls._eval_fk_impl`` call) is required because the
         data layer invokes ``NewtonManager.forward()`` on the base class, where ``cls`` is the
         base ``NewtonManager``; the bound delegate dispatches to the concrete subclass override.
         """
         cls._eval_fk(cls._world_reset_mask, cls._fk_reset_mask)
+
+        cfg = PhysicsManager._cfg
+        world_mask = cls._world_reset_mask
+        solver = cls._solver
+        if cfg is not None and cfg.solver_reset and world_mask is not None and solver is not None:
+            # Kamino's FK delegate already performs its mandatory masked reset. CPU MuJoCo owns
+            # one global MjData, so avoid clearing it on clean forward/read/render boundaries.
+            is_cpu_mujoco = isinstance(solver, SolverMuJoCo) and solver.use_mujoco_cpu
+            if not isinstance(solver, SolverKamino) and (not is_cpu_mujoco or bool(world_mask.numpy().any())):
+                solver.reset(cls._state_0, world_mask=world_mask, flags=0)
+
         if cls._fk_reset_mask is not None:
             cls._fk_reset_mask.zero_()
         if cls._world_reset_mask is not None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -397,12 +397,7 @@ class NewtonManager(PhysicsManager):
     @classmethod
     def _reset_solver_from_authored_writes(cls) -> None:
         """Clear solver-owned state selected by the current authored-write mask."""
-        if (
-            PhysicsManager._cfg is None
-            or not PhysicsManager._cfg.solver_reset
-            or cls._world_reset_mask is None
-            or cls._solver is None
-        ):
+        if not PhysicsManager._cfg.solver_reset:
             return
 
         # Kamino's FK delegate already performs its mandatory masked reset. CPU MuJoCo owns

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -395,6 +395,23 @@ class NewtonManager(PhysicsManager):
         eval_fk(cls._model, cls._state_0.joint_q, cls._state_0.joint_qd, cls._state_0, fk_mask)
 
     @classmethod
+    def _reset_solver_from_authored_writes(cls) -> None:
+        """Clear solver-owned state selected by the current authored-write mask."""
+        cfg = PhysicsManager._cfg
+        world_mask = cls._world_reset_mask
+        solver = cls._solver
+        if cfg is None or not cfg.solver_reset or world_mask is None or solver is None:
+            return
+
+        # Kamino's FK delegate already performs its mandatory masked reset. CPU MuJoCo owns
+        # one global MjData, so avoid clearing it on clean forward and step boundaries.
+        if isinstance(solver, SolverKamino):
+            return
+        if isinstance(solver, SolverMuJoCo) and solver.use_mujoco_cpu and not bool(world_mask.numpy().any()):
+            return
+        solver.reset(cls._state_0, world_mask=world_mask, flags=0)
+
+    @classmethod
     def forward(cls) -> None:
         """Update articulation kinematics without stepping physics.
 
@@ -412,17 +429,7 @@ class NewtonManager(PhysicsManager):
         base ``NewtonManager``; the bound delegate dispatches to the concrete subclass override.
         """
         cls._eval_fk(cls._world_reset_mask, cls._fk_reset_mask)
-
-        cfg = PhysicsManager._cfg
-        world_mask = cls._world_reset_mask
-        solver = cls._solver
-        if cfg is not None and cfg.solver_reset and world_mask is not None and solver is not None:
-            # Kamino's FK delegate already performs its mandatory masked reset. CPU MuJoCo owns
-            # one global MjData, so avoid clearing it on clean forward/read/render boundaries.
-            is_cpu_mujoco = isinstance(solver, SolverMuJoCo) and solver.use_mujoco_cpu
-            if not isinstance(solver, SolverKamino) and (not is_cpu_mujoco or bool(world_mask.numpy().any())):
-                solver.reset(cls._state_0, world_mask=world_mask, flags=0)
-
+        cls._reset_solver_from_authored_writes()
         if cls._fk_reset_mask is not None:
             cls._fk_reset_mask.zero_()
         if cls._world_reset_mask is not None:
@@ -723,6 +730,8 @@ class NewtonManager(PhysicsManager):
         # Only runs FK for dirtied articulations via the accumulated mask.
         if cls._needs_collision_pipeline or cls._needs_fk_before_step:
             cls._eval_fk(cls._world_reset_mask, cls._fk_reset_mask)
+
+        cls._reset_solver_from_authored_writes()
 
         # Zero both masks after consumption
         NewtonManager._world_reset_mask.zero_()

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -397,19 +397,24 @@ class NewtonManager(PhysicsManager):
     @classmethod
     def _reset_solver_from_authored_writes(cls) -> None:
         """Clear solver-owned state selected by the current authored-write mask."""
-        cfg = PhysicsManager._cfg
-        world_mask = cls._world_reset_mask
-        solver = cls._solver
-        if cfg is None or not cfg.solver_reset or world_mask is None or solver is None:
+        if (
+            PhysicsManager._cfg is None
+            or not PhysicsManager._cfg.solver_reset
+            or cls._world_reset_mask is None
+            or cls._solver is None
+        ):
             return
 
         # Kamino's FK delegate already performs its mandatory masked reset. CPU MuJoCo owns
         # one global MjData, so avoid clearing it on clean forward and step boundaries.
-        if isinstance(solver, SolverKamino):
+        if isinstance(cls._solver, SolverKamino):
             return
-        if isinstance(solver, SolverMuJoCo) and solver.use_mujoco_cpu and not bool(world_mask.numpy().any()):
-            return
-        solver.reset(cls._state_0, world_mask=world_mask, flags=0)
+        if isinstance(cls._solver, SolverMuJoCo) and cls._solver.use_mujoco_cpu:
+            if cls._world_reset_mask.shape[0] != 1:
+                raise RuntimeError("CPU MuJoCo solver reset requires exactly one world.")
+            if not bool(cls._world_reset_mask.numpy()[0]):
+                return
+        cls._solver.reset(cls._state_0, world_mask=cls._world_reset_mask, flags=0)
 
     @classmethod
     def forward(cls) -> None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
@@ -97,6 +97,14 @@ class NewtonCfg(PhysicsCfg):
     Users normally do not set this directly.
     """
 
+    solver_reset: bool = False
+    """Whether to clear solver-owned state after task-authored joint or root writes.
+
+    Isaac Lab preserves the authored positions and velocities. Solvers whose reset hook is a
+    no-op are unaffected. Kamino's mandatory state synchronization remains independent of this
+    option.
+    """
+
     num_substeps: int = 1
     """Number of substeps to use for the solver."""
 

--- a/source/isaaclab_newton/test/assets/test_articulation.py
+++ b/source/isaaclab_newton/test/assets/test_articulation.py
@@ -26,7 +26,7 @@ import warp as wp
 from isaaclab_newton.assets import Articulation
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_newton.physics import NewtonManager as SimulationManager
-from newton.solvers import SolverNotifyFlags
+from newton.solvers import SolverMuJoCo, SolverNotifyFlags
 
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
@@ -2568,6 +2568,63 @@ def test_body_q_consistent_after_root_write(num_articulations, device, articulat
         assert diff < 0.01, (
             f"body_q was stale when collide() ran: diff={diff:.4f}m, jq={jq_root.tolist()}, bq={bq_root.tolist()}"
         )
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+def test_opt_in_solver_reset_clears_selected_mjwarp_history(device):
+    """An authored write clears selected MuJoCo history without changing the authored state."""
+    sim_cfg = SimulationCfg(
+        dt=1 / 120,
+        physics=NewtonCfg(
+            solver_cfg=MJWarpSolverCfg(
+                njmax=20,
+                nconmax=20,
+                integrator="implicitfast",
+            ),
+            solver_reset=True,
+            num_substeps=1,
+            use_cuda_graph=False,
+        ),
+    )
+    with build_simulation_context(sim_cfg=sim_cfg, device=device) as sim:
+        sim._app_control_on_stop_handle = None
+        articulation, _ = generate_articulation(
+            generate_articulation_cfg(articulation_type="single_joint_explicit"),
+            num_articulations=2,
+            device=device,
+        )
+        sim.reset()
+
+        solver = SimulationManager._solver
+        assert isinstance(solver, SolverMuJoCo)
+        warm_start = wp.to_torch(solver.mjw_data.qacc_warmstart)
+        assert warm_start.shape[0] == 2
+        assert warm_start.shape[1] > 0
+
+        env_ids = torch.tensor([0], dtype=torch.int32, device=device)
+        joint_pos = articulation.data.default_joint_pos.torch[:1].clone() + 0.25
+        joint_vel = torch.full_like(articulation.data.default_joint_vel.torch[:1], 0.5)
+        articulation.write_joint_state_to_sim_index(
+            position=joint_pos,
+            velocity=joint_vel,
+            env_ids=env_ids,
+        )
+
+        state = SimulationManager._state_0
+        joint_q_before = wp.to_torch(state.joint_q).clone()
+        joint_qd_before = wp.to_torch(state.joint_qd).clone()
+        warm_start[0].fill_(13.0)
+        warm_start[1].fill_(17.0)
+        wp.synchronize_device(device)
+
+        # Public, non-integrating state access consumes the authored-write mask.
+        SimulationManager.get_state()
+        wp.synchronize_device(device)
+
+        torch.testing.assert_close(wp.to_torch(state.joint_q), joint_q_before)
+        torch.testing.assert_close(wp.to_torch(state.joint_qd), joint_qd_before)
+        assert torch.count_nonzero(warm_start[0]).item() == 0
+        torch.testing.assert_close(warm_start[1], torch.full_like(warm_start[1], 17.0))
 
 
 @pytest.mark.parametrize("add_ground_plane", [True])

--- a/source/isaaclab_newton/test/assets/test_articulation.py
+++ b/source/isaaclab_newton/test/assets/test_articulation.py
@@ -2573,6 +2573,8 @@ def test_body_q_consistent_after_root_write(num_articulations, device, articulat
 @pytest.mark.parametrize("device", ["cuda:0"])
 def test_opt_in_solver_reset_clears_selected_mjwarp_history(device):
     """An authored write clears selected MuJoCo history without changing the authored state."""
+    from unittest.mock import patch
+
     sim_cfg = SimulationCfg(
         dt=1 / 120,
         physics=NewtonCfg(
@@ -2617,14 +2619,36 @@ def test_opt_in_solver_reset_clears_selected_mjwarp_history(device):
         warm_start[1].fill_(17.0)
         wp.synchronize_device(device)
 
-        # Public, non-integrating state access consumes the authored-write mask.
-        SimulationManager.get_state()
+        # The public, non-integrating forward boundary consumes the authored-write mask.
+        sim.forward()
         wp.synchronize_device(device)
 
         torch.testing.assert_close(wp.to_torch(state.joint_q), joint_q_before)
         torch.testing.assert_close(wp.to_torch(state.joint_qd), joint_qd_before)
         assert torch.count_nonzero(warm_start[0]).item() == 0
         torch.testing.assert_close(warm_start[1], torch.full_like(warm_start[1], 17.0))
+
+        # The physics-step boundary also resets when no forward boundary consumed the mask first.
+        articulation.write_joint_state_to_sim_index(
+            position=joint_pos,
+            velocity=joint_vel,
+            env_ids=env_ids,
+        )
+        warm_start[0].fill_(23.0)
+        warm_start[1].fill_(29.0)
+        wp.synchronize_device(device)
+
+        with (
+            patch.object(SimulationManager, "_simulate_full", classmethod(lambda cls: None)),
+            patch.object(SimulationManager, "_simulate_physics_only", classmethod(lambda cls: None)),
+        ):
+            sim.step(render=False)
+        wp.synchronize_device(device)
+
+        torch.testing.assert_close(wp.to_torch(state.joint_q), joint_q_before)
+        torch.testing.assert_close(wp.to_torch(state.joint_qd), joint_qd_before)
+        assert torch.count_nonzero(warm_start[0]).item() == 0
+        torch.testing.assert_close(warm_start[1], torch.full_like(warm_start[1], 29.0))
 
 
 @pytest.mark.parametrize("add_ground_plane", [True])

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -149,6 +149,12 @@ def test_newton_cfg_post_init_propagates_class_type(
     assert cfg.class_type.__name__ == expected_manager.__name__
 
 
+def test_newton_cfg_solver_reset_is_opt_in():
+    """Solver-owned state clearing is disabled unless explicitly requested."""
+    assert NewtonCfg().solver_reset is False
+    assert NewtonCfg(solver_reset=True).solver_reset is True
+
+
 @pytest.mark.parametrize(
     "num_substeps, collision_decimation, should_warn",
     [


### PR DESCRIPTION
# Description

Task-authored joint or root writes update Newton's canonical state, but MuJoCo can retain solver-owned acceleration warm starts, applied forces, activations, and controls from the preceding episode. This adds `NewtonCfg.solver_reset`, disabled by default, and clears those buffers for dirtied worlds with `flags=0`, preserving the authored positions and velocities.

Current `develop` has two boundaries that consume the authored-write masks: explicit `forward()` and the pre-step path. Both call one stateless reset helper before clearing the masks, so data reads cannot steal the reset selection and internal-contact MJWarp is covered even though it does not enter the existing FK gate. Kamino's mandatory synchronization remains independent, while solvers with a no-op reset hook remain unaffected.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

Not applicable.

## Testing

- All targeted pre-commit hooks pass.
- `test_newton_cfg_solver_reset_is_opt_in` passes.
- Added a real two-environment CUDA MJWarp regression covering both public `sim.forward()` and `sim.step()` boundaries. It verifies the dirty world's warm-start history is cleared, the clean world's history is preserved, and authored joint positions and velocities remain unchanged.
- The CUDA integration test could not be executed in this worktree because the repository launcher selected `/usr/bin/python3.12`, which is missing `lazy_loader`; collection stopped before Isaac Lab initialized.
- The changelog-fragment check passes against current `develop`.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
