### PR TITLE
Fix Newton Cartpole camera tile sizes

### DIFF
--- a/source/isaaclab_tasks/changelog.d/kellyg-fix-newton-cartpole-tiles.rst
+++ b/source/isaaclab_tasks/changelog.d/kellyg-fix-newton-cartpole-tiles.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Cartpole camera ``newton_renderer`` presets to use tile dimensions
+  compatible with the 100x100 camera resolution.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env_cfg.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import math
 
+from isaaclab_newton.renderers import NewtonWarpRendererCfg
+
 import isaaclab.sim as sim_utils
 from isaaclab.envs import ViewerCfg
 from isaaclab.scene import InteractiveSceneCfg
@@ -32,7 +34,9 @@ class CartpoleTiledCameraCfg(PresetCfg):
         )
         width: int = 100
         height: int = 100
-        renderer_cfg: MultiBackendRendererCfg = MultiBackendRendererCfg()
+        renderer_cfg: MultiBackendRendererCfg = MultiBackendRendererCfg(
+            newton_renderer=NewtonWarpRendererCfg(tile_rendering_width=10, tile_rendering_height=10)
+        )
 
     default = BaseCartpoleTiledCameraCfg(data_types=["rgb"])
     depth = BaseCartpoleTiledCameraCfg(data_types=["depth"])

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_camera_env_cfg.py
@@ -5,6 +5,8 @@
 
 import math
 
+from isaaclab_newton.renderers import NewtonWarpRendererCfg
+
 import isaaclab.sim as sim_utils
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
@@ -43,7 +45,9 @@ class CartpoleTiledCameraCfg(PresetCfg):
         )
         width: int = 100
         height: int = 100
-        renderer_cfg: MultiBackendRendererCfg = MultiBackendRendererCfg()
+        renderer_cfg: MultiBackendRendererCfg = MultiBackendRendererCfg(
+            newton_renderer=NewtonWarpRendererCfg(tile_rendering_width=10, tile_rendering_height=10)
+        )
 
     default = BaseCartpoleTiledCameraCfg(data_types=["rgb"])
     depth = BaseCartpoleTiledCameraCfg(data_types=["depth"])


### PR DESCRIPTION
# Description

- Set Cartpole camera `newton_renderer` tile dimensions to `10x10` so they divide the `100x100` camera resolution.
- Apply the override to both direct and manager-based Cartpole camera configs.
- Add an `isaaclab_tasks` changelog fragment.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
