### PR TITLE
Optimize direct Cartpole step overhead

### DIFF
--- a/source/isaaclab_tasks/changelog.d/optimize-cartpole-overhead.rst
+++ b/source/isaaclab_tasks/changelog.d/optimize-cartpole-overhead.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed excessive per-step overhead in the direct Cartpole task by batching actuator
+  writes and fusing termination, reward, and observation calculations.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env.py
@@ -9,6 +9,8 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import torch
+from isaaclab_newton.physics import NewtonCfg
+from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab import cloner
@@ -16,6 +18,8 @@ from isaaclab.assets import Articulation
 from isaaclab.envs import DirectRLEnv
 from isaaclab.sim.spawners.from_files import GroundPlaneCfg, spawn_ground_plane
 from isaaclab.utils.math import sample_uniform, wrap_to_pi
+
+from isaaclab_tasks.core.cartpole.cartpole_post_step import _CartpolePostStepBuffers
 
 if TYPE_CHECKING:
     from isaaclab_tasks.core.cartpole.cartpole_direct_env_cfg import CartpoleEnvCfg
@@ -35,6 +39,12 @@ class CartpoleEnv(DirectRLEnv):
 
         self.joint_pos = self.cartpole.data.joint_pos.torch
         self.joint_vel = self.cartpole.data.joint_vel.torch
+        self._use_fused_post_step = self._supports_fused_post_step()
+        self._fused_inputs_require_refresh = isinstance(self.cfg.sim.physics, PhysxCfg)
+        if self._use_fused_post_step:
+            self._joint_position_warp = self.cartpole.data.joint_pos.warp
+            self._joint_velocity_warp = self.cartpole.data.joint_vel.warp
+            self._post_step_buffers = _CartpolePostStepBuffers(self.num_envs, self.device)
 
     def _setup_scene(self):
         self.cartpole = Articulation(self.cfg.robot_cfg)
@@ -57,12 +67,16 @@ class CartpoleEnv(DirectRLEnv):
         light_cfg.func("/World/Light", light_cfg, orientation=light_orientation)
 
     def _pre_physics_step(self, actions: torch.Tensor) -> None:
-        self.actions = self.action_scale * actions.clone()
-
-    def _apply_action(self) -> None:
+        self.actions = self.action_scale * actions
         self.cartpole.set_joint_effort_target_index(target=self.actions, joint_ids=self._cart_dof_idx)
 
+    def _apply_action(self) -> None:
+        # Joint effort targets persist in the articulation command buffer across decimation substeps.
+        pass
+
     def _get_observations(self) -> dict:
