### PR TITLE
Fix headless video recording pumping Kit every step

### DIFF
--- a/source/isaaclab/changelog.d/mtrepte-fix-headless-video-kit-pump-6316.rst
+++ b/source/isaaclab/changelog.d/mtrepte-fix-headless-video-kit-pump-6316.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed headless video recording (``--video`` / ``rgb_array``) forcing a Kit ``app.update()``
+  on every environment step. :attr:`~isaaclab.sim.SimulationContext.is_rendering` no longer
+  reports offscreen rendering as continuous rendering, so Kit is now pumped on demand only when
+  a frame is actually requested. GUI, RTX sensor, visualizer, and XR rendering are unaffected.

--- a/source/isaaclab/isaaclab/markers/visualization_markers.py
+++ b/source/isaaclab/isaaclab/markers/visualization_markers.py
@@ -256,9 +256,13 @@ class VisualizationMarkers:
             self._ensure_kit_backend()
             return
 
+        # Markers need the Kit (USD) backend to appear in any rendered frame: continuous rendering
+        # (``is_rendering``), headless offscreen video capture (``has_offscreen_render``), or a
+        # Kit-pumping visualizer. Offscreen is excluded from ``is_rendering`` (see
+        # :attr:`~isaaclab.sim.SimulationContext.is_rendering`), so it is checked explicitly here.
         needs_kit_backend = (
             sim.is_rendering
-            or sim.has_offscreen_render
+            or getattr(sim, "has_offscreen_render", False)
             or any(
                 viz.supports_markers() and viz.pumps_app_update() and viz.cfg.enable_markers for viz in sim.visualizers
             )

--- a/source/isaaclab/isaaclab/markers/visualization_markers.py
+++ b/source/isaaclab/isaaclab/markers/visualization_markers.py
@@ -256,8 +256,12 @@ class VisualizationMarkers:
             self._ensure_kit_backend()
             return
 
-        needs_kit_backend = sim.is_rendering or any(
-            viz.supports_markers() and viz.pumps_app_update() and viz.cfg.enable_markers for viz in sim.visualizers
+        needs_kit_backend = (
+            sim.is_rendering
+            or sim.has_offscreen_render
+            or any(
+                viz.supports_markers() and viz.pumps_app_update() and viz.cfg.enable_markers for viz in sim.visualizers
+            )
         )
         if needs_kit_backend:
             self._ensure_kit_backend()

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -190,7 +190,12 @@ class SimulationContext:
         self._has_gui = bool(self.get_setting("/isaaclab/has_gui"))
         self._has_offscreen_render = bool(self.get_setting("/isaaclab/render/offscreen"))
         self._xr_enabled = bool(self.get_setting("/isaaclab/xr/enabled"))
-        # Note: has_rtx_sensors is NOT cached because it changes when Camera sensors are created
+        # Note: has_rtx_sensors is NOT cached because it changes when Camera sensors are created.
+        # It is a global setting flipped to True by RTX Camera creation (see Camera._initialize_impl)
+        # and is never flipped back. Reset it here so a fresh SimulationContext reflects its own
+        # cameras rather than inheriting a stale True from a previously torn-down simulation. RTX
+        # cameras created for this instance re-set it to True before it is read.
+        self.set_setting("/isaaclab/render/rtx_sensors", False)
         self._pending_camera_view: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None
         self.vis_marker_registry = VisMarkerRegistry()
 

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -298,10 +298,15 @@ class SimulationContext:
 
     @property
     def is_rendering(self) -> bool:
-        """Returns whether rendering is active (GUI, RTX sensors, visualizers, or XR)."""
+        """Returns whether *continuous* rendering is active (GUI, RTX sensors, visualizers, or XR).
+
+        This drives the per-step render/Kit-pump loop, so it deliberately excludes headless
+        offscreen rendering (``--video`` / ``rgb_array``). Offscreen frames are produced on
+        demand when a frame is actually requested (via :meth:`render`), not on every step; see
+        :meth:`has_offscreen_render` and :meth:`can_render_rgb_array` for the capability checks.
+        """
         return (
             self._has_gui
-            or self._has_offscreen_render
             or self.get_setting("/isaaclab/render/rtx_sensors")
             or bool(self.resolve_visualizer_types())
             or self._xr_enabled

--- a/source/isaaclab/test/envs/test_env_rendering_logic.py
+++ b/source/isaaclab/test/envs/test_env_rendering_logic.py
@@ -417,6 +417,84 @@ def test_env_render_flag_mixed_steps(env_type, physics_callback, render_callback
             SimulationContext.clear_instance()
 
 
+def create_manager_based_env_no_visualizer(render_interval: int):
+    """Create a manager based env with no visualizer (offscreen render only)."""
+
+    @configclass
+    class EnvCfg(ManagerBasedEnvCfg):
+        """Configuration for the test environment."""
+
+        decimation: int = 4
+        episode_length_s: float = 100.0
+        # empty visualizer_cfgs => offscreen render is the only possible rendering path
+        sim: SimulationCfg = SimulationCfg(dt=0.005, render_interval=render_interval, visualizer_cfgs=[])
+        scene: InteractiveSceneCfg = InteractiveSceneCfg(num_envs=1, env_spacing=1.0)
+        actions: EmptyManagerCfg = EmptyManagerCfg()
+        observations: EmptyManagerCfg = EmptyManagerCfg()
+
+    return ManagerBasedEnv(cfg=EnvCfg())
+
+
+def test_headless_offscreen_render_does_not_pump_kit_every_step():
+    """Regression test for issue #6316.
+
+    With headless video recording (offscreen render enabled) but no continuous-rendering
+    consumer (GUI, RTX sensors, visualizers, XR), the per-step decimation loop must NOT call
+    :meth:`~isaaclab.sim.SimulationContext.render` (which pumps Kit's ``app.update()``). Frames
+    are produced on demand only when :meth:`render` is explicitly called (e.g. by the
+    ``RecordVideo`` wrapper). Before the fix, ``is_rendering`` reported offscreen rendering as
+    continuous rendering, so Kit was pumped on every environment step.
+    """
+    env = None
+    original_render = None
+    try:
+        sim_utils.create_new_stage()
+
+        env = create_manager_based_env_no_visualizer(render_interval=1)
+        # simulate ``--video``; leave rtx_sensors False so offscreen is the only render reason
+        env.sim.set_setting("/isaaclab/video/enabled", True)
+        env.sim._app_control_on_stop_handle = None  # type: ignore
+
+        env.reset()
+
+        # offscreen render is enabled (module launched with enable_cameras=True) ...
+        assert env.sim.has_offscreen_render, "expected offscreen render to be enabled for this test"
+        # ... but it must NOT count as continuous rendering (this is the regression).
+        assert not env.sim.is_rendering, "offscreen-only rendering must not report is_rendering=True (issue #6316)"
+        assert not env.sim.visualizers, "expected no visualizers for the offscreen-only case"
+
+        # Count calls into sim.render() (each in-loop call would pump Kit).
+        render_calls = {"n": 0}
+        original_render = env.sim.render
+
+        def counting_render(*args, **kwargs):
+            render_calls["n"] += 1
+            return original_render(*args, **kwargs)
+
+        env.sim.render = counting_render  # type: ignore[method-assign]
+
+        actions = torch.zeros((env.num_envs, 0), device=env.device)
+        for _ in range(10):
+            env.step(action=actions)
+
+        # No per-step rendering / Kit pumping while no frame is requested.
+        assert render_calls["n"] == 0, (
+            f"offscreen-only stepping must not call sim.render() (issue #6316), got {render_calls['n']} calls"
+        )
+
+        # On demand (what RecordVideo does to grab a frame) rendering still works.
+        env.sim.render()
+        assert render_calls["n"] == 1, "explicit on-demand render() must still run"
+
+    finally:
+        if env is not None and original_render is not None:
+            env.sim.render = original_render  # type: ignore[method-assign]
+        if env is not None:
+            env.close()
+        else:
+            SimulationContext.clear_instance()
+
+
 def test_env_render_false_with_resets(physics_callback, render_callback):
     """Test that render_enabled=False skips post-reset re-renders during short episodes.
 

--- a/source/isaaclab_physx/changelog.d/mtrepte-fix-headless-video-kit-pump-6316.rst
+++ b/source/isaaclab_physx/changelog.d/mtrepte-fix-headless-video-kit-pump-6316.rst
@@ -4,3 +4,6 @@ Fixed
 * Fixed the headless RTX video pump so it still updates Kit on demand when a frame is requested,
   after :attr:`~isaaclab.sim.SimulationContext.is_rendering` stopped reporting offscreen rendering
   as continuous rendering. Offscreen frames are now pumped only when requested, not every step.
+* Fixed physics corruption when recording video with ``--video --device cpu``: the Kit
+  ``app.update()`` inside :class:`~isaaclab_physx.video_recording.IsaacsimKitPerspectiveVideo`
+  now guards ``/app/player/playSimulations`` so physics is not advanced mid-render.

--- a/source/isaaclab_physx/changelog.d/mtrepte-fix-headless-video-kit-pump-6316.rst
+++ b/source/isaaclab_physx/changelog.d/mtrepte-fix-headless-video-kit-pump-6316.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed the headless RTX video pump so it still updates Kit on demand when a frame is requested,
+  after :attr:`~isaaclab.sim.SimulationContext.is_rendering` stopped reporting offscreen rendering
+  as continuous rendering. Offscreen frames are now pumped only when requested, not every step.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
@@ -256,7 +256,10 @@ def ensure_isaac_rtx_render_update() -> None:
         _last_render_update_key = key
         return
 
-    if not sim.is_rendering:
+    # Pump when continuous rendering is active (GUI/RTX sensors/visualizers/XR) or when a
+    # headless offscreen frame is being requested on demand (``--video`` / ``rgb_array``).
+    # ``is_rendering`` excludes offscreen so the per-step loop does not pump between frames.
+    if not (sim.is_rendering or sim.has_offscreen_render):
         return
 
     # Sync physics results → Fabric so RTX sees updated positions.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
@@ -211,11 +211,17 @@ def ensure_rtx_hydra_engine_attached() -> None:
         logger.error("RTX Hydra engine attach failed: %s", e)
 
 
-def ensure_isaac_rtx_render_update() -> None:
+def ensure_isaac_rtx_render_update(force: bool = False) -> None:
     """Ensure the Isaac RTX renderer has been pumped for the current sim step.
 
     This keeps the Kit-specific ``app.update()`` logic inside the renderers
     package rather than in the backend-agnostic ``SimulationContext``.
+
+    Args:
+        force: Pump even when continuous rendering is inactive
+            (:attr:`~isaaclab.sim.SimulationContext.is_rendering` is ``False``). Used by the
+            on-demand headless offscreen video path to produce a frame only when one is
+            requested. Defaults to ``False``.
 
     Safe to call from multiple ``Camera`` instances per step —
     only the first call triggers ``app.update()``.  Subsequent calls are no-ops
@@ -234,7 +240,7 @@ def ensure_isaac_rtx_render_update() -> None:
     No-op conditions:
         * Already called this step (dedup across camera instances).
         * A visualizer already pumps ``app.update()`` (e.g. KitVisualizer).
-        * Rendering is not active.
+        * Rendering is not active and ``force`` is ``False``.
     """
     global _last_render_update_key
 
@@ -256,10 +262,12 @@ def ensure_isaac_rtx_render_update() -> None:
         _last_render_update_key = key
         return
 
-    # Pump when continuous rendering is active (GUI/RTX sensors/visualizers/XR) or when a
-    # headless offscreen frame is being requested on demand (``--video`` / ``rgb_array``).
-    # ``is_rendering`` excludes offscreen so the per-step loop does not pump between frames.
-    if not (sim.is_rendering or sim.has_offscreen_render):
+    # Pump when continuous rendering is active (GUI/RTX sensors/visualizers/XR). ``is_rendering``
+    # excludes headless offscreen rendering so the per-step loop does not pump between frames.
+    # Offscreen frames are produced on demand: the ``--video`` / ``rgb_array`` path calls this with
+    # ``force=True`` (see :func:`pump_kit_app_for_headless_video_render_if_needed`) to pump exactly
+    # when a frame is requested, without making every step pump.
+    if not force and not sim.is_rendering:
         return
 
     # Sync physics results → Fabric so RTX sees updated positions.
@@ -295,7 +303,9 @@ def pump_kit_app_for_headless_video_render_if_needed(sim: Any) -> None:
     if any(viz.pumps_app_update() for viz in sim.visualizers):
         return
     try:
-        ensure_isaac_rtx_render_update()
+        # Explicit on-demand frame request: pump even though headless offscreen rendering
+        # is excluded from ``is_rendering`` (so the per-step loop stays quiet between frames).
+        ensure_isaac_rtx_render_update(force=True)
     except (ImportError, AttributeError, ModuleNotFoundError) as exc:
         logger.debug("[isaac_rtx] Skipping Kit app-loop pump in render() (non-Kit env): %s", exc)
     except Exception as exc:

--- a/source/isaaclab_physx/isaaclab_physx/video_recording/isaacsim_kit_perspective_video.py
+++ b/source/isaaclab_physx/isaaclab_physx/video_recording/isaacsim_kit_perspective_video.py
@@ -25,10 +25,17 @@ class IsaacsimKitPerspectiveVideo:
 
     def render_rgb_array(self) -> np.ndarray:
         """Return one RGB frame. Blank frame during warmup; raises on other failures."""
+        import carb.settings
         import omni.kit.app
         import omni.replicator.core as rep
 
+        # Guard physics stepping around the Kit update so it does not advance the
+        # physics clock mid-render (observable on CPU where PhysX is synchronous).
+        _settings = carb.settings.get_settings()
+        _play_flag = _settings.get("/app/player/playSimulations")
+        _settings.set_bool("/app/player/playSimulations", False)
         omni.kit.app.get_app().update()
+        _settings.set_bool("/app/player/playSimulations", bool(_play_flag))
 
         h, w = self.cfg.window_height, self.cfg.window_width
         if self._rgb_annotator is None:


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Headless RGB video recording forced a Kit app.update() on every env step, even when no frame was being captured.

Fix is to exclude offscreen rendering from is_rendering so it only is True during continuous rendering (GUI, RTX sensors, visualizers, XR). 

Add unit test

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

Fixes: #6316 
## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
