### PR TITLE
Assign minimal mass to massless bodies in MJWarp

### DIFF
--- a/source/isaaclab_newton/changelog.d/reb-mjwarp-massless-bodies.rst
+++ b/source/isaaclab_newton/changelog.d/reb-mjwarp-massless-bodies.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed MuJoCo model compilation failing with "mass and inertia of moving bodies must be
+  larger than mjMINVAL" when a USD asset authors massless dynamic frame bodies (e.g.
+  end-effector frames). :class:`~isaaclab_newton.physics.NewtonMJWarpManager` now raises
+  such bodies to a minimal mass and inertia before model finalization, mirroring MuJoCo's
+  ``boundmass``/``boundinertia`` compiler options.

--- a/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
@@ -12,7 +12,7 @@ import logging
 
 import numpy as np
 import warp as wp
-from newton import Contacts, Model
+from newton import BodyFlags, Contacts, Model, ModelBuilder
 from newton.solvers import SolverMuJoCo
 
 from isaaclab.physics import PhysicsManager
@@ -21,6 +21,12 @@ from .mjwarp_manager_cfg import MJWarpSolverCfg
 from .newton_manager import NewtonManager
 
 logger = logging.getLogger(__name__)
+
+_BOUND_MASS = 1.0e-3
+"""Minimum mass [kg] assigned to massless dynamic bodies before MJCF conversion."""
+
+_BOUND_INERTIA = 1.0e-6
+"""Minimum principal inertia [kg·m²] assigned to massless dynamic bodies with degenerate inertia."""
 
 
 class NewtonMJWarpManager(NewtonManager):
@@ -56,6 +62,39 @@ class NewtonMJWarpManager(NewtonManager):
                 "NewtonCfg: collision_cfg cannot be set when "
                 "solver_cfg.use_mujoco_contacts=True. Either set "
                 "use_mujoco_contacts=False or remove collision_cfg."
+            )
+
+    @classmethod
+    def _prepare_builder_for_finalize(cls, builder: ModelBuilder) -> None:
+        """Raise massless dynamic bodies to a minimal mass before finalization.
+
+        USD assets may author frame bodies (e.g. end-effector or TCP frames)
+        with ``physics:mass = 0`` while attaching them through movable joints.
+        PhysX computes a fallback mass for such bodies, but MuJoCo's compiler
+        rejects moving bodies whose mass or inertia is not larger than
+        ``mjMINVAL``. Mirroring MuJoCo's ``boundmass``/``boundinertia``
+        compiler options, raise the mass (and degenerate inertia) of massless
+        dynamic bodies to a small bound so the generated MJCF compiles.
+        """
+        kinematic_flag = int(BodyFlags.KINEMATIC)
+        bounded = []
+        for body_id, mass in enumerate(builder.body_mass):
+            if mass > 0.0 or int(builder.body_flags[body_id]) & kinematic_flag:
+                continue
+            builder.body_mass[body_id] = _BOUND_MASS
+            builder.body_inv_mass[body_id] = 1.0 / _BOUND_MASS
+            inertia_diag = np.diagonal(np.array(builder.body_inertia[body_id]).reshape(3, 3))
+            if np.min(inertia_diag) <= 0.0:
+                b, b_inv = _BOUND_INERTIA, 1.0 / _BOUND_INERTIA
+                builder.body_inertia[body_id] = wp.mat33(b, 0.0, 0.0, 0.0, b, 0.0, 0.0, 0.0, b)
+                builder.body_inv_inertia[body_id] = wp.mat33(b_inv, 0.0, 0.0, 0.0, b_inv, 0.0, 0.0, 0.0, b_inv)
+            bounded.append(builder.body_label[body_id])
+        if bounded:
+            logger.warning(
+                "Assigned minimal mass %.0e kg to %d massless dynamic bodies for MuJoCo compilation: %s",
+                _BOUND_MASS,
+                len(bounded),
+                ", ".join(bounded),
             )
 
     @classmethod

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -277,6 +277,47 @@ def test_mpm_prepare_builder_makes_kinematic_bodies_massless():
     assert np.allclose(np.array(builder.body_inertia[dynamic_body]), 2.0)
 
 