+        if self._use_fused_post_step:
+            return {"policy": self._post_step_buffers.observation_torch}
         joint_pos_rel = self.joint_pos - self.cartpole.data.default_joint_pos.torch
         joint_vel_rel = self.joint_vel - self.cartpole.data.default_joint_vel.torch
         obs = torch.cat(
@@ -78,6 +92,8 @@ class CartpoleEnv(DirectRLEnv):
         return observations
 
     def _get_rewards(self) -> torch.Tensor:
+        if self._use_fused_post_step:
+            return self._post_step_buffers.reward_torch
         total_reward = compute_rewards(
             self.cfg.rew_scale_alive,
             self.cfg.rew_scale_terminated,
@@ -93,11 +109,14 @@ class CartpoleEnv(DirectRLEnv):
         return total_reward
 
     def _get_dones(self) -> tuple[torch.Tensor, torch.Tensor]:
+        if self._use_fused_post_step:
+            self._refresh_fused_post_step_inputs()
+            self._post_step_buffers.compute_post_step(self)
+            return self._post_step_buffers.terminated_torch, self._post_step_buffers.time_out_torch
         self.joint_pos = self.cartpole.data.joint_pos.torch
         self.joint_vel = self.cartpole.data.joint_vel.torch
-
         time_out = self.episode_length_buf >= self.max_episode_length
-        out_of_bounds = torch.any(torch.abs(self.joint_pos[:, self._cart_dof_idx]) > self.cfg.max_cart_pos, dim=1)
+        out_of_bounds = torch.abs(self.joint_pos[:, self._cart_dof_idx[0]]) > self.cfg.max_cart_pos
         return out_of_bounds, time_out
 
     def _reset_idx(self, env_ids: Sequence[int] | None):
@@ -154,6 +173,29 @@ class CartpoleEnv(DirectRLEnv):
         self.cartpole.write_root_velocity_to_sim_index(root_velocity=default_root_vel, env_ids=env_ids)
         self.cartpole.write_joint_position_to_sim_index(position=joint_pos, env_ids=env_ids)
         self.cartpole.write_joint_velocity_to_sim_index(velocity=joint_vel, env_ids=env_ids)
+        if getattr(self, "_use_fused_post_step", False):
+            self._post_step_buffers.compute_observation(self)
+
+    def _supports_fused_post_step(self) -> bool:
+        """Return whether live state can safely supply fused post-step calculations."""
+        return (
+            isinstance(self.cfg.sim.physics, (NewtonCfg, PhysxCfg))
+            and self.cfg.observation_space == 4
+            and not self.cfg.compute_final_obs
+            and not self.cfg.events
+            and type(self)._get_observations is CartpoleEnv._get_observations
+            and type(self)._get_rewards is CartpoleEnv._get_rewards
+            and type(self)._get_dones is CartpoleEnv._get_dones
+            and type(self)._reset_idx is CartpoleEnv._reset_idx
+        )
+
+    def _refresh_fused_post_step_inputs(self) -> None:
+        """Pull current PhysX joint state into the stable buffers consumed by the fused kernel."""
+        if not self._fused_inputs_require_refresh:
+            return
+
+        data = self.cartpole.data
+        _ = data.joint_pos, data.joint_vel
 
 
 @torch.jit.script

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
@@ -11,6 +11,7 @@ from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
 from isaaclab.envs import DirectRLEnvCfg, ViewerCfg
 from isaaclab.scene import InteractiveSceneCfg
@@ -80,7 +81,17 @@ class CartpoleEnvCfg(DirectRLEnvCfg):
     sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=CartpolePhysicsCfg())
 
     # robot
-    robot_cfg: ArticulationCfg = CARTPOLE_CFG.replace(prim_path="/World/envs/env_.*/Robot")
+    robot_cfg: ArticulationCfg = CARTPOLE_CFG.replace(
+        prim_path="/World/envs/env_.*/Robot",
+        actuators={
+            "cartpole_actuator": ImplicitActuatorCfg(
+                joint_names_expr=[".*"],
+                effort_limit_sim=400.0,
+                stiffness=0.0,
+                damping={"slider_to_cart": 10.0, "cart_to_pole": 0.0},
+            )
+        },
+    )
     cart_dof_name = "slider_to_cart"
     pole_dof_name = "cart_to_pole"
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_post_step.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_post_step.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import warp as wp
+
+
+@wp.func
+def _wrap_to_pi(angle: wp.float32) -> wp.float32:
+    """Wrap an angle [rad] to the range ``[-pi, pi]`` using Torch remainder semantics."""
+    two_pi = 2.0 * wp.pi
+    wrapped_angle = angle + wp.pi
+    wrapped_angle = wrapped_angle - wp.floor(wrapped_angle / two_pi) * two_pi
+    return wp.where((wrapped_angle == 0.0) and (angle > 0.0), wp.pi, wrapped_angle - wp.pi)
+
+
+@wp.func
+def _write_observation(
+    env_id: int,
+    joint_position: wp.array2d(dtype=wp.float32),
+    joint_velocity: wp.array2d(dtype=wp.float32),
+    default_joint_position: wp.array2d(dtype=wp.float32),
+    default_joint_velocity: wp.array2d(dtype=wp.float32),
+    cart_dof_idx: wp.int32,
+    pole_dof_idx: wp.int32,
+    observation: wp.array2d(dtype=wp.float32),
+):
+    observation[env_id, 0] = joint_position[env_id, cart_dof_idx] - default_joint_position[env_id, cart_dof_idx]
+    observation[env_id, 1] = joint_position[env_id, pole_dof_idx] - default_joint_position[env_id, pole_dof_idx]
+    observation[env_id, 2] = joint_velocity[env_id, cart_dof_idx] - default_joint_velocity[env_id, cart_dof_idx]
+    observation[env_id, 3] = joint_velocity[env_id, pole_dof_idx] - default_joint_velocity[env_id, pole_dof_idx]
+
+
+@wp.kernel
+def _compute_cartpole_post_step(
+    joint_position: wp.array2d(dtype=wp.float32),
+    joint_velocity: wp.array2d(dtype=wp.float32),
+    default_joint_position: wp.array2d(dtype=wp.float32),
+    default_joint_velocity: wp.array2d(dtype=wp.float32),
+    episode_length: wp.array(dtype=wp.int64),
+    cart_dof_idx: wp.int32,
+    pole_dof_idx: wp.int32,
+    max_episode_length: wp.int64,
+    max_cart_position: wp.float32,
+    reward_scale_alive: wp.float32,
+    reward_scale_terminated: wp.float32,
+    reward_scale_pole_position: wp.float32,
+    reward_scale_cart_velocity: wp.float32,
+    reward_scale_pole_velocity: wp.float32,
+    step_dt: wp.float32,
+    terminated: wp.array(dtype=wp.bool),
+    time_out: wp.array(dtype=wp.bool),
+    reward: wp.array(dtype=wp.float32),
+    observation: wp.array2d(dtype=wp.float32),
+):
+    env_id = wp.tid()
+    cart_position = joint_position[env_id, cart_dof_idx]
+    pole_position = _wrap_to_pi(joint_position[env_id, pole_dof_idx])
+    cart_velocity = joint_velocity[env_id, cart_dof_idx]
+    pole_velocity = joint_velocity[env_id, pole_dof_idx]
+
+    is_terminated = wp.abs(cart_position) > max_cart_position
+    terminated[env_id] = is_terminated
+    time_out[env_id] = episode_length[env_id] >= max_episode_length
+
+    alive_reward = reward_scale_alive
+    termination_reward = wp.float32(0.0)
+    if is_terminated:
+        alive_reward = wp.float32(0.0)
+        termination_reward = reward_scale_terminated
+    pole_position_reward = reward_scale_pole_position * pole_position * pole_position
+    cart_velocity_reward = reward_scale_cart_velocity * wp.abs(cart_velocity)
+    pole_velocity_reward = reward_scale_pole_velocity * wp.abs(pole_velocity)
+    reward[env_id] = (
+        alive_reward + termination_reward + pole_position_reward + cart_velocity_reward + pole_velocity_reward
+    ) * step_dt
+
+    _write_observation(
+        env_id,
+        joint_position,
+        joint_velocity,
+        default_joint_position,
+        default_joint_velocity,
+        cart_dof_idx,
+        pole_dof_idx,
+        observation,
+    )
+
+
+@wp.kernel
+def _compute_cartpole_observation(
+    joint_position: wp.array2d(dtype=wp.float32),
+    joint_velocity: wp.array2d(dtype=wp.float32),
+    default_joint_position: wp.array2d(dtype=wp.float32),
+    default_joint_velocity: wp.array2d(dtype=wp.float32),
+    cart_dof_idx: wp.int32,
+    pole_dof_idx: wp.int32,
+    observation: wp.array2d(dtype=wp.float32),
+):
+    env_id = wp.tid()
+    _write_observation(
+        env_id,
+        joint_position,
+        joint_velocity,
+        default_joint_position,
+        default_joint_velocity,
+        cart_dof_idx,
+        pole_dof_idx,
+        observation,
+    )
+
+
+class _CartpolePostStepBuffers:
+    """Persistent task outputs used by the fused Cartpole post-step kernels."""
+
+    def __init__(self, num_envs: int, device: str):
+        self.num_envs = num_envs
+        self.device = device
+        self.terminated = wp.zeros(num_envs, dtype=wp.bool, device=device)
+        self.time_out = wp.zeros(num_envs, dtype=wp.bool, device=device)
+        self.reward = wp.zeros(num_envs, dtype=wp.float32, device=device)
+        # RL runners may retain the current observation until the next step completes.
+        self._observations = (
+            wp.zeros((num_envs, 4), dtype=wp.float32, device=device),
+            wp.zeros((num_envs, 4), dtype=wp.float32, device=device),
+        )
+        self._observation_torch = tuple(wp.to_torch(observation) for observation in self._observations)
+        self._observation_index = 0
+        self.observation = self._observations[self._observation_index]
+        self.observation_torch = self._observation_torch[self._observation_index]
+        self.terminated_torch = wp.to_torch(self.terminated)
+        self.time_out_torch = wp.to_torch(self.time_out)
+        self.reward_torch = wp.to_torch(self.reward)
+
+    def compute_post_step(self, env) -> None:
+        """Compute Cartpole dones, rewards, and observations in one launch."""
+        self._observation_index ^= 1
+        self.observation = self._observations[self._observation_index]
+        self.observation_torch = self._observation_torch[self._observation_index]
+        wp.launch(
+            _compute_cartpole_post_step,
+            dim=self.num_envs,
+            inputs=[
+                env._joint_position_warp,
+                env._joint_velocity_warp,
+                env.cartpole.data.default_joint_pos.warp,
+                env.cartpole.data.default_joint_vel.warp,
+                env.episode_length_buf,
+                env._cart_dof_idx[0],
+                env._pole_dof_idx[0],
+                env.max_episode_length,
+                env.cfg.max_cart_pos,
+                env.cfg.rew_scale_alive,
+                env.cfg.rew_scale_terminated,
+                env.cfg.rew_scale_pole_pos,
+                env.cfg.rew_scale_cart_vel,
+                env.cfg.rew_scale_pole_vel,
+                env.step_dt,
+            ],
+            outputs=[self.terminated, self.time_out, self.reward, self.observation],
+            device=self.device,
+        )
+
+    def compute_observation(self, env) -> None:
+        """Refresh observations after an index-based reset."""
+        wp.launch(
+            _compute_cartpole_observation,
+            dim=self.num_envs,
+            inputs=[
+                env._joint_position_warp,
+                env._joint_velocity_warp,
+                env.cartpole.data.default_joint_pos.warp,
+                env.cartpole.data.default_joint_vel.warp,
+                env._cart_dof_idx[0],
+                env._pole_dof_idx[0],
+            ],
+            outputs=[self.observation],
+            device=self.device,
+        )


### PR DESCRIPTION
# Description

This draft isolates the direct Cartpole hot-path changes from the runtime benchmark work in #6474 and from the locomotion/reset PR stack.

It currently demonstrates three independent ideas:

1. Configure the direct task with one implicit actuator group while preserving the original per-joint damping. This avoids redundant articulation command writes without changing the shared `CARTPOLE_CFG` asset.
2. Stage the persistent joint target once per environment step instead of once per decimation substep, and remove an unnecessary action clone.
3. Compute termination, reward, and observation outputs in one Warp kernel. Newton reads its live zero-copy state directly; PhysX explicitly refreshes its stable joint-state buffers before launching the same kernel. Unsupported task variants retain the Torch path.

The Newton device-mask reset prototype is deliberately not included. It depends on the generic reset hook and mask writers under separate review, and PhysX has no equivalent mask-native reset writer.

## Preliminary PhysX result

Measured on the same RTX 5090 workstation with 4,096 environments, 100 warm-up steps, 2,000 device-complete measured steps, and matched random-action hashes. The benchmark implementation from #6474 was held constant in separate measurement worktrees and is not present in this branch.

| Seed | Before [ms/step] | Draft [ms/step] |
|---:|---:|---:|
| 42 | 4.718 | 4.980 |
| 43 | 4.915 | 4.049 |
| 44 | 5.025 | 4.467 |
| Mean | 4.886 | 4.499 |

The mean step time falls by 7.9% and mean throughput rises from 0.839M to 0.917M env-steps/s. The paired results are noisy, including one regression, so this should be treated as evidence that some gains transfer to PhysX—not as an authoritative final estimate. PhysX still pays two state pulls per step and retains index-based reset compaction.

For context, the full Newton prototype including the separate mask-reset work reached 3.58M env-steps/s versus 1.55M before optimization (2.31x). That number is an upper-stack result and must not be attributed to this PR alone.

## Suggested landing split

I suggest using this draft to decide among four focused changes:

- backend-neutral action staging and scalar one-joint indexing;
- task-local actuator grouping, or preferably a generic articulation batching solution if preserving actuator-group identities matters;
- the cross-backend fused Cartpole post-step;
- Newton-only device-mask reset later, after its generic dependencies land.

## Type of change

- Bug fix (non-breaking change which fixes excessive runtime overhead)

## Screenshots

Not applicable.

## Validation

- `./isaaclab.sh -f`
- `./isaaclab.sh -p tools/changelog/cli.py check develop`
- Python bytecode compilation for the modified Cartpole modules
- PhysX and Newton runtime smoke runs with identical action hashes
- Three paired PhysX performance seeds with source-path and git-diff provenance recorded

One retry was required after a Kit startup crash in OpenBLAS/telemetry, before the environment loaded. The crashed process was removed from the results.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh -f`
- [x] No documentation change is required for this internal task optimization
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment for the touched package
- [x] My name already exists in `CONTRIBUTORS.md`
