### PR TITLE
Fix omni-github result schema rejecting integral numeric custom values

### DIFF
--- a/.github/actions/upload-omni-github-test-results/result-json.schema.json
+++ b/.github/actions/upload-omni-github-test-results/result-json.schema.json
@@ -221,7 +221,7 @@
       }
     },
     "customValue": {
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string",
           "maxLength": 1024
@@ -242,7 +242,7 @@
           "type": "array",
           "maxItems": 100,
           "items": {
-            "oneOf": [
+            "anyOf": [
               {
                 "type": "string",
                 "maxLength": 1024


### PR DESCRIPTION
## Summary

`.github/actions/upload-omni-github-test-results/result-json.schema.json` defines `$defs.customValue` (and its nested array `items`) with **`oneOf`**, listing both `{"type": "integer"}` and `{"type": "number"}`. Under JSON Schema draft 2020-12, `integer` is a subset of `number`, so any **integral** value matches *both* branches and `oneOf` (exactly-one) rejects it. Non-integral floats, strings, and booleans are unaffected.

This is latent today because the JUnit converter (`junit_to_omni_github_results.py`) emits no `custom` fields, so no current job hits it. It bites any producer that emits integral numeric custom values (e.g. a perf gate emitting `num_envs: 4096`, `fps_mean: 100.0`). It matters because the upload action enforces this schema as a hard gate (`action.yml`): a result file that fails validation is silently dropped (`Skipping omni-github upload ... failed schema validation`).

`oneOf` appears only in `customValue`; every other numeric field (`duration`, `retries`, `kit_build_number`, `result_schema_version`) is single-type and unaffected.

Fix: change both `oneOf` → `anyOf`, preserving the intended union (string/int/number/bool/null/array/object) while allowing integral numbers.

## Repro

Using the same `python -m jsonschema` gate the action runs, against the committed schema:

```
### Before (oneOf)
- integer (num_envs=4096)                    -> REJECTED
- integral float (fps_mean=100.0)            -> REJECTED
- non-integral float (regression_pct=-1.2)   -> accepted
- string (verdict='PASS')                    -> accepted

### After (anyOf)
- integer (num_envs=4096)                    -> accepted
- integral float (fps_mean=100.0)            -> accepted
- non-integral float (regression_pct=-1.2)   -> accepted
- string (verdict='PASS')                    -> accepted
```

## Test plan

- [ ] `python -m jsonschema result-json.schema.json --instance <result with an integral custom value>` passes after the fix
- [ ] Existing `test_junit_to_omni_github_results.py` remains green (converter output is unchanged)