### PR TITLE
[Kamino] Success Metric for Fourbar-pole and DR Legs

### DIFF
--- a/source/isaaclab_tasks/changelog.d/aserifi-kamion-success-metric.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/aserifi-kamion-success-metric.minor.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added a ``Metrics/success_rate`` metric to the fourbar-pole and DR-Legs (walk and hold-pose) tasks for unified success tracking in the benchmark tools.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
@@ -275,6 +275,8 @@ class RewardsCfg:
         weight=-2.0,
         params={"asset_cfg": _ACTUATED_JOINT_CFG},
     )
+    # Success metric (zero-weight, metric only): survived the full episode without falling/tilting.
+    success_rate = RewTerm(func=mdp.survival_success_rate, weight=0.0)
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/__init__.pyi
@@ -19,6 +19,7 @@ __all__ = [
     "joint_pd_command_l2",
     "joint_pos_tracking_exp",
     "root_orientation_exp",
+    "walk_success_rate",
 ]
 
 from .observations import gait_phase, joint_position_setpoints
@@ -34,5 +35,6 @@ from .rewards import (
     joint_pd_command_l2,
     joint_pos_tracking_exp,
     root_orientation_exp,
+    walk_success_rate,
 )
 from isaaclab.envs.mdp import *

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/__init__.pyi
@@ -19,6 +19,7 @@ __all__ = [
     "joint_pd_command_l2",
     "joint_pos_tracking_exp",
     "root_orientation_exp",
+    "survival_success_rate",
     "walk_success_rate",
 ]
 
@@ -35,6 +36,7 @@ from .rewards import (
     joint_pd_command_l2,
     joint_pos_tracking_exp,
     root_orientation_exp,
+    survival_success_rate,
     walk_success_rate,
 )
 from isaaclab.envs.mdp import *

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/rewards.py
@@ -37,6 +37,7 @@ __all__ = [
     "feet_flat",
     "feet_touchdown_vel",
     "root_orientation_exp",
+    "walk_success_rate",
 ]
 
 
@@ -222,3 +223,66 @@ def root_orientation_exp(
     root_quat = asset.data.root_link_quat_w.torch
     tilt = _quat_inv_mul(math_utils.yaw_quat(root_quat), root_quat)
     return _exp_se(torch.sum(torch.square(tilt[:, :3]), dim=1), sigma)
+
+
+class walk_success_rate(ManagerTermBase):
+    """Episode-mean velocity-tracking + gait-contact success metric for the walk task."""
+
+    def __init__(self, env: ManagerBasedRLEnv, cfg: RewardTermCfg):
+        super().__init__(cfg, env)
+        self._err_xy_sum = torch.zeros(env.num_envs, device=env.device)
+        self._err_yaw_sum = torch.zeros(env.num_envs, device=env.device)
+        self._contact_sum = torch.zeros(env.num_envs, device=env.device)
+        self._steps = torch.zeros(env.num_envs, device=env.device)
+        self._vel_xy_threshold = 0.15
+        self._vel_yaw_threshold = 0.4
+        self._contact_match_threshold = 0.7
+
+    def reset(self, env_ids: torch.Tensor):
+        denom = self._steps[env_ids].clamp_min(1.0)
+        err_xy = self._err_xy_sum[env_ids] / denom
+        err_yaw = self._err_yaw_sum[env_ids] / denom
+        contact = self._contact_sum[env_ids] / denom
+        survived = self._env.termination_manager.time_outs[env_ids]
+        success = (
+            survived
+            & (err_xy < self._vel_xy_threshold)
+            & (err_yaw < self._vel_yaw_threshold)
+            & (contact >= self._contact_match_threshold)
+        )
+        log = self._env.extras.setdefault("log", {})
+        log["Metrics/success_rate"] = success.float().mean().item()
+        log["Metrics/error_vel_xy"] = err_xy.mean().item()
+        log["Metrics/error_vel_yaw"] = err_yaw.mean().item()
+        log["Metrics/contact_match_rate"] = contact.mean().item()
+        self._err_xy_sum[env_ids] = 0.0
+        self._err_yaw_sum[env_ids] = 0.0
+        self._contact_sum[env_ids] = 0.0
+        self._steps[env_ids] = 0.0
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        command_name: str,
+        sensor_cfg: SceneEntityCfg,
+        gait_period: float,
+        contact_threshold: float,
+        vel_xy_threshold: float,
+        vel_yaw_threshold: float,
+        contact_match_threshold: float,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    ) -> torch.Tensor:
+        self._vel_xy_threshold = vel_xy_threshold
+        self._vel_yaw_threshold = vel_yaw_threshold
+        self._contact_match_threshold = contact_match_threshold
+        command = env.command_manager.get_command(command_name)
+        asset = env.scene[asset_cfg.name]
+        self._err_xy_sum += torch.linalg.norm(command[:, :2] - asset.data.root_lin_vel_b.torch[:, :2], dim=1)
+        self._err_yaw_sum += torch.abs(command[:, 2] - asset.data.root_ang_vel_b.torch[:, 2])
+        contact_sensor = env.scene.sensors[sensor_cfg.name]
+        net_forces = contact_sensor.data.net_forces_w.torch[:, sensor_cfg.body_ids]
+        observed = torch.linalg.norm(net_forces, dim=-1) > contact_threshold
+        reference = _reference_contacts(_gait_phase(env, gait_period)).bool()
+        self._contact_sum += (observed == reference).float().mean(dim=1)
+        self._steps += 1.0
+        return torch.zeros(env.num_envs, device=env.device)

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/rewards.py
@@ -37,6 +37,7 @@ __all__ = [
     "feet_flat",
     "feet_touchdown_vel",
     "root_orientation_exp",
+    "survival_success_rate",
     "walk_success_rate",
 ]
 
