### PR TITLE
Fix ground-plane import for assets without legacy prim layout

### DIFF
--- a/source/isaaclab/changelog.d/octi-fix-6326-terrain-plane.rst
+++ b/source/isaaclab/changelog.d/octi-fix-6326-terrain-plane.rst
@@ -1,0 +1,13 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.sim.spawners.from_files.spawn_ground_plane` raising ``ValueError`` for
+  ground-plane USD files that do not follow the layout of the default grid asset from Isaac Sim
+  (issue `#6326 <https://github.com/isaac-sim/IsaacLab/issues/6326>`__). The physics material is now
+  bound to all collision-enabled prims in the spawned asset instead of requiring a ``Plane``-typed
+  prim, and the color override is skipped with a warning when the asset does not contain the grid
+  shader.
+* Fixed :meth:`~isaaclab.terrains.TerrainImporter.import_ground_plane` overriding the ground plane's
+  color with black when :attr:`~isaaclab.terrains.TerrainImporterCfg.visual_material` is set to None.
+  The spawned asset's authored color is now kept unchanged in this case, matching the documented
+  semantics of :attr:`~isaaclab.sim.spawners.from_files.GroundPlaneCfg.color`.

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -24,8 +24,8 @@ from isaaclab.sim.utils import (
     change_prim_property,
     clone,
     create_prim,
+    get_all_matching_child_prims,
     get_current_stage,
-    get_first_matching_child_prim,
     select_usd_variants,
     set_prim_visibility,
 )
@@ -178,9 +178,11 @@ def spawn_ground_plane(
 ) -> Usd.Prim:
     """Spawns a ground plane into the scene.
 
-    This function loads the USD file containing the grid plane asset from Isaac Sim. It may
-    not work with other assets for ground planes. In those cases, please use the `spawn_from_usd`
-    function.
+    This function loads the USD file containing the grid plane asset from Isaac Sim by default.
+    The physics material is bound to all collision-enabled prims found in the spawned asset, so it
+    works with any ground-plane USD file. The size and color overrides are specific to the layout
+    of the default grid plane asset. When the referenced asset does not contain the corresponding
+    prims, these overrides are skipped (with a warning for the color override).
 
     Note:
         This function takes keyword arguments to be compatible with other spawners. However, it does not
@@ -212,18 +214,24 @@ def spawn_ground_plane(
 
     # Create physics material
     if cfg.physics_material is not None:
+        from pxr import UsdPhysics  # noqa: PLC0415
+
         spawn_physics_material(f"{prim_path}/physicsMaterial", cfg.physics_material, stage=stage)
-        # Apply physics material to ground plane
-        collision_prim = get_first_matching_child_prim(
+        # Apply physics material to the collision prims in the spawned asset.
+        # note: we search by the applied collision API rather than a fixed prim type or path
+        #   to stay agnostic to the layout of the referenced USD file.
+        collision_prims = get_all_matching_child_prims(
             prim_path,
-            predicate=lambda _prim: _prim.GetTypeName() == "Plane",
+            predicate=lambda _prim: _prim.HasAPI(UsdPhysics.CollisionAPI),
             stage=stage,
         )
-        if collision_prim is None:
-            raise ValueError(f"No collision prim found at path: '{prim_path}'.")
-        # bind physics material to the collision prim
-        collision_prim_path = str(collision_prim.GetPath())
-        bind_physics_material(collision_prim_path, f"{prim_path}/physicsMaterial", stage=stage)
+        if not collision_prims:
+            logger.warning(
+                f"No collision-enabled prim found under path: '{prim_path}'. Skipping physics material binding."
+            )
+        # bind physics material to the collision prims
+        for collision_prim in collision_prims:
+            bind_physics_material(str(collision_prim.GetPath()), f"{prim_path}/physicsMaterial", stage=stage)
 
     # Obtain environment prim
     environment_prim = stage.GetPrimAtPath(f"{prim_path}/Environment")
@@ -236,17 +244,22 @@ def spawn_ground_plane(
         environment_prim.GetAttribute("xformOp:scale").Set(scale)
 
     # Change the color of the plane
-    # Warning: This is specific to the default grid plane asset.
+    # Warning: This is specific to the default grid plane asset. For other assets, the color
+    #   override is skipped with a warning since the grid shader does not exist in them.
     if cfg.color is not None:
-        from pxr import Gf, Sdf  # noqa: PLC0415
+        shader_path = f"{prim_path}/Looks/theGrid/Shader"
+        if stage.GetPrimAtPath(shader_path).IsValid():
+            from pxr import Gf, Sdf  # noqa: PLC0415
 
-        # change the color
-        change_prim_property(
-            prop_path=f"{prim_path}/Looks/theGrid/Shader.inputs:diffuse_tint",
-            value=Gf.Vec3f(*cfg.color),
-            stage=stage,
-            type_to_create_if_not_exist=Sdf.ValueTypeNames.Color3f,
-        )
+            # change the color
+            change_prim_property(
+                prop_path=f"{shader_path}.inputs:diffuse_tint",
+                value=Gf.Vec3f(*cfg.color),
+                stage=stage,
+                type_to_create_if_not_exist=Sdf.ValueTypeNames.Color3f,
+            )
+        else:
+            logger.warning(f"No grid shader found at path: '{shader_path}'. Skipping color override.")
     # Remove the light from the ground plane (USD API, works without Kit/Newton)
     # It isn't bright enough and messes up with the user's lighting settings
     light_prim = stage.GetPrimAtPath(f"{prim_path}/SphereLight")

--- a/source/isaaclab/isaaclab/terrains/terrain_importer.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_importer.py
@@ -25,6 +25,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _ground_plane_color(visual_material) -> tuple[float, float, float] | None:
+    """Return the ground-plane color for a configured visual material, or None to keep the asset's own.
+
+    A None color keeps the spawned asset's color unchanged — the case when no visual material
+    is configured or when the material does not provide a diffuse color.
+    """
+    if visual_material is None:
+        return None
+    material = visual_material.to_dict()
+    if "diffuse_color" not in material:
+        logger.warning(
+            "Visual material specified for ground plane but no diffuse color found. Skipping the color override."
+        )
+        return None
+    return material["diffuse_color"]
+
+
 class TerrainImporter:
     r"""A class to handle terrain meshes and import them into the simulator.
 
