### PR TITLE
fix(newton): rebuild collision pipeline on hard reset to fix CUDA 700

### DIFF
--- a/source/isaaclab_newton/changelog.d/pverswyvelen-newton-cuda700-reset-fix.major.rst
+++ b/source/isaaclab_newton/changelog.d/pverswyvelen-newton-cuda700-reset-fix.major.rst
@@ -1,0 +1,16 @@
+Fixed
+^^^^^
+
+* Fixed a CUDA ``700`` (illegal memory access) that could occur on the first
+  simulation step after a hard reset (:meth:`NewtonManager.reset` with
+  ``soft=False``). On a hard reset the Newton :class:`Model` is re-created,
+  which reallocates its device arrays, but the collision pipeline still held
+  references to the old model. Once the old model's device buffers were freed
+  and reused (which happens under GPU memory pressure between resets), those
+  dangling references caused an illegal memory access on the first ``step()``
+  after the reset (typically surfacing in ``compute_shape_aabbs`` or
+  ``narrow_phase_kernel_gjk_mpr``). The reset now clears the cached collision
+  pipeline and contacts so a fresh pipeline is rebuilt against the re-finalized
+  model, and invalidates any previously-captured CUDA graph. The graph is then
+  re-captured by :meth:`initialize_solver` exactly as on first initialization.
+  This restores correct behavior with CUDA graph capture enabled.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -373,10 +373,27 @@ class NewtonManager(PhysicsManager):
     def reset(cls, soft: bool = False) -> None:
         """Reset physics simulation.
 
+        A hard reset (``soft=False``) re-finalizes the Newton model, reallocating
+        its device arrays. The cached collision pipeline, contacts and any
+        captured CUDA graph reference the old buffers, so they are released here
+        and rebuilt against the re-finalized model by :meth:`initialize_solver`.
+        This avoids the illegal CUDA memory access (CUDA error 700) that would
+        otherwise occur on the first step after a hard reset.
+
+        A soft reset (``soft=True``) skips this full reinitialization and reuses
+        the existing model, solver, collision pipeline and CUDA graph.
+
         Args:
             soft: If True, skip full reinitialization.
         """
         if not soft:
+            # Release the cached collision pipeline, contacts and CUDA graph;
+            # they point at the old model's freed buffers (CUDA 700 on next step).
+            NewtonManager._graph = None
+            NewtonManager._graph_capture_pending = False
+            NewtonManager._collision_pipeline = None
+            NewtonManager._contacts = None
+
             cls.start_simulation()
             cls.initialize_solver()
 

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -784,3 +784,89 @@ def test_reset_lands_in_state_0_after_odd_kamino_steps_without_cuda_graph(num_st
         assert np.allclose(canonical_joint_q, sentinel), (
             f"reset write did not land in _state_0 after {num_steps} steps: {canonical_joint_q}"
         )
+
+
+def _build_collision_scene(sim, num_boxes=8):
+    """Add ``num_boxes`` free-falling boxes over a ground plane.
+
+    Uses ``MJWarpSolverCfg(use_mujoco_contacts=False)`` so the Newton collision
+    pipeline / contacts are allocated on ``sim.reset()``.
+    """
+    builder = sim.physics_manager.create_builder()
+    for _ in range(num_boxes):
+        body = builder.add_body(mass=1.0)
+        builder.add_joint_free(child=body)
+        builder.add_shape_box(body=body, hx=0.1, hy=0.1, hz=0.1)
+    builder.add_ground_plane()
+    NewtonManager.set_builder(builder)
+
+
+# Model device arrays ``CollisionPipeline.collide()`` reads off its cached model.
+_COLLIDE_MODEL_ARRAYS = (
+    "shape_transform",
+    "shape_body",
+    "shape_type",
+    "shape_scale",
+    "shape_collision_radius",
+    "shape_source_ptr",
+    "shape_margin",
+    "shape_gap",
+    "shape_collision_aabb_lower",
+    "shape_collision_aabb_upper",
+)
+
+
+def _free_model_collide_arrays_and_churn(model, device):
+    """Free the arrays ``collide()`` reads off ``model``, then churn the allocator.
+
+    Reusing the freed blocks mimics the GPU memory pressure a real workload
+    applies between resets, so a stale pipeline still pointing at ``model``
+    would read overwritten memory on its next ``collide()``.
+    """
+    import gc
+
+    for attr in _COLLIDE_MODEL_ARRAYS:
+        arr = getattr(model, attr, None)
+        if isinstance(arr, wp.array) and arr.device.is_cuda:
+            setattr(model, attr, None)
+    gc.collect()
+    wp.synchronize_device(device)
+    _churn = [wp.zeros(1 << 16, dtype=wp.float32, device=device) for _ in range(128)]  # noqa: F841
+    wp.synchronize_device(device)
+
+
+@pytest.mark.parametrize("use_cuda_graph", [False, True])
+def test_hard_reset_then_step_runs(use_cuda_graph):
+    """A step after a second (hard) ``sim.reset()`` runs without a CUDA error.
+
+    Drives reset -> step -> hard reset, frees the old model's collide arrays and
+    churns the allocator to mimic GPU memory pressure, then steps and syncs.
+    Without the fix the stale pipeline reads the freed buffers and faults
+    (CUDA 700). Run with CUDA graphs off and on.
+    """
+    sim_cfg = SimulationCfg(
+        dt=1.0 / 120.0,
+        device="cuda:0",
+        gravity=(0.0, 0.0, -9.81),
+        physics=NewtonCfg(
+            solver_cfg=MJWarpSolverCfg(use_mujoco_contacts=False),
+            num_substeps=2,
+            use_cuda_graph=use_cuda_graph,
+        ),
+    )
+
+    with build_simulation_context(sim_cfg=sim_cfg) as sim:
+        _build_collision_scene(sim)
+
+        sim.reset()
+        assert NewtonManager._needs_collision_pipeline is True
+        old_model = NewtonManager._collision_pipeline.model
+        sim.step(render=False)
+
+        sim.reset()
+
+        _free_model_collide_arrays_and_churn(old_model, "cuda:0")
+
+        # A hard device sync surfaces any deferred illegal access as an exception.
+        sim.step(render=False)
+        wp.synchronize_device("cuda:0")


### PR DESCRIPTION
# Description

When doing a hard reset, the Newton model is re-created but the collision pipeline still holds references to the old model. Once the old model's device buffers are freed (which happens under GPU memory pressure between resets), those dangling references cause illegal CUDA memory access violations (CUDA 700) on the first `step()` after the reset — typically surfacing in `compute_shape_aabbs` or `narrow_phase_kernel_gjk_mpr`.

**Fix:** On a hard reset, clear the cached collision state (`_collision_pipeline` and `_contacts`) so `initialize_solver()` rebuilds a fresh pipeline bound to the re-finalized model. Any captured CUDA graph is also invalidated and re-captured by `initialize_solver()` exactly as on first initialization, so CUDA graph capture keeps working correctly. No special post-reset deferral is needed once the stale pipeline is rebuilt.

**Tests:** Adds a regression test `test_hard_reset_then_step_runs` (run with CUDA graph capture off and on). It drives reset → step → hard reset, frees the old model's collide arrays, churns the allocator to mimic real GPU memory pressure, then steps and syncs. On the pre-fix code this reproduces the CUDA 700; with the fix it passes.

Fixes #6483

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there



