### PR TITLE
Avoid redundant sensor backend updates

### DIFF
--- a/source/isaaclab/changelog.d/fix-sensor-freshness-cache.rst
+++ b/source/isaaclab/changelog.d/fix-sensor-freshness-cache.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed repeated sensor data reads re-running backend updates when the cached
+  data was already fresh.

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -185,11 +185,13 @@ class SensorBase(ABC):
             inputs=[env_mask, self._is_outdated, self._timestamp, self._timestamp_last_update],
             device=self._device,
         )
+        self._data_generation += 1
 
     def update(self, dt: float, force_recompute: bool = False):
         # Skip update if sensor is not initialized
         if not self._is_initialized:
             return
+        self._data_generation += 1
         # Update the timestamp for the sensors
         wp.launch(
             update_timestamp_kernel,
@@ -205,7 +207,7 @@ class SensorBase(ABC):
         )
         # Update the buffers
         if force_recompute or self._is_visualizing:
-            self._update_outdated_buffers()
+            self._update_outdated_buffers(force_recompute=force_recompute)
 
     """
     Implementation specific.
@@ -254,6 +256,8 @@ class SensorBase(ABC):
         self._is_outdated = wp.ones(self._num_envs, dtype=wp.bool, device=self._device)
         self._timestamp = wp.zeros(self._num_envs, dtype=wp.float32, device=self._device)
         self._timestamp_last_update = wp.zeros_like(self._timestamp)
+        self._data_generation = 0
+        self._data_generation_last_update = -1
 
         # Initialize debug visualization handle
         if self._debug_vis_handle is None:
@@ -389,8 +393,10 @@ class SensorBase(ABC):
     Helper functions.
     """
 
-    def _update_outdated_buffers(self):
+    def _update_outdated_buffers(self, force_recompute: bool = False) -> None:
         """Fills the sensor data for the outdated sensors."""
+        if not force_recompute and self._data_generation == self._data_generation_last_update:
+            return
         self._update_buffers_impl(self._is_outdated)
         # update timestamps and clear outdated flags
         wp.launch(
@@ -399,6 +405,7 @@ class SensorBase(ABC):
             inputs=[self._is_outdated, self._timestamp, self._timestamp_last_update],
             device=self._device,
         )
+        self._data_generation_last_update = self._data_generation
 
     def _resolve_indices_and_mask(
         self, env_ids: Sequence[int] | None = None, env_mask: wp.array | None = None

--- a/source/isaaclab/test/sensors/test_sensor_base.py
+++ b/source/isaaclab/test/sensors/test_sensor_base.py
@@ -33,10 +33,19 @@ class DummyData:
     count: torch.Tensor = None
 
 
+@wp.kernel
+def increment_count_kernel(env_mask: wp.array(dtype=wp.bool), count: wp.array(dtype=wp.int32)):
+    """Increment the count for the selected environments."""
+    env_id = wp.tid()
+    if env_mask[env_id]:
+        count[env_id] += 1
+
+
 class DummySensor(SensorBase):
     def __init__(self, cfg):
         super().__init__(cfg)
         self._data = DummyData()
+        self.backend_update_count = 0
 
     def _initialize_impl(self):
         super()._initialize_impl()
@@ -50,10 +59,13 @@ class DummySensor(SensorBase):
         return self._data
 
     def _update_buffers_impl(self, env_mask: wp.array | None = None):
-        env_ids = wp.to_torch(env_mask).nonzero(as_tuple=False).squeeze(-1)
-        if len(env_ids) == 0:
-            return
-        self._data.count[env_ids] += 1
+        self.backend_update_count += 1
+        wp.launch(
+            increment_count_kernel,
+            dim=self._num_envs,
+            inputs=[env_mask, wp.from_torch(self._data.count)],
+            device=self.device,
+        )
 
     def reset(self, env_ids: Sequence[int] | None = None, env_mask: wp.array | None = None):
         super().reset(env_ids=env_ids, env_mask=env_mask)
@@ -230,6 +242,91 @@ def test_sensor_reset(create_dummy_sensor, device):
             sensor.data.count[cont_ids],
             torch.tensor(k + 6, device=device, dtype=torch.int32).repeat(len(cont_ids)),
         )
