### PR TITLE
Drop redundant `_renderer` suffix from renderer presets

### DIFF
--- a/docs/source/features/hydra.rst
+++ b/docs/source/features/hydra.rst
@@ -408,11 +408,11 @@ to make intent explicit on the command line.
 
    * - Name
      - Renderer
-   * - ``default`` / ``isaacsim_rtx_renderer``
+   * - ``default`` / ``isaacsim_rtx``
      - Isaac Sim RTX renderer (used when no ``renderer=`` or ``presets=`` is given)
    * - ``newton_renderer``
      - Newton Warp renderer
-   * - ``ovrtx_renderer``
+   * - ``ovrtx``
      - OV RTX renderer
    * - ``rtx``
      - Automatic RTX renderer selection (Isaac Sim RTX when running with Isaac Sim, and OVRTX for kit-less)

--- a/docs/source/how-to/record_video.rst
+++ b/docs/source/how-to/record_video.rst
@@ -91,9 +91,9 @@ of active visualizers.
 
 Set ``VideoRecorderCfg.backend_source = "renderer"`` to ignore active visualizers and choose from the
 physics/renderer stack instead. In that mode, PhysX physics (``physics=physx``) or Isaac RTX
-(``renderer=isaacsim_rtx_renderer``) selects the Kit path. Newton physics (``physics=newton_mjwarp``) or
+(``renderer=isaacsim_rtx``) selects the Kit path. Newton physics (``physics=newton_mjwarp``) or
 the Newton Warp renderer (``renderer=newton_renderer``) selects the Newton GL path when no Kit
-signal is present. OVRTX (``renderer=ovrtx_renderer`` from ``isaaclab_ov``) can pair with IsaacSim
+signal is present. OVRTX (``renderer=ovrtx`` from ``isaaclab_ov``) can pair with IsaacSim
 or Newton physics; in that case the video backend is selected via the physics preset. If both Kit and
 Newton GL signals are present, the Kit path is chosen.
 
@@ -157,13 +157,13 @@ Summary
    * - Stack example (``physics=`` / ``renderer=``)
      - Video backend
      - Capture mechanism
-   * - ``physics=physx`` or ``renderer=isaacsim_rtx_renderer``
+   * - ``physics=physx`` or ``renderer=isaacsim_rtx``
      - Kit (``"kit"``)
      - ``/OmniverseKit_Persp`` + Replicator RGB
    * - ``physics=newton_mjwarp`` or ``renderer=newton_renderer`` (no Kit signals)
      - Newton GL (``"newton_gl"``)
      - ``newton.viewer.ViewerGL`` on the SDP Newton model
-   * - ``physics=newton_mjwarp`` + ``renderer=ovrtx_renderer`` (OVRTX + Newton physics)
+   * - ``physics=newton_mjwarp`` + ``renderer=ovrtx`` (OVRTX + Newton physics)
      - Newton GL (``"newton_gl"``)
      - ``newton.viewer.ViewerGL`` on the SDP Newton model
    * - ``--visualizer kit`` with default ``backend_source``

--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -148,7 +148,7 @@ The active preset is selected at launch via ``physics=``, ``renderer=``, or ``pr
    python train.py task=Isaac-Cartpole-Camera-Direct renderer=newton_renderer
 
    # Use OVRTX renderer
-   python train.py task=Isaac-Cartpole-Camera-Direct renderer=ovrtx_renderer
+   python train.py task=Isaac-Cartpole-Camera-Direct renderer=ovrtx
 
    # Use default (Isaac RTX)
    python train.py task=Isaac-Cartpole-Camera-Direct

--- a/docs/source/overview/core-concepts/visualization.rst
+++ b/docs/source/overview/core-concepts/visualization.rst
@@ -10,7 +10,7 @@ visualizers are meant for fast, interactive feedback.
 Most visualizers can be combined with any physics engine or rendering backend.
 The exception is the Kit visualizer with kit-less OV backends:
 ``--visualizer kit`` cannot be used with ``presets=ovphysx`` or
-``ovrtx_renderer`` in the same process. Use ``--visualizer newton``,
+``ovrtx`` in the same process. Use ``--visualizer newton``,
 ``--visualizer rerun``, ``--visualizer viser``, or omit ``--visualizer``
 for headless execution.
 
@@ -281,19 +281,19 @@ set ``VideoRecorderCfg.backend_source = "renderer"`` in the task configuration.
    * - Renderer preset
      - ``--visualizer kit --video``
      - ``--visualizer newton --video``
-   * - ``isaacsim_rtx_renderer``
+   * - ``isaacsim_rtx``
      - ✅ Kit RTX captures video *(default, no change)*
      - ✅ Newton GL captures video *(overrides RTX backend)*
    * - ``newton_renderer``
      - ✅ Kit RTX captures video *(overrides Newton backend)*
      - ✅ Newton GL captures video *(default, no change)*
-   * - ``ovrtx_renderer``
+   * - ``ovrtx``
      - ❌ **Raises an error** — see note below
      - ✅ Newton GL captures video; ovrtx provides camera sensor data
 
 .. note::
 
-   ``--visualizer kit`` combined with ``ovrtx_renderer`` raises a ``ValueError`` at startup.
+   ``--visualizer kit`` combined with ``ovrtx`` raises a ``ValueError`` at startup.
    Both Kit (Isaac Sim) and ovrtx ship conflicting RTX hydra libraries compiled against
    different USD namespaces (``pxrInternal_v0_25_11`` vs ``ovInternal_v0_25_11``), which
    causes a dynamic-linker crash when loaded into the same process.
