### PR TITLE
Reduce task registration startup imports

### DIFF
--- a/source/isaaclab/changelog.d/perf-startup-imports.rst
+++ b/source/isaaclab/changelog.d/perf-startup-imports.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Reduced launcher startup imports by resolving backend physics and renderer
+  config classes only when the selected launch path needs them.

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -19,19 +19,12 @@ import sys
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any
-
-from isaaclab_newton.physics import NewtonCfg
-from isaaclab_ov.renderers import OVRTXRendererCfg
-from isaaclab_ovphysx.physics import OvPhysxCfg
-from isaaclab_physx.physics import PhysxCfg
-from isaaclab_physx.renderers import IsaacRtxRendererCfg
+from typing import TYPE_CHECKING, Any
 
 from isaaclab.app.logging_utils import apply_python_logging_level, resolve_python_logging_level
-from isaaclab.physics.physics_manager_cfg import PhysicsCfg
-from isaaclab.renderers.renderer_cfg import RendererCfg
-from isaaclab.sensors.camera.camera_cfg import CameraCfg
-from isaaclab.utils._device import set_cuda_device
+
+if TYPE_CHECKING:
+    from isaaclab.physics.physics_manager_cfg import PhysicsCfg
 
 logger = logging.getLogger(__name__)
 
@@ -64,8 +57,12 @@ def make_physics_cfg(physics_cfg_str: str) -> PhysicsCfg:
         ValueError: If *physics_cfg_str* does not name a known backend.
     """
     if physics_cfg_str == "physx":
+        from isaaclab_physx.physics import PhysxCfg
+
         return PhysxCfg()
     if physics_cfg_str == "newton_mjwarp":
+        from isaaclab_newton.physics import NewtonCfg
+
         return NewtonCfg()
     if physics_cfg_str == "newton_vbd":
         # lazy import: core depends on isaaclab_contrib only when VBD is requested
@@ -79,6 +76,8 @@ def make_physics_cfg(physics_cfg_str: str) -> PhysicsCfg:
 
         return NewtonCfg(solver_cfg=VBDSolverCfg())
     if physics_cfg_str == "ovphysx":
+        from isaaclab_ovphysx.physics import OvPhysxCfg
+
         return OvPhysxCfg()
     raise ValueError(
         f"Invalid physics config: {physics_cfg_str!r} (expected 'physx', 'newton_mjwarp', 'newton_vbd', or 'ovphysx')."
@@ -92,7 +91,7 @@ Node Predicates.
 
 def _is_ovrtx_renderer(node) -> bool:
     """True when the node is an OVRTX renderer config."""
-    return isinstance(node, RendererCfg) and getattr(node, "renderer_type", None) == "ovrtx"
+    return getattr(node, "renderer_type", None) == "ovrtx"
 
 
 def _is_auto_rtx_renderer(node) -> bool:
@@ -102,6 +101,9 @@ def _is_auto_rtx_renderer(node) -> bool:
 
 def _is_kit_camera(node) -> bool:
     """True for a CameraCfg whose renderer requires Kit (not Newton)."""
+    from isaaclab.renderers.renderer_cfg import RendererCfg
+    from isaaclab.sensors.camera.camera_cfg import CameraCfg
+
     if not isinstance(node, CameraCfg):
         return False
     renderer_cfg = getattr(node, "renderer_cfg", None)
@@ -236,6 +238,9 @@ def scan(cfg, launcher_args: argparse.Namespace | dict | None = None) -> Scan:
     place). Automatic RTX renderer placeholders (``renderer_type="auto_rtx"``) are
     also resolved at this stage using the full *launcher_args* context.
     """
+    from isaaclab.physics.physics_manager_cfg import PhysicsCfg
+    from isaaclab.sensors.camera.camera_cfg import CameraCfg
+
     physics_str = _get_arg(launcher_args, "physics", None)
     physics_cfgs: list[PhysicsCfg] = []
     effective_cfg: Any = cfg
@@ -298,7 +303,14 @@ def scan(cfg, launcher_args: argparse.Namespace | dict | None = None) -> Scan:
         return config_scan
 
     use_isaac_sim = _uses_isaac_sim_runtime(config_scan, launcher_args)
-    renderer_factory = IsaacRtxRendererCfg if use_isaac_sim else OVRTXRendererCfg
+    if use_isaac_sim:
+        from isaaclab_physx.renderers import IsaacRtxRendererCfg
+
+        renderer_factory = IsaacRtxRendererCfg
+    else:
+        from isaaclab_ov.renderers import OVRTXRendererCfg
+
+        renderer_factory = OVRTXRendererCfg
 
     # Resolve every auto RTX placeholder in place, tracking camera renderers that may require Kit.
     has_auto_camera = False
@@ -394,6 +406,8 @@ def _resolve_distributed_device(cfg, launcher_args: argparse.Namespace | dict | 
     sim_cfg = getattr(cfg, "sim", None)
     if sim_cfg is not None:
         sim_cfg.device = device_str
+    from isaaclab.utils._device import set_cuda_device
+
     set_cuda_device(device_str)
     logger.info(
         "Distributed device resolved to %s (local_rank=%d, visible_gpus=%d)",

--- a/source/isaaclab_tasks/changelog.d/perf-task-imports.rst
+++ b/source/isaaclab_tasks/changelog.d/perf-task-imports.rst
@@ -1,0 +1,9 @@
+Changed
+^^^^^^^
+
+* Reduced task-registration startup imports by skipping agent configuration
+  packages during recursive Gym environment registration and contrib task
+  registration.
+* Reduced task utility import time by importing only Gym registration packages
+  during recursive task discovery and lazily resolving preset target base
+  classes.

--- a/source/isaaclab_tasks/isaaclab_tasks/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/__init__.py
@@ -47,6 +47,7 @@ from .utils import import_packages
 # during that window, __init__ runs again and re-registers every gym env.
 # We stash a flag on builtins because it is never evicted from sys.modules.
 if not getattr(builtins, "_isaaclab_tasks_registered", False):
-    _BLACKLIST_PKGS = ["utils", ".mdp", "contrib.humanoid_amp.motions"]
+    # Agent config packages are resolved lazily through Gym entry-point strings.
+    _BLACKLIST_PKGS = ["utils", ".mdp", ".agents", "contrib.humanoid_amp.motions"]
     import_packages(__name__, _BLACKLIST_PKGS)
     builtins._isaaclab_tasks_registered = True

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/anymal_c_direct/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/anymal_c_direct/__init__.py
@@ -9,7 +9,7 @@ Ant locomotion environment.
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -21,9 +21,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.anymal_c_env_cfg:AnymalCFlatEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_flat_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -33,8 +33,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.anymal_c_env_cfg:AnymalCRoughEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_rough_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/assemble_trocar/config/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/assemble_trocar/config/__init__.pyi
@@ -3,6 +3,5 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from isaaclab.utils.module import lazy_export
-
-lazy_export()
+from .camera_config import CameraBaseCfg, CameraPresets
+from .robot_config import G1_29DOF_BODY_JOINT_INDICES, G1_DEX3_JOINT_INDICES, G1RobotPresets

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/automate/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,7 +17,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.assembly_env_cfg:AssemblyEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
 )
 
@@ -28,6 +28,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.disassembly_env_cfg:DisassemblyEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/cabinet/config/openarm/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/cabinet/config/openarm/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -20,8 +20,8 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:OpenArmCabinetEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:OpenArmCabinetPPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:OpenArmCabinetPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
     disable_env_checker=True,
 )
