### PR TITLE
[Kamino] Small Cleanup

### DIFF
--- a/source/isaaclab_tasks/changelog.d/aserifi-kamino_cleanup.rst
+++ b/source/isaaclab_tasks/changelog.d/aserifi-kamino_cleanup.rst
@@ -1,0 +1,12 @@
+Changed
+^^^^^^^
+
+* Changed the Disney DR Legs walk / hold-pose Kamino stepping to ``sim.dt = 1/150``
+  with ``decimation = 3`` (previously ``0.004`` / ``5``). This keeps the 50 Hz control
+  rate while reducing the number of Kamino solver calls per control step from 5 to 3,
+  for roughly 1.6x faster simulation with equivalent task performance.
+* Changed the ``newton_kamino`` presets of the velocity (A1, AnymalB, AnymalC, Go1, Go2,
+  Cassie, G1, H1, Spot), cabinet, and shadow-hand reorient tasks to use the default
+  single physics substep (removed the ``num_substeps=2`` override), and dropped the
+  redundant explicit ``num_substeps`` overrides from the cartpole, ant, and reach Kamino
+  presets.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
@@ -67,9 +67,8 @@ def _kamino_newton_cfg() -> NewtonCfg:
             padmm_warmstart_mode="containers",
             padmm_contact_warmstart_method="geom_pair_net_force",
             padmm_use_graph_conditionals=False,
-            max_contacts_per_world=50,
+            max_contacts_per_world=32,
         ),
-        num_substeps=2,
         use_cuda_graph=True,
         default_shape_cfg=NewtonShapeCfg(margin=0.0, gap=0.001),
     )
@@ -195,7 +194,7 @@ class EventCfg:
             "pose_range": {
                 "x": (-0.05, 0.05),
                 "y": (-0.05, 0.05),
-                "z": (-0.02, 0.02),
+                "z": (0.01, 0.015),
                 "roll": (-0.1, 0.1),
                 "pitch": (-0.1, 0.1),
                 "yaw": (-3.14159, 3.14159),
@@ -266,14 +265,14 @@ class DrLegsHoldPoseEnvCfg(ManagerBasedRLEnvCfg):
     rewards: RewardsCfg = RewardsCfg()
     terminations: TerminationsCfg = TerminationsCfg()
     sim: SimulationCfg = SimulationCfg(
-        dt=0.004,
-        render_interval=5,
+        dt=1/150,
+        render_interval=3,
         physics=DrLegsPhysicsCfg(),
         physics_material=_PHYSICS_MATERIAL,
     )
 
     def __post_init__(self) -> None:
-        self.decimation = 5
+        self.decimation = 3
         self.episode_length_s = 10.0
         self.viewer.eye = (1.5, 0.5, 0.5)
         self.viewer.lookat = (0.0, 0.0, 0.265)

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
@@ -265,7 +265,7 @@ class DrLegsHoldPoseEnvCfg(ManagerBasedRLEnvCfg):
     rewards: RewardsCfg = RewardsCfg()
     terminations: TerminationsCfg = TerminationsCfg()
     sim: SimulationCfg = SimulationCfg(
-        dt=1/150,
+        dt=1 / 150,
         render_interval=3,
         physics=DrLegsPhysicsCfg(),
         physics_material=_PHYSICS_MATERIAL,

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
@@ -28,7 +28,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
@@ -76,7 +76,7 @@ class CabinetSimCfg(PresetCfg):
     newton_kamino: SimulationCfg = SimulationCfg(
         dt=1 / 600,
         render_interval=1,
-        physics=NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=1),
+        physics=NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64)),
     )
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
@@ -57,7 +57,6 @@ class CartpolePhysicsCfg(PresetCfg):
             collision_detector_pipeline="unified",
             collision_detector_max_contacts_per_pair=8,
         ),
-        num_substeps=1,
         debug_mode=False,
         use_cuda_graph=True,
     )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
@@ -67,7 +67,6 @@ class CartpolePhysicsCfg(PresetCfg):
             collision_detector_pipeline="unified",
             collision_detector_max_contacts_per_pair=8,
         ),
-        num_substeps=1,
         debug_mode=False,
         use_cuda_graph=True,
     )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
@@ -56,7 +56,6 @@ class AntPhysicsCfg(PresetCfg):
             collision_detector_pipeline="unified",
             collision_detector_max_contacts_per_pair=8,
         ),
-        num_substeps=2,
         debug_mode=False,
         use_cuda_graph=True,
     )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
@@ -63,7 +63,6 @@ class AntPhysicsCfg(PresetCfg):
             collision_detector_pipeline="unified",
             collision_detector_max_contacts_per_pair=8,
         ),
-        num_substeps=2,
         debug_mode=False,
         use_cuda_graph=True,
     )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
@@ -45,7 +45,6 @@ class ReachPhysicsCfg(PresetCfg):
     )
     newton_kamino: NewtonCfg = NewtonCfg(
         solver_cfg=KaminoSolverCfg(max_contacts_per_world=32),
-        num_substeps=2,
     )
 
     default = physx

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
@@ -291,7 +291,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     default = physx
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=128), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=128))
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
@@ -29,7 +29,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     physx = default
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
@@ -49,7 +49,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
         default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
-    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64), num_substeps=2)
+    newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 
 ##


### PR DESCRIPTION
Revisited the solver parameters. Now, the environments consistently use num_substeps=1.
Tuned also the settings for the DR Legs task, making training 3x faster.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there