@@ -206,21 +223,8 @@ class TerrainImporter:
         # store the mesh name
         self.terrain_prim_paths.append(prim_path)
 
-        # obtain ground plane color from the configured visual material
-        # note: a None color keeps the spawned asset's color unchanged. This is the case when
-        #   no visual material is configured or when it does not provide a diffuse color.
-        color = None
-        if self.cfg.visual_material is not None:
-            material = self.cfg.visual_material.to_dict()
-            if "diffuse_color" in material:
-                color = material["diffuse_color"]
-            else:
-                logger.warning(
-                    "Visual material specified for ground plane but no diffuse color found."
-                    " Skipping the color override."
-                )
-
         # get the mesh
+        color = _ground_plane_color(self.cfg.visual_material)
         ground_plane_cfg = sim_utils.GroundPlaneCfg(physics_material=self.cfg.physics_material, size=size, color=color)
         ground_plane_cfg.func(prim_path, ground_plane_cfg)
 

--- a/source/isaaclab/isaaclab/terrains/terrain_importer.py
+++ b/source/isaaclab/isaaclab/terrains/terrain_importer.py
@@ -207,16 +207,17 @@ class TerrainImporter:
         self.terrain_prim_paths.append(prim_path)
 
         # obtain ground plane color from the configured visual material
-        color = (0.0, 0.0, 0.0)
+        # note: a None color keeps the spawned asset's color unchanged. This is the case when
+        #   no visual material is configured or when it does not provide a diffuse color.
+        color = None
         if self.cfg.visual_material is not None:
             material = self.cfg.visual_material.to_dict()