@@ -313,7 +313,7 @@ set ``VideoRecorderCfg.backend_source = "renderer"`` in the task configuration.
      --max_iterations=5 \
      --num_envs=1024 \
      --benchmark_backend=summary \
-     physics=newton_mjwarp renderer=ovrtx_renderer presets=rgb
+     physics=newton_mjwarp renderer=ovrtx presets=rgb
 
 **Record video with the Isaac RTX renderer preset using the Newton video backend**
 
@@ -329,7 +329,7 @@ set ``VideoRecorderCfg.backend_source = "renderer"`` in the task configuration.
      --max_iterations=5 \
      --num_envs=1024 \
      --benchmark_backend=summary \
-     physics=physx renderer=isaacsim_rtx_renderer presets=rgb
+     physics=physx renderer=isaacsim_rtx presets=rgb
 
 **Record video with the Isaac RTX renderer preset using the Kit video backend**
 
@@ -345,7 +345,7 @@ set ``VideoRecorderCfg.backend_source = "renderer"`` in the task configuration.
      --max_iterations=5 \
      --num_envs=1024 \
      --benchmark_backend=summary \
-     physics=physx renderer=isaacsim_rtx_renderer presets=rgb
+     physics=physx renderer=isaacsim_rtx presets=rgb
 
 
 Visualizer Backends

--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -68,7 +68,7 @@ modes. The **Presets** column in each table below is divided into three labeled 
   (e.g. ``physx``, ``newton_mjwarp``, ``newton_kamino``, ``ovphysx``,
   ``newton_mjwarp_vbd``)
 * **renderer=** — renderer-backend name passed as ``renderer=NAME``
-  (e.g. ``isaacsim_rtx_renderer``, ``newton_renderer``, ``ovrtx_renderer``, ``rtx``)
+  (e.g. ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``)
 * **presets=** — environment-specific (domain) preset name passed as
   ``presets=NAME[,NAME,...]``
   (e.g. ``rgb``, ``depth``, ``single_camera``, ``duo_camera``)
@@ -118,9 +118,9 @@ Classic environments that are based on IsaacGymEnvs implementation of MuJoCo-sty
     |                  |                             | running with ``--enable_cameras``.                                      | ``newton_mjwarp``,           |
     |                  |                             |                                                                         | ``ovphysx`` (direct only)    |
     |                  |                             |                                                                         | **renderer=**                |
-    |                  |                             |                                                                         | ``isaacsim_rtx_renderer``,   |
+    |                  |                             |                                                                         | ``isaacsim_rtx``,            |
     |                  |                             |                                                                         | ``newton_renderer``,         |
-    |                  |                             |                                                                         | ``ovrtx_renderer``           |
+    |                  |                             |                                                                         | ``ovrtx``                    |
     |                  |                             |                                                                         | **presets=** ``rgb``,        |
     |                  |                             |                                                                         | ``depth``, ``albedo``,       |
     |                  |                             |                                                                         | ``semantic_segmentation``,   |
@@ -206,9 +206,9 @@ for the lift-cube environment:
     | |cube-shadow|           | |cube-shadow-vis-link|       | In-hand reorientation of a cube using Shadow hand using perceptive inputs.  | **physics=** ``physx``,      |
     |                         |                              | Requires running with ``--enable_cameras``.                                 | ``newton_mjwarp``            |
     |                         |                              |                                                                             | **renderer=**                |
-    |                         |                              |                                                                             | ``isaacsim_rtx_renderer``,   |
+    |                         |                              |                                                                             | ``isaacsim_rtx``,            |
     |                         |                              |                                                                             | ``newton_renderer``,         |
-    |                         |                              |                                                                             | ``ovrtx_renderer``           |
+    |                         |                              |                                                                             | ``ovrtx``                    |
     |                         |                              |                                                                             | **presets=** ``rgb``,        |
     |                         |                              |                                                                             | ``depth``, ``albedo``,       |
     |                         |                              |                                                                             | ``full``,                    |
@@ -236,9 +236,9 @@ for the lift-cube environment:
     | |kuka-allegro-lift|     | |ka-lift-cam-link|           | Camera (vision) variant of the lift task, adding single- and dual-camera    | **physics=** ``physx``,      |
     |                         |                              | observations via ``presets=single_camera`` / ``presets=duo_camera``.        | ``newton_mjwarp``            |
     |                         |                              |                                                                             | **renderer=**                |
-    |                         |                              |                                                                             | ``isaacsim_rtx_renderer``,   |
+    |                         |                              |                                                                             | ``isaacsim_rtx``,            |
     |                         |                              |                                                                             | ``newton_renderer``,         |
-    |                         |                              |                                                                             | ``ovrtx_renderer``           |
+    |                         |                              |                                                                             | ``ovrtx``                    |
     |                         |                              |                                                                             | **presets=**                 |
     |                         |                              |                                                                             | ``single_camera``,           |
     |                         |                              |                                                                             | ``duo_camera``,              |
@@ -252,9 +252,9 @@ for the lift-cube environment:
     | |kuka-allegro-reorient| | |ka-reorient-cam-link|       | Camera (vision) variant of the reorient task, adding single- and            | **physics=** ``physx``,      |
     |                         |                              | dual-camera observations via ``presets=single_camera`` /                    | ``newton_mjwarp``            |
     |                         |                              | ``presets=duo_camera``.                                                     | **renderer=**                |