@@ -31,8 +31,8 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:OpenArmCabinetEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:OpenArmCabinetPPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:OpenArmCabinetPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
     disable_env_checker=True,
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/cartpole_showcase/cartpole/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/cartpole_showcase/cartpole/__init__.py
@@ -9,7 +9,7 @@ Cartpole balancing environment.
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ###########################
 # Register Gym environments
@@ -25,23 +25,23 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.cartpole_env_cfg:CartpoleShowcasePresetsEnvCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_box_box_ppo_cfg.yaml",
-        "skrl_box_box_cfg_entry_point": f"{agents.__name__}:skrl_box_box_ppo_cfg.yaml",
-        "skrl_box_discrete_cfg_entry_point": f"{agents.__name__}:skrl_box_discrete_ppo_cfg.yaml",
-        "skrl_box_multidiscrete_cfg_entry_point": f"{agents.__name__}:skrl_box_multidiscrete_ppo_cfg.yaml",
-        "skrl_discrete_box_cfg_entry_point": f"{agents.__name__}:skrl_discrete_box_ppo_cfg.yaml",
-        "skrl_discrete_discrete_cfg_entry_point": f"{agents.__name__}:skrl_discrete_discrete_ppo_cfg.yaml",
-        "skrl_discrete_multidiscrete_cfg_entry_point": f"{agents.__name__}:skrl_discrete_multidiscrete_ppo_cfg.yaml",
-        "skrl_multidiscrete_box_cfg_entry_point": f"{agents.__name__}:skrl_multidiscrete_box_ppo_cfg.yaml",
-        "skrl_multidiscrete_discrete_cfg_entry_point": f"{agents.__name__}:skrl_multidiscrete_discrete_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_box_box_ppo_cfg.yaml",
+        "skrl_box_box_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_box_box_ppo_cfg.yaml",
+        "skrl_box_discrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_box_discrete_ppo_cfg.yaml",
+        "skrl_box_multidiscrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_box_multidiscrete_ppo_cfg.yaml",
+        "skrl_discrete_box_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_discrete_box_ppo_cfg.yaml",
+        "skrl_discrete_discrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_discrete_discrete_ppo_cfg.yaml",
+        "skrl_discrete_multidiscrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_discrete_multidiscrete_ppo_cfg.yaml",
+        "skrl_multidiscrete_box_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_multidiscrete_box_ppo_cfg.yaml",
+        "skrl_multidiscrete_discrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_multidiscrete_discrete_ppo_cfg.yaml",
         "skrl_multidiscrete_multidiscrete_cfg_entry_point": (
-            f"{agents.__name__}:skrl_multidiscrete_multidiscrete_ppo_cfg.yaml"
+            f"{_AGENTS_MODULE}:skrl_multidiscrete_multidiscrete_ppo_cfg.yaml"
         ),
-        "skrl_dict_box_cfg_entry_point": f"{agents.__name__}:skrl_dict_box_ppo_cfg.yaml",
-        "skrl_dict_discrete_cfg_entry_point": f"{agents.__name__}:skrl_dict_discrete_ppo_cfg.yaml",
-        "skrl_dict_multidiscrete_cfg_entry_point": f"{agents.__name__}:skrl_dict_multidiscrete_ppo_cfg.yaml",
-        "skrl_tuple_box_cfg_entry_point": f"{agents.__name__}:skrl_tuple_box_ppo_cfg.yaml",
-        "skrl_tuple_discrete_cfg_entry_point": f"{agents.__name__}:skrl_tuple_discrete_ppo_cfg.yaml",
-        "skrl_tuple_multidiscrete_cfg_entry_point": f"{agents.__name__}:skrl_tuple_multidiscrete_ppo_cfg.yaml",
+        "skrl_dict_box_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_dict_box_ppo_cfg.yaml",
+        "skrl_dict_discrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_dict_discrete_ppo_cfg.yaml",
+        "skrl_dict_multidiscrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_dict_multidiscrete_ppo_cfg.yaml",
+        "skrl_tuple_box_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_tuple_box_ppo_cfg.yaml",
+        "skrl_tuple_discrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_tuple_discrete_ppo_cfg.yaml",
+        "skrl_tuple_multidiscrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_tuple_multidiscrete_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/cartpole_showcase/cartpole_camera/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/cartpole_showcase/cartpole_camera/__init__.py
@@ -9,7 +9,7 @@ Cartpole balancing environment with camera.
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ###########################
 # Register Gym environments
@@ -27,15 +27,15 @@ gym.register(
         "env_cfg_entry_point": (
             f"{__name__}.cartpole_camera_env_cfg:CartpoleCameraShowcasePresetsEnvCfg"
         ),
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_box_box_ppo_cfg.yaml",
-        "skrl_box_box_cfg_entry_point": f"{agents.__name__}:skrl_box_box_ppo_cfg.yaml",
-        "skrl_box_discrete_cfg_entry_point": f"{agents.__name__}:skrl_box_discrete_ppo_cfg.yaml",
-        "skrl_box_multidiscrete_cfg_entry_point": f"{agents.__name__}:skrl_box_multidiscrete_ppo_cfg.yaml",
-        "skrl_dict_box_cfg_entry_point": f"{agents.__name__}:skrl_dict_box_ppo_cfg.yaml",
-        "skrl_dict_discrete_cfg_entry_point": f"{agents.__name__}:skrl_dict_discrete_ppo_cfg.yaml",
-        "skrl_dict_multidiscrete_cfg_entry_point": f"{agents.__name__}:skrl_dict_multidiscrete_ppo_cfg.yaml",
-        "skrl_tuple_box_cfg_entry_point": f"{agents.__name__}:skrl_tuple_box_ppo_cfg.yaml",
-        "skrl_tuple_discrete_cfg_entry_point": f"{agents.__name__}:skrl_tuple_discrete_ppo_cfg.yaml",
-        "skrl_tuple_multidiscrete_cfg_entry_point": f"{agents.__name__}:skrl_tuple_multidiscrete_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_box_box_ppo_cfg.yaml",
+        "skrl_box_box_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_box_box_ppo_cfg.yaml",
+        "skrl_box_discrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_box_discrete_ppo_cfg.yaml",
+        "skrl_box_multidiscrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_box_multidiscrete_ppo_cfg.yaml",
+        "skrl_dict_box_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_dict_box_ppo_cfg.yaml",
+        "skrl_dict_discrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_dict_discrete_ppo_cfg.yaml",
+        "skrl_dict_multidiscrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_dict_multidiscrete_ppo_cfg.yaml",
+        "skrl_tuple_box_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_tuple_box_ppo_cfg.yaml",
+        "skrl_tuple_discrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_tuple_discrete_ppo_cfg.yaml",
+        "skrl_tuple_multidiscrete_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_tuple_multidiscrete_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/rizon_4s/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/rizon_4s/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -19,7 +19,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:Rizon4sGearAssemblyEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:Rizon4sGearAssemblyRNNPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:Rizon4sGearAssemblyRNNPPORunnerCfg",
     },
 )
 
