### PR TITLE
Fix duplicate L_thumb_distal_joint in Fourier left hand retargeting config

### DIFF
--- a/source/isaaclab/changelog.d/zhengyuz-fix-fourier-left-duplicate-joint.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-fix-fourier-left-duplicate-joint.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed duplicate ``L_thumb_distal_joint`` entry in the Fourier left hand DexPilot retargeting config
+  (:file:`fourier_hand_left_dexpilot.yml`).

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/data/configs/dex-retargeting/fourier_hand_left_dexpilot.yml
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/fourier/data/configs/dex-retargeting/fourier_hand_left_dexpilot.yml
@@ -24,7 +24,6 @@ retargeting:
   - L_thumb_proximal_yaw_joint
   - L_thumb_proximal_pitch_joint
   - L_thumb_distal_joint
-  - L_thumb_distal_joint
   type: DexPilot
   urdf_path: /tmp/GR1_T2_left_hand.urdf
   wrist_link_name: l_hand_base_link


### PR DESCRIPTION
## Summary

- Removes the duplicated `L_thumb_distal_joint` entry in `fourier_hand_left_dexpilot.yml`'s `target_joint_names` list (reported in #6325)
- The right-hand equivalent (`fourier_hand_right_dexpilot.yml`) is unaffected

## Test plan

- [ ] Verify `fourier_hand_left_dexpilot.yml` has exactly one `L_thumb_distal_joint` entry
- [ ] Confirm OpenXR Fourier left-hand retargeting initializes without duplicate joint warnings

Fixes #6325