-    |                         |                              |                                                                             | ``isaacsim_rtx_renderer``,   |
+    |                         |                              |                                                                             | ``isaacsim_rtx``,            |
     |                         |                              |                                                                             | ``newton_renderer``,         |
-    |                         |                              |                                                                             | ``ovrtx_renderer``           |
+    |                         |                              |                                                                             | ``ovrtx``                    |
     |                         |                              |                                                                             | **presets=**                 |
     |                         |                              |                                                                             | ``single_camera``,           |
     |                         |                              |                                                                             | ``duo_camera``,              |
@@ -910,14 +910,14 @@ inferencing, including reading from an already trained checkpoint and disabling 
       - Manager Based
       - **rl_games** (PPO, FEATURE), **rsl_rl** (PPO, FEATURE)
       - | **physics=** ``newton_kamino``, ``newton_mjwarp``, ``physx``
-          | **renderer=** ``isaacsim_rtx_renderer``, ``newton_renderer``, ``ovrtx_renderer``, ``rtx``
+          | **renderer=** ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``
           | **presets=** ``albedo``, ``depth``, ``resnet18``, ``rgb``, ``semantic_segmentation``, ``simple_shading_constant_diffuse``, ``simple_shading_diffuse_mdl``, ``simple_shading_full_mdl``, ``theia_tiny``
     * - Isaac-Cartpole-Camera-Direct
       -
       - Direct
       - **rl_games** (PPO), **rsl_rl** (PPO), **skrl** (PPO)
       - | **physics=** ``newton_kamino``, ``newton_mjwarp``, ``ovphysx``, ``physx``
-          | **renderer=** ``isaacsim_rtx_renderer``, ``newton_renderer``, ``ovrtx_renderer``, ``rtx``
+          | **renderer=** ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``
           | **presets=** ``albedo``, ``depth``, ``rgb``, ``semantic_segmentation``, ``simple_shading_constant_diffuse``, ``simple_shading_diffuse_mdl``, ``simple_shading_full_mdl``
     * - IsaacContrib-Cartpole-Camera-Showcase-Direct
       -
@@ -1104,7 +1104,7 @@ inferencing, including reading from an already trained checkpoint and disabling 
       -
       - Manager Based
       - **rsl_rl** (PPO)
-      - | **renderer=** ``isaacsim_rtx_renderer``, ``newton_renderer``, ``ovrtx_renderer``, ``rtx``
+      - | **renderer=** ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``
           | **presets=** ``albedo128``, ``albedo256``, ``albedo64``, ``cube``, ``depth128``, ``depth256``, ``depth64``, ``duo_camera``, ``raycaster_depth128``, ``raycaster_depth256``, ``raycaster_depth64``, ``rgb128``, ``rgb256``, ``rgb64``, ``semantic_segmentation128``, ``semantic_segmentation256``, ``semantic_segmentation64``, ``shapes``, ``simple_shading_constant_diffuse128``, ``simple_shading_constant_diffuse256``, ``simple_shading_constant_diffuse64``, ``simple_shading_diffuse_mdl128``, ``simple_shading_diffuse_mdl256``, ``simple_shading_diffuse_mdl64``, ``simple_shading_full_mdl128``, ``simple_shading_full_mdl256``, ``simple_shading_full_mdl64``, ``single_camera``
     * - Isaac-Lift-KukaAllegro-Play
       -
@@ -1281,14 +1281,14 @@ inferencing, including reading from an already trained checkpoint and disabling 
       - Direct
       - **rl_games** (PPO), **rsl_rl** (PPO)
       - | **physics=** ``newton_mjwarp``, ``physx``
-          | **renderer=** ``isaacsim_rtx_renderer``, ``newton_renderer``, ``ovrtx_renderer``, ``rtx``
+          | **renderer=** ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``
           | **presets=** ``albedo``, ``depth``, ``full``, ``rgb``, ``semantic_segmentation``, ``simple_shading_constant_diffuse``, ``simple_shading_diffuse_mdl``, ``simple_shading_full_mdl``
     * - Isaac-Reorient-Cube-Shadow-Camera-Direct-Play
       -
       - Direct
       - **rl_games** (PPO), **rsl_rl** (PPO)
       - | **physics=** ``newton_mjwarp``, ``physx``
-          | **renderer=** ``isaacsim_rtx_renderer``, ``newton_renderer``, ``ovrtx_renderer``, ``rtx``
+          | **renderer=** ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``
           | **presets=** ``albedo``, ``depth``, ``full``, ``rgb``, ``semantic_segmentation``, ``simple_shading_constant_diffuse``, ``simple_shading_diffuse_mdl``, ``simple_shading_full_mdl``
     * - Isaac-Reorient-Cube-Shadow-Direct
       -
@@ -1314,7 +1314,7 @@ inferencing, including reading from an already trained checkpoint and disabling 
       -
       - Manager Based
       - **rsl_rl** (PPO)
