### PR TITLE
Drain stale CUDA errors before simulation start

### DIFF
--- a/source/isaaclab_newton/changelog.d/fix-warp-stale-cuda-error.rst
+++ b/source/isaaclab_newton/changelog.d/fix-warp-stale-cuda-error.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed simulation (re)initialization aborting with a spurious ``Warp CUDA
+  error 1: invalid argument`` on the first buffer copy when a prior
+  simulation lifecycle left a stale CUDA error latched (Warp does not clear
+  the error when adding a graph memory free node fails).
+  :meth:`~isaaclab_newton.physics.NewtonManager.start_simulation` now drains
+  any stale device error before dispatching initialization callbacks.

--- a/source/isaaclab_newton/changelog.d/fix-warp-stale-cuda-error.rst
+++ b/source/isaaclab_newton/changelog.d/fix-warp-stale-cuda-error.rst
@@ -2,8 +2,10 @@ Fixed
 ^^^^^
 
 * Fixed simulation (re)initialization aborting with a spurious ``Warp CUDA
-  error 1: invalid argument`` on the first buffer copy when a prior
-  simulation lifecycle left a stale CUDA error latched (Warp does not clear
-  the error when adding a graph memory free node fails).
-  :meth:`~isaaclab_newton.physics.NewtonManager.start_simulation` now drains
+  error 1: invalid argument`` on the first buffer copy when a garbage
+  collection pass inside a CUDA graph capture freed a graph-scoped
+  allocation while the capture was paused for a conditional body (Warp
+  latches the failed free's error without clearing it). Garbage collection
+  is now paused for the duration of graph capture, and
+  :meth:`~isaaclab_newton.physics.NewtonManager.start_simulation` drains
   any stale device error before dispatching initialization callbacks.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1144,6 +1144,30 @@ class NewtonManager(PhysicsManager):
             NewtonManager._fk_reset_mask.fill_(True)
 
     @classmethod
+    def _drain_stale_cuda_error(cls) -> None:
+        """Clear a stale CUDA error latched on the device before (re)initialization.
+
+        Warp 1.15 leaves the per-thread CUDA error uncleared when
+        ``wp_free_device_async`` fails to add a graph memory free node while a
+        capture is still registered (its "capture ended" sibling branch clears
+        the identical error as benign), and the next Warp array copy then
+        surfaces that stale error as its own failure, aborting simulation
+        initialization. Draining here keeps a prior simulation lifecycle's
+        latched error from poisoning this one. Remove once the upstream Warp
+        fix lands.
+        """
+        device = wp.get_device(str(PhysicsManager._device))
+        if not device.is_cuda:
+            return
+        # Private Warp API: the drain primitive is not exposed publicly; getting the
+        # device above guarantees the runtime is initialized.
+        from warp._src.context import runtime as _wp_runtime
+
+        stale = _wp_runtime.core.wp_cuda_context_check(device.context)
+        if stale != 0:
+            logger.warning("Cleared stale CUDA error %d latched by a prior Warp graph-memory free failure.", stale)
+
+    @classmethod
     def start_simulation(cls) -> None:
         """Start simulation by finalizing model and initializing state.
 
@@ -1152,6 +1176,8 @@ class NewtonManager(PhysicsManager):
         we determine whether the solver needs external collision detection.
         """
         logger.debug(f"Builder: {cls._builder}")
+
+        cls._drain_stale_cuda_error()
 
         # Create builder from USD stage if not provided
         if cls._builder is None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1186,13 +1186,42 @@ class NewtonManager(PhysicsManager):
         device = wp.get_device(str(PhysicsManager._device))
         if not device.is_cuda:
             return
-        # Private Warp API: the drain primitive is not exposed publicly; getting the
-        # device above guarantees the runtime is initialized.
-        from warp._src.context import runtime as _wp_runtime
+        # Private Warp API: the drain primitives are not exposed publicly; getting the
+        # device above guarantees the runtime is initialized. Guard the whole private
+        # interaction so a future Warp internals reshuffle degrades to a skipped drain
+        # rather than hard-failing simulation start.
+        try:
+            from warp._src.context import runtime as _wp_runtime
 
-        stale = _wp_runtime.core.wp_cuda_context_check(device.context)
-        if stale != 0:
-            logger.warning("Cleared stale CUDA error %d latched by a prior Warp graph-memory free failure.", stale)
+            core = _wp_runtime.core
+            # wp_cuda_context_check drains via cudaGetLastError() but returns the
+            # post-sync error state (0 once a non-sticky error was drained), and its
+            # internal check_cuda() prints the drained error verbatim to stderr;
+            # suppress the print and diff Warp's error buffer to report the drain.
+            before = core.wp_get_error_string()
+            was_enabled = bool(core.wp_is_error_output_enabled())
+            core.wp_set_error_output_enabled(0)
+            try:
+                persistent = core.wp_cuda_context_check(device.context)
+            finally:
+                core.wp_set_error_output_enabled(1 if was_enabled else 0)
+            after = core.wp_get_error_string()
+        except (ImportError, AttributeError) as exc:
+            logger.warning("Skipping stale CUDA error drain; Warp internals unavailable: %s", exc)
+            return
+
+        if persistent != 0:
+            logger.error(
+                "CUDA error %d persists after drain; the device context is likely unrecoverable: %s",
+                persistent,
+                after.decode(errors="replace"),
+            )
+        elif after != before:
+            logger.warning(
+                "Drained stale CUDA error latched by a prior lifecycle: %s (last Warp error recorded before drain: %s)",
+                after.decode(errors="replace"),
+                before.decode(errors="replace") or "<none>",
+            )
 
     @classmethod
     def start_simulation(cls) -> None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import ctypes
+import gc
 import logging
 import re
 from abc import abstractmethod
@@ -29,6 +30,32 @@ except OSError:
         _cudart = ctypes.CDLL("libcudart.so")
     except OSError:
         _cudart = None
+
+
+@contextlib.contextmanager
+def _paused_gc():
+    """Pause Python garbage collection for the duration of a CUDA graph capture.
+
+    A garbage-collection pass inside a capture window can drop the last
+    reference to an array allocated earlier in the capture. While the capture
+    is paused for a ``wp.capture_while``/``wp.capture_if`` conditional body,
+    Warp then inserts the memory free node into the body graph with dependency
+    nodes from the parent graph, which fails and latches a sticky CUDA error
+    that poisons a later, unrelated copy. Reference-count-driven frees are
+    deterministic solver behavior and remain allowed; only the collector is
+    deferred, and a collection runs immediately after the capture window,
+    where freeing graph-scoped allocations is handled correctly.
+    """
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        yield
+    finally:
+        if was_enabled:
+            gc.enable()
+            gc.collect()
+
+
 from newton import Axis, CollisionPipeline, Contacts, Control, Model, ModelBuilder, State, eval_fk
 from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 from newton.sensors import SensorContact as NewtonContactSensor
@@ -1591,7 +1618,7 @@ class NewtonManager(PhysicsManager):
             with Timer(name="newton_cuda_graph", msg="CUDA graph took:"):
                 if cls._usdrt_stage is None:
                     simulate = cls._simulate_full if cls._is_all_graphable() else cls._simulate_physics_only
-                    with wp.ScopedCapture(device=device) as capture:
+                    with _paused_gc(), wp.ScopedCapture(device=device) as capture:
                         simulate()
                     NewtonManager._graph = capture.graph
                     logger.info("Newton CUDA graph captured (standard Warp mode)")
@@ -1679,45 +1706,46 @@ class NewtonManager(PhysicsManager):
         fresh_handle = raw_handle.value
         fresh_stream = wp.Stream(device, cuda_stream=fresh_handle, owner=False)
 
-        # Start capture in relaxed mode BEFORE entering ScopedStream.
-        ret = _cudart.cudaStreamBeginCapture(ctypes.c_void_p(fresh_handle), ctypes.c_int(2))
-        if ret != 0:
-            _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
-            logger.warning("cudaStreamBeginCapture(relaxed) failed (code %d)", ret)
-            return None
+        with _paused_gc():
+            # Start capture in relaxed mode BEFORE entering ScopedStream.
+            ret = _cudart.cudaStreamBeginCapture(ctypes.c_void_p(fresh_handle), ctypes.c_int(2))
+            if ret != 0:
+                _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
+                logger.warning("cudaStreamBeginCapture(relaxed) failed (code %d)", ret)
+                return None
 
-        try:
-            wp.capture_begin(stream=fresh_stream, external=True)
-        except Exception as exc:
-            raw_graph = ctypes.c_void_p()
-            _cudart.cudaStreamEndCapture(ctypes.c_void_p(fresh_handle), ctypes.byref(raw_graph))
-            if raw_graph.value:
-                _cudart.cudaGraphDestroy(raw_graph)
-            _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
-            logger.warning("wp.capture_begin(external=True) failed: %s", exc)
-            return None
-
-        err_during_capture = None
-        with wp.ScopedStream(fresh_stream, sync_enter=False):
             try:
-                simulate()
+                wp.capture_begin(stream=fresh_stream, external=True)
             except Exception as exc:
-                err_during_capture = exc
+                raw_graph = ctypes.c_void_p()
+                _cudart.cudaStreamEndCapture(ctypes.c_void_p(fresh_handle), ctypes.byref(raw_graph))
+                if raw_graph.value:
+                    _cudart.cudaGraphDestroy(raw_graph)
+                _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
+                logger.warning("wp.capture_begin(external=True) failed: %s", exc)
+                return None
 
-        if err_during_capture is None:
-            try:
-                graph = wp.capture_end(stream=fresh_stream)
-            except Exception as exc:
-                err_during_capture = exc
+            err_during_capture = None
+            with wp.ScopedStream(fresh_stream, sync_enter=False):
+                try:
+                    simulate()
+                except Exception as exc:
+                    err_during_capture = exc
+
+            if err_during_capture is None:
+                try:
+                    graph = wp.capture_end(stream=fresh_stream)
+                except Exception as exc:
+                    err_during_capture = exc
+                    graph = None
+            else:
+                with contextlib.suppress(Exception):
+                    wp.capture_end(stream=fresh_stream)
                 graph = None
-        else:
-            with contextlib.suppress(Exception):
-                wp.capture_end(stream=fresh_stream)
-            graph = None
 
-        raw_graph = ctypes.c_void_p()
-        end_ret = _cudart.cudaStreamEndCapture(ctypes.c_void_p(fresh_handle), ctypes.byref(raw_graph))
-        _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
+            raw_graph = ctypes.c_void_p()
+            end_ret = _cudart.cudaStreamEndCapture(ctypes.c_void_p(fresh_handle), ctypes.byref(raw_graph))
+            _cudart.cudaStreamDestroy(ctypes.c_void_p(fresh_handle))
 
         if err_during_capture is not None:
             if raw_graph.value:


### PR DESCRIPTION
## Description

A latent Warp defect can abort Newton simulation (re)initialization with a spurious `Warp CUDA error 1: invalid argument` at the first buffer copy (`wp.clone` during `PHYSICS_READY`), in processes that run several simulation lifecycles (test suites, notebooks).

Root cause (fully diagnosed; a ~50-line pure-Warp repro exists and a Warp-side fix is in review):
- `wp.capture_while`/`wp.capture_if` pause the parent capture and resume capturing into the conditional body graph on the same stream. If a Python garbage-collection pass runs inside a body callback and drops the last reference to an array allocated in the parent graph, Warp inserts the memory free node into the body graph with parent-graph dependency nodes — which fails with `cudaErrorInvalidValue`, leaks the allocation, and leaves the CUDA per-thread error latched.
- `wp_array_copy_device` ends with `check_cuda(cudaGetLastError())`, so the next innocent Warp copy surfaces and mis-attributes the stale error — typically one test/lifecycle later, which made this look like flakiness.

This PR adds two independent layers in `NewtonManager` until the upstream Warp fix propagates:
1. **Prevention** — garbage collection is paused for the duration of graph capture (both the standard `ScopedCapture` path and the RTX relaxed-capture path), with a collection run immediately after the capture window, where freeing graph-scoped allocations is handled correctly. Reference-count-driven frees are unaffected.
2. **Defense in depth** — `start_simulation` drains (and logs) any latched CUDA error via Warp's own `wp_cuda_context_check` before dispatching initialization callbacks, so no prior lifecycle can poison the next one through any other latched-error path.

Validation: the deterministic 4-test repro (from the articulation-ordering test additions in #6336) goes red→green with the GC guard alone, with zero `failed to add a memory free node` warnings (the corrupting frees no longer happen); the full Newton articulation suite is green with ordering tests (257 passed) and on develop (236 passed). A develop-only regression test is not included because develop's current suite never arranges the triggering sequence; #6336's tests cover it organically once merged.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines]
- [x] I have run the [pre-commit checks] with `./isaaclab.sh --format`
- [x] My changes generate no new warnings
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there