### PR TITLE
Fix Newton cfgs cancelling inherited PhysX field routing

### DIFF
--- a/source/isaaclab_newton/changelog.d/vidurv-exception-shadowing.rst
+++ b/source/isaaclab_newton/changelog.d/vidurv-exception-shadowing.rst
@@ -1,0 +1,13 @@
+Fixed
+^^^^^
+
+* Fixed the Newton and MuJoCo schema cfg classes cancelling the PhysX routing of fields they
+  inherit from the solver-common base classes. Redeclaring ``_usd_field_exceptions`` as an empty
+  dict shadowed the base class's routing table, so setting ``disable_gravity``,
+  ``contact_offset``, or ``rest_offset`` on a Newton or MuJoCo cfg authored a bare ``physics:*``
+  attribute that no backend reads, and setting ``max_joint_velocity`` on
+  :class:`~isaaclab_newton.sim.schemas.NewtonJointDrivePropertiesCfg` or
+  :class:`~isaaclab_newton.sim.schemas.MujocoJointDrivePropertiesCfg` raised ``ValueError``.
+  These fields now route to their PhysX namespaces on every subclass, matching the base classes
+  and :class:`~isaaclab_newton.sim.schemas.NewtonArticulationRootPropertiesCfg`, which already
+  inherited the routing correctly.

--- a/source/isaaclab_newton/isaaclab_newton/sim/schemas/schemas_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/schemas/schemas_cfg.py
@@ -44,7 +44,10 @@ class NewtonRigidBodyPropertiesCfg(RigidBodyBaseCfg):
 
     _usd_namespace: ClassVar[str | None] = "newton"
     _usd_applied_schema: ClassVar[str | None] = None
-    _usd_field_exceptions: ClassVar[dict] = {}
+    # ``_usd_field_exceptions`` is inherited from the base cfg on purpose: it routes the
+    # PhysX-consumed fields declared there (which this class inherits) to their PhysX
+    # namespaces. Redeclaring it empty here would shadow the base dict and break that
+    # routing.
 
 
 @configclass
@@ -80,7 +83,10 @@ class MujocoRigidBodyPropertiesCfg(NewtonRigidBodyPropertiesCfg):
 
     _usd_namespace: ClassVar[str | None] = "mjc"
     _usd_applied_schema: ClassVar[str | None] = None
-    _usd_field_exceptions: ClassVar[dict] = {}
+    # ``_usd_field_exceptions`` is inherited from the base cfg on purpose: it routes the
+    # PhysX-consumed fields declared there (which this class inherits) to their PhysX
+    # namespaces. Redeclaring it empty here would shadow the base dict and break that
+    # routing.
 
     gravcomp: float | None = None
     """Gravity compensation scale for the body [dimensionless].
@@ -163,7 +169,10 @@ class NewtonJointDrivePropertiesCfg(JointDriveBaseCfg):
 
     _usd_namespace: ClassVar[str | None] = "newton"
     _usd_applied_schema: ClassVar[str | None] = None
-    _usd_field_exceptions: ClassVar[dict] = {}
+    # ``_usd_field_exceptions`` is inherited from the base cfg on purpose: it routes the
+    # PhysX-consumed fields declared there (which this class inherits) to their PhysX
+    # namespaces. Redeclaring it empty here would shadow the base dict and break that
+    # routing.
 
 
 @configclass
@@ -181,7 +190,10 @@ class MujocoJointDrivePropertiesCfg(NewtonJointDrivePropertiesCfg):
 
     _usd_namespace: ClassVar[str | None] = "mjc"
     _usd_applied_schema: ClassVar[str | None] = "MjcJointAPI"
-    _usd_field_exceptions: ClassVar[dict] = {}
+    # ``_usd_field_exceptions`` is inherited from the base cfg on purpose: it routes the
+    # PhysX-consumed fields declared there (which this class inherits) to their PhysX
+    # namespaces. Redeclaring it empty here would shadow the base dict and break that
+    # routing.
 
     actuatorgravcomp: bool | None = None
     """Route gravity compensation forces through the actuator channel.
@@ -242,7 +254,10 @@ class NewtonCollisionPropertiesCfg(CollisionBaseCfg):
 
     _usd_namespace: ClassVar[str | None] = "newton"
     _usd_applied_schema: ClassVar[str | None] = "NewtonCollisionAPI"
-    _usd_field_exceptions: ClassVar[dict] = {}
+    # ``_usd_field_exceptions`` is inherited from the base cfg on purpose: it routes the
+    # PhysX-consumed fields declared there (which this class inherits) to their PhysX
+    # namespaces. Redeclaring it empty here would shadow the base dict and break that
+    # routing.
 
     contact_margin: float | None = None
     """Outward inflation of the collision surface [m].
@@ -276,7 +291,10 @@ class NewtonMeshCollisionPropertiesCfg(NewtonCollisionPropertiesCfg, MeshCollisi
 
     _usd_namespace: ClassVar[str | None] = "newton"
     _usd_applied_schema: ClassVar[str | None] = "NewtonMeshCollisionAPI"
-    _usd_field_exceptions: ClassVar[dict] = {}
+    # ``_usd_field_exceptions`` is inherited from the base cfg on purpose: it routes the
+    # PhysX-consumed fields declared there (which this class inherits) to their PhysX
+    # namespaces. Redeclaring it empty here would shadow the base dict and break that
+    # routing.
 
     max_hull_vertices: int | None = None
     """Maximum vertices in the convex hull approximation [dimensionless].