@@ -30,7 +30,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ros_inference_env_cfg:Rizon4sGearAssemblyEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:Rizon4sGearAssemblyRNNPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:Rizon4sGearAssemblyRNNPPORunnerCfg",
     },
 )
 
@@ -41,6 +41,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ros_inference_env_cfg:Rizon4sGearAssemblyROSInferenceEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:Rizon4sGearAssemblyRNNPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:Rizon4sGearAssemblyRNNPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/ur_10e/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/ur_10e/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -19,7 +19,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:UR10e2F140GearAssemblyEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UR10GearAssemblyRNNPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UR10GearAssemblyRNNPPORunnerCfg",
     },
 )
 
@@ -39,7 +39,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:UR10e2F85GearAssemblyEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UR10GearAssemblyRNNPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UR10GearAssemblyRNNPPORunnerCfg",
     },
 )
 
@@ -59,7 +59,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ros_inference_env_cfg:UR10e2F140GearAssemblyROSInferenceEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UR10GearAssemblyRNNPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UR10GearAssemblyRNNPPORunnerCfg",
     },
 )
 
@@ -70,6 +70,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ros_inference_env_cfg:UR10e2F85GearAssemblyROSInferenceEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UR10GearAssemblyRNNPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UR10GearAssemblyRNNPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/reach/config/rizon_4s/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/reach/config/rizon_4s/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,7 +17,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:Rizon4sReachEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:Rizon4sReachPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:Rizon4sReachPPORunnerCfg",
     },
 )
 
@@ -27,7 +27,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:Rizon4sReachEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:Rizon4sReachPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:Rizon4sReachPPORunnerCfg",
     },
 )
 
@@ -37,6 +37,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ros_inference_env_cfg:Rizon4sReachROSInferenceEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:Rizon4sReachPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:Rizon4sReachPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/reach/config/ur_10e/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/reach/config/ur_10e/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,7 +17,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:UR10eReachEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:URReachPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:URReachPPORunnerCfg",
     },
 )
 
@@ -27,7 +27,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:UR10eReachEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:URReachPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:URReachPPORunnerCfg",
     },
 )
 
@@ -37,6 +37,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ros_inference_env_cfg:UR10eReachROSInferenceEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:URReachPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:URReachPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/__init__.py
@@ -7,7 +7,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 gym.register(
     id="Isaac-DrLegs-HoldPose-v0",
@@ -15,7 +15,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.hold_pose_env_cfg:DrLegsHoldPoseEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DrLegsHoldPosePPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DrLegsHoldPosePPORunnerCfg",
     },
 )
 
@@ -25,6 +25,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.walk_env_cfg:DrLegsWalkEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DrLegsWalkPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DrLegsWalkPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/drone_arl/navigation/config/arl_robot_1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/drone_arl/navigation/config/arl_robot_1/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,9 +17,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.floating_obstacles_env_cfg:FloatingObstacleEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_rough_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:NavigationEnvPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:NavigationEnvPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -29,8 +29,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.floating_obstacles_env_cfg:FloatingObstacleEnvCfg_PLAY",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_rough_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:NavigationEnvPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:NavigationEnvPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/drone_arl/track_position_state_based/config/arl_robot_1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/drone_arl/track_position_state_based/config/arl_robot_1/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,9 +17,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.no_obstacle_env_cfg:NoObstacleEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:TrackPositionNoObstaclesEnvPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:TrackPositionNoObstaclesEnvPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
     },
 )
 
@@ -29,8 +29,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.no_obstacle_env_cfg:NoObstacleEnvCfg_PLAY",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:TrackPositionNoObstaclesEnvPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:TrackPositionNoObstaclesEnvPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,7 +17,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.factory_env_cfg:FactoryTaskPegInsertCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
 )
 
@@ -27,7 +27,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.factory_env_cfg:FactoryTaskGearMeshCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
 )
 
@@ -37,6 +37,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.factory_env_cfg:FactoryTaskNutThreadCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/forge/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,7 +17,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.forge_env_cfg:ForgeTaskPegInsertCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
 )
 
@@ -27,7 +27,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.forge_env_cfg:ForgeTaskGearMeshCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
 )
 
@@ -37,6 +37,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.forge_env_cfg:ForgeTaskNutThreadCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg_nut_thread.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg_nut_thread.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/humanoid_amp/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/humanoid_amp/__init__.py
@@ -9,7 +9,7 @@ AMP Humanoid locomotion environment.
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -21,7 +21,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.humanoid_amp_env_cfg:HumanoidAmpDanceEnvCfg",
-        "skrl_amp_cfg_entry_point": f"{agents.__name__}:skrl_dance_amp_cfg.yaml",
+        "skrl_amp_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_dance_amp_cfg.yaml",
     },
 )
 
@@ -31,7 +31,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.humanoid_amp_env_cfg:HumanoidAmpRunEnvCfg",
-        "skrl_amp_cfg_entry_point": f"{agents.__name__}:skrl_run_amp_cfg.yaml",
+        "skrl_amp_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_run_amp_cfg.yaml",
     },
 )
 
@@ -41,6 +41,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.humanoid_amp_env_cfg:HumanoidAmpWalkEnvCfg",
-        "skrl_amp_cfg_entry_point": f"{agents.__name__}:skrl_walk_amp_cfg.yaml",
+        "skrl_amp_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_walk_amp_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/lift/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/lift/config/franka/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import gymnasium as gym
 
-from isaaclab_tasks.core.lift.config.franka import agents
+_AGENTS_MODULE = "isaaclab_tasks.core.lift.config.franka.agents"
 
 ##
 # Register Gym environments.
@@ -32,7 +32,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ik_rel_env_cfg:FrankaCubeLiftEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc.json",
     },
     disable_env_checker=True,
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/lift/config/openarm/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/lift/config/openarm/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -20,8 +20,8 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:OpenArmCubeLiftEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:OpenArmLiftCubePPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:OpenArmLiftCubePPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
     disable_env_checker=True,
 )
@@ -31,8 +31,8 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:OpenArmCubeLiftEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:OpenArmLiftCubePPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:OpenArmLiftCubePPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
     },
     disable_env_checker=True,
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/locomanip_pick_place/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/locomanip_pick_place/__init__.py
@@ -8,14 +8,14 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 gym.register(
     id="IsaacContrib-PickPlace-Locomanipulation-G1-Abs",
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.locomanipulation_g1_env_cfg:LocomanipulationG1EnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/locomanip_tracking/config/digit/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/locomanip_tracking/config/digit/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -16,7 +16,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.loco_manip_env_cfg:DigitLocoManipEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DigitLocoManipPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DigitLocoManipPPORunnerCfg",
     },
 )
 
