### PR TITLE
Add PPISP multi-tile consistency checks

### DIFF
--- a/source/isaaclab/test/sensors/generate_synthetic_gaussian_asset.py
+++ b/source/isaaclab/test/sensors/generate_synthetic_gaussian_asset.py
@@ -550,9 +550,12 @@ def assert_tiled_views_match(
     Args:
         tiled_images: Image batch with shape ``[num_tiles, H, W, C]``.
         max_mean_abs_diff: Maximum allowed mean absolute difference from tile zero.
-            This matches the existing tiled-camera consistency tolerance of
-            ``0.05`` in normalized RGB space while still detecting substantially
-            different or invalid tiles.
+            For LDR images scaled to ``[0, 255]``, the default of ``12.75``
+            (``0.05 * 255``) matches the existing tiled-camera consistency
+            tolerance. For HDR images, whose values are raw physical floats
+            typically in ``[0.01, 1.0]``, this default is effectively
+            vacuous; pass a tighter HDR-appropriate value such as ``0.05``
+            when comparing ``rgb_hdr`` tiles.
         label: Included in the assertion message.
     """
     prefix = f"[{label}] " if label else ""

--- a/source/isaaclab/test/sensors/generate_synthetic_gaussian_asset.py
+++ b/source/isaaclab/test/sensors/generate_synthetic_gaussian_asset.py
@@ -543,6 +543,7 @@ def assert_tiled_views_match(
     tiled_images: torch.Tensor,
     *,
     max_mean_abs_diff: float = 12.75,
+    max_relative_mean_abs_diff: float | None = None,
     label: str = "",
 ) -> None:
     """Assert that all views in a tiled image batch contain the same content.
@@ -552,10 +553,12 @@ def assert_tiled_views_match(
         max_mean_abs_diff: Maximum allowed mean absolute difference from tile zero.
             For LDR images scaled to ``[0, 255]``, the default of ``12.75``
             (``0.05 * 255``) matches the existing tiled-camera consistency
-            tolerance. For HDR images, whose values are raw physical floats
-            typically in ``[0.01, 1.0]``, this default is effectively
-            vacuous; pass a tighter HDR-appropriate value such as ``0.05``
-            when comparing ``rgb_hdr`` tiles.
+            tolerance. This absolute tolerance should not be used for HDR
+            images, whose raw physical float scale is renderer-dependent.
+        max_relative_mean_abs_diff: Maximum allowed mean absolute difference
+            from tile zero relative to tile zero's mean absolute value. If set,
+            this relative threshold is used instead of :paramref:`max_mean_abs_diff`.
+            Use this for ``rgb_hdr`` tiles.
         label: Included in the assertion message.
     """
     prefix = f"[{label}] " if label else ""
@@ -564,8 +567,18 @@ def assert_tiled_views_match(
     )
 
     reference = tiled_images[0][..., :3].float()
+    reference_mean_abs = reference.abs().mean().item()
     for tile_index in range(1, tiled_images.shape[0]):
         mean_abs_diff = (reference - tiled_images[tile_index][..., :3].float()).abs().mean().item()
+        if max_relative_mean_abs_diff is not None:
+            relative_mean_abs_diff = mean_abs_diff / max(reference_mean_abs, 1.0e-6)
+            assert relative_mean_abs_diff < max_relative_mean_abs_diff, (
+                f"{prefix}tile {tile_index} differs from tile 0: "
+                f"relative_mean_abs_diff={relative_mean_abs_diff:.4f}, "
+                f"mean_abs_diff={mean_abs_diff:.4f}, reference_mean_abs={reference_mean_abs:.4f}, "
+                f"expected relative_mean_abs_diff < {max_relative_mean_abs_diff}"
+            )
+            continue
         assert mean_abs_diff < max_mean_abs_diff, (
             f"{prefix}tile {tile_index} differs from tile 0: mean_abs_diff={mean_abs_diff:.3f}, "
             f"expected < {max_mean_abs_diff}"

--- a/source/isaaclab/test/sensors/generate_synthetic_gaussian_asset.py
+++ b/source/isaaclab/test/sensors/generate_synthetic_gaussian_asset.py
@@ -539,6 +539,36 @@ def assert_ppisp_lifts_exposure(
     )
 
 
+def assert_tiled_views_match(
+    tiled_images: torch.Tensor,
+    *,
+    max_mean_abs_diff: float = 12.75,
+    label: str = "",
+) -> None:
+    """Assert that all views in a tiled image batch contain the same content.
+
+    Args:
+        tiled_images: Image batch with shape ``[num_tiles, H, W, C]``.
+        max_mean_abs_diff: Maximum allowed mean absolute difference from tile zero.
+            This matches the existing tiled-camera consistency tolerance of
+            ``0.05`` in normalized RGB space while still detecting substantially
+            different or invalid tiles.
+        label: Included in the assertion message.
+    """
+    prefix = f"[{label}] " if label else ""
+    assert tiled_images.ndim == 4 and tiled_images.shape[0] > 1, (
+        f"{prefix}expected a multi-tile image batch, got shape={tuple(tiled_images.shape)}"
+    )
+
+    reference = tiled_images[0][..., :3].float()
+    for tile_index in range(1, tiled_images.shape[0]):
+        mean_abs_diff = (reference - tiled_images[tile_index][..., :3].float()).abs().mean().item()
+        assert mean_abs_diff < max_mean_abs_diff, (
+            f"{prefix}tile {tile_index} differs from tile 0: mean_abs_diff={mean_abs_diff:.3f}, "
+            f"expected < {max_mean_abs_diff}"
+        )
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # InteractiveScene helpers shared by the Isaac RTX-, Newton-, and OVRTX-backed
 # gaussian tests.

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
@@ -128,6 +128,7 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians(renderer_cfg_cls
             renderer_cfg=renderer_cfg_cls(),
             data_types=["rgb", "rgb_hdr"],
             sim_dt=SIM_DT,
+            stabilisation_steps=15,
             responsivity=ISAAC_RTX_RESPONSIVITY,
         )
     assert_ppisp_lifts_exposure(output["rgb_hdr"][0], output["rgb"][0], label="isaac_rtx")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
@@ -231,7 +231,7 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_multitile(render
         f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
     )
     assert_tiled_views_match(rgb, label=f"{renderer_cfg_cls.__name__} rgb")
-    assert_tiled_views_match(rgb_hdr, max_mean_abs_diff=0.05, label=f"{renderer_cfg_cls.__name__} rgb_hdr")
+    assert_tiled_views_match(rgb_hdr, max_relative_mean_abs_diff=0.05, label=f"{renderer_cfg_cls.__name__} rgb_hdr")
     for i in range(MULTI_TILE_COUNT):
         assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"isaac_rtx tile {i}")
         assert_ppisp_invariants(rgb[i], label=f"isaac_rtx tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
@@ -46,6 +46,7 @@ from generate_synthetic_gaussian_asset import (
     assert_ppisp_controller_matches_static,
     assert_ppisp_invariants,
     assert_ppisp_lifts_exposure,
+    assert_tiled_views_match,
     make_aggressive_ppisp_cfg,
     make_neutral_ppisp_cfg,
     make_synthetic_gaussian_usd,
@@ -229,6 +230,8 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_multitile(render
         f"Expected {MULTI_TILE_COUNT} tiles, got shape={tuple(rgb.shape)}. "
         f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
     )
+    assert_tiled_views_match(rgb, label=f"{renderer_cfg_cls.__name__} rgb")
+    assert_tiled_views_match(rgb_hdr, label=f"{renderer_cfg_cls.__name__} rgb_hdr")
     for i in range(MULTI_TILE_COUNT):
         assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"isaac_rtx tile {i}")
         assert_ppisp_invariants(rgb[i], label=f"isaac_rtx tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian.py
@@ -231,7 +231,7 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_multitile(render
         f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
     )
     assert_tiled_views_match(rgb, label=f"{renderer_cfg_cls.__name__} rgb")
-    assert_tiled_views_match(rgb_hdr, label=f"{renderer_cfg_cls.__name__} rgb_hdr")
+    assert_tiled_views_match(rgb_hdr, max_mean_abs_diff=0.05, label=f"{renderer_cfg_cls.__name__} rgb_hdr")
     for i in range(MULTI_TILE_COUNT):
         assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"isaac_rtx tile {i}")
         assert_ppisp_invariants(rgb[i], label=f"isaac_rtx tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_newton.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_newton.py
@@ -209,7 +209,7 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_newton_multitile
     # Newton rendering is deterministic and does not introduce RTX sampling or temporal accumulation noise,
     # so keep the cross-tile consistency check stricter than the RTX-backed tests.
     assert_tiled_views_match(rgb, max_mean_abs_diff=1.0, label="newton_warp rgb")
-    assert_tiled_views_match(rgb_hdr, max_mean_abs_diff=0.05, label="newton_warp rgb_hdr")
+    assert_tiled_views_match(rgb_hdr, max_relative_mean_abs_diff=0.01, label="newton_warp rgb_hdr")
     for i in range(MULTI_TILE_COUNT):
         assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"newton_warp tile {i}")
         assert_ppisp_invariants(rgb[i], label=f"newton_warp tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_newton.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_newton.py
@@ -59,6 +59,7 @@ if not _MISSING_MODULES:
         assert_ppisp_controller_matches_static,
         assert_ppisp_invariants,
         assert_ppisp_lifts_exposure,
+        assert_tiled_views_match,
         make_aggressive_ppisp_cfg,
         make_synthetic_gaussian_usd,
         render_synthetic_gaussian_scene,
@@ -78,6 +79,7 @@ else:
     assert_ppisp_controller_matches_static = None
     assert_ppisp_invariants = None
     assert_ppisp_lifts_exposure = None
+    assert_tiled_views_match = None
     make_aggressive_ppisp_cfg = None
     make_synthetic_gaussian_usd = None
     render_synthetic_gaussian_scene = None
@@ -204,6 +206,10 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_newton_multitile
         f"Expected {MULTI_TILE_COUNT} tiles, got shape={tuple(rgb.shape)}. "
         f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
     )
+    # Newton rendering is deterministic and does not introduce RTX sampling or temporal accumulation noise,
+    # so keep the cross-tile consistency check stricter than the RTX-backed tests.
+    assert_tiled_views_match(rgb, max_mean_abs_diff=1.0, label="newton_warp rgb")
+    assert_tiled_views_match(rgb_hdr, max_mean_abs_diff=1.0, label="newton_warp rgb_hdr")
     for i in range(MULTI_TILE_COUNT):
         assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"newton_warp tile {i}")
         assert_ppisp_invariants(rgb[i], label=f"newton_warp tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_newton.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_newton.py
@@ -209,7 +209,7 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_newton_multitile
     # Newton rendering is deterministic and does not introduce RTX sampling or temporal accumulation noise,
     # so keep the cross-tile consistency check stricter than the RTX-backed tests.
     assert_tiled_views_match(rgb, max_mean_abs_diff=1.0, label="newton_warp rgb")
-    assert_tiled_views_match(rgb_hdr, max_mean_abs_diff=1.0, label="newton_warp rgb_hdr")
+    assert_tiled_views_match(rgb_hdr, max_mean_abs_diff=0.05, label="newton_warp rgb_hdr")
     for i in range(MULTI_TILE_COUNT):
         assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"newton_warp tile {i}")
         assert_ppisp_invariants(rgb[i], label=f"newton_warp tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
@@ -53,6 +53,7 @@ from generate_synthetic_gaussian_asset import (
     assert_ppisp_controller_matches_static,
     assert_ppisp_invariants,
     assert_ppisp_lifts_exposure,
+    assert_tiled_views_match,
     make_aggressive_ppisp_cfg,
     make_neutral_ppisp_cfg,
     make_synthetic_gaussian_usd,
@@ -231,6 +232,8 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_ovrtx_multitile(
         f"Expected {MULTI_TILE_COUNT} tiles, got shape={tuple(rgb.shape)}. "
         f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
     )
+    assert_tiled_views_match(rgb, label="ovrtx rgb")
+    assert_tiled_views_match(rgb_hdr, label="ovrtx rgb_hdr")
     for i in range(MULTI_TILE_COUNT):
         assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"ovrtx tile {i}")
         assert_ppisp_invariants(rgb[i], label=f"ovrtx tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
@@ -233,7 +233,7 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_ovrtx_multitile(
         f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
     )
     assert_tiled_views_match(rgb, label="ovrtx rgb")
-    assert_tiled_views_match(rgb_hdr, label="ovrtx rgb_hdr")
+    assert_tiled_views_match(rgb_hdr, max_mean_abs_diff=0.05, label="ovrtx rgb_hdr")
     for i in range(MULTI_TILE_COUNT):
         assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"ovrtx tile {i}")
         assert_ppisp_invariants(rgb[i], label=f"ovrtx tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
@@ -233,7 +233,7 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_ovrtx_multitile(
         f"Check that the camera regex {SYNTHETIC_GAUSSIAN_CAMERA_REGEX} resolves to one camera per env."
     )
     assert_tiled_views_match(rgb, label="ovrtx rgb")
-    assert_tiled_views_match(rgb_hdr, max_mean_abs_diff=0.05, label="ovrtx rgb_hdr")
+    assert_tiled_views_match(rgb_hdr, max_relative_mean_abs_diff=0.05, label="ovrtx rgb_hdr")
     for i in range(MULTI_TILE_COUNT):
         assert_ppisp_lifts_exposure(rgb_hdr[i], rgb[i], label=f"ovrtx tile {i}")
         assert_ppisp_invariants(rgb[i], label=f"ovrtx tile {i}")

--- a/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
+++ b/source/isaaclab/test/sensors/test_camera_ppisp_gaussian_ovrtx.py
@@ -133,6 +133,7 @@ def test_camera_ppisp_wrapper_signatures_on_synthetic_gaussians_ovrtx(device):
             renderer_cfg=OVRTXRendererCfg(),
             data_types=["rgb", "rgb_hdr"],
             sim_dt=SIM_DT,
+            stabilisation_steps=15,
         )
     assert_ppisp_lifts_exposure(output["rgb_hdr"][0], output["rgb"][0], label="ovrtx")
     assert_ppisp_invariants(output["rgb"][0], label="ovrtx")


### PR DESCRIPTION
# Description

  This PR adds cross-tile consistency checks to the PPISP Gaussian camera tests.
  The multi-tile tests now verify that rendered RGB and HDR tiles are consistent
  across environments, in addition to the existing per-tile PPISP invariants.

  The checks cover the Isaac RTX, Newton Warp, and OVRTX PPISP test paths. Newton
  uses a stricter tolerance because it is deterministic and does not introduce RTX
  sampling or temporal accumulation noise. The RTX-backed paths use the existing
  tiled-camera normalized RGB tolerance.

  This PR also fixes the OVRTX PPISP demo so it no longer passes the removed
  `use_ovrtx_cloning` argument to `OVRTXRendererCfg`. The
  `--disable_ovrtx_cloning` CLI flag is retained as a deprecated no-op for
  compatibility.

  Fixes # <!-- issue number, if applicable -->

  ## Type of change

  - Bug fix (non-breaking change which fixes an issue)

  ## Screenshots

  Not applicable.

  ## Checklist

  - [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
  - [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
  - [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there