+
+
+@pytest.mark.parametrize("device", ("cpu", "cuda"))
+def test_repeated_data_reads_update_backend_once(create_dummy_sensor, device):
+    """Test that repeated data reads update the backend once per sensor update."""
+    sensor_cfg, sim, dt = create_dummy_sensor
+    sensor = DummySensor(cfg=sensor_cfg)
+    sim.step()
+    sim.reset()
+
+    sensor.update(dt=dt)
+    _ = sensor.data
+    backend_update_count = sensor.backend_update_count
+    _ = sensor.data
+
+    assert sensor.backend_update_count == backend_update_count
+
+
+@pytest.mark.parametrize("device", ("cpu", "cuda"))
+def test_reset_invalidates_cached_sensor_data(create_dummy_sensor, device):
+    """Test that full and partial resets each invalidate cached sensor data once."""
+    sensor_cfg, sim, _ = create_dummy_sensor
+    sensor = DummySensor(cfg=sensor_cfg)
+    sim.step()
+    sim.reset()
+    _ = sensor.data
+
+    sensor.reset()
+    backend_update_count = sensor.backend_update_count
+    _ = sensor.data
+    _ = sensor.data
+    assert sensor.backend_update_count == backend_update_count + 1
+
+    reset_ids = [2, 4]
+    continued_ids = [0, 1, 3]
+    sensor.reset(env_ids=reset_ids)
+    backend_update_count = sensor.backend_update_count
+    _ = sensor.data
+    _ = sensor.data
+
+    assert sensor.backend_update_count == backend_update_count + 1
+    torch.testing.assert_close(
+        sensor.data.count[reset_ids], torch.ones(len(reset_ids), dtype=torch.int32, device=device)
+    )
+    torch.testing.assert_close(
+        sensor.data.count[continued_ids], torch.ones(len(continued_ids), dtype=torch.int32, device=device)
+    )
+
+
+@pytest.mark.parametrize("device", ("cpu", "cuda"))
+def test_force_recompute_bypasses_sensor_data_cache(create_dummy_sensor, device):
+    """Test that forced recomputation bypasses a consumed freshness generation."""
+    sensor_cfg, sim, _ = create_dummy_sensor
+    sensor = DummySensor(cfg=sensor_cfg)
+    sim.step()
+    sim.reset()
+    _ = sensor.data
+    backend_update_count = sensor.backend_update_count
+
+    sensor._update_outdated_buffers(force_recompute=True)
+    _ = sensor.data
+
+    assert sensor.backend_update_count == backend_update_count + 1
+
+
+@pytest.mark.parametrize("device", ("cuda",))
+def test_repeated_data_reads_are_graph_safe(create_dummy_sensor, device):
+    """Test that CUDA graph capture records one backend refresh for repeated reads."""
+    sensor_cfg, sim, dt = create_dummy_sensor
+    sensor = DummySensor(cfg=sensor_cfg)
+    sim.step()
+    sim.reset()
+
+    # Warm up the kernels before capture.
+    sensor.update(dt=dt)
+    _ = sensor.data
+    backend_update_count = sensor.backend_update_count
+
+    with wp.ScopedCapture(device=device) as capture:
+        sensor.update(dt=dt)
+        _ = sensor.data
+        _ = sensor.data
+
+    assert sensor.backend_update_count == backend_update_count + 1
+    wp.capture_launch(capture.graph)
 
 
 @pytest.mark.parametrize("device", ("cpu",))


### PR DESCRIPTION
# Description

Repeated sensor data reads currently re-enter the backend update implementation even when the cached data is already fresh. For PhysX contact sensors, this repeats getters such as get_net_contact_forces() before the device mask can suppress masked kernel work.

This change adds a synchronization-free host freshness generation to SensorBase. Updates and resets invalidate the generation, ordinary repeated reads reuse the cached buffers, and force_recompute=True bypasses the guard. Regression coverage includes repeated reads, full and partial resets, forced recomputation, and CUDA graph capture.

No new dependencies are required.

Fixes #6315

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable; this change has no visual output.

## Testing

- ./isaaclab.sh -f
- SensorBase and selected core/PhysX sensor suites: 113 passed
- Newton sensor suites: 150 passed, 6 XPASS
- Verified the repeated-read regression fails before the fix on CPU and CUDA

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [pre-commit checks](https://pre-commit.com/) with ./isaaclab.sh -f
- [x] I have made corresponding changes to the documentation (not applicable; no public API or user workflow changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under source/<pkg>/changelog.d/ for every touched package
- [x] I have added my name to CONTRIBUTORS.md or my name already exists there