@@ -302,7 +320,10 @@ class NewtonSDFCollisionPropertiesCfg(NewtonCollisionPropertiesCfg):
 
     _usd_namespace: ClassVar[str | None] = "newton"
     _usd_applied_schema: ClassVar[str | None] = "NewtonSDFCollisionAPI"
-    _usd_field_exceptions: ClassVar[dict] = {}
+    # ``_usd_field_exceptions`` is inherited from the base cfg on purpose: it routes the
+    # PhysX-consumed fields declared there (which this class inherits) to their PhysX
+    # namespaces. Redeclaring it empty here would shadow the base dict and break that
+    # routing.
 
     sdf_max_resolution: int | None = None
     """Maximum SDF grid dimension.

--- a/source/isaaclab_newton/test/sim/test_newton_schemas.py
+++ b/source/isaaclab_newton/test/sim/test_newton_schemas.py
@@ -12,6 +12,8 @@ simulation_app = AppLauncher(headless=True).app
 
 """Rest everything follows."""
 
+import math
+
 import pytest
 from isaaclab_newton.sim.schemas import (
     MujocoJointDrivePropertiesCfg,
@@ -426,3 +428,94 @@ def test_newton_legacy_cfg_authors_contact_attrs(setup_sim):
     assert prim.GetAttribute("newton:contactDamping").Get() == pytest.approx(250.0)
     assert prim.GetAttribute("newton:contactFrictionGain").Get() == pytest.approx(40.0)
     assert prim.GetAttribute("newton:contactAdhesion").Get() == pytest.approx(0.02)
+
+
+# ---------------------------------------------------------------------------
+# Inherited PhysX-routed fields on Newton/MuJoCo cfgs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.isaacsim_ci
+def test_newton_rigid_body_disable_gravity_routes_to_physx_namespace(setup_sim):
+    """``disable_gravity`` is a PhysX-consumed field inherited from the base cfg. Setting it on
+    the Newton cfg must author ``physxRigidBody:disableGravity``, not a bare ``physics:*``
+    attribute that no backend reads."""
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim("/World/nrb_dg", prim_type="Cube")
+    schemas.define_rigid_body_properties("/World/nrb_dg", NewtonRigidBodyPropertiesCfg(disable_gravity=True))
+    prim = stage.GetPrimAtPath("/World/nrb_dg")
+    assert prim.GetAttribute("physxRigidBody:disableGravity").Get() is True
+    assert not prim.GetAttribute("physics:disableGravity").IsValid()
+
+
+@pytest.mark.isaacsim_ci
+def test_mujoco_rigid_body_disable_gravity_routes_to_physx_namespace(setup_sim):
+    """The MuJoCo rigid-body cfg inherits ``disable_gravity`` and must route it like its parents,
+    while its own ``gravcomp`` keeps its ``mjc:*`` namespace."""
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim("/World/mrb_dg", prim_type="Cube")
+    schemas.define_rigid_body_properties(
+        "/World/mrb_dg", MujocoRigidBodyPropertiesCfg(disable_gravity=True, gravcomp=0.5)
+    )
+    prim = stage.GetPrimAtPath("/World/mrb_dg")
+    assert prim.GetAttribute("physxRigidBody:disableGravity").Get() is True
+    assert prim.GetAttribute("mjc:gravcomp").Get() == pytest.approx(0.5)
+    assert not prim.GetAttribute("physics:disableGravity").IsValid()
+
+
+@pytest.mark.isaacsim_ci
+def test_newton_collision_offsets_route_to_physx_namespace(setup_sim):
+    """``contact_offset``/``rest_offset`` are PhysX-consumed fields inherited from the base cfg
+    and must author ``physxCollision:*`` attributes on Newton collision cfgs."""
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim("/World/ncol_off", prim_type="Cube")
+    schemas.define_collision_properties(
+        "/World/ncol_off", NewtonCollisionPropertiesCfg(contact_offset=0.02, rest_offset=0.01)
+    )
+    prim = stage.GetPrimAtPath("/World/ncol_off")
+    assert prim.GetAttribute("physxCollision:contactOffset").Get() == pytest.approx(0.02)
+    assert prim.GetAttribute("physxCollision:restOffset").Get() == pytest.approx(0.01)
+    assert not prim.GetAttribute("physics:contactOffset").IsValid()
+
+
+@pytest.mark.isaacsim_ci
+def test_newton_sdf_collision_offsets_route_to_physx_namespace(setup_sim):
+    """The deepest Newton collision subclass must inherit the same PhysX routing for the
+    offset fields as its parents."""
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim("/World/nsdf_off", prim_type="Cube")
+    schemas.define_collision_properties("/World/nsdf_off", NewtonSDFCollisionPropertiesCfg(contact_offset=0.02))
+    prim = stage.GetPrimAtPath("/World/nsdf_off")
+    assert prim.GetAttribute("physxCollision:contactOffset").Get() == pytest.approx(0.02)
+    assert not prim.GetAttribute("physics:contactOffset").IsValid()
+
+
+@pytest.mark.isaacsim_ci
+def test_newton_joint_drive_max_velocity_routes_to_physx_namespace(setup_sim):
+    """``max_joint_velocity`` is a PhysX-consumed field inherited from the base cfg. Setting it
+    on the Newton joint-drive cfg must author ``physxJoint:maxJointVelocity`` instead of
+    raising."""
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim("/World/njd_mv", prim_type="Xform")
+    sim_utils.create_prim("/World/njd_mv/body0", prim_type="Cube")
+    sim_utils.create_prim("/World/njd_mv/body1", prim_type="Cube")
+    UsdPhysics.RevoluteJoint.Define(stage, "/World/njd_mv/joint0")
+    schemas.modify_joint_drive_properties("/World/njd_mv", NewtonJointDrivePropertiesCfg(max_joint_velocity=5.0))
+    attr = stage.GetPrimAtPath("/World/njd_mv/joint0").GetAttribute("physxJoint:maxJointVelocity")
+    # the writer converts angular joint velocities from rad/s to PhysX's degree convention
+    assert attr.Get() == pytest.approx(math.degrees(5.0))
+
+
+@pytest.mark.isaacsim_ci
+def test_mujoco_joint_drive_max_velocity_routes_to_physx_namespace(setup_sim):
+    """The MuJoCo joint-drive cfg inherits ``max_joint_velocity`` and must route it like its
+    parents instead of raising."""
+    stage = sim_utils.get_current_stage()
+    sim_utils.create_prim("/World/mjd_mv", prim_type="Xform")
+    sim_utils.create_prim("/World/mjd_mv/body0", prim_type="Cube")
+    sim_utils.create_prim("/World/mjd_mv/body1", prim_type="Cube")
+    UsdPhysics.RevoluteJoint.Define(stage, "/World/mjd_mv/joint0")
+    schemas.modify_joint_drive_properties("/World/mjd_mv", MujocoJointDrivePropertiesCfg(max_joint_velocity=5.0))
+    attr = stage.GetPrimAtPath("/World/mjd_mv/joint0").GetAttribute("physxJoint:maxJointVelocity")
+    # the writer converts angular joint velocities from rad/s to PhysX's degree convention
+    assert attr.Get() == pytest.approx(math.degrees(5.0))


### PR DESCRIPTION
# Description

Seven Newton/MuJoCo schema cfg classes redeclare `_usd_field_exceptions: ClassVar[dict] = {}`. Python attribute lookup stops at the first class in the MRO that defines the attribute — even when the value is empty — so the redeclaration **shadows the base classes' routing table** for PhysX-consumed fields those classes inherit (`disable_gravity`, `contact_offset`, `rest_offset`, `max_joint_velocity`).

Observed behavior on develop (verified by executing the writer per class/field):

| Cfg | Field set | Actual | Intended |
|---|---|---|---|
| `NewtonRigidBodyPropertiesCfg`, `MujocoRigidBodyPropertiesCfg` | `disable_gravity` | bare `physics:disableGravity` (no consumer) | `physxRigidBody:disableGravity` |
| `NewtonCollisionPropertiesCfg` + Mesh/SDF subclasses | `contact_offset`/`rest_offset` | bare `physics:*` (no consumer) | `physxCollision:*` |
| `NewtonJointDrivePropertiesCfg`, `MujocoJointDrivePropertiesCfg` | `max_joint_velocity` | **raises `ValueError`** | `physxJoint:maxJointVelocity` |

That the shadowing is accidental is shown by `NewtonArticulationRootPropertiesCfg`, which does **not** redeclare the attribute and routes its inherited `articulation_enabled` to `physxArticulation:*` correctly — one sibling inherited the pattern right, six copied boilerplate that cancels it.

## Fix

Remove the empty redeclarations from the seven classes so the base routing applies, with a comment at each site explaining why the attribute must stay inherited. No writer changes.

## Tests

Six regression tests drive each affected field through the public writers (`define_rigid_body_properties`, `define_collision_properties`, `modify_joint_drive_properties`) and assert the PhysX-namespaced attribute is authored (with the rad/s→deg conversion for the joint velocity) and no bare `physics:*` attribute appears. All fail before the fix (two with the `ValueError`), pass after. `test_newton_schemas.py` 25/26 and core `test_schemas.py` 40/40 locally — the one unrelated failure (`test_newton_material_fragment_authors_all_six_newton_attrs`) also fails on clean develop in this environment and appears to be resolver-key drift from the recent Newton bump; flagged separately.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/`
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there