### PR TITLE
[DO-NOT-MERGE] Migrate reorient hand tasks to MuJoCo Menagerie assets

### DIFF
--- a/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
+++ b/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
@@ -1,0 +1,9 @@
+Added
+^^^^^
+
+* Added :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_CFG` and
+  :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_PHYSX_CFG` for the
+  Mujoco Menagerie Shadow Hand conversion. The PhysX configuration uses a custom spawner
+  that authors the fixed tendons missing from the MuJoCo USD Converter output.
+* Added :obj:`~isaaclab_assets.robots.allegro.ALLEGRO_HAND_MENAGERIE_CFG` for the Mujoco
+  Menagerie Allegro Hand conversion.

--- a/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
+++ b/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
@@ -21,4 +21,7 @@ Added
   :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_PHYSX_CFG` for the
   Mujoco Menagerie Shadow Hand conversion.
 * Added :obj:`~isaaclab_assets.robots.allegro.ALLEGRO_HAND_MENAGERIE_CFG` for the Mujoco
-  Menagerie Allegro Hand conversion.
+  Menagerie Allegro Hand conversion. The actuator configuration authors the motor rotor
+  inertia (``armature``) that the MJCF omits; without it the stock hand's lightweight
+  links leave the joint-space inertia near zero and Newton/MJWarp contact dynamics are
+  too noisy to train on (reorient success 0.16 vs 1.0 at 1500 iterations).

--- a/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
+++ b/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
@@ -1,9 +1,17 @@
 Added
 ^^^^^
 
+* Added :class:`~isaaclab_assets.robots.menagerie.MenagerieUsdFileCfg`, a load-time
+  adapter for Mujoco Menagerie asset conversions that fixes conversion defects on the
+  composed prims before the physics engine parses them (unauthored static friction,
+  collision pairs manufactured by welded-body splits, per-asset fixups such as PhysX
+  fixed-tendon authoring). Each fix is tagged with the upstream converter change that
+  makes it removable. Assets resolve from the public production release via
+  :obj:`~isaaclab_assets.robots.menagerie.MENAGERIE_ASSET_ROOT` (no Nucleus
+  authentication required; override with the ``MENAGERIE_ASSET_ROOT`` environment
+  variable for local mirrors).
 * Added :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_CFG` and
   :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_PHYSX_CFG` for the
-  Mujoco Menagerie Shadow Hand conversion. The PhysX configuration uses a custom spawner
-  that authors the fixed tendons missing from the MuJoCo USD Converter output.
+  Mujoco Menagerie Shadow Hand conversion.
 * Added :obj:`~isaaclab_assets.robots.allegro.ALLEGRO_HAND_MENAGERIE_CFG` for the Mujoco
   Menagerie Allegro Hand conversion.

--- a/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
+++ b/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
@@ -21,7 +21,8 @@ Added
   :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_PHYSX_CFG` for the
   Mujoco Menagerie Shadow Hand conversion.
 * Added :obj:`~isaaclab_assets.robots.allegro.ALLEGRO_HAND_MENAGERIE_CFG` for the Mujoco
-  Menagerie Allegro Hand conversion. The actuator configuration authors the motor rotor
-  inertia (``armature``) that the MJCF omits; without it the stock hand's lightweight
-  links leave the joint-space inertia near zero and Newton/MJWarp contact dynamics are
-  too noisy to train on (reorient success 0.16 vs 1.0 at 1500 iterations).
+  Menagerie Allegro Hand conversion. The patched asset authors the motor rotor inertia
+  the MJCF omits (``newton:armature``, ``mjc:armature``, and ``physxJoint:armature`` on
+  every revolute joint); without it the stock hand's lightweight links leave the
+  joint-space inertia near zero and contact dynamics are too noisy to train on
+  (reorient success 0.16 vs 1.0 at 1500 iterations).

--- a/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
+++ b/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
@@ -1,15 +1,19 @@
 Added
 ^^^^^
 
-* Added :class:`~isaaclab_assets.robots.menagerie.MenagerieUsdFileCfg`, a load-time
-  adapter for Mujoco Menagerie asset conversions that fixes conversion defects on the
-  composed prims before the physics engine parses them (unauthored static friction,
-  collision pairs manufactured by welded-body splits, per-asset fixups such as PhysX
-  fixed-tendon authoring). Each fix is tagged with the upstream converter change that
-  makes it removable. Assets resolve from the public production release via
-  :obj:`~isaaclab_assets.robots.menagerie.MENAGERIE_ASSET_ROOT` (no Nucleus
-  authentication required; override with the ``MENAGERIE_ASSET_ROOT`` environment
-  variable for local mirrors).
+* Added :class:`~isaaclab_assets.robots.menagerie.MenageriePatchedUsdFileCfg` and
+  :func:`~isaaclab_assets.robots.menagerie.patch_menagerie_asset`, which fix Mujoco
+  Menagerie conversion defects by writing them into a patched copy of the asset's USD
+  layers on disk (cached under ``~/.cache/isaaclab/menagerie_patched/``) instead of
+  authoring prims at spawn time. Each fix is detection-first and idempotent -- kept
+  drives alive in the ``mujoco`` variant, unauthored static friction, collision pairs
+  manufactured by welded-body splits, ``physx``-layer joint velocity limits, and the
+  Shadow hand's fixed tendons -- and a ``isaaclabMenageriePatchVersion`` marker on the
+  entry layer short-circuits repeated patching. Assets resolve from the public
+  production release via :obj:`~isaaclab_assets.robots.menagerie.MENAGERIE_ASSET_ROOT`
+  (no Nucleus authentication required; a local mirror is copied and the S3 release is
+  downloaded via an anonymous ``ListObjectsV2`` enumeration; override with the
+  ``MENAGERIE_ASSET_ROOT`` environment variable).
 * Added :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_CFG` and
   :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_PHYSX_CFG` for the
   Mujoco Menagerie Shadow Hand conversion.

--- a/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
+++ b/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
@@ -12,17 +12,21 @@ Added
   friction, collision pairs manufactured by welded-body splits, ``physx``-layer joint
   velocity limits, and the Shadow hand's fixed tendons -- and a
   ``isaaclabMenageriePatchVersion`` marker on the
-  entry layer short-circuits repeated patching. Assets resolve from the public
-  production release via :obj:`~isaaclab_assets.robots.menagerie.MENAGERIE_ASSET_ROOT`
-  (no Nucleus authentication required; a local mirror is copied and the S3 release is
-  downloaded via an anonymous ``ListObjectsV2`` enumeration; override with the
-  ``MENAGERIE_ASSET_ROOT`` environment variable).
+  entry layer short-circuits repeated patching. The fix parameters live in a per-asset
+  recipe registry keyed by the asset directory, so every physics variant and robot
+  configuration referencing an asset shares one declaration. Assets resolve through the
+  Isaac asset root via :obj:`~isaaclab_assets.robots.menagerie.MENAGERIE_ASSET_ROOT`
+  (the conversions are currently staged on the ``isaac-dev`` Nucleus server pending
+  production publication; override with the ``MENAGERIE_ASSET_ROOT`` environment
+  variable to use a local mirror).
 * Added :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_CFG` and
   :obj:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_MENAGERIE_PHYSX_CFG` for the
   Mujoco Menagerie Shadow Hand conversion.
 * Added :obj:`~isaaclab_assets.robots.allegro.ALLEGRO_HAND_MENAGERIE_CFG` for the Mujoco
-  Menagerie Allegro Hand conversion. The patched asset authors the motor rotor inertia
-  the MJCF omits (``newton:armature``, ``mjc:armature``, and ``physxJoint:armature`` on
-  every revolute joint); without it the stock hand's lightweight links leave the
-  joint-space inertia near zero and contact dynamics are too noisy to train on
-  (reorient success 0.16 vs 1.0 at 1500 iterations).
+  Menagerie Allegro Hand conversion, derived from :obj:`~isaaclab_assets.robots.allegro.ALLEGRO_HAND_CFG`
+  so it expresses only the asset source, spawn-frame compensation, and joint naming.
+  Physical parameters the asset can express come from the patched asset itself: it
+  authors the motor rotor inertia the MJCF omits (``newton:armature`` and
+  ``physxJoint:armature`` on every revolute joint); without it the stock hand's
+  lightweight links leave the joint-space inertia near zero and contact dynamics are
+  too noisy to train on (reorient success 0.16 vs 1.0 at 1500 iterations).

--- a/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
+++ b/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
@@ -6,9 +6,12 @@ Added
   Menagerie conversion defects by writing them into a patched copy of the asset's USD
   layers on disk (cached under ``~/.cache/isaaclab/menagerie_patched/``) instead of
   authoring prims at spawn time. Each fix is detection-first and idempotent -- kept
-  drives alive in the ``mujoco`` variant, unauthored static friction, collision pairs
-  manufactured by welded-body splits, ``physx``-layer joint velocity limits, and the
-  Shadow hand's fixed tendons -- and a ``isaaclabMenageriePatchVersion`` marker on the
+  drives alive in the ``mujoco`` variant, removed the converter's ``MjcActuator`` prims
+  so the drives are the single actuation source (Newton otherwise builds a second,
+  never-commanded servo per joint that drags it toward zero), unauthored static
+  friction, collision pairs manufactured by welded-body splits, ``physx``-layer joint
+  velocity limits, and the Shadow hand's fixed tendons -- and a
+  ``isaaclabMenageriePatchVersion`` marker on the
   entry layer short-circuits repeated patching. Assets resolve from the public
   production release via :obj:`~isaaclab_assets.robots.menagerie.MENAGERIE_ASSET_ROOT`
   (no Nucleus authentication required; a local mirror is copied and the S3 release is

--- a/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
+++ b/source/isaaclab_assets/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
@@ -10,7 +10,10 @@ Added
   so the drives are the single actuation source (Newton otherwise builds a second,
   never-commanded servo per joint that drags it toward zero), unauthored static
   friction, collision pairs manufactured by welded-body splits, ``physx``-layer joint
-  velocity limits, and the Shadow hand's fixed tendons -- and a
+  velocity limits, the Shadow hand's fixed tendons, and drive gains and force limits
+  harvested from the ``MjcActuator`` servo parameters before those prims are removed
+  (the robot configurations deliberately override the harvested gains with their
+  RL-calibrated values) -- and a
   ``isaaclabMenageriePatchVersion`` marker on the
   entry layer short-circuits repeated patching. The fix parameters live in a per-asset
   recipe registry keyed by the asset directory, so every physics variant and robot

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -94,7 +94,9 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
             max_contact_impulse=1e32,
         ),
         articulation_props=sim_utils.ArticulationRootPropertiesCfg(
-            enabled_self_collisions=True,
+            # The conversion loses MJCF's parent-child contact exclusions, so adjacent-link
+            # colliders permanently wedge the finger medial joints when self-collisions are on.
+            enabled_self_collisions=False,
             solver_position_iteration_count=8,
             solver_velocity_iteration_count=0,
             sleep_threshold=0.005,

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -71,58 +71,21 @@ ALLEGRO_HAND_CFG = ArticulationCfg(
 """Configuration of Allegro Hand robot."""
 
 
-ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
+ALLEGRO_HAND_MENAGERIE_CFG = ALLEGRO_HAND_CFG.replace(
     spawn=MenageriePatchedUsdFileCfg(
         usd_path=f"{MENAGERIE_ASSET_ROOT}/wonik_allegro/right_hand/right_hand.usda",
         # The Menagerie exports default to the "physx" variant; Newton/MJWarp needs "mujoco".
         # For PhysX runs, replace with variants={"Physics": "physx"}.
         variants={"Physics": "mujoco"},
         activate_contact_sensors=False,
-        rigid_props=sim_utils.RigidBodyPropertiesCfg(
-            disable_gravity=True,
-            retain_accelerations=False,
-            enable_gyroscopic_forces=False,
-            angular_damping=0.01,
-            max_linear_velocity=1000.0,
-            max_angular_velocity=64 / math.pi * 180.0,
-            max_depenetration_velocity=1000.0,
-            max_contact_impulse=1e32,
-        ),
-        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
-            # The conversion splits the fingertip geoms into welded ``*_tip`` bodies,
-            # manufacturing tip<->medial collision pairs that cannot exist in MuJoCo
-            # (same-body geoms never collide). The pairs are filtered in the patched asset via
-            # :attr:`~isaaclab_assets.robots.menagerie.MenageriePatchedUsdFileCfg.filtered_body_pairs`,
-            # so self-collisions can be re-enabled after a training revalidation.
-            enabled_self_collisions=False,
-            solver_position_iteration_count=8,
-            solver_velocity_iteration_count=0,
-            sleep_threshold=0.005,
-            stabilization_threshold=0.0005,
-        ),
+        # Same solver-facing properties as the legacy hand. Self-collisions stay enabled:
+        # the impossible tip<->medial pairs manufactured by the conversion's weld split are
+        # filtered in the patched asset (see ``menagerie._ASSET_PATCH_RECIPES``).
+        rigid_props=ALLEGRO_HAND_CFG.spawn.rigid_props.replace(),
+        articulation_props=ALLEGRO_HAND_CFG.spawn.articulation_props.replace(),
         # The mujoco variant authors no UsdPhysics drives (actuation is declared as MjcActuator
         # prims); IsaacLab's implicit actuators require the drive APIs to exist.
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
-        # Conversion-defect fixes written into a patched copy of the asset on disk by the
-        # Menagerie patcher (see :class:`~isaaclab_assets.robots.menagerie.MenageriePatchedUsdFileCfg`):
-        # the unauthored static friction is copied from the asset's sliding coefficient
-        # (the converter authors only ``physics:dynamicFriction``, so static falls back to
-        # zero); the collision pairs manufactured by the fingertip weld split are filtered;
-        # and a 360 deg/s joint velocity limit (from the legacy asset) is authored into the
-        # ``physx`` layer, inert for this ``mujoco`` variant but completing the patched asset.
-        filtered_body_pairs=[
-            ("ff_tip", "ff_medial"),
-            ("mf_tip", "mf_medial"),
-            ("rf_tip", "rf_medial"),
-            ("th_tip", "th_medial"),
-        ],
-        joint_velocity_limit_deg_s=360.0,
-        # Motor rotor inertia, absent from the Menagerie MJCF. The stock v4 links are
-        # ~2.6x lighter than the legacy BioTac hand's, leaving the joint-space inertia
-        # near zero; the model is authored for MuJoCo's default 2 ms timestep and the
-        # unconditioned dynamics turn contact into noise at coarser steps (reorient
-        # success 0.16 -> 1.0 at 1500 iterations). Same value the Shadow Hand uses.
-        joint_armature=2e-3,
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         # Offset so the cube's measured rest point coincides with the task's in-hand target
@@ -135,24 +98,14 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
         rot=(0.063, 0.0592, -0.6823, 0.7259),
         joint_pos={"^(?!thj0).*": 0.0, "thj0": 0.28},
     ),
-    actuators={
-        "fingers": ImplicitActuatorCfg(
-            joint_names_expr=[".*"],
-            effort_limit_sim=0.5,
-            # The Menagerie layers author no joint velocity limits (the legacy asset bakes
-            # 360 deg/s); without a limit, PhysX joint velocities spike to hundreds of rad/s
-            # and produce NaN observations.
-            velocity_limit_sim=6.28,
-            stiffness=3.0,
-            damping=0.1,
-            friction=0.01,
-        ),
-    },
-    soft_joint_pos_limit_factor=1.0,
 )
 """Configuration of the Mujoco Menagerie Allegro Hand (right), MuJoCo physics variant.
 
-Unlike the legacy BioTac-equipped :obj:`ALLEGRO_HAND_CFG` asset, this is the stock
-Allegro Hand v4 with density-derived link masses (~0.81 kg total vs ~2.14 kg) and
-per-joint calibrated limits; training rewards are expected to differ accordingly.
+Derived from :obj:`ALLEGRO_HAND_CFG`: same solver properties and actuator gains; only the
+asset source (patched Menagerie conversion), the spawn-frame compensation, and the joint
+naming differ. Physical parameters the asset can express (armature, joint velocity limits,
+friction, collision filters) come from the patched asset itself rather than the config.
+Unlike the legacy BioTac-equipped hand, this is the stock Allegro Hand v4 with
+density-derived link masses (~0.81 kg total vs ~2.14 kg) and per-joint calibrated limits;
+training rewards are expected to differ accordingly.
 """

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -117,6 +117,12 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
             ("th_tip", "th_medial"),
         ],
         joint_velocity_limit_deg_s=360.0,
+        # Motor rotor inertia, absent from the Menagerie MJCF. The stock v4 links are
+        # ~2.6x lighter than the legacy BioTac hand's, leaving the joint-space inertia
+        # near zero; the model is authored for MuJoCo's default 2 ms timestep and the
+        # unconditioned dynamics turn contact into noise at coarser steps (reorient
+        # success 0.16 -> 1.0 at 1500 iterations). Same value the Shadow Hand uses.
+        joint_armature=2e-3,
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         # Offset so the cube's measured rest point coincides with the task's in-hand target
@@ -140,12 +146,6 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
             stiffness=3.0,
             damping=0.1,
             friction=0.01,
