### PR TITLE
Honor replicate_physics in replication sessions

### DIFF
--- a/source/isaaclab/changelog.d/restore-replicate-physics-policy.minor.rst
+++ b/source/isaaclab/changelog.d/restore-replicate-physics-policy.minor.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Restored :attr:`isaaclab.scene.InteractiveSceneCfg.replicate_physics` behavior after the replication-session
+  refactor. Replication sessions can now skip physics-backend replication while retaining complete USD clones
+  for normal stage discovery.

--- a/source/isaaclab/isaaclab/cloner/replicate_session.py
+++ b/source/isaaclab/isaaclab/cloner/replicate_session.py
@@ -24,12 +24,14 @@ REPLICATION_QUEUE: list[tuple[Any, type]] = []
 """``(cfg, BackendCtxCls)`` pairs appended by ``queue_<backend>_replication`` and drained by :func:`replicate`."""
 
 
-def replicate(plan: ClonePlan, *, stage: Usd.Stage) -> None:
+def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = True) -> None:
     """Drain :data:`REPLICATION_QUEUE` against ``plan``, dispatch each backend, publish the plan.
 
-    Cfgs absent from ``plan.cfg_rows`` are silently skipped. Backend contexts run in
-    ascending ``replicate_priority`` order. The queue is cleared up front, so a backend
-    failure cannot leak stale entries into the next call.
+    Cfgs absent from ``plan.cfg_rows`` are silently skipped. When ``replicate_physics``
+    is false, contexts marked with ``replicates_physics`` are drained but not dispatched;
+    USD replication still authors the complete stage for normal physics discovery.
+    Backend contexts run in ascending ``replicate_priority`` order. The queue is cleared
+    up front, so a backend failure cannot leak stale entries into the next call.
     """
     from isaaclab.sim import SimulationContext  # noqa: PLC0415
 
@@ -42,6 +44,8 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage) -> None:
     # union keeps it as a single row — no redundant copy specs are authored.
     backend_rows: dict[type, set[int]] = {}
     for cfg, BackendCtxCls in queued:
+        if not replicate_physics and getattr(BackendCtxCls, "replicates_physics", False):
+            continue
         rows = plan.cfg_rows.get(id(cfg))
         if rows is None:
             continue
@@ -92,6 +96,7 @@ class ReplicateSession:
         stage: Usd.Stage,
         clone_strategy: Callable = sequential,
         valid_set: torch.Tensor | None = None,
+        replicate_physics: bool = True,
     ):
         """Capture arguments for :func:`make_clone_plan` and :func:`replicate`.
 
@@ -104,9 +109,13 @@ class ReplicateSession:
             clone_strategy: Prototype-to-env assignment function.
             valid_set: Optional ``[num_combos, num_groups]`` long tensor of valid
                 prototype combinations; ``None`` uses the full cartesian product.
+            replicate_physics: Whether to dispatch physics-backend replication.
+                When false, USD clones are still authored and physics discovers the
+                completed stage through its normal parsing path.
         """
         self._cfgs = cfgs
         self._stage = stage
+        self._replicate_physics = replicate_physics
         self._kwargs = dict(
             num_clones=num_clones,
             env_spacing=env_spacing,
@@ -125,7 +134,7 @@ class ReplicateSession:
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         if exc_type is None:
             assert self._plan is not None
-            replicate(self._plan, stage=self._stage)
+            replicate(self._plan, stage=self._stage, replicate_physics=self._replicate_physics)
         else:
             # Drop cfgs registered before the failure so the next session is clean.
             REPLICATION_QUEUE.clear()

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -184,6 +184,7 @@ class InteractiveScene:
             device=self.device,
             stage=self.stage,
             clone_strategy=self.cloner_cfg.clone_strategy,
+            replicate_physics=self.cfg.replicate_physics,
         ):
             if self._is_scene_setup_from_cfg():
                 self._add_entities_from_cfg()

--- a/source/isaaclab/test/scene/test_interactive_scene.py
+++ b/source/isaaclab/test/scene/test_interactive_scene.py
@@ -132,7 +132,8 @@ def test_reset_to_env_ids_input_types(device, setup_scene):
     assert_state_equal(prev_state, scene.get_state())
 
 
