### PR TITLE
Fix gripper-object penetration in SO-101 stack tasks

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,6 +57,7 @@ Guidelines for modifications:
 * Antonin Raffin
 * Arjun Bhardwaj
 * Ashwin Varghese Kuruttukulam
+* Asier Arranz
 * Bikram Pandit
 * Bingjie Tang
 * Bocheng Zou

--- a/source/isaaclab_tasks/changelog.d/fix-so101-gripper-contact-ordering.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-so101-gripper-contact-ordering.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed gripper-object penetration in the SO-101 stack tasks: the moving jaw tunneled into
+  grasped objects because the articulation position drive was resolved after the contacts.
+  Added :class:`~isaaclab_tasks.contrib.stack.config.so101.stack_joint_pos_env_cfg.SO101StackPhysicsCfg`
+  enabling ``solve_articulation_contact_last`` for these tasks.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_pos_env_cfg.py
@@ -8,6 +8,7 @@ from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.contrib.stack import mdp
 from isaaclab_tasks.contrib.stack.stack_env_cfg import (
+    PhysicsCfg,
     StackEnvCfg,
     StackEventCfg,
     apply_default_semantics,
@@ -48,6 +49,20 @@ SO101_GRIPPER_CLOSE = 0.0
 _SO101_MOUNT_Z = -0.03008
 _SO101_BASE_SEAT_POS = (0.0, 0.0, _SO101_MOUNT_Z)
 _SO101_BASE_SEAT_ROT = (0.0, 0.0, 0.70710678, 0.70710678)
+
+
+@configclass
+class SO101StackPhysicsCfg(PhysicsCfg):
+    """Physics presets for the SO-101 stack tasks.
+
+    Extends the stack-family presets with
+    :attr:`~isaaclab_physx.physics.PhysxCfg.solve_articulation_contact_last` so contacts
+    are solved after the articulation position drive and can stall the closing jaw at the
+    object surface instead of letting it tunnel through grasped objects.
+    """
+
+    default = PhysicsCfg().default.replace(solve_articulation_contact_last=True)
+    physx = default
 
 
 @configclass
@@ -127,3 +142,7 @@ class SO101CubeStackEnvCfg(StackEnvCfg):
             ],
             marker_scale=(0.05, 0.05, 0.05),
         )
+
+        # simulation settings: solve finger contacts after the position drive so they can
+        # stall the closing jaw at the object surface (see SO101StackPhysicsCfg).
+        self.sim.physics = SO101StackPhysicsCfg()

--- a/source/isaaclab_tasks/test/contrib/stack/test_so101_stack_physics_cfg.py
+++ b/source/isaaclab_tasks/test/contrib/stack/test_so101_stack_physics_cfg.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sim-free unit tests for the SO-101 stack physics preset.
+
+Regression coverage for :class:`SO101StackPhysicsCfg`: the preset must construct
+(``@configclass`` presets expose their members on instances, not on the class), it
+must enable ``solve_articulation_contact_last`` (contacts solved after the position
+drive, so the closing jaw stalls at the object surface instead of tunneling into
+it), and it must preserve the stack-family PhysX tuning. Both SO-101 stack tasks
+must actually carry the preset. No gym.make, USD, or GPU.
+"""
+
+# Both tasks expose the same class name from different modules; alias for clarity.
+from isaaclab_tasks.contrib.stack.config.so101.stack_ik_abs_env_cfg import (
+    SO101CubeStackEnvCfg as SO101CubeStackIKAbsEnvCfg,
+)
+from isaaclab_tasks.contrib.stack.config.so101.stack_joint_pos_env_cfg import (
+    SO101CubeStackEnvCfg,
+    SO101StackPhysicsCfg,
+)
+
+
+def test_preset_enables_contact_last_and_keeps_stack_tuning():
+    preset = SO101StackPhysicsCfg()
+    for physx in (preset.default, preset.physx):
+        assert physx.solve_articulation_contact_last is True
+        # stack-family tuning must be preserved (values from PhysicsCfg.default)
+        assert physx.bounce_threshold_velocity == 0.01
+        assert physx.friction_correlation_distance == 0.00625
+
+
+def test_both_so101_stack_tasks_carry_the_preset():
+    for cfg_cls in (SO101CubeStackEnvCfg, SO101CubeStackIKAbsEnvCfg):
+        cfg = cfg_cls()
+        assert isinstance(cfg.sim.physics, SO101StackPhysicsCfg)
+        assert cfg.sim.physics.physx.solve_articulation_contact_last is True


### PR DESCRIPTION
# Description

In the SO-101 contrib stack tasks, the moving jaw visibly sinks into grasped objects (measured **+14.88 mm** into a Ø34 mm cylinder — past the tube axis) and the object then rides the finger on release. Penetration depth is insensitive to gripper effort (0.45–10 N·m), friction/materials, and the object's collider approximation — the signature of a solver-ordering issue rather than a geometry or tuning problem.

**Root cause:** `physxScene:solveArticulationContactLast` defaults to `False`, so the articulation position drive is resolved after dynamic contacts on every TGS substep: the closing target is re-imposed through the object and the contact reaction on the driven side is cancelled. With the flag enabled, contacts stall the drive and the jaw stops at the object surface.

This PR extends the stack tasks' `PhysicsCfg` preset for the SO-101 configs (`SO101StackPhysicsCfg`) enabling `solve_articulation_contact_last`, preserving the stack-family PhysX tuning and the `newton_mjwarp` variant. Both SO-101 stack tasks get the fix (the IK-Abs config subclasses the joint-pos one).

Measured results (geometric penetration from PhysX link poses, pinned-object close harness, production actuator limits 1.0 N·m / 2.0 rad/s):

| Object | Before | After |
| ------ | ------ | ----- |
| Ø34 mm cylinder | +14.88 mm inside (6,871 collision verts in the tube) | **−0.64 mm** (stops outside the wall) |
| 34 mm box (independent harness) | +17.41 mm | **−0.87 mm** |

Grasp retention also improves: before the fix, the closed jaw did not actually hold the object on release (it dropped); after the fix, the grasp holds and lifts. Reproduces identically on CPU and GPU pipelines. Independent corroboration with a different SO-101 USD asset: lightwheel/leisaac#112 reaches the same conclusion. The parameter was exposed in `isaaclab` 0.46.5, but no shipped task enables it yet.

Hey @kellyguo11 👋 — we ran into this while preparing an SO-101 teleop demo and thought it was worth upstreaming, since it dramatically improves grasping behavior for the SO-101 tasks. Happy to share the full investigation if useful!

Fixes # (no linked issue — independently reported in lightwheel/leisaac#112)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Wrist-camera view of the jaw fully closed on a pinned Ø34 mm cylinder (identical setup, same drive):

| Before — jaw sinks +14.88 mm into the tube | After — jaw stops at the surface (−0.64 mm) |
| ------ | ----- |
| ![before](https://raw.githubusercontent.com/asierarranz/IsaacLab/pr-assets/so101-gripper-fix/before_jaw_settled.jpg) | ![after](https://raw.githubusercontent.com/asierarranz/IsaacLab/pr-assets/so101-gripper-fix/after_jaw_settled.jpg) |

Full closing sequence and measurements:

![before/after composite](https://raw.githubusercontent.com/asierarranz/IsaacLab/pr-assets/so101-gripper-fix/before_after_composite.jpg)

![penetration chart](https://raw.githubusercontent.com/asierarranz/IsaacLab/pr-assets/so101-gripper-fix/penetration_chart.jpg)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
