### PR TITLE
Bump Newton to include coupled solver framework

### DIFF
--- a/source/isaaclab_newton/changelog.d/pin-newton-c7ae7c7.rst
+++ b/source/isaaclab_newton/changelog.d/pin-newton-c7ae7c7.rst
@@ -3,9 +3,7 @@ Changed
 
 * Changed the ``newton[sim]`` dependency pin to Newton commit
   ``c7ae7c7648cd0717df39e5c94b95d5a02c997320``, which includes the experimental
-  coupled solver framework. Projects that install Newton separately should use
-  this commit with ``warp-lang==1.15.0.dev20260626`` and install
-  ``newton-usd-schemas>=0.3.1`` for USD parsing.
+  coupled solver framework.
 
 Added
 ^^^^^
@@ -16,6 +14,7 @@ Added
 Fixed
 ^^^^^
 
-* Fixed the cloner label renaming to read equality constraint labels from
-  Newton's ``mujoco:equality_constraint_*`` custom attributes, following the
-  upstream removal of ``ModelBuilder.equality_constraint_label``.
+* Fixed the cloner label renaming after Newton's removal of
+  ``ModelBuilder.equality_constraint_label`` by dropping the equality
+  constraint fallback; equality constraint labels are renamed through the
+  generic custom attribute handling.

--- a/source/isaaclab_newton/changelog.d/pin-newton-c7ae7c7.rst
+++ b/source/isaaclab_newton/changelog.d/pin-newton-c7ae7c7.rst
@@ -1,0 +1,19 @@
+Changed
+^^^^^^^
+
+* Changed the ``newton[sim]`` dependency pin to Newton commit
+  ``c7ae7c7648cd0717df39e5c94b95d5a02c997320``, which includes the experimental
+  coupled solver framework.
+
+Added
+^^^^^
+
+* Added the ``newton-usd-schemas`` dependency, required by Newton's USD parsing
+  since the new pin.
+
+Fixed
+^^^^^
+
+* Fixed the cloner label renaming to read equality constraint labels from
+  Newton's ``mujoco:equality_constraint_*`` custom attributes, following the
+  upstream removal of ``ModelBuilder.equality_constraint_label``.

--- a/source/isaaclab_newton/changelog.d/pin-newton-c7ae7c7.rst
+++ b/source/isaaclab_newton/changelog.d/pin-newton-c7ae7c7.rst
@@ -3,7 +3,9 @@ Changed
 
 * Changed the ``newton[sim]`` dependency pin to Newton commit
   ``c7ae7c7648cd0717df39e5c94b95d5a02c997320``, which includes the experimental
-  coupled solver framework.
+  coupled solver framework. Projects that install Newton separately should use
+  this commit with ``warp-lang==1.15.0.dev20260626`` and install
+  ``newton-usd-schemas>=0.3.1`` for USD parsing.
 
 Added
 ^^^^^

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -148,9 +148,6 @@ def rename_builder_labels(
         ):
             _rename_pair(labels, worlds, collect_body_bindings=collect_body_bindings)
 
-        if "mujoco:equality_constraint_label" not in builder.custom_attributes:
-            _rename_pair(builder.equality_constraint_label, builder.equality_constraint_world)
-
         custom_attrs = builder.custom_attributes.values()
         worlds_by_freq = {attr.frequency: attr.values for attr in custom_attrs if attr.references == "world"}
         for attr in custom_attrs:

--- a/source/isaaclab_newton/pyproject.toml
+++ b/source/isaaclab_newton/pyproject.toml
@@ -27,7 +27,8 @@ all = [
     "prettytable>=3.3.0",
     "PyOpenGL-accelerate>=3.1.0",
     "pyglet>=2.1.6,<3",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@c7ae7c7648cd0717df39e5c94b95d5a02c997320",
+    "newton-usd-schemas>=0.3.1",
 ]
 
 [tool.setuptools]

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -31,7 +31,9 @@ _VIS_LABEL_SUFFIXES = {
     "constraint_mimic_label": "ConstraintMimic",
     "equality_constraint_label": "EqualityConstraint",
 }
-_VIS_LABEL_ATTRS = tuple(_VIS_LABEL_SUFFIXES)
+# Equality constraints live in custom attributes (like real newton), not plain builder lists.
+_VIS_BUILTIN_LABEL_ATTRS = tuple(attr for attr in _VIS_LABEL_SUFFIXES if attr != "equality_constraint_label")
+_VIS_EQ_FREQ = "mujoco:equality_constraint"
 
 _TENDON_FREQ = "mujoco:tendon"
 _SRC = "/Sources/protoA"
@@ -41,10 +43,22 @@ _DST = "/World/envs/env_{}"
 class _FakeVisualizationModelBuilder:
     def __init__(self, up_axis=None):
         self.up_axis = up_axis
