### PR TITLE
Register Newton frame sites with the scene and remove post-build resolution

### DIFF
--- a/scripts/benchmarks/benchmark_view_comparison.py
+++ b/scripts/benchmarks/benchmark_view_comparison.py
@@ -173,13 +173,15 @@ def benchmark_newton(num_iterations: int) -> dict[str, float]:
         prim.GetAttribute("xformOp:translate").Set(Gf.Vec3d(0.1, 0.0, 0.05))
         prim.GetAttribute("xformOp:orient").Set(Gf.Quatd(1.0, 0.0, 0.0, 0.0))
 
+    # Newton frame views are constructed before reset; their sites resolve during the model build.
+    init_start = time.perf_counter()
+    view = NewtonSiteFrameView("/World/envs/env_.*/Cube/Sensor", device=args_cli.device)
+    timing_results["init"] = time.perf_counter() - init_start
+
     sim.reset()
     print(f"  Newton scene setup: {time.perf_counter() - start_time:.4f}s")
 
-    start_time = time.perf_counter()
-    view = NewtonSiteFrameView("/World/envs/env_.*/Cube/Sensor", device=args_cli.device)
     num_prims = view.count
-    timing_results["init"] = time.perf_counter() - start_time
 
     print(f"  Newton FrameView managing {num_prims} prims")
 

--- a/scripts/benchmarks/benchmark_view_comparison.py
+++ b/scripts/benchmarks/benchmark_view_comparison.py
@@ -138,25 +138,23 @@ def benchmark_usd_or_fabric(view_type: str, num_iterations: int) -> dict[str, fl
 @torch.no_grad()
 def benchmark_newton(num_iterations: int) -> dict[str, float]:
     """Benchmark Newton FrameView."""
+    from isaaclab import cloner
     from isaaclab.assets import RigidObjectCfg
-    from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
     from isaaclab.sim import SimulationCfg, build_simulation_context
-    from isaaclab.utils.configclass import configclass
 
     timing_results = {}
+    num_envs = args_cli.num_envs
 
-    @configclass
-    class _SceneCfg(InteractiveSceneCfg):
-        cube: RigidObjectCfg = RigidObjectCfg(
-            prim_path="{ENV_REGEX_NS}/Cube",
-            spawn=sim_utils.CuboidCfg(
-                size=(0.2, 0.2, 0.2),
-                rigid_props=sim_utils.RigidBodyPropertiesCfg(),
-                mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
-                collision_props=sim_utils.CollisionPropertiesCfg(),
-            ),
-            init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
-        )
+    cube_cfg = RigidObjectCfg(
+        prim_path="/World/envs/env_.*/Cube",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.2, 0.2, 0.2),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
+    )
 
     print("  Setting up Newton scene")
     newton_cfg = SimulationCfg(physics=NewtonCfg(solver_cfg=MJWarpSolverCfg()), device=args_cli.device)
@@ -164,19 +162,25 @@ def benchmark_newton(num_iterations: int) -> dict[str, float]:
     ctx = build_simulation_context(device=args_cli.device, sim_cfg=newton_cfg, add_ground_plane=True)
     sim = ctx.__enter__()
     sim._app_control_on_stop_handle = None
-    InteractiveScene(_SceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0))
 
+    # Newton sites register with the scene and clone during replication, so the
+    # sensor frame and the view are created inside the replication session.
     stage = sim_utils.get_current_stage()
-    for i in range(args_cli.num_envs):
-        prim = stage.DefinePrim(f"/World/envs/env_{i}/Cube/Sensor", "Xform")
+    stage.DefinePrim("/World/envs/env_0", "Xform")
+    env_ids = torch.arange(num_envs, dtype=torch.long, device=args_cli.device)
+    env_origins, _ = cloner.grid_transforms(num_envs, 2.0, device=args_cli.device)
+    with cloner.disabled_fabric_change_notifies(stage, restore=False):
+        cloner.usd_replicate(stage, ["/World/envs/env_0"], ["/World/envs/env_{}"], env_ids, positions=env_origins)
+    with cloner.ReplicateSession([cube_cfg], num_clones=num_envs, env_spacing=2.0, device=args_cli.device, stage=stage):
+        cube_cfg.class_type(cube_cfg)
+        prim = stage.DefinePrim("/World/envs/env_0/Cube/Sensor", "Xform")
         sim_utils.standardize_xform_ops(prim)
         prim.GetAttribute("xformOp:translate").Set(Gf.Vec3d(0.1, 0.0, 0.05))
         prim.GetAttribute("xformOp:orient").Set(Gf.Quatd(1.0, 0.0, 0.0, 0.0))
 
-    # Newton frame views are constructed before reset; their sites resolve during the model build.
-    init_start = time.perf_counter()
-    view = NewtonSiteFrameView("/World/envs/env_.*/Cube/Sensor", device=args_cli.device)
-    timing_results["init"] = time.perf_counter() - init_start
+        init_start = time.perf_counter()
+        view = NewtonSiteFrameView("/World/envs/env_.*/Cube/Sensor", device=args_cli.device)
+        timing_results["init"] = time.perf_counter() - init_start
 
     sim.reset()
     print(f"  Newton scene setup: {time.perf_counter() - start_time:.4f}s")

--- a/scripts/benchmarks/benchmark_xform_prim_view.py
+++ b/scripts/benchmarks/benchmark_xform_prim_view.py
@@ -50,17 +50,15 @@ from isaaclab_physx.sim.views import FabricFrameView
 from pxr import Gf
 
 import isaaclab.sim as sim_utils
+from isaaclab import cloner
 from isaaclab.assets import RigidObjectCfg
-from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg, build_simulation_context
 from isaaclab.sim.views import UsdFrameView
