### PR TITLE
Exclude docs.omniverse.nvidia.com from link checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -105,6 +105,7 @@ jobs:
           --exclude 'docs\.conda\.io'
           --exclude 'stackoverflow\.com'
           --exclude 'docs\.isaacsim\.omniverse\.nvidia\.com'
+          --exclude 'docs\.omniverse\.nvidia\.com'
           --exclude 'download\.isaacsim\.omniverse\.nvidia\.com/isaaclab/images'
           --exclude 'dx\.doi\.org/10\.1109/JRA\.1987\.1087068'
           --exclude 'andrew\.cmu\.edu/course/10-703/textbook/BartoSutton\.pdf'


### PR DESCRIPTION
## Description

The `Check for Broken Links` job is failing on `develop` and every open PR: `docs.omniverse.nvidia.com` now returns **403 Forbidden** to the lychee crawler (85 links rejected in the latest develop run, e.g. https://github.com/isaac-sim/IsaacLab/actions/runs/29400148439). Reruns do not clear it — the domain is blocking the checker's requests, not individual pages.

This adds the domain to the existing crawl-blocker exclude list, matching the sibling entries (`docs.isaacsim.omniverse.nvidia.com`, `openusd.org`, etc.).

## Type of change

- Bug fix (CI)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [pre-commit checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file (not applicable — CI-only change)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

🤖 Generated with [Claude Code](https://claude.com/claude-code)