### PR TITLE
Optimize Newton Ant direct stepping

### DIFF
--- a/source/isaaclab/changelog.d/ant-direct-device-mask-reset.rst
+++ b/source/isaaclab/changelog.d/ant-direct-device-mask-reset.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added a protected direct-environment hook for backend-native device-mask resets.

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -470,17 +470,8 @@ class DirectRLEnv(gym.Env):
         self.reward_buf = self._get_rewards()
 
         # -- reset envs that terminated/timed-out and log the episode information
-        reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1).int()
-        if len(reset_env_ids) > 0:
-            # capture the terminal observation before reset and expose it for Same-Step autoreset.
-            # apply the same observation noise as the returned obs (policy space only) so the
-            # bootstrapped terminal value matches the distribution the policy is trained on.
-            if self.cfg.compute_final_obs:
-                terminal_obs = self._get_observations()
-                if self.cfg.observation_noise_model:
-                    terminal_obs["policy"] = self._observation_noise_model(terminal_obs["policy"])
-                self.extras["final_obs"] = terminal_obs
-            self._reset_idx(reset_env_ids)
+        reset_env_ids = self._reset_envs_from_buffer()
+        if reset_env_ids is not None and len(reset_env_ids) > 0:
             # if sensors are added to the scene, make sure we render to reflect changes in reset
             if self.render_enabled and is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):
@@ -670,6 +661,31 @@ class DirectRLEnv(gym.Env):
 
         # instantiate actions (needed for tasks for which the observations computation is dependent on the actions)
         self.actions = sample_space(self.single_action_space, self.sim.device, batch_size=self.num_envs, fill_value=0)
+
+    def _reset_envs_from_buffer(self) -> torch.Tensor | None:
+        """Reset environments marked in the reset buffer.
+
+        The default implementation compacts the reset mask into environment indices. CUDA
+        environments synchronize while determining the dynamic output size of
+        ``torch.Tensor.nonzero``. Tasks with backend-native mask reset support may
+        override this hook and return None to avoid that synchronization.
+
+        Returns:
+            Reset environment indices, or None when an override completed reset
+            processing without materializing host-visible indices.
+        """
+        reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1).int()
+        if len(reset_env_ids) > 0:
+            # capture the terminal observation before reset and expose it for Same-Step autoreset.
+            # apply the same observation noise as the returned obs (policy space only) so the
+            # bootstrapped terminal value matches the distribution the policy is trained on.
+            if self.cfg.compute_final_obs:
+                terminal_obs = self._get_observations()
+                if self.cfg.observation_noise_model:
+                    terminal_obs["policy"] = self._observation_noise_model(terminal_obs["policy"])
+                self.extras["final_obs"] = terminal_obs
+            self._reset_idx(reset_env_ids)
+        return reset_env_ids
 
     def _reset_idx(self, env_ids: Sequence[int]):
         """Reset environments based on specified indices.

--- a/source/isaaclab/test/envs/test_direct_rl_env_reset_hook.py
+++ b/source/isaaclab/test/envs/test_direct_rl_env_reset_hook.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from isaaclab.envs import DirectRLEnv
+
+
+def test_default_reset_hook_preserves_index_reset() -> None:
+    env = object.__new__(DirectRLEnv)
+    env._is_closed = True
+    env.reset_buf = torch.tensor([False, True, False, True])
+    env.cfg = SimpleNamespace(compute_final_obs=False)
+    reset_calls = []
+    env._reset_idx = lambda env_ids: reset_calls.append(env_ids.clone())
+
+    reset_env_ids = env._reset_envs_from_buffer()
+
+    torch.testing.assert_close(reset_env_ids, torch.tensor([1, 3], dtype=torch.int32))
+    assert len(reset_calls) == 1
+    torch.testing.assert_close(reset_calls[0], reset_env_ids)
+
+
+def test_default_reset_hook_preserves_final_observation() -> None:
+    env = object.__new__(DirectRLEnv)
+    env._is_closed = True
+    env.reset_buf = torch.tensor([False, True])
+    env.cfg = SimpleNamespace(compute_final_obs=True, observation_noise_model=object())
+    env.extras = {}
+    env._get_observations = lambda: {"policy": torch.tensor([[1.0], [2.0]])}
+    env._observation_noise_model = lambda observation: observation + 0.5
+    reset_calls = []
+    env._reset_idx = lambda env_ids: reset_calls.append(env_ids.clone())
+
+    reset_env_ids = env._reset_envs_from_buffer()
+
+    torch.testing.assert_close(env.extras["final_obs"]["policy"], torch.tensor([[1.5], [2.5]]))
+    assert len(reset_calls) == 1
+    torch.testing.assert_close(reset_calls[0], reset_env_ids)

--- a/source/isaaclab_newton/changelog.d/ant-direct-wrench-overhead.rst
+++ b/source/isaaclab_newton/changelog.d/ant-direct-wrench-overhead.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed unnecessary wrench-buffer resets when Newton articulations had no instantaneous wrenches.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -297,7 +297,8 @@ class Articulation(BaseArticulation):
                     self._ALL_BODY_MASK,
                 ],
             )
-        self._instantaneous_wrench_composer.reset()
+        if self._instantaneous_wrench_composer.active:
+            self._instantaneous_wrench_composer.reset()
 
         if getattr(self, "_has_newton_actuators", False):
             # Raw targets go directly to Newton's control object. Newton PD

--- a/source/isaaclab_newton/test/assets/test_articulation_write_data.py
+++ b/source/isaaclab_newton/test/assets/test_articulation_write_data.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ignore private usage of variables warning
+# pyright: reportPrivateUsage=none
+
+"""Tests for Newton articulation simulation writes."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from isaaclab_newton.assets.articulation.articulation import Articulation
+
+
+@pytest.fixture
+def articulation() -> Articulation:
+    """Create an articulation shell with mocked simulation bindings."""
+    articulation = object.__new__(Articulation)
+    articulation._instantaneous_wrench_composer = MagicMock()
+    articulation._permanent_wrench_composer = MagicMock()
+    articulation._data = SimpleNamespace(
+        _joint_pos_target=MagicMock(),
+        _joint_vel_target=MagicMock(),
+        _joint_effort_target=MagicMock(),
+        _sim_bind_joint_position_target=MagicMock(),
+        _sim_bind_joint_velocity_target=MagicMock(),
+        _sim_bind_joint_act=MagicMock(),
+        _sim_bind_joint_effort=MagicMock(),
+        _sim_bind_body_external_wrench=MagicMock(),
+    )
+    articulation._has_newton_actuators = True
+    articulation._device = "cpu"
+    articulation._root_view = SimpleNamespace(count=2, link_count=3)
+    articulation._ALL_ENV_MASK = MagicMock()
+    articulation._ALL_BODY_MASK = MagicMock()
+    articulation._initialize_handle = None
+    articulation._invalidate_initialize_handle = None
+    articulation._prim_deletion_handle = None
+    articulation._debug_vis_handle = None
+    articulation._physics_ready_handle = None
+    return articulation
+
+
+def test_write_data_to_sim_skips_inactive_instantaneous_wrench_reset(articulation: Articulation):
+    """Test that an inactive instantaneous wrench composer is not reset."""
+    articulation._instantaneous_wrench_composer.active = False
+    articulation._permanent_wrench_composer.active = False
+
+    articulation.write_data_to_sim()
+
+    articulation._instantaneous_wrench_composer.reset.assert_not_called()
+
+
+@patch("isaaclab_newton.assets.articulation.articulation.wp.launch")
+def test_write_data_to_sim_clears_active_instantaneous_wrenches(launch: MagicMock, articulation: Articulation):
+    """Test that active instantaneous wrenches are applied once and then cleared."""
+    articulation._instantaneous_wrench_composer.active = True
+    articulation._permanent_wrench_composer.active = True
+
+    articulation.write_data_to_sim()
+
+    launch.assert_called_once()
+    articulation._instantaneous_wrench_composer.add_raw_buffers_from.assert_called_once_with(
+        articulation._permanent_wrench_composer
+    )
+    articulation._instantaneous_wrench_composer.compose_to_body_frame.assert_called_once_with()
+    articulation._instantaneous_wrench_composer.reset.assert_called_once_with()
+    articulation._permanent_wrench_composer.reset.assert_not_called()
+
+
+@patch("isaaclab_newton.assets.articulation.articulation.wp.launch")
+def test_write_data_to_sim_preserves_permanent_wrenches(launch: MagicMock, articulation: Articulation):
+    """Test that permanent wrenches are applied without resetting either composer."""
+    articulation._instantaneous_wrench_composer.active = False
+    articulation._permanent_wrench_composer.active = True
+
+    articulation.write_data_to_sim()
+
+    launch.assert_called_once()
+    articulation._permanent_wrench_composer.compose_to_body_frame.assert_called_once_with()
+    articulation._instantaneous_wrench_composer.reset.assert_not_called()
+    articulation._permanent_wrench_composer.reset.assert_not_called()

