### PR TITLE
[Fix] Bump test_rendering_shadow_hand.py timeout to 1500s

### DIFF
--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -65,6 +65,9 @@ PER_TEST_TIMEOUTS = {
     "test_surface_gripper.py": 3000,
     # The first test in the kitless rendering test job will take longer to run due to RTX shader compilation.
     "test_rendering_cartpole_kitless.py": 2000,
+    # Budgets ~45s per AOV: one full RTX env is built and torn down per parametrized data type.
+    # Bump this when renderer cases are added to _DEFAULT_SENSOR_DATA_TYPES in rendering_test_utils.py.
+    "test_rendering_shadow_hand.py": 1500,
     "test_contact_sensor.py": 2000,
 }
 """A dictionary of tests and their timeouts in seconds.


### PR DESCRIPTION
# Description

`test_rendering_shadow_hand.py` builds and tears down a full RTX env once per parametrized AOV (data type). It had no entry in `PER_TEST_TIMEOUTS`, so it fell back to `DEFAULT_TIMEOUT` (1000s). That budget never scaled as data types were added to `_DEFAULT_SENSOR_DATA_TYPES` (the list grew from 7 → 13), so the file eventually exceeded 1000s and timed out on CI (retry-masked).

This gives the file an explicit **1500s** budget (~45s per AOV) and adds a reminder comment to bump it when renderer cases are added.

Fixes nvbug 6299039.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

🤖 Generated with [Claude Code](https://claude.com/claude-code)