@@ -27,6 +27,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.loco_manip_env_cfg:DigitLocoManipEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DigitLocoManipPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DigitLocoManipPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/navigation/config/anymal_c/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/navigation/config/anymal_c/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,8 +17,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.navigation_env_cfg:NavigationEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:NavigationEnvPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:NavigationEnvPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -28,7 +28,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.navigation_env_cfg:NavigationEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:NavigationEnvPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:NavigationEnvPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/pick_place/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/pick_place/__init__.py
@@ -5,14 +5,14 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 gym.register(
     id="IsaacContrib-PickPlace-GR1T2-Abs",
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.pickplace_gr1t2_env_cfg:PickPlaceGR1T2EnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )
@@ -22,7 +22,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.nutpour_gr1t2_pink_ik_env_cfg:NutPourGR1T2PinkIKEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_image_nut_pouring.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_image_nut_pouring.json",
     },
     disable_env_checker=True,
 )
@@ -32,7 +32,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.exhaustpipe_gr1t2_pink_ik_env_cfg:ExhaustPipeGR1T2PinkIKEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_image_exhaust_pipe.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_image_exhaust_pipe.json",
     },
     disable_env_checker=True,
 )
@@ -42,7 +42,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.pickplace_gr1t2_waist_enabled_env_cfg:PickPlaceGR1T2WaistEnabledEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )
@@ -52,7 +52,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.pickplace_unitree_g1_inspire_hand_env_cfg:PickPlaceG1InspireFTPEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/reach/config/openarm/bimanual/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/reach/config/openarm/bimanual/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -21,8 +21,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:OpenArmReachEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:OpenArmReachPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:OpenArmReachPPORunnerCfg",
     },
 )
 
@@ -32,7 +32,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:OpenArmReachEnvCfg_PLAY",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:OpenArmReachPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:OpenArmReachPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/reach/config/openarm/unimanual/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/reach/config/openarm/unimanual/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -21,9 +21,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:OpenArmReachEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:OpenArmReachPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:OpenArmReachPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
     },
 )
 
@@ -33,8 +33,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:OpenArmReachEnvCfg_PLAY",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:OpenArmReachPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:OpenArmReachPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/franka/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -44,7 +44,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )
@@ -54,7 +54,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.stack_ik_rel_visuomotor_env_cfg:FrankaCubeStackVisuomotorEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_image_200.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_image_200.json",
     },
     disable_env_checker=True,
 )
@@ -66,7 +66,7 @@ gym.register(
         "env_cfg_entry_point": (
             f"{__name__}.stack_ik_rel_visuomotor_cosmos_env_cfg:FrankaCubeStackVisuomotorCosmosEnvCfg"
         ),
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_image_cosmos.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_image_cosmos.json",
     },
     disable_env_checker=True,
 )
@@ -76,7 +76,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackRedGreenEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )
@@ -86,7 +86,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackRedGreenBlueEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )
@@ -97,7 +97,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackBlueGreenEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )
@@ -107,7 +107,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackBlueGreenRedEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )
@@ -117,7 +117,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.stack_ik_abs_env_cfg:FrankaCubeStackEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )
@@ -147,7 +147,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg_skillgen:FrankaCubeStackSkillgenEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )
@@ -157,7 +157,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.bin_stack_ik_rel_env_cfg:FrankaBinStackEnvCfg",
-        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+        "robomimic_bc_cfg_entry_point": f"{_AGENTS_MODULE}:robomimic/bc_rnn_low_dim.json",
     },
     disable_env_checker=True,
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,9 +17,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:UnitreeA1FlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeA1FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeA1FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_ppo_cfg.yaml",
     },
 )
 
@@ -29,9 +29,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:UnitreeA1FlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeA1FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeA1FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_ppo_cfg.yaml",
     },
 )
 
@@ -41,9 +41,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:UnitreeA1RoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeA1RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeA1RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_ppo_cfg.yaml",
     },
 )
 
@@ -53,8 +53,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:UnitreeA1RoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeA1RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeA1RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -16,9 +16,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalBFlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalBFlatPPORunnerCfg",
-        "rsl_rl_with_symmetry_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalBFlatPPORunnerWithSymmetryCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalBFlatPPORunnerCfg",
+        "rsl_rl_with_symmetry_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalBFlatPPORunnerWithSymmetryCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -28,9 +28,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalBFlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalBFlatPPORunnerCfg",
-        "rsl_rl_with_symmetry_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalBFlatPPORunnerWithSymmetryCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalBFlatPPORunnerCfg",
+        "rsl_rl_with_symmetry_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalBFlatPPORunnerWithSymmetryCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -40,11 +40,11 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:AnymalBRoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalBRoughPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalBRoughPPORunnerCfg",
         "rsl_rl_with_symmetry_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalBRoughPPORunnerWithSymmetryCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalBRoughPPORunnerWithSymmetryCfg"
         ),
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -54,10 +54,10 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:AnymalBRoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalBRoughPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalBRoughPPORunnerCfg",
         "rsl_rl_with_symmetry_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalBRoughPPORunnerWithSymmetryCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalBRoughPPORunnerWithSymmetryCfg"
         ),
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,10 +17,10 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalCFlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerCfg",
-        "rsl_rl_with_symmetry_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerWithSymmetryCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_flat_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerCfg",
+        "rsl_rl_with_symmetry_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerWithSymmetryCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_flat_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -30,10 +30,10 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalCFlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerCfg",
-        "rsl_rl_with_symmetry_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerWithSymmetryCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_flat_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerCfg",
+        "rsl_rl_with_symmetry_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCFlatPPORunnerWithSymmetryCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_flat_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -43,12 +43,12 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:AnymalCRoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerCfg",
         "rsl_rl_with_symmetry_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerWithSymmetryCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerWithSymmetryCfg"
         ),
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_rough_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_rough_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -58,11 +58,11 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:AnymalCRoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerCfg",
         "rsl_rl_with_symmetry_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerWithSymmetryCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalCRoughPPORunnerWithSymmetryCfg"
         ),
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_rough_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_rough_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,8 +17,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:UnitreeGo1FlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeGo1FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeGo1FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -28,8 +28,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:UnitreeGo1FlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeGo1FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeGo1FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -39,8 +39,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:UnitreeGo1RoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeGo1RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeGo1RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -50,7 +50,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:UnitreeGo1RoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeGo1RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeGo1RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/config/franka/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from isaaclab_tasks.core.cabinet.config.franka import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments -- manager-based workflow.
@@ -16,9 +16,9 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:FrankaCabinetEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CabinetPPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_manager_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_manager_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CabinetPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_manager_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_manager_ppo_cfg.yaml",
     },
     disable_env_checker=True,
 )
@@ -28,9 +28,9 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:FrankaCabinetEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CabinetPPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_manager_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_manager_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CabinetPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_manager_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_manager_ppo_cfg.yaml",
     },
     disable_env_checker=True,
 )
@@ -45,8 +45,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.cabinet_direct_env_cfg:FrankaCabinetDirectEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_direct_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaCabinetPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_direct_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_direct_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:FrankaCabinetPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_direct_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/__init__.py
@@ -13,7 +13,7 @@ disambiguate the two workflows within the flat package layout.
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments -- direct workflow.
@@ -25,10 +25,10 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.cartpole_direct_env_cfg:CartpoleEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_direct_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CartpoleDirectPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_direct_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_direct_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CartpoleDirectPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_direct_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_ppo_cfg.yaml",
     },
 )
 
