### PR TITLE
Add support for python-env.sh for dev workflows

### DIFF
--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -38,8 +38,25 @@ if [ -d "$ISAACLAB_PATH/_isaac_sim" ]; then
     if [ -f "$ISAACLAB_PATH/_isaac_sim/setup_conda_env.sh" ]; then
         # shellcheck disable=SC1091
         . "$ISAACLAB_PATH/_isaac_sim/setup_conda_env.sh" >/dev/null 2>&1 || true
+    elif [ -f "$ISAACLAB_PATH/_isaac_sim/setup_python_env.sh" ]; then
+        export ISAAC_PATH="$ISAACLAB_PATH/_isaac_sim"
+        export CARB_APP_PATH="$ISAAC_PATH/kit"
+        export EXP_PATH="$ISAAC_PATH/apps"
+        # shellcheck disable=SC1091
+        . "$ISAACLAB_PATH/_isaac_sim/setup_python_env.sh" >/dev/null 2>&1 || true
+        # Unlike setup_conda_env.sh, setup_python_env.sh prepends Kit's
+        # pip_prebundle directories to PYTHONPATH. Those ship vendored copies of
+        # common libraries (e.g. an older typing_extensions lacking Sentinel)
+        # that then shadow the active venv/conda environment. Put the active
+        # environment's site-packages first so it always wins.
+        if [ -n "$VIRTUAL_ENV" ] || [ -n "$CONDA_PREFIX" ]; then
+            env_site_packages="$("$python_exe" -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null || true)"
+            if [ -n "$env_site_packages" ]; then
+                export PYTHONPATH="$env_site_packages:$PYTHONPATH"
+            fi
+        fi
     else
-        echo "[WARNING] _isaac_sim is present but _isaac_sim/setup_conda_env.sh is missing; Isaac Sim env vars not exported." >&2
+        echo "[WARNING] _isaac_sim is present but _isaac_sim/setup_conda_env.sh or _isaac_sim/setup_python_env.sh is missing; Isaac Sim env vars not exported." >&2
         echo "[WARNING] Re-extract the Isaac Sim binary zip if you intend to use the bundled binary." >&2
     fi
 fi


### PR DESCRIPTION
# Description

Local Isaac Sim builds (6.1+) ship setup_python_env.sh instead of setup_conda_env.sh. Isaac Lab only sourced the latter, breaking the developer workflow when _isaac_sim points at a source build. This PR falls back to setup_python_env.sh, sets the required Kit env vars, and prepends the active environment's site-packages to avoid Kit prebundle shadowing.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
