### PR TITLE
[DO NOT MERGE] Probe NGC authentication paths

### DIFF
--- a/.github/workflows/ngc-auth-diagnostic.yaml
+++ b/.github/workflows/ngc-auth-diagnostic.yaml
@@ -1,0 +1,283 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: NGC Authentication Diagnostic
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ambient-auth:
+    name: Ambient runner authentication
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        filter: tree:0
+
+    - name: Load diagnostic configuration
+      id: config
+      shell: bash
+      run: |
+        set -euo pipefail
+        config_file=.github/workflows/config.yaml
+        isaacsim_image_name=$(yq -r .isaacsim_image_name "$config_file")
+        isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$config_file")
+        ovphysx_wheelhouse_resource=$(yq -r .ovphysx_wheelhouse_resource "$config_file")
+        printf 'isaacsim_image_name=%s\n' "$isaacsim_image_name" >> "$GITHUB_OUTPUT"
+        printf 'isaacsim_image_tag=%s\n' "$isaacsim_image_tag" >> "$GITHUB_OUTPUT"
+        printf 'ovphysx_wheelhouse_resource=%s\n' "$ovphysx_wheelhouse_resource" >> "$GITHUB_OUTPUT"
+
+    - name: Probe ambient authentication
+      shell: bash
+      env:
+        ISAACSIM_IMAGE_NAME: ${{ steps.config.outputs.isaacsim_image_name }}
+        ISAACSIM_IMAGE_TAG: ${{ steps.config.outputs.isaacsim_image_tag }}
+        OVPHYSX_WHEELHOUSE_RESOURCE: ${{ steps.config.outputs.ovphysx_wheelhouse_resource }}
+      run: |
+        set -uo pipefail
+
+        NGC_CLI_VERSION=4.20.0
+        NGC_CLI_SHA256=5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b
+        NGC_CLI_URL="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VERSION}/files/ngccli_linux.zip"
+
+        default_docker_config_exists=false
+        default_docker_config_names_nvcr=false
+        default_docker_config_inspects_image=false
+        empty_docker_config_inspects_image=false
+        aws_caller_identity_available=false
+        ecr_cache_url_resolves=false
+        ecr_cache_manifest_inspectable=false
+        ngc_artifact_downloadable_without_key=false
+
+        temp_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/ngc-auth-ambient.XXXXXX")
+        empty_docker_config="${temp_root}/docker-empty"
+        ecr_docker_config="${temp_root}/docker-ecr"
+        ngc_home="${temp_root}/ngc-home"
+        ngc_download="${temp_root}/ngc-download"
+        ngc_unpack="${temp_root}/ngc-unpack"
+        ngc_zip="${temp_root}/ngccli_linux.zip"
+        mkdir -p "$empty_docker_config" "$ecr_docker_config" "$ngc_home" "$ngc_download" "$ngc_unpack"
+        cleanup() {
+          rm -rf -- "$temp_root"
+        }
+        trap cleanup EXIT
+
+        image="${ISAACSIM_IMAGE_NAME}:${ISAACSIM_IMAGE_TAG}"
+        default_docker_dir="${HOME}/.docker"
+        default_docker_config="${default_docker_dir}/config.json"
+
+        if [ -f "$default_docker_config" ]; then
+          default_docker_config_exists=true
+          if yq -e '((.auths // {}) | has("nvcr.io")) or ((.credHelpers // {}) | has("nvcr.io"))' \
+            "$default_docker_config" >/dev/null 2>&1; then
+            default_docker_config_names_nvcr=true
+          fi
+        fi
+
+        if DOCKER_CONFIG="$default_docker_dir" docker manifest inspect "$image" >/dev/null 2>&1; then
+          default_docker_config_inspects_image=true
+        fi
+
+        if DOCKER_CONFIG="$empty_docker_config" docker manifest inspect "$image" >/dev/null 2>&1; then
+          empty_docker_config_inspects_image=true
+        fi
+
+        if aws sts get-caller-identity >/dev/null 2>&1; then
+          aws_caller_identity_available=true
+        fi
+
+        ECR_URL="${ECR_CACHE_URL:-}"
+        if [ -z "$ECR_URL" ]; then
+          imds_token=$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" \
+            -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null) || imds_token=""
+          if [ -n "$imds_token" ]; then
+            instance_id=$(curl -fsS -H "X-aws-ec2-metadata-token: ${imds_token}" \
+              "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null) || instance_id=""
+            instance_region=$(curl -fsS -H "X-aws-ec2-metadata-token: ${imds_token}" \
+              "http://169.254.169.254/latest/meta-data/placement/region" 2>/dev/null) || instance_region=""
+            if [ -n "$instance_id" ] && [ -n "$instance_region" ]; then
+              ECR_URL=$(aws ssm get-parameter \
+                --name "/github-runner/${instance_id}/ecr-cache-url" \
+                --region "$instance_region" \
+                --query 'Parameter.Value' --output text 2>/dev/null) || ECR_URL=""
+            fi
+          fi
+        fi
+
+        if [ -n "$ECR_URL" ]; then
+          ecr_cache_url_resolves=true
+          ecr_registry="${ECR_URL%%/*}"
+          ecr_region="${ecr_registry#*.dkr.ecr.}"
+          ecr_region="${ecr_region%%.amazonaws.com*}"
+          if [ -n "$ecr_region" ] && [ "$ecr_region" != "$ecr_registry" ]; then
+            if aws ecr get-login-password --region "$ecr_region" 2>/dev/null |
+              DOCKER_CONFIG="$ecr_docker_config" docker login --username AWS --password-stdin \
+                "$ecr_registry" >/dev/null 2>&1; then
+              if DOCKER_CONFIG="$ecr_docker_config" docker manifest inspect \
+                "${ECR_URL}:cache-base" >/dev/null 2>&1; then
+                ecr_cache_manifest_inspectable=true
+              fi
+            fi
+          fi
+        fi
+
+        ngc_cli="${ngc_unpack}/ngc-cli/ngc"
+        if curl -fsSL -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1 &&
+          printf '%s  %s\n' "$NGC_CLI_SHA256" "$ngc_zip" | sha256sum -c - >/dev/null 2>&1 &&
+          unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1 && [ -x "$ngc_cli" ]; then
+          if (
+            unset NGC_API_KEY NGC_CLI_API_KEY
+            export HOME="$ngc_home"
+            export NGC_CLI_HOME="$ngc_home"
+            export NGC_CLI_ORG=nvidian
+            export NGC_CLI_TEAM=no-team
+            "$ngc_cli" registry resource download-version "$OVPHYSX_WHEELHOUSE_RESOURCE" \
+              --dest "$ngc_download" >/dev/null 2>&1
+          ); then
+            ngc_artifact_downloadable_without_key=true
+          fi
+        fi
+
+        {
+          printf '### Ambient authentication probes\n\n'
+          printf '| Probe | Result |\n'
+          printf '| --- | --- |\n'
+          printf '| Default Docker config exists | `%s` |\n' "$default_docker_config_exists"
+          printf '| Default Docker config names an nvcr.io auth/helper entry | `%s` |\n' \
+            "$default_docker_config_names_nvcr"
+          printf '| Default Docker config can inspect the configured Isaac Sim image | `%s` |\n' \
+            "$default_docker_config_inspects_image"
+          printf '| Empty isolated Docker config can inspect the configured Isaac Sim image | `%s` |\n' \
+            "$empty_docker_config_inspects_image"
+          printf '| AWS caller identity is available | `%s` |\n' "$aws_caller_identity_available"
+          printf '| ECR cache URL resolves from runner configuration | `%s` |\n' "$ecr_cache_url_resolves"
+          printf '| Authenticated ECR cache-base manifest is inspectable | `%s` |\n' \
+            "$ecr_cache_manifest_inspectable"
+          printf '| Isolated NGC CLI without an API key can download the configured resource | `%s` |\n' \
+            "$ngc_artifact_downloadable_without_key"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+  secret-backed-auth:
+    name: Explicit NGC secret authentication
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 30
+    env:
+      NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        filter: tree:0
+
+    - name: Load diagnostic configuration
+      id: config
+      shell: bash
+      run: |
+        set -euo pipefail
+        config_file=.github/workflows/config.yaml
+        isaacsim_image_name=$(yq -r .isaacsim_image_name "$config_file")
+        isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$config_file")
+        ovphysx_wheelhouse_resource=$(yq -r .ovphysx_wheelhouse_resource "$config_file")
+        printf 'isaacsim_image_name=%s\n' "$isaacsim_image_name" >> "$GITHUB_OUTPUT"
+        printf 'isaacsim_image_tag=%s\n' "$isaacsim_image_tag" >> "$GITHUB_OUTPUT"
+        printf 'ovphysx_wheelhouse_resource=%s\n' "$ovphysx_wheelhouse_resource" >> "$GITHUB_OUTPUT"
+
+    - name: Probe explicit NGC authentication
+      shell: bash
+      env:
+        ISAACSIM_IMAGE_NAME: ${{ steps.config.outputs.isaacsim_image_name }}
+        ISAACSIM_IMAGE_TAG: ${{ steps.config.outputs.isaacsim_image_tag }}
+        OVPHYSX_WHEELHOUSE_RESOURCE: ${{ steps.config.outputs.ovphysx_wheelhouse_resource }}
+      run: |
+        set -uo pipefail
+
+        NGC_CLI_VERSION=4.20.0
+        NGC_CLI_SHA256=5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b
+        NGC_CLI_URL="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VERSION}/files/ngccli_linux.zip"
+
+        secret_present=false
+        nvcr_login_accepted=false
+        nvcr_image_inspectable=false
+        ngc_artifact_downloadable=false
+
+        temp_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/ngc-auth-secret.XXXXXX")
+        docker_config="${temp_root}/docker"
+        ngc_home="${temp_root}/ngc-home"
+        ngc_download="${temp_root}/ngc-download"
+        ngc_unpack="${temp_root}/ngc-unpack"
+        ngc_zip="${temp_root}/ngccli_linux.zip"
+        mkdir -p "$docker_config" "$ngc_home" "$ngc_download" "$ngc_unpack"
+        cleanup() {
+          rm -rf -- "$temp_root"
+        }
+        trap cleanup EXIT
+
+        write_summary() {
+          {
+            printf '### Explicit NGC authentication probes\n\n'
+            printf '| Probe | Result |\n'
+            printf '| --- | --- |\n'
+            printf '| NGC_API_KEY is present | `%s` |\n' "$secret_present"
+            printf '| NVCR login accepts the explicit secret | `%s` |\n' "$nvcr_login_accepted"
+            printf '| NVCR image is inspectable with the explicit secret | `%s` |\n' \
+              "$nvcr_image_inspectable"
+            printf '| NGC artifact is downloadable with the explicit secret | `%s` |\n' \
+              "$ngc_artifact_downloadable"
+          } >> "$GITHUB_STEP_SUMMARY"
+        }
+
+        if [ -z "${NGC_API_KEY:-}" ]; then
+          write_summary
+          echo "::error::NGC_API_KEY is empty; explicit authentication cannot be tested"
+          exit 1
+        fi
+        secret_present=true
+
+        export DOCKER_CONFIG="$docker_config"
+        if printf '%s' "$NGC_API_KEY" |
+          docker login --username '$oauthtoken' --password-stdin nvcr.io >/dev/null 2>&1; then
+          nvcr_login_accepted=true
+          if docker manifest inspect "${ISAACSIM_IMAGE_NAME}:${ISAACSIM_IMAGE_TAG}" >/dev/null 2>&1; then
+            nvcr_image_inspectable=true
+          fi
+        fi
+
+        ngc_cli="${ngc_unpack}/ngc-cli/ngc"
+        if curl -fsSL -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1 &&
+          printf '%s  %s\n' "$NGC_CLI_SHA256" "$ngc_zip" | sha256sum -c - >/dev/null 2>&1 &&
+          unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1 && [ -x "$ngc_cli" ]; then
+          if (
+            export HOME="$ngc_home"
+            export NGC_CLI_HOME="$ngc_home"
+            export NGC_CLI_API_KEY="$NGC_API_KEY"
+            export NGC_CLI_ORG=nvidian
+            export NGC_CLI_TEAM=no-team
+            "$ngc_cli" registry resource download-version "$OVPHYSX_WHEELHOUSE_RESOURCE" \
+              --dest "$ngc_download" >/dev/null 2>&1
+          ); then
+            ngc_artifact_downloadable=true
+          fi
+        fi
+
+        write_summary
+        if [ "$nvcr_image_inspectable" != true ] || [ "$ngc_artifact_downloadable" != true ]; then
+          echo "::error::One or more explicit NGC authentication probes failed"
+          exit 1
+        fi

--- a/.github/workflows/ngc-auth-diagnostic.yaml
+++ b/.github/workflows/ngc-auth-diagnostic.yaml
@@ -81,6 +81,7 @@ jobs:
         OVPHYSX_WHEELHOUSE_RESOURCE: ${{ steps.config.outputs.ovphysx_wheelhouse_resource }}
       run: |
         set -uo pipefail
+        set +e
 
         NGC_CLI_VERSION=4.20.0
         NGC_CLI_SHA256=5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b
@@ -414,6 +415,7 @@ jobs:
         OVPHYSX_WHEELHOUSE_RESOURCE: ${{ steps.config.outputs.ovphysx_wheelhouse_resource }}
       run: |
         set -uo pipefail
+        set +e
 
         NGC_CLI_VERSION=4.20.0
         NGC_CLI_SHA256=5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b

--- a/.github/workflows/ngc-auth-diagnostic.yaml
+++ b/.github/workflows/ngc-auth-diagnostic.yaml
@@ -161,7 +161,7 @@ jobs:
           default_docker_config_exists=true
           if [ "$python3_available" = true ] &&
             python3 -c \
-              'import json, sys; config = json.load(open(sys.argv[1], encoding="utf-8")); auths = config.get("auths") or {}; helpers = config.get("credHelpers") or {}; raise SystemExit(0 if "nvcr.io" in auths or "nvcr.io" in helpers else 1)' \
+              'import json, sys; config = json.load(open(sys.argv[1], encoding="utf-8")); root_is_dict = isinstance(config, dict); auths = config.get("auths", {}) if root_is_dict else None; helpers = config.get("credHelpers", {}) if root_is_dict else None; entries_are_dicts = isinstance(auths, dict) and isinstance(helpers, dict); raise SystemExit(0 if root_is_dict and entries_are_dicts and ("nvcr.io" in auths or "nvcr.io" in helpers) else 1)' \
               "$default_docker_config" >/dev/null 2>&1; then
             default_docker_config_names_nvcr=true
           fi

--- a/.github/workflows/ngc-auth-diagnostic.yaml
+++ b/.github/workflows/ngc-auth-diagnostic.yaml
@@ -348,7 +348,7 @@ jobs:
           printf '| Ambient NGC artifact download timed out | `%s` |\n' "$ngc_download_timed_out"
           printf '| Isolated NGC CLI without an API key can download the configured resource | `%s` |\n' \
             "$ngc_artifact_downloadable_without_key"
-        } >> "$GITHUB_STEP_SUMMARY"
+        } | tee -a "$GITHUB_STEP_SUMMARY"
 
   secret-backed-auth:
     name: Explicit NGC secret authentication