-            # Motor rotor inertia, absent from the Menagerie MJCF. The stock v4 links are
-            # ~2.6x lighter than the legacy BioTac hand's, so without armature the joint-
-            # space inertia is near zero and MJWarp contact dynamics are too noisy to
-            # learn from (reorient success 0.16 -> 1.0 at 1500 iterations with this value;
-            # same value the Shadow Hand configuration uses).
-            armature=2e-3,
         ),
     },
     soft_joint_pos_limit_factor=1.0,

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -17,18 +17,13 @@ Reference:
 """
 
 import math
-import os
 
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
-MENAGERIE_ASSET_ROOT = os.environ.get(
-    "MENAGERIE_ASSET_ROOT", "omniverse://isaac-dev.ov.nvidia.com/Isaac/Samples/Mujoco_Menagerie"
-)
-"""Root of the Mujoco Menagerie asset conversions. Override with the ``MENAGERIE_ASSET_ROOT``
-environment variable to point at a local mirror when the Nucleus server is unreachable."""
+from .menagerie import MENAGERIE_ASSET_ROOT, MenagerieUsdFileCfg
 
 ##
 # Configuration
@@ -77,7 +72,7 @@ ALLEGRO_HAND_CFG = ArticulationCfg(
 
 
 ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
-    spawn=sim_utils.UsdFileCfg(
+    spawn=MenagerieUsdFileCfg(
         usd_path=f"{MENAGERIE_ASSET_ROOT}/wonik_allegro/right_hand/right_hand.usda",
         # The Menagerie exports default to the "physx" variant; Newton/MJWarp needs "mujoco".
         # For PhysX runs, replace with variants={"Physics": "physx"}.
@@ -94,8 +89,11 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
             max_contact_impulse=1e32,
         ),
         articulation_props=sim_utils.ArticulationRootPropertiesCfg(
-            # The conversion loses MJCF's parent-child contact exclusions, so adjacent-link
-            # colliders permanently wedge the finger medial joints when self-collisions are on.
+            # The conversion splits the fingertip geoms into welded ``*_tip`` bodies,
+            # manufacturing tip<->medial collision pairs that cannot exist in MuJoCo
+            # (same-body geoms never collide). The pairs are filtered at spawn via
+            # :attr:`~isaaclab_assets.robots.menagerie.MenagerieUsdFileCfg.filtered_body_pairs`,
+            # so self-collisions can be re-enabled after a training revalidation.
             enabled_self_collisions=False,
             solver_position_iteration_count=8,
             solver_velocity_iteration_count=0,
@@ -105,10 +103,17 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
         # The mujoco variant authors no UsdPhysics drives (actuation is declared as MjcActuator
         # prims); IsaacLab's implicit actuators require the drive APIs to exist.
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
-        # The conversion's physics-material bindings resolve outside the reference scope and
-        # are silently dropped, leaving the hand on default friction; bind an explicit
-        # high-friction material like the legacy asset carries.
-        physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=1.0, dynamic_friction=1.0),
+        # Conversion-defect fixes applied at load time by the Menagerie adapter: the
+        # unauthored static friction is copied from the asset's sliding coefficient
+        # (the converter authors only ``physics:dynamicFriction``, so static falls
+        # back to zero), and the collision pairs manufactured by the fingertip weld
+        # split are filtered.
+        filtered_body_pairs=[
+            ("ff_tip", "ff_medial"),
+            ("mf_tip", "mf_medial"),
+            ("rf_tip", "rf_medial"),
+            ("th_tip", "th_medial"),
+        ],
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         # Offset so the cube's measured rest point coincides with the task's in-hand target

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -103,6 +103,10 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
         # The mujoco variant authors no UsdPhysics drives (actuation is declared as MjcActuator
         # prims); IsaacLab's implicit actuators require the drive APIs to exist.
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
+        # The conversion's physics-material bindings resolve outside the reference scope and
+        # are silently dropped, leaving the hand on default friction; bind an explicit
+        # high-friction material like the legacy asset carries.
+        physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=1.0, dynamic_friction=1.0),
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         # Offset so the palm center matches the legacy asset's spawned palm position

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -105,7 +105,9 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
     ),
     init_state=ArticulationCfg.InitialStateCfg(
-        pos=(0.0, 0.0, 0.5),
+        # Offset so the palm center matches the legacy asset's spawned palm position
+        # (the Menagerie root sits at the palm; the legacy root is ~8 cm behind it).
+        pos=(0.0, -0.082, 0.512),
         # Maps the Menagerie base frame (fingers +X, spread +Y) onto the legacy asset's
         # spawned palm-up catch pose (fingers -Y, spread +X, palm facing up), derived from
         # the measured legacy fingertip layout.

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -111,9 +111,10 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
         physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=1.0, dynamic_friction=1.0),
     ),
     init_state=ArticulationCfg.InitialStateCfg(
-        # Offset so the palm center matches the legacy asset's spawned palm position
-        # (the Menagerie root sits at the palm; the legacy root is ~8 cm behind it).
-        pos=(0.0, -0.082, 0.512),
+        # Offset so the cube's measured rest point coincides with the task's in-hand target
+        # (palm-to-palm alignment leaves the cube resting on the palm heel, 8.5 cm behind
+        # the fingers' grasp zone).
+        pos=(0.0, -0.167, 0.461),
         # Maps the Menagerie base frame (fingers +X, spread +Y) onto the legacy asset's
         # spawned palm-up catch pose (fingers -Y, spread +X, palm facing up), derived from
         # the measured legacy fingertip layout.

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -23,7 +23,7 @@ from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
-from .menagerie import MENAGERIE_ASSET_ROOT, MenagerieUsdFileCfg
+from .menagerie import MENAGERIE_ASSET_ROOT, MenageriePatchedUsdFileCfg
 
 ##
 # Configuration
@@ -72,7 +72,7 @@ ALLEGRO_HAND_CFG = ArticulationCfg(
 
 
 ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
-    spawn=MenagerieUsdFileCfg(
+    spawn=MenageriePatchedUsdFileCfg(
         usd_path=f"{MENAGERIE_ASSET_ROOT}/wonik_allegro/right_hand/right_hand.usda",
         # The Menagerie exports default to the "physx" variant; Newton/MJWarp needs "mujoco".
         # For PhysX runs, replace with variants={"Physics": "physx"}.
@@ -91,8 +91,8 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
         articulation_props=sim_utils.ArticulationRootPropertiesCfg(
             # The conversion splits the fingertip geoms into welded ``*_tip`` bodies,
             # manufacturing tip<->medial collision pairs that cannot exist in MuJoCo
-            # (same-body geoms never collide). The pairs are filtered at spawn via
-            # :attr:`~isaaclab_assets.robots.menagerie.MenagerieUsdFileCfg.filtered_body_pairs`,
+            # (same-body geoms never collide). The pairs are filtered in the patched asset via
+            # :attr:`~isaaclab_assets.robots.menagerie.MenageriePatchedUsdFileCfg.filtered_body_pairs`,
             # so self-collisions can be re-enabled after a training revalidation.
             enabled_self_collisions=False,
             solver_position_iteration_count=8,
@@ -103,17 +103,20 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
         # The mujoco variant authors no UsdPhysics drives (actuation is declared as MjcActuator
         # prims); IsaacLab's implicit actuators require the drive APIs to exist.
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
-        # Conversion-defect fixes applied at load time by the Menagerie adapter: the
-        # unauthored static friction is copied from the asset's sliding coefficient
-        # (the converter authors only ``physics:dynamicFriction``, so static falls
-        # back to zero), and the collision pairs manufactured by the fingertip weld
-        # split are filtered.
+        # Conversion-defect fixes written into a patched copy of the asset on disk by the
+        # Menagerie patcher (see :class:`~isaaclab_assets.robots.menagerie.MenageriePatchedUsdFileCfg`):
+        # the unauthored static friction is copied from the asset's sliding coefficient
+        # (the converter authors only ``physics:dynamicFriction``, so static falls back to
+        # zero); the collision pairs manufactured by the fingertip weld split are filtered;
+        # and a 360 deg/s joint velocity limit (from the legacy asset) is authored into the
+        # ``physx`` layer, inert for this ``mujoco`` variant but completing the patched asset.
         filtered_body_pairs=[
             ("ff_tip", "ff_medial"),
             ("mf_tip", "mf_medial"),
             ("rf_tip", "rf_medial"),
             ("th_tip", "th_medial"),
         ],
+        joint_velocity_limit_deg_s=360.0,
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         # Offset so the cube's measured rest point coincides with the task's in-hand target

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -8,6 +8,7 @@
 The following configurations are available:
 
 * :obj:`ALLEGRO_HAND_CFG`: Allegro Hand with implicit actuator model.
+* :obj:`ALLEGRO_HAND_MENAGERIE_CFG`: Mujoco Menagerie conversion, MuJoCo physics variant (Newton/MJWarp).
 
 Reference:
 
@@ -16,11 +17,18 @@ Reference:
 """
 
 import math
+import os
 
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+
+MENAGERIE_ASSET_ROOT = os.environ.get(
+    "MENAGERIE_ASSET_ROOT", "omniverse://isaac-dev.ov.nvidia.com/Isaac/Samples/Mujoco_Menagerie"
+)
+"""Root of the Mujoco Menagerie asset conversions. Override with the ``MENAGERIE_ASSET_ROOT``
+environment variable to point at a local mirror when the Nucleus server is unreachable."""
 
 ##
 # Configuration
@@ -66,3 +74,62 @@ ALLEGRO_HAND_CFG = ArticulationCfg(
     soft_joint_pos_limit_factor=1.0,
 )
 """Configuration of Allegro Hand robot."""
+
+
+ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
+    spawn=sim_utils.UsdFileCfg(
+        usd_path=f"{MENAGERIE_ASSET_ROOT}/wonik_allegro/right_hand/right_hand.usda",
+        # The Menagerie exports default to the "physx" variant; Newton/MJWarp needs "mujoco".
+        # For PhysX runs, replace with variants={"Physics": "physx"}.
+        variants={"Physics": "mujoco"},
+        activate_contact_sensors=False,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=True,
+            retain_accelerations=False,
+            enable_gyroscopic_forces=False,
+            angular_damping=0.01,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=64 / math.pi * 180.0,
+            max_depenetration_velocity=1000.0,
+            max_contact_impulse=1e32,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            enabled_self_collisions=True,
+            solver_position_iteration_count=8,
+            solver_velocity_iteration_count=0,
+            sleep_threshold=0.005,
+            stabilization_threshold=0.0005,
+        ),
+        # The mujoco variant authors no UsdPhysics drives (actuation is declared as MjcActuator
+        # prims); IsaacLab's implicit actuators require the drive APIs to exist.
+        joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
+    ),
+    init_state=ArticulationCfg.InitialStateCfg(
+        pos=(0.0, 0.0, 0.5),
+        # Maps the Menagerie base frame (fingers +X, spread +Y) onto the legacy asset's
+        # spawned palm-up catch pose (fingers -Y, spread +X, palm facing up), derived from
+        # the measured legacy fingertip layout.
+        rot=(0.063, 0.0592, -0.6823, 0.7259),
+        joint_pos={"^(?!thj0).*": 0.0, "thj0": 0.28},
+    ),
+    actuators={
+        "fingers": ImplicitActuatorCfg(
+            joint_names_expr=[".*"],
+            effort_limit_sim=0.5,
+            # The Menagerie layers author no joint velocity limits (the legacy asset bakes
+            # 360 deg/s); without a limit, PhysX joint velocities spike to hundreds of rad/s
+            # and produce NaN observations.
+            velocity_limit_sim=6.28,
+            stiffness=3.0,
+            damping=0.1,
+            friction=0.01,
+        ),
+    },
+    soft_joint_pos_limit_factor=1.0,
+)
+"""Configuration of the Mujoco Menagerie Allegro Hand (right), MuJoCo physics variant.
+
+Unlike the legacy BioTac-equipped :obj:`ALLEGRO_HAND_CFG` asset, this is the stock
+Allegro Hand v4 with density-derived link masses (~1.26 kg total vs ~2.14 kg) and
+per-joint calibrated limits; training rewards are expected to differ accordingly.
+"""

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -127,18 +127,7 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
         # spawned palm-up catch pose (fingers -Y, spread +X, palm facing up), derived from
         # the measured legacy fingertip layout.
         rot=(0.063, 0.0592, -0.6823, 0.7259),
-        # Light pre-curl so the fingers start in the cube's grasp zone: the stock v4
-        # fingers are shorter than the legacy BioTac-equipped ones, and from a flat pose
-        # they cannot passively cradle the task cube. Improves PhysX reorient success
-        # 0.43 -> 0.53 at 500 iterations with the stock task config.
-        joint_pos={
-            "(ff|mf|rf)j1": 0.30,
-            "(ff|mf|rf)j2": 0.30,
-            "(ff|mf|rf)j3": 0.20,
-            "thj0": 0.28,
-            "(ff|mf|rf)j0": 0.0,
-            "thj[1-3]": 0.0,
-        },
+        joint_pos={"^(?!thj0).*": 0.0, "thj0": 0.28},
     ),
     actuators={
         "fingers": ImplicitActuatorCfg(
@@ -151,6 +140,12 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
             stiffness=3.0,
             damping=0.1,
             friction=0.01,
+            # Motor rotor inertia, absent from the Menagerie MJCF. The stock v4 links are
+            # ~2.6x lighter than the legacy BioTac hand's, so without armature the joint-
+            # space inertia is near zero and MJWarp contact dynamics are too noisy to
+            # learn from (reorient success 0.16 -> 1.0 at 1500 iterations with this value;
+            # same value the Shadow Hand configuration uses).
+            armature=2e-3,
         ),
     },
     soft_joint_pos_limit_factor=1.0,

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -127,7 +127,18 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
         # spawned palm-up catch pose (fingers -Y, spread +X, palm facing up), derived from
         # the measured legacy fingertip layout.
         rot=(0.063, 0.0592, -0.6823, 0.7259),
