### PR TITLE
Use optional Ray rl-games branch

### DIFF
--- a/docs/source/setup/installation/isaaclab_pip_installation.rst
+++ b/docs/source/setup/installation/isaaclab_pip_installation.rst
@@ -57,7 +57,7 @@ Install with ``isaaclab[isaacsim,all]`` for the full workflow.
 
    .. code-block:: bash
 
-      pip install "rl-games @ git+https://github.com/isaac-sim/rl_games.git@python3.11" gym standard-distutils
+      pip install "rl-games @ git+https://github.com/isaac-sim/rl_games.git@optional-ray" gym standard-distutils
 
 Installing dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ sb3 = ["stable-baselines3>=2.6", "tqdm", "rich"]
 skrl = ["skrl>=2.1.0"]
 rl-games = [
     "aiohttp>=3.12.14",
-    "rl-games @ git+https://github.com/isaac-sim/rl_games.git@python3.11",
+    "rl-games @ git+https://github.com/isaac-sim/rl_games.git@optional-ray",
     "gym",
     "standard-distutils",
 ]


### PR DESCRIPTION
# Description

This PR points Isaac Lab’s `rl-games` dependency at the public `isaac-sim/rl_games@optional-ray` branch and updates the pip installation docs to match.

The `optional-ray` branch makes `ray` an opt-in `rl-games[ray]` extra instead of a default dependency. This avoids pulling the full Ray stack into Isaac Lab Docker image builds, which was triggering prebundle mutation issues in the arm64 Docker publishing path.

Fixes the Docker publishing failure caused by default `rl-games` installs resolving `ray`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Validation

- Built `rl-games @ git+https://github.com/isaac-sim/rl_games.git@optional-ray` and verified wheel metadata exposes `ray` only as `extra == "ray"`.
- Ran `.\isaaclab.bat -f` successfully.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (N/A: no `source/<pkg>` package files touched)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there