@@ -492,7 +492,7 @@ jobs:
             printf '| Explicit NGC artifact download timed out | `%s` |\n' "$ngc_download_timed_out"
             printf '| NGC artifact is downloadable with the explicit secret | `%s` |\n' \
               "$ngc_artifact_downloadable"
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
         }
 
         if [ -z "${NGC_API_KEY:-}" ]; then

--- a/.github/workflows/ngc-auth-diagnostic.yaml
+++ b/.github/workflows/ngc-auth-diagnostic.yaml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   ambient-auth:
     name: Ambient runner authentication
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, gpu]
     timeout-minutes: 30
 
@@ -55,6 +56,9 @@ jobs:
         NGC_CLI_SHA256=5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b
         NGC_CLI_URL="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VERSION}/files/ngccli_linux.zip"
 
+        docker_cli_available=false
+        aws_cli_available=false
+        ngc_cli_ready=false
         default_docker_config_exists=false
         default_docker_config_names_nvcr=false
         default_docker_config_inspects_image=false
@@ -77,6 +81,13 @@ jobs:
         }
         trap cleanup EXIT
 
+        if command -v docker >/dev/null 2>&1; then
+          docker_cli_available=true
+        fi
+        if command -v aws >/dev/null 2>&1; then
+          aws_cli_available=true
+        fi
+
         image="${ISAACSIM_IMAGE_NAME}:${ISAACSIM_IMAGE_TAG}"
         default_docker_dir="${HOME}/.docker"
         default_docker_config="${default_docker_dir}/config.json"
@@ -89,29 +100,36 @@ jobs:
           fi
         fi
 
-        if DOCKER_CONFIG="$default_docker_dir" docker manifest inspect "$image" >/dev/null 2>&1; then
+        if [ "$docker_cli_available" = true ] &&
+          DOCKER_CONFIG="$default_docker_dir" timeout 60s docker manifest inspect \
+            "$image" >/dev/null 2>&1; then
           default_docker_config_inspects_image=true
         fi
 
-        if DOCKER_CONFIG="$empty_docker_config" docker manifest inspect "$image" >/dev/null 2>&1; then
+        if [ "$docker_cli_available" = true ] &&
+          DOCKER_CONFIG="$empty_docker_config" timeout 60s docker manifest inspect \
+            "$image" >/dev/null 2>&1; then
           empty_docker_config_inspects_image=true
         fi
 
-        if aws sts get-caller-identity >/dev/null 2>&1; then
+        if [ "$aws_cli_available" = true ] && timeout 30s aws sts get-caller-identity >/dev/null 2>&1; then
           aws_caller_identity_available=true
         fi
 
         ECR_URL="${ECR_CACHE_URL:-}"
         if [ -z "$ECR_URL" ]; then
-          imds_token=$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" \
+          imds_token=$(curl --connect-timeout 2 --max-time 5 -fsS -X PUT \
+            "http://169.254.169.254/latest/api/token" \
             -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null) || imds_token=""
           if [ -n "$imds_token" ]; then
