### PR TITLE
Improve manager and direct task hot paths

### DIFF
--- a/source/isaaclab/changelog.d/perf-managers-direct-core.rst
+++ b/source/isaaclab/changelog.d/perf-managers-direct-core.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Improved manager hot paths by avoiding redundant observation term clones and
+  caching action dimensions.

--- a/source/isaaclab/isaaclab/managers/action_manager.py
+++ b/source/isaaclab/isaaclab/managers/action_manager.py
@@ -205,6 +205,9 @@ class ActionManager(ManagerBase):
 
         # call the base class constructor (this prepares the terms)
         super().__init__(cfg, env)
+        # cache action dimensions since they are queried every environment step
+        self._action_term_dim = [term.action_dim for term in self._terms.values()]
+        self._total_action_dim = sum(self._action_term_dim)
         # create buffers to store actions
         self._action = torch.zeros((self.num_envs, self.total_action_dim), device=self.device)
         self._prev_action = torch.zeros_like(self._action)
@@ -241,7 +244,7 @@ class ActionManager(ManagerBase):
     @property
     def total_action_dim(self) -> int:
         """Total dimension of actions."""
-        return sum(self.action_term_dim)
+        return self._total_action_dim
 
     @property
     def active_terms(self) -> list[str]:
@@ -251,7 +254,7 @@ class ActionManager(ManagerBase):
     @property
     def action_term_dim(self) -> list[int]:
         """Shape of each action term."""
-        return [term.action_dim for term in self._terms.values()]
+        return self._action_term_dim
 
     @property
     def action(self) -> torch.Tensor:

--- a/source/isaaclab/isaaclab/managers/observation_manager.py
+++ b/source/isaaclab/isaaclab/managers/observation_manager.py
@@ -385,14 +385,23 @@ class ObservationManager(ManagerBase):
         # iterate over all the terms in each group
         group_term_names = self._group_obs_term_names[group_name]
         # buffer to store obs per group
-        group_obs = dict.fromkeys(group_term_names, None)
+        if self._group_obs_concatenate[group_name]:
+            group_obs: list[torch.Tensor] | dict[str, torch.Tensor] = list()
+        else:
+            group_obs = dict.fromkeys(group_term_names, None)
         # read attributes for each term
-        obs_terms = zip(group_term_names, self._group_obs_term_cfgs[group_name])
+        obs_terms = zip(
+            group_term_names,
+            self._group_obs_term_cfgs[group_name],
+            self._group_obs_term_requires_copy[group_name],
+        )
 
         # evaluate terms: compute, add noise, clip, scale, custom modifiers
-        for term_name, term_cfg in obs_terms:
+        for term_name, term_cfg, requires_copy in obs_terms:
             # compute term's value
-            obs: torch.Tensor = term_cfg.func(self._env, **term_cfg.params).clone()
+            obs: torch.Tensor = term_cfg.func(self._env, **term_cfg.params)
+            if requires_copy:
+                obs = obs.clone()
             # apply post-processing
             if term_cfg.modifiers is not None:
                 for modifier in term_cfg.modifiers:
@@ -421,16 +430,19 @@ class ObservationManager(ManagerBase):
                     circular_buffer.append(obs)
 
                 if term_cfg.flatten_history_dim:
-                    group_obs[term_name] = circular_buffer.buffer.reshape(self._env.num_envs, -1)
+                    obs = circular_buffer.buffer.reshape(self._env.num_envs, -1)
                 else:
-                    group_obs[term_name] = circular_buffer.buffer
+                    obs = circular_buffer.buffer
+
+            if self._group_obs_concatenate[group_name]:
+                group_obs.append(obs)
             else:
                 group_obs[term_name] = obs
 
         # concatenate all observations in the group together
         if self._group_obs_concatenate[group_name]:
             # set the concatenate dimension, account for the batch dimension if positive dimension is given
-            return torch.cat(list(group_obs.values()), dim=self._group_obs_concatenate_dim[group_name])
+            return torch.cat(group_obs, dim=self._group_obs_concatenate_dim[group_name])
         else:
             return group_obs
 
@@ -468,6 +480,7 @@ class ObservationManager(ManagerBase):
         self._group_obs_term_names: dict[str, list[str]] = dict()
         self._group_obs_term_dim: dict[str, list[tuple[int, ...]]] = dict()
         self._group_obs_term_cfgs: dict[str, list[ObservationTermCfg]] = dict()
