### PR TITLE
Fix UV setup for enterprise Actions policy

### DIFF
--- a/.github/actions/install-ci-run/action.yml
+++ b/.github/actions/install-ci-run/action.yml
@@ -24,9 +24,9 @@ runs:
   steps:
     # Host runs tools/run_install_ci.py (which in turn calls tools/wheel_builder/build.sh).
     # build.sh / gen_pyproject.py use stdlib ``tomllib`` (Python 3.11+). x86 runners default
-    # to Python 3.10, so install a managed 3.12 with uv and activate it for this step.
-    - name: Set up Python 3.12 via uv
-      uses: astral-sh/setup-uv@v6
+    # to Python 3.10, so install a managed 3.12 and uv, then activate a venv for this step.
+    - name: Set up Python 3.12 and uv
+      uses: ./.github/actions/setup-uv
       with:
         python-version: "3.12"
     - name: Run Tests

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -1,0 +1,44 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: "Set up uv"
+description: "Set up Python and install a pinned uv release using enterprise-approved actions"
+
+inputs:
+  python-version:
+    description: "Python version to install"
+    required: false
+    default: "3.12"
+  uv-version:
+    description: "uv version to install"
+    required: false
+    default: "0.11.21"
+  enable-cache:
+    description: "Whether to restore and save the uv cache"
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Cache uv
+      if: inputs.enable-cache == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/uv
+        key: uv-${{ runner.os }}-${{ runner.arch }}-${{ inputs.uv-version }}-${{ hashFiles('uv.lock') }}
+        restore-keys: |
+          uv-${{ runner.os }}-${{ runner.arch }}-${{ inputs.uv-version }}-
+
+    - name: Install uv
+      shell: bash
+      env:
+        UV_VERSION: ${{ inputs.uv-version }}
+      run: python -m pip install --disable-pip-version-check "uv==${UV_VERSION}"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: ./.github/actions/setup-uv
       with:
         python-version: "3.12"
 
@@ -92,7 +92,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: ./.github/actions/setup-uv
       with:
         python-version: "3.12"
 

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -181,7 +181,7 @@ jobs:
 
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: ./.github/actions/setup-uv
       with:
         python-version: '3.12'
         enable-cache: true


### PR DESCRIPTION
# Description

Replace `astral-sh/setup-uv@v6` with a repository-local composite action that uses the enterprise-approved `actions/setup-python` action and installs a pinned UV release from PyPI.

The enterprise GitHub Actions policy rejects the third-party setup action before affected jobs can start. The local action preserves Python 3.12 setup and optional UV caching without requiring an allowlist exception. It is used by the docs, license, and installation CI workflows.

No runtime dependencies are added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- `./isaaclab.sh -f`
- Confirmed no `astral-sh/setup-uv` references remain under `.github`.
- Confirmed the branch contains one focused commit directly on `upstream/develop`.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`.
- [x] Documentation changes are not required for this CI-only change.
- [x] My changes generate no new warnings.
- [x] The GitHub Actions policy check provides the regression coverage for this workflow-only fix.
- [x] No changelog fragment is required because no source package is touched.
- [x] My name already exists in `CONTRIBUTORS.md`.
