### PR TITLE
Skip inactive articulation wrench resets

### DIFF
--- a/source/isaaclab_newton/changelog.d/ant-direct-wrench-overhead.rst
+++ b/source/isaaclab_newton/changelog.d/ant-direct-wrench-overhead.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed unnecessary wrench-buffer resets when Newton articulations had no instantaneous wrenches.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -297,7 +297,8 @@ class Articulation(BaseArticulation):
                     self._ALL_BODY_MASK,
                 ],
             )
-        self._instantaneous_wrench_composer.reset()
+        if self._instantaneous_wrench_composer.active:
+            self._instantaneous_wrench_composer.reset()
 
         if getattr(self, "_has_newton_actuators", False):
             # Raw targets go directly to Newton's control object. Newton PD

--- a/source/isaaclab_ovphysx/changelog.d/skip-inactive-wrench-reset.rst
+++ b/source/isaaclab_ovphysx/changelog.d/skip-inactive-wrench-reset.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed unnecessary wrench-buffer resets when OVPhysX articulations had no instantaneous wrenches.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
@@ -244,7 +244,8 @@ class Articulation(BaseArticulation):
             )
             if self._get_binding(TT.LINK_WRENCH) is not None:
                 self._root_view.set_attribute(TT.LINK_WRENCH, self._wrench_buf)
-            inst.reset()
+            if inst.active:
+                inst.reset()
 
         # apply actuator models
         self._apply_actuator_model()

--- a/source/isaaclab_physx/changelog.d/skip-inactive-wrench-reset.rst
+++ b/source/isaaclab_physx/changelog.d/skip-inactive-wrench-reset.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed unnecessary wrench-buffer resets when PhysX articulations had no instantaneous wrenches.

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -270,7 +270,8 @@ class Articulation(BaseArticulation):
                 indices=self._ALL_INDICES,
                 is_global=False,
             )
-        self._instantaneous_wrench_composer.reset()
+        if self._instantaneous_wrench_composer.active:
+            self._instantaneous_wrench_composer.reset()
 
         if getattr(self, "_has_newton_actuators", False):
             # Newton fast path: pos/vel targets pass straight through; the


### PR DESCRIPTION
# Description

Skips resetting inactive instantaneous-wrench composers in the Newton, PhysX, and OVPhysX articulation write paths.

Newton and PhysX previously cleared all seven composer buffers on every physics substep even when no instantaneous wrench had been applied. Nsight attributed fourteen 442,368-byte clears per Ant environment step to this work on Newton. OVPhysX already avoids resets when neither composer is active; its guard removes the remaining redundant reset when only permanent wrenches are active.

The active check preserves the existing reset after every applied instantaneous wrench. An inactive composer is already fully reset: construction and full reset both zero its five input and two output buffers, while every supported add or set operation marks it active.

This is one focused slice of superseded Draft PR #6509 and is independent of benchmark PR #6474.

## Type of change

- Bug fix (non-breaking performance fix)

## Validation

- ./isaaclab.sh -p tools/changelog/cli.py check develop
- ./isaaclab.sh -f before commit
- ./isaaclab.sh -f after commit and before push
- The Newton source change was exercised by the original focused CPU/CUDA validation before the PR split; new test files are intentionally omitted from this slice.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with ./isaaclab.sh --format
- [x] Documentation changes are not required
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment for every touched package
- [x] My name already exists in CONTRIBUTORS.md