### PR TITLE
Honor replicate_physics=False in the environment cloner

### DIFF
--- a/source/isaaclab/changelog.d/honor-replicate-physics-flag.rst
+++ b/source/isaaclab/changelog.d/honor-replicate-physics-flag.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.cloner.replicate` and :class:`~isaaclab.cloner.ReplicateSession`
+  to honor :attr:`~isaaclab.scene.InteractiveSceneCfg.replicate_physics`. When set to
+  ``False``, physics-engine backends are now skipped so only USD geometry is replicated
+  and the physics engine parses each environment individually. This removes spurious
+  ``Replication of this type is not supported`` errors for deformable objects under the
+  PhysX backend.

--- a/source/isaaclab/isaaclab/cloner/replicate_session.py
+++ b/source/isaaclab/isaaclab/cloner/replicate_session.py
@@ -24,12 +24,19 @@ REPLICATION_QUEUE: list[tuple[Any, type]] = []
 """``(cfg, BackendCtxCls)`` pairs appended by ``queue_<backend>_replication`` and drained by :func:`replicate`."""
 
 
-def replicate(plan: ClonePlan, *, stage: Usd.Stage) -> None:
+def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = True) -> None:
     """Drain :data:`REPLICATION_QUEUE` against ``plan``, dispatch each backend, publish the plan.
 
     Cfgs absent from ``plan.cfg_rows`` are silently skipped. Backend contexts run in
     ascending ``replicate_priority`` order. The queue is cleared up front, so a backend
     failure cannot leak stale entries into the next call.
+
+    Args:
+        plan: Clone plan resolved by :func:`~isaaclab.cloner.make_clone_plan`.
+        stage: USD stage to author replicated prim specs into.
+        replicate_physics: If False, skip physics-engine backends (those with
+            ``is_physics_backend`` truthy) so only USD geometry is replicated and the
+            physics engine parses each environment individually. Default is True.
     """
     from isaaclab.sim import SimulationContext  # noqa: PLC0415
 
@@ -42,6 +49,9 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage) -> None:
     # union keeps it as a single row — no redundant copy specs are authored.
     backend_rows: dict[type, set[int]] = {}
     for cfg, BackendCtxCls in queued:
+        # Skip physics-engine replication when disabled; USD geometry still replicates.
+        if not replicate_physics and getattr(BackendCtxCls, "is_physics_backend", True):
+            continue
         rows = plan.cfg_rows.get(id(cfg))
         if rows is None:
             continue
@@ -92,6 +102,7 @@ class ReplicateSession:
         stage: Usd.Stage,
         clone_strategy: Callable = sequential,
         valid_set: torch.Tensor | None = None,
+        replicate_physics: bool = True,
     ):
         """Capture arguments for :func:`make_clone_plan` and :func:`replicate`.
 
@@ -104,9 +115,12 @@ class ReplicateSession:
             clone_strategy: Prototype-to-env assignment function.
             valid_set: Optional ``[num_combos, num_groups]`` long tensor of valid
                 prototype combinations; ``None`` uses the full cartesian product.
+            replicate_physics: If False, skip physics-engine backends so only USD
+                geometry is replicated. Forwarded to :func:`replicate`. Default is True.
         """
         self._cfgs = cfgs
         self._stage = stage
+        self._replicate_physics = replicate_physics
         self._kwargs = dict(
             num_clones=num_clones,
             env_spacing=env_spacing,
@@ -125,7 +139,7 @@ class ReplicateSession:
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         if exc_type is None:
             assert self._plan is not None
-            replicate(self._plan, stage=self._stage)
+            replicate(self._plan, stage=self._stage, replicate_physics=self._replicate_physics)
         else:
             # Drop cfgs registered before the failure so the next session is clean.
             REPLICATION_QUEUE.clear()

--- a/source/isaaclab/isaaclab/cloner/usd.py
+++ b/source/isaaclab/isaaclab/cloner/usd.py
@@ -31,6 +31,8 @@ class UsdReplicateContext:
     """Queue and apply USD replication work for one stage."""
 
     replicate_priority = 100
+    is_physics_backend = False
+    """USD geometry replication is authoritative and always runs, even when ``replicate_physics=False``."""
 
     def __init__(self, stage: Usd.Stage):
         """Initialize the context.

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -184,6 +184,7 @@ class InteractiveScene:
             device=self.device,
             stage=self.stage,
             clone_strategy=self.cloner_cfg.clone_strategy,
+            replicate_physics=self.cfg.replicate_physics,
         ):
             if self._is_scene_setup_from_cfg():
                 self._add_entities_from_cfg()

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -578,6 +578,63 @@ def test_replicate_runs_lower_priority_backends_first(sim):
     assert call_order == ["low", "high"]
 
 
+def test_replicate_physics_false_skips_physics_backends(sim):
+    """Regression: replicate_physics=False skips physics backends but still runs USD geometry."""
+
+    call_order: list[str] = []
+
+    class GeometryBackend:
+        replicate_priority = 100
+        is_physics_backend = False
+
+        def __init__(self, stage):
+            pass
+
+        def queue_mapping(self, *args, **kwargs):
+            pass
+
+        def replicate(self):
+            call_order.append("geometry")
+
+    class PhysicsBackend:
+        replicate_priority = 0
+        is_physics_backend = True
+
+        def __init__(self, stage):
+            pass
+
+        def queue_mapping(self, *args, **kwargs):
+            pass
+
+        def replicate(self):
+            call_order.append("physics")
+
+    cfg = SimpleNamespace(prim_path="/World/envs/env_.*/Robot")
+
+    def _make_plan():
+        return ClonePlan(
+            sources=("/World/envs/env_0",),
+            destinations=("/World/envs/env_{}",),
+            clone_mask=torch.ones((1, 2), dtype=torch.bool, device=sim.cfg.device),
+            env_ids=torch.arange(2, dtype=torch.long, device=sim.cfg.device),
+            positions=None,
+            cfg_rows={id(cfg): (0,)},
+        )
+
+    # replicate_physics=False: only the geometry backend runs.
+    REPLICATION_QUEUE.append((cfg, PhysicsBackend))
+    REPLICATION_QUEUE.append((cfg, GeometryBackend))
+    replicate(_make_plan(), stage=sim_utils.get_current_stage(), replicate_physics=False)
+    assert call_order == ["geometry"]
+
+    # Default (replicate_physics=True): both backends run.
+    call_order.clear()
+    REPLICATION_QUEUE.append((cfg, PhysicsBackend))
+    REPLICATION_QUEUE.append((cfg, GeometryBackend))
+    replicate(_make_plan(), stage=sim_utils.get_current_stage())
+    assert call_order == ["physics", "geometry"]
+
+
 def test_replicate_skips_cfgs_not_in_plan(sim):
     """Cfgs absent from plan.cfg_rows are silently skipped."""
     sentinel = MagicMock()


### PR DESCRIPTION
# Description

The queued environment cloner ignored `InteractiveSceneCfg.replicate_physics`: the flag was only consumed by the scene summary print and the prestartup event-manager guards, and never gated replication. As a result the physics-engine replicator always ran, even for presets that set `replicate_physics=False` (for example the `Isaac-Lift-Soft-Franka` task under the PhysX backend), producing spurious `omni.physx.plugin` "Replication of this type is not supported" errors for deformable prims and their materials. This restores the pre-refactor behavior in which `replicate_physics=False` disables physics-engine replication while USD geometry is still cloned to every environment.

Backend context classes now carry an `is_physics_backend` class attribute. `UsdReplicateContext` sets it to `False` so the authoritative geometry clone always runs, and the physics-engine backends (PhysX, OvPhysX, Newton) are treated as physics via the `getattr(..., True)` default, so no changes are needed in those extension packages. `replicate()` and `ReplicateSession` gain a `replicate_physics` parameter (default `True`, so existing callers are unaffected) that skips physics-engine backends when set to `False`; the physics engine then parses each environment individually from the USD-copied schemas. The fix is confined to the core `isaaclab` package.

Fixes # (no linked issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
