### PR TITLE
docs: quote isaaclab pip install requirement to fix zsh glob error

### DIFF
--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -29,7 +29,7 @@ Installing dependencies
 
    .. code-block:: none
 
-      pip install isaaclab[isaacsim,all]==2.3.2.post1 --extra-index-url https://pypi.nvidia.com
+      pip install 'isaaclab[isaacsim,all]==2.3.2.post1' --extra-index-url https://pypi.nvidia.com
 
 -  Install a CUDA-enabled PyTorch 2.7.0 build for CUDA 12.8 that matches your system architecture:
 


### PR DESCRIPTION
## Description

The pip installation command documented in `docs/source/setup/installation/isaaclab_pip_installation.rst` fails on copy-paste under **zsh**:

```
pip install isaaclab[isaacsim,all]==2.3.2.post1 --extra-index-url https://pypi.nvidia.com
```

In zsh, `isaaclab[isaacsim,all]==2.3.2.post1` is parsed as a **glob pattern** (a bracketed character-class match), and because zsh sets the `nomatch` option by default, the failed glob raises a hard error instead of falling back to the literal string the way bash does:

```
zsh: no matches found: isaaclab[isaacsim,all]
```

The command never reaches `pip`. macOS ships zsh as the default shell, so this trips up a large share of users following the guide.

## Fix

Quote the package requirement so the command is identical in bash and zsh:

```
pip install 'isaaclab[isaacsim,all]==2.3.2.post1' --extra-index-url https://pypi.nvidia.com
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) — documentation only

## Checklist

- [x] I have read the [contributor guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] My code follows the style guidelines of this project
- [x] I have verified the change works (verified the quoted command resolves the glob error in zsh; single quotes are safe since the requirement string contains no single quotes or shell expansions)
