### PR TITLE
Expose Newton BVH and renderer performance settings

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -74,6 +74,7 @@ Guidelines for modifications:
 * CY (Chien-Ying) Chen
 * David Leon
 * David Yang
+* Daniela Hasenbring
 * Dhananjay Shendre
 * Dhyan Thakkar
 * Dongxuan Fan

--- a/source/isaaclab_newton/changelog.d/newton-perf-updates.minor.rst
+++ b/source/isaaclab_newton/changelog.d/newton-perf-updates.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added Newton BVH construction settings to :class:`~isaaclab_newton.physics.NewtonCfg`
+  and render traversal/tile settings to
+  :class:`~isaaclab_newton.renderers.NewtonWarpRendererCfg`.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -883,9 +883,9 @@ class NewtonManager(PhysicsManager):
 
         builder = ModelBuilder(up_axis=up_axis or cls._up_axis, **kwargs)
         builder.default_bvh_cfg = ModelBuilder.BvhConfig(
-            cfg.bvh_constructor_geometry if isinstance(cfg, NewtonCfg) else None,
-            cfg.bvh_constructor_gaussian if isinstance(cfg, NewtonCfg) else None,
-            cfg.bvh_constructor_scene if isinstance(cfg, NewtonCfg) else None,
+            mesh_constructor=cfg.bvh_constructor_geometry if isinstance(cfg, NewtonCfg) else None,
+            gaussian_constructor=cfg.bvh_constructor_gaussian if isinstance(cfg, NewtonCfg) else None,
+            shape_constructor=cfg.bvh_constructor_scene if isinstance(cfg, NewtonCfg) else None,
         )
 
         cls._register_builder_attributes(builder)

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -885,7 +885,7 @@ class NewtonManager(PhysicsManager):
         builder.default_bvh_cfg = ModelBuilder.BvhConfig(
             cfg.bvh_constructor_geometry if isinstance(cfg, NewtonCfg) else None,
             cfg.bvh_constructor_gaussian if isinstance(cfg, NewtonCfg) else None,
-            cfg.bvh_constructor_scene if isinstance(cfg, NewtonCfg) else None
+            cfg.bvh_constructor_scene if isinstance(cfg, NewtonCfg) else None,
         )
 
         cls._register_builder_attributes(builder)

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -876,12 +876,19 @@ class NewtonManager(PhysicsManager):
         Returns:
             New builder with up-axis and per-shape defaults (gap, margin) applied.
         """
-        builder = ModelBuilder(up_axis=up_axis or cls._up_axis, **kwargs)
-        cls._register_builder_attributes(builder)
         # Resolve which NewtonShapeCfg to apply: user override if active config
         # is NewtonCfg, else the wrapper's own defaults so callers from non-Newton
         # contexts (tests, early construction) still get the rough-terrain margin.
         cfg = PhysicsManager._cfg
+
+        builder = ModelBuilder(up_axis=up_axis or cls._up_axis, **kwargs)
+        builder.default_bvh_cfg = ModelBuilder.BvhConfig(
+            cfg.bvh_constructor_geometry if isinstance(cfg, NewtonCfg) else None,
+            cfg.bvh_constructor_gaussian if isinstance(cfg, NewtonCfg) else None,
+            cfg.bvh_constructor_scene if isinstance(cfg, NewtonCfg) else None
+        )
+
+        cls._register_builder_attributes(builder)
         shape_cfg = cfg.default_shape_cfg if isinstance(cfg, NewtonCfg) else NewtonShapeCfg()
         checked_apply(shape_cfg, builder.default_shape_cfg)
         return builder

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from isaaclab.physics import PhysicsCfg
 from isaaclab.utils.configclass import configclass
@@ -152,6 +152,44 @@ class NewtonCfg(PhysicsCfg):
 
     Keep this enabled for most rigid-body scenes. Disable it when exact triangle
     meshes are intentional, for example thin or hollow MPM colliders.
+    """
+
+    bvh_constructor_geometry: Literal["lbvh", "sah", "cubql"] = "cubql"
+    """BVH construction algorithm for mesh geometry colliders.
+
+    Selects the bounding-volume-hierarchy builder Newton uses for the triangle
+    meshes of collision geometry, forwarded to :attr:`ModelBuilder.BvhConfig`.
+    Trades build time against query (traversal) quality:
+
+    - ``"lbvh"``: linear BVH; fastest to build, lowest-quality tree.
+    - ``"sah"``: surface-area-heuristic BVH; slower build, tighter tree with
+      faster ray/overlap queries.
+    - ``"cubql"``: cuBQL GPU builder; balances fast construction with good tree
+      quality on the GPU (default).
+
+    Overridden by the ``NEWTON_BVH_GEOMETRY`` environment variable when set.
+    """
+
+    bvh_constructor_scene: Literal["lbvh", "sah"] = "sah"
+    """BVH construction algorithm for the top-level scene (broad-phase) hierarchy.
+
+    Selects the builder for the BVH over all colliders used during broad-phase
+    culling, forwarded to :attr:`ModelBuilder.BvhConfig`. See
+    :attr:`bvh_constructor_geometry` for the ``"lbvh"`` / ``"sah"`` trade-off;
+    ``"cubql"`` is not available for the scene hierarchy.
+
+    Overridden by the ``NEWTON_BVH_SCENE`` environment variable when set.
+    """
+
+    bvh_constructor_gaussian: Literal["lbvh", "sah", "cubql"] = "cubql"
+    """BVH construction algorithm for Gaussian-splat primitives.
+
+    Selects the builder for the BVH over 3D Gaussian primitives (used by the
+    Gaussian renderer/collision path), forwarded to
+    :attr:`ModelBuilder.BvhConfig`. See :attr:`bvh_constructor_geometry` for the
+    ``"lbvh"`` / ``"sah"`` / ``"cubql"`` trade-off.
+
+    Overridden by the ``NEWTON_BVH_GAUSSIAN`` environment variable when set.
     """
 
     def __post_init__(self):

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager_cfg.py
@@ -166,8 +166,6 @@ class NewtonCfg(PhysicsCfg):
       faster ray/overlap queries.
     - ``"cubql"``: cuBQL GPU builder; balances fast construction with good tree
       quality on the GPU (default).