+        self._group_obs_term_requires_copy: dict[str, list[bool]] = dict()
         self._group_obs_class_term_cfgs: dict[str, list[ObservationTermCfg]] = dict()
         self._group_obs_concatenate: dict[str, bool] = dict()
         self._group_obs_concatenate_dim: dict[str, int] = dict()
@@ -505,6 +518,7 @@ class ObservationManager(ManagerBase):
             self._group_obs_term_names[group_name] = list()
             self._group_obs_term_dim[group_name] = list()
             self._group_obs_term_cfgs[group_name] = list()
+            self._group_obs_term_requires_copy[group_name] = list()
             self._group_obs_class_term_cfgs[group_name] = list()
 
             # history buffers
@@ -651,6 +665,13 @@ class ObservationManager(ManagerBase):
                         obs_dims = (obs_dims[0], int(np.prod(obs_dims[1:])))
 
                 self._group_obs_term_dim[group_name].append(obs_dims[1:])
+                self._group_obs_term_requires_copy[group_name].append(
+                    bool(term_cfg.modifiers)
+                    or term_cfg.noise is not None
+                    or term_cfg.clip is not None
+                    or term_cfg.scale is not None
+                    or (term_cfg.history_length == 0 and not group_cfg.concatenate_terms)
+                )
 
                 # add term in a separate list if term is a class
                 if isinstance(term_cfg.func, ManagerTermBase):

--- a/source/isaaclab/test/managers/test_observation_manager.py
+++ b/source/isaaclab/test/managers/test_observation_manager.py
@@ -372,6 +372,51 @@ def test_compute(setup_env):
     assert torch.equal(obs_policy[:, 8:11], obs_critic[:, 3:6])
 
 
+def test_compute_preserves_source_data(setup_env):
+    env = setup_env
+    """Test that observation outputs cannot mutate source tensors."""
+
+    @configclass
+    class MyObservationManagerCfg:
+        """Test config class for observation manager."""
+
+        @configclass
+        class PolicyCfg(ObservationGroupCfg):
+            """Test config class for concatenated raw observations."""
+
+            term_1 = ObservationTermCfg(func=pos_w_data)
+            term_2 = ObservationTermCfg(func=lin_vel_w_data)
+
+        @configclass
+        class CriticCfg(ObservationGroupCfg):
+            """Test config class for non-concatenated raw observations."""
+
+            concatenate_terms = False
+            term_1 = ObservationTermCfg(func=pos_w_data)
+
+        @configclass
+        class ScaledCfg(ObservationGroupCfg):
+            """Test config class for concatenated observations with in-place post-processing."""
+
+            term_1 = ObservationTermCfg(func=pos_w_data, scale=2.0)
+
+        policy: ObservationGroupCfg = PolicyCfg()
+        critic: ObservationGroupCfg = CriticCfg()
+        scaled: ObservationGroupCfg = ScaledCfg()
+
+    cfg = MyObservationManagerCfg()
+    obs_man = ObservationManager(cfg, env)
+
+    pos_before = env.data.pos_w.clone()
+    observations = obs_man.compute()
+
+    observations["policy"][:, :3] = 0.0
+    observations["critic"]["term_1"][:] = 0.0
+
+    torch.testing.assert_close(env.data.pos_w, pos_before)
+    torch.testing.assert_close(observations["scaled"], pos_before * 2.0)
+
+
 def test_compute_with_history(setup_env):
     env = setup_env
     """Test the observation computation with history buffers."""

--- a/source/isaaclab_tasks/changelog.d/perf-direct-core.rst
+++ b/source/isaaclab_tasks/changelog.d/perf-direct-core.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Improved direct core task stepping throughput by avoiding unnecessary action
+  tensor clones and simplifying Cartpole direct observation and reward tensor
+  operations.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_direct_env.py
@@ -154,7 +154,7 @@ class CabinetDirectEnv(DirectRLEnv):
     # pre-physics step calls
 
     def _pre_physics_step(self, actions: torch.Tensor):
-        self.actions = actions.clone().clamp(-1.0, 1.0)
+        self.actions = actions.clamp(-1.0, 1.0)
         targets = self.robot_dof_targets + self.robot_dof_speed_scales * self.dt * self.actions * self.cfg.action_scale
         self.robot_dof_targets[:] = torch.clamp(targets, self.robot_dof_lower_limits, self.robot_dof_upper_limits)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env.py
