### PR TITLE
[Fix] Cherry-pick pillow floor to stop arm64 prebundle deletion in docker installs

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-pillow-prebundle-floor.rst
+++ b/source/isaaclab/changelog.d/jichuanh-pillow-prebundle-floor.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed docker installs deleting ``pillow`` from Isaac Sim's
+  ``omni.kit.pip_archive`` prebundle by relaxing the exact ``pillow==12.2.0``
+  pin to a ``>=12.1.1`` floor. An exact pin below the version prebundled by a
+  future Isaac Sim base image forces a downgrade that deletes the prebundled
+  copy, dangling the per-file symlink farm on aarch64 and breaking extension
+  startup.

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -35,8 +35,9 @@ INSTALL_REQUIRES = [
     "einops",  # needed for transformers, doesn't always auto-install
     "warp-lang==1.13.0",
     "matplotlib>=3.10.3",  # minimum version for Python 3.12 support
-    # make sure this is consistent with isaac sim version
-    "pillow==12.2.0",
+    # pillow: floor, not exact — an exact pin below Isaac Sim's prebundled version forces a
+    # downgrade that deletes the prebundled copy other extensions symlink into (nvbugs 6410989).
+    "pillow>=12.1.1",
     # required by omni.replicator.core S3 backend
     "botocore",
     # livestream

--- a/source/isaaclab_rl/changelog.d/jichuanh-pillow-prebundle-floor.rst
+++ b/source/isaaclab_rl/changelog.d/jichuanh-pillow-prebundle-floor.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed standalone ``isaaclab_rl`` installs downgrading ``pillow`` below the
+  version prebundled by Isaac Sim: ``moviepy`` 2.x caps ``pillow<12.0``, and
+  on aarch64 the forced downgrade deleted the prebundled copy that
+  ``omni.kit.pip_archive`` shares via per-file symlinks, breaking extension
+  startup. Added a ``pillow>=12.1.1`` floor so pip resolves ``moviepy`` 1.0.3
+  instead of touching pillow.

--- a/source/isaaclab_rl/changelog.d/jichuanh-pillow-prebundle-floor.rst
+++ b/source/isaaclab_rl/changelog.d/jichuanh-pillow-prebundle-floor.rst
@@ -7,3 +7,8 @@ Fixed
   ``omni.kit.pip_archive`` shares via per-file symlinks, breaking extension
   startup. Added a ``pillow>=12.1.1`` floor so pip resolves ``moviepy`` 1.0.3
   instead of touching pillow.
+* Fixed ``--video`` recording crashing on prerelease-allowing installs by
+  bounding ``moviepy`` to ``>=1.0.3,<2.0.0.dev0``: once the pillow floor
+  excludes stable ``moviepy`` 2.x, such resolvers otherwise fall through to
+  the broken ``2.0.0.dev2`` build whose ``write_videofile`` drops the clip
+  fps.

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -30,10 +30,12 @@ INSTALL_REQUIRES = [
     # basic logger
     "tensorboard",
     # video recording
-    "moviepy",
+    # moviepy bounded to the 1.x line: stable 2.x caps pillow<12 (conflicts with the floor
+    # below), and prerelease-allowing resolvers otherwise fall through to the broken
+    # 2.0.0.dev2 build whose write_videofile crashes video recording.
+    "moviepy>=1.0.3,<2.0.0.dev0",
     # pillow floor: without it, standalone isaaclab_rl installs let moviepy 2.x (pillow<12 cap)
-    # downgrade pillow and delete Isaac Sim's prebundled copy (nvbugs 6410989); the floor makes
-    # pip back moviepy off to 1.0.3 instead of touching pillow.
+    # downgrade pillow and delete Isaac Sim's prebundled copy (nvbugs 6410989).
     "pillow>=12.1.1",
     "packaging",
     "tqdm==4.67.1",  # previous version was causing sys errors

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -31,6 +31,10 @@ INSTALL_REQUIRES = [
     "tensorboard",
     # video recording
     "moviepy",
+    # pillow floor: without it, standalone isaaclab_rl installs let moviepy 2.x (pillow<12 cap)
+    # downgrade pillow and delete Isaac Sim's prebundled copy (nvbugs 6410989); the floor makes
+    # pip back moviepy off to 1.0.3 instead of touching pillow.
+    "pillow>=12.1.1",
     "packaging",
     "tqdm==4.67.1",  # previous version was causing sys errors
 ]

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -24,8 +24,9 @@ pyproject.dependencies.all = [
     "einops",  # needed for transformers, doesn't always auto-install
     "warp-lang==1.13.0",
     "matplotlib>=3.10.3",
-    # make sure this is consistent with isaac sim version
-    "pillow==12.2.0",
+    # pillow: floor, not exact — an exact pin below Isaac Sim's prebundled version forces a
+    # downgrade that deletes the prebundled copy other extensions symlink into (nvbugs 6410989).
+    "pillow>=12.1.1",
     "botocore",
     # livestream
     # range chosen to coexist with isaacsim 6.0 (isaacsim-kernel pulls fastapi==0.117.1 -> starlette<0.49.0)
@@ -68,6 +69,9 @@ pyproject.dependencies.all = [
     "tensorboard",
     # video recording
     "moviepy",
+    # pillow floor mirrors isaaclab_rl/setup.py: keeps moviepy 2.x (pillow<12 cap) from
+    # downgrading pillow below Isaac Sim's prebundled version (nvbugs 6410989).
+    "pillow>=12.1.1",
     "packaging",
     "tqdm==4.67.1",
     # ================================================================================

--- a/tools/wheel_builder/res/python_packages.toml
+++ b/tools/wheel_builder/res/python_packages.toml
@@ -68,9 +68,10 @@ pyproject.dependencies.all = [
     # basic logger
     "tensorboard",
     # video recording
-    "moviepy",
-    # pillow floor mirrors isaaclab_rl/setup.py: keeps moviepy 2.x (pillow<12 cap) from
-    # downgrading pillow below Isaac Sim's prebundled version (nvbugs 6410989).
+    # moviepy bound and pillow floor mirror isaaclab_rl/setup.py: keep moviepy 2.x
+    # (pillow<12 cap) from downgrading pillow below Isaac Sim's prebundled version
+    # (nvbugs 6410989), and keep prerelease-allowing resolvers off the broken 2.0.0.dev2.
+    "moviepy>=1.0.3,<2.0.0.dev0",
     "pillow>=12.1.1",
     "packaging",
     "tqdm==4.67.1",


### PR DESCRIPTION
# Description

Cherry-pick of #6437 onto `release/3.0.0-beta2`, plus the `isaaclab_rl` pillow floor that this branch's per-package install path additionally needs. Unblocks the `Publish Docker Images` arm64 leg, which fails since the #6436 post-install invariant landed (run [29124274839](https://github.com/isaac-sim/IsaacLab/actions/runs/29124274839)).

## 1. Summary

- Root cause on this branch: `moviepy` (unpinned in `isaaclab_rl`) resolves to 2.2.1, which caps `pillow<12.0`. The standalone `isaaclab_rl` install batches do not have `isaaclab`'s pillow pin in their resolution set, so pip downgrades pillow to 11.3.0 and uninstalls the prebundled pillow 12.2.0 from `omni.kit.pip_archive` — on aarch64 that dangles the per-file symlink farm (228 links incl. `PIL/__init__.py`) and breaks extension startup at runtime (nvbugs 6410989). Green builds before the invariant were already doing this silently (run [28493820266](https://github.com/isaac-sim/IsaacLab/actions/runs/28493820266) shows the same `Uninstalling pillow-12.2.0`).
- `source/isaaclab_rl/setup.py`: added a `pillow>=12.1.1` floor — pip then backs moviepy off to 1.0.3 instead of touching pillow.
- `source/isaaclab/setup.py`: relaxed the exact `pillow==12.2.0` pin to `>=12.1.1` (the #6437 change), so a future Isaac Sim base-image bump past the pinned version cannot force the same downgrade.
- `tools/wheel_builder/res/python_packages.toml`: mirrored both changes.
- `moviepy` bounded to `>=1.0.3,<2.0.0.dev0` (the #6454 change adapted to this branch): with the floor excluding stable moviepy 2.x, prerelease-allowing resolvers (uv with `prerelease = "allow"`) otherwise fall through to the broken `2.0.0.dev2` build; the bound makes pip and uv both resolve stable 1.0.3.

## 2. Backport adaptations vs #6437

- This branch predates the #6009 dependency centralization, so the floor lands in the two `setup.py` files + the wheel spec instead of the root `pyproject.toml`.
- The extra `isaaclab_rl` floor is beta2-specific: develop resolves `isaaclab` + RL dependencies in one pip batch where the central floor is in scope; this branch installs per package, so `isaaclab_rl`'s own resolution needs the floor. An exact `pillow==12.2.0` in `isaaclab` demonstrably did not protect it — the failing run shows `Uninstalling pillow-12.2.0` during the `isaaclab_rl` batch with only a resolver warning for the isaaclab pin.

## 3. Test plan

- [x] Resolver regression proof (py3.12 venv with pillow 12.2.0 preinstalled — the prebundle state — then `pip install --dry-run --report` of `source/isaaclab_rl`):
  - without fix: plans `pillow 11.3.0` + `moviepy 2.2.1` (the prebundle-deleting downgrade)
  - with fix: plans `moviepy 1.0.3` + `decorator 4.4.2`; pillow untouched
- [x] `source/isaaclab/test/cli` — 140 passed, 1 skipped locally.
- [x] pre-commit clean on all files.
- [ ] Local amd64 `docker build -f docker/Dockerfile.base` with the fix (in progress).
- [ ] PR CI green (incl. Build Base Docker Image + ARM installation tests).
- [x] arm64 proof: diagnostic PR #6469 ran the exact publish arm64 leg (build-only) with this fix — green (run [29134632249](https://github.com/isaac-sim/IsaacLab/actions/runs/29134632249)): moviepy backtracks to 1.0.3, no pillow uninstall, post-install invariant passes.
- [ ] After merge: the next `Publish Docker Images` run on `release/3.0.0-beta2` validates the arm64 leg — run [29124274839](https://github.com/isaac-sim/IsaacLab/actions/runs/29124274839) is the FAIL baseline.