@@ -38,9 +38,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.cartpole_direct_camera_env_cfg:CartpoleCameraEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_camera_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CartpoleCameraDirectPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_direct_camera_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_camera_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CartpoleCameraDirectPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_direct_camera_ppo_cfg.yaml",
     },
 )
 
@@ -54,13 +54,13 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.cartpole_manager_env_cfg:CartpoleEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_manager_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CartpolePPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_manager_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CartpolePPORunnerCfg",
         "rsl_rl_with_symmetry_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:CartpolePPORunnerWithSymmetryCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CartpolePPORunnerWithSymmetryCfg"
         ),
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_manager_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_manager_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_ppo_cfg.yaml",
     },
 )
 
@@ -70,11 +70,11 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.cartpole_manager_camera_env_cfg:CartpoleCameraEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_camera_ppo_cfg.yaml",
-        "rl_games_feature_cfg_entry_point": f"{agents.__name__}:rl_games_manager_feature_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CartpoleCameraPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_camera_ppo_cfg.yaml",
+        "rl_games_feature_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_manager_feature_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CartpoleCameraPPORunnerCfg",
         "rsl_rl_feature_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:CartpoleCameraFeaturePPORunnerCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CartpoleCameraFeaturePPORunnerCfg"
         ),
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/config/kuka_allegro/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/config/kuka_allegro/__init__.py
@@ -7,7 +7,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -19,7 +19,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.dexsuite_kuka_allegro_env_cfg:DexsuiteKukaAllegroReorientEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
     },
 )
 
@@ -29,7 +29,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.dexsuite_kuka_allegro_env_cfg:DexsuiteKukaAllegroReorientEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
     },
 )
 
@@ -39,7 +39,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.dexsuite_kuka_allegro_env_cfg:DexsuiteKukaAllegroLiftEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
     },
 )
 
@@ -49,7 +49,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.dexsuite_kuka_allegro_env_cfg:DexsuiteKukaAllegroLiftEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
     },
 )
 
@@ -63,7 +63,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.dexsuite_kuka_allegro_camera_env_cfg:DexsuiteKukaAllegroReorientCameraEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
     },
 )
 
@@ -73,6 +73,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.dexsuite_kuka_allegro_camera_env_cfg:DexsuiteKukaAllegroLiftCameraEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/__init__.py
@@ -7,7 +7,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments -- manager-based workflow.
@@ -19,6 +19,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.fourbar_pole_manager_env_cfg:FourbarPoleSwingupEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_manager_ppo_cfg:FourbarPolePPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_manager_ppo_cfg:FourbarPolePPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/handover/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/handover/__init__.py
@@ -9,7 +9,7 @@ ShadowHand Over environment.
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -21,9 +21,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.handover_env_cfg:HandoverEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
-        "skrl_ippo_cfg_entry_point": f"{agents.__name__}:skrl_ippo_cfg.yaml",
-        "skrl_mappo_cfg_entry_point": f"{agents.__name__}:skrl_mappo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
+        "skrl_ippo_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ippo_cfg.yaml",
+        "skrl_mappo_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_mappo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from isaaclab_tasks.core.lift.config.franka import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -21,10 +21,10 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:FrankaCubeLiftEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:LiftCubePPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:LiftCubePPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_ppo_cfg.yaml",
     },
 )
 
@@ -34,9 +34,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:FrankaCubeLiftEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:LiftCubePPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:LiftCubePPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from isaaclab_tasks.core.lift.config.franka_soft import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,7 +17,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.franka_soft_env_cfg:FrankaSoftEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaDeformablePPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:FrankaDeformablePPORunnerCfg",
     },
 )
 
@@ -27,6 +27,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.franka_cloth_env_cfg:FrankaClothEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaDeformablePPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:FrankaDeformablePPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/__init__.py
@@ -13,7 +13,7 @@ the two workflows within the flat package layout.
 
 import gymnasium as gym
 
-from isaaclab_tasks.core.locomotion.ant import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments -- direct workflow.
@@ -25,9 +25,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ant_direct_env_cfg:AntEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_direct_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AntDirectPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_direct_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_direct_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AntDirectPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_direct_ppo_cfg.yaml",
     },
 )
 
@@ -41,9 +41,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ant_manager_env_cfg:AntEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AntPPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_manager_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_manager_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_manager_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AntPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_manager_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_manager_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_manager_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/__init__.py
@@ -13,7 +13,7 @@ package layout.
 
 import gymnasium as gym
 
-from isaaclab_tasks.core.locomotion.humanoid import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments -- direct workflow.
@@ -25,9 +25,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.humanoid_direct_env_cfg:HumanoidEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_direct_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:HumanoidDirectPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_direct_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_direct_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:HumanoidDirectPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_direct_ppo_cfg.yaml",
     },
 )
 
@@ -41,9 +41,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.humanoid_manager_env_cfg:HumanoidEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:HumanoidPPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_manager_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_manager_ppo_cfg.yaml",
-        "sb3_cfg_entry_point": f"{agents.__name__}:sb3_manager_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:HumanoidPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_manager_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_manager_ppo_cfg.yaml",
+        "sb3_cfg_entry_point": f"{_AGENTS_MODULE}:sb3_manager_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/pendulum/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/pendulum/__init__.py
@@ -9,7 +9,7 @@ Inverted Double Pendulum on a Cart balancing environment.
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -21,9 +21,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.pendulum_env_cfg:PendulumEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
-        "skrl_ippo_cfg_entry_point": f"{agents.__name__}:skrl_ippo_cfg.yaml",
-        "skrl_mappo_cfg_entry_point": f"{agents.__name__}:skrl_mappo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
+        "skrl_ippo_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ippo_cfg.yaml",
+        "skrl_mappo_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_mappo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -21,9 +21,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:FrankaReachEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaReachPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:FrankaReachPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
     },
 )
 
@@ -33,9 +33,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:FrankaReachEnvCfg_PLAY",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaReachPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:FrankaReachPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
     },
 )
 
@@ -49,7 +49,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ik_newton_env_cfg:FrankaReachEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaReachNewtonIKPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:FrankaReachNewtonIKPPORunnerCfg",
     },
     disable_env_checker=True,
 )
@@ -59,7 +59,7 @@ gym.register(
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={
         "env_cfg_entry_point": f"{__name__}.ik_newton_env_cfg:FrankaReachEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaReachNewtonIKPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:FrankaReachNewtonIKPPORunnerCfg",
     },
     disable_env_checker=True,
 )
@@ -74,7 +74,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.osc_env_cfg:FrankaReachEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaReachPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:FrankaReachPPORunnerCfg",
     },
 )
 
@@ -84,6 +84,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.osc_env_cfg:FrankaReachEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaReachPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:FrankaReachPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/ur_10/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/ur_10/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,9 +17,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:UR10ReachEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UR10ReachPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UR10ReachPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
     },
 )
 
