### PR TITLE
Resolve Python logging level outside AppLauncher

### DIFF
--- a/source/isaaclab/changelog.d/kitless-python-logging-level.rst
+++ b/source/isaaclab/changelog.d/kitless-python-logging-level.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Moved Python logging-level resolution out of :class:`~isaaclab.app.AppLauncher` into the
+  backend-agnostic helpers :func:`~isaaclab.app.logging_utils.resolve_python_logging_level` and
+  :func:`~isaaclab.app.logging_utils.apply_python_logging_level`, so that ``--verbose`` / ``--info``
+  now switch the Python logging level for kitless backends (Newton, OvPhysX) launched via
+  :func:`~isaaclab.app.launch_simulation`, not just Kit-based runs.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -28,6 +28,7 @@ with contextlib.suppress(ModuleNotFoundError):
     import isaacsim  # noqa: F401
     from isaacsim import SimulationApp
 
+from isaaclab.app.logging_utils import apply_python_logging_level, resolve_python_logging_level
 from isaaclab.app.settings_manager import get_settings_manager, initialize_carb_settings
 
 # import logger
@@ -195,25 +196,6 @@ class AppLauncher:
         return has_any, has_kit
 
     @staticmethod
-    def _resolve_python_logging_level(launcher_args: dict) -> int:
-        """Resolve the Python logging level that should survive Kit startup."""
-        if launcher_args.get("verbose", False) or "--verbose" in sys.argv:
-            return logging.DEBUG
-        if launcher_args.get("info", False) or "--info" in sys.argv:
-            return logging.INFO
-
-        level = logging.getLogger().getEffectiveLevel()
-        return logging.WARNING if level == logging.NOTSET else level
-
-    @staticmethod
-    def _apply_python_logging_level(level: int) -> None:
-        """Apply a Python logging level to the root logger and its handlers."""
-        root_logger = logging.getLogger()
-        root_logger.setLevel(level)
-        for handler in root_logger.handlers:
-            handler.setLevel(level)
-
-    @staticmethod
     def _ensure_isaaclab_info_stream_handler() -> None:
         """Add a stream handler for Isaac Lab INFO records hidden by Kit logging."""
         handler_name = "isaaclab_info_stream"
@@ -283,7 +265,7 @@ class AppLauncher:
             launcher_args.update(kwargs)
 
         # Preserve the Python logging intent before Kit installs its own logging bridge.
-        self._python_logging_level = AppLauncher._resolve_python_logging_level(launcher_args)
+        self._python_logging_level = resolve_python_logging_level(launcher_args)
 
         # Define config members that are read from env-vars or keyword args
         self._headless: bool  # 0: GUI, 1: Headless
@@ -1271,7 +1253,7 @@ class AppLauncher:
         # After SimulationApp starts, Kit installs its Python log bridge at DEBUG level.
         # Re-apply the intended Python logging level, then add a scoped stream handler for
         # Isaac Lab INFO records that Kit's bridge does not mirror to the console.
-        AppLauncher._apply_python_logging_level(self._python_logging_level)
+        apply_python_logging_level(self._python_logging_level)
         if self._python_logging_level <= logging.INFO:
             AppLauncher._ensure_isaaclab_info_stream_handler()
         elif self._python_logging_level == logging.WARNING:

--- a/source/isaaclab/isaaclab/app/logging_utils.py
+++ b/source/isaaclab/isaaclab/app/logging_utils.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Backend-agnostic resolution and application of the Python logging level.
+
+The logging intent expressed by the ``--verbose`` / ``--info`` CLI arguments must be
+honored by every simulation backend, not just the Kit-based one. Keeping the resolution
+here (rather than inside :class:`~isaaclab.app.AppLauncher`) lets the kitless launch path
+apply the same level without constructing Kit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+
+def resolve_python_logging_level(launcher_args: argparse.Namespace | dict | None = None) -> int:
+    """Resolve the intended Python logging level from launcher args and ``sys.argv``.
+
+    ``--verbose`` maps to :data:`logging.DEBUG` and ``--info`` to :data:`logging.INFO`.
+    When neither is requested, the current effective level of the root logger is kept
+    (falling back to :data:`logging.WARNING` when unset).
+
+    Args:
+        launcher_args: Parsed launcher arguments as a namespace or dict. Defaults to None,
+            which is treated as an empty set of arguments.
+
+    Returns:
+        The resolved logging level.
+    """
+    if launcher_args is None:
+        args = {}
+    elif isinstance(launcher_args, argparse.Namespace):
+        args = launcher_args.__dict__
+    else:
+        args = launcher_args
+
+    if args.get("verbose", False) or "--verbose" in sys.argv:
+        return logging.DEBUG
+    if args.get("info", False) or "--info" in sys.argv:
+        return logging.INFO
+
+    level = logging.getLogger().getEffectiveLevel()
+    return logging.WARNING if level == logging.NOTSET else level
+
+
+def apply_python_logging_level(level: int) -> None:
+    """Apply a Python logging level to the root logger and its handlers.
+
+    Args:
+        level: The logging level to apply.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    for handler in root_logger.handlers:
+        handler.setLevel(level)

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -27,6 +27,7 @@ from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 from isaaclab_physx.renderers import IsaacRtxRendererCfg
 
+from isaaclab.app.logging_utils import apply_python_logging_level, resolve_python_logging_level
 from isaaclab.physics.physics_manager_cfg import PhysicsCfg
 from isaaclab.renderers.renderer_cfg import RendererCfg
 from isaaclab.sensors.camera.camera_cfg import CameraCfg
@@ -433,6 +434,11 @@ def launch_simulation(
     _validate_runtime(config_scan, launcher_args)
     needs_kit = _uses_isaac_sim_runtime(config_scan, launcher_args)
     _set_arg(launcher_args, "visualizer_intent", config_scan.visualizer_intent)
+
+    # Kit-based backends apply the Python logging level inside AppLauncher; kitless backends
+    # never construct it, so honor --verbose / --info here to keep behavior consistent.
+    if not needs_kit:
+        apply_python_logging_level(resolve_python_logging_level(launcher_args))
 
     if needs_kit and config_scan.has_kit_camera and launcher_args is not None:
         if not _get_arg(launcher_args, "enable_cameras", False):

--- a/source/isaaclab/test/app/test_kwarg_launch.py
+++ b/source/isaaclab/test/app/test_kwarg_launch.py
@@ -121,7 +121,7 @@ def test_load_extensions_publishes_has_gui_setting(
     settings = _DummySettings()
     monkeypatch.setattr(app_launcher_module, "initialize_carb_settings", lambda: None)
     monkeypatch.setattr(app_launcher_module, "get_settings_manager", lambda: settings)
-    monkeypatch.setattr(AppLauncher, "_apply_python_logging_level", lambda _level: None)
+    monkeypatch.setattr(app_launcher_module, "apply_python_logging_level", lambda _level: None)
 
     launcher._load_extensions()
 

--- a/source/isaaclab_tasks/changelog.d/kitless-python-logging-level.skip
+++ b/source/isaaclab_tasks/changelog.d/kitless-python-logging-level.skip
@@ -1,0 +1,1 @@
+Test-only change: added a regression test for kitless Python logging-level application.

--- a/source/isaaclab_tasks/test/core/test_sim_launcher_visualizer_intent.py
+++ b/source/isaaclab_tasks/test/core/test_sim_launcher_visualizer_intent.py
@@ -90,3 +90,27 @@ def test_launch_simulation_kitless_viz_none_sets_disable_all(monkeypatch):
         pass
 
     assert captured == {"types": "", "explicit": True, "disable_all": True}
+
+
+def test_launch_simulation_kitless_applies_python_logging_level(monkeypatch):
+    """Kitless mode should apply the resolved Python logging level before yielding."""
+    captured: dict[str, object] = {}
+
+    def fake_resolve(launcher_args):
+        captured["resolve_args"] = launcher_args
+        return 42
+
+    def fake_apply(level):
+        captured["applied_level"] = level
+
+    _force_kitless(monkeypatch)
+    monkeypatch.setattr(sim_launcher, "resolve_python_logging_level", fake_resolve)
+    monkeypatch.setattr(sim_launcher, "apply_python_logging_level", fake_apply)
+
+    env_cfg = _DummyEnvCfg(_DummySimCfg(None))
+    launcher_args = argparse.Namespace(visualizer=None, visualizer_explicit=True)
+    with sim_launcher.launch_simulation(env_cfg, launcher_args):
+        pass
+
+    assert captured["resolve_args"] is launcher_args
+    assert captured["applied_level"] == 42


### PR DESCRIPTION
Move the resolution and application of the Python logging level out of the Kit-based AppLauncher into a backend-agnostic module so kitless backends can honor it too.

Previously AppLauncher owned _resolve_python_logging_level and _apply_python_logging_level, so the --verbose / --info CLI arguments only took effect for Kit-based runs. Kitless backends (Newton, OvPhysX) launched via launch_simulation never constructed AppLauncher and silently ignored them.

Extract those two helpers into isaaclab.app.logging_utils and apply the resolved level in the kitless branch of launch_simulation. The Kit-specific info-stream handler workaround stays in AppLauncher.

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