@@ -223,6 +224,20 @@ def root_orientation_exp(
     root_quat = asset.data.root_link_quat_w.torch
     tilt = _quat_inv_mul(math_utils.yaw_quat(root_quat), root_quat)
     return _exp_se(torch.sum(torch.square(tilt[:, :3]), dim=1), sigma)
+
+
+class survival_success_rate(ManagerTermBase):
+    """Logs ``Metrics/success_rate`` = fraction of environments that survived the full episode."""
+    
+    def __init__(self, env: ManagerBasedRLEnv, cfg: RewardTermCfg):
+        super().__init__(cfg, env)
+
+    def reset(self, env_ids: torch.Tensor):
+        survived = self._env.termination_manager.time_outs[env_ids]
+        self._env.extras.setdefault("log", {})["Metrics/success_rate"] = survived.float().mean().item()
+
+    def __call__(self, env: ManagerBasedRLEnv) -> torch.Tensor:
+        return torch.zeros(env.num_envs, device=env.device)
 
 
 class walk_success_rate(ManagerTermBase):

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/mdp/rewards.py
@@ -228,7 +228,7 @@ def root_orientation_exp(
 
 class survival_success_rate(ManagerTermBase):
     """Logs ``Metrics/success_rate`` = fraction of environments that survived the full episode."""
-    
+
     def __init__(self, env: ManagerBasedRLEnv, cfg: RewardTermCfg):
         super().__init__(cfg, env)
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/walk_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/walk_env_cfg.py
@@ -155,6 +155,22 @@ class WalkRewardsCfg:
     action_rate = RewTerm(func=mdp.action_rate_l2, weight=-0.001)
     action_2nd_derivative = RewTerm(func=mdp.ActionRate2L2, weight=-5.0e-5)
 
+    # -- success metric (velocity tracking + gait-contact match)
+    success_rate = RewTerm(
+        func=mdp.walk_success_rate,
+        weight=1.0,
+        params={
+            "command_name": "base_velocity",
+            "asset_cfg": SceneEntityCfg("robot"),
+            "sensor_cfg": _FOOT_SENSOR_CFG,
+            "gait_period": _GAIT_PERIOD,
+            "contact_threshold": 1.0,
+            "vel_xy_threshold": 0.15,
+            "vel_yaw_threshold": 0.4,
+            "contact_match_threshold": 0.7,
+        },
+    )
+
 
 @configclass
 class DrLegsWalkEnvCfg(DrLegsHoldPoseEnvCfg):

--- a/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/fourbar_pole_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/fourbar_pole_manager_env_cfg.py
@@ -23,7 +23,6 @@ from isaaclab.utils.configclass import configclass
 from isaaclab.visualizers import VisualizerCfg
 
 import isaaclab_tasks.core.fourbar_pole.mdp as mdp
-from isaaclab_tasks.core.fourbar_pole.mdp.rewards import UprightSuccessRateCommandCfg
 from isaaclab_tasks.utils import PresetCfg
 
 ##
@@ -96,17 +95,6 @@ class FourbarPoleSceneCfg(InteractiveSceneCfg):
 ##
 # MDP settings
 ##
-
-
-@configclass
-class CommandsCfg:
-    """Command specifications for the MDP."""
-
-    # Command term to track pole upright success rate
-    upright = UprightSuccessRateCommandCfg(
-        asset_cfg=SceneEntityCfg("robot", joint_names=["coupler_to_pole"]),
-        threshold=0.95,
-    )
 
 
 @configclass
@@ -187,11 +175,15 @@ class EventCfg:
 class RewardsCfg:
     """Reward terms for the MDP."""
 
-    # (1) Primary task: swing the pole up and keep it upright (cos is maximal upright)
+    # (1) Primary task + success tracking: swing the pole up and keep it upright (cos is maximal upright)
     pole_upright = RewTerm(
         func=mdp.pole_upright,
         weight=1.0,
-        params={"asset_cfg": SceneEntityCfg("robot", joint_names=["coupler_to_pole"])},
+        params={
+            "asset_cfg": SceneEntityCfg("robot", joint_names=["coupler_to_pole"]),
+            "success_threshold": 0.9,
+            "hold_time_s": 0.5,
+        },
     )
     # (2) Shaping: damp the pole angular velocity to settle at the top
     pole_vel = RewTerm(
@@ -234,7 +226,6 @@ class FourbarPoleSwingupEnvCfg(ManagerBasedRLEnvCfg):
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()
     actions: ActionsCfg = ActionsCfg()
-    commands: CommandsCfg = CommandsCfg()
     events: EventCfg = EventCfg()
     # MDP settings
     rewards: RewardsCfg = RewardsCfg()

--- a/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/mdp/__init__.pyi
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/mdp/__init__.pyi
@@ -4,16 +4,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 __all__ = [
-    "UprightSuccessRateCommand",
-    "UprightSuccessRateCommandCfg",
     "joint_pos_cos",
     "joint_pos_sin",
     "pole_upright",
 ]
 
 from .rewards import (
-    UprightSuccessRateCommand,
-    UprightSuccessRateCommandCfg,
     joint_pos_cos,
     joint_pos_sin,
     pole_upright,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/mdp/rewards.py
@@ -12,13 +12,11 @@ reward / success-metric terms.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import torch
 
-from isaaclab.managers import CommandTerm, CommandTermCfg, SceneEntityCfg
-from isaaclab.utils.configclass import configclass
+from isaaclab.managers import ManagerTermBase, RewardTermCfg, SceneEntityCfg
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation
@@ -41,51 +39,32 @@ def joint_pos_sin(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg) -> torch.Te
     return torch.sin(asset.data.joint_pos.torch[:, asset_cfg.joint_ids])
 
 
-def pole_upright(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg) -> torch.Tensor:
-    """Uprightness reward for the pole, maximal (``+1``) when fully upright.
+class pole_upright(ManagerTermBase):
+    """Pole-uprightness reward that also logs a sustained-upright success metric.
 
-    The pole joint is zero when upright and ``+-pi`` when hanging, so ``cos`` gives
-    a dense shaping signal in ``[-1, 1]`` that drives the swing-up.
+    Reward is ``sum(cos(pole_angle))`` -- ``+1`` upright, ``-1`` hanging. On reset it flushes
+    ``Metrics/success_rate``: the fraction of environments that held the pole within the upright
+    cone (``cos > success_threshold``) for at least the final ``hold_time_s`` seconds. Both params
+    shape only the metric, not the reward.
     """
-    asset: Articulation = env.scene[asset_cfg.name]
-    return torch.sum(torch.cos(asset.data.joint_pos.torch[:, asset_cfg.joint_ids]), dim=1)
 
-
-class UprightSuccessRateCommand(CommandTerm):
-    """Command term that tracks pole-upright terminal success as a metric."""
-
-    cfg: UprightSuccessRateCommandCfg
-
-    def __init__(self, cfg: UprightSuccessRateCommandCfg, env: ManagerBasedRLEnv):
+    def __init__(self, env: ManagerBasedRLEnv, cfg: RewardTermCfg):
         super().__init__(cfg, env)
-        self._asset_cfg = cfg.asset_cfg
-        self._asset_cfg.resolve(env.scene)
-        self._asset: Articulation = env.scene[self._asset_cfg.name]
+        self._consecutive_upright = torch.zeros(env.num_envs, device=env.device)
+        self._success = torch.zeros(env.num_envs, device=env.device)
 
-        self._command = torch.zeros((self.num_envs, 1), device=self.device)
-        self.metrics["success_rate"] = torch.zeros(self.num_envs, device=self.device)
+    def reset(self, env_ids: torch.Tensor):
+        self._env.extras.setdefault("log", {})["Metrics/success_rate"] = self._success[env_ids].mean().item()
+        self._consecutive_upright[env_ids] = 0.0
 
-    @property
-    def command(self) -> torch.Tensor:
-        return self._command
-
-    def _update_metrics(self):
-        pole_pos = self._asset.data.joint_pos.torch[:, self._asset_cfg.joint_ids]
-        self.metrics["success_rate"] = (torch.cos(pole_pos) > self.cfg.threshold).all(dim=1).float()
-
-    def _resample_command(self, env_ids: Sequence[int]):
-        pass
-
-    def _update_command(self):
-        pass
-
-
-@configclass
-class UprightSuccessRateCommandCfg(CommandTermCfg):
-    """Configuration for :class:`UprightSuccessRateCommand`."""
-
-    class_type: type[UprightSuccessRateCommand] | str = "{DIR}.rewards:UprightSuccessRateCommand"
-    resampling_time_range: tuple[float, float] = (1e6, 1e6)
-
-    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot", joint_names=["coupler_to_pole"])
-    threshold: float = 0.95
+    def __call__(
+        self, env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg, success_threshold: float, hold_time_s: float = 0.5
+    ) -> torch.Tensor:
+        hold_steps = max(1, round(hold_time_s / env.step_dt))
+        cos_pole = torch.cos(env.scene[asset_cfg.name].data.joint_pos.torch[:, asset_cfg.joint_ids])
+        upright = (cos_pole > success_threshold).all(dim=1)
+        self._consecutive_upright = torch.where(
+            upright, self._consecutive_upright + 1.0, torch.zeros_like(self._consecutive_upright)
+        )
+        self._success = (self._consecutive_upright >= hold_steps).float()
+        return torch.sum(cos_pole, dim=1)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/mdp/rewards.py
@@ -52,6 +52,8 @@ class pole_upright(ManagerTermBase):
         super().__init__(cfg, env)
         self._consecutive_upright = torch.zeros(env.num_envs, device=env.device)
         self._success = torch.zeros(env.num_envs, device=env.device)
+        hold_time_s: float = cfg.params.get("hold_time_s", 0.5)
+        self._hold_steps = max(1, round(hold_time_s / env.step_dt))
 
     def reset(self, env_ids: torch.Tensor):
         self._env.extras.setdefault("log", {})["Metrics/success_rate"] = self._success[env_ids].mean().item()
@@ -60,11 +62,10 @@ class pole_upright(ManagerTermBase):
     def __call__(
         self, env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg, success_threshold: float, hold_time_s: float = 0.5
     ) -> torch.Tensor:
-        hold_steps = max(1, round(hold_time_s / env.step_dt))
         cos_pole = torch.cos(env.scene[asset_cfg.name].data.joint_pos.torch[:, asset_cfg.joint_ids])
         upright = (cos_pole > success_threshold).all(dim=1)
         self._consecutive_upright = torch.where(
             upright, self._consecutive_upright + 1.0, torch.zeros_like(self._consecutive_upright)
         )
-        self._success = (self._consecutive_upright >= hold_steps).float()
+        self._success = (self._consecutive_upright >= self._hold_steps).float()
         return torch.sum(cos_pole, dim=1)


### PR DESCRIPTION
# Description

Add success metrics for the Kamino tasks

Adds a unified `Metrics/success_rate` metric to three tasks so training runs and the benchmark tooling can measure task success:

- Fourbar-pole: success = pole held within the upright cone (`cos > success_threshold`) for the final `hold_time_s` of the episode.
- DR-Legs walk: success = survived AND base velocity tracked within tolerance AND foot-contact pattern matched the reference gait (episode-mean).
- DR-Legs hold-pose: success = survived the full episode without falling/tilting.

All three emit the standard `Metrics/success_rate` tag, so the benchmark success tracking / `--check_success` early-stop works with no benchmark-side changes. The two threshold/hold params on each metric are logging-only and do not affect training.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
