### PR TITLE
Fix body velocities reading zeros for fixed-base articulations on Newton

### DIFF
--- a/source/isaaclab_newton/changelog.d/upstream-fix-newton-fixed-base-body-vel.rst
+++ b/source/isaaclab_newton/changelog.d/upstream-fix-newton-fixed-base-body-vel.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :attr:`~isaaclab_newton.assets.ArticulationData.body_com_vel_w` (and every derived
+  body-velocity property, e.g. :attr:`body_lin_vel_w`) reading zeros for fixed-base
+  articulations. The fixed-base fallback in the data buffers zeroed the body velocity
+  binding together with the genuinely unavailable root velocity, silently disabling all
+  body-velocity observations for fixed-base robots.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation_data.py
@@ -1655,6 +1655,12 @@ class ArticulationData(BaseArticulationData):
             self._sim_bind_root_com_vel_w = wp.zeros(
                 (self._num_instances), dtype=wp.spatial_vectorf, device=self.device
             )
+        # Body velocities are well-defined regardless of the base type (fixed-base articulations
+        # still report link velocities); fall back to zeros only when the view genuinely cannot
+        # provide them. Zeroing this binding together with the root velocity silently zeroes
+        # every body-velocity read for fixed-base robots.
+        if self._root_view.get_link_velocities(SimulationManager.get_state_0()) is None:
+            logger.warning("Failed to get body com velocities. Setting body com velocities to zeros.")
             self._sim_bind_body_com_vel_w = wp.zeros(
                 (self._num_instances, self._num_bodies), dtype=wp.spatial_vectorf, device=self.device
             )

--- a/source/isaaclab_newton/test/assets/test_articulation.py
+++ b/source/isaaclab_newton/test/assets/test_articulation.py
@@ -679,6 +679,58 @@ def test_initialization_fixed_base(sim, num_articulations, device, articulation_
 
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("articulation_type", ["panda"])
+def test_fixed_base_reports_body_velocities(sim, num_articulations, device, articulation_type):
+    """Test that fixed-base articulations report live body velocities while their joints move.
+
+    Regression test: the fixed-base fallback in ``_create_buffers`` zeroed the body
+    center-of-mass velocity binding together with the (genuinely unavailable) root velocity,
+    so :attr:`body_lin_vel_w` and :attr:`body_ang_vel_w` read zeros for every fixed-base
+    robot regardless of motion.
+
+    This test verifies that:
+    1. The articulation is fixed base
+    2. Commanding a joint-space motion moves the bodies (finite difference of positions)
+    3. The reported body velocities track the finite-difference ground truth
+
+    Args:
+        sim: The simulation fixture
+        num_articulations: Number of articulations to test
+        device: The device to run the simulation on
+    """
+    articulation_cfg = generate_articulation_cfg(articulation_type=articulation_type)
+    articulation, _ = generate_articulation(articulation_cfg, num_articulations, device=device)
+
+    # Play sim
+    sim.reset()
+    assert articulation.is_fixed_base
+
+    # command a step away from the default pose so the distal bodies move
+    joint_pos_target = articulation.data.default_joint_pos.torch.clone()
+    joint_pos_target[:, 1] += 0.5
+    prev_body_pos = articulation.data.body_link_pos_w.torch.clone()
+    reported_max = []
+    fin_diff_max = []
+    for _ in range(20):
+        articulation.set_joint_position_target(joint_pos_target)
+        articulation.write_data_to_sim()
+        sim.step()
+        articulation.update(sim.cfg.dt)
+        body_pos = articulation.data.body_link_pos_w.torch
+        reported_max.append(articulation.data.body_lin_vel_w.torch.norm(dim=-1).amax())
+        fin_diff_max.append(((body_pos - prev_body_pos) / sim.cfg.dt).norm(dim=-1).amax())
+        prev_body_pos = body_pos.clone()
+    reported_max = torch.stack(reported_max).amax()
+    fin_diff_max = torch.stack(fin_diff_max).amax()
+
+    # the commanded motion genuinely moves the bodies
+    assert fin_diff_max > 0.1
+    # and the reported body velocities track it (identically zero under the regression)
+    assert reported_max > 0.5 * fin_diff_max
+
+
+@pytest.mark.parametrize("num_articulations", [1, 2])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("add_ground_plane", [True])
 @pytest.mark.parametrize("articulation_type", ["single_joint_implicit"])
 def test_initialization_fixed_base_single_joint(sim, num_articulations, device, add_ground_plane, articulation_type):


### PR DESCRIPTION
## Description

For fixed-base articulations, the Newton backend's `ArticulationData._create_buffers` replaced the body COM velocity sim binding with zeros as part of the "no root velocity" fallback. Root and body velocities are independent: `ArticulationView.get_root_velocities` legitimately returns `None` for a non-floating base, but `get_link_velocities` is well-defined and already bound by the normal binding path — the fallback then silently overwrote it. Every downstream body-velocity read (`body_com_vel_w`, `body_lin_vel_w`, `body_ang_vel_w`, and observations built on them) returned zeros for every fixed-base robot.

In practice this silently disables all body-velocity observations for fixed-base manipulators: we found it as a dead fingertip-velocity observation channel that a policy trained against (zeros on Newton, live values on PhysX), producing an artificial sim-to-sim transfer gap.

Fix: zero the body-velocity binding only when the view genuinely cannot provide link velocities.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

Added `test_fixed_base_reports_body_velocities`: fixed-base Panda, commanded joint-space motion, asserts the reported body velocities track the finite difference of body positions. Verified to fail without the fix (reported max 0.0 vs 3.7 m/s finite-difference ground truth) and pass with it, on the mjwarp solver.

## Checklist

- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have added tests that prove my fix is effective
- [x] I have updated the changelog with a fragment under `changelog.d`
- [ ] I have updated the documentation (not applicable)