-      - | **renderer=** ``isaacsim_rtx_renderer``, ``newton_renderer``, ``ovrtx_renderer``, ``rtx``
+      - | **renderer=** ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``
           | **presets=** ``albedo128``, ``albedo256``, ``albedo64``, ``cube``, ``depth128``, ``depth256``, ``depth64``, ``duo_camera``, ``raycaster_depth128``, ``raycaster_depth256``, ``raycaster_depth64``, ``rgb128``, ``rgb256``, ``rgb64``, ``semantic_segmentation128``, ``semantic_segmentation256``, ``semantic_segmentation64``, ``shapes``, ``simple_shading_constant_diffuse128``, ``simple_shading_constant_diffuse256``, ``simple_shading_constant_diffuse64``, ``simple_shading_diffuse_mdl128``, ``simple_shading_diffuse_mdl256``, ``simple_shading_diffuse_mdl64``, ``simple_shading_full_mdl128``, ``simple_shading_full_mdl256``, ``simple_shading_full_mdl64``, ``single_camera``
     * - Isaac-Reorient-KukaAllegro-Play
       -
@@ -1386,7 +1386,7 @@ inferencing, including reading from an already trained checkpoint and disabling 
       - Manager Based
       -
       - | **physics=** ``newton_mjwarp``, ``physx``
-          | **renderer=** ``isaacsim_rtx_renderer``, ``newton_renderer``, ``ovrtx_renderer``, ``rtx``
+          | **renderer=** ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``
     * - IsaacContrib-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow
       -
       - Manager Based

--- a/docs/source/setup/quickstart_details.rst
+++ b/docs/source/setup/quickstart_details.rst
@@ -53,7 +53,7 @@ options (observation modes, camera configs, etc.). They fold into Hydra override
          ./isaaclab.sh train --rl_library rsl_rl \
            --task=Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct \
            --enable_cameras --num_envs=16 --max_iterations=10 \
-           physics=newton_mjwarp renderer=ovrtx_renderer presets=simple_shading_diffuse_mdl
+           physics=newton_mjwarp renderer=ovrtx presets=simple_shading_diffuse_mdl
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows
       :sync: windows
@@ -81,9 +81,9 @@ Available Presets
 
 **Renderer backends** (``renderer=NAME``):
 
-- ``isaacsim_rtx_renderer`` — Isaac Sim RTX (default with Isaac Sim)
+- ``isaacsim_rtx`` — Isaac Sim RTX (default with Isaac Sim)
 - ``newton_renderer`` — Newton Warp renderer
-- ``ovrtx_renderer`` — OV RTX renderer (kit-less)
+- ``ovrtx`` — OV RTX renderer (kit-less)
 - ``rtx`` — Automatic RTX renderer selection
 
 Automatic RTX selection is available only when the camera exposes the renderer
@@ -132,11 +132,11 @@ Common combinations:
    physics=newton_mjwarp renderer=newton_renderer presets=rgb
    physics=newton_mjwarp renderer=newton_renderer presets=depth
    physics=newton_mjwarp renderer=rtx presets=rgb
-   physics=physx renderer=isaacsim_rtx_renderer presets=rgb
-   physics=physx renderer=isaacsim_rtx_renderer presets=depth
-   physics=physx renderer=isaacsim_rtx_renderer presets=albedo
-   physics=newton_mjwarp renderer=ovrtx_renderer presets=rgb
-   physics=newton_mjwarp renderer=ovrtx_renderer presets=simple_shading_diffuse_mdl
+   physics=physx renderer=isaacsim_rtx presets=rgb
+   physics=physx renderer=isaacsim_rtx presets=depth
+   physics=physx renderer=isaacsim_rtx presets=albedo
+   physics=newton_mjwarp renderer=ovrtx presets=rgb
+   physics=newton_mjwarp renderer=ovrtx presets=simple_shading_diffuse_mdl
 
 Legacy ``presets=newton_mjwarp,newton_renderer,rgb`` form still works; prefer typed selectors
 for clarity. See :doc:`/source/features/hydra` for the full preset system.

--- a/scripts/benchmarks/benchmark_hydra_resolve.py
+++ b/scripts/benchmarks/benchmark_hydra_resolve.py
@@ -70,7 +70,7 @@ QUICK_CASES = (
         "cartpole_camera_newton_ovrtx",
         "Isaac-Cartpole-Camera-Direct",
         "rl_games_cfg_entry_point",
-        ("presets=newton_mjwarp,ovrtx_renderer",),
+        ("presets=newton_mjwarp,ovrtx",),
     ),
     Case("anymal_rough_scalar", "IsaacContrib-Velocity-Rough-AnymalC", None, ("env.scene.num_envs=256",)),
 )

--- a/scripts/benchmarks/utils.py
+++ b/scripts/benchmarks/utils.py
@@ -125,7 +125,7 @@ def get_preset_string(hydra_args: list[str]) -> str:
     """Extract the active preset string from CLI hydra args or an environment variable.
 
     Checks (in order):
-        1. ``presets=...`` in *hydra_args* (e.g. ``presets=physx,ovrtx_renderer,rgb``)
+        1. ``presets=...`` in *hydra_args* (e.g. ``presets=physx,ovrtx,rgb``)
         2. ``ISAACLAB_BENCHMARK_PRESET`` environment variable
         3. Falls back to ``"default"``
     """