--- a/source/isaaclab_tasks/changelog.d/ant-direct-reset-overhead.rst
+++ b/source/isaaclab_tasks/changelog.d/ant-direct-reset-overhead.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Reduced direct locomotion step and reset overhead by staging actions once per environment step,
+  avoiding duplicate articulation resets, redundant state copies, and separate joint-state writes.
+* Reduced Ant Direct step overhead by fusing Newton post-processing and using device-mask resets.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env.py
@@ -5,7 +5,14 @@
 
 from __future__ import annotations
 
+import torch
+import warp as wp
+from isaaclab_newton.physics import NewtonCfg
+
+from isaaclab.actuators import ImplicitActuator
+
 from isaaclab_tasks.core.locomotion.ant.ant_direct_env_cfg import AntEnvCfg
+from isaaclab_tasks.core.locomotion.ant.ant_post_step import _AntPostStepBuffers
 from isaaclab_tasks.core.locomotion.locomotion_direct_env import LocomotionDirectEnv
 
 
@@ -16,3 +23,101 @@ class AntEnv(LocomotionDirectEnv):
 
     def __init__(self, cfg: AntEnvCfg, render_mode: str | None = None, **kwargs):
         super().__init__(cfg, render_mode, **kwargs)
+        self._use_fused_post_step = self._supports_fused_post_step()
+        if not self._use_fused_post_step:
+            return
+
+        # Cache zero-copy state views once. The backing simulation arrays remain stable
+        # for the lifetime of the environment.
+        self.torso_position = self.robot.data.root_pos_w.torch
+        self.torso_rotation = self.robot.data.root_quat_w.torch
+        self.velocity = self.robot.data.root_lin_vel_w.torch
+        self.ang_velocity = self.robot.data.root_ang_vel_w.torch
+        self.dof_pos = self.robot.data.joint_pos.torch
+        self.dof_vel = self.robot.data.joint_vel.torch
+        self._joint_position_limits = self.robot.data.soft_joint_pos_limits.warp
+
+        self._post_step_buffers = _AntPostStepBuffers(
+            num_envs=self.num_envs,
+            num_joints=self.robot.num_joints,
+            observation_size=self.cfg.observation_space,
+            device=self.device,
+        )
+        self._post_step_buffers.bind_environment_outputs(self)
+        self._default_root_pose_w_torch = self.robot.data.default_root_pose.torch.clone()
+        self._default_root_pose_w_torch[:, :3] += self.scene.env_origins
+        self._default_root_pose_w = wp.from_torch(self._default_root_pose_w_torch, dtype=wp.transformf)
+
+    def _compute_intermediate_values(self) -> None:
+        if not self._use_fused_post_step:
+            return super()._compute_intermediate_values()
+        self._post_step_buffers.compute_intermediate_and_observation(self)
+        return None
+
+    def _get_observations(self) -> dict[str, torch.Tensor]:
+        if not self._use_fused_post_step:
+            return super()._get_observations()
+        return {"policy": self._post_step_buffers.observation_torch}
+
+    def _get_rewards(self) -> torch.Tensor:
+        if not self._use_fused_post_step:
+            return super()._get_rewards()
+        return self._post_step_buffers.reward_torch
+
+    def _get_dones(self) -> tuple[torch.Tensor, torch.Tensor]:
+        if not self._use_fused_post_step:
+            return super()._get_dones()
+        self._post_step_buffers.compute_post_step(self)
+        return self._post_step_buffers.terminated_torch, self._post_step_buffers.time_out_torch
+
+    def _reset_envs_from_buffer(self) -> torch.Tensor | None:
+        if not self._supports_mask_reset():
+            return super()._reset_envs_from_buffer()
+
+        env_mask = wp.from_torch(self.reset_buf)
+        self._reset_idx_mask(env_mask)
+        return None
+
+    def _supports_mask_reset(self) -> bool:
+        """Return whether the current Ant configuration supports synchronization-free mask resets."""
+        return (
+            self._use_fused_post_step
+            and not getattr(self.robot, "_has_newton_actuators", False)
+            and all(isinstance(actuator, ImplicitActuator) for actuator in self.robot.actuators.values())
+            and not self.cfg.events
+            and not self.cfg.action_noise_model
+            and not self.cfg.observation_noise_model
+            and not (self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0)
+        )
+
+    def _supports_fused_post_step(self) -> bool:
+        """Return whether state views and terminal outputs can safely use the fused Newton path."""
+        return isinstance(self.cfg.sim.physics, NewtonCfg) and not self.cfg.compute_final_obs
+
+    def _reset_idx_mask(self, env_mask: wp.array(dtype=wp.bool)) -> None:
+        """Reset Newton Ant environments selected by a boolean device mask."""
+        reset_count = self.reset_buf.sum()
+        survived_count = torch.logical_and(self.reset_time_outs, self.reset_buf).sum()
+        success_rate = survived_count.float() / reset_count.clamp_min(1)
+        log = self.extras.setdefault("log", {})
+        previous_success_rate = log.get("Metrics/success_rate", torch.zeros((), device=self.device))
+        if not isinstance(previous_success_rate, torch.Tensor):
+            previous_success_rate = torch.tensor(previous_success_rate, device=self.device)
+        log["Metrics/success_rate"] = torch.where(reset_count > 0, success_rate, previous_success_rate)
+
+        # Ant uses stateless implicit actuators, so only its wrench buffers need reset.
+        if self.robot.instantaneous_wrench_composer.active:
+            self.robot.instantaneous_wrench_composer.reset(env_mask=env_mask)
+        if self.robot.permanent_wrench_composer.active:
+            self.robot.permanent_wrench_composer.reset(env_mask=env_mask)
+        self.robot.write_root_pose_to_sim_mask(root_pose=self._default_root_pose_w, env_mask=env_mask)
+        self.robot.write_root_velocity_to_sim_mask(
+            root_velocity=self.robot.data.default_root_vel.warp,
+            env_mask=env_mask,
+        )
+        self.robot.write_joint_state_to_sim_mask(
+            position=self.robot.data.default_joint_pos.warp,
+            velocity=self.robot.data.default_joint_vel.warp,
+            env_mask=env_mask,
+        )
+        self._post_step_buffers.compute_masked_reset_observation(self, env_mask)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_post_step.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_post_step.py
@@ -1,0 +1,575 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import warp as wp
+
+
+@wp.func
+def _quat_apply_xyzw(quat: wp.vec4f, vector: wp.vec3f) -> wp.vec3f:
+    quat_xyz = wp.vec3f(quat[0], quat[1], quat[2])
+    cross = 2.0 * wp.cross(quat_xyz, vector)
+    return vector + quat[3] * cross + wp.cross(quat_xyz, cross)
+
+
+@wp.func
+def _quat_apply_inverse_xyzw(quat: wp.vec4f, vector: wp.vec3f) -> wp.vec3f:
+    quat_xyz = wp.vec3f(quat[0], quat[1], quat[2])
+    cross = 2.0 * wp.cross(quat_xyz, vector)
+    return vector - quat[3] * cross + wp.cross(quat_xyz, cross)
+
+
+@wp.func
+def _normalize_angle(angle: wp.float32) -> wp.float32:
+    return wp.atan2(wp.sin(angle), wp.cos(angle))
+
+
+@wp.func
+def _compute_intermediate_and_observation(
+    env_id: int,
+    targets: wp.array2d(dtype=wp.float32),
+    torso_position: wp.array2d(dtype=wp.float32),
+    torso_rotation: wp.array2d(dtype=wp.float32),
+    velocity: wp.array2d(dtype=wp.float32),
+    angular_velocity: wp.array2d(dtype=wp.float32),
+    joint_position: wp.array2d(dtype=wp.float32),
+    joint_velocity: wp.array2d(dtype=wp.float32),
+    joint_position_limits: wp.array2d(dtype=wp.vec2f),
+    actions: wp.array2d(dtype=wp.float32),
+    dt: wp.float32,
+    angular_velocity_scale: wp.float32,
+    joint_velocity_scale: wp.float32,
+    num_joints: int,
+    potentials: wp.array(dtype=wp.float32),
+    previous_potentials: wp.array(dtype=wp.float32),
+    up_projection: wp.array(dtype=wp.float32),
+    heading_projection: wp.array(dtype=wp.float32),
+    up_vector: wp.array2d(dtype=wp.float32),
+    heading_vector: wp.array2d(dtype=wp.float32),
+    local_velocity: wp.array2d(dtype=wp.float32),
+    local_angular_velocity: wp.array2d(dtype=wp.float32),
+    roll: wp.array(dtype=wp.float32),
+    pitch: wp.array(dtype=wp.float32),
+    yaw: wp.array(dtype=wp.float32),
+    angle_to_target: wp.array(dtype=wp.float32),
+    scaled_joint_position: wp.array2d(dtype=wp.float32),
+    observation: wp.array2d(dtype=wp.float32),
+):
+    position = wp.vec3f(torso_position[env_id, 0], torso_position[env_id, 1], torso_position[env_id, 2])
+    quat = wp.vec4f(
+        torso_rotation[env_id, 0],
+        torso_rotation[env_id, 1],
+        torso_rotation[env_id, 2],
+        torso_rotation[env_id, 3],
+    )
+    target_delta = wp.vec3f(
+        targets[env_id, 0] - position[0],
+        targets[env_id, 1] - position[1],
+        0.0,
+    )
+    target_distance = wp.length(target_delta)
+    target_direction = target_delta / wp.max(target_distance, 1.0e-9)
+
+    up = _quat_apply_xyzw(quat, wp.vec3f(0.0, 0.0, 1.0))
+    heading = _quat_apply_xyzw(quat, wp.vec3f(1.0, 0.0, 0.0))
+    up_proj = up[2]
+    heading_proj = wp.dot(heading, target_direction)
+
+    world_velocity = wp.vec3f(velocity[env_id, 0], velocity[env_id, 1], velocity[env_id, 2])
+    world_angular_velocity = wp.vec3f(
+        angular_velocity[env_id, 0], angular_velocity[env_id, 1], angular_velocity[env_id, 2]
+    )
+    velocity_local = _quat_apply_inverse_xyzw(quat, world_velocity)
+    angular_velocity_local = _quat_apply_inverse_xyzw(quat, world_angular_velocity)
+
+    quat_x = quat[0]
+    quat_y = quat[1]
+    quat_z = quat[2]
+    quat_w = quat[3]
+    sin_roll = 2.0 * (quat_w * quat_x + quat_y * quat_z)
+    cos_roll = 1.0 - 2.0 * (quat_x * quat_x + quat_y * quat_y)
+    roll_value = wp.atan2(sin_roll, cos_roll)
+    sin_pitch = 2.0 * (quat_w * quat_y - quat_z * quat_x)
+    pitch_value = wp.asin(sin_pitch)
+    if wp.abs(sin_pitch) >= 1.0:
+        pitch_value = wp.sign(sin_pitch) * wp.pi * 0.5
+    sin_yaw = 2.0 * (quat_w * quat_z + quat_x * quat_y)
+    cos_yaw = 1.0 - 2.0 * (quat_y * quat_y + quat_z * quat_z)
+    yaw_value = wp.atan2(sin_yaw, cos_yaw)
+    target_angle = wp.atan2(target_delta[1], target_delta[0]) - yaw_value
+
+    previous_potentials[env_id] = potentials[env_id]
+    potentials[env_id] = -target_distance / dt
+    up_projection[env_id] = up_proj
+    heading_projection[env_id] = heading_proj
+    up_vector[env_id, 0] = up[0]
+    up_vector[env_id, 1] = up[1]
+    up_vector[env_id, 2] = up[2]
+    heading_vector[env_id, 0] = heading[0]
+    heading_vector[env_id, 1] = heading[1]
+    heading_vector[env_id, 2] = heading[2]
+    local_velocity[env_id, 0] = velocity_local[0]
+    local_velocity[env_id, 1] = velocity_local[1]
+    local_velocity[env_id, 2] = velocity_local[2]
+    local_angular_velocity[env_id, 0] = angular_velocity_local[0]
+    local_angular_velocity[env_id, 1] = angular_velocity_local[1]
+    local_angular_velocity[env_id, 2] = angular_velocity_local[2]
+    roll[env_id] = roll_value
+    pitch[env_id] = pitch_value
+    yaw[env_id] = yaw_value
+    angle_to_target[env_id] = target_angle
+
+    observation[env_id, 0] = position[2]
+    observation[env_id, 1] = velocity_local[0]
+    observation[env_id, 2] = velocity_local[1]
+    observation[env_id, 3] = velocity_local[2]
+    observation[env_id, 4] = angular_velocity_local[0] * angular_velocity_scale
+    observation[env_id, 5] = angular_velocity_local[1] * angular_velocity_scale
+    observation[env_id, 6] = angular_velocity_local[2] * angular_velocity_scale
+    observation[env_id, 7] = _normalize_angle(yaw_value)
+    observation[env_id, 8] = _normalize_angle(roll_value)
+    observation[env_id, 9] = _normalize_angle(target_angle)
+    observation[env_id, 10] = up_proj
+    observation[env_id, 11] = heading_proj
+
+    joint_velocity_offset = 12 + num_joints
+    action_offset = joint_velocity_offset + num_joints
+    for joint_id in range(num_joints):
+        lower_limit = joint_position_limits[env_id, joint_id][0]
+        upper_limit = joint_position_limits[env_id, joint_id][1]
+        limit_offset = 0.5 * (lower_limit + upper_limit)
+        scaled_position = 2.0 * (joint_position[env_id, joint_id] - limit_offset) / (upper_limit - lower_limit)
+        scaled_joint_position[env_id, joint_id] = scaled_position
+        observation[env_id, 12 + joint_id] = scaled_position
+        observation[env_id, joint_velocity_offset + joint_id] = joint_velocity[env_id, joint_id] * joint_velocity_scale
+        observation[env_id, action_offset + joint_id] = actions[env_id, joint_id]
+
+
+@wp.kernel
+def compute_ant_post_step(
+    targets: wp.array2d(dtype=wp.float32),
+    torso_position: wp.array2d(dtype=wp.float32),
+    torso_rotation: wp.array2d(dtype=wp.float32),
+    velocity: wp.array2d(dtype=wp.float32),
+    angular_velocity: wp.array2d(dtype=wp.float32),
+    joint_position: wp.array2d(dtype=wp.float32),
+    joint_velocity: wp.array2d(dtype=wp.float32),
+    joint_position_limits: wp.array2d(dtype=wp.vec2f),
+    actions: wp.array2d(dtype=wp.float32),
+    episode_length: wp.array(dtype=wp.int64),
+    motor_effort_ratio: wp.array(dtype=wp.float32),
+    dt: wp.float32,
+    angular_velocity_scale: wp.float32,
+    joint_velocity_scale: wp.float32,
+    termination_height: wp.float32,
+    max_episode_length: wp.int64,
+    up_weight: wp.float32,
+    heading_weight: wp.float32,
+    actions_cost_scale: wp.float32,
+    energy_cost_scale: wp.float32,
+    death_cost: wp.float32,
+    alive_reward_scale: wp.float32,
+    num_joints: int,
+    potentials: wp.array(dtype=wp.float32),
+    previous_potentials: wp.array(dtype=wp.float32),
+    up_projection: wp.array(dtype=wp.float32),
+    heading_projection: wp.array(dtype=wp.float32),
+    up_vector: wp.array2d(dtype=wp.float32),
+    heading_vector: wp.array2d(dtype=wp.float32),
+    local_velocity: wp.array2d(dtype=wp.float32),
+    local_angular_velocity: wp.array2d(dtype=wp.float32),
+    roll: wp.array(dtype=wp.float32),
+    pitch: wp.array(dtype=wp.float32),
+    yaw: wp.array(dtype=wp.float32),
+    angle_to_target: wp.array(dtype=wp.float32),
+    scaled_joint_position: wp.array2d(dtype=wp.float32),
+    terminated: wp.array(dtype=wp.bool),
+    time_out: wp.array(dtype=wp.bool),
+    reward: wp.array(dtype=wp.float32),
+    observation: wp.array2d(dtype=wp.float32),
+):
+    env_id = wp.tid()
+    _compute_intermediate_and_observation(
+        env_id,
+        targets,
+        torso_position,
+        torso_rotation,
+        velocity,
+        angular_velocity,
+        joint_position,
+        joint_velocity,
+        joint_position_limits,
+        actions,
+        dt,
+        angular_velocity_scale,
+        joint_velocity_scale,
+        num_joints,
+        potentials,
+        previous_potentials,
+        up_projection,
+        heading_projection,
+        up_vector,
+        heading_vector,
+        local_velocity,
+        local_angular_velocity,
+        roll,
+        pitch,
+        yaw,
+        angle_to_target,
+        scaled_joint_position,
+        observation,
+    )
+
+    died = torso_position[env_id, 2] < termination_height
+    terminated[env_id] = died
+    time_out[env_id] = episode_length[env_id] >= max_episode_length - wp.int64(1)
+
+    heading_reward = heading_weight * heading_projection[env_id] / 0.8
+    if heading_projection[env_id] > 0.8:
+        heading_reward = heading_weight
+    up_reward = wp.float32(0.0)
+    if up_projection[env_id] > 0.93:
+        up_reward = up_weight
+
+    actions_cost = wp.float32(0.0)
+    electricity_cost = wp.float32(0.0)
+    joint_limit_cost = wp.float32(0.0)
+    for joint_id in range(num_joints):
+        action = actions[env_id, joint_id]
+        actions_cost += action * action
+        electricity_cost += (
+            wp.abs(action * joint_velocity[env_id, joint_id] * joint_velocity_scale) * motor_effort_ratio[joint_id]
+        )
+        if scaled_joint_position[env_id, joint_id] > 0.98:
+            joint_limit_cost += 1.0
+
+    total_reward = (
+        potentials[env_id]
+        - previous_potentials[env_id]
+        + alive_reward_scale
+        + up_reward
+        + heading_reward
+        - actions_cost_scale * actions_cost
+        - energy_cost_scale * electricity_cost
+        - joint_limit_cost
+    )
+    if died:
+        total_reward = death_cost
+    reward[env_id] = total_reward
+
+
+@wp.kernel
+def compute_ant_intermediate_and_observation(
+    targets: wp.array2d(dtype=wp.float32),
+    torso_position: wp.array2d(dtype=wp.float32),
+    torso_rotation: wp.array2d(dtype=wp.float32),
+    velocity: wp.array2d(dtype=wp.float32),
+    angular_velocity: wp.array2d(dtype=wp.float32),
+    joint_position: wp.array2d(dtype=wp.float32),
+    joint_velocity: wp.array2d(dtype=wp.float32),
+    joint_position_limits: wp.array2d(dtype=wp.vec2f),
+    actions: wp.array2d(dtype=wp.float32),
+    dt: wp.float32,
+    angular_velocity_scale: wp.float32,
+    joint_velocity_scale: wp.float32,
+    num_joints: int,
+    potentials: wp.array(dtype=wp.float32),
+    previous_potentials: wp.array(dtype=wp.float32),
+    up_projection: wp.array(dtype=wp.float32),
+    heading_projection: wp.array(dtype=wp.float32),
+    up_vector: wp.array2d(dtype=wp.float32),
+    heading_vector: wp.array2d(dtype=wp.float32),
+    local_velocity: wp.array2d(dtype=wp.float32),
+    local_angular_velocity: wp.array2d(dtype=wp.float32),
+    roll: wp.array(dtype=wp.float32),
+    pitch: wp.array(dtype=wp.float32),
+    yaw: wp.array(dtype=wp.float32),
+    angle_to_target: wp.array(dtype=wp.float32),
+    scaled_joint_position: wp.array2d(dtype=wp.float32),
+    observation: wp.array2d(dtype=wp.float32),
+):
+    env_id = wp.tid()
+    _compute_intermediate_and_observation(
+        env_id,
+        targets,
+        torso_position,
+        torso_rotation,
+        velocity,
+        angular_velocity,
+        joint_position,
+        joint_velocity,
+        joint_position_limits,
+        actions,
+        dt,
+        angular_velocity_scale,
+        joint_velocity_scale,
+        num_joints,
+        potentials,
+        previous_potentials,
+        up_projection,
+        heading_projection,
+        up_vector,
+        heading_vector,
+        local_velocity,
+        local_angular_velocity,
+        roll,
+        pitch,
+        yaw,
+        angle_to_target,
+        scaled_joint_position,
+        observation,
+    )
+
+
+@wp.kernel
+def compute_ant_masked_reset_observation(
+    env_mask: wp.array(dtype=wp.bool),
+    episode_length: wp.array(dtype=wp.int64),
+    targets: wp.array2d(dtype=wp.float32),
+    torso_position: wp.array2d(dtype=wp.float32),
+    torso_rotation: wp.array2d(dtype=wp.float32),
+    velocity: wp.array2d(dtype=wp.float32),
+    angular_velocity: wp.array2d(dtype=wp.float32),
+    joint_position: wp.array2d(dtype=wp.float32),
+    joint_velocity: wp.array2d(dtype=wp.float32),
+    joint_position_limits: wp.array2d(dtype=wp.vec2f),
+    actions: wp.array2d(dtype=wp.float32),
+    dt: wp.float32,
+    angular_velocity_scale: wp.float32,
+    joint_velocity_scale: wp.float32,
+    num_joints: int,
+    potentials: wp.array(dtype=wp.float32),
+    previous_potentials: wp.array(dtype=wp.float32),
+    up_projection: wp.array(dtype=wp.float32),
+    heading_projection: wp.array(dtype=wp.float32),
+    up_vector: wp.array2d(dtype=wp.float32),
+    heading_vector: wp.array2d(dtype=wp.float32),
+    local_velocity: wp.array2d(dtype=wp.float32),
+    local_angular_velocity: wp.array2d(dtype=wp.float32),
+    roll: wp.array(dtype=wp.float32),
+    pitch: wp.array(dtype=wp.float32),
+    yaw: wp.array(dtype=wp.float32),
+    angle_to_target: wp.array(dtype=wp.float32),
+    scaled_joint_position: wp.array2d(dtype=wp.float32),
+    observation: wp.array2d(dtype=wp.float32),
+):
+    env_id = wp.tid()
+    if env_mask[env_id]:
+        target_x = targets[env_id, 0] - torso_position[env_id, 0]
+        target_y = targets[env_id, 1] - torso_position[env_id, 1]
+        potentials[env_id] = -wp.sqrt(target_x * target_x + target_y * target_y) / dt
+        episode_length[env_id] = wp.int64(0)
+        _compute_intermediate_and_observation(
+            env_id,
+            targets,
+            torso_position,
+            torso_rotation,
+            velocity,
+            angular_velocity,
+            joint_position,
+            joint_velocity,
+            joint_position_limits,
+            actions,
+            dt,
+            angular_velocity_scale,
+            joint_velocity_scale,
+            num_joints,
+            potentials,
+            previous_potentials,
+            up_projection,
+            heading_projection,
+            up_vector,
+            heading_vector,
+            local_velocity,
+            local_angular_velocity,
+            roll,
+            pitch,
+            yaw,
+            angle_to_target,
+            scaled_joint_position,
+            observation,
+        )
+
+
+class _AntPostStepBuffers:
+    """Persistent task outputs used by the fused Ant post-step kernels."""
+
+    def __init__(self, num_envs: int, num_joints: int, observation_size: int, device: str):
+        self.num_envs = num_envs
+        self.num_joints = num_joints
+        self.device = device
+
+        self.up_projection = wp.zeros(num_envs, dtype=wp.float32, device=device)
+        self.heading_projection = wp.zeros(num_envs, dtype=wp.float32, device=device)
+        self.up_vector = wp.zeros((num_envs, 3), dtype=wp.float32, device=device)
+        self.heading_vector = wp.zeros((num_envs, 3), dtype=wp.float32, device=device)
+        self.local_velocity = wp.zeros((num_envs, 3), dtype=wp.float32, device=device)
+        self.local_angular_velocity = wp.zeros((num_envs, 3), dtype=wp.float32, device=device)
+        self.roll = wp.zeros(num_envs, dtype=wp.float32, device=device)
+        self.pitch = wp.zeros(num_envs, dtype=wp.float32, device=device)
+        self.yaw = wp.zeros(num_envs, dtype=wp.float32, device=device)
+        self.angle_to_target = wp.zeros(num_envs, dtype=wp.float32, device=device)
+        self.scaled_joint_position = wp.zeros((num_envs, num_joints), dtype=wp.float32, device=device)
+        self.terminated = wp.zeros(num_envs, dtype=wp.bool, device=device)
+        self.time_out = wp.zeros(num_envs, dtype=wp.bool, device=device)
+        self.reward = wp.zeros(num_envs, dtype=wp.float32, device=device)
+        self.observation = wp.zeros((num_envs, observation_size), dtype=wp.float32, device=device)
+
+        self.up_projection_torch = wp.to_torch(self.up_projection)
+        self.heading_projection_torch = wp.to_torch(self.heading_projection)
+        self.up_vector_torch = wp.to_torch(self.up_vector)
+        self.heading_vector_torch = wp.to_torch(self.heading_vector)
+        self.local_velocity_torch = wp.to_torch(self.local_velocity)
+        self.local_angular_velocity_torch = wp.to_torch(self.local_angular_velocity)
+        self.roll_torch = wp.to_torch(self.roll)
+        self.pitch_torch = wp.to_torch(self.pitch)
+        self.yaw_torch = wp.to_torch(self.yaw)
+        self.angle_to_target_torch = wp.to_torch(self.angle_to_target)
+        self.scaled_joint_position_torch = wp.to_torch(self.scaled_joint_position)
+        self.terminated_torch = wp.to_torch(self.terminated)
+        self.time_out_torch = wp.to_torch(self.time_out)
+        self.reward_torch = wp.to_torch(self.reward)
+        self.observation_torch = wp.to_torch(self.observation)
+
+    def bind_environment_outputs(self, env) -> None:
+        """Bind the environment's intermediate attributes to persistent zero-copy tensor views."""
+        env.up_proj = self.up_projection_torch
+        env.heading_proj = self.heading_projection_torch
+        env.up_vec = self.up_vector_torch
+        env.heading_vec = self.heading_vector_torch
+        env.vel_loc = self.local_velocity_torch
+        env.angvel_loc = self.local_angular_velocity_torch
+        env.roll = self.roll_torch
+        env.pitch = self.pitch_torch
+        env.yaw = self.yaw_torch
+        env.angle_to_target = self.angle_to_target_torch
+        env.dof_pos_scaled = self.scaled_joint_position_torch
+
+    def compute_post_step(self, env) -> None:
+        """Compute Ant intermediates, dones, reward, and observations in one launch."""
+        wp.launch(
+            compute_ant_post_step,
+            dim=self.num_envs,
+            inputs=[
+                env.targets,
+                env.torso_position,
+                env.torso_rotation,
+                env.velocity,
+                env.ang_velocity,
+                env.dof_pos,
+                env.dof_vel,
+                env._joint_position_limits,
+                env.actions,
+                env.episode_length_buf,
+                env.motor_effort_ratio,
+                env.cfg.sim.dt,
+                env.cfg.angular_velocity_scale,
+                env.cfg.dof_vel_scale,
+                env.cfg.termination_height,
+                env.max_episode_length,
+                env.cfg.up_weight,
+                env.cfg.heading_weight,
+                env.cfg.actions_cost_scale,
+                env.cfg.energy_cost_scale,
+                env.cfg.death_cost,
+                env.cfg.alive_reward_scale,
+                self.num_joints,
+                env.potentials,
+                env.prev_potentials,
+                self.up_projection,
+                self.heading_projection,
+                self.up_vector,
+                self.heading_vector,
+                self.local_velocity,
+                self.local_angular_velocity,
+                self.roll,
+                self.pitch,
+                self.yaw,
+                self.angle_to_target,
+                self.scaled_joint_position,
+                self.terminated,
+                self.time_out,
+                self.reward,
+                self.observation,
+            ],
+            device=self.device,
+        )
+
+    def compute_intermediate_and_observation(self, env) -> None:
+        """Refresh intermediates and observations after reset without changing reward or dones."""
+        wp.launch(
+            compute_ant_intermediate_and_observation,
+            dim=self.num_envs,
+            inputs=[
+                env.targets,
+                env.torso_position,
+                env.torso_rotation,
+                env.velocity,
+                env.ang_velocity,
+                env.dof_pos,
+                env.dof_vel,
+                env._joint_position_limits,
+                env.actions,
+                env.cfg.sim.dt,
+                env.cfg.angular_velocity_scale,
+                env.cfg.dof_vel_scale,
+                self.num_joints,
+                env.potentials,
+                env.prev_potentials,
+                self.up_projection,
+                self.heading_projection,
+                self.up_vector,
+                self.heading_vector,
+                self.local_velocity,
+                self.local_angular_velocity,
+                self.roll,
+                self.pitch,
+                self.yaw,
+                self.angle_to_target,
+                self.scaled_joint_position,
+                self.observation,
+            ],
+            device=self.device,
+        )
+
+    def compute_masked_reset_observation(self, env, env_mask: wp.array) -> None:
+        """Refresh reset rows and zero their episode lengths without changing terminal outputs."""
+        wp.launch(
+            compute_ant_masked_reset_observation,
+            dim=self.num_envs,
+            inputs=[
+                env_mask,
+                env.episode_length_buf,
+                env.targets,
+                env.torso_position,
+                env.torso_rotation,
+                env.velocity,
+                env.ang_velocity,
+                env.dof_pos,
+                env.dof_vel,
+                env._joint_position_limits,
+                env.actions,
+                env.cfg.sim.dt,
+                env.cfg.angular_velocity_scale,
+                env.cfg.dof_vel_scale,
+                self.num_joints,
+                env.potentials,
+                env.prev_potentials,
+                self.up_projection,
+                self.heading_projection,
+                self.up_vector,
+                self.heading_vector,
+                self.local_velocity,
+                self.local_angular_velocity,
+                self.roll,
+                self.pitch,
+                self.yaw,
+                self.angle_to_target,
+                self.scaled_joint_position,
+                self.observation,
+            ],
+            device=self.device,
+        )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/locomotion_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/locomotion_direct_env.py
@@ -94,7 +94,6 @@ class LocomotionDirectEnv(DirectRLEnv):
             joint_gears = self.cfg.joint_gears
         self.joint_gears = torch.tensor(joint_gears, dtype=torch.float32, device=self.sim.device)
         self.motor_effort_ratio = torch.ones_like(self.joint_gears, device=self.sim.device)