+def test_mjwarp_prepare_builder_bounds_massless_dynamic_bodies():
+    """Massless dynamic bodies get a minimal mass/inertia so the generated MJCF compiles.
+
+    USD frame bodies (e.g. end-effector frames) can author ``physics:mass = 0`` while
+    hanging off a movable joint; MuJoCo's compiler rejects moving bodies whose mass or
+    inertia is not larger than ``mjMINVAL``.
+    """
+    import newton
+    from isaaclab_newton.physics.mjwarp_manager import _BOUND_INERTIA, _BOUND_MASS
+
+    builder = newton.ModelBuilder()
+    diag_inertia = wp.mat33(1e-4, 0.0, 0.0, 0.0, 1e-4, 0.0, 0.0, 0.0, 1e-4)
+    massless_with_inertia = builder.add_body(mass=0.0, inertia=diag_inertia, label="ee_frame")
+    massless_degenerate = builder.add_body(mass=0.0, inertia=wp.mat33(0.0), label="tcp_frame")
+    kinematic_body = builder.add_body(mass=0.0, inertia=wp.mat33(0.0), is_kinematic=True, label="kinematic_collider")
+    dynamic_body = builder.add_body(mass=1.2, inertia=wp.mat33(2.0), label="dynamic_body")
+
+    NewtonMJWarpManager._prepare_builder_for_finalize(builder)
+
+    # massless dynamic body with valid inertia: only the mass is bounded.
+    assert builder.body_mass[massless_with_inertia] == pytest.approx(_BOUND_MASS)
+    assert builder.body_inv_mass[massless_with_inertia] == pytest.approx(1.0 / _BOUND_MASS)
+    assert np.allclose(np.array(builder.body_inertia[massless_with_inertia]), np.array(diag_inertia))
+
+    # massless dynamic body with degenerate inertia: mass and inertia are bounded.
+    assert builder.body_mass[massless_degenerate] == pytest.approx(_BOUND_MASS)
+    assert np.allclose(np.array(builder.body_inertia[massless_degenerate]).reshape(3, 3), np.eye(3) * _BOUND_INERTIA)
+    assert np.allclose(
+        np.array(builder.body_inv_inertia[massless_degenerate]).reshape(3, 3), np.eye(3) / _BOUND_INERTIA
+    )
+
+    # kinematic and regular dynamic bodies are untouched.
+    assert builder.body_mass[kinematic_body] == 0.0
+    assert builder.body_mass[dynamic_body] == pytest.approx(1.2)
+    assert np.allclose(np.array(builder.body_inertia[dynamic_body]), 2.0)
+
+    # the hook is idempotent: a second pass leaves the bounded values unchanged.
+    NewtonMJWarpManager._prepare_builder_for_finalize(builder)
+    assert builder.body_mass[massless_with_inertia] == pytest.approx(_BOUND_MASS)
+
+
 def test_active_manager_create_builder_registers_mpm_attributes():
     """The active MPM manager registers solver-specific builder attributes."""
     sim_cfg = SimulationCfg(


### PR DESCRIPTION
# Description

USD assets may author frame bodies (e.g. end-effector or TCP frames) with `physics:mass = 0` while attaching them through movable joints. PhysX computes a fallback mass for such bodies, but MuJoCo's compiler rejects moving bodies whose mass or inertia is not larger than `mjMINVAL` ("mass and inertia of moving bodies must be larger than mjMINVAL"), so model compilation failed for these assets under the MJWarp backend.

This PR overrides `_prepare_builder_for_finalize` in `NewtonMJWarpManager` to raise massless dynamic bodies to a minimal mass (`1e-3` kg), and bodies with degenerate inertia to a minimal diagonal inertia (`1e-6` kg·m²), before model finalization. Kinematic bodies and bodies with valid mass are left untouched, the pass is idempotent, and a warning lists every bounded body so silently-patched assets stay visible.

A unit test on a plain `ModelBuilder` covers all four cases: massless body with valid inertia (only mass bounded), massless body with degenerate inertia (mass and inertia bounded), kinematic body (untouched), and regular dynamic body (untouched), plus idempotency of the hook.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## References

The fix mirrors MuJoCo's [`boundmass` / `boundinertia` compiler options](https://mujoco.readthedocs.io/en/stable/XMLreference.html#compiler), its sanctioned mechanism for raising authored values to a safe lower bound. Since the Newton → MJCF conversion path does not expose these compiler options, the equivalent bounding is applied on the Newton `ModelBuilder` before finalization.

Implementation-wise, this follows the existing `_prepare_builder_for_finalize` hook pattern established by [`NewtonMPMManager`](https://github.com/isaac-sim/IsaacLab/blob/fece60787/source/isaaclab_newton/isaaclab_newton/physics/mpm_manager.py#L74-L89), which normalizes rigid-body mass properties for its solver in the same place (MPM clears mass on kinematic bodies; this PR bounds mass on massless dynamic ones). The hook itself is defined on [`NewtonManager`](https://github.com/isaac-sim/IsaacLab/blob/fece60787/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py#L911).

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
