### PR TITLE
Capture PhysX contact sensor kernels in CUDA graphs

### DIFF
--- a/scripts/benchmarks/benchmark_contact_sensor.py
+++ b/scripts/benchmarks/benchmark_contact_sensor.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark script for the PhysX contact sensor update.
+
+Measures the time spent in :meth:`ContactSensor.update` for a scene of cubes resting on a
+flat ground plane. By default the warp kernels of the sensor update are captured into CUDA
+graphs and replayed; pass ``--disable_graph`` to measure the eager (non-graphed) update for
+comparison.
+
+Usage:
+    # Graphed update (default)
+    ./isaaclab.sh -p scripts/benchmarks/benchmark_contact_sensor.py --num_envs 4096 --headless
+
+    # Eager update (baseline)
+    ./isaaclab.sh -p scripts/benchmarks/benchmark_contact_sensor.py --num_envs 4096 --disable_graph --headless
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from isaaclab.app import AppLauncher
+
+parser = argparse.ArgumentParser(description="Benchmark the PhysX contact sensor update.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments to simulate.")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed simulation steps.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up steps.")
+parser.add_argument("--disable_graph", action="store_true", help="Disable CUDA graph capture of the sensor update.")
+
+AppLauncher.add_app_launcher_args(parser)
+args_cli = parser.parse_args()
+
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import statistics
+import time
+
+import warp as wp
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import ContactSensorCfg
+from isaaclab.terrains import TerrainImporterCfg
+from isaaclab.utils.configclass import configclass
+
+
+@configclass
+class ContactSensorBenchmarkSceneCfg(InteractiveSceneCfg):
+    """Scene with one cube per environment and a contact sensor on the cube."""
+
+    terrain = TerrainImporterCfg(prim_path="/World/ground", terrain_type="plane")
+
+    cube = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Cube",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.5, 0.5, 0.5),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=False),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=True),
+            activate_contact_sensors=True,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.3)),
+    )
+
+    contact_sensor = ContactSensorCfg(
+        prim_path="{ENV_REGEX_NS}/Cube",
+        track_air_time=True,
+        update_period=0.0,
+    )
+
+
+def main():
+    sim_dt = 1.0 / 120.0
+    sim_cfg = sim_utils.SimulationCfg(dt=sim_dt, device=args_cli.device)
+    sim = sim_utils.SimulationContext(sim_cfg)
+
+    scene_cfg = ContactSensorBenchmarkSceneCfg(
+        num_envs=args_cli.num_envs, env_spacing=2.0, lazy_sensor_update=False
+    )
+    scene = InteractiveScene(scene_cfg)
+    sim.reset()
+    scene.reset()
+
+    sensor = scene["contact_sensor"]
+    if args_cli.disable_graph:
+        sensor._graph_capture_enabled = False
+
+    # warm-up: let the cubes settle on the ground and trigger the graph capture (if enabled)
+    for _ in range(args_cli.warmup_steps):
+        sim.step(render=False)
+        sensor.update(sim_dt, force_recompute=True)
+    wp.synchronize_device(sim.device)
+
+    # timed loop: per-call latency of the sensor update (synchronized)
+    update_times_ms = []
+    total_wall_ms = 0.0
+    for _ in range(args_cli.num_steps):
+        sim.step(render=False)
+        wp.synchronize_device(sim.device)
+        t_start = time.perf_counter()
+        sensor.update(sim_dt, force_recompute=True)
+        t_submit = time.perf_counter()
+        wp.synchronize_device(sim.device)
+        t_end = time.perf_counter()
+        update_times_ms.append((t_end - t_start) * 1000.0)
+        total_wall_ms += (t_submit - t_start) * 1000.0
+
+    mode = "eager" if args_cli.disable_graph else "graph"
+    print("-" * 80)
+    print("Contact sensor update benchmark (PhysX)")
+    print(f"  mode              : {mode}")
+    print(f"  device            : {sim.device}")
+    print(f"  num_envs          : {args_cli.num_envs}")
+    print(f"  num_steps         : {args_cli.num_steps}")
+    print(f"  update mean (sync): {statistics.mean(update_times_ms):.3f} ms")
+    print(f"  update p50  (sync): {statistics.median(update_times_ms):.3f} ms")
+    print(f"  update min  (sync): {min(update_times_ms):.3f} ms")
+    print(f"  submit mean (cpu) : {total_wall_ms / args_cli.num_steps:.3f} ms")
+    print("-" * 80)
+
+    # sanity check: cubes rest on the ground, so every sensor must report an upward net force
+    net_forces = sensor.data.net_forces_w.torch
+    num_in_contact = int((net_forces.norm(dim=-1) > 0.1).sum().item())
+    print(f"  sensors in contact: {num_in_contact} / {args_cli.num_envs}")
+
+
+if __name__ == "__main__":
+    main()
+    simulation_app.close()

--- a/scripts/benchmarks/benchmark_contact_sensor.py
+++ b/scripts/benchmarks/benchmark_contact_sensor.py
@@ -80,16 +80,14 @@ def main():
     sim_cfg = sim_utils.SimulationCfg(dt=sim_dt, device=args_cli.device)
     sim = sim_utils.SimulationContext(sim_cfg)
 
-    scene_cfg = ContactSensorBenchmarkSceneCfg(
-        num_envs=args_cli.num_envs, env_spacing=2.0, lazy_sensor_update=False
-    )
+    scene_cfg = ContactSensorBenchmarkSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, lazy_sensor_update=False)
     scene = InteractiveScene(scene_cfg)
     sim.reset()
     scene.reset()
 
     sensor = scene["contact_sensor"]
     if args_cli.disable_graph:
-        sensor._graph_capture_enabled = False
+        sensor._use_graph = False
 
     # warm-up: let the cubes settle on the ground and trigger the graph capture (if enabled)
     for _ in range(args_cli.warmup_steps):

--- a/source/isaaclab_physx/benchmark/sensors/benchmark_contact_sensor.py
+++ b/source/isaaclab_physx/benchmark/sensors/benchmark_contact_sensor.py
@@ -12,10 +12,10 @@ comparison.
 
 Usage:
     # Graphed update (default)
-    ./isaaclab.sh -p scripts/benchmarks/benchmark_contact_sensor.py --num_envs 4096 --headless
+    ./isaaclab.sh -p source/isaaclab_physx/benchmark/sensors/benchmark_contact_sensor.py --num_envs 4096
 
     # Eager update (baseline)
