### PR TITLE
Relocates RTX determinism settings to isaaclab_physx backend

### DIFF
--- a/docs/source/features/reproducibility.rst
+++ b/docs/source/features/reproducibility.rst
@@ -24,7 +24,7 @@ App-level deterministic rendering via ``AppLauncher``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``--deterministic`` flag is provided by :meth:`isaaclab.app.AppLauncher.add_app_launcher_args`.
-:class:`~isaaclab.app.app_launcher.AppLauncher` publishes ``/isaaclab/rendering/deterministic``.
+:class:`~isaaclab.app.app_launcher.AppLauncher` publishes ``/isaaclab/render/deterministic``.
 The Isaac RTX backend reads it on init and applies
 :func:`isaaclab_physx.renderers.isaac_rtx_renderer_utils.apply_isaac_rtx_determinism_settings`.
 

--- a/docs/source/features/reproducibility.rst
+++ b/docs/source/features/reproducibility.rst
@@ -24,8 +24,9 @@ App-level deterministic rendering via ``AppLauncher``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``--deterministic`` flag is provided by :meth:`isaaclab.app.AppLauncher.add_app_launcher_args`.
-After the simulation app starts, :class:`~isaaclab.app.app_launcher.AppLauncher` applies RTX/RTPT carb
-settings via :meth:`~isaaclab.app.app_launcher.AppLauncher.apply_rtx_determinism_settings`.
+:class:`~isaaclab.app.app_launcher.AppLauncher` publishes ``/isaaclab/rendering/deterministic``.
+The Isaac RTX backend reads it on init and applies
+:func:`isaaclab_physx.renderers.isaac_rtx_renderer_utils.apply_isaac_rtx_determinism_settings`.
 
 **Strict PyTorch determinism** (calling :meth:`~isaaclab.utils.seed.configure_seed` with
 ``torch_deterministic=True`` when you pass ``--deterministic``) is wired into the RL training entrypoints
@@ -36,7 +37,7 @@ optional PyTorch deterministic algorithms. Whether you need ``--deterministic`` 
 depends on the workload: **physics-only** simulation does not require it; **RTX** rendering
 (non-minimal mode) does require it for reproducible imagery; **Newton** rendering does not require it.
 
-To enable deterministic RTX settings from the app launcher, pass ``--deterministic``.
+Pass ``--deterministic`` to enable reproducible rendering from the app launcher. (Isaac RTX only)
 
 .. code-block:: bash
 

--- a/source/isaaclab/changelog.d/esekkin-relocate-rtx-determinism.rst
+++ b/source/isaaclab/changelog.d/esekkin-relocate-rtx-determinism.rst
@@ -2,7 +2,7 @@ Changed
 ^^^^^^^
 
 * Changed the ``--deterministic`` flag of :class:`~isaaclab.app.app_launcher.AppLauncher` to publish
-  ``/isaaclab/rendering/deterministic``. A rendering backend reads this setting on initialization and
+  ``/isaaclab/render/deterministic``. A rendering backend reads this setting on initialization and
   applies its own reproducible-rendering settings; the Isaac RTX backend is the current consumer.
 
 Removed

--- a/source/isaaclab/changelog.d/esekkin-relocate-rtx-determinism.rst
+++ b/source/isaaclab/changelog.d/esekkin-relocate-rtx-determinism.rst
@@ -8,7 +8,8 @@ Changed
 Removed
 ^^^^^^^
 
-* Removed ``AppLauncher.apply_rtx_determinism_settings()``. Pass ``--deterministic`` to
-  :class:`~isaaclab.app.app_launcher.AppLauncher`, or call
+* **Breaking:** Removed the public ``AppLauncher.apply_rtx_determinism_settings()``. To migrate, pass
+  ``--deterministic`` to :class:`~isaaclab.app.app_launcher.AppLauncher` (which now publishes
+  ``/isaaclab/render/deterministic``), or call
   :func:`isaaclab_physx.renderers.isaac_rtx_renderer_utils.apply_isaac_rtx_determinism_settings` on the
-  Isaac RTX backend.
+  Isaac RTX backend directly.