-        for attr in _VIS_LABEL_ATTRS:
+        for attr in _VIS_BUILTIN_LABEL_ATTRS:
             setattr(self, attr, [])
             setattr(self, attr.replace("_label", "_world"), [])
-        self.custom_attributes = {}
+        self.custom_attributes = {
+            "mujoco:equality_constraint_label": newton.ModelBuilder.CustomAttribute(
+                name="equality_constraint_label", frequency=_VIS_EQ_FREQ, dtype=str, default="", namespace="mujoco"
+            ),
+            "mujoco:equality_constraint_world": newton.ModelBuilder.CustomAttribute(
+                name="equality_constraint_world",
+                frequency=_VIS_EQ_FREQ,
+                dtype=int,
+                default=0,
+                namespace="mujoco",
+                references="world",
+            ),
+        }
         self.geometry_sources = []
         self.world_slices = []
         self._current_world = None
@@ -66,9 +80,13 @@ class _FakeVisualizationModelBuilder:
             return
         label_start = len(self.body_label)
         geometry_start = len(self.geometry_sources)
-        for attr, suffix in _VIS_LABEL_SUFFIXES.items():
-            getattr(self, attr).append(f"{root_path}/{suffix}")
+        for attr in _VIS_BUILTIN_LABEL_ATTRS:
+            getattr(self, attr).append(f"{root_path}/{_VIS_LABEL_SUFFIXES[attr]}")
             getattr(self, attr.replace("_label", "_world")).append(self._current_world or 0)
+        self.custom_attributes["mujoco:equality_constraint_label"].values.append(
+            f"{root_path}/{_VIS_LABEL_SUFFIXES['equality_constraint_label']}"
+        )
+        self.custom_attributes["mujoco:equality_constraint_world"].values.append(self._current_world or 0)
         self.geometry_sources.append(root_path)
         self._record_world_slice(label_start, len(self.body_label), geometry_start, len(self.geometry_sources))
 
@@ -76,15 +94,21 @@ class _FakeVisualizationModelBuilder:
         del xform
         label_start = len(self.body_label)
         geometry_start = len(self.geometry_sources)
-        for attr in _VIS_LABEL_ATTRS:
+        for attr in _VIS_BUILTIN_LABEL_ATTRS:
             labels = getattr(builder, attr)
             getattr(self, attr).extend(labels)
             getattr(self, attr.replace("_label", "_world")).extend([self._current_world] * len(labels))
+        eq_labels = builder.custom_attributes["mujoco:equality_constraint_label"].values
+        self.custom_attributes["mujoco:equality_constraint_label"].values.extend(eq_labels)
+        self.custom_attributes["mujoco:equality_constraint_world"].values.extend([self._current_world] * len(eq_labels))
         self.geometry_sources.extend(builder.geometry_sources)
         self._record_world_slice(label_start, len(self.body_label), geometry_start, len(self.geometry_sources))
 
     def labels_for_world(self, world_id, attr):
-        labels = getattr(self, attr)
+        if attr == "equality_constraint_label":
+            labels = self.custom_attributes["mujoco:equality_constraint_label"].values
+        else:
+            labels = getattr(self, attr)
         return [label for start, end, _, _ in self.world_slices[world_id] for label in labels[start:end]]
 
     def geometry_sources_for_world(self, world_id):

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -30,6 +30,7 @@ _VIS_LABEL_SUFFIXES = {
     "articulation_label": "Articulation",
     "constraint_mimic_label": "ConstraintMimic",
 }
+_VIS_LABEL_ATTRS = tuple(_VIS_LABEL_SUFFIXES)
 
 _TENDON_FREQ = "mujoco:tendon"
 _SRC = "/Sources/protoA"
@@ -39,7 +40,7 @@ _DST = "/World/envs/env_{}"
 class _FakeVisualizationModelBuilder:
     def __init__(self, up_axis=None):
         self.up_axis = up_axis
-        for attr in _VIS_LABEL_SUFFIXES:
+        for attr in _VIS_LABEL_ATTRS:
             setattr(self, attr, [])
             setattr(self, attr.replace("_label", "_world"), [])
         self.custom_attributes = {}
@@ -64,8 +65,8 @@ class _FakeVisualizationModelBuilder:
             return
         label_start = len(self.body_label)
         geometry_start = len(self.geometry_sources)
-        for attr in _VIS_LABEL_SUFFIXES:
-            getattr(self, attr).append(f"{root_path}/{_VIS_LABEL_SUFFIXES[attr]}")
+        for attr, suffix in _VIS_LABEL_SUFFIXES.items():
+            getattr(self, attr).append(f"{root_path}/{suffix}")
             getattr(self, attr.replace("_label", "_world")).append(self._current_world or 0)
         self.geometry_sources.append(root_path)
         self._record_world_slice(label_start, len(self.body_label), geometry_start, len(self.geometry_sources))
