### PR TITLE
[Fix] Cherry-pick docker install extension-startup fix (prebundle deletion, pin-pink)

### DIFF
--- a/docs/source/policy_deployment/02_gear_assembly/gear_assembly_policy.rst
+++ b/docs/source/policy_deployment/02_gear_assembly/gear_assembly_policy.rst
@@ -36,7 +36,7 @@ This environment has been successfully deployed on real UR10e and Flexiv Rizon 4
 
 **Scope of This Tutorial:**
 
-This tutorial focuses exclusively on the **training part** of the sim-to-real transfer workflow in Isaac Lab. For the complete deployment workflow on the real robot, including the exact steps to set up the vision pipeline, robot interface and the ROS inference node to run your trained policy on real hardware, please refer to the `Isaac ROS Documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_ur_dnn_policy/index.html>`_.
+This tutorial focuses exclusively on the **training part** of the sim-to-real transfer workflow in Isaac Lab. For the complete deployment workflow on the real robot, including the exact steps to set up the vision pipeline, robot interface and the ROS inference node to run your trained policy on real hardware, please refer to the `Isaac ROS Documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_dnn_policy/index.html>`_.
 
 Overview
 --------
@@ -755,7 +755,7 @@ Replace the log directory path with your actual training log location if differe
 Step 3: Deploy on Real Robot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once training is complete, follow the `Isaac ROS inference documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_ur_dnn_policy/index.html>`_ to deploy your policy.
+Once training is complete, follow the `Isaac ROS inference documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_dnn_policy/index.html>`_ to deploy your policy.
 
 The Isaac ROS deployment pipeline directly uses the trained model checkpoint (``.pt`` file) along with the ``agent.yaml`` and ``env.yaml`` configuration files generated during training. No additional export step is required.
 

--- a/source/isaaclab/changelog.d/jichuanh-docker-install-prebundle-safety.rst
+++ b/source/isaaclab/changelog.d/jichuanh-docker-install-prebundle-safety.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Added a fail-loud post-install check that aborts installation when pip
+  operations leave a prebundled Isaac Sim package with a dangling
+  ``__init__.py`` (other new dangling symlinks are reported as warnings).
+* Fixed the ``isaacsim.robot_motion.pink`` extension failing to load after
+  installation by moving the ``pin-pink`` pin from ``3.1.0`` to ``3.3.0``, which
+  provides ``pink.exceptions.NoSolutionFound`` while staying below the pink 3.4
+  task-API break. Environments installed manually should update with
+  ``pip install pin-pink==3.3.0``.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -208,7 +208,8 @@ def _maybe_preinstall_arm_nlopt(python_exe: str, pip_cmd: list[str]) -> None:
 # via the cmeel ``pin`` wheel, which provides the ``pinocchio`` Python module under
 # ``cmeel.prefix/lib/python3.12/site-packages/`` and registers it on sys.path via a
 # ``cmeel.pth`` hook. DAQP provides the QP solver selected by the Pink IK controller.
-_PINK_IK_STACK = ("pin", "pin-pink==3.1.0", "daqp==0.8.5")
+# pin-pink: Isaac Sim 6.x needs >=3.3, 3.4+ breaks pink_ik; daqp >0.8.5 changes behavior.
+_PINK_IK_STACK = ("pin", "pin-pink==3.3.0", "daqp==0.8.5")
 
 
 def _ensure_pink_ik_dependencies_installed(python_exe: str, pip_cmd: list[str], *, probe_env: dict[str, str]) -> None:
@@ -263,7 +264,7 @@ def _ensure_pink_ik_dependencies_installed(python_exe: str, pip_cmd: list[str], 
         print_warning(
             "Force-installing the cmeel pinocchio and DAQP stack failed (returncode "
             f"{install_result.returncode}). The pink IK controller and its tests will not be"
-            " usable until ``pin pin-pink==3.1.0 daqp==0.8.5`` is installed manually."
+            f" usable until ``{' '.join(_PINK_IK_STACK)}`` is installed manually."
         )
 
 
@@ -730,6 +731,98 @@ def _force_remove(path: Path) -> None:
         os.rmdir(path)
 
 
+def _discover_prebundle_dirs() -> set[Path]:
+    """Find every ``pip_prebundle`` directory under the Isaac Sim installation.
+
+    Searches both the Isaac Sim tree and the Omniverse cache roots — some Isaac
+    Sim directories are symlinked into ``~/.local/share/ov`` and would be missed
+    by a plain ``rglob()`` on ``_isaac_sim``. Returns an empty set when no Isaac
+    Sim installation is present.
+    """
+    isaacsim_path = extract_isaacsim_path(required=False)
+    if isaacsim_path is None or not isaacsim_path.exists():
+        return set()
+
+    candidate_roots: set[Path] = set()
+    for root in (
+        isaacsim_path,
+        isaacsim_path.resolve(),
+        isaacsim_path / "extscache",
+        Path.home() / ".local" / "share" / "ov" / "data" / "exts",
+        Path.home() / ".local" / "share" / "ov" / "data" / "exts" / "v2",
+    ):
+        if root.exists():
+            candidate_roots.add(root)
+            candidate_roots.add(root.resolve())
+
+    prebundle_dirs: set[Path] = set()
+    for root in candidate_roots:
+        prebundle_dirs.update(root.rglob("pip_prebundle"))
+    return prebundle_dirs
+
+
+def _find_dangling_prebundle_symlinks() -> set[Path]:
+    """Find symlinks under Isaac Sim prebundles whose targets do not resolve.
+
+    Isaac Sim deduplicates packages shared by several extensions as per-file
+    symlink farms between ``pip_prebundle`` directories. pip operations routinely
+    replace prebundled distributions with copies in ``site-packages`` — harmless
+    on its own — but deleting a copy that other prebundles link into leaves
+    dangling symlinks that break extension startup at runtime.
+    """
+    dangling: set[Path] = set()
+    for prebundle_dir in _discover_prebundle_dirs():
+        for root, _dirs, files in os.walk(prebundle_dir):
+            for name in files:
+                path = Path(root) / name
+                if path.is_symlink() and not path.exists():
+                    dangling.add(path)
+    return dangling
+
+
+def _assert_no_new_dangling_prebundle_symlinks(before: set[Path]) -> None:
+    """Fail when the installation broke a prebundled package's symlinked ``__init__.py``.
+
+    A new dangling symlink means a pip operation deleted a prebundled package
+    that other extensions reference through Isaac Sim's symlink farms — the
+    failure mode behind the ``packaging`` removal cascade in nvbugs 6343978
+    (14 extensions failing to start). Routine pip replacements do leave a few
+    dozen dangling links to files Python never imports at startup (test modules,
+    ``WHEEL``/license files, cmake hooks), so only a dangling ``__init__.py`` —
+    which makes the whole package unimportable — fails the install; other new
+    dangling links are reported as warnings.
+
+    Args:
+        before: Dangling symlinks from :func:`_find_dangling_prebundle_symlinks`,
+            collected before the pip operations.
+
+    Raises:
+        RuntimeError: If the installation left a prebundled package with a
+            dangling ``__init__.py``.
+    """
+    introduced = sorted(_find_dangling_prebundle_symlinks() - before)
+    if not introduced:
+        return
+    broken_packages = [p for p in introduced if p.name == "__init__.py"]
+    if broken_packages:
+        shown = "\n  ".join(str(p) for p in broken_packages)
+        raise RuntimeError(
+            f"Installation broke {len(broken_packages)} prebundled package(s) in Isaac Sim"
+            f" (dangling __init__.py, {len(introduced)} new dangling symlink(s) total):\n  "
+            + shown
+            + "\nA pip operation deleted a prebundled package that other Isaac Sim extensions share"
+            " via symlinks; extensions will fail to start at runtime (see nvbugs 6343978). This"
+            " usually means a dependency pin forced pip to downgrade/replace the prebundled copy —"
+            " fix that pin instead of shipping a broken prebundle, and restore the Isaac Sim"
+            " installation before retrying."
+        )
+    print_warning(
+        f"Installation left {len(introduced)} new dangling symlink(s) in Isaac Sim prebundles"
+        " (no package __init__.py affected — extensions should still start). First few: "
+        + ", ".join(str(p) for p in introduced[:5])
+    )
+
+
 def _repoint_prebundle_packages() -> None:
     """Replace prebundled packages in Isaac Sim with symlinks to the active environment.
 
@@ -763,25 +856,7 @@ def _repoint_prebundle_packages() -> None:
         print_warning(f"site-packages directory not found: {site_packages} — skipping prebundle repoint.")
         return
 
-    # Discover pip_prebundle directories from both the Isaac Sim tree and
-    # Omniverse cache roots. Some Isaac Sim directories are symlinked into
-    # ~/.local/share/ov and may be missed by a plain rglob() on _isaac_sim.
-    candidate_roots: set[Path] = set()
-    for root in (
-        isaacsim_path,
-        isaacsim_path.resolve(),
-        isaacsim_path / "extscache",
-        Path.home() / ".local" / "share" / "ov" / "data" / "exts",
-        Path.home() / ".local" / "share" / "ov" / "data" / "exts" / "v2",
-    ):
-        if root.exists():
-            candidate_roots.add(root)
-            candidate_roots.add(root.resolve())
-
-    prebundle_dirs: set[Path] = set()
-    for root in candidate_roots:
-        prebundle_dirs.update(root.rglob("pip_prebundle"))
-
+    prebundle_dirs = _discover_prebundle_dirs()
     if not prebundle_dirs:
         print_debug("No pip_prebundle directories found under Isaac Sim.")
         return
@@ -987,6 +1062,10 @@ def command_install(install_type: str = "all") -> None:
     if saved_pythonpath is not None:
         probe_env["PYTHONPATH"] = saved_pythonpath
 
+    # Baseline for the post-install integrity check: no pip operation below may
+    # leave new dangling symlinks in Isaac Sim's prebundles (nvbugs 6343978).
+    dangling_symlinks_before = _find_dangling_prebundle_symlinks()
+
     try:
         # Upgrade pip first to avoid compatibility issues (skip when using uv).
         if not using_uv:
@@ -1037,6 +1116,12 @@ def command_install(install_type: str = "all") -> None:
         # the active venv/conda versions are always loaded regardless of PYTHONPATH
         # ordering (e.g. torch+cu130 in venv vs torch+cu128 in prebundle on aarch64).
         _repoint_prebundle_packages()
+
+        # Fail loud if any pip operation above broke Isaac Sim's cross-extension
+        # symlink farms. Prebundle deletions on their own are routine (pip
+        # replaces those packages in site-packages, which shadows the prebundle
+        # at runtime); only newly dangling symlinks break extension startup.
+        _assert_no_new_dangling_prebundle_symlinks(dangling_symlinks_before)
 
     finally:
         # Restore LD_PRELOAD if we cleared it.

--- a/source/isaaclab/isaaclab/controllers/pink_ik/pink_ik.py
+++ b/source/isaaclab/isaaclab/controllers/pink_ik/pink_ik.py
@@ -271,14 +271,14 @@ class PinkIKController:
         except SolverNotFound as e:
             raise RuntimeError(
                 f"Pink IK requires the '{_QP_SOLVER}' QP solver. Install the Pink IK stack with "
-                "``./isaaclab.sh -i`` or manually install ``pin pin-pink==3.1.0 daqp==0.8.5``."
+                "``./isaaclab.sh -i`` or manually install ``pin pin-pink==3.3.0 daqp==0.8.5``."
             ) from e
         except TypeError as e:
             if "primal_start" in str(e):
                 raise RuntimeError(
                     "Pink IK requires a DAQP version compatible with qpsolvers warm-start arguments. "
                     "Install the Pink IK stack with ``./isaaclab.sh -i`` or manually install "
-                    "``pin pin-pink==3.1.0 daqp==0.8.5``."
+                    "``pin pin-pink==3.3.0 daqp==0.8.5``."
                 ) from e
             return _return_current_joint_positions(e)
         except (AssertionError, Exception) as e:

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -68,7 +68,7 @@ SUPPORTED_ARCHS = "platform_machine in 'x86_64,AMD64'"
 INSTALL_REQUIRES += [
     # required by isaaclab.isaaclab.controllers.pink_ik
     f"pin ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
-    f"pin-pink==3.1.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
+    f"pin-pink==3.3.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
     f"daqp==0.8.5 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
 ]
 # Adds OpenUSD dependencies based on architecture for Kit less mode.

--- a/source/isaaclab/test/cli/test_install_prebundle.py
+++ b/source/isaaclab/test/cli/test_install_prebundle.py
@@ -3,15 +3,21 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Tests for prebundle probe and _split_install_items.
+"""Tests for prebundle probe, _split_install_items, and prebundle dist integrity.
 
 Supplements test_install_commands.py with tests that verify the probe
-script text and the comma-separated install item parser.
+script text, the comma-separated install item parser, and the
+snapshot/assert pair guarding Isaac Sim prebundles against pip removals.
 """
 
+import shutil
 from unittest import mock
 
+import pytest
+
 from isaaclab.cli.commands.install import (
+    _assert_no_new_dangling_prebundle_symlinks,
+    _find_dangling_prebundle_symlinks,
     _torch_first_on_sys_path_is_prebundle,
     split_install_items,
 )
@@ -79,3 +85,76 @@ class TestTorchProbeScriptContent:
         probe_script = captured_cmd[2]  # [python_exe, "-c", probe]
         assert "pip_prebundle" in probe_script, "Probe must check for 'pip_prebundle'"
         assert "extsDeprecated" not in probe_script, "Probe must NOT check only for 'extsDeprecated'"
+
+
+# ---------------------------------------------------------------------------
+# prebundle dangling-symlink integrity
+# ---------------------------------------------------------------------------
+
+
+class TestPrebundleSymlinkIntegrity:
+    """Tests for :func:`_find_dangling_prebundle_symlinks` and
+    :func:`_assert_no_new_dangling_prebundle_symlinks`.
+
+    Regression guard for nvbugs 6343978: a pip downgrade deleted ``packaging``
+    from the ``omni.isaac.core_archive`` prebundle, dangling the per-file
+    symlink farm ``omni.services.pip_archive`` shares with it and cascading
+    into 14 extension startup failures. Prebundle deletions by themselves are
+    routine (site-packages shadows them); only new dangling symlinks fail.
+    """
+
+    def _make_prebundles(self, tmp_path):
+        core = tmp_path / "exts" / "omni.isaac.core_archive" / "pip_prebundle"
+        (core / "packaging").mkdir(parents=True)
+        (core / "packaging" / "__init__.py").write_text("")
+        services = tmp_path / "extscache" / "omni.services.pip_archive" / "pip_prebundle"
+        (services / "packaging").mkdir(parents=True)
+        (services / "packaging" / "__init__.py").symlink_to(core / "packaging" / "__init__.py")
+        return core, services
+
+    def test_intact_farm_has_no_dangling_links(self, tmp_path):
+        core, services = self._make_prebundles(tmp_path)
+        with mock.patch("isaaclab.cli.commands.install._discover_prebundle_dirs", return_value={core, services}):
+            assert _find_dangling_prebundle_symlinks() == set()
+            _assert_no_new_dangling_prebundle_symlinks(set())
+
+    def test_raises_when_symlink_target_deleted(self, tmp_path):
+        """Deleting the shared copy must fail the install, naming the broken link."""
+        core, services = self._make_prebundles(tmp_path)
+        with mock.patch("isaaclab.cli.commands.install._discover_prebundle_dirs", return_value={core, services}):
+            before = _find_dangling_prebundle_symlinks()
+            shutil.rmtree(core / "packaging")
+            with pytest.raises(RuntimeError, match="dangling symlink") as excinfo:
+                _assert_no_new_dangling_prebundle_symlinks(before)
+        assert str(services / "packaging" / "__init__.py") in str(excinfo.value)
+
+    def test_preexisting_dangling_links_are_tolerated(self, tmp_path):
+        """Links already broken before the install do not fail it."""
+        core, services = self._make_prebundles(tmp_path)
+        (services / "stale.py").symlink_to(core / "does-not-exist.py")
+        with mock.patch("isaaclab.cli.commands.install._discover_prebundle_dirs", return_value={core, services}):
+            before = _find_dangling_prebundle_symlinks()
+            assert before == {services / "stale.py"}
+            _assert_no_new_dangling_prebundle_symlinks(before)
+
+    def test_routine_dist_replacement_passes(self, tmp_path):
+        """Deleting a prebundled package nothing links into is not a violation."""
+        core, services = self._make_prebundles(tmp_path)
+        (core / "six.py").write_text("")
+        with mock.patch("isaaclab.cli.commands.install._discover_prebundle_dirs", return_value={core, services}):
+            before = _find_dangling_prebundle_symlinks()
+            (core / "six.py").unlink()
+            _assert_no_new_dangling_prebundle_symlinks(before)
+
+    def test_non_package_dangles_warn_but_pass(self, tmp_path):
+        """Routine residue (dangling non-__init__ files) warns without failing.
+
+        Every docker build leaves a few dozen dangling links to files Python
+        never imports at startup (test modules, WHEEL/license files, cmake
+        hooks); those must not abort the install.
+        """
+        core, services = self._make_prebundles(tmp_path)
+        (services / "WHEEL").symlink_to(core / "gone-WHEEL")
+        (services / "test_module.py").symlink_to(core / "gone-test.py")
+        with mock.patch("isaaclab.cli.commands.install._discover_prebundle_dirs", return_value={core, services}):
+            _assert_no_new_dangling_prebundle_symlinks(set())

--- a/source/isaaclab_rl/changelog.d/jichuanh-docker-install-prebundle-safety.rst
+++ b/source/isaaclab_rl/changelog.d/jichuanh-docker-install-prebundle-safety.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed docker installs deleting ``packaging`` from Isaac Sim's
+  ``omni.isaac.core_archive`` prebundle by removing the ``packaging<24`` bound
+  (no consumer requires it). The deletion dangled the symlink farm that
+  ``omni.services.pip_archive`` shares with it and broke 13 extensions at
+  startup.

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -31,7 +31,7 @@ INSTALL_REQUIRES = [
     "tensorboard",
     # video recording
     "moviepy",
-    "packaging<24",
+    "packaging",
     "tqdm==4.67.1",  # previous version was causing sys errors
 ]
 

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -51,7 +51,7 @@ pyproject.dependencies.all = [
     "pydantic>=2.7,<2.12",
     "lazy_loader>=0.4",
     "pin ; platform_system == 'Linux'",
-    "pin-pink>=2.3.6 ; platform_system == 'Linux'",
+    "pin-pink==3.3.0 ; platform_system == 'Linux'",
     # ================================================================================
     # https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab_rl/setup.py
     # ================================================================================
@@ -68,7 +68,7 @@ pyproject.dependencies.all = [
     "tensorboard",
     # video recording
     "moviepy",
-    "packaging<24",
+    "packaging",
     "tqdm==4.67.1",
     # ================================================================================
     # https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab_tasks/setup.py


### PR DESCRIPTION
# Description

Cherry-pick of #6329 onto `release/3.0.0-beta2` — the follow-up to #6295 for NVBug 6410989 (continuation of NVBug 6343978): Docker streaming works but the log floods with 438 `[Error]` lines and 14 Isaac Sim extensions fail to load. uv installs are unaffected.

## 1. Summary

- Relaxed the vestigial `packaging<24` bound in `isaaclab_rl` — it forced pip to downgrade `packaging` and delete it from the `omni.isaac.core_archive` prebundle, dangling the per-file symlink farm `omni.services.pip_archive` shares with it (13 extension startup failures).
- Bumped `pin-pink` `3.1.0` → `3.3.0` at every pin site — `isaacsim.robot_motion.pink` needs `pink.exceptions.NoSolutionFound` (pink ≥ 3.3.0); pink 3.4+ stays excluded (pink_ik task-API break, #5846). The wheel spec's `pin-pink>=2.3.6` also becomes `==3.3.0` (it currently resolves to 4.x).
- Added the fail-loud post-install invariant: the install aborts when pip leaves a prebundled Isaac Sim package with a dangling `__init__.py`; other new dangling links only warn.

## 2. Backport adaptations vs #6329

This branch predates the #6009 dependency centralization, so:

- Pin edits land in `source/isaaclab/setup.py`, `source/isaaclab_rl/setup.py`, and `tools/wheel_builder/res/python_packages.toml` instead of the root `pyproject.toml`.
- The install CLI keeps its hardcoded `_PINK_IK_STACK` (bumped to 3.3.0); the pyproject-derived stack from #6329 and its tests are not ported — the derivation would `KeyError` here since the root `pyproject.toml` has no pin entries on this branch.
- `import pytest` added to `test_install_prebundle.py` (develop had it from an intermediate commit not on this branch).

## 3. Heads-up: the invariant can surface latent arm64 breakage

On develop, the first nightly image build containing #6329 failed its arm64 leg because the invariant caught a real prebundle breakage (Pillow deleted from `omni.kit.pip_archive`). If this release branch's arm64 docker build has a similar latent issue, the invariant will turn a silently-broken image into a failed build — that is by design, but worth knowing before merging.

## 4. Test plan

- [x] `source/isaaclab/test/cli/` — 141 passed locally (prebundle invariant tests included).
- [ ] PR CI green.