### PR TITLE
Add Newton backend to Franka lift

### DIFF
--- a/scripts/reinforcement_learning/common.py
+++ b/scripts/reinforcement_learning/common.py
@@ -30,6 +30,12 @@ from isaaclab.utils.dict import print_dict
 from isaaclab.utils.images import make_camera_output_grid, normalize_camera_output_for_display
 from isaaclab.utils.io import dump_yaml
 
+# Importing Isaac Sim's launcher can prepend bundled, older Python packages.
+# Restore the virtual environment's packages before RL libraries are imported.
+from isaaclab import _deprioritize_prebundle_paths  # isort: skip
+
+_deprioritize_prebundle_paths()
+
 RUN_MANIFEST_FILENAME = "run.json"
 RUN_MANIFEST_VERSION = 1
 CHECKPOINT_SELECTORS = frozenset({"latest", "best"})

--- a/scripts/reinforcement_learning/play.py
+++ b/scripts/reinforcement_learning/play.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from isaaclab import _deprioritize_prebundle_paths
+
+_deprioritize_prebundle_paths()
+
 from common import dispatch_library_entrypoint
 
 SCRIPT_DIR = Path(__file__).resolve().parent

--- a/scripts/reinforcement_learning/rsl_rl/play_rsl_rl.py
+++ b/scripts/reinforcement_learning/rsl_rl/play_rsl_rl.py
@@ -111,6 +111,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
         # note: certain randomizations occur in the environment initialization so we set the seed here
         env_cfg.seed = agent_cfg.seed
         env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
+        agent_cfg.device = env_cfg.sim.device
 
         # specify directory for logging experiments
         log_root_path = os.path.join("logs", "rsl_rl", agent_cfg.experiment_name)

--- a/scripts/reinforcement_learning/rsl_rl/train_rsl_rl.py
+++ b/scripts/reinforcement_learning/rsl_rl/train_rsl_rl.py
@@ -130,10 +130,10 @@ def run(argv: list[str]) -> None:
 
         env_cfg.seed = agent_cfg.seed
         validate_distributed_device(args_cli)
+        agent_cfg.device = env_cfg.sim.device
 
         if args_cli.distributed:
             global_rank = int(os.getenv("RANK", "0"))
-            agent_cfg.device = env_cfg.sim.device
 
             seed = agent_cfg.seed + global_rank
             env_cfg.seed = seed

--- a/scripts/reinforcement_learning/train.py
+++ b/scripts/reinforcement_learning/train.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from isaaclab import _deprioritize_prebundle_paths
+
+_deprioritize_prebundle_paths()
+
 from common import dispatch_library_entrypoint
 
 SCRIPT_DIR = Path(__file__).resolve().parent

--- a/source/isaaclab_newton/changelog.d/max-newton-replication-scaling.rst
+++ b/source/isaaclab_newton/changelog.d/max-newton-replication-scaling.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed quadratic startup time when cloning Newton environments with registered sites.
+* Fixed Newton CUDA graph capture selecting the default GPU instead of the configured physics device.
+* Fixed static collider poses in cloned, offset Newton environments.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -65,7 +65,10 @@ def replicate_builder_mapping(
     source_site_indices = source_site_indices or {}
     env_root_sites = env_root_sites or {}
     num_worlds = mapping.size(1)
-    local_site_map: dict[str, list[list[int]]] = {}
+    site_labels = set(env_root_sites)
+    for labels in source_site_indices.values():
+        site_labels.update(labels)
+    local_site_map: dict[str, list[list[int]]] = {label: [[] for _ in range(num_worlds)] for label in site_labels}
     world_xforms: list[wp.transform] = []
     source_world_indices = mapping.to(dtype=torch.int64).argmax(dim=1)
 
@@ -76,7 +79,7 @@ def replicate_builder_mapping(
 
         for label, xform in env_root_sites.items():
             site_idx = builder.add_site(body=-1, xform=wp.transform_multiply(world_xform, xform), label=label)
-            local_site_map.setdefault(label, [[] for _ in range(num_worlds)])[col].append(site_idx)
+            local_site_map[label][col].append(site_idx)
 
         for row in torch.nonzero(mapping[:, col], as_tuple=True)[0].tolist():
             source_builder = source_builders[sources[int(row)]]
@@ -88,7 +91,7 @@ def replicate_builder_mapping(
             )
 
             for label, source_shape_indices in source_site_indices.get(id(source_builder), {}).items():
-                local_indices = local_site_map.setdefault(label, [[] for _ in range(num_worlds)])[col]
+                local_indices = local_site_map[label][col]
                 local_indices.extend(offset + shape_idx for shape_idx in source_shape_indices)
 
         for hook in per_world_builder_hooks:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1536,7 +1536,7 @@ class NewtonManager(PhysicsManager):
             with Timer(name="newton_cuda_graph", msg="CUDA graph took:"):
                 if cls._usdrt_stage is None:
                     simulate = cls._simulate_full if cls._is_all_graphable() else cls._simulate_physics_only
-                    with wp.ScopedCapture() as capture:
+                    with wp.ScopedCapture(device=device) as capture:
                         simulate()
                     NewtonManager._graph = capture.graph
                     logger.info("Newton CUDA graph captured (standard Warp mode)")

--- a/source/isaaclab_newton/pyproject.toml
+++ b/source/isaaclab_newton/pyproject.toml
@@ -27,7 +27,7 @@ all = [
     "prettytable>=3.3.0",
     "PyOpenGL-accelerate>=3.1.0",
     "pyglet>=2.1.6,<3",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim,importers] @ git+https://github.com/maxkra15/newton.git@bee486b86320840665c16ba5f5a3b8a8b34c5048",
 ]
 
 [tool.setuptools]

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -301,6 +301,36 @@ class TestReplicateBuilderMapping(unittest.TestCase):
         self.assertEqual(builder.geometry_sources_for_world(0), ["/Sources/active"])
         self.assertEqual(builder.geometry_sources_for_world(1), [])
 
+    def test_site_map_storage_is_allocated_once(self):
+        sources = ("/Sources/active",)
+        source_builder = self._source_builder(sources[0])
+        source_builders = {sources[0]: source_builder}
+        builder = _FakeVisualizationModelBuilder()
+        num_worlds = 4
+        range_call_count = 0
+        builtin_range = range
+
+        def counting_range(*args):
+            nonlocal range_call_count
+            if args == (num_worlds,):
+                range_call_count += 1
+            return builtin_range(*args)
+
+        with mock.patch.object(newton_clone_utils_module, "range", counting_range, create=True):
+            site_map, _ = replicate_builder_mapping(
+                builder,
+                sources,
+                torch.ones((1, num_worlds), dtype=torch.bool),
+                torch.zeros((num_worlds, 3)),
+                torch.tensor([[0.0, 0.0, 0.0, 1.0]]).repeat(num_worlds, 1),
+                source_builders,
+                source_site_indices={id(source_builder): {"tracked_site": [0]}},
+            )
+
+        self.assertEqual(site_map["tracked_site"], [[world] for world in range(num_worlds)])
+        # One range for the world loop and one to allocate tracked_site's per-world rows.
+        self.assertEqual(range_call_count, 2)
+
 
 class TestVisualizationClonePlan(unittest.TestCase):
     @staticmethod

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import isaaclab_newton.physics.newton_manager as newton_manager_module
 import numpy as np
 import pytest
 import warp as wp
@@ -424,6 +425,56 @@ def test_mpm_unsupported_cuda_graph_capture_uses_eager_execution(monkeypatch):
 
     assert NewtonManager._graph is None
     assert NewtonManager._graph_capture_pending is False
+
+
+def test_headless_cuda_graph_capture_uses_physics_device(monkeypatch):
+    """Headless capture must target the configured device on multi-GPU systems."""
+    from isaaclab.physics import PhysicsManager
+
+    capture_devices = []
+    graph = object()
+
+    class _Capture:
+        def __init__(self, device=None, **kwargs):
+            del kwargs
+            capture_devices.append(device)
+            self.graph = graph
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            del args
+
+    class _Timer:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            del args
+
+    monkeypatch.setattr(
+        PhysicsManager,
+        "_cfg",
+        NewtonCfg(solver_cfg=MJWarpSolverCfg(), use_cuda_graph=True),
+        raising=False,
+    )
+    monkeypatch.setattr(PhysicsManager, "_device", "cuda:1", raising=False)
+    monkeypatch.setattr(NewtonMJWarpManager, "_usdrt_stage", None, raising=False)
+    monkeypatch.setattr(NewtonMJWarpManager, "_solver", object(), raising=False)
+    monkeypatch.setattr(NewtonMJWarpManager, "_supports_cuda_graph_capture", classmethod(lambda cls: True))
+    monkeypatch.setattr(NewtonMJWarpManager, "_is_all_graphable", classmethod(lambda cls: False))
+    monkeypatch.setattr(NewtonMJWarpManager, "_simulate_physics_only", classmethod(lambda cls: None))
+    monkeypatch.setattr(newton_manager_module.wp, "ScopedCapture", _Capture)
+    monkeypatch.setattr(newton_manager_module, "Timer", _Timer)
+
+    NewtonMJWarpManager._capture_or_defer_graph()
+
+    assert capture_devices == ["cuda:1"]
+    assert NewtonManager._graph is graph
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab_physx/changelog.d/max-franka-lift-newton-pin.rst
+++ b/source/isaaclab_physx/changelog.d/max-franka-lift-newton-pin.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed static collider poses in cloned, offset Newton environments.

--- a/source/isaaclab_physx/pyproject.toml
+++ b/source/isaaclab_physx/pyproject.toml
@@ -24,7 +24,7 @@ Repository = "https://github.com/isaac-sim/IsaacLab"
 
 [project.optional-dependencies]
 newton = [
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim,importers] @ git+https://github.com/maxkra15/newton.git@bee486b86320840665c16ba5f5a3b8a8b34c5048",
 ]
 
 [tool.setuptools]

--- a/source/isaaclab_tasks/changelog.d/max-franka-lift-newton-mjwarp.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/max-franka-lift-newton-mjwarp.minor.rst
@@ -4,3 +4,8 @@ Added
 * Added a Newton MJWarp physics preset to the Franka rigid cube-lift task.
 * Added Newton-specific Franka actuator and exploration tuning for stable cube-lift training.
 * Added a Newton-only Franka lift task with relative IK actions and a grasp-to-random-reset mastery curriculum.
+
+Changed
+^^^^^^^
+
+* Changed Newton Franka lift success to require sustained position and orientation accuracy.

--- a/source/isaaclab_tasks/changelog.d/max-franka-lift-newton-mjwarp.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/max-franka-lift-newton-mjwarp.minor.rst
@@ -3,3 +3,4 @@ Added
 
 * Added a Newton MJWarp physics preset to the Franka rigid cube-lift task.
 * Added Newton-specific Franka actuator and exploration tuning for stable cube-lift training.
+* Added a Newton-only Franka lift task with relative IK actions and a grasp-to-random-reset mastery curriculum.

--- a/source/isaaclab_tasks/changelog.d/max-franka-lift-newton-mjwarp.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/max-franka-lift-newton-mjwarp.minor.rst
@@ -9,3 +9,4 @@ Changed
 ^^^^^^^
 
 * Changed Newton Franka lift success to require sustained position and orientation accuracy.
+* Improved Newton lift orientation learning with broad-angle shaping and lifted-object angular stabilization.

--- a/source/isaaclab_tasks/changelog.d/max-franka-lift-newton-mjwarp.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/max-franka-lift-newton-mjwarp.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added a Newton MJWarp physics preset to the Franka rigid cube-lift task.
+* Added Newton-specific Franka actuator and exploration tuning for stable cube-lift training.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/__init__.py
@@ -40,3 +40,30 @@ gym.register(
         "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
     },
 )
