### PR TITLE
Limit PXR_WORK_THREAD_LIMIT to 1 to prevent freeze in CI/CD for shadow hand

### DIFF
--- a/source/isaaclab_tasks/test/core/test_rendering_shadow_hand.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_shadow_hand.py
@@ -5,8 +5,16 @@
 
 """Rendering correctness tests for Shadow Hand environment backend combinations."""
 
+import os
+
+# Work around a known OpenUSD thread-safety crash in
+# UsdPhysics.LoadUsdPhysicsFromRange for collider-dense assets. OpenUSD reads
+# this once when pxr initializes, so set it before test modules import pxr and
+# preserve any caller-provided override.
+os.environ.setdefault("PXR_WORK_THREAD_LIMIT", "1")
+
 # Launch Isaac Sim Simulator first for kit-based combinations.
-from isaaclab.app import AppLauncher
+from isaaclab.app import AppLauncher  # noqa: E402
 
 app_launcher = AppLauncher(headless=True, enable_cameras=True)
 simulation_app = app_launcher.app


### PR DESCRIPTION
# Description

It has been observed that some of our rendering correctness tests, specifically `test_rendering_shadow_hand.py` with combination of Newton + IsaacSimRTX make tests to hang indefinitely.  Eventually tests time out and process is being killed.

After attaching to a hanging process with GDB the call stack looks as follows:

```
Python / Boost.Python
└─ _LoadUsdPhysicsFromRange(...)
   └─ LoadUsdPhysicsFromRange(...)                     parseUtils.cpp:3286
      └─ _CallReportFn<UsdPhysicsRigidBodyDesc>(...)
         └─ report callback                            parseUtils.cpp:1690
            └─ moveDescsToDict<RigidBodyDesc>(...)     wrapParseUtils.cpp:49
               └─ copy vector<RigidBodyDesc>           26 descriptors
                  └─ copy UsdPhysicsRigidBodyDesc
                     └─ copy vector<SdfPath>            8 paths
                        └─ copy SdfPath
                           └─ add path-node reference
                              └─ atomic fetch_add(1)
```

The `LoadUsdPhysicsFromRange` is documented in Newton repository:

https://github.com/newton-physics/newton/blob/main/newton/tests/thirdparty/unittest_parallel.py#L27

```
# Work around a known OpenUSD thread-safety crash in
# UsdPhysics.LoadUsdPhysicsFromRange for collider-dense assets. OpenUSD reads
# this once when pxr initializes, so set it before test modules import pxr and
# preserve any caller-provided override.
```

Relevant upstream ticket:

https://github.com/isaac-sim/IsaacSim/issues/692


## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
