### PR TITLE
Remove flatdict dependency

### DIFF
--- a/.github/actions/multi-gpu/multi_gpu_shard_runner.sh
+++ b/.github/actions/multi-gpu/multi_gpu_shard_runner.sh
@@ -49,7 +49,7 @@ mkdir -p /tmp/mgpu-base-home /tmp/mgpu-pyuserbase
 
 # Pytest deps (same as run-tests action). junitparser is imported at
 # tools/conftest.py load time, so it must be present first.
-./isaaclab.sh -p -m pip install pytest pytest-mock junitparser flatdict flaky "coverage>=7.6.1"
+./isaaclab.sh -p -m pip install pytest pytest-mock junitparser flaky "coverage>=7.6.1"
 
 # Shard count from nvidia-smi -L (truth; torch under-counts MIG).
 MIG_COUNT=$(nvidia-smi -L | grep -c "^  MIG ")  # grep -c = count of matching lines (MIG slices)

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -394,7 +394,7 @@ runs:
               # set this detect-only flag, which makes cold asset downloads
               # fall back to slow repeated retries.
               unset HUB__ARGS__DETECT_ONLY
-              ./isaaclab.sh -p -m pip install pytest pytest-mock junitparser flatdict flaky \"coverage>=7.6.1\"
+              ./isaaclab.sh -p -m pip install pytest pytest-mock junitparser flaky \"coverage>=7.6.1\"
               if [ -n \"\${TEST_WHEELHOUSE_PACKAGES:-}\" ]; then
                 if [ ! -d \"\${TEST_WHEELHOUSE_PATH:-}\" ]; then
                   echo \"Wheelhouse path is missing: \${TEST_WHEELHOUSE_PATH:-}\"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,7 +266,6 @@ autodoc_mock_imports = [
     "pink",
     "pinocchio",
     "qpsolvers",
-    "flatdict",
     "filelock",
     "IPython",
     "cv2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ test = [
     "pytest",
     "pytest-mock",
     "junitparser",
-    "flatdict>=4.1.0",
     "flaky",
     # numba subclasses coverage.types.Tracer at import; >=7.6.1 restores that shim
     "coverage>=7.6.1",


### PR DESCRIPTION
# Description

Remove the unused `flatdict` dependency from the root test extra and the two CI bootstrap commands that install test tooling. Also remove `flatdict` from the Sphinx mocked-import list.

The repository no longer imports or otherwise uses `flatdict`, so retaining it adds unnecessary installation and dependency-resolution work.

Dependencies required by this change: none. This change removes `flatdict`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- `./isaaclab.sh -p -m pytest source/isaaclab/test/cli/test_uv_run_pyproject.py` (6 passed)
- `bash -n .github/actions/multi-gpu/multi_gpu_shard_runner.sh`
- Parsed `pyproject.toml` and asserted the test extra contains no `flatdict` requirement
- Searched the repository for remaining live `flatdict` references; only the historical changelog entry remains
- `./isaaclab.sh -f` (passed before commit and again before push)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (no new test was needed for this metadata-only removal; existing metadata tests pass)
- [x] I have added a changelog fragment for every touched package (not applicable; no package under `source/` was changed)
- [x] My name already exists in `CONTRIBUTORS.md`
