### PR TITLE
Fix double environment reset at episode boundaries in record_demos.py

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,6 +57,7 @@ Guidelines for modifications:
 * Antonin Raffin
 * Arjun Bhardwaj
 * Ashwin Varghese Kuruttukulam
+* Asier Arranz
 * Bikram Pandit
 * Bingjie Tang
 * Bocheng Zou

--- a/scripts/tools/record_demos.py
+++ b/scripts/tools/record_demos.py
@@ -478,7 +478,10 @@ def handle_reset(
         Reset success step count (0).
     """
     print("Resetting environment...")
-    env.sim.reset()
+    # Do not call `env.sim.reset()` here: it performs a stop/play cycle that snaps every body
+    # back to its authored spawn pose before `env.reset()` applies the managed reset, so the
+    # scene visibly resets twice and the first recorded frames of the next episode can be
+    # corrupted. `env.reset()` alone fully restores the managers, events and recorder state.
     env.recorder_manager.reset()
     env.reset()
     if teleop_interface is not None and hasattr(teleop_interface, "reset"):


### PR DESCRIPTION
# Description

When recording teleop demos, every episode boundary resets the scene twice, which glitches in the headset; this makes it reset once.

**Root cause:** `handle_reset()` in `scripts/tools/record_demos.py` calls `env.sim.reset()` right before `env.reset()`. The `sim.reset()` stop/play cycle snaps every body back to its authored spawn pose, and then the managed reset moves everything again to the actual reset state. The pilot sees the scene jump twice, and the first recorded frames of the next episode can capture the stale spawn poses.

**Fix:** drop the `env.sim.reset()` call at the episode boundary. `env.reset()` alone restores the managers, events and recorder state. The initial `sim.reset()` before the recording loop starts is left as is, since that one runs before any episode exists and is needed to start the simulation.

Verified by flying XR recording sessions on a Quest 3: episode transitions now show a single clean reset and the first frames of each new episode match the reset state.

No changelog fragment: the change only touches `scripts/`, no `source/<pkg>` package.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