-
-    Overridden by the ``NEWTON_BVH_GEOMETRY`` environment variable when set.
     """
 
     bvh_constructor_scene: Literal["lbvh", "sah"] = "sah"
@@ -177,8 +175,6 @@ class NewtonCfg(PhysicsCfg):
     culling, forwarded to :attr:`ModelBuilder.BvhConfig`. See
     :attr:`bvh_constructor_geometry` for the ``"lbvh"`` / ``"sah"`` trade-off;
     ``"cubql"`` is not available for the scene hierarchy.
-
-    Overridden by the ``NEWTON_BVH_SCENE`` environment variable when set.
     """
 
     bvh_constructor_gaussian: Literal["lbvh", "sah", "cubql"] = "cubql"
@@ -188,8 +184,6 @@ class NewtonCfg(PhysicsCfg):
     Gaussian renderer/collision path), forwarded to
     :attr:`ModelBuilder.BvhConfig`. See :attr:`bvh_constructor_geometry` for the
     ``"lbvh"`` / ``"sah"`` / ``"cubql"`` trade-off.
-
-    Overridden by the ``NEWTON_BVH_GAUSSIAN`` environment variable when set.
     """
 
     def __post_init__(self):

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -246,7 +246,7 @@ class NewtonWarpRenderer(BaseRenderer):
                 enable_ambient_lighting=self.cfg.enable_ambient_lighting,
                 enable_backface_culling=self.cfg.enable_backface_culling,
                 max_distance=self.cfg.max_distance,
-                render_order = newton.sensors.SensorTiledCamera.RenderOrder.TILED,
+                render_order=newton.sensors.SensorTiledCamera.RenderOrder.TILED,
                 tile_width=self.cfg.tile_rendering_width,
                 tile_height=self.cfg.tile_rendering_height,
             ),

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -357,6 +357,7 @@ class NewtonWarpRenderer(BaseRenderer):
             shape_index_image=render_data.outputs.instance_segmentation_image,
             # ARGB 93% gray to improve visibility of dark objects and align with RTX renderer background
             clear_data=newton.sensors.SensorTiledCamera.ClearData(clear_color=0xFFEEEEEE),
+            kernel_block_dim=self.cfg.kernel_block_dim,
         )
 
         # Post-render PPISP: HDR scene-linear → LDR RGBA. Source/destination

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -246,8 +246,18 @@ class NewtonWarpRenderer(BaseRenderer):
                 enable_ambient_lighting=self.cfg.enable_ambient_lighting,
                 enable_backface_culling=self.cfg.enable_backface_culling,
                 max_distance=self.cfg.max_distance,
+                render_order = newton.sensors.SensorTiledCamera.RenderOrder.TILED,
+                tile_width=self.cfg.tile_rendering_width,
+                tile_height=self.cfg.tile_rendering_height,
             ),
         )
+
+        if self.cfg.render_order == "pixel_priority":
+            self.newton_sensor.render_config.render_order = newton.sensors.SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
+        elif self.cfg.render_order == "view_priority":
+            self.newton_sensor.render_config.render_order = newton.sensors.SensorTiledCamera.RenderOrder.VIEW_PRIORITY
+        else:
+            self.newton_sensor.render_config.render_order = newton.sensors.SensorTiledCamera.RenderOrder.TILED
 
         # Newton ``v1.2.0rc2`` made shape-BVH construction explicit; ``SensorTiledCamera.update``
         # no longer auto-builds when a non-``None`` state is passed, and the underlying

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
@@ -7,6 +7,7 @@
 
 from isaaclab.renderers.renderer_cfg import RendererCfg
 from isaaclab.utils.configclass import configclass
+from typing import Literal
 
 
 @configclass
@@ -36,3 +37,12 @@ class NewtonWarpRendererCfg(RendererCfg):
 
     colorize_instance_segmentation: bool = True
     """Expose ``instance_segmentation_fast`` as ``(N, H, W, 4) uint8`` if True, else ``(N, H, W, 1) int32``."""
+
+    render_order: Literal["pixel_priority", "view_priority", "tiled"] = "tiled"
+    """Render traversal order."""
+
+    tile_rendering_width: int = 8
+    """Tile width for tiled rendering"""
+
+    tile_rendering_height: int = 8
+    """Tile height for tiled rendering"""

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
@@ -47,3 +47,6 @@ class NewtonWarpRendererCfg(RendererCfg):
 
     tile_rendering_height: int = 8
     """Tile height [px] for tiled rendering."""
+
+    kernel_block_dim: int = 64
+    """Thread block dimension forwarded to Newton."""

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
@@ -5,9 +5,10 @@
 
 """Configuration for Newton Warp Renderer."""
 
+from typing import Literal
+
 from isaaclab.renderers.renderer_cfg import RendererCfg
 from isaaclab.utils.configclass import configclass
-from typing import Literal
 
 
 @configclass
@@ -39,10 +40,10 @@ class NewtonWarpRendererCfg(RendererCfg):
     """Expose ``instance_segmentation_fast`` as ``(N, H, W, 4) uint8`` if True, else ``(N, H, W, 1) int32``."""
 
     render_order: Literal["pixel_priority", "view_priority", "tiled"] = "tiled"
-    """Render traversal order."""
+    """Render traversal order for the Newton tiled camera."""
 
     tile_rendering_width: int = 8
-    """Tile width for tiled rendering"""
+    """Tile width [px] for tiled rendering."""
 
     tile_rendering_height: int = 8
-    """Tile height for tiled rendering"""
+    """Tile height [px] for tiled rendering."""

--- a/source/isaaclab_tasks/changelog.d/fix-cartpole-render-order-test.skip
+++ b/source/isaaclab_tasks/changelog.d/fix-cartpole-render-order-test.skip
@@ -1,0 +1,1 @@
+No changelog entry: test-only Cartpole rendering configuration fix.

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -886,6 +886,8 @@ def rendering_test_cartpole(
     )
 
     env_cfg.scene.num_envs = 4
+    if getattr(env_cfg.tiled_camera.renderer_cfg, "renderer_type", None) == "newton_warp":
+        env_cfg.tiled_camera.renderer_cfg.render_order = "pixel_priority"
 
     if renderer == "ovrtx_renderer":
         _redirect_ovrtx_renderer_log_to_stdout(env_cfg)


### PR DESCRIPTION
# Description

Expose Newton performance tuning knobs for BVH construction and tiled camera rendering.

- Added `NewtonCfg` fields for geometry, scene, and Gaussian BVH constructor selection, forwarded into Newton's `ModelBuilder.BvhConfig`.
- Added `NewtonWarpRendererCfg` fields for render traversal order and tile dimensions, forwarded into `SensorTiledCamera.RenderConfig`.
- Added an `isaaclab_newton` minor changelog fragment and updated `CONTRIBUTORS.md`.
- No new dependencies.

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## New feature / API change

```python
from isaaclab_newton.physics import NewtonCfg
from isaaclab_newton.renderers import NewtonWarpRendererCfg

newton_cfg = NewtonCfg(
    bvh_constructor_geometry="cubql",
    bvh_constructor_scene="sah",
    bvh_constructor_gaussian="cubql",
)

renderer_cfg = NewtonWarpRendererCfg(
    render_order="tiled",
    tile_rendering_width=8,
    tile_rendering_height=8,
)
```

## Checklist

- [x] I have read and understood the contribution guidelines (https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the pre-commit checks (https://pre-commit.com/) with ./isaaclab.sh --format
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under source/<pkg>/changelog.d/ for every touched package (do not edit CHANGELOG.rst or bump extension.toml — CI handles that)
- [x] I have added my name to the CONTRIBUTORS.md or my name already exists there
