### PR TITLE
Add segmentation annotator support to Newton Warp renderer integration

### DIFF
--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -107,7 +107,7 @@ parameters.
     tiled_camera: CameraCfg = CameraCfg(
         prim_path="/World/envs/env_.*/Camera",
         offset=CameraCfg.OffsetCfg(pos=(-7.0, 0.0, 3.0), rot=(0.9945, 0.0, 0.1045, 0.0), convention="world"),
-        data_types=["rgb", "depth"],  # only rgb and depth supported with Newton renderer
+        data_types=["rgb", "depth"],  # see the support matrix below for all Newton-supported types
         spawn=sim_utils.PinholeCameraCfg(
             focal_length=24.0, focus_distance=400.0, horizontal_aperture=20.955, clipping_range=(0.1, 20.0)
         ),
@@ -244,7 +244,7 @@ is :class:`~isaaclab_ov.renderers.OVRTXRendererCfg`, and ``Newton Warp`` is
    * - ``semantic_segmentation``
      - ✅
      - ✅
-     - ❌
+     - ✅
    * - ``instance_segmentation_fast``
      - ✅
      - ✅

--- a/source/isaaclab/changelog.d/newton-warp-segmentation.minor.rst
+++ b/source/isaaclab/changelog.d/newton-warp-segmentation.minor.rst
@@ -1,0 +1,8 @@
+Added
+^^^^^
+
+* Added :mod:`isaaclab.renderers.segmentation_colors`, a shared host + Warp implementation of the
+  Replicator-compatible segmentation colorization (``random_color_from_id`` / ``color_hash`` /
+  ``pack_rgba`` and the reserved ``BACKGROUND`` / ``UNLABELLED`` ids). It provides a single source of
+  truth for the color palette used by the OVRTX and Newton Warp renderers so colorized segmentation
+  outputs are visually consistent across backends.

--- a/source/isaaclab/isaaclab/renderers/segmentation_colors.py
+++ b/source/isaaclab/isaaclab/renderers/segmentation_colors.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared segmentation colorization used across renderer backends.
+
+Segmentation ids are mapped to visually distinct RGBA colors by golden-ratio hue spacing in HSV
+space, matching the Isaac RTX / Replicator convention so colorized segmentation outputs are visually
+consistent across the RTX, OVRTX and Newton Warp renderers. Ids ``0`` (BACKGROUND) and ``1``
+(UNLABELLED) are reserved and always map to ``(0, 0, 0, 0)`` and ``(0, 0, 0, 255)`` respectively.
+
+Two equivalent implementations are provided from a single source of truth:
+
+* :func:`random_color_from_id` / :func:`color_hash` run on the host (Python), used to build color
+  palettes and the ``(r, g, b, a)`` tuple keys of ``camera.data.info`` id-to-label maps.
+* :func:`random_color_from_id_wp` / :func:`color_hash_wp` are Warp device functions callable from
+  kernels that colorize an id image in place.
+
+The two must stay in agreement; ``test_segmentation_colors.py`` asserts they produce identical output.
+"""
+
+from __future__ import annotations
+
+import warp as wp
+
+# Reserved ids shared by every segmentation output.
+BACKGROUND_ID: int = 0
+"""Id of pixels where nothing was hit (ray miss / background)."""
+UNLABELLED_ID: int = 1
+"""Id of geometry with no semantic label matching the active filter."""
+
+
+def pack_rgba(color: tuple[int, int, int, int]) -> int:
+    """Pack an ``(r, g, b, a)`` tuple into a little-endian ``r | g<<8 | b<<16 | a<<24`` uint32."""
+    r, g, b, a = color
+    return (r & 0xFF) | ((g & 0xFF) << 8) | ((b & 0xFF) << 16) | ((a & 0xFF) << 24)
+
+
+def unpack_rgba(color: int) -> tuple[int, int, int, int]:
+    """Unpack a little-endian ``r | g<<8 | b<<16 | a<<24`` uint32 into an ``(r, g, b, a)`` tuple."""
+    return (color & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF, (color >> 24) & 0xFF)
+
+
+def color_hash(seed: int) -> int:
+    """Host equivalent of :func:`color_hash_wp` (uint32 arithmetic, overflow truncates to 32 bits)."""
+    mask32 = 0xFFFFFFFF
+    h = seed & mask32
+    h ^= h >> 16
+    h = (h * 0x85EBCA6B) & mask32
+    h ^= h >> 13
+    h = (h * 0xC2B2AE35) & mask32
+    h ^= h >> 16
+    return h & mask32
+
+
+def random_color_from_id(input_id: int) -> tuple[int, int, int, int]:
+    """Host equivalent of :func:`random_color_from_id_wp`, returning an ``(r, g, b, a)`` tuple.
+
+    ``0`` (BACKGROUND) maps to ``(0, 0, 0, 0)`` and ``1`` (UNLABELLED) to ``(0, 0, 0, 255)`` as
+    special cases; all other ids get a deterministic, visually distinct opaque color.
+    """
+    if input_id == BACKGROUND_ID:
+        return (0, 0, 0, 0)
+    if input_id == UNLABELLED_ID:
+        return (0, 0, 0, 255)
+
+    hash_val = color_hash(input_id)
+
+    golden_ratio_inv = 1.0 / 1.618033988749895
+    hue = (input_id * golden_ratio_inv) % 1.0
+    hue = (hue + (hash_val & 0xFFFF) / 65536.0 * 0.1) % 1.0
+
+    saturation = 0.7 + 0.3 * (((hash_val >> 16) & 0xFF) / 255.0)
+    value = 0.8 + 0.2 * (((hash_val >> 8) & 0xFF) / 255.0)
+
+    hue_i = int(hue * 6.0)
+    hue_f = hue * 6.0 - hue_i
+    p = value * (1.0 - saturation)
+    q = value * (1.0 - saturation * hue_f)
+    t = value * (1.0 - saturation * (1.0 - hue_f))
+
+    hue_i %= 6
+    if hue_i == 0:
+        r, g, b = value, t, p
+    elif hue_i == 1:
+        r, g, b = q, value, p
+    elif hue_i == 2:
+        r, g, b = p, value, t
+    elif hue_i == 3:
+        r, g, b = p, q, value
+    elif hue_i == 4:
+        r, g, b = t, p, value
+    else:
+        r, g, b = value, p, q
+
+    ri = min(255, max(0, int(r * 255.0)))
+    gi = min(255, max(0, int(g * 255.0)))
+    bi = min(255, max(0, int(b * 255.0)))
+    return (ri, gi, bi, 255)
+
+
+@wp.func
+def color_hash_wp(seed: wp.uint32) -> wp.uint32:
+    """MurmurHash3-style 32-bit finalizer matching omni.replicator's ``randomColoursCPU``.
+
+    Arithmetic is intentionally uint32 so multiplications overflow and truncate to 32 bits.
+    Computing in a wider type yields different bits and breaks parity with Replicator / Isaac RTX.
+    """
+    h = seed
+    h = h ^ (h >> wp.uint32(16))
+    h = h * wp.uint32(0x85EBCA6B)
+    h = h ^ (h >> wp.uint32(13))
+    h = h * wp.uint32(0xC2B2AE35)
+    h = h ^ (h >> wp.uint32(16))
+    return h
+
+
+@wp.func
+def random_color_from_id_wp(input_id: wp.uint32) -> wp.uint32:
+    """Generate a deterministic, visually distinct color from a segmentation id.
+
+    Uses golden-ratio hue spacing in HSV space then converts to RGB, packed as
+    ``r | (g<<8) | (b<<16) | (a<<24)``. Id ``0`` maps to ``0`` (BACKGROUND) and id ``1`` to
+    ``0xFF000000`` (UNLABELLED, opaque black).
+    """
+    if input_id == wp.uint32(0):
+        # BACKGROUND special case
+        return wp.uint32(0)
+    if input_id == wp.uint32(1):
+        # UNLABELLED special case
+        return wp.uint32(0xFF000000)
+
+    hash_val = color_hash_wp(input_id)
+
+    # Golden ratio inverse = 1.0 / 1.618033988749895 (Replicator constant)
+    GOLDEN_RATIO_INV = wp.float64(1.0) / wp.float64(1.618033988749895)
+
+    # Use golden ratio spacing for maximum hue spread
+    hue_tmp = wp.float64(input_id) * GOLDEN_RATIO_INV
+    hue = hue_tmp - wp.floor(hue_tmp)
+
+    # Add hash-based perturbation for better distribution
+    hue_perturbation = wp.float64(hash_val & wp.uint32(0xFFFF)) / wp.float64(65536.0)
+    hue_tmp = hue + hue_perturbation * wp.float64(0.1)
+    hue = hue_tmp - wp.floor(hue_tmp)
+
+    # Use hash to determine saturation and value for maximum spread
+    sat_part = wp.uint32((hash_val >> wp.uint32(16)) & wp.uint32(0xFF))
+    val_part = wp.uint32((hash_val >> wp.uint32(8)) & wp.uint32(0xFF))
+
+    # Saturation: 0.7 to 1.0 for vibrant colors
+    saturation = wp.float64(0.7) + wp.float64(0.3) * (wp.float64(sat_part) / wp.float64(255.0))
+
+    # Value: 0.8 to 1.0 for bright colors
+    value = wp.float64(0.8) + wp.float64(0.2) * (wp.float64(val_part) / wp.float64(255.0))
+
+    # HSV to RGB conversion (match Replicator: ``f`` uses pre-modulo ``int(hue*6)``, then ``i %= 6``).
+    hue_i = wp.int32(hue * wp.float64(6.0))
+    hue_f = hue * wp.float64(6.0) - wp.float64(hue_i)
+    p = value * (wp.float64(1.0) - saturation)
+    q = value * (wp.float64(1.0) - saturation * hue_f)
+    t = value * (wp.float64(1.0) - saturation * (wp.float64(1.0) - hue_f))
+
+    r = wp.float64(0.0)
+    g = wp.float64(0.0)
+    b = wp.float64(0.0)
+
+    hue_i = hue_i % 6
+
+    if hue_i == 0:
+        r = value
+        g = t
+        b = p
+    elif hue_i == 1:
+        r = q
+        g = value
+        b = p
+    elif hue_i == 2:
+        r = p
+        g = value
+        b = t
+    elif hue_i == 3:
+        r = p
+        g = q
+        b = value
+    elif hue_i == 4:
+        r = t
+        g = p
+        b = value
+    else:
+        r = value
+        g = p
+        b = q
+
+    ri = wp.min(255, wp.max(0, wp.int32(r * wp.float64(255.0))))
+    gi = wp.min(255, wp.max(0, wp.int32(g * wp.float64(255.0))))
+    bi = wp.min(255, wp.max(0, wp.int32(b * wp.float64(255.0))))
+    ai = wp.int32(255)
+
+    color = (
+        wp.uint32(ri)
+        | (wp.uint32(gi) << wp.uint32(8))
+        | (wp.uint32(bi) << wp.uint32(16))
+        | (wp.uint32(ai) << wp.uint32(24))
+    )
+    return color

--- a/source/isaaclab/test/renderers/test_camera_output_contract.py
+++ b/source/isaaclab/test/renderers/test_camera_output_contract.py
@@ -136,9 +136,33 @@ def test_newton_warp_supported_output_types_key_set():
         RenderBufferKind.DISTANCE_TO_CAMERA,
         RenderBufferKind.DISTANCE_TO_IMAGE_PLANE,
         RenderBufferKind.NORMALS,
+        RenderBufferKind.SEMANTIC_SEGMENTATION,
         RenderBufferKind.INSTANCE_SEGMENTATION_FAST,
     }
     assert specs[RenderBufferKind.RGB_HDR] == RenderBufferSpec(3, wp.float32)
+
+
+@pytest.mark.parametrize("colorize", [True, False])
+def test_newton_warp_segmentation_spec_follows_colorize_flags(colorize):
+    """Segmentation specs are RGBA uint8 when colorized, else single-channel int32 (matching RTX)."""
+    pytest.importorskip("isaaclab_newton")
+    pytest.importorskip("newton")
+    from isaaclab_newton.renderers.newton_warp_renderer import NewtonWarpRenderer
+    from isaaclab_newton.renderers.newton_warp_renderer_cfg import NewtonWarpRendererCfg
+
+    renderer = NewtonWarpRenderer.__new__(NewtonWarpRenderer)
+    renderer.cfg = NewtonWarpRendererCfg(
+        colorize_semantic_segmentation=colorize,
+        colorize_instance_segmentation=colorize,
+    )
+    specs = renderer.supported_output_types()
+
+    expected = RenderBufferSpec(4, wp.uint8) if colorize else RenderBufferSpec(1, wp.int32)
+    for kind in (
+        RenderBufferKind.SEMANTIC_SEGMENTATION,
+        RenderBufferKind.INSTANCE_SEGMENTATION_FAST,
+    ):
+        assert specs[kind] == expected
 
 
 def test_newton_warp_wraps_requested_rgb_hdr_output():

--- a/source/isaaclab/test/renderers/test_segmentation_colors.py
+++ b/source/isaaclab/test/renderers/test_segmentation_colors.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the shared segmentation colorization (host vs Warp device parity)."""
+
+import pytest
+
+pytest.importorskip("warp")
+
+import warp as wp
+
+from isaaclab.renderers.segmentation_colors import (
+    BACKGROUND_ID,
+    UNLABELLED_ID,
+    color_hash,
+    pack_rgba,
+    random_color_from_id,
+    random_color_from_id_wp,
+    unpack_rgba,
+)
+
+
+@wp.kernel
+def _colorize_ids_kernel(ids: wp.array(dtype=wp.uint32), out: wp.array(dtype=wp.uint32)):
+    i = wp.tid()
+    out[i] = random_color_from_id_wp(ids[i])
+
+
+def test_reserved_colors():
+    """BACKGROUND is transparent black, UNLABELLED is opaque black."""
+    assert random_color_from_id(BACKGROUND_ID) == (0, 0, 0, 0)
+    assert random_color_from_id(UNLABELLED_ID) == (0, 0, 0, 255)
+    assert pack_rgba(random_color_from_id(BACKGROUND_ID)) == 0
+    assert pack_rgba(random_color_from_id(UNLABELLED_ID)) == 0xFF000000
+
+
+def test_pack_rgba_is_little_endian():
+    assert pack_rgba((1, 2, 3, 4)) == 1 | (2 << 8) | (3 << 16) | (4 << 24)
+
+
+def test_unpack_rgba_is_inverse_of_pack():
+    for color in [(0, 0, 0, 0), (255, 255, 255, 255), (1, 2, 3, 4), (0, 0, 0, 255)]:
+        assert unpack_rgba(pack_rgba(color)) == color
+
+
+def test_color_hash_is_uint32():
+    for seed in (0, 1, 2, 12345, 0xFFFFFFFF):
+        h = color_hash(seed)
+        assert 0 <= h <= 0xFFFFFFFF
+
+
+@pytest.mark.parametrize("device", ["cpu"])
+def test_host_and_device_random_color_agree(device):
+    """The host and Warp implementations must produce byte-identical colors for every id."""
+    ids = list(range(256)) + [1000, 65535, 123456]
+    ids_wp = wp.array(ids, dtype=wp.uint32, device=device)
+    out_wp = wp.zeros(len(ids), dtype=wp.uint32, device=device)
+    wp.launch(_colorize_ids_kernel, dim=len(ids), inputs=[ids_wp], outputs=[out_wp], device=device)
+
+    device_colors = out_wp.numpy().tolist()
+    host_colors = [pack_rgba(random_color_from_id(i)) for i in ids]
+    assert device_colors == host_colors

--- a/source/isaaclab_newton/changelog.d/newton-warp-segmentation.minor.rst
+++ b/source/isaaclab_newton/changelog.d/newton-warp-segmentation.minor.rst
@@ -1,0 +1,13 @@
+Added
+^^^^^
+
+* Added ``semantic_segmentation`` camera data-type support to
+  :class:`~isaaclab_newton.renderers.NewtonWarpRenderer`, and brought the existing
+  ``instance_segmentation_fast`` output up to the full Isaac RTX contract (colorized palettes plus
+  ``idToLabels`` / ``idToSemantics`` metadata on ``camera.data.info``). Both are reconstructed on
+  the host from Newton's per-shape index buffer and the USD stage's :class:`UsdSemantics.LabelsAPI`
+  labels, reaching parity with :class:`~isaaclab_physx.renderers.IsaacRtxRenderer`.
+* Added :attr:`~isaaclab_newton.renderers.NewtonWarpRendererCfg.semantic_filter`,
+  :attr:`~isaaclab_newton.renderers.NewtonWarpRendererCfg.colorize_semantic_segmentation`, and
+  :attr:`~isaaclab_newton.renderers.NewtonWarpRendererCfg.semantic_segmentation_mapping` to
+  :class:`~isaaclab_newton.renderers.NewtonWarpRendererCfg`, mirroring the Isaac RTX renderer.

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -22,6 +22,7 @@ from isaaclab.utils.warp.warp_math import convert_camera_frame_orientation_conve
 
 from ..physics.newton_manager import NewtonManager
 from .newton_warp_renderer_cfg import NewtonWarpRendererCfg
+from .segmentation import NewtonSegmentationMapper, NewtonSegmentationMapping
 
 if TYPE_CHECKING:
     from isaaclab_ppisp import PpispPipeline
@@ -57,12 +58,16 @@ class RenderData:
     # The depth family (``distance_to_camera`` / ``distance_to_image_plane`` / ``depth``) is handled
     # separately in :meth:`set_outputs` rather than through this map, because Newton emits a single
     # ray-hit-distance buffer that must be reused as the source for the planar-depth conversion.
+    #
+    # The segmentation family (``semantic_segmentation`` / ``instance_segmentation_fast``) is likewise
+    # handled separately: Newton emits a single per-shape index buffer that is remapped into each
+    # requested segmentation output by
+    # :class:`~isaaclab_newton.renderers.segmentation.NewtonSegmentationMapper`.
     _OUTPUT_MAP: dict[str, tuple[str, type]] = {
         str(RenderBufferKind.RGBA): ("color_image", wp.uint32),
         str(RenderBufferKind.RGB_HDR): ("hdr_color_image", wp.vec3f),
         str(RenderBufferKind.ALBEDO): ("albedo_image", wp.uint32),
         str(RenderBufferKind.NORMALS): ("normals_image", wp.vec3f),
-        str(RenderBufferKind.INSTANCE_SEGMENTATION_FAST): ("instance_segmentation_image", wp.uint32),
     }
 
     # Newton's native ``depth_image`` is the ray-hit (euclidean) distance from the camera optical
@@ -87,10 +92,20 @@ class RenderData:
         # ``distance_to_camera`` output or to an internal scratch buffer (see :meth:`set_outputs`).
         depth_image: wp.array(dtype=wp.float32, ndim=4) = None
         normals_image: wp.array(dtype=wp.vec3f, ndim=4) = None
-        instance_segmentation_image: wp.array(dtype=wp.uint32, ndim=4) = None
+        # Buffer Newton fills with the per-pixel shape index; the source for all segmentation outputs.
+        shape_index_image: wp.array(dtype=wp.uint32, ndim=4) = None
 
-    def __init__(self, newton_sensor: newton.sensors.SensorTiledCamera, spec: CameraRenderSpec):
+    def __init__(
+        self,
+        newton_sensor: newton.sensors.SensorTiledCamera,
+        spec: CameraRenderSpec,
+        seg_mapper: NewtonSegmentationMapper | None = None,
+        renderer_cfg: NewtonWarpRendererCfg | None = None,
+    ):
         self.newton_sensor = newton_sensor
+        # Shared, scene-static segmentation lookup builder (``None`` until segmentation is requested).
+        self._seg_mapper = seg_mapper
+        self._renderer_cfg = renderer_cfg
 
         self.num_cameras = 1
 
@@ -107,6 +122,9 @@ class RenderData:
         # Internal ray-depth buffer allocated only when a planar-depth output is requested without
         # ``distance_to_camera``; gives ``convert_ray_depth_to_forward_depth`` a source to read from.
         self._ray_depth_scratch: wp.array | None = None
+        # Requested segmentation outputs keyed by data-type name -> (destination view, mapping). Each view
+        # aliases the caller's output buffer as ``(world_count, 1, H, W)`` uint32.
+        self._seg_dests: dict[str, tuple[wp.array, NewtonSegmentationMapping]] = {}
         self.width = getattr(spec.cfg, "width", 100)
         self.height = getattr(spec.cfg, "height", 100)
         # Camera clipping planes [m] from ``spawn.clipping_range`` (``[0]`` near, ``[1]`` far).
@@ -151,15 +169,37 @@ class RenderData:
         shape = (self.newton_sensor.model.world_count, self.num_cameras, self.height, self.width)
         self._depth_dests = {}
         self._ray_depth_scratch = None
+        self._seg_dests = {}
+        self.outputs.shape_index_image = None
         ray_depth_dest: wp.array | None = None
         for output_name, proxy in output_data.items():
             # Depth family: bind each requested output to a float32 destination view. Newton fills
-            # only the ray-hit distance; planar outputs are derived from it in :meth:`convert_plane_depth`.
+            # only the ray-hit distance; planar outputs are derived from it in :meth:`_convert_plane_depth`.
             if output_name == self._RAY_DEPTH_KIND or output_name in self._PLANE_DEPTH_KINDS:
                 dest = self._view(proxy, wp.float32, shape)
                 self._depth_dests[output_name] = dest
                 if output_name == self._RAY_DEPTH_KIND:
                     ray_depth_dest = dest
+                continue
+            # Segmentation family: bind each requested output to a destination view — colorized RGBA
+            # (uint32 packed) or raw int32 ids (matching the Isaac RTX / OVRTX contract).  Newton
+            # fills only the shape-index scratch (uint32), which is remapped into each output in
+            # :meth:`_convert_segmentation`.
+            if output_name == RenderBufferKind.SEMANTIC_SEGMENTATION:
+                colorize = bool(self._renderer_cfg.colorize_semantic_segmentation)
+            elif output_name == RenderBufferKind.INSTANCE_SEGMENTATION_FAST:
+                colorize = bool(self._renderer_cfg.colorize_instance_segmentation)
+            else:
+                colorize = None
+            if colorize is not None:
+                if self._seg_mapper is None:
+                    raise RuntimeError(
+                        f"Output '{output_name}' requires a segmentation mapper, but none was created. "
+                        "Ensure the camera's data_types includes the segmentation output."
+                    )
+                seg_mapping = self._seg_mapper.get_mapping(output_name, colorize)
+                dest = self._view(proxy, wp.uint32 if colorize else wp.int32, shape)
+                self._seg_dests[output_name] = (dest, seg_mapping)
                 continue
             mapping = self._OUTPUT_MAP.get(output_name)
             if mapping is None:
@@ -178,6 +218,10 @@ class RenderData:
             self.outputs.depth_image = self._ray_depth_scratch
         else:
             self.outputs.depth_image = None
+        # Allocate the shape-index buffer Newton fills when any segmentation output is requested; all
+        # requested segmentation outputs are remapped from this single buffer in :meth:`_convert_segmentation`.
+        if self._seg_dests:
+            self.outputs.shape_index_image = wp.zeros(shape, dtype=wp.uint32, device=self.newton_sensor.model.device)
         # When PPISP is composed but the user did not request the raw HDR AOV,
         # allocate an internal HDR scratch buffer and route a vec3f-shaped view
         # of it as the Newton sensor's ``hdr_color_image`` so the renderer
@@ -211,6 +255,8 @@ class RenderData:
     def get_output(self, output_name: str) -> wp.array:
         if output_name in self._depth_dests:
             return self._depth_dests[output_name]
+        elif output_name in self._seg_dests:
+            return self._seg_dests[output_name][0]
         elif output_name == RenderBufferKind.RGBA:
             return self.outputs.color_image
         elif output_name == RenderBufferKind.RGB_HDR:
@@ -219,11 +265,26 @@ class RenderData:
             return self.outputs.albedo_image
         elif output_name == RenderBufferKind.NORMALS:
             return self.outputs.normals_image
-        elif output_name == RenderBufferKind.INSTANCE_SEGMENTATION_FAST:
-            return self.outputs.instance_segmentation_image
         return None
 
-    def convert_plane_depth(self):
+    def _convert_segmentation(self):
+        """Remap Newton's shape-index buffer into each requested segmentation output.
+
+        Newton emits a single per-pixel shape index (:attr:`CameraOutputs.shape_index_image`);
+        ``semantic_segmentation`` / ``instance_segmentation_fast`` are each derived from it by a
+        :class:`~isaaclab_newton.renderers.segmentation.NewtonSegmentationMapping`.
+        No-op when no segmentation output was requested.
+        """
+        if self.outputs.shape_index_image is None:
+            return
+        for dest, seg_mapping in self._seg_dests.values():
+            seg_mapping.convert_shape_index_to_output(self.outputs.shape_index_image, dest)
+
+    def segmentation_info(self) -> dict[str, dict]:
+        """Per-output ``idToLabels`` / ``idToSemantics`` info for the requested segmentation outputs."""
+        return {name: seg_mapping.info for name, (_dest, seg_mapping) in self._seg_dests.items()}
+
+    def _convert_plane_depth(self):
         """Fill any planar-depth outputs from the ray-hit distance Newton just rendered.
 
         Newton emits ``distance_to_camera`` (euclidean ray distance). ``depth`` and
@@ -241,7 +302,7 @@ class RenderData:
                     out_depth=dest,
                 )
 
-    def apply_depth_clipping(self, behavior: str):
+    def _apply_depth_clipping(self, behavior: str):
         """Apply the renderer's depth-clipping behavior to the depth-family outputs.
 
         Newton writes ``0.0`` for rays that miss all geometry or fall beyond the far plane
@@ -321,6 +382,10 @@ class NewtonWarpRenderer(BaseRenderer):
 
         self.cfg = cfg
         self.newton_sensor: newton.sensors.SensorTiledCamera | None = None
+        # USD stage captured in ``prepare_cameras``; used by the segmentation mapper to read semantics.
+        self._stage: Any = None
+        # Shared, scene-static segmentation lookup builder, created lazily in ``create_render_data``.
+        self._seg_mapper: NewtonSegmentationMapper | None = None
 
         sim = SimulationContext.instance()
         current_req = sim.get_scene_data_requirements()
@@ -369,9 +434,12 @@ class NewtonWarpRenderer(BaseRenderer):
     def supported_output_types(self) -> dict[RenderBufferKind, RenderBufferSpec]:
         """Publish the per-output layout this Newton Warp backend writes.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.supported_output_types`."""
-        seg_spec = (
-            RenderBufferSpec(4, wp.uint8) if self.cfg.colorize_instance_segmentation else RenderBufferSpec(1, wp.int32)
-        )
+
+        def seg_spec(colorize: bool) -> RenderBufferSpec:
+            # Colorized segmentation is RGBA uint8; raw segmentation is a single int32 id channel
+            # (matching the Isaac RTX / OVRTX contract so backend-independent consumers see the same dtype).
+            return RenderBufferSpec(4, wp.uint8) if colorize else RenderBufferSpec(1, wp.int32)
+
         return {
             RenderBufferKind.RGBA: RenderBufferSpec(4, wp.uint8),
             RenderBufferKind.RGB: RenderBufferSpec(3, wp.uint8),
@@ -381,7 +449,8 @@ class NewtonWarpRenderer(BaseRenderer):
             RenderBufferKind.DISTANCE_TO_CAMERA: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_IMAGE_PLANE: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.NORMALS: RenderBufferSpec(3, wp.float32),
-            RenderBufferKind.INSTANCE_SEGMENTATION_FAST: seg_spec,
+            RenderBufferKind.SEMANTIC_SEGMENTATION: seg_spec(self.cfg.colorize_semantic_segmentation),
+            RenderBufferKind.INSTANCE_SEGMENTATION_FAST: seg_spec(self.cfg.colorize_instance_segmentation),
         }
 
     def prepare_cameras(self, stage: Any, spec: CameraRenderSpec) -> None:
@@ -390,7 +459,11 @@ class NewtonWarpRenderer(BaseRenderer):
         :mod:`isaaclab.sensors.camera` does not depend on PPISP; the renderer
         owns the sentinel-resolution + cfg-normalization step. Newton has no
         USD-side overrides to author beyond this.
+
+        Also captures the USD ``stage`` so the segmentation mapper can read the scene's
+        :class:`UsdSemantics.LabelsAPI` labels when a segmentation output is requested.
         """
+        self._stage = stage
         if spec.cfg.isp_cfg is None:
             return
         try:
@@ -409,7 +482,26 @@ class NewtonWarpRenderer(BaseRenderer):
     def create_render_data(self, spec: CameraRenderSpec) -> RenderData:
         """Create render data for the Newton tiled camera.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.create_render_data`."""
-        return RenderData(self.newton_sensor, spec)
+
+        # Build the shared segmentation mapper and its per-kind lookup tables up-front for all
+        # requested segmentation outputs.
+        if (
+            RenderBufferKind.SEMANTIC_SEGMENTATION in spec.cfg.data_types
+            or RenderBufferKind.INSTANCE_SEGMENTATION_FAST in spec.cfg.data_types
+        ):
+            if self._seg_mapper is None:
+                self._seg_mapper = NewtonSegmentationMapper(self._newton_model, self._stage, self.cfg)
+        if RenderBufferKind.SEMANTIC_SEGMENTATION in spec.cfg.data_types:
+            self._seg_mapper.build_mapping(
+                RenderBufferKind.SEMANTIC_SEGMENTATION, bool(self.cfg.colorize_semantic_segmentation)
+            )
+        if RenderBufferKind.INSTANCE_SEGMENTATION_FAST in spec.cfg.data_types:
+            self._seg_mapper.build_mapping(
+                RenderBufferKind.INSTANCE_SEGMENTATION_FAST, bool(self.cfg.colorize_instance_segmentation)
+            )
+
+        render_data = RenderData(self.newton_sensor, spec, seg_mapper=self._seg_mapper, renderer_cfg=self.cfg)
+        return render_data
 
     def set_outputs(self, render_data: RenderData, output_data: dict[str, ProxyArray]):
         """Store output buffers. See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.set_outputs`."""
@@ -467,9 +559,9 @@ class NewtonWarpRenderer(BaseRenderer):
         # Use the renderer's clear value to fill distance_to_camera background when it is the only
         # depth output requested. This avoids a post-render kernel pass for that common case.
         # Planar-depth outputs (depth / distance_to_image_plane) are derived by
-        # convert_plane_depth(), which reads the same ray-depth buffer; pre-clearing to far_clip
+        # _convert_plane_depth(), which reads the same ray-depth buffer; pre-clearing to far_clip
         # would make it compute far_clip * cos(θ) per pixel instead of 0.0, so the <= 0.0
-        # sentinel that apply_depth_clipping relies on would no longer identify background pixels.
+        # sentinel that _apply_depth_clipping relies on would no longer identify background pixels.
         _depth_kinds = set(render_data._depth_dests)
         _use_depth_clear = (
             self.cfg.depth_clipping_behavior == "max"
@@ -487,7 +579,7 @@ class NewtonWarpRenderer(BaseRenderer):
             albedo_image=render_data.outputs.albedo_image,
             depth_image=render_data.outputs.depth_image,
             normal_image=render_data.outputs.normals_image,
-            shape_index_image=render_data.outputs.instance_segmentation_image,
+            shape_index_image=render_data.outputs.shape_index_image,
             # ARGB 93% gray to improve visibility of dark objects and align with RTX renderer background
             clear_data=newton.sensors.SensorTiledCamera.ClearData(
                 clear_color=0xFFEEEEEE,
@@ -499,8 +591,11 @@ class NewtonWarpRenderer(BaseRenderer):
         if _depth_kinds & render_data._PLANE_DEPTH_KINDS:
             # Derive planar depth from the ray-hit distance, then clip. Deliberately no clear_depth
             # here: the ray-depth buffer feeds convert_plane_depth() (see the _use_depth_clear note).
-            render_data.convert_plane_depth()
-            render_data.apply_depth_clipping(self.cfg.depth_clipping_behavior)
+            render_data._convert_plane_depth()
+            render_data._apply_depth_clipping(self.cfg.depth_clipping_behavior)
+
+        # Remap the shape-index buffer into the requested segmentation outputs.
+        render_data._convert_segmentation()
 
     def read_output(self, render_data: RenderData, camera_data: CameraData) -> None:
         """Copy rendered outputs to the camera data buffers.
@@ -513,6 +608,11 @@ class NewtonWarpRenderer(BaseRenderer):
                 output_wp = camera_data.output[output_name].warp
                 if image_data.ptr != output_wp.ptr:
                     wp.copy(output_wp, image_data)
+
+        # Publish the segmentation id-to-label metadata (idToLabels / idToSemantics) alongside the
+        # pixel buffers.
+        for output_name, info in render_data.segmentation_info().items():
+            camera_data.info[output_name] = info
 
     def cleanup(self, render_data: RenderData | None):
         """Release resources and drop the camera's sensor task.

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer_cfg.py
@@ -54,8 +54,49 @@ class NewtonWarpRendererCfg(RendererCfg):
     create_default_light: bool = True
     """Create a default directional light source in the scene."""
 
+    semantic_filter: str | list[str] = "*:*"
+    """A string or list specifying a semantic filter predicate for :attr:`semantic_segmentation` and
+    :attr:`instance_segmentation_fast`. Defaults to ``"*:*"`` (all semantic types and labels).
+
+    Mirrors :attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.semantic_filter`. If a string, it is a
+    disjunctive-normal-form predicate over ``(semantic_type, labels)`` clauses separated by ``;``. Each
+    clause is ``type:labels`` where ``labels`` supports ``&`` (and), ``|`` / ``,`` (or), ``!`` (not), and
+    ``*`` (any); ``type`` may be ``*``. For example ``"class:* ; * : shelf"`` keeps every prim with a
+    ``class`` label or any prim carrying the label ``shelf``. If a list, each entry is a bare semantic
+    type, i.e. ``["class"]`` is equivalent to ``"class:*"``.
+
+    .. note::
+        Semantic labels are read from the USD stage's :class:`UsdSemantics.LabelsAPI` (authored by
+        :attr:`~isaaclab.sim.spawners.SpawnerCfg.semantic_tags`), resolving labels inherited from
+        ancestor prims. Newton's ray tracer only emits a per-shape index; the semantic/instance
+        mappings are reconstructed on the host from ``model.shape_label`` prim paths.
+    """
+
+    colorize_semantic_segmentation: bool = True
+    """Whether to colorize the semantic segmentation image. Defaults to True.
+
+    If True, :attr:`semantic_segmentation` is returned as an ``(N, H, W, 4) uint8`` RGBA image where each
+    semantic id is mapped to a color and ``data.info["semantic_segmentation"]["idToLabels"]`` maps the
+    color to its label. If False, it is returned as an ``(N, H, W, 1) int32`` id image and ``idToLabels``
+    maps the id to its label.
+    """
+
     colorize_instance_segmentation: bool = True
-    """Expose ``instance_segmentation_fast`` as ``(N, H, W, 4) uint8`` if True, else ``(N, H, W, 1) int32``."""
+    """Whether to colorize the instance segmentation image. Defaults to True.
+
+    If True, :attr:`instance_segmentation_fast` is returned as an ``(N, H, W, 4) uint8`` RGBA image, else
+    an ``(N, H, W, 1) int32`` id image. ``data.info["instance_segmentation_fast"]`` provides ``idToLabels``
+    (id/color to prim path) and ``idToSemantics`` (id/color to semantic label).
+    """
+
+    semantic_segmentation_mapping: dict = {}
+    """Optional mapping from ``"type:label"`` to an explicit RGBA color tuple for
+    :attr:`semantic_segmentation` when :attr:`colorize_semantic_segmentation` is True. Defaults to ``{}``.
+
+    Mirrors :attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.semantic_segmentation_mapping`. For
+    example ``{"class:cube": (255, 36, 66, 255)}`` forces cube-labeled pixels to that color. Labels absent
+    from the mapping fall back to the deterministic palette shared with the RTX renderer.
+    """
 
     render_order: Literal["pixel_priority", "view_priority", "tiled"] = "tiled"
     """Render traversal order for the Newton tiled camera."""

--- a/source/isaaclab_newton/isaaclab_newton/renderers/segmentation.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/segmentation.py
@@ -1,0 +1,542 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Segmentation-mapping helpers for the Newton Warp renderer.
+
+Newton's ray tracer emits a single per-pixel *shape index* (``shape_index_image``), i.e. the global
+index of the model shape hit by each ray. Isaac Lab's camera contract instead exposes two
+segmentation outputs — ``semantic_segmentation`` and ``instance_segmentation_fast`` — each with its own
+id space and an accompanying ``idToLabels`` / ``idToSemantics`` mapping
+(see :class:`~isaaclab.sensors.camera.CameraData`).
+
+This module reconstructs those outputs on the host from the Newton model's per-shape prim paths
+(``model.shape_label``) and the USD stage's :class:`UsdSemantics.LabelsAPI` labels (authored by
+:attr:`~isaaclab.sim.spawners.SpawnerCfg.semantic_tags`), then remaps the shape-index image into each
+requested output with a Warp kernel. Colors match the Isaac RTX / OVRTX palette so colorized outputs
+are visually consistent across renderers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, TypeAlias
+
+import numpy as np
+import warp as wp
+
+# Colorization (host ``random_color_from_id`` / ``pack_rgba``) and the reserved BACKGROUND / UNLABELLED
+# ids are shared with the RTX and OVRTX renderers to keep colorized segmentation visually consistent.
+from isaaclab.renderers.segmentation_colors import BACKGROUND_ID, UNLABELLED_ID, pack_rgba, random_color_from_id
+from isaaclab.utils.timer import Timer
+
+if TYPE_CHECKING:
+    import newton
+
+    from pxr import Usd
+
+_UNLABELLED_COLOR: int = 0xFF000000
+"""Packed RGBA color for UNLABELLED pixels: ``(0, 0, 0, 255)`` opaque black."""
+
+# Newton ray-tracer sentinel values. These mirror the constants in
+# ``newton._src.sensors.warp_raytrace.raytrace`` (``NO_HIT_SHAPE_ID``, ``MAX_SHAPE_ID``), which are
+# not re-exported by Newton's public API. Keep in sync if Newton changes them.
+_NEWTON_NO_HIT_SHAPE_ID: int = 0xFFFFFFFF
+"""Shape-index value written by the Newton ray tracer when a ray hits nothing (ray miss)."""
+_NEWTON_MAX_SHAPE_ID: int = 0xFFFFFFF0
+"""Guard threshold: any shape_index >= this value is a synthetic/sentinel id, not a real shape."""
+
+_FIRST_ID: int = 2
+"""First id assigned to a real semantic/instance group (0 and 1 are reserved)."""
+
+SegId: TypeAlias = int
+"""Integer segmentation id assigned to a group and written into the output image per pixel.
+
+Distinct from Newton's ``shape_index`` (the raw per-pixel geometry index the ray tracer emits):
+``shape_index`` identifies a single shape in the Newton model, while ``SegId`` identifies a semantic
+or instance group that may span many shapes. The ``shape_to_id`` array bridges them:
+``shape_to_id[shape_index] -> SegId``.
+"""
+
+_SegKind = Literal["semantic_segmentation", "instance_segmentation_fast"]
+
+SemanticType: TypeAlias = str
+"""A semantic type string as authored in :class:`UsdSemantics.LabelsAPI`, e.g. ``"class"``."""
+
+SemanticLabels: TypeAlias = list[str]
+"""The list of label strings for one semantic type, e.g. ``["cartpole"]``."""
+
+SemanticLabelString: TypeAlias = str
+"""Comma-joined form of :data:`SemanticLabels` used in info dicts, e.g. ``"cartpole"``."""
+
+SemanticPrimPath: TypeAlias = str
+"""USD prim path of the nearest labelled ancestor of a shape, used as the instance grouping key."""
+
+
+# ------------------------------------------------------------------------------------------------
+# Semantic-filter predicate — RTX parity.
+#
+# The Isaac RTX renderer evaluates :attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.semantic_filter`
+# inside Replicator's C++ ``SyntheticData`` instance-mapping filter (see
+# :func:`isaaclab_physx.renderers.isaac_rtx_renderer._camera_semantic_filter_predicate`). The kit-less
+# Newton path has no Replicator, so the three functions below re-implement the *same* predicate grammar
+# on the host so :attr:`~isaaclab_newton.renderers.NewtonWarpRendererCfg.semantic_filter` selects
+# exactly the labels the RTX renderer would. The grammar is documented on
+# :attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.semantic_filter`.
+# ------------------------------------------------------------------------------------------------
+
+
+def _eval_label_expr(expr: str, labels: set[str]) -> bool:
+    """Evaluate one clause's label expression against a prim's label set (RTX-parity grammar).
+
+    Grammar (matching the Isaac RTX / Replicator ``semantic_filter`` predicate): an OR of ``|`` / ``,``
+    separated terms; each term is an AND of ``&`` separated factors; each factor is ``label``,
+    ``!label`` (negation) or ``*`` (any).
+    """
+    expr = expr.strip()
+    if not expr:
+        return False
+    for term in expr.replace(",", "|").split("|"):
+        term = term.strip()
+        if not term:
+            continue
+        if all(_eval_label_factor(factor.strip(), labels) for factor in term.split("&")):
+            return True
+    return False
+
+
+def _eval_label_factor(factor: str, labels: set[str]) -> bool:
+    """Evaluate a single filter factor: ``*`` (any), ``!label`` (absent) or ``label`` (present)."""
+    if factor == "*":
+        return True
+    if factor.startswith("!"):
+        return factor[1:].strip() not in labels
+    return factor in labels
+
+
+def _parse_semantic_filter(semantic_filter: str | list[str]) -> list[tuple[str, str]]:
+    """Normalize a semantic filter into a list of ``(type, label_expr)`` clauses (RTX parity).
+
+    Reproduces the normalization in
+    :func:`isaaclab_physx.renderers.isaac_rtx_renderer._camera_semantic_filter_predicate` so the same
+    :attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.semantic_filter` value behaves identically on
+    the Newton Warp backend: a list is treated as bare semantic types (``["class"] -> "class:*"``); a
+    string is a ``;``-separated disjunction of ``type:label_expr`` clauses (e.g.
+    ``"class:* ; *:shelf"``).  Within each ``;``-separated segment, commas that precede an
+    ``identifier:`` token introduce additional ``(type, label_expr)`` pairs (e.g.
+    ``"class:cartpole, material:wood"`` yields two independent clauses).  Commas within a
+    ``label_expr`` that are not followed by a type token remain as label-level OR operators (handled
+    by :func:`_eval_label_expr`).
+
+    The split heuristic relies on the fact that label factors never contain ``:``, so any
+    comma-separated token that contains ``:`` must be the start of a new ``type:label_expr`` pair
+    rather than a continuation of the current label expression.
+    """
+    if isinstance(semantic_filter, list):
+        text = "; ".join(f"{t}:*" for t in semantic_filter)
+    else:
+        text = semantic_filter
+    clauses: list[tuple[str, str]] = []
+    for segment in text.split(";"):
+        segment = segment.strip()
+        if not segment:
+            continue
+        # Accumulate comma-separated tokens into type:label_expr clauses.  A token that contains
+        # ':' opens a new clause; a token without ':' is a label-level OR term and is re-joined
+        # (with its comma) onto the current clause's label expression.
+        parts = segment.split(",")
+        current = parts[0]
+        for part in parts[1:]:
+            if ":" in part:
+                sem_type, _, label_expr = current.partition(":")
+                clauses.append((sem_type.strip(), label_expr.strip() or "*"))
+                current = part
+            else:
+                current = current + "," + part
+        sem_type, _, label_expr = current.partition(":")
+        clauses.append((sem_type.strip(), label_expr.strip() or "*"))
+    return clauses
+
+
+@wp.kernel(enable_backward=False)
+def _remap_shape_index_to_id_kernel(
+    shape_index: wp.array(dtype=wp.uint32, ndim=4),
+    shape_to_id: wp.array(dtype=wp.uint32),
+    shape_count: wp.int32,
+    out_id: wp.array(dtype=wp.int32, ndim=4),
+):
+    """Write the segmentation id of each pixel's shape."""
+    w, c, y, x = wp.tid()
+    idx = shape_index[w, c, y, x]
+    if idx == wp.uint32(wp.static(_NEWTON_NO_HIT_SHAPE_ID)):
+        # Ray missed all geometry — no surface was hit.
+        out_id[w, c, y, x] = wp.int32(wp.static(BACKGROUND_ID))
+    elif idx >= wp.uint32(wp.static(_NEWTON_MAX_SHAPE_ID)):
+        # Synthetic hit (particles, deformable mesh, etc.) — real geometry but no shape-array entry.
+        out_id[w, c, y, x] = wp.int32(wp.static(UNLABELLED_ID))
+    elif idx < wp.uint32(shape_count):
+        # Normal geometry hit — look up the pre-built segmentation id for this shape.
+        out_id[w, c, y, x] = wp.int32(shape_to_id[wp.int32(idx)])
+    else:
+        # Index is in the valid uint32 range but beyond shape_count — should not happen in practice.
+        out_id[w, c, y, x] = wp.int32(wp.static(UNLABELLED_ID))
+
+
+@wp.kernel(enable_backward=False)
+def _remap_shape_index_to_color_kernel(
+    shape_index: wp.array(dtype=wp.uint32, ndim=4),
+    shape_to_color: wp.array(dtype=wp.uint32),
+    shape_count: wp.int32,
+    out_color: wp.array(dtype=wp.uint32, ndim=4),
+):
+    """Write the packed RGBA color of each pixel's shape."""
+    w, c, y, x = wp.tid()
+    idx = shape_index[w, c, y, x]
+    if idx == wp.uint32(wp.static(_NEWTON_NO_HIT_SHAPE_ID)):
+        # Ray missed all geometry — no surface was hit.
+        out_color[w, c, y, x] = wp.uint32(0)
+    elif idx >= wp.uint32(wp.static(_NEWTON_MAX_SHAPE_ID)):
+        # Synthetic hit (particles, deformable mesh, etc.) — real geometry but no shape-array entry.
+        out_color[w, c, y, x] = wp.uint32(wp.static(_UNLABELLED_COLOR))
+    elif idx < wp.uint32(shape_count):
+        # Normal geometry hit — look up the pre-built color for this shape.
+        out_color[w, c, y, x] = shape_to_color[wp.int32(idx)]
+    else:
+        # Index is in the valid uint32 range but beyond shape_count — should not happen in practice.
+        out_color[w, c, y, x] = wp.uint32(wp.static(_UNLABELLED_COLOR))
+
+
+@dataclass
+class NewtonSegmentationMapping:
+    """Device lookup tables and host metadata for one segmentation output.
+
+    Built once per (kind, colorize) by :meth:`NewtonSegmentationMapper.mapping` and reused across frames
+    since the scene geometry and semantics are static after construction.
+    """
+
+    kind: _SegKind
+    colorize: bool
+    shape_count: int
+    shape_to_id: wp.array  # uint32, shape [shape_count]
+    shape_to_color: wp.array | None  # uint32, shape [shape_count]; None when not colorized
+    info: dict[str, dict]
+
+    def convert_shape_index_to_output(self, shape_index: wp.array, out_view: wp.array) -> None:
+        """Generate the segmentation output into ``out_view`` (colorized RGBA or raw uint32 ids).
+
+        Args:
+            shape_index: Newton ``shape_index_image`` scratch, ``(world_count, 1, H, W)`` uint32.
+            out_view: Destination view aliasing the camera output buffer as ``(world_count, 1, H, W)``,
+                dtype uint32 (both colorized and non-colorized).
+        """
+        if self.shape_count == 0:
+            out_view.zero_()
+            return
+        if self.colorize:
+            wp.launch(
+                _remap_shape_index_to_color_kernel,
+                dim=shape_index.shape,
+                inputs=[shape_index, self.shape_to_color, self.shape_count],
+                outputs=[out_view],
+                device=out_view.device,
+            )
+        else:
+            wp.launch(
+                _remap_shape_index_to_id_kernel,
+                dim=shape_index.shape,
+                inputs=[shape_index, self.shape_to_id, self.shape_count],
+                outputs=[out_view],
+                device=out_view.device,
+            )
+
+
+class NewtonSegmentationMapper:
+    """Builds per-shape segmentation lookup tables from a Newton model and its USD stage."""
+
+    def __init__(self, model: newton.Model, stage: Usd.Stage | None, cfg) -> None:
+        """Initialize the mapper from the Newton model, USD stage, and renderer config.
+
+        Construction is cheap — it only captures references and snapshots ``model.shape_label``.
+        Call :meth:`build_mapping` to do the actual per-shape USD resolution and id assignment.
+
+        Args:
+            model: The compiled Newton model; ``model.shape_label`` maps shape indices to USD prim paths.
+            stage: The live USD stage used to read :class:`UsdSemantics.LabelsAPI` labels. May be
+                ``None`` in stageless setups, in which case every shape is treated as unlabelled.
+            cfg: Renderer config exposing ``semantic_filter`` and ``semantic_segmentation_mapping``.
+        """
+        self._model = model
+        self._stage = stage
+        self._cfg = cfg
+        self._shape_labels: list[str] = list(getattr(model, "shape_label", []) or [])
+        self._shape_count = len(self._shape_labels)
+        self._device = str(model.device)
+        self._filter_clauses = _parse_semantic_filter(cfg.semantic_filter)
+        # Cache of prim path -> (matched_labels or None); labels resolved with ancestor inheritance.
+        self._matched_cache: dict[str, tuple[dict[SemanticType, SemanticLabels], SemanticPrimPath] | None] = {}
+        self._mappings: dict[tuple[str, bool], NewtonSegmentationMapping] = {}
+
+    def build_mapping(self, kind: _SegKind, colorize: bool) -> None:
+        """Build and cache the :class:`NewtonSegmentationMapping` for ``kind`` at the requested colorization."""
+        key = (kind, colorize)
+        if key not in self._mappings:
+            with Timer(
+                f"[INFO]: Time taken for NewtonSegmentationMapper.build_mapping ({kind}, colorize={colorize})",
+                f"newton_segmentation_build_mapping_{kind}_{colorize}",
+                enable=True,
+            ):
+                self._mappings[key] = self._build_mapping(kind, colorize)
+
+    def get_mapping(self, kind: _SegKind, colorize: bool) -> NewtonSegmentationMapping:
+        """Return the pre-built :class:`NewtonSegmentationMapping` for ``kind``; must call
+        :meth:`build_mapping` first."""
+        return self._mappings[(kind, colorize)]
+
+    # -- host resolution ---------------------------------------------------------------------------
+
+    def _resolve_semantic_match(
+        self, prim_path: str
+    ) -> tuple[dict[SemanticType, SemanticLabels], SemanticPrimPath] | None:
+        """Return ``(filtered_labels, matched_ancestor_path)`` for ``prim_path``, inheriting from ancestors.
+
+        Walks from the prim up to the stage root, returning the labels of the *nearest* prim that
+        carries a :class:`UsdSemantics.LabelsAPI` label satisfying :attr:`semantic_filter`, together
+        with its USD path. The path is used by ``instance_segmentation_fast`` as the grouping key —
+        shapes under the same returned path share one instance id. Returns ``None`` when no ancestor
+        matches (i.e. the prim is unlabelled for this filter).
+
+        Every ancestor visited during the walk is checked against the cache *before* calling
+        :func:`~isaaclab.sim.utils.semantics.get_labels`, so a cached intermediate ancestor
+        short-circuits the traversal immediately. All newly-visited paths are back-filled with
+        ``result`` at the end, so sibling shapes that share an ancestry prefix resolve in O(1)
+        on subsequent calls without re-walking the hierarchy or re-querying USD.
+        """
+        if prim_path in self._matched_cache:
+            return self._matched_cache[prim_path]
+
+        result: tuple[dict[SemanticType, SemanticLabels], SemanticPrimPath] | None = None
+        # Paths visited this traversal that were not already in the cache; back-filled at the end.
+        traversed: list[str] = []
+        if self._stage is not None and prim_path.startswith("/"):
+            from isaaclab.sim.utils.semantics import get_labels  # noqa: PLC0415
+
+            prim = self._stage.GetPrimAtPath(prim_path)
+            while prim is not None and prim.IsValid() and prim.GetPath().pathString != "/":
+                ancestor_path = prim.GetPath().pathString
+                if ancestor_path in self._matched_cache:
+                    # Already resolved by a prior traversal — skip the USD query and walk no further.
+                    result = self._matched_cache[ancestor_path]
+                    break
+                traversed.append(ancestor_path)
+                labels = get_labels(prim)
+                if labels:
+                    kept = self._apply_filter(labels)
+                    if kept:
+                        result = (kept, ancestor_path)
+                        self._matched_cache[ancestor_path] = result
+                        break
+                prim = prim.GetParent()
+
+        # Back-fill every newly-visited path so later callers sharing any prefix skip the walk.
+        for path in traversed:
+            if path not in self._matched_cache:
+                self._matched_cache[path] = result
+        # Handle the stage=None / non-absolute-path edge cases where traversed may be empty.
+        if prim_path not in self._matched_cache:
+            self._matched_cache[prim_path] = result
+        return result
+
+    def _apply_filter(self, labels: dict[SemanticType, SemanticLabels]) -> dict[SemanticType, SemanticLabels]:
+        """Restrict ``labels`` (``{type: [labels]}``) to the types/labels passing the semantic filter.
+
+        Applies the RTX-parity predicate parsed by :func:`_parse_semantic_filter`: a semantic type is
+        kept when some filter clause matches its type (or ``*``) and its label set satisfies the
+        clause's expression, mirroring the Isaac RTX / Replicator ``semantic_filter`` behavior. Returns
+        an empty dict when the prim matches no clause (i.e. it is UNLABELLED for this filter).
+        """
+        if not self._filter_clauses:
+            # Empty filter means no filtering — all labels pass through, matching RTX behavior.
+            return dict(labels)
+        kept: dict[SemanticType, SemanticLabels] = {}
+        for sem_type, sem_labels in labels.items():
+            label_set = set(sem_labels)
+            for clause_type, clause_expr in self._filter_clauses:
+                if clause_type not in ("*", sem_type):
+                    continue
+                if _eval_label_expr(clause_expr, label_set):
+                    kept[sem_type] = list(sem_labels)
+                    break
+        return kept
+
+    @staticmethod
+    def _semantics_payload(labels: dict[SemanticType, SemanticLabels]) -> dict[SemanticType, SemanticLabelString]:
+        """Collapse raw USD labels into the comma-joined payload form used in ``idToLabels`` / ``idToSemantics``.
+
+        Converts ``{"class": ["cartpole"]}`` → ``{"class": "cartpole"}``.
+        """
+        return {sem_type: ",".join(sem_labels) for sem_type, sem_labels in labels.items()}
+
+    def _build_mapping(self, kind: _SegKind, colorize: bool) -> NewtonSegmentationMapping:
+        """Build the :class:`NewtonSegmentationMapping` for ``kind``.
+
+        Iterates over every shape in the Newton model by index, resolves its USD semantic labels
+        (inheriting from ancestors), and assigns a :data:`SegId` by grouping shapes that belong to
+        the same logical unit:
+
+        - ``semantic_segmentation``: shapes with identical label payloads share one id (e.g. all
+          ``class:cartpole`` shapes across all environments map to the same class id).
+        - ``instance_segmentation_fast``: shapes under the same nearest labelled ancestor prim share
+          one id (e.g. pole and cart of one robot instance share that instance's id, while a second
+          robot gets a distinct id).
+
+        Shapes with no matching USD semantic ancestor are assigned :data:`UNLABELLED_ID`; ray-miss
+        pixels receive :data:`BACKGROUND_ID` at kernel dispatch time via
+        :meth:`NewtonSegmentationMapping.convert_shape_index_to_output`.
+        """
+        shape_to_id = np.zeros(self._shape_count, dtype=np.uint32)
+
+        # seg_id -> label/semantics metadata written into the info dict.
+        id_labels: dict[SegId, object] = {}
+        id_semantics: dict[SegId, dict[SemanticType, SemanticLabelString]] = {}
+
+        # Maps a group key to its assigned seg_id so that shapes belonging to the same group
+        # (same semantic class for semantic_segmentation, same labelled ancestor prim for
+        # instance_segmentation_fast) reuse the same id rather than receiving a new one each time.
+        group_key_to_id: dict[object, SegId] = {}
+        next_id = _FIRST_ID
+
+        for shape_index, prim_path in enumerate(self._shape_labels):
+            match = self._resolve_semantic_match(prim_path)
+            if match is None:
+                shape_to_id[shape_index] = UNLABELLED_ID
+                continue
+            matched, ancestor_path = match
+            if kind == "instance_segmentation_fast":
+                # All shapes under the same labelled ancestor prim form one instance group.
+                group_key = ancestor_path
+                label_value = ancestor_path
+                semantics_value = self._semantics_payload(matched)
+            else:  # semantic_segmentation
+                payload = self._semantics_payload(matched)
+                # All shapes with the same label payload (e.g. class:cartpole) form one semantic group.
+                group_key = tuple(sorted(payload.items()))
+                label_value = payload
+                semantics_value = None
+
+            seg_id = group_key_to_id.get(group_key)
+            if seg_id is None:
+                seg_id = next_id
+                next_id += 1
+                group_key_to_id[group_key] = seg_id
+                id_labels[seg_id] = label_value
+                if semantics_value is not None:
+                    id_semantics[seg_id] = semantics_value
+            shape_to_id[shape_index] = seg_id
+
+        info = self._build_info(kind, colorize, id_labels, id_semantics)
+        shape_to_color = self._build_color_palette(kind, colorize, shape_to_id, id_labels)
+
+        return NewtonSegmentationMapping(
+            kind=kind,
+            colorize=colorize,
+            shape_count=self._shape_count,
+            shape_to_id=wp.array(shape_to_id, dtype=wp.uint32, device=self._device),
+            shape_to_color=(
+                wp.array(shape_to_color, dtype=wp.uint32, device=self._device) if shape_to_color is not None else None
+            ),
+            info=info,
+        )
+
+    # -- info + color assembly ---------------------------------------------------------------------
+
+    def _id_to_color(self, seg_id: int, label_value: object) -> tuple[int, int, int, int]:
+        """Resolve the RGBA color for a :data:`SegId`.
+
+        Checks ``semantic_segmentation_mapping`` in the renderer config for a user-specified color
+        override keyed by ``"type:label"`` (e.g. ``"class:cartpole"``). Falls back to the palette
+        color derived from the id via :func:`random_color_from_id` when no override matches.
+        """
+        mapping = self._cfg.semantic_segmentation_mapping
+        if mapping and isinstance(label_value, dict):
+            for sem_type, sem_labels in label_value.items():
+                for lbl in sem_labels.split(","):
+                    override = mapping.get(f"{sem_type}:{lbl}")
+                    if override is not None:
+                        return tuple(int(component) for component in override)  # type: ignore[return-value]
+        return random_color_from_id(seg_id)
+
+    def _reserved_semantics_label(self, name: str) -> dict[SemanticType, SemanticLabelString]:
+        """Return the fixed label payload for a reserved id (``BACKGROUND`` or ``UNLABELLED``)."""
+        return {"class": name}
+
+    def _build_info(
+        self,
+        kind: _SegKind,
+        colorize: bool,
+        id_labels: dict[SegId, object],
+        id_semantics: dict[SegId, dict[SemanticType, SemanticLabelString]],
+    ) -> dict[str, dict]:
+        """Assemble the Replicator-compatible info dict containing ``idToLabels`` and, for instance
+        segmentation, ``idToSemantics``.
+
+        When colorized, info dict keys are ``(r, g, b, a)`` color tuples matching the packed RGBA
+        pixel values; otherwise they are raw :data:`SegId` integers. Reserved ids
+        (:data:`BACKGROUND_ID`, :data:`UNLABELLED_ID`) are always included.
+        """
+        # Reserved entries present for every segmentation output.
+        reserved_labels: dict[SegId, object]
+        reserved_semantics: dict[SegId, dict[SemanticType, SemanticLabelString]]
+        if kind == "semantic_segmentation":
+            reserved_labels = {
+                BACKGROUND_ID: self._reserved_semantics_label("BACKGROUND"),
+                UNLABELLED_ID: self._reserved_semantics_label("UNLABELLED"),
+            }
+            reserved_semantics = {}
+        else:
+            reserved_labels = {BACKGROUND_ID: "BACKGROUND", UNLABELLED_ID: "UNLABELLED"}
+            reserved_semantics = {
+                BACKGROUND_ID: self._reserved_semantics_label("BACKGROUND"),
+                UNLABELLED_ID: self._reserved_semantics_label("UNLABELLED"),
+            }
+
+        all_labels = {**reserved_labels, **id_labels}
+
+        def key_for(seg_id: SegId) -> SegId | tuple:
+            if colorize:
+                return self._id_to_color(seg_id, id_labels.get(seg_id, all_labels[seg_id]))
+            return seg_id
+
+        id_to_labels = {key_for(seg_id): value for seg_id, value in all_labels.items()}
+        info: dict[str, dict] = {"idToLabels": id_to_labels}
+
+        if kind == "instance_segmentation_fast":
+            all_semantics = {**reserved_semantics, **id_semantics}
+            info["idToSemantics"] = {key_for(seg_id): value for seg_id, value in all_semantics.items()}
+        return info
+
+    def _build_color_palette(
+        self,
+        kind: _SegKind,
+        colorize: bool,
+        shape_to_id: np.ndarray,
+        id_labels: dict[SegId, object],
+    ) -> np.ndarray | None:
+        """Build a per-shape packed-RGBA color palette for the colorize kernel.
+
+        Returns a ``uint32`` array of length ``shape_count`` where each entry is the RGBA color for
+        that shape's :data:`SegId`, honoring ``semantic_segmentation_mapping`` overrides. Returns
+        ``None`` when colorization is not requested or the model has no shapes.
+        """
+        if not colorize or self._shape_count == 0:
+            return None
+        color_cache: dict[SegId, int] = {}
+        shape_to_color = np.zeros(self._shape_count, dtype=np.uint32)
+        for shape_index in range(self._shape_count):
+            seg_id: SegId = int(shape_to_id[shape_index])
+            packed = color_cache.get(seg_id)
+            if packed is None:
+                packed = pack_rgba(self._id_to_color(seg_id, id_labels.get(seg_id)))
+                color_cache[seg_id] = packed
+            shape_to_color[shape_index] = packed
+        return shape_to_color

--- a/source/isaaclab_newton/test/renderers/test_segmentation.py
+++ b/source/isaaclab_newton/test/renderers/test_segmentation.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for the Newton Warp renderer's segmentation mapping (no GPU / sim required)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("warp")
+pytest.importorskip("pxr")
+
+from isaaclab_newton.renderers.segmentation import NewtonSegmentationMapper
+
+from pxr import Usd
+
+# The color palette / reserved ids live in core and are unit-tested there
+# (``isaaclab/test/renderers/test_segmentation_colors.py``); here they are only an oracle for the
+# mapper's info-dict keys.
+from isaaclab.renderers.segmentation_colors import BACKGROUND_ID, UNLABELLED_ID, pack_rgba, random_color_from_id
+from isaaclab.sim.utils.semantics import add_labels
+
+
+def _cfg(**overrides):
+    """Minimal renderer-cfg stand-in exposing only the fields the mapper reads."""
+    base = {
+        "semantic_filter": "*:*",
+        "semantic_segmentation_mapping": {},
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _scene():
+    """Two cartpole robots (each with labelled root) plus an unlabelled ground plane.
+
+    Returns the in-memory stage and the per-shape prim-path list (``model.shape_label``).
+    """
+    stage = Usd.Stage.CreateInMemory()
+    shape_paths = [
+        "/World/envs/env_0/Robot/pole/geom",
+        "/World/envs/env_0/Robot/cart/geom",
+        "/World/envs/env_1/Robot/pole/geom",
+        "/World/ground/geom",
+    ]
+    for path in shape_paths:
+        stage.DefinePrim(path, "Mesh")
+    # Semantic label authored on the robot roots; inherited by the descendant geom shapes.
+    for robot in ("/World/envs/env_0/Robot", "/World/envs/env_1/Robot"):
+        add_labels(stage.GetPrimAtPath(robot), labels=["cartpole"], instance_name="class")
+    return stage, shape_paths
+
+
+def _model(shape_paths):
+    return SimpleNamespace(shape_label=list(shape_paths), device="cpu")
+
+
+def test_semantic_segmentation_shares_class_id_across_envs():
+    """All cartpole shapes across envs share one class id; the unlabelled ground is UNLABELLED."""
+    stage, shape_paths = _scene()
+    mapper = NewtonSegmentationMapper(_model(shape_paths), stage, _cfg())
+    mapper.build_mapping("semantic_segmentation", colorize=False)
+    mapping = mapper.get_mapping("semantic_segmentation", colorize=False)
+
+    ids = mapping.shape_to_id.numpy().tolist()
+    # env_0 pole, env_0 cart, env_1 pole all share the cartpole class id; ground is UNLABELLED.
+    assert ids[0] == ids[1] == ids[2]
+    assert ids[0] >= 2
+    assert ids[3] == UNLABELLED_ID
+    labels = mapping.info["idToLabels"]
+    assert labels[BACKGROUND_ID] == {"class": "BACKGROUND"}
+    assert labels[UNLABELLED_ID] == {"class": "UNLABELLED"}
+    assert labels[ids[0]] == {"class": "cartpole"}
+
+
+def test_instance_segmentation_groups_by_labelled_ancestor():
+    """Shapes group by their nearest labelled ancestor; idToSemantics carries the class label."""
+    stage, shape_paths = _scene()
+    mapper = NewtonSegmentationMapper(_model(shape_paths), stage, _cfg())
+    mapper.build_mapping("instance_segmentation_fast", colorize=False)
+    mapping = mapper.get_mapping("instance_segmentation_fast", colorize=False)
+
+    ids = mapping.shape_to_id.numpy().tolist()
+    # env_0 pole and cart share the env_0/Robot instance; env_1 is a separate instance; ground unlabelled.
+    assert ids[0] == ids[1]
+    assert ids[2] != ids[0]
+    assert ids[3] == UNLABELLED_ID
+    assert mapping.info["idToLabels"][ids[0]] == "/World/envs/env_0/Robot"
+    assert mapping.info["idToSemantics"][ids[0]] == {"class": "cartpole"}
+
+
+def test_colorize_info_keys_are_color_tuples():
+    """With colorization, info keys are ``(r, g, b, a)`` color tuples and a color palette is built."""
+    stage, shape_paths = _scene()
+    mapper = NewtonSegmentationMapper(_model(shape_paths), stage, _cfg())
+    mapper.build_mapping("semantic_segmentation", colorize=True)
+    mapping = mapper.get_mapping("semantic_segmentation", colorize=True)
+
+    assert mapping.shape_to_color is not None
+    assert random_color_from_id(BACKGROUND_ID) in mapping.info["idToLabels"]
+    assert random_color_from_id(UNLABELLED_ID) in mapping.info["idToLabels"]
+
+
+def test_semantic_filter_excludes_non_matching_types():
+    """A filter restricted to an absent type marks every shape UNLABELLED."""
+    stage, shape_paths = _scene()
+    mapper = NewtonSegmentationMapper(_model(shape_paths), stage, _cfg(semantic_filter=["shape"]))
+    mapper.build_mapping("semantic_segmentation", colorize=False)
+    mapping = mapper.get_mapping("semantic_segmentation", colorize=False)
+
+    assert mapping.shape_to_id.numpy().tolist() == [UNLABELLED_ID] * len(shape_paths)
+
+
+def test_semantic_filter_comma_separated_type_clauses():
+    """Comma-separated ``type:label`` pairs within one semicolon group each match independently.
+
+    Filter ``"class:cartpole, material:wood"`` must label shapes annotated with ``class:cartpole``
+    *and* shapes annotated with ``material:wood``; before the fix only the first type clause was
+    parsed, leaving ``material:wood`` shapes UNLABELLED.
+    """
+    stage = Usd.Stage.CreateInMemory()
+    shape_paths = [
+        "/World/robot/geom",
+        "/World/shelf/geom",
+        "/World/ground/geom",
+    ]
+    for path in shape_paths:
+        stage.DefinePrim(path, "Mesh")
+    # Different semantic types on distinct parent prims.
+    add_labels(stage.GetPrimAtPath("/World/robot"), labels=["cartpole"], instance_name="class")
+    add_labels(stage.GetPrimAtPath("/World/shelf"), labels=["wood"], instance_name="material")
+
+    mapper = NewtonSegmentationMapper(_model(shape_paths), stage, _cfg(semantic_filter="class:cartpole, material:wood"))
+    mapper.build_mapping("semantic_segmentation", colorize=False)
+    mapping = mapper.get_mapping("semantic_segmentation", colorize=False)
+
+    ids = mapping.shape_to_id.numpy().tolist()
+    assert ids[0] >= 2, "class:cartpole shape should be labelled"
+    assert ids[1] >= 2, "material:wood shape should be labelled (was UNLABELLED before fix)"
+    assert ids[0] != ids[1], "different label payloads must map to different ids"
+    assert ids[2] == UNLABELLED_ID
+
+
+def test_ancestor_cache_prevents_redundant_get_labels_calls():
+    """Each unique ancestor prim is queried at most once even when many shapes share ancestry.
+
+    Before the fix, a labelled robot root with N leaf shapes caused N redundant ``get_labels``
+    calls on the same root prim because the cache was only consulted for the original leaf path,
+    not for each intermediate ancestor during the walk.
+    """
+    from unittest.mock import patch
+
+    import isaaclab.sim.utils.semantics as _semantics_mod
+
+    stage, shape_paths = _scene()
+    mapper = NewtonSegmentationMapper(_model(shape_paths), stage, _cfg())
+
+    original_get_labels = _semantics_mod.get_labels
+    queried_paths: list[str] = []
+
+    def counting_get_labels(prim):
+        queried_paths.append(prim.GetPath().pathString)
+        return original_get_labels(prim)
+
+    with patch.object(_semantics_mod, "get_labels", side_effect=counting_get_labels):
+        mapper.build_mapping("semantic_segmentation", colorize=False)
+
+    duplicates = [p for p in set(queried_paths) if queried_paths.count(p) > 1]
+    assert not duplicates, f"Prims queried more than once (ancestor cache missed): {duplicates}"
+
+
+def test_semantic_segmentation_mapping_overrides_color():
+    """``semantic_segmentation_mapping`` forces the class color and its info key."""
+    stage, shape_paths = _scene()
+    override = (255, 36, 66, 255)
+    mapper = NewtonSegmentationMapper(
+        _model(shape_paths), stage, _cfg(semantic_segmentation_mapping={"class:cartpole": override})
+    )
+    mapper.build_mapping("semantic_segmentation", colorize=True)
+    mapping = mapper.get_mapping("semantic_segmentation", colorize=True)
+
+    # The cartpole class id must be colored with the override, and keyed by it in idToLabels.
+    assert override in mapping.info["idToLabels"]
+    assert mapping.info["idToLabels"][override] == {"class": "cartpole"}
+    packed = pack_rgba(override)
+    assert packed in mapping.shape_to_color.numpy().tolist()

--- a/source/isaaclab_ov/changelog.d/newton-warp-segmentation.skip
+++ b/source/isaaclab_ov/changelog.d/newton-warp-segmentation.skip
@@ -1,0 +1,3 @@
+Refactor-only: the OVRTX renderer's segmentation colorization Warp functions
+(random_color_from_id / color_hash) now import from the shared
+isaaclab.renderers.segmentation_colors module instead of duplicating them. No behavior change.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
@@ -23,6 +23,8 @@ from typing import TypeAlias
 import numpy as np
 import warp as wp
 
+from isaaclab.renderers.segmentation_colors import BACKGROUND_ID, UNLABELLED_ID, unpack_rgba
+
 from .ovrtx_renderer_kernels import generate_random_colors_from_ids_kernel
 
 # A 128-bit identifier as four ``uint32`` words, low word first: the stable ID key of the StableIdMap /
@@ -35,16 +37,12 @@ RawLabel: TypeAlias = str
 # One decoded IdentifierMap entry: its 128-bit id paired with its label.
 StableIdLabelPair: TypeAlias = tuple[StableId, RawLabel]
 
-# Reserved semantic IDs shared by the OVRTX SemanticSegmentation AOV and Isaac RTX / Replicator:
-# ID 0 is BACKGROUND (no prim), ID 1 is UNLABELLED (a prim with no matching semantic label). Entries
-# with ID >= 2 are decoded from the SemanticIdMap render var.
-_SEMANTIC_ID_BACKGROUND = 0
-_SEMANTIC_ID_UNLABELLED = 1
 # Single source of truth for the reserved ID 0/1 label names, shared across every segmentation map and
 # matching the ``"BACKGROUND"`` / ``"UNLABELLED"`` strings Replicator writes for pixel IDs 0 and 1.
+# IDs are imported from :mod:`isaaclab.renderers.segmentation_colors` to stay in sync across backends.
 _RESERVED_LABEL_NAMES: dict[int, str] = {
-    _SEMANTIC_ID_BACKGROUND: "BACKGROUND",
-    _SEMANTIC_ID_UNLABELLED: "UNLABELLED",
+    BACKGROUND_ID: "BACKGROUND",
+    UNLABELLED_ID: "UNLABELLED",
 }
 # Number of reserved IDs (BACKGROUND, UNLABELLED). Real per-instance entries are offset by this count: entry
 # ``i`` of the StableIdSemanticIdMap corresponds to pixel ID ``i + _NUM_RESERVED_IDS``, and semantic IDs
@@ -219,8 +217,7 @@ def _color_keys_for_ids(ids: list[int], device: str) -> list[RgbaColor]:
     )
     keys: list[RgbaColor] = []
     for color in colors_wp.numpy().reshape(-1):
-        color = int(color)
-        keys.append((color & 0xFF, (color >> 8) & 0xFF, (color >> 16) & 0xFF, (color >> 24) & 0xFF))
+        keys.append(unpack_rgba(int(color)))
     return keys
 
 
@@ -281,21 +278,21 @@ def build_instance_id_to_labels_and_semantics(
         ``idToSemantics`` maps each key to a ``{type: label}`` dict.
     """
     # Pixel IDs 0/1 are reserved; entry ``i`` corresponds to pixel ID ``i + _NUM_RESERVED_IDS``.
-    pixel_ids: list[int] = [_SEMANTIC_ID_BACKGROUND, _SEMANTIC_ID_UNLABELLED]
+    pixel_ids: list[int] = [BACKGROUND_ID, UNLABELLED_ID]
     prim_paths: list[str] = [
-        _RESERVED_INSTANCE_LABELS[_SEMANTIC_ID_BACKGROUND],
-        _RESERVED_INSTANCE_LABELS[_SEMANTIC_ID_UNLABELLED],
+        _RESERVED_INSTANCE_LABELS[BACKGROUND_ID],
+        _RESERVED_INSTANCE_LABELS[UNLABELLED_ID],
     ]
     semantics: list[dict[str, str]] = [
-        _RESERVED_SEMANTIC_LABELS[_SEMANTIC_ID_BACKGROUND],
-        _RESERVED_SEMANTIC_LABELS[_SEMANTIC_ID_UNLABELLED],
+        _RESERVED_SEMANTIC_LABELS[BACKGROUND_ID],
+        _RESERVED_SEMANTIC_LABELS[UNLABELLED_ID],
     ]
     for index, (stable_id, semantic_id) in enumerate(stable_id_semantic_id_map):
         pixel_ids.append(index + _NUM_RESERVED_IDS)
         # Fall back to UNLABELLED when a stable/semantic ID is missing from its map (defensive; the producer
         # only emits pixel IDs >= 2 for labelled prims, so both lookups are expected to hit).
-        prim_paths.append(stable_id_to_path.get(stable_id, _RESERVED_INSTANCE_LABELS[_SEMANTIC_ID_UNLABELLED]))
-        semantics.append(semantic_id_to_labels.get(semantic_id, _RESERVED_SEMANTIC_LABELS[_SEMANTIC_ID_UNLABELLED]))
+        prim_paths.append(stable_id_to_path.get(stable_id, _RESERVED_INSTANCE_LABELS[UNLABELLED_ID]))
+        semantics.append(semantic_id_to_labels.get(semantic_id, _RESERVED_SEMANTIC_LABELS[UNLABELLED_ID]))
 
     keys = _color_keys_for_ids(pixel_ids, device) if colorize else [str(pixel_id) for pixel_id in pixel_ids]
     id_to_labels = {key: prim_paths[idx] for idx, key in enumerate(keys)}

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
@@ -9,6 +9,9 @@ from typing import Any
 
 import warp as wp
 
+# Segmentation colorization is shared across renderer backends to keep colors visually consistent.
+from isaaclab.renderers.segmentation_colors import random_color_from_id_wp
+
 
 @wp.kernel
 def create_camera_transforms_kernel(
@@ -157,119 +160,6 @@ def extract_depth_tile_from_tiled_buffer_kernel(
     tile_buffer[y, x, 0] = tiled_buffer[src_y, src_x]
 
 
-@wp.func
-def color_hash(seed: wp.uint32) -> wp.uint32:
-    """MurmurHash3-style 32-bit finalizer, matching omni.replicator's ``randomColoursCPU``.
-
-    The arithmetic is intentionally done in ``uint32`` so the multiplications overflow and truncate to
-    32 bits (modular arithmetic). This wraparound is load-bearing: the reference implementation relies on
-    it, and computing the hash in a wider type (e.g. ``uint64``) yields different bits and therefore
-    different colors, breaking parity with Replicator / Isaac RTX colorized segmentation.
-    """
-    h = seed
-    h = h ^ (h >> wp.uint32(16))
-    h = h * wp.uint32(0x85EBCA6B)
-    h = h ^ (h >> wp.uint32(13))
-    h = h * wp.uint32(0xC2B2AE35)
-    h = h ^ (h >> wp.uint32(16))
-    return h
-
-
-@wp.func
-def random_color_from_id(input_id: wp.uint32) -> wp.uint32:
-    """Generate random color from a single ID.
-
-    Generate visually distinct colours by linearly spacing the hue channel in HSV space and then convert to RGB space.
-
-    Args:
-        input_id: uint32 semantic ID
-
-    Returns:
-        uint32 color: ``r | (g<<8) | (b<<16) | (a<<24)``
-    """
-    if input_id == wp.uint32(0):
-        # BACKGROUND special case
-        return wp.uint32(0)
-    if input_id == wp.uint32(1):
-        # UNLABELLED special case
-        return wp.uint32(0xFF000000)
-
-    hash_val = color_hash(input_id)
-
-    # Golden ratio inverse = 1.0 / 1.618033988749895 (Replicator constant)
-    GOLDEN_RATIO_INV = wp.float64(1.0) / wp.float64(1.618033988749895)
-
-    # Use golden ratio spacing for maximum hue spread
-    hue_tmp = wp.float64(input_id) * GOLDEN_RATIO_INV
-    hue = hue_tmp - wp.floor(hue_tmp)
-
-    # Add hash-based perturbation for better distribution
-    hue_perturbation = wp.float64(hash_val & wp.uint32(0xFFFF)) / wp.float64(65536.0)
-    hue_tmp = hue + hue_perturbation * wp.float64(0.1)
-    hue = hue_tmp - wp.floor(hue_tmp)
-
-    # Use hash to determine saturation and value for maximum spread
-    sat_part = wp.uint32((hash_val >> wp.uint32(16)) & wp.uint32(0xFF))
-    val_part = wp.uint32((hash_val >> wp.uint32(8)) & wp.uint32(0xFF))
-
-    # Saturation: 0.7 to 1.0 for vibrant colors
-    saturation = wp.float64(0.7) + wp.float64(0.3) * (wp.float64(sat_part) / wp.float64(255.0))
-
-    # Value: 0.8 to 1.0 for bright colors
-    value = wp.float64(0.8) + wp.float64(0.2) * (wp.float64(val_part) / wp.float64(255.0))
-
-    # HSV to RGB conversion (match Replicator: ``f`` uses pre-modulo ``int(hue*6)``, then ``i %= 6``).
-    hue_i = wp.int32(hue * wp.float64(6.0))
-    hue_f = hue * wp.float64(6.0) - wp.float64(hue_i)
-    p = value * (wp.float64(1.0) - saturation)
-    q = value * (wp.float64(1.0) - saturation * hue_f)
-    t = value * (wp.float64(1.0) - saturation * (wp.float64(1.0) - hue_f))
-
-    r = wp.float64(0.0)
-    g = wp.float64(0.0)
-    b = wp.float64(0.0)
-
-    hue_i = hue_i % 6
-
-    if hue_i == 0:
-        r = value
-        g = t
-        b = p
-    elif hue_i == 1:
-        r = q
-        g = value
-        b = p
-    elif hue_i == 2:
-        r = p
-        g = value
-        b = t
-    elif hue_i == 3:
-        r = p
-        g = q
-        b = value
-    elif hue_i == 4:
-        r = t
-        g = p
-        b = value
-    else:
-        r = value
-        g = p
-        b = q
-
-    ri = wp.min(255, wp.max(0, wp.int32(r * wp.float64(255.0))))
-    gi = wp.min(255, wp.max(0, wp.int32(g * wp.float64(255.0))))
-    bi = wp.min(255, wp.max(0, wp.int32(b * wp.float64(255.0))))
-    ai = wp.int32(255)
-
-    color = (
-        wp.uint32(ri)
-        | (wp.uint32(gi) << wp.uint32(8))
-        | (wp.uint32(bi) << wp.uint32(16))
-        | (wp.uint32(ai) << wp.uint32(24))
-    )
-    return color
-
-
 @wp.kernel
 def generate_random_colors_from_ids_kernel(
     input_ids: wp.array(dtype=wp.uint32, ndim=3),  # type: ignore
@@ -282,7 +172,7 @@ def generate_random_colors_from_ids_kernel(
         output_colors: 3D uint32 array for colors per pixel; each word is ``r | (g<<8) | (b<<16) | (a<<24)``.
     """
     i, j, k = wp.tid()
-    output_colors[i, j, k] = random_color_from_id(input_ids[i, j, k])
+    output_colors[i, j, k] = random_color_from_id_wp(input_ids[i, j, k])
 
 
 @wp.kernel

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py
@@ -5,8 +5,6 @@
 
 """Unit tests for OVRTX renderer kernels."""
 
-import math
-
 import numpy as np
 import pytest
 import warp as wp
@@ -15,62 +13,9 @@ from isaaclab_ov.renderers.ovrtx_renderer_kernels import (
     generate_random_colors_from_ids_kernel,
 )
 
+from isaaclab.renderers.segmentation_colors import pack_rgba, random_color_from_id
+
 DEVICE = "cuda:0"
-
-
-def _color_hash(seed: int) -> int:
-    # MurmurHash3-style 32-bit finalizer with wraparound, matching color_hash in ovrtx_renderer_kernels
-    # and omni.replicator's randomColoursCPU. The 32-bit truncation (0xFFFFFFFF masks) is load-bearing.
-    mask = 0xFFFFFFFF
-    h = seed & mask
-    h ^= h >> 16
-    h = (h * 0x85EBCA6B) & mask
-    h ^= h >> 13
-    h = (h * 0xC2B2AE35) & mask
-    h ^= h >> 16
-    return h & mask
-
-
-def _random_colours_id(input_id: int) -> tuple[int, int, int, int]:
-    GOLDEN_RATIO_INV = 1.0 / 1.618033988749895
-
-    hash_val = _color_hash(input_id)
-    hue = math.fmod(input_id * GOLDEN_RATIO_INV, 1.0)
-    hue_perturbation = (hash_val & 0xFFFF) / 65536.0
-    hue = math.fmod(hue + hue_perturbation * 0.1, 1.0)
-    sat_hash = hash_val >> 16
-    val_hash = hash_val >> 8
-    saturation = 0.7 + 0.3 * ((sat_hash & 0xFF) / 255.0)
-    value = 0.8 + 0.2 * ((val_hash & 0xFF) / 255.0)
-    i = int(hue * 6.0)
-    f = (hue * 6.0) - i
-    p = value * (1.0 - saturation)
-    q = value * (1.0 - saturation * f)
-    t = value * (1.0 - saturation * (1.0 - f))
-    i = i % 6
-    if i == 0:
-        r, g, b = value, t, p
-    elif i == 1:
-        r, g, b = q, value, p
-    elif i == 2:
-        r, g, b = p, value, t
-    elif i == 3:
-        r, g, b = p, q, value
-    elif i == 4:
-        r, g, b = t, p, value
-    else:
-        r, g, b = value, p, q
-    return (int(r * 255), int(g * 255), int(b * 255), 255)
-
-
-def _reference_color(input_id: int) -> int:
-    if input_id == 0:
-        return 0
-    if input_id == 1:
-        return 0xFF000000
-
-    r, g, b, a = _random_colours_id(input_id)
-    return r | (g << 8) | (b << 16) | (a << 24)
 
 
 def _reference_extract_all_depth_tiles(
@@ -561,83 +506,41 @@ class TestExtractAllRgbFloatTilesKernel:
         np.testing.assert_allclose(output_wp.numpy(), expected, rtol=0, atol=0)
 
 
-class TestRandomColorsFromIdsKernel:
-    """Tests for generate_random_colors_from_ids_kernel."""
+@pytest.mark.skipif(not wp.is_cuda_available(), reason="CUDA not available")
+class TestGenerateRandomColorsFromIdsKernel:
+    """generate_random_colors_from_ids_kernel agrees with the shared segmentation_colors reference."""
 
-    def test_random_colors(self):
-        inputs_np = np.array([[[0], [1]], [[2], [3]]], dtype=np.uint32)
-        input_ids = wp.array(inputs_np, dtype=wp.uint32, ndim=3, device=DEVICE)
-        output_colors = wp.zeros(shape=inputs_np.shape, dtype=wp.uint32, device=DEVICE)
-
-        wp.launch(
-            kernel=generate_random_colors_from_ids_kernel,
-            dim=inputs_np.shape,
-            inputs=[input_ids, output_colors],
-            device=DEVICE,
-        )
+    def _launch(self, ids_np: np.ndarray) -> np.ndarray:
+        ids_wp = wp.array(ids_np, dtype=wp.uint32, device=DEVICE)
+        out_wp = wp.zeros(ids_np.shape, dtype=wp.uint32, device=DEVICE)
+        wp.launch(generate_random_colors_from_ids_kernel, dim=ids_np.shape, inputs=[ids_wp, out_wp], device=DEVICE)
         wp.synchronize()
+        return out_wp.numpy()
 
-        out_np = output_colors.numpy()
-        for (i, j, k), input_id in np.ndenumerate(inputs_np):
-            input_id = int(np.uint32(input_id))
-            ref_color = _reference_color(input_id)
-            out_color = int(out_np[i, j, k])
-            assert out_color == ref_color, (
-                f"At ({i},{j},{k}) id={input_id}: expected 0x{ref_color:08x}, got 0x{out_color:08x}"
+    def test_matches_host_reference(self):
+        """Output matches pack_rgba(random_color_from_id(id)) for a small grid of ids."""
+        ids_np = np.array([[[0], [1]], [[2], [3]]], dtype=np.uint32)
+        out_np = self._launch(ids_np)
+        for (i, j, k), input_id in np.ndenumerate(ids_np):
+            expected = pack_rgba(random_color_from_id(int(np.uint32(input_id))))
+            assert int(out_np[i, j, k]) == expected, (
+                f"At ({i},{j},{k}) id={input_id}: expected 0x{expected:08x}, got 0x{int(out_np[i, j, k]):08x}"
             )
 
     def test_deterministic_across_launches(self):
-        shape = (4, 4, 1)
+        """Two launches with the same input produce identical output."""
         rng = np.random.default_rng(42)
-        inputs_np = rng.integers(0, 2**31, size=shape, dtype=np.uint32)
-        input_ids = wp.array(inputs_np, dtype=wp.uint32, ndim=3, device=DEVICE)
-        output_colors = wp.zeros(shape=shape, dtype=wp.uint32, device=DEVICE)
+        ids_np = rng.integers(0, 2**31, size=(4, 4, 1), dtype=np.uint32)
+        first = self._launch(ids_np).copy()
+        second = self._launch(ids_np)
+        np.testing.assert_array_equal(first, second)
 
-        wp.launch(
-            kernel=generate_random_colors_from_ids_kernel,
-            dim=shape,
-            inputs=[input_ids, output_colors],
-            device=DEVICE,
-        )
-        wp.synchronize()
-        first_run = output_colors.numpy().copy()
-
-        wp.launch(
-            kernel=generate_random_colors_from_ids_kernel,
-            dim=shape,
-            inputs=[input_ids, output_colors],
-            device=DEVICE,
-        )
-        wp.synchronize()
-        second_run = output_colors.numpy()
-
-        np.testing.assert_array_equal(first_run, second_run)
-
-    @pytest.mark.parametrize(
-        "input_value",
-        [
-            0,
-            1,
-            2,
-            3,
-            100,
-        ],
-    )
+    @pytest.mark.parametrize("input_value", [0, 1, 2, 3, 100])
     def test_single_value(self, input_value):
-        inputs_np = np.array([[[input_value]]], dtype=np.uint32)
-        input_ids = wp.array(inputs_np, dtype=wp.uint32, ndim=3, device=DEVICE)
-        output_colors = wp.zeros(shape=(1, 1, 1), dtype=wp.uint32, device=DEVICE)
-
-        wp.launch(
-            kernel=generate_random_colors_from_ids_kernel,
-            dim=(1, 1, 1),
-            inputs=[input_ids, output_colors],
-            device=DEVICE,
-        )
-        wp.synchronize()
-
-        ref_color = _reference_color(int(np.uint32(input_value)))
-        out_color = int(output_colors.numpy()[0, 0, 0])
-        assert out_color == ref_color, (
-            f"id=0x{int(np.uint32(input_value)):08x}: expected 0x{ref_color:08x}, got 0x{out_color:08x}"
+        ids_np = np.array([[[input_value]]], dtype=np.uint32)
+        out_np = self._launch(ids_np)
+        expected = pack_rgba(random_color_from_id(int(np.uint32(input_value))))
+        out_color = int(out_np[0, 0, 0])
+        assert out_color == expected, (
+            f"id=0x{int(np.uint32(input_value)):08x}: expected 0x{expected:08x}, got 0x{out_color:08x}"
         )

--- a/source/isaaclab_tasks/changelog.d/newton-warp-segmentation.skip
+++ b/source/isaaclab_tasks/changelog.d/newton-warp-segmentation.skip
@@ -1,0 +1,6 @@
+Test-only: extended the rendering correctness tests to cover the Newton Warp renderer's
+semantic_segmentation, instance_segmentation_fast and instance_id_segmentation_fast camera
+data types.
+
+Also updated the Newton Warp supported-data-type sets in the dexsuite and shadow_hand camera
+env configs' validate_config checks to accept the three segmentation data types.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/dexsuite_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/dexsuite_env_cfg.py
@@ -513,7 +513,15 @@ class DexsuiteReorientEnvCfg(ManagerBasedRLEnvCfg):
     def validate_config(self):
         """Check for invalid preset combinations after resolution."""
 
-        warp_supported = {"rgb", "depth", "distance_to_camera", "distance_to_image_plane", "normals"}
+        warp_supported = {
+            "rgb",
+            "depth",
+            "distance_to_camera",
+            "distance_to_image_plane",
+            "normals",
+            "semantic_segmentation",
+            "instance_segmentation_fast",
+        }
         for cam_attr in ("base_camera", "wrist_camera"):
             cam = getattr(self.scene, cam_attr, None)
             if cam is None:

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_camera_env_cfg.py
@@ -124,7 +124,15 @@ class ShadowHandCameraEnvCfg(ShadowHandEnvCfg):
     def validate_config(self):
         """Check renderer/data-type and feature-extractor compatibility."""
         renderer_type = getattr(self.tiled_camera.renderer_cfg, "renderer_type", None)
-        warp_supported = {"rgb", "depth", "distance_to_camera", "distance_to_image_plane", "normals"}
+        warp_supported = {
+            "rgb",
+            "depth",
+            "distance_to_camera",
+            "distance_to_image_plane",
+            "normals",
+            "semantic_segmentation",
+            "instance_segmentation_fast",
+        }
         if renderer_type == "newton_warp":
             unsupported = set(self.tiled_camera.data_types) - warp_supported
             if unsupported:

--- a/source/isaaclab_tasks/test/core/test_shadow_hand_camera_presets.py
+++ b/source/isaaclab_tasks/test/core/test_shadow_hand_camera_presets.py
@@ -83,10 +83,11 @@ _VALID_COMBOS = [
     pytest.param("ovrtx", ["rgb"], True, marks=pytest.mark.skip(reason="OVRTX testing disabled")),
     pytest.param("ovrtx", ["albedo"], True, marks=pytest.mark.skip(reason="OVRTX testing disabled")),
     pytest.param("ovrtx", ["depth"], False, marks=pytest.mark.skip(reason="OVRTX testing disabled")),
-    # ── Warp renderer: only rgb and depth are supported ──
+    # ── Warp renderer: rgb, depth, and semantic_segmentation are supported ──
     ("newton_warp", ["rgb"], True),
     ("newton_warp", ["depth"], False),  # depth-only OK when CNN disabled
     ("newton_warp", ["rgb", "depth"], True),  # multiple supported types
+    ("newton_warp", ["rgb", "depth", "semantic_segmentation"], True),
 ]
 
 
@@ -126,12 +127,6 @@ _INVALID_COMBOS = [
         ["simple_shading_full_mdl"],
         True,
         "simple_shading_full_mdl",
-    ),
-    (
-        "newton_warp",
-        ["rgb", "depth", "semantic_segmentation"],
-        True,
-        "semantic_segmentation",
     ),
     # ── Depth-only with CNN enabled is not valid for training ──
     (
@@ -277,10 +272,8 @@ def test_all_renderer_presets_present(shadow_hand_camera_presets):
 # when paired with the warp renderer preset
 # ---------------------------------------------------------------------------
 
-_WARP_VALID_CAMERA_PRESETS = ["rgb", "depth"]
+_WARP_VALID_CAMERA_PRESETS = ["rgb", "depth", "default", "full"]
 _WARP_INVALID_CAMERA_PRESETS = [
-    "default",
-    "full",
     "albedo",
     "simple_shading_constant_diffuse",
     "simple_shading_diffuse_mdl",
@@ -290,7 +283,7 @@ _WARP_INVALID_CAMERA_PRESETS = [
 
 @pytest.mark.parametrize("camera_preset", _WARP_VALID_CAMERA_PRESETS)
 def test_warp_with_valid_camera_preset(shadow_hand_camera_presets, camera_preset):
-    """Warp + {rgb, depth} camera presets must not raise (depth with CNN disabled)."""
+    """Warp + supported camera presets must not raise (depth-only with CNN disabled)."""
     camera_cfg = shadow_hand_camera_presets["tiled_camera"][camera_preset]
     warp_cfg = shadow_hand_camera_presets["tiled_camera.renderer_cfg"]["newton_renderer"]
     enabled = camera_cfg.data_types != ["depth"]  # disable CNN for depth-only

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a61b7fa453e59dbc33e59c35ca36ed3ae29050cffd5adf5f206141d662876d14
+size 481

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d38538c38906a217cc36c7ebc6e2a94d98a9c79dce2126a02383c30819ea1fa
+size 433

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a61b7fa453e59dbc33e59c35ca36ed3ae29050cffd5adf5f206141d662876d14
+size 481

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d38538c38906a217cc36c7ebc6e2a94d98a9c79dce2126a02383c30819ea1fa
+size 433

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a61b7fa453e59dbc33e59c35ca36ed3ae29050cffd5adf5f206141d662876d14
+size 481

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d38538c38906a217cc36c7ebc6e2a94d98a9c79dce2126a02383c30819ea1fa
+size 433

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d09ddafa5b21f333ee65f9ab86bf9eb99481525480380d77c765229a92e19973
+size 732

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d09ddafa5b21f333ee65f9ab86bf9eb99481525480380d77c765229a92e19973
+size 732

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96895c3f87211009ddefbf0aa5f143bf2a0c107a7fb050491533b1ae0af1bc55
+size 737

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/physx-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96895c3f87211009ddefbf0aa5f143bf2a0c107a7fb050491533b1ae0af1bc55
+size 737

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:000fb2b759ecb6c06afb34b9fd5149e714976a7b4cde1fa5103877f8f12d4412
+size 726

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:000fb2b759ecb6c06afb34b9fd5149e714976a7b4cde1fa5103877f8f12d4412
+size 726

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d25387bbd7203a4eb231bd757f2065805b71565d096cf3045801f840ca552ef9
+size 724

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/physx-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d25387bbd7203a4eb231bd757f2065805b71565d096cf3045801f840ca552ef9
+size 724

--- a/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0099f828e8434faab832d3b033095382f847891783ec438ba1cc53127e72309
+size 1843

--- a/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0099f828e8434faab832d3b033095382f847891783ec438ba1cc53127e72309
+size 1843

--- a/source/isaaclab_tasks/test/golden_images/franka_soft/newton-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_soft/newton-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e96614a9cfe79aa4b73bc0c9a87dd4e2cadb5309a238c445d678367555f4310e
+size 1753

--- a/source/isaaclab_tasks/test/golden_images/franka_soft/newton-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_soft/newton-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e96614a9cfe79aa4b73bc0c9a87dd4e2cadb5309a238c445d678367555f4310e
+size 1753

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14a57fd90a28f14c81076e9dc45fdbe30c747b3ff9adc441df1358afc56c1dc1
+size 1470

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9714b89ec649ab4f2b837992f517df83631ea2122a237af944aa9493039b3e26
+size 1424

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-newton_renderer-instance_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-newton_renderer-instance_segmentation_fast.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb406cc5cb329fd10394fddfb9e0fbc8ea0e118410afdceaa586345e4b4e784b
+size 1543

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-newton_renderer-semantic_segmentation.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-newton_renderer-semantic_segmentation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a636738ac79d72991f8961dbac43f6440b16460416eea6dc9c115ed63032112
+size 1482

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -139,6 +139,8 @@ _NEWTON_WARP_DATA_TYPES = (
     "distance_to_camera",
     "distance_to_image_plane",
     "normals",
+    "semantic_segmentation",
+    "instance_segmentation_fast",
 )
 
 # Data types the OVRTX renderer supports. ``instance_id_segmentation_fast`` is intentionally


### PR DESCRIPTION
# Description

Bring the segmentation annotators (`semantic_segmentation`,  `instance_segmentation_fast`) in the Newton Warp renderer integration to full parity with what the Isaac RTX renderer provides.  This includes producing the idToLabels and/or idToSemantics dicts for mapping segmented IDs/colors to their respective prim path or semantic label.

The main difference between supporting segmentation annotators for Newton warp vs ovrtx is that the Newton model only tracks the prim paths for each shape but not their semantic labels.   So via the NewtonModel.shape_label array and its USD stage, we build the mappings from shape_index -> semantics upfront.  Then there are warp kernels that process the shape index image into either an ID map or colorized map (see new golden images).  All this logic is encapsulated in the new `isaaclab_newton/renderers/segmentation.py` module.

Light refactoring was done to share common variables / logic for around segmentation and colorization between the ovrtx and newton renderer integrations.

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Screenshots

See golden images

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