@@ -29,8 +29,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.joint_pos_env_cfg:UR10ReachEnvCfg_PLAY",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UR10ReachPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UR10ReachPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/__init__.py
@@ -7,7 +7,7 @@
 
 import gymnasium as gym
 
-from isaaclab_tasks.core.reorient.config.allegro_hand import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments -- manager-based workflow.
@@ -19,9 +19,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.allegro_hand_manager_env_cfg:AllegroCubeEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AllegroCubePPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_manager_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_manager_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AllegroCubePPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_manager_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_manager_ppo_cfg.yaml",
     },
 )
 
@@ -31,9 +31,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.allegro_hand_manager_env_cfg:AllegroCubeEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AllegroCubePPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_manager_ppo_cfg.yaml",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_manager_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AllegroCubePPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_manager_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_manager_ppo_cfg.yaml",
     },
 )
 
@@ -47,8 +47,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.allegro_hand_direct_env_cfg:AllegroHandEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_direct_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AllegroHandPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_direct_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_direct_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AllegroHandPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_direct_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/__init__.py
@@ -9,7 +9,7 @@ Shadow Hand environment.
 
 import gymnasium as gym
 
-from isaaclab_tasks.core.reorient.config.shadow_hand import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -23,9 +23,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.shadow_hand_env_cfg:ShadowHandEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:ShadowHandPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:ShadowHandPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ppo_cfg.yaml",
     },
 )
 
@@ -35,9 +35,9 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.shadow_hand_env_cfg:ShadowHandOpenAIEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_ff_cfg.yaml",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:ShadowHandAsymFFPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_ff_ppo_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_ff_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:ShadowHandAsymFFPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_ff_ppo_cfg.yaml",
     },
 )
 
@@ -47,7 +47,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.shadow_hand_env_cfg:ShadowHandOpenAIEnvCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_lstm_cfg.yaml",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_lstm_cfg.yaml",
     },
 )
 
@@ -61,8 +61,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.shadow_hand_camera_env_cfg:ShadowHandCameraEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:ShadowHandCameraFFPPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_camera_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:ShadowHandCameraFFPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_camera_cfg.yaml",
     },
 )
 
@@ -72,8 +72,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.shadow_hand_camera_env_cfg:ShadowHandCameraEnvPlayCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:ShadowHandCameraFFPPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_camera_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:ShadowHandCameraFFPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_camera_cfg.yaml",
     },
 )
 
@@ -83,7 +83,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.shadow_hand_camera_env_cfg:ShadowHandCameraBenchmarkEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:ShadowHandCameraFFPPORunnerCfg",
-        "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_ppo_camera_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:ShadowHandCameraFFPPORunnerCfg",
+        "rl_games_cfg_entry_point": f"{_AGENTS_MODULE}:rl_games_ppo_camera_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,16 +17,16 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalDFlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerCfg",
-        "rsl_rl_recurrent_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerRecurrentCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerCfg",
+        "rsl_rl_recurrent_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerRecurrentCfg",
         "rsl_rl_distillation_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_distillation_cfg:AnymalDFlatDistillationRunnerCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_distillation_cfg:AnymalDFlatDistillationRunnerCfg"
         ),
         "rsl_rl_distillation_recurrent_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_distillation_cfg:AnymalDFlatDistillationRunnerRecurrentCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_distillation_cfg:AnymalDFlatDistillationRunnerRecurrentCfg"
         ),
-        "rsl_rl_with_symmetry_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerWithSymmetryCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_with_symmetry_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerWithSymmetryCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -36,16 +36,16 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalDFlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerCfg",
-        "rsl_rl_recurrent_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerRecurrentCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerCfg",
+        "rsl_rl_recurrent_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerRecurrentCfg",
         "rsl_rl_distillation_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_distillation_cfg:AnymalDFlatDistillationRunnerCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_distillation_cfg:AnymalDFlatDistillationRunnerCfg"
         ),
         "rsl_rl_distillation_recurrent_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_distillation_cfg:AnymalDFlatDistillationRunnerRecurrentCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_distillation_cfg:AnymalDFlatDistillationRunnerRecurrentCfg"
         ),
-        "rsl_rl_with_symmetry_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerWithSymmetryCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_with_symmetry_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerWithSymmetryCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -55,11 +55,11 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:AnymalDRoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDRoughPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDRoughPPORunnerCfg",
         "rsl_rl_with_symmetry_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDRoughPPORunnerWithSymmetryCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDRoughPPORunnerWithSymmetryCfg"
         ),
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -69,10 +69,10 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:AnymalDRoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDRoughPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDRoughPPORunnerCfg",
         "rsl_rl_with_symmetry_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDRoughPPORunnerWithSymmetryCfg"
+            f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:AnymalDRoughPPORunnerWithSymmetryCfg"
         ),
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,8 +17,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:CassieFlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CassieFlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CassieFlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -28,8 +28,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:CassieFlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CassieFlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CassieFlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -39,8 +39,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:CassieRoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CassieRoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CassieRoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -50,7 +50,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:CassieRoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CassieRoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:CassieRoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/digit/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/digit/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -16,7 +16,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:DigitFlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DigitFlatPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DigitFlatPPORunnerCfg",
     },
 )
 
@@ -27,7 +27,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:DigitFlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DigitFlatPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DigitFlatPPORunnerCfg",
     },
 )
 
@@ -38,7 +38,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:DigitRoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DigitRoughPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DigitRoughPPORunnerCfg",
     },
 )
 
@@ -49,6 +49,6 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:DigitRoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:DigitRoughPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:DigitRoughPPORunnerCfg",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,8 +17,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:G1RoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:G1RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:G1RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -29,8 +29,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:G1RoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:G1RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:G1RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -41,8 +41,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:G1FlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:G1FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:G1FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -53,7 +53,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:G1FlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:G1FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:G1FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,8 +17,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:UnitreeGo2FlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeGo2FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeGo2FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -28,8 +28,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:UnitreeGo2FlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeGo2FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeGo2FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -39,8 +39,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:UnitreeGo2RoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeGo2RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeGo2RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -50,7 +50,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:UnitreeGo2RoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeGo2RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:UnitreeGo2RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,8 +17,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:H1RoughEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:H1RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:H1RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -29,8 +29,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.rough_env_cfg:H1RoughEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:H1RoughPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_rough_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:H1RoughPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_rough_ppo_cfg.yaml",
     },
 )
 
@@ -41,8 +41,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:H1FlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:H1FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:H1FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -53,7 +53,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:H1FlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:H1FlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:H1FlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/__init__.py
@@ -5,7 +5,7 @@
 
 import gymnasium as gym
 
-from . import agents
+_AGENTS_MODULE = f"{__name__}.agents"
 
 ##
 # Register Gym environments.
@@ -17,8 +17,8 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:SpotFlatEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:SpotFlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:SpotFlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )
 