--- a/source/isaaclab/changelog.d/esekkin-relocate-rtx-determinism.rst
+++ b/source/isaaclab/changelog.d/esekkin-relocate-rtx-determinism.rst
@@ -1,0 +1,14 @@
+Changed
+^^^^^^^
+
+* Changed the ``--deterministic`` flag of :class:`~isaaclab.app.app_launcher.AppLauncher` to publish
+  ``/isaaclab/rendering/deterministic``. A rendering backend reads this setting on initialization and
+  applies its own reproducible-rendering settings; the Isaac RTX backend is the current consumer.
+
+Removed
+^^^^^^^
+
+* Removed ``AppLauncher.apply_rtx_determinism_settings()``. Pass ``--deterministic`` to
+  :class:`~isaaclab.app.app_launcher.AppLauncher`, or call
+  :func:`isaaclab_physx.renderers.isaac_rtx_renderer_utils.apply_isaac_rtx_determinism_settings` on the
+  Isaac RTX backend.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -127,16 +127,6 @@ class AppLauncher:
                 settings.set_int("/isaaclab/visualizer/max_visible_envs", -1)
 
     @staticmethod
-    def apply_rtx_determinism_settings() -> None:
-        """Apply RTX RealTimePathTracing and disable RTPT caches for reproducible RTX rendering.
-        Called after :class:`isaacsim.simulation_app.SimulationApp` starts whenever ``--deterministic`` is set.
-        """
-        settings = get_settings_manager()
-        settings.set_string("/rtx/rendermode", "RealTimePathTracing")
-        settings.set_bool("/rtx/rtpt/cached/enabled", False)
-        settings.set_bool("/rtx/rtpt/lightcache/cached/enabled", False)
-
-    @staticmethod
     def _parse_visualizer_csv(value: str) -> list[str] | None:
         """Parse visualizer list from a single comma-delimited CLI token."""
         valid = {"kit", "newton", "rerun", "viser", "none"}
@@ -445,7 +435,7 @@ class AppLauncher:
           * If headless is True and enable_cameras is False, the experience file is set to
             ``isaaclab.python.headless.kit``.
 
-        * ``deterministic`` (bool): After startup, applies RTX/RTPT carb settings for reproducible rendering.
+        * ``deterministic`` (bool): Publishes ``/isaaclab/rendering/deterministic`` for reproducible rendering.
           Does not change how the default experience file is chosen.
 
         * ``kit_args`` (str): Optional command line arguments to be passed to Omniverse Kit directly.
@@ -585,7 +575,7 @@ class AppLauncher:
             "--deterministic",
             action="store_true",
             default=AppLauncher._APPLAUNCHER_CFG_INFO["deterministic"][1],
-            help="After startup, apply RTX/RTPT settings for reproducible rendering (see AppLauncher docs).",
+            help="Request reproducible rendering (see AppLauncher docs).",
         )
         arg_group.add_argument(
             "--kit_args",
@@ -1163,7 +1153,7 @@ class AppLauncher:
                 "tensor views when launched through Isaac Lab with livestreaming enabled. Omit '--experience' so "
                 "AppLauncher can select an Isaac Lab experience file, or remove the 'isaacsim.exp.full' dependency."
             )
-        self._apply_rtx_determinism = bool(deterministic_mode)
+        self._deterministic_rendering = bool(deterministic_mode)
         logger.info("Loading experience file: %s", self._sim_experience_file)
 
     @staticmethod
@@ -1271,10 +1261,6 @@ class AppLauncher:
         # Use SettingsManager (backs onto carb when in Omniverse after initialize_carb_settings).
         initialize_carb_settings()
 
-        if self._apply_rtx_determinism:
-            AppLauncher.apply_rtx_determinism_settings()
-            logger.info("Applied RTX settings for deterministic rendering (--deterministic).")
-
         # After SimulationApp starts, Kit installs its Python log bridge at DEBUG level.
         # Re-apply the intended Python logging level, then add a scoped stream handler for
         # Isaac Lab INFO records that Kit's bridge does not mirror to the console.
@@ -1309,6 +1295,8 @@ class AppLauncher:
 
         # set setting to indicate no RTX sensors are used (set to True when RTX sensor is created)
         settings.set_bool("/isaaclab/render/rtx_sensors", False)
