### PR TITLE
Reuse controller and sensor buffers

### DIFF
--- a/source/isaaclab/changelog.d/perf-controller-buffers.rst
+++ b/source/isaaclab/changelog.d/perf-controller-buffers.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Improved actuator, controller, and ray-caster hot paths by reusing temporary
+  tensor buffers and cached identity matrices.

--- a/source/isaaclab/isaaclab/actuators/actuator_net.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_net.py
@@ -128,11 +128,17 @@ class ActuatorNetMLP(DCMotor):
         self.network = torch.jit.load(file_bytes, map_location=self._device).eval()
 
         # create buffers for MLP history
-        history_length = max(self.cfg.input_idx) + 1
+        self._input_idx = tuple(self.cfg.input_idx)
+        history_length = max(self._input_idx) + 1
         self._joint_pos_error_history = torch.zeros(
             self._num_envs, history_length, self.num_joints, device=self._device
         )
         self._joint_vel_history = torch.zeros(self._num_envs, history_length, self.num_joints, device=self._device)
+        self._input_idx_tensor = torch.tensor(self._input_idx, dtype=torch.long, device=self._device)
+        self._num_network_inputs = len(self._input_idx)
+        self._network_input = torch.empty(
+            self._num_envs * self.num_joints, 2 * self._num_network_inputs, device=self._device
+        )
 
     """
     Operations.
@@ -158,16 +164,18 @@ class ActuatorNetMLP(DCMotor):
 
         # compute network inputs
         # -- positions
-        pos_input = torch.cat([self._joint_pos_error_history[:, i].unsqueeze(2) for i in self.cfg.input_idx], dim=2)
-        pos_input = pos_input.view(self._num_envs * self.num_joints, -1)
+        pos_input = self._joint_pos_error_history.index_select(1, self._input_idx_tensor)
+        pos_input = pos_input.transpose(1, 2).reshape(self._num_envs * self.num_joints, -1)
         # -- velocity
-        vel_input = torch.cat([self._joint_vel_history[:, i].unsqueeze(2) for i in self.cfg.input_idx], dim=2)
-        vel_input = vel_input.view(self._num_envs * self.num_joints, -1)
+        vel_input = self._joint_vel_history.index_select(1, self._input_idx_tensor)
+        vel_input = vel_input.transpose(1, 2).reshape(self._num_envs * self.num_joints, -1)
         # -- scale and concatenate inputs
         if self.cfg.input_order == "pos_vel":
-            network_input = torch.cat([pos_input * self.cfg.pos_scale, vel_input * self.cfg.vel_scale], dim=1)
+            torch.mul(pos_input, self.cfg.pos_scale, out=self._network_input[:, : self._num_network_inputs])
+            torch.mul(vel_input, self.cfg.vel_scale, out=self._network_input[:, self._num_network_inputs :])
         elif self.cfg.input_order == "vel_pos":
-            network_input = torch.cat([vel_input * self.cfg.vel_scale, pos_input * self.cfg.pos_scale], dim=1)
+            torch.mul(vel_input, self.cfg.vel_scale, out=self._network_input[:, : self._num_network_inputs])
+            torch.mul(pos_input, self.cfg.pos_scale, out=self._network_input[:, self._num_network_inputs :])
         else:
             raise ValueError(
                 f"Invalid input order for MLP actuator net: {self.cfg.input_order}. Must be 'pos_vel' or 'vel_pos'."
@@ -175,7 +183,7 @@ class ActuatorNetMLP(DCMotor):
 
         # run network inference
         with torch.inference_mode():
-            torques = self.network(network_input).view(self._num_envs, self.num_joints)
+            torques = self.network(self._network_input).view(self._num_envs, self.num_joints)
         self.computed_effort = torques.view(self._num_envs, self.num_joints) * self.cfg.torque_scale
 
         # clip the computed effort based on the motor limits

--- a/source/isaaclab/isaaclab/controllers/differential_ik.py
+++ b/source/isaaclab/isaaclab/controllers/differential_ik.py
@@ -80,6 +80,7 @@ class DifferentialIKController:
                 else tuple(float(value) for value in ori_weight)
             )
             self._orientation_weight = torch.tensor(weight_tuple, device=self._device)
+        self._eye_matrices: dict[int, torch.Tensor] = {}
         # -- optional joint position limits for null-space joint-limit avoidance (set externally)
         self._joint_pos_lower = None
         self._joint_pos_upper = None
@@ -200,7 +201,8 @@ class DifferentialIKController:
         # compute the delta in joint-space
         delta_joint_pos = self._compute_delta_joint_pos(delta_pose=task_error, jacobian=task_jacobian)
         # add an optional null-space joint-limit-avoidance bias (a no-op when joint_limit_avoidance_gain == 0)
-        delta_joint_pos = delta_joint_pos + self._joint_limit_avoidance(joint_pos, task_jacobian)
+        if self.cfg.joint_limit_avoidance_gain > 0.0 and self._joint_pos_lower is not None:
+            delta_joint_pos = delta_joint_pos + self._joint_limit_avoidance(joint_pos, task_jacobian)
         # return the desired joint positions
         return joint_pos + delta_joint_pos
 
@@ -260,11 +262,11 @@ class DifferentialIKController:
             lambda_val = self.cfg.ik_params["lambda_val"]
             # computation
             jacobian_T = torch.transpose(jacobian, dim0=1, dim1=2)
-            lambda_matrix = (lambda_val**2) * torch.eye(n=jacobian.shape[1], device=self._device)
-            delta_joint_pos = (
-                jacobian_T @ torch.inverse(jacobian @ jacobian_T + lambda_matrix) @ delta_pose.unsqueeze(-1)
-            )
-            delta_joint_pos = delta_joint_pos.squeeze(-1)
+            lambda_matrix = (lambda_val**2) * self._get_eye_matrix(jacobian.shape[1])
+            delta_joint_pos = torch.bmm(
+                jacobian_T,
+                torch.linalg.solve(torch.bmm(jacobian, jacobian_T) + lambda_matrix, delta_pose.unsqueeze(-1)),
+            ).squeeze(-1)
         elif self.cfg.ik_method == "adaptive_dls":  # manipulability-aware damped least squares
             # parameters
             lambda_min = self.cfg.ik_params["lambda_min"]
@@ -278,7 +280,7 @@ class DifferentialIKController:
             ratio = (sigma_min / sigma_thresh).clamp(max=1.0)
             lambda_sq = lambda_min**2 + (1.0 - ratio**2) * (lambda_max**2 - lambda_min**2)  # (N,)
             jacobian_T = torch.transpose(jacobian, dim0=1, dim1=2)
-            lambda_matrix = lambda_sq.view(-1, 1, 1) * torch.eye(n=jacobian.shape[1], device=self._device)
+            lambda_matrix = lambda_sq.view(-1, 1, 1) * self._get_eye_matrix(jacobian.shape[1])
             delta_joint_pos = torch.bmm(
                 jacobian_T,
                 torch.linalg.solve(torch.bmm(jacobian, jacobian_T) + lambda_matrix, delta_pose.unsqueeze(-1)),
@@ -287,6 +289,12 @@ class DifferentialIKController:
             raise ValueError(f"Unsupported inverse-kinematics method: {self.cfg.ik_method}")
 
         return delta_joint_pos
+
+    def _get_eye_matrix(self, size: int) -> torch.Tensor:
+        """Return a cached identity matrix on the controller device."""
+        if size not in self._eye_matrices:
+            self._eye_matrices[size] = torch.eye(n=size, device=self._device)
+        return self._eye_matrices[size]
 
     def _compute_pose_task(
         self, ee_pos: torch.Tensor, ee_quat: torch.Tensor, jacobian: torch.Tensor
@@ -347,5 +355,5 @@ class DifferentialIKController:
         j_pos = task_jacobian[:, :3, :]
         j_pos_pinv = torch.linalg.pinv(j_pos)
         num_joints = task_jacobian.shape[2]
-        null_proj = torch.eye(num_joints, device=self._device) - torch.bmm(j_pos_pinv, j_pos)
+        null_proj = self._get_eye_matrix(num_joints) - torch.bmm(j_pos_pinv, j_pos)
         return torch.bmm(null_proj, dq_center.unsqueeze(-1)).squeeze(-1)

--- a/source/isaaclab/isaaclab/controllers/operational_space.py
+++ b/source/isaaclab/isaaclab/controllers/operational_space.py
@@ -78,16 +78,26 @@ class OperationalSpaceController:
         self._selection_matrix_force_b = torch.zeros_like(self._selection_matrix_force_task)
         # -- commands
         self._task_space_target_task = torch.zeros(self.num_envs, self.target_dim, device=self._device)
+        self._identity_task_frame_pose_b = torch.zeros(self.num_envs, 7, device=self._device)
+        self._identity_task_frame_pose_b[:, 6] = 1.0
         # -- Placeholders for motion/force control
         self.desired_ee_pose_task = None
         self.desired_ee_pose_b = None
         self.desired_ee_wrench_task = None
         self.desired_ee_wrench_b = None
+        # -- reusable target buffers
+        self._desired_ee_pose_task = torch.zeros(self.num_envs, 7, device=self._device)
+        self._desired_ee_pose_b = torch.zeros_like(self._desired_ee_pose_task)
+        self._desired_ee_wrench_task = torch.zeros(self.num_envs, 6, device=self._device)
+        self._desired_ee_wrench_b = torch.zeros_like(self._desired_ee_wrench_task)
         # -- buffer for operational space mass matrix
         self._os_mass_matrix_b = torch.zeros(self.num_envs, 6, 6, device=self._device)
         # -- Placeholder for the inverse of joint space mass matrix
         self._mass_matrix_inv = None
         # -- motion control gains
+        self._motion_damping_ratio_task = torch.as_tensor(
+            self.cfg.motion_damping_ratio_task, dtype=torch.float, device=self._device
+        ).reshape(1, -1)
         self._motion_p_gains_task = torch.diag_embed(
             torch.ones(self.num_envs, 6, device=self._device)
             * torch.tensor(self.cfg.motion_stiffness_task, dtype=torch.float, device=self._device)
@@ -96,9 +106,7 @@ class OperationalSpaceController:
         # -- -- to act due to coupling
         self._motion_p_gains_task[:] = self._selection_matrix_motion_task @ self._motion_p_gains_task[:]
         self._motion_d_gains_task = torch.diag_embed(
-            2
-            * torch.diagonal(self._motion_p_gains_task, dim1=-2, dim2=-1).sqrt()
-            * torch.as_tensor(self.cfg.motion_damping_ratio_task, dtype=torch.float, device=self._device).reshape(1, -1)
+            2 * torch.diagonal(self._motion_p_gains_task, dim1=-2, dim2=-1).sqrt() * self._motion_damping_ratio_task
         )
         # -- -- motion control gains in root frame
         self._motion_p_gains_b = torch.zeros_like(self._motion_p_gains_task)
@@ -229,12 +237,8 @@ class OperationalSpaceController:
             self._task_space_target_task[:] = task_space_command.squeeze(dim=-1)
             self._motion_p_gains_task[:] = torch.diag_embed(stiffness)
             self._motion_p_gains_task[:] = self._selection_matrix_motion_task @ self._motion_p_gains_task[:]
-            self._motion_d_gains_task = torch.diag_embed(
-                2
-                * torch.diagonal(self._motion_p_gains_task, dim1=-2, dim2=-1).sqrt()
-                * torch.as_tensor(self.cfg.motion_damping_ratio_task, dtype=torch.float, device=self._device).reshape(
-                    1, -1
-                )
+            self._motion_d_gains_task[:] = torch.diag_embed(
+                2 * torch.diagonal(self._motion_p_gains_task, dim1=-2, dim2=-1).sqrt() * self._motion_damping_ratio_task
             )
         elif self.cfg.impedance_mode == "variable":
             # split input command
@@ -257,10 +261,7 @@ class OperationalSpaceController:
             raise ValueError(f"Invalid impedance mode: {self.cfg.impedance_mode}.")
 
         if current_task_frame_pose_b is None:
-            # xyzw format: identity quat is [0, 0, 0, 1]
-            current_task_frame_pose_b = torch.tensor(
-                [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]] * self.num_envs, device=self._device
-            )
+            current_task_frame_pose_b = self._identity_task_frame_pose_b
 
         # Resolve the target commands
         target_groups = torch.split(self._task_space_target_task, self.target_list, dim=1)
@@ -280,13 +281,17 @@ class OperationalSpaceController:
                 desired_ee_pos_task, desired_ee_rot_task = apply_delta_pose(
                     current_ee_pos_task, current_ee_rot_task, target
                 )
-                self.desired_ee_pose_task = torch.cat([desired_ee_pos_task, desired_ee_rot_task], dim=-1)
+                self.desired_ee_pose_task = self._desired_ee_pose_task
+                self.desired_ee_pose_task[:, :3] = desired_ee_pos_task
+                self.desired_ee_pose_task[:, 3:] = desired_ee_rot_task
             elif command_type == "pose_abs":
                 # compute targets
-                self.desired_ee_pose_task = target.clone()
+                self.desired_ee_pose_task = self._desired_ee_pose_task
+                self.desired_ee_pose_task[:] = target
             elif command_type == "wrench_abs":
                 # compute targets
-                self.desired_ee_wrench_task = target.clone()
+                self.desired_ee_wrench_task = self._desired_ee_wrench_task
+                self.desired_ee_wrench_task[:] = target
             else:
                 raise ValueError(f"Invalid control command: {command_type}.")
 
@@ -328,7 +333,7 @@ class OperationalSpaceController:
 
         # Transform desired pose from task frame to root frame
         if self.desired_ee_pose_task is not None:
-            self.desired_ee_pose_b = torch.zeros_like(self.desired_ee_pose_task)
+            self.desired_ee_pose_b = self._desired_ee_pose_b
             self.desired_ee_pose_b[:, :3], self.desired_ee_pose_b[:, 3:] = combine_frame_transforms(
                 current_task_frame_pose_b[:, :3],
                 current_task_frame_pose_b[:, 3:],
@@ -338,7 +343,7 @@ class OperationalSpaceController:
 
         # Transform desired wrenches to root frame
         if self.desired_ee_wrench_task is not None:
-            self.desired_ee_wrench_b = torch.zeros_like(self.desired_ee_wrench_task)
+            self.desired_ee_wrench_b = self._desired_ee_wrench_b
             self.desired_ee_wrench_b[:, :3] = (R_task_b @ self.desired_ee_wrench_task[:, :3].unsqueeze(-1)).squeeze(-1)
             self.desired_ee_wrench_b[:, 3:] = (R_task_b @ self.desired_ee_wrench_task[:, 3:].unsqueeze(-1)).squeeze(
                 -1

--- a/source/isaaclab/isaaclab/sensors/ray_caster/base_ray_caster.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/base_ray_caster.py
@@ -232,6 +232,8 @@ class BaseRayCaster(SensorBase):
 
         # Data buffers
         self._data.create_buffers(self._view_count, self.num_rays, self._device)
+        self._view_poses_w_torch = torch.empty((self._view_count, 7), device=self._device)
+        self._view_poses_w = wp.from_torch(self._view_poses_w_torch).view(wp.transformf)
 
         # Dummy distance/normal buffers required by the merged raycast_mesh_masked_kernel signature.
         # Sized (1, 1) even though the kernel is launched at (num_envs, num_rays): the kernel only
@@ -252,8 +254,18 @@ class BaseRayCaster(SensorBase):
         pos_w, quat_w = self._view.get_world_poses()
         pos_torch = pos_w.torch.reshape(-1, 3)
         quat_torch = quat_w.torch.reshape(-1, 4)
-        poses = torch.cat([pos_torch, quat_torch], dim=-1).contiguous()
-        return wp.from_torch(poses).view(wp.transformf)
+        if (
+            not hasattr(self, "_view_poses_w_torch")
+            or self._view_poses_w_torch.shape[0] != pos_torch.shape[0]
+            or self._view_poses_w_torch.dtype != pos_torch.dtype
+            or self._view_poses_w_torch.device != pos_torch.device
+        ):
+            self._view_poses_w_torch = torch.empty(
+                (pos_torch.shape[0], 7), device=pos_torch.device, dtype=pos_torch.dtype
+            )
+            self._view_poses_w = wp.from_torch(self._view_poses_w_torch).view(wp.transformf)
+        torch.cat((pos_torch, quat_torch), dim=-1, out=self._view_poses_w_torch)
+        return self._view_poses_w
 
     def _update_ray_infos(self, env_mask: wp.array):
         """Updates sensor poses and ray world-frame buffers via a single warp kernel."""


### PR DESCRIPTION
# Description

Reuses temporary buffers in actuator, controller, and ray-caster hot paths to reduce per-step tensor allocation overhead.

This PR:

- changes `ActuatorNetMLP` input assembly to use cached input-index tensors and a reusable network input buffer
- caches Differential IK identity matrices and skips the joint-limit-avoidance path when disabled
- reuses OSC command/target buffers and the identity task-frame pose buffer
- reuses the ray-caster view transform tensor/Warp view instead of allocating a new concatenated tensor each update

Fixes #

## Benchmark impact

Framework microbenchmarks at 4096 CUDA environments showed the intended hot-path reductions:

| Path | Before | After | Time reduction |
|---|---:|---:|---:|
| `ActuatorNetMLP` input assembly | 33.97 us | 27.30 us | -19.6% |
| Differential IK DLS solve setup | 92.36 us | 61.44 us | -33.5% |
| Differential IK disabled JLA path | 6.42 us | 0.04 us | -99.4% |
| OSC pose command setup | 4,153.07 us | 269.64 us | -93.5% |
| Ray-caster view transform assembly | 5.35 us | 2.80 us | -47.6% |

End-to-end rough-terrain Go2 runtime with the height scanner active was neutral within single-run noise:

| Task | Baseline FPS | Optimized FPS | Delta |
|---|---:|---:|---:|
| `Isaac-Velocity-Rough-UnitreeGo2`, 1024 envs, 200 frames | 83,736.62 | 83,473.88 | -0.31% |

Interpretation: the allocation cleanup is visible in isolated actuator/IK/OSC/ray-caster paths, but the Go2 height-scan task is dominated by physics, ray casting, rewards, and observation assembly at this scale.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- `./isaaclab.sh -p -m pytest source/isaaclab/test/controllers/test_differential_ik_features.py source/isaaclab/test/controllers/test_operational_space.py source/isaaclab/test/sensors/test_ray_caster_kernels.py`
- `./isaaclab.sh -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation, or documentation is not required for this internal performance cleanup
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