@@ -28,7 +28,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.flat_env_cfg:SpotFlatEnvCfg_PLAY",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:SpotFlatPPORunnerCfg",
-        "skrl_cfg_entry_point": f"{agents.__name__}:skrl_flat_ppo_cfg.yaml",
+        "rsl_rl_cfg_entry_point": f"{_AGENTS_MODULE}.rsl_rl_ppo_cfg:SpotFlatPPORunnerCfg",
+        "skrl_cfg_entry_point": f"{_AGENTS_MODULE}:skrl_flat_ppo_cfg.yaml",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -319,7 +319,7 @@ def _pick_alternative(
             consumed_selected.add(name)
         if typed_hits is not None:
             # record which typed targets (physics/renderer) this name landed on
-            targets = {t for t in PresetTarget if t.base_classes and isinstance(val, t.base_classes)}
+            targets = {t for t in PresetTarget if t.is_typed and isinstance(val, t.base_classes)}
             if targets:
                 typed_hits.setdefault(raw_name, set()).update(targets)
                 typed_hits.setdefault(name, set()).update(targets)
@@ -595,7 +595,7 @@ def register_task(task_name: str, agent_entry: str) -> tuple:
     # CLI preset tokens: ``presets=NAME[,...]`` broadcasts (no typing claim),
     # while ``physics=NAME`` / ``renderer=NAME`` are typed selectors that must
     # resolve against a config of that type (enforced after resolution).
-    typed_labels = {target.value: target for target in PresetTarget if target.base_classes}
+    typed_labels = {target.value: target for target in PresetTarget if target.is_typed}
     global_presets: list[str] = []
     requested_targets: dict[PresetTarget, set[str]] = {}
     override_items: list[tuple[str, str, str]] = []

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/importer.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/importer.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.machinery
 import pkgutil
 import sys
 
@@ -15,11 +16,12 @@ import sys
 def import_packages(package_name: str, blacklist_pkgs: list[str] | None = None):
     """Import all sub-packages in a package recursively.
 
-    Only **packages** (directories with ``__init__.py``) are imported — plain
-    ``.py`` modules (e.g. ``env_cfg.py``, ``env.py``) are skipped.  This is
-    sufficient because ``gym.register()`` calls live exclusively in
-    ``__init__.py`` files, and avoids eagerly importing every config module
-    at startup.
+    Only **packages** (directories with ``__init__.py``) that contain
+    ``gym.register`` calls are imported — plain ``.py`` modules (e.g.
+    ``env_cfg.py``, ``env.py``) and registry-free package parents are skipped.
+    This is sufficient because task registration calls live exclusively in
+    ``__init__.py`` files, and avoids eagerly importing config helper modules
+    while walking the tree.
 
     Args:
         package_name: The package name.
@@ -71,26 +73,43 @@ def _walk_packages(
         if any([black_pkg_name in info.name for black_pkg_name in blacklist_pkgs]):
             continue
 
-        # Only import packages (directories with __init__.py), not plain .py
-        # modules.  The walk exists to trigger gym.register() calls which live
-        # exclusively in __init__.py files.  Skipping bare modules avoids
-        # eagerly importing every env_cfg / env / agent config at startup.
         if not info.ispkg:
             continue
 
-        yield info
+        module_spec = info.module_finder.find_spec(info.name, None)
+        if module_spec is None:
+            continue
 
-        try:
-            __import__(info.name)
-        except Exception:
-            if onerror is not None:
-                onerror(info.name)
+        child_path: list = list(module_spec.submodule_search_locations or [])
+
+        # Only import package initializers that actually register tasks.  We
+        # still recurse into registry-free parents using the package paths from
+        # the module spec so nested registration packages are discovered without
+        # executing every parent ``__init__``.
+        if _has_gym_registration(module_spec):
+            yield info
+
+            try:
+                __import__(info.name)
+            except Exception:
+                if onerror is not None:
+                    onerror(info.name)
+                else:
+                    raise
             else:
-                raise
-        else:
-            path: list = getattr(sys.modules[info.name], "__path__", [])
+                child_path = list(getattr(sys.modules[info.name], "__path__", child_path))
 
-            # don't traverse path items we've seen before
-            path = [p for p in path if not seen(p)]
+        child_path = [p for p in child_path if not seen(p)]
+        yield from _walk_packages(child_path, info.name + ".", onerror, blacklist_pkgs)
 
-            yield from _walk_packages(path, info.name + ".", onerror, blacklist_pkgs)
+
+def _has_gym_registration(module_spec: importlib.machinery.ModuleSpec) -> bool:
+    """Return whether a package initializer contains Gym task registrations."""
+    init_path = module_spec.origin
+    if init_path is None:
+        return False
+    try:
+        with open(init_path, "rb") as init_file:
+            return b"gym.register" in init_file.read()
+    except OSError:
+        return False

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
@@ -240,15 +240,15 @@ class _DescriptionBuilder:
     @staticmethod
     def _syntax(target: PresetTarget) -> str:
         """User-facing selector form: ``physics=NAME`` vs ``presets=NAME[,NAME,...]``."""
-        if target.base_classes:  # typed: single name
+        if target.is_typed:  # typed: single name
             return f"{target.value}=NAME"
         return f"{target.value}=NAME[,NAME,...]"  # DOMAIN: comma-separated broadcast
 
     @staticmethod
     def _description(target: PresetTarget) -> str:
         """One-line description; for typed targets includes the cfg base class name."""
-        if target.base_classes:
-            return f"(typed) selects a {target.base_classes[0].__name__} variant"
+        if target.is_typed:
+            return f"(typed) selects a {target.base_class_names[0]} variant"
         return "broadcast: applied to every matching PresetCfg"
 
 
@@ -315,7 +315,7 @@ def _bucket_variants_by_target(walked: dict) -> dict[PresetTarget, set[str]]:
     :class:`~isaaclab.renderers.renderer_cfg.RendererCfg` bucket automatically
     regardless of what name the env_cfg gives the field.
     """
-    typed_targets = [t for t in PresetTarget if t.base_classes]
+    typed_targets = [t for t in PresetTarget if t.is_typed]
     result: dict[PresetTarget, set[str]] = {target: set() for target in PresetTarget}
     for path_dict in walked.values():
         for name, cfg in path_dict.items():

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
@@ -26,9 +26,7 @@ from __future__ import annotations
 
 import enum
 import functools
-
-from isaaclab.physics import PhysicsCfg
-from isaaclab.renderers.renderer_cfg import RendererCfg
+import importlib
 
 
 class PresetTarget(enum.Enum):
@@ -52,10 +50,14 @@ class PresetTarget(enum.Enum):
     Adding a new target = appending one enum member.
     """
 
-    # Members. Tuple values are (label, base_classes, legacy_aliases); the
+    # Members. Tuple values are (label, base_class_paths, legacy_aliases); the
     # enum metaclass collects the whole namespace before constructing members,
     # so ``__new__`` below unpacks each tuple regardless of declaration order.
-    PHYSICS = ("physics", (PhysicsCfg,), {"newton": "newton_mjwarp", "kamino": "newton_kamino"})
+    PHYSICS = (
+        "physics",
+        ("isaaclab.physics:PhysicsCfg",),
+        {"newton": "newton_mjwarp", "kamino": "newton_kamino"},
+    )
     """Physics backends -- ``physics=NAME`` selector.
 
     Legacy aliases ``newton`` -> ``newton_mjwarp`` and ``kamino`` -> ``newton_kamino``
@@ -68,7 +70,11 @@ class PresetTarget(enum.Enum):
     future release.
     """
 
-    RENDERER = ("renderer", (RendererCfg,), {"ovrtx_renderer": "ovrtx", "isaacsim_rtx_renderer": "isaacsim_rtx"})
+    RENDERER = (
+        "renderer",
+        ("isaaclab.renderers.renderer_cfg:RendererCfg",),
+        {"ovrtx_renderer": "ovrtx", "isaacsim_rtx_renderer": "isaacsim_rtx"},
+    )
     """Camera-sensor renderers -- ``renderer=NAME`` selector.
 
     Legacy aliases ``ovrtx_renderer`` -> ``ovrtx`` and
@@ -94,17 +100,17 @@ class PresetTarget(enum.Enum):
     def __new__(
         cls,
         label: str,
-        base_classes: tuple[type, ...] = (),
+        base_class_paths: tuple[str, ...] = (),
         legacy_aliases: dict[str, str] | None = None,
     ):
-        """Construct a member from its ``(label, base_classes, legacy_aliases)`` tuple.
+        """Construct a member from its ``(label, base_class_paths, legacy_aliases)`` tuple.
 
         Args:
             label: Hydra-style selector key (e.g. ``"physics"`` is recognized
                 as the ``physics=NAME`` token and becomes ``self.value``).
-            base_classes: Cfg base classes whose instances route to this
-                target via :func:`isinstance`. Defaults to ``()`` (no typed
-                routing).
+            base_class_paths: Import paths for cfg base classes whose instances
+                route to this target via :func:`isinstance`. Defaults to ``()``
+                (no typed routing).
             legacy_aliases: Optional deprecated-to-canonical map for this
                 target; copied so members cannot alias each other's tables.
 
@@ -114,9 +120,23 @@ class PresetTarget(enum.Enum):
         """
         obj = object.__new__(cls)
         obj._value_ = label
-        obj.base_classes = tuple(base_classes)
+        obj._base_class_paths = tuple(base_class_paths)
+        obj._base_classes = None
+        obj.base_class_names = tuple(path.rsplit(":", 1)[-1] for path in base_class_paths)
+        obj.is_typed = bool(base_class_paths)
         obj.legacy_aliases = dict(legacy_aliases) if legacy_aliases else {}
         return obj
+
+    @property
+    def base_classes(self) -> tuple[type, ...]:
+        """Cfg base classes whose instances route to this target.
+
+        The classes are imported lazily so normal CLI parsing can use selector
+        metadata without importing backend config modules, torch, or Warp.
+        """
+        if self._base_classes is None:
+            self._base_classes = tuple(_import_symbol(path) for path in self._base_class_paths)
+        return self._base_classes
 
     @classmethod
     @functools.cache
@@ -135,3 +155,9 @@ class PresetTarget(enum.Enum):
             aggregated across all members.
         """
         return {name: rep for target in cls for name, rep in target.legacy_aliases.items()}
+
+
+def _import_symbol(path: str) -> type:
+    """Import ``module:attribute`` and return the attribute."""
+    module_name, attr_name = path.split(":", 1)
+    return getattr(importlib.import_module(module_name), attr_name)

--- a/source/isaaclab_tasks/test/core/test_importer.py
+++ b/source/isaaclab_tasks/test/core/test_importer.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for task package importing utilities."""
+
+from __future__ import annotations
+
+import sys
+import uuid
+
+import gymnasium as gym
+
+from isaaclab_tasks.utils.importer import import_packages
+
+
+def test_import_packages_only_imports_registration_packages(tmp_path, monkeypatch):
+    """Registry-free leaf packages should not execute during recursive task registration."""
+    package_root = tmp_path / "sample_tasks"
+    (package_root / "registry_free_leaf").mkdir(parents=True)
+    (package_root / "registered").mkdir()
+    (package_root / "__init__.py").write_text("")
+    (package_root / "registry_free_leaf" / "__init__.py").write_text("raise RuntimeError('should not import')\n")
+
+    task_id = f"Isaac-Importer-Test-{uuid.uuid4()}-v0"
+    (package_root / "registered" / "__init__.py").write_text(
+        "import gymnasium as gym\n"
+        f"gym.register(id={task_id!r}, entry_point='sample_tasks.registered:DummyEnv')\n"
+        "class DummyEnv:\n"
+        "    pass\n"
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    sys.modules.pop("sample_tasks", None)
+    sys.modules.pop("sample_tasks.registry_free_leaf", None)
+    sys.modules.pop("sample_tasks.registered", None)
+
+    import_packages("sample_tasks")
+
+    assert task_id in gym.registry
+    assert "sample_tasks.registry_free_leaf" not in sys.modules


### PR DESCRIPTION
# Description

Reduces Python startup/import overhead for task discovery, preset CLI setup, and launcher argument paths.

This PR:

- makes launcher backend physics/renderer imports lazy
- skips `.agents` packages during recursive task registration
- changes task registrations to use agent module path strings instead of importing agent packages eagerly
- makes the recursive importer import only package initializers that contain `gym.register`
- lazily resolves `PresetTarget` backend base classes so preset CLI text does not import backend config modules
- switches the trocar config package to `lazy_export()` and adds a `.pyi` surface for exported names

Fixes #

## Benchmark impact

Import-focused benchmark results from the exploration pass:

| Import path | Before | After | Delta |
|---|---:|---:|---:|
| `import isaaclab_tasks`, 7-run mean | 1.072 s | 1.011 s | -61 ms (-5.7%) |
| Eager `isaaclab_tasks.*.agents` packages | 21 | 0 | removed |
| `from isaaclab.app import add_launcher_args` | ~0.97 s | ~0.039 s | ~25x faster |
| `from isaaclab_tasks.utils import setup_preset_cli` | ~0.95 s | 0.12-0.16 s | ~6-8x faster |

Validation spot checks on this split measured:

| Import path | Time |
|---|---:|
| `from isaaclab.app import add_launcher_args` | 0.028 s |
| `from isaaclab_tasks.utils import setup_preset_cli` | 0.119 s |

Full task startup is still dominated by runtime libraries and scene creation, so these changes mostly improve CLI/task-discovery latency rather than end-to-end training startup. The final Go2 startup pass stayed near noise: PhysX total was 9.902 s before the final startup pass and 9.790 s after; Newton/MJWarp total was 13.644 s before and 13.663 s after.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- `./isaaclab.sh -p -m pytest source/isaaclab_tasks/test/core/test_importer.py`
- `./isaaclab.sh -p -c "import time; t=time.perf_counter(); from isaaclab.app import add_launcher_args; print(time.perf_counter()-t)"`
- `./isaaclab.sh -p -c "import time; t=time.perf_counter(); from isaaclab_tasks.utils import setup_preset_cli; print(time.perf_counter()-t)"`
- `./isaaclab.sh -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation, or documentation is not required for this internal performance cleanup
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
