### PR TITLE
Add carb shim to Docker curobo

### DIFF
--- a/.github/actions/_lib/compute-deps-hash/action.yml
+++ b/.github/actions/_lib/compute-deps-hash/action.yml
@@ -47,6 +47,7 @@ runs:
         # Exact files/dirs whose full content is hashed. The Dockerfile is first.
         deps_files=(
           "${DOCKERFILE_PATH}"
+          docker/scripts/install_carb_env_shim.sh
           isaaclab.sh
           environment.yml
           source/isaaclab/isaaclab/cli

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -50,42 +50,12 @@ RUN apt-get update && \
     git-lfs \
     wget
 
-# Install the Carbonite env shim (libcarb.env.shim.so) that serializes glibc's
-# environment functions (getenv/setenv/putenv/unsetenv/secure_getenv/clearenv).
-# Carb/Kit/Omni plugins call these from worker threads while other threads
-# mutate the environment, which intermittently crashes CI with
-# `libc.so.6!getenv+0x56` SIGSEGVs. The shim now ships inside Isaac Sim's
-# Carbonite, so we copy it out of the install tree rather than vendoring a
-# prebuilt binary.
-#
-# Activation uses /etc/ld.so.preload (not ENV LD_PRELOAD) because Isaac Sim's
-# `_isaac_sim/python.sh` unconditionally overwrites LD_PRELOAD with
-# `kit/libcarb.so` before exec'ing the interpreter, which would strip our
-# shim. /etc/ld.so.preload is read by the dynamic linker for every process
-# and cannot be turned off by env-var manipulation.
-RUN install_carb_env_shim() { \
-      local dst=/usr/local/lib/libcarb.env.shim.so; \
-      local src=""; \
-      for c in \
-        "${ISAACSIM_ROOT_PATH}/kit/kernel/plugins/libcarb.env.shim.so" \
-        "${ISAACSIM_ROOT_PATH}/kit/libcarb.env.shim.so" \
-        "${ISAACSIM_ROOT_PATH}/_build/linux-x86_64/release/kit/kernel/plugins/libcarb.env.shim.so" \
-        "${ISAACSIM_ROOT_PATH}/_build/target-deps/carb_sdk_plugins/_build/linux-x86_64/release/libcarb.env.shim.so" \
-      ; do \
-        if [ -f "${c}" ]; then src="${c}"; break; fi; \
-      done; \
-      if [ -z "${src}" ]; then \
-        src="$(find "${ISAACSIM_ROOT_PATH}" -name libcarb.env.shim.so -type f 2>/dev/null | head -n1)"; \
-      fi; \
-      if [ -n "${src}" ] && [ -f "${src}" ]; then \
-        install -m 0755 "${src}" "${dst}" && \
-        echo "${dst}" > /etc/ld.so.preload && \
-        echo "installed carb env shim from ${src}"; \
-      else \
-        echo "no carb env shim found under ${ISAACSIM_ROOT_PATH}; skipping /etc/ld.so.preload" >&2; \
-      fi; \
-    }; \
-    install_carb_env_shim
+# Install the Carbonite environment shim that serializes glibc environment
+# access across Kit worker threads. Use /etc/ld.so.preload because Isaac Sim's
+# python.sh overwrites LD_PRELOAD before launching the interpreter.
+COPY docker/scripts/install_carb_env_shim.sh /tmp/install_carb_env_shim.sh
+RUN /bin/bash /tmp/install_carb_env_shim.sh "${ISAACSIM_ROOT_PATH}" && \
+    rm /tmp/install_carb_env_shim.sh
 
 # arm64-only build deps:
 # - imgui-bundle has no prebuilt arm64 wheel; needs GL/X11 dev headers.

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -49,6 +49,13 @@ RUN apt-get update && \
     git \
     wget
 
+# Install the Carbonite environment shim that serializes glibc environment
+# access across Kit worker threads. Use /etc/ld.so.preload because Isaac Sim's
+# python.sh overwrites LD_PRELOAD before launching the interpreter.
+COPY docker/scripts/install_carb_env_shim.sh /tmp/install_carb_env_shim.sh
+RUN /bin/bash /tmp/install_carb_env_shim.sh "${ISAACSIM_ROOT_PATH}" && \
+    rm /tmp/install_carb_env_shim.sh
+
 # arm64-only build deps:
 # - imgui-bundle has no prebuilt arm64 wheel; needs GL/X11 dev headers.
 RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \

--- a/docker/scripts/install_carb_env_shim.sh
+++ b/docker/scripts/install_carb_env_shim.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright (c) 2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -euo pipefail
+
+isaacsim_root_path="${1:?Usage: install_carb_env_shim.sh ISAACSIM_ROOT_PATH [DESTINATION] [PRELOAD_FILE]}"
+destination="${2:-/usr/local/lib/libcarb.env.shim.so}"
+preload_file="${3:-/etc/ld.so.preload}"
+source_shim=""
+
+candidate_paths=(
+    "${isaacsim_root_path}/kit/kernel/plugins/libcarb.env.shim.so"
+    "${isaacsim_root_path}/kit/libcarb.env.shim.so"
+    "${isaacsim_root_path}/_build/linux-x86_64/release/kit/kernel/plugins/libcarb.env.shim.so"
+    "${isaacsim_root_path}/_build/target-deps/carb_sdk_plugins/_build/linux-x86_64/release/libcarb.env.shim.so"
+)
+
+for candidate_path in "${candidate_paths[@]}"; do
+    if [[ -f "${candidate_path}" ]]; then
+        source_shim="${candidate_path}"
+        break
+    fi
+done
+
+if [[ -z "${source_shim}" ]]; then
+    source_shim="$(find "${isaacsim_root_path}" -name libcarb.env.shim.so -type f -print -quit 2>/dev/null || true)"
+fi
+
+if [[ -z "${source_shim}" || ! -f "${source_shim}" ]]; then
+    echo "no carb env shim found under ${isaacsim_root_path}; skipping ${preload_file}" >&2
+    exit 0
+fi
+
+install -D -m 0755 "${source_shim}" "${destination}"
+mkdir -p "$(dirname "${preload_file}")"
+touch "${preload_file}"
+
+if ! grep -Fqx -- "${destination}" "${preload_file}"; then
+    if [[ -s "${preload_file}" && -n "$(tail -c 1 "${preload_file}")" ]]; then
+        printf '\n' >> "${preload_file}"
+    fi
+    printf '%s\n' "${destination}" >> "${preload_file}"
+fi
+
+echo "installed carb env shim from ${source_shim}"

--- a/docker/test/test_carb_env_shim.py
+++ b/docker/test/test_carb_env_shim.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKER_DIR = REPO_ROOT / "docker"
+SHIM_INSTALLER = DOCKER_DIR / "scripts" / "install_carb_env_shim.sh"
+SHIMMED_DOCKERFILES = ["Dockerfile.base", "Dockerfile.curobo"]
+
+
+@pytest.mark.parametrize("dockerfile_name", SHIMMED_DOCKERFILES)
+def test_dockerfiles_run_shared_carb_env_shim_installer(dockerfile_name: str):
+    """Verify each Isaac Sim Dockerfile runs the shared Carbonite environment shim installer."""
+    dockerfile_text = (DOCKER_DIR / dockerfile_name).read_text(encoding="utf-8")
+
+    assert "COPY docker/scripts/install_carb_env_shim.sh /tmp/install_carb_env_shim.sh" in dockerfile_text
+    assert 'RUN /bin/bash /tmp/install_carb_env_shim.sh "${ISAACSIM_ROOT_PATH}"' in dockerfile_text
+
+
+@pytest.mark.parametrize("preload_terminator", ["", "\n"], ids=["without_final_newline", "with_final_newline"])
+def test_carb_env_shim_installer_copies_shim_and_preserves_preloads(tmp_path: Path, preload_terminator: str):
+    """Verify the shared installer copies the shim and adds one preload entry."""
+    isaacsim_root = tmp_path / "isaac-sim"
+    source_shim = isaacsim_root / "kit" / "kernel" / "plugins" / "libcarb.env.shim.so"
+    source_shim.parent.mkdir(parents=True)
+    source_shim.write_bytes(b"carbonite environment shim")
+
+    installed_shim = tmp_path / "usr" / "local" / "lib" / "libcarb.env.shim.so"
+    preload_file = tmp_path / "etc" / "ld.so.preload"
+    preload_file.parent.mkdir(parents=True)
+    preload_file.write_text(f"/usr/local/lib/existing-shim.so{preload_terminator}", encoding="utf-8")
+
+    command = ["bash", str(SHIM_INSTALLER), str(isaacsim_root), str(installed_shim), str(preload_file)]
+    for _ in range(2):
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+    assert installed_shim.read_bytes() == source_shim.read_bytes()
+    assert stat.S_IMODE(installed_shim.stat().st_mode) == 0o755
+    assert preload_file.read_text(encoding="utf-8").splitlines() == [
+        "/usr/local/lib/existing-shim.so",
+        str(installed_shim),
+    ]
+
+
+def test_dependency_cache_hash_tracks_carb_env_shim_installer():
+    """Verify helper-only changes invalidate the Docker dependency image cache."""
+    action = REPO_ROOT / ".github" / "actions" / "_lib" / "compute-deps-hash" / "action.yml"
+
+    assert "docker/scripts/install_carb_env_shim.sh" in action.read_text(encoding="utf-8")


### PR DESCRIPTION
# Description

Docker.curobo has been failing with getenv in the callstack. It turns out curobo did not use carbonite shim layer for get/set env thread safety.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
