### PR TITLE
fix(rsl_rl): default obs_groups for new runners

### DIFF
--- a/source/isaaclab_rl/changelog.d/fix-rsl-rl-play-obs-groups.rst
+++ b/source/isaaclab_rl/changelog.d/fix-rsl-rl-play-obs-groups.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab_rl.rsl_rl.utils.handle_deprecated_rsl_rl_cfg` leaving ``obs_groups``
+  unset on ``OnPolicyRunner`` configs for rsl-rl-lib >= 4.0.0, which made every play and
+  evaluation script hang during runner initialization.

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/utils.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/utils.py
@@ -67,6 +67,8 @@ def handle_deprecated_rsl_rl_cfg(agent_cfg: RslRlBaseRunnerCfg, installed_versio
 
     # Handle configurations for rsl-rl >= 4.0.0
     else:
+        _set_default_obs_groups(agent_cfg)
+
         # Handle deprecated policy configuration
         if _has_non_missing_attr(agent_cfg, "policy"):
             print(
@@ -226,6 +228,15 @@ def _clear_new_model_cfg(agent_cfg, model_name: str):
         " or use the `policy` configuration for rsl-rl < 4.0.0."
     )
     setattr(agent_cfg, model_name, MISSING)
+
+
+def _set_default_obs_groups(agent_cfg):
+    if (
+        getattr(agent_cfg, "class_name", None) == "OnPolicyRunner"
+        and hasattr(agent_cfg, "obs_groups")
+        and _is_missing(agent_cfg.obs_groups)
+    ):
+        agent_cfg.obs_groups = {"actor": ["policy"], "critic": ["policy"]}
 
 
 def _validate_old_stochastic_cfg(model_cfg):

--- a/source/isaaclab_rl/test/test_rsl_rl_cfg_deprecation.py
+++ b/source/isaaclab_rl/test/test_rsl_rl_cfg_deprecation.py
@@ -369,6 +369,21 @@ class TestV4:
         assert _is_missing(cfg.actor) and _is_missing(cfg.critic)
 
 
+class TestObsGroups:
+    @pytest.mark.parametrize("installed_version", ["4.0.0", "5.0.0"])
+    def test_defaults_missing_obs_groups_for_on_policy_runner(self, installed_version):
+        cfg = _on_policy_runner(policy=_ppo_mlp_policy(), algorithm=_ppo_algo())
+        handle_deprecated_rsl_rl_cfg(cfg, installed_version)
+        assert cfg.obs_groups == {"actor": ["policy"], "critic": ["policy"]}
+        assert cfg.to_dict()["obs_groups"] == {"actor": ["policy"], "critic": ["policy"]}
+
+    @pytest.mark.parametrize("installed_version", ["4.0.0", "5.0.0"])
+    def test_preserves_existing_obs_groups(self, installed_version):
+        obs_groups = {"policy": ["policy"], "critic": ["critic"]}
+        cfg = _on_policy_runner(policy=_ppo_mlp_policy(), algorithm=_ppo_algo(), obs_groups=obs_groups)
+        handle_deprecated_rsl_rl_cfg(cfg, installed_version)
+        assert cfg.obs_groups == obs_groups
+
 # ===================================================================
 # rsl-rl >= 5.0.0
 # ===================================================================

--- a/source/isaaclab_rl/test/test_rsl_rl_cfg_deprecation.py
+++ b/source/isaaclab_rl/test/test_rsl_rl_cfg_deprecation.py
@@ -384,6 +384,12 @@ class TestObsGroups:
         handle_deprecated_rsl_rl_cfg(cfg, installed_version)
         assert cfg.obs_groups == obs_groups
 
+    def test_does_not_default_obs_groups_below_4(self):
+        cfg = _on_policy_runner(policy=_ppo_mlp_policy(), algorithm=_ppo_algo())
+        handle_deprecated_rsl_rl_cfg(cfg, "3.9.0")
+        assert _is_missing(cfg.obs_groups)
+
+
 # ===================================================================
 # rsl-rl >= 5.0.0
 # ===================================================================


### PR DESCRIPTION
Summary:
- Populate a default `obs_groups` mapping for `OnPolicyRunner` configs when running with rsl-rl >= 4.0.0.
- Preserve any explicitly configured `obs_groups` values.
- Add regression coverage for missing and existing `obs_groups` in the rsl-rl deprecation helper.

Why:
- rsl-rl 4.x expects `obs_groups` in runner configs. Existing `play.py` already routes configs through `handle_deprecated_rsl_rl_cfg()` before calling `OnPolicyRunner`, so filling the missing default there keeps play/eval paths compatible without changing each script separately.

Validation:
- [x] `python -m compileall source\isaaclab_rl\isaaclab_rl\rsl_rl\utils.py`
- [x] `python -m compileall source\isaaclab_rl\test\test_rsl_rl_cfg_deprecation.py`
- [x] `python -m ruff check source\isaaclab_rl\isaaclab_rl\rsl_rl\utils.py source\isaaclab_rl\test\test_rsl_rl_cfg_deprecation.py`
- [x] lightweight `handle_deprecated_rsl_rl_cfg()` dummy-runner check for default and preserved `obs_groups`
- [ ] `python -m pytest source\isaaclab_rl\test\test_rsl_rl_cfg_deprecation.py -q` (collection is blocked in this local environment by missing Isaac Sim / Warp packages)

Notes for reviewers:
- Closes #5363.
- This does not change public APIs or training logic; it only fills a compatibility default when the runner config omits `obs_groups`.