-            instance_id=$(curl -fsS -H "X-aws-ec2-metadata-token: ${imds_token}" \
+            instance_id=$(curl --connect-timeout 2 --max-time 5 -fsS \
+              -H "X-aws-ec2-metadata-token: ${imds_token}" \
               "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null) || instance_id=""
-            instance_region=$(curl -fsS -H "X-aws-ec2-metadata-token: ${imds_token}" \
+            instance_region=$(curl --connect-timeout 2 --max-time 5 -fsS \
+              -H "X-aws-ec2-metadata-token: ${imds_token}" \
               "http://169.254.169.254/latest/meta-data/placement/region" 2>/dev/null) || instance_region=""
-            if [ -n "$instance_id" ] && [ -n "$instance_region" ]; then
-              ECR_URL=$(aws ssm get-parameter \
+            if [ "$aws_cli_available" = true ] && [ -n "$instance_id" ] && [ -n "$instance_region" ]; then
+              ECR_URL=$(timeout 30s aws ssm get-parameter \
                 --name "/github-runner/${instance_id}/ecr-cache-url" \
                 --region "$instance_region" \
                 --query 'Parameter.Value' --output text 2>/dev/null) || ECR_URL=""
@@ -124,11 +142,12 @@ jobs:
           ecr_registry="${ECR_URL%%/*}"
           ecr_region="${ecr_registry#*.dkr.ecr.}"
           ecr_region="${ecr_region%%.amazonaws.com*}"
-          if [ -n "$ecr_region" ] && [ "$ecr_region" != "$ecr_registry" ]; then
-            if aws ecr get-login-password --region "$ecr_region" 2>/dev/null |
-              DOCKER_CONFIG="$ecr_docker_config" docker login --username AWS --password-stdin \
-                "$ecr_registry" >/dev/null 2>&1; then
-              if DOCKER_CONFIG="$ecr_docker_config" docker manifest inspect \
+          if [ "$docker_cli_available" = true ] && [ "$aws_cli_available" = true ] &&
+            [ -n "$ecr_region" ] && [ "$ecr_region" != "$ecr_registry" ]; then
+            if timeout 60s aws ecr get-login-password --region "$ecr_region" 2>/dev/null |
+              DOCKER_CONFIG="$ecr_docker_config" timeout 60s docker login \
+                --username AWS --password-stdin "$ecr_registry" >/dev/null 2>&1; then
+              if DOCKER_CONFIG="$ecr_docker_config" timeout 60s docker manifest inspect \
                 "${ECR_URL}:cache-base" >/dev/null 2>&1; then
                 ecr_cache_manifest_inspectable=true
               fi
@@ -137,17 +156,21 @@ jobs:
         fi
 
         ngc_cli="${ngc_unpack}/ngc-cli/ngc"
-        if curl -fsSL -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1 &&
+        if curl --connect-timeout 10 --max-time 180 -fsSL \
+          -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1 &&
           printf '%s  %s\n' "$NGC_CLI_SHA256" "$ngc_zip" | sha256sum -c - >/dev/null 2>&1 &&
-          unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1 && [ -x "$ngc_cli" ]; then
+          timeout 60s unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1 &&
+          [ -x "$ngc_cli" ]; then
+          ngc_cli_ready=true
           if (
             unset NGC_API_KEY NGC_CLI_API_KEY
             export HOME="$ngc_home"
             export NGC_CLI_HOME="$ngc_home"
             export NGC_CLI_ORG=nvidian
             export NGC_CLI_TEAM=no-team
-            "$ngc_cli" registry resource download-version "$OVPHYSX_WHEELHOUSE_RESOURCE" \
-              --dest "$ngc_download" >/dev/null 2>&1
+            timeout 10m "$ngc_cli" registry resource download-version \
+              "$OVPHYSX_WHEELHOUSE_RESOURCE" --dest "$ngc_download" \
+              </dev/null >/dev/null 2>&1
           ); then
             ngc_artifact_downloadable_without_key=true
           fi
@@ -157,6 +180,9 @@ jobs:
           printf '### Ambient authentication probes\n\n'
           printf '| Probe | Result |\n'
           printf '| --- | --- |\n'
+          printf '| Docker CLI is available | `%s` |\n' "$docker_cli_available"
+          printf '| AWS CLI is available | `%s` |\n' "$aws_cli_available"
+          printf '| NGC CLI download, checksum, and unpack are ready | `%s` |\n' "$ngc_cli_ready"
           printf '| Default Docker config exists | `%s` |\n' "$default_docker_config_exists"
           printf '| Default Docker config names an nvcr.io auth/helper entry | `%s` |\n' \
             "$default_docker_config_names_nvcr"
@@ -212,6 +238,9 @@ jobs:
         NGC_CLI_SHA256=5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b
         NGC_CLI_URL="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VERSION}/files/ngccli_linux.zip"
 
+        docker_cli_available=false
+        aws_cli_available=false
+        ngc_cli_ready=false
         secret_present=false
         nvcr_login_accepted=false
         nvcr_image_inspectable=false
@@ -229,11 +258,21 @@ jobs:
         }
         trap cleanup EXIT
 
+        if command -v docker >/dev/null 2>&1; then
+          docker_cli_available=true
+        fi
+        if command -v aws >/dev/null 2>&1; then
+          aws_cli_available=true
+        fi
+
         write_summary() {
           {
             printf '### Explicit NGC authentication probes\n\n'
             printf '| Probe | Result |\n'
             printf '| --- | --- |\n'
+            printf '| Docker CLI is available | `%s` |\n' "$docker_cli_available"
+            printf '| AWS CLI is available | `%s` |\n' "$aws_cli_available"
+            printf '| NGC CLI download, checksum, and unpack are ready | `%s` |\n' "$ngc_cli_ready"
             printf '| NGC_API_KEY is present | `%s` |\n' "$secret_present"
             printf '| NVCR login accepts the explicit secret | `%s` |\n' "$nvcr_login_accepted"
             printf '| NVCR image is inspectable with the explicit secret | `%s` |\n' \
@@ -251,26 +290,34 @@ jobs:
         secret_present=true
 
         export DOCKER_CONFIG="$docker_config"
-        if printf '%s' "$NGC_API_KEY" |
-          docker login --username '$oauthtoken' --password-stdin nvcr.io >/dev/null 2>&1; then
-          nvcr_login_accepted=true
-          if docker manifest inspect "${ISAACSIM_IMAGE_NAME}:${ISAACSIM_IMAGE_TAG}" >/dev/null 2>&1; then
-            nvcr_image_inspectable=true
+        if [ "$docker_cli_available" = true ]; then
+          if printf '%s' "$NGC_API_KEY" |
+            timeout 60s docker login --username '$oauthtoken' --password-stdin \
+              nvcr.io >/dev/null 2>&1; then
+            nvcr_login_accepted=true
+            if timeout 60s docker manifest inspect \
+              "${ISAACSIM_IMAGE_NAME}:${ISAACSIM_IMAGE_TAG}" >/dev/null 2>&1; then
+              nvcr_image_inspectable=true
+            fi
           fi
         fi
 
         ngc_cli="${ngc_unpack}/ngc-cli/ngc"
-        if curl -fsSL -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1 &&
+        if curl --connect-timeout 10 --max-time 180 -fsSL \
+          -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1 &&
           printf '%s  %s\n' "$NGC_CLI_SHA256" "$ngc_zip" | sha256sum -c - >/dev/null 2>&1 &&
-          unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1 && [ -x "$ngc_cli" ]; then
+          timeout 60s unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1 &&
+          [ -x "$ngc_cli" ]; then
+          ngc_cli_ready=true
           if (
             export HOME="$ngc_home"
             export NGC_CLI_HOME="$ngc_home"
             export NGC_CLI_API_KEY="$NGC_API_KEY"
             export NGC_CLI_ORG=nvidian
             export NGC_CLI_TEAM=no-team
-            "$ngc_cli" registry resource download-version "$OVPHYSX_WHEELHOUSE_RESOURCE" \
-              --dest "$ngc_download" >/dev/null 2>&1
+            timeout 10m "$ngc_cli" registry resource download-version \
+              "$OVPHYSX_WHEELHOUSE_RESOURCE" --dest "$ngc_download" \
+              </dev/null >/dev/null 2>&1
           ); then
             ngc_artifact_downloadable=true
           fi

--- a/.github/workflows/ngc-auth-diagnostic.yaml
+++ b/.github/workflows/ngc-auth-diagnostic.yaml
@@ -36,9 +36,39 @@ jobs:
       run: |
         set -euo pipefail
         config_file=.github/workflows/config.yaml
-        isaacsim_image_name=$(yq -r .isaacsim_image_name "$config_file")
-        isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$config_file")
-        ovphysx_wheelhouse_resource=$(yq -r .ovphysx_wheelhouse_resource "$config_file")
+        read_config_value() {
+          config_key=$1
+          config_value=$(sed -n \
+            "s/^[[:space:]]*${config_key}[[:space:]]*:[[:space:]]*//p" "$config_file" | \
+            sed -n '1{s/[[:space:]]*$//;p;}')
+          case "$config_value" in
+            \"*\")
+              config_value=${config_value#\"}
+              config_value=${config_value%\"}
+              ;;
+            \'*\')
+              config_value=${config_value#\'}
+              config_value=${config_value%\'}
+              ;;
+          esac
+          printf '%s' "$config_value"
+        }
+
+        isaacsim_image_name=$(read_config_value isaacsim_image_name)
+        isaacsim_image_tag=$(read_config_value isaacsim_image_tag)
+        ovphysx_wheelhouse_resource=$(read_config_value ovphysx_wheelhouse_resource)
+        if [ -z "$isaacsim_image_name" ]; then
+          echo "::error::Missing required diagnostic configuration value: isaacsim_image_name"
+          exit 1
+        fi
+        if [ -z "$isaacsim_image_tag" ]; then
+          echo "::error::Missing required diagnostic configuration value: isaacsim_image_tag"
+          exit 1
+        fi
+        if [ -z "$ovphysx_wheelhouse_resource" ]; then
+          echo "::error::Missing required diagnostic configuration value: ovphysx_wheelhouse_resource"
+          exit 1
+        fi
         printf 'isaacsim_image_name=%s\n' "$isaacsim_image_name" >> "$GITHUB_OUTPUT"
         printf 'isaacsim_image_tag=%s\n' "$isaacsim_image_tag" >> "$GITHUB_OUTPUT"
         printf 'ovphysx_wheelhouse_resource=%s\n' "$ovphysx_wheelhouse_resource" >> "$GITHUB_OUTPUT"
@@ -57,6 +87,7 @@ jobs:
         NGC_CLI_URL="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VERSION}/files/ngccli_linux.zip"
 
         timeout_cli_available=false
+        python3_available=false
         docker_cli_available=false
         aws_cli_available=false
         ngc_cli_setup_attempted=false
@@ -112,6 +143,9 @@ jobs:
         if command -v timeout >/dev/null 2>&1; then
           timeout_cli_available=true
         fi
+        if command -v python3 >/dev/null 2>&1; then
+          python3_available=true
+        fi
         if command -v docker >/dev/null 2>&1; then
           docker_cli_available=true
         fi
@@ -125,8 +159,10 @@ jobs:
 
         if [ -f "$default_docker_config" ]; then
           default_docker_config_exists=true
-          if yq -e '((.auths // {}) | has("nvcr.io")) or ((.credHelpers // {}) | has("nvcr.io"))' \
-            "$default_docker_config" >/dev/null 2>&1; then
+          if [ "$python3_available" = true ] &&
+            python3 -c \
+              'import json, sys; config = json.load(open(sys.argv[1], encoding="utf-8")); auths = config.get("auths") or {}; helpers = config.get("credHelpers") or {}; raise SystemExit(0 if "nvcr.io" in auths or "nvcr.io" in helpers else 1)' \
+              "$default_docker_config" >/dev/null 2>&1; then
             default_docker_config_names_nvcr=true
           fi
         fi
@@ -271,6 +307,7 @@ jobs:
           printf '| Probe | Result |\n'
           printf '| --- | --- |\n'
           printf '| Timeout tool is available | `%s` |\n' "$timeout_cli_available"
+          printf '| Python 3 is available | `%s` |\n' "$python3_available"
           printf '| Docker CLI is available | `%s` |\n' "$docker_cli_available"
           printf '| AWS CLI is available | `%s` |\n' "$aws_cli_available"
           printf '| NGC CLI setup was attempted | `%s` |\n' "$ngc_cli_setup_attempted"
@@ -332,9 +369,39 @@ jobs:
       run: |
         set -euo pipefail
         config_file=.github/workflows/config.yaml
-        isaacsim_image_name=$(yq -r .isaacsim_image_name "$config_file")
-        isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$config_file")
-        ovphysx_wheelhouse_resource=$(yq -r .ovphysx_wheelhouse_resource "$config_file")
+        read_config_value() {
+          config_key=$1
+          config_value=$(sed -n \
+            "s/^[[:space:]]*${config_key}[[:space:]]*:[[:space:]]*//p" "$config_file" | \
+            sed -n '1{s/[[:space:]]*$//;p;}')
+          case "$config_value" in
+            \"*\")
+              config_value=${config_value#\"}
+              config_value=${config_value%\"}
+              ;;
+            \'*\')
+              config_value=${config_value#\'}
+              config_value=${config_value%\'}
+              ;;
+          esac
+          printf '%s' "$config_value"
+        }
+
+        isaacsim_image_name=$(read_config_value isaacsim_image_name)
+        isaacsim_image_tag=$(read_config_value isaacsim_image_tag)
+        ovphysx_wheelhouse_resource=$(read_config_value ovphysx_wheelhouse_resource)
+        if [ -z "$isaacsim_image_name" ]; then
+          echo "::error::Missing required diagnostic configuration value: isaacsim_image_name"
+          exit 1
+        fi
+        if [ -z "$isaacsim_image_tag" ]; then
+          echo "::error::Missing required diagnostic configuration value: isaacsim_image_tag"
+          exit 1
+        fi
+        if [ -z "$ovphysx_wheelhouse_resource" ]; then
+          echo "::error::Missing required diagnostic configuration value: ovphysx_wheelhouse_resource"
+          exit 1
+        fi
         printf 'isaacsim_image_name=%s\n' "$isaacsim_image_name" >> "$GITHUB_OUTPUT"
         printf 'isaacsim_image_tag=%s\n' "$isaacsim_image_tag" >> "$GITHUB_OUTPUT"
         printf 'ovphysx_wheelhouse_resource=%s\n' "$ovphysx_wheelhouse_resource" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ngc-auth-diagnostic.yaml
+++ b/.github/workflows/ngc-auth-diagnostic.yaml
@@ -56,31 +56,62 @@ jobs:
         NGC_CLI_SHA256=5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b
         NGC_CLI_URL="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VERSION}/files/ngccli_linux.zip"
 
+        timeout_cli_available=false
         docker_cli_available=false
         aws_cli_available=false
+        ngc_cli_setup_attempted=false
+        ngc_cli_setup_timed_out=false
         ngc_cli_ready=false
         default_docker_config_exists=false
         default_docker_config_names_nvcr=false
+        default_docker_image_inspect_attempted=false
+        default_docker_image_inspect_timed_out=false
         default_docker_config_inspects_image=false
+        empty_docker_image_inspect_attempted=false
+        empty_docker_image_inspect_timed_out=false
         empty_docker_config_inspects_image=false
+        aws_caller_identity_attempted=false
+        aws_caller_identity_timed_out=false
         aws_caller_identity_available=false
         ecr_cache_url_resolves=false
+        ecr_url_lookup_attempted=false
+        ecr_url_lookup_timed_out=false
+        ecr_login_attempted=false
+        ecr_login_timed_out=false
+        ecr_login_succeeded=false
+        ecr_manifest_inspect_attempted=false
+        ecr_manifest_inspect_timed_out=false
         ecr_cache_manifest_inspectable=false
+        ngc_download_attempted=false
+        ngc_download_timed_out=false
         ngc_artifact_downloadable_without_key=false
 
-        temp_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/ngc-auth-ambient.XXXXXX")
+        temp_root=""
+        if ! temp_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/ngc-auth-ambient.XXXXXX") ||
+          [ -z "$temp_root" ]; then
+          echo "::error::Failed to create a non-empty temporary directory for ambient authentication probes"
+          exit 1
+        fi
+        cleanup() {
+          rm -rf -- "$temp_root"
+        }
+        trap cleanup EXIT
+
         empty_docker_config="${temp_root}/docker-empty"
         ecr_docker_config="${temp_root}/docker-ecr"
         ngc_home="${temp_root}/ngc-home"
         ngc_download="${temp_root}/ngc-download"
         ngc_unpack="${temp_root}/ngc-unpack"
         ngc_zip="${temp_root}/ngccli_linux.zip"
-        mkdir -p "$empty_docker_config" "$ecr_docker_config" "$ngc_home" "$ngc_download" "$ngc_unpack"
-        cleanup() {
-          rm -rf -- "$temp_root"
-        }
-        trap cleanup EXIT
+        if ! mkdir -p \
+          "$empty_docker_config" "$ecr_docker_config" "$ngc_home" "$ngc_download" "$ngc_unpack"; then
+          echo "::error::Failed to initialize temporary directories for ambient authentication probes"
+          exit 1
+        fi
 
+        if command -v timeout >/dev/null 2>&1; then
+          timeout_cli_available=true
+        fi
         if command -v docker >/dev/null 2>&1; then
           docker_cli_available=true
         fi
@@ -100,20 +131,37 @@ jobs:
           fi
         fi
 
-        if [ "$docker_cli_available" = true ] &&
+        if [ "$timeout_cli_available" = true ] && [ "$docker_cli_available" = true ]; then
+          default_docker_image_inspect_attempted=true
           DOCKER_CONFIG="$default_docker_dir" timeout 60s docker manifest inspect \
-            "$image" >/dev/null 2>&1; then
-          default_docker_config_inspects_image=true
-        fi
+            "$image" >/dev/null 2>&1
+          default_docker_image_inspect_status=$?
+          if [ "$default_docker_image_inspect_status" -eq 0 ]; then
+            default_docker_config_inspects_image=true
+          elif [ "$default_docker_image_inspect_status" -eq 124 ]; then
+            default_docker_image_inspect_timed_out=true
+          fi
 
-        if [ "$docker_cli_available" = true ] &&
+          empty_docker_image_inspect_attempted=true
           DOCKER_CONFIG="$empty_docker_config" timeout 60s docker manifest inspect \
-            "$image" >/dev/null 2>&1; then
-          empty_docker_config_inspects_image=true
+            "$image" >/dev/null 2>&1
+          empty_docker_image_inspect_status=$?
+          if [ "$empty_docker_image_inspect_status" -eq 0 ]; then
+            empty_docker_config_inspects_image=true
+          elif [ "$empty_docker_image_inspect_status" -eq 124 ]; then
+            empty_docker_image_inspect_timed_out=true
+          fi
         fi
 
-        if [ "$aws_cli_available" = true ] && timeout 30s aws sts get-caller-identity >/dev/null 2>&1; then
-          aws_caller_identity_available=true
+        if [ "$timeout_cli_available" = true ] && [ "$aws_cli_available" = true ]; then
+          aws_caller_identity_attempted=true
+          timeout 30s aws sts get-caller-identity >/dev/null 2>&1
+          aws_caller_identity_status=$?
+          if [ "$aws_caller_identity_status" -eq 0 ]; then
+            aws_caller_identity_available=true
+          elif [ "$aws_caller_identity_status" -eq 124 ]; then
+            aws_caller_identity_timed_out=true
+          fi
         fi
 
         ECR_URL="${ECR_CACHE_URL:-}"
@@ -128,11 +176,20 @@ jobs:
             instance_region=$(curl --connect-timeout 2 --max-time 5 -fsS \
               -H "X-aws-ec2-metadata-token: ${imds_token}" \
               "http://169.254.169.254/latest/meta-data/placement/region" 2>/dev/null) || instance_region=""
-            if [ "$aws_cli_available" = true ] && [ -n "$instance_id" ] && [ -n "$instance_region" ]; then
+            if [ "$timeout_cli_available" = true ] && [ "$aws_cli_available" = true ] &&
+              [ -n "$instance_id" ] && [ -n "$instance_region" ]; then
+              ecr_url_lookup_attempted=true
               ECR_URL=$(timeout 30s aws ssm get-parameter \
                 --name "/github-runner/${instance_id}/ecr-cache-url" \
                 --region "$instance_region" \
-                --query 'Parameter.Value' --output text 2>/dev/null) || ECR_URL=""
+                --query 'Parameter.Value' --output text 2>/dev/null)
+              ecr_url_lookup_status=$?
+              if [ "$ecr_url_lookup_status" -eq 124 ]; then
+                ecr_url_lookup_timed_out=true
+                ECR_URL=""
+              elif [ "$ecr_url_lookup_status" -ne 0 ]; then
+                ECR_URL=""
+              fi
             fi
           fi
         fi
@@ -142,27 +199,57 @@ jobs:
           ecr_registry="${ECR_URL%%/*}"
           ecr_region="${ecr_registry#*.dkr.ecr.}"
           ecr_region="${ecr_region%%.amazonaws.com*}"
-          if [ "$docker_cli_available" = true ] && [ "$aws_cli_available" = true ] &&
-            [ -n "$ecr_region" ] && [ "$ecr_region" != "$ecr_registry" ]; then
-            if timeout 60s aws ecr get-login-password --region "$ecr_region" 2>/dev/null |
+          if [ "$timeout_cli_available" = true ] && [ "$docker_cli_available" = true ] &&
+            [ "$aws_cli_available" = true ] && [ -n "$ecr_region" ] &&
+            [ "$ecr_region" != "$ecr_registry" ]; then
+            ecr_login_attempted=true
+            timeout 60s aws ecr get-login-password --region "$ecr_region" 2>/dev/null |
               DOCKER_CONFIG="$ecr_docker_config" timeout 60s docker login \
-                --username AWS --password-stdin "$ecr_registry" >/dev/null 2>&1; then
-              if DOCKER_CONFIG="$ecr_docker_config" timeout 60s docker manifest inspect \
-                "${ECR_URL}:cache-base" >/dev/null 2>&1; then
+                --username AWS --password-stdin "$ecr_registry" >/dev/null 2>&1
+            ecr_login_status=("${PIPESTATUS[@]}")
+            if [ "${ecr_login_status[0]}" -eq 124 ] || [ "${ecr_login_status[1]}" -eq 124 ]; then
+              ecr_login_timed_out=true
+            elif [ "${ecr_login_status[0]}" -eq 0 ] && [ "${ecr_login_status[1]}" -eq 0 ]; then
+              ecr_login_succeeded=true
+            fi
+
+            if [ "$ecr_login_succeeded" = true ]; then
+              ecr_manifest_inspect_attempted=true
+              DOCKER_CONFIG="$ecr_docker_config" timeout 60s docker manifest inspect \
+                "${ECR_URL}:cache-base" >/dev/null 2>&1
+              ecr_manifest_inspect_status=$?
+              if [ "$ecr_manifest_inspect_status" -eq 0 ]; then
                 ecr_cache_manifest_inspectable=true
+              elif [ "$ecr_manifest_inspect_status" -eq 124 ]; then
+                ecr_manifest_inspect_timed_out=true
               fi
             fi
           fi
         fi
 
         ngc_cli="${ngc_unpack}/ngc-cli/ngc"
-        if curl --connect-timeout 10 --max-time 180 -fsSL \
-          -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1 &&
-          printf '%s  %s\n' "$NGC_CLI_SHA256" "$ngc_zip" | sha256sum -c - >/dev/null 2>&1 &&
-          timeout 60s unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1 &&
-          [ -x "$ngc_cli" ]; then
-          ngc_cli_ready=true
-          if (
+        if [ "$timeout_cli_available" = true ]; then
+          ngc_cli_setup_attempted=true
+          curl --connect-timeout 10 --max-time 180 -fsSL \
+            -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1
+          ngc_cli_download_status=$?
+          if [ "$ngc_cli_download_status" -eq 28 ]; then
+            ngc_cli_setup_timed_out=true
+          elif [ "$ngc_cli_download_status" -eq 0 ] &&
+            printf '%s  %s\n' "$NGC_CLI_SHA256" "$ngc_zip" | sha256sum -c - >/dev/null 2>&1; then
+            timeout 60s unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1
+            ngc_cli_unpack_status=$?
+            if [ "$ngc_cli_unpack_status" -eq 124 ]; then
+              ngc_cli_setup_timed_out=true
+            elif [ "$ngc_cli_unpack_status" -eq 0 ] && [ -x "$ngc_cli" ]; then
+              ngc_cli_ready=true
+            fi
+          fi
+        fi
+
+        if [ "$ngc_cli_ready" = true ]; then
+          ngc_download_attempted=true
+          (
             unset NGC_API_KEY NGC_CLI_API_KEY
             export HOME="$ngc_home"
             export NGC_CLI_HOME="$ngc_home"
@@ -171,29 +258,56 @@ jobs:
             timeout 10m "$ngc_cli" registry resource download-version \
               "$OVPHYSX_WHEELHOUSE_RESOURCE" --dest "$ngc_download" \
               </dev/null >/dev/null 2>&1
-          ); then
+          )
+          ngc_download_status=$?
+          if [ "$ngc_download_status" -eq 0 ]; then
             ngc_artifact_downloadable_without_key=true
+          elif [ "$ngc_download_status" -eq 124 ]; then
+            ngc_download_timed_out=true
           fi
         fi
-
         {
           printf '### Ambient authentication probes\n\n'
           printf '| Probe | Result |\n'
           printf '| --- | --- |\n'
+          printf '| Timeout tool is available | `%s` |\n' "$timeout_cli_available"
           printf '| Docker CLI is available | `%s` |\n' "$docker_cli_available"
           printf '| AWS CLI is available | `%s` |\n' "$aws_cli_available"
+          printf '| NGC CLI setup was attempted | `%s` |\n' "$ngc_cli_setup_attempted"
+          printf '| NGC CLI setup timed out | `%s` |\n' "$ngc_cli_setup_timed_out"
           printf '| NGC CLI download, checksum, and unpack are ready | `%s` |\n' "$ngc_cli_ready"
           printf '| Default Docker config exists | `%s` |\n' "$default_docker_config_exists"
           printf '| Default Docker config names an nvcr.io auth/helper entry | `%s` |\n' \
             "$default_docker_config_names_nvcr"
+          printf '| Default Docker image inspection was attempted | `%s` |\n' \
+            "$default_docker_image_inspect_attempted"
+          printf '| Default Docker image inspection timed out | `%s` |\n' \
+            "$default_docker_image_inspect_timed_out"
           printf '| Default Docker config can inspect the configured Isaac Sim image | `%s` |\n' \
             "$default_docker_config_inspects_image"
+          printf '| Empty Docker image inspection was attempted | `%s` |\n' \
+            "$empty_docker_image_inspect_attempted"
+          printf '| Empty Docker image inspection timed out | `%s` |\n' \
+            "$empty_docker_image_inspect_timed_out"
           printf '| Empty isolated Docker config can inspect the configured Isaac Sim image | `%s` |\n' \
             "$empty_docker_config_inspects_image"
+          printf '| AWS caller identity check was attempted | `%s` |\n' "$aws_caller_identity_attempted"
+          printf '| AWS caller identity check timed out | `%s` |\n' "$aws_caller_identity_timed_out"
           printf '| AWS caller identity is available | `%s` |\n' "$aws_caller_identity_available"
           printf '| ECR cache URL resolves from runner configuration | `%s` |\n' "$ecr_cache_url_resolves"
+          printf '| ECR URL SSM lookup was attempted | `%s` |\n' "$ecr_url_lookup_attempted"
+          printf '| ECR URL SSM lookup timed out | `%s` |\n' "$ecr_url_lookup_timed_out"
+          printf '| ECR login was attempted | `%s` |\n' "$ecr_login_attempted"
+          printf '| ECR login timed out | `%s` |\n' "$ecr_login_timed_out"
+          printf '| ECR login succeeded | `%s` |\n' "$ecr_login_succeeded"
+          printf '| ECR cache-base manifest inspection was attempted | `%s` |\n' \
+            "$ecr_manifest_inspect_attempted"
+          printf '| ECR cache-base manifest inspection timed out | `%s` |\n' \
+            "$ecr_manifest_inspect_timed_out"
           printf '| Authenticated ECR cache-base manifest is inspectable | `%s` |\n' \
             "$ecr_cache_manifest_inspectable"
+          printf '| Ambient NGC artifact download was attempted | `%s` |\n' "$ngc_download_attempted"
+          printf '| Ambient NGC artifact download timed out | `%s` |\n' "$ngc_download_timed_out"
           printf '| Isolated NGC CLI without an API key can download the configured resource | `%s` |\n' \
             "$ngc_artifact_downloadable_without_key"
         } >> "$GITHUB_STEP_SUMMARY"
@@ -238,26 +352,47 @@ jobs:
         NGC_CLI_SHA256=5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b
         NGC_CLI_URL="https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/${NGC_CLI_VERSION}/files/ngccli_linux.zip"
 
+        timeout_cli_available=false
         docker_cli_available=false
         aws_cli_available=false
+        ngc_cli_setup_attempted=false
+        ngc_cli_setup_timed_out=false
         ngc_cli_ready=false
         secret_present=false
+        nvcr_login_attempted=false
+        nvcr_login_timed_out=false
         nvcr_login_accepted=false
+        nvcr_image_inspect_attempted=false
+        nvcr_image_inspect_timed_out=false
         nvcr_image_inspectable=false
+        ngc_download_attempted=false
+        ngc_download_timed_out=false
         ngc_artifact_downloadable=false
 
-        temp_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/ngc-auth-secret.XXXXXX")
-        docker_config="${temp_root}/docker"
-        ngc_home="${temp_root}/ngc-home"
-        ngc_download="${temp_root}/ngc-download"
-        ngc_unpack="${temp_root}/ngc-unpack"
-        ngc_zip="${temp_root}/ngccli_linux.zip"
-        mkdir -p "$docker_config" "$ngc_home" "$ngc_download" "$ngc_unpack"
+        temp_root=""
+        if ! temp_root=$(mktemp -d "${RUNNER_TEMP:-/tmp}/ngc-auth-secret.XXXXXX") ||
+          [ -z "$temp_root" ]; then
+          echo "::error::Failed to create a non-empty temporary directory for explicit authentication probes"
+          exit 1
+        fi
         cleanup() {
           rm -rf -- "$temp_root"
         }
         trap cleanup EXIT
 
+        docker_config="${temp_root}/docker"
+        ngc_home="${temp_root}/ngc-home"
+        ngc_download="${temp_root}/ngc-download"
+        ngc_unpack="${temp_root}/ngc-unpack"
+        ngc_zip="${temp_root}/ngccli_linux.zip"
+        if ! mkdir -p "$docker_config" "$ngc_home" "$ngc_download" "$ngc_unpack"; then
+          echo "::error::Failed to initialize temporary directories for explicit authentication probes"
+          exit 1
+        fi
+
+        if command -v timeout >/dev/null 2>&1; then
+          timeout_cli_available=true
+        fi
         if command -v docker >/dev/null 2>&1; then
           docker_cli_available=true
         fi
@@ -270,13 +405,22 @@ jobs:
             printf '### Explicit NGC authentication probes\n\n'
             printf '| Probe | Result |\n'
             printf '| --- | --- |\n'
+            printf '| Timeout tool is available | `%s` |\n' "$timeout_cli_available"
             printf '| Docker CLI is available | `%s` |\n' "$docker_cli_available"
             printf '| AWS CLI is available | `%s` |\n' "$aws_cli_available"
+            printf '| NGC CLI setup was attempted | `%s` |\n' "$ngc_cli_setup_attempted"
+            printf '| NGC CLI setup timed out | `%s` |\n' "$ngc_cli_setup_timed_out"
             printf '| NGC CLI download, checksum, and unpack are ready | `%s` |\n' "$ngc_cli_ready"
             printf '| NGC_API_KEY is present | `%s` |\n' "$secret_present"
+            printf '| NVCR login was attempted | `%s` |\n' "$nvcr_login_attempted"
+            printf '| NVCR login timed out | `%s` |\n' "$nvcr_login_timed_out"
             printf '| NVCR login accepts the explicit secret | `%s` |\n' "$nvcr_login_accepted"
+            printf '| NVCR image inspection was attempted | `%s` |\n' "$nvcr_image_inspect_attempted"
+            printf '| NVCR image inspection timed out | `%s` |\n' "$nvcr_image_inspect_timed_out"
             printf '| NVCR image is inspectable with the explicit secret | `%s` |\n' \
               "$nvcr_image_inspectable"
+            printf '| Explicit NGC artifact download was attempted | `%s` |\n' "$ngc_download_attempted"
+            printf '| Explicit NGC artifact download timed out | `%s` |\n' "$ngc_download_timed_out"
             printf '| NGC artifact is downloadable with the explicit secret | `%s` |\n' \
               "$ngc_artifact_downloadable"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -290,26 +434,54 @@ jobs:
         secret_present=true
 
         export DOCKER_CONFIG="$docker_config"
-        if [ "$docker_cli_available" = true ]; then
-          if printf '%s' "$NGC_API_KEY" |
+        if [ "$timeout_cli_available" = true ] && [ "$docker_cli_available" = true ]; then
+          nvcr_login_attempted=true
+          printf '%s' "$NGC_API_KEY" |
             timeout 60s docker login --username '$oauthtoken' --password-stdin \
-              nvcr.io >/dev/null 2>&1; then
+              nvcr.io >/dev/null 2>&1
+          nvcr_login_status=${PIPESTATUS[1]}
+          if [ "$nvcr_login_status" -eq 0 ]; then
             nvcr_login_accepted=true
-            if timeout 60s docker manifest inspect \
-              "${ISAACSIM_IMAGE_NAME}:${ISAACSIM_IMAGE_TAG}" >/dev/null 2>&1; then
+          elif [ "$nvcr_login_status" -eq 124 ]; then
+            nvcr_login_timed_out=true
+          fi
+
+          if [ "$nvcr_login_accepted" = true ]; then
+            nvcr_image_inspect_attempted=true
+            timeout 60s docker manifest inspect \
+              "${ISAACSIM_IMAGE_NAME}:${ISAACSIM_IMAGE_TAG}" >/dev/null 2>&1
+            nvcr_image_inspect_status=$?
+            if [ "$nvcr_image_inspect_status" -eq 0 ]; then
               nvcr_image_inspectable=true
+            elif [ "$nvcr_image_inspect_status" -eq 124 ]; then
+              nvcr_image_inspect_timed_out=true
             fi
           fi
         fi
 
         ngc_cli="${ngc_unpack}/ngc-cli/ngc"
-        if curl --connect-timeout 10 --max-time 180 -fsSL \
-          -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1 &&
-          printf '%s  %s\n' "$NGC_CLI_SHA256" "$ngc_zip" | sha256sum -c - >/dev/null 2>&1 &&
-          timeout 60s unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1 &&
-          [ -x "$ngc_cli" ]; then
-          ngc_cli_ready=true
-          if (
+        if [ "$timeout_cli_available" = true ]; then
+          ngc_cli_setup_attempted=true
+          curl --connect-timeout 10 --max-time 180 -fsSL \
+            -o "$ngc_zip" "$NGC_CLI_URL" >/dev/null 2>&1
+          ngc_cli_download_status=$?
+          if [ "$ngc_cli_download_status" -eq 28 ]; then
+            ngc_cli_setup_timed_out=true
+          elif [ "$ngc_cli_download_status" -eq 0 ] &&
+            printf '%s  %s\n' "$NGC_CLI_SHA256" "$ngc_zip" | sha256sum -c - >/dev/null 2>&1; then
+            timeout 60s unzip -q "$ngc_zip" -d "$ngc_unpack" >/dev/null 2>&1
+            ngc_cli_unpack_status=$?
+            if [ "$ngc_cli_unpack_status" -eq 124 ]; then
+              ngc_cli_setup_timed_out=true
+            elif [ "$ngc_cli_unpack_status" -eq 0 ] && [ -x "$ngc_cli" ]; then
+              ngc_cli_ready=true
+            fi
+          fi
+        fi
+
+        if [ "$ngc_cli_ready" = true ]; then
+          ngc_download_attempted=true
+          (
             export HOME="$ngc_home"
             export NGC_CLI_HOME="$ngc_home"
             export NGC_CLI_API_KEY="$NGC_API_KEY"
@@ -318,13 +490,16 @@ jobs:
             timeout 10m "$ngc_cli" registry resource download-version \
               "$OVPHYSX_WHEELHOUSE_RESOURCE" --dest "$ngc_download" \
               </dev/null >/dev/null 2>&1
-          ); then
+          )
+          ngc_download_status=$?
+          if [ "$ngc_download_status" -eq 0 ]; then
             ngc_artifact_downloadable=true
+          elif [ "$ngc_download_status" -eq 124 ]; then
+            ngc_download_timed_out=true
           fi
         fi
-
         write_summary
         if [ "$nvcr_image_inspectable" != true ] || [ "$ngc_artifact_downloadable" != true ]; then
-          echo "::error::One or more explicit NGC authentication probes failed"
+          echo "::error::One or more explicit NGC service checks failed; inspect readiness and timeout rows before attributing failures to credentials"
           exit 1
         fi

--- a/docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md
+++ b/docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md
@@ -1,0 +1,155 @@
+<!--
+Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# NGC Authentication Diagnostic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a temporary pull-request workflow that proves which authentication source lets CI reach NVCR containers, ECR-cached containers, and NGC artifacts.
+
+**Architecture:** Create one standalone workflow containing an ambient-auth job and a same-repository secret-backed job. Each job isolates client configuration, suppresses command output that could contain credentials, and publishes only boolean outcomes to the GitHub job summary. Existing production workflows and actions remain unchanged.
+
+**Tech Stack:** GitHub Actions YAML, Bash, Docker CLI, AWS CLI, NGC CLI 4.20.0, repository pre-commit hooks.
+
+---
+
+### Task 1: Add the diagnostic workflow
+
+**Files:**
+- Create: `.github/workflows/ngc-auth-diagnostic.yaml`
+- Modify: `docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md`
+
+- [x] **Step 1: Verify the workflow does not exist**
+
+Run:
+
+```bash
+test -f .github/workflows/ngc-auth-diagnostic.yaml
+```
+
+Expected: exit status 1 because the diagnostic workflow has not been created.
+
+- [x] **Step 2: Create the workflow skeleton**
+
+Create `.github/workflows/ngc-auth-diagnostic.yaml` with the 2026 SPDX header,
+the name `NGC Authentication Diagnostic`, and only this trigger:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [develop]
+```
+
+Grant only `contents: read`, use pull-request concurrency, and define two jobs
+on `[self-hosted, gpu]`, each with a 30-minute timeout:
+
+```yaml
+jobs:
+  ambient-auth:
+    name: Ambient runner authentication
+  secret-backed-auth:
+    name: Explicit NGC secret authentication
+    if: github.event.pull_request.head.repo.full_name == github.repository
+```
+
+Neither job may use `pull_request_target`. Only `secret-backed-auth` may refer to
+`${{ secrets.NGC_API_KEY }}`.
+
+- [x] **Step 3: Implement the ambient probe**
+
+Checkout the repository, load `isaacsim_image_name`, `isaacsim_image_tag`, and
+`ovphysx_wheelhouse_resource` from `.github/workflows/config.yaml`, then run one
+`bash` probe with `set -uo pipefail` and temporary directories cleaned by a
+`trap`. The probe must collect these booleans without printing configuration or
+captured command output:
+
+```text
+default Docker config exists
+default Docker config names an nvcr.io auth/helper entry
+default Docker config can inspect the configured Isaac Sim image
+empty isolated Docker config can inspect the configured Isaac Sim image
+AWS caller identity is available
+ECR cache URL is available from ECR_CACHE_URL or runner SSM
+authenticated ECR cache-base manifest is inspectable
+isolated NGC CLI without an API key can download the configured resource
+```
+
+Resolve the ECR URL with the same precedence used by
+`.github/actions/ecr-build-push-pull/action.yml`: `ECR_CACHE_URL`, then EC2 IMDS
+plus `/github-runner/<instance-id>/ecr-cache-url`. Authenticate to ECR in an
+isolated Docker config using `aws ecr get-login-password` before inspecting
+`${ECR_URL}:cache-base`.
+
+Install NGC CLI 4.20.0 from the public NVIDIA URL and verify SHA-256
+`5cf084c88998c58ad8abf7849d2d1b41d578423886eb03018df10194e341d35b`.
+Run the ambient artifact probe with `NGC_API_KEY` and `NGC_CLI_API_KEY` unset,
+an isolated `HOME`/`NGC_CLI_HOME`, org `nvidian`, and team `no-team`.
+
+Append a Markdown table of the booleans to `$GITHUB_STEP_SUMMARY`. Probe
+failures must remain visible as `false` but must not stop later probes.
+
+- [x] **Step 4: Implement the secret-backed probe**
+
+Set only this job environment mapping:
+
+```yaml
+env:
+  NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+```
+
+Fail immediately with a clear error if the secret is empty. In isolated Docker
+configuration, authenticate using:
+
+```bash
+printf '%s' "$NGC_API_KEY" |
+  docker login --username '$oauthtoken' --password-stdin nvcr.io
+```
+
+Suppress login and inspect output, inspect the configured Isaac Sim image, then
+use the verified NGC CLI with `NGC_CLI_API_KEY="$NGC_API_KEY"` and isolated
+NGC home to download the configured OVPhysX resource. Append a Markdown table
+containing only these booleans:
+
+```text
+NGC_API_KEY is present
+NVCR login accepts the explicit secret
+NVCR image is inspectable with the explicit secret
+NGC artifact is downloadable with the explicit secret
+```
+
+Exit nonzero when either secret-backed service probe fails so a trusted PR
+cannot look green when the shared secret is unusable.
+
+- [x] **Step 5: Validate the workflow locally**
+
+Run:
+
+```bash
+test -f .github/workflows/ngc-auth-diagnostic.yaml
+./isaaclab.sh -f
+```
+
+Expected: the file-existence check exits 0 and every pre-commit hook passes.
+If pre-commit modifies files, review and stage them, then run `./isaaclab.sh -f`
+again.
+
+- [x] **Step 6: Review and commit**
+
+Confirm `git diff --check` passes, verify no production workflow/action changed,
+and inspect the workflow for secret output, `set -x`, `pull_request_target`, and
+unguarded secret usage. Force-add this ignored plan file, stage the workflow,
+and commit:
+
+```bash
+git add .github/workflows/ngc-auth-diagnostic.yaml
+git add -f docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md
+git commit -m "Add NGC authentication diagnostic"
+```
+
+Do not push or open the PR; the coordinating agent performs those steps after
+independent review.

--- a/docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md
+++ b/docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md
@@ -52,13 +52,15 @@ on `[self-hosted, gpu]`, each with a 30-minute timeout:
 jobs:
   ambient-auth:
     name: Ambient runner authentication
+    if: github.event.pull_request.head.repo.full_name == github.repository
   secret-backed-auth:
     name: Explicit NGC secret authentication
     if: github.event.pull_request.head.repo.full_name == github.repository
 ```
 
-Neither job may use `pull_request_target`. Only `secret-backed-auth` may refer to
-`${{ secrets.NGC_API_KEY }}`.
+Neither job may use `pull_request_target`. Guard both jobs to same-repository pull
+requests so fork-authored code never runs on persistent self-hosted runners. Only
+`secret-backed-auth` may refer to `${{ secrets.NGC_API_KEY }}`.
 
 - [x] **Step 3: Implement the ambient probe**
 
@@ -69,6 +71,9 @@ Checkout the repository, load `isaacsim_image_name`, `isaacsim_image_tag`, and
 captured command output:
 
 ```text
+Docker CLI is available
+AWS CLI is available
+NGC CLI download, checksum, and unpack are ready
 default Docker config exists
 default Docker config names an nvcr.io auth/helper entry
 default Docker config can inspect the configured Isaac Sim image
@@ -90,8 +95,10 @@ Install NGC CLI 4.20.0 from the public NVIDIA URL and verify SHA-256
 Run the ambient artifact probe with `NGC_API_KEY` and `NGC_CLI_API_KEY` unset,
 an isolated `HOME`/`NGC_CLI_HOME`, org `nvidian`, and team `no-team`.
 
-Append a Markdown table of the booleans to `$GITHUB_STEP_SUMMARY`. Probe
-failures must remain visible as `false` but must not stop later probes.
+Bound Docker, AWS, unzip, and NGC commands with `timeout`; bound every `curl`
+with connection and total timeouts; and close NGC CLI stdin with `/dev/null`. Append
+a Markdown table of the booleans to `$GITHUB_STEP_SUMMARY`. Probe failures must
+remain visible as `false` but must not stop later probes.
 
 - [x] **Step 4: Implement the secret-backed probe**
 
@@ -107,15 +114,19 @@ configuration, authenticate using:
 
 ```bash
 printf '%s' "$NGC_API_KEY" |
-  docker login --username '$oauthtoken' --password-stdin nvcr.io
+  timeout 60s docker login --username '$oauthtoken' --password-stdin nvcr.io
 ```
 
 Suppress login and inspect output, inspect the configured Isaac Sim image, then
 use the verified NGC CLI with `NGC_CLI_API_KEY="$NGC_API_KEY"` and isolated
-NGC home to download the configured OVPhysX resource. Append a Markdown table
+NGC home and closed stdin to download the configured OVPhysX resource. Bound
+all external client operations as in the ambient probe. Append a Markdown table
 containing only these booleans:
 
 ```text
+Docker CLI is available
+AWS CLI is available
+NGC CLI download, checksum, and unpack are ready
 NGC_API_KEY is present
 NVCR login accepts the explicit secret
 NVCR image is inspectable with the explicit secret

--- a/docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md
+++ b/docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md
@@ -65,7 +65,8 @@ requests so fork-authored code never runs on persistent self-hosted runners. Onl
 - [x] **Step 3: Implement the ambient probe**
 
 Checkout the repository, load `isaacsim_image_name`, `isaacsim_image_tag`, and
-`ovphysx_wheelhouse_resource` from `.github/workflows/config.yaml`, then run one
+`ovphysx_wheelhouse_resource` from `.github/workflows/config.yaml` with a
+quote-aware `sed` parser and no `yq` dependency, then run one
 `bash` probe with `set -uo pipefail` and temporary directories cleaned by a
 `trap`. Check that `mktemp` returns a non-empty path, install the cleanup trap
 immediately, and fail cleanly if temporary subdirectory creation fails. The probe
@@ -74,6 +75,7 @@ output:
 
 ```text
 Timeout tool is available
+Python 3 is available
 Docker CLI is available
 AWS CLI is available
 NGC CLI download, checksum, and unpack are ready
@@ -155,6 +157,11 @@ test -f .github/workflows/ngc-auth-diagnostic.yaml
 Expected: the file-existence check exits 0 and every pre-commit hook passes.
 If pre-commit modifies files, review and stage them, then run `./isaaclab.sh -f`
 again.
+
+Regression evidence: CI run `28798383155` failed in configuration loading with
+exit `127` and `yq: command not found`. A structural RED check must show the old
+workflow contains `yq`; the GREEN check must show none and verify that the
+dependency-free parser preserves the full quoted resource value after its colon.
 
 - [x] **Step 6: Review and commit**
 

--- a/docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md
+++ b/docs/superpowers/plans/2026-07-06-ngc-auth-diagnostic.md
@@ -67,10 +67,13 @@ requests so fork-authored code never runs on persistent self-hosted runners. Onl
 Checkout the repository, load `isaacsim_image_name`, `isaacsim_image_tag`, and
 `ovphysx_wheelhouse_resource` from `.github/workflows/config.yaml`, then run one
 `bash` probe with `set -uo pipefail` and temporary directories cleaned by a
-`trap`. The probe must collect these booleans without printing configuration or
-captured command output:
+`trap`. Check that `mktemp` returns a non-empty path, install the cleanup trap
+immediately, and fail cleanly if temporary subdirectory creation fails. The probe
+must collect these booleans without printing configuration or captured command
+output:
 
 ```text
+Timeout tool is available
 Docker CLI is available
 AWS CLI is available
 NGC CLI download, checksum, and unpack are ready
@@ -96,9 +99,11 @@ Run the ambient artifact probe with `NGC_API_KEY` and `NGC_CLI_API_KEY` unset,
 an isolated `HOME`/`NGC_CLI_HOME`, org `nvidian`, and team `no-team`.
 
 Bound Docker, AWS, unzip, and NGC commands with `timeout`; bound every `curl`
-with connection and total timeouts; and close NGC CLI stdin with `/dev/null`. Append
-a Markdown table of the booleans to `$GITHUB_STEP_SUMMARY`. Probe failures must
-remain visible as `false` but must not stop later probes.
+with connection and total timeouts; and close NGC CLI stdin with `/dev/null`.
+Report `timeout` readiness, separate ECR login success from manifest inspection,
+and record attempted and timed-out booleans for NVCR, ECR, and NGC operations.
+Append a Markdown table of the booleans to `$GITHUB_STEP_SUMMARY`. Probe failures
+must remain visible as `false` but must not stop later probes.
 
 - [x] **Step 4: Implement the secret-backed probe**
 
@@ -124,17 +129,19 @@ all external client operations as in the ambient probe. Append a Markdown table
 containing only these booleans:
 
 ```text
+Timeout tool is available
 Docker CLI is available
 AWS CLI is available
 NGC CLI download, checksum, and unpack are ready
 NGC_API_KEY is present
-NVCR login accepts the explicit secret
-NVCR image is inspectable with the explicit secret
-NGC artifact is downloadable with the explicit secret
+NVCR login attempted, timed out, and accepted
+NVCR image inspection attempted, timed out, and succeeded
+NGC artifact download attempted, timed out, and succeeded
 ```
 
 Exit nonzero when either secret-backed service probe fails so a trusted PR
-cannot look green when the shared secret is unusable.
+cannot look green when a service check fails. The error must direct readers to
+readiness and timeout rows before attributing the failure to credentials.
 
 - [x] **Step 5: Validate the workflow locally**
 

--- a/docs/superpowers/specs/2026-07-06-ngc-auth-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-07-06-ngc-auth-diagnostic-design.md
@@ -1,0 +1,77 @@
+<!--
+Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# NGC Authentication Diagnostic Design
+
+## Objective
+
+Determine why fork pull-request CI can obtain the Isaac Sim container while it
+cannot download the OVPhysX wheelhouse from NGC. The diagnostic must distinguish
+anonymous registry access, persistent self-hosted-runner credentials, the AWS
+ECR cache, and explicitly injected GitHub Actions secrets.
+
+This is a temporary diagnostic only. It must not modify production build or test
+behavior and its pull request must be marked `[DO NOT MERGE]`.
+
+## Approach
+
+Add one standalone pull-request workflow that runs on the same self-hosted GPU
+runner class as the Docker and OVPhysX jobs. The workflow contains independent
+ambient and secret-backed probes so a result from one authentication source
+cannot mask another.
+
+The ambient probe does not reference `secrets.NGC_API_KEY`. It will:
+
+1. Report whether the runner has a Docker configuration, Docker credential
+   helper, NGC CLI configuration, and AWS identity, without printing their
+   contents.
+2. Test the configured Isaac Sim NVCR image with the runner's default Docker
+   configuration.
+3. Test the same image with a new empty `DOCKER_CONFIG` to determine whether the
+   image is anonymously readable.
+4. Test the configured ECR cache path using the runner's AWS identity.
+5. Attempt to inspect or download the configured OVPhysX NGC resource with an
+   isolated NGC home and no API key.
+
+The secret-backed probe is restricted to a pull request whose head repository is
+`isaac-sim/IsaacLab`. It explicitly injects `secrets.NGC_API_KEY` and repeats the
+NVCR and OVPhysX resource operations with isolated client configuration. This
+confirms whether the same secret authorizes both NGC services.
+
+## Safety
+
+- Never print API keys, Docker auth records, configuration contents, or command
+  lines containing credentials.
+- Report only credential/configuration presence, registry/resource identifiers,
+  exit status, and redacted success/failure summaries.
+- Use temporary Docker and NGC configuration directories and remove them with
+  `trap` cleanup.
+- Restrict secret-backed execution to same-repository pull requests.
+- Do not use `pull_request_target` and do not execute fork code with secrets.
+- Keep diagnostic failures non-destructive while making each failed probe visible
+  in the job summary.
+
+## Expected Interpretation
+
+- Default Docker succeeds and empty-config Docker fails: persistent runner Docker
+  credentials provide NVCR access.
+- Both Docker probes succeed: the Isaac Sim image is anonymously readable.
+- ECR succeeds while both NVCR probes fail: the normal Docker path is satisfied
+  by the runner-authenticated ECR cache rather than NGC.
+- Ambient artifact access fails while secret-backed access succeeds: artifacts
+  require the GitHub Actions secret and have no runner-side fallback.
+- Both secret-backed probes succeed: one NGC API key can authenticate both NVCR
+  and the artifact registry; the difference is credential delivery, not service
+  capability.
+
+## Verification and Deliverable
+
+Validate workflow syntax and run all repository pre-commit hooks before pushing.
+Push the branch to the upstream repository so the pull request is same-repository,
+then open a draft PR named `[DO NOT MERGE] Probe NGC authentication paths`.
+Interpret the resulting logs and job summary; do not convert the diagnostic into
+a production fix in the same PR.


### PR DESCRIPTION
## Purpose

This is a temporary diagnostic PR. **Do not merge it.**

It compares four authentication paths on the self-hosted GPU runner without changing existing build or test behavior:

- the runner's ambient Docker configuration against the Isaac Sim NVCR image;
- an empty Docker configuration against the same image;
- the runner's AWS identity and ECR cache access;
- isolated NGC artifact access without and with the explicit `NGC_API_KEY` secret.

Both jobs are restricted to same-repository pull requests. The ambient job deliberately receives no NGC secret. The explicit job receives the repository secret and tests both NVCR login and the configured OVPhysX resource. Summaries contain only readiness, attempted, timeout, and success booleans; command output and credentials are suppressed.

## Expected interpretation

- Empty Docker config succeeds: the configured NVCR image is anonymously readable.
- Default Docker succeeds but empty config fails: the runner has ambient Docker credentials.
- ECR succeeds while NVCR does not: normal CI is being satisfied by the AWS-authenticated ECR cache.
- Ambient artifact access fails while explicit artifact access succeeds: the artifact path depends on the GitHub Actions secret and lacks an ambient runner fallback.
- The explicit secret succeeds for both NVCR and artifacts: the difference is credential delivery, not separate NGC credentials.

## Validation

- `./isaaclab.sh -f`
- embedded Bash syntax checks
- secret-scope and same-repository guard checks
- independent specification and security reviews

After the workflow completes, this PR will be used only to record and interpret the results.