-    ./isaaclab.sh -p scripts/benchmarks/benchmark_contact_sensor.py --num_envs 4096 --disable_graph --headless
+    ./isaaclab.sh -p source/isaaclab_physx/benchmark/sensors/benchmark_contact_sensor.py --num_envs 4096 --disable_graph
 """
 
 from __future__ import annotations

--- a/source/isaaclab_physx/changelog.d/antoiner-physx-contact-sensor-graph.rst
+++ b/source/isaaclab_physx/changelog.d/antoiner-physx-contact-sensor-graph.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Changed the buffer update of the contact sensor to capture its warp kernels into CUDA
+  graphs and replay them on subsequent updates, reducing the per-step CPU overhead of the
+  sensor. The PhysX tensor reads still run eagerly since they cannot be graph-captured.
+  The kernels also run eagerly on CPU devices, when an outer CUDA graph capture is active,
+  or when graph capture fails.

--- a/source/isaaclab_physx/changelog.d/antoiner-physx-contact-sensor-graph.rst
+++ b/source/isaaclab_physx/changelog.d/antoiner-physx-contact-sensor-graph.rst
@@ -4,5 +4,6 @@ Changed
 * Changed the buffer update of the contact sensor to capture its warp kernels into CUDA
   graphs and replay them on subsequent updates, reducing the per-step CPU overhead of the
   sensor. The PhysX tensor reads still run eagerly since they cannot be graph-captured.
-  The kernels also run eagerly on CPU devices, when an outer CUDA graph capture is active,
-  or when graph capture fails.
+  The kernels also run eagerly on CPU devices or when graph capture fails. Updating the
+  sensor while an outer CUDA graph capture is active now raises an error, since replays
+  of such a graph would consume stale contact data.

--- a/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import torch
@@ -100,10 +100,25 @@ class ContactSensor(BaseContactSensor):
         self._ALL_ENV_MASK: wp.array | None = None
         self._reset_mask: wp.array | None = None
 
-        # CUDA graphs for the buffer update, keyed by stage name (see :meth:`_update_buffers_impl`).
-        # Each entry stores the captured graph and the pointers of its baked input arrays.
-        self._update_graphs: dict[str, tuple[wp.Graph, tuple[int, ...]]] = {}
-        self._graph_capture_enabled: bool = True
+        # CUDA graph capture state for the buffer update (set in _initialize_impl, see
+        # :meth:`_update_buffers_impl`)
+        self._use_graph: bool = False
+        self._compute_graph: wp.Graph | None = None
+        self._graph_env_mask: wp.array | None = None
+        self._env_mask: wp.array | None = None
+        # Warp views over the PhysX output buffers, built lazily on the first fetch since the
+        # buffers are allocated once and refreshed in place (see :meth:`_fetch_physx_buffers`)
+        self._net_forces_flat: wp.array | None = None
+        self._force_matrix_flat: wp.array | None = None
+        self._poses_flat: wp.array | None = None
+        self._contact_points_flat: wp.array | None = None
+        self._friction_forces_flat: wp.array | None = None
+        self._friction_counts: wp.array | None = None
+        self._friction_start_indices: wp.array | None = None
+        # Staged copies of the contact count and start-index buffers, which get_friction_data
+        # would otherwise overwrite (it shares those buffers with get_contact_data)
+        self._contact_counts: wp.array | None = None
+        self._contact_start_indices: wp.array | None = None
 
         # check if max_contact_data_count_per_prim is set
         if self.cfg.max_contact_data_count_per_prim is None:
@@ -358,6 +373,9 @@ class ContactSensor(BaseContactSensor):
 
         self._create_buffers()
 
+        # capture the update kernels into a CUDA graph on CUDA devices (see _update_buffers_impl)
+        self._use_graph = wp.get_device(self._device).is_cuda
+
     def _create_buffers(self) -> None:
         # Store filter shapes count
         self._num_filter_shapes = self.contact_view.filter_count if self.cfg.filter_prim_paths_expr else 0
@@ -381,196 +399,172 @@ class ContactSensor(BaseContactSensor):
         """Fills the buffers of the sensor data.
 
         The PhysX tensor reads enqueue their work on the legacy CUDA stream and therefore cannot
