### PR TITLE
Fix XrCfg.near_plane being ignored in AR/VR profile XR sessions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,6 +56,7 @@ Guidelines for modifications:
 * Anton Bjørndahl Mortensen
 * Antonin Raffin
 * Arjun Bhardwaj
+* Asier Arranz
 * Ashwin Varghese Kuruttukulam
 * Bikram Pandit
 * Bingjie Tang

--- a/source/isaaclab_teleop/changelog.d/aarranz-fix-xr-nearplane-profile-override.rst
+++ b/source/isaaclab_teleop/changelog.d/aarranz-fix-xr-nearplane-profile-override.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed :attr:`~isaaclab_teleop.XrCfg.near_plane` having no effect in XR sessions running
+  under the ``ar`` or ``vr`` device profile (e.g. CloudXR): the profile-specific carb
+  settings take precedence over the generic ``/persistent/xr/render/nearPlane`` and are
+  now written as well (both in the XR anchor manager and the deprecated ``OpenXRDevice``).

--- a/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/manus_vive.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/manus_vive.py
@@ -111,6 +111,10 @@ class ManusVive(DeviceBase):
             orientation=self._xr_cfg.anchor_rot,
         )
         carb.settings.get_settings().set_float("/persistent/xr/render/nearPlane", self._xr_cfg.near_plane)
+        # Also write the ar/vr profile-specific settings: they default to 0.15 and
+        # take precedence over the generic path (see XrAnchorManager for details).
+        carb.settings.get_settings().set_float("/persistent/xr/profile/ar/render/nearPlane", self._xr_cfg.near_plane)
+        carb.settings.get_settings().set_float("/persistent/xr/profile/vr/render/nearPlane", self._xr_cfg.near_plane)
         carb.settings.get_settings().set_string("/persistent/xr/anchorMode", "custom anchor")
         carb.settings.get_settings().set_string("/xrstage/customAnchor", xr_anchor_prim_path)
 

--- a/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/openxr_device.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/deprecated/openxr/openxr_device.py
@@ -129,9 +129,14 @@ class OpenXRDevice(DeviceBase):
             )
 
         if hasattr(carb, "settings"):
-            carb.settings.get_settings().set_float("/persistent/xr/render/nearPlane", self._xr_cfg.near_plane)
-            carb.settings.get_settings().set_string("/persistent/xr/anchorMode", "custom anchor")
-            carb.settings.get_settings().set_string("/xrstage/customAnchor", self._xr_anchor_headset_path)
+            settings = carb.settings.get_settings()
+            settings.set_float("/persistent/xr/render/nearPlane", self._xr_cfg.near_plane)
+            # Also write the ar/vr profile-specific settings: they default to 0.15 and
+            # take precedence over the generic path (see XrAnchorManager for details).
+            settings.set_float("/persistent/xr/profile/ar/render/nearPlane", self._xr_cfg.near_plane)
+            settings.set_float("/persistent/xr/profile/vr/render/nearPlane", self._xr_cfg.near_plane)
+            settings.set_string("/persistent/xr/anchorMode", "custom anchor")
+            settings.set_string("/xrstage/customAnchor", self._xr_anchor_headset_path)
 
         # Button binding support
         self.__button_subscriptions: dict[str, dict] = {}

--- a/source/isaaclab_teleop/isaaclab_teleop/xr_anchor_manager.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/xr_anchor_manager.py
@@ -117,9 +117,15 @@ class XrAnchorManager:
 
         # Configure carb settings for XR rendering
         if hasattr(carb, "settings"):
-            carb.settings.get_settings().set_float("/persistent/xr/render/nearPlane", self._xr_cfg.near_plane)
-            carb.settings.get_settings().set_string("/persistent/xr/anchorMode", "custom anchor")
-            carb.settings.get_settings().set_string("/xrstage/customAnchor", self._xr_anchor_headset_path)
+            settings = carb.settings.get_settings()
+            settings.set_float("/persistent/xr/render/nearPlane", self._xr_cfg.near_plane)
+            # The ar/vr profile-specific settings default to 0.15 and take precedence
+            # over the generic path above, so profile-based sessions (e.g. CloudXR)
+            # would keep culling geometry closer than 15 cm unless they are written too.
+            settings.set_float("/persistent/xr/profile/ar/render/nearPlane", self._xr_cfg.near_plane)
+            settings.set_float("/persistent/xr/profile/vr/render/nearPlane", self._xr_cfg.near_plane)
+            settings.set_string("/persistent/xr/anchorMode", "custom anchor")
+            settings.set_string("/xrstage/customAnchor", self._xr_anchor_headset_path)
 
         self._anchor_sync: XrAnchorSynchronizer | None = None
         if self._xr_core is not None:

--- a/source/isaaclab_teleop/test/test_oxr_device.py
+++ b/source/isaaclab_teleop/test/test_oxr_device.py
@@ -174,7 +174,7 @@ def test_xr_anchor(empty_env, mock_xrcore):
     """Test XR anchor creation and configuration."""
     env, env_cfg = empty_env
     # Use xyzw format for quaternion: identity is (0, 0, 0, 1)
-    env_cfg.xr = XrCfg(anchor_pos=(1, 2, 3), anchor_rot=(0, 0, 0, 1))
+    env_cfg.xr = XrCfg(anchor_pos=(1, 2, 3), anchor_rot=(0, 0, 0, 1), near_plane=0.05)
 
     device = OpenXRDevice(OpenXRDeviceCfg(xr_cfg=env_cfg.xr))
 
@@ -190,6 +190,13 @@ def test_xr_anchor(empty_env, mock_xrcore):
     # Check that xr anchor mode and custom anchor are set correctly
     assert carb.settings.get_settings().get("/persistent/xr/anchorMode") == "custom anchor"
     assert carb.settings.get_settings().get("/xrstage/customAnchor") == "/World/XRAnchor"
+
+    # Check the configured near plane reaches the generic AND the profile-specific
+    # settings: the ar/vr profile paths default to 0.15 and take precedence, so a
+    # non-default value (0.05) would never reach a profile-based session otherwise.
+    assert carb.settings.get_settings().get("/persistent/xr/render/nearPlane") == pytest.approx(0.05)
+    assert carb.settings.get_settings().get("/persistent/xr/profile/ar/render/nearPlane") == pytest.approx(0.05)
+    assert carb.settings.get_settings().get("/persistent/xr/profile/vr/render/nearPlane") == pytest.approx(0.05)
 
     device.reset()
 


### PR DESCRIPTION
## Description

In XR teleoperation you naturally lean in to look at things up close — and today anything closer than ~15 cm disappears, no matter what `near_plane` you configure. That breaks close-up inspection in CloudXR sessions.

**Cause:** Isaac Lab writes the generic `/persistent/xr/render/nearPlane`, but the profile-specific settings (`/persistent/xr/profile/{ar|vr}/render/nearPlane`) default to `0.15` (set in `apps/isaaclab.python.xr.openxr.kit`) and take precedence — the configured value never reaches profile-based sessions.

## Fix

- Write the `ar`/`vr` profile settings alongside the generic one, in `XrAnchorManager` and in the deprecated `OpenXRDevice` (same bug).
- `test_xr_anchor` now uses a non-default `near_plane=0.05` and asserts all three settings paths.
- Verified on a Quest 3 + CloudXR setup: near clipping now matches the configured value.

No restore-on-teardown, matching how this code path already handles its other persistent settings. Both profiles are written so behavior is deterministic regardless of the active profile.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (changelog fragment; no doc pages affected)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