@@ -31,6 +31,8 @@ class CartpoleEnv(DirectRLEnv):
 
         self._cart_dof_idx, _ = self.cartpole.find_joints(self.cfg.cart_dof_name)
         self._pole_dof_idx, _ = self.cartpole.find_joints(self.cfg.pole_dof_name)
+        self._cart_dof_idx_scalar = self._cart_dof_idx[0]
+        self._pole_dof_idx_scalar = self._pole_dof_idx[0]
         self.action_scale = self.cfg.action_scale
 
         self.joint_pos = self.cartpole.data.joint_pos.torch
@@ -57,23 +59,19 @@ class CartpoleEnv(DirectRLEnv):
         light_cfg.func("/World/Light", light_cfg, orientation=light_orientation)
 
     def _pre_physics_step(self, actions: torch.Tensor) -> None:
-        self.actions = self.action_scale * actions.clone()
+        self.actions = self.action_scale * actions
 
     def _apply_action(self) -> None:
         self.cartpole.set_joint_effort_target_index(target=self.actions, joint_ids=self._cart_dof_idx)
 
     def _get_observations(self) -> dict:
-        joint_pos_rel = self.joint_pos - self.cartpole.data.default_joint_pos.torch
-        joint_vel_rel = self.joint_vel - self.cartpole.data.default_joint_vel.torch
-        obs = torch.cat(
-            (
-                joint_pos_rel[:, self._cart_dof_idx[0]].unsqueeze(dim=1),
-                joint_pos_rel[:, self._pole_dof_idx[0]].unsqueeze(dim=1),
-                joint_vel_rel[:, self._cart_dof_idx[0]].unsqueeze(dim=1),
-                joint_vel_rel[:, self._pole_dof_idx[0]].unsqueeze(dim=1),
-            ),
-            dim=-1,
-        )
+        default_joint_pos = self.cartpole.data.default_joint_pos.torch
+        default_joint_vel = self.cartpole.data.default_joint_vel.torch
+        obs = torch.empty((self.num_envs, 4), dtype=self.joint_pos.dtype, device=self.joint_pos.device)
+        obs[:, 0] = self.joint_pos[:, self._cart_dof_idx_scalar] - default_joint_pos[:, self._cart_dof_idx_scalar]
+        obs[:, 1] = self.joint_pos[:, self._pole_dof_idx_scalar] - default_joint_pos[:, self._pole_dof_idx_scalar]
+        obs[:, 2] = self.joint_vel[:, self._cart_dof_idx_scalar] - default_joint_vel[:, self._cart_dof_idx_scalar]
+        obs[:, 3] = self.joint_vel[:, self._pole_dof_idx_scalar] - default_joint_vel[:, self._pole_dof_idx_scalar]
         observations = {"policy": obs}
         return observations
 
@@ -84,9 +82,9 @@ class CartpoleEnv(DirectRLEnv):
             self.cfg.rew_scale_pole_pos,
             self.cfg.rew_scale_cart_vel,
             self.cfg.rew_scale_pole_vel,
-            self.joint_pos[:, self._pole_dof_idx[0]],
-            self.joint_vel[:, self._pole_dof_idx[0]],
-            self.joint_vel[:, self._cart_dof_idx[0]],
+            self.joint_pos[:, self._pole_dof_idx_scalar],
+            self.joint_vel[:, self._pole_dof_idx_scalar],
+            self.joint_vel[:, self._cart_dof_idx_scalar],
             self.reset_terminated,
             self.step_dt,
         )
@@ -97,7 +95,7 @@ class CartpoleEnv(DirectRLEnv):
         self.joint_vel = self.cartpole.data.joint_vel.torch
 
         time_out = self.episode_length_buf >= self.max_episode_length
-        out_of_bounds = torch.any(torch.abs(self.joint_pos[:, self._cart_dof_idx]) > self.cfg.max_cart_pos, dim=1)
+        out_of_bounds = torch.abs(self.joint_pos[:, self._cart_dof_idx_scalar]) > self.cfg.max_cart_pos
         return out_of_bounds, time_out
 
     def _reset_idx(self, env_ids: Sequence[int] | None):