--- a/source/isaaclab/changelog.d/renderer-preset-alias.rst
+++ b/source/isaaclab/changelog.d/renderer-preset-alias.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Updated the ``launch_simulation`` runtime-compatibility error and help text to
+  reference the suffix-less renderer presets ``ovrtx`` and ``isaacsim_rtx``
+  instead of ``ovrtx_renderer`` and ``isaacsim_rtx_renderer``.

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -351,11 +351,11 @@ def _validate_runtime(scan: Scan, launcher_args: argparse.Namespace | dict | Non
         "\n"
         "To fix this, pick one of the following supported combinations:\n"
         "  * Keep Isaac Sim / Kit and switch the renderer:\n"
-        "      presets=isaacsim_rtx_renderer\n"
+        "      presets=isaacsim_rtx\n"
         "    (uses `IsaacRtxRendererCfg`, the Kit-compatible renderer.)\n"
         "  * Keep the OVRTX renderer and switch to a kitless physics backend\n"
         "    (and avoid `--visualizer kit`):\n"
-        "      presets=newton_mjwarp,ovrtx_renderer\n"
+        "      presets=newton_mjwarp,ovrtx\n"
     )
 
 
@@ -423,7 +423,7 @@ def launch_simulation(
     # with a targeted hint (_validate_runtime covers the broader ovrtx-vs-Kit cases).
     if "kit" in visualizer_types and config_scan.has_ovrtx:
         raise ValueError(
-            "[launch_simulation] '--visualizer kit' is incompatible with 'ovrtx_renderer'. "
+            "[launch_simulation] '--visualizer kit' is incompatible with 'ovrtx'. "
             "Both Kit (Isaac Sim) and ovrtx ship conflicting RTX hydra libraries "
             "(librtx.hydra.so, liblegacy.hydra.so) compiled against different USD namespaces, "
             "which causes a dynamic-linker crash when loaded into the same process. "

--- a/source/isaaclab/isaaclab/test/benchmark/schema.py
+++ b/source/isaaclab/isaaclab/test/benchmark/schema.py
@@ -135,7 +135,7 @@ class RunConfig:
         rendering_backend: Rendering backend, or ``"none"`` for headless runs
             with no camera sensors.
         presets: Active Hydra preset tokens applied to the run (e.g.
-            ``["rgb", "ovrtx_renderer"]``). Open-ended so sensor data types,
+            ``["rgb", "ovrtx"]``). Open-ended so sensor data types,
             resolutions, and any other domain presets are captured without a
             closed enum; ``physics_backend`` / ``rendering_backend`` surface the
             two primary grouping dimensions as typed fields.

--- a/source/isaaclab/test/benchmark/test_schema.py
+++ b/source/isaaclab/test/benchmark/test_schema.py
@@ -300,13 +300,13 @@ def test_extra_field_round_trips(tmp_path):
 def test_run_config_presets_round_trip(tmp_path):
     """RunConfig.presets is an open-ended token list; defaults to [] and round-trips."""
     assert RunConfig(physics_backend="physx").presets == []
-    cfg = RunConfig(physics_backend="newton_mjwarp", rendering_backend="ovrtx", presets=["rgb", "ovrtx_renderer"])
+    cfg = RunConfig(physics_backend="newton_mjwarp", rendering_backend="ovrtx", presets=["rgb", "ovrtx"])
     base = _minimal_training_bundle()
     bundle = dataclasses.replace(base, run=dataclasses.replace(base.run, config=cfg))
     path = os.path.join(tmp_path, "training.json")
     write_bundle_file(bundle, path)
     with open(path) as f:
         data = json.load(f)
-    assert data["run"]["config"]["presets"] == ["rgb", "ovrtx_renderer"]
+    assert data["run"]["config"]["presets"] == ["rgb", "ovrtx"]
     assert "sensor_dtype" not in data["run"]["config"]
     assert "sensor_resolution" not in data["run"]["config"]

--- a/source/isaaclab_tasks/changelog.d/renderer-preset-alias.rst
+++ b/source/isaaclab_tasks/changelog.d/renderer-preset-alias.rst
@@ -1,0 +1,16 @@
+Changed
+^^^^^^^
+
+* Renamed the renderer presets ``ovrtx_renderer`` -> ``ovrtx`` and
+  ``isaacsim_rtx_renderer`` -> ``isaacsim_rtx`` to drop the redundant
+  ``_renderer`` suffix (the ``renderer=`` selector already names the category).
+  The old ``ovrtx_renderer`` / ``isaacsim_rtx_renderer`` spellings still resolve
+  as deprecated aliases and emit a :class:`FutureWarning`; migrate to the
+  suffix-less names, which will become the only accepted form in a future
+  release.
+
+Deprecated
+^^^^^^^^^^
+
+* Deprecated the renderer preset names ``ovrtx_renderer`` and
+  ``isaacsim_rtx_renderer`` in favor of ``ovrtx`` and ``isaacsim_rtx``.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_camera_env_cfg.py
@@ -99,7 +99,7 @@ class ShadowHandTiledCameraCfg(PresetCfg):
 
             presets=depth          # depth rendering, default renderer
             presets=depth,newton_renderer     # depth rendering with Newton renderer
-            presets=depth,ovrtx_renderer    # depth rendering with OVRTX renderer
+            presets=depth,ovrtx    # depth rendering with OVRTX renderer
     """
 
     semantic_segmentation: _ShadowHandBaseTiledCameraCfg = _ShadowHandBaseTiledCameraCfg(
@@ -166,7 +166,7 @@ class ShadowHandCameraBenchmarkEnvCfg(ShadowHandCameraEnvCfg):
     The renderer backend and camera data types can still be selected via ``presets``::
 
         presets = newton_renderer  # benchmark with Newton renderer
-        presets = ovrtx_renderer  # benchmark with OVRTX renderer
+        presets = ovrtx  # benchmark with OVRTX renderer
         presets = rgb  # benchmark RGB rendering only
         presets = depth, newton_renderer  # benchmark depth rendering with Newton
     """

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
@@ -68,8 +68,17 @@ class PresetTarget(enum.Enum):
     future release.
     """
 
-    RENDERER = ("renderer", (RendererCfg,))
-    """Camera-sensor renderers -- ``renderer=NAME`` selector."""
+    RENDERER = ("renderer", (RendererCfg,), {"ovrtx_renderer": "ovrtx", "isaacsim_rtx_renderer": "isaacsim_rtx"})
+    """Camera-sensor renderers -- ``renderer=NAME`` selector.
+
+    Legacy aliases ``ovrtx_renderer`` -> ``ovrtx`` and
+    ``isaacsim_rtx_renderer`` -> ``isaacsim_rtx`` exist because the renderer
+    presets dropped their redundant ``_renderer`` suffix (the ``renderer=``
+    selector already names the category). Hydra's resolver (see
+    :func:`~isaaclab_tasks.utils.hydra._normalize_preset_name`) consults these
+    and emits a :class:`FutureWarning`; the aliases will be removed in a
+    future release.
+    """
 
     DOMAIN = ("presets",)
     """Free-form env-specific presets -- ``presets=NAME[,...]`` selector (catch-all).

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/presets.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/presets.py
@@ -25,8 +25,8 @@ class MultiBackendRendererCfg(PresetCfg):
     default: IsaacRtxRendererCfg = IsaacRtxRendererCfg()
     rtx: _AutoRtxRendererCfg = _AutoRtxRendererCfg()
     newton_renderer: NewtonWarpRendererCfg = NewtonWarpRendererCfg()