@@ -74,7 +75,7 @@ class _FakeVisualizationModelBuilder:
         del xform
         label_start = len(self.body_label)
         geometry_start = len(self.geometry_sources)
-        for attr in _VIS_LABEL_SUFFIXES:
+        for attr in _VIS_LABEL_ATTRS:
             labels = getattr(builder, attr)
             getattr(self, attr).extend(labels)
             getattr(self, attr.replace("_label", "_world")).extend([self._current_world] * len(labels))

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -29,11 +29,7 @@ _VIS_LABEL_SUFFIXES = {
     "shape_label": "Shape",
     "articulation_label": "Articulation",
     "constraint_mimic_label": "ConstraintMimic",
-    "equality_constraint_label": "EqualityConstraint",
 }
-# Equality constraints live in custom attributes (like real newton), not plain builder lists.
-_VIS_BUILTIN_LABEL_ATTRS = tuple(attr for attr in _VIS_LABEL_SUFFIXES if attr != "equality_constraint_label")
-_VIS_EQ_FREQ = "mujoco:equality_constraint"
 
 _TENDON_FREQ = "mujoco:tendon"
 _SRC = "/Sources/protoA"
@@ -43,22 +39,10 @@ _DST = "/World/envs/env_{}"
 class _FakeVisualizationModelBuilder:
     def __init__(self, up_axis=None):
         self.up_axis = up_axis
-        for attr in _VIS_BUILTIN_LABEL_ATTRS:
+        for attr in _VIS_LABEL_SUFFIXES:
             setattr(self, attr, [])
             setattr(self, attr.replace("_label", "_world"), [])
-        self.custom_attributes = {
-            "mujoco:equality_constraint_label": newton.ModelBuilder.CustomAttribute(
-                name="equality_constraint_label", frequency=_VIS_EQ_FREQ, dtype=str, default="", namespace="mujoco"
-            ),
-            "mujoco:equality_constraint_world": newton.ModelBuilder.CustomAttribute(
-                name="equality_constraint_world",
-                frequency=_VIS_EQ_FREQ,
-                dtype=int,
-                default=0,
-                namespace="mujoco",
-                references="world",
-            ),
-        }
+        self.custom_attributes = {}
         self.geometry_sources = []
         self.world_slices = []
         self._current_world = None
@@ -80,13 +64,9 @@ class _FakeVisualizationModelBuilder:
             return
         label_start = len(self.body_label)
         geometry_start = len(self.geometry_sources)
-        for attr in _VIS_BUILTIN_LABEL_ATTRS:
+        for attr in _VIS_LABEL_SUFFIXES:
             getattr(self, attr).append(f"{root_path}/{_VIS_LABEL_SUFFIXES[attr]}")
             getattr(self, attr.replace("_label", "_world")).append(self._current_world or 0)
-        self.custom_attributes["mujoco:equality_constraint_label"].values.append(
-            f"{root_path}/{_VIS_LABEL_SUFFIXES['equality_constraint_label']}"
-        )
-        self.custom_attributes["mujoco:equality_constraint_world"].values.append(self._current_world or 0)
         self.geometry_sources.append(root_path)
         self._record_world_slice(label_start, len(self.body_label), geometry_start, len(self.geometry_sources))
 
@@ -94,21 +74,15 @@ class _FakeVisualizationModelBuilder:
         del xform
         label_start = len(self.body_label)
         geometry_start = len(self.geometry_sources)
-        for attr in _VIS_BUILTIN_LABEL_ATTRS:
+        for attr in _VIS_LABEL_SUFFIXES:
             labels = getattr(builder, attr)
             getattr(self, attr).extend(labels)
             getattr(self, attr.replace("_label", "_world")).extend([self._current_world] * len(labels))
-        eq_labels = builder.custom_attributes["mujoco:equality_constraint_label"].values
-        self.custom_attributes["mujoco:equality_constraint_label"].values.extend(eq_labels)
-        self.custom_attributes["mujoco:equality_constraint_world"].values.extend([self._current_world] * len(eq_labels))
         self.geometry_sources.extend(builder.geometry_sources)
         self._record_world_slice(label_start, len(self.body_label), geometry_start, len(self.geometry_sources))
 
     def labels_for_world(self, world_id, attr):
-        if attr == "equality_constraint_label":
-            labels = self.custom_attributes["mujoco:equality_constraint_label"].values
-        else:
-            labels = getattr(self, attr)
+        labels = getattr(self, attr)
         return [label for start, end, _, _ in self.world_slices[world_id] for label in labels[start:end]]
 
     def geometry_sources_for_world(self, world_id):

