### PR TITLE
[Docs] Fix broken Isaac ROS DNN policy link failing link-check CI

### DIFF
--- a/docs/source/policy_deployment/02_gear_assembly/gear_assembly_policy.rst
+++ b/docs/source/policy_deployment/02_gear_assembly/gear_assembly_policy.rst
@@ -36,7 +36,7 @@ This environment has been successfully deployed on real UR10e and Flexiv Rizon 4
 
 **Scope of This Tutorial:**
 
-This tutorial focuses exclusively on the **training part** of the sim-to-real transfer workflow in Isaac Lab. For the complete deployment workflow on the real robot, including the exact steps to set up the vision pipeline, robot interface and the ROS inference node to run your trained policy on real hardware, please refer to the `Isaac ROS Documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_ur_dnn_policy/index.html>`_.
+This tutorial focuses exclusively on the **training part** of the sim-to-real transfer workflow in Isaac Lab. For the complete deployment workflow on the real robot, including the exact steps to set up the vision pipeline, robot interface and the ROS inference node to run your trained policy on real hardware, please refer to the `Isaac ROS Documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_dnn_policy/index.html>`_.
 
 Overview
 --------
@@ -755,7 +755,7 @@ Replace the log directory path with your actual training log location if differe
 Step 3: Deploy on Real Robot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once training is complete, follow the `Isaac ROS inference documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_ur_dnn_policy/index.html>`_ to deploy your policy.
+Once training is complete, follow the `Isaac ROS inference documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_dnn_policy/index.html>`_ to deploy your policy.
 
 The Isaac ROS deployment pipeline directly uses the trained model checkpoint (``.pt`` file) along with the ``agent.yaml`` and ``env.yaml`` configuration files generated during training. No additional export step is required.
 


### PR DESCRIPTION
## 1. Summary

The Isaac ROS docs dropped the `ur_` prefix from the UR DNN policy package page, so the URL `https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_ur_dnn_policy/index.html` now returns 404 and fails the **Check Documentation Links** job on every docs-touching PR (e.g. [this run](https://github.com/isaac-sim/IsaacLab/actions/runs/28883464896/job/85677493362)). This updates the two references in `gear_assembly_policy.rst` to the renamed page, `isaac_ros_manipulation_dnn_policy`, which is the same UR DNN policy deployment content at its new location.

## 2. Test plan

- [x] Old URL returns 404, new URL returns 200 (`curl`); new page is linked from the Isaac for Manipulation index and covers the UR DNN policy workflow
- [x] **Check Documentation Links** CI job passes on this PR