-        be captured into a CUDA graph. They run eagerly on every update and refresh the same
-        cached output buffers in place. The warp kernels that consume those buffers are captured
-        into per-stage CUDA graphs on the first update and replayed afterwards, which removes
-        most of the per-update kernel-launch overhead (see :meth:`_run_update_stage`).
+        be captured into a CUDA graph. They run eagerly on every update and refresh preallocated
+        output buffers in place (see :meth:`_fetch_physx_buffers`). The warp kernels that consume
+        those buffers (see :meth:`_compute`) are captured into a CUDA graph on the first update
+        and replayed afterwards, which removes the per-update kernel-launch overhead.
+
+        The kernels run eagerly (no capture or replay) when the device is not a CUDA device, when
+        an outer CUDA graph capture is active (they are then recorded into that graph instead),
+        when a previous capture attempt failed, or when :paramref:`env_mask` resolves to a
+        different array than the one baked into the graph.
         """
         # Convert env_mask to warp array
         env_mask = self._resolve_indices_and_mask(None, env_mask)
+        # Refresh the PhysX contact data (not graph-capturable)
+        self._fetch_physx_buffers()
+        # _compute reads the mask from this attribute; the captured graph bakes the array
+        # assigned at capture time, so replaying requires the same array
+        self._env_mask = env_mask
 
-        # Replaying a graph is only possible when no outer capture is active. During an outer
-        # capture, the kernels run "eagerly" and are recorded into that graph instead.
         device = wp.get_device(self._device)
-        use_graph = self._graph_capture_enabled and device.is_cuda and not device.is_capturing
+        replayable = self._compute_graph is not None and env_mask is self._graph_env_mask
+        if not self._use_graph or device.is_capturing or (self._compute_graph is not None and not replayable):
+            self._compute()
+            return
+        if replayable:
+            wp.capture_launch(self._compute_graph)
+            return
 
-        # -- Net forces --
-        # PhysX returns (N*B, 3) float32 -> (N*B,) vec3f
-        net_forces_flat = self.contact_view.get_net_contact_forces(dt=self._sim_physics_dt).view(wp.vec3f)
-        # PhysX returns (N*B, M, 3) float32 -> (N*B, M) vec3f
-        if self.cfg.filter_prim_paths_expr:
-            force_matrix_flat = self.contact_view.get_contact_force_matrix(dt=self._sim_physics_dt).view(wp.vec3f)
-        else:
-            force_matrix_flat = None
-
-        def launch_net_forces():
-            wp.launch(
-                update_net_forces_kernel,
-                dim=(self._num_envs, self._num_sensors),
-                inputs=[
-                    net_forces_flat,
-                    force_matrix_flat,
-                    env_mask,
-                    self._num_sensors,
-                    self._num_filter_shapes,
-                    self._history_length,
-                    self.cfg.force_threshold,
-                    self._timestamp,
-                    self._timestamp_last_update,
-                ],
-                outputs=[
-                    self._data._net_forces_w,
-                    self._data._net_forces_w_history,
-                    self._data._force_matrix_w,
-                    self._data._force_matrix_w_history,
-                    self._data._current_air_time,
-                    self._data._current_contact_time,
-                    self._data._last_air_time,
-                    self._data._last_contact_time,
-                ],
-                device=self._device,
+        # Warm-up: run eagerly once so that first-call allocations happen outside the capture.
+        # This also produces this update's data, since the capture only records the work.
+        self._compute()
+        try:
+            with wp.ScopedCapture(device=device) as capture:
+                self._compute()
+        except Exception as exc:
+            self._use_graph = False
+            logger.warning(
+                f"Failed to capture the update of the contact sensor at '{self.cfg.prim_path}' into a"
+                f" CUDA graph. Falling back to eager kernel launches. Reason: {exc}"
             )
+            return
+        self._compute_graph = capture.graph
+        self._graph_env_mask = env_mask
 
-        self._run_update_stage(
-            "net_forces", launch_net_forces, (net_forces_flat, force_matrix_flat, env_mask), use_graph
+    def _fetch_physx_buffers(self) -> None:
+        """Refreshes the contact data from PhysX and lazily builds the warp views over it.
+
+        The PhysX tensor getters allocate their output buffers once and refresh them in place on
+        every call, so the views (and the CUDA graph that consumes them) stay valid across
+        updates. Since ``get_friction_data`` refreshes the same count and start-index buffers as
+        ``get_contact_data``, the contact-point counts are staged into sensor-owned copies before
+        the friction read overwrites them.
+        """
+        # PhysX returns (N*B, 3) float32 -> viewed as (N*B,) vec3f
+        net_forces = self.contact_view.get_net_contact_forces(dt=self._sim_physics_dt)
+        if self._net_forces_flat is None:
+            self._net_forces_flat = net_forces.view(wp.vec3f)
+
+        # PhysX returns (N*B, M, 3) float32 -> viewed as (N*B, M) vec3f
+        if self.cfg.filter_prim_paths_expr:
+            force_matrix = self.contact_view.get_contact_force_matrix(dt=self._sim_physics_dt)
+            if self._force_matrix_flat is None:
+                self._force_matrix_flat = force_matrix.view(wp.vec3f)
+
+        # PhysX returns (N*B, 7) float32 -> viewed as (N*B,) transformf
+        if self.cfg.track_pose:
+            poses = self.body_physx_view.get_transforms()
+            if self._poses_flat is None:
+                self._poses_flat = poses.view(wp.transformf)
+
+        # points: (total_contacts, 3) float32 -> viewed as (total_contacts,) vec3f
+        if self.cfg.track_contact_points:
+            _, points, _, _, counts, start_indices = self.contact_view.get_contact_data(dt=self._sim_physics_dt)
+            if self._contact_points_flat is None:
+                self._contact_points_flat = points.view(wp.vec3f)
+                self._contact_counts = wp.clone(counts)
+                self._contact_start_indices = wp.clone(start_indices)
+            else:
+                wp.copy(self._contact_counts, counts)
+                wp.copy(self._contact_start_indices, start_indices)
+
+        # frictions: (total_contacts, 3) float32 -> viewed as (total_contacts,) vec3f
+        if self.cfg.track_friction_forces:
+            frictions, _, counts, start_indices = self.contact_view.get_friction_data(dt=self._sim_physics_dt)
+            if self._friction_forces_flat is None:
+                self._friction_forces_flat = frictions.view(wp.vec3f)
+                self._friction_counts = counts
+                self._friction_start_indices = start_indices
+
+    def _compute(self) -> None:
+        """Launches the warp kernels that update the sensor data from the fetched PhysX buffers.
+
+        This method is captured into a CUDA graph: it must contain only warp kernel launches on
+        preallocated arrays (no allocations and no Python branching on GPU data).
+        """
+        wp.launch(
+            update_net_forces_kernel,
+            dim=(self._num_envs, self._num_sensors),
+            inputs=[
+                self._net_forces_flat,
+                self._force_matrix_flat,
+                self._env_mask,
+                self._num_sensors,
+                self._num_filter_shapes,
+                self._history_length,
+                self.cfg.force_threshold,
+                self._timestamp,
+                self._timestamp_last_update,
+            ],
+            outputs=[
+                self._data._net_forces_w,
+                self._data._net_forces_w_history,
+                self._data._force_matrix_w,
+                self._data._force_matrix_w_history,
+                self._data._current_air_time,
+                self._data._current_contact_time,
+                self._data._last_air_time,
+                self._data._last_contact_time,
+            ],
+            device=self._device,
         )
 
         # -- Pose --
         if self.cfg.track_pose:
-            # PhysX returns (N*B, 7) float32 -> (N*B,) transformf
-            poses_flat = self.body_physx_view.get_transforms().view(wp.transformf)
-
-            def launch_pose():
-                wp.launch(
-                    split_flat_pose_to_pos_quat,
-                    dim=(self._num_envs, self._num_sensors),
-                    inputs=[poses_flat, env_mask, self._num_sensors],
-                    outputs=[self._data._pos_w, self._data._quat_w],
-                    device=self.device,
-                )
-
-            self._run_update_stage("pose", launch_pose, (poses_flat, env_mask), use_graph)
+            wp.launch(
+                split_flat_pose_to_pos_quat,
+                dim=(self._num_envs, self._num_sensors),
+                inputs=[self._poses_flat, self._env_mask, self._num_sensors],
+                outputs=[self._data._pos_w, self._data._quat_w],
+                device=self.device,
+            )
 
         # -- Contact points --
-        # note: get_contact_data and get_friction_data refresh the same count and start-index
-        #   buffers, so each stage's kernel must run before the next stage's PhysX read.
         if self.cfg.track_contact_points:
-            _, buffer_contact_points, _, _, buffer_count, buffer_start_indices = self.contact_view.get_contact_data(
-                dt=self._sim_physics_dt
-            )
-            # buffer_contact_points: (total_contacts, 3) float32 -> (total_contacts,) vec3f
-            pts_vec3 = buffer_contact_points.view(wp.vec3f)
-
-            def launch_contact_points():
-                wp.launch(
-                    unpack_contact_buffer_data,
-                    dim=(self._num_envs, self._num_sensors, self._num_filter_shapes),
-                    inputs=[
-                        pts_vec3,
-                        buffer_count,
-                        buffer_start_indices,
-                        env_mask,
-                        self._num_sensors,
-                        True,
-                        float("nan"),
-                    ],
-                    outputs=[self._data._contact_pos_w],
-                    device=self.device,
-                )
-
-            self._run_update_stage(
-                "contact_points",
-                launch_contact_points,
-                (pts_vec3, buffer_count, buffer_start_indices, env_mask),
-                use_graph,
+            wp.launch(
+                unpack_contact_buffer_data,
+                dim=(self._num_envs, self._num_sensors, self._num_filter_shapes),
+                inputs=[
+                    self._contact_points_flat,
+                    self._contact_counts,
+                    self._contact_start_indices,
+                    self._env_mask,
+                    self._num_sensors,
+                    True,
+                    float("nan"),
+                ],
+                outputs=[self._data._contact_pos_w],
+                device=self.device,
             )
 
         # -- Friction forces --
         if self.cfg.track_friction_forces:
-            friction_forces, _, buffer_count, buffer_start_indices = self.contact_view.get_friction_data(
-                dt=self._sim_physics_dt
+            wp.launch(
+                unpack_contact_buffer_data,
+                dim=(self._num_envs, self._num_sensors, self._num_filter_shapes),
+                inputs=[
+                    self._friction_forces_flat,
+                    self._friction_counts,
+                    self._friction_start_indices,
+                    self._env_mask,
+                    self._num_sensors,
+                    False,
+                    0.0,
+                ],
+                outputs=[self._data._friction_forces_w],
+                device=self.device,
             )
-            friction_vec3 = friction_forces.view(wp.vec3f)
-
-            def launch_friction_forces():
-                wp.launch(
-                    unpack_contact_buffer_data,
-                    dim=(self._num_envs, self._num_sensors, self._num_filter_shapes),
-                    inputs=[
-                        friction_vec3,
-                        buffer_count,
-                        buffer_start_indices,
-                        env_mask,
-                        self._num_sensors,
-                        False,
-                        0.0,
-                    ],
-                    outputs=[self._data._friction_forces_w],
-                    device=self.device,
-                )
-
-            self._run_update_stage(
-                "friction_forces",
-                launch_friction_forces,
-                (friction_vec3, buffer_count, buffer_start_indices, env_mask),
-                use_graph,
-            )
-
-    def _run_update_stage(
-        self,
-        stage: str,
-        launch_fn: Callable[[], None],
-        inputs: tuple[wp.array | None, ...],
-        use_graph: bool,
-    ) -> None:
-        """Runs one stage of the buffer update, as a CUDA graph replay when possible.
-
-        On the first graphed call for a stage, the kernel launches are run eagerly once (so that
-        first-call allocations happen outside the capture and the data for this update is
-        produced) and then recorded into a CUDA graph. Subsequent calls replay the graph, which
-        skips the Python-side launch overhead. The graph bakes the device pointers of *inputs*,
-        so it is dropped and re-captured if any of them changes, and all graphs are dropped when
-        the physics views are invalidated.
-
-        If a capture attempt fails, the sensor falls back to eager launches for its lifetime and
-        a warning is logged once.
-
-        Args:
-            stage: Unique name identifying the captured scope.
-            launch_fn: A callable that launches the stage's warp kernels. It must be safe to
-                capture, i.e. contain only warp kernel launches on preallocated arrays.
-            inputs: The input arrays whose pointers are baked into the graph. ``None`` entries
-                are ignored.
-            use_graph: Whether graph capture/replay may be used for this call. If False, the
-                kernels are launched eagerly.
-        """
-        if not use_graph:
-            launch_fn()
-            return
-        input_ptrs = tuple(array.ptr for array in inputs if array is not None)
-        entry = self._update_graphs.get(stage)
-        if entry is not None:
-            graph, captured_ptrs = entry
-            if input_ptrs == captured_ptrs:
-                wp.capture_launch(graph)
-                return
-            # an input buffer moved: drop the stale graph and re-capture below
-            del self._update_graphs[stage]
-        # Warm-up: run eagerly once so that first-call allocations happen outside the capture.
-        # This also produces this update's data, since the capture only records the work.
-        launch_fn()
-        try:
-            with wp.ScopedCapture(device=self._device) as capture:
-                launch_fn()
-        except Exception as exc:
-            self._graph_capture_enabled = False
-            logger.warning(
-                f"Failed to capture the '{stage}' update stage of the contact sensor at"
-                f" '{self.cfg.prim_path}' into a CUDA graph. Falling back to eager kernel launches."
-                f" Reason: {exc}"
-            )
-            return
-        self._update_graphs[stage] = (capture.graph, input_ptrs)
 
     def _set_debug_vis_impl(self, debug_vis: bool):
         # set visibility of markers
@@ -616,5 +610,14 @@ class ContactSensor(BaseContactSensor):
         # set all existing views to None to invalidate them
         self._body_physx_view = None
         self._contact_view = None
-        # drop the captured update graphs since they reference buffers of the invalidated views
-        self._update_graphs.clear()
+        # drop the captured graph and the cached warp views since they reference buffers owned
+        # by the invalidated views
+        self._compute_graph = None
+        self._graph_env_mask = None
+        self._net_forces_flat = None
+        self._force_matrix_flat = None
+        self._poses_flat = None
+        self._contact_points_flat = None
+        self._friction_forces_flat = None
+        self._friction_counts = None
+        self._friction_start_indices = None

--- a/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
@@ -104,7 +104,6 @@ class ContactSensor(BaseContactSensor):
         # :meth:`_update_buffers_impl`)
         self._use_graph: bool = False
         self._compute_graph: wp.Graph | None = None
-        self._graph_env_mask: wp.array | None = None
         self._env_mask: wp.array | None = None
         # Warp views over the PhysX output buffers, built lazily on the first fetch since the
         # buffers are allocated once and refreshed in place (see :meth:`_fetch_physx_buffers`)
@@ -406,41 +405,34 @@ class ContactSensor(BaseContactSensor):
 
         The kernels run eagerly (no capture or replay) when the device is not a CUDA device, when
         an outer CUDA graph capture is active (they are then recorded into that graph instead),
-        when a previous capture attempt failed, or when :paramref:`env_mask` resolves to a
-        different array than the one baked into the graph.
+        or when a previous capture attempt failed.
         """
         # Convert env_mask to warp array
         env_mask = self._resolve_indices_and_mask(None, env_mask)
         # Refresh the PhysX contact data (not graph-capturable)
         self._fetch_physx_buffers()