+
+        settings.set_bool("/isaaclab/rendering/deterministic", self._deterministic_rendering)
 
         # set fabric update flag to disable updating transforms when rendering is disabled
         settings.set_bool("/physics/fabricUpdateTransformations", self._rendering_enabled())

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -435,7 +435,7 @@ class AppLauncher:
           * If headless is True and enable_cameras is False, the experience file is set to
             ``isaaclab.python.headless.kit``.
 
-        * ``deterministic`` (bool): Publishes ``/isaaclab/rendering/deterministic`` for reproducible rendering.
+        * ``deterministic`` (bool): Publishes ``/isaaclab/render/deterministic`` for reproducible rendering.
           Does not change how the default experience file is chosen.
 
         * ``kit_args`` (str): Optional command line arguments to be passed to Omniverse Kit directly.
@@ -1296,7 +1296,8 @@ class AppLauncher:
         # set setting to indicate no RTX sensors are used (set to True when RTX sensor is created)
         settings.set_bool("/isaaclab/render/rtx_sensors", False)
 
-        settings.set_bool("/isaaclab/rendering/deterministic", self._deterministic_rendering)
+        # publish the reproducible-rendering intent; rendering backends read this on initialization
+        settings.set_bool("/isaaclab/render/deterministic", self._deterministic_rendering)
 
         # set fabric update flag to disable updating transforms when rendering is disabled
         settings.set_bool("/physics/fabricUpdateTransformations", self._rendering_enabled())

--- a/source/isaaclab/test/app/test_kwarg_launch.py
+++ b/source/isaaclab/test/app/test_kwarg_launch.py
@@ -106,6 +106,30 @@ class _DummySettings:
         self.values[path] = value
 
 