-def test_scene_publishes_plan_via_replicate(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("replicate_physics", [True, False])
+def test_scene_publishes_plan_via_replicate(monkeypatch: pytest.MonkeyPatch, replicate_physics: bool):
     """A cfg-driven scene forwards the right plan and stage to cloner.replicate.
 
     Uses a test-seam fake to isolate this unit test from real backend dispatch; queue
@@ -143,21 +144,22 @@ def test_scene_publishes_plan_via_replicate(monkeypatch: pytest.MonkeyPatch):
 
     captured: list = []
 
-    def fake_replicate(plan, *, stage):
-        captured.append((plan, stage))
+    def fake_replicate(plan, *, stage, replicate_physics):
+        captured.append((plan, stage, replicate_physics))
 
     monkeypatch.setattr(replicate_session_module, "replicate", fake_replicate)
 
     with build_simulation_context(device="cpu", auto_add_lighting=False, add_ground_plane=False) as sim:
         sim._app_control_on_stop_handle = None
-        scene = InteractiveScene(MySceneCfg(num_envs=4, env_spacing=1.0))
+        scene = InteractiveScene(MySceneCfg(num_envs=4, env_spacing=1.0, replicate_physics=replicate_physics))
 
     assert len(captured) == 1
-    plan, stage = captured[0]
+    plan, stage, forwarded_replicate_physics = captured[0]
     assert plan.sources == ("/World/envs/env_0",)
     assert plan.destinations == ("/World/envs/env_{}",)
     assert plan.clone_mask.shape == (1, 4)
     assert stage is scene.stage
+    assert forwarded_replicate_physics is replicate_physics
 
 
 def test_collect_asset_cfgs_resolves_env_regex_macros():

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -578,6 +578,52 @@ def test_replicate_runs_lower_priority_backends_first(sim):
     assert call_order == ["low", "high"]
 
 
+def test_replicate_can_skip_physics_backends(sim):
+    """replicate_physics=False drains physics work while retaining USD-style work."""
+
+    call_order: list[str] = []
+
+    class PhysicsCtx:
+        replicates_physics = True
+
+        def __init__(self, stage):
+            pass
+
+        def queue_mapping(self, *args, **kwargs):
+            call_order.append("physics-queued")
+
+        def replicate(self):
+            call_order.append("physics-replicated")
+
+    class UsdCtx:
+        def __init__(self, stage):
+            pass
+
+        def queue_mapping(self, *args, **kwargs):
+            call_order.append("usd-queued")
+
+        def replicate(self):
+            call_order.append("usd-replicated")
+
+    cfg = SimpleNamespace(prim_path="/World/envs/env_.*/Robot")
+    REPLICATION_QUEUE.append((cfg, PhysicsCtx))
+    REPLICATION_QUEUE.append((cfg, UsdCtx))
+    plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool, device=sim.cfg.device),
+        env_ids=torch.arange(2, dtype=torch.long, device=sim.cfg.device),
+        positions=None,
+        cfg_rows={id(cfg): (0,)},
+    )
+
+    replicate(plan, stage=sim_utils.get_current_stage(), replicate_physics=False)
+
+    assert call_order == ["usd-queued", "usd-replicated"]
+    assert REPLICATION_QUEUE == []
+    assert sim.get_clone_plan() is plan
+
+
 def test_replicate_skips_cfgs_not_in_plan(sim):
     """Cfgs absent from plan.cfg_rows are silently skipped."""
     sentinel = MagicMock()

--- a/source/isaaclab_newton/changelog.d/restore-replicate-physics-policy.skip
+++ b/source/isaaclab_newton/changelog.d/restore-replicate-physics-policy.skip
@@ -1,0 +1,2 @@
+Marked the Newton replication context as physics work so core replication sessions can honor
+``InteractiveSceneCfg.replicate_physics=False`` without importing backend-specific types.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
@@ -111,6 +111,8 @@ def _build_newton_builder_from_mapping(
 class NewtonReplicateContext:
     """Queue and run Newton replication work for one stage."""
 
+    replicates_physics = True
+
     def __init__(
         self,
         stage: Usd.Stage,

--- a/source/isaaclab_ovphysx/changelog.d/restore-replicate-physics-policy.skip
+++ b/source/isaaclab_ovphysx/changelog.d/restore-replicate-physics-policy.skip
@@ -1,0 +1,2 @@
+Marked the OV PhysX replication context as physics work so core replication sessions can honor
+``InteractiveSceneCfg.replicate_physics=False`` without importing backend-specific types.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/cloner/replicate.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/cloner/replicate.py
@@ -42,6 +42,8 @@ def _select_env_ids(env_ids: torch.Tensor, mapping: torch.Tensor, row: int) -> t
 class OvPhysxReplicateContext:
     """Queue and run OvPhysX clone operations for one stage."""
 
+    replicates_physics = True
+
     def __init__(self, stage: Usd.Stage):
         """Initialize the context.
 

--- a/source/isaaclab_physx/changelog.d/restore-replicate-physics-policy.skip
+++ b/source/isaaclab_physx/changelog.d/restore-replicate-physics-policy.skip
@@ -1,0 +1,2 @@
+Marked the PhysX replication context as physics work so core replication sessions can honor
+``InteractiveSceneCfg.replicate_physics=False`` without importing backend-specific types.

--- a/source/isaaclab_physx/isaaclab_physx/cloner/replicate.py
+++ b/source/isaaclab_physx/isaaclab_physx/cloner/replicate.py
@@ -28,6 +28,8 @@ def _select_env_ids(env_ids: torch.Tensor, mapping: torch.Tensor, row: int) -> t
 class PhysxReplicateContext:
     """Queue and run PhysX replication work for one stage."""
 
+    replicates_physics = True
+
     def __init__(self, stage: Usd.Stage):
         """Initialize the context.
 


### PR DESCRIPTION
## Summary

- propagate `InteractiveSceneCfg.replicate_physics` into `ReplicateSession`
- skip physics-backend replication when `replicate_physics=False`
- continue USD replication so physics can discover the completed stage normally
- add coverage for policy forwarding, queue draining, and backend dispatch

## Problem

The replication-session refactor in `c7cbe661d07` stopped honoring `InteractiveSceneCfg.replicate_physics`.

Before that refactor, `replicate_physics=False` performed USD cloning without invoking backend physics replication. After the refactor, `InteractiveScene` entered a `ReplicateSession` that unconditionally dispatched every queued replication context.

This caused scenes explicitly configured with `replicate_physics=False` to invoke native PhysX replication unexpectedly.

## Implementation

`replicate()` and `ReplicateSession` now accept a `replicate_physics` argument, defaulting to `True` for compatibility with existing callers.

Physics replication contexts declare `replicates_physics = True`. When physics replication is disabled, those contexts are drained from the queue but not dispatched. USD replication still runs, preserving the complete stage needed for normal physics discovery.

PhysX, OVPhysX, and Newton replication contexts are marked consistently.

## Validation

- focused tests cover both enabled and disabled physics replication
- Ruff passes on all changed Python files
- downstream CPU suite: `347 passed, 41 skipped`
- 4/4 independent four-GPU PhysX + RTX runs using heterogeneous object mappings completed 10/10 training epochs, saved final checkpoints, and uploaded outputs with `replicate_physics=False`

The runtime-tested patch was applied to the IsaacLab revision pinned by the downstream image. The commit submitted here is an equivalent clean port onto the current `develop` branch.

## Important follow-up

This change restores the intended `replicate_physics=False` behavior, but it does not resolve a second issue observed during debugging:

With `replicate_physics=True`, native PhysX replication of a heterogeneous `ClonePlan`, where different environment rows receive different rigid-object prototypes/configurations, intermittently corrupts native memory under a multi-GPU PhysX + RTX workload. Observed failures include:

- `malloc(): unaligned tcache chunk detected`
- `double free or corruption`
- worker termination by `SIGABRT`

Disabling only object physics replication eliminated the failure in 4/4 runs, and restoring the scene-level `replicate_physics=False` policy passed another 4/4 runs.

This suggests a separate issue in the heterogeneous mGPU physics-replication path. It should be investigated independently; this PR restores the supported opt-out path but does not claim to fix that underlying failure.