### PR TITLE
Fix perf-smoke seeder JIT cache isolation

### DIFF
--- a/tools/perf_smoke_test/seed_baselines.py
+++ b/tools/perf_smoke_test/seed_baselines.py
@@ -40,8 +40,10 @@ records. Samples are pushed with :func:`baseline_manager.update_baselines_git`
 from __future__ import annotations
 
 import argparse
+import atexit
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -349,14 +351,35 @@ def _prepare_seed_source(workdir: Path, seed_src_dir: Path, sha: str) -> None:
 
 
 def _prepare_jit_cache(cache_dir: Path) -> Path:
-    """Create a writable JIT cache directory for one benchmark container."""
+    """Create a writable JIT cache directory for one task/backend bucket."""
     for subdir in (cache_dir / "warp", cache_dir / "nv"):
         subdir.mkdir(parents=True, exist_ok=True)
-    # Containers can write cache files as a different uid than the runner. Open
-    # the per-sample cache root before the bind mount so ownership never leaks
-    # across samples or workflow runs.
+    # Containers can write cache files as a different uid than the runner.
     _run(["chmod", "-R", "0777", str(cache_dir)], check=False)
     return cache_dir
+
+
+def _jit_cache_path(
+    cache_root: Path, target_branch: str, commit: str, task_id: str, backend_key: str
+) -> Path:
+    """Return the cache shared by repeated samples of one task/backend bucket."""
+    return (
+        cache_root
+        / _safe_path_component(target_branch)
+        / commit[:8]
+        / _safe_path_component(task_id)
+        / _safe_path_component(backend_key)
+    )
+
+
+def _cleanup_jit_cache(cache_dir: Path) -> None:
+    """Remove the disposable JIT cache for one seeder invocation."""
+    if not cache_dir.exists():
+        return
+    subprocess.run(["chmod", "-R", "a+rwX", str(cache_dir)], check=False, capture_output=True, text=True)
+    shutil.rmtree(cache_dir, ignore_errors=True)
+    if cache_dir.exists():
+        print(f"::warning::[seed] Could not fully remove JIT cache {cache_dir}")
 
 
 def _docker_run_benchmark(
@@ -374,6 +397,9 @@ def _docker_run_benchmark(
     seed_token = f"--seed {task.seed}" if task.seed is not None else ""
     inner = (
         "set -e\n"
+        # Warp creates nested cache directories at runtime. A permissive umask
+        # keeps them writable when successive containers use different host uids.
+        "umask 000\n"
         "cd /workspace/isaaclab\n"
         "rm -f _isaac_sim\n"
         "ln -s /isaac-sim _isaac_sim\n"
@@ -600,12 +626,15 @@ def main() -> int:
     seed_src_dir = (
         Path(args.seed_src_dir).resolve() if args.seed_src_dir else Path(tempfile.gettempdir()) / "perf-seed-src"
     )
+    run_id = os.environ.get("GITHUB_RUN_ID", f"local-{os.getpid()}")
+    run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "0")
     jit_cache_root = (
         workdir
         / "jit-cache"
         / "seed"
-        / f"run-{os.environ.get('GITHUB_RUN_ID', 'local')}-attempt-{os.environ.get('GITHUB_RUN_ATTEMPT', '0')}"
+        / f"run-{run_id}-attempt-{run_attempt}"
     )
+    atexit.register(_cleanup_jit_cache, jit_cache_root)
     kit_cache = workdir / "kit-cache"
     kit_cache.mkdir(parents=True, exist_ok=True)
     _run(["chmod", "-R", "0777", str(kit_cache)], check=False)
@@ -652,6 +681,9 @@ def main() -> int:
                 prep_skips.append(f"{target_branch}/{short}")
                 continue
         for task in tasks:
+            task_jit_cache = _prepare_jit_cache(
+                _jit_cache_path(jit_cache_root, target_branch, commit, task.task_id, task.backend_key)
+            )
             for sample_idx in range(args.samples_per_commit):
                 total += 1
                 artifact_dir = (
@@ -667,21 +699,13 @@ def main() -> int:
                 )
 
                 _write_launch_config(task, artifact_dir, gpu_model)
-                sample_jit_cache = _prepare_jit_cache(
-                    jit_cache_root
-                    / target_dir
-                    / short
-                    / _safe_path_component(task.task_id)
-                    / task.backend_key
-                    / f"sample{sample_idx}"
-                )
                 subprocess.run(["docker", "rm", "-f", container], capture_output=True, text=True)
                 start = time.time()
                 exit_code = _docker_run_benchmark(
                     image=args.image,
                     task=task,
                     artifact_dir=artifact_dir,
-                    jit_cache=sample_jit_cache,
+                    jit_cache=task_jit_cache,
                     kit_cache=kit_cache,
                     seed_src_dir=seed_src_dir if source_mount else None,
                     container_name=container,

--- a/tools/perf_smoke_test/seed_baselines.py
+++ b/tools/perf_smoke_test/seed_baselines.py
@@ -348,6 +348,17 @@ def _prepare_seed_source(workdir: Path, seed_src_dir: Path, sha: str) -> None:
     subprocess.run(["chmod", "-R", "a+rwX", str(seed_src_dir)], check=False)
 
 
+def _prepare_jit_cache(cache_dir: Path) -> Path:
+    """Create a writable JIT cache directory for one benchmark container."""
+    for subdir in (cache_dir / "warp", cache_dir / "nv"):
+        subdir.mkdir(parents=True, exist_ok=True)
+    # Containers can write cache files as a different uid than the runner. Open
+    # the per-sample cache root before the bind mount so ownership never leaks
+    # across samples or workflow runs.
+    _run(["chmod", "-R", "0777", str(cache_dir)], check=False)
+    return cache_dir
+
+
 def _docker_run_benchmark(
     *,
     image: str,
@@ -589,11 +600,15 @@ def main() -> int:
     seed_src_dir = (
         Path(args.seed_src_dir).resolve() if args.seed_src_dir else Path(tempfile.gettempdir()) / "perf-seed-src"
     )
-    jit_cache = workdir / "jit-cache"
+    jit_cache_root = (
+        workdir
+        / "jit-cache"
+        / "seed"
+        / f"run-{os.environ.get('GITHUB_RUN_ID', 'local')}-attempt-{os.environ.get('GITHUB_RUN_ATTEMPT', '0')}"
+    )
     kit_cache = workdir / "kit-cache"
-    for sub in (jit_cache / "warp", jit_cache / "nv", kit_cache):
-        sub.mkdir(parents=True, exist_ok=True)
-    _run(["chmod", "-R", "0777", str(jit_cache), str(kit_cache)], check=False)
+    kit_cache.mkdir(parents=True, exist_ok=True)
+    _run(["chmod", "-R", "0777", str(kit_cache)], check=False)
 
     plan = _build_seed_plan(args)
     plan = _filter_plan_by_ancestry(
@@ -652,13 +667,21 @@ def main() -> int:
                 )
 
                 _write_launch_config(task, artifact_dir, gpu_model)
+                sample_jit_cache = _prepare_jit_cache(
+                    jit_cache_root
+                    / target_dir
+                    / short
+                    / _safe_path_component(task.task_id)
+                    / task.backend_key
+                    / f"sample{sample_idx}"
+                )
                 subprocess.run(["docker", "rm", "-f", container], capture_output=True, text=True)
                 start = time.time()
                 exit_code = _docker_run_benchmark(
                     image=args.image,
                     task=task,
                     artifact_dir=artifact_dir,
-                    jit_cache=jit_cache,
+                    jit_cache=sample_jit_cache,
                     kit_cache=kit_cache,
                     seed_src_dir=seed_src_dir if source_mount else None,
                     container_name=container,

--- a/tools/perf_smoke_test/seed_baselines.py
+++ b/tools/perf_smoke_test/seed_baselines.py
@@ -359,9 +359,7 @@ def _prepare_jit_cache(cache_dir: Path) -> Path:
     return cache_dir
 
 
-def _jit_cache_path(
-    cache_root: Path, target_branch: str, commit: str, task_id: str, backend_key: str
-) -> Path:
+def _jit_cache_path(cache_root: Path, target_branch: str, commit: str, task_id: str, backend_key: str) -> Path:
     """Return the cache shared by repeated samples of one task/backend bucket."""
     return (
         cache_root
@@ -628,12 +626,7 @@ def main() -> int:
     )
     run_id = os.environ.get("GITHUB_RUN_ID", f"local-{os.getpid()}")
     run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "0")
-    jit_cache_root = (
-        workdir
-        / "jit-cache"
-        / "seed"
-        / f"run-{run_id}-attempt-{run_attempt}"
-    )
+    jit_cache_root = workdir / "jit-cache" / "seed" / f"run-{run_id}-attempt-{run_attempt}"
     atexit.register(_cleanup_jit_cache, jit_cache_root)
     kit_cache = workdir / "kit-cache"
     kit_cache.mkdir(parents=True, exist_ok=True)

--- a/tools/perf_smoke_test/test/test_seed_ancestry.py
+++ b/tools/perf_smoke_test/test/test_seed_ancestry.py
@@ -133,9 +133,9 @@ def test_filter_unresolvable_tip_keeps_when_lenient_raises_when_strict(repo) -> 
         seed_baselines._filter_plan_by_ancestry(plan, work, target_sha="", strict=True)
 
 
-def test_prepare_jit_cache_opens_sample_cache(tmp_path: Path) -> None:
-    """Each seed sample gets writable Warp/CUDA cache roots."""
-    cache_dir = tmp_path / "jit-cache" / "seed" / "sample0"
+def test_prepare_jit_cache_opens_task_cache(tmp_path: Path) -> None:
+    """Each task/backend bucket gets writable Warp/CUDA cache roots."""
+    cache_dir = tmp_path / "jit-cache" / "seed" / "task" / "newton"
 
     prepared = seed_baselines._prepare_jit_cache(cache_dir)
 
@@ -143,3 +143,40 @@ def test_prepare_jit_cache_opens_sample_cache(tmp_path: Path) -> None:
     assert (cache_dir / "warp").is_dir()
     assert (cache_dir / "nv").is_dir()
     assert cache_dir.stat().st_mode & 0o777 == 0o777
+
+
+def test_jit_cache_reuses_samples_and_isolates_backends(tmp_path: Path) -> None:
+    """Repeated samples share compiled kernels, but different backends do not."""
+    cache_root = tmp_path / "jit-cache" / "seed" / "run-1-attempt-1"
+    newton_cache = seed_baselines._jit_cache_path(
+        cache_root, "perf-smoke/develop-staging", "abcdef123456", "Isaac-Cartpole-Direct", "newton"
+    )
+    repeated_newton_cache = seed_baselines._jit_cache_path(
+        cache_root, "perf-smoke/develop-staging", "abcdef123456", "Isaac-Cartpole-Direct", "newton"
+    )
+    physx_cache = seed_baselines._jit_cache_path(
+        cache_root, "perf-smoke/develop-staging", "abcdef123456", "Isaac-Cartpole-Direct", "physx"
+    )
+
+    _ = seed_baselines._prepare_jit_cache(newton_cache)
+    compiled_kernel = newton_cache / "warp" / "compiled-kernel.so"
+    compiled_kernel.write_bytes(b"compiled")
+    _ = seed_baselines._prepare_jit_cache(repeated_newton_cache)
+
+    assert repeated_newton_cache == newton_cache
+    assert compiled_kernel.read_bytes() == b"compiled"
+    assert physx_cache != newton_cache
+    assert not physx_cache.exists()
+
+
+def test_cleanup_jit_cache_removes_run_tree(tmp_path: Path) -> None:
+    """Seeder exit cleanup removes compiled kernels from its run directory."""
+    cache_dir = tmp_path / "jit-cache" / "seed" / "run-1-attempt-1"
+    compiled_dir = cache_dir / "warp" / "version" / "module"
+    compiled_dir.mkdir(parents=True)
+    (compiled_dir / "kernel.so").write_bytes(b"compiled")
+    compiled_dir.chmod(0o500)
+
+    seed_baselines._cleanup_jit_cache(cache_dir)
+
+    assert not cache_dir.exists()

--- a/tools/perf_smoke_test/test/test_seed_ancestry.py
+++ b/tools/perf_smoke_test/test/test_seed_ancestry.py
@@ -131,3 +131,15 @@ def test_filter_unresolvable_tip_keeps_when_lenient_raises_when_strict(repo) -> 
 
     with pytest.raises(RuntimeError, match="cannot resolve tip"):
         seed_baselines._filter_plan_by_ancestry(plan, work, target_sha="", strict=True)
+
+
+def test_prepare_jit_cache_opens_sample_cache(tmp_path: Path) -> None:
+    """Each seed sample gets writable Warp/CUDA cache roots."""
+    cache_dir = tmp_path / "jit-cache" / "seed" / "sample0"
+
+    prepared = seed_baselines._prepare_jit_cache(cache_dir)
+
+    assert prepared == cache_dir
+    assert (cache_dir / "warp").is_dir()
+    assert (cache_dir / "nv").is_dir()
+    assert cache_dir.stat().st_mode & 0o777 == 0o777


### PR DESCRIPTION
## Summary

Fixes the L40S baseline seeding failure seen in the post-#6498 staging run:

```text
PermissionError: [Errno 13] Permission denied: /tmp/jit-cache/warp/...
```

The seed workflow runs many benchmark containers serially in one job. Reusing one host-mounted JIT cache allowed one container to leave Warp cache directories with ownership/permissions that blocked later samples from compiling Newton/Warp kernels.

This change gives the seeder a per-run/per-attempt JIT cache root and a per-sample cache directory, while keeping the Kit cache shared.

## Test plan

- [x] `/home/horde/dev/IsaacLab-fork/.venv/bin/python -m pytest tools/perf_smoke_test/test/test_seed_ancestry.py --noconftest -q -p no:cacheprovider`
- [x] `/home/horde/dev/IsaacLab-fork/.venv/bin/python -m pytest tools/perf_smoke_test/test/ --noconftest -q -p no:cacheprovider`
- [ ] Rerun `Performance Smoke - Seed Baselines` on `perf-smoke/develop-staging` after merge to validate on L40S.