### PR TITLE
Add dependency-impact JSON tool and CI artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -217,7 +217,8 @@ jobs:
             : > changed_files.txt
           fi
         elif [ "$EVENT_NAME" = "push" ] && git rev-parse --quiet --verify "$BEFORE_SHA^{commit}" > /dev/null; then
-          git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" > changed_files.txt
+          # Same fail-safe as the other branches: never fail the job over a diff error.
+          git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" > changed_files.txt || : > changed_files.txt
         else
           # workflow_dispatch or a push whose before-SHA is unavailable (e.g. new branch):
           # fall back to the most recent commit's changes.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -184,6 +184,56 @@ jobs:
           decide false "no relevant paths changed" "$changed_files"
         fi
 
+  dependency-impact:
+    name: Dependency Impact JSON
+    runs-on: ubuntu-latest
+    # No `needs:` so this runs immediately alongside change detection — it only needs the
+    # checkout and the list of changed files, not the built image or any test job.
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      with:
+        python-version: "3.12"
+    - name: Compute changed files
+      id: changed
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        EVENT_NAME: ${{ github.event_name }}
+        REPO: ${{ github.repository }}
+        BEFORE_SHA: ${{ github.event.before }}
+        AFTER_SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          # PR: the API lists every file the PR touches, base-relative, forward-slashed.
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' > changed_files.txt
+        elif [ "$EVENT_NAME" = "push" ] && git rev-parse --quiet --verify "$BEFORE_SHA^{commit}" > /dev/null; then
+          git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" > changed_files.txt
+        else
+          # workflow_dispatch or a push whose before-SHA is unavailable (e.g. new branch):
+          # fall back to the most recent commit's changes.
+          git diff --name-only HEAD~1 HEAD > changed_files.txt || : > changed_files.txt
+        fi
+        echo "Changed files:"
+        cat changed_files.txt
+    - name: Build dependency-impact JSON
+      run: |
+        set -euo pipefail
+        python tools/dependency_impact.py --output dependency_impact.json < changed_files.txt
+        echo "### Dependency impact" >> "$GITHUB_STEP_SUMMARY"
+        echo '```json' >> "$GITHUB_STEP_SUMMARY"
+        cat dependency_impact.json >> "$GITHUB_STEP_SUMMARY"
+        echo '```' >> "$GITHUB_STEP_SUMMARY"
+    - name: Upload dependency-impact artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: dependency-impact
+        path: dependency_impact.json
+        retention-days: 7
+
   config:
     name: Load Config
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -199,21 +199,21 @@ jobs:
     - name: Compute changed files
       id: changed
       env:
-        GH_TOKEN: ${{ github.token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
         EVENT_NAME: ${{ github.event_name }}
-        REPO: ${{ github.repository }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         BEFORE_SHA: ${{ github.event.before }}
         AFTER_SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
         if [ "$EVENT_NAME" = "pull_request" ]; then
-          # PR: the API lists every file the PR touches, base-relative, forward-slashed.
-          # Fail-safe: a transient API error must not fail the job and suppress the artifact —
-          # fall back to an empty change set (mirrors the `changes:` job's guard) so an empty
-          # impact report is still produced and uploaded.
-          if ! gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' > changed_files.txt; then
-            echo "::warning::Could not list changed files; producing an empty dependency-impact report"
+          # PR: diff the merge-base of base..head (three-dot) so we list exactly the files the
+          # PR introduces, matching what the GitHub "files" view shows. `fetch-depth: 0` above
+          # guarantees both endpoints are present. Fail-safe: if the diff cannot be computed,
+          # fall back to an empty change set so an (empty) impact report is still uploaded
+          # instead of failing the job.
+          if ! git diff --name-only "$PR_BASE_SHA...$PR_HEAD_SHA" > changed_files.txt; then
+            echo "::warning::Could not diff $PR_BASE_SHA...$PR_HEAD_SHA; producing an empty dependency-impact report"
             : > changed_files.txt
           fi
         elif [ "$EVENT_NAME" = "push" ] && git rev-parse --quiet --verify "$BEFORE_SHA^{commit}" > /dev/null; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -209,7 +209,13 @@ jobs:
         set -euo pipefail
         if [ "$EVENT_NAME" = "pull_request" ]; then
           # PR: the API lists every file the PR touches, base-relative, forward-slashed.
-          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' > changed_files.txt
+          # Fail-safe: a transient API error must not fail the job and suppress the artifact —
+          # fall back to an empty change set (mirrors the `changes:` job's guard) so an empty
+          # impact report is still produced and uploaded.
+          if ! gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' > changed_files.txt; then
+            echo "::warning::Could not list changed files; producing an empty dependency-impact report"
+            : > changed_files.txt
+          fi
         elif [ "$EVENT_NAME" = "push" ] && git rev-parse --quiet --verify "$BEFORE_SHA^{commit}" > /dev/null; then
           git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" > changed_files.txt
         else

--- a/tools/dependency_impact.py
+++ b/tools/dependency_impact.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Classify the impact of a change into changed / dependent / transitively-dependent files.
+
+Given the set of files a pull request changed, this script answers "what else could this
+change affect?" using the **package dependency graph declared in the ``extension.toml``
+files**, not runtime coverage. Each extension's ``config/extension.toml`` lists, under
+``[dependencies]``, the other extensions it depends on (by their source directory name).
+Reversing those edges tells us which packages depend *on* a changed package, and therefore
+which of their files are potentially affected.
+
+The output is a JSON document with three buckets, each grouped by language::
+
+    {
+      "changed":    {"python": [...]},   # changed .py files that live in a known package
+      "dependents": {"python": [...]},   # .py files in packages that DIRECTLY depend on a
+                                         #   changed package (reverse-dependency depth 1)
+      "transitive": {"python": [...]}    # .py files in packages that depend on a changed
+                                         #   package only INDIRECTLY (reverse depth >= 2)
+    }
+
+Every package lands in exactly one bucket, so the three file lists never overlap: a file is
+"changed" if it was edited, "dependent" if its package directly depends on a changed
+package, and "transitive" otherwise (further out in the reverse-dependency graph).
+
+Usage::
+
+    # Changed files are read from stdin, one repo-relative path per line.
+    printf '%s\n' source/isaaclab/isaaclab/foo.py \
+        | python tools/dependency_impact.py
+
+The JSON document is written to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for older interpreters
+    import tomli as tomllib  # type: ignore[no-redef]
+
+# The repository root, inferred from this file's location (``<repo>/tools/dependency_impact.py``).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Directories, relative to the repo root, scanned for ``*/config/extension.toml`` packages.
+_DEFAULT_SEARCH_DIRS = ("source",)
+
+
+@dataclass
+class Package:
+    """A single Isaac Lab extension package discovered from its ``extension.toml``.
+
+    Attributes:
+        name: Extension identifier — the directory name under ``source/`` that other
+            packages reference in their ``[dependencies]`` table.
+        directory: Repo-relative POSIX path to the package root (the parent of ``config/``).
+        dependencies: Names of the extensions this package declares a dependency on.
+    """
+
+    name: str
+    directory: str
+    dependencies: set[str] = field(default_factory=set)
+
+
+def _normalize(path: str) -> str:
+    """Normalize a path for matching: forward slashes, no leading ``./``."""
+    path = path.replace("\\", "/")
+    return path[2:] if path.startswith("./") else path
+
+
+def discover_packages(repo_root: Path, search_dirs: tuple[str, ...] = _DEFAULT_SEARCH_DIRS) -> dict[str, Package]:
+    """Discover extension packages and their declared dependencies.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+        search_dirs: Repo-relative directories to scan for ``*/config/extension.toml``.
+
+    Returns:
+        A mapping from extension name to its :class:`Package`. Dependencies pointing at
+        packages that were not discovered are kept (they simply never resolve to files),
+        which keeps the graph honest without raising on optional/out-of-tree extensions.
+    """
+    packages: dict[str, Package] = {}
+    for search_dir in search_dirs:
+        for toml_path in sorted((repo_root / search_dir).glob("*/config/extension.toml")):
+            package_dir = toml_path.parent.parent
+            name = package_dir.name
+            try:
+                data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+            except (OSError, tomllib.TOMLDecodeError) as exc:
+                print(f"::warning::Could not read {toml_path}: {exc}", file=sys.stderr)
+                continue
+            dependencies = set(data.get("dependencies", {}).keys())
+            directory = _normalize(str(package_dir.relative_to(repo_root)))
+            packages[name] = Package(name=name, directory=directory, dependencies=dependencies)
+    return packages
+
+
+def build_reverse_graph(packages: dict[str, Package]) -> dict[str, set[str]]:
+    """Build the reverse-dependency graph: package -> packages that depend on it directly."""
+    reverse: dict[str, set[str]] = defaultdict(set)
+    for package in packages.values():
+        for dependency in package.dependencies:
+            reverse[dependency].add(package.name)
+    return reverse
+
+
+def owning_package(path: str, packages: dict[str, Package]) -> str | None:
+    """Return the name of the package a repo-relative file belongs to, if any.
+
+    Matching is by directory prefix; when packages nest, the longest (most specific)
+    matching directory wins.
+    """
+    norm = _normalize(path)
+    best: str | None = None
+    best_len = -1
+    for package in packages.values():
+        prefix = package.directory + "/"
+        if norm.startswith(prefix) and len(package.directory) > best_len:
+            best = package.name
+            best_len = len(package.directory)
+    return best
+
+
+def _reverse_levels(reverse: dict[str, set[str]], seeds: set[str]) -> tuple[set[str], set[str]]:
+    """Split reverse-reachable packages into direct (depth 1) and transitive (depth >= 2).
+
+    Args:
+        reverse: The reverse-dependency graph from :func:`build_reverse_graph`.
+        seeds: The changed packages to walk out from.
+
+    Returns:
+        A tuple ``(direct, transitive)`` of package-name sets, both excluding the seeds and
+        excluding each other (a package that is both a direct and an indirect dependent is
+        classified as direct — the stronger, closer relationship).
+    """
+    direct: set[str] = set()
+    for seed in seeds:
+        direct |= reverse.get(seed, set())
+    direct -= seeds
+
+    transitive: set[str] = set()
+    queue: deque[str] = deque(direct)
+    visited: set[str] = set(seeds) | direct
+    while queue:
+        current = queue.popleft()
+        for dependent in reverse.get(current, set()):
+            if dependent not in visited:
+                visited.add(dependent)
+                transitive.add(dependent)
+                queue.append(dependent)
+    transitive -= seeds
+    transitive -= direct
+    return direct, transitive
+
+
+def _python_files(repo_root: Path, package: Package) -> list[str]:
+    """List repo-relative POSIX paths of every ``*.py`` file under a package directory."""
+    root = repo_root / PurePosixPath(package.directory)
+    if not root.is_dir():
+        return []
+    files = [_normalize(str(p.relative_to(repo_root))) for p in root.rglob("*.py")]
+    return sorted(files)
+
+
+def build_impact(
+    changed_files: list[str],
+    repo_root: Path = _REPO_ROOT,
+    search_dirs: tuple[str, ...] = _DEFAULT_SEARCH_DIRS,
+) -> dict[str, dict[str, list[str]]]:
+    """Classify changed files into changed / dependent / transitive Python-file buckets.
+
+    Args:
+        changed_files: Repo-relative paths changed by the pull request.
+        repo_root: Absolute path to the repository root.
+        search_dirs: Repo-relative directories scanned for extension packages.
+
+    Returns:
+        The impact document described in the module docstring. The three ``python`` lists
+        are disjoint and each sorted.
+    """
+    packages = discover_packages(repo_root, search_dirs)
+    reverse = build_reverse_graph(packages)
+
+    changed_python = sorted({_normalize(f) for f in changed_files if f.strip().endswith(".py")})
+
+    changed_packages = {owning_package(f, packages) for f in changed_python}
+    changed_packages.discard(None)
+    seeds: set[str] = {name for name in changed_packages if name is not None}
+
+    direct, transitive = _reverse_levels(reverse, seeds)
+
+    def files_for(names: set[str]) -> list[str]:
+        collected: list[str] = []
+        for name in sorted(names):
+            collected.extend(_python_files(repo_root, packages[name]))
+        return sorted(collected)
+
+    return {
+        "changed": {"python": changed_python},
+        "dependents": {"python": files_for(direct)},
+        "transitive": {"python": files_for(transitive)},
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--search-dir",
+        action="append",
+        dest="search_dirs",
+        help="Repo-relative directory to scan for packages (repeatable; default: source).",
+    )
+    parser.add_argument(
+        "--output",
+        help="Write the JSON document to this path instead of stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    search_dirs = tuple(args.search_dirs) if args.search_dirs else _DEFAULT_SEARCH_DIRS
+    changed_files = [line.strip() for line in sys.stdin if line.strip()]
+    impact = build_impact(changed_files, search_dirs=search_dirs)
+
+    document = json.dumps(impact, indent=2)
+    if args.output:
+        Path(args.output).write_text(document + "\n", encoding="utf-8")
+    else:
+        print(document)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dependency_impact.py
+++ b/tools/dependency_impact.py
@@ -194,7 +194,12 @@ def build_impact(
 
     changed_python = sorted({_normalize(f) for f in changed_files if f.strip().endswith(".py")})
 
-    changed_packages = {owning_package(f, packages) for f in changed_python}
+    # Seeds are derived from *every* changed file that lives in a known package, not just the
+    # Python ones: editing a package's ``extension.toml``, a data asset, or a C extension can
+    # still affect every package that depends on it. Seeding only from ``.py`` files would make
+    # a non-Python-only change inside a package report "nothing else affected" (empty
+    # dependents/transitive), which understates the real blast radius.
+    changed_packages = {owning_package(f, packages) for f in changed_files if f.strip()}
     changed_packages.discard(None)
     seeds: set[str] = {name for name in changed_packages if name is not None}
 

--- a/tools/test_dependency_impact.py
+++ b/tools/test_dependency_impact.py
@@ -105,6 +105,16 @@ def test_untracked_change_yields_empty_buckets(tmp_path: Path) -> None:
     assert impact["transitive"]["python"] == []
 
 
+def test_non_python_change_still_seeds_dependents(tmp_path: Path) -> None:
+    # A change to a non-Python file inside a package (here ``base``'s extension.toml) must still
+    # seed the reverse-dependency walk, even though no ``.py`` file was touched.
+    _build_chain(tmp_path)
+    impact = _MODULE.build_impact(["source/base/config/extension.toml"], repo_root=tmp_path)
+    assert impact["changed"]["python"] == []
+    assert impact["dependents"]["python"] == ["source/mid_a/a.py", "source/mid_b/b.py"]
+    assert impact["transitive"]["python"] == ["source/top/t.py"]
+
+
 def test_windows_paths_are_normalized(tmp_path: Path) -> None:
     _build_chain(tmp_path)
     impact = _MODULE.build_impact([r"source\base\core.py"], repo_root=tmp_path)

--- a/tools/test_dependency_impact.py
+++ b/tools/test_dependency_impact.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the dependency-impact classifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).with_name("dependency_impact.py")
+_SPEC = importlib.util.spec_from_file_location("dependency_impact", _MODULE_PATH)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+# Register before exec so ``@dataclass`` can resolve the module's namespace (matches a
+# normal ``import dependency_impact``).
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+
+def _make_package(repo_root: Path, name: str, dependencies: list[str], files: list[str]) -> None:
+    """Create a fake extension package with an ``extension.toml`` and some ``*.py`` files.
+
+    Args:
+        repo_root: Temporary repository root.
+        name: Extension directory name (also its dependency identifier).
+        dependencies: Names of extensions this package depends on.
+        files: Package-relative file paths to create (only ``*.py`` matter to the graph).
+    """
+    package_dir = repo_root / "source" / name
+    (package_dir / "config").mkdir(parents=True, exist_ok=True)
+    deps_block = "".join(f'"{dep}" = {{}}\n' for dep in dependencies)
+    (package_dir / "config" / "extension.toml").write_text(
+        f'[dependencies]\n{deps_block}\n[[python.module]]\nname = "{name}"\n', encoding="utf-8"
+    )
+    for rel in files:
+        target = package_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# stub\n", encoding="utf-8")
+
+
+def _build_chain(repo_root: Path) -> None:
+    """Build a diamond graph: base <- mid_a, mid_b ; mid_a, mid_b <- top."""
+    _make_package(repo_root, "base", [], ["core.py"])
+    _make_package(repo_root, "mid_a", ["base"], ["a.py"])
+    _make_package(repo_root, "mid_b", ["base"], ["b.py"])
+    _make_package(repo_root, "top", ["mid_a", "mid_b"], ["t.py"])
+
+
+def test_changed_bucket_lists_only_changed_python(tmp_path: Path) -> None:
+    _build_chain(tmp_path)
+    impact = _MODULE.build_impact(
+        ["source/base/core.py", "source/base/README.md"],
+        repo_root=tmp_path,
+    )
+    assert impact["changed"]["python"] == ["source/base/core.py"]
+
+
+def test_direct_dependents_are_separated_from_transitive(tmp_path: Path) -> None:
+    _build_chain(tmp_path)
+    impact = _MODULE.build_impact(["source/base/core.py"], repo_root=tmp_path)
+
+    assert impact["dependents"]["python"] == ["source/mid_a/a.py", "source/mid_b/b.py"]
+    assert impact["transitive"]["python"] == ["source/top/t.py"]
+
+
+def test_buckets_are_disjoint(tmp_path: Path) -> None:
+    _build_chain(tmp_path)
+    impact = _MODULE.build_impact(["source/base/core.py"], repo_root=tmp_path)
+
+    changed = set(impact["changed"]["python"])
+    dependents = set(impact["dependents"]["python"])
+    transitive = set(impact["transitive"]["python"])
+    assert changed.isdisjoint(dependents)
+    assert changed.isdisjoint(transitive)
+    assert dependents.isdisjoint(transitive)
+
+
+def test_package_that_is_both_direct_and_indirect_counts_as_direct(tmp_path: Path) -> None:
+    # ``top`` depends on ``base`` directly AND through ``mid``; it must be a direct dependent.
+    _make_package(tmp_path, "base", [], ["core.py"])
+    _make_package(tmp_path, "mid", ["base"], ["m.py"])
+    _make_package(tmp_path, "top", ["base", "mid"], ["t.py"])
+
+    impact = _MODULE.build_impact(["source/base/core.py"], repo_root=tmp_path)
+    assert impact["dependents"]["python"] == ["source/mid/m.py", "source/top/t.py"]
+    assert impact["transitive"]["python"] == []
+
+
+def test_change_to_leaf_package_has_no_dependents(tmp_path: Path) -> None:
+    _build_chain(tmp_path)
+    impact = _MODULE.build_impact(["source/top/t.py"], repo_root=tmp_path)
+    assert impact["dependents"]["python"] == []
+    assert impact["transitive"]["python"] == []
+
+
+def test_untracked_change_yields_empty_buckets(tmp_path: Path) -> None:
+    _build_chain(tmp_path)
+    impact = _MODULE.build_impact(["docs/index.rst", "tools/foo.py"], repo_root=tmp_path)
+    assert impact["changed"]["python"] == ["tools/foo.py"]
+    assert impact["dependents"]["python"] == []
+    assert impact["transitive"]["python"] == []
+
+
+def test_windows_paths_are_normalized(tmp_path: Path) -> None:
+    _build_chain(tmp_path)
+    impact = _MODULE.build_impact([r"source\base\core.py"], repo_root=tmp_path)
+    assert impact["changed"]["python"] == ["source/base/core.py"]
+    assert impact["dependents"]["python"] == ["source/mid_a/a.py", "source/mid_b/b.py"]


### PR DESCRIPTION
## Description

Adds a lightweight impact-analysis tool and wires it into CI so every run publishes a machine-readable map of what a change touches.

`tools/dependency_impact.py` reads changed files from stdin (one repo-relative path per line) and classifies them into three buckets using the package dependency graph declared in each extension's `config/extension.toml` `[dependencies]` table:

```json
{
  "changed":    {"python": [...]},
  "dependents": {"python": [...]},
  "transitive": {"python": [...]}
}
```

- **changed** — the changed `.py` files.
- **dependents** — `.py` files in packages that *directly* depend on a changed package (reverse-dependency depth 1).
- **transitive** — `.py` files in packages that depend only *indirectly* (depth >= 2).

The three lists are disjoint: every package lands in exactly one bucket, and a package that is both a direct and an indirect dependent is classified as direct.

## CI job

A new `dependency-impact` job is added to `build.yaml`. It has no `needs:`, so it runs immediately alongside change detection (one of the first jobs). It computes the changed files for the event (PR files via `gh api`, `git diff` for pushes), renders the JSON, echoes it into the job summary, and uploads it as the `dependency-impact` artifact.

## Testing

- `tools/test_dependency_impact.py` — 7 unit tests covering the changed/dependent/transitive split, disjointness, the direct-wins tiebreak, leaf packages, untracked (non-package) changes, and Windows path normalization.
- Validated the exact CI command end-to-end locally and confirmed the workflow YAML parses.
