### PR TITLE
Speed up configclass parsing

### DIFF
--- a/source/isaaclab/changelog.d/perf-configclass-parsing.rst
+++ b/source/isaaclab/changelog.d/perf-configclass-parsing.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Improved config parsing by reducing reflection and repeated copying in
+  :mod:`isaaclab.utils.configclass`.

--- a/source/isaaclab/isaaclab/utils/configclass.py
+++ b/source/isaaclab/isaaclab/utils/configclass.py
@@ -23,6 +23,15 @@ _CALLABLE_STR_WITH_DIR_RE = re.compile(r"^\{DIR\}(?:\.[A-Za-z_][A-Za-z0-9_]*)*:[
 _CONFIGCLASS_METHODS = ["to_dict", "from_dict", "replace", "copy", "validate"]
 """List of class methods added at runtime to dataclass."""
 
+_CONFIGCLASS_FIELD_MODULE_DIR_CACHE = "__configclass_field_module_dir_cache__"
+"""Name of the per-class cache storing field module directories."""
+
+_CACHE_MISS = object()
+"""Sentinel value used for cache lookups."""
+
+_IMMUTABLE_VALUE_TYPES = (str, int, float, bool, bytes, type(None))
+"""Exact immutable value types that do not need :func:`deepcopy`."""
+
 """
 Wrapper around dataclass.
 """
@@ -188,37 +197,59 @@ def _copy_class(obj: object) -> object:
 def _field_module_dir(obj: Any, key: str | None = None) -> str | None:
     """Return module parent package path for an object or one of its declared fields."""
     cls = type(obj)
-    if key is not None:
-        # Use nearest declaration in MRO (subclass override wins).
-        # We prefer __configclass_own_fields__ (the snapshot taken before
-        # _process_mutable_types copies parent fields into every subclass's
-        # __dict__) so that {DIR} resolves relative to the class that
-        # *originally* declared the field, not the subclass that inherited it.
-        for mro_cls in cls.__mro__:
-            if mro_cls is object:
-                continue
-            own_fields = getattr(mro_cls, "__configclass_own_fields__", None)
-            if own_fields is not None:
-                if key in own_fields:
-                    cls = mro_cls
-                    break
-            elif key in mro_cls.__dict__:
-                cls = mro_cls
+    if key is None:
+        return _module_dir(cls)
+
+    cache = getattr(cls, _CONFIGCLASS_FIELD_MODULE_DIR_CACHE, None)
+    if cache is None:
+        cache = {}
+        setattr(cls, _CONFIGCLASS_FIELD_MODULE_DIR_CACHE, cache)
+
+    cached_value = cache.get(key, _CACHE_MISS)
+    if cached_value is not _CACHE_MISS:
+        declaring_cls, module_name, module_dir = cached_value
+        if getattr(declaring_cls, "__module__", "") == module_name:
+            return module_dir
+
+    # Use nearest declaration in MRO (subclass override wins).  We prefer
+    # __configclass_own_fields__ (the snapshot taken before
+    # _process_mutable_types copies parent fields into every subclass's
+    # __dict__) so that {DIR} resolves relative to the class that originally
+    # declared the field, not the subclass that inherited it.
+    declaring_cls = cls
+    for mro_cls in cls.__mro__:
+        if mro_cls is object:
+            continue
+        own_fields = getattr(mro_cls, "__configclass_own_fields__", None)
+        if own_fields is not None:
+            if key in own_fields:
+                declaring_cls = mro_cls
                 break
-    module_name = getattr(cls, "__module__", "")
-    return module_name.rsplit(".", 1)[0] if "." in module_name else (module_name or None)
+        elif key in mro_cls.__dict__:
+            declaring_cls = mro_cls
+            break
+
+    module_dir = _module_dir(declaring_cls)
+    cache[key] = (declaring_cls, getattr(declaring_cls, "__module__", ""), module_dir)
+    return module_dir
 
 
 def _wrap_resolvable_strings(value: Any, module_dir: str | None = None, _seen: set[int] | None = None) -> Any:
     """Recursively wrap callable-like strings with :class:`ResolvableString`."""
-    if isinstance(value, str) and (_CALLABLE_STR_RE.match(value) or _CALLABLE_STR_WITH_DIR_RE.match(value)):
-        if "{DIR}" in value:
-            if module_dir is None:
-                raise ValueError(f"Cannot resolve '{{DIR}}' in '{value}' because no module context is available.")
-            value = value.replace("{DIR}", module_dir)
-        return ResolvableString(value)
-    is_dataclass_instance = hasattr(value, "__dataclass_fields__") and hasattr(value, "__dict__")
+    if isinstance(value, ResolvableString):
+        return value
+    if isinstance(value, str):
+        if _CALLABLE_STR_RE.match(value) or _CALLABLE_STR_WITH_DIR_RE.match(value):
+            if "{DIR}" in value:
+                if module_dir is None:
+                    raise ValueError(f"Cannot resolve '{{DIR}}' in '{value}' because no module context is available.")
+                value = value.replace("{DIR}", module_dir)
+            return ResolvableString(value)
+        return value
     is_container = isinstance(value, (list, tuple, dict))
+    is_dataclass_instance = hasattr(value, "__dict__") and hasattr(value, "__dataclass_fields__")
+    if not is_container and not is_dataclass_instance:
+        return value
     if is_dataclass_instance or is_container:
         if _seen is None:
             _seen = set()
@@ -492,17 +523,20 @@ def _custom_post_init(obj):
     proxy type i.e. a read only proxy for mapping objects. The error is thrown when using hierarchical data-classes
     for configuration.
     """
-    for key in dir(obj):
+    try:
+        items = tuple(obj.__dict__.items())
+    except AttributeError:
+        items = tuple((field.name, getattr(obj, field.name)) for field in dataclasses.fields(obj))
+
+    for key, value in items:
         # skip dunder members
         if key.startswith("__"):
             continue
-        # get data member
-        value = getattr(obj, key)
         # check annotation
         ann = obj.__class__.__dict__.get(key)
         # duplicate data members that are mutable
         if not callable(value) and not isinstance(ann, property):
-            copied_value = deepcopy(value)
+            copied_value = _copy_config_value(value)
             setattr(obj, key, _wrap_resolvable_strings(copied_value, module_dir=_field_module_dir(obj, key)))
 
 
@@ -581,6 +615,19 @@ def _skippable_class_member(key: str, value: Any, hints: dict | None = None) -> 
     return False
 
 
+def _module_dir(cls: type) -> str | None:
+    """Return the parent module path for a class."""
+    module_name = getattr(cls, "__module__", "")
+    return module_name.rsplit(".", 1)[0] if "." in module_name else (module_name or None)
+
+
+def _copy_config_value(value: Any) -> Any:
+    """Copy a config value while preserving immutable scalar identities."""
+    if type(value) in _IMMUTABLE_VALUE_TYPES:
+        return value
+    return deepcopy(value)
+
+
 def _return_f(f: Any) -> Callable[[], Any]:
     """Returns default factory function for creating mutable/immutable variables.
 
@@ -597,11 +644,11 @@ def _return_f(f: Any) -> Callable[[], Any]:
     def _wrap():
         if isinstance(f, Field):
             if f.default_factory is MISSING:
-                return deepcopy(f.default)
+                return _copy_config_value(f.default)
             else:
                 return f.default_factory
         else:
-            return deepcopy(f)
+            return _copy_config_value(f)
 
     return _wrap
 

--- a/source/isaaclab/test/utils/test_configclass.py
+++ b/source/isaaclab/test/utils/test_configclass.py
@@ -697,6 +697,53 @@ def test_dir_resolution_uses_declaring_class_for_inherited_field():
     assert str(cfg.class_type) == "test_pkg.parent.base_mod:BaseSymbol"
 
 
+def test_dir_resolution_cache_updates_when_module_changes():
+    """{DIR} cache should follow module changes on the declaring class."""
+
+    @configclass
+    class _BaseCfg:
+        class_type: type | str = "{DIR}.base_mod:BaseSymbol"
+
+    @configclass
+    class _ChildCfg(_BaseCfg):
+        pass
+
+    _BaseCfg.__module__ = "test_pkg.parent.base_cfg"
+    cfg = _ChildCfg()
+
+    assert str(cfg.class_type) == "test_pkg.parent.base_mod:BaseSymbol"
+
+    _BaseCfg.__module__ = "updated_pkg.parent.base_cfg"
+    cfg = _ChildCfg()
+
+    assert str(cfg.class_type) == "updated_pkg.parent.base_mod:BaseSymbol"
+
+
+def test_post_init_added_mutable_attribute_is_copied():
+    """Mutable attributes added by user post-init should remain instance-owned."""
+    shared_values = ["shared"]
+
+    @configclass
+    class _PostInitMutableCfg:
+        value: int = 0
+
+        def __post_init__(self):
+            self.extra_values = shared_values
+
+    cfg_a = _PostInitMutableCfg()
+    cfg_b = _PostInitMutableCfg()
+
+    assert cfg_a.extra_values == ["shared"]
+    assert cfg_b.extra_values == ["shared"]
+    assert cfg_a.extra_values is not shared_values
+    assert cfg_b.extra_values is not shared_values
+    assert cfg_a.extra_values is not cfg_b.extra_values
+
+    cfg_a.extra_values.append("a")
+
+    assert cfg_b.extra_values == ["shared"]
+
+
 def test_config_update_different_iterable_lengths():
     """Iterables are whole replaced, even if their lengths are different."""
 


### PR DESCRIPTION
# Description

Speeds up `configclass` parsing by reducing repeated reflection and copying during config object construction.

This PR:

- walks instance fields from `obj.__dict__` in `_custom_post_init()` instead of using `dir(obj)`
- caches `{DIR}` field module-directory lookup per config class/field, with invalidation when the declaring module changes
- fast-returns existing `ResolvableString` instances and plain strings that cannot be callable strings
- skips `deepcopy()` for exact immutable scalar defaults where copying cannot change ownership
- adds regression coverage for `{DIR}` cache invalidation and post-init-added mutable attributes

Fixes #

## Benchmark impact

Config parsing benchmark results:

| Task | Benchmark | Before | After | Delta |
|---|---|---:|---:|---:|
| `Isaac-Velocity-Flat-UnitreeGo2` | Startup `task_config` phase | 0.501 s | 0.443 s | -11.6% |
| `Isaac-Lift-KukaAllegro` | Startup `task_config` phase | 0.801 s | 0.690 s | -13.8% |
| `Isaac-Velocity-Flat-UnitreeGo2` | Warm `resolve_task_config()` mean | 8.82 ms | 7.84 ms | -11.1% |
| `Isaac-Lift-KukaAllegro` | Warm `resolve_task_config()` mean | 19.59 ms | 15.36 ms | -21.6% |

DexSuite lift profile reductions:

| Function | Before calls | After calls | Before own time | After own time |
|---|---:|---:|---:|---:|
| `copy.deepcopy` | 126,185 | 104,600 | 0.102 s | 0.083 s |
| `configclass._wrap_resolvable_strings` | 51,965 | 44,532 | 0.078 s | 0.052 s |
| `configclass._field_module_dir` | 42,327 | 38,385 | 0.030 s | 0.019 s |
| `configclass._custom_post_init` | 662 | 662 | 0.020 s | 0.012 s |

Caveat: the change assumes config classes are effectively static after decoration. Runtime monkey-patching of field ownership is not a supported pattern and could bypass the field-module cache until the class/module metadata changes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- `./isaaclab.sh -p -m pytest source/isaaclab/test/utils/test_configclass.py`
- `./isaaclab.sh -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation, or documentation is not required for this internal performance cleanup
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