-    ovrtx_renderer: OVRTXRendererCfg = OVRTXRendererCfg()
-    isaacsim_rtx_renderer = default
+    ovrtx: OVRTXRendererCfg = OVRTXRendererCfg()
+    isaacsim_rtx = default
 
 
 def set_isaac_rtx_global_settings(renderer_cfg: Any, **settings: Any) -> None:
@@ -40,7 +40,7 @@ def set_isaac_rtx_global_settings(renderer_cfg: Any, **settings: Any) -> None:
         if getattr(cfg, "renderer_type", None) == "isaac_rtx" and hasattr(cfg, "global_settings"):
             for key, value in settings.items():
                 setattr(cfg.global_settings, key, value)
-        for attr_name in ("default", "isaacsim_rtx_renderer"):
+        for attr_name in ("default", "isaacsim_rtx"):
             _visit(getattr(cfg, attr_name, None))
 
     _visit(renderer_cfg)

--- a/source/isaaclab_tasks/test/core/test_hydra.py
+++ b/source/isaaclab_tasks/test/core/test_hydra.py
@@ -366,6 +366,27 @@ def test_legacy_kamino_attribute_alias_warns():
         assert cfg.kamino is cfg.newton_kamino
 
 
+@pytest.mark.parametrize(
+    "legacy_name,canonical_name",
+    [
+        ("ovrtx_renderer", "ovrtx"),
+        ("isaacsim_rtx_renderer", "isaacsim_rtx"),
+    ],
+)
+def test_legacy_renderer_suffix_attribute_alias_warns(legacy_name, canonical_name):
+    """The suffixed renderer preset names alias to their ``_renderer``-less fields during deprecation."""
+
+    @configclass
+    class _RendererPresetsCfg(PresetCfg):
+        default: PhysxCfg = PhysxCfg()
+        ovrtx: PhysxCfg = PhysxCfg()
+        isaacsim_rtx: PhysxCfg = PhysxCfg()
+
+    cfg = _RendererPresetsCfg()
+    with pytest.warns(FutureWarning, match=f"Preset '{legacy_name}' is deprecated"):
+        assert getattr(cfg, legacy_name) is getattr(cfg, canonical_name)
+
+
 def test_legacy_alias_suppressed_when_legacy_name_is_real_field():
     """An env that legitimately defines ``newton`` should not warn or be remapped."""
 

--- a/source/isaaclab_tasks/test/core/test_preset_kit_decision.py
+++ b/source/isaaclab_tasks/test/core/test_preset_kit_decision.py
@@ -5,7 +5,7 @@
 
 """Tests for preset resolution and Kit decision logic.
 
-These tests verify that given presets (e.g. ``presets=newton_mjwarp,ovrtx_renderer``),
+These tests verify that given presets (e.g. ``presets=newton_mjwarp,ovrtx``),
 the config-based logic correctly decides whether Isaac Sim Kit is needed.
 No Kit/GPU required — safe for CI and beginners.
 """
@@ -69,7 +69,7 @@ def test_rtx_is_renderer_selector():
 
 def test_preset_mjwarp_ovrtx_does_not_need_kit():
     """Newton + OVRTX renderer is kitless — no AppLauncher required."""
-    env_cfg = _resolve_with_presets("newton_mjwarp,ovrtx_renderer")
+    env_cfg = _resolve_with_presets("newton_mjwarp,ovrtx")
     needs_kit = scan(env_cfg).needs_kit
     assert needs_kit is False
 
