### PR TITLE
Make CircularBuffer first-push backfill branchless

### DIFF
--- a/source/isaaclab/changelog.d/zhengyuz-perf-circular-buffer-branchless-backfill.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-perf-circular-buffer-branchless-backfill.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed :meth:`~isaaclab.utils.buffers.CircularBuffer.append` to apply the first-push
+  backfill branchlessly with :func:`torch.where`, removing a host-synchronizing ``nonzero``
+  and a device-scalar branch per append while resets are pending.

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -139,6 +139,9 @@ class CircularBuffer:
         Args:
             batch_ids: Elements to reset in the batch dimension. Default is None, which resets all the batch indices.
         """
+        # nothing to reset; arming the backfill would cost one full-buffer pass in append
+        if batch_ids is not None and len(batch_ids) == 0:
+            return
         batch_ids_resolved: Sequence[int] | slice
         if batch_ids is None:
             batch_ids_resolved = slice(None)

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -189,12 +189,15 @@ class CircularBuffer:
             self._buffer.narrow(k_pos, k - 1, 1).copy_(data.unsqueeze(k_pos))
 
         if self._need_reset:
+            # branchless backfill: boolean-mask indexing and an any() gate both synchronize
+            # the stream; torch.where(out=...) stays on-device
             is_first_push = self._num_pushes == 0
-            if torch.any(is_first_push):
-                if self._stack_dim_internal is None:
-                    self._buffer[:, is_first_push] = data[is_first_push]
-                else:
-                    self._buffer[is_first_push] = data[is_first_push].unsqueeze(self._stack_dim_internal)
+            if self._stack_dim_internal is None:
+                mask = is_first_push.view(1, -1, *([1] * (data.ndim - 1)))
+                torch.where(mask, data.unsqueeze(0), self._buffer, out=self._buffer)
+            else:
+                mask = is_first_push.view(-1, *([1] * (self._buffer.ndim - 1)))
+                torch.where(mask, data.unsqueeze(self._stack_dim_internal), self._buffer, out=self._buffer)
             self._need_reset = False
 
         self._num_pushes += 1


### PR DESCRIPTION
## Description

`CircularBuffer.append` backfills all history slots on the first push after a reset. The current implementation gates the backfill on `torch.any(is_first_push)` (device-scalar to Python bool) and applies it with boolean-mask indexing (host-synchronizing `nonzero`). With per-env resets, both fire on nearly every append at scale: with 8 history-enabled observation buffers this costs ~24 stream syncs per env step at 8192 envs.

This change applies the backfill branchlessly with `torch.where(..., out=self._buffer)`: in-place, no allocation, no host synchronization, identical results.

## Benchmark

Standalone A/B on this file only (RTX 5090, torch CUDA): `batch_size=8192`, `max_len=5`, feature dim 32, 2000 steps, each step resetting a random 2% of batch ids (typical episode-termination rate) followed by one append. Warmup excluded, `torch.cuda.synchronize()` outside the timed loop.

| layout | develop | this PR | speedup |
|---|---|---|---|
| legacy (`stack_dim=None`) | 143.3 µs/append | 78.6 µs/append | **1.82×** |
| stacked (`stack_dim=1`) | 152.0 µs/append | 85.9 µs/append | **1.77×** |
| no pending resets (both layouts' shared path) | 30.1 µs/append | 30.0 µs/append | 1.00× |

Equivalence: after the 2000 mixed reset/append steps, `torch.equal(buffer_old, buffer_new)` is `True` in both layouts.

In a full dexsuite training loop (Isaac-Lift-Franka, Newton/mjwarp, 8192 envs) this was part of a sweep that removed ~56 of ~133 `cudaStreamSynchronize` calls per env step, worth ~+20% collection FPS overall.

## Related work

#5395 and #4275 attacked the same sync class earlier; most of their content has since landed via the frame-stacking refactor (#5574/#5849): the CPU-side `_need_reset` gate, `_max_len_int` (no `.item()` in the `max_length` property), the sync-free `__getitem__`, and the `DelayBuffer` clone removal are all in `develop` today. The masked first-push backfill inside the `_need_reset` branch is the one remaining per-step sync from that series — this PR completes it.

## Type of change

- Bug fix / performance (non-breaking)

## Checklist

- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have added my changelog fragment under `changelog.d`