### PR TITLE
Fix fragment writers to modify existing rigid-body, collision, and mass prims

### DIFF
--- a/source/isaaclab/changelog.d/vidurv-nested-fragment-writers.rst
+++ b/source/isaaclab/changelog.d/vidurv-nested-fragment-writers.rst
@@ -9,3 +9,8 @@ Fixed
   carries none. Previously, passing a fragment list for ``rigid_props`` on a USD asset whose
   spawn prim carries the articulation root turned the asset's links into nested rigid bodies,
   and the PhysX parser dropped the articulation's joints.
+* Fixed :func:`~isaaclab.sim.schemas.apply_collision_properties` unconditionally returning
+  ``True``. It now raises ``ValueError`` on an invalid prim path and reports fragment failures
+  and skipped instanced prims in its return value, matching
+  :func:`~isaaclab.sim.schemas.apply_rigid_body_properties` and
+  :func:`~isaaclab.sim.schemas.apply_mass_properties`.

--- a/source/isaaclab/changelog.d/vidurv-nested-fragment-writers.rst
+++ b/source/isaaclab/changelog.d/vidurv-nested-fragment-writers.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.sim.schemas.apply_rigid_body_properties`,
+  :func:`~isaaclab.sim.schemas.apply_collision_properties`, and
+  :func:`~isaaclab.sim.schemas.apply_mass_properties` force-applying their defining USD API on
+  the input prim. They now modify the prims in the subtree that already carry the API, matching
+  the legacy nested writers, and only apply a fresh API on the input prim when the subtree
+  carries none. Previously, passing a fragment list for ``rigid_props`` on a USD asset whose
+  spawn prim carries the articulation root turned the asset's links into nested rigid bodies,
+  and the PhysX parser dropped the articulation's joints.

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -547,37 +547,110 @@ Rigid body properties.
 """
 
 
+def _resolve_fragment_targets(
+    prim_path: str,
+    api_type,
+    stage: Usd.Stage,
+    apply_fresh: bool,
+) -> tuple[list, bool]:
+    """Resolve the prims a fragment family writer should author on.
+
+    Mirrors the legacy nested writers: prims under ``prim_path`` that already carry ``api_type``
+    are modified in place, without descending past a match (nested applications of the same
+    physics schema are not allowed, so a match's descendants are pruned). Only when the subtree
+    carries no such prim is the defining API freshly applied to ``prim_path`` itself -- the
+    bare-prim case used by the shape and mesh spawners. Instanced prims cannot be authored on and
+    are skipped with a warning.
+
+    Args:
+        prim_path: The prim path whose subtree is searched.
+        api_type: The defining USD API schema type (e.g. ``UsdPhysics.RigidBodyAPI``).
+        stage: The stage containing the prim.
+        apply_fresh: Whether to apply ``api_type`` on ``prim_path`` when the subtree has no
+            carrier of it (presence-gated define-fresh).
+
+    Returns:
+        A tuple ``(targets, any_skipped)``: the writable target prims, and whether any instanced
+        prim had to be skipped.
+
+    Raises:
+        ValueError: When the prim path is not valid.
+    """
+    prim = stage.GetPrimAtPath(prim_path)
+    if not prim.IsValid():
+        raise ValueError(f"Prim path '{prim_path}' is not valid.")
+    # breadth-first collection; pruning descendants of a match reproduces the legacy nested
+    # writer's stop-on-success traversal
+    matches = []
+    for candidate in get_all_matching_child_prims(
+        prim_path,
+        lambda p: p.HasAPI(api_type),
+        stage=stage,
+        traverse_instance_prims=True,
+    ):
+        if not any(candidate.GetPath().HasPrefix(match.GetPath()) for match in matches):
+            matches.append(candidate)
+    targets = []
+    skipped = []
+    for match in matches:
+        if match.IsInstance() or match.IsInstanceProxy():
+            skipped.append(match)
+        else:
+            targets.append(match)
+    if not matches and apply_fresh:
+        if prim.IsInstance() or prim.IsInstanceProxy():
+            skipped.append(prim)
+        else:
+            api_type.Apply(prim)
+            targets.append(prim)
+    if skipped:
+        logger.warning(
+            "Skipping %s updates on instanced prims: %s.",
+            api_type.__name__,
+            [p.GetPath().pathString for p in skipped],
+        )
+    return targets, bool(skipped)
+
+
 def apply_rigid_body_properties(
     prim_path: str, fragments: Iterable[schemas_cfg.RigidBodyFragment], stage: Usd.Stage | None = None
 ) -> bool:
-    """Apply a list of rigid-body fragments to a prim.
+    """Apply a list of rigid-body fragments to the rigid bodies under a prim.
 
-    Applies ``UsdPhysics.RigidBodyAPI`` as the implicit anchor (the defining schema for a rigid
-    body), then dispatches each fragment via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`.
-    Backend fragments carry backend-specific funcs, so core never imports a backend.
+    Existing rigid bodies in the subtree are modified in place (matching the legacy nested
+    writer): real assets author ``UsdPhysics.RigidBodyAPI`` on their link prims, and anchoring a
+    fresh rigid body on the spawn prim instead would nest those links under a new body -- the
+    PhysX parser then drops the articulation's joint graph. Only when the subtree carries no
+    rigid body is ``UsdPhysics.RigidBodyAPI`` applied to ``prim_path`` itself (the bare-prim case
+    used by the shape and mesh spawners). Each fragment is dispatched to every resolved target
+    via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`; backend fragments carry
+    backend-specific funcs, so core never imports a backend.
 
     Args:
-        prim_path: The prim path to apply the rigid-body schemas on.
+        prim_path: The prim path whose subtree is searched for rigid bodies.
         fragments: An iterable of :class:`~isaaclab.sim.schemas.RigidBodyFragment` instances.
         stage: The stage where to find the prim. Defaults to None, in which case the current
             stage is used.
 
     Returns:
-        True if the properties were successfully set.
+        True if every target and fragment succeeds and no instanced prim was skipped.
+
+    Raises:
+        ValueError: When the prim path is not valid.
     """
+    fragments = list(fragments)
     if stage is None:
         stage = get_current_stage()
-    prim = stage.GetPrimAtPath(prim_path)
-    # fail loudly on an invalid path (matches the legacy define_rigid_body_properties writer)
-    if not prim.IsValid():
-        raise ValueError(f"Prim path '{prim_path}' is not valid.")
-    if not UsdPhysics.RigidBodyAPI(prim):
-        UsdPhysics.RigidBodyAPI.Apply(prim)
-    # aggregate per-fragment results so a reported failure is not masked by the always-applied anchor
-    success = True
-    for cfg in fragments:
-        func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
-        success = bool(func(cfg, prim_path, stage)) and success
+    targets, any_skipped = _resolve_fragment_targets(
+        prim_path, UsdPhysics.RigidBodyAPI, stage, apply_fresh=bool(fragments)
+    )
+    # aggregate per-target, per-fragment results so a reported failure is not masked
+    success = not any_skipped
+    for target in targets:
+        target_path = target.GetPath().pathString
+        for cfg in fragments:
+            func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
+            success = bool(func(cfg, target_path, stage)) and success
     return success
 
 
@@ -778,29 +851,40 @@ def apply_collision_properties(
 ) -> bool:
     """Apply a list of collision fragments to a prim.
 
-    Applies ``UsdPhysics.CollisionAPI`` as the implicit anchor (the defining schema for a
-    collider), then dispatches each fragment via its
-    :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend fragments carry backend-specific
-    funcs, so core never imports a backend.
+    Existing colliders in the subtree are modified in place (matching the legacy nested writer):
+    real assets author ``UsdPhysics.CollisionAPI`` on their collider prims, and anchoring a fresh
+    collider on the spawn prim would change what the physics parser collides. Only when the
+    subtree carries no collider is ``UsdPhysics.CollisionAPI`` applied to ``prim_path`` itself
+    (the bare-prim case used by the shape and mesh spawners). Each fragment is dispatched to
+    every resolved target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend
+    fragments carry backend-specific funcs, so core never imports a backend.
 
     Args:
-        prim_path: The prim path to apply the collision schemas on.
+        prim_path: The prim path whose subtree is searched for colliders.
         fragments: An iterable of :class:`~isaaclab.sim.schemas.CollisionFragment` instances.
         stage: The stage where to find the prim. Defaults to None, in which case the current
             stage is used.
 
     Returns:
-        True if the properties were successfully set.
+        True if every target and fragment succeeds and no instanced prim was skipped.
+
+    Raises:
+        ValueError: When the prim path is not valid.
     """
+    fragments = list(fragments)
     if stage is None:
         stage = get_current_stage()
-    prim = stage.GetPrimAtPath(prim_path)
-    if not UsdPhysics.CollisionAPI(prim):
-        UsdPhysics.CollisionAPI.Apply(prim)
-    for cfg in fragments:
-        func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
-        func(cfg, prim_path, stage)
-    return True
+    targets, any_skipped = _resolve_fragment_targets(
+        prim_path, UsdPhysics.CollisionAPI, stage, apply_fresh=bool(fragments)
+    )
+    # aggregate per-target, per-fragment results so a reported failure is not masked
+    success = not any_skipped
+    for target in targets:
+        target_path = target.GetPath().pathString
+        for cfg in fragments:
+            func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
+            success = bool(func(cfg, target_path, stage)) and success
+    return success
 
 
 def define_collision_properties(
@@ -902,31 +986,35 @@ def apply_mass_properties(
 ) -> bool:
     """Apply a list of mass fragments to a prim.
 
-    Applies ``UsdPhysics.MassAPI`` as the implicit anchor (the defining schema for mass properties),
-    then dispatches each fragment via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`.
+    Existing mass-bearing prims in the subtree are modified in place (matching the legacy nested
+    writer): real assets author ``UsdPhysics.MassAPI`` on their link prims. Only when the subtree
+    carries none is ``UsdPhysics.MassAPI`` applied to ``prim_path`` itself (the bare-prim case
+    used by the shape and mesh spawners). Each fragment is dispatched to every resolved target
+    via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`.
 
     Args:
-        prim_path: The prim path to apply the mass schemas on.
+        prim_path: The prim path whose subtree is searched for mass-bearing prims.
         fragments: An iterable of :class:`~isaaclab.sim.schemas.MassFragment` instances.
         stage: The stage where to find the prim. Defaults to None, in which case the current
             stage is used.
 
     Returns:
-        True if the properties were successfully set.
+        True if every target and fragment succeeds and no instanced prim was skipped.
+
+    Raises:
+        ValueError: When the prim path is not valid.
     """
+    fragments = list(fragments)
     if stage is None:
         stage = get_current_stage()
-    prim = stage.GetPrimAtPath(prim_path)
-    # fail loudly on an invalid path (matches the legacy define_mass_properties writer)
-    if not prim.IsValid():
-        raise ValueError(f"Prim path '{prim_path}' is not valid.")
-    if not UsdPhysics.MassAPI(prim):
-        UsdPhysics.MassAPI.Apply(prim)
-    # aggregate per-fragment results so a reported failure is not masked by the always-applied anchor
-    success = True
-    for cfg in fragments:
-        func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
-        success = bool(func(cfg, prim_path, stage)) and success
+    targets, any_skipped = _resolve_fragment_targets(prim_path, UsdPhysics.MassAPI, stage, apply_fresh=bool(fragments))
+    # aggregate per-target, per-fragment results so a reported failure is not masked
+    success = not any_skipped
+    for target in targets:
+        target_path = target.GetPath().pathString
+        for cfg in fragments:
+            func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
+            success = bool(func(cfg, target_path, stage)) and success
     return success
 
 

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -553,25 +553,25 @@ def _resolve_fragment_targets(
     stage: Usd.Stage,
     apply_fresh: bool,
 ) -> tuple[list, bool]:
-    """Resolve the prims a fragment family writer should author on.
+    """Resolve the prims that a fragment family writer should author on.
 
-    Mirrors the legacy nested writers: prims under ``prim_path`` that already carry ``api_type``
-    are modified in place, without descending past a match (nested applications of the same
-    physics schema are not allowed, so a match's descendants are pruned). Only when the subtree
-    carries no such prim is the defining API freshly applied to ``prim_path`` itself -- the
-    bare-prim case used by the shape and mesh spawners. Instanced prims cannot be authored on and
-    are skipped with a warning.
+    This mirrors the legacy nested writers: prims under ``prim_path`` that already carry
+    ``api_type`` are modified in place, and the search does not descend past a match, since
+    nested applications of the same physics schema are not allowed. Only when the subtree
+    carries no such prim is the defining API applied freshly to ``prim_path`` itself -- the
+    bare-prim case used by the shape and mesh spawners. Instanced prims cannot be edited, so
+    they are skipped with a warning.
 
     Args:
         prim_path: The prim path whose subtree is searched.
         api_type: The defining USD API schema type (e.g. ``UsdPhysics.RigidBodyAPI``).
         stage: The stage containing the prim.
-        apply_fresh: Whether to apply ``api_type`` on ``prim_path`` when the subtree has no
-            carrier of it (presence-gated define-fresh).
+        apply_fresh: Whether to apply ``api_type`` to ``prim_path`` when the subtree contains
+            no carrier of it.
 
     Returns:
-        A tuple ``(targets, any_skipped)``: the writable target prims, and whether any instanced
-        prim had to be skipped.
+        A tuple ``(targets, any_skipped)`` holding the writable target prims and whether any
+        instanced prim was skipped.
 
     Raises:
         ValueError: When the prim path is not valid.
@@ -622,13 +622,13 @@ def apply_rigid_body_properties(
 ) -> bool:
     """Apply a list of rigid-body fragments to the rigid bodies under a prim.
 
-    Existing rigid bodies in the subtree are modified in place (matching the legacy nested
-    writer): real assets author ``UsdPhysics.RigidBodyAPI`` on their link prims, and anchoring a
-    fresh rigid body on the spawn prim instead would nest those links under a new body -- the
-    PhysX parser then drops the articulation's joint graph. Only when the subtree carries no
-    rigid body is ``UsdPhysics.RigidBodyAPI`` applied to ``prim_path`` itself (the bare-prim case
-    used by the shape and mesh spawners). Each fragment is dispatched to every resolved target
-    via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`; backend fragments carry
+    Existing rigid bodies in the subtree are modified in place, matching the legacy nested
+    writer. Real assets author ``UsdPhysics.RigidBodyAPI`` on their link prims, so anchoring a
+    fresh rigid body on the spawn prim instead would nest those links under a new body and the
+    PhysX parser would drop the articulation's joint graph. Only when the subtree carries no
+    rigid body is ``UsdPhysics.RigidBodyAPI`` applied to ``prim_path`` itself -- the bare-prim
+    case used by the shape and mesh spawners. Each fragment is dispatched to every resolved
+    target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend fragments carry
     backend-specific funcs, so core never imports a backend.
 
     Args:
@@ -638,7 +638,7 @@ def apply_rigid_body_properties(
             stage is used.
 
     Returns:
-        True if every target and fragment succeeds and no instanced prim was skipped.
+        True if every target and fragment succeeded and no instanced prim was skipped.
 
     Raises:
         ValueError: When the prim path is not valid.
@@ -856,11 +856,11 @@ def apply_collision_properties(
 ) -> bool:
     """Apply a list of collision fragments to a prim.
 
-    Existing colliders in the subtree are modified in place (matching the legacy nested writer):
-    real assets author ``UsdPhysics.CollisionAPI`` on their collider prims, and anchoring a fresh
-    collider on the spawn prim would change what the physics parser collides. Only when the
+    Existing colliders in the subtree are modified in place, matching the legacy nested writer.
+    Real assets author ``UsdPhysics.CollisionAPI`` on their collider prims, so anchoring a fresh
+    collider on the spawn prim would change the scene's collision geometry. Only when the
     subtree carries no collider is ``UsdPhysics.CollisionAPI`` applied to ``prim_path`` itself
-    (the bare-prim case used by the shape and mesh spawners). Each fragment is dispatched to
+    -- the bare-prim case used by the shape and mesh spawners. Each fragment is dispatched to
     every resolved target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend
     fragments carry backend-specific funcs, so core never imports a backend.
 
@@ -871,7 +871,7 @@ def apply_collision_properties(
             stage is used.
 
     Returns:
-        True if every target and fragment succeeds and no instanced prim was skipped.
+        True if every target and fragment succeeded and no instanced prim was skipped.
 
     Raises:
         ValueError: When the prim path is not valid.
@@ -991,11 +991,11 @@ def apply_mass_properties(
 ) -> bool:
     """Apply a list of mass fragments to a prim.
 
-    Existing mass-bearing prims in the subtree are modified in place (matching the legacy nested
-    writer): real assets author ``UsdPhysics.MassAPI`` on their link prims. Only when the subtree
-    carries none is ``UsdPhysics.MassAPI`` applied to ``prim_path`` itself (the bare-prim case
-    used by the shape and mesh spawners). Each fragment is dispatched to every resolved target
-    via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`.
+    Existing mass-bearing prims in the subtree are modified in place, matching the legacy nested
+    writer, since real assets author ``UsdPhysics.MassAPI`` on their link prims. Only when the
+    subtree carries none is ``UsdPhysics.MassAPI`` applied to ``prim_path`` itself -- the
+    bare-prim case used by the shape and mesh spawners. Each fragment is dispatched to every
+    resolved target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`.
 
     Args:
         prim_path: The prim path whose subtree is searched for mass-bearing prims.
@@ -1004,7 +1004,7 @@ def apply_mass_properties(
             stage is used.
 
     Returns:
-        True if every target and fragment succeeds and no instanced prim was skipped.
+        True if every target and fragment succeeded and no instanced prim was skipped.
 
     Raises:
         ValueError: When the prim path is not valid.

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -579,17 +579,22 @@ def _resolve_fragment_targets(
     prim = stage.GetPrimAtPath(prim_path)
     if not prim.IsValid():
         raise ValueError(f"Prim path '{prim_path}' is not valid.")
-    # breadth-first collection; pruning descendants of a match reproduces the legacy nested
-    # writer's stop-on-success traversal
-    matches = []
-    for candidate in get_all_matching_child_prims(
+    # collect every carrier in the subtree, then keep only the outermost ones: nested
+    # applications of the same physics schema are not allowed, and the legacy nested writers
+    # stop descending at the first carrier on each branch. The pruning is a second pass over
+    # the full result so it does not depend on the traversal order of the query.
+    candidates = get_all_matching_child_prims(
         prim_path,
         lambda p: p.HasAPI(api_type),
         stage=stage,
         traverse_instance_prims=True,
-    ):
-        if not any(candidate.GetPath().HasPrefix(match.GetPath()) for match in matches):
-            matches.append(candidate)
+    )
+    candidate_paths = [candidate.GetPath() for candidate in candidates]
+    matches = [
+        candidate
+        for candidate, path in zip(candidates, candidate_paths)
+        if not any(path != other and path.HasPrefix(other) for other in candidate_paths)
+    ]
     targets = []
     skipped = []
     for match in matches:

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -543,7 +543,7 @@ def modify_articulation_root_properties(
 
 
 """
-Rigid body properties.
+Fragment-writer helpers.
 """
 
 
@@ -579,30 +579,26 @@ def _resolve_fragment_targets(
     prim = stage.GetPrimAtPath(prim_path)
     if not prim.IsValid():
         raise ValueError(f"Prim path '{prim_path}' is not valid.")
-    # collect every carrier in the subtree, then keep only the outermost ones: nested
-    # applications of the same physics schema are not allowed, and the legacy nested writers
-    # stop descending at the first carrier on each branch. The pruning is a second pass over
-    # the full result so it does not depend on the traversal order of the query.
-    candidates = get_all_matching_child_prims(
-        prim_path,
-        lambda p: p.HasAPI(api_type),
-        stage=stage,
-        traverse_instance_prims=True,
-    )
-    candidate_paths = [candidate.GetPath() for candidate in candidates]
-    matches = [
-        candidate
-        for candidate, path in zip(candidates, candidate_paths)
-        if not any(path != other and path.HasPrefix(other) for other in candidate_paths)
-    ]
+    # breadth-first search that stops descending at the first carrier on each branch, like the
+    # legacy nested writers: nested applications of the same physics schema are not allowed, so
+    # nothing below a carrier is ever a target. This keeps the search linear in the subtree size
+    # instead of collecting every carrier and pruning afterwards. Carriers on instanced prims are
+    # read-only and collected separately so they can be reported.
     targets = []
     skipped = []
-    for match in matches:
-        if match.IsInstance() or match.IsInstanceProxy():
-            skipped.append(match)
-        else:
-            targets.append(match)
-    if not matches and apply_fresh:
+    prims_queue = [prim]
+    index = 0
+    while index < len(prims_queue):
+        candidate = prims_queue[index]
+        index += 1
+        if candidate.HasAPI(api_type):
+            if candidate.IsInstance() or candidate.IsInstanceProxy():
+                skipped.append(candidate)
+            else:
+                targets.append(candidate)
+            continue
+        prims_queue += candidate.GetFilteredChildren(Usd.TraverseInstanceProxies())
+    if not targets and not skipped and apply_fresh:
         if prim.IsInstance() or prim.IsInstanceProxy():
             skipped.append(prim)
         else:
@@ -615,6 +611,11 @@ def _resolve_fragment_targets(
             [p.GetPath().pathString for p in skipped],
         )
     return targets, bool(skipped)
+
+
+"""
+Rigid body properties.
+"""
 
 
 def apply_rigid_body_properties(
@@ -654,8 +655,7 @@ def apply_rigid_body_properties(
     for target in targets:
         target_path = target.GetPath().pathString
         for cfg in fragments:
-            func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
-            success = bool(func(cfg, target_path, stage)) and success
+            success = bool(cfg.func(cfg, target_path, stage)) and success
     return success
 
 
@@ -854,7 +854,7 @@ Collision properties.
 def apply_collision_properties(
     prim_path: str, fragments: Iterable[schemas_cfg.CollisionFragment], stage: Usd.Stage | None = None
 ) -> bool:
-    """Apply a list of collision fragments to a prim.
+    """Apply a list of collision fragments to the colliders under a prim.
 
     Existing colliders in the subtree are modified in place, matching the legacy nested writer.
     Real assets author ``UsdPhysics.CollisionAPI`` on their collider prims, so anchoring a fresh
@@ -887,8 +887,7 @@ def apply_collision_properties(
     for target in targets:
         target_path = target.GetPath().pathString
         for cfg in fragments:
-            func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
-            success = bool(func(cfg, target_path, stage)) and success
+            success = bool(cfg.func(cfg, target_path, stage)) and success
     return success
 
 
@@ -989,7 +988,7 @@ Mass properties.
 def apply_mass_properties(
     prim_path: str, fragments: Iterable[schemas_cfg.MassFragment], stage: Usd.Stage | None = None
 ) -> bool:
-    """Apply a list of mass fragments to a prim.
+    """Apply a list of mass fragments to the mass-bearing prims under a prim.
 
     Existing mass-bearing prims in the subtree are modified in place, matching the legacy nested
     writer, since real assets author ``UsdPhysics.MassAPI`` on their link prims. Only when the
@@ -1018,8 +1017,7 @@ def apply_mass_properties(
     for target in targets:
         target_path = target.GetPath().pathString
         for cfg in fragments:
-            func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
-            success = bool(func(cfg, target_path, stage)) and success
+            success = bool(cfg.func(cfg, target_path, stage)) and success
     return success
 
 

--- a/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
+++ b/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+# launch omniverse app
+simulation_app = AppLauncher(headless=True).app
+
+"""Rest everything follows."""
+
+import os
+
+import pytest
+
+from pxr import Usd, UsdGeom, UsdPhysics
+
+import isaaclab.sim as sim_utils
+from isaaclab.sim import SimulationCfg, SimulationContext
+from isaaclab.sim.schemas import MassCfg
+
+from isaaclab_physx.sim.schemas import PhysxCollisionCfg, PhysxRigidBodyCfg
+
+
+def _author_robot_usd(path: str) -> None:
+    """Author a minimal articulated-robot USD layout.
+
+    Mirrors how real robot assets are structured: the default (spawn) prim carries
+    ``ArticulationRootAPI``, the link prims carry ``RigidBodyAPI`` and ``MassAPI``, and the
+    collider prims under the links carry ``CollisionAPI``. The spawn prim itself carries no
+    rigid-body, collision, or mass schema.
+    """
+    stage = Usd.Stage.CreateNew(path)
+    robot = UsdGeom.Xform.Define(stage, "/Robot")
+    UsdPhysics.ArticulationRootAPI.Apply(robot.GetPrim())
+    for link_name in ("link1", "link2"):
+        link = UsdGeom.Xform.Define(stage, f"/Robot/{link_name}").GetPrim()
+        UsdPhysics.RigidBodyAPI.Apply(link)
+        UsdPhysics.MassAPI.Apply(link)
+        collider = UsdGeom.Cube.Define(stage, f"/Robot/{link_name}/collider").GetPrim()
+        UsdPhysics.CollisionAPI.Apply(collider)
+    stage.SetDefaultPrim(robot.GetPrim())
+    stage.Save()
+
+
+def _spawn_robot(tmp_path, prim_path: str, **cfg_kwargs):
+    """Author the robot asset and spawn it at *prim_path* through the production USD spawn path."""
+    from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
+    from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+
+    usd_path = os.path.join(tmp_path, "robot.usda")
+    _author_robot_usd(usd_path)
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    cfg = UsdFileCfg(usd_path=usd_path, **cfg_kwargs)
+    _spawn_from_usd_file(prim_path, usd_path, cfg)
+    return sim_utils.get_current_stage()
+
+
+# -------------------------------------------------------------------------------------
+# Regression: fragment writers must target the asset's existing schema-bearing prims,
+# not force-anchor the defining API on the spawn prim.
+# -------------------------------------------------------------------------------------
+
+
+def test_rigid_body_fragments_target_existing_bodies_on_usd_asset(tmp_path):
+    """Fragment ``rigid_props`` on a USD robot must modify the existing link bodies in place.
+
+    Force-applying ``RigidBodyAPI`` on the spawn prim (which already carries the articulation
+    root) turns the asset's links into nested rigid bodies, and the PhysX parser then drops the
+    articulation's joints. The fragment path must match the legacy nested writer: author onto the
+    prims that already carry the API and leave the spawn prim untouched.
+    """
+    stage = _spawn_robot(
+        tmp_path,
+        "/World/RobotA",
+        rigid_props=[PhysxRigidBodyCfg(max_depenetration_velocity=5.0)],
+    )
+    spawn_prim = stage.GetPrimAtPath("/World/RobotA")
+    # the spawn prim keeps its articulation root and gains NO rigid-body anchor or attrs
+    assert spawn_prim.HasAPI(UsdPhysics.ArticulationRootAPI)
+    assert not spawn_prim.HasAPI(UsdPhysics.RigidBodyAPI)
+    assert not spawn_prim.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()
+    # every existing link body received the fragment's attribute
+    for link_name in ("link1", "link2"):
+        link = stage.GetPrimAtPath(f"/World/RobotA/{link_name}")
+        assert link.HasAPI(UsdPhysics.RigidBodyAPI)
+        assert link.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(5.0)
+
+
+def test_collision_fragments_target_existing_colliders_on_usd_asset(tmp_path):
+    """Fragment ``collision_props`` must modify the asset's existing collider prims in place."""
+    stage = _spawn_robot(
+        tmp_path,
+        "/World/RobotB",
+        collision_props=[PhysxCollisionCfg(contact_offset=0.02)],
+    )
+    spawn_prim = stage.GetPrimAtPath("/World/RobotB")
+    assert not spawn_prim.HasAPI(UsdPhysics.CollisionAPI)
+    assert not spawn_prim.GetAttribute("physxCollision:contactOffset").HasAuthoredValue()
+    for link_name in ("link1", "link2"):
+        collider = stage.GetPrimAtPath(f"/World/RobotB/{link_name}/collider")
+        assert collider.HasAPI(UsdPhysics.CollisionAPI)
+        assert collider.GetAttribute("physxCollision:contactOffset").Get() == pytest.approx(0.02)
+
+
+def test_mass_fragments_target_existing_mass_prims_on_usd_asset(tmp_path):
+    """Fragment ``mass_props`` must modify the asset's existing mass-bearing link prims in place."""
+    stage = _spawn_robot(
+        tmp_path,
+        "/World/RobotC",
+        mass_props=[MassCfg(mass=2.0)],
+    )
+    spawn_prim = stage.GetPrimAtPath("/World/RobotC")
+    assert not spawn_prim.HasAPI(UsdPhysics.MassAPI)
+    assert not spawn_prim.GetAttribute("physics:mass").HasAuthoredValue()
+    for link_name in ("link1", "link2"):
+        link = stage.GetPrimAtPath(f"/World/RobotC/{link_name}")
+        assert link.GetAttribute("physics:mass").Get() == pytest.approx(2.0)
+
+
+def test_fragment_and_legacy_paths_place_apis_identically_on_usd_asset(tmp_path):
+    """On a real asset topology, the fragment path must place APIs exactly where legacy does.
+
+    Spawns two copies of the same robot asset; configures one through the legacy single-cfg
+    path and one through the fragment path with equivalent values; asserts every prim in both
+    subtrees carries the same applied-schema set and the same authored attribute values.
+    """
+    from isaaclab_physx.sim.schemas import PhysxRigidBodyPropertiesCfg
+
+    from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
+    from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+
+    usd_path = os.path.join(tmp_path, "robot.usda")
+    _author_robot_usd(usd_path)
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    legacy_cfg = UsdFileCfg(
+        usd_path=usd_path, rigid_props=PhysxRigidBodyPropertiesCfg(max_depenetration_velocity=5.0)
+    )
+    frag_cfg = UsdFileCfg(
+        usd_path=usd_path, rigid_props=[PhysxRigidBodyCfg(max_depenetration_velocity=5.0)]
+    )
+    _spawn_from_usd_file("/World/Legacy", usd_path, legacy_cfg)
+    _spawn_from_usd_file("/World/Frag", usd_path, frag_cfg)
+    stage = sim_utils.get_current_stage()
+
+    legacy_root = stage.GetPrimAtPath("/World/Legacy")
+    frag_root = stage.GetPrimAtPath("/World/Frag")
+    legacy_prims = {p.GetPath().pathString.removeprefix("/World/Legacy"): p for p in Usd.PrimRange(legacy_root)}
+    frag_prims = {p.GetPath().pathString.removeprefix("/World/Frag"): p for p in Usd.PrimRange(frag_root)}
+    assert legacy_prims.keys() == frag_prims.keys()
+    for rel_path, legacy_prim in legacy_prims.items():
+        frag_prim = frag_prims[rel_path]
+        assert set(legacy_prim.GetAppliedSchemas()) == set(frag_prim.GetAppliedSchemas()), rel_path
+        legacy_attrs = {a.GetName(): a.Get() for a in legacy_prim.GetAttributes() if a.HasAuthoredValue()}
+        frag_attrs = {a.GetName(): a.Get() for a in frag_prim.GetAttributes() if a.HasAuthoredValue()}
+        assert legacy_attrs == frag_attrs, rel_path
+
+
+# -------------------------------------------------------------------------------------
+# Preserved behavior: bare prims (shape/mesh spawners) still get a fresh anchor,
+# and traversal does not descend past an existing schema-bearing prim.
+# -------------------------------------------------------------------------------------
+
+
+def test_rigid_body_fragments_define_fresh_on_bare_prim():
+    """With no rigid body anywhere in the subtree, the writer anchors the input prim itself."""
+    from isaaclab.sim.schemas import apply_rigid_body_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    UsdGeom.Xform.Define(stage, "/World/Bare")
+    apply_rigid_body_properties("/World/Bare", [PhysxRigidBodyCfg(max_depenetration_velocity=3.0)], stage)
+    prim = stage.GetPrimAtPath("/World/Bare")
+    assert prim.HasAPI(UsdPhysics.RigidBodyAPI)
+    assert prim.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(3.0)
+
+
+def test_rigid_body_fragments_do_not_descend_past_existing_body():
+    """Traversal stops at the first schema-bearing prim on each branch (nested bodies are
+    illegal in physics), matching the legacy nested writer's stop-on-success behavior."""
+    from isaaclab.sim.schemas import apply_rigid_body_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    UsdGeom.Xform.Define(stage, "/World/Top")
+    outer = UsdGeom.Xform.Define(stage, "/World/Top/outer").GetPrim()
+    inner = UsdGeom.Xform.Define(stage, "/World/Top/outer/inner").GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(outer)
+    UsdPhysics.RigidBodyAPI.Apply(inner)  # ill-formed nesting in the source asset
+
+    apply_rigid_body_properties("/World/Top", [PhysxRigidBodyCfg(max_depenetration_velocity=7.0)], stage)
+
+    assert outer.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(7.0)
+    # the nested body is not modified: legacy stops descending once a prim succeeds
+    assert not inner.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()

--- a/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
+++ b/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
@@ -23,6 +23,8 @@ import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.sim.schemas import MassCfg
 
+pytestmark = pytest.mark.integration
+
 
 def _author_robot_usd(path: str) -> None:
     """Author a minimal articulated-robot USD layout.
@@ -170,8 +172,9 @@ def test_rigid_body_fragments_define_fresh_on_bare_prim():
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
     UsdGeom.Xform.Define(stage, "/World/Bare")
-    apply_rigid_body_properties("/World/Bare", [PhysxRigidBodyCfg(max_depenetration_velocity=3.0)], stage)
+    result = apply_rigid_body_properties("/World/Bare", [PhysxRigidBodyCfg(max_depenetration_velocity=3.0)], stage)
     prim = stage.GetPrimAtPath("/World/Bare")
+    assert result is True
     assert prim.HasAPI(UsdPhysics.RigidBodyAPI)
     assert prim.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(3.0)
 
@@ -190,8 +193,52 @@ def test_rigid_body_fragments_do_not_descend_past_existing_body():
     UsdPhysics.RigidBodyAPI.Apply(outer)
     UsdPhysics.RigidBodyAPI.Apply(inner)  # ill-formed nesting in the source asset
 
-    apply_rigid_body_properties("/World/Top", [PhysxRigidBodyCfg(max_depenetration_velocity=7.0)], stage)
+    result = apply_rigid_body_properties("/World/Top", [PhysxRigidBodyCfg(max_depenetration_velocity=7.0)], stage)
 
+    assert result is True
     assert outer.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(7.0)
     # the nested body is not modified: legacy stops descending once a prim succeeds
     assert not inner.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()
+
+
+def test_rigid_body_fragments_skip_instanced_carriers(caplog):
+    """A carrier inside an instance is a read-only proxy: skipped with a warning and a False return.
+
+    The hidden carrier also suppresses the define-fresh fallback, so the input prim gains no
+    rigid-body anchor.
+    """
+    from isaaclab.sim.schemas import apply_rigid_body_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    source = UsdGeom.Xform.Define(stage, "/World/Source").GetPrim()
+    source_body = UsdGeom.Xform.Define(stage, "/World/Source/body").GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(source_body)
+    instance = UsdGeom.Xform.Define(stage, "/World/Asset").GetPrim()
+    instance.GetReferences().AddInternalReference(source.GetPath())
+    instance.SetInstanceable(True)
+    proxy_body = stage.GetPrimAtPath("/World/Asset/body")
+    assert proxy_body.IsInstanceProxy() and proxy_body.HasAPI(UsdPhysics.RigidBodyAPI)
+
+    with caplog.at_level("WARNING"):
+        result = apply_rigid_body_properties("/World/Asset", [PhysxRigidBodyCfg(max_depenetration_velocity=5.0)], stage)
+
+    assert result is False
+    assert not instance.HasAPI(UsdPhysics.RigidBodyAPI)
+    assert not proxy_body.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()
+    assert "/World/Asset/body" in caplog.text
+
+
+def test_rigid_body_fragments_empty_list_authors_nothing():
+    """An empty fragment list is a no-op: no anchor API is authored and the writer reports success."""
+    from isaaclab.sim.schemas import apply_rigid_body_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    UsdGeom.Xform.Define(stage, "/World/Bare")
+    result = apply_rigid_body_properties("/World/Bare", [], stage)
+    prim = stage.GetPrimAtPath("/World/Bare")
+    assert result is True
+    assert not prim.HasAPI(UsdPhysics.RigidBodyAPI)

--- a/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
+++ b/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
@@ -15,14 +15,13 @@ simulation_app = AppLauncher(headless=True).app
 import os
 
 import pytest
+from isaaclab_physx.sim.schemas import PhysxCollisionCfg, PhysxRigidBodyCfg
 
 from pxr import Usd, UsdGeom, UsdPhysics
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.sim.schemas import MassCfg
-
-from isaaclab_physx.sim.schemas import PhysxCollisionCfg, PhysxRigidBodyCfg
 
 
 def _author_robot_usd(path: str) -> None:
@@ -138,12 +137,8 @@ def test_fragment_and_legacy_paths_place_apis_identically_on_usd_asset(tmp_path)
     _author_robot_usd(usd_path)
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
-    legacy_cfg = UsdFileCfg(
-        usd_path=usd_path, rigid_props=PhysxRigidBodyPropertiesCfg(max_depenetration_velocity=5.0)
-    )
-    frag_cfg = UsdFileCfg(
-        usd_path=usd_path, rigid_props=[PhysxRigidBodyCfg(max_depenetration_velocity=5.0)]
-    )
+    legacy_cfg = UsdFileCfg(usd_path=usd_path, rigid_props=PhysxRigidBodyPropertiesCfg(max_depenetration_velocity=5.0))
+    frag_cfg = UsdFileCfg(usd_path=usd_path, rigid_props=[PhysxRigidBodyCfg(max_depenetration_velocity=5.0)])
     _spawn_from_usd_file("/World/Legacy", usd_path, legacy_cfg)
     _spawn_from_usd_file("/World/Frag", usd_path, frag_cfg)
     stage = sim_utils.get_current_stage()


### PR DESCRIPTION
# Description

The `apply_rigid_body_properties`, `apply_collision_properties`, and `apply_mass_properties` fragment family writers force-applied their defining USD API (`RigidBodyAPI` / `CollisionAPI` / `MassAPI`) directly on the input prim. The legacy writers they replace are `@apply_nested`: they modify the prims that *already carry* the API and never author a fresh one.

For bare-prim spawns (shapes, meshes) the define-fresh behavior is correct, which is why all existing tests passed. The failure needs a real USD asset: robot assets author `RigidBodyAPI` on their **link** prims and (commonly) `ArticulationRootAPI` on the **spawn** prim. Configuring `rigid_props` as a fragment list on such an asset force-anchored a new rigid body on the spawn prim, turning every link into a nested rigid body — the PhysX parser then drops the articulation's joint graph (`Articulation` initialization fails with an empty joint registry). Reproduced A/B on the cartpole asset.

## Fix

Resolve targets the way the legacy nested writers do, mirroring the articulation-root writer's existing pattern: collect subtree prims already carrying the defining API (breadth-first, without descending past a match — nested applications of the same physics schema are not allowed), dispatch every fragment to each; apply a fresh API on the input prim **only** when the subtree carries none (presence-gated), preserving the bare-prim spawner behavior. Instanced prims are skipped with a warning. The shared resolution lives in one helper used by all three writers.

## Tests

New `test_schema_writer_nested_targets.py` (all fail before the fix, pass after):
- fragment `rigid_props`/`collision_props`/`mass_props` through the production USD spawn path on an articulated asset: attributes land on the links/colliders, the spawn prim gains no anchor;
- fragment vs legacy path on the same asset: identical per-prim applied-schema sets and authored attributes;
- bare-prim define-fresh preserved; traversal does not descend past an existing body.

Existing suites re-run green: schema/collision/mass/mesh-collision fragments, spawn meshes, schemas (101 tests total).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/`
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there