-from isaaclab.utils.configclass import configclass
 
 
-@configclass
-class _NewtonSceneCfg(InteractiveSceneCfg):
-    cube: RigidObjectCfg = RigidObjectCfg(
-        prim_path="{ENV_REGEX_NS}/Object",
+def _newton_cube_cfg() -> RigidObjectCfg:
+    return RigidObjectCfg(
+        prim_path="/World/envs/env_.*/Object",
         spawn=sim_utils.CuboidCfg(
             size=(0.2, 0.2, 0.2),
             rigid_props=sim_utils.RigidBodyPropertiesCfg(),
@@ -97,19 +95,26 @@ def benchmark_frame_view(  # noqa: C901
         ctx = build_simulation_context(device=device, sim_cfg=newton_cfg, add_ground_plane=True)
         sim = ctx.__enter__()
         sim._app_control_on_stop_handle = None
-        InteractiveScene(_NewtonSceneCfg(num_envs=num_envs, env_spacing=2.0))
 
+        # Newton sites register with the scene and clone during replication, so the
+        # sensor frame and the view are created inside the replication session.
         stage = sim_utils.get_current_stage()
-        for i in range(num_envs):
-            prim = stage.DefinePrim(f"/World/envs/env_{i}/Object/Sensor", "Xform")
+        stage.DefinePrim("/World/envs/env_0", "Xform")
+        env_ids = torch.arange(num_envs, dtype=torch.long, device=device)
+        env_origins, _ = cloner.grid_transforms(num_envs, 2.0, device=device)
+        with cloner.disabled_fabric_change_notifies(stage, restore=False):
+            cloner.usd_replicate(stage, ["/World/envs/env_0"], ["/World/envs/env_{}"], env_ids, positions=env_origins)
+        cube_cfg = _newton_cube_cfg()
+        with cloner.ReplicateSession([cube_cfg], num_clones=num_envs, env_spacing=2.0, device=device, stage=stage):
+            cube_cfg.class_type(cube_cfg)
+            prim = stage.DefinePrim("/World/envs/env_0/Object/Sensor", "Xform")
             sim_utils.standardize_xform_ops(prim)
             prim.GetAttribute("xformOp:translate").Set(Gf.Vec3d(0.1, 0.0, 0.05))
             prim.GetAttribute("xformOp:orient").Set(Gf.Quatd(1.0, 0.0, 0.0, 0.0))
 
-        # Newton frame views are constructed before reset; their sites resolve during the model build.
-        start_time = time.perf_counter()
-        xform_view = NewtonSiteFrameView("/World/envs/env_.*/Object/Sensor", device=device)
-        timing_results["init"] = time.perf_counter() - start_time
+            start_time = time.perf_counter()
+            xform_view = NewtonSiteFrameView("/World/envs/env_.*/Object/Sensor", device=device)
+            timing_results["init"] = time.perf_counter() - start_time
 
         sim.reset()
         cleanup = lambda: ctx.__exit__(None, None, None)  # noqa: E731

--- a/scripts/benchmarks/benchmark_xform_prim_view.py
+++ b/scripts/benchmarks/benchmark_xform_prim_view.py
@@ -106,11 +106,12 @@ def benchmark_frame_view(  # noqa: C901
             prim.GetAttribute("xformOp:translate").Set(Gf.Vec3d(0.1, 0.0, 0.05))
             prim.GetAttribute("xformOp:orient").Set(Gf.Quatd(1.0, 0.0, 0.0, 0.0))
 
-        sim.reset()
-
+        # Newton frame views are constructed before reset; their sites resolve during the model build.
         start_time = time.perf_counter()
         xform_view = NewtonSiteFrameView("/World/envs/env_.*/Object/Sensor", device=device)
         timing_results["init"] = time.perf_counter() - start_time
+
+        sim.reset()
         cleanup = lambda: ctx.__exit__(None, None, None)  # noqa: E731
 
     else:

--- a/source/isaaclab/changelog.d/octi-frameview-deferred-init.rst
+++ b/source/isaaclab/changelog.d/octi-frameview-deferred-init.rst
@@ -1,0 +1,20 @@
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab.cloner.ReplicateSession` to publish the clone plan when
+  the session enters instead of when it exits, so entities constructed inside the
+  session (sensors, frame views, ray casters) resolve prims through the plan
+  consistently with post-replication code. A failed session unpublishes its plan.
+* Changed frame views to a uniform two-phase lifecycle: every backend view can be
+  constructed alongside the rest of the scene and completes its initialization
+  through its backend's own lifecycle (Newton registers frame sites at construction
+  so they clone with the scene; PhysX and OVPhysX resolve prims once physics is
+  ready). The camera sensor constructs its frame view at construction on every
+  backend.
+
+Fixed
+^^^^^
+
+* Fixed weak-reference physics callbacks raising ``ReferenceError`` during event
+  dispatch after their owner was garbage-collected; the registry entry is now
+  deregistered when the owner is collected.

--- a/source/isaaclab/isaaclab/cloner/replicate_session.py
+++ b/source/isaaclab/isaaclab/cloner/replicate_session.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
+from isaaclab.sim import SimulationContext
+
 from .cloner_strategies import sequential
 
 if TYPE_CHECKING:
@@ -31,8 +33,6 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage) -> None:
     ascending ``replicate_priority`` order. The queue is cleared up front, so a backend
     failure cannot leak stale entries into the next call.
     """
-    from isaaclab.sim import SimulationContext  # noqa: PLC0415
-
     queued = list(REPLICATION_QUEUE)
     REPLICATION_QUEUE.clear()
 
@@ -120,6 +120,10 @@ class ReplicateSession:
         from .cloner_utils import make_clone_plan  # noqa: PLC0415
 
         self._plan = make_clone_plan(self._cfgs, **self._kwargs)
+        # Publish immediately: the plan is complete once built, and entities
+        # constructed inside the session (sensors, frame views, ray casters) resolve
+        # prims through it the same way post-replication code does.
+        SimulationContext.instance().set_clone_plan(self._plan)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
@@ -127,8 +131,10 @@ class ReplicateSession:
             assert self._plan is not None
             replicate(self._plan, stage=self._stage)
         else:
-            # Drop cfgs registered before the failure so the next session is clean.
+            # Drop cfgs registered before the failure so the next session is clean,
+            # and unpublish the failed plan — its destinations were never created.
             REPLICATION_QUEUE.clear()
+            SimulationContext.instance().set_clone_plan(None)
 
     @property
     def plan(self) -> ClonePlan:

--- a/source/isaaclab/isaaclab/physics/physics_manager.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager.py
@@ -134,7 +134,7 @@ class PhysicsManager(ABC):
         cls._callback_id += 1
 
         if wrap_weak_ref:
-            callback = cls._wrap_weak_ref(callback)
+            callback = cls._wrap_weak_ref(callback, cid)
 
         subscription = cls._subscribe_to_event(cid, callback, event, order, name)
 
@@ -166,7 +166,14 @@ class PhysicsManager(ABC):
             event: The event to dispatch.
             payload: Optional data to pass to callbacks.
         """
-        matching = [(cid, cb, order) for cid, (ev, cb, order, name, sub) in cls._callbacks.items() if ev == event]
+        # Snapshot the keys before filtering: weak-ref finalizers deregister entries
+        # when their owner is collected, and a collection can run at any allocation,
+        # so the registry must not be iterated directly while building the snapshot.
+        matching = []
+        for cid in list(cls._callbacks):
+            entry = cls._callbacks.get(cid)
+            if entry is not None and entry[0] == event:
+                matching.append((cid, entry[1], entry[2]))
         matching.sort(key=lambda x: x[2])
 
         for _, callback, _ in matching:
@@ -193,17 +200,21 @@ class PhysicsManager(ABC):
         cls._callbacks.clear()
 
     @classmethod
-    def _wrap_weak_ref(cls, callback: Callable) -> Callable:
+    def _wrap_weak_ref(cls, callback: Callable, callback_id: int) -> Callable:
         """Wrap bound methods with weak references to prevent leaks.
+
+        The registry entry is deregistered when the owner is garbage-collected, so
+        stale callbacks do not accumulate between dispatches.
 
         Args:
             callback: The callback to wrap.
+            callback_id: Registry id to deregister when the owner is collected.
 
         Returns:
             Wrapped callback if it's a bound method, otherwise original.
         """
         if hasattr(callback, "__self__"):
-            obj_ref = weakref.proxy(callback.__self__)
+            obj_ref = weakref.proxy(callback.__self__, lambda _proxy: cls.deregister_callback(callback_id))
             method_name = callback.__name__
 
             def weak_callback(payload: Any) -> Any:

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -174,6 +174,18 @@ class Camera(SensorBase):
                 raise RuntimeError(f"Could not find prim with path {spawn_target!r}.")
         queue_usd_replication(self._source_cfg)
 
+        # Assigned in _initialize_impl; initialized here so a constructor failure below
+        # leaves the instance safely finalizable.
+        self._renderer: BaseRenderer | None = None
+        self._render_data = None
+
+        # The frame view is constructed with the sensor like any other scene entity:
+        # each backend registers what its frames need (e.g. Newton site requests, so
+        # replication clones them with the rest of the scene) and completes its
+        # initialization through its own physics lifecycle.
+        device = sim_utils.SimulationContext.instance().device
+        self._view = FrameView(self.cfg.prim_path, device=device, stage=self.stage)
+
         # An ISP (any ``isp_cfg`` other than ``None``) requires the HDR AOV;
         # an explicit ``"rgb_hdr"`` in ``data_types`` also requires the
         # HDR-routing flag flipped on the RTX-bearing backends.
@@ -206,9 +218,6 @@ class Camera(SensorBase):
         self._sensor_prims: list[UsdGeom.Camera] = list()
         # Allocated in :meth:`_create_buffers` once the renderer's output contract is known.
         self._data: CameraData | None = None
-        # Renderer and render data — assigned in _initialize_impl.
-        self._renderer: BaseRenderer | None = None
-        self._render_data = None
 
     def __del__(self):
         """Unsubscribes from callbacks and cleans up renderer resources."""
@@ -518,7 +527,8 @@ class Camera(SensorBase):
         # references to prims located in the stage.
         sim_ctx.render_context.ensure_prepare_stage(self.stage, self._num_envs)
 
-        self._view = FrameView(self.cfg.prim_path, device=self._device, stage=self.stage)
+        if self._view is None:
+            self._view = FrameView(self.cfg.prim_path, device=self._device, stage=self.stage)
         # Check that sizes are correct
         if self._view.count != self._num_envs:
             raise RuntimeError(

--- a/source/isaaclab/isaaclab/sim/views/base_frame_view.py
+++ b/source/isaaclab/isaaclab/sim/views/base_frame_view.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import warp as wp
 
@@ -46,9 +46,33 @@ class BaseFrameView(abc.ABC):
     scope first.
     """
 
+    _is_initialized: bool = False
+    """Whether :meth:`_initialize_impl` has run. Class-level default; set on the
+    instance by :meth:`_initialize_callback`."""
+
     # Class-level default; instance-level value is set by the writer's
     # __enter__ / __exit__ to track the active scope on this view.
     _active_writer: FrameViewSpaceWriterBase | None = None
+
+    def _initialize_callback(self, event: Any = None) -> None:
+        """Complete initialization exactly once.
+
+        Constructors call this directly when their physics backend is already ready,
+        or hook it to the backend's ready event, so views can be constructed
+        alongside the rest of the scene and initialize once the backend is.
+        """
+        if not self._is_initialized:
+            self._initialize_impl()
+            self._is_initialized = True
+
+    def _initialize_impl(self) -> None:
+        """Complete initialization once the physics backend is ready.
+
+        Backends whose state is unavailable at construction override this and defer
+        the corresponding work (prim resolution, backend bindings) to it; views whose
+        state is fully available at construction initialize in ``__init__`` and keep
+        the default no-op.
+        """
 
     @property
     @abc.abstractmethod

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -658,6 +658,37 @@ def test_replicate_session_clears_queue_when_asset_init_fails(sim):
     sentinel_cls.assert_not_called()
 
 
+def test_replicate_session_publishes_plan_on_enter(sim):
+    """The clone plan is visible to entities constructed inside the session."""
+    from isaaclab.cloner import ReplicateSession
+
+    with ReplicateSession(
+        cfgs=[],
+        num_clones=2,
+        env_spacing=1.0,
+        device=sim.cfg.device,
+        stage=sim_utils.get_current_stage(),
+    ) as session:
+        assert sim.get_clone_plan() is session.plan
+
+
+def test_replicate_session_unpublishes_plan_when_asset_init_fails(sim):
+    """A failed session does not leave its never-replicated plan published."""
+    from isaaclab.cloner import ReplicateSession
+
+    with pytest.raises(RuntimeError, match="asset boom"):
+        with ReplicateSession(
+            cfgs=[],
+            num_clones=2,
+            env_spacing=1.0,
+            device=sim.cfg.device,
+            stage=sim_utils.get_current_stage(),
+        ):
+            raise RuntimeError("asset boom")
+
+    assert sim.get_clone_plan() is None
+
+
 def test_iter_clone_plan_matches(sim):
     """ClonePlan entries can be matched by destination path expression."""
     plan = ClonePlan(

--- a/source/isaaclab_newton/changelog.d/octi-frameview-deferred-init.major.rst
+++ b/source/isaaclab_newton/changelog.d/octi-frameview-deferred-init.major.rst
@@ -7,6 +7,19 @@ Changed
   Resolving frames against the finalized model is no longer supported: constructing a
   view after the Newton model is built raises ``RuntimeError``. Construct frame views
   before :meth:`~isaaclab.sim.SimulationContext.reset` instead.
+* **Breaking:** Changed :meth:`~isaaclab_newton.physics.NewtonManager.cl_register_site`
+  to reject registrations that arrive after the scene builder exists. Sites are
+  injected into the scene builders and cloned with the scene, so registering one after
+  replication silently skipped cloning and could recycle another sensor's site label.
+  Construct sensors and frame views inside the scene (or, without replication, before
+  the simulation resets) instead.
+* Changed :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView` to register the
+  source body path of each matched clone-plan row and merge the resulting sites per
+  environment, so heterogeneously spawned assets resolve each environment's own
+  variant frame.
+* Removed the site re-registration on ``STOP`` from the Newton IMU, frame transformer,
+  and PVA sensors; the Newton context tears its state down entirely on stop, so the
+  re-registered sites were discarded immediately.
 
 Fixed
 ^^^^^
@@ -14,3 +27,10 @@ Fixed
 * Fixed the Newton multi-mesh ray caster registering glob-style patterns for tracked
   clone-plan targets; site patterns are matched as regexes, so tracked env-scoped
   targets failed site injection when the clone plan is available at construction.
+* Fixed frame views on heterogeneously spawned assets
+  (:class:`~isaaclab.sim.spawners.MultiAssetSpawnerCfg` and
+  :class:`~isaaclab.sim.spawners.MultiUsdFileCfg`) duplicating frames across source
+  variants; each environment now resolves exactly one frame from its own variant.
+* Fixed site registration on bodies outside the cloned environments (e.g. a shared
+  table or fixture) failing during replication; such sites are now injected into the
+  main builder once, like global sites.

--- a/source/isaaclab_newton/changelog.d/octi-frameview-deferred-init.major.rst
+++ b/source/isaaclab_newton/changelog.d/octi-frameview-deferred-init.major.rst
@@ -17,9 +17,6 @@ Changed
   source body path of each matched clone-plan row and merge the resulting sites per
   environment, so heterogeneously spawned assets resolve each environment's own
   variant frame.
-* Removed the site re-registration on ``STOP`` from the Newton IMU, frame transformer,
-  and PVA sensors; the Newton context tears its state down entirely on stop, so the
-  re-registered sites were discarded immediately.
 
 Fixed
 ^^^^^

--- a/source/isaaclab_newton/changelog.d/octi-frameview-deferred-init.major.rst
+++ b/source/isaaclab_newton/changelog.d/octi-frameview-deferred-init.major.rst
@@ -1,0 +1,16 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Changed :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView` to the
+  frame-view two-phase lifecycle, so camera frame views are constructed with the scene
+  and their sites register and clone consistently with the other sensor sites.
+  Resolving frames against the finalized model is no longer supported: constructing a
+  view after the Newton model is built raises ``RuntimeError``. Construct frame views
+  before :meth:`~isaaclab.sim.SimulationContext.reset` instead.
+
+Fixed
+^^^^^
+
+* Fixed the Newton multi-mesh ray caster registering glob-style patterns for tracked
+  clone-plan targets; site patterns are matched as regexes, so tracked env-scoped
+  targets failed site injection when the clone plan is available at construction.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -57,7 +57,7 @@ def replicate_builder_mapping(
     source_builders: dict[str, ModelBuilder],
     *,
     source_site_indices: dict[int, dict[str, list[int]]] | None = None,
-    env_root_sites: dict[str, wp.transform] | None = None,
+    env_root_sites: dict[str, tuple[wp.transform, tuple[int, ...] | None]] | None = None,
     per_world_builder_hooks: Sequence[Callable[[ModelBuilder, int, list[float], list[float]], None]] = (),
     post_replicate_hooks: Sequence[Callable[[ModelBuilder], None]] = (),
 ) -> tuple[dict[str, list[list[int]]], list[wp.transform]]:
@@ -74,9 +74,12 @@ def replicate_builder_mapping(
         world_xform = wp.transform(positions[col], quaternions[col])
         world_xforms.append(world_xform)
 
-        for label, xform in env_root_sites.items():
+        for label, (xform, worlds) in env_root_sites.items():
+            local_indices = local_site_map.setdefault(label, [[] for _ in range(num_worlds)])
+            if worlds is not None and col not in worlds:
+                continue
             site_idx = builder.add_site(body=-1, xform=wp.transform_multiply(world_xform, xform), label=label)
-            local_site_map.setdefault(label, [[] for _ in range(num_worlds)])[col].append(site_idx)
+            local_indices[col].append(site_idx)
 
         for row in torch.nonzero(mapping[:, col], as_tuple=True)[0].tolist():
             source_builder = source_builders[sources[int(row)]]

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -918,31 +918,43 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def cl_register_site(cls, body_pattern: str | None, xform: wp.transform, *, per_world: bool = False) -> str:
-        """Register a site request for injection into prototypes before replication.
+        """Register a site request for injection into the scene builders.
 
-        Sensors call this during ``__init__``. Sites are injected into prototype
+        Sensors call this during ``__init__``. Sites are injected into source
         builders by :meth:`_cl_inject_sites` (called from ``newton_replicate``)
-        before ``add_builder``, so they replicate correctly per-world.
+        before ``add_builder``, so they replicate correctly per-world; on stages
+        without replication they are injected into the flat builder when the
+        simulation starts. Sites are part of the scene build, so registering
+        one after the scene builder exists raises.
 
         Identical ``(body_pattern, per_world, transform)`` registrations share sites.
 
-        The *body_pattern* is matched against prototype-local body labels
-        (e.g. ``"Robot/link.*"``) when replication is active, or against the
-        flat builder's body labels in the fallback path. Wildcard patterns
-        that match multiple bodies create one site per matched body.
+        The *body_pattern* is matched against source-builder body labels
+        (source USD paths) when replication is active, or against the flat
+        builder's body labels otherwise. Wildcard patterns that match multiple
+        bodies create one site per matched body.
 
         Args:
             body_pattern: Regex pattern matched against body labels in the
-                prototype builder (e.g. ``"Robot/link0"`` or ``"Robot/finger.*"``
-                for multi-body wildcards), or ``None`` for global sites
-                (world-origin reference, etc.).
+                source builders, or ``None`` for global sites (world-origin
+                reference, etc.).
             xform: Site transform relative to body.
             per_world: When ``True``, ``body_pattern`` must be ``None`` and one
                 bodyless site is created in each cloned world's frame.
 
         Returns:
             Assigned site label suffix.
+
+        Raises:
+            RuntimeError: If the scene builder has already been built.
         """
+        if cls._builder is not None or cls._model is not None:
+            raise RuntimeError(
+                f"Site registration for pattern '{body_pattern}' arrived after the scene was built:"
+                " sites are injected into the scene builders and cloned with the scene, so sensors"
+                " and frame views must be constructed before the scene replicates (or, without"
+                " replication, before the simulation resets)."
+            )
         if per_world and body_pattern is not None:
             raise ValueError("per_world site registration requires body_pattern=None.")
         xform_key = tuple(xform)
@@ -987,10 +999,12 @@ class NewtonManager(PhysicsManager):
     ) -> tuple[dict[str, int], dict[int, dict[str, list[int]]], dict[str, wp.transform]]:
         """Inject registered sites into source builders before replication.
 
-        Non-global sites are matched against source builder body labels using
+        Non-global sites are matched against source builder body labels and
+        the main builder's (non-cloned) body labels using
         :func:`resolve_matching_names` (regex). Global sites
         (``body_pattern is None``) are added to *main_builder* with
-        ``body=-1``.
+        ``body=-1``; sites on non-cloned main-builder bodies are added to
+        *main_builder* once, like global sites.
 
         Returns source-builder-local shape indices so that ``newton_replicate`` can
         compute final indices during replication without a second pattern match.
@@ -1040,19 +1054,37 @@ class NewtonManager(PhysicsManager):
                     logger.debug(f"Injected site '{site_label}' into source builder")
                 source_site_indices.setdefault(source_builder_id, {})[label] = site_indices
 
+            main_indices, main_names = resolve_matching_names(
+                body_pattern, list(main_builder.body_label), raise_when_no_match=False
+            )
+            if len(main_indices) > 1:
+                raise ValueError(
+                    f"Site '{label}' with body_pattern '{body_pattern}' matched multiple non-cloned"
+                    f" bodies {main_names}; non-cloned body sites must resolve to a single body."
+                )
+            if main_indices:
+                any_matched = True
+                global_site_indices[label] = main_builder.add_site(
+                    body=main_indices[0], xform=xform, label=f"{main_names[0]}/{label}"
+                )
+
             if not any_matched:
                 raise ValueError(
-                    f"Site '{label}' with body_pattern '{body_pattern}' matched no source-builder bodies "
-                    f"across {len(source_builders)} source builder(s). "
-                    f"Check that the pattern matches a body label in a source builder."
+                    f"Site '{label}' with body_pattern '{body_pattern}' matched no bodies across "
+                    f"{len(source_builders)} source builder(s) or the main builder. "
+                    f"Check that the pattern matches a body label."
                 )
 
         cls._cl_pending_sites.clear()
         return global_site_indices, source_site_indices, env_root_sites
 
     @classmethod
-    def _cl_inject_sites_fallback(cls) -> None:
-        """Inject pending sites into the flat builder (no-replication path).
+    def _cl_inject_sites_flat(cls) -> None:
+        """Inject pending sites into the flat builder (non-replicated stage).
+
+        Replicated stages drain the pending sites during replication and reject
+        later registrations, so only never-replicated stages reach this with
+        pending sites.
 
         Populates :attr:`_cl_site_index_map` with the unified per-world structure:
 
@@ -1161,9 +1193,9 @@ class NewtonManager(PhysicsManager):
         logger.info("Dispatching MODEL_INIT callbacks")
         cls.dispatch_event(PhysicsEvent.MODEL_INIT)
 
-        # Inject any pending site requests (no-replication fallback path).
-        # In the replication path, _cl_inject_sites() already ran from newton_replicate.
-        cls._cl_inject_sites_fallback()
+        # Inject pending site requests on never-replicated stages. In the
+        # replication path, _cl_inject_sites() already drained them.
+        cls._cl_inject_sites_flat()
 
         device = PhysicsManager._device
         logger.info(f"Finalizing model on device: {device}")

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -917,7 +917,14 @@ class NewtonManager(PhysicsManager):
         """
 
     @classmethod
-    def cl_register_site(cls, body_pattern: str | None, xform: wp.transform, *, per_world: bool = False) -> str:
+    def cl_register_site(
+        cls,
+        body_pattern: str | None,
+        xform: wp.transform,
+        *,
+        per_world: bool = False,
+        worlds: tuple[int, ...] | None = None,
+    ) -> str:
         """Register a site request for injection into the scene builders.
 
         Sensors call this during ``__init__``. Sites are injected into source
@@ -941,6 +948,9 @@ class NewtonManager(PhysicsManager):
             xform: Site transform relative to body.
             per_world: When ``True``, ``body_pattern`` must be ``None`` and one
                 bodyless site is created in each cloned world's frame.
+            worlds: Optional world indices that receive the per-world site.
+                ``None`` targets every cloned world. Only valid with
+                ``per_world=True``.
 
         Returns:
             Assigned site label suffix.
@@ -957,8 +967,10 @@ class NewtonManager(PhysicsManager):
             )
         if per_world and body_pattern is not None:
             raise ValueError("per_world site registration requires body_pattern=None.")
+        if worlds is not None and not per_world:
+            raise ValueError("worlds is only valid for per_world site registration.")
         xform_key = tuple(xform)
-        key = (body_pattern, per_world, xform_key)
+        key = (body_pattern, per_world, worlds, xform_key)
         if key in cls._cl_pending_sites:
             return cls._cl_pending_sites[key][0]
         label = f"ft_{len(cls._cl_pending_sites)}"
@@ -1019,16 +1031,16 @@ class NewtonManager(PhysicsManager):
             Tuple of ``(global_site_indices, source_site_indices, env_root_sites)`` where
             *global_site_indices* maps ``{label: main_builder_shape_idx}``,
             *source_site_indices* maps ``{id(source_builder): {label: [source_local_shape_idx, ...]}}``,
-            and *env_root_sites* maps ``{label: env_root_relative_transform}``.
+            and *env_root_sites* maps ``{label: (env_root_relative_transform, worlds)}``.
         """
         global_site_indices: dict[str, int] = {}
         source_site_indices: dict[int, dict[str, list[int]]] = {}
 
-        env_root_sites: dict[str, wp.transform] = {}
+        env_root_sites: dict[str, tuple[wp.transform, tuple[int, ...] | None]] = {}
 
-        for (body_pattern, per_world, _xform_key), (label, xform) in cls._cl_pending_sites.items():
+        for (body_pattern, per_world, worlds, _xform_key), (label, xform) in cls._cl_pending_sites.items():
             if per_world:
-                env_root_sites[label] = xform
+                env_root_sites[label] = (xform, worlds)
                 continue
             if body_pattern is None:
                 site_idx = main_builder.add_site(body=-1, xform=xform, label=label)
@@ -1054,19 +1066,23 @@ class NewtonManager(PhysicsManager):
                     logger.debug(f"Injected site '{site_label}' into source builder")
                 source_site_indices.setdefault(source_builder_id, {})[label] = site_indices
 
-            main_indices, main_names = resolve_matching_names(
-                body_pattern, list(main_builder.body_label), raise_when_no_match=False
-            )
-            if len(main_indices) > 1:
-                raise ValueError(
-                    f"Site '{label}' with body_pattern '{body_pattern}' matched multiple non-cloned"
-                    f" bodies {main_names}; non-cloned body sites must resolve to a single body."
+            if not any_matched:
+                # Patterns resolve in source space; only a pattern that matches no
+                # source builder may target a non-cloned main-builder body. The site
+                # map entry is single-index, so the match must be unambiguous.
+                main_indices, main_names = resolve_matching_names(
+                    body_pattern, list(main_builder.body_label), raise_when_no_match=False
                 )
-            if main_indices:
-                any_matched = True
-                global_site_indices[label] = main_builder.add_site(
-                    body=main_indices[0], xform=xform, label=f"{main_names[0]}/{label}"
-                )
+                if len(main_indices) > 1:
+                    raise ValueError(
+                        f"Site '{label}' with body_pattern '{body_pattern}' matched multiple non-cloned"
+                        f" bodies {main_names}; non-cloned body sites must resolve to a single body."
+                    )
+                if main_indices:
+                    any_matched = True
+                    global_site_indices[label] = main_builder.add_site(
+                        body=main_indices[0], xform=xform, label=f"{main_names[0]}/{label}"
+                    )
 
             if not any_matched:
                 raise ValueError(
@@ -1094,7 +1110,7 @@ class NewtonManager(PhysicsManager):
         builder = cls._builder
         body_labels = list(builder.body_label)
 
-        for (body_pattern, per_world, _xform_key), (label, xform) in cls._cl_pending_sites.items():
+        for (body_pattern, per_world, _worlds, _xform_key), (label, xform) in cls._cl_pending_sites.items():
             if per_world:
                 site_idx = builder.add_site(body=-1, xform=xform, label=label)
                 cls._cl_site_index_map[label] = (None, [[site_idx]])

--- a/source/isaaclab_newton/isaaclab_newton/sensors/frame_transformer/frame_transformer.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/frame_transformer/frame_transformer.py
@@ -331,24 +331,12 @@ class FrameTransformer(BaseFrameTransformer):
     """
 
     def _invalidate_initialize_callback(self, event):
-        """Clears references to the native sensor and re-registers sites.
+        """Clears references to the native sensor.
 
-        Re-registering here ensures sites survive a non-teardown stop/reinit cycle.
-        During ``NewtonManager.close()``, Newton state is cleared after ``STOP`` so
-        stale registrations from old sensors cannot leak into the next context.
+        Sites are registered once at construction and cloned with the scene;
+        a stopped context tears the Newton state down entirely, so there is
+        nothing to re-register here.
         """
         super()._invalidate_initialize_callback(event)
         self._newton_transforms = None
         self._sensor_index = None
-
-        # Re-register sites so a subsequent start_simulation picks them up.
-        self._world_origin_label = NewtonManager.cl_register_site(None, wp.transform())
-
-        source_offset = wp.transform(self.cfg.source_frame_offset.pos, self.cfg.source_frame_offset.rot)
-        self._source_label = NewtonManager.cl_register_site(self.cfg.prim_path, source_offset)
-
-        self._target_labels = []
-        for target_frame in self.cfg.target_frames:
-            target_offset = wp.transform(target_frame.offset.pos, target_frame.offset.rot)
-            label = NewtonManager.cl_register_site(target_frame.prim_path, target_offset)
-            self._target_labels.append(label)

--- a/source/isaaclab_newton/isaaclab_newton/sensors/imu/imu.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/imu/imu.py
@@ -169,12 +169,11 @@ class Imu(BaseImu):
         )
 
     def _invalidate_initialize_callback(self, event):
-        """Clears references to the native Newton sensor and re-registers site/attributes.
+        """Clears references to the native Newton sensor.
 
-        Re-registering here ensures the site and ``body_qdd`` attribute survive a
-        non-teardown stop/reinit cycle. During ``NewtonManager.close()``, Newton
-        state is cleared after ``STOP`` so stale registrations from old sensors
-        cannot leak into the next context.
+        Sites are registered once at construction and cloned with the scene;
+        a stopped context tears the Newton state down entirely, so there is
+        nothing to re-register here.
         """
         super()._invalidate_initialize_callback(event)
         self._newton_sensor = None
@@ -185,8 +184,3 @@ class Imu(BaseImu):
             self._data._ang_vel_b.zero_()
         if self._data._lin_acc_b is not None:
             self._data._lin_acc_b.zero_()
-
-        # Re-register so a subsequent start_simulation picks them up.
-        offset_xform = wp.transform(self.cfg.offset.pos, self.cfg.offset.rot)
-        self._site_label = NewtonManager.cl_register_site(self.cfg.prim_path, offset_xform)
-        NewtonManager.request_extended_state_attribute("body_qdd")

--- a/source/isaaclab_newton/isaaclab_newton/sensors/pva/pva.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/pva/pva.py
@@ -239,7 +239,12 @@ class Pva(BasePva):
         )
 
     def _invalidate_initialize_callback(self, event):
-        """Clears references for re-initialization and re-registers with NewtonManager."""
+        """Clears references for re-initialization.
+
+        Sites are registered once at construction and cloned with the scene;
+        a stopped context tears the Newton state down entirely, so there is
+        nothing to re-register here.
+        """
         super()._invalidate_initialize_callback(event)
         self._newton_model = None
         self._site_indices = None
@@ -257,8 +262,3 @@ class Pva(BasePva):
         ]:
             if buf is not None:
                 buf.zero_()
-
-        # Re-register so a subsequent start_simulation picks them up.
-        offset_xform = wp.transform(self.cfg.offset.pos, self.cfg.offset.rot)
-        self._site_label = NewtonManager.cl_register_site(self.cfg.prim_path, offset_xform)
-        NewtonManager.request_extended_state_attribute("body_qdd")

--- a/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/ray_caster.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/ray_caster.py
@@ -131,6 +131,8 @@ class _NewtonRayCasterMixin:
             source_path, dest_glob, asset_suffix = resolved
             # ``resolve_clone_plan_source`` returns a glob-style destination root;
             # Newton site patterns are regexes, so restore the ``.*`` env wildcard.
+            # The same expressions are recomputed by ``BaseMultiMeshRayCaster``
+            # when it initializes tracked targets, so both derivations must match.
             dest_expr = dest_glob.replace("*", ".*")
             walk_root = source_path + asset_suffix
             source_prims = sim_utils.find_matching_prims(walk_root)

--- a/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/ray_caster.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/ray_caster.py
@@ -129,6 +129,9 @@ class _NewtonRayCasterMixin:
         resolved = resolve_clone_plan_source(prim_expr, plan) if plan is not None else None
         if resolved is not None:
             source_path, dest_glob, asset_suffix = resolved
+            # ``resolve_clone_plan_source`` returns a glob-style destination root;
+            # Newton site patterns are regexes, so restore the ``.*`` env wildcard.
+            dest_expr = dest_glob.replace("*", ".*")
             walk_root = source_path + asset_suffix
             source_prims = sim_utils.find_matching_prims(walk_root)
             if not source_prims:
@@ -143,7 +146,7 @@ class _NewtonRayCasterMixin:
                         " to dynamic targets."
                     )
                 owner_prim_path = str(body.GetPath())
-                owner_exprs.append(dest_glob + owner_prim_path[len(source_path) :])
+                owner_exprs.append(dest_expr + owner_prim_path[len(source_path) :])
             return list(dict.fromkeys(owner_exprs))
 
         # Legacy fallback: no clone plan, or the target is not owned by any plan row.

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -3,11 +3,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Newton-backed FrameView using Newton body labels and injected sites."""
+"""Newton-backed FrameView using injected Newton sites."""
 
 from __future__ import annotations
-
-import logging
 
 import warp as wp
 
@@ -18,24 +16,11 @@ from isaaclab.cloner.cloner_utils import get_suffix, iter_clone_plan_matches, sp
 from isaaclab.physics import PhysicsEvent
 from isaaclab.sim.views.base_frame_view import BaseFrameView
 from isaaclab.sim.views.xform_space_writer import FrameViewLocalSpaceWriter, FrameViewWorldSpaceWriter
-from isaaclab.utils.string import resolve_matching_names
 from isaaclab.utils.warp import ProxyArray
 
 from isaaclab_newton.physics.newton_manager import NewtonManager
 
-logger = logging.getLogger(__name__)
-
 WORLD_BODY_INDEX = -1
-
-# Regex metacharacters that mark a body pattern as a genuine expression rather than a literal
-# USD path. Patterns free of these can be resolved via an exact dict lookup instead of scanning
-# every body label with a compiled regex.
-_REGEX_TOKENS = frozenset(".*[]()+?|\\^$")
-
-
-def _has_regex_tokens(pattern: str) -> bool:
-    """Return whether ``pattern`` contains regex metacharacters (i.e. is not a literal path)."""
-    return any(token in _REGEX_TOKENS for token in pattern)
 
 
 @wp.kernel
@@ -179,9 +164,11 @@ def _scatter_xform_scales(
 class NewtonSiteFrameView(BaseFrameView):
     """Batched Newton site view for non-physics frames.
 
-    The public construction contract matches the generic :class:`FrameView`:
-    callers provide a prim expression and the backend resolves the source prim
-    into Newton body-local or world-local sites.
+    Callers provide a prim expression and the backend resolves the source prim
+    into Newton body-local or world-local sites. The sites are registered at
+    construction and cloned with the scene, so the view must be constructed
+    before the Newton model is built; it completes its initialization once the
+    model is ready.
     """
 
     def __init__(
@@ -200,6 +187,9 @@ class NewtonSiteFrameView(BaseFrameView):
             validate_xform_ops: Whether to validate source USD xform ops.
             stage: USD stage that contains the source prims.
             **kwargs: Unused.
+
+        Raises:
+            RuntimeError: If the Newton model has already been built.
         """
         del kwargs
 
@@ -209,6 +199,12 @@ class NewtonSiteFrameView(BaseFrameView):
         self._prims = []
 
         stage = sim_utils.get_current_stage() if stage is None else stage
+        if NewtonManager.get_model() is not None:
+            raise RuntimeError(
+                f"NewtonSiteFrameView '{self._prim_path}' constructed after the Newton model was built:"
+                " frame sites are registered at construction and cloned with the scene, so frame views"
+                " must be constructed before the simulation resets."
+            )
         self._site_specs = self._resolve_site_specs(stage, validate_xform_ops)
         self._site_labels: list[str] = []
         self._site_label_scales: list[tuple[float, float, float]] = []
@@ -228,49 +224,29 @@ class NewtonSiteFrameView(BaseFrameView):
         self._scale_ta: ProxyArray | None = None
         self._count = 0
 
-        model = NewtonManager.get_model()
-        if model is not None:
-            self._initialize_from_specs(model)
-        else:
-            for body_patterns, xform, scale, per_world, _env_ids in self._site_specs:
-                if body_patterns is None:
-                    self._site_labels.append(NewtonManager.cl_register_site(None, xform, per_world=per_world))
+        for body_patterns, xform, scale, per_world in self._site_specs:
+            if body_patterns is None:
+                self._site_labels.append(NewtonManager.cl_register_site(None, xform, per_world=per_world))
+                self._site_label_scales.append(scale)
+            else:
+                for body_pattern in body_patterns:
+                    self._site_labels.append(NewtonManager.cl_register_site(body_pattern, xform))
                     self._site_label_scales.append(scale)
-                else:
-                    for body_pattern in body_patterns:
-                        self._site_labels.append(NewtonManager.cl_register_site(body_pattern, xform))
-                        self._site_label_scales.append(scale)
-            self._physics_ready_handle = NewtonManager.register_callback(
-                self._on_physics_ready, PhysicsEvent.PHYSICS_READY, name=f"site_view_{self._prim_path}"
-            )
+        NewtonManager.register_callback(
+            self._initialize_callback, PhysicsEvent.PHYSICS_READY, name=f"site_view_{self._prim_path}"
+        )
 
     def _resolve_site_specs(
         self, stage, validate_xform_ops: bool
-    ) -> list[tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool, tuple[int, ...] | None]]:
+    ) -> list[tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool]]:
         """Resolve source prims into Newton site registration specs."""
         plan = sim_utils.SimulationContext.instance().get_clone_plan()
-        model = NewtonManager.get_model()
-        body_labels = list(model.body_label) if model is not None else ()
-        shape_labels = list(model.shape_label) if model is not None else ()
-        use_clone_body_pattern = model is None
-        specs: list[
-            tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool, tuple[int, ...] | None]
-        ] = []
+        specs: list[tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool]] = []
 
         for path_expr in self._prim_paths:
-            if resolve_matching_names(path_expr, body_labels, raise_when_no_match=False)[1]:
-                raise ValueError(
-                    f"FrameView prim '{path_expr}' is a Newton physics body. "
-                    "FrameView should only be used for non-physics frames."
-                )
-            if resolve_matching_names(path_expr, shape_labels, raise_when_no_match=False)[1]:
-                raise ValueError(
-                    f"FrameView prim '{path_expr}' is a Newton collision shape. "
-                    "FrameView should only be used for non-physics frames."
-                )
             matches = tuple(iter_clone_plan_matches(plan, path_expr)) if plan is not None else ()
             if matches:
-                for source_root, destination_template, source_path, env_ids in matches:
+                for source_root, destination_template, source_path, _env_ids in matches:
                     source_prim = None
                     if not any(token in source_path for token in "*[]()+?|\\"):
                         source_prim = stage.GetPrimAtPath(source_path)
@@ -280,13 +256,7 @@ class NewtonSiteFrameView(BaseFrameView):
                         raise RuntimeError(f"FrameView '{path_expr}' could not resolve source prim '{source_path}'.")
                     specs.append(
                         self._resolve_source_prim(
-                            source_prim,
-                            validate_xform_ops,
-                            source_root,
-                            destination_template,
-                            env_ids,
-                            use_clone_body_pattern,
-                            stage,
+                            source_prim, validate_xform_ops, source_root, destination_template, stage
                         )
                     )
                 continue
@@ -294,9 +264,7 @@ class NewtonSiteFrameView(BaseFrameView):
             prim = sim_utils.find_first_matching_prim(path_expr, stage)
             if prim is None or not prim.IsValid():
                 raise RuntimeError(f"FrameView '{path_expr}' could not resolve a source prim.")
-            specs.append(
-                self._resolve_source_prim(prim, validate_xform_ops, None, None, None, use_clone_body_pattern, stage)
-            )
+            specs.append(self._resolve_source_prim(prim, validate_xform_ops, None, None, stage))
 
         return specs
 
@@ -306,10 +274,8 @@ class NewtonSiteFrameView(BaseFrameView):
         validate_xform_ops: bool,
         source_root: str | None,
         destination_template: str | None,
-        env_ids: tuple[int, ...] | None,
-        use_clone_body_pattern: bool,
         stage,
-    ) -> tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool, tuple[int, ...] | None]:
+    ) -> tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool]:
         """Resolve one source prim into body patterns, local frame, and xform scale."""
         prim_path = prim.GetPath().pathString
         if prim.HasAPI(UsdPhysics.RigidBodyAPI) or prim.HasAPI(UsdPhysics.ArticulationRootAPI):
@@ -335,38 +301,24 @@ class NewtonSiteFrameView(BaseFrameView):
                 pos, quat = sim_utils.resolve_prim_pose(prim, body_prim)
                 body_path = body_prim.GetPath().pathString
                 if source_root is not None and destination_template is not None:
-                    assert env_ids is not None
                     if body_path == source_root:
                         suffix = ""
                     elif body_path.startswith(source_root + "/"):
                         suffix = body_path[len(source_root) :]
                     elif source_root.startswith(body_path + "/"):
                         suffix = source_root[len(body_path) :]
-                        if use_clone_body_pattern:
-                            destination_root = destination_template.format(".*")
-                            if not destination_root.endswith(suffix):
-                                raise RuntimeError(
-                                    f"FrameView destination root '{destination_root}' does not end with '{suffix}'."
-                                )
-                            return (destination_root[: -len(suffix)],), wp.transform(pos, quat), scale, False, env_ids
-                        body_patterns = []
-                        for env_id in env_ids:
-                            destination_root = destination_template.format(env_id)
-                            if not destination_root.endswith(suffix):
-                                raise RuntimeError(
-                                    f"FrameView destination root '{destination_root}' does not end with '{suffix}'."
-                                )
-                            body_patterns.append(destination_root[: -len(suffix)])
-                        return tuple(body_patterns), wp.transform(pos, quat), scale, False, env_ids
+                        destination_root = destination_template.format(".*")
+                        if not destination_root.endswith(suffix):
+                            raise RuntimeError(
+                                f"FrameView destination root '{destination_root}' does not end with '{suffix}'."
+                            )
+                        return (destination_root[: -len(suffix)],), wp.transform(pos, quat), scale, False
                     else:
                         raise RuntimeError(f"FrameView source body '{body_path}' is not under '{source_root}'.")
-                    if use_clone_body_pattern:
-                        body_patterns = (destination_template.format(".*") + suffix,)
-                    else:
-                        body_patterns = tuple(destination_template.format(env_id) + suffix for env_id in env_ids)
+                    body_patterns = (destination_template.format(".*") + suffix,)
                 else:
                     body_patterns = (body_path,)
-                return body_patterns, wp.transform(pos, quat), scale, False, env_ids
+                return body_patterns, wp.transform(pos, quat), scale, False
             body_prim = body_prim.GetParent()
 
         ref_path = source_root
@@ -377,10 +329,10 @@ class NewtonSiteFrameView(BaseFrameView):
                 ref_path = source_root[: -len(source_suffix)] if source_suffix else source_root
         ref_prim = stage.GetPrimAtPath(ref_path) if ref_path is not None else None
         pos, quat = sim_utils.resolve_prim_pose(prim, ref_prim if ref_prim and ref_prim.IsValid() else None)
-        return None, wp.transform(pos, quat), scale, source_root is not None, env_ids
+        return None, wp.transform(pos, quat), scale, source_root is not None
 
-    def _on_physics_ready(self, _event) -> None:
-        """Callback invoked when the Newton model becomes available."""
+    def _initialize_impl(self) -> None:
+        """Resolve the injected sites once the Newton model is built."""
         self._initialize_from_site_map(NewtonManager.get_model())
 
     def _initialize_from_site_map(self, model) -> None:
@@ -401,54 +353,6 @@ class NewtonSiteFrameView(BaseFrameView):
                 site_bodies.append(int(body_t[site_idx].item()))
                 site_locals.append([float(v) for v in xform_t[site_idx].tolist()])
                 site_scales.append(scale)
-
-        self._create_buffers(site_bodies, site_locals, site_scales)
-
-    def _initialize_from_specs(self, model) -> None:
-        """Initialize arrays directly from resolved specs and Newton body labels."""
-        body_labels = list(model.body_label)
-        # Exact label -> index map, built once. Replicated frames expand to one concrete
-        # body path per environment, so matching each against every label via regex is
-        # ``O(num_envs * num_bodies)`` (quadratic in ``num_envs``). Fast-pathing literal
-        # paths through this map keeps the common per-environment case linear; genuine
-        # regex patterns (e.g. the cloned ``.*`` pattern) still fall back to a full scan.
-        label_to_index = {label: idx for idx, label in enumerate(body_labels)}
-        site_bodies: list[int] = []
-        site_locals: list[list[float]] = []
-        site_scales: list[tuple[float, float, float]] = []
-
-        for body_patterns, xform, scale, per_world, env_ids in self._site_specs:
-            if body_patterns is None:
-                if per_world:
-                    if NewtonManager._world_xforms is None:
-                        raise RuntimeError(f"FrameView '{self._prim_path}' needs Newton cloned-world transforms.")
-                    world_ids = range(len(NewtonManager._world_xforms)) if env_ids is None else env_ids
-                    for world_id in world_ids:
-                        world_xform = NewtonManager._world_xforms[world_id]
-                        site_bodies.append(WORLD_BODY_INDEX)
-                        site_locals.append([float(v) for v in wp.transform_multiply(world_xform, xform)])
-                        site_scales.append(scale)
-                else:
-                    site_bodies.append(WORLD_BODY_INDEX)
-                    site_locals.append([float(v) for v in xform])
-                    site_scales.append(scale)
-                continue
-
-            for body_pattern in body_patterns:
-                exact_index = label_to_index.get(body_pattern) if not _has_regex_tokens(body_pattern) else None
-                if exact_index is not None:
-                    matched_indices = [exact_index]
-                else:
-                    matched_indices, _ = resolve_matching_names(body_pattern, body_labels, raise_when_no_match=False)
-                if not matched_indices:
-                    raise ValueError(
-                        f"FrameView '{self._prim_path}' body pattern '{body_pattern}' matched no Newton bodies."
-                    )
-
-                for body_idx in matched_indices:
-                    site_bodies.append(body_idx)
-                    site_locals.append([float(v) for v in xform])
-                    site_scales.append(scale)
 
         self._create_buffers(site_bodies, site_locals, site_scales)
 

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -221,8 +221,8 @@ class NewtonSiteFrameView(BaseFrameView):
 
         for specs in spec_groups:
             group: list[tuple[str, tuple[float, float, float]]] = []
-            for body_path, xform, scale, per_world in specs:
-                label = NewtonManager.cl_register_site(body_path, xform, per_world=per_world)
+            for body_path, xform, scale, per_world, worlds in specs:
+                label = NewtonManager.cl_register_site(body_path, xform, per_world=per_world, worlds=worlds)
                 if not any(existing == label for existing, _ in group):
                     group.append((label, scale))
             self._site_groups.append(group)
@@ -232,7 +232,7 @@ class NewtonSiteFrameView(BaseFrameView):
 
     def _resolve_site_specs(
         self, stage, validate_xform_ops: bool
-    ) -> list[list[tuple[str | None, wp.transform, tuple[float, float, float], bool]]]:
+    ) -> list[list[tuple[str | None, wp.transform, tuple[float, float, float], bool, tuple[int, ...] | None]]]:
         """Resolve source prims into Newton site registration specs, one group per path expression.
 
         A clone plan can match one path expression with several rows (one per
@@ -240,13 +240,15 @@ class NewtonSiteFrameView(BaseFrameView):
         one spec per matched row.
         """
         plan = sim_utils.SimulationContext.instance().get_clone_plan()
-        spec_groups: list[list[tuple[str | None, wp.transform, tuple[float, float, float], bool]]] = []
+        spec_groups: list[
+            list[tuple[str | None, wp.transform, tuple[float, float, float], bool, tuple[int, ...] | None]]
+        ] = []
 
         for path_expr in self._prim_paths:
             matches = tuple(iter_clone_plan_matches(plan, path_expr)) if plan is not None else ()
             if matches:
                 group = []
-                for source_root, destination_template, source_path, _env_ids in matches:
+                for source_root, destination_template, source_path, env_ids in matches:
                     source_prim = None
                     if not any(token in source_path for token in "*[]()+?|\\"):
                         source_prim = stage.GetPrimAtPath(source_path)
@@ -256,7 +258,7 @@ class NewtonSiteFrameView(BaseFrameView):
                         raise RuntimeError(f"FrameView '{path_expr}' could not resolve source prim '{source_path}'.")
                     group.append(
                         self._resolve_source_prim(
-                            source_prim, validate_xform_ops, source_root, destination_template, stage
+                            source_prim, validate_xform_ops, source_root, destination_template, env_ids, stage
                         )
                     )
                 spec_groups.append(group)
@@ -265,7 +267,7 @@ class NewtonSiteFrameView(BaseFrameView):
             prim = sim_utils.find_first_matching_prim(path_expr, stage)
             if prim is None or not prim.IsValid():
                 raise RuntimeError(f"FrameView '{path_expr}' could not resolve a source prim.")
-            spec_groups.append([self._resolve_source_prim(prim, validate_xform_ops, None, None, stage)])
+            spec_groups.append([self._resolve_source_prim(prim, validate_xform_ops, None, None, None, stage)])
 
         return spec_groups
 
@@ -275,8 +277,9 @@ class NewtonSiteFrameView(BaseFrameView):
         validate_xform_ops: bool,
         source_root: str | None,
         destination_template: str | None,
+        env_ids: tuple[int, ...] | None,
         stage,
-    ) -> tuple[str | None, wp.transform, tuple[float, float, float], bool]:
+    ) -> tuple[str | None, wp.transform, tuple[float, float, float], bool, tuple[int, ...] | None]:
         """Resolve one source prim into its body path, local frame, and xform scale."""
         prim_path = prim.GetPath().pathString
         if prim.HasAPI(UsdPhysics.RigidBodyAPI) or prim.HasAPI(UsdPhysics.ArticulationRootAPI):
@@ -307,7 +310,7 @@ class NewtonSiteFrameView(BaseFrameView):
                     or source_root.startswith(body_path + "/")
                 ):
                     raise RuntimeError(f"FrameView source body '{body_path}' is not under '{source_root}'.")
-                return body_path, wp.transform(pos, quat), scale, False
+                return body_path, wp.transform(pos, quat), scale, False, None
             body_prim = body_prim.GetParent()
 
         ref_path = source_root
@@ -318,7 +321,8 @@ class NewtonSiteFrameView(BaseFrameView):
                 ref_path = source_root[: -len(source_suffix)] if source_suffix else source_root
         ref_prim = stage.GetPrimAtPath(ref_path) if ref_path is not None else None
         pos, quat = sim_utils.resolve_prim_pose(prim, ref_prim if ref_prim and ref_prim.IsValid() else None)
-        return None, wp.transform(pos, quat), scale, source_root is not None
+        per_world = source_root is not None
+        return None, wp.transform(pos, quat), scale, per_world, env_ids if per_world else None
 
     def _initialize_impl(self) -> None:
         """Resolve the injected sites once the Newton model is built."""

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -167,8 +167,9 @@ class NewtonSiteFrameView(BaseFrameView):
     Callers provide a prim expression and the backend resolves the source prim
     into Newton body-local or world-local sites. The sites are registered at
     construction and cloned with the scene, so the view must be constructed
-    before the Newton model is built; it completes its initialization once the
-    model is ready.
+    before the scene replicates (or, without replication, before the
+    simulation resets); it completes its initialization once the model is
+    ready.
     """
 
     def __init__(
@@ -189,7 +190,8 @@ class NewtonSiteFrameView(BaseFrameView):
             **kwargs: Unused.
 
         Raises:
-            RuntimeError: If the Newton model has already been built.
+            RuntimeError: If the scene has already been built; site
+                registration rejects late arrivals.
         """
         del kwargs
 
@@ -199,15 +201,8 @@ class NewtonSiteFrameView(BaseFrameView):
         self._prims = []
 
         stage = sim_utils.get_current_stage() if stage is None else stage
-        if NewtonManager.get_model() is not None:
-            raise RuntimeError(
-                f"NewtonSiteFrameView '{self._prim_path}' constructed after the Newton model was built:"
-                " frame sites are registered at construction and cloned with the scene, so frame views"
-                " must be constructed before the simulation resets."
-            )
-        self._site_specs = self._resolve_site_specs(stage, validate_xform_ops)
-        self._site_labels: list[str] = []
-        self._site_label_scales: list[tuple[float, float, float]] = []
+        spec_groups = self._resolve_site_specs(stage, validate_xform_ops)
+        self._site_groups: list[list[tuple[str, tuple[float, float, float]]]] = []
         self._site_body: wp.array | None = None
         self._site_local: wp.array | None = None
         self._site_xform_scale: wp.array | None = None
@@ -224,28 +219,33 @@ class NewtonSiteFrameView(BaseFrameView):
         self._scale_ta: ProxyArray | None = None
         self._count = 0
 
-        for body_patterns, xform, scale, per_world in self._site_specs:
-            if body_patterns is None:
-                self._site_labels.append(NewtonManager.cl_register_site(None, xform, per_world=per_world))
-                self._site_label_scales.append(scale)
-            else:
-                for body_pattern in body_patterns:
-                    self._site_labels.append(NewtonManager.cl_register_site(body_pattern, xform))
-                    self._site_label_scales.append(scale)
+        for specs in spec_groups:
+            group: list[tuple[str, tuple[float, float, float]]] = []
+            for body_path, xform, scale, per_world in specs:
+                label = NewtonManager.cl_register_site(body_path, xform, per_world=per_world)
+                if not any(existing == label for existing, _ in group):
+                    group.append((label, scale))
+            self._site_groups.append(group)
         NewtonManager.register_callback(
             self._initialize_callback, PhysicsEvent.PHYSICS_READY, name=f"site_view_{self._prim_path}"
         )
 
     def _resolve_site_specs(
         self, stage, validate_xform_ops: bool
-    ) -> list[tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool]]:
-        """Resolve source prims into Newton site registration specs."""
+    ) -> list[list[tuple[str | None, wp.transform, tuple[float, float, float], bool]]]:
+        """Resolve source prims into Newton site registration specs, one group per path expression.
+
+        A clone plan can match one path expression with several rows (one per
+        source variant of a heterogeneously spawned asset), so each group holds
+        one spec per matched row.
+        """
         plan = sim_utils.SimulationContext.instance().get_clone_plan()
-        specs: list[tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool]] = []
+        spec_groups: list[list[tuple[str | None, wp.transform, tuple[float, float, float], bool]]] = []
 
         for path_expr in self._prim_paths:
             matches = tuple(iter_clone_plan_matches(plan, path_expr)) if plan is not None else ()
             if matches:
+                group = []
                 for source_root, destination_template, source_path, _env_ids in matches:
                     source_prim = None
                     if not any(token in source_path for token in "*[]()+?|\\"):
@@ -254,19 +254,20 @@ class NewtonSiteFrameView(BaseFrameView):
                         source_prim = sim_utils.find_first_matching_prim(source_path, stage)
                     if source_prim is None or not source_prim.IsValid():
                         raise RuntimeError(f"FrameView '{path_expr}' could not resolve source prim '{source_path}'.")
-                    specs.append(
+                    group.append(
                         self._resolve_source_prim(
                             source_prim, validate_xform_ops, source_root, destination_template, stage
                         )
                     )
+                spec_groups.append(group)
                 continue
 
             prim = sim_utils.find_first_matching_prim(path_expr, stage)
             if prim is None or not prim.IsValid():
                 raise RuntimeError(f"FrameView '{path_expr}' could not resolve a source prim.")
-            specs.append(self._resolve_source_prim(prim, validate_xform_ops, None, None, stage))
+            spec_groups.append([self._resolve_source_prim(prim, validate_xform_ops, None, None, stage)])
 
-        return specs
+        return spec_groups
 
     def _resolve_source_prim(
         self,
@@ -275,8 +276,8 @@ class NewtonSiteFrameView(BaseFrameView):
         source_root: str | None,
         destination_template: str | None,
         stage,
-    ) -> tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool]:
-        """Resolve one source prim into body patterns, local frame, and xform scale."""
+    ) -> tuple[str | None, wp.transform, tuple[float, float, float], bool]:
+        """Resolve one source prim into its body path, local frame, and xform scale."""
         prim_path = prim.GetPath().pathString
         if prim.HasAPI(UsdPhysics.RigidBodyAPI) or prim.HasAPI(UsdPhysics.ArticulationRootAPI):
             raise ValueError(
@@ -300,25 +301,13 @@ class NewtonSiteFrameView(BaseFrameView):
             if body_prim.HasAPI(UsdPhysics.RigidBodyAPI) or body_prim.HasAPI(UsdPhysics.ArticulationRootAPI):
                 pos, quat = sim_utils.resolve_prim_pose(prim, body_prim)
                 body_path = body_prim.GetPath().pathString
-                if source_root is not None and destination_template is not None:
-                    if body_path == source_root:
-                        suffix = ""
-                    elif body_path.startswith(source_root + "/"):
-                        suffix = body_path[len(source_root) :]
-                    elif source_root.startswith(body_path + "/"):
-                        suffix = source_root[len(body_path) :]
-                        destination_root = destination_template.format(".*")
-                        if not destination_root.endswith(suffix):
-                            raise RuntimeError(
-                                f"FrameView destination root '{destination_root}' does not end with '{suffix}'."
-                            )
-                        return (destination_root[: -len(suffix)],), wp.transform(pos, quat), scale, False
-                    else:
-                        raise RuntimeError(f"FrameView source body '{body_path}' is not under '{source_root}'.")
-                    body_patterns = (destination_template.format(".*") + suffix,)
-                else:
-                    body_patterns = (body_path,)
-                return body_patterns, wp.transform(pos, quat), scale, False
+                if source_root is not None and not (
+                    body_path == source_root
+                    or body_path.startswith(source_root + "/")
+                    or source_root.startswith(body_path + "/")
+                ):
+                    raise RuntimeError(f"FrameView source body '{body_path}' is not under '{source_root}'.")
+                return body_path, wp.transform(pos, quat), scale, False
             body_prim = body_prim.GetParent()
 
         ref_path = source_root
@@ -344,15 +333,24 @@ class NewtonSiteFrameView(BaseFrameView):
         site_locals: list[list[float]] = []
         site_scales: list[tuple[float, float, float]] = []
 
-        for site_label, scale in zip(self._site_labels, self._site_label_scales, strict=True):
-            global_idx, per_world = site_map[site_label]
-            site_indices = (
-                [global_idx] if per_world is None else [site_idx for sites in per_world for site_idx in sites]
-            )
-            for site_idx in site_indices:
-                site_bodies.append(int(body_t[site_idx].item()))
-                site_locals.append([float(v) for v in xform_t[site_idx].tolist()])
-                site_scales.append(scale)
+        def append_site(site_idx: int, scale: tuple[float, float, float]) -> None:
+            site_bodies.append(int(body_t[site_idx].item()))
+            site_locals.append([float(v) for v in xform_t[site_idx].tolist()])
+            site_scales.append(scale)
+
+        for group in self._site_groups:
+            entries = [(site_map[label], scale) for label, scale in group]
+            if len(entries) == 1 and entries[0][0][1] is None:
+                (global_idx, _), scale = entries[0]
+                append_site(global_idx, scale)
+                continue
+            # A group holds one label per source variant; their per-world lists
+            # partition the environments, so merging per world keeps env order.
+            num_worlds = len(entries[0][0][1])
+            for world in range(num_worlds):
+                for (_global_idx, per_world), scale in entries:
+                    for site_idx in per_world[world]:
+                        append_site(site_idx, scale)
 
         self._create_buffers(site_bodies, site_locals, site_scales)
 

--- a/source/isaaclab_newton/test/sensors/test_site_injection.py
+++ b/source/isaaclab_newton/test/sensors/test_site_injection.py
@@ -86,7 +86,7 @@ class TestFallbackGlobalSite:
 
     def test_global_site_entry_is_int_none_tuple(self):
         xform = wp.transform()
-        NewtonManager._cl_pending_sites = {(None, False, tuple(xform)): ("ft_0", xform)}
+        NewtonManager._cl_pending_sites = {(None, False, None, tuple(xform)): ("ft_0", xform)}
         NewtonManager._cl_inject_sites_flat()
 
         entry = NewtonManager._cl_site_index_map["ft_0"]
@@ -96,7 +96,7 @@ class TestFallbackGlobalSite:
 
     def test_global_site_pending_cleared(self):
         xform = wp.transform()
-        NewtonManager._cl_pending_sites = {(None, False, tuple(xform)): ("ft_0", xform)}
+        NewtonManager._cl_pending_sites = {(None, False, None, tuple(xform)): ("ft_0", xform)}
         NewtonManager._cl_inject_sites_flat()
 
         assert len(NewtonManager._cl_pending_sites) == 0
@@ -111,7 +111,7 @@ class TestFallbackLocalSingleBody:
 
     def test_single_body_entry_shape(self):
         xform = wp.transform()
-        NewtonManager._cl_pending_sites = {("Robot/base", False, tuple(xform)): ("ft_0", xform)}
+        NewtonManager._cl_pending_sites = {("Robot/base", False, None, tuple(xform)): ("ft_0", xform)}
         NewtonManager._cl_inject_sites_flat()
 
         entry = NewtonManager._cl_site_index_map["ft_0"]
@@ -132,7 +132,7 @@ class TestFallbackLocalWildcard:
 
     def test_wildcard_entry_shape(self):
         xform = wp.transform()
-        NewtonManager._cl_pending_sites = {("Robot/.*_foot", False, tuple(xform)): ("ft_0", xform)}
+        NewtonManager._cl_pending_sites = {("Robot/.*_foot", False, None, tuple(xform)): ("ft_0", xform)}
         NewtonManager._cl_inject_sites_flat()
 
         entry = NewtonManager._cl_site_index_map["ft_0"]
@@ -143,7 +143,7 @@ class TestFallbackLocalWildcard:
 
     def test_no_match_raises(self):
         xform = wp.transform()
-        NewtonManager._cl_pending_sites = {("Robot/nonexistent", False, tuple(xform)): ("ft_0", xform)}
+        NewtonManager._cl_pending_sites = {("Robot/nonexistent", False, None, tuple(xform)): ("ft_0", xform)}
         with pytest.raises(ValueError):
             NewtonManager._cl_inject_sites_flat()
 
@@ -180,7 +180,7 @@ class TestWorldSite:
 
         assert global_sites == {}
         assert proto_sites == {}
-        assert world_sites[label] == xform
+        assert world_sites[label] == (xform, None)
         assert NewtonManager._cl_pending_sites == {}
 
 
@@ -202,6 +202,48 @@ class TestRegistrationWindow:
         NewtonManager._model = object()
         with pytest.raises(RuntimeError, match="after the scene was built"):
             NewtonManager.cl_register_site(None, wp.transform(), per_world=True)
+
+
+class TestPerWorldMembership:
+    """Per-world sites registered with explicit worlds only land in those worlds."""
+
+    def setup_method(self):
+        NewtonManager.clear()
+
+    def teardown_method(self):
+        NewtonManager.clear()
+
+    def test_worlds_partition_the_envs(self):
+        import torch
+        from isaaclab_newton.cloner.newton_clone_utils import replicate_builder_mapping
+        from newton import ModelBuilder
+
+        xform_a = wp.transform((0.1, 0.0, 0.0), wp.quat_identity())
+        xform_b = wp.transform((0.2, 0.0, 0.0), wp.quat_identity())
+        label_a = NewtonManager.cl_register_site(None, xform_a, per_world=True, worlds=(0, 2))
+        label_b = NewtonManager.cl_register_site(None, xform_b, per_world=True, worlds=(1, 3))
+        assert label_a != label_b
+
+        main_builder = ModelBuilder()
+        _, _, env_root_sites = NewtonManager._cl_inject_sites(main_builder, {})
+
+        num_envs = 4
+        positions = torch.zeros((num_envs, 3))
+        quaternions = torch.zeros((num_envs, 4))
+        quaternions[:, 3] = 1.0
+        mapping = torch.ones((1, num_envs), dtype=torch.bool)
+        local_site_map, _ = replicate_builder_mapping(
+            main_builder, (), mapping[0:0], positions, quaternions, {}, env_root_sites=env_root_sites
+        )
+
+        per_world_a = local_site_map[label_a]
+        per_world_b = local_site_map[label_b]
+        assert [len(sites) for sites in per_world_a] == [1, 0, 1, 0]
+        assert [len(sites) for sites in per_world_b] == [0, 1, 0, 1]
+
+    def test_worlds_without_per_world_raises(self):
+        with pytest.raises(ValueError, match="worlds"):
+            NewtonManager.cl_register_site(None, wp.transform(), worlds=(0,))
 
 
 class TestInjectSitesMainBuilderBodies:
@@ -228,6 +270,16 @@ class TestInjectSitesMainBuilderBodies:
         NewtonManager.cl_register_site("/World/Table.*", wp.transform())
         with pytest.raises(ValueError, match="multiple non-cloned"):
             NewtonManager._cl_inject_sites(MockBuilder(["/World/Table_a", "/World/Table_b"]), {})
+
+    def test_source_match_wins_over_main_builder(self):
+        label = NewtonManager.cl_register_site("/World/.*/base", wp.transform())
+        source = MockBuilder(["/World/envs/env_0/Robot/base"])
+        global_sites, proto_sites, _ = NewtonManager._cl_inject_sites(
+            MockBuilder(["/World/Station/base"]), {"/World/envs/env_0/Robot": source}
+        )
+
+        assert label not in global_sites
+        assert proto_sites == {id(source): {label: [0]}}
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab_newton/test/sensors/test_site_injection.py
+++ b/source/isaaclab_newton/test/sensors/test_site_injection.py
@@ -60,7 +60,7 @@ class TestTransformToVecQuat:
 
 
 # ---------------------------------------------------------------------------
-# NewtonManager._cl_inject_sites_fallback
+# NewtonManager._cl_inject_sites_flat / cl_register_site window
 # ---------------------------------------------------------------------------
 
 
@@ -87,7 +87,7 @@ class TestFallbackGlobalSite:
     def test_global_site_entry_is_int_none_tuple(self):
         xform = wp.transform()
         NewtonManager._cl_pending_sites = {(None, False, tuple(xform)): ("ft_0", xform)}
-        NewtonManager._cl_inject_sites_fallback()
+        NewtonManager._cl_inject_sites_flat()
 
         entry = NewtonManager._cl_site_index_map["ft_0"]
         global_idx, per_world = entry
@@ -97,7 +97,7 @@ class TestFallbackGlobalSite:
     def test_global_site_pending_cleared(self):
         xform = wp.transform()
         NewtonManager._cl_pending_sites = {(None, False, tuple(xform)): ("ft_0", xform)}
-        NewtonManager._cl_inject_sites_fallback()
+        NewtonManager._cl_inject_sites_flat()
 
         assert len(NewtonManager._cl_pending_sites) == 0
 
@@ -112,7 +112,7 @@ class TestFallbackLocalSingleBody:
     def test_single_body_entry_shape(self):
         xform = wp.transform()
         NewtonManager._cl_pending_sites = {("Robot/base", False, tuple(xform)): ("ft_0", xform)}
-        NewtonManager._cl_inject_sites_fallback()
+        NewtonManager._cl_inject_sites_flat()
 
         entry = NewtonManager._cl_site_index_map["ft_0"]
         global_idx, per_world = entry
@@ -133,7 +133,7 @@ class TestFallbackLocalWildcard:
     def test_wildcard_entry_shape(self):
         xform = wp.transform()
         NewtonManager._cl_pending_sites = {("Robot/.*_foot", False, tuple(xform)): ("ft_0", xform)}
-        NewtonManager._cl_inject_sites_fallback()
+        NewtonManager._cl_inject_sites_flat()
 
         entry = NewtonManager._cl_site_index_map["ft_0"]
         global_idx, per_world = entry
@@ -145,7 +145,7 @@ class TestFallbackLocalWildcard:
         xform = wp.transform()
         NewtonManager._cl_pending_sites = {("Robot/nonexistent", False, tuple(xform)): ("ft_0", xform)}
         with pytest.raises(ValueError):
-            NewtonManager._cl_inject_sites_fallback()
+            NewtonManager._cl_inject_sites_flat()
 
 
 class TestWorldSite:
@@ -153,7 +153,6 @@ class TestWorldSite:
 
     def setup_method(self):
         NewtonManager.clear()
-        NewtonManager._builder = MockBuilder([])
 
     def test_world_site_reuses_label(self):
         xform = wp.transform((1.0, 2.0, 3.0), wp.quat_identity())
@@ -162,10 +161,11 @@ class TestWorldSite:
 
         assert label_0 == label_1
 
-    def test_world_site_fallback_entry_is_local(self):
+    def test_world_site_flat_entry_is_local(self):
         xform = wp.transform((1.0, 2.0, 3.0), wp.quat_identity())
         label = NewtonManager.cl_register_site(None, xform, per_world=True)
-        NewtonManager._cl_inject_sites_fallback()
+        NewtonManager._builder = MockBuilder([])
+        NewtonManager._cl_inject_sites_flat()
 
         global_idx, per_world = NewtonManager._cl_site_index_map[label]
         assert global_idx is None
@@ -182,6 +182,52 @@ class TestWorldSite:
         assert proto_sites == {}
         assert world_sites[label] == xform
         assert NewtonManager._cl_pending_sites == {}
+
+
+class TestRegistrationWindow:
+    """Site registration is rejected once the scene builder exists."""
+
+    def setup_method(self):
+        NewtonManager.clear()
+
+    def teardown_method(self):
+        NewtonManager.clear()
+
+    def test_register_after_builder_raises(self):
+        NewtonManager._builder = MockBuilder([])
+        with pytest.raises(RuntimeError, match="after the scene was built"):
+            NewtonManager.cl_register_site("Robot/base", wp.transform())
+
+    def test_register_after_model_raises(self):
+        NewtonManager._model = object()
+        with pytest.raises(RuntimeError, match="after the scene was built"):
+            NewtonManager.cl_register_site(None, wp.transform(), per_world=True)
+
+
+class TestInjectSitesMainBuilderBodies:
+    """Body sites on non-cloned (main-builder) bodies inject once, like globals."""
+
+    def setup_method(self):
+        NewtonManager.clear()
+
+    def teardown_method(self):
+        NewtonManager.clear()
+
+    def test_main_builder_body_site_is_global_entry(self):
+        xform = wp.transform()
+        label = NewtonManager.cl_register_site("/World/Table", xform)
+        global_sites, proto_sites, world_sites = NewtonManager._cl_inject_sites(
+            MockBuilder(["/World/Table"]), {"/World/envs/env_0/Robot": MockBuilder(["/World/envs/env_0/Robot/base"])}
+        )
+
+        assert label in global_sites
+        assert proto_sites == {}
+        assert world_sites == {}
+
+    def test_ambiguous_main_builder_match_raises(self):
+        NewtonManager.cl_register_site("/World/Table.*", wp.transform())
+        with pytest.raises(ValueError, match="multiple non-cloned"):
+            NewtonManager._cl_inject_sites(MockBuilder(["/World/Table_a", "/World/Table_b"]), {})
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab_newton/test/sim/test_views_xform_prim_newton.py
+++ b/source/isaaclab_newton/test/sim/test_views_xform_prim_newton.py
@@ -6,8 +6,12 @@
 """Newton backend tests for FrameView.
 
 Imports the shared contract tests and provides the Newton-specific
-``view_factory`` fixture.  Also includes Newton-only guard tests and
-the world-attached prim edge case.
+``view_factory`` fixture.  Also includes Newton-only guard tests, the
+world-attached prim edge case, and heterogeneous multi-asset cloning.
+
+Newton frame views register sites that clone with the scene, so every
+view is constructed inside the replication session (the same window in
+which :class:`~isaaclab.scene.InteractiveScene` constructs sensors).
 """
 
 import sys
@@ -26,27 +30,51 @@ from isaaclab_newton.physics.newton_manager import NewtonManager
 from isaaclab_newton.sim.views import NewtonSiteFrameView as FrameView
 
 import isaaclab.sim as sim_utils
+from isaaclab import cloner
 from isaaclab.assets import RigidObjectCfg
-from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg, build_simulation_context
-from isaaclab.utils.configclass import configclass
 
 NEWTON_SIM_CFG = SimulationCfg(physics=NewtonCfg(solver_cfg=MJWarpSolverCfg()))
 WORLD_MARKER_POS = (5.0, 3.0, 1.0)
 
 
-@configclass
-class _SceneCfg(InteractiveSceneCfg):
-    cube: RigidObjectCfg = RigidObjectCfg(
-        prim_path="{ENV_REGEX_NS}/Cube",
-        spawn=sim_utils.CuboidCfg(
-            size=(0.2, 0.2, 0.2),
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(),
-            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
-            collision_props=sim_utils.CollisionPropertiesCfg(),
-        ),
+def _cube_spawn_cfg(size=(0.2, 0.2, 0.2)):
+    return sim_utils.CuboidCfg(
+        size=size,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(),
+        mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        collision_props=sim_utils.CollisionPropertiesCfg(),
+    )
+
+
+def _cube_cfg(spawn=None):
+    return RigidObjectCfg(
+        prim_path="/World/envs/env_.*/Cube",
+        spawn=spawn if spawn is not None else _cube_spawn_cfg(),
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
     )
+
+
+def _replicate_cube_scene(num_envs, device, session_body, cube_cfg=None):
+    """Clone a cube per env and run ``session_body`` inside the replication session.
+
+    Mirrors what :class:`~isaaclab.scene.InteractiveScene` does: author the env
+    namespace, build the clone plan, construct assets inside the session, and
+    replicate on exit. Returns whatever ``session_body`` returns.
+    """
+    stage = sim_utils.get_current_stage()
+    stage.DefinePrim("/World/envs/env_0", "Xform")
+    env_ids = torch.arange(num_envs, dtype=torch.long, device=device)
+    env_origins, _ = cloner.grid_transforms(num_envs, 2.0, device=device)
+    with cloner.disabled_fabric_change_notifies(stage, restore=False):
+        cloner.usd_replicate(stage, ["/World/envs/env_0"], ["/World/envs/env_{}"], env_ids, positions=env_origins)
+
+    cube_cfg = cube_cfg if cube_cfg is not None else _cube_cfg()
+    session = cloner.ReplicateSession([cube_cfg], num_clones=num_envs, env_spacing=2.0, device=device, stage=stage)
+    with session:
+        cube_cfg.class_type(cube_cfg)
+        result = session_body()
+    return result, session
 
 
 def _sim_context(device, num_envs=4):
@@ -82,9 +110,12 @@ def view_factory():
         ctx = _sim_context(device, num_envs=num_envs)
         sim = ctx.__enter__()
         sim._app_control_on_stop_handle = None
-        InteractiveScene(_SceneCfg(num_envs=num_envs, env_spacing=2.0))
-        sim_utils.create_prim("/World/envs/env_0/Cube/CameraMount", translation=CHILD_OFFSET)
-        view = FrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
+
+        def build_view():
+            sim_utils.create_prim("/World/envs/env_0/Cube/CameraMount", translation=CHILD_OFFSET)
+            return FrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
+
+        view, _ = _replicate_cube_scene(num_envs, device, build_view)
         sim.reset()
 
         return ViewBundle(
@@ -108,10 +139,12 @@ def test_reject_body_path(device):
     ctx = _sim_context(device, num_envs=2)
     sim = ctx.__enter__()
     sim._app_control_on_stop_handle = None
-    InteractiveScene(_SceneCfg(num_envs=2, env_spacing=2.0))
 
-    with pytest.raises(ValueError, match="physics body"):
-        FrameView("/World/envs/env_.*/Cube", device=device)
+    def build_view():
+        with pytest.raises(ValueError, match="physics body"):
+            FrameView("/World/envs/env_.*/Cube", device=device)
+
+    _replicate_cube_scene(2, device, build_view)
     ctx.__exit__(None, None, None)
 
 
@@ -122,14 +155,15 @@ def test_clone_plan_view_uses_source_child_without_destination_usd(device):
     ctx = _sim_context(device, num_envs=num_envs)
     sim = ctx.__enter__()
     sim._app_control_on_stop_handle = None
-    InteractiveScene(_SceneCfg(num_envs=num_envs, env_spacing=2.0))
-
     stage = sim_utils.get_current_stage()
-    assert stage.GetPrimAtPath("/World/envs/env_0/Cube").IsValid()
-    assert not stage.GetPrimAtPath("/World/envs/env_1/Cube").IsValid()
-    sim_utils.create_prim("/World/envs/env_0/Cube/CameraMount", translation=CHILD_OFFSET)
 
-    view = FrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
+    def build_view():
+        assert stage.GetPrimAtPath("/World/envs/env_0/Cube").IsValid()
+        assert not stage.GetPrimAtPath("/World/envs/env_1/Cube").IsValid()
+        sim_utils.create_prim("/World/envs/env_0/Cube/CameraMount", translation=CHILD_OFFSET)
+        return FrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
+
+    view, _ = _replicate_cube_scene(num_envs, device, build_view)
     sim.reset()
 
     assert view.count == num_envs
@@ -141,18 +175,79 @@ def test_clone_plan_view_uses_source_child_without_destination_usd(device):
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_view_construction_after_replication_raises(device):
+    """FrameView constructed after the scene replicated raises a contract error."""
+    num_envs = 3
+    ctx = _sim_context(device, num_envs=num_envs)
+    sim = ctx.__enter__()
+    sim._app_control_on_stop_handle = None
+
+    def create_mount():
+        sim_utils.create_prim("/World/envs/env_0/Cube/CameraMount", translation=CHILD_OFFSET)
+
+    _replicate_cube_scene(num_envs, device, create_mount)
+    with pytest.raises(RuntimeError, match="after the scene was built"):
+        FrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
+    ctx.__exit__(None, None, None)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 def test_view_construction_after_reset_raises(device):
     """FrameView constructed after the Newton model is built raises a contract error."""
     num_envs = 3
     ctx = _sim_context(device, num_envs=num_envs)
     sim = ctx.__enter__()
     sim._app_control_on_stop_handle = None
-    InteractiveScene(_SceneCfg(num_envs=num_envs, env_spacing=2.0))
-    sim_utils.create_prim("/World/envs/env_0/Cube/CameraMount", translation=CHILD_OFFSET)
 
+    def create_mount():
+        sim_utils.create_prim("/World/envs/env_0/Cube/CameraMount", translation=CHILD_OFFSET)
+
+    _replicate_cube_scene(num_envs, device, create_mount)
     sim.reset()
-    with pytest.raises(RuntimeError, match="after the Newton model was built"):
+    with pytest.raises(RuntimeError, match="after the scene was built"):
         FrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
+    ctx.__exit__(None, None, None)
+
+
+# ==================================================================
+# Newton-only: heterogeneous multi-asset cloning
+# ==================================================================
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_heterogeneous_sources_resolve_per_variant(device):
+    """Each env resolves its own variant's frame; count and env order stay intact."""
+    num_envs = 4
+    variant_offsets = {0: (0.05, 0.0, 0.1), 1: (-0.05, 0.0, 0.2)}
+    ctx = _sim_context(device, num_envs=num_envs)
+    sim = ctx.__enter__()
+    sim._app_control_on_stop_handle = None
+
+    multi_spawn = sim_utils.MultiAssetSpawnerCfg(
+        assets_cfg=[_cube_spawn_cfg(size=(0.2, 0.2, 0.2)), _cube_spawn_cfg(size=(0.3, 0.3, 0.3))],
+        random_choice=False,
+    )
+    cube_cfg = _cube_cfg(spawn=multi_spawn)
+
+    def build_view():
+        source_prims = sorted(
+            prim.GetPath().pathString for prim in sim_utils.find_matching_prims("/World/envs/env_.*/Cube")
+        )
+        assert len(source_prims) == 2, source_prims
+        for variant, source in enumerate(source_prims):
+            sim_utils.create_prim(f"{source}/CameraMount", translation=variant_offsets[variant])
+        return FrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
+
+    view, session = _replicate_cube_scene(num_envs, device, build_view, cube_cfg=cube_cfg)
+    cfg_rows = sorted(session.plan.cfg_rows[id(cube_cfg)])
+    variant_of_env = session.plan.clone_mask[cfg_rows].to(torch.long).argmax(dim=0)
+    sim.reset()
+
+    assert view.count == num_envs
+    offsets = torch.stack([torch.tensor(variant_offsets[int(v)]) for v in variant_of_env]).to(device)
+    expected = _get_body_positions(num_envs, device) + offsets
+    pos = view.get_world_poses()[0].torch
+    torch.testing.assert_close(pos, expected, atol=1e-5, rtol=0)
     ctx.__exit__(None, None, None)
 
 
@@ -167,10 +262,12 @@ def test_world_attached_returns_initial_pose(device):
     ctx = _sim_context(device, num_envs=2)
     sim = ctx.__enter__()
     sim._app_control_on_stop_handle = None
-    InteractiveScene(_SceneCfg(num_envs=2, env_spacing=2.0))
 
-    sim_utils.create_prim("/World/StaticMarker", translation=WORLD_MARKER_POS)
-    view = FrameView("/World/StaticMarker", device=device)
+    def build_view():
+        sim_utils.create_prim("/World/StaticMarker", translation=WORLD_MARKER_POS)
+        return FrameView("/World/StaticMarker", device=device)
+
+    view, _ = _replicate_cube_scene(2, device, build_view)
     sim.reset()
 
     pos = view.get_world_poses()[0].torch
@@ -185,10 +282,12 @@ def test_world_attached_set_world_roundtrip(device):
     ctx = _sim_context(device, num_envs=2)
     sim = ctx.__enter__()
     sim._app_control_on_stop_handle = None
-    InteractiveScene(_SceneCfg(num_envs=2, env_spacing=2.0))
 
-    sim_utils.create_prim("/World/StaticMarker", translation=WORLD_MARKER_POS)
-    view = FrameView("/World/StaticMarker", device=device)
+    def build_view():
+        sim_utils.create_prim("/World/StaticMarker", translation=WORLD_MARKER_POS)
+        return FrameView("/World/StaticMarker", device=device)
+
+    view, _ = _replicate_cube_scene(2, device, build_view)
     sim.reset()
 
     new_pos = _wp_vec3f([[10.0, 20.0, 30.0]], device=device)

--- a/source/isaaclab_newton/test/sim/test_views_xform_prim_newton.py
+++ b/source/isaaclab_newton/test/sim/test_views_xform_prim_newton.py
@@ -109,28 +109,9 @@ def test_reject_body_path(device):
     sim = ctx.__enter__()
     sim._app_control_on_stop_handle = None
     InteractiveScene(_SceneCfg(num_envs=2, env_spacing=2.0))
-    sim.reset()
 
     with pytest.raises(ValueError, match="physics body"):
         FrameView("/World/envs/env_.*/Cube", device=device)
-    ctx.__exit__(None, None, None)
-
-
-@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
-def test_reject_shape_path(device):
-    """FrameView rejects prim paths that resolve to a Newton collision shape."""
-    ctx = _sim_context(device, num_envs=2)
-    sim = ctx.__enter__()
-    sim._app_control_on_stop_handle = None
-    InteractiveScene(_SceneCfg(num_envs=2, env_spacing=2.0))
-    sim.reset()
-
-    shape_labels = list(NewtonManager.get_model().shape_label)
-    if not shape_labels:
-        pytest.skip("No shapes in model")
-
-    with pytest.raises(ValueError, match="collision shape"):
-        FrameView(shape_labels[0], device=device)
     ctx.__exit__(None, None, None)
 
 
@@ -160,8 +141,8 @@ def test_clone_plan_view_uses_source_child_without_destination_usd(device):
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
-def test_view_can_resolve_from_body_labels_after_reset(device):
-    """FrameView can resolve a body-local frame directly from Newton body labels."""
+def test_view_construction_after_reset_raises(device):
+    """FrameView constructed after the Newton model is built raises a contract error."""
     num_envs = 3
     ctx = _sim_context(device, num_envs=num_envs)
     sim = ctx.__enter__()
@@ -170,11 +151,8 @@ def test_view_can_resolve_from_body_labels_after_reset(device):
     sim_utils.create_prim("/World/envs/env_0/Cube/CameraMount", translation=CHILD_OFFSET)
 
     sim.reset()
-    view = FrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
-
-    pos = view.get_world_poses()[0].torch
-    expected = _get_body_positions(num_envs, device) + torch.tensor(CHILD_OFFSET, device=device)
-    torch.testing.assert_close(pos, expected, atol=1e-5, rtol=0)
+    with pytest.raises(RuntimeError, match="after the Newton model was built"):
+        FrameView("/World/envs/env_.*/Cube/CameraMount", device=device)
     ctx.__exit__(None, None, None)
 
 
@@ -191,9 +169,9 @@ def test_world_attached_returns_initial_pose(device):
     sim._app_control_on_stop_handle = None
     InteractiveScene(_SceneCfg(num_envs=2, env_spacing=2.0))
 
-    sim.reset()
     sim_utils.create_prim("/World/StaticMarker", translation=WORLD_MARKER_POS)
     view = FrameView("/World/StaticMarker", device=device)
+    sim.reset()
 
     pos = view.get_world_poses()[0].torch
     expected = torch.tensor([list(WORLD_MARKER_POS)], device=device)
@@ -209,9 +187,9 @@ def test_world_attached_set_world_roundtrip(device):
     sim._app_control_on_stop_handle = None
     InteractiveScene(_SceneCfg(num_envs=2, env_spacing=2.0))
 
-    sim.reset()
     sim_utils.create_prim("/World/StaticMarker", translation=WORLD_MARKER_POS)
     view = FrameView("/World/StaticMarker", device=device)
+    sim.reset()
 
     new_pos = _wp_vec3f([[10.0, 20.0, 30.0]], device=device)
     new_quat = _wp_vec4f([[0.0, 0.0, 0.0, 1.0]], device=device)

--- a/source/isaaclab_ovphysx/changelog.d/octi-frameview-deferred-init.rst
+++ b/source/isaaclab_ovphysx/changelog.d/octi-frameview-deferred-init.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_ovphysx.sim.views.OvPhysxFrameView` to the frame-view
+  two-phase lifecycle: prim resolution moved into the deferred initialization
+  phase, so the view can be constructed before cloning authors its prims.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/sim/views/ovphysx_frame_view.py
@@ -312,20 +312,22 @@ class OvPhysxFrameView(BaseFrameView):
 
         stage = sim_utils.get_current_stage() if stage is None else stage
         self._stage = stage
-        self._prims: list[Usd.Prim] = sim_utils.find_matching_prims(prim_path, stage=stage)
-        if not self._prims:
-            raise ValueError(f"OvPhysxFrameView: pattern {prim_path!r} matched zero prims.")
+        self._prims: list[Usd.Prim] = []
+        self._prim_paths_cache: list[str] = []
+        self._synthetic_prim_paths: list[str] | None = None
 
         # Lazy USD view for scales / visibility.
         self._usd_view: UsdFrameView | None = None
 
-        # Try synchronous init; defer to PHYSICS_READY if the PhysX instance is not yet alive.
-        physx = self._try_get_physx()
-        if physx is not None:
-            self._initialize_impl(physx)
+        # Uniform two-phase lifecycle: initialize now when this context's warmup has
+        # run, else once PHYSICS_READY fires. The gate is per-context on purpose: the
+        # PhysX instance handle is process-global and survives a context teardown, so
+        # it cannot signal that the current context's scene is loaded.
+        if OvPhysxManager._warmup_done:
+            self._initialize_callback()
         else:
             OvPhysxManager.register_callback(
-                self._on_physics_ready,
+                self._initialize_callback,
                 PhysicsEvent.PHYSICS_READY,
                 name=f"ovphysx_frame_view_{prim_path}",
             )
@@ -335,14 +337,7 @@ class OvPhysxFrameView(BaseFrameView):
         """Return the active OVPhysX ``PhysX`` instance, or ``None`` if not yet created."""
         return OvPhysxManager.get_physx_instance()
 
-    def _on_physics_ready(self, _event) -> None:
-        """Callback invoked when the OVPhysX ``PhysX`` instance becomes available."""
-        physx = self._try_get_physx()
-        if physx is None:
-            raise RuntimeError("OvPhysxFrameView: PHYSICS_READY fired but OvPhysxManager has no PhysX instance.")
-        self._initialize_impl(physx)
-
-    def _initialize_impl(self, physx: Any) -> None:
+    def _initialize_impl(self) -> None:
         """Resolve prims to rigid-body ancestors and create a RIGID_BODY_POSE tensor binding.
 
         Site discovery handles two scene-construction modes:
@@ -359,6 +354,13 @@ class OvPhysxFrameView(BaseFrameView):
         """
         from isaaclab_ovphysx import tensor_types as TT  # noqa: PLC0415
         from isaaclab_ovphysx.sim.views.ovphysx_view import OvPhysxView  # noqa: PLC0415
+
+        # The warmup gate guarantees the PhysX instance exists on every path here.
+        physx = self._try_get_physx()
+        self._prims = sim_utils.find_matching_prims(self._prim_path, stage=self._stage)
+        if not self._prims:
+            raise ValueError(f"OvPhysxFrameView: pattern {self._prim_path!r} matched zero prims.")
+        self._prim_paths_cache = [p.GetPath().pathString for p in self._prims]
 
         xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
         identity_xform7 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
@@ -460,7 +462,7 @@ class OvPhysxFrameView(BaseFrameView):
                 parent_ancestor.append(pap)
                 parent_site_local.append(template_parent_site_local)
                 synthetic_prim_paths.append(synthetic_path)
-            self._synthetic_prim_paths: list[str] | None = synthetic_prim_paths
+            self._synthetic_prim_paths = synthetic_prim_paths
         else:
             self._synthetic_prim_paths = None
 
@@ -575,10 +577,8 @@ class OvPhysxFrameView(BaseFrameView):
         the paths are synthesized by replacing ``env_0`` in the template prim's
         path with each binding row's env_id.
         """
-        if hasattr(self, "_synthetic_prim_paths") and self._synthetic_prim_paths is not None:
+        if self._synthetic_prim_paths is not None:
             return self._synthetic_prim_paths
-        if not hasattr(self, "_prim_paths_cache"):
-            self._prim_paths_cache = [p.GetPath().pathString for p in self._prims]
         return self._prim_paths_cache
 
     @property

--- a/source/isaaclab_physx/changelog.d/octi-frameview-deferred-init.rst
+++ b/source/isaaclab_physx/changelog.d/octi-frameview-deferred-init.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_physx.sim.views.FabricFrameView` to the frame-view
+  two-phase lifecycle: expressions whose prims are not fully authored yet (e.g. a
+  camera frame constructed before cloning) defer prim resolution until physics is
+  ready, while views whose prims already exist keep initializing at construction.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -484,7 +484,7 @@ class PhysxManager(PhysicsManager):
         if isinstance(event, IsaacEvents):
             cid = cls._callback_id
             cls._callback_id += 1
-            cb = cls._wrap_weak_ref(callback) if wrap_weak_ref else callback
+            cb = cls._wrap_weak_ref(callback, cid) if wrap_weak_ref else callback
             sub = cls._subscribe_isaac(cb, event, order, name)
             cls._callbacks[cid] = (event, cb, order, name, sub)
             return CallbackHandle(cid, cls)

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -14,12 +14,18 @@ import warp as wp
 
 from pxr import Gf, Usd, UsdGeom
 
+import isaaclab.sim as sim_utils
 from isaaclab.app.settings_manager import SettingsManager
+from isaaclab.cloner.cloner_utils import iter_clone_plan_matches
+from isaaclab.physics import PhysicsEvent
+from isaaclab.sim.simulation_context import SimulationContext
 from isaaclab.sim.views.base_frame_view import BaseFrameView
 from isaaclab.sim.views.usd_frame_view import UsdFrameView
 from isaaclab.sim.views.xform_space_writer import FrameViewLocalSpaceWriter, FrameViewWorldSpaceWriter
 from isaaclab.utils.warp import ProxyArray
 from isaaclab.utils.warp import fabric as fabric_utils
+
+from isaaclab_physx.physics import PhysxManager
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +191,10 @@ class FabricFrameView(BaseFrameView):
                 :class:`~isaaclab.sim.views.FrameView` factory can forward backend-agnostic
                 kwargs without each backend having to know about every option.
         """
-        self._usd_view = UsdFrameView(prim_path, device=device, validate_xform_ops=validate_xform_ops, stage=stage)
+        self._prim_path_expr = prim_path
+        self._validate_xform_ops = validate_xform_ops
+        self._usd_stage = stage if stage is not None else sim_utils.get_current_stage()
+        self._usd_view: UsdFrameView | None = None
         self._device = device
 
         settings = SettingsManager.instance()
@@ -224,6 +233,49 @@ class FabricFrameView(BaseFrameView):
 
         # Sentinel passed to compose/decompose kernels for unused slots.
         self._fabric_empty_2d_array_sentinel: wp.array | None = None
+
+        # Uniform two-phase lifecycle: a USD-backed view is ready as soon as its
+        # prims are fully authored, so all current consumers initialize at
+        # construction exactly as before. Only expressions whose prims are still
+        # to be cloned (e.g. a camera frame constructed before replication) defer
+        # to PHYSICS_READY.
+        if self._prims_authored(prim_path, self._usd_stage):
+            self._initialize_callback()
+        else:
+            PhysxManager.register_callback(
+                self._initialize_callback, PhysicsEvent.PHYSICS_READY, name=f"fabric_frame_view_{prim_path}"
+            )
+
+    @staticmethod
+    def _prims_authored(prim_path: str, stage: Usd.Stage) -> bool:
+        """Whether the expression's prims are fully authored on the stage.
+
+        For an expression owned by the clone plan, the source prim exists before
+        replication authors the per-environment clones, so readiness is judged by
+        the last environment's destination prim rather than the first match.
+        """
+        ctx = SimulationContext.instance()
+        if ctx is None:
+            # No backend: the USD stage holds all the prims there will ever be.
+            return True
+        if sim_utils.find_first_matching_prim(prim_path, stage) is None:
+            return False
+        plan = ctx.get_clone_plan()
+        matches = tuple(iter_clone_plan_matches(plan, prim_path)) if plan is not None else ()
+        if not matches:
+            return True
+        source_root, destination_template, source_path, env_ids = matches[0]
+        suffix = source_path[len(source_root) :]
+        return stage.GetPrimAtPath(destination_template.format(env_ids[-1]) + suffix).IsValid()
+
+    def _initialize_impl(self) -> None:
+        """Resolve the wrapped USD view once the expression's prims are authored."""
+        self._usd_view = UsdFrameView(
+            self._prim_path_expr,
+            device=self._device,
+            validate_xform_ops=self._validate_xform_ops,
+            stage=self._usd_stage,
+        )
 
     # ------------------------------------------------------------------
     # Delegated properties

--- a/source/isaaclab_tasks/changelog.d/octi-frameview-deferred-init.rst
+++ b/source/isaaclab_tasks/changelog.d/octi-frameview-deferred-init.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed the direct-workflow camera environments (cartpole camera, shadow hand camera)
+  constructing their tiled camera before the clone plan is published. On the Newton
+  backend the camera frame view resolves its per-environment frames through the plan,
+  so the plan built by :meth:`~isaaclab.cloner.ClonePlan.from_env_0` is now published
+  before the camera is constructed.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -50,10 +50,13 @@ class CartpoleCameraEnv(CartpoleEnv):
     def _setup_scene(self):
         """Setup the scene with the cartpole and camera (no ground plane, which obstructs the view)."""
         self.cartpole = Articulation(self.cfg.robot_cfg)
-        self._tiled_camera = Camera(self.cfg.tiled_camera)
         src, dest = "/World/envs/env_0", "/World/envs/env_{}"
         pos = cloner.grid_transforms(self.scene.num_envs, self.scene.cfg.env_spacing, device=self.device)[0]
         plan = cloner.ClonePlan.from_env_0(src, dest, self.scene.num_envs, self.device, pos)
+        # Publish the plan before constructing sensors so they resolve their prims
+        # through it and register per-env frames that clone with the scene.
+        sim_utils.SimulationContext.instance().set_clone_plan(plan)
+        self._tiled_camera = Camera(self.cfg.tiled_camera)
         cloner.replicate(plan, stage=self.scene.stage)
 
         if self.device == "cpu":

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_camera_env.py
@@ -50,10 +50,13 @@ class ShadowHandCameraEnv(ReorientDirectEnv):
         self.hand = Articulation(self.cfg.robot_cfg)
         self.object: Articulation | RigidObject = self.cfg.object_cfg.class_type(self.cfg.object_cfg)
         self._joint_wrench_sensor = self._create_joint_wrench_sensor()
-        self._tiled_camera = Camera(self.cfg.tiled_camera)
         src, dest = "/World/envs/env_0", "/World/envs/env_{}"
         pos = cloner.grid_transforms(self.scene.num_envs, self.scene.cfg.env_spacing, device=self.device)[0]
         plan = cloner.ClonePlan.from_env_0(src, dest, self.scene.num_envs, self.device, pos)
+        # Publish the plan before constructing sensors so they resolve their prims
+        # through it and register per-env frames that clone with the scene.
+        sim_utils.SimulationContext.instance().set_clone_plan(plan)
+        self._tiled_camera = Camera(self.cfg.tiled_camera)
         cloner.replicate(plan, stage=self.scene.stage)
         # add articulation to scene - we must register to scene to randomize with EventManager
         self.scene.articulations["robot"] = self.hand


### PR DESCRIPTION
# Description

Follow-up to #6423. That PR speeds up `NewtonSiteFrameView` startup by replacing the per-environment
regex scan over `model.body_label` with an exact lookup map — a resolution-side fix. This PR removes
the post-build resolution path entirely by fixing the root cause: camera frame views were the only
site consumer constructed *after* the Newton model build, which forced a second frame-resolution
mechanism that no other sensor needs.

## Frame views construct with the scene (commit 1)

- Every frame-view backend now follows one two-phase lifecycle: construct alongside the scene,
  complete initialization through the backend's own readiness signal (`_initialize_impl` hook on
  `BaseFrameView`). Newton views register frame sites at construction so they clone with the scene
  like IMU/FrameTransformer/PVA sites; PhysX and OVPhysX views resolve prims once physics is ready.
- `Camera` constructs its frame view in `__init__` on every backend.
- `ReplicateSession` publishes the clone plan on `__enter__` (instead of `__exit__`), so entities
  constructed inside the session resolve prims through the plan exactly like post-replication code.
  A failed session unpublishes the plan.
- The Newton post-build resolution path (`_initialize_from_specs`, per-env pattern expansion, and
  the label lookup map from #6423) is deleted — with views constructed before the build there is
  nothing left for it to serve.
- Also fixes: weak-ref physics callbacks leaking registry entries after owner GC; the Newton
  multi-mesh ray caster feeding glob-style patterns into regex site matching.

## Sites must register before the scene builds (commit 2)

- `NewtonManager.cl_register_site` now raises once the scene builder exists. Sites are injected
  into the scene builders and cloned with the scene; a site registered after replication silently
  skipped cloning (`count == 1` instead of `num_envs`) and could recycle another registrant's
  counter-based `ft_N` label, silently corrupting the earlier registrant's resolved bodies. The
  flat injection at simulation start remains only for never-replicated stages; the dead STOP-time
  re-registration is removed from the IMU, frame transformer, and PVA sensors (STOP is only
  dispatched from `close()` on this backend, and `clear()` discards the re-registered state
  immediately after).
- With registration guaranteed to happen before replication, all matching happens in source space:
  frame views register the source body path of each matched clone-plan row and merge the resulting
  per-world sites per environment. This fixes heterogeneously spawned assets
  (`MultiAssetSpawnerCfg`/`MultiUsdFileCfg`), where every variant row previously collapsed onto one
  destination-wide `.*` pattern and produced duplicated or cross-variant frames.
- Sites on bodies outside the cloned environments (a shared table, fixture, ...) now inject into
  the main builder once, like global sites, instead of failing replication.

## Breaking changes

- Constructing a Newton frame view — or registering any Newton site — after the scene replicates
  (or, without replication, after the first reset) raises `RuntimeError`. Construct sensors and
  frame views inside the scene cfg, or before `sim.reset()` on non-replicated stages.

## Review-driven hardening (commit 3)

An adversarial review pass over the branch surfaced and fixed three more holes:

- Per-world sites now carry world membership (`cl_register_site(..., worlds=...)`), so a
  heterogeneous asset's world-anchored frame sites land only in their variant's environments
  instead of every world (previously `count == variants * num_envs` for body-less frame prims
  with variant-differing offsets).
- Non-cloned main-builder bodies are matched only when a pattern matches no source builder — the
  site map entry cannot represent a label owning sites in both spaces, and the main-builder site
  was silently discarded on overlap.
- The direct-workflow camera environments (cartpole camera, shadow hand camera) constructed their
  tiled camera against the empty scene plan, yielding one global site instead of per-env frames;
  they now publish the `from_env_0` plan before constructing the camera.

## Known open items

- Runtime render-only cameras over an already-built scene hit the new contract error on Newton:
  visualizer-owned cameras (`create_visualizer_camera`, called from `initialize_visualizers`
  *after* the physics reset, when tiled camera views are enabled with `tiled_cam_prim_path=None`)
  and the two `ppisp_camera` demos (cameras constructed after `InteractiveScene`). These flows
  spawn or bind cameras post-build by design; they need their own decision (USD-backed views for
  runtime render cameras, or pre-declared cameras) and are tracked as a follow-up. They fail with
  a clear contract error rather than silently misbehaving.
- Pre-existing (unchanged by this PR): the Newton multi-mesh ray caster's tracked-target
  registration cannot rendezvous with `BaseMultiMeshRayCaster` for articulation-root targets or
  multi-owner sources (KeyError at initialization); PhysX handles these. Follow-up.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