-        self._joint_dof_idx, _ = self.robot.find_joints(".*")
 
         self.potentials = torch.zeros(self.num_envs, dtype=torch.float32, device=self.sim.device)
         self.prev_potentials = torch.zeros_like(self.potentials)
@@ -132,10 +131,12 @@ class LocomotionDirectEnv(DirectRLEnv):
 
     def _pre_physics_step(self, actions: torch.Tensor) -> None:
         self.actions = actions.clone()
+        forces = self.action_scale * self.joint_gears * torch.clamp(self.actions, -1.0, 1.0)
+        self.robot.set_joint_effort_target_index(target=forces)
 
     def _apply_action(self) -> None:
-        forces = self.action_scale * self.joint_gears * torch.clamp(self.actions, -1.0, 1.0)
-        self.robot.set_joint_effort_target_index(target=forces, joint_ids=self._joint_dof_idx)
+        # Joint effort targets persist in the articulation command buffer across decimation substeps.
+        pass
 
     def _compute_intermediate_values(self):
         self.torso_position, self.torso_rotation = (
@@ -232,24 +233,27 @@ class LocomotionDirectEnv(DirectRLEnv):
 
         # Log survival success rate (survived = timed out without falling)
         survived = self.reset_time_outs[env_ids].float()
-        self.extras.setdefault("log", {})["Metrics/success_rate"] = survived.mean().item()
+        self.extras.setdefault("log", {})["Metrics/success_rate"] = survived.mean()
 
-        self.robot.reset(env_ids)
         super()._reset_idx(env_ids)
 
-        joint_pos = self.robot.data.default_joint_pos.torch[env_ids].clone()
-        joint_vel = self.robot.data.default_joint_vel.torch[env_ids].clone()
-        default_root_pose = self.robot.data.default_root_pose.torch[env_ids].clone()
-        default_root_vel = self.robot.data.default_root_vel.torch[env_ids].clone()
+        joint_pos = self.robot.data.default_joint_pos.torch[env_ids]
+        joint_vel = self.robot.data.default_joint_vel.torch[env_ids]
+        default_root_pose = self.robot.data.default_root_pose.torch[env_ids]
+        default_root_vel = self.robot.data.default_root_vel.torch[env_ids]
         default_root_pose[:, :3] += self.scene.env_origins[env_ids]
 
         self.robot.write_root_pose_to_sim_index(root_pose=default_root_pose, env_ids=env_ids)
         self.robot.write_root_velocity_to_sim_index(root_velocity=default_root_vel, env_ids=env_ids)
-        self.robot.write_joint_position_to_sim_index(position=joint_pos, env_ids=env_ids)
-        self.robot.write_joint_velocity_to_sim_index(velocity=joint_vel, env_ids=env_ids)
+        if hasattr(self.robot, "write_joint_state_to_sim_index"):
+            self.robot.write_joint_state_to_sim_index(position=joint_pos, velocity=joint_vel, env_ids=env_ids)
+        else:
+            # OVPhysX does not yet provide the fused writer.
+            self.robot.write_joint_position_to_sim_index(position=joint_pos, env_ids=env_ids)
+            self.robot.write_joint_velocity_to_sim_index(velocity=joint_vel, env_ids=env_ids)
 
         to_target = self.targets[env_ids] - default_root_pose[:, :3]
-        to_target[:, 2] = 0.0
+        to_target[:, 2].zero_()
         self.potentials[env_ids] = -torch.linalg.norm(to_target, ord=2, dim=-1) / self.cfg.sim.dt
 
         self._compute_intermediate_values()
@@ -327,7 +331,7 @@ def compute_intermediate_values(
     dt: float,
 ):
     to_target = targets - torso_position
-    to_target[:, 2] = 0.0
+    to_target[:, 2].zero_()
 
     torso_quat, up_proj, heading_proj, up_vec, heading_vec = compute_heading_and_up(
         torso_rotation, inv_start_rot, to_target, basis_vec0, basis_vec1, 2

--- a/source/isaaclab_tasks/test/core/test_ant_direct_post_step.py
+++ b/source/isaaclab_tasks/test/core/test_ant_direct_post_step.py
@@ -1,0 +1,380 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+import warp as wp
+from isaaclab_newton.physics import NewtonCfg
+from isaaclab_physx.physics import PhysxCfg
+
+from isaaclab_tasks.core.locomotion.ant.ant_direct_env import AntEnv
+from isaaclab_tasks.core.locomotion.ant.ant_post_step import _AntPostStepBuffers
+from isaaclab_tasks.core.locomotion.locomotion_direct_env import (
+    compute_intermediate_values,
+    compute_rewards,
+    normalize_angle,
+)
+
+_NUM_ENVS = 8
+_NUM_JOINTS = 8
+_OBSERVATION_SIZE = 12 + 3 * _NUM_JOINTS
+
+
+def _make_environment_data(device: str) -> SimpleNamespace:
+    dtype = torch.float32
+    angles = torch.tensor(
+        [0.0, torch.pi - 1.0e-5, -torch.pi + 1.0e-5, 0.5, -0.7, 1.2, -2.1, 0.9],
+        dtype=dtype,
+        device=device,
+    )
+    half_angles = 0.5 * angles
+    torso_rotation = torch.zeros((_NUM_ENVS, 4), dtype=dtype, device=device)
+    torso_rotation[:, 2] = torch.sin(half_angles)
+    torso_rotation[:, 3] = torch.cos(half_angles)
+    # Exercise the pitch saturation branch with an exactly normalized 90-degree rotation.
+    torso_rotation[-1] = torch.tensor([0.0, 2.0**-0.5, 0.0, 2.0**-0.5], dtype=dtype, device=device)
+
+    torso_position = torch.tensor(
+        [
+            [0.0, 0.0, 0.31 - 1.0e-5],
+            [2.0, -1.0, 0.31],
+            [-2.0, 3.0, 0.31 + 1.0e-5],
+            [0.5, 0.25, 0.8],
+            [-0.5, -0.25, -0.2],
+            [4.0, -3.0, 1.0],
+            [-4.0, 3.0, 0.5],
+            [1.0, 2.0, 0.4],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    targets = torso_position.clone()
+    targets[:, 0] += torch.tensor([1000.0, 0.0, -4.0, 2.0, -3.0, 1.0, -1.0, 5.0], device=device)
+    targets[:, 1] += torch.tensor([0.0, 0.0, 3.0, -2.0, 4.0, -1.0, 1.0, 2.0], device=device)
+    targets[:, 2] += 7.0  # Stable task semantics ignore target height.
+
+    values = torch.arange(_NUM_ENVS * 3, dtype=dtype, device=device).reshape(_NUM_ENVS, 3)
+    velocity = (values - 8.0) * 0.17
+    angular_velocity = (11.0 - values) * 0.13
+    joint_position = torch.linspace(-1.2, 1.2, _NUM_ENVS * _NUM_JOINTS, device=device).reshape(_NUM_ENVS, _NUM_JOINTS)
+    joint_velocity = torch.linspace(2.0, -2.0, _NUM_ENVS * _NUM_JOINTS, device=device).reshape(_NUM_ENVS, _NUM_JOINTS)
+    actions = torch.linspace(-1.5, 1.5, _NUM_ENVS * _NUM_JOINTS, device=device).reshape(_NUM_ENVS, _NUM_JOINTS)
+
+    cfg = SimpleNamespace(
+        sim=SimpleNamespace(dt=1.0 / 120.0),
+        angular_velocity_scale=1.0,
+        dof_vel_scale=0.2,
+        termination_height=0.31,
+        up_weight=0.1,
+        heading_weight=0.5,
+        actions_cost_scale=0.005,
+        energy_cost_scale=0.05,
+        death_cost=-2.0,
+        alive_reward_scale=0.5,
+    )
+    return SimpleNamespace(
+        cfg=cfg,
+        targets=targets,
+        torso_position=torso_position,
+        torso_rotation=torso_rotation,
+        velocity=velocity,
+        ang_velocity=angular_velocity,
+        dof_pos=joint_position,
+        dof_vel=joint_velocity,
+        _joint_position_lower_limits=torch.linspace(-1.4, -0.7, _NUM_JOINTS, device=device),
+        _joint_position_upper_limits=torch.linspace(0.8, 1.5, _NUM_JOINTS, device=device),
+        _joint_position_limits=wp.from_torch(
+            torch.stack(
+                (
+                    torch.linspace(-1.4, -0.7, _NUM_JOINTS, device=device).expand(_NUM_ENVS, -1),
+                    torch.linspace(0.8, 1.5, _NUM_JOINTS, device=device).expand(_NUM_ENVS, -1),
+                ),
+                dim=-1,
+            ).contiguous(),
+            dtype=wp.vec2f,
+        ),
+        actions=actions,
+        episode_length_buf=torch.tensor([0, 898, 899, 900, 10, 899, 1, 50], dtype=torch.int64, device=device),
+        motor_effort_ratio=torch.linspace(0.7, 1.3, _NUM_JOINTS, device=device),
+        max_episode_length=900,
+        potentials=torch.linspace(-100.0, -107.0, _NUM_ENVS, device=device),
+        prev_potentials=torch.linspace(-90.0, -97.0, _NUM_ENVS, device=device),
+    )
+
+
+def _compute_torch_reference(env: SimpleNamespace) -> dict[str, torch.Tensor]:
+    inv_start_rotation = torch.tensor([0.0, 0.0, 0.0, 1.0], device=env.torso_position.device).repeat(_NUM_ENVS, 1)
+    heading_basis = torch.tensor([1.0, 0.0, 0.0], device=env.torso_position.device).repeat(_NUM_ENVS, 1)
+    up_basis = torch.tensor([0.0, 0.0, 1.0], device=env.torso_position.device).repeat(_NUM_ENVS, 1)
+    potentials = env.potentials.clone()
+    previous_potentials = env.prev_potentials.clone()
+    (
+        up_projection,
+        heading_projection,
+        up_vector,
+        heading_vector,
+        local_velocity,
+        local_angular_velocity,
+        roll,
+        pitch,
+        yaw,
+        angle_to_target,
+        scaled_joint_position,
+        previous_potentials,
+        potentials,
+    ) = compute_intermediate_values(
+        env.targets,
+        env.torso_position,
+        env.torso_rotation,
+        env.velocity,
+        env.ang_velocity,
+        env.dof_pos,
+        env._joint_position_lower_limits,
+        env._joint_position_upper_limits,
+        inv_start_rotation,
+        heading_basis,
+        up_basis,
+        potentials,
+        previous_potentials,
+        env.cfg.sim.dt,
+    )
+    terminated = env.torso_position[:, 2] < env.cfg.termination_height
+    time_out = env.episode_length_buf >= env.max_episode_length - 1
+    reward = compute_rewards(
+        env.actions,
+        terminated,
+        env.cfg.up_weight,
+        env.cfg.heading_weight,
+        heading_projection,
+        up_projection,
+        env.dof_vel,
+        scaled_joint_position,
+        potentials,
+        previous_potentials,
+        env.cfg.actions_cost_scale,
+        env.cfg.energy_cost_scale,
+        env.cfg.dof_vel_scale,
+        env.cfg.death_cost,
+        env.cfg.alive_reward_scale,
+        env.motor_effort_ratio,
+    )
+    observation = torch.cat(
+        (
+            env.torso_position[:, 2:3],
+            local_velocity,
+            local_angular_velocity * env.cfg.angular_velocity_scale,
+            normalize_angle(yaw).unsqueeze(-1),
+            normalize_angle(roll).unsqueeze(-1),
+            normalize_angle(angle_to_target).unsqueeze(-1),
+            up_projection.unsqueeze(-1),
+            heading_projection.unsqueeze(-1),
+            scaled_joint_position,
+            env.dof_vel * env.cfg.dof_vel_scale,
+            env.actions,
+        ),
+        dim=-1,
+    )
+    return {
+        "up_projection": up_projection,
+        "heading_projection": heading_projection,
+        "up_vector": up_vector,
+        "heading_vector": heading_vector,
+        "local_velocity": local_velocity,
+        "local_angular_velocity": local_angular_velocity,
+        "roll": roll,
+        "pitch": pitch,
+        "yaw": yaw,
+        "angle_to_target": angle_to_target,
+        "scaled_joint_position": scaled_joint_position,
+        "previous_potentials": previous_potentials,
+        "potentials": potentials,
+        "terminated": terminated,
+        "time_out": time_out,
+        "reward": reward,
+        "observation": observation,
+    }
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_fused_post_step_matches_torch_reference(device: str):
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    env = _make_environment_data(device)
+    reference = _compute_torch_reference(env)
+    buffers = _AntPostStepBuffers(_NUM_ENVS, _NUM_JOINTS, _OBSERVATION_SIZE, device)
+    buffers.bind_environment_outputs(env)
+    buffers.compute_post_step(env)
+    wp.synchronize_device(device)
+
+    actual = {
+        "up_projection": buffers.up_projection_torch,
+        "heading_projection": buffers.heading_projection_torch,
+        "up_vector": buffers.up_vector_torch,
+        "heading_vector": buffers.heading_vector_torch,
+        "local_velocity": buffers.local_velocity_torch,
+        "local_angular_velocity": buffers.local_angular_velocity_torch,
+        "roll": buffers.roll_torch,
+        "pitch": buffers.pitch_torch,
+        "yaw": buffers.yaw_torch,
+        "angle_to_target": buffers.angle_to_target_torch,
+        "scaled_joint_position": buffers.scaled_joint_position_torch,
+        "previous_potentials": env.prev_potentials,
+        "potentials": env.potentials,
+        "terminated": buffers.terminated_torch,
+        "time_out": buffers.time_out_torch,
+        "reward": buffers.reward_torch,
+        "observation": buffers.observation_torch,
+    }
+    for name, expected in reference.items():
+        torch.testing.assert_close(actual[name], expected, rtol=2.0e-5, atol=2.0e-5, equal_nan=True)
+
+
+def test_post_reset_refresh_preserves_terminal_outputs():
+    env = _make_environment_data("cpu")
+    buffers = _AntPostStepBuffers(_NUM_ENVS, _NUM_JOINTS, _OBSERVATION_SIZE, "cpu")
+    buffers.bind_environment_outputs(env)
+    buffers.compute_post_step(env)
+    wp.synchronize_device("cpu")
+    reward = buffers.reward_torch.clone()
+    terminated = buffers.terminated_torch.clone()
+    time_out = buffers.time_out_torch.clone()
+
+    env.torso_position[:, 0] += 0.25
+    env.velocity.mul_(0.5)
+    env.actions.neg_()
+    reference = _compute_torch_reference(env)
+    buffers.compute_intermediate_and_observation(env)
+    wp.synchronize_device("cpu")
+
+    torch.testing.assert_close(buffers.reward_torch, reward)
+    torch.testing.assert_close(buffers.terminated_torch, terminated)
+    torch.testing.assert_close(buffers.time_out_torch, time_out)
+    torch.testing.assert_close(buffers.observation_torch, reference["observation"], rtol=2.0e-5, atol=2.0e-5)
+    torch.testing.assert_close(env.potentials, reference["potentials"], rtol=2.0e-5, atol=2.0e-5)
+    torch.testing.assert_close(env.prev_potentials, reference["previous_potentials"], rtol=2.0e-5, atol=2.0e-5)
+
+
+def test_masked_reset_refresh_updates_only_selected_environments():
+    env = _make_environment_data("cpu")
+    buffers = _AntPostStepBuffers(_NUM_ENVS, _NUM_JOINTS, _OBSERVATION_SIZE, "cpu")
+    buffers.bind_environment_outputs(env)
+    buffers.compute_post_step(env)
+    wp.synchronize_device("cpu")
+
+    env_mask = torch.tensor([True, False, False, True, False, True, False, False])
+    env.torso_position[env_mask] = torch.tensor(
+        [[0.25, -0.5, 0.5], [1.5, 0.75, 0.5], [-2.0, 1.0, 0.5]],
+        dtype=torch.float32,
+    )
+    env.velocity[env_mask] = 0.0
+    env.ang_velocity[env_mask] = 0.0
+    env.dof_pos[env_mask] = 0.0
+    env.dof_vel[env_mask] = 0.0
+
+    observation_before = buffers.observation_torch.clone()
+    potentials_before = env.potentials.clone()
+    previous_potentials_before = env.prev_potentials.clone()
+    reward_before = buffers.reward_torch.clone()
+    terminated_before = buffers.terminated_torch.clone()
+    time_out_before = buffers.time_out_torch.clone()
+    episode_length_before = env.episode_length_buf.clone()
+
+    reference_env = SimpleNamespace(**vars(env))
+    reference_env.potentials = env.potentials.clone()
+    target_delta = env.targets[env_mask, :2] - env.torso_position[env_mask, :2]
+    reference_env.potentials[env_mask] = -torch.linalg.norm(target_delta, dim=-1) / env.cfg.sim.dt
+    reference = _compute_torch_reference(reference_env)
+
+    buffers.compute_masked_reset_observation(env, wp.from_torch(env_mask))
+    wp.synchronize_device("cpu")
+
+    torch.testing.assert_close(
+        buffers.observation_torch[env_mask], reference["observation"][env_mask], rtol=2e-5, atol=2e-5
+    )
+    torch.testing.assert_close(env.potentials[env_mask], reference["potentials"][env_mask], rtol=2e-5, atol=2e-5)
+    torch.testing.assert_close(
+        env.prev_potentials[env_mask], reference["previous_potentials"][env_mask], rtol=2e-5, atol=2e-5
+    )
+    torch.testing.assert_close(buffers.observation_torch[~env_mask], observation_before[~env_mask])
+    torch.testing.assert_close(env.potentials[~env_mask], potentials_before[~env_mask])
+    torch.testing.assert_close(env.prev_potentials[~env_mask], previous_potentials_before[~env_mask])
+    torch.testing.assert_close(buffers.reward_torch, reward_before)
+    torch.testing.assert_close(buffers.terminated_torch, terminated_before)
+    torch.testing.assert_close(buffers.time_out_torch, time_out_before)
+    torch.testing.assert_close(env.episode_length_buf[env_mask], torch.zeros(3, dtype=torch.int64))
+    torch.testing.assert_close(env.episode_length_buf[~env_mask], episode_length_before[~env_mask])
+
+
+@pytest.mark.parametrize(
+    ("physics", "compute_final_obs"),
+    [(PhysxCfg(), False), (NewtonCfg(), True)],
+)
+def test_fused_post_step_falls_back_for_unsupported_configurations(
+    physics, compute_final_obs: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env = object.__new__(AntEnv)
+    env._is_closed = True
+    env.cfg = SimpleNamespace(sim=SimpleNamespace(physics=physics), compute_final_obs=compute_final_obs)
+    env._use_fused_post_step = env._supports_fused_post_step()
+    expected = (torch.tensor([True]), torch.tensor([False]))
+    fallback = Mock(return_value=expected)
+    monkeypatch.setattr("isaaclab_tasks.core.locomotion.locomotion_direct_env.LocomotionDirectEnv._get_dones", fallback)
+
+    assert not env._use_fused_post_step
+    assert env._get_dones() is expected
+    fallback.assert_called_once_with()
+
+
+def test_fused_post_step_selects_newton_without_final_observations() -> None:
+    env = object.__new__(AntEnv)
+    env._is_closed = True
+    env.cfg = SimpleNamespace(sim=SimpleNamespace(physics=NewtonCfg()), compute_final_obs=False)
+
+    assert env._supports_fused_post_step()
+
+
+def test_masked_reset_preserves_robot_buffers_and_metrics() -> None:
+    env = object.__new__(AntEnv)
+    env._is_closed = True
+    env.sim = SimpleNamespace(device="cpu")
+    env.reset_buf = torch.tensor([False, True, False, True])
+    env.reset_time_outs = torch.tensor([False, True, False, False])
+    env.extras = {}
+    instantaneous_wrench_composer = Mock(active=True)
+    permanent_wrench_composer = Mock(active=True)
+    env.robot = Mock(
+        instantaneous_wrench_composer=instantaneous_wrench_composer,
+        permanent_wrench_composer=permanent_wrench_composer,
+    )
+    env.robot.data = SimpleNamespace(
+        default_root_vel=SimpleNamespace(warp=object()),
+        default_joint_pos=SimpleNamespace(warp=object()),
+        default_joint_vel=SimpleNamespace(warp=object()),
+    )
+    env._default_root_pose_w = object()
+    env._post_step_buffers = Mock()
+    env_mask = wp.from_torch(env.reset_buf)
+
+    env._reset_idx_mask(env_mask)
+
+    torch.testing.assert_close(env.extras["log"]["Metrics/success_rate"], torch.tensor(0.5))
+    instantaneous_wrench_composer.reset.assert_called_once_with(env_mask=env_mask)
+    permanent_wrench_composer.reset.assert_called_once_with(env_mask=env_mask)
+    env.robot.write_root_pose_to_sim_mask.assert_called_once_with(root_pose=env._default_root_pose_w, env_mask=env_mask)
+    env.robot.write_root_velocity_to_sim_mask.assert_called_once_with(
+        root_velocity=env.robot.data.default_root_vel.warp, env_mask=env_mask
+    )
+    env.robot.write_joint_state_to_sim_mask.assert_called_once_with(
+        position=env.robot.data.default_joint_pos.warp,
+        velocity=env.robot.data.default_joint_vel.warp,
+        env_mask=env_mask,
+    )
+    env._post_step_buffers.compute_masked_reset_observation.assert_called_once_with(env, env_mask)

--- a/source/isaaclab_tasks/test/core/test_locomotion_direct_action.py
+++ b/source/isaaclab_tasks/test/core/test_locomotion_direct_action.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import torch
+
+from isaaclab_tasks.core.locomotion.locomotion_direct_env import LocomotionDirectEnv
+
+
+def test_action_target_is_staged_once_per_environment_step():
+    """Test that effort targets are staged once and persist across decimation substeps."""
+    env = object.__new__(LocomotionDirectEnv)
+    env._is_closed = True
+    env.action_scale = 0.5
+    env.joint_gears = torch.tensor([2.0, 3.0, 4.0])
+    env._joint_dof_idx = torch.arange(3)
+    env.robot = Mock()
+    actions = torch.tensor([[-2.0, -0.5, 1.5], [0.25, 2.0, -1.25]])
+
+    env._pre_physics_step(actions)
+    for _ in range(4):
+        env._apply_action()
+
+    env.robot.set_joint_effort_target_index.assert_called_once()
+    expected_target = 0.5 * env.joint_gears * torch.clamp(actions, -1.0, 1.0)
+    torch.testing.assert_close(env.robot.set_joint_effort_target_index.call_args.kwargs["target"], expected_target)
+    torch.testing.assert_close(env.actions, actions)
+    assert env.actions.data_ptr() != actions.data_ptr()

--- a/source/isaaclab_tasks/test/core/test_locomotion_direct_reset.py
+++ b/source/isaaclab_tasks/test/core/test_locomotion_direct_reset.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from isaaclab_tasks.core.locomotion.locomotion_direct_env import LocomotionDirectEnv
+
+_NUM_ENVS = 4
+_NUM_JOINTS = 3
+
+
+def _make_environment() -> tuple[LocomotionDirectEnv, Mock]:
+    env = object.__new__(LocomotionDirectEnv)
+    env._is_closed = True
+    reset_time_outs = torch.tensor([False, True, False, True])
+    default_joint_pos = torch.arange(_NUM_ENVS * _NUM_JOINTS, dtype=torch.float32).reshape(_NUM_ENVS, _NUM_JOINTS)
+    default_joint_vel = default_joint_pos + 20.0
+    default_root_pose = torch.zeros((_NUM_ENVS, 7), dtype=torch.float32)
+    default_root_pose[:, 6] = 1.0
+    default_root_vel = torch.arange(_NUM_ENVS * 6, dtype=torch.float32).reshape(_NUM_ENVS, 6)
+
+    robot = Mock()
+    robot.data = SimpleNamespace(
+        default_joint_pos=SimpleNamespace(torch=default_joint_pos),
+        default_joint_vel=SimpleNamespace(torch=default_joint_vel),
+        default_root_pose=SimpleNamespace(torch=default_root_pose),
+        default_root_vel=SimpleNamespace(torch=default_root_vel),
+    )
+    scene = SimpleNamespace(
+        num_envs=_NUM_ENVS,
+        env_origins=torch.tensor([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 20.0, 0.0], [0.0, 0.0, 30.0]]),
+    )
+    scene.reset = Mock(side_effect=robot.reset)
+
+    env.robot = robot
+    env.scene = scene
+    env.cfg = SimpleNamespace(
+        sim=SimpleNamespace(dt=1.0 / 120.0),
+        events=None,
+        action_noise_model=None,
+        observation_noise_model=None,
+    )
+    env.reset_time_outs = reset_time_outs
+    env.extras = {}
+    env.episode_length_buf = torch.arange(_NUM_ENVS)
+    env.targets = torch.tensor([1000.0, 0.0, 0.0]).repeat(_NUM_ENVS, 1)
+    env.potentials = torch.zeros(_NUM_ENVS)
+    env._compute_intermediate_values = Mock()
+    return env, robot
+
+
+def test_reset_idx_resets_articulation_once_through_scene():
+    env, robot = _make_environment()
+    env_ids = torch.tensor([1, 3])
+
+    env._reset_idx(env_ids)
+
+    env.scene.reset.assert_called_once_with(env_ids)
+    robot.reset.assert_called_once_with(env_ids)
+
+
+def test_reset_idx_keeps_success_rate_on_device():
+    env, _ = _make_environment()
+    env_ids = torch.tensor([0, 1, 2])
+
+    env._reset_idx(env_ids)
+
+    success_rate = env.extras["log"]["Metrics/success_rate"]
+    assert isinstance(success_rate, torch.Tensor)
+    assert success_rate.device == env.reset_time_outs.device
+    torch.testing.assert_close(success_rate, torch.tensor(1.0 / 3.0))
+
+
+def test_reset_idx_uses_fused_joint_state_writer():
+    env, robot = _make_environment()
+    env_ids = torch.tensor([1, 3])
+
+    env._reset_idx(env_ids)
+
+    robot.write_joint_state_to_sim_index.assert_called_once()
+    call = robot.write_joint_state_to_sim_index.call_args
+    torch.testing.assert_close(call.kwargs["position"], robot.data.default_joint_pos.torch[env_ids])
+    torch.testing.assert_close(call.kwargs["velocity"], robot.data.default_joint_vel.torch[env_ids])
+    torch.testing.assert_close(call.kwargs["env_ids"], env_ids)
+    robot.write_joint_position_to_sim_index.assert_not_called()
+    robot.write_joint_velocity_to_sim_index.assert_not_called()
+
+
+def test_reset_idx_does_not_mutate_default_state():
+    env, robot = _make_environment()
+    env_ids = torch.tensor([1, 3])
+    default_root_pose = robot.data.default_root_pose.torch.clone()
+    default_root_velocity = robot.data.default_root_vel.torch.clone()
+    default_joint_position = robot.data.default_joint_pos.torch.clone()
+    default_joint_velocity = robot.data.default_joint_vel.torch.clone()
+
+    env._reset_idx(env_ids)
+
+    torch.testing.assert_close(robot.data.default_root_pose.torch, default_root_pose)
+    torch.testing.assert_close(robot.data.default_root_vel.torch, default_root_velocity)
+    torch.testing.assert_close(robot.data.default_joint_pos.torch, default_joint_position)
+    torch.testing.assert_close(robot.data.default_joint_vel.torch, default_joint_velocity)


### PR DESCRIPTION
## Summary

This Draft PR shows the code changes required to let `Isaac-Ant-Direct` benefit from Newton zero-copy state access instead of spending most of the step in task orchestration.

- Fuse stable Ant intermediate values, terminations, rewards, and observations into one Warp post-step kernel.
- Keep reset selection on the GPU with a guarded device-mask reset hook.
- Stage persistent effort targets once per environment step instead of once per physics substep.
- Remove repeated all-joint index uploads, duplicate reset work, and redundant state copies/writes.
- Skip inactive Newton instantaneous-wrench buffer clears.
- Preserve the original Torch path for PhysX and unsupported Newton configurations.

This is a fresh PR based directly on `develop`. It does not modify or depend on #6474.

## Performance

RTX 5090, 4,096 environments, Newton/MJWarp, 100 warm-up steps, 1,000 measured steps, pre-generated seeded actions, with one device synchronization before and after the complete measured window:

| Seed | Control | Optimized | Reduction | Speedup |
|---:|---:|---:|---:|---:|
| 42 | 3.308513 ms | 1.359872 ms | 58.898% | 2.433x |
| 43 | 3.047741 ms | 1.361723 ms | 55.320% | 2.238x |
| 44 | 3.012498 ms | 1.364235 ms | 54.714% | 2.208x |
| Mean | 3.122917 ms | 1.361944 ms | 56.311% paired mean | 2.293x aggregate |

Aggregate throughput improves from **1.312M to 3.007M env-steps/s**. The optimized stable task reaches the same throughput class as the 2.98M env-steps/s experimental Warp/mask upper-bound task without substituting its different semantics.

Same-mode Nsight traces show:

- task post-processing launches: 55 per step to 1 per step;
- non-graph kernel launches: 2,000 to 1,160 over 20 steps;
- reset compaction kernels: eliminated;
- per-step `cudaStreamSynchronize`: 40 calls / 11.536 ms to zero;
- inactive wrench clears: 14 per step to zero.

## Semantic guards

- The fused post-step runs only on Newton with `compute_final_obs=False`.
- PhysX retains its pull-on-demand state path.
- Mask reset requires stateless `ImplicitActuator` instances, no Newton actuator adapter, no events or noise, and no reset rerendering.
- Active wrench composers are cleared with the reset mask; inactive composers launch no work.
- Live joint-limit views preserve runtime limit updates.
- Stable XYZW quaternion math, termination, reward, observation layout, timeout boundary, potential bookkeeping, and terminal outputs are retained.

## Type of change

- [x] Bug fix / performance optimization (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Screenshots

Not applicable; this is a headless simulation performance change.

## Validation

- [x] `18 passed` across focused CPU/CUDA regression tests.
- [x] Regression tests were confirmed to fail without the relevant fixes.
- [x] Live PhysX Ant fallback smoke test passed.
- [x] Three 4,096-environment Newton device-complete repetitions passed.
- [x] `./isaaclab.sh -p tools/changelog/cli.py check develop` passed.
- [x] `./isaaclab.sh -f` passed after the final commit.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks with `./isaaclab.sh -f`.
- [x] Documentation changes are not required for this internal guarded optimization; the benchmark contract and results are included above.
- [x] No new warnings were identified; focused tests report existing deprecation warnings.
- [x] I have added tests that prove the fixes are effective.
- [x] I have added one changelog fragment for each touched package.
- [x] Antoine Richard is already listed in `CONTRIBUTORS.md`.