### PR TITLE
Friction combine mode for kamino

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,6 +76,7 @@ Guidelines for modifications:
 * Chenyu Yang
 * Connor Smith
 * CY (Chien-Ying) Chen
+* David Cao-Mueller
 * David Leon
 * David Yang
 * Daniela Hasenbring

--- a/source/isaaclab_newton/changelog.d/kamino-material-mix-modes.minor.rst
+++ b/source/isaaclab_newton/changelog.d/kamino-material-mix-modes.minor.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_newton.physics.KaminoSolverCfg.material_friction_mix_mode` and
+  :attr:`~isaaclab_newton.physics.KaminoSolverCfg.material_restitution_mix_mode` to control
+  how the friction and restitution coefficients of two contacting shapes are mixed into
+  contact-pair values by the Kamino solver.

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from isaaclab.utils.configclass import configclass
 
@@ -182,6 +182,21 @@ class KaminoSolverCfg(NewtonSolverCfg):
     problem. Disabling may be useful for debugging or profiling solver behavior.
     """
 
+    material_friction_mix_mode: Literal["average", "multiply", "max", "min"] = "average"
+    """How the friction coefficients of two contacting shapes are mixed into a contact-pair value.
+
+    Applied by Kamino for both contact-generation paths (Newton's collision pipeline and
+    Kamino's internal collision detector). Note that per-material combine modes (e.g. PhysX's
+    ``physxMaterial:frictionCombineMode``) are not supported by Newton; this solver-wide mode
+    governs all contact pairs.
+    """
+
+    material_restitution_mix_mode: Literal["average", "multiply", "max", "min"] = "min"
+    """How the restitution coefficients of two contacting shapes are mixed into a contact-pair value.
+
+    See :attr:`material_friction_mix_mode` for details on scope and limitations.
+    """
+
     def to_solver_config(self) -> SolverKamino.Config:
         """Build a :class:`SolverKamino.Config` from this configuration.
 
@@ -196,6 +211,7 @@ class KaminoSolverCfg(NewtonSolverCfg):
             ConstrainedDynamicsConfig,
             ConstraintStabilizationConfig,
             ForwardKinematicsSolverConfig,
+            MaterialManagerConfig,
             PADMMSolverConfig,
         )
         from newton.solvers import SolverKamino
@@ -238,6 +254,10 @@ class KaminoSolverCfg(NewtonSolverCfg):
             ),
             dynamics=ConstrainedDynamicsConfig(
                 preconditioning=self.dynamics_preconditioning,
+            ),
+            materials=MaterialManagerConfig(
+                friction_mix_mode=self.material_friction_mix_mode,
+                restitution_mix_mode=self.material_restitution_mix_mode,
             ),
             padmm=PADMMSolverConfig(
                 max_iterations=self.padmm_max_iterations,


### PR DESCRIPTION
# Description

Add Option to set Friction Combine Mode for Kamino. This MR needs to be merged first: https://github.com/newton-physics/newton/pull/3382

Fixes # (issue)

Currently average combine mode has been hardcoded.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there