### PR TITLE
Reduce Newton cloner replication overhead

### DIFF
--- a/source/isaaclab_newton/changelog.d/perf-newton-cloner.rst
+++ b/source/isaaclab_newton/changelog.d/perf-newton-cloner.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Reduced Newton scene replication overhead by reusing clone mapping rows and
+  per-world transforms during builder replication.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -67,22 +67,41 @@ def replicate_builder_mapping(
     num_worlds = mapping.size(1)
     local_site_map: dict[str, list[list[int]]] = {}
     world_xforms: list[wp.transform] = []
-    source_world_indices = mapping.to(dtype=torch.int64).argmax(dim=1)
+    mapping_rows = mapping.detach().cpu().tolist()
+    rows_by_world: list[list[int]] = [[] for _ in range(num_worlds)]
+    source_world_indices: list[int] = []
+    for row, world_mask in enumerate(mapping_rows):
+        source_col = 0
+        source_col_found = False
+        for col, is_mapped in enumerate(world_mask):
+            if is_mapped:
+                rows_by_world[col].append(row)
+                if not source_col_found:
+                    source_col = col
+                    source_col_found = True
+        source_world_indices.append(source_col)
 
-    for col in range(num_worlds):
+    positions_list = positions.detach().cpu().tolist()
+    quaternions_list = quaternions.detach().cpu().tolist()
+    source_xforms = [
+        wp.transform(positions_list[source_col], quaternions_list[source_col]) for source_col in source_world_indices
+    ]
+
+    for col, rows in enumerate(rows_by_world):
         builder.begin_world()
-        world_xform = wp.transform(positions[col], quaternions[col])
+        world_position = positions_list[col]
+        world_quaternion = quaternions_list[col]
+        world_xform = wp.transform(world_position, world_quaternion)
         world_xforms.append(world_xform)
 
         for label, xform in env_root_sites.items():
             site_idx = builder.add_site(body=-1, xform=wp.transform_multiply(world_xform, xform), label=label)
             local_site_map.setdefault(label, [[] for _ in range(num_worlds)])[col].append(site_idx)
 
-        for row in torch.nonzero(mapping[:, col], as_tuple=True)[0].tolist():
-            source_builder = source_builders[sources[int(row)]]
+        for row in rows:
+            source_builder = source_builders[sources[row]]
             offset = builder.shape_count
-            source_col = int(source_world_indices[int(row)])
-            source_xform = wp.transform(positions[source_col], quaternions[source_col])
+            source_xform = source_xforms[row]
             builder.add_builder(
                 source_builder, xform=wp.transform_multiply(world_xform, wp.transform_inverse(source_xform))
             )
@@ -92,7 +111,7 @@ def replicate_builder_mapping(
                 local_indices.extend(offset + shape_idx for shape_idx in source_shape_indices)
 
         for hook in per_world_builder_hooks:
-            hook(builder, col, positions[col].tolist(), quaternions[col].tolist())
+            hook(builder, col, world_position, world_quaternion)
         builder.end_world()
 
     for hook in post_replicate_hooks:


### PR DESCRIPTION
# Description

Reduces avoidable Python work in Newton scene replication by precomputing clone mapping rows and reusable world/source transforms.

This PR:

- converts the clone mapping tensor to host rows once
- groups source rows by destination world before builder replication
- precomputes source world transforms instead of rebuilding them inside the world loop
- reuses host position/quaternion lists for per-world hooks

Fixes #

## Benchmark impact

The final Go2 Newton startup pass showed this cleanup is low risk but not a material end-to-end startup win by itself:

| Case | App | Imports | Config | Env creation | First step | Total |
|---|---:|---:|---:|---:|---:|---:|
| Go2 flat Newton/MJWarp before final startup pass | 0.001 s | 1.869 s | 0.336 s | 11.345 s | 0.093 s | 13.644 s |
| Go2 flat Newton/MJWarp after final startup pass | 0.004 s | 1.875 s | 0.485 s | 11.199 s | 0.100 s | 13.663 s |

Environment creation was 0.146 s lower in that single-run comparison, but total startup was effectively unchanged (+0.019 s) because the remaining cost is dominated by Newton builder/model/solver setup and startup phase noise. This PR should be reviewed as a small Python-side cleanup, not as the change that brings Newton startup below PhysX.

Related startup ablations showed larger Newton changes need backend-level work: disabling CUDA graph capture shifted about 0.8 s out of environment creation into first step, and LBVH/mesh-simplification toggles stayed too small to close the PhysX gap.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- `PYTHONPATH=<split source paths> ./isaaclab.sh -p -m pytest source/isaaclab_newton/test/cloner/test_rename_builder_labels.py`
- `./isaaclab.sh -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation, or documentation is not required for this internal performance cleanup
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
