### PR TITLE
Add fused OVPhysX joint-state writer

### DIFF
--- a/source/isaaclab_ovphysx/changelog.d/ovphysx-fused-joint-state-writer.minor.rst
+++ b/source/isaaclab_ovphysx/changelog.d/ovphysx-fused-joint-state-writer.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added :meth:`~isaaclab_ovphysx.assets.Articulation.write_joint_state_to_sim_index` to update
+  joint position and velocity state in one device kernel.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
@@ -823,6 +823,57 @@ class Articulation(BaseArticulation):
             TT.ROOT_VELOCITY, self.data._root_com_vel_w.data.view(wp.float32), mask=env_mask_wp
         )
 
+    def write_joint_state_to_sim_index(
+        self,
+        *,
+        position: torch.Tensor | wp.array,
+        velocity: torch.Tensor | wp.array,
+        joint_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
+        env_ids: Sequence[int] | torch.Tensor | wp.array | None = None,
+        skip_forward: bool = False,
+    ) -> None:
+        """Set joint positions and velocities over selected indices into the simulation.
+
+        The joint position and velocity caches, finite-difference velocity baseline, and
+        joint acceleration cache are updated in one device kernel.
+
+        .. note::
+            This method expects partial data.
+
+        Args:
+            position: Joint positions [m or rad, depending on joint type]. Shape is
+                (len(env_ids), len(joint_ids)) with dtype wp.float32.
+            velocity: Joint velocities [m/s or rad/s, depending on joint type]. Shape is
+                (len(env_ids), len(joint_ids)) with dtype wp.float32.
+            joint_ids: Joint indices. Defaults to None (all joints).
+            env_ids: Environment indices. Defaults to None (all environments).
+            skip_forward: Whether to skip invalidating cached data after the write. When True, the caller
+                must invalidate stale cached data before reading it back. Defaults to False.
+        """
+        env_ids = self._resolve_env_ids(env_ids)
+        joint_ids = self._resolve_joint_ids(joint_ids)
+        expected_shape = (env_ids.shape[0], joint_ids.shape[0])
+        self.assert_shape_and_dtype(position, expected_shape, wp.float32, "position")
+        self.assert_shape_and_dtype(velocity, expected_shape, wp.float32, "velocity")
+        wp.launch(
+            shared_kernels.write_joint_state_to_buffer_with_indices,
+            dim=expected_shape,
+            inputs=[position, velocity, env_ids, joint_ids],
+            outputs=[
+                self._data._joint_pos_buf.data,
+                self._data._joint_vel_buf.data,
+                self._data._previous_joint_vel,
+                self._data._joint_acc.data,
+            ],
+            device=self._device,
+        )
+        self._data._joint_acc.timestamp = self._data._sim_timestamp
+        if not skip_forward:
+            self._data._reset_pose()
+            self._data._reset_velocity()
+        self._root_view.set_attribute(TT.DOF_POSITION, self._data._joint_pos_buf.data, indices=env_ids)
+        self._root_view.set_attribute(TT.DOF_VELOCITY, self._data._joint_vel_buf.data, indices=env_ids)
+
     def write_joint_position_to_sim_index(
         self,
         *,

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/kernels.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/kernels.py
@@ -866,6 +866,28 @@ def write_2d_data_to_buffer_with_indices(
 
 
 @wp.kernel
+def write_joint_state_to_buffer_with_indices(
+    position: wp.array2d(dtype=wp.float32),
+    velocity: wp.array2d(dtype=wp.float32),
+    env_ids: wp.array(dtype=wp.int32),
+    joint_ids: wp.array(dtype=wp.int32),
+    out_position: wp.array2d(dtype=wp.float32),
+    out_velocity: wp.array2d(dtype=wp.float32),
+    previous_velocity: wp.array2d(dtype=wp.float32),
+    acceleration: wp.array2d(dtype=wp.float32),
+):
+    """Write joint position and velocity state to selected buffer entries."""
+    i, j = wp.tid()
+    env_id = env_ids[i]
+    joint_id = joint_ids[j]
+    joint_velocity = velocity[i, j]
+    out_position[env_id, joint_id] = position[i, j]
+    out_velocity[env_id, joint_id] = joint_velocity
+    previous_velocity[env_id, joint_id] = joint_velocity
+    acceleration[env_id, joint_id] = 0.0
+
+
+@wp.kernel
 def write_body_inertia_to_buffer_index(
     in_data: wp.array3d(dtype=wp.float32),
     env_ids: wp.array(dtype=wp.int32),

--- a/source/isaaclab_ovphysx/test/assets/test_articulation.py
+++ b/source/isaaclab_ovphysx/test/assets/test_articulation.py
@@ -2110,6 +2110,57 @@ def test_setting_invalid_articulation_root_prim_path(sim, device):
         sim.reset()
 
 
+@pytest.mark.parametrize("device", test_devices())
+def test_write_joint_state_to_sim_index_partial(sim, device):
+    """Test fused joint-state writes with partial environment and joint indices."""
+    sim._app_control_on_stop_handle = None
+    articulation_cfg = generate_articulation_cfg(articulation_type="anymal")
+    articulation, _ = generate_articulation(articulation_cfg, 2, device)
+    sim.reset()
+
+    original_joint_pos = articulation.data.joint_pos.torch.clone()
+    original_joint_vel = articulation.data.joint_vel.torch.clone()
+    _ = articulation.data.body_link_pose_w
+    _ = articulation.data.body_com_vel_w
+    pose_timestamp = articulation.data._body_link_pose_w.timestamp
+    velocity_timestamp = articulation.data._body_com_vel_w.timestamp
+
+    previous_joint_vel = wp.to_torch(articulation.data._previous_joint_vel)
+    joint_acc = wp.to_torch(articulation.data._joint_acc.data)
+    previous_joint_vel.fill_(3.0)
+    joint_acc.fill_(4.0)
+    articulation.data._joint_acc.timestamp = -1.0
+
+    position = torch.tensor([[0.1, -0.1]], device=device)
+    velocity = torch.tensor([[0.2, -0.2]], device=device)
+    articulation.write_joint_state_to_sim_index(
+        position=position, velocity=velocity, env_ids=[1], joint_ids=[0, 2], skip_forward=True
+    )
+
+    expected_joint_pos = original_joint_pos.clone()
+    expected_joint_vel = original_joint_vel.clone()
+    expected_previous_joint_vel = torch.full_like(previous_joint_vel, 3.0)
+    expected_joint_acc = torch.full_like(joint_acc, 4.0)
+    expected_joint_pos[1, [0, 2]] = position[0]
+    expected_joint_vel[1, [0, 2]] = velocity[0]
+    expected_previous_joint_vel[1, [0, 2]] = velocity[0]
+    expected_joint_acc[1, [0, 2]] = 0.0
+
+    torch.testing.assert_close(articulation.data.joint_pos.torch, expected_joint_pos)
+    torch.testing.assert_close(articulation.data.joint_vel.torch, expected_joint_vel)
+    torch.testing.assert_close(previous_joint_vel, expected_previous_joint_vel)
+    torch.testing.assert_close(joint_acc, expected_joint_acc)
+    assert articulation.data._joint_acc.timestamp == articulation.data._sim_timestamp
+    assert articulation.data._body_link_pose_w.timestamp == pose_timestamp
+    assert articulation.data._body_com_vel_w.timestamp == velocity_timestamp
+    torch.testing.assert_close(_read_binding_to_torch(articulation, TT.DOF_POSITION, device), expected_joint_pos)
+    torch.testing.assert_close(_read_binding_to_torch(articulation, TT.DOF_VELOCITY, device), expected_joint_vel)
+
+    articulation.write_joint_state_to_sim_index(position=position, velocity=velocity, env_ids=[1], joint_ids=[0, 2])
+    assert articulation.data._body_link_pose_w.timestamp < articulation.data._sim_timestamp
+    assert articulation.data._body_com_vel_w.timestamp < articulation.data._sim_timestamp
+
+
 @pytest.mark.parametrize("num_articulations", [1, 2])
 @pytest.mark.parametrize("device", test_devices())
 @pytest.mark.parametrize("gravity_enabled", [False])
@@ -2150,8 +2201,7 @@ def test_write_joint_state_data_consistency(sim, num_articulations, device, grav
     rand_joint_pos = pos_dist.sample()
     rand_joint_vel = vel_dist.sample()
 
-    articulation.write_joint_position_to_sim_index(position=rand_joint_pos)
-    articulation.write_joint_velocity_to_sim_index(velocity=rand_joint_vel)
+    articulation.write_joint_state_to_sim_index(position=rand_joint_pos, velocity=rand_joint_vel)
     # make sure valued updated
     body_link_pose_w = articulation.data.body_link_pose_w.torch
     body_com_vel_w = articulation.data.body_com_vel_w.torch


### PR DESCRIPTION
# Description

Adds Articulation.write_joint_state_to_sim_index to the OVPhysX backend.

The existing reset path updates the same state through separate position and velocity writers. That requires four Warp cache-update kernels: one for position, then three for velocity, the finite-difference baseline, and acceleration zeroing. The new writer performs those cache updates in one kernel while preserving the two OVPhysX tensor-binding writes required to update DOF position and velocity.

The method preserves the existing semantics:

- resolves partial environment and joint indices through the standard OVPhysX helpers
- updates joint position and velocity caches
- synchronizes the previous-velocity baseline and zeros selected joint accelerations
- stamps the joint-acceleration cache
- invalidates pose and velocity dependents once unless skip_forward is requested
- leaves unselected environments and joints unchanged

This is a focused OVPhysX backend PR. It has no dependency on #6512, although the compatibility path there can use this method automatically when both changes are present.

## Type of change

- New feature (non-breaking change which adds functionality)

## Validation

- Focused CPU OVPhysX tests: 3 passed, 207 deselected
- The modified integration test fails on origin/develop with the expected missing-method AttributeError
- Changelog gate: ./isaaclab.sh -p tools/changelog/cli.py check develop
- Full pre-commit: ./isaaclab.sh -f
- Full documentation build was attempted but remained silent for several minutes and was terminated; the public API docstring and RST cross-reference checks pass

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with ./isaaclab.sh -f
- [x] I have documented the public API and added a changelog fragment
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] I have added a changelog fragment under source/isaaclab_ovphysx/changelog.d/
- [x] My name already exists in CONTRIBUTORS.md