-        # _compute reads the mask from this attribute; the captured graph bakes the array
-        # assigned at capture time, so replaying requires the same array
+        # _compute reads the stable outdated-environment mask from this attribute.
         self._env_mask = env_mask
 
         device = wp.get_device(self._device)
-        replayable = self._compute_graph is not None and env_mask is self._graph_env_mask
-        if not self._use_graph or device.is_capturing or (self._compute_graph is not None and not replayable):
+        if not self._use_graph or device.is_capturing:
             self._compute()
             return
-        if replayable:
-            wp.capture_launch(self._compute_graph)
-            return
 
-        # Warm-up: run eagerly once so that first-call allocations happen outside the capture.
-        # This also produces this update's data, since the capture only records the work.
-        self._compute()
-        try:
-            with wp.ScopedCapture(device=device) as capture:
+        if self._compute_graph is None:
+            try:
+                with wp.ScopedCapture(device=device) as capture:
+                    self._compute()
+            except Exception as exc:
+                self._use_graph = False
+                logger.warning(
+                    f"Failed to capture the update of the contact sensor at '{self.cfg.prim_path}' into a"
+                    f" CUDA graph. Falling back to eager kernel launches. Reason: {exc}"
+                )
                 self._compute()
-        except Exception as exc:
-            self._use_graph = False
-            logger.warning(
-                f"Failed to capture the update of the contact sensor at '{self.cfg.prim_path}' into a"
-                f" CUDA graph. Falling back to eager kernel launches. Reason: {exc}"
-            )
-            return
-        self._compute_graph = capture.graph
-        self._graph_env_mask = env_mask
+                return
+            self._compute_graph = capture.graph
+        wp.capture_launch(self._compute_graph)
 
     def _fetch_physx_buffers(self) -> None:
         """Refreshes the contact data from PhysX and lazily builds the warp views over it.
@@ -613,7 +605,6 @@ class ContactSensor(BaseContactSensor):
         # drop the captured graph and the cached warp views since they reference buffers owned
         # by the invalidated views
         self._compute_graph = None
-        self._graph_env_mask = None
         self._net_forces_flat = None
         self._force_matrix_flat = None
         self._poses_flat = None

--- a/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
@@ -403,10 +403,22 @@ class ContactSensor(BaseContactSensor):
         those buffers (see :meth:`_compute`) are captured into a CUDA graph on the first update
         and replayed afterwards, which removes the per-update kernel-launch overhead.
 
-        The kernels run eagerly (no capture or replay) when the device is not a CUDA device, when
-        an outer CUDA graph capture is active (they are then recorded into that graph instead),
-        or when a previous capture attempt failed.
+        The kernels run eagerly (no capture or replay) when the device is not a CUDA device or
+        when a previous capture attempt failed.
+
+        Raises:
+            RuntimeError: If an outer CUDA graph capture is active. The PhysX tensor reads
+                cannot be graph-captured, so replays of such a graph would consume stale
+                contact data.
         """