-            # defaults to the `GroundPlaneCfg` color if diffuse color attribute is not found
             if "diffuse_color" in material:
                 color = material["diffuse_color"]
             else:
                 logger.warning(
                     "Visual material specified for ground plane but no diffuse color found."
-                    " Using default color: (0.0, 0.0, 0.0)"
+                    " Skipping the color override."
                 )
 
         # get the mesh

--- a/source/isaaclab/test/sim/test_spawn_ground_plane_asset_contract.py
+++ b/source/isaaclab/test/sim/test_spawn_ground_plane_asset_contract.py
@@ -14,7 +14,6 @@ overrides when the corresponding prims exist. See: https://github.com/isaac-sim/
 from __future__ import annotations
 
 import logging
-import types
 
 import pytest
 
@@ -181,7 +180,7 @@ def test_legacy_grid_asset_keeps_full_behavior(stage, legacy_grid_asset):
 
 
 """
-Tests - TerrainImporter.import_ground_plane.
+Tests - TerrainImporter ground-plane color contract.
 """
 
 
@@ -193,32 +192,12 @@ Tests - TerrainImporter.import_ground_plane.
         pytest.param(sim_utils.GlassMdlCfg(), None, id="material_without_diffuse_color"),
     ],
 )
-def test_import_ground_plane_color_contract(stage, monkeypatch, visual_material, expected_color):
+def test_ground_plane_color_contract(visual_material, expected_color, caplog):
     """The terrain importer only overrides the ground-plane color when a diffuse color is configured."""
-    import isaaclab.terrains.terrain_importer as terrain_importer_module
-    from isaaclab.terrains import TerrainImporter, TerrainImporterCfg
+    from isaaclab.terrains.terrain_importer import _ground_plane_color
 
-    captured = {}
+    with caplog.at_level(logging.WARNING):
+        assert _ground_plane_color(visual_material) == expected_color
 
-    def _spy_ground_plane_cfg(**kwargs):
-        captured.update(kwargs)
-        return types.SimpleNamespace(func=lambda *args, **_kwargs: None, **kwargs)
-
-    monkeypatch.setattr(terrain_importer_module.sim_utils, "GroundPlaneCfg", _spy_ground_plane_cfg)
-    monkeypatch.setattr(
-        terrain_importer_module.sim_utils.SimulationContext,
-        "instance",
-        classmethod(lambda _cls: types.SimpleNamespace(device="cpu")),
-    )
-
-    cfg = TerrainImporterCfg(
-        prim_path="/World/ground",
-        terrain_type="plane",
-        num_envs=1,
-        env_spacing=1.0,
-        physics_material=None,
-        visual_material=visual_material,
-    )
-    TerrainImporter(cfg)
-
-    assert captured["color"] == expected_color
+    if visual_material is not None and expected_color is None:
+        assert "Skipping the color override" in caplog.text