@@ -142,6 +142,6 @@ def test_preset_default_needs_kit():
 
 def test_preset_mjwarp_isaac_rtx_needs_kit():
     """Newton + Isaac RTX renderer requires Kit (RTX runs in Kit)."""
-    env_cfg = _resolve_with_presets("newton_mjwarp,isaacsim_rtx_renderer")
+    env_cfg = _resolve_with_presets("newton_mjwarp,isaacsim_rtx")
     needs_kit = scan(env_cfg).needs_kit
     assert needs_kit is True

--- a/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
+++ b/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
@@ -8,7 +8,7 @@
 The OVRTX renderer is kitless and cannot run together with Isaac Sim / Kit
 runtimes (``PhysxCfg`` physics or the Kit visualizer). These tests verify that
 invalid combinations selected via ``presets=...`` (or ``--visualizer kit``) raise
-a clear error pointing the user at the correct ``isaacsim_rtx_renderer`` preset.
+a clear error pointing the user at the correct ``isaacsim_rtx`` preset.
 No Kit/GPU required — safe for CI and beginners.
 """
 
@@ -55,19 +55,19 @@ def _resolve_with_presets(presets: str):
 
 def test_default_physx_plus_ovrtx_raises():
     """Default physics is PhysxCfg; pairing it with the OVRTX renderer must raise."""
-    env_cfg = _resolve_with_presets("ovrtx_renderer")
+    env_cfg = _resolve_with_presets("ovrtx")
     with pytest.raises(ValueError, match=r"OVRTX renderer.*Isaac Sim / Kit"):
         validate_runtime_compatibility(env_cfg)
 
 
 def test_explicit_physx_plus_ovrtx_raises():
-    """Explicit physx preset + ovrtx_renderer is the canonical invalid combination."""
-    env_cfg = _resolve_with_presets("physx,ovrtx_renderer")
+    """Explicit physx preset + ovrtx is the canonical invalid combination."""
+    env_cfg = _resolve_with_presets("physx,ovrtx")
     with pytest.raises(ValueError) as excinfo:
         validate_runtime_compatibility(env_cfg)
     msg = str(excinfo.value)
     assert "PhysxCfg" in msg
-    assert "isaacsim_rtx_renderer" in msg
+    assert "isaacsim_rtx" in msg
 
 
 def test_kit_visualizer_plus_ovrtx_raises():
@@ -76,18 +76,18 @@ def test_kit_visualizer_plus_ovrtx_raises():
     Use Newton physics so the only Kit-side runtime is the visualizer; this
     isolates the visualizer-vs-renderer check from the physics-vs-renderer one.
     """
-    env_cfg = _resolve_with_presets("newton,ovrtx_renderer")
+    env_cfg = _resolve_with_presets("newton,ovrtx")
     launcher_args = argparse.Namespace(visualizer="kit")
     with pytest.raises(ValueError) as excinfo:
         validate_runtime_compatibility(env_cfg, launcher_args)
     msg = str(excinfo.value)
     assert "Kit visualizer" in msg
-    assert "isaacsim_rtx_renderer" in msg
+    assert "isaacsim_rtx" in msg
 
 
 def test_kit_visualizer_dict_args_plus_ovrtx_raises():
     """The dict form of launcher args (used by Hydra) must also be inspected."""
-    env_cfg = _resolve_with_presets("newton,ovrtx_renderer")
+    env_cfg = _resolve_with_presets("newton,ovrtx")
     with pytest.raises(ValueError, match=r"Kit visualizer"):
         validate_runtime_compatibility(env_cfg, {"visualizer": "kit,newton"})
 
@@ -99,7 +99,7 @@ def test_kit_visualizer_dict_args_plus_ovrtx_raises():
 
 def test_ovphysx_plus_kit_visualizer_raises():
     """OvPhysX cannot share a process with the Kit visualizer."""
-    env_cfg = _resolve_with_presets("ovphysx,isaacsim_rtx_renderer")
+    env_cfg = _resolve_with_presets("ovphysx,isaacsim_rtx")
     launcher_args = argparse.Namespace(visualizer="kit")
     with pytest.raises(ValueError) as excinfo:
         validate_runtime_compatibility(env_cfg, launcher_args)
@@ -110,7 +110,7 @@ def test_ovphysx_plus_kit_visualizer_raises():
 
 def test_ovphysx_dict_args_plus_kit_visualizer_raises():
     """The dict launcher-args form must also reject OvPhysX with Kit visualization."""
-    env_cfg = _resolve_with_presets("ovphysx,isaacsim_rtx_renderer")
+    env_cfg = _resolve_with_presets("ovphysx,isaacsim_rtx")
     with pytest.raises(ValueError, match=r"OvPhysX.*Kit visualizer"):
         validate_runtime_compatibility(env_cfg, {"visualizer": "kit,newton"})
 
@@ -122,13 +122,13 @@ def test_ovphysx_dict_args_plus_kit_visualizer_raises():
 
 def test_newton_plus_ovrtx_is_valid():
     """Newton physics + OVRTX renderer is the supported kitless combination."""
-    env_cfg = _resolve_with_presets("newton,ovrtx_renderer")
+    env_cfg = _resolve_with_presets("newton,ovrtx")
     validate_runtime_compatibility(env_cfg)
 
 
 def test_physx_plus_isaacsim_rtx_is_valid():
     """PhysX physics + Isaac RTX renderer is the supported Kit combination."""