--- a/source/isaaclab_physx/changelog.d/pin-newton-c7ae7c7.rst
+++ b/source/isaaclab_physx/changelog.d/pin-newton-c7ae7c7.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed the ``newton[sim]`` dependency pin of the ``newton`` extra to Newton
+  commit ``c7ae7c7648cd0717df39e5c94b95d5a02c997320`` and added the
+  ``newton-usd-schemas`` dependency required by Newton's USD parsing.

--- a/source/isaaclab_physx/pyproject.toml
+++ b/source/isaaclab_physx/pyproject.toml
@@ -24,7 +24,8 @@ Repository = "https://github.com/isaac-sim/IsaacLab"
 
 [project.optional-dependencies]
 newton = [
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@c7ae7c7648cd0717df39e5c94b95d5a02c997320",
+    "newton-usd-schemas>=0.3.1",
 ]
 
 [tool.setuptools]

--- a/source/isaaclab_visualizers/changelog.d/pin-newton-c7ae7c7.rst
+++ b/source/isaaclab_visualizers/changelog.d/pin-newton-c7ae7c7.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed the ``newton[sim]`` dependency pin of the visualizer extras to Newton
+  commit ``c7ae7c7648cd0717df39e5c94b95d5a02c997320`` and added the
+  ``newton-usd-schemas`` dependency required by Newton's USD parsing.

--- a/source/isaaclab_visualizers/pyproject.toml
+++ b/source/isaaclab_visualizers/pyproject.toml
@@ -29,24 +29,28 @@ Repository = "https://github.com/isaac-sim/IsaacLab"
 kit = []
 newton = [
     "warp-lang",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@c7ae7c7648cd0717df39e5c94b95d5a02c997320",
+    "newton-usd-schemas>=0.3.1",
     "PyOpenGL-accelerate",
     "pyglet>=2.1.6,<3",
     "imgui-bundle>=1.92.5",
     "typing-extensions>=4.15.0",
 ]
 rerun = [
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@c7ae7c7648cd0717df39e5c94b95d5a02c997320",
+    "newton-usd-schemas>=0.3.1",
     "rerun-sdk>=0.29.0",
     "pyarrow==22.0.0",
 ]
 viser = [
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@c7ae7c7648cd0717df39e5c94b95d5a02c997320",
+    "newton-usd-schemas>=0.3.1",
     "viser>=1.0.16",
 ]
 all = [
     "imgui-bundle>=1.92.5",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@c7ae7c7648cd0717df39e5c94b95d5a02c997320",
+    "newton-usd-schemas>=0.3.1",
     "PyOpenGL-accelerate",
     "pyglet>=2.1.6,<3",
     # Match rerun-sdk's supported Arrow stack and avoid resolver drift across environments.

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -88,7 +88,8 @@ pyproject.optional-dependencies.all = [
     # ================================================================================
     { "newton" = [
         "warp-lang==1.15.0.dev20260626",
-        "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+        "newton[sim] @ git+https://github.com/newton-physics/newton.git@c7ae7c7648cd0717df39e5c94b95d5a02c997320",
+        "newton-usd-schemas>=0.3.1",
         "PyOpenGL-accelerate==3.1.10"
     ] },
     # ================================================================================


### PR DESCRIPTION
# Description

Pins every active newton[sim] dependency to Newton commit c7ae7c7648cd0717df39e5c94b95d5a02c997320 (current main), which includes the experimental coupled solver framework (newton-physics/newton#2848). Upstream comparison: https://github.com/newton-physics/newton/compare/2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee...c7ae7c7648cd0717df39e5c94b95d5a02c997320

Compatibility updates: adds newton-usd-schemas>=0.3.1 next to each pin since Newton now hard-requires it for USD parsing (newton-physics/newton#3117) and it only ships in the heavy newton[importers] extra; removes the cloner fallback reading the deleted ModelBuilder.equality_constraint_* attributes (newton-physics/newton#3296), which are now handled through the mujoco:equality_constraint_* custom attributes, and updates the fake builder in the cloner test accordingly.

Verified in a fresh uv env: full isaaclab_newton test suite (340 passed non-gated plus all Isaac-Sim-gated files: articulation 236, rigid object 94, rigid object collection 158, actuators 71, schemas 20), contrib rigid-deformable coupling (4 passed), and end-to-end cartpole training with presets=newton_mjwarp. Note: isaacsim-core 6.0.0.1 hard-pins newton==1.2.0, so installing Isaac Sim after the Newton pin clobbers it; the documented ./isaaclab.sh -i order handles this correctly.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there