### PR TITLE
Gate Newton reset-mask consumption on a host-side dirty flag

### DIFF
--- a/source/isaaclab_newton/changelog.d/zhengyuz-perf-newton-reset-mask-gating.rst
+++ b/source/isaaclab_newton/changelog.d/zhengyuz-perf-newton-reset-mask-gating.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Changed :meth:`~isaaclab_newton.physics.NewtonManager.step` and
+  :meth:`~isaaclab_newton.physics.NewtonManager.forward` to skip the reset-mask consumption
+  (solver-internals reset, masked FK, mask zeroing) when no asset write dirtied the masks
+  since the last boundary. A clean mask already made every launch a GPU no-op, but the host
+  dispatch ran on every physics step.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -271,6 +271,7 @@ class NewtonManager(PhysicsManager):
     # Per-world reset masks (allocated in start_simulation, consumed in step/forward).
     _world_reset_mask: wp.array | None = None  # (num_envs,) wp.bool — for SolverKamino.reset(world_mask=...)
     _fk_reset_mask: wp.array | None = None  # (articulation_count,) wp.bool — for eval_fk(mask=...)
+    _reset_masks_dirty: bool = True  # host-side mirror of "any bit set in the reset masks"
     # Solver-specialized FK delegate. Bound in initialize_solver() to the active subclass's choice of FK implementation.
     _eval_fk: Callable[[wp.array | None, wp.array | None], None] = _eval_fk_unbound
 
@@ -410,12 +411,15 @@ class NewtonManager(PhysicsManager):
         data layer invokes ``NewtonManager.forward()`` on the base class, where ``cls`` is the
         base ``NewtonManager``; the bound delegate dispatches to the concrete subclass override.
         """
+        if not cls._reset_masks_dirty:
+            return
         cls._reset_solver_internals(cls._world_reset_mask)
         cls._eval_fk(cls._world_reset_mask, cls._fk_reset_mask)
         if cls._fk_reset_mask is not None:
             cls._fk_reset_mask.zero_()
         if cls._world_reset_mask is not None:
             cls._world_reset_mask.zero_()
+        NewtonManager._reset_masks_dirty = False
 
     @classmethod
     def pre_render(cls) -> None:
@@ -679,7 +683,8 @@ class NewtonManager(PhysicsManager):
         if sim is None or not sim.is_playing():
             return
 
-        cls._reset_solver_internals(cls._world_reset_mask)
+        if cls._reset_masks_dirty:
+            cls._reset_solver_internals(cls._world_reset_mask)
 
         # Notify solver of model changes
         if cls._model_changes:
@@ -712,12 +717,14 @@ class NewtonManager(PhysicsManager):
         # for their internal collider queries. Maximal-coordinate solvers
         # that treat body state as the main state (e.g. Kamino) require FK before step.
         # Only runs FK for dirtied articulations via the accumulated mask.
-        if cls._needs_collision_pipeline or cls._needs_fk_before_step:
-            cls._eval_fk(cls._world_reset_mask, cls._fk_reset_mask)
+        if cls._reset_masks_dirty:
+            if cls._needs_collision_pipeline or cls._needs_fk_before_step:
+                cls._eval_fk(cls._world_reset_mask, cls._fk_reset_mask)
 
-        # Zero both masks after consumption
-        NewtonManager._world_reset_mask.zero_()
-        NewtonManager._fk_reset_mask.zero_()
+            # Zero both masks after consumption
+            NewtonManager._world_reset_mask.zero_()
+            NewtonManager._fk_reset_mask.zero_()
+            NewtonManager._reset_masks_dirty = False
 
         physics_dt = cls._solver_dt * cls._num_substeps
         use_graph = cfg is not None and cfg.use_cuda_graph and cls._graph is not None and "cuda" in device  # type: ignore[union-attr]
@@ -826,6 +833,7 @@ class NewtonManager(PhysicsManager):
         NewtonManager._use_newton_actuators_active = False
         NewtonManager._decimation = 1
         # Per-world reset masks
+        NewtonManager._reset_masks_dirty = True
         NewtonManager._world_reset_mask = None
         NewtonManager._fk_reset_mask = None
         NewtonManager._graph = None
@@ -1121,6 +1129,7 @@ class NewtonManager(PhysicsManager):
 
         if cls._world_reset_mask is None or cls._fk_reset_mask is None:
             return
+        NewtonManager._reset_masks_dirty = True
 
         if articulation_ids is not None and env_mask is not None:
             wp.launch(


### PR DESCRIPTION
## Description

**This is not a bug fix — behavior is identical before and after.** It removes unnecessary per-step CPU work.

Every physics step, `NewtonManager.step()` and `forward()` run a cleanup block meant for environments that were just reset: it tells the solver to clear its carried-over state for those environments, recomputes their body poses, and clears the bookkeeping masks. The block is driven by per-environment masks, so when nothing was reset it does nothing — but the CPU still dispatches all of it every step, and most steps nothing was reset (with decimation 4, at least 3 of every 4 steps).

This change keeps a simple boolean on the CPU — set whenever any asset write marks an environment as reset (`invalidate_fk`, the only place the masks are written), cleared when the block consumes the masks — and skips the whole block when the boolean says nothing happened.

## Measured effect — honest framing

What it saves: a few GPU-call dispatches per quiet step (a solver reset call, one kernel launch, two memsets).

What it does **not** do: make training measurably faster. A/B at 8192 environments (block gated vs deliberately run every step, two rounds each): 202.1k / 202.9k samples-per-second vs 203.7k / 201.9k — identical within noise. The saved work was not on the critical path in my setup.

So the value is: less pointless per-step dispatch, and the mask lifecycle becomes explicit (one writer, one consumer, a flag that says whether there is anything to consume). If that is not judged worth an extra state flag, closing this PR is a completely reasonable call.

No interaction with #6470 — different file, different mechanism.

## Type of change

- Performance / cleanliness (non-breaking, no behavior change)

## Checklist

- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have added my changelog fragment under `changelog.d`