-    env_cfg = _resolve_with_presets("physx,isaacsim_rtx_renderer")
+    env_cfg = _resolve_with_presets("physx,isaacsim_rtx")
     validate_runtime_compatibility(env_cfg)
 
 
@@ -192,11 +192,11 @@ def test_livestream_rtx_injects_kit_before_auto_rtx_resolution(monkeypatch: pyte
 
 def test_newton_plus_isaacsim_rtx_is_valid():
     """Newton + Isaac RTX renderer is supported (RTX runs in Kit, Newton syncs to USD)."""
-    env_cfg = _resolve_with_presets("newton,isaacsim_rtx_renderer")
+    env_cfg = _resolve_with_presets("newton,isaacsim_rtx")
     validate_runtime_compatibility(env_cfg)
 
 
 def test_kit_visualizer_with_isaacsim_rtx_is_valid():
     """``--visualizer kit`` is fine as long as no OVRTX renderer is configured."""
-    env_cfg = _resolve_with_presets("newton,isaacsim_rtx_renderer")
+    env_cfg = _resolve_with_presets("newton,isaacsim_rtx")
     validate_runtime_compatibility(env_cfg, argparse.Namespace(visualizer="kit"))

--- a/source/isaaclab_tasks/test/core/test_shadow_hand_camera_presets.py
+++ b/source/isaaclab_tasks/test/core/test_shadow_hand_camera_presets.py
@@ -235,9 +235,9 @@ def test_all_camera_presets_present(shadow_hand_camera_presets):
 _RENDERER_PRESETS = [
     # preset_name, expected_class
     ("default", IsaacRtxRendererCfg),
-    ("isaacsim_rtx_renderer", IsaacRtxRendererCfg),
+    ("isaacsim_rtx", IsaacRtxRendererCfg),
     ("newton_renderer", NewtonWarpRendererCfg),
-    pytest.param("ovrtx_renderer", OVRTXRendererCfg, marks=pytest.mark.skip(reason="OVRTX testing disabled")),
+    pytest.param("ovrtx", OVRTXRendererCfg, marks=pytest.mark.skip(reason="OVRTX testing disabled")),
 ]
 
 
@@ -267,7 +267,7 @@ def test_rtx_preset_has_auto_renderer_type(shadow_hand_camera_presets):
 def test_all_renderer_presets_present(shadow_hand_camera_presets):
     """Every preset in MultiBackendRendererCfg is discoverable."""
     renderer_presets = shadow_hand_camera_presets["tiled_camera.renderer_cfg"]
-    expected_names = {"default", "rtx", "isaacsim_rtx_renderer", "newton_renderer", "ovrtx_renderer"}
+    expected_names = {"default", "rtx", "isaacsim_rtx", "newton_renderer", "ovrtx"}
     missing = expected_names - set(renderer_presets.keys())
     assert not missing, f"Renderer presets missing from collected presets: {missing}"
 


### PR DESCRIPTION
## Summary

Renderer presets repeated the category that the `renderer=` selector already names. This PR drops the redundant `_renderer` suffix while keeping the old spellings working as deprecated aliases:

| Old | New |
|---|---|
| `ovrtx_renderer` | `ovrtx` |
| `isaacsim_rtx_renderer` | `isaacsim_rtx` |

`newton_renderer` is intentionally **left unchanged** (no alias): the bare `newton` spelling is deliberately avoided across the codebase — it's a live physics deprecation alias (`newton` → `newton_mjwarp`) and is guarded by `test_newton_solver_preset_names.py` — so renaming the renderer to `newton` would reintroduce that ambiguity.

## Fixes (OMPE-98828)

## How it works

The rename reuses the existing per-target legacy-alias mechanism (the same one that powers `newton` → `newton_mjwarp`): the aliases live on `PresetTarget.RENDERER.legacy_aliases`, so `renderer=ovrtx_renderer` / `presets=...,ovrtx_renderer` still resolve — they just emit a `FutureWarning` pointing at the new name. The aliases will be removed in a future release.

Nice side effect: the preset name `ovrtx` now matches its underlying `renderer_type` value.

## Changes

- **`presets.py`** — renamed the `MultiBackendRendererCfg` fields and updated `set_isaac_rtx_global_settings`.
- **`preset_target.py`** — added the alias map + docstring to `PresetTarget.RENDERER`.
- **`sim_launcher.py`** — help text and runtime-compatibility error messages now use the suffix-less names.
- **Docs / benchmark scripts / shadow-hand task docstrings** — updated example strings (re-padded the affected RST grid tables in `environments.rst`).
- **Tests** — updated `test_runtime_compatibility.py`, `test_preset_kit_decision.py`, `test_shadow_hand_camera_presets.py` to the canonical names, and added a parametrized alias regression test in `test_hydra.py`.
- Changelog fragments for `isaaclab` and `isaaclab_tasks`.

## Notes

- The golden-image test infra (`rendering_test_utils.py` + ~190 golden files) builds renderer labels as `f"{renderer}_renderer"`, which are used both as `presets=` tokens and as on-disk filenames. Those old spellings still resolve via the new alias, so it was left untouched (renaming 190 golden files is out of scope).

## Testing

Verified the alias-resolution logic and ran `pre-commit` on all changed files (all hooks pass). The full pytest suite requires a GPU/Isaac Sim environment not available locally — CI will exercise it.