+@pytest.mark.parametrize("deterministic", [True, False])
+def test_load_extensions_publishes_deterministic_setting(monkeypatch: pytest.MonkeyPatch, deterministic: bool):
+    """Publish ``/isaaclab/rendering/deterministic`` from ``_load_extensions``."""
+    launcher = AppLauncher.__new__(AppLauncher)
+    launcher._deterministic_rendering = deterministic
+    launcher._python_logging_level = logging.ERROR
+    launcher._headless = True
+    launcher._livestream = 0
+    launcher._enable_cameras = False
+    launcher._offscreen_render = False
+    launcher._render_viewport = False
+    launcher._xr = False
+    launcher._video_enabled = False
+
+    settings = _DummySettings()
+    monkeypatch.setattr(app_launcher_module, "initialize_carb_settings", lambda: None)
+    monkeypatch.setattr(app_launcher_module, "get_settings_manager", lambda: settings)
+    monkeypatch.setattr(app_launcher_module, "apply_python_logging_level", lambda _level: None)
+
+    launcher._load_extensions()
+
+    assert settings.values["/isaaclab/rendering/deterministic"] is deterministic
+
+
 @pytest.mark.parametrize(
     ("headless", "livestream", "xr", "expected_has_gui"),
     [
@@ -120,7 +144,7 @@ def test_load_extensions_publishes_has_gui_setting(
 ):
     """Publish the GUI state consumed by SimulationContext and RTX rendering."""
     launcher = AppLauncher.__new__(AppLauncher)
-    launcher._apply_rtx_determinism = False
+    launcher._deterministic_rendering = False
     launcher._python_logging_level = logging.ERROR
     launcher._headless = headless
     launcher._livestream = livestream
@@ -323,7 +347,7 @@ def _new_launcher_for_experience_check():
     launcher._enable_cameras = False
     launcher._headless = False
     launcher._xr = False
-    launcher._apply_rtx_determinism = False
+    launcher._deterministic_rendering = False
     launcher.is_isaac_sim_version_5 = lambda: False
     return launcher
 

--- a/source/isaaclab/test/app/test_kwarg_launch.py
+++ b/source/isaaclab/test/app/test_kwarg_launch.py
@@ -108,7 +108,7 @@ class _DummySettings:
 
 @pytest.mark.parametrize("deterministic", [True, False])
 def test_load_extensions_publishes_deterministic_setting(monkeypatch: pytest.MonkeyPatch, deterministic: bool):
-    """Publish ``/isaaclab/rendering/deterministic`` from ``_load_extensions``."""
+    """Publish ``/isaaclab/render/deterministic`` from ``_load_extensions``."""
     launcher = AppLauncher.__new__(AppLauncher)
     launcher._deterministic_rendering = deterministic
     launcher._python_logging_level = logging.ERROR
@@ -127,7 +127,7 @@ def test_load_extensions_publishes_deterministic_setting(monkeypatch: pytest.Mon
 
     launcher._load_extensions()
 
-    assert settings.values["/isaaclab/rendering/deterministic"] is deterministic
+    assert settings.values["/isaaclab/render/deterministic"] is deterministic
 
 
 @pytest.mark.parametrize(

--- a/source/isaaclab/test/sim/test_simulation_render_config.py
+++ b/source/isaaclab/test/sim/test_simulation_render_config.py
@@ -173,6 +173,36 @@ def test_isaac_rtx_global_settings(monkeypatch):
     assert rep_settings.antialiasing == "DLAA"
 
 
+def test_isaac_rtx_determinism_settings(monkeypatch):
+    """Write RTPT reproducibility carb settings."""
+    utils = _import_isaac_rtx_utils(monkeypatch)
+    settings = _FakeSettings()
+    monkeypatch.setattr(utils, "get_settings_manager", lambda: settings)
+
+    utils.apply_isaac_rtx_determinism_settings()
+
+    assert settings.get("/rtx/rendermode") == "RealTimePathTracing"
+    assert settings.get("/rtx/rtpt/cached/enabled") is False
+    assert settings.get("/rtx/rtpt/lightcache/cached/enabled") is False
+
+
+def test_isaac_rtx_determinism_settings_accepts_explicit_manager(monkeypatch):
+    """Use the provided settings manager when one is passed."""
+    utils = _import_isaac_rtx_utils(monkeypatch)
+
+    def _fail():
+        raise AssertionError("global settings manager should not be queried when one is provided")
+
+    monkeypatch.setattr(utils, "get_settings_manager", _fail)
+    settings = _FakeSettings()
+
+    utils.apply_isaac_rtx_determinism_settings(settings)
+
+    assert settings.get("/rtx/rendermode") == "RealTimePathTracing"
+    assert settings.get("/rtx/rtpt/cached/enabled") is False
+    assert settings.get("/rtx/rtpt/lightcache/cached/enabled") is False
+
+
 def test_isaac_rtx_camera_experience_defaults():
     """Test that camera app files carry the high-fidelity RTX defaults."""
     isaaclab_app_exp_path = Path(__file__).resolve().parents[4] / "apps"

--- a/source/isaaclab_physx/changelog.d/esekkin-relocate-rtx-determinism.rst
+++ b/source/isaaclab_physx/changelog.d/esekkin-relocate-rtx-determinism.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added :func:`~isaaclab_physx.renderers.isaac_rtx_renderer_utils.apply_isaac_rtx_determinism_settings`
+  to apply Isaac RTX RealTimePathTracing and RTPT cache settings for reproducible rendering.
+* Added :class:`~isaaclab_physx.renderers.isaac_rtx_renderer.IsaacRtxRenderer` support for
+  ``/isaaclab/rendering/deterministic`` (set via ``--deterministic``).

--- a/source/isaaclab_physx/changelog.d/esekkin-relocate-rtx-determinism.rst
+++ b/source/isaaclab_physx/changelog.d/esekkin-relocate-rtx-determinism.rst
@@ -4,4 +4,4 @@ Added
 * Added :func:`~isaaclab_physx.renderers.isaac_rtx_renderer_utils.apply_isaac_rtx_determinism_settings`
   to apply Isaac RTX RealTimePathTracing and RTPT cache settings for reproducible rendering.
 * Added :class:`~isaaclab_physx.renderers.isaac_rtx_renderer.IsaacRtxRenderer` support for
-  ``/isaaclab/rendering/deterministic`` (set via ``--deterministic``).
+  ``/isaaclab/render/deterministic`` (set via ``--deterministic``).

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -122,7 +122,7 @@ class IsaacRtxRenderer(BaseRenderer):
         self.cfg = cfg
         settings = get_settings_manager()
         apply_isaac_rtx_global_settings(self.cfg.global_settings, settings)
-        if settings.get("/isaaclab/rendering/deterministic", False):
+        if settings.get("/isaaclab/render/deterministic", False):
             apply_isaac_rtx_determinism_settings(settings)
         # RTX rendering requires the app to be launched with ``--enable_cameras``.
         if not settings.get("/isaaclab/cameras_enabled"):

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -28,6 +28,7 @@ from isaaclab.utils.warp.kernels import reshape_tiled_image
 from isaaclab.utils.warp.warp_math import clamp_depth_to_inf_wp, replace_inf_depth_wp
 
 from .isaac_rtx_renderer_utils import (
+    apply_isaac_rtx_determinism_settings,
     apply_isaac_rtx_global_settings,
     ensure_isaac_rtx_render_update,
     ensure_rtx_hydra_engine_attached,
@@ -121,6 +122,8 @@ class IsaacRtxRenderer(BaseRenderer):
         self.cfg = cfg
         settings = get_settings_manager()
         apply_isaac_rtx_global_settings(self.cfg.global_settings, settings)
+        if settings.get("/isaaclab/rendering/deterministic", False):
+            apply_isaac_rtx_determinism_settings(settings)
         # RTX rendering requires the app to be launched with ``--enable_cameras``.
         if not settings.get("/isaaclab/cameras_enabled"):
             raise RuntimeError(

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
@@ -65,6 +65,21 @@ def _setting_path_from_key(key: str) -> str:
     return key
 
 
+def apply_isaac_rtx_determinism_settings(settings: SettingsManager | None = None) -> None:
+    """Apply Isaac RTX settings for reproducible rendering.
+
+    Selects RealTimePathTracing and disables the RTPT color and light caches.
+
+    Args:
+        settings: Settings manager to apply settings through. If None, the global settings manager is used.
+    """
+    if settings is None:
+        settings = get_settings_manager()
+    settings.set("/rtx/rendermode", "RealTimePathTracing")
+    settings.set("/rtx/rtpt/cached/enabled", False)
+    settings.set("/rtx/rtpt/lightcache/cached/enabled", False)
+
+
 def apply_isaac_rtx_global_settings(
     global_settings: IsaacRtxRendererGlobalSettingsCfg,
     settings: SettingsManager | None = None,

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
@@ -78,6 +78,7 @@ def apply_isaac_rtx_determinism_settings(settings: SettingsManager | None = None
     settings.set("/rtx/rendermode", "RealTimePathTracing")
     settings.set("/rtx/rtpt/cached/enabled", False)
     settings.set("/rtx/rtpt/lightcache/cached/enabled", False)
+    logger.info("Applied Isaac RTX settings for deterministic rendering.")
 
 
 def apply_isaac_rtx_global_settings(

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
@@ -107,6 +107,45 @@ def test_depth_only_camera_color_render_setting(monkeypatch, has_gui, expected_d
     assert color_render_calls[-1] == call("/rtx/sdg/force/disableColorRender", expected_disable_color_render)
 
 
+_MISSING = object()
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected_called"),
+    [
+        pytest.param(True, True, id="deterministic-true-applies-settings"),
+        pytest.param(False, False, id="deterministic-false-skips-settings"),
+        pytest.param(_MISSING, False, id="deterministic-missing-skips-settings"),
+    ],
+)
+def test_deterministic_flag_gates_rtx_determinism_settings(monkeypatch, stored, expected_called):
+    """IsaacRtxRenderer applies RTX determinism settings only when ``/isaaclab/render/deterministic`` is true."""
+    _install_omni_stubs(monkeypatch)
+    import isaaclab_physx.renderers.isaac_rtx_renderer as rtx_renderer
+    from isaaclab_physx.renderers.isaac_rtx_renderer_cfg import IsaacRtxRendererCfg
+
+    # RTX rendering requires cameras to be enabled.
+    settings_values = {"/isaaclab/cameras_enabled": True}
+    if stored is not _MISSING:
+        settings_values["/isaaclab/render/deterministic"] = stored
+
+    settings = MagicMock()
+    settings.get.side_effect = settings_values.get
+    determinism_mock = MagicMock()
+
+    with (
+        patch.object(rtx_renderer, "get_settings_manager", return_value=settings),
+        patch.object(rtx_renderer, "apply_isaac_rtx_global_settings"),
+        patch.object(rtx_renderer, "apply_isaac_rtx_determinism_settings", determinism_mock),
+        patch.object(rtx_renderer, "ensure_rtx_hydra_engine_attached"),
+    ):
+        rtx_renderer.IsaacRtxRenderer(IsaacRtxRendererCfg())
+
+    assert determinism_mock.called is expected_called
+    if expected_called:
+        determinism_mock.assert_called_once_with(settings)
+
+
 def test_isaac_rtx_read_output_clears_stale_metadata_and_keeps_seeded_keys(monkeypatch):
     """read_output replaces (not merges): a dropped annotator info resets its info entry, seeded keys persist."""
     _install_omni_stubs(monkeypatch)

--- a/source/isaaclab_visualizers/changelog.d/esekkin-relocate-rtx-determinism.skip
+++ b/source/isaaclab_visualizers/changelog.d/esekkin-relocate-rtx-determinism.skip
@@ -1,0 +1,2 @@
+Test-only change: updates the visualizer integration test helper to stop calling the
+removed ``AppLauncher.apply_rtx_determinism_settings()``. No user-facing behavior change.

--- a/source/isaaclab_visualizers/test/visualizer_integration_utils.py
+++ b/source/isaaclab_visualizers/test/visualizer_integration_utils.py
@@ -39,7 +39,6 @@ from isaaclab_visualizers.kit import KitVisualizer, KitVisualizerCfg
 from isaaclab_visualizers.newton import NewtonVisualizer, NewtonVisualizerCfg
 
 import isaaclab.sim as sim_utils
-from isaaclab.app import AppLauncher
 from isaaclab.envs.utils.camera_view import camera_rgb_batch, compose_rgb_grid_tensor
 from isaaclab.sim import SimulationContext
 
@@ -236,8 +235,7 @@ def assert_no_newton_imgui_bundle_warning(capsys: pytest.CaptureFixture[str], ca
 
 
 def _configure_sim_for_visualizer_test(env: CartpoleCameraEnv) -> None:
-    """Settings used by the previous smoke tests; keep RTX sensors enabled for camera paths."""
-    AppLauncher.apply_rtx_determinism_settings()
+    """Enable RTX sensors for camera visualizer integration tests."""
     env.sim.set_setting("/isaaclab/render/rtx_sensors", True)
     env.sim._app_control_on_stop_handle = None  # type: ignore[attr-defined]
 

--- a/source/isaaclab_visualizers/test/visualizer_integration_utils.py
+++ b/source/isaaclab_visualizers/test/visualizer_integration_utils.py
@@ -235,7 +235,7 @@ def assert_no_newton_imgui_bundle_warning(capsys: pytest.CaptureFixture[str], ca
 
 
 def _configure_sim_for_visualizer_test(env: CartpoleCameraEnv) -> None:
-    """Enable RTX sensors for camera visualizer integration tests."""
+    """Set ``/isaaclab/render/rtx_sensors`` True so the sim takes the RTX-sensor render path."""
     env.sim.set_setting("/isaaclab/render/rtx_sensors", True)
     env.sim._app_control_on_stop_handle = None  # type: ignore[attr-defined]
 


### PR DESCRIPTION
# Description

- Removes `AppLauncher.apply_rtx_determinism_settings()` and the `/rtx/...` carb writes from core `isaaclab.app`.
- `AppLauncher` now publishes the backend-agnostic `/isaaclab/render/deterministic` setting from `--deterministic`.
- `IsaacRtxRenderer` consumes that setting on init and applies RTPT reproducibility settings via the new `apply_isaac_rtx_determinism_settings()` in `isaaclab_physx`.

## Type of change

- Refactor

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there