### PR TITLE
Add OVRTX instance segmentation idToLabels/idToSemantics

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovrtx-instance-segmentation.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-instance-segmentation.rst
@@ -1,0 +1,25 @@
+Added
+^^^^^
+
+* Added ``idToLabels`` (instance to USD prim path) and ``idToSemantics`` (instance to semantic label)
+  mappings to the OVRTX renderer's ``instance_segmentation_fast`` output, exposed through
+  ``camera.data.info["instance_segmentation_fast"]``. The mappings are decoded from the
+  ``StableIdSemanticIdMap``, ``StableIdMap``, and ``SemanticIdMap`` render vars and are keyed by the raw
+  ``(r, g, b, a)`` color tuple when ``colorize_instance_segmentation=True`` (matching Replicator's fast
+  instance-segmentation node) or by the raw instance ID otherwise.
+
+Changed
+^^^^^^^
+
+* Changed the colorized ``semantic_segmentation`` ``idToLabels`` keys produced by the OVRTX renderer from the
+  stringified ``"(r, g, b, a)"`` form to raw ``(r, g, b, a)`` tuples, matching Replicator's fast segmentation
+  nodes and the Isaac RTX renderer. Index ``camera.data.info["semantic_segmentation"]["idToLabels"]`` with an
+  ``(r, g, b, a)`` tuple instead of its string form.
+
+Fixed
+^^^^^
+
+* Fixed the OVRTX renderer raising ``RuntimeError: Cannot convert Torch type torch.uint32`` when reading a
+  non-colorized ID segmentation output (``semantic_segmentation``, ``instance_segmentation_fast``, or
+  ``instance_id_segmentation_fast`` with the corresponding ``colorize_*`` flag set to ``False``) on Torch
+  builds that expose ``torch.uint32``.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
@@ -88,6 +88,8 @@ def _decode_identifier_map(id_map: np.ndarray, map_name: str) -> list[tuple[tupl
     if data.size < 4:
         return []
 
+    # ``<u4`` (little-endian): matches the ovannotators reference decoder. kit writes native ``uint32_t``
+    # struct fields with no byte-swap, so this is correct on the (little-endian) platforms it targets.
     entry_dtype = np.dtype([("id", "<u4", (4,)), ("label_length", "<u4"), ("label_offset", "<u4")])
     num_entries = int.from_bytes(data[-4:].tobytes(), byteorder="little")
     entries_size = num_entries * entry_dtype.itemsize

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
@@ -64,7 +64,7 @@ def parse_semantic_label(raw_label: str) -> dict[str, str]:
     return labels
 
 
-def decode_identifier_map(id_map: np.ndarray, map_name: str) -> list[tuple[tuple[int, int, int, int], str]]:
+def _decode_identifier_map(id_map: np.ndarray, map_name: str) -> list[tuple[tuple[int, int, int, int], str]]:
     """Decode an OVRTX ``IdentifierMap``-layout render var buffer into ``(id, raw_label)`` pairs.
 
     Shared layout for the ``SemanticIdMap`` and ``StableIdMap`` render vars: the buffer packs, in order,
@@ -118,7 +118,7 @@ def decode_identifier_map(id_map: np.ndarray, map_name: str) -> list[tuple[tuple
 def decode_semantic_id_map(id_map: np.ndarray) -> dict[int, dict[str, str]]:
     """Decode the OVRTX ``SemanticIdMap`` render var buffer into ``{semantic_id: {type: label}}``.
 
-    The ``id[0]`` field of each :func:`decode_identifier_map` entry is the semantic ID, and the label is
+    The ``id[0]`` field of each :func:`_decode_identifier_map` entry is the semantic ID, and the label is
     parsed with :func:`parse_semantic_label`.
 
     Args:
@@ -130,14 +130,14 @@ def decode_semantic_id_map(id_map: np.ndarray) -> dict[int, dict[str, str]]:
     """
     return {
         id_words[0]: parse_semantic_label(raw_label)
-        for id_words, raw_label in decode_identifier_map(id_map, "SemanticIdMap")
+        for id_words, raw_label in _decode_identifier_map(id_map, "SemanticIdMap")
     }
 
 
 def decode_stable_id_map(id_map: np.ndarray) -> dict[tuple[int, int, int, int], str]:
     """Decode the OVRTX ``StableIdMap`` render var buffer into ``{stable_id: prim_path}``.
 
-    Same :func:`decode_identifier_map` layout as the SemanticIdMap, but the four ``id`` words form the
+    Same :func:`_decode_identifier_map` layout as the SemanticIdMap, but the four ``id`` words form the
     128-bit stable ID key and the label is a USD prim-path string (not a semantic label, so it is not parsed).
 
     Args:
@@ -146,7 +146,7 @@ def decode_stable_id_map(id_map: np.ndarray) -> dict[tuple[int, int, int, int], 
     Returns:
         Mapping from the four-word stable ID to its USD prim-path string.
     """
-    return {id_words: raw_label for id_words, raw_label in decode_identifier_map(id_map, "StableIdMap")}
+    return {id_words: raw_label for id_words, raw_label in _decode_identifier_map(id_map, "StableIdMap")}
 
 
 def decode_stable_id_semantic_id_map(id_map: np.ndarray) -> list[tuple[tuple[int, int, int, int], int]]:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
@@ -3,10 +3,16 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Semantic annotator utilities for the OVRTX renderer.
+"""Host-side stand-in for the not-yet-released ``ovannotators`` segmentation annotators.
 
-Decodes the OVRTX ``SemanticIdMap`` render var into an ``idToLabels`` mapping compatible with the
-Isaac RTX / Replicator contract exposed through ``camera.data.info["semantic_segmentation"]``.
+Until ``ovannotators`` ships, these helpers decode the OVRTX segmentation "map" render vars and rebuild the
+``idToLabels`` / ``idToSemantics`` info dicts that Replicator / Isaac RTX expose through ``camera.data.info``:
+
+- ``semantic_segmentation``: from ``SemanticIdMap`` -> ``idToLabels`` (id -> ``{type: label}``).
+- ``instance_segmentation_fast``: from ``StableIdSemanticIdMap`` + ``StableIdMap`` + ``SemanticIdMap`` ->
+  ``idToLabels`` (instance -> USD prim path) and ``idToSemantics`` (instance -> ``{type: label}``).
+
+For colorized outputs the keys are raw ``(r, g, b, a)`` tuples, matching Replicator's fast segmentation nodes.
 """
 
 from __future__ import annotations
@@ -21,9 +27,17 @@ from .ovrtx_renderer_kernels import generate_random_colors_from_ids_kernel
 # with ID >= 2 are decoded from the SemanticIdMap render var.
 SEMANTIC_ID_BACKGROUND = 0
 SEMANTIC_ID_UNLABELLED = 1
+# Single source of truth for the reserved ID 0/1 label names, shared across every segmentation map and
+# matching the ``"BACKGROUND"`` / ``"UNLABELLED"`` strings Replicator writes for pixel IDs 0 and 1.
+_RESERVED_LABEL_NAMES: dict[int, str] = {
+    SEMANTIC_ID_BACKGROUND: "BACKGROUND",
+    SEMANTIC_ID_UNLABELLED: "UNLABELLED",
+}
+# Reserved prim-path labels (plain strings) for the instance-segmentation ``idToLabels`` mapping.
+RESERVED_INSTANCE_LABELS: dict[int, str] = dict(_RESERVED_LABEL_NAMES)
+# Reserved ``{type: label}`` dicts for the semantic ``idToLabels`` and instance ``idToSemantics`` mappings.
 RESERVED_SEMANTIC_LABELS: dict[int, dict[str, str]] = {
-    SEMANTIC_ID_BACKGROUND: {"class": "BACKGROUND"},
-    SEMANTIC_ID_UNLABELLED: {"class": "UNLABELLED"},
+    reserved_id: {"class": name} for reserved_id, name in _RESERVED_LABEL_NAMES.items()
 }
 
 
@@ -50,13 +64,62 @@ def parse_semantic_label(raw_label: str) -> dict[str, str]:
     return labels
 
 
+def decode_identifier_map(id_map: np.ndarray, map_name: str) -> list[tuple[tuple[int, int, int, int], str]]:
+    """Decode an OVRTX ``IdentifierMap``-layout render var buffer into ``(id, raw_label)`` pairs.
+
+    Shared layout for the ``SemanticIdMap`` and ``StableIdMap`` render vars: the buffer packs, in order,
+    an array of ``IdentifierMap`` entries, the label string blob, and a trailing ``uint32`` entry count.
+    Each entry is ``{uint32 id[4]; uint32 labelLength; uint32 labelOffset}``; the label bytes live at
+    ``[labelOffset, labelOffset + labelLength)`` measured from the buffer base. Mirrors the reference decode
+    shipped with the ovrtx runtime.
+
+    Args:
+        id_map: Raw map buffer mapped to host memory (any dtype; viewed as bytes).
+        map_name: Buffer name used in corruption error messages (e.g. ``"SemanticIdMap"``).
+
+    Returns:
+        One ``(id, raw_label)`` pair per entry in buffer order. ``id`` is the four ``uint32`` identifier
+        words; ``raw_label`` is the decoded, right-stripped UTF-8 label string.
+
+    Raises:
+        ValueError: If the entry count or any label range exceeds the buffer bounds.
+    """
+    data = np.ascontiguousarray(id_map).view(np.uint8).reshape(-1)
+    if data.size < 4:
+        return []
+
+    entry_dtype = np.dtype([("id", "<u4", (4,)), ("label_length", "<u4"), ("label_offset", "<u4")])
+    num_entries = int.from_bytes(data[-4:].tobytes(), byteorder="little")
+    entries_size = num_entries * entry_dtype.itemsize
+    if entries_size > data.size - 4:
+        raise ValueError(
+            f"Corrupt {map_name}: {num_entries} entries ({entries_size} bytes) exceed buffer size {data.size}."
+        )
+
+    # Labels live between the entries and the trailing 4-byte entry count, so a valid label must end at or
+    # before ``data.size - 4`` (never spilling into the count field), consistent with the check above.
+    labels_end = data.size - 4
+    entries = data[:entries_size].view(entry_dtype).reshape(num_entries)
+    decoded: list[tuple[tuple[int, int, int, int], str]] = []
+    for entry in entries:
+        id_words = tuple(int(word) for word in entry["id"])
+        label_offset = int(entry["label_offset"])
+        label_end = label_offset + int(entry["label_length"])
+        if label_end > labels_end:
+            raise ValueError(
+                f"Corrupt {map_name}: label for id {id_words} spans [{label_offset}, {label_end}) beyond"
+                f" the label region end {labels_end} (buffer size {data.size}, minus the 4-byte entry count)."
+            )
+        raw_label = data[label_offset:label_end].tobytes().decode("utf-8").rstrip("\x00").rstrip()
+        decoded.append((id_words, raw_label))
+    return decoded
+
+
 def decode_semantic_id_map(id_map: np.ndarray) -> dict[int, dict[str, str]]:
     """Decode the OVRTX ``SemanticIdMap`` render var buffer into ``{semantic_id: {type: label}}``.
 
-    The buffer packs, in order: an array of ``SemanticIdentifierMap`` entries, the label string blob, and a
-    trailing ``uint32`` entry count. Each entry is ``{uint32 id[4]; uint32 labelLength; uint32 labelOffset}``;
-    the ``id[0]`` field is the semantic ID and the label bytes live at ``[labelOffset, labelOffset + labelLength)``.
-    Mirrors the reference decode shipped with the ovrtx runtime.
+    The ``id[0]`` field of each :func:`decode_identifier_map` entry is the semantic ID, and the label is
+    parsed with :func:`parse_semantic_label`.
 
     Args:
         id_map: Raw SemanticIdMap buffer mapped to host memory (any dtype; viewed as bytes).
@@ -65,51 +128,68 @@ def decode_semantic_id_map(id_map: np.ndarray) -> dict[int, dict[str, str]]:
         Mapping from semantic ID (>= 2) to its parsed ``{type: label}`` dict. Reserved IDs (0/1) are not
         included; callers add BACKGROUND/UNLABELLED separately (see :data:`RESERVED_SEMANTIC_LABELS`).
     """
-    data = np.ascontiguousarray(id_map).view(np.uint8).reshape(-1)
-    if data.size < 4:
-        return {}
-
-    entry_dtype = np.dtype([("id", "<u4", (4,)), ("label_length", "<u4"), ("label_offset", "<u4")])
-    num_entries = int.from_bytes(data[-4:].tobytes(), byteorder="little")
-    entries_size = num_entries * entry_dtype.itemsize
-    if entries_size > data.size - 4:
-        raise ValueError(
-            f"Corrupt SemanticIdMap: {num_entries} entries ({entries_size} bytes) exceed buffer size {data.size}."
-        )
-
-    # Labels live between the entries and the trailing 4-byte entry count, so a valid label must end at or
-    # before ``data.size - 4`` (never spilling into the count field), consistent with the check above.
-    labels_end = data.size - 4
-    entries = data[:entries_size].view(entry_dtype).reshape(num_entries)
-    labels_by_id: dict[int, dict[str, str]] = {}
-    for entry in entries:
-        semantic_id = int(entry["id"][0])
-        label_offset = int(entry["label_offset"])
-        label_end = label_offset + int(entry["label_length"])
-        if label_end > labels_end:
-            raise ValueError(
-                f"Corrupt SemanticIdMap: label for id {semantic_id} spans [{label_offset}, {label_end}) beyond"
-                f" the label region end {labels_end} (buffer size {data.size}, minus the 4-byte entry count)."
-            )
-        raw_label = data[label_offset:label_end].tobytes().decode("utf-8").rstrip("\x00").rstrip()
-        labels_by_id[semantic_id] = parse_semantic_label(raw_label)
-    return labels_by_id
+    return {
+        id_words[0]: parse_semantic_label(raw_label)
+        for id_words, raw_label in decode_identifier_map(id_map, "SemanticIdMap")
+    }
 
 
-def semantic_color_keys(semantic_ids: list[int], device: str) -> list[str]:
-    """Return the ``"(r, g, b, a)"`` color-tuple key for each semantic ID.
+def decode_stable_id_map(id_map: np.ndarray) -> dict[tuple[int, int, int, int], str]:
+    """Decode the OVRTX ``StableIdMap`` render var buffer into ``{stable_id: prim_path}``.
 
-    Colors are computed with the same kernel that colorizes the segmentation buffer
-    (:func:`generate_random_colors_from_ids_kernel`), so the returned keys match the pixel colors.
+    Same :func:`decode_identifier_map` layout as the SemanticIdMap, but the four ``id`` words form the
+    128-bit stable ID key and the label is a USD prim-path string (not a semantic label, so it is not parsed).
 
     Args:
-        semantic_ids: Semantic IDs to colorize, in the order the keys are returned.
+        id_map: Raw StableIdMap buffer mapped to host memory (any dtype; viewed as bytes).
+
+    Returns:
+        Mapping from the four-word stable ID to its USD prim-path string.
+    """
+    return {id_words: raw_label for id_words, raw_label in decode_identifier_map(id_map, "StableIdMap")}
+
+
+def decode_stable_id_semantic_id_map(id_map: np.ndarray) -> list[tuple[tuple[int, int, int, int], int]]:
+    """Decode the OVRTX ``StableIdSemanticIdMap`` render var buffer into per-instance ``(stable_id, semantic_id)``.
+
+    Unlike the identifier maps, this buffer is a pure fixed-size array of ``StableIdSemanticIdMapValues``
+    entries ``{uint32 stableId[4]; uint32 semanticId[4]}`` (32 bytes each) with no label blob and no trailing
+    count; the entry count is ``buffer_bytes // 32``. Array position ``i`` corresponds to the instance-segmentation
+    pixel ID ``i + 2`` (IDs 0 and 1 are the reserved BACKGROUND/UNLABELLED values).
+
+    Args:
+        id_map: Raw StableIdSemanticIdMap buffer mapped to host memory (any dtype; viewed as bytes).
+
+    Returns:
+        One ``(stable_id, semantic_id)`` per entry, indexed by ``pixel_id - 2``. ``stable_id`` is the four
+        ``uint32`` stable-ID words (the :func:`decode_stable_id_map` key); ``semantic_id`` is ``semanticId[0]``.
+    """
+    data = np.ascontiguousarray(id_map).view(np.uint8).reshape(-1)
+    entry_dtype = np.dtype([("stable_id", "<u4", (4,)), ("semantic_id", "<u4", (4,))])
+    num_entries = data.size // entry_dtype.itemsize
+    if num_entries == 0:
+        return []
+    entries = data[: num_entries * entry_dtype.itemsize].view(entry_dtype).reshape(num_entries)
+    return [(tuple(int(word) for word in entry["stable_id"]), int(entry["semantic_id"][0])) for entry in entries]
+
+
+def color_keys_for_ids(ids: list[int], device: str) -> list[tuple[int, int, int, int]]:
+    """Return the ``(r, g, b, a)`` color-tuple key for each segmentation ID.
+
+    Colors are computed with the same kernel that colorizes the segmentation buffer
+    (:func:`generate_random_colors_from_ids_kernel`), so the returned keys match the pixel colors. Used for
+    both semantic IDs and instance-segmentation pixel IDs, which share the same colorization. These raw tuples
+    are the ``idToLabels`` / ``idToSemantics`` key form for the colorized outputs, matching Replicator's fast
+    C++ segmentation nodes.
+
+    Args:
+        ids: Segmentation IDs to colorize, in the order the keys are returned.
         device: Warp device on which to run the colorization kernel (e.g. ``"cuda:0"``).
 
     Returns:
-        One ``"(r, g, b, a)"`` string per input ID, in the same order.
+        One ``(r, g, b, a)`` tuple key per input ID, in the same order.
     """
-    ids_wp = wp.array(np.asarray(semantic_ids, dtype=np.uint32).reshape(1, -1, 1), dtype=wp.uint32, device=device)
+    ids_wp = wp.array(np.asarray(ids, dtype=np.uint32).reshape(1, -1, 1), dtype=wp.uint32, device=device)
     colors_wp = wp.zeros(shape=ids_wp.shape, dtype=wp.uint32, device=device)
     wp.launch(
         kernel=generate_random_colors_from_ids_kernel,
@@ -117,28 +197,28 @@ def semantic_color_keys(semantic_ids: list[int], device: str) -> list[str]:
         inputs=[ids_wp, colors_wp],
         device=device,
     )
-    keys: list[str] = []
+    keys: list[tuple[int, int, int, int]] = []
     for color in colors_wp.numpy().reshape(-1):
         color = int(color)
-        rgba = (color & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF, (color >> 24) & 0xFF)
-        keys.append(str(rgba))
+        keys.append((color & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF, (color >> 24) & 0xFF))
     return keys
 
 
 def build_semantic_id_to_labels(
     labels_by_id: dict[int, dict[str, str]], colorize: bool, device: str
-) -> dict[str, dict[str, str]]:
-    """Build the ``idToLabels`` mapping from decoded semantic IDs, keyed by ID or RGBA color.
+) -> dict[tuple[int, int, int, int] | str, dict[str, str]]:
+    """Build the ``idToLabels`` mapping from decoded semantic IDs, keyed by RGBA color tuple or ID.
 
     Args:
         labels_by_id: Decoded ``{semantic_id: {type: label}}`` for IDs >= 2 from the SemanticIdMap.
-        colorize: If True, keys are ``"(r, g, b, a)"`` color tuples matching the colorized segmentation
-            buffer; otherwise keys are the decimal semantic IDs (matching the raw ``int32`` output).
+        colorize: If True, keys are ``(r, g, b, a)`` color tuples matching the colorized segmentation buffer
+            (the Replicator fast-node contract); otherwise keys are the decimal semantic ID strings (matching
+            the raw ``int32`` output).
         device: Warp device used to compute colors when ``colorize`` is True.
 
     Returns:
-        Mapping from string key to ``{type: label}``, always including the reserved BACKGROUND (ID 0) and
-        UNLABELLED (ID 1) entries.
+        Mapping from key to ``{type: label}``, always including the reserved BACKGROUND (ID 0) and UNLABELLED
+        (ID 1) entries.
     """
     id_labels: dict[int, dict[str, str]] = {**RESERVED_SEMANTIC_LABELS, **labels_by_id}
     sorted_ids = sorted(id_labels)
@@ -146,5 +226,57 @@ def build_semantic_id_to_labels(
     if not colorize:
         return {str(semantic_id): id_labels[semantic_id] for semantic_id in sorted_ids}
 
-    color_keys = semantic_color_keys(sorted_ids, device)
+    color_keys = color_keys_for_ids(sorted_ids, device)
     return {color_keys[idx]: id_labels[semantic_id] for idx, semantic_id in enumerate(sorted_ids)}
+
+
+def build_instance_id_to_labels_and_semantics(
+    stable_id_semantic_id_map: list[tuple[tuple[int, int, int, int], int]],
+    stable_id_to_path: dict[tuple[int, int, int, int], str],
+    semantic_id_to_labels: dict[int, dict[str, str]],
+    colorize: bool,
+    device: str,
+) -> tuple[dict[tuple[int, int, int, int] | str, str], dict[tuple[int, int, int, int] | str, dict[str, str]]]:
+    """Build the instance-segmentation ``idToLabels`` and ``idToSemantics`` mappings.
+
+    Resolves each instance pixel ID through the three decoded maps, following the ovrtx / Replicator chain:
+    pixel ID ``i + 2`` indexes ``stable_id_semantic_id_map[i]`` to get its stable ID and semantic ID; the
+    stable ID resolves to a USD prim path via ``stable_id_to_path`` (``idToLabels``) and the semantic ID
+    resolves to a ``{type: label}`` dict via ``semantic_id_to_labels`` (``idToSemantics``). Pixel IDs 0 and 1
+    are the reserved BACKGROUND / UNLABELLED entries and are always included.
+
+    Args:
+        stable_id_semantic_id_map: Decoded ``StableIdSemanticIdMap`` entries from
+            :func:`decode_stable_id_semantic_id_map`, indexed by ``pixel_id - 2``.
+        stable_id_to_path: Decoded ``{stable_id: prim_path}`` from :func:`decode_stable_id_map`.
+        semantic_id_to_labels: Decoded ``{semantic_id: {type: label}}`` from :func:`decode_semantic_id_map`.
+        colorize: If True, keys are ``(r, g, b, a)`` color tuples matching the colorized segmentation buffer
+            (the Replicator fast-node contract); otherwise keys are the decimal pixel ID strings (matching the
+            raw ``uint32`` output).
+        device: Warp device used to compute colors when ``colorize`` is True.
+
+    Returns:
+        A ``(idToLabels, idToSemantics)`` tuple. ``idToLabels`` maps each key to a USD prim-path string;
+        ``idToSemantics`` maps each key to a ``{type: label}`` dict.
+    """
+    # Pixel IDs 0/1 are reserved; entry ``i`` corresponds to pixel ID ``i + 2``.
+    pixel_ids: list[int] = [SEMANTIC_ID_BACKGROUND, SEMANTIC_ID_UNLABELLED]
+    prim_paths: list[str] = [
+        RESERVED_INSTANCE_LABELS[SEMANTIC_ID_BACKGROUND],
+        RESERVED_INSTANCE_LABELS[SEMANTIC_ID_UNLABELLED],
+    ]
+    semantics: list[dict[str, str]] = [
+        RESERVED_SEMANTIC_LABELS[SEMANTIC_ID_BACKGROUND],
+        RESERVED_SEMANTIC_LABELS[SEMANTIC_ID_UNLABELLED],
+    ]
+    for index, (stable_id, semantic_id) in enumerate(stable_id_semantic_id_map):
+        pixel_ids.append(index + 2)
+        # Fall back to UNLABELLED when a stable/semantic ID is missing from its map (defensive; the producer
+        # only emits pixel IDs >= 2 for labelled prims, so both lookups are expected to hit).
+        prim_paths.append(stable_id_to_path.get(stable_id, RESERVED_INSTANCE_LABELS[SEMANTIC_ID_UNLABELLED]))
+        semantics.append(semantic_id_to_labels.get(semantic_id, RESERVED_SEMANTIC_LABELS[SEMANTIC_ID_UNLABELLED]))
+
+    keys = color_keys_for_ids(pixel_ids, device) if colorize else [str(pixel_id) for pixel_id in pixel_ids]
+    id_to_labels = {key: prim_paths[idx] for idx, key in enumerate(keys)}
+    id_to_semantics = {key: semantics[idx] for idx, key in enumerate(keys)}
+    return id_to_labels, id_to_semantics

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
@@ -17,10 +17,22 @@ For colorized outputs the keys are raw ``(r, g, b, a)`` tuples, matching Replica
 
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import numpy as np
 import warp as wp
 
 from .ovrtx_renderer_kernels import generate_random_colors_from_ids_kernel
+
+# A 128-bit identifier as four ``uint32`` words, low word first: the stable ID key of the StableIdMap /
+# StableIdSemanticIdMap, and the raw ``id`` field of every IdentifierMap entry.
+StableId: TypeAlias = tuple[int, int, int, int]
+# A colorized segmentation key: the ``(r, g, b, a)`` value of a colorized instance/semantic pixel.
+RgbaColor: TypeAlias = tuple[int, int, int, int]
+# A decoded, right-stripped UTF-8 label from an IdentifierMap entry (a semantic label or a USD prim path).
+RawLabel: TypeAlias = str
+# One decoded IdentifierMap entry: its 128-bit id paired with its label.
+StableIdLabelPair: TypeAlias = tuple[StableId, RawLabel]
 
 # Reserved semantic IDs shared by the OVRTX SemanticSegmentation AOV and Isaac RTX / Replicator:
 # ID 0 is BACKGROUND (no prim), ID 1 is UNLABELLED (a prim with no matching semantic label). Entries
@@ -68,7 +80,7 @@ def _parse_semantic_label(raw_label: str) -> dict[str, str]:
     return labels
 
 
-def _decode_identifier_map(id_map: np.ndarray, map_name: str) -> list[tuple[tuple[int, int, int, int], str]]:
+def _decode_identifier_map(id_map: np.ndarray, map_name: str) -> list[StableIdLabelPair]:
     """Decode an OVRTX ``IdentifierMap``-layout render var buffer into ``(id, raw_label)`` pairs.
 
     Shared layout for the ``SemanticIdMap`` and ``StableIdMap`` render vars: the buffer packs, in order,
@@ -106,7 +118,7 @@ def _decode_identifier_map(id_map: np.ndarray, map_name: str) -> list[tuple[tupl
     # before ``data.size - 4`` (never spilling into the count field), consistent with the check above.
     labels_end = data.size - 4
     entries = data[:entries_size].view(entry_dtype).reshape(num_entries)
-    decoded: list[tuple[tuple[int, int, int, int], str]] = []
+    decoded: list[StableIdLabelPair] = []
     for entry in entries:
         id_words = tuple(int(word) for word in entry["id"])
         label_offset = int(entry["label_offset"])
@@ -140,7 +152,7 @@ def decode_semantic_id_map(id_map: np.ndarray) -> dict[int, dict[str, str]]:
     }
 
 
-def decode_stable_id_map(id_map: np.ndarray) -> dict[tuple[int, int, int, int], str]:
+def decode_stable_id_map(id_map: np.ndarray) -> dict[StableId, RawLabel]:
     """Decode the OVRTX ``StableIdMap`` render var buffer into ``{stable_id: prim_path}``.
 
     Same :func:`_decode_identifier_map` layout as the SemanticIdMap, but the four ``id`` words form the
@@ -155,7 +167,7 @@ def decode_stable_id_map(id_map: np.ndarray) -> dict[tuple[int, int, int, int], 
     return {id_words: raw_label for id_words, raw_label in _decode_identifier_map(id_map, "StableIdMap")}
 
 
-def decode_stable_id_semantic_id_map(id_map: np.ndarray) -> list[tuple[tuple[int, int, int, int], int]]:
+def decode_stable_id_semantic_id_map(id_map: np.ndarray) -> list[tuple[StableId, int]]:
     """Decode the OVRTX ``StableIdSemanticIdMap`` render var buffer into per-instance ``(stable_id, semantic_id)``.
 
     Unlike the identifier maps, this buffer is a pure fixed-size array of ``StableIdSemanticIdMapValues``
@@ -180,7 +192,7 @@ def decode_stable_id_semantic_id_map(id_map: np.ndarray) -> list[tuple[tuple[int
     return [(tuple(int(word) for word in entry["stable_id"]), int(entry["semantic_id"][0])) for entry in entries]
 
 
-def _color_keys_for_ids(ids: list[int], device: str) -> list[tuple[int, int, int, int]]:
+def _color_keys_for_ids(ids: list[int], device: str) -> list[RgbaColor]:
     """Return the ``(r, g, b, a)`` color-tuple key for each segmentation ID.
 
     Colors are computed with the same kernel that colorizes the segmentation buffer
@@ -204,7 +216,7 @@ def _color_keys_for_ids(ids: list[int], device: str) -> list[tuple[int, int, int
         inputs=[ids_wp, colors_wp],
         device=device,
     )
-    keys: list[tuple[int, int, int, int]] = []
+    keys: list[RgbaColor] = []
     for color in colors_wp.numpy().reshape(-1):
         color = int(color)
         keys.append((color & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF, (color >> 24) & 0xFF))
@@ -213,7 +225,7 @@ def _color_keys_for_ids(ids: list[int], device: str) -> list[tuple[int, int, int
 
 def build_semantic_id_to_labels(
     labels_by_id: dict[int, dict[str, str]], colorize: bool, device: str
-) -> dict[tuple[int, int, int, int] | str, dict[str, str]]:
+) -> dict[RgbaColor | str, dict[str, str]]:
     """Build the ``idToLabels`` mapping from decoded semantic IDs, keyed by RGBA color tuple or ID.
 
     Args:
@@ -238,12 +250,12 @@ def build_semantic_id_to_labels(
 
 
 def build_instance_id_to_labels_and_semantics(
-    stable_id_semantic_id_map: list[tuple[tuple[int, int, int, int], int]],
-    stable_id_to_path: dict[tuple[int, int, int, int], str],
+    stable_id_semantic_id_map: list[tuple[StableId, int]],
+    stable_id_to_path: dict[StableId, RawLabel],
     semantic_id_to_labels: dict[int, dict[str, str]],
     colorize: bool,
     device: str,
-) -> tuple[dict[tuple[int, int, int, int] | str, str], dict[tuple[int, int, int, int] | str, dict[str, str]]]:
+) -> tuple[dict[RgbaColor | str, str], dict[RgbaColor | str, dict[str, str]]]:
     """Build the instance-segmentation ``idToLabels`` and ``idToSemantics`` mappings.
 
     Resolves each instance pixel ID through the three decoded maps, following the ovrtx / Replicator chain:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
@@ -25,27 +25,27 @@ from .ovrtx_renderer_kernels import generate_random_colors_from_ids_kernel
 # Reserved semantic IDs shared by the OVRTX SemanticSegmentation AOV and Isaac RTX / Replicator:
 # ID 0 is BACKGROUND (no prim), ID 1 is UNLABELLED (a prim with no matching semantic label). Entries
 # with ID >= 2 are decoded from the SemanticIdMap render var.
-SEMANTIC_ID_BACKGROUND = 0
-SEMANTIC_ID_UNLABELLED = 1
+_SEMANTIC_ID_BACKGROUND = 0
+_SEMANTIC_ID_UNLABELLED = 1
 # Single source of truth for the reserved ID 0/1 label names, shared across every segmentation map and
 # matching the ``"BACKGROUND"`` / ``"UNLABELLED"`` strings Replicator writes for pixel IDs 0 and 1.
 _RESERVED_LABEL_NAMES: dict[int, str] = {
-    SEMANTIC_ID_BACKGROUND: "BACKGROUND",
-    SEMANTIC_ID_UNLABELLED: "UNLABELLED",
+    _SEMANTIC_ID_BACKGROUND: "BACKGROUND",
+    _SEMANTIC_ID_UNLABELLED: "UNLABELLED",
 }
 # Number of reserved IDs (BACKGROUND, UNLABELLED). Real per-instance entries are offset by this count: entry
-# ``i`` of the StableIdSemanticIdMap corresponds to pixel ID ``i + NUM_RESERVED_IDS``, and semantic IDs
-# ``>= NUM_RESERVED_IDS`` are real (see the ``+ 2`` offset in the ovrtx / Replicator contract).
-NUM_RESERVED_IDS = len(_RESERVED_LABEL_NAMES)
+# ``i`` of the StableIdSemanticIdMap corresponds to pixel ID ``i + _NUM_RESERVED_IDS``, and semantic IDs
+# ``>= _NUM_RESERVED_IDS`` are real (see the ``+ 2`` offset in the ovrtx / Replicator contract).
+_NUM_RESERVED_IDS = len(_RESERVED_LABEL_NAMES)
 # Reserved prim-path labels (plain strings) for the instance-segmentation ``idToLabels`` mapping.
-RESERVED_INSTANCE_LABELS: dict[int, str] = dict(_RESERVED_LABEL_NAMES)
+_RESERVED_INSTANCE_LABELS: dict[int, str] = dict(_RESERVED_LABEL_NAMES)
 # Reserved ``{type: label}`` dicts for the semantic ``idToLabels`` and instance ``idToSemantics`` mappings.
-RESERVED_SEMANTIC_LABELS: dict[int, dict[str, str]] = {
+_RESERVED_SEMANTIC_LABELS: dict[int, dict[str, str]] = {
     reserved_id: {"class": name} for reserved_id, name in _RESERVED_LABEL_NAMES.items()
 }
 
 
-def parse_semantic_label(raw_label: str) -> dict[str, str]:
+def _parse_semantic_label(raw_label: str) -> dict[str, str]:
     """Parse a raw OVRTX semantic label string into a ``{semantic_type: label}`` dict.
 
     OVRTX encodes labels as ``"<type>: <label>;"`` segments (e.g. ``"class: cone;"``), matching the
@@ -125,17 +125,17 @@ def decode_semantic_id_map(id_map: np.ndarray) -> dict[int, dict[str, str]]:
     """Decode the OVRTX ``SemanticIdMap`` render var buffer into ``{semantic_id: {type: label}}``.
 
     The ``id[0]`` field of each :func:`_decode_identifier_map` entry is the semantic ID, and the label is
-    parsed with :func:`parse_semantic_label`.
+    parsed with :func:`_parse_semantic_label`.
 
     Args:
         id_map: Raw SemanticIdMap buffer mapped to host memory (any dtype; viewed as bytes).
 
     Returns:
         Mapping from semantic ID (>= 2) to its parsed ``{type: label}`` dict. Reserved IDs (0/1) are not
-        included; callers add BACKGROUND/UNLABELLED separately (see :data:`RESERVED_SEMANTIC_LABELS`).
+        included; callers add BACKGROUND/UNLABELLED separately (see :data:`_RESERVED_SEMANTIC_LABELS`).
     """
     return {
-        id_words[0]: parse_semantic_label(raw_label)
+        id_words[0]: _parse_semantic_label(raw_label)
         for id_words, raw_label in _decode_identifier_map(id_map, "SemanticIdMap")
     }
 
@@ -161,13 +161,13 @@ def decode_stable_id_semantic_id_map(id_map: np.ndarray) -> list[tuple[tuple[int
     Unlike the identifier maps, this buffer is a pure fixed-size array of ``StableIdSemanticIdMapValues``
     entries ``{uint32 stableId[4]; uint32 semanticId[4]}`` (32 bytes each) with no label blob and no trailing
     count; the entry count is ``buffer_bytes // 32``. Array position ``i`` corresponds to the instance-segmentation
-    pixel ID ``i + NUM_RESERVED_IDS`` (IDs 0 and 1 are the reserved BACKGROUND/UNLABELLED values).
+    pixel ID ``i + _NUM_RESERVED_IDS`` (IDs 0 and 1 are the reserved BACKGROUND/UNLABELLED values).
 
     Args:
         id_map: Raw StableIdSemanticIdMap buffer mapped to host memory (any dtype; viewed as bytes).
 
     Returns:
-        One ``(stable_id, semantic_id)`` per entry, indexed by ``pixel_id - NUM_RESERVED_IDS``. ``stable_id``
+        One ``(stable_id, semantic_id)`` per entry, indexed by ``pixel_id - _NUM_RESERVED_IDS``. ``stable_id``
         is the four ``uint32`` stable-ID words (the :func:`decode_stable_id_map` key); ``semantic_id`` is
         ``semanticId[0]``.
     """
@@ -180,7 +180,7 @@ def decode_stable_id_semantic_id_map(id_map: np.ndarray) -> list[tuple[tuple[int
     return [(tuple(int(word) for word in entry["stable_id"]), int(entry["semantic_id"][0])) for entry in entries]
 
 
-def color_keys_for_ids(ids: list[int], device: str) -> list[tuple[int, int, int, int]]:
+def _color_keys_for_ids(ids: list[int], device: str) -> list[tuple[int, int, int, int]]:
     """Return the ``(r, g, b, a)`` color-tuple key for each segmentation ID.
 
     Colors are computed with the same kernel that colorizes the segmentation buffer
@@ -227,13 +227,13 @@ def build_semantic_id_to_labels(
         Mapping from key to ``{type: label}``, always including the reserved BACKGROUND (ID 0) and UNLABELLED
         (ID 1) entries.
     """
-    id_labels: dict[int, dict[str, str]] = {**RESERVED_SEMANTIC_LABELS, **labels_by_id}
+    id_labels: dict[int, dict[str, str]] = {**_RESERVED_SEMANTIC_LABELS, **labels_by_id}
     sorted_ids = sorted(id_labels)
 
     if not colorize:
         return {str(semantic_id): id_labels[semantic_id] for semantic_id in sorted_ids}
 
-    color_keys = color_keys_for_ids(sorted_ids, device)
+    color_keys = _color_keys_for_ids(sorted_ids, device)
     return {color_keys[idx]: id_labels[semantic_id] for idx, semantic_id in enumerate(sorted_ids)}
 
 
@@ -247,14 +247,15 @@ def build_instance_id_to_labels_and_semantics(
     """Build the instance-segmentation ``idToLabels`` and ``idToSemantics`` mappings.
 
     Resolves each instance pixel ID through the three decoded maps, following the ovrtx / Replicator chain:
-    pixel ID ``i + NUM_RESERVED_IDS`` indexes ``stable_id_semantic_id_map[i]`` to get its stable ID and semantic ID; the
-    stable ID resolves to a USD prim path via ``stable_id_to_path`` (``idToLabels``) and the semantic ID
+    pixel ID ``i + _NUM_RESERVED_IDS`` indexes ``stable_id_semantic_id_map[i]`` to get its stable ID and
+    semantic ID; the stable ID resolves to a USD prim path via ``stable_id_to_path`` (``idToLabels``) and the
+    semantic ID
     resolves to a ``{type: label}`` dict via ``semantic_id_to_labels`` (``idToSemantics``). Pixel IDs 0 and 1
     are the reserved BACKGROUND / UNLABELLED entries and are always included.
 
     Args:
         stable_id_semantic_id_map: Decoded ``StableIdSemanticIdMap`` entries from
-            :func:`decode_stable_id_semantic_id_map`, indexed by ``pixel_id - NUM_RESERVED_IDS``.
+            :func:`decode_stable_id_semantic_id_map`, indexed by ``pixel_id - _NUM_RESERVED_IDS``.
         stable_id_to_path: Decoded ``{stable_id: prim_path}`` from :func:`decode_stable_id_map`.
         semantic_id_to_labels: Decoded ``{semantic_id: {type: label}}`` from :func:`decode_semantic_id_map`.
         colorize: If True, keys are ``(r, g, b, a)`` color tuples matching the colorized segmentation buffer
@@ -266,24 +267,24 @@ def build_instance_id_to_labels_and_semantics(
         A ``(idToLabels, idToSemantics)`` tuple. ``idToLabels`` maps each key to a USD prim-path string;
         ``idToSemantics`` maps each key to a ``{type: label}`` dict.
     """
-    # Pixel IDs 0/1 are reserved; entry ``i`` corresponds to pixel ID ``i + NUM_RESERVED_IDS``.
-    pixel_ids: list[int] = [SEMANTIC_ID_BACKGROUND, SEMANTIC_ID_UNLABELLED]
+    # Pixel IDs 0/1 are reserved; entry ``i`` corresponds to pixel ID ``i + _NUM_RESERVED_IDS``.
+    pixel_ids: list[int] = [_SEMANTIC_ID_BACKGROUND, _SEMANTIC_ID_UNLABELLED]
     prim_paths: list[str] = [
-        RESERVED_INSTANCE_LABELS[SEMANTIC_ID_BACKGROUND],
-        RESERVED_INSTANCE_LABELS[SEMANTIC_ID_UNLABELLED],
+        _RESERVED_INSTANCE_LABELS[_SEMANTIC_ID_BACKGROUND],
+        _RESERVED_INSTANCE_LABELS[_SEMANTIC_ID_UNLABELLED],
     ]
     semantics: list[dict[str, str]] = [
-        RESERVED_SEMANTIC_LABELS[SEMANTIC_ID_BACKGROUND],
-        RESERVED_SEMANTIC_LABELS[SEMANTIC_ID_UNLABELLED],
+        _RESERVED_SEMANTIC_LABELS[_SEMANTIC_ID_BACKGROUND],
+        _RESERVED_SEMANTIC_LABELS[_SEMANTIC_ID_UNLABELLED],
     ]
     for index, (stable_id, semantic_id) in enumerate(stable_id_semantic_id_map):
-        pixel_ids.append(index + NUM_RESERVED_IDS)
+        pixel_ids.append(index + _NUM_RESERVED_IDS)
         # Fall back to UNLABELLED when a stable/semantic ID is missing from its map (defensive; the producer
         # only emits pixel IDs >= 2 for labelled prims, so both lookups are expected to hit).
-        prim_paths.append(stable_id_to_path.get(stable_id, RESERVED_INSTANCE_LABELS[SEMANTIC_ID_UNLABELLED]))
-        semantics.append(semantic_id_to_labels.get(semantic_id, RESERVED_SEMANTIC_LABELS[SEMANTIC_ID_UNLABELLED]))
+        prim_paths.append(stable_id_to_path.get(stable_id, _RESERVED_INSTANCE_LABELS[_SEMANTIC_ID_UNLABELLED]))
+        semantics.append(semantic_id_to_labels.get(semantic_id, _RESERVED_SEMANTIC_LABELS[_SEMANTIC_ID_UNLABELLED]))
 
-    keys = color_keys_for_ids(pixel_ids, device) if colorize else [str(pixel_id) for pixel_id in pixel_ids]
+    keys = _color_keys_for_ids(pixel_ids, device) if colorize else [str(pixel_id) for pixel_id in pixel_ids]
     id_to_labels = {key: prim_paths[idx] for idx, key in enumerate(keys)}
     id_to_semantics = {key: semantics[idx] for idx, key in enumerate(keys)}
     return id_to_labels, id_to_semantics

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Host-side stand-in for the not-yet-released ``ovannotators`` segmentation annotators.
+"""Host-side stand-in for the not-yet-released ``ovannotators`` library.  This module will be replaced
+by the library once released.
 
 Until ``ovannotators`` ships, these helpers decode the OVRTX segmentation "map" render vars and rebuild the
 ``idToLabels`` / ``idToSemantics`` info dicts that Replicator / Isaac RTX expose through ``camera.data.info``:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
@@ -33,6 +33,10 @@ _RESERVED_LABEL_NAMES: dict[int, str] = {
     SEMANTIC_ID_BACKGROUND: "BACKGROUND",
     SEMANTIC_ID_UNLABELLED: "UNLABELLED",
 }
+# Number of reserved IDs (BACKGROUND, UNLABELLED). Real per-instance entries are offset by this count: entry
+# ``i`` of the StableIdSemanticIdMap corresponds to pixel ID ``i + NUM_RESERVED_IDS``, and semantic IDs
+# ``>= NUM_RESERVED_IDS`` are real (see the ``+ 2`` offset in the ovrtx / Replicator contract).
+NUM_RESERVED_IDS = len(_RESERVED_LABEL_NAMES)
 # Reserved prim-path labels (plain strings) for the instance-segmentation ``idToLabels`` mapping.
 RESERVED_INSTANCE_LABELS: dict[int, str] = dict(_RESERVED_LABEL_NAMES)
 # Reserved ``{type: label}`` dicts for the semantic ``idToLabels`` and instance ``idToSemantics`` mappings.
@@ -157,14 +161,15 @@ def decode_stable_id_semantic_id_map(id_map: np.ndarray) -> list[tuple[tuple[int
     Unlike the identifier maps, this buffer is a pure fixed-size array of ``StableIdSemanticIdMapValues``
     entries ``{uint32 stableId[4]; uint32 semanticId[4]}`` (32 bytes each) with no label blob and no trailing
     count; the entry count is ``buffer_bytes // 32``. Array position ``i`` corresponds to the instance-segmentation
-    pixel ID ``i + 2`` (IDs 0 and 1 are the reserved BACKGROUND/UNLABELLED values).
+    pixel ID ``i + NUM_RESERVED_IDS`` (IDs 0 and 1 are the reserved BACKGROUND/UNLABELLED values).
 
     Args:
         id_map: Raw StableIdSemanticIdMap buffer mapped to host memory (any dtype; viewed as bytes).
 
     Returns:
-        One ``(stable_id, semantic_id)`` per entry, indexed by ``pixel_id - 2``. ``stable_id`` is the four
-        ``uint32`` stable-ID words (the :func:`decode_stable_id_map` key); ``semantic_id`` is ``semanticId[0]``.
+        One ``(stable_id, semantic_id)`` per entry, indexed by ``pixel_id - NUM_RESERVED_IDS``. ``stable_id``
+        is the four ``uint32`` stable-ID words (the :func:`decode_stable_id_map` key); ``semantic_id`` is
+        ``semanticId[0]``.
     """
     data = np.ascontiguousarray(id_map).view(np.uint8).reshape(-1)
     entry_dtype = np.dtype([("stable_id", "<u4", (4,)), ("semantic_id", "<u4", (4,))])
@@ -242,14 +247,14 @@ def build_instance_id_to_labels_and_semantics(
     """Build the instance-segmentation ``idToLabels`` and ``idToSemantics`` mappings.
 
     Resolves each instance pixel ID through the three decoded maps, following the ovrtx / Replicator chain:
-    pixel ID ``i + 2`` indexes ``stable_id_semantic_id_map[i]`` to get its stable ID and semantic ID; the
+    pixel ID ``i + NUM_RESERVED_IDS`` indexes ``stable_id_semantic_id_map[i]`` to get its stable ID and semantic ID; the
     stable ID resolves to a USD prim path via ``stable_id_to_path`` (``idToLabels``) and the semantic ID
     resolves to a ``{type: label}`` dict via ``semantic_id_to_labels`` (``idToSemantics``). Pixel IDs 0 and 1
     are the reserved BACKGROUND / UNLABELLED entries and are always included.
 
     Args:
         stable_id_semantic_id_map: Decoded ``StableIdSemanticIdMap`` entries from
-            :func:`decode_stable_id_semantic_id_map`, indexed by ``pixel_id - 2``.
+            :func:`decode_stable_id_semantic_id_map`, indexed by ``pixel_id - NUM_RESERVED_IDS``.
         stable_id_to_path: Decoded ``{stable_id: prim_path}`` from :func:`decode_stable_id_map`.
         semantic_id_to_labels: Decoded ``{semantic_id: {type: label}}`` from :func:`decode_semantic_id_map`.
         colorize: If True, keys are ``(r, g, b, a)`` color tuples matching the colorized segmentation buffer
@@ -261,7 +266,7 @@ def build_instance_id_to_labels_and_semantics(
         A ``(idToLabels, idToSemantics)`` tuple. ``idToLabels`` maps each key to a USD prim-path string;
         ``idToSemantics`` maps each key to a ``{type: label}`` dict.
     """
-    # Pixel IDs 0/1 are reserved; entry ``i`` corresponds to pixel ID ``i + 2``.
+    # Pixel IDs 0/1 are reserved; entry ``i`` corresponds to pixel ID ``i + NUM_RESERVED_IDS``.
     pixel_ids: list[int] = [SEMANTIC_ID_BACKGROUND, SEMANTIC_ID_UNLABELLED]
     prim_paths: list[str] = [
         RESERVED_INSTANCE_LABELS[SEMANTIC_ID_BACKGROUND],
@@ -272,7 +277,7 @@ def build_instance_id_to_labels_and_semantics(
         RESERVED_SEMANTIC_LABELS[SEMANTIC_ID_UNLABELLED],
     ]
     for index, (stable_id, semantic_id) in enumerate(stable_id_semantic_id_map):
-        pixel_ids.append(index + 2)
+        pixel_ids.append(index + NUM_RESERVED_IDS)
         # Fall back to UNLABELLED when a stable/semantic ID is missing from its map (defensive; the producer
         # only emits pixel IDs >= 2 for labelled prims, so both lookups are expected to hit).
         prim_paths.append(stable_id_to_path.get(stable_id, RESERVED_INSTANCE_LABELS[SEMANTIC_ID_UNLABELLED]))

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -958,6 +958,12 @@ class OVRTXRenderer(BaseRenderer):
     def _process_instance_segmentation_maps(self, render_data: OVRTXRenderData, frame) -> None:
         """Decode the instance-segmentation map render vars into ``renderer_info["instance_segmentation_fast"]``.
 
+        An *instance pixel ID* is a compact integer that the renderer assigns to each visible object instance.
+        Every pixel in the segmentation buffer holds the ID of the instance rendered at that location; the same
+        ID maps to the same object across the entire frame.  ID 0 is reserved for BACKGROUND (no geometry), and
+        ID 1 for UNLABELLED (geometry with no semantic annotation).  All other IDs are dynamically assigned per
+        frame.
+
         Populates ``"idToLabels"`` (instance pixel ID -> USD prim path) and ``"idToSemantics"`` (instance pixel
         ID -> ``{semantic_type: label}``) compatible with Isaac RTX / Replicator. Resolving both requires all
         three map render vars — ``StableIdSemanticIdMap`` (pixel ID -> stable ID + semantic ID), ``StableIdMap``
@@ -982,11 +988,11 @@ class OVRTXRenderer(BaseRenderer):
             )
 
         with frame.render_vars["StableIdSemanticIdMap"].map(device=Device.CPU) as mapping:
-            stable_id_semantic_id_map = decode_stable_id_semantic_id_map(np.from_dlpack(mapping.tensor))
+            stable_id_semantic_id_map = decode_stable_id_semantic_id_map(np.from_dlpack(mapping))
         with frame.render_vars["StableIdMap"].map(device=Device.CPU) as mapping:
-            stable_id_to_path = decode_stable_id_map(np.from_dlpack(mapping.tensor))
+            stable_id_to_path = decode_stable_id_map(np.from_dlpack(mapping))
         with frame.render_vars["SemanticIdMap"].map(device=Device.CPU) as mapping:
-            semantic_id_to_labels = decode_semantic_id_map(np.from_dlpack(mapping.tensor))
+            semantic_id_to_labels = decode_semantic_id_map(np.from_dlpack(mapping))
 
         id_to_labels, id_to_semantics = build_instance_id_to_labels_and_semantics(
             stable_id_semantic_id_map,

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -961,18 +961,25 @@ class OVRTXRenderer(BaseRenderer):
         Populates ``"idToLabels"`` (instance pixel ID -> USD prim path) and ``"idToSemantics"`` (instance pixel
         ID -> ``{semantic_type: label}``) compatible with Isaac RTX / Replicator. Resolving both requires all
         three map render vars — ``StableIdSemanticIdMap`` (pixel ID -> stable ID + semantic ID), ``StableIdMap``
-        (stable ID -> prim path), and ``SemanticIdMap`` (semantic ID -> label) — so nothing is written unless all
-        are present. Keys are the raw pixel IDs (``colorize_instance_segmentation=False``) or the RGBA color
-        tuples the segmentation buffer uses (``colorize_instance_segmentation=True``); the reserved BACKGROUND
-        (ID 0) and UNLABELLED (ID 1) entries are always included.
+        (stable ID -> prim path), and ``SemanticIdMap`` (semantic ID -> label). Keys are the raw pixel IDs
+        (``colorize_instance_segmentation=False``) or the RGBA color tuples the segmentation buffer uses
+        (``colorize_instance_segmentation=True``); the reserved BACKGROUND (ID 0) and UNLABELLED (ID 1) entries
+        are always included.
+
+        Raises:
+            RuntimeError: If any of the three required render vars is absent from ``frame``.
 
         Args:
             render_data: OVRTX render data for the current frame.
             frame: OVRTX frame holding the mapped render vars.
         """
         required_vars = ("StableIdSemanticIdMap", "StableIdMap", "SemanticIdMap")
-        if any(var_name not in frame.render_vars for var_name in required_vars):
-            return
+        missing = [v for v in required_vars if v not in frame.render_vars]
+        if missing:
+            raise RuntimeError(
+                f"instance_segmentation_fast was requested but the following render vars are missing from the "
+                f"OVRTX frame: {missing}. Available vars: {list(frame.render_vars.keys())}"
+            )
 
         with frame.render_vars["StableIdSemanticIdMap"].map(device=Device.CPU) as mapping:
             stable_id_semantic_id_map = decode_stable_id_semantic_id_map(np.from_dlpack(mapping.tensor))
@@ -1153,7 +1160,7 @@ class OVRTXRenderer(BaseRenderer):
             self.cfg.colorize_instance_segmentation,
         )
         # Decode the StableIdSemanticIdMap/StableIdMap/SemanticIdMap trio into
-        # camera.data.info["instance_segmentation_fast"]["idToLabels" / "idToSemantics"].
+        # camera.data.info["instance_segmentation_fast"]["idToLabels"] and ["idToSemantics"].
         if "instance_segmentation_fast" in output_buffers:
             self._process_instance_segmentation_maps(render_data, frame)
 

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -66,7 +66,13 @@ from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.warp.warp_math import convert_camera_frame_orientation_convention_wp
 
-from .ovrtx_annotator_utils import build_semantic_id_to_labels, decode_semantic_id_map
+from .ovrtx_annotator_utils import (
+    build_instance_id_to_labels_and_semantics,
+    build_semantic_id_to_labels,
+    decode_semantic_id_map,
+    decode_stable_id_map,
+    decode_stable_id_semantic_id_map,
+)
 from .ovrtx_renderer_cfg import OVRTXRendererCfg
 from .ovrtx_renderer_kernels import (
     create_camera_transforms_kernel,
@@ -224,7 +230,8 @@ class OVRTXRenderData:
         self.num_rows = math.ceil(self.num_envs / self.num_cols)
         self.warp_buffers: dict[str, wp.array] = {}
         # Per-output metadata collected during render() and copied into CameraData.info by read_output().
-        # Currently only "semantic_segmentation" is populated (with an "idToLabels" mapping).
+        # Populated for "semantic_segmentation" (with an "idToLabels" mapping) and
+        # "instance_segmentation_fast" (with "idToLabels" and "idToSemantics" mappings).
         self.renderer_info: dict[str, Any] = {}
         # Post-render PPISP pipeline composed when ``spec.cfg.isp_cfg`` is set.
         # ``isp_cfg`` is already fully normalized by ``prepare_cameras`` by the time it reaches here.
@@ -917,11 +924,11 @@ class OVRTXRenderer(BaseRenderer):
                 tiled_data = wp.from_torch(colors_uint8, dtype=wp.uint8)
                 self._extract_rgba_tiles(render_data, tiled_data, output_buffers, buffer_key)
             else:
-                # Non-colorized: ensure (TH, TW, 1) shape for the uint32 extraction kernel.
-                data_torch = wp.to_torch(tiled_data)
-                if data_torch.dim() == 2:
-                    data_torch = data_torch.unsqueeze(-1)
-                tiled_data = wp.from_torch(data_torch, dtype=wp.uint32)
+                # Non-colorized: ensure (TH, TW, 1) shape for the uint32 extraction kernel. Reshape the warp
+                # array directly instead of round-tripping through torch, which raises on ``torch.uint32``
+                # (newer torch exposes the dtype but ``wp.from_torch`` still rejects it).
+                if tiled_data.ndim == 2:
+                    tiled_data = tiled_data.reshape((*tiled_data.shape, 1))
                 self._launch_extract_all_tiles(render_data, tiled_data, output_buffers[buffer_key])
 
     def _process_semantic_id_map(self, render_data: OVRTXRenderData, frame) -> None:
@@ -946,6 +953,44 @@ class OVRTXRenderer(BaseRenderer):
             "idToLabels": build_semantic_id_to_labels(
                 labels_by_id, colorize=self.cfg.colorize_semantic_segmentation, device=self._device
             )
+        }
+
+    def _process_instance_segmentation_maps(self, render_data: OVRTXRenderData, frame) -> None:
+        """Decode the instance-segmentation map render vars into ``renderer_info["instance_segmentation_fast"]``.
+
+        Populates ``"idToLabels"`` (instance pixel ID -> USD prim path) and ``"idToSemantics"`` (instance pixel
+        ID -> ``{semantic_type: label}``) compatible with Isaac RTX / Replicator. Resolving both requires all
+        three map render vars — ``StableIdSemanticIdMap`` (pixel ID -> stable ID + semantic ID), ``StableIdMap``
+        (stable ID -> prim path), and ``SemanticIdMap`` (semantic ID -> label) — so nothing is written unless all
+        are present. Keys are the raw pixel IDs (``colorize_instance_segmentation=False``) or the RGBA color
+        tuples the segmentation buffer uses (``colorize_instance_segmentation=True``); the reserved BACKGROUND
+        (ID 0) and UNLABELLED (ID 1) entries are always included.
+
+        Args:
+            render_data: OVRTX render data for the current frame.
+            frame: OVRTX frame holding the mapped render vars.
+        """
+        required_vars = ("StableIdSemanticIdMap", "StableIdMap", "SemanticIdMap")
+        if any(var_name not in frame.render_vars for var_name in required_vars):
+            return
+
+        with frame.render_vars["StableIdSemanticIdMap"].map(device=Device.CPU) as mapping:
+            stable_id_semantic_id_map = decode_stable_id_semantic_id_map(np.from_dlpack(mapping.tensor))
+        with frame.render_vars["StableIdMap"].map(device=Device.CPU) as mapping:
+            stable_id_to_path = decode_stable_id_map(np.from_dlpack(mapping.tensor))
+        with frame.render_vars["SemanticIdMap"].map(device=Device.CPU) as mapping:
+            semantic_id_to_labels = decode_semantic_id_map(np.from_dlpack(mapping.tensor))
+
+        id_to_labels, id_to_semantics = build_instance_id_to_labels_and_semantics(
+            stable_id_semantic_id_map,
+            stable_id_to_path,
+            semantic_id_to_labels,
+            colorize=self.cfg.colorize_instance_segmentation,
+            device=self._device,
+        )
+        render_data.renderer_info["instance_segmentation_fast"] = {
+            "idToLabels": id_to_labels,
+            "idToSemantics": id_to_semantics,
         }
 
     def _launch_extract_all_tiles(
@@ -1107,6 +1152,10 @@ class OVRTXRenderer(BaseRenderer):
             "instance_segmentation_fast",
             self.cfg.colorize_instance_segmentation,
         )
+        # Decode the StableIdSemanticIdMap/StableIdMap/SemanticIdMap trio into
+        # camera.data.info["instance_segmentation_fast"]["idToLabels" / "idToSemantics"].
+        if "instance_segmentation_fast" in output_buffers:
+            self._process_instance_segmentation_maps(render_data, frame)
 
         self._process_id_segmentation_render_var(
             render_data,

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
@@ -55,6 +55,10 @@ class OVRTXRendererCfg(RendererCfg):
 
     If True, instance IDs are mapped to RGBA colors and returned as a ``uint8`` 4-channel array.
     If False, raw instance IDs are returned as a ``uint32`` 1-channel array.
+
+    Regardless of this setting, the instance ID (or color) to prim-path mapping is exposed via
+    ``camera.data.info["instance_segmentation_fast"]["idToLabels"]`` and the instance ID (or color) to
+    semantic-label mapping via ``camera.data.info["instance_segmentation_fast"]["idToSemantics"]``.
     """
 
     colorize_instance_id_segmentation: bool = True

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -95,16 +95,19 @@ def get_render_var_config(data_types: list[str]) -> tuple[str, str, str]:
 def get_render_var_configs(data_types: list[str]) -> list[tuple[str, str, str]]:
     """Return render var configs needed for the requested data types.
 
-    Returns the single render var resolved by :func:`get_render_var_config`,
-    plus ``HdrColor`` when both ``"rgb"`` (or ``"rgba"``) and ``"rgb_hdr"`` are
-    in ``data_types`` so PPISP can consume the HDR AOV alongside the LDR
-    destination on the same render product, plus ``SemanticIdMap`` when
-    ``"semantic_segmentation"`` is requested so the semantic-ID-to-label
-    mapping can be decoded for ``camera.data.info``, plus the
-    ``StableIdSemanticIdMap`` / ``SemanticIdMap`` / ``StableIdMap`` trio when
-    ``"instance_segmentation_fast"`` is requested so the instance-ID-to-prim-path
-    (``idToLabels``) and instance-ID-to-semantic (``idToSemantics``) mappings can be
-    decoded. Other multi-AOV combinations are not supported.
+    Each config is a ``(render_var_path, render_var_name, source_name)`` tuple as defined by
+    :func:`get_render_var_config`. Always includes the single render var resolved by
+    :func:`get_render_var_config`, plus the following extras when applicable:
+
+    * ``HdrColor`` — when both ``"rgb"`` (or ``"rgba"``) and ``"rgb_hdr"`` are requested, so
+      PPISP can consume the HDR AOV alongside the LDR destination on the same render product.
+    * ``SemanticIdMap`` — when ``"semantic_segmentation"`` is requested, so the
+      semantic-ID-to-label mapping can be decoded for ``camera.data.info``.
+    * ``StableIdSemanticIdMap``, ``StableIdMap``, ``SemanticIdMap`` — when
+      ``"instance_segmentation_fast"`` is requested, so the instance-ID-to-prim-path
+      (``idToLabels``) and instance-ID-to-semantic (``idToSemantics``) mappings can be decoded.
+
+    Other multi-AOV combinations are not supported.
     """
     data_types = data_types if data_types else ["rgb"]
     render_vars: list[tuple[str, str, str]] = [get_render_var_config(data_types)]

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -111,17 +111,17 @@ def get_render_var_configs(data_types: list[str]) -> list[tuple[str, str, str]]:
     use_rgb = any(dt in ["rgb", "rgba"] for dt in data_types)
     if use_rgb and "rgb_hdr" in data_types:
         render_vars.append(("/Render/Vars/HdrColor", "HdrColor", "HdrColor"))
-    # When semantic segmentation is the resolved AOV, also author the SemanticIdMap render var so the
-    # renderer can decode the semantic-ID-to-label mapping into camera.data.info["semantic_segmentation"].
-    if render_vars[0][2] == "SemanticSegmentation":
-        render_vars.append(("/Render/Vars/SemanticIdMap", "SemanticIdMap", "SemanticIdMap"))
-    # When instance segmentation is the resolved AOV, author the three map render vars needed to resolve each
-    # NonStableInstanceSegmentation pixel ID to a prim path (StableIdSemanticIdMap -> StableIdMap) and a
-    # semantic label (StableIdSemanticIdMap -> SemanticIdMap) for camera.data.info["instance_segmentation_fast"].
-    if render_vars[0][2] == "NonStableInstanceSegmentation":
+    # Author the ID-to-label map render vars needed to decode the segmentation info dicts. These are keyed off
+    # the requested data types (not the single AOV resolved by get_render_var_config) so they are still authored
+    # when segmentation is combined with other outputs. instance_segmentation_fast needs StableIdSemanticIdMap +
+    # StableIdMap to resolve each pixel to a prim path.
+    if "instance_segmentation_fast" in data_types:
         render_vars.append(("/Render/Vars/StableIdSemanticIdMap", "StableIdSemanticIdMap", "StableIdSemanticIdMap"))
-        render_vars.append(("/Render/Vars/SemanticIdMap", "SemanticIdMap", "SemanticIdMap"))
         render_vars.append(("/Render/Vars/StableIdMap", "StableIdMap", "StableIdMap"))
+    # SemanticIdMap resolves the semantic-ID-to-label mapping and is shared by both semantic_segmentation and
+    # instance_segmentation_fast, so it is authored once when either output is requested.
+    if "semantic_segmentation" in data_types or "instance_segmentation_fast" in data_types:
+        render_vars.append(("/Render/Vars/SemanticIdMap", "SemanticIdMap", "SemanticIdMap"))
     return render_vars
 
 

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -100,8 +100,11 @@ def get_render_var_configs(data_types: list[str]) -> list[tuple[str, str, str]]:
     in ``data_types`` so PPISP can consume the HDR AOV alongside the LDR
     destination on the same render product, plus ``SemanticIdMap`` when
     ``"semantic_segmentation"`` is requested so the semantic-ID-to-label
-    mapping can be decoded for ``camera.data.info``. Other multi-AOV
-    combinations are not supported.
+    mapping can be decoded for ``camera.data.info``, plus the
+    ``StableIdSemanticIdMap`` / ``SemanticIdMap`` / ``StableIdMap`` trio when
+    ``"instance_segmentation_fast"`` is requested so the instance-ID-to-prim-path
+    (``idToLabels``) and instance-ID-to-semantic (``idToSemantics``) mappings can be
+    decoded. Other multi-AOV combinations are not supported.
     """
     data_types = data_types if data_types else ["rgb"]
     render_vars: list[tuple[str, str, str]] = [get_render_var_config(data_types)]
@@ -112,6 +115,13 @@ def get_render_var_configs(data_types: list[str]) -> list[tuple[str, str, str]]:
     # renderer can decode the semantic-ID-to-label mapping into camera.data.info["semantic_segmentation"].
     if render_vars[0][2] == "SemanticSegmentation":
         render_vars.append(("/Render/Vars/SemanticIdMap", "SemanticIdMap", "SemanticIdMap"))
+    # When instance segmentation is the resolved AOV, author the three map render vars needed to resolve each
+    # NonStableInstanceSegmentation pixel ID to a prim path (StableIdSemanticIdMap -> StableIdMap) and a
+    # semantic label (StableIdSemanticIdMap -> SemanticIdMap) for camera.data.info["instance_segmentation_fast"].
+    if render_vars[0][2] == "NonStableInstanceSegmentation":
+        render_vars.append(("/Render/Vars/StableIdSemanticIdMap", "StableIdSemanticIdMap", "StableIdSemanticIdMap"))
+        render_vars.append(("/Render/Vars/SemanticIdMap", "SemanticIdMap", "SemanticIdMap"))
+        render_vars.append(("/Render/Vars/StableIdMap", "StableIdMap", "StableIdMap"))
     return render_vars
 
 

--- a/source/isaaclab_ov/test/test_ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/test/test_ovrtx_annotator_utils.py
@@ -24,6 +24,8 @@ pytestmark = [
 if not _MISSING_MODULES:
     import numpy as np  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_annotator_utils import (  # noqa: E402
+        StableId,
+        StableIdLabelPair,
         _parse_semantic_label,
         build_instance_id_to_labels_and_semantics,
         build_semantic_id_to_labels,
@@ -112,7 +114,7 @@ def test_build_semantic_id_to_labels_colorize_keys_by_color():
     assert len(id_to_labels) == 3
 
 
-def _encode_identifier_map(entries: "list[tuple[tuple[int, int, int, int], str]]") -> "np.ndarray":
+def _encode_identifier_map(entries: "list[StableIdLabelPair]") -> "np.ndarray":
     """Encode ``(id_words, raw_label)`` pairs into an IdentifierMap byte buffer (SemanticIdMap / StableIdMap).
 
     Layout mirrors the OVRTX render var: packed ``IdentifierMap`` entries, the UTF-8 label blob, then a
@@ -132,7 +134,7 @@ def _encode_identifier_map(entries: "list[tuple[tuple[int, int, int, int], str]]
     return np.frombuffer(buffer, dtype=np.uint8).copy()
 
 
-def _encode_stable_id_semantic_id_map(entries: "list[tuple[tuple[int, int, int, int], int]]") -> "np.ndarray":
+def _encode_stable_id_semantic_id_map(entries: "list[tuple[StableId, int]]") -> "np.ndarray":
     """Encode ``(stable_id_words, semantic_id)`` pairs into a StableIdSemanticIdMap byte buffer.
 
     Layout mirrors the OVRTX render var: a pure fixed-size array of ``StableIdSemanticIdMapValues`` entries

--- a/source/isaaclab_ov/test/test_ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/test/test_ovrtx_annotator_utils.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Tests for the OVRTX semantic annotator utilities (SemanticIdMap decode -> idToLabels)."""
+"""Tests for the OVRTX segmentation annotator utilities (map decode -> idToLabels / idToSemantics)."""
 
 import importlib.util
 
@@ -24,8 +24,11 @@ pytestmark = [
 if not _MISSING_MODULES:
     import numpy as np  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_annotator_utils import (  # noqa: E402
+        build_instance_id_to_labels_and_semantics,
         build_semantic_id_to_labels,
         decode_semantic_id_map,
+        decode_stable_id_map,
+        decode_stable_id_semantic_id_map,
         parse_semantic_label,
     )
 
@@ -97,13 +100,111 @@ def test_build_semantic_id_to_labels_non_colorize_keys_by_id():
 
 
 def test_build_semantic_id_to_labels_colorize_keys_by_color():
-    """Colorized idToLabels is keyed by ``"(r, g, b, a)"``; reserved IDs use the fixed BACKGROUND/UNLABELLED colors."""
+    """Colorized idToLabels is keyed by ``(r, g, b, a)`` tuples; reserved IDs use the fixed reserved colors."""
     if not torch.cuda.is_available():
         pytest.skip("colorized key computation runs a Warp kernel that requires a CUDA device")
 
     id_to_labels = build_semantic_id_to_labels({2: {"class": "cone"}}, colorize=True, device="cuda:0")
     # BACKGROUND -> transparent black, UNLABELLED -> opaque black (matches the colorization kernel).
-    assert id_to_labels["(0, 0, 0, 0)"] == {"class": "BACKGROUND"}
-    assert id_to_labels["(0, 0, 0, 255)"] == {"class": "UNLABELLED"}
+    assert id_to_labels[(0, 0, 0, 0)] == {"class": "BACKGROUND"}
+    assert id_to_labels[(0, 0, 0, 255)] == {"class": "UNLABELLED"}
     assert {"class": "cone"} in id_to_labels.values()
     assert len(id_to_labels) == 3
+
+
+def _encode_identifier_map(entries: "list[tuple[tuple[int, int, int, int], str]]") -> "np.ndarray":
+    """Encode ``(id_words, raw_label)`` pairs into an IdentifierMap byte buffer (SemanticIdMap / StableIdMap).
+
+    Layout mirrors the OVRTX render var: packed ``IdentifierMap`` entries, the UTF-8 label blob, then a
+    trailing little-endian ``uint32`` entry count.
+    """
+    entry_dtype = np.dtype([("id", "<u4", (4,)), ("label_length", "<u4"), ("label_offset", "<u4")])
+    header_size = len(entries) * entry_dtype.itemsize
+    entry_arr = np.zeros(len(entries), dtype=entry_dtype)
+    label_blob = b""
+    for i, (id_words, label) in enumerate(entries):
+        label_bytes = label.encode("utf-8")
+        entry_arr[i]["id"] = id_words
+        entry_arr[i]["label_length"] = len(label_bytes)
+        entry_arr[i]["label_offset"] = header_size + len(label_blob)
+        label_blob += label_bytes
+    buffer = entry_arr.tobytes() + label_blob + int(len(entries)).to_bytes(4, "little")
+    return np.frombuffer(buffer, dtype=np.uint8).copy()
+
+
+def _encode_stable_id_semantic_id_map(entries: "list[tuple[tuple[int, int, int, int], int]]") -> "np.ndarray":
+    """Encode ``(stable_id_words, semantic_id)`` pairs into a StableIdSemanticIdMap byte buffer.
+
+    Layout mirrors the OVRTX render var: a pure fixed-size array of ``StableIdSemanticIdMapValues`` entries
+    ``{uint32 stableId[4]; uint32 semanticId[4]}`` with no label blob and no trailing count.
+    """
+    entry_dtype = np.dtype([("stable_id", "<u4", (4,)), ("semantic_id", "<u4", (4,))])
+    entry_arr = np.zeros(len(entries), dtype=entry_dtype)
+    for i, (stable_id_words, semantic_id) in enumerate(entries):
+        entry_arr[i]["stable_id"] = stable_id_words
+        entry_arr[i]["semantic_id"][0] = semantic_id
+    return np.frombuffer(entry_arr.tobytes(), dtype=np.uint8).copy()
+
+
+def test_decode_stable_id_map_round_trips_prim_paths():
+    """Decoding an encoded StableIdMap recovers the four-word stable ID to prim-path mapping."""
+    stable_id_map = _encode_identifier_map([((1, 0, 0, 0), "/World/Cone"), ((2, 3, 0, 0), "/World/Cube")])
+    assert decode_stable_id_map(stable_id_map) == {(1, 0, 0, 0): "/World/Cone", (2, 3, 0, 0): "/World/Cube"}
+
+
+def test_decode_stable_id_map_rejects_corrupt_entry_count():
+    """A StableIdMap whose entry count exceeds the buffer raises with the map name in the message."""
+    stable_id_map = _encode_identifier_map([((1, 0, 0, 0), "/World/Cone")])
+    stable_id_map[-4:] = np.frombuffer(int(999).to_bytes(4, "little"), dtype=np.uint8)
+    with pytest.raises(ValueError, match="Corrupt StableIdMap"):
+        decode_stable_id_map(stable_id_map)
+
+
+def test_decode_stable_id_semantic_id_map_indexes_by_pixel_id():
+    """Each StableIdSemanticIdMap entry decodes to (stable_id, semanticId[0]) at position pixel_id - 2."""
+    buffer = _encode_stable_id_semantic_id_map([((1, 0, 0, 0), 2), ((5, 6, 0, 0), 3)])
+    assert decode_stable_id_semantic_id_map(buffer) == [((1, 0, 0, 0), 2), ((5, 6, 0, 0), 3)]
+
+
+def test_decode_stable_id_semantic_id_map_handles_empty_buffer():
+    """A StableIdSemanticIdMap smaller than one entry decodes to an empty list instead of raising."""
+    assert decode_stable_id_semantic_id_map(np.zeros(0, dtype=np.uint8)) == []
+
+
+def test_build_instance_id_to_labels_and_semantics_non_colorize_keys_by_id():
+    """Non-colorized instance maps are keyed by decimal pixel ID with the reserved BACKGROUND/UNLABELLED entries."""
+    id_to_labels, id_to_semantics = build_instance_id_to_labels_and_semantics(
+        stable_id_semantic_id_map=[((1, 0, 0, 0), 2)],
+        stable_id_to_path={(1, 0, 0, 0): "/World/Cone"},
+        semantic_id_to_labels={2: {"class": "cone"}},
+        colorize=False,
+        device="cpu",
+    )
+    assert id_to_labels == {"0": "BACKGROUND", "1": "UNLABELLED", "2": "/World/Cone"}
+    assert id_to_semantics == {
+        "0": {"class": "BACKGROUND"},
+        "1": {"class": "UNLABELLED"},
+        "2": {"class": "cone"},
+    }
+
+
+def test_build_instance_id_to_labels_and_semantics_colorize_keys_by_color():
+    """Colorized instance maps are keyed by ``(r, g, b, a)`` tuples; reserved IDs use the fixed reserved colors."""
+    if not torch.cuda.is_available():
+        pytest.skip("colorized key computation runs a Warp kernel that requires a CUDA device")
+
+    id_to_labels, id_to_semantics = build_instance_id_to_labels_and_semantics(
+        stable_id_semantic_id_map=[((1, 0, 0, 0), 2)],
+        stable_id_to_path={(1, 0, 0, 0): "/World/Cone"},
+        semantic_id_to_labels={2: {"class": "cone"}},
+        colorize=True,
+        device="cuda:0",
+    )
+    # BACKGROUND -> transparent black, UNLABELLED -> opaque black (matches the colorization kernel).
+    assert id_to_labels[(0, 0, 0, 0)] == "BACKGROUND"
+    assert id_to_labels[(0, 0, 0, 255)] == "UNLABELLED"
+    assert "/World/Cone" in id_to_labels.values()
+    assert id_to_semantics[(0, 0, 0, 0)] == {"class": "BACKGROUND"}
+    assert id_to_semantics[(0, 0, 0, 255)] == {"class": "UNLABELLED"}
+    assert {"class": "cone"} in id_to_semantics.values()
+    assert len(id_to_labels) == 3 and len(id_to_semantics) == 3

--- a/source/isaaclab_ov/test/test_ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/test/test_ovrtx_annotator_utils.py
@@ -24,12 +24,12 @@ pytestmark = [
 if not _MISSING_MODULES:
     import numpy as np  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_annotator_utils import (  # noqa: E402
+        _parse_semantic_label,
         build_instance_id_to_labels_and_semantics,
         build_semantic_id_to_labels,
         decode_semantic_id_map,
         decode_stable_id_map,
         decode_stable_id_semantic_id_map,
-        parse_semantic_label,
     )
 
 
@@ -55,9 +55,9 @@ def _encode_semantic_id_map(entries: list[tuple[int, str]]) -> "np.ndarray":
 
 def test_parse_semantic_label_splits_type_and_label():
     """Raw ``"<type>: <label>;"`` strings parse into ``{type: label}`` dicts like Replicator idToLabels."""
-    assert parse_semantic_label("class: cone;") == {"class": "cone"}
-    assert parse_semantic_label("class: robot; type: arm;") == {"class": "robot", "type": "arm"}
-    assert parse_semantic_label("") == {}
+    assert _parse_semantic_label("class: cone;") == {"class": "cone"}
+    assert _parse_semantic_label("class: robot; type: arm;") == {"class": "robot", "type": "arm"}
+    assert _parse_semantic_label("") == {}
 
 
 def test_decode_semantic_id_map_round_trips_entries():

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -163,6 +163,40 @@ def test_ovrtx_semantic_segmentation_authors_semantic_and_id_map_render_vars():
     assert 'uniform string sourceName = "SemanticIdMap"' in render_scope
 
 
+def test_ovrtx_instance_segmentation_authors_pixel_and_map_render_vars():
+    """Requesting instance segmentation authors the pixel AOV plus the three ID/label map render vars."""
+    render_var_configs = get_render_var_configs(["instance_segmentation_fast"])
+
+    assert render_var_configs == [
+        (
+            "/Render/Vars/NonStableInstanceSegmentation",
+            "NonStableInstanceSegmentation",
+            "NonStableInstanceSegmentation",
+        ),
+        ("/Render/Vars/StableIdSemanticIdMap", "StableIdSemanticIdMap", "StableIdSemanticIdMap"),
+        ("/Render/Vars/SemanticIdMap", "SemanticIdMap", "SemanticIdMap"),
+        ("/Render/Vars/StableIdMap", "StableIdMap", "StableIdMap"),
+    ]
+
+    render_scope = build_render_scope_usd(
+        camera_paths=["/World/envs/env_0/Camera"],
+        render_product_name="RenderProduct",
+        render_var_path=render_var_configs[0][0],
+        render_var_name=render_var_configs[0][1],
+        source_name=render_var_configs[0][2],
+        tiled_width=16,
+        tiled_height=8,
+        render_var_configs=render_var_configs,
+    )
+
+    assert (
+        "rel orderedVars = [</Render/Vars/NonStableInstanceSegmentation>, </Render/Vars/StableIdSemanticIdMap>,"
+        " </Render/Vars/SemanticIdMap>, </Render/Vars/StableIdMap>]" in render_scope
+    )
+    assert 'uniform string sourceName = "StableIdSemanticIdMap"' in render_scope
+    assert 'uniform string sourceName = "StableIdMap"' in render_scope
+
+
 def test_export_stage_keeps_all_env_content_when_all_roots_are_sources():
     """Listing every env root as a source preserves the full stage content."""
     num_envs = 4

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -174,8 +174,8 @@ def test_ovrtx_instance_segmentation_authors_pixel_and_map_render_vars():
             "NonStableInstanceSegmentation",
         ),
         ("/Render/Vars/StableIdSemanticIdMap", "StableIdSemanticIdMap", "StableIdSemanticIdMap"),
-        ("/Render/Vars/SemanticIdMap", "SemanticIdMap", "SemanticIdMap"),
         ("/Render/Vars/StableIdMap", "StableIdMap", "StableIdMap"),
+        ("/Render/Vars/SemanticIdMap", "SemanticIdMap", "SemanticIdMap"),
     ]
 
     render_scope = build_render_scope_usd(
@@ -191,10 +191,20 @@ def test_ovrtx_instance_segmentation_authors_pixel_and_map_render_vars():
 
     assert (
         "rel orderedVars = [</Render/Vars/NonStableInstanceSegmentation>, </Render/Vars/StableIdSemanticIdMap>,"
-        " </Render/Vars/SemanticIdMap>, </Render/Vars/StableIdMap>]" in render_scope
+        " </Render/Vars/StableIdMap>, </Render/Vars/SemanticIdMap>]" in render_scope
     )
     assert 'uniform string sourceName = "StableIdSemanticIdMap"' in render_scope
     assert 'uniform string sourceName = "StableIdMap"' in render_scope
+
+
+def test_ovrtx_semantic_and_instance_segmentation_share_a_single_semantic_id_map():
+    """Requesting both segmentation outputs authors ``SemanticIdMap`` exactly once (it is shared)."""
+    render_var_configs = get_render_var_configs(["semantic_segmentation", "instance_segmentation_fast"])
+
+    sources = [source for _, _, source in render_var_configs]
+    assert sources.count("SemanticIdMap") == 1
+    # Both segmentations' map render vars are authored regardless of which AOV get_render_var_config resolves.
+    assert {"SemanticIdMap", "StableIdSemanticIdMap", "StableIdMap"} <= set(sources)
 
 
 def test_export_stage_keeps_all_env_content_when_all_roots_are_sources():

--- a/source/isaaclab_tasks/changelog.d/ovrtx-instance-segmentation.skip
+++ b/source/isaaclab_tasks/changelog.d/ovrtx-instance-segmentation.skip
@@ -1,0 +1,4 @@
+Test-only: added ``maybe_validate_instance_segmentation_fast`` and a ``stringify_keys`` option on
+``maybe_validate_semantic_segmentation`` in ``test/rendering_test_utils.py`` to validate the segmentation
+``idToLabels`` / ``idToSemantics`` contract (RGBA-tuple keys for instance segmentation, stringified keys for
+the Isaac RTX ``semantic_segmentation`` annotator). No user-facing API change.

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -1348,6 +1348,9 @@ def rendering_test_franka_cloth(
     if physics_backend == "ovphysx":
         pytest.skip("FrankaCloth env cfg does not define an ovphysx preset yet.")
 
+    if renderer == "ovrtx_renderer" and data_type == "instance_segmentation_fast":
+        pytest.skip("instance_segmentation_fast crashes with the OVRTX renderer on franka_cloth (OMPE-101520).")
+
     from isaaclab.envs import ManagerBasedRLEnv
 
     env_cfg = _make_franka_cloth_camera_env_cfg(data_type)
@@ -1471,6 +1474,9 @@ def rendering_test_franka_soft(
 ) -> None:
     if physics_backend == "ovphysx":
         pytest.skip("FrankaSoft env cfg does not define an ovphysx preset yet.")
+
+    if renderer == "ovrtx_renderer" and data_type == "instance_segmentation_fast":
+        pytest.skip("instance_segmentation_fast crashes with the OVRTX renderer on franka_soft (OMPE-101520).")
 
     if physics_backend == "physx" and renderer == "newton_renderer":
         pytest.skip("The test cases will be enabled after Newton Github Issue#3228 is fixed.")

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -7,7 +7,7 @@
 
 import os
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
@@ -16,6 +16,9 @@ from PIL import Image, ImageChops
 
 from isaaclab.utils.images import make_camera_output_grid, normalize_camera_output_for_display
 from isaaclab.utils.warp import ProxyArray
+
+if TYPE_CHECKING:
+    from isaaclab.sensors.camera import CameraData
 
 # Directory containing golden images.
 _GOLDEN_IMAGES_DIRECTORY = os.path.join(os.path.dirname(os.path.abspath(__file__)), "golden_images")
@@ -750,27 +753,124 @@ def validate_camera_outputs(
 def maybe_validate_semantic_segmentation(
     data_type: str,
     info: dict[str, Any] | None,
-    expected_id_to_labels: dict[str, dict[str, str]],
+    expected_id_to_labels: dict[tuple[int, int, int, int], dict[str, str]],
+    stringify_keys: bool = False,
 ) -> None:
     """For the ``semantic_segmentation`` data type, assert ``camera.data.info`` matches ground truth.
 
-    No-op for any other data type. The ``idToLabels`` mapping (keyed by RGBA color for the default colorized
-    output) is a Replicator contract that both the Isaac RTX and OVRTX renderers must satisfy, so it is
-    compared for exact equality against the expected mapping.
+    No-op for any other data type. The ``idToLabels`` mapping (keyed by the colorized RGBA value for the
+    default colorized output) is a Replicator contract that both the Isaac RTX and OVRTX renderers must
+    satisfy, so it is compared for exact equality against the expected mapping.
+
+    ``expected_id_to_labels`` is keyed by raw ``(r, g, b, a)`` **tuples** (the form the OVRTX renderer and
+    Replicator's fast nodes produce). isaacsim's Isaac RTX ``semantic_segmentation`` annotator, however,
+    returns the stringified ``"(r, g, b, a)"`` keys, so pass ``stringify_keys=True`` for that renderer to cast
+    the expected keys to ``str`` before comparing.
 
     Args:
         data_type: The camera data type under test.
         info: The ``camera.data.info`` dict (or ``None``) produced by the renderer.
-        expected_id_to_labels: Expected ``idToLabels`` mapping (color/ID key -> ``{semantic_type: label}``).
+        expected_id_to_labels: Expected ``idToLabels`` mapping (RGBA-tuple key -> ``{semantic_type: label}``).
+        stringify_keys: Cast the expected keys to ``str`` before comparing, to match a renderer that returns
+            stringified color keys (isaacsim Isaac RTX ``semantic_segmentation``).
     """
     if data_type != "semantic_segmentation":
         return
 
+    expected = (
+        {str(key): value for key, value in expected_id_to_labels.items()} if stringify_keys else expected_id_to_labels
+    )
+
     assert info is not None, "camera.data.info is None; renderer did not populate segmentation metadata."
-    assert info["semantic_segmentation"]["idToLabels"] == expected_id_to_labels, (
+    assert info["semantic_segmentation"]["idToLabels"] == expected, (
         f"semantic_segmentation idToLabels mismatch.\n"
-        f"  expected: {expected_id_to_labels}\n"
+        f"  expected: {expected}\n"
         f"  actual:   {info['semantic_segmentation']}"
+    )
+
+
+def maybe_validate_instance_segmentation_fast(
+    data_type: str,
+    camera_data: "CameraData",
+    expected_prim_paths: set[str],
+    expected_semantics: list[dict[str, str]],
+) -> None:
+    """For the ``instance_segmentation_fast`` data type, assert ``camera.data.info`` matches ground truth.
+
+    No-op for any other data type. Instance segmentation exposes two mappings that the Isaac RTX and OVRTX
+    renderers must both satisfy: ``idToLabels`` (instance -> USD prim path) and ``idToSemantics`` (instance ->
+    ``{semantic_type: label}``), both keyed by the colorized ``(r, g, b, a)`` instance value.
+
+    The colorized keys come from ``NonStableInstanceSegmentation`` ids, whose id -> prim assignment is not
+    stable across runs, so the keys cannot be hard-coded. Instead they are validated for self-consistency
+    against the rendered image: each map's key set must equal the unique colors in ``instance_image`` plus the
+    reserved BACKGROUND / UNLABELLED keys (which the maps always include even when those pixels are not
+    rendered). The *values* are then compared against the expected ground truth.
+
+    Concretely it checks:
+
+    - each map's key set equals the unique image colors plus the reserved BACKGROUND / UNLABELLED keys,
+    - the reserved BACKGROUND / UNLABELLED entries (fixed colorized keys) are present and correct,
+    - the set of non-reserved prim paths (``idToLabels`` values) equals ``expected_prim_paths``, and
+    - the multiset of non-reserved semantic labels (``idToSemantics`` values) equals ``expected_semantics``.
+
+    Args:
+        data_type: The camera data type under test.
+        camera_data: The camera's :class:`~isaaclab.sensors.camera.CameraData`; its ``info`` and colorized
+            ``instance_segmentation_fast`` output image are read internally.
+        expected_prim_paths: Expected set of non-reserved ``idToLabels`` values (one USD prim path per instance).
+        expected_semantics: Expected multiset of non-reserved ``idToSemantics`` values (``{semantic_type: label}``
+            per instance).
+    """
+    if data_type != "instance_segmentation_fast":
+        return
+
+    info = camera_data.info
+    assert info is not None, "camera.data.info is None; renderer did not populate segmentation metadata."
+    segmentation = info["instance_segmentation_fast"]
+    id_to_labels = segmentation["idToLabels"]
+    id_to_semantics = segmentation["idToSemantics"]
+
+    # Reserved BACKGROUND / UNLABELLED entries have fixed colorized (RGBA tuple) keys and are always present in
+    # the maps even when the corresponding pixels are not rendered (e.g. no unlabelled prim in view).
+    reserved_keys = {(0, 0, 0, 0), (0, 0, 0, 255)}
+
+    # The colorized keys are non-stable across runs, so validate them against the rendered image instead of
+    # hard-coding: the map keys must be exactly the unique colors present in the image plus the reserved keys.
+    instance_image = camera_data.output["instance_segmentation_fast"]
+    color_image = instance_image if isinstance(instance_image, torch.Tensor) else instance_image.torch
+    color_image = color_image.reshape(-1, color_image.shape[-1]).cpu().numpy()
+    unique_colors = {tuple(int(channel) for channel in row) for row in np.unique(color_image, axis=0)}
+    assert set(id_to_labels) == unique_colors | reserved_keys, (
+        f"instance_segmentation_fast idToLabels keys != rendered colors + reserved.\n"
+        f"  image colors:    {sorted(unique_colors)}\n"
+        f"  idToLabels keys: {sorted(id_to_labels)}"
+    )
+    assert set(id_to_semantics) == unique_colors | reserved_keys, (
+        f"instance_segmentation_fast idToSemantics keys != rendered colors + reserved.\n"
+        f"  image colors:       {sorted(unique_colors)}\n"
+        f"  idToSemantics keys: {sorted(id_to_semantics)}"
+    )
+    assert id_to_labels.get((0, 0, 0, 0)) == "BACKGROUND"
+    assert id_to_labels.get((0, 0, 0, 255)) == "UNLABELLED"
+    assert id_to_semantics.get((0, 0, 0, 0)) == {"class": "BACKGROUND"}
+    assert id_to_semantics.get((0, 0, 0, 255)) == {"class": "UNLABELLED"}
+
+    actual_prim_paths = {value for key, value in id_to_labels.items() if key not in reserved_keys}
+    assert actual_prim_paths == expected_prim_paths, (
+        f"instance_segmentation_fast idToLabels prim paths mismatch.\n"
+        f"  expected: {sorted(expected_prim_paths)}\n"
+        f"  actual:   {sorted(actual_prim_paths)}"
+    )
+
+    def _as_multiset(semantics: list[dict[str, str]]) -> list[tuple[tuple[str, str], ...]]:
+        return sorted(tuple(sorted(entry.items())) for entry in semantics)
+
+    actual_semantics = [value for key, value in id_to_semantics.items() if key not in reserved_keys]
+    assert _as_multiset(actual_semantics) == _as_multiset(expected_semantics), (
+        f"instance_segmentation_fast idToSemantics labels mismatch.\n"
+        f"  expected: {expected_semantics}\n"
+        f"  actual:   {actual_semantics}"
     )
 
 
@@ -870,10 +970,21 @@ def rendering_test_shadow_hand(
             data_type,
             env._tiled_camera.data.info,
             expected_id_to_labels={
-                "(0, 0, 0, 0)": {"class": "BACKGROUND"},
-                "(0, 0, 0, 255)": {"class": "UNLABELLED"},
-                "(33, 243, 3, 255)": {"class": "cube"},
+                (0, 0, 0, 0): {"class": "BACKGROUND"},
+                (0, 0, 0, 255): {"class": "UNLABELLED"},
+                (33, 243, 3, 255): {"class": "cube"},
             },
+            # isaacsim Isaac RTX semantic_segmentation returns stringified color keys; OVRTX returns raw tuples.
+            stringify_keys=(renderer == "isaacsim_rtx_renderer"),
+        )
+
+        # Instance segmentation yields one instance per env's ``class:cube`` object (num_envs=4). The colorized
+        # keys are non-stable, so they are validated against the rendered image; only the values are hard-coded.
+        maybe_validate_instance_segmentation_fast(
+            data_type,
+            env._tiled_camera.data,
+            expected_prim_paths={f"/World/envs/env_{i}/object" for i in range(4)},
+            expected_semantics=[{"class": "cube"} for _ in range(4)],
         )
     finally:
         if env is not None:
@@ -999,10 +1110,21 @@ def rendering_test_cartpole(
             data_type,
             env._tiled_camera.data.info,
             expected_id_to_labels={
-                "(0, 0, 0, 0)": {"class": "BACKGROUND"},
-                "(0, 0, 0, 255)": {"class": "UNLABELLED"},
-                "(33, 243, 3, 255)": {"class": "cartpole"},
+                (0, 0, 0, 0): {"class": "BACKGROUND"},
+                (0, 0, 0, 255): {"class": "UNLABELLED"},
+                (33, 243, 3, 255): {"class": "cartpole"},
             },
+            # isaacsim Isaac RTX semantic_segmentation returns stringified color keys; OVRTX returns raw tuples.
+            stringify_keys=(renderer == "isaacsim_rtx_renderer"),
+        )
+
+        # Instance segmentation yields one instance per env's ``class:cartpole`` robot (num_envs=4). The colorized
+        # keys are non-stable, so they are validated against the rendered image; only the values are hard-coded.
+        maybe_validate_instance_segmentation_fast(
+            data_type,
+            env._tiled_camera.data,
+            expected_prim_paths={f"/World/envs/env_{i}/Robot" for i in range(4)},
+            expected_semantics=[{"class": "cartpole"} for _ in range(4)],
         )
     finally:
         if env is not None:


### PR DESCRIPTION
# Description

The main changes involved updating ovrtx renderer integration's `instance_segmentation_fast` annotator to output `idToLabels` and `idToSemantics` matching Isaac RTX.  And making sure there is test coverage in our rendering correctness.

The the midst of these changes, I noticed that we were stringifying the keys of `semantic_segmentation`'s idToLabels which seem un-desirable, so I've changed it to a tuple.  IsaacRTX is still producing the stringified keys for this annotator, something I will follow up with the synthetic data team.

When I tried to adding an additional ovrtx integration test validating the non-colorized code paths with a procedurally generated USDA scene - I noticed a potential bug with the StableIdMap render var, this has been flagged in internal slack, will see if it can be addressed of which I will follow up with adding this additional integration test. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there