-        joint_pos={"^(?!thj0).*": 0.0, "thj0": 0.28},
+        # Light pre-curl so the fingers start in the cube's grasp zone: the stock v4
+        # fingers are shorter than the legacy BioTac-equipped ones, and from a flat pose
+        # they cannot passively cradle the task cube. Improves PhysX reorient success
+        # 0.43 -> 0.53 at 500 iterations with the stock task config.
+        joint_pos={
+            "(ff|mf|rf)j1": 0.30,
+            "(ff|mf|rf)j2": 0.30,
+            "(ff|mf|rf)j3": 0.20,
+            "thj0": 0.28,
+            "(ff|mf|rf)j0": 0.0,
+            "thj[1-3]": 0.0,
+        },
     ),
     actuators={
         "fingers": ImplicitActuatorCfg(
@@ -147,6 +158,6 @@ ALLEGRO_HAND_MENAGERIE_CFG = ArticulationCfg(
 """Configuration of the Mujoco Menagerie Allegro Hand (right), MuJoCo physics variant.
 
 Unlike the legacy BioTac-equipped :obj:`ALLEGRO_HAND_CFG` asset, this is the stock
-Allegro Hand v4 with density-derived link masses (~1.26 kg total vs ~2.14 kg) and
+Allegro Hand v4 with density-derived link masses (~0.81 kg total vs ~2.14 kg) and
 per-joint calibrated limits; training rewards are expected to differ accordingly.
 """

--- a/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
@@ -61,7 +61,7 @@ _PATCH_CACHE_ROOT = os.path.join(os.path.expanduser("~"), ".cache", "isaaclab", 
 _PATCH_MARKER_KEY = "isaaclabMenageriePatchVersion"
 """``customLayerData`` key stamped on a fully patched entry layer."""
 
-_PATCH_VERSION = 5
+_PATCH_VERSION = 6
 """Bump when the set or content of the fixes below changes, to invalidate stale caches."""
 
 _ASSET_PATCH_RECIPES: dict[str, dict] = {
@@ -158,6 +158,109 @@ def _strip_drive_deletes(mujoco_layer: str) -> None:
         return
     layer.Save()
     _log_applied(f"{fix} ({count} joints)")
+
+
+def _author_drive_actuation(mujoco_layer: str, physics_layer: str) -> None:
+    """Author drive gains and force limits from the converter's ``MjcActuator`` params.
+
+    UPSTREAM(asset): the conversion carries the MJCF actuation spec only on the
+    ``MjcActuator`` prims (position-servo kp in ``mjc:biasPrm``/``mjc:gainPrm``, torque
+    limit in ``mjc:forceRange``) and the joint damping only as ``mjc:damping`` — none of
+    which the PhysX or Newton import paths consume. The shared-layer drives carry the
+    force limits but author no stiffness or damping, so consumers had to restate
+    per-joint gain tables in their configs. Harvest the servo gain onto the drives so
+    the asset is the single actuation source; runs before :func:`_remove_mjc_actuators`
+    discards the source prims. Delete once the converter authors drive gains directly.
+
+    Direct-actuator joints get their gains in the shared physics layer (both variants).
+    Tendon-driven couplings get the tendon actuator's gain authored per coupled joint in
+    the ``mujoco`` layer only: the Newton lane drives those joints directly (standing in
+    for the removed tendon actuator), while the ``physx`` variant couples them through
+    the authored PhysX tendons and must not see additional drives.
+
+    USD angular-drive gains are interpreted per-degree on import (UsdPhysics convention;
+    Newton divides by pi/180), while MJCF servo gains and joint damping are per-radian,
+    so authored values are scaled by pi/180.
+    """
+    import math
+
+    from pxr import Sdf, Usd, UsdPhysics
+
+    fix = "author drive gains from MjcActuator params"
+    per_deg = math.pi / 180.0
+
+    mstage = Usd.Stage.Open(mujoco_layer)
+    pstage = Usd.Stage.Open(physics_layer)
+
+    direct: dict = {}
+    coupled: dict = {}
+    for prim in mstage.TraverseAll():
+        if prim.GetTypeName() != "MjcActuator":
+            continue
+        targets = prim.GetRelationship("mjc:target").GetTargets()
+        if not targets:
+            continue
+        bias = prim.GetAttribute("mjc:biasPrm").Get()
+        gain = prim.GetAttribute("mjc:gainPrm").Get()
+        if bias is not None and len(bias) > 1 and float(bias[1]) != 0.0:
+            kp = -float(bias[1])
+        elif gain:
+            kp = float(gain[0])
+        else:
+            continue
+        force_attr = prim.GetAttribute("mjc:forceRange:max")
+        max_force = float(force_attr.Get()) if force_attr and force_attr.HasAuthoredValue() else None
+        target_prim = mstage.GetPrimAtPath(targets[0])
+        if target_prim and target_prim.GetTypeName() == "MjcTendon":
+            path_rel = target_prim.GetRelationship("mjc:path")
+            for joint_path in path_rel.GetTargets() if path_rel else []:
+                coupled[joint_path] = (kp, max_force)
+        else:
+            direct[targets[0]] = kp
+
+    def _joint_damping(path) -> float:
+        joint = mstage.GetPrimAtPath(path)
+        attr = joint.GetAttribute("mjc:damping") if joint else None
+        return float(attr.Get()) if attr and attr.HasAuthoredValue() else 0.0
+
+    if not direct and not coupled:
+        _log_skipped(fix)
+        return
+    authored_already = [
+        pstage.GetPrimAtPath(p).GetAttribute("drive:angular:physics:stiffness").HasAuthoredValue()
+        for p in direct
+        if pstage.GetPrimAtPath(p)
+    ]
+    if authored_already and all(authored_already):
+        _log_skipped(fix)
+        return
+
+    count = 0
+    for path, kp in direct.items():
+        joint = pstage.GetPrimAtPath(path)
+        if not joint:
+            continue
+        joint.CreateAttribute("drive:angular:physics:stiffness", Sdf.ValueTypeNames.Float).Set(kp * per_deg)
+        joint.CreateAttribute("drive:angular:physics:damping", Sdf.ValueTypeNames.Float).Set(
+            _joint_damping(path) * per_deg
+        )
+        count += 1
+    pstage.GetRootLayer().Save()
+
+    tendon_count = 0
+    for path, (kp, max_force) in coupled.items():
+        joint = mstage.GetPrimAtPath(path)
+        if not joint:
+            continue
+        drive = UsdPhysics.DriveAPI.Apply(joint, "angular")
+        drive.CreateTypeAttr().Set("force")
+        drive.CreateStiffnessAttr().Set(kp * per_deg)
+        drive.CreateDampingAttr().Set(_joint_damping(path) * per_deg)
+        if max_force is not None:
+            drive.CreateMaxForceAttr().Set(max_force)
+        tendon_count += 1
+    mstage.GetRootLayer().Save()
+    _log_applied(f"{fix} ({count} direct, {tendon_count} tendon-coupled joint(s))")
 
 
 def _remove_mjc_actuators(mujoco_layer: str) -> None:
@@ -426,6 +529,7 @@ def patch_menagerie_asset(
     physx_layer = os.path.join(physics_dir, "physx.usda")
 
     _strip_drive_deletes(mujoco_layer)
+    _author_drive_actuation(mujoco_layer, physics_layer)
     _remove_mjc_actuators(mujoco_layer)
     if author_static_friction:
         _author_static_friction(physics_layer)

--- a/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
@@ -3,22 +3,42 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Load-time adapter for Mujoco Menagerie asset conversions.
+"""File-based patcher for Mujoco Menagerie asset conversions.
 
 The Menagerie source models (https://github.com/google-deepmind/mujoco_menagerie) are
 correct and complete for MuJoCo. The USD conversions, however, drop guarantees that
 MuJoCo provides implicitly and that other engines need authored explicitly. This module
-is the single bridge for those conversion defects: every fix is applied to the composed
-prims at spawn time, before the physics engine parses them, and is tagged with the
-upstream asset/converter change that makes it deletable.
+is the single bridge for those conversion defects.
+
+Rather than editing prims on the composed stage at spawn time, every fix is written into
+a **patched copy** of the asset's USD layers on disk, so the change is inspectable and
+diff-able against the stock conversion. The workflow is:
+
+1. Resolve the asset directory (``payloads/`` + entry ``.usda``) from
+   :obj:`MENAGERIE_ASSET_ROOT` -- a local mirror is copied, the public S3 release is
+   downloaded via an anonymous ``ListObjectsV2`` enumeration.
+2. Materialize it once under ``~/.cache/isaaclab/menagerie_patched/<asset-relpath>/``.
+3. Run :func:`patch_menagerie_asset`, which applies one function per conversion defect.
+   Each fix is **detection-first** (it inspects the layer and skips when the fix is
+   already present) and tagged with the upstream asset/converter change that makes it
+   deletable. After all fixes land, the entry layer is stamped with a
+   ``isaaclabMenageriePatchVersion`` marker so subsequent spawns short-circuit.
+4. Spawn the stock :class:`~isaaclab.sim.spawners.from_files.from_files_cfg.UsdFileCfg`
+   path against the patched entry layer -- no stage authoring happens at spawn.
 
 Faithful source content (base frames, masses, joint limits, naming) is intentionally
-NOT touched here — task and robot configurations adapt to it instead.
+NOT touched here -- task and robot configurations adapt to it instead.
 """
 
 import os
-from collections.abc import Callable
+import shutil
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
+
+from filelock import FileLock
 
 import isaaclab.sim as sim_utils
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
@@ -35,8 +55,73 @@ Nucleus authentication is required. Override with the ``MENAGERIE_ASSET_ROOT``
 environment variable to point at a local mirror.
 """
 
+_PATCH_CACHE_ROOT = os.path.join(os.path.expanduser("~"), ".cache", "isaaclab", "menagerie_patched")
+"""Root of the on-disk cache of patched Menagerie assets."""
 
-def _author_static_friction(prim: "Usd.Prim") -> None:
+_PATCH_MARKER_KEY = "isaaclabMenageriePatchVersion"
+"""``customLayerData`` key stamped on a fully patched entry layer."""
+
+_PATCH_VERSION = 1
+"""Bump when the set or content of the fixes below changes, to invalidate stale caches."""
+
+
+"""
+Conversion-defect fixes.
+
+Each function operates on one USD layer file of a patched asset copy, is detection-first
+(skips when the fix is already present), and prints a ``[menagerie-patch]`` line so a
+patch run reads as a checklist of what changed.
+"""
+
+
+def _log_applied(fix: str) -> None:
+    print(f"[menagerie-patch] applied: {fix}")
+
+
+def _log_skipped(fix: str) -> None:
+    print(f"[menagerie-patch] skipped: {fix} (already present)")
+
+
+def _strip_drive_deletes(mujoco_layer: str) -> None:
+    """Keep the shared layer's UsdPhysics drives alive in the ``mujoco`` variant.
+
+    UPSTREAM(asset): the converter authors the actuation as ``MjcActuator`` prims and, in
+    the mujoco variant, deletes the per-joint drive APIs with
+    ``delete apiSchemas = ["PhysicsDriveAPI:angular", "PhysicsJointStateAPI:angular"]``.
+    IsaacLab's implicit actuators require those drive APIs to exist. Removing the delete
+    entries lets the drives composed from the shared physics layer survive. Delete once
+    the converter stops dropping them.
+    """
+    from pxr import Sdf
+
+    fix = "strip mujoco drive deletes"
+    layer = Sdf.Layer.FindOrOpen(mujoco_layer)
+    count = 0
+
+    def visit(prim_spec):
+        nonlocal count
+        if prim_spec.HasInfo("apiSchemas"):
+            list_op = prim_spec.GetInfo("apiSchemas")
+            if list_op.deletedItems:
+                new_op = Sdf.TokenListOp()
+                new_op.explicitItems = list_op.explicitItems
+                new_op.prependedItems = list_op.prependedItems
+                new_op.appendedItems = list_op.appendedItems
+                prim_spec.SetInfo("apiSchemas", new_op)
+                count += 1
+        for child in prim_spec.nameChildren:
+            visit(child)
+
+    for root in layer.rootPrims:
+        visit(root)
+    if count == 0:
+        _log_skipped(fix)
+        return
+    layer.Save()
+    _log_applied(f"{fix} ({count} joints)")
+
+
+def _author_static_friction(physics_layer: str) -> None:
     """Author ``physics:staticFriction`` on physics materials that lack it.
 
     UPSTREAM(asset): the converter authors only ``physics:dynamicFriction``; the static
@@ -44,22 +129,24 @@ def _author_static_friction(prim: "Usd.Prim") -> None:
     MuJoCo has a single sliding coefficient that plays both roles, so the faithful
     translation copies the dynamic value. Delete once the converter authors it.
     """
-    from pxr import Usd, UsdPhysics
+    from pxr import Sdf, Usd, UsdPhysics
 
-    for child in Usd.PrimRange(prim):
-        if not child.HasAPI(UsdPhysics.MaterialAPI):
-            continue
-        material = UsdPhysics.MaterialAPI(child)
-        static_attr = material.GetStaticFrictionAttr()
-        if static_attr and static_attr.HasAuthoredValue():
-            continue
-        dynamic_attr = material.GetDynamicFrictionAttr()
-        dynamic = dynamic_attr.Get() if dynamic_attr and dynamic_attr.HasAuthoredValue() else None
-        if dynamic is not None:
-            material.CreateStaticFrictionAttr(dynamic)
+    fix = "author static friction"
+    stage = Usd.Stage.Open(physics_layer)
+    materials = [prim for prim in stage.TraverseAll() if prim.HasAPI(UsdPhysics.MaterialAPI)]
+    missing = [m for m in materials if not m.GetAttribute("physics:staticFriction").HasAuthoredValue()]
+    if not missing:
+        _log_skipped(fix)
+        return
+    for material in missing:
+        dynamic_attr = material.GetAttribute("physics:dynamicFriction")
+        value = dynamic_attr.Get() if dynamic_attr and dynamic_attr.HasAuthoredValue() else 1.0
+        material.CreateAttribute("physics:staticFriction", Sdf.ValueTypeNames.Float).Set(value)
+    stage.GetRootLayer().Save()
+    _log_applied(f"{fix} ({len(missing)} material(s))")
 
 
-def _author_filtered_pairs(prim: "Usd.Prim", pairs: list[tuple[str, str]]) -> None:
+def _author_filtered_pairs(physics_layer: str, pairs: list[tuple[str, str]]) -> None:
     """Author collision filtered pairs between bodies named in ``pairs``.
 
     UPSTREAM(asset): the converter splits welded geoms (e.g. fingertips) out of their
@@ -69,45 +156,311 @@ def _author_filtered_pairs(prim: "Usd.Prim", pairs: list[tuple[str, str]]) -> No
     """
     from pxr import Usd, UsdPhysics
 
-    bodies = {child.GetName(): child for child in Usd.PrimRange(prim)}
+    fix = "author weld-split filtered pairs"
+    stage = Usd.Stage.Open(physics_layer)
+    by_name: dict[str, Usd.Prim] = {}
+    for prim in stage.TraverseAll():
+        by_name.setdefault(prim.GetName(), prim)
+
+    authored = 0
     for name_a, name_b in pairs:
-        body_a, body_b = bodies.get(name_a), bodies.get(name_b)
+        body_a, body_b = by_name.get(name_a), by_name.get(name_b)
         if body_a is None or body_b is None:
             continue
         api = UsdPhysics.FilteredPairsAPI.Apply(body_a)
-        api.GetFilteredPairsRel().AddTarget(body_b.GetPath())
+        rel = api.GetFilteredPairsRel()
+        if body_b.GetPath() in rel.GetTargets():
+            continue
+        rel.AddTarget(body_b.GetPath())
+        authored += 1
+    if authored == 0:
+        _log_skipped(fix)
+        return
+    stage.GetRootLayer().Save()
+    _log_applied(f"{fix} ({authored} pair(s))")
+
+
+def _author_joint_velocity_limit(physx_layer: str, limit_deg_s: float) -> None:
+    """Author ``physxJoint:maxJointVelocity`` [deg/s] on every revolute joint.
+
+    UPSTREAM(asset): the MJCF has no joint velocity limits (MuJoCo bounds motion
+    implicitly), so PhysX joint velocities spike and produce NaN states. This is an
+    engine requirement rather than source content, so it is authored into the
+    engine-specific ``physx`` layer only. Delete once the converter emits a limit.
+    """
+    from pxr import Sdf, Usd, UsdPhysics
+
+    fix = "author joint velocity limit"
+    stage = Usd.Stage.Open(physx_layer)
+    joints = [
+        prim
+        for prim in stage.TraverseAll()
+        if prim.GetTypeName() == "PhysicsRevoluteJoint" or prim.IsA(UsdPhysics.RevoluteJoint)
+    ]
+    missing = [j for j in joints if not j.GetAttribute("physxJoint:maxJointVelocity").HasAuthoredValue()]
+    if not missing:
+        _log_skipped(fix)
+        return
+    for joint in missing:
+        over = stage.OverridePrim(joint.GetPath())
+        over.CreateAttribute("physxJoint:maxJointVelocity", Sdf.ValueTypeNames.Float).Set(limit_deg_s)
+    stage.GetRootLayer().Save()
+    _log_applied(f"{fix} ({limit_deg_s} deg/s on {len(missing)} joints)")
+
+
+def _author_shadow_fixed_tendons(physx_layer: str) -> None:
+    """Author the PhysX fixed tendons that the Menagerie ``physx`` layer omits.
+
+    UPSTREAM(asset): the MuJoCo USD Converter does not translate MJCF tendon couplings
+    into PhysX tendon schemas, so the four distal finger joints are left uncoupled and
+    undriven. This replicates the legacy ``ShadowHand`` asset's distal-middle couplings:
+    per finger, tendon length ``-0.00805 * theta_middle + 0.00705 * theta_distal``
+    constrained to ``+/-0.001`` around rest length 0, so the distal joint tracks the
+    middle joint. Authored into the ``physx`` layer only. Delete once the converter
+    emits the tendons.
+    """
+    from pxr import Sdf, Usd
+
+    fix = "author shadow fixed tendons"
+    stage = Usd.Stage.Open(physx_layer)
+    by_name: dict[str, Usd.Prim] = {}
+    for prim in stage.TraverseAll():
+        name = prim.GetName()
+        if name.startswith("rh_"):
+            by_name.setdefault(name, prim)
+
+    probe = by_name.get("rh_FFJ2")
+    if probe is not None and probe.GetAttribute("physxTendon:rh_T_FFJ1c:gearing").HasAuthoredValue():
+        _log_skipped(fix)
+        return
+
+    for finger in ("FF", "MF", "RF", "LF"):
+        tendon = f"rh_T_{finger}J1c"
+        root_joint = stage.OverridePrim(by_name[f"rh_{finger}J2"].GetPath())
+        axis_joint = stage.OverridePrim(by_name[f"rh_{finger}J1"].GetPath())
+        root_joint.AddAppliedSchema(f"PhysxTendonAxisRootAPI:{tendon}")
+        for attr, type_name, value in (
+            # All gains zero: parity with the legacy asset's RUNTIME values (its configured
+            # FixedTendonPropertiesCfg never lands due to the instanceable-prim issue, so the
+            # baseline trains with zero-gain tendons). A stiff coupling (limitStiffness 30)
+            # drags coupled joints to their limits against the weak position drives.
+            ("limitStiffness", Sdf.ValueTypeNames.Float, 0.0),
+            ("damping", Sdf.ValueTypeNames.Float, 0.0),
+            ("stiffness", Sdf.ValueTypeNames.Float, 0.0),
+            ("restLength", Sdf.ValueTypeNames.Float, 0.0),
+            ("lowerLimit", Sdf.ValueTypeNames.Float, -0.001),
+            ("upperLimit", Sdf.ValueTypeNames.Float, 0.001),
+            ("gearing", Sdf.ValueTypeNames.FloatArray, [-0.00805]),
+        ):
+            root_joint.CreateAttribute(f"physxTendon:{tendon}:{attr}", type_name).Set(value)
+        axis_joint.AddAppliedSchema(f"PhysxTendonAxisAPI:{tendon}")
+        axis_joint.CreateAttribute(f"physxTendon:{tendon}:gearing", Sdf.ValueTypeNames.FloatArray).Set([0.00705])
+    stage.GetRootLayer().Save()
+    _log_applied(f"{fix} (4 fingers)")
+
+
+def patch_menagerie_asset(
+    asset_dir: str,
+    entry_name: str | None = None,
+    *,
+    author_static_friction: bool = True,
+    filtered_body_pairs: Iterable[tuple[str, str]] = (),
+    joint_velocity_limit_deg_s: float | None = None,
+    author_shadow_tendons: bool = False,
+) -> str:
+    """Apply the Menagerie conversion fixes in place to a copy of an asset directory.
+
+    The function is idempotent: it stamps a ``isaaclabMenageriePatchVersion`` marker on
+    the entry layer's ``customLayerData`` and short-circuits when the marker is current,
+    and every individual fix is detection-first, so re-running never double-authors.
+
+    Args:
+        asset_dir: Directory holding the entry ``.usda`` and its ``payloads/`` tree. It is
+            modified in place, so callers must pass a copy, not the source asset.
+        entry_name: File name of the entry layer within :paramref:`asset_dir`. When
+            ``None``, the single top-level ``.usda`` file is used.
+        author_static_friction: Copy the material's dynamic friction to the unauthored
+            static coefficient.
+        filtered_body_pairs: Body-name pairs to exclude from collision (pairs manufactured
+            by the conversion's weld splits).
+        joint_velocity_limit_deg_s: Max joint velocity [deg/s] to author on every revolute
+            joint in the ``physx`` layer. When ``None``, no limit is authored.
+        author_shadow_tendons: Author the four Shadow-hand distal-middle fixed tendons in
+            the ``physx`` layer.
+
+    Returns:
+        The path to the patched entry layer.
+    """
+    if entry_name is None:
+        entries = [f for f in os.listdir(asset_dir) if f.endswith((".usda", ".usd"))]
+        if len(entries) != 1:
+            raise ValueError(f"Expected exactly one top-level USD entry in '{asset_dir}', found {entries}.")
+        entry_name = entries[0]
+    entry_path = os.path.join(asset_dir, entry_name)
+
+    if _read_patch_marker(entry_path) == _PATCH_VERSION:
+        print(f"[menagerie-patch] up-to-date: {asset_dir} (patch v{_PATCH_VERSION})")
+        return entry_path
+
+    physics_dir = os.path.join(asset_dir, "payloads", "Physics")
+    mujoco_layer = os.path.join(physics_dir, "mujoco.usda")
+    physics_layer = os.path.join(physics_dir, "physics.usda")
+    physx_layer = os.path.join(physics_dir, "physx.usda")
+
+    _strip_drive_deletes(mujoco_layer)
+    if author_static_friction:
+        _author_static_friction(physics_layer)
+    if filtered_body_pairs:
+        _author_filtered_pairs(physics_layer, list(filtered_body_pairs))
+    if joint_velocity_limit_deg_s is not None:
+        _author_joint_velocity_limit(physx_layer, joint_velocity_limit_deg_s)
+    if author_shadow_tendons:
+        _author_shadow_fixed_tendons(physx_layer)
+
+    _write_patch_marker(entry_path)
+    return entry_path
+
+
+def _read_patch_marker(entry_path: str) -> int | None:
+    """Return the patch-version marker stamped on the entry layer, or ``None``."""
+    from pxr import Sdf
+
+    layer = Sdf.Layer.FindOrOpen(entry_path)
+    if layer is None:
+        return None
+    return layer.customLayerData.get(_PATCH_MARKER_KEY)
+
+
+def _write_patch_marker(entry_path: str) -> None:
+    """Stamp the current patch version on the entry layer's ``customLayerData``."""
+    from pxr import Sdf
+
+    layer = Sdf.Layer.FindOrOpen(entry_path)
+    data = dict(layer.customLayerData)
+    data[_PATCH_MARKER_KEY] = _PATCH_VERSION
+    layer.customLayerData = data
+    layer.Save()
+
+
+"""
+Source resolution and patched-asset cache.
+"""
+
+
+def _s3_list_keys(bucket_host: str, prefix: str) -> list[str]:
+    """Enumerate object keys under ``prefix`` via an anonymous S3 ``ListObjectsV2`` call."""
+    namespace = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
+    keys: list[str] = []
+    token: str | None = None
+    while True:
+        query = {"list-type": "2", "prefix": prefix}
+        if token is not None:
+            query["continuation-token"] = token
+        url = f"{bucket_host}/?{urllib.parse.urlencode(query)}"
+        with urllib.request.urlopen(url, timeout=60) as response:
+            root = ET.fromstring(response.read())
+        keys.extend(node.text for node in root.findall(".//s3:Contents/s3:Key", namespace) if node.text)
+        if root.findtext(".//s3:IsTruncated", default="false", namespaces=namespace) != "true":
+            break
+        token = root.findtext(".//s3:NextContinuationToken", namespaces=namespace)
+    return keys
+
+
+def _download_s3_asset(root_url: str, asset_reldir: str, dest_dir: str) -> None:
+    """Download every file of an S3-hosted asset folder into ``dest_dir``."""
+    parsed = urllib.parse.urlparse(root_url)
+    bucket_host = f"{parsed.scheme}://{parsed.netloc}"
+    prefix = f"{parsed.path.strip('/')}/{asset_reldir}/"
+    keys = _s3_list_keys(bucket_host, prefix)
+    if not keys:
+        raise FileNotFoundError(f"No objects found under S3 prefix '{prefix}'.")
+    for key in keys:
+        rel = key[len(prefix) :]
+        if not rel:
+            continue
+        dest = os.path.join(dest_dir, *rel.split("/"))
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        url = f"{bucket_host}/{urllib.parse.quote(key)}"
+        with urllib.request.urlopen(url, timeout=120) as response, open(dest, "wb") as handle:
+            shutil.copyfileobj(response, handle)
+
+
+def _materialize_source(root: str, asset_reldir: str, dest_dir: str) -> None:
+    """Copy or download the source asset folder into a fresh ``dest_dir``."""
+    if os.path.isdir(dest_dir):
+        shutil.rmtree(dest_dir)
+    if root.startswith(("http://", "https://")):
+        os.makedirs(dest_dir, exist_ok=True)
+        _download_s3_asset(root, asset_reldir, dest_dir)
+    else:
+        shutil.copytree(os.path.join(root, asset_reldir), dest_dir)
+
+
+def _ensure_patched_asset(cfg: "MenageriePatchedUsdFileCfg") -> str:
+    """Materialize (once) and patch the asset referenced by ``cfg``; return its entry path.
+
+    The cache short-circuits on the entry layer's patch marker, so a materialize/patch only
+    runs the first time an asset is spawned. A file lock serializes the work across ranks to
+    avoid concurrent download/copy races on the shared cache directory.
+    """
+    usd_path = cfg.usd_path
+    if not usd_path.startswith(MENAGERIE_ASSET_ROOT):
+        raise ValueError(f"Menagerie asset '{usd_path}' is not under MENAGERIE_ASSET_ROOT '{MENAGERIE_ASSET_ROOT}'.")
+    relpath = usd_path[len(MENAGERIE_ASSET_ROOT) :].lstrip("/")
+    asset_reldir, entry_name = os.path.split(relpath)
+    cache_dir = os.path.join(_PATCH_CACHE_ROOT, *asset_reldir.split("/"))
+    entry_path = os.path.join(cache_dir, entry_name)
+
+    os.makedirs(_PATCH_CACHE_ROOT, exist_ok=True)
+    with FileLock(cache_dir.rstrip("/") + ".lock"):
+        if not (os.path.exists(entry_path) and _read_patch_marker(entry_path) == _PATCH_VERSION):
+            _materialize_source(MENAGERIE_ASSET_ROOT, asset_reldir, cache_dir)
+            patch_menagerie_asset(
+                cache_dir,
+                entry_name,
+                author_static_friction=cfg.author_static_friction,
+                filtered_body_pairs=cfg.filtered_body_pairs,
+                joint_velocity_limit_deg_s=cfg.joint_velocity_limit_deg_s,
+                author_shadow_tendons=cfg.author_shadow_tendons,
+            )
+    return entry_path
 
 
 def spawn_menagerie_asset(
     prim_path: str,
-    cfg: "MenagerieUsdFileCfg",
+    cfg: "MenageriePatchedUsdFileCfg",
     translation: tuple[float, float, float] | None = None,
     orientation: tuple[float, float, float, float] | None = None,
     **kwargs,
 ) -> "Usd.Prim":
-    """Spawn a Menagerie asset conversion and apply the load-time conversion fixes."""
+    """Spawn a Menagerie asset from its patched copy on disk.
+
+    Ensures the patched copy exists (materialize + :func:`patch_menagerie_asset`), then
+    delegates to the stock USD-file spawn path against the patched entry layer. No stage
+    authoring happens here.
+    """
     # Deferred imports: this module is imported by the task-config registry before the
     # simulation app starts, when pxr and the spawner internals are not yet loadable.
     from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
     from isaaclab.sim.utils import clone
 
+    patched_usd_path = _ensure_patched_asset(cfg)
+
     @clone
     def _spawn(prim_path, cfg, translation=None, orientation=None, **inner_kwargs):
-        prim = _spawn_from_usd_file(prim_path, cfg.usd_path, cfg, translation, orientation)
-        if cfg.author_static_friction:
-            _author_static_friction(prim)
-        if cfg.filtered_body_pairs:
-            _author_filtered_pairs(prim, cfg.filtered_body_pairs)
-        for fixup in cfg.extra_fixups:
-            fixup(prim)
-        return prim
+        return _spawn_from_usd_file(prim_path, patched_usd_path, cfg, translation, orientation)
 
     return _spawn(prim_path, cfg, translation, orientation, **kwargs)
 
 
 @configclass
-class MenagerieUsdFileCfg(sim_utils.UsdFileCfg):
-    """Spawn configuration for Menagerie conversions with load-time conversion fixes."""
+class MenageriePatchedUsdFileCfg(sim_utils.UsdFileCfg):
+    """Spawn configuration that patches a Menagerie conversion on disk before loading it.
+
+    The patch parameters describe the full set of fixes for the asset directory (shared by
+    all physics variants of the same asset), so the cached copy is complete regardless of
+    which variant spawns first.
+    """
 
     func: Callable = spawn_menagerie_asset
 
@@ -117,5 +470,8 @@ class MenagerieUsdFileCfg(sim_utils.UsdFileCfg):
     filtered_body_pairs: list[tuple[str, str]] = []
     """Body-name pairs to exclude from collision (pairs manufactured by the conversion)."""
 
-    extra_fixups: list[Callable] = []
-    """Additional per-asset fixups called with the spawned prim (e.g. tendon authoring)."""
+    joint_velocity_limit_deg_s: float | None = None
+    """Max joint velocity [deg/s] to author on every revolute joint in the ``physx`` layer."""
+
+    author_shadow_tendons: bool = False
+    """Author the four Shadow-hand distal-middle fixed tendons in the ``physx`` layer."""

--- a/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
@@ -61,7 +61,7 @@ _PATCH_CACHE_ROOT = os.path.join(os.path.expanduser("~"), ".cache", "isaaclab", 
 _PATCH_MARKER_KEY = "isaaclabMenageriePatchVersion"
 """``customLayerData`` key stamped on a fully patched entry layer."""
 
-_PATCH_VERSION = 1
+_PATCH_VERSION = 2
 """Bump when the set or content of the fixes below changes, to invalidate stale caches."""
 
 
@@ -119,6 +119,34 @@ def _strip_drive_deletes(mujoco_layer: str) -> None:
         return
     layer.Save()
     _log_applied(f"{fix} ({count} joints)")
+
+
+def _remove_mjc_actuators(mujoco_layer: str) -> None:
+    """Remove the converter's ``MjcActuator`` prims so the drive APIs own actuation.
+
+    UPSTREAM(importer): with :meth:`_strip_drive_deletes` re-enabling the per-joint
+    UsdPhysics drives, the ``mujoco`` variant declares actuation TWICE — the native
+    ``MjcActuator`` prims (MJCF servo, kp=1) and the drives (task actuator config).
+    Newton's USD importer builds MuJoCo actuators from both, so every joint carries a
+    second servo whose control target IsaacLab never writes; it idles at ctrl=0 and
+    drags the joint toward zero with kp/(kp+kp_drive) of the command authority
+    (measured: 32 actuators for 16 joints, uniform 0.75 tracking = 3/(3+1)).
+    Removing the ``MjcActuator`` prims leaves exactly one actuation source per joint,
+    matching the legacy-asset contract. Delete once the importer deduplicates joints
+    that have both an ``MjcActuator`` and an authored drive.
+    """
+    from pxr import Usd
+
+    fix = "remove MjcActuator prims (double actuation)"
+    stage = Usd.Stage.Open(mujoco_layer)
+    actuators = [prim for prim in stage.TraverseAll() if prim.GetTypeName() == "MjcActuator"]
+    if not actuators:
+        _log_skipped(fix)
+        return
+    for prim in actuators:
+        stage.RemovePrim(prim.GetPath())
+    stage.GetRootLayer().Save()
+    _log_applied(f"{fix} ({len(actuators)} actuator(s))")
 
 
 def _author_static_friction(physics_layer: str) -> None:
@@ -308,6 +336,7 @@ def patch_menagerie_asset(
     physx_layer = os.path.join(physics_dir, "physx.usda")
 
     _strip_drive_deletes(mujoco_layer)
+    _remove_mjc_actuators(mujoco_layer)
     if author_static_friction:
         _author_static_friction(physics_layer)
     if filtered_body_pairs:

--- a/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
@@ -64,6 +64,45 @@ _PATCH_MARKER_KEY = "isaaclabMenageriePatchVersion"
 _PATCH_VERSION = 5
 """Bump when the set or content of the fixes below changes, to invalidate stale caches."""
 
+_ASSET_PATCH_RECIPES: dict[str, dict] = {
+    "wonik_allegro/right_hand": {
+        # The conversion splits the welded fingertip geoms into ``*_tip`` bodies,
+        # manufacturing tip<->medial collision pairs that cannot exist in MuJoCo
+        # (same-body geoms never collide).
+        "filtered_body_pairs": [
+            ("ff_tip", "ff_medial"),
+            ("mf_tip", "mf_medial"),
+            ("rf_tip", "rf_medial"),
+            ("th_tip", "th_medial"),
+        ],
+        # The Menagerie layers author no joint velocity limits (the legacy asset bakes
+        # 360 deg/s); without one, PhysX joint velocities spike and produce NaNs.
+        "joint_velocity_limit_deg_s": 360.0,
+        # Motor rotor inertia, absent from the Menagerie MJCF. The stock v4 links are
+        # ~2.6x lighter than the legacy BioTac hand's, leaving the joint-space inertia
+        # near zero; the model is authored for MuJoCo's default 2 ms timestep and the
+        # unconditioned dynamics turn contact into noise at coarser steps (reorient
+        # success 0.16 -> 1.0 at 1500 iterations). Same value the Shadow Hand uses.
+        "joint_armature": 2e-3,
+    },
+    "shadow_hand/right_hand": {
+        # Legacy asset's baked joint velocity limit; the Menagerie layers omit one and
+        # PhysX needs it for stability.
+        "joint_velocity_limit_deg_s": 5729.6,
+        # The MuJoCo USD Converter does not translate MJCF tendon couplings into PhysX
+        # tendon schemas, leaving the four distal finger joints uncoupled and undriven
+        # in the ``physx`` variant.
+        "author_shadow_tendons": True,
+    },
+}
+"""Per-asset conversion-defect fix parameters, keyed by asset directory under
+:obj:`MENAGERIE_ASSET_ROOT`.
+
+The recipe describes the full fix set for the asset directory (shared by all physics
+variants and all robot configurations referencing it), so the patched cache is complete
+regardless of which consumer spawns first. When the fixed assets ship upstream, delete
+the corresponding entry here."""
+
 
 """
 Conversion-defect fixes.
@@ -493,6 +532,8 @@ def _ensure_patched_asset(cfg: "MenageriePatchedUsdFileCfg") -> str:
     cache_dir = os.path.join(_PATCH_CACHE_ROOT, *asset_reldir.split("/"))
     entry_path = os.path.join(cache_dir, entry_name)
 
+    recipe = _ASSET_PATCH_RECIPES.get(asset_reldir, {})
+
     os.makedirs(_PATCH_CACHE_ROOT, exist_ok=True)
     with FileLock(cache_dir.rstrip("/") + ".lock"):
         if not (os.path.exists(entry_path) and _read_patch_marker(entry_path) == _PATCH_VERSION):
@@ -500,11 +541,10 @@ def _ensure_patched_asset(cfg: "MenageriePatchedUsdFileCfg") -> str:
             patch_menagerie_asset(
                 cache_dir,
                 entry_name,
-                author_static_friction=cfg.author_static_friction,
-                filtered_body_pairs=cfg.filtered_body_pairs,
-                joint_velocity_limit_deg_s=cfg.joint_velocity_limit_deg_s,
-                joint_armature=cfg.joint_armature,
-                author_shadow_tendons=cfg.author_shadow_tendons,
+                filtered_body_pairs=recipe.get("filtered_body_pairs", ()),
+                joint_velocity_limit_deg_s=recipe.get("joint_velocity_limit_deg_s"),
+                joint_armature=recipe.get("joint_armature"),
+                author_shadow_tendons=recipe.get("author_shadow_tendons", False),
             )
     return entry_path
 
@@ -540,24 +580,9 @@ def spawn_menagerie_asset(
 class MenageriePatchedUsdFileCfg(sim_utils.UsdFileCfg):
     """Spawn configuration that patches a Menagerie conversion on disk before loading it.
 
-    The patch parameters describe the full set of fixes for the asset directory (shared by
-    all physics variants of the same asset), so the cached copy is complete regardless of
-    which variant spawns first.
+    The fix parameters for each asset live in :obj:`_ASSET_PATCH_RECIPES`, keyed by the
+    asset's directory: they describe defects of the asset itself, shared by all physics
+    variants and all robot configurations referencing it.
     """
 
     func: Callable = spawn_menagerie_asset
-
-    author_static_friction: bool = True
-    """Copy the material's dynamic friction to the unauthored static coefficient."""
-
-    filtered_body_pairs: list[tuple[str, str]] = []
-    """Body-name pairs to exclude from collision (pairs manufactured by the conversion)."""
-
-    joint_velocity_limit_deg_s: float | None = None
-    """Max joint velocity [deg/s] to author on every revolute joint in the ``physx`` layer."""
-
-    joint_armature: float | None = None
-    """Motor rotor inertia to author on every revolute joint, in both physics variants."""
-
-    author_shadow_tendons: bool = False
-    """Author the four Shadow-hand distal-middle fixed tendons in the ``physx`` layer."""

--- a/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
@@ -61,7 +61,7 @@ _PATCH_CACHE_ROOT = os.path.join(os.path.expanduser("~"), ".cache", "isaaclab", 
 _PATCH_MARKER_KEY = "isaaclabMenageriePatchVersion"
 """``customLayerData`` key stamped on a fully patched entry layer."""
 
-_PATCH_VERSION = 2
+_PATCH_VERSION = 4
 """Bump when the set or content of the fixes below changes, to invalidate stale caches."""
 
 
@@ -236,6 +236,54 @@ def _author_joint_velocity_limit(physx_layer: str, limit_deg_s: float) -> None:
     _log_applied(f"{fix} ({limit_deg_s} deg/s on {len(missing)} joints)")
 
 
+def _author_joint_armature(mujoco_layer: str, physx_layer: str, armature: float) -> None:
+    """Author the motor rotor inertia on every revolute joint, in both physics variants.
+
+    UPSTREAM(model): the Menagerie MJCF authors no ``armature``, but the physical hand's
+    motors have rotor inertia, and the stock links are light enough that without it the
+    joint-space inertia is near zero. The model is authored for MuJoCo's default 2 ms
+    timestep; at the coarser steps engines commonly run, integration of the unconditioned
+    dynamics turns contact into noise (Allegro reorient success 0.16 vs 1.0 at 1500
+    iterations). Authored as ``mjc:armature`` in the ``mujoco`` layer (consumed by
+    Newton's importer) and ``physxJoint:armature`` in the ``physx`` layer. Delete once
+    the source model (or the robot spec upstream) authors it.
+    """
+    from pxr import Sdf, Usd, UsdPhysics
+
+    fix = f"author joint armature ({armature})"
+
+    def joints_of(layer_path):
+        stage = Usd.Stage.Open(layer_path)
+        return stage, [
+            prim
+            for prim in stage.TraverseAll()
+            if prim.GetTypeName() == "PhysicsRevoluteJoint" or prim.IsA(UsdPhysics.RevoluteJoint)
+        ]
+
+    authored = 0
+    # ``newton:armature`` is what Isaac Lab's Newton import path reads (its schema
+    # resolver list is [newton, physx]; the mjc resolver is not registered).
+    # ``mjc:armature`` keeps the mujoco variant faithful for native MuJoCo-USD
+    # consumers; ``physxJoint:armature`` covers the physx variant.
+    for layer_path, attr_name, sdf_type in (
+        (mujoco_layer, "newton:armature", Sdf.ValueTypeNames.Float),
+        (mujoco_layer, "mjc:armature", Sdf.ValueTypeNames.Double),
+        (physx_layer, "physxJoint:armature", Sdf.ValueTypeNames.Float),
+    ):
+        stage, joints = joints_of(layer_path)
+        missing = [j for j in joints if not j.GetAttribute(attr_name).HasAuthoredValue()]
+        for joint in missing:
+            over = stage.OverridePrim(joint.GetPath())
+            over.CreateAttribute(attr_name, sdf_type).Set(armature)
+        if missing:
+            stage.GetRootLayer().Save()
+            authored += len(missing)
+    if authored == 0:
+        _log_skipped(fix)
+        return
+    _log_applied(f"{fix} ({authored} joint attribute(s) across variants)")
+
+
 def _author_shadow_fixed_tendons(physx_layer: str) -> None:
     """Author the PhysX fixed tendons that the Menagerie ``physx`` layer omits.
 
@@ -294,6 +342,7 @@ def patch_menagerie_asset(
     author_static_friction: bool = True,
     filtered_body_pairs: Iterable[tuple[str, str]] = (),
     joint_velocity_limit_deg_s: float | None = None,
+    joint_armature: float | None = None,
     author_shadow_tendons: bool = False,
 ) -> str:
     """Apply the Menagerie conversion fixes in place to a copy of an asset directory.
@@ -313,6 +362,8 @@ def patch_menagerie_asset(
             by the conversion's weld splits).
         joint_velocity_limit_deg_s: Max joint velocity [deg/s] to author on every revolute
             joint in the ``physx`` layer. When ``None``, no limit is authored.
+        joint_armature: Motor rotor inertia to author on every revolute joint, in both
+            the ``mujoco`` and ``physx`` layers. When ``None``, none is authored.
         author_shadow_tendons: Author the four Shadow-hand distal-middle fixed tendons in
             the ``physx`` layer.
 
@@ -343,6 +394,8 @@ def patch_menagerie_asset(
         _author_filtered_pairs(physics_layer, list(filtered_body_pairs))
     if joint_velocity_limit_deg_s is not None:
         _author_joint_velocity_limit(physx_layer, joint_velocity_limit_deg_s)
+    if joint_armature is not None:
+        _author_joint_armature(mujoco_layer, physx_layer, joint_armature)
     if author_shadow_tendons:
         _author_shadow_fixed_tendons(physx_layer)
 
@@ -450,6 +503,7 @@ def _ensure_patched_asset(cfg: "MenageriePatchedUsdFileCfg") -> str:
                 author_static_friction=cfg.author_static_friction,
                 filtered_body_pairs=cfg.filtered_body_pairs,
                 joint_velocity_limit_deg_s=cfg.joint_velocity_limit_deg_s,
+                joint_armature=cfg.joint_armature,
                 author_shadow_tendons=cfg.author_shadow_tendons,
             )
     return entry_path
@@ -501,6 +555,9 @@ class MenageriePatchedUsdFileCfg(sim_utils.UsdFileCfg):
 
     joint_velocity_limit_deg_s: float | None = None
     """Max joint velocity [deg/s] to author on every revolute joint in the ``physx`` layer."""
+
+    joint_armature: float | None = None
+    """Motor rotor inertia to author on every revolute joint, in both physics variants."""
 
     author_shadow_tendons: bool = False
     """Author the four Shadow-hand distal-middle fixed tendons in the ``physx`` layer."""

--- a/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Load-time adapter for Mujoco Menagerie asset conversions.
+
+The Menagerie source models (https://github.com/google-deepmind/mujoco_menagerie) are
+correct and complete for MuJoCo. The USD conversions, however, drop guarantees that
+MuJoCo provides implicitly and that other engines need authored explicitly. This module
+is the single bridge for those conversion defects: every fix is applied to the composed
+prims at spawn time, before the physics engine parses them, and is tagged with the
+upstream asset/converter change that makes it deletable.
+
+Faithful source content (base frames, masses, joint limits, naming) is intentionally
+NOT touched here — task and robot configurations adapt to it instead.
+"""
+
+import os
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import isaaclab.sim as sim_utils
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils.configclass import configclass
+
+if TYPE_CHECKING:
+    from pxr import Usd
+
+MENAGERIE_ASSET_ROOT = os.environ.get("MENAGERIE_ASSET_ROOT", f"{ISAAC_NUCLEUS_DIR}/Samples/Mujoco_Menagerie")
+"""Root of the Mujoco Menagerie asset conversions.
+
+Resolves through the Isaac asset root to the public production release (S3), so no
+Nucleus authentication is required. Override with the ``MENAGERIE_ASSET_ROOT``
+environment variable to point at a local mirror.
+"""
+
+
+def _author_static_friction(prim: "Usd.Prim") -> None:
+    """Author ``physics:staticFriction`` on physics materials that lack it.
+
+    UPSTREAM(asset): the converter authors only ``physics:dynamicFriction``; the static
+    coefficient falls back to 0 and grasped objects slide out of a motionless hand.
+    MuJoCo has a single sliding coefficient that plays both roles, so the faithful
+    translation copies the dynamic value. Delete once the converter authors it.
+    """
+    from pxr import Usd, UsdPhysics
+
+    for child in Usd.PrimRange(prim):
+        if not child.HasAPI(UsdPhysics.MaterialAPI):
+            continue
+        material = UsdPhysics.MaterialAPI(child)
+        static_attr = material.GetStaticFrictionAttr()
+        if static_attr and static_attr.HasAuthoredValue():
+            continue
+        dynamic_attr = material.GetDynamicFrictionAttr()
+        dynamic = dynamic_attr.Get() if dynamic_attr and dynamic_attr.HasAuthoredValue() else None
+        if dynamic is not None:
+            material.CreateStaticFrictionAttr(dynamic)
+
+
+def _author_filtered_pairs(prim: "Usd.Prim", pairs: list[tuple[str, str]]) -> None:
+    """Author collision filtered pairs between bodies named in ``pairs``.
+
+    UPSTREAM(asset): the converter splits welded geoms (e.g. fingertips) out of their
+    source body, manufacturing collision pairs that cannot exist in MuJoCo, where
+    same-body geoms never collide. The durable fix is to not split (or to author these
+    filters in the conversion); delete once that lands.
+    """
+    from pxr import Usd, UsdPhysics
+
+    bodies = {child.GetName(): child for child in Usd.PrimRange(prim)}
+    for name_a, name_b in pairs:
+        body_a, body_b = bodies.get(name_a), bodies.get(name_b)
+        if body_a is None or body_b is None:
+            continue
+        api = UsdPhysics.FilteredPairsAPI.Apply(body_a)
+        api.GetFilteredPairsRel().AddTarget(body_b.GetPath())
+
+
+def spawn_menagerie_asset(
+    prim_path: str,
+    cfg: "MenagerieUsdFileCfg",
+    translation: tuple[float, float, float] | None = None,
+    orientation: tuple[float, float, float, float] | None = None,
+    **kwargs,
+) -> "Usd.Prim":
+    """Spawn a Menagerie asset conversion and apply the load-time conversion fixes."""
+    # Deferred imports: this module is imported by the task-config registry before the
+    # simulation app starts, when pxr and the spawner internals are not yet loadable.
+    from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
+    from isaaclab.sim.utils import clone
+
+    @clone
+    def _spawn(prim_path, cfg, translation=None, orientation=None, **inner_kwargs):
+        prim = _spawn_from_usd_file(prim_path, cfg.usd_path, cfg, translation, orientation)
+        if cfg.author_static_friction:
+            _author_static_friction(prim)
+        if cfg.filtered_body_pairs:
+            _author_filtered_pairs(prim, cfg.filtered_body_pairs)
+        for fixup in cfg.extra_fixups:
+            fixup(prim)
+        return prim
+
+    return _spawn(prim_path, cfg, translation, orientation, **kwargs)
+
+
+@configclass
+class MenagerieUsdFileCfg(sim_utils.UsdFileCfg):
+    """Spawn configuration for Menagerie conversions with load-time conversion fixes."""
+
+    func: Callable = spawn_menagerie_asset
+
+    author_static_friction: bool = True
+    """Copy the material's dynamic friction to the unauthored static coefficient."""
+
+    filtered_body_pairs: list[tuple[str, str]] = []
+    """Body-name pairs to exclude from collision (pairs manufactured by the conversion)."""
+
+    extra_fixups: list[Callable] = []
+    """Additional per-asset fixups called with the spawned prim (e.g. tendon authoring)."""

--- a/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/menagerie.py
@@ -61,7 +61,7 @@ _PATCH_CACHE_ROOT = os.path.join(os.path.expanduser("~"), ".cache", "isaaclab", 
 _PATCH_MARKER_KEY = "isaaclabMenageriePatchVersion"
 """``customLayerData`` key stamped on a fully patched entry layer."""
 
-_PATCH_VERSION = 4
+_PATCH_VERSION = 5
 """Bump when the set or content of the fixes below changes, to invalidate stale caches."""
 
 
@@ -262,12 +262,12 @@ def _author_joint_armature(mujoco_layer: str, physx_layer: str, armature: float)
 
     authored = 0
     # ``newton:armature`` is what Isaac Lab's Newton import path reads (its schema
-    # resolver list is [newton, physx]; the mjc resolver is not registered).
-    # ``mjc:armature`` keeps the mujoco variant faithful for native MuJoCo-USD
-    # consumers; ``physxJoint:armature`` covers the physx variant.
+    # resolver list is [newton, physx]; the mjc resolver is not registered, so
+    # ``mjc:armature`` would be ignored and is intentionally NOT authored — the
+    # source MJCF has no armature, and the patched file should not diverge further
+    # than required). ``physxJoint:armature`` covers the physx variant.
     for layer_path, attr_name, sdf_type in (
         (mujoco_layer, "newton:armature", Sdf.ValueTypeNames.Float),
-        (mujoco_layer, "mjc:armature", Sdf.ValueTypeNames.Double),
         (physx_layer, "physxJoint:armature", Sdf.ValueTypeNames.Float),
     ):
         stage, joints = joints_of(layer_path)

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -17,24 +17,17 @@ Reference:
 
 """
 
-import os
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
-from isaaclab.utils.configclass import configclass
+
+from .menagerie import MENAGERIE_ASSET_ROOT, MenagerieUsdFileCfg
 
 if TYPE_CHECKING:
     from pxr import Usd
-
-MENAGERIE_ASSET_ROOT = os.environ.get(
-    "MENAGERIE_ASSET_ROOT", "omniverse://isaac-dev.ov.nvidia.com/Isaac/Samples/Mujoco_Menagerie"
-)
-"""Root of the Mujoco Menagerie asset conversions. Override with the ``MENAGERIE_ASSET_ROOT``
-environment variable to point at a local mirror when the Nucleus server is unreachable."""
 
 ##
 # Configuration
@@ -101,7 +94,7 @@ SHADOW_HAND_CFG = ArticulationCfg(
 
 
 SHADOW_HAND_MENAGERIE_CFG = ArticulationCfg(
-    spawn=sim_utils.UsdFileCfg(
+    spawn=MenagerieUsdFileCfg(
         usd_path=f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda",
         # The Menagerie exports default to the "physx" variant; Newton/MJWarp needs the
         # "mujoco" variant, which composes the MjcTendon distal couplings.
@@ -201,43 +194,13 @@ def _author_shadow_hand_fixed_tendons(prim: "Usd.Prim") -> None:
         axis_joint.CreateAttribute(f"physxTendon:{tendon}:gearing", Sdf.ValueTypeNames.FloatArray).Set([0.00705])
 
 
-def spawn_shadow_hand_menagerie_physx(
-    prim_path: str,
-    cfg: "ShadowHandMenageriePhysxSpawnCfg",
-    translation: tuple[float, float, float] | None = None,
-    orientation: tuple[float, float, float, float] | None = None,
-    **kwargs,
-) -> "Usd.Prim":
-    """Spawn the Menagerie Shadow Hand and author the missing PhysX fixed tendons.
-
-    The MuJoCo USD Converter does not translate MJCF tendon couplings into PhysX tendon
-    schemas, so the ``physx`` variant leaves the four distal finger joints uncoupled and
-    undriven. This spawner authors them post-spawn until the converter gains support.
-    """
-    # Deferred imports: this module is imported by the task-config registry before the
-    # simulation app starts, when pxr and the spawner internals are not yet loadable.
-    from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
-    from isaaclab.sim.utils import clone
-
-    @clone
-    def _spawn(prim_path, cfg, translation=None, orientation=None, **inner_kwargs):
-        prim = _spawn_from_usd_file(prim_path, cfg.usd_path, cfg, translation, orientation)
-        _author_shadow_hand_fixed_tendons(prim)
-        return prim
-
-    return _spawn(prim_path, cfg, translation, orientation, **kwargs)
-
-
-@configclass
-class ShadowHandMenageriePhysxSpawnCfg(sim_utils.UsdFileCfg):
-    """Spawn configuration for the Menagerie Shadow Hand on PhysX with authored fixed tendons."""
-
-    func: Callable = spawn_shadow_hand_menagerie_physx
-
-
 SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
-    spawn=ShadowHandMenageriePhysxSpawnCfg(
+    spawn=MenagerieUsdFileCfg(
         usd_path=f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda",
+        # UPSTREAM(asset): the MuJoCo USD Converter does not translate MJCF tendon
+        # couplings into PhysX tendon schemas, so the ``physx`` variant leaves the four
+        # distal finger joints uncoupled and undriven. Authored at spawn until then.
+        extra_fixups=[_author_shadow_hand_fixed_tendons],
         variants={"Physics": "physx"},
         activate_contact_sensors=False,
         rigid_props=sim_utils.RigidBodyPropertiesCfg(
@@ -305,6 +268,7 @@ SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
 
 .. note::
     The Menagerie PhysX variant carries no fixed-tendon authoring (converter gap), so the
-    spawner authors the four distal-middle couplings from the legacy asset's template. See
-    :func:`spawn_shadow_hand_menagerie_physx`.
+    Menagerie adapter authors the four distal-middle couplings from the legacy asset's
+    template at spawn time. See :func:`_author_shadow_hand_fixed_tendons` and
+    :class:`~isaaclab_assets.robots.menagerie.MenagerieUsdFileCfg`.
 """

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -8,6 +8,8 @@
 The following configurations are available:
 
 * :obj:`SHADOW_HAND_CFG`: Shadow Hand with implicit actuator model.
+* :obj:`SHADOW_HAND_MENAGERIE_CFG`: Mujoco Menagerie conversion, MuJoCo physics variant (Newton/MJWarp).
+* :obj:`SHADOW_HAND_MENAGERIE_PHYSX_CFG`: Mujoco Menagerie conversion, PhysX physics variant.
 
 Reference:
 
@@ -15,10 +17,24 @@ Reference:
 
 """
 
+import os
+from collections.abc import Callable
+
+from pxr import Sdf, Usd
+
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
+from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
+from isaaclab.sim.utils import clone
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils.configclass import configclass
+
+MENAGERIE_ASSET_ROOT = os.environ.get(
+    "MENAGERIE_ASSET_ROOT", "omniverse://isaac-dev.ov.nvidia.com/Isaac/Samples/Mujoco_Menagerie"
+)
+"""Root of the Mujoco Menagerie asset conversions. Override with the ``MENAGERIE_ASSET_ROOT``
+environment variable to point at a local mirror when the Nucleus server is unreachable."""
 
 ##
 # Configuration
@@ -82,3 +98,203 @@ SHADOW_HAND_CFG = ArticulationCfg(
     soft_joint_pos_limit_factor=1.0,
 )
 """Configuration of Shadow Hand robot."""
+
+
+SHADOW_HAND_MENAGERIE_CFG = ArticulationCfg(
+    spawn=sim_utils.UsdFileCfg(
+        usd_path=f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda",
+        # The Menagerie exports default to the "physx" variant; Newton/MJWarp needs the
+        # "mujoco" variant, which composes the MjcTendon distal couplings.
+        variants={"Physics": "mujoco"},
+        activate_contact_sensors=False,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=True,
+            retain_accelerations=True,
+            max_depenetration_velocity=1000.0,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(enabled_self_collisions=True),
+        joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
+        fixed_tendons_props=sim_utils.FixedTendonPropertiesCfg(damping=0.1),
+    ),
+    init_state=ArticulationCfg.InitialStateCfg(
+        pos=(0.0, 0.0, 0.5),
+        # Same compensation as the ShadowHandNewton reference: Newton's import bakes the root
+        # body's USD orientation into the root fixed joint, so it must be re-applied at spawn.
+        rot=(0.0, 0.0, -0.70710678118, 0.70710678118),
+        joint_pos={".*": 0.0},
+    ),
+    actuators={
+        # Derived from the ShadowHandNewton reference actuator table via the naming map:
+        # fingers keep their index (robot0_FFJn -> rh_FFJn), thumb/wrist shift by +1
+        # (robot0_THJn -> rh_THJ{n+1}, robot0_WRJn -> rh_WRJ{n+1}).
+        "fingers": ImplicitActuatorCfg(
+            joint_names_expr=["rh_WR.*", "rh_(FF|MF|RF|LF)J(3|2|1)", "rh_LFJ4", "rh_THJ.*"],
+            effort_limit_sim={
+                "rh_WRJ2": 4.785,
+                "rh_WRJ1": 2.175,
+                "rh_(FF|MF|RF|LF)J1": 0.7245,
+                "rh_FFJ(3|2)": 0.9,
+                "rh_MFJ(3|2)": 0.9,
+                "rh_RFJ(3|2)": 0.9,
+                "rh_LFJ(4|3|2)": 0.9,
+                "rh_THJ5": 2.3722,
+                "rh_THJ4": 1.45,
+                "rh_THJ(3|2)": 0.99,
+                "rh_THJ1": 0.81,
+            },
+            stiffness={
+                "rh_WRJ.*": 5.0,
+                "rh_(FF|MF|RF|LF)J(3|2|1)": 1.0,
+                "rh_LFJ4": 1.0,
+                "rh_THJ.*": 1.0,
+            },
+            damping={
+                "rh_WRJ.*": 0.5,
+                "rh_(FF|MF|RF|LF)J(3|2|1)": 0.1,
+                "rh_LFJ4": 0.1,
+                "rh_THJ.*": 0.1,
+            },
+            friction=1e-2,
+            armature=2e-3,
+        ),
+    },
+    soft_joint_pos_limit_factor=1.0,
+)
+"""Configuration of the Mujoco Menagerie Shadow Hand (right), MuJoCo physics variant.
+
+Intended for the Newton/MJWarp backend. Physics content matches the
+``ShadowHandNewton`` reference asset exactly (joints, limits, masses, tendons);
+only the joint/body naming differs.
+"""
+
+
+def _author_shadow_hand_fixed_tendons(prim: Usd.Prim) -> None:
+    """Author the PhysX fixed tendons that the Menagerie ``physx`` layer omits.
+
+    Replicates the legacy ``ShadowHand`` asset's distal-middle finger couplings: per finger,
+    tendon length ``-0.00805 * theta_middle + 0.00705 * theta_distal`` constrained to
+    ``+/-0.001`` around rest length 0, so the distal joint tracks the middle joint.
+    """
+    joints = {p.GetName(): p for p in Usd.PrimRange(prim) if p.GetName().startswith("rh_")}
+    for finger in ("FF", "MF", "RF", "LF"):
+        tendon = f"rh_T_{finger}J1c"
+        root_joint = joints[f"rh_{finger}J2"]
+        axis_joint = joints[f"rh_{finger}J1"]
+        root_joint.AddAppliedSchema(f"PhysxTendonAxisRootAPI:{tendon}")
+        for attr, type_name, value in (
+            # limitStiffness/damping match the legacy asset's runtime values (applied there
+            # via FixedTendonPropertiesCfg); authored directly here since the spawn-time
+            # property pass runs before these tendons exist.
+            ("limitStiffness", Sdf.ValueTypeNames.Float, 30.0),
+            ("damping", Sdf.ValueTypeNames.Float, 0.1),
+            ("stiffness", Sdf.ValueTypeNames.Float, 0.0),
+            ("restLength", Sdf.ValueTypeNames.Float, 0.0),
+            ("lowerLimit", Sdf.ValueTypeNames.Float, -0.001),
+            ("upperLimit", Sdf.ValueTypeNames.Float, 0.001),
+            ("gearing", Sdf.ValueTypeNames.FloatArray, [-0.00805]),
+        ):
+            root_joint.CreateAttribute(f"physxTendon:{tendon}:{attr}", type_name).Set(value)
+        axis_joint.AddAppliedSchema(f"PhysxTendonAxisAPI:{tendon}")
+        axis_joint.CreateAttribute(f"physxTendon:{tendon}:gearing", Sdf.ValueTypeNames.FloatArray).Set([0.00705])
+
+
+@clone
+def spawn_shadow_hand_menagerie_physx(
+    prim_path: str,
+    cfg: "ShadowHandMenageriePhysxSpawnCfg",
+    translation: tuple[float, float, float] | None = None,
+    orientation: tuple[float, float, float, float] | None = None,
+    **kwargs,
+) -> Usd.Prim:
+    """Spawn the Menagerie Shadow Hand and author the missing PhysX fixed tendons.
+
+    The MuJoCo USD Converter does not translate MJCF tendon couplings into PhysX tendon
+    schemas, so the ``physx`` variant leaves the four distal finger joints uncoupled and
+    undriven. This spawner authors them post-spawn until the converter gains support.
+    """
+    prim = _spawn_from_usd_file(prim_path, cfg.usd_path, cfg, translation, orientation)
+    _author_shadow_hand_fixed_tendons(prim)
+    # Re-apply the tendon properties: the pass inside the USD spawn ran before the tendons
+    # existed, and the coupling only transmits through the configured limit stiffness.
+    if cfg.fixed_tendons_props is not None:
+        sim_utils.schemas.modify_fixed_tendon_properties(prim.GetPath().pathString, cfg.fixed_tendons_props)
+    return prim
+
+
+@configclass
+class ShadowHandMenageriePhysxSpawnCfg(sim_utils.UsdFileCfg):
+    """Spawn configuration for the Menagerie Shadow Hand on PhysX with authored fixed tendons."""
+
+    func: Callable = spawn_shadow_hand_menagerie_physx
+
+
+SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
+    spawn=ShadowHandMenageriePhysxSpawnCfg(
+        usd_path=f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda",
+        variants={"Physics": "physx"},
+        activate_contact_sensors=False,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=True,
+            retain_accelerations=True,
+            max_depenetration_velocity=1000.0,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            enabled_self_collisions=True,
+            solver_position_iteration_count=8,
+            solver_velocity_iteration_count=0,
+            sleep_threshold=0.005,
+            stabilization_threshold=0.0005,
+        ),
+        joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force"),
+        # Tunes the tendons authored by the spawner, matching the legacy asset's runtime values.
+        fixed_tendons_props=sim_utils.FixedTendonPropertiesCfg(limit_stiffness=30.0, damping=0.1),
+    ),
+    init_state=ArticulationCfg.InitialStateCfg(
+        pos=(0.0, 0.0, 0.5),
+        rot=(0.0, 0.0, 0.0, 1.0),
+        joint_pos={".*": 0.0},
+    ),
+    actuators={
+        # Derived from SHADOW_HAND_CFG (legacy 0-indexed naming) via the naming map:
+        # all joints shift by +1 (robot0_FFJn -> rh_FFJ{n+1}, ..., robot0_WRJn -> rh_WRJ{n+1}).
+        "fingers": ImplicitActuatorCfg(
+            joint_names_expr=["rh_WR.*", "rh_(FF|MF|RF|LF)J(4|3|2)", "rh_LFJ5", "rh_THJ.*"],
+            # The legacy asset bakes a 5729.58 deg/s joint velocity limit; the Menagerie
+            # layers author none, which destabilizes PhysX.
+            velocity_limit_sim=100.0,
+            effort_limit_sim={
+                "rh_WRJ2": 4.785,
+                "rh_WRJ1": 2.175,
+                "rh_(FF|MF|RF|LF)J2": 0.7245,
+                "rh_FFJ(4|3)": 0.9,
+                "rh_MFJ(4|3)": 0.9,
+                "rh_RFJ(4|3)": 0.9,
+                "rh_LFJ(5|4|3)": 0.9,
+                "rh_THJ5": 2.3722,
+                "rh_THJ4": 1.45,
+                "rh_THJ(3|2)": 0.99,
+                "rh_THJ1": 0.81,
+            },
+            stiffness={
+                "rh_WRJ.*": 5.0,
+                "rh_(FF|MF|RF|LF)J(4|3|2)": 1.0,
+                "rh_LFJ5": 1.0,
+                "rh_THJ.*": 1.0,
+            },
+            damping={
+                "rh_WRJ.*": 0.5,
+                "rh_(FF|MF|RF|LF)J(4|3|2)": 0.1,
+                "rh_LFJ5": 0.1,
+                "rh_THJ.*": 0.1,
+            },
+        ),
+    },
+    soft_joint_pos_limit_factor=1.0,
+)
+"""Configuration of the Mujoco Menagerie Shadow Hand (right), PhysX physics variant.
+
+.. note::
+    The Menagerie PhysX variant carries no fixed-tendon authoring (converter gap), so the
+    spawner authors the four distal-middle couplings from the legacy asset's template. See
+    :func:`spawn_shadow_hand_menagerie_physx`.
+"""

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -88,20 +88,24 @@ SHADOW_HAND_CFG = ArticulationCfg(
 """Configuration of Shadow Hand robot."""
 
 
-SHADOW_HAND_MENAGERIE_CFG = ArticulationCfg(
+_SHADOW_MENAGERIE_USD_PATH = f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda"
+"""Entry layer of the Mujoco Menagerie Shadow Hand conversion (both physics variants)."""
+
+
+SHADOW_HAND_MENAGERIE_CFG = SHADOW_HAND_CFG.replace(
     spawn=MenageriePatchedUsdFileCfg(
-        usd_path=f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda",
+        usd_path=_SHADOW_MENAGERIE_USD_PATH,
         # The Menagerie exports default to the "physx" variant; Newton/MJWarp needs the
         # "mujoco" variant, which composes the MjcTendon distal couplings.
         variants={"Physics": "mujoco"},
         activate_contact_sensors=False,
-        rigid_props=sim_utils.RigidBodyPropertiesCfg(
-            disable_gravity=True,
-            retain_accelerations=True,
-            max_depenetration_velocity=1000.0,
-        ),
-        articulation_props=sim_utils.ArticulationRootPropertiesCfg(enabled_self_collisions=True),
+        # Same solver-facing properties as the legacy hand.
+        rigid_props=SHADOW_HAND_CFG.spawn.rigid_props.replace(),
+        articulation_props=SHADOW_HAND_CFG.spawn.articulation_props.replace(),
+        # The mujoco variant authors no UsdPhysics drives (actuation is declared as
+        # MjcActuator prims); IsaacLab's implicit actuators require the drive APIs to exist.
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
+        # MjcTendon couplings take damping only (no PhysX limit-stiffness semantics).
         fixed_tendons_props=sim_utils.FixedTendonPropertiesCfg(damping=0.1),
     ),
     init_state=ArticulationCfg.InitialStateCfg(
@@ -146,7 +150,6 @@ SHADOW_HAND_MENAGERIE_CFG = ArticulationCfg(
             armature=2e-3,
         ),
     },
-    soft_joint_pos_limit_factor=1.0,
 )
 """Configuration of the Mujoco Menagerie Shadow Hand (right), MuJoCo physics variant.
 
@@ -156,29 +159,19 @@ only the joint/body naming differs.
 """
 
 
-SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
+SHADOW_HAND_MENAGERIE_PHYSX_CFG = SHADOW_HAND_CFG.replace(
     spawn=MenageriePatchedUsdFileCfg(
-        usd_path=f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda",
+        usd_path=_SHADOW_MENAGERIE_USD_PATH,
         # The patched asset authors the distal-finger tendon couplings and the legacy
         # 5729.6 deg/s joint velocity limit into the ``physx`` layer (the converter
         # translates neither); see ``menagerie._ASSET_PATCH_RECIPES``.
         variants={"Physics": "physx"},
         activate_contact_sensors=False,
-        rigid_props=sim_utils.RigidBodyPropertiesCfg(
-            disable_gravity=True,
-            retain_accelerations=True,
-            max_depenetration_velocity=1000.0,
-        ),
-        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
-            enabled_self_collisions=True,
-            solver_position_iteration_count=8,
-            solver_velocity_iteration_count=0,
-            sleep_threshold=0.005,
-            stabilization_threshold=0.0005,
-        ),
+        # Same solver-facing properties and tendon tuning as the legacy hand.
+        rigid_props=SHADOW_HAND_CFG.spawn.rigid_props.replace(),
+        articulation_props=SHADOW_HAND_CFG.spawn.articulation_props.replace(),
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force"),
-        # Tunes the tendons authored by the spawner, matching the legacy asset's runtime values.
-        fixed_tendons_props=sim_utils.FixedTendonPropertiesCfg(limit_stiffness=30.0, damping=0.1),
+        fixed_tendons_props=SHADOW_HAND_CFG.spawn.fixed_tendons_props.replace(),
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         pos=(0.0, 0.0, 0.5),
@@ -220,7 +213,6 @@ SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
             },
         ),
     },
-    soft_joint_pos_limit_factor=1.0,
 )
 """Configuration of the Mujoco Menagerie Shadow Hand (right), PhysX physics variant.
 

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -184,11 +184,12 @@ def _author_shadow_hand_fixed_tendons(prim: "Usd.Prim") -> None:
         axis_joint = joints[f"rh_{finger}J1"]
         root_joint.AddAppliedSchema(f"PhysxTendonAxisRootAPI:{tendon}")
         for attr, type_name, value in (
-            # limitStiffness/damping match the legacy asset's runtime values (applied there
-            # via FixedTendonPropertiesCfg); authored directly here since the spawn-time
-            # property pass runs before these tendons exist.
-            ("limitStiffness", Sdf.ValueTypeNames.Float, 30.0),
-            ("damping", Sdf.ValueTypeNames.Float, 0.1),
+            # All gains zero: parity with the legacy asset's RUNTIME values (its configured
+            # FixedTendonPropertiesCfg never lands due to the instanceable-prim issue, so the
+            # baseline trains with zero-gain tendons). A stiff coupling (limitStiffness 30)
+            # drags coupled joints to their limits against the weak position drives.
+            ("limitStiffness", Sdf.ValueTypeNames.Float, 0.0),
+            ("damping", Sdf.ValueTypeNames.Float, 0.0),
             ("stiffness", Sdf.ValueTypeNames.Float, 0.0),
             ("restLength", Sdf.ValueTypeNames.Float, 0.0),
             ("lowerLimit", Sdf.ValueTypeNames.Float, -0.001),
@@ -257,7 +258,10 @@ SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         pos=(0.0, 0.0, 0.5),
-        rot=(0.0, 0.0, 0.0, 1.0),
+        # Maps the Menagerie native frame onto the legacy asset's spawned pose under the
+        # task's PhysX preset (fingers -Y beneath the falling cube), derived from the
+        # measured legacy fingertip layout.
+        rot=(-0.0061, -0.0054, -0.6743, 0.7384),
         joint_pos={".*": 0.0},
     ),
     actuators={

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -103,12 +103,6 @@ SHADOW_HAND_MENAGERIE_CFG = ArticulationCfg(
         articulation_props=sim_utils.ArticulationRootPropertiesCfg(enabled_self_collisions=True),
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
         fixed_tendons_props=sim_utils.FixedTendonPropertiesCfg(damping=0.1),
-        # The mujoco variant needs only the static-friction fix at runtime, but it shares a
-        # patched cache directory with the physx variant below. The patch parameters describe
-        # the full asset fix set so the cache is complete regardless of which variant spawns
-        # first; the physx-layer fixes (velocity limit, tendons) are inert for this variant.
-        joint_velocity_limit_deg_s=5729.6,
-        author_shadow_tendons=True,
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         pos=(0.0, 0.0, 0.5),
@@ -165,13 +159,9 @@ only the joint/body naming differs.
 SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
     spawn=MenageriePatchedUsdFileCfg(
         usd_path=f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda",
-        # UPSTREAM(asset): the MuJoCo USD Converter does not translate MJCF tendon couplings
-        # into PhysX tendon schemas, so the ``physx`` variant leaves the four distal finger
-        # joints uncoupled and undriven; the patcher authors them into the ``physx`` layer.
-        # It also authors the legacy asset's 5729.6 deg/s joint velocity limit, which the
-        # Menagerie layers omit and PhysX needs for stability.
-        author_shadow_tendons=True,
-        joint_velocity_limit_deg_s=5729.6,
+        # The patched asset authors the distal-finger tendon couplings and the legacy
+        # 5729.6 deg/s joint velocity limit into the ``physx`` layer (the converter
+        # translates neither); see ``menagerie._ASSET_PATCH_RECIPES``.
         variants={"Physics": "physx"},
         activate_contact_sensors=False,
         rigid_props=sim_utils.RigidBodyPropertiesCfg(
@@ -203,9 +193,6 @@ SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
         # all joints shift by +1 (robot0_FFJn -> rh_FFJ{n+1}, ..., robot0_WRJn -> rh_WRJ{n+1}).
         "fingers": ImplicitActuatorCfg(
             joint_names_expr=["rh_WR.*", "rh_(FF|MF|RF|LF)J(4|3|2)", "rh_LFJ5", "rh_THJ.*"],
-            # The legacy asset bakes a 5729.58 deg/s joint velocity limit; the Menagerie
-            # layers author none, which destabilizes PhysX.
-            velocity_limit_sim=100.0,
             effort_limit_sim={
                 "rh_WRJ2": 4.785,
                 "rh_WRJ1": 2.175,

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -17,17 +17,12 @@ Reference:
 
 """
 
-from typing import TYPE_CHECKING
-
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
-from .menagerie import MENAGERIE_ASSET_ROOT, MenagerieUsdFileCfg
-
-if TYPE_CHECKING:
-    from pxr import Usd
+from .menagerie import MENAGERIE_ASSET_ROOT, MenageriePatchedUsdFileCfg
 
 ##
 # Configuration
@@ -94,7 +89,7 @@ SHADOW_HAND_CFG = ArticulationCfg(
 
 
 SHADOW_HAND_MENAGERIE_CFG = ArticulationCfg(
-    spawn=MenagerieUsdFileCfg(
+    spawn=MenageriePatchedUsdFileCfg(
         usd_path=f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda",
         # The Menagerie exports default to the "physx" variant; Newton/MJWarp needs the
         # "mujoco" variant, which composes the MjcTendon distal couplings.
@@ -108,6 +103,12 @@ SHADOW_HAND_MENAGERIE_CFG = ArticulationCfg(
         articulation_props=sim_utils.ArticulationRootPropertiesCfg(enabled_self_collisions=True),
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
         fixed_tendons_props=sim_utils.FixedTendonPropertiesCfg(damping=0.1),
+        # The mujoco variant needs only the static-friction fix at runtime, but it shares a
+        # patched cache directory with the physx variant below. The patch parameters describe
+        # the full asset fix set so the cache is complete regardless of which variant spawns
+        # first; the physx-layer fixes (velocity limit, tendons) are inert for this variant.
+        joint_velocity_limit_deg_s=5729.6,
+        author_shadow_tendons=True,
     ),
     init_state=ArticulationCfg.InitialStateCfg(
         pos=(0.0, 0.0, 0.5),
@@ -161,46 +162,16 @@ only the joint/body naming differs.
 """
 
 
-def _author_shadow_hand_fixed_tendons(prim: "Usd.Prim") -> None:
-    """Author the PhysX fixed tendons that the Menagerie ``physx`` layer omits.
-
-    Replicates the legacy ``ShadowHand`` asset's distal-middle finger couplings: per finger,
-    tendon length ``-0.00805 * theta_middle + 0.00705 * theta_distal`` constrained to
-    ``+/-0.001`` around rest length 0, so the distal joint tracks the middle joint.
-    """
-    from pxr import Sdf, Usd
-
-    joints = {p.GetName(): p for p in Usd.PrimRange(prim) if p.GetName().startswith("rh_")}
-    for finger in ("FF", "MF", "RF", "LF"):
-        tendon = f"rh_T_{finger}J1c"
-        root_joint = joints[f"rh_{finger}J2"]
-        axis_joint = joints[f"rh_{finger}J1"]
-        root_joint.AddAppliedSchema(f"PhysxTendonAxisRootAPI:{tendon}")
-        for attr, type_name, value in (
-            # All gains zero: parity with the legacy asset's RUNTIME values (its configured
-            # FixedTendonPropertiesCfg never lands due to the instanceable-prim issue, so the
-            # baseline trains with zero-gain tendons). A stiff coupling (limitStiffness 30)
-            # drags coupled joints to their limits against the weak position drives.
-            ("limitStiffness", Sdf.ValueTypeNames.Float, 0.0),
-            ("damping", Sdf.ValueTypeNames.Float, 0.0),
-            ("stiffness", Sdf.ValueTypeNames.Float, 0.0),
-            ("restLength", Sdf.ValueTypeNames.Float, 0.0),
-            ("lowerLimit", Sdf.ValueTypeNames.Float, -0.001),
-            ("upperLimit", Sdf.ValueTypeNames.Float, 0.001),
-            ("gearing", Sdf.ValueTypeNames.FloatArray, [-0.00805]),
-        ):
-            root_joint.CreateAttribute(f"physxTendon:{tendon}:{attr}", type_name).Set(value)
-        axis_joint.AddAppliedSchema(f"PhysxTendonAxisAPI:{tendon}")
-        axis_joint.CreateAttribute(f"physxTendon:{tendon}:gearing", Sdf.ValueTypeNames.FloatArray).Set([0.00705])
-
-
 SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
-    spawn=MenagerieUsdFileCfg(
+    spawn=MenageriePatchedUsdFileCfg(
         usd_path=f"{MENAGERIE_ASSET_ROOT}/shadow_hand/right_hand/right_hand.usda",
-        # UPSTREAM(asset): the MuJoCo USD Converter does not translate MJCF tendon
-        # couplings into PhysX tendon schemas, so the ``physx`` variant leaves the four
-        # distal finger joints uncoupled and undriven. Authored at spawn until then.
-        extra_fixups=[_author_shadow_hand_fixed_tendons],
+        # UPSTREAM(asset): the MuJoCo USD Converter does not translate MJCF tendon couplings
+        # into PhysX tendon schemas, so the ``physx`` variant leaves the four distal finger
+        # joints uncoupled and undriven; the patcher authors them into the ``physx`` layer.
+        # It also authors the legacy asset's 5729.6 deg/s joint velocity limit, which the
+        # Menagerie layers omit and PhysX needs for stability.
+        author_shadow_tendons=True,
+        joint_velocity_limit_deg_s=5729.6,
         variants={"Physics": "physx"},
         activate_contact_sensors=False,
         rigid_props=sim_utils.RigidBodyPropertiesCfg(
@@ -268,7 +239,8 @@ SHADOW_HAND_MENAGERIE_PHYSX_CFG = ArticulationCfg(
 
 .. note::
     The Menagerie PhysX variant carries no fixed-tendon authoring (converter gap), so the
-    Menagerie adapter authors the four distal-middle couplings from the legacy asset's
-    template at spawn time. See :func:`_author_shadow_hand_fixed_tendons` and
-    :class:`~isaaclab_assets.robots.menagerie.MenagerieUsdFileCfg`.
+    Menagerie patcher authors the four distal-middle couplings from the legacy asset's
+    template into a patched copy of the asset's ``physx`` layer on disk. See
+    :func:`~isaaclab_assets.robots.menagerie.patch_menagerie_asset` and
+    :class:`~isaaclab_assets.robots.menagerie.MenageriePatchedUsdFileCfg`.
 """

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -19,16 +19,16 @@ Reference:
 
 import os
 from collections.abc import Callable
-
-from pxr import Sdf, Usd
+from typing import TYPE_CHECKING
 
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
-from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
-from isaaclab.sim.utils import clone
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
+
+if TYPE_CHECKING:
+    from pxr import Usd
 
 MENAGERIE_ASSET_ROOT = os.environ.get(
     "MENAGERIE_ASSET_ROOT", "omniverse://isaac-dev.ov.nvidia.com/Isaac/Samples/Mujoco_Menagerie"
@@ -168,13 +168,15 @@ only the joint/body naming differs.
 """
 
 
-def _author_shadow_hand_fixed_tendons(prim: Usd.Prim) -> None:
+def _author_shadow_hand_fixed_tendons(prim: "Usd.Prim") -> None:
     """Author the PhysX fixed tendons that the Menagerie ``physx`` layer omits.
 
     Replicates the legacy ``ShadowHand`` asset's distal-middle finger couplings: per finger,
     tendon length ``-0.00805 * theta_middle + 0.00705 * theta_distal`` constrained to
     ``+/-0.001`` around rest length 0, so the distal joint tracks the middle joint.
     """
+    from pxr import Sdf, Usd
+
     joints = {p.GetName(): p for p in Usd.PrimRange(prim) if p.GetName().startswith("rh_")}
     for finger in ("FF", "MF", "RF", "LF"):
         tendon = f"rh_T_{finger}J1c"
@@ -198,27 +200,31 @@ def _author_shadow_hand_fixed_tendons(prim: Usd.Prim) -> None:
         axis_joint.CreateAttribute(f"physxTendon:{tendon}:gearing", Sdf.ValueTypeNames.FloatArray).Set([0.00705])
 
 
-@clone
 def spawn_shadow_hand_menagerie_physx(
     prim_path: str,
     cfg: "ShadowHandMenageriePhysxSpawnCfg",
     translation: tuple[float, float, float] | None = None,
     orientation: tuple[float, float, float, float] | None = None,
     **kwargs,
-) -> Usd.Prim:
+) -> "Usd.Prim":
     """Spawn the Menagerie Shadow Hand and author the missing PhysX fixed tendons.
 
     The MuJoCo USD Converter does not translate MJCF tendon couplings into PhysX tendon
     schemas, so the ``physx`` variant leaves the four distal finger joints uncoupled and
     undriven. This spawner authors them post-spawn until the converter gains support.
     """
-    prim = _spawn_from_usd_file(prim_path, cfg.usd_path, cfg, translation, orientation)
-    _author_shadow_hand_fixed_tendons(prim)
-    # Re-apply the tendon properties: the pass inside the USD spawn ran before the tendons
-    # existed, and the coupling only transmits through the configured limit stiffness.
-    if cfg.fixed_tendons_props is not None:
-        sim_utils.schemas.modify_fixed_tendon_properties(prim.GetPath().pathString, cfg.fixed_tendons_props)
-    return prim
+    # Deferred imports: this module is imported by the task-config registry before the
+    # simulation app starts, when pxr and the spawner internals are not yet loadable.
+    from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
+    from isaaclab.sim.utils import clone
+
+    @clone
+    def _spawn(prim_path, cfg, translation=None, orientation=None, **inner_kwargs):
+        prim = _spawn_from_usd_file(prim_path, cfg.usd_path, cfg, translation, orientation)
+        _author_shadow_hand_fixed_tendons(prim)
+        return prim
+
+    return _spawn(prim_path, cfg, translation, orientation, **kwargs)
 
 
 @configclass

--- a/source/isaaclab_tasks/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-menagerie-hand-validation.minor.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Changed the ``Isaac-Reorient-Cube-Shadow-Direct`` and
+  ``Isaac-Reorient-Cube-Allegro-Direct`` tasks to use the Mujoco Menagerie hand assets.
+  Joint and body names now follow the official robot naming: use ``rh_FFJ3`` instead of
+  ``robot0_FFJ3`` for the Shadow Hand, and ``ffj0``/``ff_distal`` instead of
+  ``index_joint_0``/``index_link_3`` for the Allegro Hand.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
@@ -99,11 +99,7 @@ class PhysicsCfg(PresetCfg):
             iterations=100,
             # save_to_mjcf="AllegroHand.xml",
         ),
-        # The Menagerie links are ~2.6x lighter than the legacy BioTac hand's, so at the
-        # legacy 2-substep rate a fast finger penetrates the cube deeply within one
-        # substep and the corrective impulse ejects it (measured: cube launched in
-        # 33-37/64 envs under a worst-case finger sweep at 2 substeps, 0/64 at 4).
-        num_substeps=4,
+        num_substeps=2,
         debug_mode=False,
     )
     ovphysx = OvPhysxCfg()

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
@@ -156,11 +156,13 @@ class AllegroHandEnvCfg(DirectRLEnvCfg):
         "thj2",
         "thj3",
     ]
+    # The *_tip bodies carry the fingertip collision geometry (the *_distal bodies are
+    # collider-less in the Menagerie conversion), so contact wrenches resolve on them.
     fingertip_body_names = [
-        "ff_distal",
-        "mf_distal",
-        "rf_distal",
-        "th_distal",
+        "ff_tip",
+        "mf_tip",
+        "rf_tip",
+        "th_tip",
     ]
 
     # in-hand object

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
@@ -99,7 +99,11 @@ class PhysicsCfg(PresetCfg):
             iterations=100,
             # save_to_mjcf="AllegroHand.xml",
         ),
-        num_substeps=2,
+        # The Menagerie links are ~2.6x lighter than the legacy BioTac hand's, so at the
+        # legacy 2-substep rate a fast finger penetrates the cube deeply within one
+        # substep and the corrective impulse ejects it (measured: cube launched in
+        # 33-37/64 envs under a worst-case finger sweep at 2 substeps, 0/64 at 4).
+        num_substeps=4,
         debug_mode=False,
     )
     ovphysx = OvPhysxCfg()

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
@@ -20,7 +20,7 @@ from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.utils import PresetCfg
 
-from isaaclab_assets.robots.allegro import ALLEGRO_HAND_CFG
+from isaaclab_assets.robots.allegro import ALLEGRO_HAND_MENAGERIE_CFG
 
 
 @configclass
@@ -104,6 +104,18 @@ class PhysicsCfg(PresetCfg):
 
 
 @configclass
+class AllegroHandRobotCfg(PresetCfg):
+    """Robot presets: the same Menagerie asset with the physics variant matching each engine."""
+
+    newton_mjwarp = ALLEGRO_HAND_MENAGERIE_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+    physx = ALLEGRO_HAND_MENAGERIE_CFG.replace(
+        prim_path="/World/envs/env_.*/Robot",
+        spawn=ALLEGRO_HAND_MENAGERIE_CFG.spawn.replace(variants={"Physics": "physx"}),
+    )
+    default = physx
+
+
+@configclass
 class AllegroHandEnvCfg(DirectRLEnvCfg):
     # env
     decimation = 4
@@ -124,31 +136,31 @@ class AllegroHandEnvCfg(DirectRLEnvCfg):
         physics=PhysicsCfg(),
     )
     # robot
-    robot_cfg: ArticulationCfg = ALLEGRO_HAND_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+    robot_cfg: AllegroHandRobotCfg = AllegroHandRobotCfg()
 
     actuated_joint_names = [
-        "index_joint_0",
-        "middle_joint_0",
-        "ring_joint_0",
-        "thumb_joint_0",
-        "index_joint_1",
-        "index_joint_2",
-        "index_joint_3",
-        "middle_joint_1",
-        "middle_joint_2",
-        "middle_joint_3",
-        "ring_joint_1",
-        "ring_joint_2",
-        "ring_joint_3",
-        "thumb_joint_1",
-        "thumb_joint_2",
-        "thumb_joint_3",
+        "ffj0",
+        "mfj0",
+        "rfj0",
+        "thj0",
+        "ffj1",
+        "ffj2",
+        "ffj3",
+        "mfj1",
+        "mfj2",
+        "mfj3",
+        "rfj1",
+        "rfj2",
+        "rfj3",
+        "thj1",
+        "thj2",
+        "thj3",
     ]
     fingertip_body_names = [
-        "index_link_3",
-        "middle_link_3",
-        "ring_link_3",
-        "thumb_link_3",
+        "ff_distal",
+        "mf_distal",
+        "rf_distal",
+        "th_distal",
     ]
 
     # in-hand object

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
@@ -88,8 +88,11 @@ class PhysicsCfg(PresetCfg):
         solver_cfg=MJWarpSolverCfg(
             solver="newton",
             integrator="implicitfast",
-            njmax=80,
-            nconmax=70,
+            # Sized for the legacy asset's colliders; the Menagerie conversion carries more
+            # contact-generating primitives (per-link boxes/capsules + welded tips) and
+            # saturates the smaller pools, dropping contacts.
+            njmax=200,
+            nconmax=150,
             impratio=10.0,
             cone="elliptic",
             update_data_interval=2,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_env_cfg.py
@@ -8,7 +8,6 @@ from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
 import isaaclab.sim as sim_utils
-from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.envs import DirectRLEnvCfg
 from isaaclab.managers import EventTermCfg as EventTerm
@@ -23,7 +22,7 @@ from isaaclab.utils.noise import GaussianNoiseCfg, NoiseModelWithAdditiveBiasCfg
 
 from isaaclab_tasks.utils import PresetCfg
 
-from isaaclab_assets.robots.shadow_hand import SHADOW_HAND_CFG
+from isaaclab_assets.robots.shadow_hand import SHADOW_HAND_MENAGERIE_CFG, SHADOW_HAND_MENAGERIE_PHYSX_CFG
 
 
 @configclass
@@ -139,73 +138,64 @@ class ShadowHandEventCfg(PresetCfg):
 
 @configclass
 class ShadowHandRobotCfg(PresetCfg):
-    physx = SHADOW_HAND_CFG.replace(prim_path="/World/envs/env_.*/Robot").replace(
-        init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.0, 0.0, 0.5),
-            rot=(0.0, 0.0, 0.0, 1.0),
-            joint_pos={".*": 0.0},
-        )
-    )
-    newton_mjwarp = ArticulationCfg(
-        prim_path="/World/envs/env_.*/Robot",
-        spawn=sim_utils.UsdFileCfg(
-            # newton/mujoco have separate usd schema
-            usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/ShadowRobot/ShadowHandNewton/shadow_hand_instanceable.usda",
-            activate_contact_sensors=False,
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
-                disable_gravity=True,
-                retain_accelerations=True,
-                max_depenetration_velocity=1000.0,
-            ),
-            articulation_props=sim_utils.ArticulationRootPropertiesCfg(enabled_self_collisions=True),
-            joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
-            fixed_tendons_props=sim_utils.FixedTendonPropertiesCfg(damping=0.1),
-        ),
-        init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.0, 0.0, 0.5),
-            # WARNING(Octi): Newton's import_usd.py bakes the USD body xformOp rotation into
-            # joint_X_p for the root fixed joint, which cancels with the matching localPose1
-            # rotation in joint_X_c during FK (joint_X_p * inv(joint_X_c) ≈ identity). This
-            # discards the root body's native USD orientation, so we must re-apply it here as a
-            # spawn rotation. PhysX or USD does not have this issue. Remove once Newton fixes root joint
-            # transform handling in import_usd.py.
-            rot=(0.0, 0.0, -0.70710678118, 0.70710678118),
-            joint_pos={".*": 0.0},
-        ),
-        actuators={
-            "fingers": ImplicitActuatorCfg(
-                joint_names_expr=["robot0_WR.*", "robot0_(FF|MF|RF|LF|TH)J(3|2|1)", "robot0_(LF|TH)J4", "robot0_THJ0"],
-                effort_limit_sim={
-                    "robot0_WRJ1": 4.785,
-                    "robot0_WRJ0": 2.175,
-                    "robot0_(FF|MF|RF|LF)J1": 0.7245,
-                    "robot0_FFJ(3|2)": 0.9,
-                    "robot0_MFJ(3|2)": 0.9,
-                    "robot0_RFJ(3|2)": 0.9,
-                    "robot0_LFJ(4|3|2)": 0.9,
-                    "robot0_THJ4": 2.3722,
-                    "robot0_THJ3": 1.45,
-                    "robot0_THJ(2|1)": 0.99,
-                    "robot0_THJ0": 0.81,
-                },
-                stiffness={
-                    "robot0_WRJ.*": 5.0,
-                    "robot0_(FF|MF|RF|LF|TH)J(3|2|1)": 1.0,
-                    "robot0_(LF|TH)J4": 1.0,
-                    "robot0_THJ0": 1.0,
-                },
-                damping={
-                    "robot0_WRJ.*": 0.5,
-                    "robot0_(FF|MF|RF|LF|TH)J(3|2|1)": 0.1,
-                    "robot0_(LF|TH)J4": 0.1,
-                    "robot0_THJ0": 0.1,
-                },
-                friction=1e-2,
-                armature=2e-3,
-            ),
-        },
-        soft_joint_pos_limit_factor=1.0,
-    )
+    physx = SHADOW_HAND_MENAGERIE_PHYSX_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+    newton_mjwarp = SHADOW_HAND_MENAGERIE_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+    default = physx
+
+
+@configclass
+class ShadowHandActuatedJointsCfg(PresetCfg):
+    """Actuation topology per engine, following each engine's reference configuration.
+
+    The PhysX list keeps the legacy asset's topology (knuckles and middle joints driven,
+    distal joints following via fixed tendons); the Newton list keeps the ``ShadowHandNewton``
+    reference topology (distal joints driven directly, finger knuckles passive).
+    """
+
+    physx = [
+        "rh_WRJ2",
+        "rh_WRJ1",
+        "rh_FFJ4",
+        "rh_FFJ3",
+        "rh_FFJ2",
+        "rh_MFJ4",
+        "rh_MFJ3",
+        "rh_MFJ2",
+        "rh_RFJ4",
+        "rh_RFJ3",
+        "rh_RFJ2",
+        "rh_LFJ5",
+        "rh_LFJ4",
+        "rh_LFJ3",
+        "rh_LFJ2",
+        "rh_THJ5",
+        "rh_THJ4",
+        "rh_THJ3",
+        "rh_THJ2",
+        "rh_THJ1",
+    ]
+    newton_mjwarp = [
+        "rh_WRJ2",
+        "rh_WRJ1",
+        "rh_FFJ3",
+        "rh_FFJ2",
+        "rh_FFJ1",
+        "rh_MFJ3",
+        "rh_MFJ2",
+        "rh_MFJ1",
+        "rh_RFJ3",
+        "rh_RFJ2",
+        "rh_RFJ1",
+        "rh_LFJ4",
+        "rh_LFJ3",
+        "rh_LFJ2",
+        "rh_LFJ1",
+        "rh_THJ5",
+        "rh_THJ4",
+        "rh_THJ3",
+        "rh_THJ2",
+        "rh_THJ1",
+    ]
     default = physx
 
 
@@ -309,34 +299,13 @@ class ShadowHandEnvCfg(DirectRLEnvCfg):
     )
     # robot
     robot_cfg: ShadowHandRobotCfg = ShadowHandRobotCfg()
-    actuated_joint_names = [
-        "robot0_WRJ1",
-        "robot0_WRJ0",
-        "robot0_FFJ3",
-        "robot0_FFJ2",
-        "robot0_FFJ1",
-        "robot0_MFJ3",
-        "robot0_MFJ2",
-        "robot0_MFJ1",
-        "robot0_RFJ3",
-        "robot0_RFJ2",
-        "robot0_RFJ1",
-        "robot0_LFJ4",
-        "robot0_LFJ3",
-        "robot0_LFJ2",
-        "robot0_LFJ1",
-        "robot0_THJ4",
-        "robot0_THJ3",
-        "robot0_THJ2",
-        "robot0_THJ1",
-        "robot0_THJ0",
-    ]
+    actuated_joint_names: ShadowHandActuatedJointsCfg = ShadowHandActuatedJointsCfg()
     fingertip_body_names = [
-        "robot0_ffdistal",
-        "robot0_mfdistal",
-        "robot0_rfdistal",
-        "robot0_lfdistal",
-        "robot0_thdistal",
+        "rh_ffdistal",
+        "rh_mfdistal",
+        "rh_rfdistal",
+        "rh_lfdistal",
+        "rh_thdistal",
     ]
 
     # in-hand object


### PR DESCRIPTION
# Description

Migrates the Shadow and Allegro cube-reorientation tasks to the MuJoCo Menagerie conversions (public S3 release, no Nucleus auth). **DO-NOT-MERGE: validation + findings-sharing.**

# 1. Asset-level fixes needed (for the asset/converter team)

| # | Fix needed at asset/converter level | Failure it causes today | Bridge in this PR (file-based patcher) |
|---|---|---|---|
| 1 | Author `physics:staticFriction` (MuJoCo's single sliding coefficient maps to both) | static friction = 0 → grasped objects slide out | copy dynamic → static |
| 2 | Don't split welded fingertip geoms into `*_tip` bodies (or author the manufactured tip↔medial filters) | impossible-in-MuJoCo self-collision pairs wedge fingers | author 4 filtered pairs |
| 3 | Keep `UsdPhysics.DriveAPI` in the mujoco variant | standard consumers see zero actuated joints | strip the drive deletes |
| 4 | Settle the drive-vs-`MjcActuator` contract (with drives restored, Newton builds both → phantom kp=1 servo steals 25% authority per joint; Shadow 0.53→0.94 from removal; the legacy Shadow Newton asset has the same defect) | weak, unresponsive joints | remove `MjcActuator` prims |
| 5 | Author joint velocity limits in the physx layer (MJCF has none; PhysX needs them) | velocity spikes → NaN observations | author legacy limits |
| 6 | Translate MJCF tendons to PhysX tendon schemas | Shadow distal joints uncoupled on PhysX | author the couplings |
| 7 | Author motor rotor inertia (`armature=2e-3`, absent from MJCF; light stock links + steps coarser than MuJoCo's 2 ms default → contact is unlearnable noise; faithful home: upstream MJCF/robot spec) | Newton training collapse (0.16 SR); PhysX capped (0.53) | author `newton:armature` + `physxJoint:armature` per joint |

Minor/documentation: pin + document the default `Physics` variant; publish old→new name maps; instanceable export option; grasp-frame annotation; document Allegro joint-limit source choice.

# 2. Isaac Lab-side adaptation (this PR, for review)

* `isaaclab_assets/robots/menagerie.py`: file-based patcher — patched copy on disk (`~/.cache/isaaclab/menagerie_patched/`), detection-first per fix, versioned marker; assets resolve from S3 via `MENAGERIE_ASSET_ROOT`. Source content (frames, masses, limits, naming) never modified.
* New robot cfgs `ALLEGRO_HAND_MENAGERIE_CFG`, `SHADOW_HAND_MENAGERIE_*_CFG`: measured base-frame/spawn compensation; actuator gains/limits carried over from the legacy configs (`armature` left unset — asset value flows through); Allegro self-collisions off pending revalidation (weld-split pairs filtered in-asset).
* Task cfgs: engine presets select the matching asset variant (`mujoco`/`physx`); Newton contact pools sized for the conversion's collider count; joint/body names follow the official robot naming (**breaking**: `ffj0` replaces `index_joint_0`, `rh_FFJ3` replaces `robot0_FFJ3`).

# 3. Training validation (reorient, 1500 iters, seed 42, 8192 envs, stock PPO)

| success / reward @1500 | Newton | PhysX |
|---|---|---|
| **Allegro** | **0.997** / 2854 | **0.909** / 1301 |
| **Shadow** | **0.938** / 3854 | **0.994** / 6237 |
| legacy refs | Allegro 0.904 · Shadow 0.53 | Shadow 0.60 |

Matches or beats legacy in every cell; minimality ablated (earlier pre-curl and substep workarounds removed once armature landed); every cell verified by rollout video.

**Performance / memory** (same task, 8192 envs, 300 iterations, seed 42; arms run **sequentially on one idle L40** at this PR's head vs the pre-PR baseline, 2 repetitions for Newton, pid-level GPU-occupancy audit per arm):

| final config | training speed [iter/s] (vs legacy) | peak GPU memory (vs legacy) |
|---|---|---|
| Menagerie × Newton | 1.10 iter/s, reps 1.11/1.10 (**1.49× faster**, legacy 0.74 iter/s, reps 0.75/0.73) | 7,260 MiB (**+17%**, legacy 6,202) |
| Menagerie × PhysX | 1.01 iter/s (**1.13× faster**, legacy 0.89 iter/s) | 6,838 MiB (**−3%**, legacy 7,060) |

The Newton memory increase tracks the conversion's non-instanceable geometry (see the instanceable-export ask in section 1). Headless training throughput improves because the conversion carries fewer/simpler colliders than the legacy BioTac hand; rendered or scene-creation-heavy workflows can still regress from the non-instanceable geometry.

**Official benchmarking-harness cross-check** (the PR-5908 harness, ``--mode benchmark``, rsl_rl; Allegro 500 iters / Shadow 3000 iters; duration includes startup; memory = per-GPU peak):

| cell | Menagerie | legacy |
|---|---|---|
| Allegro × Newton | PASS — reward 1042, 520 s, 7.3 GB | PASS — reward 335, 782 s, 6.2 GB |
| Shadow × Newton | PASS — reward 5876, 2199 s, 6.9 GB | **FAIL — NaN observations at iteration 0** |
| Allegro × PhysX | PASS — reward 328, 693 s, 6.8 GB | PASS — reward 395, 702 s, 7.1 GB |
| Shadow × PhysX | PASS — reward 7301, 3998 s, 9.4 GB | PASS — reward 6262, 2800 s, 8.2 GB |

Newton cross-validates the sequential A/B above (Allegro 1.50× faster end-to-end), and the legacy Shadow asset does not run on Newton at all (reproduces the asset-team grid's "baseline crashed"). The one real regression: **Shadow × PhysX trains 1.43× slower with +15% memory** on the conversion (final reward is higher) — direction-consistent with the asset team's raw-asset slowdown report; root-cause follow-up queued (authored PhysX tendons and non-instanceable collider count are the suspects).

# Merge path (once fixed assets ship on S3)

Every patch is detection-first, so fixed assets pass through the patcher untouched — the PR works against them unchanged. Full cleanup is then mechanical: swap `MenageriePatchedUsdFileCfg` → `UsdFileCfg` and delete the patch functions. Exceptions that need coordination: (1) the fixed assets must author armature as `newton:armature`/`physxJoint:armature` (or Isaac Lab's importer must add the mjc schema resolver first); (2) if fingertip welds are un-split, re-enable self-collisions and drop the filtered pairs (revalidation run); (3) drop `ensure_drives_exist` and the now-redundant config `velocity_limit_sim`.

# Follow-ups

* Newton importer: deduplicate actuation when a joint has both `MjcActuator` and a drive; reads `newton:armature` only (`mjc:armature` ignored — resolver list is `[newton, physx]`); root-orientation baked into the root fixed joint (spawn compensation is interim).
* Goal `VisualizationMarkers` don't render in the kitless Newton lane (fix in progress).
* Regenerate Shadow rendering golden images (CI diff still pictures the legacy hand).
* Shadow/PhysX jitter root-cause; Allegro self-collision re-enable revalidation.