+
+
+gym.register(
+    id="Isaac-Lift-Cube-Franka-Newton-Curriculum",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.newton_curriculum_env_cfg:FrankaCubeLiftNewtonCurriculumEnvCfg",
+        "rsl_rl_cfg_entry_point": (
+            f"{agents.__name__}.rsl_rl_ppo_cfg:LiftCubeNewtonCurriculumPPORunnerCfg"
+        ),
+    },
+)
+
+gym.register(
+    id="Isaac-Lift-Cube-Franka-Newton-Curriculum-Play",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": (
+            f"{__name__}.newton_curriculum_env_cfg:FrankaCubeLiftNewtonCurriculumEnvCfg_PLAY"
+        ),
+        "rsl_rl_cfg_entry_point": (
+            f"{agents.__name__}.rsl_rl_ppo_cfg:LiftCubeNewtonCurriculumPPORunnerCfg"
+        ),
+    },
+)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/agents/rsl_rl_ppo_cfg.py
@@ -21,7 +21,7 @@ class FixedRangeGaussianDistributionCfg(RslRlMLPModelCfg.GaussianDistributionCfg
 class CurriculumGaussianDistributionCfg(RslRlMLPModelCfg.GaussianDistributionCfg):
     """Learnable exploration noise bounded away from zero."""
 
-    std_range: tuple[float, float] = (0.1, 1.0)
+    std_range: tuple[float, float] = (0.01, 1.0)
 
 
 @configclass
@@ -74,7 +74,7 @@ class LiftCubeNewtonCurriculumPPORunnerCfg(RslRlOnPolicyRunnerCfg):
         hidden_dims=[256, 256, 128],
         activation="elu",
         obs_normalization=True,
-        distribution_cfg=CurriculumGaussianDistributionCfg(init_std=0.6),
+        distribution_cfg=CurriculumGaussianDistributionCfg(init_std=0.10),
     )
     critic = RslRlMLPModelCfg(
         hidden_dims=[256, 256, 128],

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/agents/rsl_rl_ppo_cfg.py
@@ -18,6 +18,13 @@ class FixedRangeGaussianDistributionCfg(RslRlMLPModelCfg.GaussianDistributionCfg
 
 
 @configclass
+class CurriculumGaussianDistributionCfg(RslRlMLPModelCfg.GaussianDistributionCfg):
+    """Learnable exploration noise bounded away from zero."""
+
+    std_range: tuple[float, float] = (0.1, 1.0)
+
+
+@configclass
 class LiftCubePPORunnerCfg(RslRlOnPolicyRunnerCfg):
     num_steps_per_env = 24
     max_iterations = 1500
@@ -48,6 +55,42 @@ class LiftCubePPORunnerCfg(RslRlOnPolicyRunnerCfg):
         learning_rate=1.0e-4,
         schedule="adaptive",
         gamma=0.98,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+    )
+
+
+@configclass
+class LiftCubeNewtonCurriculumPPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    """PPO configuration for Newton-only mastery curriculum training."""
+
+    num_steps_per_env = 24
+    max_iterations = 3000
+    save_interval = 50
+    experiment_name = "franka_lift_newton_curriculum"
+    clip_actions = 1.0
+    actor = RslRlMLPModelCfg(
+        hidden_dims=[256, 256, 128],
+        activation="elu",
+        obs_normalization=True,
+        distribution_cfg=CurriculumGaussianDistributionCfg(init_std=0.6),
+    )
+    critic = RslRlMLPModelCfg(
+        hidden_dims=[256, 256, 128],
+        activation="elu",
+        obs_normalization=True,
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.001,
+        num_learning_epochs=5,
+        num_mini_batches=8,
+        learning_rate=3.0e-4,
+        schedule="adaptive",
+        gamma=0.99,
         lam=0.95,
         desired_kl=0.01,
         max_grad_norm=1.0,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/agents/rsl_rl_ppo_cfg.py
@@ -7,6 +7,15 @@ from isaaclab.utils.configclass import configclass
 
 from isaaclab_rl.rsl_rl import RslRlMLPModelCfg, RslRlOnPolicyRunnerCfg, RslRlPpoAlgorithmCfg
 
+from isaaclab_tasks.utils import preset
+
+
+@configclass
+class FixedRangeGaussianDistributionCfg(RslRlMLPModelCfg.GaussianDistributionCfg):
+    """Gaussian exploration whose standard deviation is clamped to one."""
+
+    std_range: tuple[float, float] = (1.0, 1.0)
+
 
 @configclass
 class LiftCubePPORunnerCfg(RslRlOnPolicyRunnerCfg):
@@ -14,11 +23,15 @@ class LiftCubePPORunnerCfg(RslRlOnPolicyRunnerCfg):
     max_iterations = 1500
     save_interval = 50
     experiment_name = "franka_lift"
+    clip_actions = preset(default=None, newton_mjwarp=1.0)
     actor = RslRlMLPModelCfg(
         hidden_dims=[256, 128, 64],
         activation="elu",
         obs_normalization=False,
-        distribution_cfg=RslRlMLPModelCfg.GaussianDistributionCfg(init_std=1.0),
+        distribution_cfg=preset(
+            default=RslRlMLPModelCfg.GaussianDistributionCfg(init_std=1.0),
+            newton_mjwarp=FixedRangeGaussianDistributionCfg(init_std=1.0),
+        ),
     )
     critic = RslRlMLPModelCfg(
         hidden_dims=[256, 128, 64],
@@ -29,7 +42,7 @@ class LiftCubePPORunnerCfg(RslRlOnPolicyRunnerCfg):
         value_loss_coef=1.0,
         use_clipped_value_loss=True,
         clip_param=0.2,
-        entropy_coef=0.006,
+        entropy_coef=preset(default=0.006, newton_mjwarp=0.001),
         num_learning_epochs=5,
         num_mini_batches=4,
         learning_rate=1.0e-4,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/joint_pos_env_cfg.py
@@ -13,6 +13,7 @@ from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.lift import mdp
 from isaaclab_tasks.core.lift.lift_env_cfg import LiftEnvCfg
+from isaaclab_tasks.utils import preset
 
 ##
 # Pre-defined configs
@@ -29,10 +30,17 @@ class FrankaCubeLiftEnvCfg(LiftEnvCfg):
 
         # Set Franka as robot
         self.scene.robot = FRANKA_PANDA_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+        self.scene.robot.actuators["panda_shoulder"].armature = preset(default=1e-3, newton_mjwarp=0.1)
+        self.scene.robot.actuators["panda_forearm"].armature = preset(default=1e-3, newton_mjwarp=0.1)
+        self.scene.robot.actuators["panda_shoulder"].damping = preset(default=4.0, newton_mjwarp=10.0)
+        self.scene.robot.actuators["panda_forearm"].damping = preset(default=4.0, newton_mjwarp=10.0)
 
         # Set actions for the specific robot type (franka)
         self.actions.arm_action = mdp.JointPositionActionCfg(
-            asset_name="robot", joint_names=["panda_joint.*"], scale=0.5, use_default_offset=True
+            asset_name="robot",
+            joint_names=["panda_joint.*"],
+            scale=0.5,
+            use_default_offset=True,
         )
         self.actions.gripper_action = mdp.BinaryJointPositionActionCfg(
             asset_name="robot",

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/newton_curriculum_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/newton_curriculum_env_cfg.py
@@ -5,6 +5,7 @@
 
 """Newton-only curriculum configuration for Franka cube lifting."""
 
+from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
 from isaaclab.managers import CurriculumTermCfg as CurrTerm
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
@@ -12,8 +13,6 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
-from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
-from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.lift import mdp
@@ -37,6 +36,10 @@ class NewtonCurriculumObservationsCfg:
             func=mdp.object_goal_position_relative,
             params={"command_name": "object_pose"},
         )
+        object_orientation_to_goal = ObsTerm(
+            func=mdp.object_goal_orientation_error,
+            params={"command_name": "object_pose"},
+        )
         object_height = ObsTerm(func=mdp.object_height_above_table)
         actions = ObsTerm(func=mdp.last_action)
 
@@ -52,14 +55,18 @@ class NewtonCurriculumEventsCfg:
     """Reset events for the adaptive grasp-to-lift curriculum."""
 
     reset_all = EventTerm(func=mdp.reset_scene_to_default, mode="reset")
-    reset_curriculum = EventTerm(func=mdp.reset_franka_lift_curriculum, mode="reset")
+    reset_curriculum = EventTerm(
+        func=mdp.reset_franka_lift_curriculum,
+        mode="reset",
+        params={"closed_finger_position": 0.016},
+    )
 
 
 @configclass
 class NewtonCurriculumRewardsCfg:
     """Sparse progress shaping with a dominant terminal success bonus."""
 
-    reaching_object = RewTerm(func=mdp.object_ee_distance, params={"std": 0.08}, weight=2.0)
+    reaching_object = RewTerm(func=mdp.curriculum_object_ee_distance, params={"std": 0.08}, weight=2.0)
     lift_progress = RewTerm(
         func=mdp.object_lift_progress,
         params={"minimal_height": 0.02, "target_height": 0.20},
@@ -67,21 +74,46 @@ class NewtonCurriculumRewardsCfg:
     )
     object_goal_tracking = RewTerm(
         func=mdp.object_goal_distance,
+        params={"std": 0.12, "minimal_height": 0.10, "command_name": "object_pose"},
+        weight=3.0,
+    )
+    object_goal_orientation = RewTerm(
+        func=mdp.object_goal_orientation_distance,
         params={"std": 0.25, "minimal_height": 0.10, "command_name": "object_pose"},
+        weight=3.0,
+    )
+    object_goal_fine_tracking = RewTerm(
+        func=mdp.object_goal_distance,
+        params={"std": 0.025, "minimal_height": 0.10, "command_name": "object_pose"},
         weight=2.0,
+    )
+    object_goal_fine_orientation = RewTerm(
+        func=mdp.object_goal_orientation_distance,
+        params={"std": 0.10, "minimal_height": 0.10, "command_name": "object_pose"},
+        weight=2.0,
+    )
+    object_goal_pose_accuracy = RewTerm(
+        func=mdp.object_goal_pose_accuracy,
+        params={
+            "position_threshold": 0.02,
+            "orientation_threshold": 0.15,
+            "command_name": "object_pose",
+        },
+        weight=10.0,
     )
     success_bonus = RewTerm(
         func=mdp.is_terminated_term,
         params={"term_keys": "success"},
-        # RewardManager multiplies by the 0.02-s control step: 2500 * 0.02 = 50.
-        weight=2500.0,
+        # RewardManager multiplies by the 0.02-s control step: 5000 * 0.02 = 100.
+        weight=5000.0,
     )
     close_near_object = RewTerm(
-        func=mdp.gripper_close_near_object,
+        func=mdp.curriculum_gripper_close_near_object,
         params={"std": 0.05},
         weight=2.0,
     )
     action_rate = RewTerm(func=mdp.action_rate_l2, weight=-1e-3)
+    action_magnitude = RewTerm(func=mdp.action_l2, weight=-0.05)
     joint_vel = RewTerm(
         func=mdp.joint_vel_l2,
         weight=-1e-4,
@@ -89,7 +121,7 @@ class NewtonCurriculumRewardsCfg:
     )
     object_dropping = RewTerm(
         func=mdp.is_terminated_term,
-        weight=-5.0,
+        weight=-50.0,
         params={"term_keys": "object_dropping"},
     )
 
@@ -100,12 +132,25 @@ class NewtonCurriculumTerminationsCfg:
 
     time_out = DoneTerm(func=mdp.time_out, time_out=True)
     success = DoneTerm(
-        func=mdp.object_reached_goal,
-        params={"command_name": "object_pose", "threshold": 0.05},
+        func=mdp.ObjectPoseHeld,
+        params={
+            "command_name": "object_pose",
+            "position_threshold": 0.02,
+            "orientation_threshold": 0.15,
+            "hold_time": 1.0,
+        },
     )
     object_dropping = DoneTerm(
-        func=mdp.root_height_below_minimum,
-        params={"minimum_height": -0.05, "asset_cfg": SceneEntityCfg("object")},
+        func=mdp.curriculum_object_below_reset_height,
+        params={
+            "high_object_height": 0.349140,
+            "low_object_height": 0.029296,
+            "transition_start": 0.30,
+            "transition_end": 0.55,
+            "height_margin": 0.10,
+            "minimum_height": -0.05,
+            "object_cfg": SceneEntityCfg("object"),
+        },
     )
 
 
@@ -139,17 +184,17 @@ class FrankaCubeLiftNewtonCurriculumEnvCfg(FrankaCubeLiftEnvCfg):
         self.scene.robot = FRANKA_PANDA_HIGH_PD_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
         self.scene.robot.actuators["panda_shoulder"].armature = 0.1
         self.scene.robot.actuators["panda_forearm"].armature = 0.1
-        self.scene.robot.actuators["panda_shoulder"].stiffness = 2000.0
-        self.scene.robot.actuators["panda_forearm"].stiffness = 2000.0
-        self.scene.robot.actuators["panda_shoulder"].damping = 200.0
-        self.scene.robot.actuators["panda_forearm"].damping = 200.0
+        self.scene.robot.actuators["panda_shoulder"].stiffness = 20000.0
+        self.scene.robot.actuators["panda_forearm"].stiffness = 20000.0
+        self.scene.robot.actuators["panda_shoulder"].damping = 2000.0
+        self.scene.robot.actuators["panda_forearm"].damping = 2000.0
         self.scene.robot.actuators["panda_shoulder"].effort_limit_sim = 200.0
         self.scene.robot.actuators["panda_forearm"].effort_limit_sim = 100.0
         self.scene.robot.actuators["panda_hand"].effort_limit_sim = 40.0
 
         # Relative task-space control lets the policy reuse the same approach and
         # transport motion across the curriculum's changing reset poses.
-        self.actions.arm_action = DifferentialInverseKinematicsActionCfg(
+        self.actions.arm_action = mdp.CurriculumDifferentialInverseKinematicsActionCfg(
             asset_name="robot",
             joint_names=["panda_joint.*"],
             body_name="panda_hand",
@@ -161,15 +206,23 @@ class FrankaCubeLiftNewtonCurriculumEnvCfg(FrankaCubeLiftEnvCfg):
                 joint_limit_avoidance_gain=0.1,
             ),
             scale=(0.1, 0.1, 0.1, 0.25, 0.25, 0.25),
-            body_offset=DifferentialInverseKinematicsActionCfg.OffsetCfg(pos=[0.0, 0.0, 0.1034]),
+            body_offset=mdp.CurriculumDifferentialInverseKinematicsActionCfg.OffsetCfg(pos=[0.0, 0.0, 0.1034]),
+            full_control_difficulty=0.30,
         )
-        self.actions.gripper_action.close_command_expr = {"panda_finger_.*": 0.014}
+        self.actions.gripper_action = mdp.CurriculumGripperActionCfg(
+            asset_name="robot",
+            joint_names=["panda_finger.*"],
+            open_command_expr={"panda_finger_.*": 0.04},
+            close_command_expr={"panda_finger_.*": 0.016},
+            force_close_below_difficulty=0.45,
+        )
 
         self.commands.object_pose = mdp.CurriculumPoseCommandCfg(
             asset_name="robot",
             body_name="panda_hand",
             resampling_time_range=(5.0, 5.0),
-            debug_vis=True,
+            debug_vis=False,
+            tracked_object_name="object",
             easy_goal=(0.499620, 0.0, 0.349140),
             full_goal_difficulty=0.30,
             ranges=mdp.CurriculumPoseCommandCfg.Ranges(
@@ -196,3 +249,4 @@ class FrankaCubeLiftNewtonCurriculumEnvCfg_PLAY(FrankaCubeLiftNewtonCurriculumEn
         super().__post_init__()
         self.scene.num_envs = 50
         self.curriculum.lift_difficulty.params["initial_difficulty"] = 40
+        self.commands.object_pose.debug_vis = False

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/newton_curriculum_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/newton_curriculum_env_cfg.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Newton-only curriculum configuration for Franka cube lifting."""
+
+from isaaclab.managers import CurriculumTermCfg as CurrTerm
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
+from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
+from isaaclab.utils.configclass import configclass
+
+from isaaclab_tasks.core.lift import mdp
+from isaaclab_tasks.core.lift.lift_env_cfg import LiftPhysicsCfg
+
+from .joint_pos_env_cfg import FrankaCubeLiftEnvCfg
+
+from isaaclab_assets.robots.franka import FRANKA_PANDA_HIGH_PD_CFG  # isort: skip
+
+
+@configclass
+class NewtonCurriculumObservationsCfg:
+    """Task-relative observations for the Newton lift policy."""
+
+    @configclass
+    class PolicyCfg(ObsGroup):
+        joint_pos = ObsTerm(func=mdp.joint_pos_rel)
+        joint_vel = ObsTerm(func=mdp.joint_vel_rel, scale=0.1)
+        ee_to_object = ObsTerm(func=mdp.object_position_relative_to_ee)
+        object_to_goal = ObsTerm(
+            func=mdp.object_goal_position_relative,
+            params={"command_name": "object_pose"},
+        )
+        object_height = ObsTerm(func=mdp.object_height_above_table)
+        actions = ObsTerm(func=mdp.last_action)
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+    policy: PolicyCfg = PolicyCfg()
+
+
+@configclass
+class NewtonCurriculumEventsCfg:
+    """Reset events for the adaptive grasp-to-lift curriculum."""
+
+    reset_all = EventTerm(func=mdp.reset_scene_to_default, mode="reset")
+    reset_curriculum = EventTerm(func=mdp.reset_franka_lift_curriculum, mode="reset")
+
+
+@configclass
+class NewtonCurriculumRewardsCfg:
+    """Sparse progress shaping with a dominant terminal success bonus."""
+
+    reaching_object = RewTerm(func=mdp.object_ee_distance, params={"std": 0.08}, weight=2.0)
+    lift_progress = RewTerm(
+        func=mdp.object_lift_progress,
+        params={"minimal_height": 0.02, "target_height": 0.20},
+        weight=1.0,
+    )
+    object_goal_tracking = RewTerm(
+        func=mdp.object_goal_distance,
+        params={"std": 0.25, "minimal_height": 0.10, "command_name": "object_pose"},
+        weight=2.0,
+    )
+    success_bonus = RewTerm(
+        func=mdp.is_terminated_term,
+        params={"term_keys": "success"},
+        # RewardManager multiplies by the 0.02-s control step: 2500 * 0.02 = 50.
+        weight=2500.0,
+    )
+    close_near_object = RewTerm(
+        func=mdp.gripper_close_near_object,
+        params={"std": 0.05},
+        weight=2.0,
+    )
+    action_rate = RewTerm(func=mdp.action_rate_l2, weight=-1e-3)
+    joint_vel = RewTerm(
+        func=mdp.joint_vel_l2,
+        weight=-1e-4,
+        params={"asset_cfg": SceneEntityCfg("robot")},
+    )
+    object_dropping = RewTerm(
+        func=mdp.is_terminated_term,
+        weight=-5.0,
+        params={"term_keys": "object_dropping"},
+    )
+
+
+@configclass
+class NewtonCurriculumTerminationsCfg:
+    """Terminate on success, timeout, or an irrecoverable object drop."""
+
+    time_out = DoneTerm(func=mdp.time_out, time_out=True)
+    success = DoneTerm(
+        func=mdp.object_reached_goal,
+        params={"command_name": "object_pose", "threshold": 0.05},
+    )
+    object_dropping = DoneTerm(
+        func=mdp.root_height_below_minimum,
+        params={"minimum_height": -0.05, "asset_cfg": SceneEntityCfg("object")},
+    )
+
+
+@configclass
+class NewtonLiftCurriculumCfg:
+    """Per-environment mastery curriculum for Newton cube lifting."""
+
+    lift_difficulty = CurrTerm(
+        func=mdp.LiftDifficultyScheduler,
+        params={
+            "success_termination_name": "success",
+            "initial_difficulty": 0,
+            "max_difficulty": 40,
+            "successes_to_promote": 1,
+        },
+    )
+
+
+@configclass
+class FrankaCubeLiftNewtonCurriculumEnvCfg(FrankaCubeLiftEnvCfg):
+    """Franka lift task whose physics and learning curriculum are Newton-only."""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        # Pin this task to Newton so it cannot silently fall back to PhysX.
+        self.sim.physics = LiftPhysicsCfg().newton_mjwarp
+
+        # Newton has no gravity compensation; use the existing high-PD, gravity-free
+        # Franka model so reset IK configurations remain controllable.
+        self.scene.robot = FRANKA_PANDA_HIGH_PD_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+        self.scene.robot.actuators["panda_shoulder"].armature = 0.1
+        self.scene.robot.actuators["panda_forearm"].armature = 0.1
+        self.scene.robot.actuators["panda_shoulder"].stiffness = 2000.0
+        self.scene.robot.actuators["panda_forearm"].stiffness = 2000.0
+        self.scene.robot.actuators["panda_shoulder"].damping = 200.0
+        self.scene.robot.actuators["panda_forearm"].damping = 200.0
+        self.scene.robot.actuators["panda_shoulder"].effort_limit_sim = 200.0
+        self.scene.robot.actuators["panda_forearm"].effort_limit_sim = 100.0
+        self.scene.robot.actuators["panda_hand"].effort_limit_sim = 40.0
+
+        # Relative task-space control lets the policy reuse the same approach and
+        # transport motion across the curriculum's changing reset poses.
+        self.actions.arm_action = DifferentialInverseKinematicsActionCfg(
+            asset_name="robot",
+            joint_names=["panda_joint.*"],
+            body_name="panda_hand",
+            controller=DifferentialIKControllerCfg(
+                command_type="pose",
+                use_relative_mode=True,
+                ik_method="dls",
+                ik_params={"lambda_val": 0.05},
+                joint_limit_avoidance_gain=0.1,
+            ),
+            scale=(0.1, 0.1, 0.1, 0.25, 0.25, 0.25),
+            body_offset=DifferentialInverseKinematicsActionCfg.OffsetCfg(pos=[0.0, 0.0, 0.1034]),
+        )
+        self.actions.gripper_action.close_command_expr = {"panda_finger_.*": 0.014}
+
+        self.commands.object_pose = mdp.CurriculumPoseCommandCfg(
+            asset_name="robot",
+            body_name="panda_hand",
+            resampling_time_range=(5.0, 5.0),
+            debug_vis=True,
+            easy_goal=(0.499620, 0.0, 0.349140),
+            full_goal_difficulty=0.30,
+            ranges=mdp.CurriculumPoseCommandCfg.Ranges(
+                pos_x=(0.4, 0.6),
+                pos_y=(-0.25, 0.25),
+                pos_z=(0.25, 0.5),
+                roll=(0.0, 0.0),
+                pitch=(0.0, 0.0),
+                yaw=(0.0, 0.0),
+            ),
+        )
+        self.observations = NewtonCurriculumObservationsCfg()
+        self.events = NewtonCurriculumEventsCfg()
+        self.rewards = NewtonCurriculumRewardsCfg()
+        self.terminations = NewtonCurriculumTerminationsCfg()
+        self.curriculum = NewtonLiftCurriculumCfg()
+
+
+@configclass
+class FrankaCubeLiftNewtonCurriculumEnvCfg_PLAY(FrankaCubeLiftNewtonCurriculumEnvCfg):
+    """Evaluation configuration that starts every environment at final difficulty."""
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.scene.num_envs = 50
+        self.curriculum.lift_difficulty.params["initial_difficulty"] = 40

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/newton_curriculum_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/newton_curriculum_env_cfg.py
@@ -79,8 +79,8 @@ class NewtonCurriculumRewardsCfg:
     )
     object_goal_orientation = RewTerm(
         func=mdp.object_goal_orientation_distance,
-        params={"std": 0.25, "minimal_height": 0.10, "command_name": "object_pose"},
-        weight=3.0,
+        params={"std": 1.0, "minimal_height": 0.10, "command_name": "object_pose"},
+        weight=4.0,
     )
     object_goal_fine_tracking = RewTerm(
         func=mdp.object_goal_distance,
@@ -114,6 +114,11 @@ class NewtonCurriculumRewardsCfg:
     )
     action_rate = RewTerm(func=mdp.action_rate_l2, weight=-1e-3)
     action_magnitude = RewTerm(func=mdp.action_l2, weight=-0.05)
+    object_angular_velocity = RewTerm(
+        func=mdp.object_angular_velocity_l2,
+        params={"minimal_height": 0.10},
+        weight=-0.02,
+    )
     joint_vel = RewTerm(
         func=mdp.joint_vel_l2,
         weight=-1e-4,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/lift_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/lift_env_cfg.py
@@ -5,6 +5,7 @@
 
 from dataclasses import MISSING
 
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.assets import DeformableObjectCfg
 from isaaclab_physx.physics import PhysxCfg
 
@@ -25,6 +26,34 @@ from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.lift import mdp
+from isaaclab_tasks.utils import PresetCfg, preset
+
+
+@configclass
+class LiftPhysicsCfg(PresetCfg):
+    """Physics-backend presets for rigid-object lift tasks."""
+
+    physx: PhysxCfg = PhysxCfg(
+        bounce_threshold_velocity=0.01,
+        gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
+        gpu_total_aggregate_pairs_capacity=16 * 1024,
+        friction_correlation_distance=0.00625,
+    )
+
+    newton_mjwarp: NewtonCfg = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            njmax=100,
+            nconmax=100,
+            cone="elliptic",
+            integrator="implicitfast",
+            impratio=10,
+        ),
+        num_substeps=2,
+        debug_mode=False,
+    )
+
+    default = physx
+
 
 ##
 # Scene definition
@@ -160,6 +189,12 @@ class RewardsCfg:
         params={"asset_cfg": SceneEntityCfg("robot")},
     )
 
+    object_dropping = RewTerm(
+        func=mdp.is_terminated_term,
+        weight=preset(default=0.0, newton_mjwarp=-200.0),
+        params={"term_keys": "object_dropping"},
+    )
+
 
 @configclass
 class TerminationsCfg:
@@ -215,9 +250,4 @@ class LiftEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.dt = 0.01  # 100Hz
         self.sim.render_interval = self.decimation
 
-        self.sim.physics = PhysxCfg(
-            bounce_threshold_velocity=0.01,
-            gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
-            gpu_total_aggregate_pairs_capacity=16 * 1024,
-            friction_correlation_distance=0.00625,
-        )
+        self.sim.physics = LiftPhysicsCfg()

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/__init__.pyi
@@ -8,12 +8,16 @@ __all__ = [
     "object_position_in_robot_root_frame",
     "object_position_relative_to_ee",
     "object_goal_position_relative",
+    "object_goal_orientation_error",
     "object_height_above_table",
     "deformable_com_in_robot_root_frame",
     "DeformableSampledPointsInRobotRootFrame",
     # rewards
     "object_ee_distance",
+    "curriculum_object_ee_distance",
     "object_goal_distance",
+    "object_goal_orientation_distance",
+    "object_goal_pose_accuracy",
     "object_is_lifted",
     "object_lift_progress",
     "deformable_lifted",
@@ -21,14 +25,22 @@ __all__ = [
     "deformable_com_goal_distance",
     "gripper_close_action",
     "gripper_close_near_object",
+    "curriculum_gripper_close_near_object",
     # terminations
     "object_reached_goal",
+    "ObjectPoseHeld",
+    "curriculum_object_below_reset_height",
     "deformable_com_below_minimum",
     "deformable_outside_table_bounds",
     "ee_below_minimum",
     # commands
     "CurriculumPoseCommand",
     "CurriculumPoseCommandCfg",
+    # actions
+    "CurriculumGripperAction",
+    "CurriculumGripperActionCfg",
+    "CurriculumDifferentialInverseKinematicsAction",
+    "CurriculumDifferentialInverseKinematicsActionCfg",
     # curricula
     "LiftDifficultyScheduler",
     "lift_difficulty_fraction",
@@ -36,6 +48,12 @@ __all__ = [
     "reset_franka_lift_curriculum",
 ]
 
+from .actions import (
+    CurriculumDifferentialInverseKinematicsAction,
+    CurriculumDifferentialInverseKinematicsActionCfg,
+    CurriculumGripperAction,
+    CurriculumGripperActionCfg,
+)
 from .commands import CurriculumPoseCommand, CurriculumPoseCommandCfg
 from .curriculums import LiftDifficultyScheduler, lift_difficulty_fraction
 from .events import reset_franka_lift_curriculum
@@ -45,6 +63,7 @@ from .observations import (
     deformable_com_in_robot_root_frame,
     object_position_in_robot_root_frame,
     object_goal_position_relative,
+    object_goal_orientation_error,
     object_height_above_table,
     object_position_relative_to_ee,
 )
@@ -52,14 +71,20 @@ from .rewards import (
     deformable_com_goal_distance,
     deformable_ee_distance,
     deformable_lifted,
+    curriculum_gripper_close_near_object,
+    curriculum_object_ee_distance,
     gripper_close_action,
     gripper_close_near_object,
     object_ee_distance,
     object_goal_distance,
+    object_goal_orientation_distance,
+    object_goal_pose_accuracy,
     object_is_lifted,
     object_lift_progress,
 )
 from .terminations import (
+    ObjectPoseHeld,
+    curriculum_object_below_reset_height,
     deformable_com_below_minimum,
     deformable_outside_table_bounds,
     ee_below_minimum,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/__init__.pyi
@@ -6,36 +6,58 @@
 __all__ = [
     # observations
     "object_position_in_robot_root_frame",
+    "object_position_relative_to_ee",
+    "object_goal_position_relative",
+    "object_height_above_table",
     "deformable_com_in_robot_root_frame",
     "DeformableSampledPointsInRobotRootFrame",
     # rewards
     "object_ee_distance",
     "object_goal_distance",
     "object_is_lifted",
+    "object_lift_progress",
     "deformable_lifted",
     "deformable_ee_distance",
     "deformable_com_goal_distance",
     "gripper_close_action",
+    "gripper_close_near_object",
     # terminations
     "object_reached_goal",
     "deformable_com_below_minimum",
     "deformable_outside_table_bounds",
     "ee_below_minimum",
+    # commands
+    "CurriculumPoseCommand",
+    "CurriculumPoseCommandCfg",
+    # curricula
+    "LiftDifficultyScheduler",
+    "lift_difficulty_fraction",
+    # events
+    "reset_franka_lift_curriculum",
 ]
+
+from .commands import CurriculumPoseCommand, CurriculumPoseCommandCfg
+from .curriculums import LiftDifficultyScheduler, lift_difficulty_fraction
+from .events import reset_franka_lift_curriculum
 
 from .observations import (
     DeformableSampledPointsInRobotRootFrame,
     deformable_com_in_robot_root_frame,
     object_position_in_robot_root_frame,
+    object_goal_position_relative,
+    object_height_above_table,
+    object_position_relative_to_ee,
 )
 from .rewards import (
     deformable_com_goal_distance,
     deformable_ee_distance,
     deformable_lifted,
     gripper_close_action,
+    gripper_close_near_object,
     object_ee_distance,
     object_goal_distance,
     object_is_lifted,
+    object_lift_progress,
 )
 from .terminations import (
     deformable_com_below_minimum,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/__init__.pyi
@@ -18,6 +18,7 @@ __all__ = [
     "object_goal_distance",
     "object_goal_orientation_distance",
     "object_goal_pose_accuracy",
+    "object_angular_velocity_l2",
     "object_is_lifted",
     "object_lift_progress",
     "deformable_lifted",
@@ -79,6 +80,7 @@ from .rewards import (
     object_goal_distance,
     object_goal_orientation_distance,
     object_goal_pose_accuracy,
+    object_angular_velocity_l2,
     object_is_lifted,
     object_lift_progress,
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/actions.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/actions.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Curriculum-aware actions for lift tasks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from isaaclab.envs.mdp.actions.actions_cfg import BinaryJointPositionActionCfg, DifferentialInverseKinematicsActionCfg
+from isaaclab.envs.mdp.actions.binary_joint_actions import BinaryJointPositionAction
+from isaaclab.envs.mdp.actions.task_space_actions import DifferentialInverseKinematicsAction
+from isaaclab.utils.configclass import configclass
+
+from .curriculums import lift_difficulty_fraction
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv
+
+
+class CurriculumGripperAction(BinaryJointPositionAction):
+    """Keep a pre-grasped curriculum reset closed until grasp learning begins."""
+
+    cfg: CurriculumGripperActionCfg
+
+    def __init__(self, cfg: CurriculumGripperActionCfg, env: ManagerBasedEnv) -> None:
+        super().__init__(cfg, env)
+        self._env_ids = torch.arange(self.num_envs, device=self.device)
+
+    def process_actions(self, actions: torch.Tensor) -> None:
+        """Apply policy actions, overriding early pre-grasped stages with close."""
+        super().process_actions(actions)
+        difficulty = lift_difficulty_fraction(self._env, self._env_ids)
+        force_close = difficulty < self.cfg.force_close_below_difficulty
+        self._processed_actions[force_close] = self._close_command
+
+
+class CurriculumDifferentialInverseKinematicsAction(DifferentialInverseKinematicsAction):
+    """Ramp task-space control authority with the goal-distribution difficulty."""
+
+    cfg: CurriculumDifferentialInverseKinematicsActionCfg
+
+    def __init__(self, cfg: CurriculumDifferentialInverseKinematicsActionCfg, env: ManagerBasedEnv) -> None:
+        super().__init__(cfg, env)
+        self._env_ids = torch.arange(self.num_envs, device=self.device)
+
+    def process_actions(self, actions: torch.Tensor) -> None:
+        """Scale physical arm motion while preserving raw policy actions for learning."""
+        difficulty = lift_difficulty_fraction(self._env, self._env_ids)
+        control_scale = (difficulty / self.cfg.full_control_difficulty).clamp(0.0, 1.0).unsqueeze(-1)
+        processed_actions = actions * control_scale
+        super().process_actions(processed_actions)
+        self._raw_actions[:] = actions
+
+
+@configclass
+class CurriculumGripperActionCfg(BinaryJointPositionActionCfg):
+    """Configuration for :class:`CurriculumGripperAction`."""
+
+    class_type: type[CurriculumGripperAction] = CurriculumGripperAction
+
+    force_close_below_difficulty: float = 0.45
+    """Normalized difficulty below which the physical gripper stays closed."""
+
+
+@configclass
+class CurriculumDifferentialInverseKinematicsActionCfg(DifferentialInverseKinematicsActionCfg):
+    """Configuration for :class:`CurriculumDifferentialInverseKinematicsAction`."""
+
+    class_type: type[CurriculumDifferentialInverseKinematicsAction] = CurriculumDifferentialInverseKinematicsAction
+
+    full_control_difficulty: float = 0.3
+    """Normalized difficulty at which policy arm commands reach their configured scale."""

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/commands.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/commands.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Curriculum-aware commands for lift tasks."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+
+from isaaclab.envs.mdp import UniformPoseCommand, UniformPoseCommandCfg
+from isaaclab.utils.configclass import configclass
+
+from .curriculums import lift_difficulty_fraction
+
+
+class CurriculumPoseCommand(UniformPoseCommand):
+    """Blend a fixed easy goal into the full uniformly sampled goal distribution."""
+
+    cfg: CurriculumPoseCommandCfg
+
+    def _resample_command(self, env_ids: Sequence[int]) -> None:
+        super()._resample_command(env_ids)
+        difficulty = lift_difficulty_fraction(self._env, env_ids)
+        blend = (difficulty / self.cfg.full_goal_difficulty).clamp(0.0, 1.0).unsqueeze(-1)
+        easy_goal = torch.tensor(self.cfg.easy_goal, device=self.device)
+        self.pose_command_b[env_ids, :3] = torch.lerp(easy_goal, self.pose_command_b[env_ids, :3], blend)
+
+
+@configclass
+class CurriculumPoseCommandCfg(UniformPoseCommandCfg):
+    """Configuration for :class:`CurriculumPoseCommand`."""
+
+    class_type: type[CurriculumPoseCommand] = CurriculumPoseCommand
+
+    easy_goal: tuple[float, float, float] = (0.5, 0.0, 0.35)
+    """Goal position used at zero difficulty in the robot root frame [m]."""
+
+    full_goal_difficulty: float = 0.3
+    """Difficulty fraction at which the full goal distribution is active."""

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/commands.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/commands.py
@@ -8,19 +8,55 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import torch
 
 from isaaclab.envs.mdp import UniformPoseCommand, UniformPoseCommandCfg
 from isaaclab.utils.configclass import configclass
+from isaaclab.utils.math import combine_frame_transforms, compute_pose_error
 
 from .curriculums import lift_difficulty_fraction
+
+if TYPE_CHECKING:
+    from isaaclab.assets import RigidObject
+    from isaaclab.envs import ManagerBasedEnv
 
 
 class CurriculumPoseCommand(UniformPoseCommand):
     """Blend a fixed easy goal into the full uniformly sampled goal distribution."""
 
     cfg: CurriculumPoseCommandCfg
+
+    def __init__(self, cfg: CurriculumPoseCommandCfg, env: ManagerBasedEnv):
+        super().__init__(cfg, env)
+        self.object: RigidObject = env.scene[cfg.tracked_object_name]
+
+    def _update_metrics(self) -> None:
+        self.pose_command_w[:, :3], self.pose_command_w[:, 3:] = combine_frame_transforms(
+            self.robot.data.root_pos_w.torch,
+            self.robot.data.root_quat_w.torch,
+            self.pose_command_b[:, :3],
+            self.pose_command_b[:, 3:],
+        )
+        pos_error, rot_error = compute_pose_error(
+            self.pose_command_w[:, :3],
+            self.pose_command_w[:, 3:],
+            self.object.data.root_pos_w.torch,
+            self.object.data.root_quat_w.torch,
+        )
+        self.metrics["position_error"] = torch.linalg.norm(pos_error, dim=-1)
+        self.metrics["orientation_error"] = torch.linalg.norm(rot_error, dim=-1)
+
+    def _debug_vis_callback(self, event) -> None:
+        del event
+        if not self.robot.is_initialized or not self.object.is_initialized:
+            return
+        self.goal_pose_visualizer.visualize(self.pose_command_w[:, :3], self.pose_command_w[:, 3:])
+        self.current_pose_visualizer.visualize(
+            self.object.data.root_pos_w.torch,
+            self.object.data.root_quat_w.torch,
+        )
 
     def _resample_command(self, env_ids: Sequence[int]) -> None:
         super()._resample_command(env_ids)
@@ -35,6 +71,9 @@ class CurriculumPoseCommandCfg(UniformPoseCommandCfg):
     """Configuration for :class:`CurriculumPoseCommand`."""
 
     class_type: type[CurriculumPoseCommand] = CurriculumPoseCommand
+
+    tracked_object_name: str = "object"
+    """Scene entity whose pose is used for command metrics and visualization."""
 
     easy_goal: tuple[float, float, float] = (0.5, 0.0, 0.35)
     """Goal position used at zero difficulty in the robot root frame [m]."""

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/curriculums.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/curriculums.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Adaptive curricula for rigid-object lift tasks."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import torch
+
+from isaaclab.managers import CurriculumTermCfg, ManagerTermBase
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+class LiftDifficultyScheduler(ManagerTermBase):
+    """Advance each environment after task success at its current level.
+
+    Difficulty is promotion-only so environments cannot retreat to easy resets.
+    The task's success termination is authoritative: reaching the goal ends the
+    episode, advances the reset distribution, and prevents any post-success drop
+    from affecting curriculum progression.
+    """
+
+    def __init__(self, cfg: CurriculumTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        initial = cfg.params.get("initial_difficulty", 0)
+        self.difficulties = torch.full((env.num_envs,), initial, dtype=torch.long, device=env.device)
+        self.success_streak = torch.zeros(env.num_envs, dtype=torch.long, device=env.device)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],
+        success_termination_name: str,
+        initial_difficulty: int = 0,
+        max_difficulty: int = 20,
+        successes_to_promote: int = 3,
+    ) -> dict[str, torch.Tensor]:
+        """Update levels and return aggregate curriculum metrics."""
+        del initial_difficulty
+        succeeded = env.termination_manager.get_term(success_termination_name)[env_ids]
+        self.success_streak[env_ids] = torch.where(
+            succeeded,
+            self.success_streak[env_ids] + 1,
+            torch.zeros_like(self.success_streak[env_ids]),
+        )
+        promote = self.success_streak[env_ids] >= successes_to_promote
+        self.difficulties[env_ids] = (self.difficulties[env_ids] + promote.long()).clamp(max=max_difficulty)
+        self.success_streak[env_ids] = torch.where(
+            promote,
+            torch.zeros_like(self.success_streak[env_ids]),
+            self.success_streak[env_ids],
+        )
+        fractions = self.difficulties.float() / max(max_difficulty, 1)
+        return {
+            "mean_level": self.difficulties.float().mean(),
+            "mean_fraction": fractions.mean(),
+            "at_final_level": (self.difficulties == max_difficulty).float().mean(),
+            "mastery_rate": succeeded.float().mean(),
+        }
+
+    def difficulty_fraction(self, env_ids: Sequence[int], max_difficulty: int | None = None) -> torch.Tensor:
+        """Return normalized per-environment difficulty in ``[0, 1]``."""
+        if max_difficulty is None:
+            max_difficulty = self.cfg.params.get("max_difficulty", 20)
+        return self.difficulties[env_ids].float() / max(max_difficulty, 1)
+
+    def get_state(self) -> dict[str, torch.Tensor]:
+        """Return curriculum state for checkpointing."""
+        return {"difficulties": self.difficulties, "success_streak": self.success_streak}
+
+    def set_state(self, state: dict[str, torch.Tensor]) -> None:
+        """Restore curriculum state from a checkpoint."""
+        self.difficulties.copy_(state["difficulties"].to(self.device))
+        self.success_streak.copy_(state["success_streak"].to(self.device))
+
+
+def lift_difficulty_fraction(env: ManagerBasedRLEnv, env_ids: Sequence[int]) -> torch.Tensor:
+    """Return the active lift curriculum's normalized per-environment difficulty."""
+    term: LiftDifficultyScheduler = env.curriculum_manager.cfg.lift_difficulty.func
+    return term.difficulty_fraction(env_ids)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/events.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/events.py
@@ -28,6 +28,7 @@ def _smoothstep(value: torch.Tensor) -> torch.Tensor:
 def reset_franka_lift_curriculum(
     env: ManagerBasedRLEnv,
     env_ids: torch.Tensor,
+    closed_finger_position: float = 0.016,
     robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
     object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
 ) -> None:
@@ -63,7 +64,7 @@ def reset_franka_lift_curriculum(
     finger_ids = robot.find_joints("panda_finger_joint.*")[0]
     grasp_arm = torch.lerp(high_arm, low_arm, move_to_table)
     joint_pos[:, arm_ids] = torch.lerp(grasp_arm, joint_pos[:, arm_ids], restore_default)
-    closed_fingers = torch.full((len(env_ids), len(finger_ids)), 0.014, device=env.device)
+    closed_fingers = torch.full((len(env_ids), len(finger_ids)), closed_finger_position, device=env.device)
     joint_pos[:, finger_ids] = torch.lerp(closed_fingers, joint_pos[:, finger_ids], release_object)
     joint_vel = torch.zeros_like(joint_pos)
     robot.write_joint_position_to_sim_index(position=joint_pos, env_ids=env_ids)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/events.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/events.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Curriculum reset events for rigid-object lift tasks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from isaaclab.managers import SceneEntityCfg
+
+from .curriculums import lift_difficulty_fraction
+
+if TYPE_CHECKING:
+    from isaaclab.assets import Articulation, RigidObject
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def _smoothstep(value: torch.Tensor) -> torch.Tensor:
+    value = value.clamp(0.0, 1.0)
+    return value * value * (3.0 - 2.0 * value)
+
+
+def reset_franka_lift_curriculum(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> None:
+    """Reset a Franka lift episode according to its adaptive difficulty.
+
+    The reference joint configurations were solved with Newton's articulation
+    Jacobians. The curriculum starts with a lifted cube already in the gripper,
+    moves the grasp to the table, opens the gripper, and finally restores the
+    default arm pose and full object-position randomization.
+    """
+    robot: Articulation = env.scene[robot_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    difficulty = lift_difficulty_fraction(env, env_ids).unsqueeze(-1)
+
+    high_arm = torch.tensor(
+        [0.001342, -0.362166, -0.003198, -2.751293, -0.008638, 3.183486, 0.747609],
+        device=env.device,
+    )
+    low_arm = torch.tensor(
+        [0.008757, 0.465495, -0.007622, -2.340756, -0.011284, 2.768182, 0.738861],
+        device=env.device,
+    )
+    high_object = torch.tensor([0.499620, 0.0, 0.349140], device=env.device)
+    low_object = torch.tensor([0.499772, 0.0, 0.029296], device=env.device)
+    table_object = torch.tensor([0.5, 0.0, 0.0174], device=env.device)
+
+    move_to_table = _smoothstep((difficulty - 0.30) / 0.25)
+    release_object = _smoothstep((difficulty - 0.55) / 0.20)
+    restore_default = _smoothstep((difficulty - 0.75) / 0.25)
+
+    joint_pos = robot.data.default_joint_pos.torch[env_ids].clone()
+    arm_ids = robot.find_joints([f"panda_joint{index}" for index in range(1, 8)])[0]
+    finger_ids = robot.find_joints("panda_finger_joint.*")[0]
+    grasp_arm = torch.lerp(high_arm, low_arm, move_to_table)
+    joint_pos[:, arm_ids] = torch.lerp(grasp_arm, joint_pos[:, arm_ids], restore_default)
+    closed_fingers = torch.full((len(env_ids), len(finger_ids)), 0.014, device=env.device)
+    joint_pos[:, finger_ids] = torch.lerp(closed_fingers, joint_pos[:, finger_ids], release_object)
+    joint_vel = torch.zeros_like(joint_pos)
+    robot.write_joint_position_to_sim_index(position=joint_pos, env_ids=env_ids)
+    robot.write_joint_velocity_to_sim_index(velocity=joint_vel, env_ids=env_ids)
+    robot.set_joint_position_target_index(target=joint_pos, env_ids=env_ids)
+
+    grasp_object = torch.lerp(high_object, low_object, move_to_table)
+    object_pos_b = torch.lerp(grasp_object, table_object, release_object)
+    random_xy = torch.empty((len(env_ids), 2), device=env.device)
+    random_xy[:, 0].uniform_(-0.1, 0.1)
+    random_xy[:, 1].uniform_(-0.25, 0.25)
+    object_pos_b[:, :2] += restore_default * random_xy
+
+    object_pose = object.data.default_root_pose.torch[env_ids].clone()
+    object_pose[:, :3] = object_pos_b + env.scene.env_origins[env_ids]
+    object_velocity = torch.zeros((len(env_ids), 6), device=env.device)
+    object.write_root_pose_to_sim_index(root_pose=object_pose, env_ids=env_ids)
+    object.write_root_velocity_to_sim_index(root_velocity=object_velocity, env_ids=env_ids)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/observations.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from isaaclab.assets import Articulation, DeformableObject, RigidObject
     from isaaclab.envs import ManagerBasedRLEnv
     from isaaclab.managers import ObservationTermCfg
+    from isaaclab.sensors import FrameTransformer
 
 
 def object_position_in_robot_root_frame(
@@ -33,6 +34,45 @@ def object_position_in_robot_root_frame(
     object_pos_w = object.data.root_pos_w.torch[:, :3]
     object_pos_b, _ = subtract_frame_transforms(robot.data.root_pos_w.torch, robot.data.root_quat_w.torch, object_pos_w)
     return object_pos_b
+
+
+def object_position_relative_to_ee(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame"),
+) -> torch.Tensor:
+    """Object position relative to the end effector [m]."""
+    object: RigidObject = env.scene[object_cfg.name]
+    ee_frame: FrameTransformer = env.scene[ee_frame_cfg.name]
+    return object.data.root_pos_w.torch[:, :3] - ee_frame.data.target_pos_w.torch[..., 0, :]
+
+
+def object_goal_position_relative(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Goal position relative to the object, expressed in the robot root frame [m]."""
+    robot: Articulation = env.scene[robot_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    object_pos_b, _ = subtract_frame_transforms(
+        robot.data.root_pos_w.torch,
+        robot.data.root_quat_w.torch,
+        object.data.root_pos_w.torch[:, :3],
+    )
+    return env.command_manager.get_command(command_name)[:, :3] - object_pos_b
+
+
+def object_height_above_table(
+    env: ManagerBasedRLEnv,
+    table_height: float = 0.0,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Object height above the table surface [m]."""
+    object: RigidObject = env.scene[object_cfg.name]
+    height = object.data.root_pos_w.torch[:, 2] - env.scene.env_origins[:, 2] - table_height
+    return height.unsqueeze(-1)
 
 
 def deformable_com_in_robot_root_frame(

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/observations.py
@@ -14,7 +14,7 @@ import torch
 import warp as wp
 
 from isaaclab.managers import ManagerTermBase, SceneEntityCfg
-from isaaclab.utils.math import subtract_frame_transforms
+from isaaclab.utils.math import combine_frame_transforms, quat_box_minus, subtract_frame_transforms
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation, DeformableObject, RigidObject
@@ -62,6 +62,24 @@ def object_goal_position_relative(
         object.data.root_pos_w.torch[:, :3],
     )
     return env.command_manager.get_command(command_name)[:, :3] - object_pos_b
+
+
+def object_goal_orientation_error(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Axis-angle rotation from the object's orientation to its commanded orientation [rad]."""
+    robot: Articulation = env.scene[robot_cfg.name]
+    object: RigidObject = env.scene[object_cfg.name]
+    command = env.command_manager.get_command(command_name)
+    _, goal_quat_w = combine_frame_transforms(
+        robot.data.root_pos_w.torch,
+        robot.data.root_quat_w.torch,
+        q12=command[:, 3:7],
+    )
+    return quat_box_minus(goal_quat_w, object.data.root_quat_w.torch)
 
 
 def object_height_above_table(

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/rewards.py
@@ -29,6 +29,18 @@ def object_is_lifted(
     return torch.where(object.data.root_pos_w.torch[:, 2] > minimal_height, 1.0, 0.0)
 
 
+def object_lift_progress(
+    env: ManagerBasedRLEnv,
+    minimal_height: float,
+    target_height: float,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Reward normalized object-height progress between two heights [m]."""
+    object: RigidObject = env.scene[object_cfg.name]
+    object_height = object.data.root_pos_w.torch[:, 2] - env.scene.env_origins[:, 2]
+    return ((object_height - minimal_height) / (target_height - minimal_height)).clamp(0.0, 1.0)
+
+
 def object_ee_distance(
     env: ManagerBasedRLEnv,
     std: float,
@@ -70,6 +82,13 @@ class object_goal_distance(ManagerTermBase):
                 self._succeeded[env_ids].float().mean().item()
             )
             self._succeeded[env_ids] = False
+
+    @property
+    def succeeded(self) -> torch.Tensor:
+        """Per-environment sticky success state for the current episode."""
+        if not self._track_success:
+            raise RuntimeError("Success tracking requires the 'success_threshold' parameter.")
+        return self._succeeded
 
     def __call__(
         self,
@@ -181,3 +200,16 @@ def gripper_close_action(env: ManagerBasedRLEnv, action_name: str = "gripper_act
     """
     gripper_action = env.action_manager.get_term(action_name).raw_actions
     return torch.any(gripper_action < 0.0, dim=1).float()
+
+
+def gripper_close_near_object(
+    env: ManagerBasedRLEnv,
+    std: float,
+    action_name: str = "gripper_action",
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame"),
+) -> torch.Tensor:
+    """Reward closing only when the end effector is near the object."""
+    close_command = gripper_close_action(env, action_name)
+    proximity = object_ee_distance(env, std, object_cfg, ee_frame_cfg)
+    return close_command * proximity

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/rewards.py
@@ -168,6 +168,18 @@ def object_goal_pose_accuracy(
     return ((position_error <= position_threshold) & (orientation_error <= orientation_threshold)).float()
 
 
+def object_angular_velocity_l2(
+    env: ManagerBasedRLEnv,
+    minimal_height: float,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Penalize object rotation while lifted so precise orientation can settle."""
+    obj: RigidObject = env.scene[object_cfg.name]
+    is_lifted = obj.data.root_pos_w.torch[:, 2] > minimal_height
+    angular_speed_squared = torch.sum(torch.square(obj.data.root_ang_vel_w.torch), dim=1)
+    return is_lifted.float() * angular_speed_squared
+
+
 def deformable_lifted(
     env: ManagerBasedRLEnv,
     minimal_height: float,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/rewards.py
@@ -13,12 +13,14 @@ import torch
 import warp as wp
 
 from isaaclab.managers import ManagerTermBase, RewardTermCfg, SceneEntityCfg
-from isaaclab.utils.math import combine_frame_transforms
+from isaaclab.utils.math import combine_frame_transforms, quat_error_magnitude, quat_mul
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation, DeformableObject, RigidObject
     from isaaclab.envs import ManagerBasedRLEnv
     from isaaclab.sensors import FrameTransformer
+
+from .curriculums import lift_difficulty_fraction
 
 
 def object_is_lifted(
@@ -59,6 +61,17 @@ def object_ee_distance(
     object_ee_distance = torch.linalg.norm(cube_pos_w - ee_w, dim=1)
 
     return 1 - torch.tanh(object_ee_distance / std)
+
+
+def curriculum_object_ee_distance(
+    env: ManagerBasedRLEnv,
+    std: float,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame"),
+) -> torch.Tensor:
+    """Ramp reaching reward in as the curriculum transitions away from pre-grasped resets."""
+    difficulty = lift_difficulty_fraction(env, slice(None))
+    return difficulty * object_ee_distance(env, std, object_cfg, ee_frame_cfg)
 
 
 class object_goal_distance(ManagerTermBase):
@@ -112,6 +125,47 @@ class object_goal_distance(ManagerTermBase):
         if success_threshold is not None:
             self._succeeded |= is_lifted & (distance < success_threshold)
         return is_lifted.float() * (1 - torch.tanh(distance / std))
+
+
+def object_goal_orientation_distance(
+    env: ManagerBasedRLEnv,
+    std: float,
+    minimal_height: float,
+    command_name: str,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Reward object orientation tracking using a tanh kernel."""
+    robot: RigidObject = env.scene[robot_cfg.name]
+    obj: RigidObject = env.scene[object_cfg.name]
+    command = env.command_manager.get_command(command_name)
+    goal_quat_w = quat_mul(robot.data.root_quat_w.torch, command[:, 3:7])
+    orientation_error = quat_error_magnitude(obj.data.root_quat_w.torch, goal_quat_w)
+    is_lifted = obj.data.root_pos_w.torch[:, 2] > minimal_height
+    return is_lifted.float() * (1 - torch.tanh(orientation_error / std))
+
+
+def object_goal_pose_accuracy(
+    env: ManagerBasedRLEnv,
+    position_threshold: float,
+    orientation_threshold: float,
+    command_name: str,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Reward every step that the object remains inside the precise goal tolerance."""
+    robot: RigidObject = env.scene[robot_cfg.name]
+    obj: RigidObject = env.scene[object_cfg.name]
+    command = env.command_manager.get_command(command_name)
+    goal_pos_w, _ = combine_frame_transforms(
+        robot.data.root_pos_w.torch,
+        robot.data.root_quat_w.torch,
+        command[:, :3],
+    )
+    goal_quat_w = quat_mul(robot.data.root_quat_w.torch, command[:, 3:7])
+    position_error = torch.linalg.norm(goal_pos_w - obj.data.root_pos_w.torch, dim=1)
+    orientation_error = quat_error_magnitude(obj.data.root_quat_w.torch, goal_quat_w)
+    return ((position_error <= position_threshold) & (orientation_error <= orientation_threshold)).float()
 
 
 def deformable_lifted(
@@ -213,3 +267,15 @@ def gripper_close_near_object(
     close_command = gripper_close_action(env, action_name)
     proximity = object_ee_distance(env, std, object_cfg, ee_frame_cfg)
     return close_command * proximity
+
+
+def curriculum_gripper_close_near_object(
+    env: ManagerBasedRLEnv,
+    std: float,
+    action_name: str = "gripper_action",
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    ee_frame_cfg: SceneEntityCfg = SceneEntityCfg("ee_frame"),
+) -> torch.Tensor:
+    """Ramp grasp-command shaping in as policy control becomes necessary."""
+    difficulty = lift_difficulty_fraction(env, slice(None))
+    return difficulty * gripper_close_near_object(env, std, action_name, object_cfg, ee_frame_cfg)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/terminations.py
@@ -11,18 +11,22 @@ the termination introduced by the function.
 
 from __future__ import annotations
 
+import math
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import torch
 import warp as wp
 
-from isaaclab.managers import SceneEntityCfg
-from isaaclab.utils.math import combine_frame_transforms
+from isaaclab.managers import ManagerTermBase, SceneEntityCfg, TerminationTermCfg
+from isaaclab.utils.math import combine_frame_transforms, quat_error_magnitude, quat_mul
 
 if TYPE_CHECKING:
     from isaaclab.assets import DeformableObject, RigidObject
     from isaaclab.envs import ManagerBasedRLEnv
     from isaaclab.sensors import FrameTransformer
+
+from .curriculums import lift_difficulty_fraction
 
 
 def object_reached_goal(
@@ -58,6 +62,82 @@ def object_reached_goal(
 
     # rewarded if the object is lifted above the threshold
     return distance < threshold
+
+
+class ObjectPoseHeld(ManagerTermBase):
+    """Terminate after the object continuously holds the commanded pose."""
+
+    def __init__(self, cfg: TerminationTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        hold_time = cfg.params.get("hold_time", 1.0)
+        if hold_time <= 0.0:
+            raise ValueError(f"hold_time must be positive, got {hold_time}.")
+        self.hold_steps = max(1, math.ceil(hold_time / env.step_dt))
+        self.consecutive_steps = torch.zeros(env.num_envs, dtype=torch.int32, device=env.device)
+        self.position_error = torch.full((env.num_envs,), float("inf"), device=env.device)
+        self.orientation_error = torch.full((env.num_envs,), float("inf"), device=env.device)
+
+    def reset(self, env_ids: Sequence[int] | None = None) -> None:
+        """Clear held-pose progress for the reset environments."""
+        if env_ids is None:
+            env_ids = slice(None)
+        self.consecutive_steps[env_ids] = 0
+        self.position_error[env_ids] = float("inf")
+        self.orientation_error[env_ids] = float("inf")
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        command_name: str,
+        position_threshold: float,
+        orientation_threshold: float,
+        hold_time: float,
+        robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    ) -> torch.Tensor:
+        """Update held-pose progress and return the sustained success signal."""
+        del hold_time
+        robot: RigidObject = env.scene[robot_cfg.name]
+        object: RigidObject = env.scene[object_cfg.name]
+        command = env.command_manager.get_command(command_name)
+        goal_pos_w, _ = combine_frame_transforms(
+            robot.data.root_pos_w.torch,
+            robot.data.root_quat_w.torch,
+            command[:, :3],
+        )
+        goal_quat_w = quat_mul(robot.data.root_quat_w.torch, command[:, 3:7])
+        self.position_error = torch.linalg.norm(goal_pos_w - object.data.root_pos_w.torch, dim=1)
+        self.orientation_error = quat_error_magnitude(object.data.root_quat_w.torch, goal_quat_w)
+        within_tolerance = (self.position_error <= position_threshold) & (
+            self.orientation_error <= orientation_threshold
+        )
+        self.consecutive_steps = torch.where(
+            within_tolerance,
+            self.consecutive_steps + 1,
+            torch.zeros_like(self.consecutive_steps),
+        )
+        return self.consecutive_steps >= self.hold_steps
+
+
+def curriculum_object_below_reset_height(
+    env: ManagerBasedRLEnv,
+    high_object_height: float,
+    low_object_height: float,
+    transition_start: float,
+    transition_end: float,
+    height_margin: float,
+    minimum_height: float,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    """Terminate failed pre-grasped episodes before they exploit table-level shaping."""
+    object: RigidObject = env.scene[object_cfg.name]
+    difficulty = lift_difficulty_fraction(env, slice(None))
+    blend = ((difficulty - transition_start) / (transition_end - transition_start)).clamp(0.0, 1.0)
+    blend = blend * blend * (3.0 - 2.0 * blend)
+    expected_height = high_object_height + blend * (low_object_height - high_object_height)
+    threshold = (expected_height - height_margin).clamp(min=minimum_height)
+    object_height = object.data.root_pos_w.torch[:, 2] - env.scene.env_origins[:, 2]
+    return object_height < threshold
 
 
 def deformable_com_below_minimum(

--- a/source/isaaclab_tasks/test/core/test_lift_cube_newton_cfg.py
+++ b/source/isaaclab_tasks/test/core/test_lift_cube_newton_cfg.py
@@ -12,12 +12,15 @@ import sys
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
+
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.core.lift.lift_env_cfg import LiftPhysicsCfg
 from isaaclab_tasks.utils.hydra import resolve_task_config
 from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
 
 _TASK = "Isaac-Lift-Cube-Franka"
+_CURRICULUM_TASK = "Isaac-Lift-Cube-Franka-Newton-Curriculum"
 _AGENT = "rsl_rl_cfg_entry_point"
 
 
@@ -63,3 +66,31 @@ def test_lift_cube_resolves_newton_mjwarp_physics_selector() -> None:
     assert cfg.rewards.object_dropping.params["term_keys"] == "object_dropping"
     assert cfg.curriculum.action_rate.params["num_steps"] == 10000
     assert cfg.curriculum.joint_vel.params["num_steps"] == 10000
+
+
+def test_newton_curriculum_task_is_newton_only_and_uses_final_task_curriculum() -> None:
+    """The curriculum task should pin Newton and remove the abrupt penalty schedule."""
+    cfg = load_cfg_from_registry(_CURRICULUM_TASK, "env_cfg_entry_point")
+    agent_cfg = load_cfg_from_registry(_CURRICULUM_TASK, _AGENT)
+
+    assert isinstance(cfg.sim.physics, NewtonCfg)
+    assert isinstance(cfg.actions.arm_action, DifferentialInverseKinematicsActionCfg)
+    assert cfg.actions.arm_action.scale == (0.1, 0.1, 0.1, 0.25, 0.25, 0.25)
+    assert cfg.actions.arm_action.controller.use_relative_mode
+    assert cfg.actions.gripper_action.close_command_expr == {"panda_finger_.*": 0.014}
+    assert cfg.scene.robot.spawn.rigid_props.disable_gravity
+    assert cfg.scene.robot.actuators["panda_shoulder"].stiffness == 2000.0
+    assert cfg.scene.robot.actuators["panda_forearm"].effort_limit_sim == 100.0
+    assert cfg.events.reset_curriculum.func is not None
+    assert cfg.curriculum.lift_difficulty.params["max_difficulty"] == 40
+    assert cfg.curriculum.lift_difficulty.params["initial_difficulty"] == 0
+    assert cfg.curriculum.lift_difficulty.params["successes_to_promote"] == 1
+    assert cfg.curriculum.lift_difficulty.params["success_termination_name"] == "success"
+    assert cfg.rewards.action_rate.weight == -1e-3
+    assert cfg.rewards.joint_vel.weight == -1e-4
+    assert cfg.rewards.success_bonus.weight == 2500.0
+    assert cfg.terminations.success.params["threshold"] == 0.05
+    assert cfg.observations.policy.ee_to_object.func is not None
+    assert cfg.observations.policy.object_to_goal.func is not None
+    assert agent_cfg.clip_actions == 1.0
+    assert agent_cfg.actor.distribution_cfg.std_range == (0.1, 1.0)

--- a/source/isaaclab_tasks/test/core/test_lift_cube_newton_cfg.py
+++ b/source/isaaclab_tasks/test/core/test_lift_cube_newton_cfg.py
@@ -12,10 +12,9 @@ import sys
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
-from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
-
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.core.lift.lift_env_cfg import LiftPhysicsCfg
+from isaaclab_tasks.core.lift.mdp import CurriculumDifferentialInverseKinematicsActionCfg
 from isaaclab_tasks.utils.hydra import resolve_task_config
 from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
 
@@ -74,23 +73,40 @@ def test_newton_curriculum_task_is_newton_only_and_uses_final_task_curriculum() 
     agent_cfg = load_cfg_from_registry(_CURRICULUM_TASK, _AGENT)
 
     assert isinstance(cfg.sim.physics, NewtonCfg)
-    assert isinstance(cfg.actions.arm_action, DifferentialInverseKinematicsActionCfg)
+    assert isinstance(cfg.actions.arm_action, CurriculumDifferentialInverseKinematicsActionCfg)
     assert cfg.actions.arm_action.scale == (0.1, 0.1, 0.1, 0.25, 0.25, 0.25)
     assert cfg.actions.arm_action.controller.use_relative_mode
-    assert cfg.actions.gripper_action.close_command_expr == {"panda_finger_.*": 0.014}
+    assert cfg.actions.arm_action.full_control_difficulty == 0.30
+    assert cfg.actions.gripper_action.close_command_expr == {"panda_finger_.*": 0.016}
+    assert cfg.actions.gripper_action.force_close_below_difficulty == 0.45
     assert cfg.scene.robot.spawn.rigid_props.disable_gravity
-    assert cfg.scene.robot.actuators["panda_shoulder"].stiffness == 2000.0
+    assert cfg.scene.robot.actuators["panda_shoulder"].stiffness == 20000.0
+    assert cfg.scene.robot.actuators["panda_forearm"].damping == 2000.0
     assert cfg.scene.robot.actuators["panda_forearm"].effort_limit_sim == 100.0
     assert cfg.events.reset_curriculum.func is not None
+    assert cfg.events.reset_curriculum.params["closed_finger_position"] == 0.016
     assert cfg.curriculum.lift_difficulty.params["max_difficulty"] == 40
     assert cfg.curriculum.lift_difficulty.params["initial_difficulty"] == 0
     assert cfg.curriculum.lift_difficulty.params["successes_to_promote"] == 1
     assert cfg.curriculum.lift_difficulty.params["success_termination_name"] == "success"
     assert cfg.rewards.action_rate.weight == -1e-3
     assert cfg.rewards.joint_vel.weight == -1e-4
-    assert cfg.rewards.success_bonus.weight == 2500.0
-    assert cfg.terminations.success.params["threshold"] == 0.05
+    assert cfg.rewards.object_goal_tracking.params["std"] == 0.12
+    assert cfg.rewards.object_goal_orientation.weight == 3.0
+    assert cfg.rewards.object_goal_fine_tracking.params["std"] == 0.025
+    assert cfg.rewards.object_goal_fine_orientation.params["std"] == 0.10
+    assert cfg.rewards.object_goal_pose_accuracy.weight == 10.0
+    assert cfg.rewards.action_magnitude.weight == -0.05
+    assert cfg.rewards.object_dropping.weight == -50.0
+    assert cfg.rewards.success_bonus.weight == 5000.0
+    assert cfg.terminations.success.params["position_threshold"] == 0.02
+    assert cfg.terminations.success.params["orientation_threshold"] == 0.15
+    assert cfg.terminations.success.params["hold_time"] == 1.0
+    assert cfg.terminations.object_dropping.func is not None
+    assert cfg.terminations.object_dropping.params["height_margin"] == 0.10
     assert cfg.observations.policy.ee_to_object.func is not None
     assert cfg.observations.policy.object_to_goal.func is not None
+    assert cfg.observations.policy.object_orientation_to_goal.func is not None
     assert agent_cfg.clip_actions == 1.0
-    assert agent_cfg.actor.distribution_cfg.std_range == (0.1, 1.0)
+    assert agent_cfg.actor.distribution_cfg.init_std == 0.10
+    assert agent_cfg.actor.distribution_cfg.std_range == (0.01, 1.0)

--- a/source/isaaclab_tasks/test/core/test_lift_cube_newton_cfg.py
+++ b/source/isaaclab_tasks/test/core/test_lift_cube_newton_cfg.py
@@ -92,11 +92,13 @@ def test_newton_curriculum_task_is_newton_only_and_uses_final_task_curriculum() 
     assert cfg.rewards.action_rate.weight == -1e-3
     assert cfg.rewards.joint_vel.weight == -1e-4
     assert cfg.rewards.object_goal_tracking.params["std"] == 0.12
-    assert cfg.rewards.object_goal_orientation.weight == 3.0
+    assert cfg.rewards.object_goal_orientation.params["std"] == 1.0
+    assert cfg.rewards.object_goal_orientation.weight == 4.0
     assert cfg.rewards.object_goal_fine_tracking.params["std"] == 0.025
     assert cfg.rewards.object_goal_fine_orientation.params["std"] == 0.10
     assert cfg.rewards.object_goal_pose_accuracy.weight == 10.0
     assert cfg.rewards.action_magnitude.weight == -0.05
+    assert cfg.rewards.object_angular_velocity.weight == -0.02
     assert cfg.rewards.object_dropping.weight == -50.0
     assert cfg.rewards.success_bonus.weight == 5000.0
     assert cfg.terminations.success.params["position_threshold"] == 0.02

--- a/source/isaaclab_tasks/test/core/test_lift_cube_newton_cfg.py
+++ b/source/isaaclab_tasks/test/core/test_lift_cube_newton_cfg.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Configuration checks for the Franka rigid cube-lift physics presets."""
+
+from __future__ import annotations
+
+import sys
+
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_physx.physics import PhysxCfg
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.core.lift.lift_env_cfg import LiftPhysicsCfg
+from isaaclab_tasks.utils.hydra import resolve_task_config
+from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
+
+_TASK = "Isaac-Lift-Cube-Franka"
+_AGENT = "rsl_rl_cfg_entry_point"
+
+
+def test_lift_cube_preserves_physx_default() -> None:
+    """The existing task behavior should remain on its tuned PhysX configuration."""
+    cfg = load_cfg_from_registry(_TASK, "env_cfg_entry_point")
+
+    assert isinstance(cfg.sim.physics, LiftPhysicsCfg)
+    assert isinstance(cfg.sim.physics.default, PhysxCfg)
+    assert cfg.sim.physics.default.bounce_threshold_velocity == 0.01
+    assert cfg.sim.physics.default.friction_correlation_distance == 0.00625
+    agent_cfg = load_cfg_from_registry(_TASK, _AGENT)
+    assert agent_cfg.clip_actions.default is None
+    assert cfg.rewards.object_dropping.weight.default == 0.0
+
+
+def test_lift_cube_resolves_newton_mjwarp_physics_selector() -> None:
+    """The typed selector should replace the physics preset with Newton MJWarp."""
+    original_argv = sys.argv
+    try:
+        sys.argv = [sys.argv[0], "physics=newton_mjwarp"]
+        cfg, agent_cfg = resolve_task_config(_TASK, _AGENT)
+    finally:
+        sys.argv = original_argv
+
+    assert isinstance(cfg.sim.physics, NewtonCfg)
+    assert isinstance(cfg.sim.physics.solver_cfg, MJWarpSolverCfg)
+    assert cfg.sim.physics.solver_cfg.integrator == "implicitfast"
+    assert cfg.sim.physics.solver_cfg.cone == "elliptic"
+    assert cfg.sim.physics.solver_cfg.impratio == 10
+    assert cfg.sim.physics.num_substeps == 2
+    assert cfg.scene.robot.actuators["panda_shoulder"].armature == 0.1
+    assert cfg.scene.robot.actuators["panda_forearm"].armature == 0.1
+    assert cfg.scene.robot.actuators["panda_shoulder"].damping == 10.0
+    assert cfg.scene.robot.actuators["panda_forearm"].damping == 10.0
+    assert cfg.actions.arm_action.scale == 0.5
+    assert agent_cfg.actor.distribution_cfg.init_std == 1.0
+    assert agent_cfg.actor.distribution_cfg.std_range == (1.0, 1.0)
+    assert agent_cfg.algorithm.entropy_coef == 0.001
+    assert agent_cfg.algorithm.schedule == "adaptive"
+    assert agent_cfg.clip_actions == 1.0
+    assert cfg.rewards.object_dropping.weight == -200.0
+    assert cfg.rewards.object_dropping.params["term_keys"] == "object_dropping"
+    assert cfg.curriculum.action_rate.params["num_steps"] == 10000
+    assert cfg.curriculum.joint_vel.params["num_steps"] == 10000

--- a/source/isaaclab_tasks/test/core/test_lift_curriculum.py
+++ b/source/isaaclab_tasks/test/core/test_lift_curriculum.py
@@ -15,6 +15,7 @@ from isaaclab_tasks.core.lift.mdp import (
     LiftDifficultyScheduler,
     ObjectPoseHeld,
     curriculum_object_below_reset_height,
+    object_angular_velocity_l2,
     object_goal_pose_accuracy,
 )
 
@@ -179,3 +180,16 @@ def test_curriculum_drop_height_rejects_failed_pregrasp_without_changing_final_f
         height_margin=0.10,
         minimum_height=-0.05,
     ).tolist() == [True, True]
+
+
+def test_object_angular_velocity_penalty_only_applies_while_lifted() -> None:
+    """Table-level objects should not receive the lifted stabilization penalty."""
+    object = SimpleNamespace(
+        data=SimpleNamespace(
+            root_pos_w=SimpleNamespace(torch=torch.tensor([[0.0, 0.0, 0.3], [0.0, 0.0, 0.05]])),
+            root_ang_vel_w=SimpleNamespace(torch=torch.tensor([[1.0, 2.0, 2.0], [1.0, 2.0, 2.0]])),
+        )
+    )
+    env = SimpleNamespace(scene={"object": object})
+
+    assert object_angular_velocity_l2(env, minimal_height=0.10).tolist() == [9.0, 0.0]

--- a/source/isaaclab_tasks/test/core/test_lift_curriculum.py
+++ b/source/isaaclab_tasks/test/core/test_lift_curriculum.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for the adaptive rigid-object lift curriculum."""
+
+from types import SimpleNamespace
+
+import torch
+
+from isaaclab.managers import CurriculumTermCfg
+from isaaclab_tasks.core.lift.mdp.curriculums import LiftDifficultyScheduler
+
+
+class _TerminationManager:
+    def __init__(self, success: torch.Tensor):
+        self.success = success
+
+    def get_term(self, _: str) -> torch.Tensor:
+        return self.success
+
+
+def test_lift_difficulty_requires_success_termination() -> None:
+    """Only the task's success termination should advance the curriculum."""
+    termination_manager = _TerminationManager(torch.tensor([False, True]))
+    env = SimpleNamespace(
+        num_envs=2,
+        device="cpu",
+        termination_manager=termination_manager,
+    )
+    cfg = CurriculumTermCfg(
+        func=LiftDifficultyScheduler,
+        params={
+            "success_termination_name": "success",
+            "max_difficulty": 20,
+            "successes_to_promote": 3,
+        },
+    )
+    scheduler = LiftDifficultyScheduler(cfg, env)
+    env_ids = torch.arange(2)
+
+    for _ in range(3):
+        scheduler(env, env_ids, **cfg.params)
+
+    assert scheduler.difficulties.tolist() == [0, 1]
+    assert scheduler.success_streak.tolist() == [0, 0]
+
+
+def test_lift_difficulty_resets_streak_after_failure() -> None:
+    """Successes separated by a failed episode should not promote difficulty."""
+    termination_manager = _TerminationManager(torch.tensor([True]))
+    env = SimpleNamespace(
+        num_envs=1,
+        device="cpu",
+        termination_manager=termination_manager,
+    )
+    cfg = CurriculumTermCfg(
+        func=LiftDifficultyScheduler,
+        params={
+            "success_termination_name": "success",
+            "max_difficulty": 20,
+            "successes_to_promote": 3,
+        },
+    )
+    scheduler = LiftDifficultyScheduler(cfg, env)
+
+    scheduler(env, torch.tensor([0]), **cfg.params)
+    termination_manager.success[0] = False
+    scheduler(env, torch.tensor([0]), **cfg.params)
+    termination_manager.success[0] = True
+    scheduler(env, torch.tensor([0]), **cfg.params)
+
+    assert scheduler.difficulties.item() == 0
+    assert scheduler.success_streak.item() == 1

--- a/source/isaaclab_tasks/test/core/test_lift_curriculum.py
+++ b/source/isaaclab_tasks/test/core/test_lift_curriculum.py
@@ -9,8 +9,14 @@ from types import SimpleNamespace
 
 import torch
 
-from isaaclab.managers import CurriculumTermCfg
-from isaaclab_tasks.core.lift.mdp.curriculums import LiftDifficultyScheduler
+from isaaclab.managers import CurriculumTermCfg, TerminationTermCfg
+
+from isaaclab_tasks.core.lift.mdp import (
+    LiftDifficultyScheduler,
+    ObjectPoseHeld,
+    curriculum_object_below_reset_height,
+    object_goal_pose_accuracy,
+)
 
 
 class _TerminationManager:
@@ -73,3 +79,103 @@ def test_lift_difficulty_resets_streak_after_failure() -> None:
 
     assert scheduler.difficulties.item() == 0
     assert scheduler.success_streak.item() == 1
+
+
+def test_object_pose_held_requires_continuous_position_and_orientation_accuracy() -> None:
+    """Success should require every tolerance to hold for the configured duration."""
+    identity = torch.tensor([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]])
+    rotated = identity.clone()
+    rotated[1] = torch.tensor([0.0, 0.0, 0.1, 0.994987])
+    robot = SimpleNamespace(
+        data=SimpleNamespace(
+            root_pos_w=SimpleNamespace(torch=torch.zeros(2, 3)),
+            root_quat_w=SimpleNamespace(torch=identity),
+        )
+    )
+    object = SimpleNamespace(
+        data=SimpleNamespace(
+            root_pos_w=SimpleNamespace(torch=torch.tensor([[0.0, 0.0, 0.3], [0.0, 0.0, 0.3]])),
+            root_quat_w=SimpleNamespace(torch=rotated),
+        )
+    )
+    command = torch.tensor(
+        [
+            [0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    env = SimpleNamespace(
+        num_envs=2,
+        device="cpu",
+        step_dt=0.02,
+        scene={"robot": robot, "object": object},
+        command_manager=SimpleNamespace(get_command=lambda _: command),
+    )
+    cfg = TerminationTermCfg(
+        func=ObjectPoseHeld,
+        params={
+            "command_name": "object_pose",
+            "position_threshold": 0.02,
+            "orientation_threshold": 0.15,
+            "hold_time": 1.0,
+        },
+    )
+    accuracy = object_goal_pose_accuracy(
+        env,
+        command_name="object_pose",
+        position_threshold=0.02,
+        orientation_threshold=0.15,
+    )
+    assert accuracy.tolist() == [1.0, 0.0]
+    success = ObjectPoseHeld(cfg, env)
+
+    for _ in range(49):
+        assert not success(env, **cfg.params).any()
+
+    assert success(env, **cfg.params).tolist() == [True, False]
+    object.data.root_pos_w.torch[0, 0] = 0.1
+    assert not success(env, **cfg.params).any()
+    assert success.consecutive_steps.tolist() == [0, 0]
+
+
+def test_curriculum_drop_height_rejects_failed_pregrasp_without_changing_final_floor() -> None:
+    """Early lifted resets should fail above the final task's below-table floor."""
+    scheduler_env = SimpleNamespace(num_envs=2, device="cpu")
+    scheduler_cfg = CurriculumTermCfg(
+        func=LiftDifficultyScheduler,
+        params={"initial_difficulty": 0, "max_difficulty": 40},
+    )
+    scheduler = LiftDifficultyScheduler(scheduler_cfg, scheduler_env)
+    scheduler.difficulties[:] = torch.tensor([0, 40])
+    object = SimpleNamespace(
+        data=SimpleNamespace(root_pos_w=SimpleNamespace(torch=torch.tensor([[0.0, 0.0, 0.24], [0.0, 0.0, -0.04]])))
+    )
+    scene = type("Scene", (), {"env_origins": torch.zeros(2, 3), "__getitem__": lambda _, name: object})()
+    env = SimpleNamespace(
+        scene=scene,
+        curriculum_manager=SimpleNamespace(
+            cfg=SimpleNamespace(lift_difficulty=SimpleNamespace(func=scheduler)),
+        ),
+    )
+
+    dropped = curriculum_object_below_reset_height(
+        env,
+        high_object_height=0.349140,
+        low_object_height=0.029296,
+        transition_start=0.30,
+        transition_end=0.55,
+        height_margin=0.10,
+        minimum_height=-0.05,
+    )
+    assert dropped.tolist() == [True, False]
+
+    object.data.root_pos_w.torch[1, 2] = -0.06
+    assert curriculum_object_below_reset_height(
+        env,
+        high_object_height=0.349140,
+        low_object_height=0.029296,
+        transition_start=0.30,
+        transition_end=0.55,
+        height_margin=0.10,
+        minimum_height=-0.05,
+    ).tolist() == [True, True]

--- a/source/isaaclab_visualizers/changelog.d/max-franka-lift-newton-pin.rst
+++ b/source/isaaclab_visualizers/changelog.d/max-franka-lift-newton-pin.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed static collider poses in cloned, offset Newton environments.

--- a/source/isaaclab_visualizers/pyproject.toml
+++ b/source/isaaclab_visualizers/pyproject.toml
@@ -29,24 +29,24 @@ Repository = "https://github.com/isaac-sim/IsaacLab"
 kit = []
 newton = [
     "warp-lang",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim,importers] @ git+https://github.com/maxkra15/newton.git@bee486b86320840665c16ba5f5a3b8a8b34c5048",
     "PyOpenGL-accelerate",
     "pyglet>=2.1.6,<3",
     "imgui-bundle>=1.92.5",
     "typing-extensions>=4.15.0",
 ]
 rerun = [
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim,importers] @ git+https://github.com/maxkra15/newton.git@bee486b86320840665c16ba5f5a3b8a8b34c5048",
     "rerun-sdk>=0.29.0",
     "pyarrow==22.0.0",
 ]
 viser = [
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim,importers] @ git+https://github.com/maxkra15/newton.git@bee486b86320840665c16ba5f5a3b8a8b34c5048",
     "viser>=1.0.16",
 ]
 all = [
     "imgui-bundle>=1.92.5",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@2064e3b79807dcc1679d1eb86ef7efd9ef0f28ee",
+    "newton[sim,importers] @ git+https://github.com/maxkra15/newton.git@bee486b86320840665c16ba5f5a3b8a8b34c5048",
     "PyOpenGL-accelerate",
     "pyglet>=2.1.6,<3",
     # Match rerun-sdk's supported Arrow stack and avoid resolver drift across environments.


### PR DESCRIPTION
# Description

  Adds a Newton MJWarp physics preset to the `Isaac-Lift-Cube-Franka` task, selectable with:

  ```bash
  physics=newton_mjwarp
  ```
  The existing PhysX configuration remains the default.

  This also fixes two Newton backend issues:

  - Removes quadratic site-map allocation during environment cloning by allocating per-world storage
    once.

  - Ensures CUDA graph capture uses the configured physics device on multi-GPU systems.

  The cloning fix reduced scene creation time for 4,096 environments from approximately 11.8 seconds to
  3.7 seconds, a roughly 3.2× speedup.

  No new dependencies are introduced; this uses the existing Isaac Lab Newton and MJWarp dependencies.

  Fixes: N/A

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

  ## Testing

  - 14 focused tests passed.
  - Full ./isaaclab.sh --format checks passed.

  ## Checklist

  - [x] I have read and understood the contribution guidelines
    (https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)

  - [x] I have run the pre-commit checks (https://pre-commit.com/) with ./isaaclab.sh --format
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have added changelog fragments; package versioning is handled by CI