### PR TITLE
Add direct environment reset hook

### DIFF
--- a/source/isaaclab/changelog.d/ant-direct-device-mask-reset.rst
+++ b/source/isaaclab/changelog.d/ant-direct-device-mask-reset.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added a protected direct-environment hook for backend-native device-mask resets.

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -471,7 +471,16 @@ class DirectRLEnv(gym.Env):
 
         # -- reset envs that terminated/timed-out and log the episode information
         reset_env_ids = self._reset_envs_from_buffer()
-        if reset_env_ids is not None and len(reset_env_ids) > 0:
+        if reset_env_ids is None:
+            if self.cfg.compute_final_obs:
+                raise RuntimeError(
+                    "Mask-native reset overrides must return reset indices when compute_final_obs is enabled."
+                )
+            if self.render_enabled and is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
+                raise RuntimeError(
+                    "Mask-native reset overrides must return reset indices when RTX reset rerenders are enabled."
+                )
+        elif len(reset_env_ids) > 0:
             # if sensors are added to the scene, make sure we render to reflect changes in reset
             if self.render_enabled and is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):
@@ -668,7 +677,9 @@ class DirectRLEnv(gym.Env):
         The default implementation compacts the reset mask into environment indices. CUDA
         environments synchronize while determining the dynamic output size of
         ``torch.Tensor.nonzero``. Tasks with backend-native mask reset support may
-        override this hook and return None to avoid that synchronization.
+        override this hook and return None to avoid that synchronization. Returning None
+        is only supported when terminal-observation capture and RTX reset rerenders are
+        disabled. Overrides must delegate to this implementation in those configurations.
 
         Returns:
             Reset environment indices, or None when an override completed reset

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -470,17 +470,8 @@ class DirectRLEnv(gym.Env):
         self.reward_buf = self._get_rewards()
 
         # -- reset envs that terminated/timed-out and log the episode information
-        reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1).int()
-        if len(reset_env_ids) > 0:
-            # capture the terminal observation before reset and expose it for Same-Step autoreset.
-            # apply the same observation noise as the returned obs (policy space only) so the
-            # bootstrapped terminal value matches the distribution the policy is trained on.
-            if self.cfg.compute_final_obs:
-                terminal_obs = self._get_observations()
-                if self.cfg.observation_noise_model:
-                    terminal_obs["policy"] = self._observation_noise_model(terminal_obs["policy"])
-                self.extras["final_obs"] = terminal_obs
-            self._reset_idx(reset_env_ids)
+        reset_env_ids = self._reset_envs_from_buffer()
+        if reset_env_ids is not None and len(reset_env_ids) > 0:
             # if sensors are added to the scene, make sure we render to reflect changes in reset
             if self.render_enabled and is_rendering and self.has_rtx_sensors and self.cfg.num_rerenders_on_reset > 0:
                 for _ in range(self.cfg.num_rerenders_on_reset):
@@ -670,6 +661,31 @@ class DirectRLEnv(gym.Env):
 
         # instantiate actions (needed for tasks for which the observations computation is dependent on the actions)
         self.actions = sample_space(self.single_action_space, self.sim.device, batch_size=self.num_envs, fill_value=0)
+
+    def _reset_envs_from_buffer(self) -> torch.Tensor | None:
+        """Reset environments marked in the reset buffer.
+
+        The default implementation compacts the reset mask into environment indices. CUDA
+        environments synchronize while determining the dynamic output size of
+        ``torch.Tensor.nonzero``. Tasks with backend-native mask reset support may
+        override this hook and return None to avoid that synchronization.
+
+        Returns:
+            Reset environment indices, or None when an override completed reset
+            processing without materializing host-visible indices.
+        """
+        reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1).int()
+        if len(reset_env_ids) > 0:
+            # capture the terminal observation before reset and expose it for Same-Step autoreset.
+            # apply the same observation noise as the returned obs (policy space only) so the
+            # bootstrapped terminal value matches the distribution the policy is trained on.
+            if self.cfg.compute_final_obs:
+                terminal_obs = self._get_observations()
+                if self.cfg.observation_noise_model:
+                    terminal_obs["policy"] = self._observation_noise_model(terminal_obs["policy"])
+                self.extras["final_obs"] = terminal_obs
+            self._reset_idx(reset_env_ids)
+        return reset_env_ids
 
     def _reset_idx(self, env_ids: Sequence[int]):
         """Reset environments based on specified indices.


### PR DESCRIPTION
# Description

Adds a protected DirectRLEnv reset hook that preserves the existing indexed reset behavior by default while allowing backend-native task implementations to complete reset processing from a device mask without materializing dynamic reset indices on the host.

CUDA torch.nonzero compaction requires determining a dynamic output size and can synchronize the stream. The hook isolates that policy decision without changing existing DirectRLEnv task semantics.

ManagerBasedRLEnv is intentionally not included. Its scene, event, recorder, curriculum, observation, action, reward, command, and termination reset contracts currently require compact environment IDs, so adding the same hook there would not yet provide a synchronization-free path.

This is one focused slice of superseded Draft PR #6509 and is independent of benchmark PR #6474.

## Type of change

- New feature (non-breaking protected extension point)

## Validation

- ./isaaclab.sh -p tools/changelog/cli.py check develop
- ./isaaclab.sh -f before commit
- ./isaaclab.sh -f after commit and before push
- The source change was exercised by the original focused CPU/CUDA validation before the PR split; new test files are intentionally omitted from this slice.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with ./isaaclab.sh --format
- [x] Documentation changes are not required for this protected hook
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment for the touched package
- [x] My name already exists in CONTRIBUTORS.md