--- a/source/isaaclab/test/sim/test_spawn_ground_plane_asset_contract.py
+++ b/source/isaaclab/test/sim/test_spawn_ground_plane_asset_contract.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the ground-plane spawner contract against different asset layouts (no Kit required).
+
+The ground-plane spawner historically assumed the internal layout of the default grid asset from
+Isaac Sim (a ``Plane``-typed collision prim and the ``Looks/theGrid/Shader`` material). These tests
+verify that the spawner works with any ground-plane USD file and only applies the asset-specific
+overrides when the corresponding prims exist. See: https://github.com/isaac-sim/IsaacLab/issues/6326
+"""
+
+from __future__ import annotations
+
+import logging
+import types
+
+import pytest
+
+from pxr import Gf, Sdf, Usd, UsdGeom, UsdLux, UsdPhysics, UsdShade
+
+import isaaclab.sim as sim_utils
+from isaaclab.sim.utils import create_new_stage, get_current_stage
+
+pytestmark = pytest.mark.unit
+
+
+"""
+Fixtures.
+"""
+
+
+@pytest.fixture
+def stage() -> Usd.Stage:
+    """Create a blank new stage for each test."""
+    create_new_stage()
+    return get_current_stage()
+
+
+@pytest.fixture
+def legacy_grid_asset(tmp_path) -> str:
+    """Create a ground-plane USD file that mimics the layout of the default grid asset from Isaac Sim."""
+    asset_path = str(tmp_path / "legacy_grid_ground.usda")
+    stage = Usd.Stage.CreateNew(asset_path)
+    world = UsdGeom.Xform.Define(stage, "/World")
+    stage.SetDefaultPrim(world.GetPrim())
+    # grid material and shader (targeted by the color override)
+    UsdShade.Material.Define(stage, "/World/Looks/theGrid")
+    shader = UsdShade.Shader.Define(stage, "/World/Looks/theGrid/Shader")
+    shader.CreateInput("diffuse_tint", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(1.0, 1.0, 1.0))
+    # collision plane
+    plane = UsdGeom.Plane.Define(stage, "/World/GroundPlane/CollisionPlane")
+    UsdPhysics.CollisionAPI.Apply(plane.GetPrim())
+    # environment mesh (targeted by the size override)
+    environment = UsdGeom.Xform.Define(stage, "/World/Environment")
+    environment.AddScaleOp().Set(Gf.Vec3f(1.0, 1.0, 1.0))
+    # sphere light (hidden by the spawner)
+    UsdLux.SphereLight.Define(stage, "/World/SphereLight")
+    stage.Save()
+    return asset_path
+
+
+@pytest.fixture
+def mesh_ground_asset(tmp_path) -> str:
+    """Create a ground-plane USD file with a mesh-based collider and no legacy grid prims."""
+    asset_path = str(tmp_path / "mesh_ground.usda")
+    stage = Usd.Stage.CreateNew(asset_path)
+    world = UsdGeom.Xform.Define(stage, "/World")
+    stage.SetDefaultPrim(world.GetPrim())
+    # collision-enabled ground mesh
+    mesh = UsdGeom.Mesh.Define(stage, "/World/Geometry/GroundMesh")
+    mesh.CreatePointsAttr([(-50, -50, 0), (50, -50, 0), (50, 50, 0), (-50, 50, 0)])
+    mesh.CreateFaceVertexCountsAttr([4])
+    mesh.CreateFaceVertexIndicesAttr([0, 1, 2, 3])
+    UsdPhysics.CollisionAPI.Apply(mesh.GetPrim())
+    # preview-surface material bound to the mesh
+    material = UsdShade.Material.Define(stage, "/World/Looks/GroundMat")
+    shader = UsdShade.Shader.Define(stage, "/World/Looks/GroundMat/PreviewShader")
+    shader.CreateIdAttr("UsdPreviewSurface")
+    material.CreateSurfaceOutput().ConnectToSource(shader.CreateOutput("surface", Sdf.ValueTypeNames.Token))
+    UsdShade.MaterialBindingAPI.Apply(mesh.GetPrim()).Bind(material)
+    stage.Save()
+    return asset_path
+
+
+@pytest.fixture
+def no_collision_asset(tmp_path) -> str:
+    """Create a ground-plane USD file without any collision-enabled prim."""
+    asset_path = str(tmp_path / "no_collision_ground.usda")
+    stage = Usd.Stage.CreateNew(asset_path)
+    world = UsdGeom.Xform.Define(stage, "/World")
+    stage.SetDefaultPrim(world.GetPrim())
+    mesh = UsdGeom.Mesh.Define(stage, "/World/Geometry/GroundMesh")
+    mesh.CreatePointsAttr([(-50, -50, 0), (50, -50, 0), (50, 50, 0), (-50, 50, 0)])
+    mesh.CreateFaceVertexCountsAttr([4])
+    mesh.CreateFaceVertexIndicesAttr([0, 1, 2, 3])
+    stage.Save()
+    return asset_path
+
+
+"""
+Tests - spawn_ground_plane.
+"""
+
+
+def test_physics_material_binds_to_collision_enabled_prims(stage, mesh_ground_asset):
+    """Physics material binds to prims with a collision API, independent of the prim type."""
+    cfg = sim_utils.GroundPlaneCfg(
+        usd_path=mesh_ground_asset,
+        physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=1.0, dynamic_friction=1.0),
+        color=None,
+    )
+    prim = cfg.func("/World/ground", cfg)
+
+    assert prim.IsValid()
+    mesh_prim = stage.GetPrimAtPath("/World/ground/Geometry/GroundMesh")
+    binding_rel = mesh_prim.GetRelationship("material:binding:physics")
+    assert binding_rel.IsValid()
+    assert binding_rel.GetTargets() == [Sdf.Path("/World/ground/physicsMaterial")]
+
+
+def test_missing_collision_prim_warns_and_skips_binding(stage, no_collision_asset, caplog):
+    """Physics material binding is skipped with a warning when the asset has no collision prim."""
+    cfg = sim_utils.GroundPlaneCfg(
+        usd_path=no_collision_asset,
+        physics_material=sim_utils.RigidBodyMaterialCfg(),
+        color=None,
+    )
+    with caplog.at_level(logging.WARNING):
+        prim = cfg.func("/World/ground", cfg)
+
+    assert prim.IsValid()
+    assert "Skipping physics material binding" in caplog.text
+
+
+def test_color_override_skipped_when_grid_shader_missing(stage, mesh_ground_asset, caplog):
+    """Color override is skipped with a warning when the asset has no legacy grid shader."""
+    cfg = sim_utils.GroundPlaneCfg(usd_path=mesh_ground_asset, physics_material=None, color=(1.0, 0.0, 0.0))
+    with caplog.at_level(logging.WARNING):
+        prim = cfg.func("/World/ground", cfg)
+
+    assert prim.IsValid()
+    assert "Skipping color override" in caplog.text
+    assert not stage.GetPrimAtPath("/World/ground/Looks/theGrid/Shader").IsValid()
+
+
+def test_spawn_without_overrides_succeeds_on_any_asset(stage, mesh_ground_asset):
+    """Spawning with no material or color overrides works with any ground-plane asset."""
+    cfg = sim_utils.GroundPlaneCfg(usd_path=mesh_ground_asset, physics_material=None, color=None)
+    prim = cfg.func("/World/ground", cfg)
+
+    assert prim.IsValid()
+
+
+def test_legacy_grid_asset_keeps_full_behavior(stage, legacy_grid_asset):
+    """All overrides still apply to assets that follow the default grid asset's layout."""
+    cfg = sim_utils.GroundPlaneCfg(
+        usd_path=legacy_grid_asset,
+        physics_material=sim_utils.RigidBodyMaterialCfg(),
+        color=(0.2, 0.3, 0.4),
+        size=(200.0, 300.0),
+    )
+    prim = cfg.func("/World/ground", cfg)
+    assert prim.IsValid()
+
+    # physics material is bound to the collision plane
+    plane_prim = stage.GetPrimAtPath("/World/ground/GroundPlane/CollisionPlane")
+    binding_rel = plane_prim.GetRelationship("material:binding:physics")
+    assert binding_rel.IsValid()
+    assert binding_rel.GetTargets() == [Sdf.Path("/World/ground/physicsMaterial")]
+    # color is written to the grid shader
+    shader = UsdShade.Shader(stage.GetPrimAtPath("/World/ground/Looks/theGrid/Shader"))
+    assert shader.GetInput("diffuse_tint").Get() == Gf.Vec3f(0.2, 0.3, 0.4)
+    # size is applied to the environment prim
+    environment_prim = stage.GetPrimAtPath("/World/ground/Environment")
+    assert environment_prim.GetAttribute("xformOp:scale").Get() == Gf.Vec3f(2.0, 3.0, 1.0)
+    # light is hidden
+    light_prim = stage.GetPrimAtPath("/World/ground/SphereLight")
+    assert UsdGeom.Imageable(light_prim).ComputeVisibility() == UsdGeom.Tokens.invisible
+
+
+"""
+Tests - TerrainImporter.import_ground_plane.
+"""
+
+
+@pytest.mark.parametrize(
+    ("visual_material", "expected_color"),
+    [
+        pytest.param(None, None, id="no_visual_material"),
+        pytest.param(sim_utils.PreviewSurfaceCfg(diffuse_color=(0.1, 0.2, 0.3)), (0.1, 0.2, 0.3), id="diffuse_color"),
+        pytest.param(sim_utils.GlassMdlCfg(), None, id="material_without_diffuse_color"),
+    ],
+)
+def test_import_ground_plane_color_contract(stage, monkeypatch, visual_material, expected_color):
+    """The terrain importer only overrides the ground-plane color when a diffuse color is configured."""
+    import isaaclab.terrains.terrain_importer as terrain_importer_module
+    from isaaclab.terrains import TerrainImporter, TerrainImporterCfg
+
+    captured = {}
+
+    def _spy_ground_plane_cfg(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(func=lambda *args, **_kwargs: None, **kwargs)
+
+    monkeypatch.setattr(terrain_importer_module.sim_utils, "GroundPlaneCfg", _spy_ground_plane_cfg)
+    monkeypatch.setattr(
+        terrain_importer_module.sim_utils.SimulationContext,
+        "instance",
+        classmethod(lambda _cls: types.SimpleNamespace(device="cpu")),
+    )
+
+    cfg = TerrainImporterCfg(
+        prim_path="/World/ground",
+        terrain_type="plane",
+        num_envs=1,
+        env_spacing=1.0,
+        physics_material=None,
+        visual_material=visual_material,
+    )
+    TerrainImporter(cfg)
+
+    assert captured["color"] == expected_color


### PR DESCRIPTION
# Description

`TerrainImporter.import_ground_plane()` / `spawn_ground_plane()` assumed the internal layout of the default grid asset from Isaac Sim: a `Plane`-typed collision prim and the `Looks/theGrid/Shader` material. Any ground-plane USD file with a different layout failed with a `ValueError` during environment creation — even for a default `TerrainImporterCfg`, since `physics_material` defaults to a non-None material.

This PR makes the plane import robust to the asset's layout:

- **Physics material**: bound to all collision-enabled prims (prims with `UsdPhysics.CollisionAPI` applied) instead of requiring a `Plane`-typed child prim. If the asset has no collision prim, the binding is skipped with a warning instead of raising. Note that binding by collision API matches what `bind_physics_material()` accepts anyway — binding to a `Plane` prim without a collision API was already a silent no-op.
- **Color override**: `spawn_ground_plane()` only writes the legacy `Looks/theGrid/Shader.inputs:diffuse_tint` property when that shader exists in the spawned asset, and skips it with a warning otherwise.
- **Color contract**: `TerrainImporter.import_ground_plane()` now passes `color=None` when no visual material is configured (or the material provides no diffuse color), matching the documented semantics of `GroundPlaneCfg.color` ("If None, then the color remains unchanged"). Previously it always forced a black tint.

Behavior notes for reviewers:

- The default grid asset (verified identical on the production and staging asset servers) has `PhysicsCollisionAPI` authored on its `CollisionPlane`, so binding, tint, and scale behavior with the shipped asset is unchanged. Verified end-to-end against the cloud asset.
- The only intentional behavior change: an explicit `visual_material=None` on `TerrainImporterCfg` now keeps the asset's authored color instead of tinting it black. The default config (dark-gray preview surface) is unaffected.

The new unit tests run without Kit and without network access (they build minimal legacy-replica and mesh-collider assets locally). All 5 regression tests fail without the fix; the 3 backward-compatibility tests pass on both sides.

Fixes #6326

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

🤖 Generated with [Claude Code](https://claude.com/claude-code)