+        device = wp.get_device(self._device)
+        if device.is_capturing:
+            raise RuntimeError(
+                f"Cannot update the contact sensor at '{self.cfg.prim_path}' while a CUDA graph capture"
+                " is active: the PhysX tensor reads cannot be graph-captured, so replaying the captured"
+                " graph would consume stale contact data."
+            )
+
         # Convert env_mask to warp array
         env_mask = self._resolve_indices_and_mask(None, env_mask)
         # Refresh the PhysX contact data (not graph-capturable)
@@ -414,8 +426,7 @@ class ContactSensor(BaseContactSensor):
         # _compute reads the stable outdated-environment mask from this attribute.
         self._env_mask = env_mask
 
-        device = wp.get_device(self._device)
-        if not self._use_graph or device.is_capturing:
+        if not self._use_graph:
             self._compute()
             return
 
@@ -434,40 +445,57 @@ class ContactSensor(BaseContactSensor):
             self._compute_graph = capture.graph
         wp.capture_launch(self._compute_graph)
 
+    @staticmethod
+    def _checked_view(buffer: wp.array, view: wp.array | None, dtype) -> wp.array:
+        """Returns the cached typed view over ``buffer``, verifying pointer stability.
+
+        The cached views (and the CUDA graph that consumes them) are only valid because the
+        PhysX tensor getters allocate their output buffers once and refresh the same memory in
+        place on every call. If a getter ever returns a re-backed buffer, the cached views would
+        silently read stale data, so a pointer change fails loudly here instead.
+        """
+        if view is None:
+            return buffer.view(dtype)
+        if buffer.ptr != view.ptr:
+            raise RuntimeError(
+                "A PhysX contact buffer was re-allocated after its warp view was cached. The cached"
+                " views and the captured CUDA graph require pointer-stable buffers refreshed in place."
+            )
+        return view
+
     def _fetch_physx_buffers(self) -> None:
         """Refreshes the contact data from PhysX and lazily builds the warp views over it.
 
         The PhysX tensor getters allocate their output buffers once and refresh them in place on
         every call, so the views (and the CUDA graph that consumes them) stay valid across
-        updates. Since ``get_friction_data`` refreshes the same count and start-index buffers as
-        ``get_contact_data``, the contact-point counts are staged into sensor-owned copies before
-        the friction read overwrites them.
+        updates (a pointer change raises via :meth:`_checked_view`). Since ``get_friction_data``
+        refreshes the same count and start-index buffers as ``get_contact_data``, the
+        contact-point counts are staged into sensor-owned copies before the friction read
+        overwrites them.
         """
         # PhysX returns (N*B, 3) float32 -> viewed as (N*B,) vec3f
         net_forces = self.contact_view.get_net_contact_forces(dt=self._sim_physics_dt)
-        if self._net_forces_flat is None:
-            self._net_forces_flat = net_forces.view(wp.vec3f)
+        self._net_forces_flat = self._checked_view(net_forces, self._net_forces_flat, wp.vec3f)
 
         # PhysX returns (N*B, M, 3) float32 -> viewed as (N*B, M) vec3f
         if self.cfg.filter_prim_paths_expr:
             force_matrix = self.contact_view.get_contact_force_matrix(dt=self._sim_physics_dt)
-            if self._force_matrix_flat is None:
-                self._force_matrix_flat = force_matrix.view(wp.vec3f)
+            self._force_matrix_flat = self._checked_view(force_matrix, self._force_matrix_flat, wp.vec3f)
 
         # PhysX returns (N*B, 7) float32 -> viewed as (N*B,) transformf
         if self.cfg.track_pose:
             poses = self.body_physx_view.get_transforms()
-            if self._poses_flat is None:
-                self._poses_flat = poses.view(wp.transformf)
+            self._poses_flat = self._checked_view(poses, self._poses_flat, wp.transformf)
 
         # points: (total_contacts, 3) float32 -> viewed as (total_contacts,) vec3f
         if self.cfg.track_contact_points:
             _, points, _, _, counts, start_indices = self.contact_view.get_contact_data(dt=self._sim_physics_dt)
             if self._contact_points_flat is None:
-                self._contact_points_flat = points.view(wp.vec3f)
+                self._contact_points_flat = self._checked_view(points, None, wp.vec3f)
                 self._contact_counts = wp.clone(counts)
                 self._contact_start_indices = wp.clone(start_indices)
             else:
+                self._contact_points_flat = self._checked_view(points, self._contact_points_flat, wp.vec3f)
                 wp.copy(self._contact_counts, counts)
                 wp.copy(self._contact_start_indices, start_indices)
 
@@ -475,9 +503,11 @@ class ContactSensor(BaseContactSensor):
         if self.cfg.track_friction_forces:
             frictions, _, counts, start_indices = self.contact_view.get_friction_data(dt=self._sim_physics_dt)
             if self._friction_forces_flat is None:
-                self._friction_forces_flat = frictions.view(wp.vec3f)
+                self._friction_forces_flat = self._checked_view(frictions, None, wp.vec3f)
                 self._friction_counts = counts
                 self._friction_start_indices = start_indices