@@ -172,8 +170,8 @@ def compute_rewards(
     pole_pos = wrap_to_pi(pole_pos)
     rew_alive = rew_scale_alive * (1.0 - reset_terminated.float())
     rew_termination = rew_scale_terminated * reset_terminated.float()
-    rew_pole_pos = rew_scale_pole_pos * torch.sum(torch.square(pole_pos).unsqueeze(dim=1), dim=-1)
-    rew_cart_vel = rew_scale_cart_vel * torch.sum(torch.abs(cart_vel).unsqueeze(dim=1), dim=-1)
-    rew_pole_vel = rew_scale_pole_vel * torch.sum(torch.abs(pole_vel).unsqueeze(dim=1), dim=-1)
+    rew_pole_pos = rew_scale_pole_pos * torch.square(pole_pos)
+    rew_cart_vel = rew_scale_cart_vel * torch.abs(cart_vel)
+    rew_pole_vel = rew_scale_pole_vel * torch.abs(pole_vel)
     total_reward = (rew_alive + rew_termination + rew_pole_pos + rew_cart_vel + rew_pole_vel) * step_dt
     return total_reward

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/locomotion_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/locomotion_direct_env.py
@@ -131,7 +131,7 @@ class LocomotionDirectEnv(DirectRLEnv):
         light_cfg.func("/World/Light", light_cfg)
 
     def _pre_physics_step(self, actions: torch.Tensor) -> None:
-        self.actions = actions.clone()
+        self.actions = actions
 
     def _apply_action(self) -> None:
         forces = self.action_scale * self.joint_gears * torch.clamp(self.actions, -1.0, 1.0)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/reorient_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/reorient_direct_env.py
@@ -128,7 +128,7 @@ class ReorientDirectEnv(DirectRLEnv):
         return JointWrenchSensor(JointWrenchSensorCfg(prim_path=self.cfg.robot_cfg.prim_path))
 
     def _pre_physics_step(self, actions: torch.Tensor) -> None:
-        self.actions = actions.clone()
+        self.actions = actions
 
     def _apply_action(self) -> None:
         self.cur_targets[:, self.actuated_dof_indices] = unscale_transform(


### PR DESCRIPTION
# Description

Improves the training hot paths that are shared by manager-based tasks and the selected direct core tasks.

This PR:

- caches `ActionManager` action dimensions instead of rebuilding them every step
- avoids unconditional observation term clones when concatenated terms do not need in-place post-processing
- keeps a regression test that mutating returned observation outputs does not mutate source tensors
- removes avoidable action clones in core direct tasks
- simplifies Cartpole direct observation, reward, and termination tensor work

Fixes #

## Benchmark impact

Runtime throughput from the exploration benchmark set:

| Task | Baseline FPS | Optimized FPS | Delta |
|---|---:|---:|---:|
| `Isaac-Cartpole-Direct` | 326,798.82 | 349,495.25 | +6.95% |
| `Isaac-Ant` | 248,768.20 | 253,743.87 | +2.00% |
| `Isaac-Velocity-Flat-UnitreeGo2` | 218,373.12 | 223,769.76 | +2.47% |
| `Isaac-Open-Drawer-Franka` | 129,490.49 | 132,211.63 | +2.10% |
| `Isaac-Ant-Direct` | 456,616.43 | 456,017.78 | -0.13% |

Short RSL-RL throughput checks:

| Task | Baseline total FPS | Optimized total FPS | Delta |
|---|---:|---:|---:|
| `Isaac-Cartpole-Direct`, 10 iters | 139,522.60 | 139,602.60 | +0.06% |
| `Isaac-Ant`, 50 iters | 145,352.32 | 147,341.06 | +1.37% |
| `Isaac-Velocity-Flat-UnitreeGo2`, 150 iters | 106,937.88 | 109,667.20 | +2.55% |

Convergence sanity: the Cartpole direct 10-iteration run preserved the same max reward, last reward, max episode length, and last episode length. The Go2 150-iteration reward curve stayed in the same learning regime, but the final seed-42 reward was slightly below baseline, so longer multi-seed validation is still recommended before treating convergence neutrality as final.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- `./isaaclab.sh -p -m pytest source/isaaclab/test/managers/test_observation_manager.py`
- `./isaaclab.sh -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation, or documentation is not required for this internal performance cleanup
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