+            else:
+                self._friction_forces_flat = self._checked_view(frictions, self._friction_forces_flat, wp.vec3f)
 
     def _compute(self) -> None:
         """Launches the warp kernels that update the sensor data from the fetched PhysX buffers.

--- a/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
@@ -8,8 +8,9 @@
 
 from __future__ import annotations
 
+import logging
 import re
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
 import torch
@@ -36,6 +37,8 @@ from .kernels import (
 
 if TYPE_CHECKING:
     from isaaclab.sensors.contact_sensor import ContactSensorCfg
+
+logger = logging.getLogger(__name__)
 
 
 class ContactSensor(BaseContactSensor):
@@ -96,6 +99,11 @@ class ContactSensor(BaseContactSensor):
         self._ALL_ENV_INDICES: wp.array | None = None
         self._ALL_ENV_MASK: wp.array | None = None
         self._reset_mask: wp.array | None = None
+
+        # CUDA graphs for the buffer update, keyed by stage name (see :meth:`_update_buffers_impl`).
+        # Each entry stores the captured graph and the pointers of its baked input arrays.
+        self._update_graphs: dict[str, tuple[wp.Graph, tuple[int, ...]]] = {}
+        self._graph_capture_enabled: bool = True
 
         # check if max_contact_data_count_per_prim is set
         if self.cfg.max_contact_data_count_per_prim is None:
@@ -370,10 +378,23 @@ class ContactSensor(BaseContactSensor):
         )
 
     def _update_buffers_impl(self, env_mask: wp.array | None = None):
-        """Fills the buffers of the sensor data."""
+        """Fills the buffers of the sensor data.
+
+        The PhysX tensor reads enqueue their work on the legacy CUDA stream and therefore cannot
+        be captured into a CUDA graph. They run eagerly on every update and refresh the same
+        cached output buffers in place. The warp kernels that consume those buffers are captured
+        into per-stage CUDA graphs on the first update and replayed afterwards, which removes
+        most of the per-update kernel-launch overhead (see :meth:`_run_update_stage`).
+        """
         # Convert env_mask to warp array
         env_mask = self._resolve_indices_and_mask(None, env_mask)
 
+        # Replaying a graph is only possible when no outer capture is active. During an outer
+        # capture, the kernels run "eagerly" and are recorded into that graph instead.
+        device = wp.get_device(self._device)
+        use_graph = self._graph_capture_enabled and device.is_cuda and not device.is_capturing
+
+        # -- Net forces --
         # PhysX returns (N*B, 3) float32 -> (N*B,) vec3f
         net_forces_flat = self.contact_view.get_net_contact_forces(dt=self._sim_physics_dt).view(wp.vec3f)
         # PhysX returns (N*B, M, 3) float32 -> (N*B, M) vec3f
@@ -381,67 +402,87 @@ class ContactSensor(BaseContactSensor):
             force_matrix_flat = self.contact_view.get_contact_force_matrix(dt=self._sim_physics_dt).view(wp.vec3f)
         else:
             force_matrix_flat = None
-        #
-        wp.launch(
-            update_net_forces_kernel,
-            dim=(self._num_envs, self._num_sensors),
-            inputs=[
-                net_forces_flat,
-                force_matrix_flat,
-                env_mask,
-                self._num_sensors,
-                self._num_filter_shapes,
-                self._history_length,
-                self.cfg.force_threshold,
-                self._timestamp,
-                self._timestamp_last_update,
-            ],
-            outputs=[
-                self._data._net_forces_w,
-                self._data._net_forces_w_history,
-                self._data._force_matrix_w,
-                self._data._force_matrix_w_history,
-                self._data._current_air_time,
-                self._data._current_contact_time,
-                self._data._last_air_time,
-                self._data._last_contact_time,
-            ],
-            device=self._device,
+
+        def launch_net_forces():
+            wp.launch(
+                update_net_forces_kernel,
+                dim=(self._num_envs, self._num_sensors),
+                inputs=[
+                    net_forces_flat,
+                    force_matrix_flat,
+                    env_mask,
+                    self._num_sensors,
+                    self._num_filter_shapes,
+                    self._history_length,
+                    self.cfg.force_threshold,
+                    self._timestamp,
+                    self._timestamp_last_update,
+                ],
+                outputs=[
+                    self._data._net_forces_w,
+                    self._data._net_forces_w_history,
+                    self._data._force_matrix_w,
+                    self._data._force_matrix_w_history,
+                    self._data._current_air_time,
+                    self._data._current_contact_time,
+                    self._data._last_air_time,
+                    self._data._last_contact_time,
+                ],
+                device=self._device,
+            )
+
+        self._run_update_stage(
+            "net_forces", launch_net_forces, (net_forces_flat, force_matrix_flat, env_mask), use_graph
         )
 
         # -- Pose --
         if self.cfg.track_pose:
             # PhysX returns (N*B, 7) float32 -> (N*B,) transformf
             poses_flat = self.body_physx_view.get_transforms().view(wp.transformf)
-            wp.launch(
-                split_flat_pose_to_pos_quat,
-                dim=(self._num_envs, self._num_sensors),
-                inputs=[poses_flat, env_mask, self._num_sensors],
-                outputs=[self._data._pos_w, self._data._quat_w],
-                device=self.device,
-            )
+
+            def launch_pose():
+                wp.launch(
+                    split_flat_pose_to_pos_quat,
+                    dim=(self._num_envs, self._num_sensors),
+                    inputs=[poses_flat, env_mask, self._num_sensors],
+                    outputs=[self._data._pos_w, self._data._quat_w],
+                    device=self.device,
+                )
+
+            self._run_update_stage("pose", launch_pose, (poses_flat, env_mask), use_graph)
 
         # -- Contact points --
+        # note: get_contact_data and get_friction_data refresh the same count and start-index
+        #   buffers, so each stage's kernel must run before the next stage's PhysX read.
         if self.cfg.track_contact_points:
             _, buffer_contact_points, _, _, buffer_count, buffer_start_indices = self.contact_view.get_contact_data(
                 dt=self._sim_physics_dt
             )
             # buffer_contact_points: (total_contacts, 3) float32 -> (total_contacts,) vec3f
             pts_vec3 = buffer_contact_points.view(wp.vec3f)
-            wp.launch(
-                unpack_contact_buffer_data,
-                dim=(self._num_envs, self._num_sensors, self._num_filter_shapes),
-                inputs=[
-                    pts_vec3,
-                    buffer_count,
-                    buffer_start_indices,
-                    env_mask,
-                    self._num_sensors,
-                    True,
-                    float("nan"),
-                ],
-                outputs=[self._data._contact_pos_w],
-                device=self.device,
+
+            def launch_contact_points():
+                wp.launch(
+                    unpack_contact_buffer_data,
+                    dim=(self._num_envs, self._num_sensors, self._num_filter_shapes),
+                    inputs=[
+                        pts_vec3,
+                        buffer_count,
+                        buffer_start_indices,
+                        env_mask,
+                        self._num_sensors,
+                        True,
+                        float("nan"),
+                    ],
+                    outputs=[self._data._contact_pos_w],
+                    device=self.device,
+                )
+
+            self._run_update_stage(
+                "contact_points",
+                launch_contact_points,
+                (pts_vec3, buffer_count, buffer_start_indices, env_mask),
+                use_graph,
             )
 
         # -- Friction forces --
@@ -450,21 +491,86 @@ class ContactSensor(BaseContactSensor):
                 dt=self._sim_physics_dt
             )
             friction_vec3 = friction_forces.view(wp.vec3f)
-            wp.launch(
-                unpack_contact_buffer_data,
-                dim=(self._num_envs, self._num_sensors, self._num_filter_shapes),
-                inputs=[
-                    friction_vec3,
-                    buffer_count,
-                    buffer_start_indices,
-                    env_mask,
-                    self._num_sensors,
-                    False,
-                    0.0,
-                ],
-                outputs=[self._data._friction_forces_w],
-                device=self.device,
+
+            def launch_friction_forces():
+                wp.launch(
+                    unpack_contact_buffer_data,
+                    dim=(self._num_envs, self._num_sensors, self._num_filter_shapes),
+                    inputs=[
+                        friction_vec3,
+                        buffer_count,
+                        buffer_start_indices,
+                        env_mask,
+                        self._num_sensors,
+                        False,
+                        0.0,
+                    ],
+                    outputs=[self._data._friction_forces_w],
+                    device=self.device,
+                )
+
+            self._run_update_stage(
+                "friction_forces",
+                launch_friction_forces,
+                (friction_vec3, buffer_count, buffer_start_indices, env_mask),
+                use_graph,
             )
+
+    def _run_update_stage(
+        self,
+        stage: str,
+        launch_fn: Callable[[], None],
+        inputs: tuple[wp.array | None, ...],
+        use_graph: bool,
+    ) -> None:
+        """Runs one stage of the buffer update, as a CUDA graph replay when possible.
+
+        On the first graphed call for a stage, the kernel launches are run eagerly once (so that
+        first-call allocations happen outside the capture and the data for this update is
+        produced) and then recorded into a CUDA graph. Subsequent calls replay the graph, which
+        skips the Python-side launch overhead. The graph bakes the device pointers of *inputs*,
+        so it is dropped and re-captured if any of them changes, and all graphs are dropped when
+        the physics views are invalidated.
+
+        If a capture attempt fails, the sensor falls back to eager launches for its lifetime and
+        a warning is logged once.
+
+        Args:
+            stage: Unique name identifying the captured scope.
+            launch_fn: A callable that launches the stage's warp kernels. It must be safe to
+                capture, i.e. contain only warp kernel launches on preallocated arrays.
+            inputs: The input arrays whose pointers are baked into the graph. ``None`` entries
+                are ignored.
+            use_graph: Whether graph capture/replay may be used for this call. If False, the
+                kernels are launched eagerly.
+        """
+        if not use_graph:
+            launch_fn()
+            return
+        input_ptrs = tuple(array.ptr for array in inputs if array is not None)
+        entry = self._update_graphs.get(stage)
+        if entry is not None:
+            graph, captured_ptrs = entry
+            if input_ptrs == captured_ptrs:
+                wp.capture_launch(graph)
+                return
+            # an input buffer moved: drop the stale graph and re-capture below
+            del self._update_graphs[stage]
+        # Warm-up: run eagerly once so that first-call allocations happen outside the capture.
+        # This also produces this update's data, since the capture only records the work.
+        launch_fn()
+        try:
+            with wp.ScopedCapture(device=self._device) as capture:
+                launch_fn()
+        except Exception as exc:
+            self._graph_capture_enabled = False
+            logger.warning(
+                f"Failed to capture the '{stage}' update stage of the contact sensor at"
+                f" '{self.cfg.prim_path}' into a CUDA graph. Falling back to eager kernel launches."
+                f" Reason: {exc}"
+            )
+            return
+        self._update_graphs[stage] = (capture.graph, input_ptrs)
 
     def _set_debug_vis_impl(self, debug_vis: bool):
         # set visibility of markers
@@ -510,3 +616,5 @@ class ContactSensor(BaseContactSensor):
         # set all existing views to None to invalidate them
         self._body_physx_view = None
         self._contact_view = None
+        # drop the captured update graphs since they reference buffers of the invalidated views
+        self._update_graphs.clear()

--- a/source/isaaclab_physx/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_physx/test/sensors/test_contact_sensor.py
@@ -16,11 +16,13 @@ simulation_app = AppLauncher(headless=True).app
 
 from dataclasses import MISSING
 from enum import Enum
+from types import SimpleNamespace
 
 import pytest
 import torch
 import warp as wp
 from flaky import flaky
+from isaaclab_physx.sensors.contact_sensor import contact_sensor as contact_sensor_module
 from isaaclab_physx.sensors.contact_sensor.contact_sensor import ContactSensor as PhysxContactSensor
 
 import isaaclab.sim as sim_utils
@@ -28,6 +30,7 @@ from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.assets import RigidObject, RigidObjectCfg
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import ContactSensor, ContactSensorCfg
+from isaaclab.sensors.contact_sensor import BaseContactSensor
 from isaaclab.sim import SimulationCfg, SimulationContext, build_simulation_context
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.terrains import HfRandomUniformTerrainCfg, TerrainGeneratorCfg, TerrainImporterCfg
@@ -225,14 +228,10 @@ def setup_simulation():
     return sim_dt, durations, terrains, devices, settings
 
 
-def test_cuda_graph_capture_launches_first_update_without_eager_compute():
-    """The initial graph capture should execute the update through one graph launch."""
-    device = "cuda:0"
-    env_mask = wp.ones(1, dtype=wp.bool, device=device)
-    source = wp.ones(1, dtype=wp.int32, device=device)
-    destination = wp.zeros(1, dtype=wp.int32, device=device)
-
+def _make_graph_test_sensor(device: str = "cuda:0") -> PhysxContactSensor:
+    """Create a minimal contact sensor for graph unit tests without a USD scene."""
     sensor = PhysxContactSensor.__new__(PhysxContactSensor)
+    sensor.cfg = SimpleNamespace(prim_path="/World/Sensor")
     sensor._device = device
     sensor._use_graph = True
     sensor._compute_graph = None
@@ -241,6 +240,16 @@ def test_cuda_graph_capture_launches_first_update_without_eager_compute():
     sensor._prim_deletion_handle = None
     sensor._resolve_indices_and_mask = lambda env_ids, mask: mask
     sensor._fetch_physx_buffers = lambda: None
+    return sensor
+
+
+def test_cuda_graph_capture_launches_first_update_without_eager_compute():
+    """The initial graph capture should execute the update through one graph launch."""
+    device = "cuda:0"
+    env_mask = wp.ones(1, dtype=wp.bool, device=device)
+    source = wp.ones(1, dtype=wp.int32, device=device)
+    destination = wp.zeros(1, dtype=wp.int32, device=device)
+    sensor = _make_graph_test_sensor()
 
     compute_call_count = 0
 
@@ -262,6 +271,101 @@ def test_cuda_graph_capture_launches_first_update_without_eager_compute():
 
     assert compute_call_count == 1
     assert destination.numpy().tolist() == [2]
+
+
+def test_contact_sensor_refuses_update_inside_outer_graph_capture():
+    """Updating the sensor during an outer capture should raise before touching PhysX."""
+    device = "cuda:0"
+    env_mask = wp.ones(1, dtype=wp.bool, device=device)
+    source = wp.ones(1, dtype=wp.int32, device=device)
+    destination = wp.zeros(1, dtype=wp.int32, device=device)
+    sensor = _make_graph_test_sensor()
+
+    fetch_call_count = 0
+
+    def fetch() -> None:
+        nonlocal fetch_call_count
+        fetch_call_count += 1
+
+    sensor._fetch_physx_buffers = fetch
+
+    with wp.ScopedCapture(device=wp.get_device(device)):
+        with pytest.raises(RuntimeError, match="CUDA graph capture"):
+            sensor._update_buffers_impl(env_mask)
+        # record something so the outer capture does not end empty
+        wp.copy(destination, source)
+
+    assert sensor._compute_graph is None
+    assert fetch_call_count == 0
+
+
+def test_contact_sensor_falls_back_when_graph_capture_fails(monkeypatch):
+    """A capture failure should disable graphs and still produce data eagerly."""
+    device = "cuda:0"
+    env_mask = wp.ones(1, dtype=wp.bool, device=device)
+    source = wp.ones(1, dtype=wp.int32, device=device)
+    destination = wp.zeros(1, dtype=wp.int32, device=device)
+    sensor = _make_graph_test_sensor()
+
+    compute_call_count = 0
+
+    def compute() -> None:
+        nonlocal compute_call_count
+        compute_call_count += 1
+        wp.copy(destination, source)
+
+    sensor._compute = compute
+
+    class _FailingCapture:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            raise RuntimeError("capture unavailable")
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(contact_sensor_module.wp, "ScopedCapture", _FailingCapture)
+
+    sensor._update_buffers_impl(env_mask)
+    wp.synchronize_device(device)
+
+    assert sensor._use_graph is False
+    assert sensor._compute_graph is None
+    assert compute_call_count == 1
+    assert destination.numpy().tolist() == [1]
+
+    sensor._update_buffers_impl(env_mask)
+    wp.synchronize_device(device)
+
+    assert compute_call_count == 2
+
+
+def test_contact_sensor_invalidation_drops_cached_graph_state(monkeypatch):
+    """Invalidation should clear the captured graph and every cached warp view."""
+    sensor = _make_graph_test_sensor()
+    monkeypatch.setattr(BaseContactSensor, "_invalidate_initialize_callback", lambda self, event: None)
+
+    cached_attrs = [
+        "_body_physx_view",
+        "_contact_view",
+        "_compute_graph",
+        "_net_forces_flat",
+        "_force_matrix_flat",
+        "_poses_flat",
+        "_contact_points_flat",
+        "_friction_forces_flat",
+        "_friction_counts",
+        "_friction_start_indices",
+    ]
+    for attr in cached_attrs:
+        setattr(sensor, attr, object())
+
+    sensor._invalidate_initialize_callback(None)
+
+    for attr in cached_attrs:
+        assert getattr(sensor, attr) is None, attr
 
 
 @pytest.mark.parametrize("disable_contact_processing", [True, False])

--- a/source/isaaclab_physx/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_physx/test/sensors/test_contact_sensor.py
@@ -21,6 +21,7 @@ import pytest
 import torch
 import warp as wp
 from flaky import flaky
+from isaaclab_physx.sensors.contact_sensor.contact_sensor import ContactSensor as PhysxContactSensor
 
 import isaaclab.sim as sim_utils
 from isaaclab.app.settings_manager import get_settings_manager
@@ -222,6 +223,45 @@ def setup_simulation():
     devices = ["cuda:0", "cpu"]
     settings = get_settings_manager()
     return sim_dt, durations, terrains, devices, settings
+
+
+def test_cuda_graph_capture_launches_first_update_without_eager_compute():
+    """The initial graph capture should execute the update through one graph launch."""
+    device = "cuda:0"
+    env_mask = wp.ones(1, dtype=wp.bool, device=device)
+    source = wp.ones(1, dtype=wp.int32, device=device)
+    destination = wp.zeros(1, dtype=wp.int32, device=device)
+
+    sensor = PhysxContactSensor.__new__(PhysxContactSensor)
+    sensor._device = device
+    sensor._use_graph = True
+    sensor._compute_graph = None
+    sensor._initialize_handle = None
+    sensor._invalidate_initialize_handle = None
+    sensor._prim_deletion_handle = None
+    sensor._resolve_indices_and_mask = lambda env_ids, mask: mask
+    sensor._fetch_physx_buffers = lambda: None
+
+    compute_call_count = 0
+
+    def compute() -> None:
+        nonlocal compute_call_count
+        compute_call_count += 1
+        wp.copy(destination, source)
+
+    sensor._compute = compute
+    sensor._update_buffers_impl(env_mask)
+    wp.synchronize_device(device)
+
+    assert compute_call_count == 1
+    assert destination.numpy().tolist() == [1]
+
+    source.fill_(2)
+    sensor._update_buffers_impl(env_mask)
+    wp.synchronize_device(device)
+
+    assert compute_call_count == 1
+    assert destination.numpy().tolist() == [2]
 
 
 @pytest.mark.parametrize("disable_contact_processing", [True, False])


### PR DESCRIPTION
# Description

Reports came in that our stack is slow with PhysX, and profiling the contact sensor update confirmed that the eager `wp.launch` calls dominate its per-step CPU cost: a single eager launch of `update_net_forces_kernel` costs ~110 us of CPU submit time, while replaying the same kernel from a CUDA graph costs ~7 us. The PhysX tensor reads themselves are comparatively cheap (~34 us).

This PR captures the warp kernels of the PhysX `ContactSensor` buffer update into CUDA graphs on first use and replays them on subsequent updates:

- **PhysX tensor reads stay eager.** They cannot be captured — `GpuRigidContactView` enqueues its work on the legacy CUDA stream, and capture fails with `operation would make the legacy stream depend on a capturing blocking stream`. Fortunately the tensor API caches its output buffers and refreshes them in place on every call, so the getters run eagerly before each graph replay and the graphed kernels read the refreshed data.
- **Per-stage graphs.** `get_contact_data` and `get_friction_data` share their count/start-index buffers on the view, so each stage's kernel must run before the next stage's PhysX read. Each stage (net forces, pose, contact points, friction forces) is therefore captured as its own graph, preserving the exact ordering of the eager path.
- **Only graphs when not already being graphed.** If an outer CUDA graph capture is active (`device.is_capturing`), the kernels run "eagerly" and are recorded into that outer graph instead of replaying a nested one.
- **Safe fallbacks.** Eager execution on CPU devices; a one-time warning and permanent eager fallback if capture fails; graphs bake input pointers and are dropped/re-captured if a pointer changes; all graphs are dropped when the physics views are invalidated.

A new benchmark script compares the two paths:

```bash
./isaaclab.sh -p scripts/benchmarks/benchmark_contact_sensor.py --num_envs 4096 --headless
./isaaclab.sh -p scripts/benchmarks/benchmark_contact_sensor.py --num_envs 4096 --disable_graph --headless
```

Results on an RTX 5000 Ada laptop GPU (default sensor config: net forces + air time, 500 timed steps, mean synchronized update time):

| num_envs | eager | graphed |
|---|---|---|
| 32 | 0.463 ms | 0.407 ms |
| 4096 | 0.490 ms | 0.391 ms |

The saving matches one graphed kernel (the default config launches a single kernel per update); configs with `track_pose` / `track_contact_points` / `track_friction_forces` graph up to four. The remaining overhead is the base-class `update_timestamp_kernel` / `update_outdated_envs_kernel` launches in `SensorBase`, which are shared across backends and left for a follow-up.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
